### PR TITLE
fix: Complete .attune directory branding migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-02-02
+
+### Fixed
+
+- **vscode_bridge.py**: Updated `get_empathy_dir()` to use `.attune` directory (completes branding migration from `.empathy`)
+- **test_vscode_bridge_coverage_boost.py**: Aligned test expectations with `.attune` directory naming
+
 ## [2.1.0] - 2026-02-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "2.1.0"
+version = "2.1.1"
 description = "AI collaboration framework with real LLM agent execution, AskUserQuestion tool integration, Socratic agent generation, progressive tier escalation (70-85% cost savings), meta-orchestration, dynamic agent composition (10 patterns including Anthropic-inspired), intelligent caching (85% hit rate), semantic workflow discovery, visual workflow editor, MCP integration for Claude Code, and multi-agent orchestration."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/src/attune/vscode_bridge.py
+++ b/src/attune/vscode_bridge.py
@@ -43,10 +43,13 @@ class CodeReviewResult:
 
 
 def get_empathy_dir() -> Path:
-    """Get the .empathy directory, creating if needed."""
-    empathy_dir = Path(".empathy")
-    empathy_dir.mkdir(exist_ok=True)
-    return empathy_dir
+    """Get the .attune directory, creating if needed.
+
+    Note: Function retains 'empathy' name for backward compatibility.
+    """
+    attune_dir = Path(".attune")
+    attune_dir.mkdir(exist_ok=True)
+    return attune_dir
 
 
 def write_code_review_results(

--- a/tests/unit/test_vscode_bridge_coverage_boost.py
+++ b/tests/unit/test_vscode_bridge_coverage_boost.py
@@ -183,13 +183,13 @@ class TestGetEmpathyDir:
     """Test get_empathy_dir function."""
 
     def test_get_empathy_dir_creates_directory(self, tmp_path, monkeypatch):
-        """Test that get_empathy_dir creates .empathy directory."""
+        """Test that get_empathy_dir creates .attune directory."""
         # Change to temp directory
         monkeypatch.chdir(tmp_path)
 
         empathy_dir = get_empathy_dir()
 
-        assert empathy_dir == Path(".empathy")
+        assert empathy_dir == Path(".attune")
         assert empathy_dir.exists()
         assert empathy_dir.is_dir()
 
@@ -199,11 +199,11 @@ class TestGetEmpathyDir:
         monkeypatch.chdir(tmp_path)
 
         # Create directory first
-        (tmp_path / ".empathy").mkdir()
+        (tmp_path / ".attune").mkdir()
 
         empathy_dir = get_empathy_dir()
 
-        assert empathy_dir == Path(".empathy")
+        assert empathy_dir == Path(".attune")
         assert empathy_dir.exists()
 
 
@@ -584,7 +584,7 @@ class TestSendToVSCode:
         result = send_to_vscode("Test message")
 
         # Extract path from message
-        assert ".empathy" in result
+        assert ".attune" in result
         assert "code-review-results.json" in result
 
         # Verify path exists


### PR DESCRIPTION
## Summary

- Updated `get_empathy_dir()` to create and return `.attune` instead of `.empathy`
- Updated test expectations to match `.attune` directory naming
- Bumped version to 2.1.1

## Test plan

- [x] All 26 vscode_bridge tests pass
- [x] `get_empathy_dir()` now returns `.attune` directory


🤖 Generated with [Claude Code](https://claude.com/claude-code)