### PR TITLE
chore: Bump to v2.1.2 for correct PyPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.2] - 2026-02-02
+
+### Fixed
+
+- **PyPI packaging**: Re-release to include `.attune` branding fix (2.1.1 was built before the fix was merged)
+
 ## [2.1.1] - 2026-02-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "2.1.1"
+version = "2.1.2"
 description = "AI collaboration framework with real LLM agent execution, AskUserQuestion tool integration, Socratic agent generation, progressive tier escalation (70-85% cost savings), meta-orchestration, dynamic agent composition (10 patterns including Anthropic-inspired), intelligent caching (85% hit rate), semantic workflow discovery, visual workflow editor, MCP integration for Claude Code, and multi-agent orchestration."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- 2.1.1 on PyPI was built before the `.attune` branding fix was merged
- This release ensures users get the correct package contents

## Test plan

- [x] Package built and verified: `get_empathy_dir()` returns `.attune`
- [x] Tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)