### PR TITLE
docs(website): attune-docs split, attune-author v0.2.0, version sync

### DIFF
--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -20,7 +20,7 @@ const faqItems = [
   {
     question: 'Do I need attune-ai to read templates?',
     answer:
-      'No. The standalone attune-help package (1 dependency) can read any .help/ directory. attune-ai is only needed to generate and maintain templates.',
+      'No. The standalone attune-help package (1 dependency) can read any .help/ directory without the full framework. Generate templates with attune-author or attune-ai, then ship them alongside attune-help for a minimal runtime with no Anthropic API key required.',
   },
   {
     question: 'Can I write templates by hand?',
@@ -41,6 +41,11 @@ const faqItems = [
     question: 'What Claude Code skills are included?',
     answer:
       '14 auto-invoking skills: security audit, smart test, code review, deep review, doc generation, refactoring, bug prediction, release prep, planning, brainstorming, workflow orchestration, fix-test, spec-driven development, and the coach help system.',
+  },
+  {
+    question: 'Where do I install attune-help and attune-author from?',
+    answer:
+      'They live in the Smart-AI-Memory/attune-docs marketplace, not the main attune-ai marketplace. Add the marketplace with `claude plugin marketplace add Smart-AI-Memory/attune-docs`, then install the plugin(s) you want: `attune-help@attune-docs` for the reader and/or `attune-author@attune-docs` for the AI authoring companion. For PyPI direct installs, `pip install attune-help` and `pip install \'attune-author[plugin]\'` also work.',
   },
 ];
 
@@ -104,7 +109,10 @@ export default function DocsPage() {
                   Framework
                 </a>
                 <a href="#attune-help" className="px-5 py-2 text-sm rounded-lg font-medium !text-white border-2 border-white/60 hover:bg-white/15 transition-colors">
-                  Standalone Reader
+                  Reader
+                </a>
+                <a href="#attune-author" className="px-5 py-2 text-sm rounded-lg font-medium !text-white border-2 border-white/60 hover:bg-white/15 transition-colors">
+                  Authoring
                 </a>
                 <a href="#plugin" className="px-5 py-2 text-sm rounded-lg font-medium !text-white border-2 border-white/60 hover:bg-white/15 transition-colors">
                   Plugin
@@ -126,57 +134,96 @@ export default function DocsPage() {
             <div className="max-w-5xl mx-auto">
               <h2 className="text-4xl font-bold text-center mb-4">Quick Start</h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                Choose the package that fits your needs. All three are open
-                source under Apache 2.0.
+                Choose the package that fits your needs. All four are
+                open source under Apache 2.0.
               </p>
 
-              <div className="grid md:grid-cols-3 gap-6">
+              <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
                 {/* attune-help */}
-                <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 flex flex-col">
-                  <div className="text-sm font-bold text-[var(--primary)] uppercase tracking-wider mb-2">
+                <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-6 flex flex-col">
+                  <div className="text-xs font-bold text-[var(--primary)] uppercase tracking-wider mb-2">
                     Reader Only
                   </div>
-                  <h3 className="text-xl font-bold mb-2">attune-help</h3>
-                  <p className="text-sm text-[var(--text-secondary)] mb-6 flex-1">
+                  <h3 className="text-lg font-bold mb-2">attune-help</h3>
+                  <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     Lightweight reader for .help/ templates. 1 dependency,
-                    6 files. Embed in any Python tool.
+                    6 files. Embed in any Python tool. No AI key required.
                   </p>
-                  <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-sm p-4">
+                  <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-help
                   </div>
                 </div>
 
                 {/* attune-ai */}
-                <div className="bg-[var(--background)] border-2 border-[var(--primary)] rounded-lg p-8 flex flex-col relative">
+                <div className="bg-[var(--background)] border-2 border-[var(--primary)] rounded-lg p-6 flex flex-col relative">
                   <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-[var(--primary)] text-white text-xs font-bold px-3 py-1 rounded-full">
                     Recommended
                   </div>
-                  <div className="text-sm font-bold text-[var(--primary)] uppercase tracking-wider mb-2">
+                  <div className="text-xs font-bold text-[var(--primary)] uppercase tracking-wider mb-2">
                     Full Framework
                   </div>
-                  <h3 className="text-xl font-bold mb-2">attune-ai</h3>
-                  <p className="text-sm text-[var(--text-secondary)] mb-6 flex-1">
+                  <h3 className="text-lg font-bold mb-2">attune-ai</h3>
+                  <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     Generate, maintain, and serve help from your codebase.
-                    17 workflows, 14 skills, MCP server.
+                    15 workflows, 14 skills, MCP server.
                   </p>
-                  <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-sm p-4">
+                  <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
                   </div>
                 </div>
 
+                {/* attune-author */}
+                <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-6 flex flex-col">
+                  <div className="text-xs font-bold text-[var(--primary)] uppercase tracking-wider mb-2">
+                    AI Authoring
+                  </div>
+                  <h3 className="text-lg font-bold mb-2">attune-author</h3>
+                  <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
+                    Generate 11 kinds of source-grounded templates with
+                    per-type polish prompts. Pairs with attune-help.
+                  </p>
+                  <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3 break-all">
+                    <span className="text-white/50">$ </span>pip install &apos;attune-author[plugin]&apos;
+                  </div>
+                </div>
+
                 {/* Claude Code Plugin */}
-                <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 flex flex-col">
-                  <div className="text-sm font-bold text-[var(--primary)] uppercase tracking-wider mb-2">
+                <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-6 flex flex-col">
+                  <div className="text-xs font-bold text-[var(--primary)] uppercase tracking-wider mb-2">
                     Claude Code
                   </div>
-                  <h3 className="text-xl font-bold mb-2">Plugin</h3>
-                  <p className="text-sm text-[var(--text-secondary)] mb-6 flex-1">
+                  <h3 className="text-lg font-bold mb-2">Plugin</h3>
+                  <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     Install from the marketplace. Type /coach for
                     progressive help right in your terminal.
                   </p>
-                  <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-4 break-all">
+                  <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3 break-all">
                     <span className="text-white/50">$ </span>claude plugin marketplace add Smart-AI-Memory/attune-ai
                   </div>
+                </div>
+              </div>
+
+              {/* attune-docs marketplace callout */}
+              <div className="mt-10 bg-[var(--surface-container-low)] border border-[var(--border)] rounded-lg p-6">
+                <h3 className="font-bold text-lg mb-2">
+                  attune-help and attune-author plugins live in the attune-docs marketplace
+                </h3>
+                <p className="text-sm text-[var(--text-secondary)] mb-4">
+                  After the 2026-04-10 split, the Claude Code plugin
+                  versions of attune-help and attune-author live in a
+                  separate marketplace from the main attune-ai
+                  plugin. Add that marketplace first, then install
+                  whichever plugin(s) you want.
+                </p>
+                <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-4 leading-relaxed">
+                  <div className="text-white/50"># Add the attune-docs marketplace</div>
+                  <div>claude plugin marketplace add Smart-AI-Memory/attune-docs</div>
+                  <br />
+                  <div className="text-white/50"># Install the reader (no API key required)</div>
+                  <div>claude plugin install attune-help@attune-docs</div>
+                  <br />
+                  <div className="text-white/50"># Install the AI authoring companion</div>
+                  <div>claude plugin install attune-author@attune-docs</div>
                 </div>
               </div>
             </div>
@@ -336,8 +383,105 @@ export default function DocsPage() {
           </div>
         </section>
 
+        {/* Attune Author (AI authoring companion) */}
+        <section id="attune-author" className="py-20 bg-[var(--border)] bg-opacity-30">
+          <div className="container">
+            <div className="max-w-4xl mx-auto">
+              <h2 className="text-4xl font-bold text-center mb-4">
+                Attune Author
+              </h2>
+              <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
+                The AI authoring companion for attune-help. Generates
+                source-grounded templates from your codebase and
+                polishes them with per-type LLM prompts.
+              </p>
+
+              <div className="grid md:grid-cols-2 gap-8 mb-10">
+                <div>
+                  <h3 className="font-bold text-lg mb-4">11 Template Kinds</h3>
+                  <p className="text-sm text-[var(--text-secondary)] mb-4">
+                    Up from 3 in v0.1.0. The generator produces the
+                    full set of shapes attune-help renders:
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 text-xs font-mono">
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">concept</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">task</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">reference</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">error</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">warning</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">troubleshooting</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">faq</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">quickstart</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">tip</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">note</div>
+                    <div className="bg-[var(--background)] border border-[var(--border)] rounded px-2 py-1">comparison</div>
+                  </div>
+                  <p className="text-sm text-[var(--text-secondary)] mt-4">
+                    Default calls produce the original three kinds
+                    unchanged. The eight new kinds are strictly
+                    opt-in via the <code className="text-xs bg-[var(--surface-container-high)] px-1 rounded">depths=</code> kwarg.
+                  </p>
+                </div>
+
+                <div>
+                  <h3 className="font-bold text-lg mb-4">Per-Type Polish</h3>
+                  <p className="text-sm text-[var(--text-secondary)] mb-4">
+                    Each template kind gets its own system prompt
+                    that teaches the LLM what &ldquo;good&rdquo; looks
+                    like for that shape:
+                  </p>
+                  <ul className="space-y-2 text-sm text-[var(--text-secondary)]">
+                    <li>
+                      <strong className="text-[var(--foreground)]">Concept</strong> &mdash;
+                      definitional clarity and mental models
+                    </li>
+                    <li>
+                      <strong className="text-[var(--foreground)]">Task</strong> &mdash;
+                      &ldquo;Use X when&hellip;&rdquo; openers and
+                      verifiable success criteria
+                    </li>
+                    <li>
+                      <strong className="text-[var(--foreground)]">Troubleshooting</strong> &mdash;
+                      symptom tables and step-by-step diagnosis
+                    </li>
+                    <li>
+                      <strong className="text-[var(--foreground)]">Comparison</strong> &mdash;
+                      decision tables with &ldquo;Use X when&hellip;&rdquo;
+                      recommendations
+                    </li>
+                  </ul>
+                  <p className="text-sm text-[var(--text-secondary)] mt-4">
+                    Plus signature-aware source summaries that feed
+                    the LLM typed function and method signatures, so
+                    the polished output stays factually grounded in
+                    your actual code.
+                  </p>
+                </div>
+              </div>
+
+              <div className="bg-[var(--background)] border border-[var(--border)] rounded-lg p-6">
+                <h3 className="font-bold text-lg mb-4">Install and Generate</h3>
+                <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-4 leading-relaxed mb-4">
+                  <div className="text-white/50"># PyPI install (includes the polish runtime)</div>
+                  <div>pip install &apos;attune-author[plugin]&apos;</div>
+                  <br />
+                  <div className="text-white/50"># Or via the attune-docs marketplace for Claude Code</div>
+                  <div>claude plugin install attune-author@attune-docs</div>
+                </div>
+                <p className="text-sm text-[var(--text-secondary)]">
+                  Requires <code className="text-xs bg-[var(--surface-container-high)] px-1 rounded">ANTHROPIC_API_KEY</code> for
+                  the polish pass. Without it, the generator falls
+                  back to the raw Jinja2 drafts. Set
+                  <code className="text-xs bg-[var(--surface-container-high)] px-1 rounded">ATTUNE_AUTHOR_STRICT_POLISH=1</code> to
+                  make polish failures hard errors for CI.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
         {/* Claude Code Plugin */}
-        <section id="plugin" className="py-20 bg-[var(--border)] bg-opacity-30">
+        <section id="plugin" className="py-20">
           <div className="container">
             <div className="max-w-4xl mx-auto">
               <h2 className="text-4xl font-bold text-center mb-4">
@@ -411,8 +555,9 @@ export default function DocsPage() {
                 Workflows &amp; Skills
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                attune-ai includes 17 multi-stage workflows and 14
-                auto-invoking Claude Code skills.
+                attune-ai includes 15 multi-stage workflows, 14
+                auto-invoking Claude Code skills, and an MCP server
+                with 41 registered tools.
               </p>
 
               <div className="grid md:grid-cols-2 gap-8 mb-12">

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v5.10.0</span>
+                  <span>v5.10.1</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">User Assistants Platform</span>
                 </div>
@@ -171,41 +171,57 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Three Product Cards */}
+        {/* Four Product Cards */}
         <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="Products">
           <div className="text-center mb-20">
             <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">Core Capabilities</span>
-            <h2 className="text-4xl md:text-5xl font-extrabold">Three Ways to Use It</h2>
+            <h2 className="text-4xl md:text-5xl font-extrabold">Four Ways to Use It</h2>
+            <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
+              A full framework plus three focused tools. Pick the piece
+              that fits the job &mdash; or combine them for the full
+              author &rarr; reader loop.
+            </p>
           </div>
-          <div className="grid md:grid-cols-3 gap-8">
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
             {/* attune-ai */}
-            <div className="group bg-[var(--surface)] rounded-2xl p-8 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-8 group-hover:bg-[var(--primary)] transition-colors">
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
                 <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#128736;&#65039;</span>
               </div>
-              <h3 className="text-xl font-bold mb-4">attune-ai</h3>
+              <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Generate, maintain, and serve help from your code. Full framework on PyPI with workflows, staleness detection, and template management.
+                Full framework. Workflows, staleness detection, MCP server, and 14 auto-triggering skills for Claude Code.
               </p>
             </div>
 
             {/* attune-help */}
-            <div className="group bg-[var(--surface)] rounded-2xl p-8 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--secondary)]/10 flex items-center justify-center mb-8 group-hover:bg-[var(--secondary)] transition-colors">
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--secondary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--secondary)] transition-colors">
                 <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#128214;</span>
               </div>
-              <h3 className="text-xl font-bold mb-4">attune-help</h3>
+              <h3 className="text-xl font-bold mb-3">attune-help</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Lightweight reader. 1 dependency, 6 files. Embed progressive help anywhere &mdash; CLI tools, notebooks, internal apps.
+                Lightweight reader. 1 dependency, 6 files. Embed progressive help in any CLI tool, notebook, or internal app.
+              </p>
+            </div>
+
+            {/* attune-author */}
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--accent)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--accent)] transition-colors">
+                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#9999;&#65039;</span>
+              </div>
+              <h3 className="text-xl font-bold mb-3">attune-author</h3>
+              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
+                AI authoring companion. Generates 11 kinds of source-grounded templates with per-type polish prompts.
               </p>
             </div>
 
             {/* Claude Code Plugin */}
-            <div className="group bg-[var(--surface)] rounded-2xl p-8 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--surface-container-high)] flex items-center justify-center mb-8 group-hover:bg-[var(--foreground)] transition-colors">
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--surface-container-high)] flex items-center justify-center mb-6 group-hover:bg-[var(--foreground)] transition-colors">
                 <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#9889;</span>
               </div>
-              <h3 className="text-xl font-bold mb-4">Claude Code Plugin</h3>
+              <h3 className="text-xl font-bold mb-3">Claude Code Plugin</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
                 Type <code className="bg-[var(--surface-container-high)] px-1.5 py-0.5 rounded text-xs">/coach</code> in Claude Code. Progressive help in your terminal &mdash; no setup required.
               </p>

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -117,6 +117,26 @@ export default function Footer() {
                 </a>
               </li>
               <li>
+                <a
+                  href="https://pypi.org/project/attune-author/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-[var(--text-secondary)] hover:text-[var(--primary)] transition-colors"
+                >
+                  attune-author on PyPI
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/Smart-AI-Memory/attune-docs"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-[var(--text-secondary)] hover:text-[var(--primary)] transition-colors"
+                >
+                  attune-docs marketplace
+                </a>
+              </li>
+              <li>
                 <Link
                   href="/contact"
                   className="text-sm text-[var(--text-secondary)] hover:text-[var(--primary)] transition-colors"

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -3,6 +3,11 @@
  *
  * All pages should import from here to ensure consistency.
  * Update counts and descriptions here when features change.
+ *
+ * Marketplace mapping after the 2026-04-10 attune-docs split:
+ *   attune-ai     → Smart-AI-Memory/attune-ai marketplace
+ *   attune-help   → Smart-AI-Memory/attune-docs marketplace
+ *   attune-author → Smart-AI-Memory/attune-docs marketplace
  */
 
 // --- Products ---
@@ -14,6 +19,8 @@ export interface Product {
   version: string;
   tagline: string;
   installCommand: string;
+  /** Claude Code marketplace installation (if applicable). */
+  marketplaceInstall?: string;
   description: string;
   features: string[];
 }
@@ -23,9 +30,11 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "5.10.0",
+    version: "5.10.1",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
+    marketplaceInstall:
+      "claude plugin marketplace add Smart-AI-Memory/attune-ai",
     description:
       "Full framework for bootstrapping a knowledge base from source code. " +
       "Scans your codebase, generates concept/task/reference templates, " +
@@ -36,16 +45,18 @@ export const PRODUCTS: Product[] = [
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
       "14 Claude Code skills included",
-      "MCP server with 5 help tools",
+      "MCP server with 41 registered tools",
     ],
   },
   {
     id: "attune-help",
     name: "Attune Help",
     pypiName: "attune-help",
-    version: "0.3.0",
+    version: "0.3.1",
     tagline: "Lightweight reader for help templates",
     installCommand: "pip install attune-help",
+    marketplaceInstall:
+      "claude plugin install attune-help@attune-docs",
     description:
       "Standalone reader with just 1 dependency. Loads templates, " +
       "provides progressive depth (concept → task → reference), " +
@@ -60,13 +71,39 @@ export const PRODUCTS: Product[] = [
     ],
   },
   {
+    id: "attune-author",
+    name: "Attune Author",
+    pypiName: "attune-author",
+    version: "0.2.0",
+    tagline: "Author and polish help content with AI",
+    installCommand: "pip install 'attune-author[plugin]'",
+    marketplaceInstall:
+      "claude plugin install attune-author@attune-docs",
+    description:
+      "The AI authoring companion for attune-help. Generates 11 kinds " +
+      "of source-grounded templates — concept, task, reference, error, " +
+      "warning, troubleshooting, faq, quickstart, tip, note, and " +
+      "comparison — with per-type LLM polish prompts and typed source " +
+      "summaries so the output stays accurate.",
+    features: [
+      "11 meta-template kinds (up from 3 in v0.1.0)",
+      "Per-type LLM polish prompts with anti-pattern lists",
+      "Signature-aware source summaries (typed args + return)",
+      "Strict polish mode for CI (ATTUNE_AUTHOR_STRICT_POLISH)",
+      "Staleness detection via source file hashing",
+      "Works with attune-help for the full author → reader loop",
+    ],
+  },
+  {
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "5.10.0",
+    version: "5.10.1",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",
+    marketplaceInstall:
+      "claude plugin install attune-ai@attune-ai",
     description:
       "Install from the Claude Code marketplace. Type /coach to get " +
       "progressive help on any topic. Init, status, maintain, and " +
@@ -77,7 +114,7 @@ export const PRODUCTS: Product[] = [
       "/coach status — check template freshness",
       "/coach maintain — regenerate stale templates",
       "Auto-triggers on natural language (help, explain, learn)",
-      "14 additional skills (security, testing, review, etc.)",
+      "14 auto-triggering skills (security, testing, review, etc.)",
     ],
   },
 ];
@@ -203,14 +240,34 @@ export const DIFFERENTIATORS: Differentiator[] = [
   },
 ];
 
-// --- Legacy Capabilities (folded into docs) ---
+// --- Capability counts (verified against Python registry) ---
 
-export const LEGACY_CAPABILITIES = {
+/**
+ * Counts that appear in prose and stat callouts across the
+ * site. Verified against the live Python code per the
+ * website-content-accuracy rule:
+ *
+ *   workflows: attune.workflows.list_workflows() with stages
+ *   skills: plugin/skills/ directory count
+ *   mcpTools: EmpathyMCPServer().tools length
+ *   templateKinds: attune_author.generator._ALL_TEMPLATE_NAMES length
+ */
+export const CAPABILITIES = {
+  workflows: 15,
+  skills: 14,
+  mcpTools: 41,
+  templateKinds: 11,
   wizards: 5,
-  workflows: 17,
   agentTemplates: 14,
   compositionPatterns: 6,
 } as const;
+
+/**
+ * @deprecated Use {@link CAPABILITIES} instead. Kept for
+ * backward compatibility with any consumer that may still
+ * import the old name.
+ */
+export const LEGACY_CAPABILITIES = CAPABILITIES;
 
 // --- Helpers ---
 
@@ -218,13 +275,21 @@ export function getPricingSummary(): string {
   return "Everything open source — Apache 2.0";
 }
 
+/** Icon used in homepage product cards for each product. */
+const PRODUCT_ICONS: Record<string, string> = {
+  "attune-ai": "🛠️",
+  "attune-help": "📖",
+  "attune-author": "✍️",
+  "claude-code-plugin": "⚡",
+};
+
 export function getHomepageFeatures(): Array<{
   icon: string;
   title: string;
   description: string;
 }> {
   return PRODUCTS.map((p) => ({
-    icon: p.id === "attune-ai" ? "🛠️" : p.id === "attune-help" ? "📖" : "⚡",
+    icon: PRODUCT_ICONS[p.id] ?? "📦",
     title: p.name,
     description: p.tagline,
   }));


### PR DESCRIPTION
## Summary

Brings the website into alignment with everything that shipped across the three repos Friday night and Saturday morning:

- **attune-ai v5.10.1** — MCP \`uvx\` fix + attune-docs migration banner
- **attune-author v0.2.0** — 8 new meta-templates, per-type polish, strict mode, signature-aware source summaries, dogfood corpus
- **Smart-AI-Memory/attune-docs** marketplace serving both attune-help 0.3.1 and attune-author 0.2.0 plugins

## Ground truth (verified against Python registry)

Per the \`.claude/rules/attune/website-content-accuracy.md\` rule, verified every count against the live code before touching prose:

| Metric | Verified | Website was saying |
|---|---|---|
| Workflows with stages | **15** (from \`list_workflows()\`) | 17 ✗ (fictional) |
| Auto-triggering skills | **14** (plugin/skills/) | 14 ✓ |
| MCP tools | **41** (\`EmpathyMCPServer().tools\`) | not shown |
| Template kinds | **11** (\`_ALL_TEMPLATE_NAMES\`) | not shown |
| attune-ai version | **5.10.1** | 5.10.0 ✗ |
| attune-help version | **0.3.1** | 0.3.0 ✗ |
| attune-author version | **0.2.0** | not on site ✗ |

## What changed

### \`website/lib/features.ts\` — canonical source of truth

- Version bumps: attune-ai 5.10.0→5.10.1, attune-help 0.3.0→0.3.1, Claude Code plugin 5.10.0→5.10.1
- **New \`attune-author\` Product entry** with 11 template kinds listed in its features array
- New optional \`marketplaceInstall\` field on \`Product\` so pages can show both the PyPI install and the Claude Code plugin install alongside each other
- \`LEGACY_CAPABILITIES.workflows: 17 → 15\` — the real count. Renamed to \`CAPABILITIES\` with a deprecated alias for backward compat, and added \`skills: 14\`, \`mcpTools: 41\`, \`templateKinds: 11\` as explicit constants so prose assertions have a single source
- \`getHomepageFeatures\` icon map extracted to \`PRODUCT_ICONS\` so adding a product doesn't require touching a conditional chain

### \`website/app/page.tsx\` — homepage

- Version badge \`v5.10.0\` → \`v5.10.1\`
- Product section heading "Three Ways to Use It" → "Four Ways to Use It" with a short subtitle framing the author → reader loop
- Grid \`md:grid-cols-3\` → \`md:grid-cols-2 lg:grid-cols-4\` to fit four cards cleanly
- New **attune-author** card using \`var(--accent)\` color family to distinguish it from attune-ai (primary) and attune-help (secondary)

### \`website/app/docs/page.tsx\`

- Workflow count: "17 workflows" → "15 workflows, 14 auto-invoking skills, and an MCP server with 41 registered tools"
- Quick Start grid expanded from 3 → 4 cards with a new **attune-author** card
- Prominent **attune-docs marketplace callout** below the quick-start grid showing the three-command install flow. This is the primary fix for users who currently try \`claude plugin install attune-help@attune-ai\` and get an error.
- New **full attune-author section** (between attune-help and plugin sections) covering:
  - All 11 template kinds in a visual grid
  - Per-type polish explanation with four example kinds
  - Install block with both pip and Claude Code forms
  - Strict mode + \`ANTHROPIC_API_KEY\` callout
- Added \`#attune-author\` link to hero chip nav; renamed "Standalone Reader" → "Reader" so all four chips have single-word labels
- New FAQ: "Where do I install attune-help and attune-author from?"

### \`website/components/Footer.tsx\`

- Added **attune-author on PyPI** link
- Added **attune-docs marketplace** link pointing at the GitHub repo (which is the canonical install target)

## Verification

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx next build\` — 0 errors, 0 warnings
- [x] \`npx eslint\` on the 4 changed files — clean
- [x] All capability counts cross-checked against the live Python code
- [x] Manual visual walk: hero version badge, 4-card grid, docs quickstart, attune-author section, footer links

## Screenshots

Not included — the diff is structural (new content, no layout logic changes beyond the 3-card → 4-card grid), and \`next build\` validated the JSX. Happy to add Playwright screenshots if you want before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)