### PR TITLE
feat: attune-help core dependency + website rebalance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -671,9 +671,7 @@ exclude_lines = [
 ]
 
 # Editable sibling repos: packages now live in their own dedicated repos.
-# See Smart-AI-Memory/attune-help and Smart-AI-Memory/attune-author.
-# Historical packages/attune-help and packages/attune-author dirs are
-# tombstoned in this repo (see their README.md files for the new home).
+# Editable sibling repo for local development.
+# attune-help is now a PyPI dependency (no source override needed).
 [tool.uv.sources]
 attune-author = { path = "../attune-author", editable = true }
-attune-help = { path = "../attune-help", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "5.10.1"
+version = "5.10.2"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
@@ -70,11 +70,9 @@ dependencies = [
     "claude-agent-sdk>=0.1.0,<1.0.0",  # Agents SDK for workflow execution
     "python-multipart>=0.0.22",  # Pin above GHSA-59g5-xgcq-4qw3 / GHSA-wp53-j4wj-2cfg (transitive via mcp)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
-    # NOTE: attune-author lives in packages/ as a workspace-only dev dep.
-    # It is NOT a runtime requirement of attune-ai — the help system's
-    # local submodules (bootstrap, generator, manifest, staleness, etc.)
-    # are self-contained. attune-author is for authoring/refactoring help
-    # content during development.
+    "attune-help>=0.5.1",  # Progressive-depth help runtime + MCP tools
+    # NOTE: attune-author is a workspace-only dev dep for authoring/
+    # refactoring help content — NOT a runtime requirement.
     # NOTE: redis moved to [memory] optional - not needed for CLI/skill usage
 ]
 # NOTE: CrewAI dependency removed in v3.1.3 (deprecated since v4.4.0)

--- a/src/attune/help/feedback.py
+++ b/src/attune/help/feedback.py
@@ -61,7 +61,7 @@ def _save_feedback(generated_dir: Path, data: dict) -> None:
         json.dumps(data, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
-    tmp.rename(path)
+    tmp.replace(path)  # replace() is cross-platform; rename() fails on Windows
 
 
 def record_template_feedback(

--- a/src/attune/help/preamble.py
+++ b/src/attune/help/preamble.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from attune_help.preamble import _extract_preamble as _extract_preamble
+
 logger = logging.getLogger(__name__)
 
 
@@ -55,49 +57,6 @@ def get_preamble(
         return None
 
     return _extract_preamble(text)
-
-
-try:
-    from attune_help.preamble import (
-        _extract_preamble as _extract_preamble,
-    )
-except ImportError:  # attune-help not installed
-
-    def _extract_preamble(text: str) -> str | None:  # type: ignore[misc]
-        """Extract preamble from task template content.
-
-        Skips YAML frontmatter and the h1 heading, returns
-        the first non-empty paragraph.
-
-        Args:
-            text: Full task template content.
-
-        Returns:
-            Preamble line, or None.
-        """
-        lines = text.split("\n")
-
-        # Skip frontmatter
-        in_frontmatter = False
-        content_start = 0
-        for i, line in enumerate(lines):
-            if i == 0 and line.strip() == "---":
-                in_frontmatter = True
-                continue
-            if in_frontmatter and line.strip() == "---":
-                content_start = i + 1
-                break
-
-        # Find first non-empty, non-heading line
-        for line in lines[content_start:]:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            if stripped.startswith("#"):
-                continue
-            return stripped
-
-        return None
 
 
 def get_related_preambles(

--- a/src/attune/memory/security/audit_logger.py
+++ b/src/attune/memory/security/audit_logger.py
@@ -187,7 +187,7 @@ class AuditLogger(
             rotated_name = f"{self.log_filename}.{timestamp}"
             rotated_path = self.log_dir / rotated_name
 
-            self.log_path.rename(rotated_path)
+            self.log_path.replace(rotated_path)
             logger.info(f"Audit log rotated: {rotated_path}")
 
             # Clean up old logs beyond retention period

--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -426,7 +426,7 @@ class UsageTracker:
                 counter += 1
 
             # Rename current file
-            self.usage_file.rename(rotated_file)
+            self.usage_file.replace(rotated_file)
 
             # Clean up old files
             self._cleanup_old_files()

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -5,18 +5,24 @@ import GitHubStarsBadge from '@/components/GitHubStarsBadge';
 import TestsBadge from '@/components/TestsBadge';
 import { generateStructuredData } from '@/lib/metadata';
 
-const codeExample = `from attune_help import HelpEngine
+// Hero code sample shows the full author → reader loop
+// across all three packages so the homepage doesn't
+// elevate one product over the others. Kept intentionally
+// short — the goal is to tell the story in ~10 lines of
+// Python, not to document every API.
+const codeExample = `# 1. attune-author — generate polished, source-grounded
+#    templates from your codebase (CI or dev time)
+from attune_author.generator import generate_feature_templates
+generate_feature_templates(feature, help_dir=".help", project_root=".")
 
+# 2. attune-help — read them at runtime. 1 dependency,
+#    no API key required. Embed anywhere.
+from attune_help import HelpEngine
 engine = HelpEngine(template_dir=".help/templates")
-
-# First call: concept (what is it?)
 print(engine.lookup("security-audit"))
 
-# Repeat: task (how to do it)
-print(engine.lookup("security-audit"))
-
-# Again: reference (full API detail)
-print(engine.lookup("security-audit"))`;
+# 3. attune-ai — /coach in Claude Code, plus workflows,
+#    MCP tools, and the full author ⇄ reader pipeline`;
 
 export default function Home() {
   const softwareSchema = generateStructuredData('product');
@@ -51,10 +57,10 @@ export default function Home() {
                   automatically. Enhance with human expertise when it matters.
                 </p>
                 <div className="flex flex-col sm:flex-row gap-4">
-                  <div className="flex items-center bg-[var(--foreground)] text-[var(--background)] px-4 py-3 rounded-lg font-mono text-sm group cursor-pointer border border-white/20">
-                    <span className="opacity-50 mr-2">$</span>
-                    <span>pip install attune-help</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="ml-4 opacity-40 group-hover:opacity-100 transition-opacity" aria-hidden="true">
+                  <div className="flex items-center bg-[var(--foreground)] text-[var(--background)] px-4 py-3 rounded-lg font-mono text-xs sm:text-sm group cursor-pointer border border-white/20 overflow-x-auto">
+                    <span className="opacity-50 mr-2 shrink-0">$</span>
+                    <span className="whitespace-nowrap">claude plugin marketplace add Smart-AI-Memory/attune-ai</span>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="ml-4 opacity-40 group-hover:opacity-100 transition-opacity shrink-0" aria-hidden="true">
                       <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
                       <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
                     </svg>
@@ -66,6 +72,14 @@ export default function Home() {
                     See How It Works
                   </Link>
                 </div>
+                <p className="mt-4 text-xs text-[var(--text-muted)] leading-relaxed max-w-xl">
+                  Or install directly from PyPI:{' '}
+                  <code className="font-mono text-[var(--foreground)] bg-[var(--surface-container-high)] px-1 rounded">pip install attune-ai</code>
+                  {' '}&middot;{' '}
+                  <code className="font-mono text-[var(--foreground)] bg-[var(--surface-container-high)] px-1 rounded">attune-help</code>
+                  {' '}&middot;{' '}
+                  <code className="font-mono text-[var(--foreground)] bg-[var(--surface-container-high)] px-1 rounded">&apos;attune-author[plugin]&apos;</code>
+                </p>
                 {/* Trust badges */}
                 <div className="flex flex-wrap gap-3 mt-8">
                   <GitHubStarsBadge />
@@ -129,34 +143,59 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Code Example Section */}
-        <section className="py-24 bg-[var(--surface-container-low)]" aria-label="Code example">
+        {/* Platform overview — one code sample, three packages */}
+        <section className="py-24 bg-[var(--surface-container-low)]" aria-label="Platform overview">
           <div className="max-w-7xl mx-auto px-6">
             <div className="flex flex-col md:flex-row gap-16 items-start">
-              <div className="md:w-1/3">
-                <h2 className="text-3xl font-extrabold mb-6">Your Code Becomes Your Docs</h2>
+              <div className="md:w-2/5">
+                <h2 className="text-3xl font-extrabold mb-6">How the Platform Fits Together</h2>
                 <p className="text-[var(--text-secondary)] mb-8 leading-relaxed">
-                  Point the engine at your codebase. Each repeat query goes deeper &mdash; from concept to task to full reference.
+                  Three focused Python packages that compose into a
+                  full author &rarr; reader loop. Use the full stack, or
+                  drop in just the piece you need.
                 </p>
-                <ul className="space-y-4">
-                  <li className="flex items-center gap-3">
-                    <span className="text-[var(--secondary)]">&#10003;</span>
-                    <span className="font-medium text-sm">Generated from source code</span>
+                <ul className="space-y-5">
+                  <li className="flex items-start gap-3">
+                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--accent)]/15 text-[var(--accent)] font-bold text-xs shrink-0 mt-0.5">1</span>
+                    <div>
+                      <div className="font-semibold text-sm"><code className="font-mono">attune-author</code></div>
+                      <p className="text-xs text-[var(--text-secondary)] leading-relaxed mt-1">
+                        Generates 11 kinds of source-grounded templates with
+                        per-type LLM polish. Runs at dev time or in CI.
+                      </p>
+                    </div>
                   </li>
-                  <li className="flex items-center gap-3">
-                    <span className="text-[var(--secondary)]">&#10003;</span>
-                    <span className="font-medium text-sm">Progressive depth: concept, task, reference</span>
+                  <li className="flex items-start gap-3">
+                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--secondary)]/15 text-[var(--secondary)] font-bold text-xs shrink-0 mt-0.5">2</span>
+                    <div>
+                      <div className="font-semibold text-sm"><code className="font-mono">attune-help</code></div>
+                      <p className="text-xs text-[var(--text-secondary)] leading-relaxed mt-1">
+                        Reads the templates at runtime. 1 dependency, no API
+                        key required. Embed in any Python tool.
+                      </p>
+                    </div>
                   </li>
-                  <li className="flex items-center gap-3">
-                    <span className="text-[var(--secondary)]">&#10003;</span>
-                    <span className="font-medium text-sm">Open Source &mdash; Apache 2.0</span>
+                  <li className="flex items-start gap-3">
+                    <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--primary)]/15 text-[var(--primary)] font-bold text-xs shrink-0 mt-0.5">3</span>
+                    <div>
+                      <div className="font-semibold text-sm"><code className="font-mono">attune-ai</code></div>
+                      <p className="text-xs text-[var(--text-secondary)] leading-relaxed mt-1">
+                        Full framework for Claude Code. 15 workflows, 14
+                        auto-triggering skills, MCP server with 41 tools.
+                      </p>
+                    </div>
                   </li>
                 </ul>
+                <div className="mt-8 pt-6 border-t border-[var(--border)]/40">
+                  <p className="text-xs text-[var(--text-muted)]">
+                    All three are open source &mdash; Apache 2.0.
+                  </p>
+                </div>
               </div>
-              <div className="md:w-2/3 w-full">
+              <div className="md:w-3/5 w-full">
                 <div className="bg-[#213145] rounded-xl overflow-hidden shadow-2xl">
                   <div className="flex items-center px-4 py-2 bg-[#2a3b50] border-b border-white/5">
-                    <span className="text-[10px] font-mono text-white/50 uppercase tracking-widest">help_example.py</span>
+                    <span className="text-[10px] font-mono text-white/50 uppercase tracking-widest">author_reader_loop.py</span>
                     <div className="ml-auto flex gap-1.5">
                       <div className="w-2.5 h-2.5 rounded-full bg-white/10"></div>
                       <div className="w-2.5 h-2.5 rounded-full bg-white/10"></div>


### PR DESCRIPTION
## Summary

- Make `attune-help>=0.5.1` a core runtime dependency so the progressive-depth help system works out of the box
- Remove `ImportError` fallback for `_extract_preamble` — attune-help is now guaranteed present
- Version bump to 5.10.2 (already published to PyPI)
- Includes prior website homepage rebalancing commits

## Test plan

- [x] `from attune.help.preamble import _extract_preamble` resolves from `attune_help.preamble`
- [x] `HelpEngine().preamble('security-audit')` returns a non-None string
- [x] `python -m build` succeeds
- [x] `twine check` passes
- [x] Published to PyPI as 5.10.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)