### PR TITLE
chore+docs: pre-release audit + Plan B execution lessons

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1516,4 +1516,43 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   missing — otherwise `end-of-file-fixer` pre-commit hooks
   will reject the commit. Check with `if not text.endswith
   ("\n"): text += "\n"`.
+
+- **`gh api -X PATCH ... -f name=N` rejects integers as
+  strings**: `gh api` flag `-f` always sends string values, so
+  `-f required_approving_review_count=1` produces a 422 error
+  `"1" is not an integer`. Use `-F` instead — it infers the
+  type (integer, boolean, etc.) from the value. Specifically
+  matters for `branches/<name>/protection/required_pull_request_reviews`
+  updates during the temp-remove-review/admin-merge/restore
+  dance.
+
+- **`gh pr merge --admin` prints a fast-forward warning even
+  when the remote merge succeeds**: After an admin-merge, the
+  CLI attempts a local fast-forward of your local main to
+  origin/main. If your local main diverged (e.g., you had
+  feature-branch commits before the squash), the CLI prints
+  `fatal: Not possible to fast-forward, aborting` and
+  `! warning: not possible to fast-forward to: "main"`. The
+  remote merge already succeeded — the warning is about the
+  local refresh failing. Always verify the actual merge state
+  via `gh pr view <n> --json state,mergedAt,mergeCommit`
+  before assuming the command failed.
+
+- **After a squash merge of a feature branch, local main can
+  have "extra" commits that are already in the squash**: If
+  you had any of the feature branch commits locally on main
+  before the squash (e.g., from a pull on release/v5.10.0
+  that got replayed onto main), `git pull` after the squash
+  merge tries to rebase and conflicts because the same tree
+  content exists on main at a different commit hash. Safe
+  fix: run `git log --oneline main ^origin/main` to see the
+  "extra" local commits, confirm the content is included in
+  the squash (`git show <squash-commit> --stat` shows the
+  expected files), then `git reset --hard origin/main`.
+
+- **`gh pr checks --json` field names**: the field is
+  `bucket` (pass/fail/pending/skipping/cancel), not
+  `conclusion`. Full field list is exposed by passing an
+  invalid field name and reading the error message. Useful
+  for scripted pre-merge checks.
 <!-- attune-lessons-end -->

--- a/.github/workflows/cross-repo-compat.yml
+++ b/.github/workflows/cross-repo-compat.yml
@@ -1,0 +1,60 @@
+name: Cross-repo compat (attune-help main)
+
+# Pulls attune-help from its main branch and runs this repo's
+# test suite against it. Catches silent breakage between
+# attune-help releases before it ships as a CHANGELOG surprise.
+
+on:
+  schedule:
+    # Monday 14:00 UTC, well clear of weekend release windows.
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-against-attune-help-main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout attune-ai
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Checkout attune-help (main)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: Smart-AI-Memory/attune-help
+          path: _attune-help-main
+          ref: main
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Install this repo with dev deps first (pulls attune-help
+          # from PyPI), then override with the main checkout so the
+          # test run actually exercises the in-flight attune-help.
+          pip install -e ".[dev]"
+          pip install -e ./_attune-help-main --force-reinstall --no-deps
+
+      - name: Show attune-help version under test
+        run: |
+          python -c "import attune_help; print(f'attune_help {attune_help.__version__} from {attune_help.__file__}')"
+
+      - name: Run tests
+        run: |
+          python -m pytest tests/ -v \
+            --ignore=tests/integration \
+            -m "not slow and not network and not llm" \
+            -x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to Attune AI (formerly Empathy Framework) will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Weekly cross-repo compat CI** — new
+  `.github/workflows/cross-repo-compat.yml` pulls
+  attune-help from its `main` branch every Monday and runs
+  this repo's test suite against it. Catches breakage
+  between attune-help releases before it ships as a
+  CHANGELOG surprise. Also triggerable on demand via
+  `workflow_dispatch`.
+
+### Changed
+
+- **`attune-help` pin upper-capped** — now
+  `>=0.5.1,<0.6` (was `>=0.5.1`). Prevents silent breakage
+  if attune-help ships a pre-1.0 minor bump with breaking
+  changes. Bump the cap deliberately when attune-help 0.6
+  lands.
+- **MCP dispatch table namespacing documented** — the
+  `help_*` / `lookup_*` / `author_*` prefix ownership is
+  now spelled out in `_build_dispatch_table()` so users
+  running multiple attune MCP servers understand which
+  tool does what. Real consolidation (deprecate attune-ai's
+  internal help engine, delegate to attune-help) is
+  backlog.
+
+### Fixed
+
+- **Dead `release_prep_crew.py` coverage-omit entry
+  removed** — the file was deleted in a previous release
+  but the omit rule lingered in `pyproject.toml`.
+- **Ghost `v4.0.3` reference cleared from pytest config
+  comment** — the test_generator exclusion rationale no
+  longer points at a long-past release.
+
 ## [6.0.0] - 2026-04-13
 
 ### Added (6.0.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     "claude-agent-sdk>=0.1.0,<1.0.0",  # Agents SDK for workflow execution
     "python-multipart>=0.0.22",  # Pin above GHSA-59g5-xgcq-4qw3 / GHSA-wp53-j4wj-2cfg (transitive via mcp)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
-    "attune-help>=0.5.1",  # Progressive-depth help runtime + MCP tools
+    "attune-help>=0.5.1,<0.6",  # Progressive-depth help runtime + MCP tools. Upper cap: pre-1.0 minor bumps may break.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
     # NOTE: redis moved to [memory] optional - not needed for CLI/skill usage
@@ -527,11 +527,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-# Exclude pre-existing failing tests (tracked for v4.0.3)
-# - wizards_consolidated module missing (2 test files)
-# - test_generator mock issues (1 test file)
+# test_generator has mock issues with __file__ attribute — needs rewrite.
 norecursedirs = [
-    "tests/unit/test_generator",  # Mock issues with __file__ attribute
+    "tests/unit/test_generator",
 ]
 addopts = [
     "--verbose",
@@ -588,7 +586,7 @@ omit = [
     "*/models/auth_cli.py",  # Interactive auth setup
     "*/monitoring/alerts_cli.py",  # Monitoring CLI
     # Deprecated modules
-    "*/workflows/release_prep_crew.py",  # Deprecated CrewAI workflow
+    # release_prep_crew.py omit entry removed — file was deleted.
     # Legacy/alternative CLIs
     "attune_software/cli/*.py",  # Plugin CLI subcommands
     # Infrastructure requiring external deps

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -225,6 +225,20 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
     def _build_dispatch_table(self) -> dict[str, Any]:
         """Build tool name -> handler mapping.
 
+        Tool namespace across the attune suite (avoid collisions
+        and duplicated UX when a user enables multiple MCP servers):
+
+        - ``help_*`` (here): attune-ai's own help engine
+          (``attune.help.engine``, ``attune.workflows.help_maintenance``).
+          Overlaps in intent with the two below; kept for now because
+          attune-ai still ships its internal help system. Consolidation
+          with ``attune-help``/``attune-author`` is a backlog item —
+          see CHANGELOG / audit punch list.
+        - ``lookup_*`` (attune-help MCP server): read-side lookup over
+          the rendered content (``attune_help.HelpEngine``).
+        - ``author_*`` (attune-author MCP server): write-side authoring
+          of the source-of-truth templates that attune-help renders.
+
         Returns:
             Dict mapping tool names to async handler callables.
             All handlers accept (args: dict) and return dict.


### PR DESCRIPTION
## Summary

Two unpushed signed commits that accumulated on local main after v6.0.0 shipped:

- \`000b88cd\` — **chore: pre-release audit** (your commit, pre-existing, now re-signed). Weekly cross-repo compat workflow, attune-help upper-cap, MCP tool namespace docs.
- \`e23a8e8b\` — **docs: Plan B execution lessons** (gh api integer flags, gh pr merge --admin fast-forward warning, local-main-after-squash drift, gh pr checks --json bucket field).

Both were blocked from direct-to-main push by (1) missing signatures and (2) the \`Analyze (python)\` required check only firing on PRs. Rebased onto origin/main with --exec signing; content unchanged.

## Test plan

- [ ] CI checks pass (including \`Analyze (python)\`)
- [ ] Both commits show as verified in the GitHub signatures view

🤖 Generated with [Claude Code](https://claude.com/claude-code)