### PR TITLE
chore: add cross-promotion hook to attune-ai marketplace description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "email": "patrick.roebuck@smartaimemory.com"
   },
   "metadata": {
-    "description": "AI-powered developer workflows for Claude Code — skills-first architecture with auto-triggering from natural language",
+    "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
     "version": "6.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
-      "description": "14 auto-triggering skills for security audits, code reviews, test generation, bug prediction, and release preparation. Say what you need — Claude picks the right skill.",
+      "description": "14 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
       "version": "6.0.0",
       "author": {


### PR DESCRIPTION
## Summary

Plan B step 6 — narrow the attune-ai marketplace description to the developer-tool story and add a trailing pointer to Smart-AI-Memory/attune-docs for funnel-3 discovery.

Two text changes in \`.claude-plugin/marketplace.json\`:
- \`metadata.description\`: rephrased around "Developer workflow tool for building AI-powered products"
- \`plugins[0].description\`: appends "Looking for help content tools? See Smart-AI-Memory/attune-docs."

No structural changes. Plugin source, version, tags, and source path all unchanged.

## Test plan

- [ ] JSON parses (verified locally with \`python -m json.tool\`)
- [ ] Description appears correctly in \`/plugin marketplace list\` after \`/plugin marketplace update attune-ai\`
- [ ] Existing installs of attune-ai are not affected (no plugin.json change, just marketplace metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)