### PR TITLE
fix(workflows): raise SDK budget caps to fit multi-subagent workflows

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1587,4 +1587,57 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   no-op after `git pull` — it's a real drift fix. Always
   `uv lock --check` after pulling, and bundle uv.lock fixes with
   the next reasonable PR rather than treating them as noise.
+
+- **`uv sync` wipes packages installed via `pip install`**:
+  Running `.venv/bin/python -m pip install pip-audit` into the
+  venv looks successful, but a subsequent `uv sync --extra dev
+  --extra developer` removes it because `uv sync` enforces the
+  lockfile. The symptom is a confusing `No module named
+  pip_audit` right after a successful install. Fix: use
+  `uv run --with pip-audit pip-audit --strict` for ephemeral
+  audit tools, or add the tool to a dev extra in
+  `pyproject.toml` so the lockfile keeps it.
+
+- **Anchor-tag buttons need `!text-white no-underline`**: The
+  existing lesson about `text-white` being overridden on
+  `gradient-primary` sections also applies to plain `<a>`
+  elements styled as primary buttons (e.g., hero CTAs with
+  `bg-[var(--primary)]`). Global styles set the link color to
+  the primary blue and add an underline, producing invisible
+  blue-on-blue text. Use `!text-white no-underline` on
+  anchor-styled buttons, even outside gradient sections.
+
+- **"SDK adapter swallows subagent findings" lesson was
+  wrong — adapter is fine, budget cap cuts the stream
+  early**: Verified with a 157-message trace of
+  `security-audit` (max_turns=30).
+  `collect_agent_output()` at
+  `src/attune/workflows/agent_sdk_adapter.py:48-91` already
+  captures all `AssistantMessage` TextBlocks (including from
+  subagents — those carry `parent_tool_use_id=<task-id>`,
+  no filter needed). The real issue: with 4-5 Opus subagents
+  spawned in parallel, the stream ends with
+  `ResultMessage(result=None, num_turns=2, is_error=False)`
+  — looks clean but is actually silent early termination at
+  the `max_budget_usd` cap (was $2.00 for "standard"
+  depth; bumped to $10.00 in the fix). Subagents were still
+  exploring (emitting
+  `ToolUseBlock`, not terminal `TextBlock`) when the stream
+  was cut, so the orchestrator never received their
+  findings to synthesize. Fix is in workflow config
+  (budgets), not the adapter: raise `max_budget_usd` for
+  multi-subagent workflows, or set
+  `ATTUNE_MAX_BUDGET_USD=0` to disable caps, or
+  restructure to run fewer/cheaper subagents.
+
+- **Squash-merge deletes the remote branch; subsequent push
+  silently recreates it with no PR attached**: After a squash
+  merge, GitHub deletes the feature branch. If you push more
+  commits to the same branch name later, `git push` succeeds
+  with `* [new branch]` output — GitHub recreates the branch
+  but there's no PR attached. Commits are orphaned on a branch
+  no one watches. Always check `gh pr view <n> --json state`
+  before adding more commits to a branch — if state is
+  `MERGED`, rebase onto `origin/main` and open a new PR
+  instead of pushing to the stale branch.
 <!-- attune-lessons-end -->

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -122,11 +122,22 @@ def build_result_text(
     return "No results returned."
 
 
-# Budget defaults by depth level
+# Budget defaults by depth level.
+#
+# These caps target multi-subagent workflows like security-audit
+# and code-review, which spawn 4-5 parallel Opus subagents that
+# each make 15-25 tool calls before synthesis. A trace of
+# security-audit with the prior $2 "standard" cap showed the SDK
+# cutting the stream mid-exploration after ~100s with
+# ``ResultMessage(result=None, is_error=False)`` — silent early
+# termination before any subagent produced final findings.
+#
+# Set ``ATTUNE_MAX_BUDGET_USD=0`` to disable caps entirely, or
+# any positive float to override the depth default.
 _DEFAULT_BUDGET_USD: dict[str, float] = {
-    "quick": 0.50,
-    "standard": 2.00,
-    "deep": 5.00,
+    "quick": 2.00,
+    "standard": 10.00,
+    "deep": 25.00,
 }
 
 
@@ -144,12 +155,18 @@ def get_max_budget_usd(depth: str = "standard") -> float | None:
 
     Returns:
         Budget cap in USD, or None if caps are disabled.
+
+    Notes:
+        For pre-release audits where the default caps feel too
+        restrictive, export ``ATTUNE_MAX_BUDGET_USD=0`` to let
+        multi-subagent workflows run to completion. Subscription
+        users pay no per-request cost for these runs.
     """
     override = os.environ.get("ATTUNE_MAX_BUDGET_USD")
     if override is not None:
         val = float(override)
         return val if val > 0 else None
-    return _DEFAULT_BUDGET_USD.get(depth, 2.00)
+    return _DEFAULT_BUDGET_USD.get(depth, 10.00)
 
 
 # Role-keyword to model mapping for subagents

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -455,25 +455,25 @@ class TestAgentSDKResultAdapterCostExtraction:
 class TestGetMaxBudgetUsd:
     """Test budget helper for workflow depth caps."""
 
-    def test_quick_depth_returns_half_dollar(self) -> None:
-        """Given 'quick' depth, returns 0.50."""
-        assert get_max_budget_usd("quick") == 0.50
+    def test_quick_depth_returns_two_dollars(self) -> None:
+        """Given 'quick' depth, returns 2.00."""
+        assert get_max_budget_usd("quick") == 2.00
 
-    def test_standard_depth_returns_two_dollars(self) -> None:
-        """Given 'standard' depth, returns 2.00."""
-        assert get_max_budget_usd("standard") == 2.00
+    def test_standard_depth_returns_ten_dollars(self) -> None:
+        """Given 'standard' depth, returns 10.00."""
+        assert get_max_budget_usd("standard") == 10.00
 
-    def test_deep_depth_returns_five_dollars(self) -> None:
-        """Given 'deep' depth, returns 5.00."""
-        assert get_max_budget_usd("deep") == 5.00
+    def test_deep_depth_returns_twentyfive_dollars(self) -> None:
+        """Given 'deep' depth, returns 25.00."""
+        assert get_max_budget_usd("deep") == 25.00
 
     def test_unknown_depth_falls_back_to_standard(self) -> None:
-        """Given unknown depth, returns 2.00 (standard default)."""
-        assert get_max_budget_usd("unknown") == 2.00
+        """Given unknown depth, returns 10.00 (standard default)."""
+        assert get_max_budget_usd("unknown") == 10.00
 
     def test_default_depth_is_standard(self) -> None:
-        """Given no argument, defaults to 'standard' (2.00)."""
-        assert get_max_budget_usd() == 2.00
+        """Given no argument, defaults to 'standard' (10.00)."""
+        assert get_max_budget_usd() == 10.00
 
     def test_env_var_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Given ATTUNE_MAX_BUDGET_USD env var, overrides depth default."""


### PR DESCRIPTION
## Root cause
Verified via 157-message SDK trace that \`security-audit\` and \`code-review\` spawn 4-5 Opus subagents in parallel. The prior \$2 cap for "standard" depth cuts the stream mid-exploration with \`ResultMessage(result=None, is_error=False)\` — looks clean, but is actually silent early termination before any subagent produced final findings.

The adapter's \`collect_agent_output()\` was never broken; it already captures \`AssistantMessage\` text from all streams including subagents (\`parent_tool_use_id\` set).

## Changes

| Depth | Was | Now |
|---|---|---|
| quick | \$0.50 | \$2.00 |
| standard | \$2.00 | \$10.00 |
| deep | \$5.00 | \$25.00 |

- Docstring now documents \`ATTUNE_MAX_BUDGET_USD=0\` for full disable (subscription runs).
- \`TestGetMaxBudgetUsd\` assertions updated to new defaults.
- Lesson file corrected: the "SDK adapter swallows subagent findings" diagnosis was wrong.

## Impact
- **Subscription users**: no change (Anthropic billing, not per-request).
- **API-key users**: higher cap per workflow run — expected since multi-subagent runs cost real money. Set \`ATTUNE_MAX_BUDGET_USD\` if you want tighter limits.

## Test plan
- [x] \`pytest tests/unit/workflows/test_agent_sdk_adapter.py::TestGetMaxBudgetUsd -x\` passes
- [ ] CI green
- [ ] Manual rerun of \`attune workflow run security-audit --path src/attune/\` now produces non-empty findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)