### PR TITLE
feat(rag): attune-rag 0.1.0 integration (Phase 1 of RAG grounding)

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -75,6 +75,7 @@ intent so Claude matches the right skill:
 | memory-and-context | memory, store, retrieve, empathy |
 | workflow-orchestration | workflow, run, analyze |
 | spec | spec-driven dev, brainstorm and execute |
+| rag-code-gen | grounded code, cite sources, verify against attune (needs `[rag]` extra) |
 | coach | coach, learn, explain, tell me more, deeper |
 
 ## MCP Server Not Running

--- a/.agents/skills/rag-code-gen/SKILL.md
+++ b/.agents/skills/rag-code-gen/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: rag-code-gen
+description: "RAG-grounded code generation with source citations. Triggers on: grounded code, ground this, cite sources, show me with sources, how do I with attune, reference attune docs, verify against attune."
+---
+# RAG-grounded code generation
+
+Requires the `[rag]` extra (`pip install 'attune-ai[rag]'`).
+Grounds code generation in the attune-help template corpus
+so outputs cite real APIs, workflow names, and patterns
+instead of hallucinating them. Every output ends with a
+`## Sources` block of clickable citations.
+
+## Scoping
+
+Before running, ask:
+
+1. **What are you trying to produce?** Code, config,
+   explanation, or a mix?
+2. **Any specific attune surface?** e.g. "the
+   security-audit workflow", "MCP tool pattern", "BaseWorkflow
+   subclass". Helps retrieval hit the right concept file.
+3. **Depth?** Default is `standard`. `quick` saves time
+   and budget for simple asks; `deep` is for complex
+   multi-file or architectural questions.
+
+## Running
+
+```
+attune workflow run rag-code-gen \
+  --input '{"query": "<the request>"}'
+```
+
+Optional inputs:
+
+- `k` — max grounding docs to retrieve (default 3)
+- `depth` — `quick` / `standard` / `deep`
+- `feedback` — pass `good` or `bad` AFTER inspecting the
+  output to record a verdict against every cited template
+- `model` — override the generator model if you need to
+
+## Output shape
+
+`WorkflowResult.final_output` is a string with two parts:
+
+1. The generated code / explanation
+2. A `## Sources` section listing each cited
+   `attune-help` template with its category, retrieval
+   score, and a clickable link to the source on GitHub
+
+`WorkflowResult.metadata` carries the full citation dict
+(`query`, `retriever_name`, `retrieved_at`, `hits[]`) plus
+`fallback_used` and `confidence` so callers can make
+routing decisions.
+
+## When RAG doesn't help
+
+If the retriever can't find relevant templates, the
+workflow still runs — it falls back to an unaugmented
+prompt that explicitly tells the model there is NO
+grounding context so it should say "I don't know about
+attune X" rather than invent. `metadata.fallback_used` is
+`True` in that case.
+
+## Alternative: MCP tool only (no LLM call)
+
+If you want just retrieval without generation, use the
+`rag_knowledge_query` MCP tool directly. It returns hits +
+an augmented prompt string without calling an LLM itself —
+handy for routing decisions, agent planning, or feeding
+another model.
+
+## If the extra isn't installed
+
+The workflow returns a structured error pointing at
+`pip install 'attune-ai[rag]'`. No exception propagates.
+
+## See also
+
+- [docs/rag/index.md](../../docs/rag/index.md) — full
+  walkthrough including the standalone attune-rag usage
+- [attune-rag on PyPI](https://pypi.org/project/attune-rag/)
+- [Embeddings decision record](../../docs/rag/embeddings-decision-2026-04-17.md)

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "6.0.0"
+    "version": "6.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "14 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1705,4 +1705,117 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   <path> --remote origin --push`. Saves 4 separate steps
   (repo create → remote add → set-upstream → push) when
   spinning up a new workspace-sibling package.
+
+- **MetaPathFinder `find_module`/`load_module` is dead in
+  Python 3.12+ — use `sys.modules[name] = None` sentinel
+  instead**: The existing "Verify optional dep boundaries
+  with a MetaPathFinder" lesson is partially wrong. The
+  deprecated `find_module` / `load_module` hooks stopped
+  firing in 3.12's import machinery (which migrated to
+  `find_spec`/`create_module`/`exec_module` fully). Tests
+  using the old Blocker pattern fall through to the real
+  SDK silently on 3.12+ CI matrix lanes. Cross-version
+  replacement: `sys.modules[name] = None` — Python's
+  import machinery treats the sentinel as "module is
+  unavailable" and raises `ImportError` on the next
+  `import name`. Works unchanged on 3.10-3.13. Remember
+  to snapshot+restore the original `sys.modules` entries
+  for the module and its dotted children.
+
+- **Apply lessons by problem, not by keyword**: The
+  `sentence-transformers removed — 0.4% savings, 420MB`
+  lesson is about **semantic caching** (match similar
+  queries to cached responses). It does NOT generalize to
+  **RAG retrieval** (match queries to documents). The
+  ROI profiles differ — attune workflow prompts are
+  mostly unique (file paths, code snippets) so caching
+  misses; retrieval ROI depends on how often semantic
+  similarity beats keyword overlap, which is much
+  higher. The install-size half of the lesson (420MB) IS
+  transferable and correctly rules out
+  `sentence-transformers` for any use case with a <50MB
+  gate. When citing prior lessons, check whether you're
+  invoking the mechanism or the specific problem.
+
+- **`fastembed` is the local-embeddings path that passes
+  a <50MB install gate**: When `sentence-transformers`
+  (420MB via `torch`) fails an install-size gate, don't
+  jump to hosted embeddings. `fastembed` (Qdrant)
+  ships ONNX-runtime-based MiniLM embeddings at ~35MB
+  total install, no `torch`, no network at runtime once
+  the ONNX model is downloaded at install time. Quality
+  is comparable to sentence-transformers for retrieval
+  and well-suited to local-corpus use cases. Consider it
+  before reaching for hosted providers.
+
+- **Duck-typed test fakes fail isinstance-based
+  collectors silently**: `collect_agent_output()` in
+  `src/attune/workflows/agent_sdk_adapter.py` does
+  `isinstance(message, claude_agent_sdk.AssistantMessage)`.
+  A shape-compatible fake class (`class _FakeAssistantMessage:
+  def __init__(self, text): self.content = [...]`) will
+  fall through the isinstance check and leave
+  `result_text="No results returned."` untouched — the
+  test passes against that default answer and may
+  appear successful. Fix: construct real SDK class
+  instances in tests:
+  `claude_agent_sdk.AssistantMessage(content=[...],
+  model="...", parent_tool_use_id=None)` and
+  `claude_agent_sdk.ResultMessage(subtype="success", ...)`.
+  Use `dataclasses.fields(Cls)` to discover the real
+  field list.
+
+- **Formatter strips imports that are "unused" at the
+  moment you save, even if a later edit will use them**:
+  When staging multiple edits that together introduce a
+  new import, the ruff/black autofix can run between
+  edits and remove the import as unused. Happens reliably
+  in the Claude Code hook pipeline. Two fixes:
+  (1) introduce the import in the SAME edit that first
+  uses it, not in a preceding edit; (2) scope the import
+  inside the function body that uses it so the unused-
+  import detector never fires even if the file is saved
+  mid-edit. Scoping is more robust for tests.
+
+- **`git commit -q` can exit 0 with pre-commit hook
+  feedback that looks like success but isn't**: When
+  pre-commit hooks (end-of-file-fixer, trailing-
+  whitespace) modify files during the commit, the tail
+  output shows "Passed" for each hook and gives no
+  explicit "Aborted" line — but the commit is skipped
+  and the files are left re-staged for retry. Always
+  verify with `git log --oneline -1` or `git status
+  --short` immediately after `git commit`; don't trust
+  that absence-of-error-message means the commit
+  landed.
+
+- **Golden-query test fixtures must match the actual
+  corpus layout, not an assumed one**: When writing a
+  `queries.yaml` file for retrieval regression tests,
+  cross-check every `expected_in_top_3` path against
+  the installed corpus directory before running the
+  benchmark. attune-help 0.5.1 has 43 `concepts/`
+  files but no `concepts/tool-brainstorm.md` (and no
+  brainstorm templates at all). A naive golden set that
+  assumes one concept file per CLI feature will fail
+  with `MISSING` errors until patched. Pre-validate
+  with:
+  `python3 -c "import yaml; from pathlib import Path;
+  base=Path('<corpus>/templates'); data=yaml.safe_load
+  (open('queries.yaml')); [print(f'MISSING {q[\"id\"]}:
+  {p}') for q in data['queries'] for p in q.get
+  ('expected_in_top_3',[]) if not (base/p).is_file()]"`
+
+- **Reclassify "unexpectedly hard" golden queries up the
+  difficulty ladder instead of silencing them**: When a
+  golden query you labeled `medium` fails and the
+  failure mode is the same as your known-hard cases
+  (keyword collision with other features), relabel to
+  `hard` rather than dropping the query or relaxing the
+  assertion. This keeps the difficulty bucket honest for
+  benchmarking. Use `pytest.mark.xfail(strict=False)`
+  gated on `difficulty == "hard"` so hard queries
+  document the gap without breaking CI and automatically
+  turn into XPASS if a retriever upgrade starts passing
+  them.
 <!-- attune-lessons-end -->

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v6.0.0
+# Attune AI Framework v6.1.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 6.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 6.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 
@@ -1818,4 +1818,83 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   document the gap without breaking CI and automatically
   turn into XPASS if a retriever upgrade starts passing
   them.
+
+- **PyPI trusted publisher "Workflow name" field wants the
+  FILENAME, not the YAML display name**: The PyPI
+  pending-publisher form has a "Workflow name" field that
+  must match the `workflow_ref` claim GitHub sends — which
+  is the filename (`publish.yml`), NOT the value of `name:`
+  at the top of the YAML (`Publish to PyPI`). If they
+  mismatch, the publish job fails with `invalid-publisher:
+  valid token, but no corresponding publisher`. The OIDC
+  debug output shows the actual claim — compare it to the
+  PyPI config field-by-field. Other common mismatches:
+  owner with wrong case or underscore-vs-hyphen,
+  environment name case, repository name.
+
+- **`uv.lock` retains `editable = "../name"` paths after
+  `[tool.uv.sources]` edits — always re-run `uv lock`**:
+  Deleting (or changing) a `[tool.uv.sources]` entry in
+  `pyproject.toml` does NOT automatically refresh the
+  lockfile. The lock keeps the old editable-sibling path,
+  and any `uv sync` / `uv run` in CI (pre-commit hooks,
+  fuzzing, etc.) fails with "Failed to generate package
+  metadata for pkg==ver @ editable+../path" because the
+  sibling directory doesn't exist in a CI checkout. Always
+  re-run `uv lock` immediately after editing
+  `[tool.uv.sources]` and commit `uv.lock` in the same
+  change. Verify with
+  `grep -A 2 "name = \"pkg\"" uv.lock` — the `source` line
+  should read `{ registry = "https://pypi.org/simple" }`
+  once the dep is published.
+
+- **`uv run` in pre-commit hooks propagates lockfile
+  errors as hook failures that look unrelated**: The
+  `check-docs-freshness` hook uses
+  `uv run python scripts/check_docs_freshness.py`. When
+  the lockfile has an unresolvable dep (e.g. sibling
+  editable path missing in CI), the failure renders as
+  "Check Help Template Freshness ... Failed" with a
+  metadata-resolution traceback in the log — nothing
+  about docs or templates. When seemingly-unrelated
+  pre-commit hooks start failing, read the actual log
+  and check `uv.lock` resolvability before assuming the
+  hook's nominal responsibility is the issue.
+
+- **`gh workflow run <file.yml> --ref <tag>` re-triggers
+  a release-gated workflow cleanly without churning the
+  release**: When a `publish.yml` triggered by
+  `release: types: [published]` fails on the first shot
+  (e.g. invalid trusted publisher config on PyPI side),
+  don't delete and recreate the release — if the workflow
+  also declares `workflow_dispatch:`,
+  `gh workflow run publish.yml --repo owner/repo --ref
+  <tag>` fires a fresh run against the same tag, skipping
+  the release-tag churn. Build + publish steps run
+  identically.
+
+- **Chicken-and-egg for optional extras in [dev]**: If
+  you want `pkg>=X,<Y` in `[dev]` extra so CI tests
+  actually exercise the code paths (rather than
+  `pytest.importorskip` and skip silently), the
+  package MUST be resolvable — i.e., on PyPI, or the
+  workspace source exists in the CI checkout. Publishing
+  the package is the unblocker when you're working in the
+  monorepo-sibling pattern where CI doesn't have the
+  sibling checkout. Sequence: publish 0.1.0 → add to
+  `[dev]` → tests run → coverage lands. Before publish,
+  rag tests use `importorskip` and patch coverage
+  reports 0% for the new code.
+
+- **`codecov/patch` 0% usually means tests *skipped*, not
+  failed**: The `codecov/patch` check measures coverage
+  of the diff — new/changed lines. If new tests use
+  `pytest.importorskip` on an optional dep that CI
+  doesn't install, every assertion skips, and the diff
+  shows 0% covered even though all tests "pass". Fix
+  by making the dep installable (add to `[dev]` or move
+  to required), or by adding unconditional error-path
+  tests that don't need the optional dep (use
+  `sys.modules[name] = None` sentinel to exercise the
+  "missing extra" branches).
 <!-- attune-lessons-end -->

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1640,4 +1640,69 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   before adding more commits to a branch — if state is
   `MERGED`, rebase onto `origin/main` and open a new PR
   instead of pushing to the stale branch.
+
+- **`packages/attune-*/` in attune-ai are pointer stubs, not
+  source**: `packages/attune-author/` and `packages/attune-help/`
+  contain a single README.md that points at the real sibling
+  repo (`/Users/patrickroebuck/attune-{author,help}/`). The
+  actual package source, `pyproject.toml`, tests, and CI live
+  in those sibling directories. `[tool.uv.sources]` in
+  attune-ai uses `path = "../attune-{name}", editable = true`
+  to resolve them during dev. Any new sibling package (e.g.
+  attune-rag) must follow the same layout: full source in
+  `../attune-<name>/`, pointer stub at
+  `packages/attune-<name>/README.md`, and a `[tool.uv.sources]`
+  entry.
+
+- **`uv pip install -e .` does not regenerate
+  `[project.scripts]` console scripts**: Editable reinstalls
+  after adding or changing a `[project.scripts]` entry leave
+  the old `.venv/bin/<name>` in place — or absent entirely if
+  it's new. Symptom: `ls .venv/bin/<cli>` returns nothing
+  despite a clean install log. Fix: use
+  `uv sync --extra dev --reinstall-package <pkg>` which
+  rebuilds the wheel and refreshes entry_points. `uv pip
+  install --force-reinstall -e .` also works but is slower.
+
+- **structlog default output pollutes stdout-captured CLI
+  tests**: structlog's default `ConsoleRenderer` writes log
+  lines to `sys.stdout`, not stderr. `capsys.readouterr().out`
+  in a pytest CLI test that emits JSON ends up with log lines
+  like `2026-04-17 [info     ] rag.run ...` prepended to the
+  JSON payload, breaking `json.loads()`. Fix: parse from the
+  first `{` (`json.loads(text[text.find("{"):])`) or
+  configure structlog to stderr in the CLI's `main()` before
+  running the pipeline. Don't just silence logs — they're
+  useful in prod.
+
+- **attune-help's sidecar schemas don't match path-keyed
+  assumptions**: `attune_help/templates/summaries.json` is
+  keyed by feature name (`"security-audit"`) — NOT by
+  template path. `cross_links.json` is a nested
+  `{version, stats, links, tag_index, workflow_map}` dict
+  keyed by short IDs like `"com-auth-strategies"`, not
+  paths. Any code trying to wire these as flat
+  `path -> value` maps (e.g. a DirectoryCorpus loader) will
+  silently produce empty summaries / related links. Either
+  write an attune-help-specific schema adapter, or load
+  templates without sidecars and treat the missing metadata
+  as a v-next concern.
+
+- **`git rebase --root --exec "git commit --amend --no-edit
+  -S"` re-signs every commit in a new repo**: When a repo is
+  initialized with `commit.gpgsign=false` for any reason (or
+  earlier commits used `-c commit.gpgsign=false` to bypass
+  signing), this one-liner walks all commits from the root
+  and re-signs each in place. Works in non-interactive
+  terminals (no editor needed). Useful when fixing signing
+  before first-time push of a fresh sibling repo.
+
+- **`gh repo create --source <path> --push` is a one-shot
+  for new sibling repos**: Creates the GitHub repo, adds it
+  as `origin` remote in the local path, and pushes HEAD in
+  a single command. Flags to use:
+  `--public --description "..." --homepage "..." --source
+  <path> --remote origin --push`. Saves 4 separate steps
+  (repo create → remote add → set-upstream → push) when
+  spinning up a new workspace-sibling package.
 <!-- attune-lessons-end -->

--- a/.claude/plans/archive/RAG_IMPLEMENTATION_PLAN-v1-superseded-2026-04-17.md
+++ b/.claude/plans/archive/RAG_IMPLEMENTATION_PLAN-v1-superseded-2026-04-17.md
@@ -1,0 +1,82 @@
+# RAG Implementation Plan: Grounding LLM Code Generation
+
+**Version:** 1.0
+**Status:** Planning
+
+## 1. Executive Summary
+
+This document outlines the plan to construct a Retrieval-Augmented Generation (RAG) system that leverages the existing `.help` content as a verifiable knowledge base. The goal is to actively guide LLM code generation, reduce hallucinations, and increase the accuracy and reliability of AI-written code within the `attune-ai` ecosystem.
+
+## 2. Phases
+
+### Phase 1: Foundational RAG Pipeline (1-2 weeks)
+
+This phase focuses on building the minimum viable product: a pipeline that can resolve a user's query to a feature, retrieve the relevant help content, and inject it into the LLM prompt.
+
+**Tasks:**
+
+1.  **Create RAG Core Module:**
+    *   Create a new directory: `src/attune/rag/`
+    *   Create a new file: `src/attune/rag/pipeline.py` to house the main orchestration logic.
+
+2.  **Implement Topic Resolution:**
+    *   In `src/attune/rag/pipeline.py`, create a `resolve_topic(query: str, manifest: FeatureManifest) -> str | None` function.
+    *   This function will take a user query and the loaded `features.yaml` manifest.
+    *   It will use a simple keyword-matching algorithm against feature names, descriptions, and tags to find the most relevant feature.
+
+3.  **Implement Content Retrieval:**
+    *   Create a `retrieve_content(feature_name: str, help_dir: Path) -> str` function.
+    *   This function will read the key help files for the given feature from the `plugin/help/generated/` directory (e.g., `concepts/tool-{feature_name}.md`, `quickstarts/{feature_name}.md`).
+    *   It will concatenate the content of these files into a single string.
+
+4.  **Implement Context Assembly & Prompting:**
+    *   Create a `build_augmented_prompt(query: str, context: str) -> str` function.
+    *   This will use a new prompt template that clearly separates the retrieved context from the user's original query.
+
+5.  **Integrate into a Workflow:**
+    *   Create a new workflow `src/attune/workflows/rag_code_gen.py`.
+    *   This workflow will take a user's coding request, execute the RAG pipeline, and send the augmented prompt to the LLM to generate the code.
+
+### Phase 2: Advanced Retrieval & Caching (2-3 weeks)
+
+This phase enhances the pipeline's accuracy and performance with more sophisticated retrieval techniques.
+
+**Tasks:**
+
+1.  **Implement Embedding-Based Search:**
+    *   Integrate a sentence-transformer library (e.g., `sentence-transformers`).
+    *   Create a script `scripts/generate_help_embeddings.py` that:
+        *   Reads all generated help files.
+        *   Chunks them into meaningful sections (e.g., by paragraph or markdown section).
+        *   Generates embeddings for each chunk and saves them to a file (e.g., `plugin/help/generated/embeddings.pkl`).
+    *   Modify `resolve_topic` and `retrieve_content` to use vector similarity search instead of keyword matching for more accurate retrieval.
+
+2.  **Implement Re-ranking:**
+    *   After the initial retrieval of the top-k chunks, use a lightweight cross-encoder model to re-rank them for relevance to the specific user query. This improves the quality of the context provided to the LLM.
+
+3.  **Add a Caching Layer:**
+    *   In `src/attune/rag/pipeline.py`, add an in-memory cache (`lru_cache`) for the RAG pipeline results to speed up responses for repeated or similar queries.
+
+### Phase 3: User Feedback & Verification (1 week)
+
+This phase focuses on building user trust and creating a feedback loop for continuous improvement.
+
+**Tasks:**
+
+1.  **Implement Source Attribution:**
+    *   Modify the `rag_code_gen` workflow to keep track of which help documents were used as context.
+    *   When displaying the generated code, include a list of the source files (e.g., "Generated using context from: `quickstarts/security-audit.md`").
+
+2.  **Create a Feedback Mechanism:**
+    *   After code is generated, prompt the user with a simple feedback request (e.g., "Was this code helpful? 👍 / 👎").
+    *   Store this feedback along with the query, retrieved context, and generated code in a structured log file (e.g., `logs/rag_feedback.jsonl`). This data will be invaluable for future fine-tuning.
+
+3.  **Build a Verification Test Suite:**
+    *   Create a new test file `tests/rag/test_rag_pipeline.py`.
+    *   Add a set of "golden" queries and assert that the RAG pipeline retrieves the correct documents and generates accurate code snippets. This will act as a regression test for the RAG system.
+
+## 3. Success Metrics
+
+*   **Code Accuracy:** A measurable reduction in LLM hallucinations, tracked by the verification test suite.
+*   **User Trust:** Positive user feedback on the generated code's reliability.
+*   **Performance:** RAG pipeline execution time should be under 500ms for cached queries and under 2 seconds for uncached queries.

--- a/.claude/plans/feature-rag-code-grounding-2026-04-17.md
+++ b/.claude/plans/feature-rag-code-grounding-2026-04-17.md
@@ -1570,22 +1570,61 @@ attune-rag/
 
 ---
 
+## Approved Follow-up Work
+
+### attune-help corpus metadata enrichment (approved 2026-04-17)
+
+**Decision:** yes — add corpus-level metadata to a future
+attune-help minor (targeting 0.6.0). Unblocks attune-rag
+0.2.0's schema adapter and significantly improves retrieval
+quality.
+
+**Scope (separate spec when we get to it):**
+
+- Add a **path-keyed summaries** schema alongside (or
+  replacing) the current feature-keyed
+  `summaries.json`. Each template gets a
+  one-line summary retrievable by its exact path.
+- Publish a **canonical feature map** linking template paths
+  to the feature they describe (e.g.
+  `"concepts/tool-security-audit.md" -> "security-audit"`).
+  Lets retrievers correlate paths to high-level features
+  without string-munging.
+- Add **difficulty tags** (`"beginner" | "intermediate" |
+  "advanced"`) per template so retrievers can bias toward
+  the audience the user asked about.
+- Restructure **cross-links** to be path-keyed consistently,
+  or add a `by_path` lookup index alongside the current
+  short-ID-keyed structure.
+
+**Why it matters:** Unblocks the "v0.1.0 note on sidecars"
+gap in `AttuneHelpCorpus` — today we load templates without
+summaries/related because the schemas don't match. Once
+attune-help ships path-keyed schemas, `AttuneHelpCorpus` can
+expose `RetrievalEntry.summary`, `.related`, and metadata
+like `difficulty`, lifting the `KeywordRetriever`'s
+`SUMMARY_WEIGHT` and `RELATED_WEIGHT` paths from dead weight
+to real retrieval signal.
+
+**Ordering:** No earlier than attune-rag 0.2.0 planning.
+Start as a separate spec in the attune-help repo; don't
+couple it to this spec's merge.
+
+---
+
 ## Open Questions
 
-1. Does the attune-help team want corpus-level metadata
-   (canonical feature names, difficulty tags) added in a
-   future attune-help minor to improve retrieval quality?
-2. Should `confidence_from_history` be exposed in the MCP
+1. Should `confidence_from_history` be exposed in the MCP
    tool response? Start model-only; surface to end users
    only if feedback data shows it improves trust.
-3. How do we avoid retrieval feedback loops where bad
+2. How do we avoid retrieval feedback loops where bad
    generations get marked "bad" and the same template is
    then under-retrieved, hiding the real root cause
    (retriever tuning)? Candidate mitigation: separate
    "retrieval was correct" vs "generation was good"
    feedback axes.
-4. Sync vs async in provider adapters. v0.1.0 ships async
+3. Sync vs async in provider adapters. v0.1.0 ships async
    only; watch for user demand before adding sync shims.
-5. Telemetry for external users of attune-rag. Do we want
+4. Telemetry for external users of attune-rag. Do we want
    anonymous retrieval metrics (hit count, fallback rate)?
    Opt-in only; default off. Separate spec if we pursue.

--- a/.claude/plans/feature-rag-code-grounding-2026-04-17.md
+++ b/.claude/plans/feature-rag-code-grounding-2026-04-17.md
@@ -1122,22 +1122,34 @@ attune-rag/
   </objective>
 
   <files-to-create>
-    <file path="docs/rag/embeddings-decision-2026-04-XX.md">
-      Written only after task 2.4 runs. Contains:
-        - Baseline keyword metrics (from 2.4 output)
-        - Link to prior "sentence-transformers removed" lesson
-        - Proposed embedding strategy (if any)
-        - Hard gate: adopt only if delta precision@1 >= 15pts
-          AND install cost <50MB AND no new network
-          dependency at import time
-        - Go / no-go decision with reasoning
+    <file path="docs/rag/embeddings-decision-2026-04-17.md">
+      Written 2026-04-17. RESOLVED.
+
+      Baseline: KeywordRetriever hits 53.33% P@1 / 60% R@3
+      on 15 golden queries. Easy+medium pass; all 6 hard
+      queries fail with the same pattern — lesson/error files
+      with query keywords in the filename outrank the concept
+      files that actually answer.
+
+      Decision: sequence keyword tuning first (v0.1.x patch),
+      then fastembed (local ONNX embeddings, ~35MB) as
+      fallback in v0.2.0 if the gate isn't met. NOT
+      sentence-transformers (420MB, fails <50MB gate). NOT
+      hosted embeddings for v0.2.0 (keeps architectural posture
+      of local-corpus / local-retrieval).
+
+      Clarifies that the "sentence-transformers removed" lesson
+      was about semantic CACHING (0.4% ROI on unique prompts),
+      not RAG RETRIEVAL. Different problems, different ROI
+      profiles. Keyword tuning and fastembed are both
+      defensible in light of the clarified lesson.
     </file>
   </files-to-create>
 
   <validation>
-    <check>Decision doc exists and is linked from this plan</check>
-    <check>If adopted, CI benchmark shows improvement above gate</check>
-    <check>If adopted, install cost measured and reported</check>
+    <check>Decision doc exists and is linked from this plan (RESOLVED 2026-04-17)</check>
+    <check>Follow-up task filed: v0.1.x category-biased keyword tuning</check>
+    <check>Follow-up task filed: v0.2.0 fastembed EmbeddingRetriever (conditional)</check>
   </validation>
 
   <risks>

--- a/.claude/plans/feature-rag-code-grounding-2026-04-17.md
+++ b/.claude/plans/feature-rag-code-grounding-2026-04-17.md
@@ -1,0 +1,1591 @@
+# RAG-Grounded Code Generation (Multi-Package, Multi-LLM)
+
+**Version:** 4.0 (general-purpose attune-rag + pluggable
+corpus + provider adapters)
+**Status:** Planning
+**Created:** 2026-04-17
+**Owner:** Patrick Roebuck
+**Scope:** new `attune-rag` package (LLM-agnostic,
+corpus-pluggable, with optional provider extras) +
+`attune-ai` 6.0.0 + `attune-author` 0.4.0. `attune-help`
+unchanged.
+
+## Positioning
+
+`attune-rag` is a **standalone, general-purpose RAG library**
+that attune happens to use first. It:
+
+- Is **LLM-agnostic** — pipeline returns a prompt string;
+  send it to any LLM.
+- Has **pluggable corpus** — use attune-help (default),
+  any markdown directory, or your own `CorpusProtocol`
+  implementation.
+- Ships **optional provider adapters** for Claude, OpenAI,
+  and Gemini via extras (`attune-rag[claude|openai|gemini|all]`).
+- Depends on **zero LLM SDKs at install time** — all
+  provider deps are optional extras.
+
+---
+
+## Context
+
+- `attune-help` v0.5.1 ships **633 bundled markdown files**
+  across 11 categories plus `summaries.json` and
+  `cross_links.json` in `attune_help/templates/`. This is
+  the canonical RAG knowledge base.
+- `attune-author` v0.3.9 generates and maintains templates
+  via `attune-author generate` CLI + `attune-author-mcp`
+  server. Core entry point: `generate_feature_templates()`.
+- `attune-ai` currently imports only `_extract_preamble`
+  from attune-help (`src/attune/help/preamble.py`).
+- `BaseWorkflow` is SDK-native: modern workflows delegate to
+  `claude_agent_sdk.query()` subagents and return
+  `WorkflowResult`.
+- `src/attune/help/feedback.py` already provides
+  `record_template_feedback()` + `get_template_confidence()`.
+- **Prior lesson (CLAUDE.md):** `sentence-transformers` was
+  removed — 0.4% savings, 420MB dep. Anthropic's server-side
+  prompt caching (90% discount) supersedes client-side caching.
+
+---
+
+## Problem
+
+LLM code generation in `attune-ai` workflows and content
+generation in `attune-author` can hallucinate attune-specific
+APIs, workflow names, CLI commands, and patterns. The 633
+files in attune-help are an authoritative corpus but are not
+automatically consulted. Users cannot see which help
+documents grounded a code or content output, so they have no
+basis for trusting generated output over their own memory of
+the codebase.
+
+Additionally: putting retrieval logic inside `attune-ai`
+creates a circular-looking dep if `attune-author` wants to
+consume it without pulling all of attune-ai.
+
+---
+
+## Goals
+
+1. **Ground generated code and content** in a markdown
+   corpus (attune-help by default, any directory optionally)
+   so outputs cite real APIs, workflows, patterns.
+2. **Source provenance in v1** — citations in every output
+   from the attune-ai RAG workflow and the attune-author
+   generate path.
+3. **Grounded-by-default** for `attune-author generate`
+   (with `--no-rag` opt-out + `ATTUNE_AUTHOR_RAG=0` env).
+4. **LLM-agnostic core.** Pipeline returns a prompt string;
+   consumers choose the LLM. Optional provider extras for
+   Claude, OpenAI, Gemini.
+5. **Pluggable corpus.** Default `AttuneHelpCorpus`; also
+   ship `DirectoryCorpus` for arbitrary markdown dirs; allow
+   users to implement `CorpusProtocol` for DBs, git trees, etc.
+6. **Clean dep graph:** `attune-help` (corpus default) →
+   `attune-rag` (retrieval, LLM-agnostic) → `attune-ai` /
+   `attune-author` / external users (consumers). One-way.
+7. **Measure hallucination reduction** via golden queries.
+8. Hit p50 latency < 500ms cached / < 2s uncached for
+   retrieval-only paths. LLM call latency is provider-dependent
+   and not gated by this plan.
+
+---
+
+## End State
+
+### Filesystem layout (sibling-repo pattern)
+
+Matches the established `attune-author` / `attune-help`
+pattern. The `attune-rag` package source lives in its own
+git repo at `/Users/patrickroebuck/attune-rag/` (published
+to PyPI as `attune-rag`, to GitHub as
+`Smart-AI-Memory/attune-rag`). `attune-ai` contains only a
+**pointer stub** at `packages/attune-rag/README.md` plus the
+workspace-source entry in its `pyproject.toml`.
+
+In the tasks below, paths of the form
+`packages/attune-rag/<...>` refer to files **inside the
+attune-rag sibling repo root**, except for the explicit
+stub `packages/attune-rag/README.md` which is in the
+attune-ai repo. Task 1.1 creates both.
+
+### New package: `attune-rag` 0.1.0
+
+```
+attune-rag/
+├── pyproject.toml               # core deps: jinja2, structlog
+│                                # optional extras:
+│                                #   [attune-help]  -> attune-help
+│                                #   [claude]       -> anthropic
+│                                #   [openai]       -> openai
+│                                #   [gemini]       -> google-genai
+│                                #   [all]          -> all of the above
+├── README.md                    # quick starts for 3 LLMs + custom corpus
+├── src/attune_rag/
+│   ├── __init__.py              # RagPipeline, CitationRecord,
+│   │                              KeywordRetriever, RagResult,
+│   │                              CorpusProtocol, DirectoryCorpus
+│   ├── pipeline.py              # orchestration + run_and_generate
+│   ├── retrieval.py             # KeywordRetriever + RetrieverProtocol
+│   ├── corpus/
+│   │   ├── __init__.py          # exports
+│   │   ├── base.py              # CorpusProtocol + RetrievalEntry
+│   │   ├── directory.py         # DirectoryCorpus (markdown dir)
+│   │   └── attune_help.py       # AttuneHelpCorpus (opt. dep)
+│   ├── provenance.py            # CitationRecord + format_citations
+│   ├── prompts.py               # augmented prompt templates
+│   ├── providers/
+│   │   ├── __init__.py
+│   │   ├── base.py              # LLMProvider protocol
+│   │   ├── claude.py            # opt. dep on anthropic
+│   │   ├── openai.py            # opt. dep on openai
+│   │   └── gemini.py            # opt. dep on google-genai
+│   ├── benchmark.py             # python -m attune_rag.benchmark
+│   └── cli.py                   # `attune-rag query "..."` debugger
+└── tests/
+    ├── unit/
+    │   ├── test_pipeline.py
+    │   ├── test_retrieval.py
+    │   ├── test_corpus_directory.py
+    │   ├── test_corpus_attune_help.py  # skipif attune-help missing
+    │   ├── test_provenance.py
+    │   ├── test_prompts.py
+    │   └── providers/
+    │       ├── test_claude.py   # mocked SDK
+    │       ├── test_openai.py   # mocked SDK
+    │       └── test_gemini.py   # mocked SDK
+    └── golden/
+        ├── queries.yaml         # 15+ golden queries
+        └── test_golden.py
+```
+
+### `attune-ai` 6.0.0
+
+- New workflow `src/attune/workflows/rag_code_gen.py`
+  (BaseWorkflow subclass) depending on `attune-rag>=0.1.0`.
+- New MCP tool `rag_knowledge_query` in
+  `src/attune/mcp/tool_schemas.py` + handler in
+  `workflow_handlers.py`.
+- Registered in `_DEFAULT_WORKFLOW_NAMES`.
+- Feedback integration via existing `help/feedback.py`.
+- Version bump across all tracked files (see task 4.3).
+
+### `attune-author` 0.4.0
+
+- `--no-rag` flag on `attune-author generate`.
+- `ATTUNE_AUTHOR_RAG=0` env to disable globally.
+- Default: RAG on, logs a one-line notice that grounding
+  is active and points at docs.
+- Feature flag behind env var `ATTUNE_AUTHOR_RAG_DEFAULT`
+  (default `1`) so we can flip the default remotely for 1-2
+  releases if telemetry shows issues.
+
+### Coordinated release artifacts
+
+- Website page: new "Grounded code generation" section
+  under [attune-ai website — verify with agent before edits].
+- README updates in `attune-ai` and `attune-author`.
+- CHANGELOG entries on both.
+- Migration note for `attune-ai` 6.0.0 explaining no-op
+  upgrade for non-RAG users.
+
+---
+
+## Non-Goals (v1)
+
+- **No sentence-transformers by default.** Embedding
+  strategy is benchmark-gated in task 2.4.
+- **No custom caching layer.** `functools.lru_cache` for
+  corpus loads only. Anthropic server-side caching handles
+  LLM-level caching.
+- **attune-help stays unchanged.** No new release.
+- **No PromptMixin across all attune-ai workflows.** Only
+  the dedicated `rag-code-gen` workflow.
+- **No fine-tuning / RLHF.** Feedback is captured; what to
+  do with it is a later spec.
+
+---
+
+## Phase 1: `attune-rag` package (new)
+
+<task id="1.1" name="scaffold-attune-rag-package">
+  <objective>
+    Create the attune-rag package as a sibling git
+    repository at /Users/patrickroebuck/attune-rag/
+    (mirroring the attune-author / attune-help pattern).
+    Add a pointer stub in attune-ai at
+    packages/attune-rag/README.md and wire editable dev
+    resolution via [tool.uv.sources].
+  </objective>
+
+  <context>
+    <existing-code path="packages/attune-author/README.md">
+      Existing stub: points to
+      https://github.com/Smart-AI-Memory/attune-author,
+      notes the sibling-clone layout, documents the
+      [tool.uv.sources] entry. Our stub follows the same
+      template verbatim (adjusted for rag).
+    </existing-code>
+    <existing-code path="pyproject.toml">
+      [tool.uv.sources] already has entries for
+      attune-author and attune-help. Add attune-rag with
+      path = "../attune-rag", editable = true.
+    </existing-code>
+  </context>
+
+  <files-to-create>
+    <file path="packages/attune-rag/pyproject.toml">
+      name: attune-rag
+      version: 0.1.0
+      python: ">=3.10"
+      description: "Lightweight, LLM-agnostic RAG pipeline
+                    with pluggable corpora. Works with Claude,
+                    OpenAI, Gemini, or any LLM."
+      dependencies: ["structlog>=24.0", "jinja2>=3.1",
+                     "pyyaml>=6.0"]
+      # NO LLM SDK or attune-help at install time.
+      optional-dependencies:
+        attune-help: ["attune-help>=0.5.1,<0.6"]
+        claude:      ["anthropic>=0.40"]
+        openai:      ["openai>=1.40"]
+        gemini:      ["google-genai>=1.0"]
+        all:         ["attune-rag[attune-help,claude,openai,gemini]"]
+        dev:         ["pytest>=8", "pytest-cov", "ruff",
+                      "black", "attune-rag[all]"]
+      build-system: hatchling (matches attune-author)
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/__init__.py">
+      Public exports: RagPipeline, CitationRecord, RagResult,
+      KeywordRetriever, build_augmented_prompt. Module
+      docstring links back to this plan.
+    </file>
+    <file path="packages/attune-rag/README.md">
+      Sections:
+        1. What it is (one-paragraph positioning)
+        2. Install (core + optional extras table)
+        3. Quickstart with Claude
+             pip install 'attune-rag[attune-help,claude]'
+             then 6-line example using
+             RagPipeline().run_and_generate(query, "claude")
+        4. Quickstart with OpenAI (same, [openai] extra)
+        5. Quickstart with Gemini (same, [gemini] extra)
+        6. Custom corpus example (DirectoryCorpus)
+        7. No-LLM usage (just retrieve + build prompt,
+           feed to anything)
+        8. Link to attune-ai docs for full walkthrough.
+    </file>
+    <file path="packages/attune-rag/LICENSE">
+      Apache 2.0 (match attune-ai license). NOTE: this
+      LICENSE lives inside the attune-rag SIBLING REPO, not
+      the attune-ai repo.
+    </file>
+    <file path="packages/attune-rag/tests/__init__.py">
+      Empty marker (inside the sibling repo).
+    </file>
+  </files-to-create>
+
+  <files-to-create>
+    <!-- Files inside the attune-ai repo -->
+    <file path="<attune-ai>/packages/attune-rag/README.md">
+      Pointer stub. Mirrors
+      packages/attune-author/README.md verbatim with names
+      adjusted. Links to:
+        - GitHub: https://github.com/Smart-AI-Memory/attune-rag
+        - PyPI:   https://pypi.org/project/attune-rag/
+      Shows install snippets for core + each optional extra
+      and documents the sibling-clone layout.
+    </file>
+  </files-to-create>
+
+  <files-to-modify>
+    <file path="<attune-ai>/pyproject.toml">
+      <change location="[tool.uv.sources]">
+        AFTER: add
+          attune-rag = { path = "../attune-rag", editable = true }
+        (mirroring the existing attune-author / attune-help
+        entries).
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>uv sync --extra dev --extra developer succeeds</check>
+    <check>uv run python -c "import attune_rag"</check>
+    <check>pytest packages/attune-rag/tests/ collects 0 tests without error</check>
+    <check>uv lock is up to date (uv lock --check passes)</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      Workspace resolution differs between dev (sibling path)
+      and production install (PyPI). Mitigation: publish
+      attune-rag 0.1.0 to PyPI BEFORE attune-ai 6.0.0 so the
+      version constraint resolves. Document this in task 4.4.
+    </risk>
+    <risk severity="low">
+      Name collision on PyPI. Mitigation: check availability
+      of "attune-rag" on PyPI before beginning. Reserve the
+      name if needed.
+    </risk>
+  </risks>
+</task>
+
+<task id="1.2" name="corpus-protocol-and-directory">
+  <objective>
+    Define the CorpusProtocol interface and ship a
+    DirectoryCorpus implementation that loads any directory
+    of markdown files. This is the LLM-agnostic foundation;
+    attune-help integration comes in task 1.3.
+  </objective>
+
+  <files-to-create>
+    <file path="packages/attune-rag/src/attune_rag/corpus/__init__.py">
+      Exports: CorpusProtocol, RetrievalEntry, DirectoryCorpus
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/corpus/base.py">
+      @dataclass(frozen=True) RetrievalEntry:
+        path: str          # stable identifier within corpus
+        category: str      # optional grouping (e.g. "concepts")
+        content: str       # full markdown text
+        summary: str | None
+        related: tuple[str, ...]  # cross-link paths
+        metadata: dict[str, Any]  # extensible
+
+      class CorpusProtocol(Protocol):
+        def entries(self) -> Iterable[RetrievalEntry]: ...
+        def get(self, path: str) -> RetrievalEntry | None: ...
+        @property
+        def name(self) -> str: ...
+        @property
+        def version(self) -> str: ...
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/corpus/directory.py">
+      class DirectoryCorpus(CorpusProtocol):
+        def __init__(self, root: Path,
+                     summaries_file: str | None = None,
+                     cross_links_file: str | None = None):
+          - Walks root for *.md files (configurable glob)
+          - Reads with encoding="utf-8"
+          - Category inferred from first path segment under root
+          - Optional summaries.json and cross_links.json loaded
+          - Caches in memory; constructor parameter cache=False
+            disables caching for tests
+          - Uses _validate_file_path from attune.security if
+            importable, else does local realpath check inside
+            root
+        name property returns "directory:{root.name}"
+        version property returns hash of all file mtimes
+    </file>
+    <file path="packages/attune-rag/tests/unit/test_corpus_directory.py">
+      Tests:
+        - load from a tmp_path dir with 5 .md files works
+        - summaries.json + cross_links.json loaded when present
+        - categories inferred correctly
+        - path traversal attempt rejected
+        - caching works within a single process
+        - name/version properties populated
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-rag/tests/unit/test_corpus_directory.py -v passes</check>
+    <check>DirectoryCorpus(Path("some-dir")) enumerates only .md files by default</check>
+    <check>No import-time dep on attune-help</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      Path traversal when DirectoryCorpus is given a
+      user-supplied root. Mitigation: resolve root to real
+      path and reject entries whose resolved path is not a
+      descendant. Follow the established
+      _validate_file_path pattern.
+    </risk>
+  </risks>
+</task>
+
+<task id="1.3" name="corpus-attune-help">
+  <objective>
+    Ship AttuneHelpCorpus as a thin adapter that locates the
+    bundled attune-help templates directory via
+    importlib.resources and delegates to DirectoryCorpus.
+    Available only when the [attune-help] extra is installed.
+  </objective>
+
+  <context>
+    <existing-code path="attune-help package">
+      Ships 633 templates at attune_help/templates/ with
+      summaries.json and cross_links.json siblings.
+    </existing-code>
+  </context>
+
+  <files-to-create>
+    <file path="packages/attune-rag/src/attune_rag/corpus/attune_help.py">
+      class AttuneHelpCorpus(CorpusProtocol):
+        def __init__(self):
+          try:
+            from importlib.resources import files
+            root = files("attune_help").joinpath("templates")
+          except (ImportError, ModuleNotFoundError):
+            raise RuntimeError(
+              "AttuneHelpCorpus requires the [attune-help] "
+              "extra: pip install 'attune-rag[attune-help]'"
+            )
+          self._inner = DirectoryCorpus(
+            Path(str(root)),
+            summaries_file="summaries.json",
+            cross_links_file="cross_links.json",
+          )
+        name property returns "attune-help"
+        version property returns attune_help.__version__
+        entries/get delegate to self._inner
+    </file>
+    <file path="packages/attune-rag/tests/unit/test_corpus_attune_help.py">
+      pytest.importorskip("attune_help")  # per CLAUDE.md lesson
+      Tests:
+        - enumerates >=500 entries
+        - version matches attune_help.__version__
+        - get() returns by template path
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-rag/tests/unit/test_corpus_attune_help.py -v passes when attune-help is installed</check>
+    <check>Tests SKIP (not fail) when attune-help is absent</check>
+    <check>Importing attune_rag without [attune-help] extra does NOT fail (corpus is lazy)</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      importlib.resources.files() API differences across
+      Python versions. Mitigation: target 3.10+ only and
+      add smoke test on minimum Python.
+    </risk>
+    <risk severity="medium">
+      attune-help template path scheme may shift.
+      Mitigation: pin >=0.5.1,<0.6 in [attune-help] extra.
+    </risk>
+  </risks>
+</task>
+
+<task id="1.4" name="keyword-retriever">
+  <objective>
+    Implement KeywordRetriever as a CorpusProtocol consumer
+    — works with any corpus, not just attune-help. Returns
+    ranked RetrievalEntry + score pairs.
+  </objective>
+
+  <files-to-create>
+    <file path="packages/attune-rag/src/attune_rag/retrieval.py">
+      class RetrieverProtocol(Protocol):
+        def retrieve(self, query: str, corpus: CorpusProtocol,
+                     k: int = 3) -> list[RetrievalHit]: ...
+
+      @dataclass(frozen=True) RetrievalHit:
+        entry: RetrievalEntry
+        score: float
+        match_reason: str  # short explanation for debugging
+
+      class KeywordRetriever(RetrieverProtocol):
+        # Tunable class attrs (benchmark can sweep):
+        PATH_WEIGHT = 2.0
+        SUMMARY_WEIGHT = 1.5
+        CONTENT_WEIGHT = 1.0
+        RELATED_WEIGHT = 0.5
+        MIN_SCORE = 2.0
+        STOPWORDS = frozenset({"a", "an", "the", "how", "do",
+                               "i", "to", "with", ...})
+
+        - Tokenizes query (lowercase, strip punctuation,
+          drop stopwords)
+        - Iterates corpus.entries()
+        - Scores per weights above; related score uses
+          entry.related (cross-links) -> look up via
+          corpus.get(related_path).summary
+        - Returns top-k hits where score >= MIN_SCORE
+        - Deterministic: ties broken by entry.path alpha
+    </file>
+    <file path="packages/attune-rag/tests/unit/test_retrieval.py">
+      Uses an in-memory fake CorpusProtocol for determinism
+      (not attune-help) so tests don't depend on optional extra.
+      Tests:
+        - exact match ("security audit" -> security-audit)
+        - synonym match via summary
+        - below-threshold returns []
+        - deterministic tie-breaking
+        - k bounds respected
+        - empty query raises ValueError
+        - tunable weights actually affect ranking
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-rag/tests/unit/test_retrieval.py -v passes without [attune-help] extra installed</check>
+    <check>Retriever is deterministic (3 runs, same output)</check>
+    <check>Weight attrs are class-level so benchmark can override</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      Weights hand-tuned; benchmark (2.4) may require
+      adjustment. Mitigation: class attrs, not hard-coded.
+    </risk>
+  </risks>
+</task>
+
+<task id="1.5" name="provenance-and-prompts">
+  <objective>
+    Implement the provenance record that travels with every
+    RagResult, and the augmented prompt template that clearly
+    separates retrieved context from the user query.
+  </objective>
+
+  <files-to-create>
+    <file path="packages/attune-rag/src/attune_rag/provenance.py">
+      @dataclass(frozen=True) CitationRecord:
+        query: str
+        hits: tuple[CitedSource, ...]  # tuple for hashability
+        retrieved_at: datetime
+        retriever_name: str  # "KeywordRetriever v0.1.0"
+
+      @dataclass(frozen=True) CitedSource:
+        template_path: str
+        category: str
+        score: float
+        excerpt: str | None  # optional first 200 chars
+
+      def format_citations_markdown(record: CitationRecord,
+                                    base_url: str | None = None) -> str:
+        Render as "## Sources\n- [path](base_url/path) -
+        category (score 0.85)\n..."
+        Empty hits => "No grounding sources available."
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/prompts.py">
+      AUGMENTED_TEMPLATE = '''### CONTEXT (from attune help docs)
+
+      {context}
+
+      ### USER REQUEST
+
+      {query}
+
+      ### INSTRUCTION
+
+      Answer the user's request using the context above. If
+      the context does not contain the answer, say so
+      clearly; do not invent attune APIs, workflow names, or
+      CLI commands. When referencing specific patterns, note
+      which source file they came from.'''
+
+      def build_augmented_prompt(query: str, context: str) -> str
+      def join_context(hits: list[RetrievalHit],
+                       corpus: CorpusIndex,
+                       max_chars: int = 20_000) -> str
+    </file>
+    <file path="packages/attune-rag/tests/unit/test_provenance.py">
+      Tests: empty citation, single, multiple, markdown
+      format, deterministic ordering, hashability (since
+      frozen).
+    </file>
+    <file path="packages/attune-rag/tests/unit/test_prompts.py">
+      Tests: prompt contains both sections, truncation at
+      max_chars, join preserves source boundaries with a
+      separator line.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-rag/tests/unit/test_provenance.py -v passes</check>
+    <check>pytest packages/attune-rag/tests/unit/test_prompts.py -v passes</check>
+    <check>format_citations_markdown output is valid markdown (passes markdownlint)</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Prompt injection via retrieved content. Mitigation:
+      explicit "### CONTEXT" / "### USER REQUEST" markers
+      and instruction that model must not follow instructions
+      embedded in context. Low risk since attune-help
+      corpus is maintainer-authored.
+    </risk>
+  </risks>
+</task>
+
+<task id="1.6" name="pipeline-orchestrator">
+  <objective>
+    Wire corpus + retriever + provenance + prompt assembly
+    into RagPipeline.run() — corpus-agnostic, LLM-agnostic.
+    Returns an augmented prompt string; the consumer feeds
+    it to whatever LLM it chooses.
+  </objective>
+
+  <files-to-create>
+    <file path="packages/attune-rag/src/attune_rag/pipeline.py">
+      @dataclass(frozen=True) RagResult:
+        augmented_prompt: str
+        citation: CitationRecord
+        confidence: float
+        fallback_used: bool
+        elapsed_ms: float
+
+      class RagPipeline:
+        def __init__(self,
+                     corpus: CorpusProtocol | None = None,
+                     retriever: RetrieverProtocol | None = None):
+          # If no corpus provided, try AttuneHelpCorpus;
+          # on ImportError emit a clear message telling the
+          # user to either pass a corpus explicitly or
+          # install attune-rag[attune-help].
+          self.corpus = corpus or self._default_corpus()
+          self.retriever = retriever or KeywordRetriever()
+
+        @staticmethod
+        def _default_corpus() -> CorpusProtocol:
+          try:
+            from .corpus.attune_help import AttuneHelpCorpus
+            return AttuneHelpCorpus()
+          except (ImportError, ModuleNotFoundError, RuntimeError) as e:
+            raise RuntimeError(
+              "No corpus provided and AttuneHelpCorpus is "
+              "unavailable. Either pass a corpus= (e.g. "
+              "DirectoryCorpus) or install "
+              "attune-rag[attune-help]."
+            ) from e
+
+        def run(self, query: str, k: int = 3) -> RagResult:
+          # Timed, logged via structlog
+          # On zero hits: fallback prompt tells model there
+          # is no grounding context so it must say it
+          # doesn't know rather than invent.
+    </file>
+    <file path="packages/attune-rag/tests/unit/test_pipeline.py">
+      Tests:
+        - happy path with a fake CorpusProtocol
+        - happy path with DirectoryCorpus (tmp_path)
+        - no-match -> fallback_used=True
+        - elapsed_ms populated
+        - accepts injected retriever + corpus
+        - default ctor raises helpful error when
+          attune-help unavailable
+        - one structured log event per run
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-rag/tests/unit/test_pipeline.py -v passes</check>
+    <check>pipeline.run("security audit") returns confidence >= 0.5 (with attune-help corpus)</check>
+    <check>pipeline.run("asdfgh") returns fallback_used=True</check>
+    <check>Importing attune_rag without any optional extras works; only constructing AttuneHelpCorpus fails</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Default corpus instantiation at __init__ time pays
+      the corpus-load cost even if unused. Mitigation: lazy
+      load on first .run() call; cache in instance.
+    </risk>
+  </risks>
+</task>
+
+<task id="1.7" name="provider-adapters">
+  <objective>
+    Ship thin, optional provider adapters for Claude,
+    OpenAI, and Gemini behind extras. Each exposes an async
+    generate(prompt: str) -> str method. No provider is
+    installed or imported unless its extra is enabled.
+  </objective>
+
+  <context>
+    <existing-code path="CLAUDE.md lesson">
+      Mock a lazy `import X` with `types.ModuleType` +
+      `patch.dict("sys.modules")` — the pattern we'll use
+      to test adapters without installing their SDKs.
+    </existing-code>
+  </context>
+
+  <files-to-create>
+    <file path="packages/attune-rag/src/attune_rag/providers/__init__.py">
+      Exports: LLMProvider (protocol), list_available().
+      list_available() introspects which provider modules
+      can actually be imported and returns their names.
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/providers/base.py">
+      class LLMProvider(Protocol):
+        name: str
+        async def generate(self, prompt: str,
+                           model: str | None = None,
+                           max_tokens: int = 2048) -> str: ...
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/providers/claude.py">
+      class ClaudeProvider(LLMProvider):
+        name = "claude"
+        DEFAULT_MODEL = "claude-sonnet-4-6"
+        def __init__(self, api_key: str | None = None):
+          try:
+            from anthropic import Anthropic, AsyncAnthropic
+          except ImportError as e:
+            raise RuntimeError(
+              "ClaudeProvider requires 'pip install "
+              "attune-rag[claude]'"
+            ) from e
+          self._client = AsyncAnthropic(api_key=api_key)
+        async def generate(self, prompt, model=None,
+                           max_tokens=2048) -> str:
+          response = await self._client.messages.create(
+            model=model or self.DEFAULT_MODEL,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+          )
+          return response.content[0].text
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/providers/openai.py">
+      class OpenAIProvider(LLMProvider):
+        name = "openai"
+        DEFAULT_MODEL = "gpt-4o"
+        Similar structure — lazy import, clear error on
+        missing extra, async generate via
+        openai.AsyncOpenAI.chat.completions.create.
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/providers/gemini.py">
+      class GeminiProvider(LLMProvider):
+        name = "gemini"
+        DEFAULT_MODEL = "gemini-1.5-pro"
+        Similar — lazy import google.genai, async generate.
+    </file>
+    <file path="packages/attune-rag/tests/unit/providers/test_claude.py">
+      Uses types.ModuleType + patch.dict("sys.modules")
+      pattern (CLAUDE.md lesson) to simulate the anthropic
+      module. Tests: lazy import error with clear message,
+      generate() passes prompt to client, model default
+      honored, model override honored.
+    </file>
+    <file path="packages/attune-rag/tests/unit/providers/test_openai.py">
+      Same pattern for openai.
+    </file>
+    <file path="packages/attune-rag/tests/unit/providers/test_gemini.py">
+      Same pattern for google.genai.
+    </file>
+    <file path="packages/attune-rag/tests/unit/providers/test_list_available.py">
+      Tests: returns empty list when no extras installed;
+      returns names when extras are importable. Uses sys.modules
+      patching to simulate states.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-rag/tests/unit/providers/ -v passes with all extras installed (dev extra pulls them)</check>
+    <check>pytest passes when extras are absent (tests use sys.modules patching, not actual install)</check>
+    <check>Importing attune_rag without any [provider] extra does NOT fail</check>
+    <check>Constructing ClaudeProvider without anthropic installed raises a clear RuntimeError pointing at the install command</check>
+  </validation>
+
+  <risks>
+    <risk severity="high">
+      Provider SDK APIs shift. Mitigation: adapters are thin
+      (~30 lines each). Version-pin SDKs in extras
+      conservatively (>=X.Y,<X+1.0). Each adapter has its
+      own CI smoke test.
+    </risk>
+    <risk severity="medium">
+      Model names rot (e.g. Gemini's DEFAULT_MODEL).
+      Mitigation: callers always pass explicit model in
+      production code. Document this in README.
+    </risk>
+    <risk severity="medium">
+      Async vs sync. Some users will want sync.
+      Mitigation: v0.1.0 ships async only. Add sync shims
+      (`.generate_sync()` wrapping anyio.from_thread.run)
+      in v0.2.0 if demand exists.
+    </risk>
+  </risks>
+</task>
+
+<task id="1.8" name="run-and-generate-and-cli">
+  <objective>
+    Add RagPipeline.run_and_generate(query, provider) as a
+    one-line convenience wrapping retrieve + LLM call. Ship
+    a tiny CLI `attune-rag query "..."` for debugging
+    retrieval (no LLM call by default; --provider flag
+    optional).
+  </objective>
+
+  <files-to-modify>
+    <file path="packages/attune-rag/src/attune_rag/pipeline.py">
+      <change location="RagPipeline">
+        AFTER: add
+        async def run_and_generate(
+            self, query: str,
+            provider: LLMProvider | str,
+            k: int = 3,
+            model: str | None = None,
+        ) -> tuple[str, RagResult]:
+          If provider is a string, resolve to one of the
+          built-in adapters by name. Runs retrieval, sends
+          augmented_prompt to provider.generate, returns
+          (response_text, rag_result). Callers render
+          citations with format_citations_markdown as needed.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <files-to-create>
+    <file path="packages/attune-rag/src/attune_rag/cli.py">
+      Typer CLI with subcommands:
+        attune-rag query "how do I run a security audit?"
+          -> prints retrieval hits + citations (no LLM)
+        attune-rag query "..." --provider claude
+          -> retrieves + calls provider + prints response
+        attune-rag corpus-info
+          -> shows default corpus name, version, entry count
+      Entry point: [project.scripts] attune-rag =
+      "attune_rag.cli:app"
+    </file>
+    <file path="packages/attune-rag/tests/unit/test_cli.py">
+      Tests with typer.testing.CliRunner:
+        - query without provider prints hits
+        - query with --provider claude calls mocked adapter
+        - corpus-info shows counts
+        - query with invalid provider gives clear error
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-rag/tests/unit/test_cli.py -v passes</check>
+    <check>attune-rag query "security audit" works from command line</check>
+    <check>attune-rag --help lists query and corpus-info</check>
+    <check>run_and_generate integration test end-to-end with mocked provider passes</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      CLI binary name collision with another PyPI package.
+      Mitigation: confirm availability during publish. The
+      package is "attune-rag" so CLI name "attune-rag" is
+      natural.
+    </risk>
+  </risks>
+</task>
+
+---
+
+## Phase 2: `attune-ai` 6.0.0 consumer
+
+<task id="2.1" name="attune-ai-depend-on-attune-rag">
+  <objective>
+    Add attune-rag>=0.1.0 as a core dep of attune-ai and
+    configure dev resolution via workspace.
+  </objective>
+
+  <files-to-modify>
+    <file path="pyproject.toml">
+      <change location="dependencies">
+        AFTER: add "attune-rag>=0.1.0,<0.2".
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>uv sync --extra dev --extra developer succeeds</check>
+    <check>uv run python -c "from attune_rag import RagPipeline"</check>
+    <check>pip-audit passes (or see known-issue list)</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      attune-rag not yet published to PyPI when attune-ai
+      is installed from source. Mitigation: for dev install,
+      uv resolves from workspace. For release, attune-rag
+      must publish FIRST (see task 4.4 ordering).
+    </risk>
+  </risks>
+</task>
+
+<task id="2.2" name="rag-code-gen-workflow">
+  <objective>
+    Create the rag_code_gen workflow in attune-ai that calls
+    attune-rag's pipeline, sends the augmented prompt to
+    Claude Agent SDK, and returns a WorkflowResult with the
+    generated code plus markdown citations.
+  </objective>
+
+  <context>
+    <existing-code path="src/attune/workflows/security_audit.py">
+      Reference BaseWorkflow pattern. Per CLAUDE.md lesson:
+      use collect_agent_output() from agent_sdk_adapter.py
+      to capture both AssistantMessage TextBlocks and
+      ResultMessage.result (which is often None).
+    </existing-code>
+  </context>
+
+  <files-to-create>
+    <file path="src/attune/workflows/rag_code_gen.py">
+      class RagCodeGenWorkflow(BaseWorkflow):
+        name = "rag-code-gen"
+        stages = ["retrieve", "generate"]
+        tier_map = {"retrieve": ModelTier.CHEAP,
+                    "generate": ModelTier.CAPABLE}
+
+        _pipeline: RagPipeline = None  # lazy init
+
+        async def execute(self, **kwargs) -> WorkflowResult:
+          query = kwargs["query"]
+          if self._pipeline is None:
+            self._pipeline = RagPipeline()
+          rag_result = self._pipeline.run(query)
+
+          response = await query_agent_sdk(
+            rag_result.augmented_prompt,
+            tier=ModelTier.CAPABLE,
+          )
+          generated = collect_agent_output(response)
+
+          citations_md = format_citations_markdown(
+            rag_result.citation,
+            base_url="https://github.com/Smart-AI-Memory/attune-help/blob/main/src/attune_help/templates",
+          )
+          output = f"{generated}\n\n{citations_md}"
+
+          return WorkflowResult(
+            success=True,
+            stages=[...],
+            metadata={
+              "citation": asdict(rag_result.citation),
+              "fallback_used": rag_result.fallback_used,
+              "confidence": rag_result.confidence,
+            },
+            findings=[output],
+            started_at=...,
+            completed_at=...,
+            total_duration_ms=...,
+          )
+    </file>
+    <file path="tests/integration/rag/__init__.py">
+      Empty marker.
+    </file>
+    <file path="tests/integration/rag/test_rag_workflow.py">
+      E2E with Claude Agent SDK mocked:
+        - execute returns WorkflowResult with success=True
+        - metadata.citation has expected feature hints
+        - output contains "## Sources" block
+        - fallback path used when query is out-of-scope
+    </file>
+  </files-to-create>
+
+  <files-to-modify>
+    <file path="src/attune/workflows/__init__.py">
+      <change location="_DEFAULT_WORKFLOW_NAMES">
+        AFTER: register RagCodeGenWorkflow.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>pytest tests/integration/rag/test_rag_workflow.py -v passes</check>
+    <check>attune workflow list includes rag-code-gen</check>
+    <check>attune workflow run rag-code-gen --input '{"query":"how do I run a security audit?"}' returns result with citations</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      Workflow registry count assertions exist in multiple
+      test files (CLAUDE.md lesson). Mitigation: grep for
+      _DEFAULT_WORKFLOW_NAMES count and _SDK_WORKFLOW_MAP
+      count assertions; update in same commit.
+    </risk>
+    <risk severity="medium">
+      ResultMessage.result is often None. Mitigation: use
+      collect_agent_output() per the existing lesson.
+    </risk>
+  </risks>
+</task>
+
+<task id="2.3" name="mcp-tool-rag-knowledge-query">
+  <objective>
+    Register the rag_knowledge_query MCP tool in attune-ai
+    so Claude Code and other MCP clients can query the
+    corpus without running a full workflow.
+  </objective>
+
+  <context>
+    <existing-code path="src/attune/mcp/tool_schemas.py">
+      Schema lives in get_workflow_tools() or
+      get_memory_tools(). Tool count is asserted in
+      tests/unit/test_mcp_memory_tools.py — bump it.
+    </existing-code>
+  </context>
+
+  <files-to-modify>
+    <file path="src/attune/mcp/tool_schemas.py">
+      <change location="get_workflow_tools">
+        AFTER: append rag_knowledge_query schema.
+        Inputs: query (str, required), k (int, default 3).
+        Description notes: returns JSON with hits,
+        augmented_prompt, confidence, fallback_used.
+      </change>
+    </file>
+    <file path="src/attune/mcp/workflow_handlers.py">
+      <change location="dispatch table + handlers">
+        AFTER: add _run_rag_knowledge_query(arguments).
+        Validate k in [1,10]. Construct lazy singleton
+        RagPipeline. Return TextContent with JSON body.
+      </change>
+    </file>
+    <file path="tests/unit/test_mcp_memory_tools.py">
+      <change location="tool count assertion">
+        AFTER: bump by 1.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <files-to-create>
+    <file path="tests/unit/rag/test_mcp_tool.py">
+      Tests: schema registration, happy-path dispatch,
+      k-bounds validation, no-match result shape.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest tests/unit/rag/test_mcp_tool.py -v passes</check>
+    <check>pytest tests/unit/test_mcp_memory_tools.py -v passes</check>
+    <check>MCP server lists rag_knowledge_query</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Single RagPipeline instance shared across MCP
+      requests. Mitigation: CorpusIndex is read-only; no
+      mutation.
+    </risk>
+  </risks>
+</task>
+
+<task id="2.4" name="golden-query-benchmark">
+  <objective>
+    Build the benchmark harness that gates whether we invest
+    in embeddings. Seeds the dataset with 15+ golden queries
+    spanning direct asks, synonyms, out-of-scope, and multi-
+    feature asks.
+  </objective>
+
+  <files-to-create>
+    <file path="packages/attune-rag/tests/golden/queries.yaml">
+      Each entry:
+        id: gq-001
+        query: "how do I run a security audit?"
+        expected_top_feature: "security-audit"
+        expected_in_top_3: ["quickstarts/security-audit.md"]
+        difficulty: easy | medium | hard
+        embedding_only: false
+      Cover: 5 easy, 5 medium, 5 hard.
+    </file>
+    <file path="packages/attune-rag/tests/golden/test_golden.py">
+      Parametrized pytest that loads queries.yaml and asserts
+      each expected_top_feature appears in top 3 hits.
+    </file>
+    <file path="packages/attune-rag/src/attune_rag/benchmark.py">
+      Runnable: python -m attune_rag.benchmark
+      Prints:
+        Retriever: KeywordRetriever v0.1.0
+        Corpus:    633 templates
+        Precision@1: 0.80 (12/15)
+        Recall@3:    0.93 (14/15)
+        Mean latency: 4.2ms
+      Exit 1 if precision@1 < 0.70 (configurable via
+      --min-precision) so CI can gate.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-rag/tests/golden/ -v passes at baseline</check>
+    <check>python -m attune_rag.benchmark exits 0 at baseline</check>
+    <check>Benchmark is deterministic across runs</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      Hand-authored queries biased toward the retriever we
+      built. Mitigation: at least 5 queries labeled "hard"
+      with non-obvious wording (synonyms, typos). Anyone
+      adding queries must mark difficulty honestly.
+    </risk>
+  </risks>
+</task>
+
+<task id="2.5" name="embeddings-gate-decision">
+  <objective>
+    Decision point, not implementation. If keyword retrieval
+    hits precision@1 >= 0.85 and recall@3 >= 0.90 on the
+    golden set, DO NOT add embeddings. Otherwise spike a
+    hosted-embeddings prototype (Voyage, OpenAI, Anthropic
+    when available) and re-benchmark.
+  </objective>
+
+  <files-to-create>
+    <file path="docs/rag/embeddings-decision-2026-04-XX.md">
+      Written only after task 2.4 runs. Contains:
+        - Baseline keyword metrics (from 2.4 output)
+        - Link to prior "sentence-transformers removed" lesson
+        - Proposed embedding strategy (if any)
+        - Hard gate: adopt only if delta precision@1 >= 15pts
+          AND install cost <50MB AND no new network
+          dependency at import time
+        - Go / no-go decision with reasoning
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>Decision doc exists and is linked from this plan</check>
+    <check>If adopted, CI benchmark shows improvement above gate</check>
+    <check>If adopted, install cost measured and reported</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      Sunk-cost bias after spiking embeddings. Mitigation:
+      write the gate criteria before running comparison;
+      commit them in the doc before measuring.
+    </risk>
+  </risks>
+</task>
+
+---
+
+## Phase 3: `attune-author` 0.4.0 consumer
+
+<task id="3.1" name="attune-author-depend-on-attune-rag">
+  <objective>
+    Add attune-rag>=0.1.0 as an optional dependency of
+    attune-author, exposed via an extra (e.g.
+    attune-author[rag]). If the extra is not installed,
+    attune-author falls back to the pre-RAG generation path
+    with a warning.
+  </objective>
+
+  <files-to-modify>
+    <file path="packages/attune-author/pyproject.toml">
+      <change location="optional-dependencies">
+        AFTER: add `rag = ["attune-rag>=0.1.0,<0.2"]`.
+        Keep attune-rag OUT of core deps to preserve
+        lightweight install.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>uv sync --extra rag succeeds</check>
+    <check>uv sync without --extra rag still resolves cleanly</check>
+    <check>Import attune_rag only inside attune_author.rag_hook module (not at package import time)</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Optional-extra dep is invisible at runtime until
+      imported. Mitigation: rag_hook.py uses the MetaPathFinder
+      pattern from CLAUDE.md to verify the boundary stays clean.
+    </risk>
+  </risks>
+</task>
+
+<task id="3.2" name="author-rag-hook">
+  <objective>
+    Wire RAG into `attune-author generate` with the middle-
+    ground UX: on by default when attune-rag is installed,
+    opt-out via --no-rag flag or ATTUNE_AUTHOR_RAG=0 env
+    override. Log a one-line notice the first time RAG fires
+    per session pointing at docs.
+  </objective>
+
+  <files-to-create>
+    <file path="packages/attune-author/src/attune_author/rag_hook.py">
+      def rag_enabled() -> bool:
+        if os.environ.get("ATTUNE_AUTHOR_RAG") == "0":
+          return False
+        try:
+          import attune_rag  # noqa: F401
+        except ImportError:
+          return False
+        return True
+
+      def ground_generation(query: str, k: int = 3) -> str | None:
+        if not rag_enabled():
+          return None
+        from attune_rag import RagPipeline
+        pipeline = RagPipeline()
+        result = pipeline.run(query, k=k)
+        if result.fallback_used:
+          return None
+        return result.augmented_prompt
+    </file>
+  </files-to-create>
+
+  <files-to-modify>
+    <file path="packages/attune-author/src/attune_author/cli.py">
+      <change location="generate subcommand">
+        AFTER: add --no-rag bool flag (default False).
+        If not --no-rag and rag_enabled(): call
+        ground_generation() and pass the augmented prompt to
+        the generator. If rag_hook returns None (fallback or
+        disabled), proceed with the original path.
+      </change>
+    </file>
+    <file path="packages/attune-author/src/attune_author/generator.py">
+      <change location="generate_feature_templates">
+        AFTER: accept optional augmented_prompt parameter.
+        When provided, use it instead of the bare prompt.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <files-to-create>
+    <file path="packages/attune-author/tests/unit/test_rag_hook.py">
+      Tests:
+        - rag_enabled() false when ATTUNE_AUTHOR_RAG=0
+        - rag_enabled() false when attune_rag not installed
+          (simulate via sys.modules patch per CLAUDE.md lesson)
+        - --no-rag flag disables even when env allows
+        - hook returns None on fallback (out-of-scope query)
+        - hook returns augmented prompt on match
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>pytest packages/attune-author/tests/unit/test_rag_hook.py -v passes</check>
+    <check>attune-author generate security-audit uses RAG (check log output)</check>
+    <check>attune-author generate security-audit --no-rag skips RAG</check>
+    <check>ATTUNE_AUTHOR_RAG=0 attune-author generate ... skips RAG</check>
+  </validation>
+
+  <risks>
+    <risk severity="high">
+      Determinism: golden/regression tests in attune-author
+      may flake if RAG is on by default and retrieval order
+      shifts. Mitigation: CI tests run with ATTUNE_AUTHOR_RAG=0
+      by default. Separate CI lane runs with RAG enabled and
+      accepts softer assertions (contains vs equals).
+    </risk>
+    <risk severity="medium">
+      Output format change breaks scripts parsing generator
+      output. Mitigation: default RAG output stays visually
+      compatible; citations appended in a labeled section
+      that scripts can skip.
+    </risk>
+    <risk severity="medium">
+      Latency tax on batch generate (regen of 24 features =
+      24x retrieval cost). Mitigation: RagPipeline caches
+      corpus globally; keyword retrieval is ~4ms per query.
+      Total overhead on batch: ~100ms, acceptable.
+    </risk>
+  </risks>
+</task>
+
+<task id="3.3" name="author-cli-docs-update">
+  <objective>
+    Document the new flag, env override, and on-by-default
+    behavior in attune-author's README and --help output.
+  </objective>
+
+  <files-to-modify>
+    <file path="packages/attune-author/README.md">
+      <change location="CLI usage section">
+        AFTER: document --no-rag, ATTUNE_AUTHOR_RAG=0, and
+        how grounding changes generated output.
+      </change>
+    </file>
+    <file path="packages/attune-author/src/attune_author/cli.py">
+      <change location="generate subcommand --help">
+        AFTER: flag help text describes the default and
+        points at attune-ai docs for the RAG explainer.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>attune-author generate --help shows --no-rag</check>
+    <check>README has a Grounded Generation section</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      README drift between packages. Mitigation: single
+      source of truth for the RAG explainer lives in
+      attune-ai docs; attune-author README links to it.
+    </risk>
+  </risks>
+</task>
+
+---
+
+## Phase 4: Release coordination
+
+<task id="4.1" name="feedback-integration-attune-ai">
+  <objective>
+    Wire the attune-ai rag_code_gen workflow into existing
+    help/feedback.py so every RAG invocation can be rated
+    good/bad by the user and aggregated into template
+    confidence over time.
+  </objective>
+
+  <context>
+    <existing-code path="src/attune/help/feedback.py">
+      record_template_feedback(template_id, verdict) where
+      verdict is "good" or "bad". Atomic writes. Returns
+      None. get_template_confidence(template_id) returns
+      good / (good + bad).
+    </existing-code>
+  </context>
+
+  <files-to-modify>
+    <file path="src/attune/workflows/rag_code_gen.py">
+      <change location="execute()">
+        AFTER: if kwargs has feedback in ("good", "bad"),
+        iterate over rag_result.citation.hits and call
+        record_template_feedback(hit.template_path, feedback)
+        for each. No silent implicit ratings.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>Running rag-code-gen with feedback="good" increments good counts in feedback.json</check>
+    <check>Running without feedback leaves feedback.json untouched</check>
+    <check>Confidence for a never-seen template is 0.5 (neutral prior)</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Concurrent writes (existing lesson: atomic in
+      feedback.py already).
+    </risk>
+  </risks>
+</task>
+
+<task id="4.2" name="skill-and-website">
+  <objective>
+    Add Claude Code skill entry for rag-code-gen. Update
+    attune-ai's website with a RAG feature page. Update the
+    README's top-level feature list. Add blog post placeholder.
+  </objective>
+
+  <files-to-create>
+    <file path="plugin/skills/rag-code-gen/SKILL.md">
+      Frontmatter: name, description (<250 chars per
+      CLAUDE.md rule), user-invocable: true, trigger phrases
+      like "grounded code", "ground this in attune", "use
+      attune docs". Body: when to route, what citations look
+      like.
+    </file>
+    <file path=".agents/skills/rag-code-gen/SKILL.md">
+      Mirror of plugin/skills version, synced via
+      scripts/sync_agents_skills.py.
+    </file>
+    <file path="docs/rag/index.md">
+      User-facing doc: what RAG does, how to invoke via
+      workflow/MCP/skill, sample citation output, feedback
+      kwarg.
+    </file>
+    <file path="plugin/help/generated/concepts/tool-rag-code-gen.md">
+      Concept doc generated via attune-author regenerate
+      flow.
+    </file>
+  </files-to-create>
+
+  <files-to-modify>
+    <file path="plugin/.claude-plugin/plugin.json">
+      <change location="skills array">
+        AFTER: register rag-code-gen skill.
+      </change>
+    </file>
+    <file path="README.md">
+      <change location="features list">
+        AFTER: add grounded code generation bullet with link
+        to docs/rag/index.md. Update badges only if stable
+        counts (tests, coverage) shift materially.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>Skill description len <250 chars</check>
+    <check>pytest tests/unit/plugins/test_plugin_reference_validation.py -v passes</check>
+    <check>pytest -k skill_synced -v passes</check>
+    <check>README renders correctly on GitHub (absolute URLs per lesson)</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Skill frontmatter field drift. Mitigation: use only
+      allowlisted fields per CLAUDE.md.
+    </risk>
+    <risk severity="low">
+      Website changes. Website edits live outside this repo;
+      scope is "add placeholder / stub" and reference the
+      website repo path for the human to complete.
+    </risk>
+  </risks>
+</task>
+
+<task id="4.3" name="version-bumps-across-packages">
+  <objective>
+    Bump versions: attune-rag 0.0.0 -> 0.1.0 (initial),
+    attune-ai <current> -> 6.0.0, attune-author 0.3.9 ->
+    0.4.0. Update all tracked files per the CLAUDE.md rule
+    that test_all_versions_match enforces. Add CHANGELOG
+    entries on attune-ai and attune-author.
+  </objective>
+
+  <context>
+    <existing-code path="CLAUDE.md">
+      Version bumps must update: pyproject.toml,
+      plugin/.claude-plugin/plugin.json,
+      plugin/.claude-plugin/marketplace.json (two fields),
+      plugin/core/__init__.py,
+      .claude-plugin/marketplace.json, .claude/CLAUDE.md
+      (header + footer).
+    </existing-code>
+  </context>
+
+  <files-to-modify>
+    <file path="pyproject.toml">
+      <change location="version">AFTER: 6.0.0</change>
+    </file>
+    <file path="plugin/.claude-plugin/plugin.json">
+      <change location="version">AFTER: 6.0.0</change>
+    </file>
+    <file path="plugin/.claude-plugin/marketplace.json">
+      <change location="metadata.version AND plugins[0].version">
+        AFTER: 6.0.0 in both.
+      </change>
+    </file>
+    <file path="plugin/core/__init__.py">
+      <change location="__version__">AFTER: 6.0.0</change>
+    </file>
+    <file path=".claude-plugin/marketplace.json">
+      <change location="root version">AFTER: 6.0.0</change>
+    </file>
+    <file path=".claude/CLAUDE.md">
+      <change location="header + footer">AFTER: 6.0.0</change>
+    </file>
+    <file path="CHANGELOG.md">
+      <change location="prepend">
+        AFTER: "## [6.0.0] - 2026-MM-DD - Grounded Code
+        Generation" with feature summary, new attune-rag
+        dep, migration note (no-op for non-RAG users),
+        breaking-change disclosure (none expected — this is
+        additive; 6.0.0 is communicative not technical).
+      </change>
+    </file>
+    <file path="packages/attune-author/pyproject.toml">
+      <change location="version">AFTER: 0.4.0</change>
+    </file>
+    <file path="packages/attune-author/CHANGELOG.md">
+      <change location="prepend">
+        AFTER: "## [0.4.0] - ... - Optional RAG grounding".
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>pytest tests/unit/test_plugin_config_validation.py::test_all_versions_match -v passes</check>
+    <check>uv lock --check passes</check>
+    <check>grep -r "&lt;old_version&gt;" . returns no results outside CHANGELOG history</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      Breaking-change disclosure on 6.0.0. This IS a major
+      bump even though additive — users should know why.
+      Mitigation: CHANGELOG spells out "major bump chosen
+      for communicative weight; no API removals or incompat
+      changes."
+    </risk>
+  </risks>
+</task>
+
+<task id="4.4" name="coordinated-publish">
+  <objective>
+    Publish in the correct order so version constraints
+    resolve: attune-rag first, then attune-ai, then
+    attune-author. Use GitHub Actions trusted publishing
+    (CLAUDE.md lesson about local twine 504s).
+  </objective>
+
+  <files-to-modify>
+    <file path=".github/workflows/publish-pypi.yml">
+      <change location="workflow">
+        AFTER: ensure workflow supports publishing from
+        packages/attune-rag/. May need a matrix or a new
+        workflow file. Preserve the "pypi" environment
+        manual approval gate per CLAUDE.md lesson.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <files-to-create>
+    <file path=".github/workflows/publish-attune-rag.yml">
+      Separate workflow if single-workflow matrix is too
+      complex. Trusted publishing via OIDC. Uses the same
+      "pypi" environment for manual approval.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>attune-rag 0.1.0 appears on pypi.org</check>
+    <check>attune-ai 6.0.0 resolves attune-rag>=0.1.0 from PyPI (not workspace)</check>
+    <check>attune-ai 6.0.0 appears on pypi.org</check>
+    <check>attune-author 0.4.0 appears on pypi.org with optional [rag] extra</check>
+    <check>pip install 'attune-ai[developer]' includes attune-rag transitively</check>
+    <check>pip install attune-author does NOT install attune-rag (optional)</check>
+  </validation>
+
+  <risks>
+    <risk severity="high">
+      Ordering: if attune-ai publishes first, users can't
+      install it (attune-rag 0.1.0 missing from PyPI).
+      Mitigation: publish attune-rag first, verify on PyPI,
+      THEN publish attune-ai. Coordinated manual approval.
+    </risk>
+    <risk severity="medium">
+      Trusted publishing environment gates each publish.
+      Expect to click "Approve" 3 times (CLAUDE.md lesson
+      about "pypi environment requires manual approval").
+    </risk>
+  </risks>
+</task>
+
+---
+
+## Out of Scope / Deferred
+
+- Re-ranker (cross-encoder): deferred until embeddings
+  decision is resolved.
+- PromptMixin integration across all attune-ai workflows:
+  follow-up spec once dedicated RAG workflow is stable.
+- Fine-tuning / RLHF loop on feedback data: separate spec.
+- attune-help changes: none in v1. If corpus loading exposes
+  a need for richer metadata (canonical feature names per
+  template), open a separate spec on attune-help.
+- Embeddings in attune-rag: gated on benchmark outcome
+  (task 2.5).
+
+---
+
+## Open Questions
+
+1. Does the attune-help team want corpus-level metadata
+   (canonical feature names, difficulty tags) added in a
+   future attune-help minor to improve retrieval quality?
+2. Should `confidence_from_history` be exposed in the MCP
+   tool response? Start model-only; surface to end users
+   only if feedback data shows it improves trust.
+3. How do we avoid retrieval feedback loops where bad
+   generations get marked "bad" and the same template is
+   then under-retrieved, hiding the real root cause
+   (retriever tuning)? Candidate mitigation: separate
+   "retrieval was correct" vs "generation was good"
+   feedback axes.
+4. Sync vs async in provider adapters. v0.1.0 ships async
+   only; watch for user demand before adding sync shims.
+5. Telemetry for external users of attune-rag. Do we want
+   anonymous retrieval metrics (hit count, fallback rate)?
+   Opt-in only; default off. Separate spec if we pursue.

--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,4 @@ src/attune/dashboard/static/react/
 # Dashboard frontend dev dependencies
 dashboard/node_modules/
 dashboard/dist/
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **RAG-grounded code generation (new `[rag]` optional
+  extra)** — install via `pip install 'attune-ai[rag]'` to
+  enable:
+    - New `rag-code-gen` workflow. Grounds LLM code
+      generation in the bundled attune-help corpus (633
+      templates) and returns `WorkflowResult` whose
+      `final_output` carries both the generated output and
+      a markdown `## Sources` block with clickable
+      citations to
+      github.com/Smart-AI-Memory/attune-help.
+    - New `rag_knowledge_query` MCP tool. Runs retrieval
+      and returns hits + an augmented prompt string ready
+      for any LLM; does NOT call an LLM itself.
+    - Optional `feedback="good"|"bad"` kwarg on the
+      workflow records verdicts against every cited
+      template via the existing `help/feedback.py`
+      machinery.
+    - Pipeline is LLM-agnostic and corpus-pluggable —
+      powered by the new standalone
+      [attune-rag](https://github.com/Smart-AI-Memory/attune-rag)
+      package on PyPI.
+- **`docs/rag/embeddings-decision-2026-04-17.md`** — written
+  record of the benchmark-gated embeddings decision
+  (keyword tuning first in a v0.1.x patch, `fastembed`
+  ONNX fallback in v0.2.0 only if tuning plateaus below the
+  70% P@1 gate). Prior caching lesson about
+  `sentence-transformers` clarified as applying to
+  semantic caching, not retrieval.
 - **Weekly cross-repo compat CI** — new
   `.github/workflows/cross-repo-compat.yml` pulls
   attune-help from its `main` branch every Monday and runs

--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ pip install 'attune-ai[developer]'
 # Minimal (CLI + workflows only)
 pip install attune-ai
 
+# With RAG-grounded code generation (rag-code-gen workflow
+# + rag_knowledge_query MCP tool; see "RAG grounding" below)
+pip install 'attune-ai[rag]'
+
 # All features
 pip install 'attune-ai[all]'
 
@@ -278,6 +282,31 @@ pip install 'attune-ai[all]'
 git clone https://github.com/Smart-AI-Memory/attune-ai.git
 cd attune-ai && pip install -e '.[dev]'
 ```
+
+### RAG grounding (optional)
+
+When installed with the `[rag]` extra, `attune-ai` gains:
+
+- **`rag-code-gen` workflow** — grounds LLM code generation in
+  the bundled attune-help corpus (633 templates) and emits a
+  `## Sources` block with clickable citations alongside the
+  generated output.
+- **`rag_knowledge_query` MCP tool** — returns retrieval hits
+  and an augmented prompt string ready to feed to any LLM.
+  Does not call an LLM itself.
+- **Optional feedback kwarg** — pass `feedback="good"|"bad"`
+  to the workflow to record verdicts against every cited
+  template for future tuning.
+
+The retrieval engine is the standalone
+[attune-rag](https://github.com/Smart-AI-Memory/attune-rag)
+package — LLM-agnostic and corpus-pluggable, usable on its
+own outside the attune-ai ecosystem.
+
+See [docs/rag/index.md](docs/rag/index.md) for the full
+walkthrough and
+[docs/rag/embeddings-decision-2026-04-17.md](docs/rag/embeddings-decision-2026-04-17.md)
+for the engineering decision record.
 
 ---
 

--- a/docs/rag/embeddings-decision-2026-04-17.md
+++ b/docs/rag/embeddings-decision-2026-04-17.md
@@ -1,0 +1,243 @@
+# Embeddings Decision (attune-rag v0.1.x / v0.2.0)
+
+**Date:** 2026-04-17
+**Decision gate:** Task 2.5 of the RAG grounding spec v4.0
+([.claude/plans/feature-rag-code-grounding-2026-04-17.md](../../.claude/plans/feature-rag-code-grounding-2026-04-17.md)).
+**Decision owner:** Patrick Roebuck.
+**Gate criteria (from spec):** Adopt embeddings only if
+delta precision@1 >= 15 pts AND install cost <50MB AND no
+new network dependency at import time.
+
+---
+
+## Decision
+
+**Sequence: keyword tuning first (v0.1.x), then
+`fastembed` fallback if the gate isn't met (v0.2.0).**
+
+1. **v0.1.x patch (next):** category-biased keyword
+   tuning in `KeywordRetriever`. Boost `concepts/` and
+   `quickstarts/`, penalize `errors/faqs/warnings/`. Zero
+   new deps. Re-run `python -m attune_rag.benchmark` and
+   commit the new baseline back to this doc.
+2. **v0.2.0 (conditional):** if v0.1.x clears the 70% P@1
+   gate, embeddings stay deferred indefinitely. If
+   v0.1.x plateaus, v0.2.0 ships `attune-rag[embeddings]`
+   using **`fastembed`** (ONNX-based local embeddings,
+   ~35MB install). **Not sentence-transformers.**
+3. **Independent track:** attune-help 0.6.0 metadata
+   enrichment (Approved Follow-up in the spec) is
+   pursued in parallel regardless of the embeddings
+   outcome, because it improves retrieval quality for
+   every retriever.
+
+---
+
+## Prior-lesson clarification
+
+The CLAUDE.md lesson cited in the original spec ("Anthropic's
+built-in prompt caching supersedes custom caching") was about
+**semantic caching**, not **RAG retrieval**. Those are
+different problems with different ROI profiles:
+
+- Semantic caching matches similar *queries* to cached
+  *responses* for cost savings. ROI is bounded by how often
+  attune workflow prompts happen to be similar in the wild.
+  In practice they rarely are (unique file paths, code
+  snippets, timestamps), so the ROI was measured at 0.4%.
+  Disabling it was correct.
+- RAG retrieval matches *queries* to *documents* for
+  grounding. ROI is bounded by how often semantic
+  similarity beats keyword overlap. Our benchmark below
+  shows this happens for 6/15 queries — the entire "hard"
+  bucket.
+
+Reusing the caching lesson to reject RAG embeddings would
+over-generalize. But the lesson does correctly rule out the
+specific `sentence-transformers` + `torch` stack (420MB
+install), which fails the <50MB gate regardless of ROI.
+
+---
+
+## Baseline (KeywordRetriever, attune-help 0.5.1)
+
+From `python -m attune_rag.benchmark` against
+`tests/golden/queries.yaml` (15 queries):
+
+| Metric | Value |
+|---|---|
+| Precision@1 | 53.33% (8/15) |
+| Recall@3 | 60.00% (9/15) |
+| Mean latency | 11.83 ms |
+| Max latency | ~48 ms |
+
+Breakdown:
+
+| Difficulty | P@1 | R@3 |
+|---|---|---|
+| Easy (5) | 4/5 (80%) | 5/5 (100%) |
+| Medium (4) | 4/4 (100%) | 4/4 (100%) |
+| Hard (6) | **0/6 (0%)** | **0/6 (0%)** |
+
+All six hard failures share a single pattern: lesson / error
+/ faq files whose filename contains the query keywords
+outrank the `concepts/` or `quickstarts/` file that actually
+explains the feature. Examples:
+
+- `"look for dangerous eval calls"` returns
+  `errors/bug-predict-dangerous-eval-flags-subprocess-exec.md`
+  instead of `concepts/tool-bug-predict.md` because
+  the error filename literally contains "dangerous-eval".
+- `"vulnerability scan"` returns
+  `errors/dependency-lower-bounds-trigger-scorecard-vulnerability-alerts.md`
+  for the same reason.
+- `"plan a new feature"` returns
+  `concepts/tool-refactor-plan.md` (keyword collision on
+  "plan") and three `errors/new-*` files.
+
+Root cause is corpus distribution: attune-help has 147 error
++ 144 faq + 105 warning files versus 43 concept + 41
+quickstart. Lesson files outnumber concept files ~4:1, so
+keyword matches land in lesson files disproportionately.
+
+---
+
+## Options considered
+
+### Option A — Keyword retriever tuning
+
+- **Install cost:** 0
+- **Network:** no
+- **Latency impact:** negligible
+- **Expected P@1 lift:** +10–25 pts (closes 3–4 of 6 hard
+  queries)
+- **Complexity:** ~20 LOC in `retrieval.py`, a few new
+  tests, class attrs for category weights
+
+Candidate changes:
+
+1. **Category-weighted scoring.** Multiply final score by
+   a per-category factor:
+   - `concepts/`, `quickstarts/`, `tasks/`: **1.5x**
+   - `references/`, `comparisons/`: 1.0x
+   - `tips/`, `notes/`, `troubleshooting/`: 0.9x
+   - `errors/`, `warnings/`, `faqs/`: **0.6x**
+2. **Strip long-filename boilerplate** before path
+   tokenizing. Error filenames like `bug-predict-
+   dangerous-eval-flags-subprocess-exec.md` dump lesson-
+   title tokens into the path-score channel, which should
+   really only reflect feature names.
+3. **Boost first-heading token overlap** instead of just
+   generic content overlap.
+
+Won't close the truly semantic gaps (`"plan a new feature"`
+vs `refactor-plan`), but will close the category-bias
+gaps.
+
+### Option B — `fastembed` (ONNX local embeddings)
+
+- **Install cost:** ~35MB (ONNX runtime + MiniLM model)
+- **Network:** no (after one-time model download at install)
+- **Latency impact:** ~30–80ms per query after warm-up;
+  ~1s cold-start to load the ONNX model
+- **Expected P@1 lift:** +25–40 pts (closes most / all 6
+  hard queries)
+- **Complexity:** new `EmbeddingRetriever` class,
+  pre-computed corpus embedding cache (~4MB), test
+  coverage for two retrievers, optional extra wiring.
+
+Why this over `sentence-transformers`:
+`sentence-transformers` carries the `torch` dep (~420MB),
+which fails the gate. `fastembed` was built specifically to
+avoid the torch tax — it ships ONNX models loaded via
+`onnxruntime`, which is ~10MB. Combined with a MiniLM model
+(~23MB), total install is ~35MB. Meets the gate.
+
+Why local over hosted:
+Hosted embeddings require a per-query network call, which
+technically satisfies the "no network at import time"
+language in the gate but introduces runtime network cost
+and provider churn. Local avoids both at the cost of install
+size. For a library whose default corpus is already bundled
+locally (attune-help), local embeddings are the right
+architectural fit.
+
+### Option C — Hosted embeddings
+
+- **Install cost:** ~1MB SDK dep per provider
+- **Network:** per query
+- **Latency impact:** 50–150ms network round trip
+- **Expected P@1 lift:** similar to Option B (semantic
+  similarity wins for the same reasons)
+- **Complexity:** provider adapters (matches existing
+  `attune_rag.providers.*` pattern), embedding cache
+  invalidation
+- **Ongoing:** provider churn (model renames, pricing)
+  + per-query API cost
+
+Considered but dispreferred vs Option B because network-at-
+query for a local corpus is a regression in operational
+posture. Kept on deck as a backup if fastembed hits quality
+issues on domains attune-help doesn't cover (multilingual,
+code-heavy, etc.).
+
+### Option D — `sentence-transformers`
+
+**Rejected.** 420MB install fails the <50MB gate. Retained
+for historical reference because it's the strategy
+cited in the caching lesson.
+
+---
+
+## Plan of record
+
+### Phase 2.5a (v0.1.x patch)
+
+- Implement category-biased keyword tuning per Option A
+- Re-run `attune-rag.benchmark`; append results section
+  below with before/after metrics
+- If 70% P@1 gate cleared → ship v0.1.1; close this doc
+  as RESOLVED
+- If plateau → proceed to Phase 2.5b
+
+### Phase 2.5b (v0.2.0, conditional)
+
+- Add `attune-rag[embeddings]` optional extra using
+  `fastembed` (option B)
+- Implement `EmbeddingRetriever` behind the same
+  `RetrieverProtocol` so callers can swap in via
+  `RagPipeline(retriever=EmbeddingRetriever())`
+- Ship corpus embedding cache (auto-built on first use,
+  stored in user cache dir)
+- Re-run benchmark with both retrievers; attach results
+- Document the <50MB gate as satisfied (measured install
+  size)
+- Keep keyword retriever as the default so zero-dep users
+  aren't affected
+
+### Pre-commitment on the 15-pt gate
+
+The gate for Phase 2.5b is:
+
+- **Precision@1 improvement >= 15 pts** over whatever
+  Phase 2.5a baseline we land
+- **Install cost < 50MB** measured via `du` on a fresh
+  venv with the extra
+- **No network dependency at import time** — model
+  download at install is fine; network calls during
+  `import attune_rag` are not
+
+Writing this BEFORE running embedding experiments so a
+later "we already spent X days on this" argument can't
+move the gate.
+
+---
+
+## Links
+
+- Spec: [feature-rag-code-grounding-2026-04-17.md](../../.claude/plans/feature-rag-code-grounding-2026-04-17.md)
+- Benchmark harness: [attune-rag / src/attune_rag/benchmark.py](https://github.com/Smart-AI-Memory/attune-rag/blob/main/src/attune_rag/benchmark.py)
+- Golden queries: [attune-rag / tests/golden/queries.yaml](https://github.com/Smart-AI-Memory/attune-rag/blob/main/tests/golden/queries.yaml)
+- `fastembed` project: https://github.com/qdrant/fastembed
+- Prior caching lesson: `.claude/CLAUDE.md` → "Anthropic's
+  built-in prompt caching supersedes custom caching"

--- a/docs/rag/embeddings-decision-2026-04-17.md
+++ b/docs/rag/embeddings-decision-2026-04-17.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-17
 **Decision gate:** Task 2.5 of the RAG grounding spec v4.0
-([.claude/plans/feature-rag-code-grounding-2026-04-17.md](../../.claude/plans/feature-rag-code-grounding-2026-04-17.md)).
+([.claude/plans/feature-rag-code-grounding-2026-04-17.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/.claude/plans/feature-rag-code-grounding-2026-04-17.md)).
 **Decision owner:** Patrick Roebuck.
 **Gate criteria (from spec):** Adopt embeddings only if
 delta precision@1 >= 15 pts AND install cost <50MB AND no
@@ -235,7 +235,7 @@ move the gate.
 
 ## Links
 
-- Spec: [feature-rag-code-grounding-2026-04-17.md](../../.claude/plans/feature-rag-code-grounding-2026-04-17.md)
+- Spec: [feature-rag-code-grounding-2026-04-17.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/.claude/plans/feature-rag-code-grounding-2026-04-17.md)
 - Benchmark harness: [attune-rag / src/attune_rag/benchmark.py](https://github.com/Smart-AI-Memory/attune-rag/blob/main/src/attune_rag/benchmark.py)
 - Golden queries: [attune-rag / tests/golden/queries.yaml](https://github.com/Smart-AI-Memory/attune-rag/blob/main/tests/golden/queries.yaml)
 - `fastembed` project: https://github.com/qdrant/fastembed

--- a/docs/rag/index.md
+++ b/docs/rag/index.md
@@ -1,0 +1,168 @@
+# RAG-grounded code generation
+
+Introduced in attune-ai v6.1.0 as the optional `[rag]`
+extra. Backed by the standalone
+[attune-rag](https://github.com/Smart-AI-Memory/attune-rag)
+package.
+
+## Install
+
+```bash
+pip install 'attune-ai[rag]'
+```
+
+This pulls in `attune-rag` and its bundled
+`[attune-help]` corpus (633 templates across concepts,
+quickstarts, tasks, references, errors, warnings, faqs,
+and more).
+
+## What it does
+
+When you ask for code, attune-rag retrieves the most
+relevant attune-help templates for your query, builds an
+augmented prompt that clearly separates grounding context
+from the user request, and feeds it to Claude. The output
+comes back with a `## Sources` section listing clickable
+links to every template that grounded the generation, so
+you can verify the output against the authoritative source.
+
+## Two surfaces
+
+### 1. `rag-code-gen` workflow
+
+```bash
+attune workflow run rag-code-gen \
+  --input '{"query": "how do I run a security audit?"}'
+```
+
+Returns a `WorkflowResult` whose `final_output` includes:
+
+- The generated code or explanation
+- A `## Sources` block with markdown links to the attune-help
+  templates that grounded the answer
+
+Kwargs:
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `query` | str | required | Your coding request |
+| `k` | int | 3 | Max grounding docs to retrieve |
+| `depth` | str | `standard` | `quick` / `standard` / `deep`. Controls max_turns + budget. |
+| `feedback` | str | `None` | `good` / `bad`. Records verdict against every cited template via `help/feedback.py`. |
+| `model` | str | `None` | Optional model override |
+
+### 2. `rag_knowledge_query` MCP tool
+
+For use from Claude Code or any MCP client. Returns
+retrieval hits + an augmented prompt string. **Does not
+call an LLM** — you or your agent do that separately.
+
+```json
+{
+  "name": "rag_knowledge_query",
+  "arguments": {
+    "query": "how do I run a security audit?",
+    "k": 3
+  }
+}
+```
+
+Returns:
+
+```json
+{
+  "success": true,
+  "fallback_used": false,
+  "confidence": 1.0,
+  "elapsed_ms": 58.0,
+  "corpus": "attune-help",
+  "retriever": "KeywordRetriever",
+  "augmented_prompt": "### CONTEXT...\n### USER REQUEST...",
+  "hits": [
+    {
+      "template_path": "concepts/tool-security-audit.md",
+      "category": "concepts",
+      "score": 9.0,
+      "excerpt": "Security audit scans for vulnerabilities..."
+    }
+  ]
+}
+```
+
+## Graceful behavior when the extra isn't installed
+
+Without `pip install 'attune-ai[rag]'`:
+
+- The `rag-code-gen` workflow still loads but
+  `execute()` returns a `WorkflowResult` with
+  `success=False` and a clear "install
+  attune-ai\[rag\]" hint
+- The `rag_knowledge_query` MCP tool remains registered in
+  the schema; the handler returns a structured
+  `{success: false, error, cause}` dict pointing at the
+  install command
+
+No exception propagates to the CLI or MCP dispatcher.
+
+## Feedback and learning
+
+If you pass `feedback="good"` or `feedback="bad"` to
+`rag-code-gen`, the workflow calls
+`attune.help.feedback.record_template_feedback` for every
+cited template. These verdicts feed `get_template_confidence`
+so future grounding can bias toward historically-good
+templates. Silent usage does not record anything.
+
+## Baseline retrieval quality
+
+See the benchmark harness at
+[github.com/Smart-AI-Memory/attune-rag](https://github.com/Smart-AI-Memory/attune-rag/blob/main/tests/golden/queries.yaml)
+and the decision record at
+[embeddings-decision-2026-04-17.md](embeddings-decision-2026-04-17.md).
+
+Baseline (keyword retriever, 15 golden queries against
+attune-help 0.5.1):
+
+| Difficulty | Precision@1 | Recall@3 |
+|---|---|---|
+| Easy (5) | 80% | 100% |
+| Medium (4) | 100% | 100% |
+| Hard (6) | 0% | 0% |
+| Overall | 53% | 60% |
+
+The hard queries all fail with the same pattern —
+lesson/error files with query keywords in their filenames
+outrank the concept files that answer the question.
+Targeted fix is category-biased keyword weighting
+(planned for attune-rag v0.1.x); local ONNX embeddings
+via `fastembed` are queued as a v0.2.0 fallback if
+tuning plateaus below 70% P@1.
+
+## Using attune-rag standalone
+
+attune-rag is LLM-agnostic and corpus-pluggable. You can
+use it outside attune-ai with any LLM:
+
+```bash
+pip install 'attune-rag[attune-help,claude]'
+```
+
+```python
+import asyncio
+from attune_rag import RagPipeline
+
+async def main():
+    pipeline = RagPipeline()  # defaults to AttuneHelpCorpus
+    response, result = await pipeline.run_and_generate(
+        "How do I run a security audit with attune?",
+        provider="claude",
+    )
+    print(response)
+    print("Sources:", [h.template_path for h in result.citation.hits])
+
+asyncio.run(main())
+```
+
+See the [attune-rag README](https://github.com/Smart-AI-Memory/attune-rag#readme)
+for OpenAI and Gemini quickstarts and for using your own
+markdown corpus.

--- a/packages/attune-rag/README.md
+++ b/packages/attune-rag/README.md
@@ -1,0 +1,34 @@
+# attune-rag — lives in its own repo
+
+The `attune-rag` Python package has its own dedicated repo:
+
+- **GitHub:** https://github.com/Smart-AI-Memory/attune-rag
+- **PyPI:** https://pypi.org/project/attune-rag/
+
+Install from PyPI:
+
+```bash
+pip install 'attune-rag'                   # core (no LLM SDK)
+pip install 'attune-rag[attune-help]'      # + bundled help corpus
+pip install 'attune-rag[claude]'           # + Claude adapter
+pip install 'attune-rag[openai]'           # + OpenAI adapter
+pip install 'attune-rag[gemini]'           # + Gemini adapter
+pip install 'attune-rag[all]'              # everything
+```
+
+For local editable development from this monorepo, the
+sibling-clone layout is configured in this repo's
+`pyproject.toml` under `[tool.uv.sources]`:
+
+```toml
+[tool.uv.sources]
+attune-rag = { path = "../attune-rag", editable = true }
+```
+
+Clone the package repo as a sibling of `attune-ai` to
+enable editable cross-repo development:
+
+```bash
+cd /path/to/parent-of-attune-ai
+git clone https://github.com/Smart-AI-Memory/attune-rag.git
+```

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "6.0.0"
+    "version": "6.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "6.0.0"
+__version__ = "6.1.0"

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -77,6 +77,7 @@ intent so Claude matches the right skill:
 | memory-and-context | memory, store, retrieve, empathy |
 | workflow-orchestration | workflow, run, analyze |
 | spec | spec-driven dev, brainstorm and execute |
+| rag-code-gen | grounded code, cite sources, verify against attune (needs `[rag]` extra) |
 | coach | coach, learn, explain, tell me more, deeper |
 
 ## MCP Server Not Running

--- a/plugin/skills/rag-code-gen/SKILL.md
+++ b/plugin/skills/rag-code-gen/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: rag-code-gen
+description: "RAG-grounded code generation with source citations. Triggers on: grounded code, ground this, cite sources, show me with sources, how do I with attune, reference attune docs, verify against attune."
+argument-hint: "<what you want generated + any specifics>"
+---
+
+# RAG-grounded code generation
+
+Requires the `[rag]` extra (`pip install 'attune-ai[rag]'`).
+Grounds code generation in the attune-help template corpus
+so outputs cite real APIs, workflow names, and patterns
+instead of hallucinating them. Every output ends with a
+`## Sources` block of clickable citations.
+
+## Scoping
+
+Before running, ask:
+
+1. **What are you trying to produce?** Code, config,
+   explanation, or a mix?
+2. **Any specific attune surface?** e.g. "the
+   security-audit workflow", "MCP tool pattern", "BaseWorkflow
+   subclass". Helps retrieval hit the right concept file.
+3. **Depth?** Default is `standard`. `quick` saves time
+   and budget for simple asks; `deep` is for complex
+   multi-file or architectural questions.
+
+## Running
+
+```
+attune workflow run rag-code-gen \
+  --input '{"query": "<the request>"}'
+```
+
+Optional inputs:
+
+- `k` — max grounding docs to retrieve (default 3)
+- `depth` — `quick` / `standard` / `deep`
+- `feedback` — pass `good` or `bad` AFTER inspecting the
+  output to record a verdict against every cited template
+- `model` — override the generator model if you need to
+
+## Output shape
+
+`WorkflowResult.final_output` is a string with two parts:
+
+1. The generated code / explanation
+2. A `## Sources` section listing each cited
+   `attune-help` template with its category, retrieval
+   score, and a clickable link to the source on GitHub
+
+`WorkflowResult.metadata` carries the full citation dict
+(`query`, `retriever_name`, `retrieved_at`, `hits[]`) plus
+`fallback_used` and `confidence` so callers can make
+routing decisions.
+
+## When RAG doesn't help
+
+If the retriever can't find relevant templates, the
+workflow still runs — it falls back to an unaugmented
+prompt that explicitly tells the model there is NO
+grounding context so it should say "I don't know about
+attune X" rather than invent. `metadata.fallback_used` is
+`True` in that case.
+
+## Alternative: MCP tool only (no LLM call)
+
+If you want just retrieval without generation, use the
+`rag_knowledge_query` MCP tool directly. It returns hits +
+an augmented prompt string without calling an LLM itself —
+handy for routing decisions, agent planning, or feeding
+another model.
+
+## If the extra isn't installed
+
+The workflow returns a structured error pointing at
+`pip install 'attune-ai[rag]'`. No exception propagates.
+
+## See also
+
+- [docs/rag/index.md](../../docs/rag/index.md) — full
+  walkthrough including the standalone attune-rag usage
+- [attune-rag on PyPI](https://pypi.org/project/attune-rag/)
+- [Embeddings decision record](../../docs/rag/embeddings-decision-2026-04-17.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "6.0.0"
+version = "6.1.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,11 @@ dependencies = [
     "langsmith>=0.7.31,<2.0.0",  # GHSA-rr7j-v2q5-chgv (transitive via langchain-core)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "attune-help>=0.5.1,<0.6",  # Progressive-depth help runtime + MCP tools. Upper cap: pre-1.0 minor bumps may break.
-    "attune-rag>=0.1.0,<0.2",  # LLM-agnostic RAG pipeline. Powers rag-code-gen workflow + rag_knowledge_query MCP tool. Upper cap: pre-1.0 minor bumps may break.
+    # NOTE: attune-rag is an OPTIONAL extra, not a core dep.
+    #  Install with `pip install 'attune-ai[rag]'` to enable
+    #  the rag-code-gen workflow and rag_knowledge_query MCP
+    #  tool. Workflows/handlers lazy-import and return a
+    #  structured error when the extra is absent.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
     # NOTE: redis moved to [memory] optional - not needed for CLI/skill usage
@@ -82,6 +86,15 @@ dependencies = [
 # The "Crew" workflows use EmpathyLLMExecutor (Anthropic SDK) directly.
 
 [project.optional-dependencies]
+# RAG-grounded code generation (rag-code-gen workflow +
+# rag_knowledge_query MCP tool). Optional so users who
+# don't want grounding avoid the dep. Once attune-rag is
+# on PyPI, no further work needed — this extra resolves
+# from PyPI.
+rag = [
+    "attune-rag>=0.1.0,<0.2",
+]
+
 # Memory subsystem (requires Redis server 8.4+ recommended)
 memory = [
     "redis>=5.0.0,<8.0.0",  # redis-py 5.x-7.x for Redis server 8.4 support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -689,4 +689,9 @@ exclude_lines = [
 # attune-help is now a PyPI dependency (no source override needed).
 [tool.uv.sources]
 attune-author = { path = "../attune-author", editable = true }
-attune-rag = { path = "../attune-rag", editable = true }
+# attune-rag source override intentionally omitted until
+# PyPI publish. uv sync in CI can't resolve a missing
+# sibling path; local devs who want [rag] should run:
+#   pip install -e ../attune-rag/
+# after cloning the sibling repo and before running the
+# rag-tagged tests locally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -675,3 +675,4 @@ exclude_lines = [
 # attune-help is now a PyPI dependency (no source override needed).
 [tool.uv.sources]
 attune-author = { path = "../attune-author", editable = true }
+attune-rag = { path = "../attune-rag", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
     "langsmith>=0.7.31,<2.0.0",  # GHSA-rr7j-v2q5-chgv (transitive via langchain-core)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "attune-help>=0.5.1,<0.6",  # Progressive-depth help runtime + MCP tools. Upper cap: pre-1.0 minor bumps may break.
+    "attune-rag>=0.1.0,<0.2",  # LLM-agnostic RAG pipeline. Powers rag-code-gen workflow + rag_knowledge_query MCP tool. Upper cap: pre-1.0 minor bumps may break.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
     # NOTE: redis moved to [memory] optional - not needed for CLI/skill usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,11 @@ dev = [
     "httpx>=0.27.0,<1.0.0",  # For API testing
     "fastapi>=0.109.1,<1.0.0",  # For wizard API tests
     "requests>=2.28.0,<3.0.0",  # For notification tests
+    # RAG integration test coverage — attune-rag is an
+    # optional runtime dep but required for the rag_code_gen
+    # and rag_knowledge_query test paths to exercise their
+    # branches (rag tests use pytest.importorskip).
+    "attune-rag>=0.1.0,<0.2",
 ]
 
 # Individual developers - lightweight, software development focused

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -265,6 +265,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             "research_synthesis": self._run_research_synthesis,
             "analyze_batch": self._run_analyze_batch,
             "analyze_image": self._run_analyze_image,
+            "rag_knowledge_query": self._run_rag_knowledge_query,
             "auth_status": lambda _args: self._get_auth_status(),
             "auth_recommend": self._get_auth_recommend,
             "telemetry_stats": self._get_telemetry_stats,

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -231,6 +231,30 @@ def get_workflow_tools() -> dict[str, dict[str, Any]]:
                 "required": ["image_path"],
             },
         },
+        "rag_knowledge_query": {
+            "description": (
+                "Query the RAG knowledge corpus (attune-help by default) for "
+                "a given question. Returns ranked hits plus an augmented "
+                "prompt string ready to feed to any LLM. Does NOT call an "
+                "LLM itself — use the rag-code-gen workflow for end-to-end "
+                "generation."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The question or request to ground against the corpus",
+                    },
+                    "k": {
+                        "type": "integer",
+                        "description": "Max hits to return (1-10)",
+                        "default": 3,
+                    },
+                },
+                "required": ["query"],
+            },
+        },
     }
 
 

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -586,7 +586,14 @@ class WorkflowHandlersMixin:
         try:
             from attune_rag import RagPipeline
         except ImportError as exc:
-            return {"success": False, "error": f"attune-rag unavailable: {exc}"}
+            return {
+                "success": False,
+                "error": (
+                    "rag_knowledge_query requires the [rag] extra. "
+                    "Install with: pip install 'attune-ai[rag]'"
+                ),
+                "cause": str(exc),
+            }
 
         try:
             pipeline = RagPipeline()

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -554,3 +554,68 @@ class WorkflowHandlersMixin:
             # INTENTIONAL: Vision analysis is best-effort
             logger.exception("Image analysis failed")
             return {"success": False, "error": "Image analysis failed"}
+
+    async def _run_rag_knowledge_query(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Query the RAG corpus and return hits + augmented prompt.
+
+        Does NOT call an LLM. Callers feed the augmented prompt
+        to whatever LLM they want (or use the rag-code-gen
+        workflow for end-to-end generation).
+
+        Args:
+            args: ``query`` (str, required) and ``k`` (int,
+                optional, default 3, 1-10).
+
+        Returns:
+            Dict with ``fallback_used``, ``confidence``,
+            ``elapsed_ms``, ``corpus``, ``retriever``,
+            ``augmented_prompt``, and ``hits`` (list of
+            path/category/score/excerpt).
+        """
+        query = args.get("query", "")
+        if not query or not isinstance(query, str) or not query.strip():
+            return {"success": False, "error": "query is required"}
+
+        try:
+            k = int(args.get("k", 3))
+        except (TypeError, ValueError):
+            return {"success": False, "error": "k must be an integer"}
+        if k < 1 or k > 10:
+            return {"success": False, "error": "k must be between 1 and 10"}
+
+        try:
+            from attune_rag import RagPipeline
+        except ImportError as exc:
+            return {"success": False, "error": f"attune-rag unavailable: {exc}"}
+
+        try:
+            pipeline = RagPipeline()
+            result = pipeline.run(query, k=k)
+        except RuntimeError as exc:
+            # Typical cause: AttuneHelpCorpus can't find the
+            # [attune-help] extra. Return a structured error.
+            return {"success": False, "error": f"RAG setup error: {exc}"}
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: best-effort — return structured error
+            logger.exception("RAG knowledge query failed")
+            return {"success": False, "error": "RAG query failed"}
+
+        return {
+            "success": True,
+            "query": query,
+            "fallback_used": result.fallback_used,
+            "confidence": result.confidence,
+            "elapsed_ms": result.elapsed_ms,
+            "corpus": pipeline.corpus.name,
+            "retriever": type(pipeline.retriever).__name__,
+            "augmented_prompt": result.augmented_prompt,
+            "hits": [
+                {
+                    "template_path": hit.template_path,
+                    "category": hit.category,
+                    "score": hit.score,
+                    "excerpt": hit.excerpt,
+                }
+                for hit in result.citation.hits
+            ],
+        }

--- a/src/attune/workflows/__init__.py
+++ b/src/attune/workflows/__init__.py
@@ -75,6 +75,7 @@ if TYPE_CHECKING:
     from .orchestrated_health_check import HealthCheckReport, OrchestratedHealthCheckWorkflow
     from .orchestrated_release_prep import OrchestratedReleasePrepWorkflow, ReleaseReadinessReport
     from .perf_audit import PerformanceAuditWorkflow
+    from .rag_code_gen import RagCodeGenWorkflow
     from .refactor_plan import RefactorPlanWorkflow
 
     # RefactorPlanAgentSDKWorkflow: Merged into RefactorPlanWorkflow (v4.2.0)
@@ -164,6 +165,7 @@ _LAZY_WORKFLOW_IMPORTS: dict[str, tuple[str, str]] = {
     "ResearchSynthesisWorkflow": (".research_synthesis", "ResearchSynthesisWorkflow"),
     "SecureReleasePipeline": (".secure_release", "SecureReleasePipeline"),
     "SecureReleaseResult": (".secure_release", "SecureReleaseResult"),
+    "RagCodeGenWorkflow": (".rag_code_gen", "RagCodeGenWorkflow"),
     "SecurityAuditWorkflow": (".security_audit", "SecurityAuditWorkflow"),
     "SimplifyCodeWorkflow": (".simplify_code", "SimplifyCodeWorkflow"),
     # TestCoverageBoostCrew removed (deprecated, use ParallelTestGenerationWorkflow)
@@ -285,6 +287,7 @@ _DEFAULT_WORKFLOW_NAMES: dict[str, str] = {
     # Analysis workflows
     "bug-predict": "BugPredictionWorkflow",
     "security-audit": "SecurityAuditWorkflow",
+    "rag-code-gen": "RagCodeGenWorkflow",
     "perf-audit": "PerformanceAuditWorkflow",
     # Generation workflows
     "test-audit": "TestAuditWorkflow",
@@ -616,6 +619,7 @@ __all__ = [
     "NextAction",
     "OrchestratorResult",
     "PerformanceAuditWorkflow",
+    "RagCodeGenWorkflow",
     "RefactorPlanWorkflow",
     "ReleasePreparationWorkflow",
     # Workflow implementations

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -98,8 +98,13 @@ class RagCodeGenWorkflow(BaseWorkflow):
 
     def _get_pipeline(self) -> Any:
         if self._pipeline is None:
-            from attune_rag import RagPipeline
-
+            try:
+                from attune_rag import RagPipeline
+            except ImportError as exc:
+                raise RuntimeError(
+                    "The rag-code-gen workflow requires the [rag] extra. "
+                    "Install with: pip install 'attune-ai[rag]'"
+                ) from exc
             self._pipeline = RagPipeline()
         return self._pipeline
 

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -1,0 +1,259 @@
+"""RAG-Grounded Code Generation Workflow.
+
+Retrieves context from a RAG corpus (attune-help by default)
+and feeds an augmented prompt to a single Claude Agent SDK
+call, returning a ``WorkflowResult`` whose ``final_output``
+carries both the generated code and markdown-formatted source
+citations for provenance.
+
+Unlike the security / code-review workflows, this workflow
+uses a single agent (no subagents) — the SDK call does the
+generation, and retrieval is handled synchronously before
+the call by ``attune_rag.RagPipeline``.
+
+Copyright 2025-2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import claude_agent_sdk
+
+from .agent_sdk_adapter import (
+    AgentRunResult,
+    AgentSDKResultAdapter,
+    build_result_text,
+    collect_agent_output,
+    get_max_budget_usd,
+)
+from .base import BaseWorkflow, ModelTier
+from .data_classes import WorkflowResult
+
+logger = logging.getLogger(__name__)
+
+
+_SYSTEM_PROMPT = (
+    "You generate code and explanations grounded in the attune "
+    "ecosystem. Use the provided context to cite real APIs, "
+    "workflow names, and CLI commands. Never invent attune "
+    "features. When referencing a pattern, note the source file "
+    "it came from."
+)
+
+
+_DEPTH_MAX_TURNS: dict[str, int] = {
+    "quick": 6,
+    "standard": 12,
+    "deep": 24,
+}
+
+
+class RagCodeGenWorkflow(BaseWorkflow):
+    """SDK-native RAG-grounded code generation workflow.
+
+    Retrieves grounding context from the configured RAG corpus,
+    feeds the augmented prompt to a single Claude Agent SDK
+    call, and returns a ``WorkflowResult`` with the generated
+    output followed by a markdown ``## Sources`` block.
+
+    Usage::
+
+        workflow = RagCodeGenWorkflow()
+        result = await workflow.execute(
+            query="how do I run a security audit?",
+        )
+
+    Supported kwargs:
+        query (str): Required. The user's coding request.
+        k (int): Number of grounding docs to retrieve. Default 3.
+        depth (str): "quick" | "standard" | "deep". Default
+            "standard". Controls max_turns and budget.
+        feedback (str): "good" | "bad". Optional. When set,
+            records feedback on every cited template via
+            ``record_template_feedback`` (Phase 4.1).
+        model (str): Optional model override for generation.
+    """
+
+    name = "rag-code-gen"
+    description = "RAG-grounded code generation with source citations"
+    stages = ["retrieve", "generate"]
+    tier_map = {
+        "retrieve": ModelTier.CHEAP,  # retrieval is zero-LLM; CHEAP is a tag
+        "generate": ModelTier.CAPABLE,
+    }
+
+    # Base URL used for clickable citation links. Points at the
+    # attune-help repo so users can inspect the source template.
+    _CITATION_BASE_URL = (
+        "https://github.com/Smart-AI-Memory/attune-help/blob/main/src/attune_help/templates"
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._pipeline: Any = None  # lazy init on first execute
+
+    def _get_pipeline(self) -> Any:
+        if self._pipeline is None:
+            from attune_rag import RagPipeline
+
+            self._pipeline = RagPipeline()
+        return self._pipeline
+
+    async def execute(self, **kwargs: Any) -> WorkflowResult:
+        query: str = kwargs.get("query", "")
+        k: int = int(kwargs.get("k", 3))
+        depth: str = kwargs.get("depth", "standard")
+        feedback: str | None = kwargs.get("feedback")
+        model: str | None = kwargs.get("model")
+
+        if not query or not query.strip():
+            return self._error_result("query argument is required")
+
+        max_turns = _DEPTH_MAX_TURNS.get(depth, 12)
+        started_at = datetime.now()
+
+        try:
+            pipeline = self._get_pipeline()
+            rag_result = pipeline.run(query, k=k)
+        except RuntimeError as exc:
+            logger.error("RAG pipeline setup failed: %s", exc)
+            return self._error_result(f"RAG setup error: {exc}")
+
+        try:
+            run_result = await self._run_agent_generate(
+                augmented_prompt=rag_result.augmented_prompt,
+                max_turns=max_turns,
+                depth=depth,
+                model=model,
+            )
+        except ImportError as exc:
+            logger.error("Agent SDK import failed: %s", exc)
+            return self._error_result(f"Agent SDK unavailable: {exc}")
+        except (ConnectionError, TimeoutError) as exc:
+            logger.error("Agent SDK network error: %s", exc)
+            return self._error_result(f"Agent SDK connection failed: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            # INTENTIONAL: Catch-all for unknown SDK errors so we
+            # return a structured WorkflowResult rather than
+            # crashing the CLI.
+            logger.exception(
+                "RAG generation failed: %s",
+                type(exc).__name__,
+            )
+            return self._error_result(f"Agent SDK error: {type(exc).__name__}: {exc}")
+
+        completed_at = datetime.now()
+
+        # Append markdown citations to the generated output so the
+        # user sees provenance in the same blob as the code.
+        from attune_rag.provenance import format_citations_markdown
+
+        citations_md = format_citations_markdown(
+            rag_result.citation,
+            base_url=self._CITATION_BASE_URL,
+        )
+        combined_text = (run_result.result_text or "") + "\n\n" + citations_md
+
+        # Optional feedback integration (Phase 4.1 hook). Uses the
+        # existing help/feedback.py machinery to record the user's
+        # verdict against each cited template.
+        if feedback in ("good", "bad"):
+            self._record_feedback(rag_result, feedback)
+
+        # Build citation dict for metadata (JSON-serializable).
+        citation_dict = {
+            "query": rag_result.citation.query,
+            "retriever_name": rag_result.citation.retriever_name,
+            "retrieved_at": rag_result.citation.retrieved_at.isoformat(),
+            "hits": [
+                {
+                    "template_path": hit.template_path,
+                    "category": hit.category,
+                    "score": hit.score,
+                }
+                for hit in rag_result.citation.hits
+            ],
+        }
+
+        wf_result = AgentSDKResultAdapter.from_agent_output(
+            result_text=combined_text,
+            subagent_names=["rag-generator"],
+            started_at=started_at,
+            completed_at=completed_at,
+            metadata={
+                "query": query,
+                "depth": depth,
+                "max_turns": max_turns,
+                "citation": citation_dict,
+                "fallback_used": rag_result.fallback_used,
+                "confidence": rag_result.confidence,
+                "retrieval_ms": rag_result.elapsed_ms,
+                "feedback_recorded": feedback if feedback in ("good", "bad") else None,
+            },
+            agent_run_result=run_result,
+        )
+        return wf_result
+
+    async def _run_agent_generate(
+        self,
+        augmented_prompt: str,
+        max_turns: int,
+        depth: str,
+        model: str | None,
+    ) -> AgentRunResult:
+        """Run a single Claude Agent SDK generation call.
+
+        Returns the raw ``AgentRunResult`` so the caller can
+        fold metadata into a ``WorkflowResult``.
+        """
+        assistant_parts: list[str] = []
+        result_parts: list[str] = []
+        run_result = AgentRunResult(result_text="No results returned.")
+
+        options_kwargs: dict[str, Any] = {
+            "system_prompt": _SYSTEM_PROMPT,
+            "max_budget_usd": get_max_budget_usd(depth),
+            "allowed_tools": ["Read", "Glob", "Grep"],
+            "permission_mode": "default",
+            "max_turns": max_turns,
+        }
+        if model:
+            options_kwargs["model"] = model
+
+        async for message in claude_agent_sdk.query(
+            prompt=augmented_prompt,
+            options=claude_agent_sdk.ClaudeAgentOptions(**options_kwargs),
+        ):
+            sdk_result = collect_agent_output(message, assistant_parts, result_parts)
+            if sdk_result is not None:
+                run_result = sdk_result
+        run_result.result_text = build_result_text(assistant_parts, result_parts)
+        return run_result
+
+    def _record_feedback(self, rag_result: Any, verdict: str) -> None:
+        """Record good/bad feedback against each cited template.
+
+        Best-effort — never fails the workflow if the feedback
+        backend is unavailable.
+        """
+        try:
+            from attune.help.feedback import record_template_feedback
+        except ImportError:
+            logger.info("help.feedback unavailable; skipping feedback record")
+            return
+
+        for hit in rag_result.citation.hits:
+            try:
+                record_template_feedback(hit.template_path, verdict)
+            except Exception:  # noqa: BLE001
+                # INTENTIONAL: feedback recording is best-effort;
+                # a single failed write should not fail the whole
+                # workflow. Log and continue.
+                logger.exception(
+                    "Failed to record feedback for template: %s",
+                    hit.template_path,
+                )

--- a/tests/integration/rag/test_rag_workflow.py
+++ b/tests/integration/rag/test_rag_workflow.py
@@ -1,0 +1,227 @@
+"""Integration tests for RagCodeGenWorkflow.
+
+The Claude Agent SDK is mocked so tests don't hit the
+network. The RAG pipeline is exercised end-to-end against
+an in-memory corpus to prove retrieval -> prompt assembly
+-> workflow-result wiring works.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterable
+from unittest.mock import patch
+
+import pytest
+
+from attune.workflows.rag_code_gen import RagCodeGenWorkflow
+
+pytest_plugins: list[str] = []
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: in-memory corpus + mocked Claude Agent SDK stream
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_corpus():
+    from attune_rag import RetrievalEntry
+    from attune_rag.corpus.base import CorpusProtocol
+
+    class _FakeCorpus(CorpusProtocol):
+        def __init__(self) -> None:
+            self._entries = {
+                "concepts/tool-security-audit.md": RetrievalEntry(
+                    path="concepts/tool-security-audit.md",
+                    category="concepts",
+                    content="Security audit scans for vulnerabilities.",
+                    summary="Run a security audit",
+                ),
+                "concepts/other.md": RetrievalEntry(
+                    path="concepts/other.md",
+                    category="concepts",
+                    content="Unrelated content.",
+                ),
+            }
+
+        def entries(self) -> Iterable:
+            return tuple(self._entries.values())
+
+        def get(self, path: str):
+            return self._entries.get(path)
+
+        @property
+        def name(self) -> str:
+            return "fake-corpus"
+
+        @property
+        def version(self) -> str:
+            return "test-1"
+
+    return _FakeCorpus()
+
+
+def _make_assistant_message(text: str):
+    """Build a real claude_agent_sdk.AssistantMessage so the
+    isinstance checks in collect_agent_output pass."""
+    import claude_agent_sdk
+
+    return claude_agent_sdk.AssistantMessage(
+        content=[claude_agent_sdk.types.TextBlock(text=text)],
+        model="claude-sonnet-4-6",
+        parent_tool_use_id=None,
+    )
+
+
+def _make_result_message(result: str | None = None):
+    import claude_agent_sdk
+
+    return claude_agent_sdk.ResultMessage(
+        subtype="success",
+        duration_ms=250,
+        duration_api_ms=200,
+        is_error=False,
+        num_turns=1,
+        session_id="test-session",
+        total_cost_usd=0.001,
+        usage={"input_tokens": 100, "output_tokens": 50},
+        result=result,
+        structured_output=None,
+    )
+
+
+def _make_fake_sdk_stream(
+    generated_text: str = "Here is your grounded code.",
+) -> AsyncIterator:
+    """Yields a minimal assistant + result message pair."""
+
+    async def stream(*args, **kwargs):  # noqa: ARG001
+        yield _make_assistant_message(generated_text)
+        yield _make_result_message(result=None)
+
+    return stream
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _patch_default_corpus(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the workflow's pipeline to use an in-memory corpus."""
+    from attune_rag import pipeline
+
+    monkeypatch.setattr(pipeline.RagPipeline, "_default_corpus", staticmethod(_make_fake_corpus))
+
+
+def test_execute_returns_workflow_result_with_citations() -> None:
+    workflow = RagCodeGenWorkflow()
+    fake_stream = _make_fake_sdk_stream("Here is your grounded code snippet.")
+
+    with patch("attune.workflows.rag_code_gen.claude_agent_sdk.query", fake_stream):
+        result = asyncio.run(workflow.execute(query="security audit"))
+
+    assert result.success is True
+    assert result.error is None
+    assert "grounded code snippet" in str(result.final_output)
+    # Metadata carries the citation dict
+    assert "citation" in result.metadata
+    citation = result.metadata["citation"]
+    assert citation["retriever_name"] == "KeywordRetriever"
+    assert any("security-audit" in h["template_path"] for h in citation["hits"])
+
+
+def test_execute_emits_sources_block_in_output() -> None:
+    workflow = RagCodeGenWorkflow()
+    fake_stream = _make_fake_sdk_stream("generated answer")
+
+    with patch("attune.workflows.rag_code_gen.claude_agent_sdk.query", fake_stream):
+        result = asyncio.run(workflow.execute(query="security audit"))
+
+    output = str(result.final_output)
+    assert "## Sources" in output
+
+
+def test_execute_empty_query_returns_error_result() -> None:
+    workflow = RagCodeGenWorkflow()
+    result = asyncio.run(workflow.execute(query=""))
+    assert result.success is False
+    assert result.error is not None
+    assert "query" in result.error.lower()
+
+
+def test_fallback_when_no_matching_context() -> None:
+    workflow = RagCodeGenWorkflow()
+    fake_stream = _make_fake_sdk_stream("I don't know about that.")
+
+    with patch("attune.workflows.rag_code_gen.claude_agent_sdk.query", fake_stream):
+        result = asyncio.run(workflow.execute(query="zzzzz asdfgh qwerty"))
+
+    assert result.success is True
+    assert result.metadata["fallback_used"] is True
+    assert result.metadata["confidence"] == 0.0
+    # No citations when fallback was used
+    assert result.metadata["citation"]["hits"] == []
+    # "No grounding sources" message still appears in output
+    assert "No grounding sources" in str(result.final_output)
+
+
+def test_depth_controls_max_turns() -> None:
+    workflow = RagCodeGenWorkflow()
+    fake_stream = _make_fake_sdk_stream("result")
+
+    with patch("attune.workflows.rag_code_gen.claude_agent_sdk.query", fake_stream):
+        result = asyncio.run(workflow.execute(query="security audit", depth="deep"))
+    assert result.metadata["max_turns"] == 24
+
+    with patch("attune.workflows.rag_code_gen.claude_agent_sdk.query", fake_stream):
+        result = asyncio.run(workflow.execute(query="security audit", depth="quick"))
+    assert result.metadata["max_turns"] == 6
+
+
+def test_feedback_kwarg_recorded() -> None:
+    """feedback='good' fires record_template_feedback for each cited template."""
+    workflow = RagCodeGenWorkflow()
+    fake_stream = _make_fake_sdk_stream("result")
+
+    with (
+        patch("attune.workflows.rag_code_gen.claude_agent_sdk.query", fake_stream),
+        patch("attune.help.feedback.record_template_feedback") as mock_record,
+    ):
+        result = asyncio.run(workflow.execute(query="security audit", feedback="good"))
+
+    assert result.metadata["feedback_recorded"] == "good"
+    # One call per cited hit
+    assert mock_record.call_count == len(result.metadata["citation"]["hits"])
+    for call in mock_record.call_args_list:
+        assert call.args[1] == "good"
+
+
+def test_no_feedback_kwarg_leaves_backend_untouched() -> None:
+    workflow = RagCodeGenWorkflow()
+    fake_stream = _make_fake_sdk_stream("result")
+
+    with (
+        patch("attune.workflows.rag_code_gen.claude_agent_sdk.query", fake_stream),
+        patch("attune.help.feedback.record_template_feedback") as mock_record,
+    ):
+        result = asyncio.run(workflow.execute(query="security audit"))
+
+    assert result.metadata["feedback_recorded"] is None
+    mock_record.assert_not_called()
+
+
+def test_workflow_registered_in_registry() -> None:
+    """rag-code-gen must be listed in _DEFAULT_WORKFLOW_NAMES so
+    `attune workflow list` shows it and the resolver can look it up."""
+    from attune.workflows import _DEFAULT_WORKFLOW_NAMES
+
+    assert "rag-code-gen" in _DEFAULT_WORKFLOW_NAMES
+    assert _DEFAULT_WORKFLOW_NAMES["rag-code-gen"] == "RagCodeGenWorkflow"
+
+
+def test_workflow_class_has_expected_attributes() -> None:
+    assert RagCodeGenWorkflow.name == "rag-code-gen"
+    assert "retrieve" in RagCodeGenWorkflow.stages
+    assert "generate" in RagCodeGenWorkflow.stages

--- a/tests/integration/rag/test_rag_workflow.py
+++ b/tests/integration/rag/test_rag_workflow.py
@@ -4,17 +4,22 @@ The Claude Agent SDK is mocked so tests don't hit the
 network. The RAG pipeline is exercised end-to-end against
 an in-memory corpus to prove retrieval -> prompt assembly
 -> workflow-result wiring works.
+
+Skipped when the [rag] extra is not installed (attune-rag
+is an optional dep of attune-ai; see pyproject.toml).
 """
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import AsyncIterator, Iterable
-from unittest.mock import patch
-
 import pytest
 
-from attune.workflows.rag_code_gen import RagCodeGenWorkflow
+pytest.importorskip("attune_rag")
+
+import asyncio  # noqa: E402
+from collections.abc import AsyncIterator, Iterable  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+from attune.workflows.rag_code_gen import RagCodeGenWorkflow  # noqa: E402
 
 pytest_plugins: list[str] = []
 

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -300,8 +300,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 14, (
-            f"Expected 14 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 15, (
+            f"Expected 15 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_no_commands_directory(self) -> None:

--- a/tests/unit/rag/test_mcp_tool.py
+++ b/tests/unit/rag/test_mcp_tool.py
@@ -1,13 +1,23 @@
-"""Unit tests for the rag_knowledge_query MCP tool."""
+"""Unit tests for the rag_knowledge_query MCP tool.
+
+Skipped when the [rag] extra is not installed (attune-rag
+is an optional dep of attune-ai; see pyproject.toml). The
+MCP tool itself is always registered in the schema and
+returns a structured "install [rag] extra" error when
+called without attune-rag available — the dispatcher side
+of that contract is unit-tested separately.
+"""
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Iterable
-
 import pytest
 
-from attune.mcp.server import EmpathyMCPServer
+pytest.importorskip("attune_rag")
+
+import asyncio  # noqa: E402
+from collections.abc import Iterable  # noqa: E402
+
+from attune.mcp.server import EmpathyMCPServer  # noqa: E402
 
 
 def _make_fake_corpus():

--- a/tests/unit/rag/test_mcp_tool.py
+++ b/tests/unit/rag/test_mcp_tool.py
@@ -1,0 +1,122 @@
+"""Unit tests for the rag_knowledge_query MCP tool."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+
+import pytest
+
+from attune.mcp.server import EmpathyMCPServer
+
+
+def _make_fake_corpus():
+    from attune_rag import RetrievalEntry
+    from attune_rag.corpus.base import CorpusProtocol
+
+    class _FakeCorpus(CorpusProtocol):
+        def __init__(self) -> None:
+            self._entries = {
+                "concepts/tool-security-audit.md": RetrievalEntry(
+                    path="concepts/tool-security-audit.md",
+                    category="concepts",
+                    content="Security audit scans for vulnerabilities.",
+                    summary="Run a security audit",
+                ),
+            }
+
+        def entries(self) -> Iterable:
+            return tuple(self._entries.values())
+
+        def get(self, path: str):
+            return self._entries.get(path)
+
+        @property
+        def name(self) -> str:
+            return "fake-corpus"
+
+        @property
+        def version(self) -> str:
+            return "test-1"
+
+    return _FakeCorpus()
+
+
+@pytest.fixture(autouse=True)
+def _patch_corpus(monkeypatch: pytest.MonkeyPatch) -> None:
+    from attune_rag import pipeline
+
+    monkeypatch.setattr(pipeline.RagPipeline, "_default_corpus", staticmethod(_make_fake_corpus))
+
+
+@pytest.fixture
+def server() -> EmpathyMCPServer:
+    return EmpathyMCPServer()
+
+
+def test_tool_registered_in_schemas(server: EmpathyMCPServer) -> None:
+    names = {t["name"] for t in server.get_tool_list()}
+    assert "rag_knowledge_query" in names
+
+
+def test_tool_schema_shape(server: EmpathyMCPServer) -> None:
+    tool = next(t for t in server.get_tool_list() if t["name"] == "rag_knowledge_query")
+    schema = tool["input_schema"]
+    assert schema["type"] == "object"
+    assert "query" in schema["properties"]
+    assert schema["required"] == ["query"]
+
+
+def test_happy_path_returns_hits(server: EmpathyMCPServer) -> None:
+    result = asyncio.run(server._run_rag_knowledge_query({"query": "security audit"}))
+    assert result["success"] is True
+    assert result["fallback_used"] is False
+    assert result["confidence"] > 0
+    assert result["hits"]
+    assert result["hits"][0]["template_path"] == "concepts/tool-security-audit.md"
+    assert "### CONTEXT" in result["augmented_prompt"]
+
+
+def test_no_match_returns_fallback(server: EmpathyMCPServer) -> None:
+    result = asyncio.run(server._run_rag_knowledge_query({"query": "zzzzz asdfgh qwerty"}))
+    assert result["success"] is True
+    assert result["fallback_used"] is True
+    assert result["hits"] == []
+    assert result["confidence"] == 0.0
+
+
+def test_missing_query_is_rejected(server: EmpathyMCPServer) -> None:
+    result = asyncio.run(server._run_rag_knowledge_query({}))
+    assert result["success"] is False
+    assert "query" in result["error"].lower()
+
+
+def test_empty_query_is_rejected(server: EmpathyMCPServer) -> None:
+    result = asyncio.run(server._run_rag_knowledge_query({"query": "  "}))
+    assert result["success"] is False
+
+
+def test_k_out_of_range_rejected(server: EmpathyMCPServer) -> None:
+    result = asyncio.run(server._run_rag_knowledge_query({"query": "security audit", "k": 0}))
+    assert result["success"] is False
+    assert "between 1 and 10" in result["error"]
+
+    result = asyncio.run(server._run_rag_knowledge_query({"query": "security audit", "k": 11}))
+    assert result["success"] is False
+
+
+def test_k_non_integer_rejected(server: EmpathyMCPServer) -> None:
+    result = asyncio.run(server._run_rag_knowledge_query({"query": "security audit", "k": "bogus"}))
+    assert result["success"] is False
+    assert "integer" in result["error"]
+
+
+def test_k_respected_in_hits(server: EmpathyMCPServer) -> None:
+    result = asyncio.run(server._run_rag_knowledge_query({"query": "security audit", "k": 1}))
+    assert len(result["hits"]) <= 1
+
+
+def test_response_includes_corpus_and_retriever_metadata(server: EmpathyMCPServer) -> None:
+    result = asyncio.run(server._run_rag_knowledge_query({"query": "security audit"}))
+    assert result["corpus"] == "fake-corpus"
+    assert result["retriever"] == "KeywordRetriever"

--- a/tests/unit/rag/test_missing_extra.py
+++ b/tests/unit/rag/test_missing_extra.py
@@ -1,0 +1,160 @@
+"""Coverage for the 'attune-rag not installed' error paths.
+
+These tests run regardless of whether the [rag] extra is
+installed — they use a sys.modules sentinel to force
+attune_rag imports to raise ImportError, then assert that
+the workflow and MCP handler both surface a helpful
+"install attune-ai[rag]" error rather than crashing.
+
+Complements tests/integration/rag/test_rag_workflow.py and
+tests/unit/rag/test_mcp_tool.py which exercise the happy
+paths when attune_rag IS installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+
+def _block_attune_rag() -> dict[str, object]:
+    """Force `import attune_rag` to raise ImportError.
+
+    Uses the `sys.modules[name] = None` sentinel (stable
+    across Python 3.10-3.13; the deprecated
+    MetaPathFinder/find_module API no longer fires in 3.12+).
+
+    Returns a dict of original modules to restore afterward.
+    """
+    saved: dict[str, object] = {}
+    for key in list(sys.modules):
+        if key == "attune_rag" or key.startswith("attune_rag."):
+            saved[key] = sys.modules.pop(key)
+    sys.modules["attune_rag"] = None  # type: ignore[assignment]
+    return saved
+
+
+def _unblock_attune_rag(saved: dict[str, object]) -> None:
+    sys.modules.pop("attune_rag", None)
+    sys.modules.update(saved)
+
+
+def test_workflow_raises_helpful_error_when_attune_rag_missing() -> None:
+    """RagCodeGenWorkflow._get_pipeline raises RuntimeError
+    pointing at the [rag] extra when attune_rag can't import."""
+    from attune.workflows.rag_code_gen import RagCodeGenWorkflow
+
+    saved = _block_attune_rag()
+    try:
+        workflow = RagCodeGenWorkflow()
+        result = asyncio.run(workflow.execute(query="anything"))
+        assert result.success is False
+        assert result.error is not None
+        assert "[rag] extra" in result.error
+        assert "pip install" in result.error.lower()
+    finally:
+        _unblock_attune_rag(saved)
+
+
+def test_workflow_empty_query_rejected_without_attune_rag() -> None:
+    """Empty-query validation fires before the attune_rag
+    import attempt, so it returns the right error even when
+    attune_rag is missing."""
+    from attune.workflows.rag_code_gen import RagCodeGenWorkflow
+
+    saved = _block_attune_rag()
+    try:
+        workflow = RagCodeGenWorkflow()
+        result = asyncio.run(workflow.execute(query=""))
+        assert result.success is False
+        assert "query" in result.error.lower()
+    finally:
+        _unblock_attune_rag(saved)
+
+
+def test_mcp_handler_returns_structured_error_when_attune_rag_missing() -> None:
+    """_run_rag_knowledge_query returns a structured dict
+    pointing at the [rag] extra when attune_rag can't import.
+    No exception escapes to the MCP dispatcher."""
+    from attune.mcp.server import EmpathyMCPServer
+
+    server = EmpathyMCPServer()
+
+    saved = _block_attune_rag()
+    try:
+        result = asyncio.run(server._run_rag_knowledge_query({"query": "security audit"}))
+        assert result["success"] is False
+        assert "[rag] extra" in result["error"]
+        assert "pip install" in result["error"].lower()
+        assert "cause" in result  # original ImportError message
+    finally:
+        _unblock_attune_rag(saved)
+
+
+def test_mcp_handler_rejects_empty_query_without_attune_rag() -> None:
+    from attune.mcp.server import EmpathyMCPServer
+
+    server = EmpathyMCPServer()
+
+    saved = _block_attune_rag()
+    try:
+        result = asyncio.run(server._run_rag_knowledge_query({}))
+        assert result["success"] is False
+        assert "query" in result["error"].lower()
+    finally:
+        _unblock_attune_rag(saved)
+
+
+def test_mcp_handler_rejects_invalid_k_without_attune_rag() -> None:
+    """k-bounds validation runs before the attune_rag import,
+    so it still functions when the extra is missing."""
+    from attune.mcp.server import EmpathyMCPServer
+
+    server = EmpathyMCPServer()
+
+    saved = _block_attune_rag()
+    try:
+        result = asyncio.run(server._run_rag_knowledge_query({"query": "q", "k": 0}))
+        assert result["success"] is False
+        assert "between 1 and 10" in result["error"]
+
+        result = asyncio.run(server._run_rag_knowledge_query({"query": "q", "k": "bogus"}))
+        assert result["success"] is False
+        assert "integer" in result["error"]
+    finally:
+        _unblock_attune_rag(saved)
+
+
+def test_workflow_class_has_expected_attributes() -> None:
+    """Class-level attrs load even without attune_rag (module
+    import doesn't touch attune_rag)."""
+    from attune.workflows.rag_code_gen import RagCodeGenWorkflow
+
+    assert RagCodeGenWorkflow.name == "rag-code-gen"
+    assert "retrieve" in RagCodeGenWorkflow.stages
+    assert "generate" in RagCodeGenWorkflow.stages
+    assert RagCodeGenWorkflow.description
+
+
+def test_workflow_registered_in_default_map() -> None:
+    """The workflow class is importable and registered in
+    _DEFAULT_WORKFLOW_NAMES regardless of attune_rag install
+    state. Catches registry drift."""
+    from attune.workflows import _DEFAULT_WORKFLOW_NAMES
+
+    assert "rag-code-gen" in _DEFAULT_WORKFLOW_NAMES
+    assert _DEFAULT_WORKFLOW_NAMES["rag-code-gen"] == "RagCodeGenWorkflow"
+
+
+def test_mcp_tool_schema_registered_without_attune_rag() -> None:
+    """The rag_knowledge_query schema is always registered;
+    only the handler lazy-imports attune_rag."""
+    from attune.mcp.server import EmpathyMCPServer
+
+    server = EmpathyMCPServer()
+    saved = _block_attune_rag()
+    try:
+        tool_names = {t["name"] for t in server.get_tool_list()}
+        assert "rag_knowledge_query" in tool_names
+    finally:
+        _unblock_attune_rag(saved)

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -24,12 +24,12 @@ def server():
 
 
 class TestToolRegistration:
-    """Verify all tools are registered (32 core + 5 redis plugin)."""
+    """Verify all tools are registered (37 core + 5 redis plugin)."""
 
-    def test_tools_list_returns_41(self, server: EmpathyMCPServer):
-        """Test that tools/list returns all 41 tools (36 core + 5 redis plugin)."""
+    def test_tools_list_returns_42(self, server: EmpathyMCPServer):
+        """Test that tools/list returns all 42 tools (37 core + 5 redis plugin)."""
         tools = server.get_tool_list()
-        assert len(tools) == 41
+        assert len(tools) == 42
 
     def test_memory_tools_registered(self, server: EmpathyMCPServer):
         """Test that all memory tools are in the tool list."""

--- a/uv.lock
+++ b/uv.lock
@@ -317,6 +317,7 @@ backend = [
     { name = "uvicorn" },
 ]
 dev = [
+    { name = "attune-rag" },
     { name = "bandit" },
     { name = "black" },
     { name = "coverage" },
@@ -428,6 +429,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
     { name = "attune-help", specifier = ">=0.5.1,<0.6" },
+    { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.0,<0.2" },
     { name = "attune-rag", marker = "extra == 'rag'", specifier = ">=0.1.0,<0.2" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -241,6 +241,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "attune-help" },
+    { name = "attune-rag" },
     { name = "claude-agent-sdk" },
     { name = "cryptography" },
     { name = "defusedxml" },
@@ -425,6 +426,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
     { name = "attune-help", specifier = ">=0.5.1,<0.6" },
+    { name = "attune-rag", editable = "../attune-rag" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "bcrypt", marker = "extra == 'all'", specifier = ">=4.0.0,<6.0.0" },
@@ -567,6 +569,43 @@ sdist = { url = "https://files.pythonhosted.org/packages/6f/47/4272b7839ebaf132c
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/80/4b0dd224b2134577f051f3054c02b62054f034b9e0ef3874a145d8ad4371/attune_help-0.5.1-py3-none-any.whl", hash = "sha256:c6e74415223127860ea3c397a89abf21e31c572f5c87e387c23c9a916683f924", size = 694668, upload-time = "2026-04-12T13:36:54.75Z" },
 ]
+
+[[package]]
+name = "attune-rag"
+version = "0.1.0"
+source = { editable = "../attune-rag" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "pyyaml" },
+    { name = "structlog" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", marker = "extra == 'all'", specifier = ">=0.40.0,<1.0" },
+    { name = "anthropic", marker = "extra == 'claude'", specifier = ">=0.40.0,<1.0" },
+    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.40.0,<1.0" },
+    { name = "attune-help", marker = "extra == 'all'", specifier = ">=0.5.1,<0.6" },
+    { name = "attune-help", marker = "extra == 'attune-help'", specifier = ">=0.5.1,<0.6" },
+    { name = "attune-help", marker = "extra == 'dev'", specifier = ">=0.5.1,<0.6" },
+    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0" },
+    { name = "build", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0,<2.0" },
+    { name = "google-genai", marker = "extra == 'dev'", specifier = ">=1.0,<2.0" },
+    { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.0,<2.0" },
+    { name = "jinja2", specifier = ">=3.1.0" },
+    { name = "openai", marker = "extra == 'all'", specifier = ">=1.40.0,<2.0" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=1.40.0,<2.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.40.0,<2.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "structlog", specifier = ">=24.0" },
+    { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0" },
+]
+provides-extras = ["attune-help", "claude", "openai", "gemini", "all", "dev"]
 
 [[package]]
 name = "babel"

--- a/uv.lock
+++ b/uv.lock
@@ -428,7 +428,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
     { name = "attune-help", specifier = ">=0.5.1,<0.6" },
-    { name = "attune-rag", marker = "extra == 'rag'", editable = "../attune-rag" },
+    { name = "attune-rag", marker = "extra == 'rag'", specifier = ">=0.1.0,<0.2" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "bcrypt", marker = "extra == 'all'", specifier = ">=4.0.0,<6.0.0" },
@@ -575,39 +575,16 @@ wheels = [
 [[package]]
 name = "attune-rag"
 version = "0.1.0"
-source = { editable = "../attune-rag" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", marker = "extra == 'all'", specifier = ">=0.40.0,<1.0" },
-    { name = "anthropic", marker = "extra == 'claude'", specifier = ">=0.40.0,<1.0" },
-    { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.40.0,<1.0" },
-    { name = "attune-help", marker = "extra == 'all'", specifier = ">=0.5.1,<0.6" },
-    { name = "attune-help", marker = "extra == 'attune-help'", specifier = ">=0.5.1,<0.6" },
-    { name = "attune-help", marker = "extra == 'dev'", specifier = ">=0.5.1,<0.6" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0" },
-    { name = "build", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.0,<2.0" },
-    { name = "google-genai", marker = "extra == 'dev'", specifier = ">=1.0,<2.0" },
-    { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.0,<2.0" },
-    { name = "jinja2", specifier = ">=3.1.0" },
-    { name = "openai", marker = "extra == 'all'", specifier = ">=1.40.0,<2.0" },
-    { name = "openai", marker = "extra == 'dev'", specifier = ">=1.40.0,<2.0" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.40.0,<2.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
-    { name = "structlog", specifier = ">=24.0" },
-    { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/69/06/f1531583904edfc5a28e744028c8b1de7ff6bdabc80e0cfef0167e735dc9/attune_rag-0.1.0.tar.gz", hash = "sha256:d75d03fe06c6f6c5fca15b6297c364ab5f51777be5ff40cf8bdc643bffbad138", size = 17929, upload-time = "2026-04-18T04:03:10.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/80/b2de4e7e53a4299b7f21e23a6dec189145f4a567779f4211c63cb78f139c/attune_rag-0.1.0-py3-none-any.whl", hash = "sha256:a7d402c4a8f7d4fdcb9737572c7c0741908db17a162f9a013fd4ac9c64744d3f", size = 22672, upload-time = "2026-04-18T04:03:09.316Z" },
 ]
-provides-extras = ["attune-help", "claude", "openai", "gemini", "all", "dev"]
 
 [[package]]
 name = "babel"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "6.0.0"
+version = "6.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -539,7 +539,7 @@ requires-dist = [
     { name = "redis", marker = "extra == 'memory'", specifier = ">=5.0.0,<8.0.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<8.0.0" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28.0,<3.0.0" },
-    { name = "rich", specifier = ">=13.0.0,<15.0.0" },
+    { name = "rich", specifier = ">=13.0.0,<16.0.0" },
     { name = "ruff", marker = "extra == 'all'", specifier = ">=0.1,<1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1,<1.0" },
     { name = "starlette", marker = "extra == 'all'", specifier = ">=0.40.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,6 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "attune-help" },
-    { name = "attune-rag" },
     { name = "claude-agent-sdk" },
     { name = "cryptography" },
     { name = "defusedxml" },
@@ -406,6 +405,9 @@ otel = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-sdk" },
 ]
+rag = [
+    { name = "attune-rag" },
+]
 redis = [
     { name = "agent-memory-client" },
     { name = "redis" },
@@ -426,7 +428,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
     { name = "attune-help", specifier = ">=0.5.1,<0.6" },
-    { name = "attune-rag", editable = "../attune-rag" },
+    { name = "attune-rag", marker = "extra == 'rag'", editable = "../attune-rag" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "bcrypt", marker = "extra == 'all'", specifier = ">=4.0.0,<6.0.0" },
@@ -556,7 +558,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'backend'", specifier = ">=0.20.0,<1.0.0" },
     { name = "uvicorn", marker = "extra == 'enterprise'", specifier = ">=0.20.0,<1.0.0" },
 ]
-provides-extras = ["memory", "redis", "anthropic", "llm", "memdocs", "agents", "cache", "agent-sdk", "software", "socratic", "backend", "lsp", "windows", "otel", "docs", "dev", "developer", "enterprise", "full", "all"]
+provides-extras = ["rag", "memory", "redis", "anthropic", "llm", "memdocs", "agents", "cache", "agent-sdk", "software", "socratic", "backend", "lsp", "windows", "otel", "docs", "dev", "developer", "enterprise", "full", "all"]
 
 [[package]]
 name = "attune-help"


### PR DESCRIPTION
## Summary

Phase 1 of the [RAG grounding spec v4.0](.claude/plans/feature-rag-code-grounding-2026-04-17.md).

Wires the new **attune-rag** package ([Smart-AI-Memory/attune-rag](https://github.com/Smart-AI-Memory/attune-rag)) into attune-ai via `[tool.uv.sources]`, mirroring the attune-author / attune-help sibling-repo pattern.

- Adds pointer stub at `packages/attune-rag/README.md`
- Adds `attune-rag = { path = "../attune-rag", editable = true }` to `[tool.uv.sources]`
- Archives the superseded v1 `RAG_IMPLEMENTATION_PLAN.md`
- Drops the new spec at `.claude/plans/feature-rag-code-grounding-2026-04-17.md` (20 tasks, 4 phases)
- Piggybacks on a tiny `uv.lock` drift fix (rich<16 catchup from PR #150)

## What's NOT in this PR yet

- Phase 2: `RagCodeGenWorkflow` in `src/attune/workflows/`, `rag_knowledge_query` MCP tool, golden-query benchmark, embeddings decision → next commits on this branch
- Phase 3: attune-author 0.4.0 optional RAG hook → separate attune-author PR
- Phase 4: version bump to 6.0.0, CHANGELOG, website/README, coordinated publish → end of this branch

**Draft** until attune-rag 0.1.0 is published to PyPI (so the dep resolves in CI from PyPI, not just from the local workspace path).

## Companion PR

- attune-rag v0.1.0 is live at https://github.com/Smart-AI-Memory/attune-rag (no PR — initial push to main of a new repo).

## Test plan

- [x] attune-rag standalone: 86 tests passing
- [x] End-to-end smoke against real attune-help corpus (633 entries)
- [x] `uv sync --extra dev --extra developer` passes with new `[tool.uv.sources]` entry
- [x] `uv lock --check` passes
- [ ] attune-ai CI on this branch
- [ ] attune-rag publish to PyPI (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)