### PR TITLE
docs(rag): Phase 2.5a plateau — route to fastembed

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1948,4 +1948,32 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   because I set up their `pypi` envs with no
   branch/tag restriction when creating them for the RAG
   release.
-<!-- attune-lessons-end -->
+
+- **Naive suffix-strip stemming fails on English
+  doubling-consonant words**: A simple stemmer that
+  strips suffixes like `-ing`, `-ion`, `-ate`, `-s`
+  correctly matches most singular/plural and
+  verb-form pairs ("bugs"/"bug", "orchestrate"/
+  "orchestrator"). But words with doubled consonants
+  before the suffix break: "planning" strips to
+  "planni" (8 − 3 = 5 chars ≥ min), not "plan". So a
+  user query "plan a new feature" against a
+  `concepts/tool-planning.md` target still misses
+  because "plan" and "planni" don't equate. Full
+  Porter/Krovetz stemmers handle this via rules that
+  restore the dropped consonant (`planning → plann →
+  plan`). Going beyond a simple suffix-strip in a
+  zero-dep retriever isn't worth it — the cases that
+  doubling rules fix are exactly the cases semantic
+  embeddings handle naturally. Documented in
+  attune-rag 0.1.1's benchmark plateau at 66.67% P@1.
+
+- **F841 unused-fixture lint fires when a test is
+  refactored to assert on a helper**: Building a test
+  with `corpus = FakeCorpus([...])` then changing the
+  assertion to call `_stem(...)` directly leaves the
+  `corpus` variable unused. Ruff catches this; local
+  `pytest` doesn't. Always run
+  `uv run python -m ruff check tests/` before
+  pushing test-refactor commits to avoid a CI-only
+  failure across the whole matrix.

--- a/docs/rag/embeddings-decision-2026-04-17.md
+++ b/docs/rag/embeddings-decision-2026-04-17.md
@@ -233,6 +233,37 @@ move the gate.
 
 ---
 
+## Phase 2.5a result (attune-rag 0.1.1, 2026-04-18)
+
+Tuning landed: category weights, filename-length cap on
+path hits, and a minimal suffix stemmer. Re-ran
+`attune-rag.benchmark` against the same 15-query golden set
+and attune-help 0.5.1 corpus.
+
+| Metric | Baseline (0.1.0) | Tuned (0.1.1) | Delta |
+|---|---|---|---|
+| Precision@1 | 53.33% | 66.67% | **+13.34 pts** |
+| Recall@3 | 60.00% | 73.33% | **+13.33 pts** |
+| Easy P@1 | 4/5 | 5/5 | +1 |
+| Medium P@1 | 4/4 | 4/4 | — |
+| Hard P@1 | 0/6 | 1/6 | +1 |
+| Mean latency | 11.83 ms | 42.45 ms | +30.6 ms |
+
+**Gate result: NOT MET (3.33 pts short of 70%).** Landing
+at the top of Option A's predicted +10–25 pts range. The
+four unrecovered hard queries — `plan a new feature`,
+`vulnerability scan`, `orchestrate documentation workflow`,
+`look for dangerous eval calls` — have zero token overlap
+with their targets and require semantic similarity, exactly
+as anticipated above.
+
+### Decision: proceed to Phase 2.5b
+
+Per the pre-committed gate, v0.1.1 ships the tuning
+improvement and v0.2.0 adds `attune-rag[embeddings]` using
+`fastembed`. Keyword retrieval remains the default for
+zero-dep users.
+
 ## Links
 
 - Spec: [feature-rag-code-grounding-2026-04-17.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/.claude/plans/feature-rag-code-grounding-2026-04-17.md)


### PR DESCRIPTION
## Summary

Documents the Phase 2.5a outcome in
[docs/rag/embeddings-decision-2026-04-17.md](../blob/main/docs/rag/embeddings-decision-2026-04-17.md):

- attune-rag 0.1.1 landed category weights, filename-length
  path cap, and a suffix stemmer.
- Precision@1 went from 53.33% → **66.67%** (+13.34 pts),
  Recall@3 from 60% → **73.33%** (+13.33 pts).
- The pre-committed 70% P@1 gate is not met. Four remaining
  hard queries have zero token overlap with their targets.
- Per the gate, next work escalates to v0.2.0
  `attune-rag[embeddings]` via `fastembed`.

Companion to [attune-rag#1](https://github.com/Smart-AI-Memory/attune-rag/pull/1).

## Test plan

- [x] Doc-only change
- [x] mkdocs build not needed (single file edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)