### PR TITLE
refactor: decouple attune-ai from attune-help; promote attune-rag to core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,7 @@ dependencies = [
     "cryptography>=46.0.7",  # CVE-2026-39892 (transitive via PyJWT[crypto])
     "langsmith>=0.7.31,<2.0.0",  # GHSA-rr7j-v2q5-chgv (transitive via langchain-core)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
-    "attune-help>=0.5.1,<0.8",  # Progressive-depth help runtime + MCP tools. Cap raised from <0.6 to <0.8 to admit attune-help 0.7.0 (path-keyed summaries, CLI, Beta). 0.7.0 is additive; no API breaks per its CHANGELOG.
-    # NOTE: attune-rag is an OPTIONAL extra, not a core dep.
-    #  Install with `pip install 'attune-ai[rag]'` to enable
-    #  the rag-code-gen workflow and rag_knowledge_query MCP
-    #  tool. Workflows/handlers lazy-import and return a
-    #  structured error when the extra is absent.
+    "attune-rag>=0.1.5,<0.2",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
     # NOTE: redis moved to [memory] optional - not needed for CLI/skill usage
@@ -86,20 +81,10 @@ dependencies = [
 # The "Crew" workflows use EmpathyLLMExecutor (Anthropic SDK) directly.
 
 [project.optional-dependencies]
-# RAG-grounded code generation (rag-code-gen workflow +
-# rag_knowledge_query MCP tool). Optional so users who
-# don't want grounding avoid the dep. Once attune-rag is
-# on PyPI, no further work needed — this extra resolves
-# from PyPI.
-rag = [
-    # Floor at 0.1.5 so installs automatically get the
-    # <passage>-sentinel + injection-defense clause that
-    # `RagCodeGenWorkflow` relies on via its pinned
-    # `prompt_variant="citation"`. Older versions resolve but
-    # ship a prompt flow vulnerable to corpus-borne prompt
-    # injection.
-    "attune-rag>=0.1.5,<0.2",
-]
+# attune-rag promoted to core dep in v3.x (required for acceptable accuracy).
+# The [rag] extra is kept as a no-op alias for backward compat with any
+# install scripts that used `pip install attune-ai[rag]`.
+rag = []
 
 # Help authoring (generate / regenerate / polish the
 # project's own `.help/` templates). Optional because
@@ -109,12 +94,9 @@ rag = [
 # the `attune-author` CLI run inside this venv without
 # a sibling checkout. `[tool.uv.sources]` (below) routes
 # to the sibling path for workspace dev; PyPI is the
-# fallback. Floor is `>=0.4.1` because 0.4.0 capped
-# `attune-help<0.6`, which would force-downgrade
-# attune-help back below 0.7.0 and collide with the
-# `>=0.7.0` requirement from attune-rag 0.1.4+.
+# fallback.
 author = [
-    "attune-author>=0.4.1,<0.5",
+    "attune-author>=0.5.1,<0.6",
 ]
 
 # Memory subsystem (requires Redis server 8.4+ recommended)
@@ -714,7 +696,7 @@ exclude_lines = [
 ]
 
 # Sibling repos — all published to PyPI:
-#   attune-help    — core dep (>=0.5.1,<0.8)
+#   attune-rag     — core dep (>=0.1.5,<0.2) — promoted from optional; required for accuracy
 #   attune-author  — [author] optional extra (>=0.4.1,<0.5)
 #   attune-rag     — [rag] optional extra (>=0.1.5,<0.2)
 #

--- a/src/attune/help/preamble.py
+++ b/src/attune/help/preamble.py
@@ -13,9 +13,31 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from attune_help.preamble import _extract_preamble as _extract_preamble
-
 logger = logging.getLogger(__name__)
+
+
+def _extract_preamble(text: str) -> str | None:
+    """Extract preamble from task template content.
+
+    Skips YAML frontmatter and the h1 heading, returns
+    the first non-empty paragraph.
+    """
+    lines = text.split("\n")
+    in_frontmatter = False
+    content_start = 0
+    for i, line in enumerate(lines):
+        if i == 0 and line.strip() == "---":
+            in_frontmatter = True
+            continue
+        if in_frontmatter and line.strip() == "---":
+            content_start = i + 1
+            break
+    for line in lines[content_start:]:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        return stripped
+    return None
 
 
 def get_preamble(

--- a/uv.lock
+++ b/uv.lock
@@ -236,11 +236,11 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "6.4.0"
+version = "6.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
-    { name = "attune-help" },
+    { name = "attune-rag" },
     { name = "claude-agent-sdk" },
     { name = "cryptography" },
     { name = "defusedxml" },
@@ -409,9 +409,6 @@ otel = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-sdk" },
 ]
-rag = [
-    { name = "attune-rag" },
-]
 redis = [
     { name = "agent-memory-client" },
     { name = "redis" },
@@ -431,10 +428,9 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'enterprise'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
-    { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.4.1,<0.5" },
-    { name = "attune-help", specifier = ">=0.5.1,<0.8" },
+    { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.5.1,<0.6" },
+    { name = "attune-rag", specifier = ">=0.1.5,<0.2" },
     { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.2" },
-    { name = "attune-rag", marker = "extra == 'rag'", specifier = ">=0.1.5,<0.2" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "bcrypt", marker = "extra == 'all'", specifier = ">=4.0.0,<6.0.0" },
@@ -568,7 +564,7 @@ provides-extras = ["rag", "author", "memory", "redis", "anthropic", "llm", "memd
 
 [[package]]
 name = "attune-author"
-version = "0.4.2"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attune-help" },
@@ -576,21 +572,21 @@ dependencies = [
     { name = "python-frontmatter" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/e6/4acb1ac4a726856f6e895b4cba47767a6ce4c885d4c28e2902bf97887dc4/attune_author-0.4.2.tar.gz", hash = "sha256:86399d176bdc5cb427259074bdffa0c23a41fb0eec196d8ce38516703d37fc3d", size = 114491, upload-time = "2026-04-19T16:04:31.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/37/a7b7d23437e913476e80bda1ef1be07ec7d1dac92522e83eda7fdae63075/attune_author-0.5.1.tar.gz", hash = "sha256:ad4e0413486bc975428c3880b9f7b3e192cc943585f755f5c1881edad278f06d", size = 121339, upload-time = "2026-04-30T22:17:06.551Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/68/e0cdeec76b2ab33e98fa01ad388dd30431517ba96d132615554772ebb44b/attune_author-0.4.2-py3-none-any.whl", hash = "sha256:94128af4c2f53975c634e8b218c72b739e82a23dcc8aed98a6e607ecf6d1112d", size = 83437, upload-time = "2026-04-19T16:04:29.791Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/02/7a5f00ac08f5ef801a21d1b7c9cfae7c19aa952fb1e4ec881bc6981db557/attune_author-0.5.1-py3-none-any.whl", hash = "sha256:0b38a324c929d511de63c69ce4fc838f19fdd54d853fdad6e31cbbe63cbb05ee", size = 88646, upload-time = "2026-04-30T22:17:04.349Z" },
 ]
 
 [[package]]
 name = "attune-help"
-version = "0.7.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-frontmatter" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/7d/1272632cf6bca5d2e6d2458862fe3db27369c2807c5cef69822c9573b909/attune_help-0.7.0.tar.gz", hash = "sha256:e45fd10f66b7ba4d571e78f68565835e067005de874d0ba720c5e183e7881e77", size = 417299, upload-time = "2026-04-19T02:56:25.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/51/f05685a70095d8c0684a1a5073a1c755f0bced97e2f1bfa1cc10f9ac48b9/attune_help-0.10.0.tar.gz", hash = "sha256:de7be67343499333fbc1d6d70e5d91083429f98892fc5ad6e4f491d4d8f64980", size = 433748, upload-time = "2026-04-30T22:10:48.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/47/4d0d60f7ab6c0d94abe0dca8060346771f781003e13f16682f496997ab45/attune_help-0.7.0-py3-none-any.whl", hash = "sha256:16067046c55f505271281606f90cd06cbecba59e697ba8781d7d1416d4baf8e9", size = 704311, upload-time = "2026-04-19T02:56:23.597Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9b/5af199e744104df092054d47d987a6cc9e46dbd53c27cb1f3595b0d62000/attune_help-0.10.0-py3-none-any.whl", hash = "sha256:b8967de92580d6833950f007becb9a882abac11601b7b98a0bd8961bc0151d1e", size = 717277, upload-time = "2026-04-30T22:10:47.032Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Drop `attune-help` as a core dep** — the only runtime import was `_extract_preamble` in `help/preamble.py`, now inlined (17 lines of pure string parsing). attune-ai and the attune-help/attune-author/attune-rag ecosystem are now independent release trains.
- **Promote `attune-rag` from `[rag]` optional to core dep** (`>=0.1.5,<0.2`) — required for acceptable retrieval accuracy. `[rag]` extra kept as a no-op alias for backward compat.
- **Bump `[author]` extra** to `attune-author>=0.5.1,<0.6`.

## Test plan

- [x] `tests/unit/help/test_preamble.py` — 26/26 pass with inlined `_extract_preamble`
- [x] `grep -r "from attune_help" src/` — zero hits
- [x] All pre-commit hooks pass (black, ruff, bandit, detect-secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)