### PR TITLE
release: v6.5.0 — decouple attune-ai from attune-help ecosystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.0] - 2026-04-30
+
+### Changed — decouple attune-ai from attune-help ecosystem
+
+attune-ai and the attune-help/attune-author/attune-rag docs ecosystem
+are now fully independent release trains with no shared runtime
+dependencies.
+
+- **Removed** `attune-help` as a core dependency. The only consumer was
+  a single `_extract_preamble` import in `src/attune/help/preamble.py`;
+  that function is now inlined (17 lines of pure string parsing, no new
+  deps).
+- **Promoted** `attune-rag` from the optional `[rag]` extra to a core
+  dependency (`>=0.1.5,<0.2`). attune-rag is required for acceptable
+  retrieval accuracy in the help system and was already pulled in by
+  most installations.
+- **`[rag]` extra** kept as a no-op alias for backward compatibility —
+  existing installs with `attune-ai[rag]` continue to work.
+- **`[author]` extra** bumped to `attune-author>=0.5.1,<0.6`.
+
 ## [6.4.1] - 2026-04-27
 
 Test-only patch release. No production code changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "6.4.1"
+version = "6.5.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump version to 6.5.0 and add CHANGELOG entry for the dependency decoupling shipped in PR #184.

## Changes
- `pyproject.toml`: version `6.4.1` → `6.5.0`
- `CHANGELOG.md`: add `[6.5.0]` entry documenting the attune-help removal and attune-rag promotion