### PR TITLE
release: v6.5.2 — fix ecosystem overview; introduce attune-gui as doc hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,24 @@
 
 ---
 
-**Ecosystem overview.** `attune-ai` is the hub: CLI,
-multi-agent workflows, MCP tools, and Claude Code skills.
-It ships with **`attune-rag`** as a core dependency
-(v0.1.11 — retrieval + citation-forced generation, prompt
-caching, LLM-agnostic). The optional **`[author]`** extra
-pulls in **`attune-author`** (v0.6.x — authoring, staleness
-detection, on-disk polish cache). **`attune-help`**
-(v0.10.x — progressive-depth template runtime, template
-aliases for improved retrieval) is consumed via
-attune-rag's corpus layer. Separate repos, separate release
-cadences, separate PyPI packages.
+**Ecosystem overview.** `attune-ai` is the developer
+workflow hub: CLI, multi-agent analysis workflows, MCP
+tools, and Claude Code skills. For creating and managing
+help content and docs, the dedicated hub is
+**[`attune-gui`](https://github.com/Smart-AI-Memory/attune-gui)**
+— a local Living Docs dashboard that wraps
+`attune-rag`, `attune-help`, and `attune-author` in a
+single UI. `attune-ai` ships with **`attune-rag`** as a
+core dependency (v0.1.11 — retrieval + citation-forced
+generation, prompt caching, LLM-agnostic). The optional
+**`[author]`** extra pulls in **`attune-author`** (v0.6.x
+— authoring, staleness detection, on-disk polish cache).
+**`attune-help`** (v0.10.x — progressive-depth template
+runtime) is a standalone package; it is not pulled in by
+a standard `attune-ai` install, and is available as an
+optional corpus for `attune-rag` via
+`pip install 'attune-rag[attune-help]'`. Separate repos,
+separate release cadences, separate PyPI packages.
 
 > The Claude Code plugin marketplace for help content
 > moved to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "6.5.1"
+version = "6.5.2"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Corrects the ecosystem overview paragraph: `attune-help` is **not** pulled in by a standard `attune-ai` install — it was removed as a core dep in v6.5.0 and is only available as an optional corpus for `attune-rag` via `pip install 'attune-rag[attune-help]'`
- Positions `attune-gui` as the dedicated hub for creating and managing help content and docs (rather than attune-ai, which is the developer workflow hub)

## Test plan

- [ ] README ecosystem overview accurately reflects the v6.5.x dependency graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)