### PR TITLE
chore: sync uv.lock to attune-ai 6.5.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "6.5.3"
+version = "6.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bumps the `attune-ai` entry in `uv.lock` from `6.5.3` to `6.5.4` to match the version released in [0ae09c31](https://github.com/Smart-AI-Memory/attune-ai/commit/0ae09c31).
- Single-line change.

## Why

The release commit shipped the version bump but didn't regenerate the lockfile. The `Check Help Template Freshness` pre-commit hook regenerates it on every CI run and fails on every PR until the lock catches up — see PR #193's failed pre-commit check for an example.

## Test plan

- [ ] CI's `Check Help Template Freshness` hook passes (the failure that motivated this PR)
- [ ] All test matrices stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)