### PR TITLE
fix(mcp): cross-project release-prep robustness

### DIFF
--- a/src/attune/agents/release/coverage_agent.py
+++ b/src/attune/agents/release/coverage_agent.py
@@ -15,6 +15,7 @@ from typing import Any
 from uuid import uuid4
 
 from attune.agents.state.store import AgentStateStore
+from attune.utils.coverage import detect_coverage_target as _detect_coverage_target
 
 from .base_agent import ReleaseAgent, _run_command
 from .release_models import Tier
@@ -68,12 +69,13 @@ class TestCoverageAgent(ReleaseAgent):
                     test_count = int(count_match.group(1))
 
             # Step 2: Try actual coverage (with short timeout)
+            cov_target = _detect_coverage_target(codebase_path)
             cov_returncode, cov_stdout, _cov_stderr = _run_command(
                 [
                     "uv",
                     "run",
                     "pytest",
-                    "--cov=src",
+                    f"--cov={cov_target}",
                     "--cov-report=term-missing",
                     "-x",
                     "-q",

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -99,12 +99,19 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
 
         Args:
             workspace_root: Root directory for workspace path
-                containment. Defaults to current working directory.
+                containment. Resolution order: explicit argument >
+                ``ATTUNE_MCP_WORKSPACE_ROOT`` env var > current
+                working directory. Setting the env var lets users
+                broaden the sandbox to a parent directory (e.g. the
+                main checkout when the MCP launches in a worktree)
+                without code changes.
             user_id: Identity for memory operations. Defaults
                 to the OS login name or "mcp-session".
 
         """
-        self._workspace_root = workspace_root or os.getcwd()
+        self._workspace_root = (
+            workspace_root or os.environ.get("ATTUNE_MCP_WORKSPACE_ROOT") or os.getcwd()
+        )
         self._user_id = user_id or _get_default_user_id()
         self.tools = self._register_tools()
         self.resources = self._register_resources()
@@ -446,11 +453,19 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         workflow = ReleasePreparationWorkflow()
         result = await workflow.execute(path=validated_path)
 
+        # ``final_output`` is dict-shaped on the happy path but degrades to a
+        # plain string when the workflow short-circuits (e.g. with an error
+        # message). Coerce to a dict view so the response shape stays stable
+        # and ``.get()`` doesn't AttributeError.
+        final_output = result.final_output
+        if not isinstance(final_output, dict):
+            final_output = {"recommendation": str(final_output)}
+
         return {
             "success": result.success,
-            "approved": result.final_output.get("approved"),
-            "health_score": result.final_output.get("health_score"),
-            "recommendation": result.final_output.get("recommendation"),
+            "approved": final_output.get("approved"),
+            "health_score": final_output.get("health_score"),
+            "recommendation": final_output.get("recommendation"),
             "cost": result.cost_report.total_cost,
         }
 

--- a/src/attune/orchestration/tools/testing.py
+++ b/src/attune/orchestration/tools/testing.py
@@ -43,8 +43,10 @@ class RealCoverageAnalyzer:
     def analyze(self, use_existing: bool = True) -> CoverageReport:
         """Run coverage analysis on all project packages.
 
-        Analyzes coverage for: attune, attune_llm_toolkit,
-        attune_software_plugin
+        Coverage targets are detected from the project's ``pyproject.toml``
+        via :func:`attune.utils.coverage.detect_coverage_targets`, so this
+        works against any project layout (src/, flat, or hatch wheel
+        packages), not just attune-ai itself.
 
         Args:
             use_existing: Use existing coverage.json if available (default: True)

--- a/src/attune/orchestration/tools/testing.py
+++ b/src/attune/orchestration/tools/testing.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from attune.utils.coverage import detect_coverage_targets
+
 from ._shared import _validate_file_path
 
 logger = logging.getLogger(__name__)
@@ -75,12 +77,10 @@ class RealCoverageAnalyzer:
                 # Run pytest with coverage on test suite
                 logger.info("Running test suite to generate coverage (may take 2-5 minutes)")
 
-                # Use actual package names (match pyproject.toml configuration)
-                cov_packages = [
-                    "attune",
-                    "attune_llm_toolkit",
-                    "attune_software_plugin",
-                ]
+                # Detect coverage targets from the project's pyproject.toml
+                # so this works on any project, not just attune-ai. Falls back
+                # to ``["src"]`` for the conventional layout.
+                cov_packages = detect_coverage_targets(self.project_root)
 
                 cmd = [
                     "pytest",
@@ -111,7 +111,8 @@ class RealCoverageAnalyzer:
         # Read coverage.json
         if not coverage_file.exists():
             raise RuntimeError(
-                "Coverage report not found. Run 'pytest --cov=src --cov-report=json' first.",
+                "Coverage report not found. Run 'pytest --cov=<your-package> "
+                "--cov-report=json' first.",
             )
 
         try:

--- a/src/attune/utils/coverage.py
+++ b/src/attune/utils/coverage.py
@@ -1,0 +1,82 @@
+"""Helpers for picking the right ``--cov=<target>`` argument per project.
+
+Several agents and orchestrators run ``pytest --cov`` against arbitrary
+projects, not just attune-ai itself. Hard-coding ``--cov=src`` (or the
+attune-ai package list) makes those tools report 0% coverage on any
+project that uses a different layout (e.g. ``sidecar/<pkg>``,
+``packages/<pkg>``, or a flat top-level package).
+
+:func:`detect_coverage_targets` reads ``pyproject.toml`` to pick a
+sensible target list.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+logger = logging.getLogger(__name__)
+
+
+def detect_coverage_targets(codebase_path: str | Path) -> list[str]:
+    """Return one or more ``--cov`` arguments for ``codebase_path``.
+
+    Heuristic, in priority order:
+
+    1. ``[tool.coverage.run] source`` in ``pyproject.toml``.
+    2. ``[tool.hatch.build.targets.wheel] packages`` (covers projects that
+       ship from a non-``src/`` layout, e.g. attune-gui's ``sidecar/attune_gui``).
+    3. The package name from ``[project] name`` if a directory of the same
+       name (or its dashes-to-underscores form) exists under ``src/`` or at
+       the root.
+    4. Fall back to ``["src"]`` for the conventional layout.
+
+    The return value is always a non-empty list so callers can iterate.
+    """
+    root = Path(codebase_path)
+    pyproject = root / "pyproject.toml"
+    if not pyproject.is_file():
+        return ["src"]
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return ["src"]
+
+    cov_run = data.get("tool", {}).get("coverage", {}).get("run", {})
+    sources = cov_run.get("source") or cov_run.get("source_pkgs")
+    if isinstance(sources, list) and sources:
+        return [str(s) for s in sources]
+
+    hatch_packages = (
+        data.get("tool", {})
+        .get("hatch", {})
+        .get("build", {})
+        .get("targets", {})
+        .get("wheel", {})
+        .get("packages")
+    )
+    if isinstance(hatch_packages, list) and hatch_packages:
+        return [str(p) for p in hatch_packages]
+
+    name = data.get("project", {}).get("name")
+    if isinstance(name, str) and name:
+        for candidate in (name, name.replace("-", "_")):
+            if (root / "src" / candidate).is_dir():
+                return [f"src/{candidate}"]
+            if (root / candidate).is_dir():
+                return [candidate]
+
+    return ["src"]
+
+
+def detect_coverage_target(codebase_path: str | Path) -> str:
+    """Convenience wrapper for callers that only want one target."""
+    return detect_coverage_targets(codebase_path)[0]

--- a/tests/unit/mcp/handlers/test_workflow_handlers.py
+++ b/tests/unit/mcp/handlers/test_workflow_handlers.py
@@ -396,3 +396,28 @@ class TestRunReleasePrep:
             await server._run_release_prep({"path": "/proj"})
 
         mod.ReleasePreparationWorkflow.return_value.execute.assert_awaited_once_with(path="/proj")
+
+    @pytest.mark.asyncio
+    async def test_run_release_prep_handles_string_final_output(self):
+        """Regression: when ``final_output`` degrades to a plain string
+        (workflow short-circuited with an error message), the handler
+        must not AttributeError on ``.get()``. The string is surfaced as
+        ``recommendation`` and the dict-shaped fields are ``None``."""
+        server = _make_server()
+        result = _make_result(
+            success=False,
+            final_output="Workflow short-circuited: missing API key",
+            total_cost=0.0,
+        )
+        mod = _make_workflow_module(
+            "attune.workflows.release_prep", "ReleasePreparationWorkflow", result
+        )
+
+        with patch.dict(sys.modules, {"attune.workflows.release_prep": mod}):
+            out = await server._run_release_prep({"path": "."})
+
+        assert out["success"] is False
+        assert out["approved"] is None
+        assert out["health_score"] is None
+        assert out["recommendation"] == "Workflow short-circuited: missing API key"
+        assert out["cost"] == 0.0

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -73,6 +73,32 @@ class TestServerInit:
         server = _make_server(tmp_path)
         assert server._workspace_root == str(tmp_path)
 
+    def test_env_var_workspace_root(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """ATTUNE_MCP_WORKSPACE_ROOT broadens the sandbox without code changes.
+
+        Use case: the MCP server launches in a git worktree but needs to
+        operate on a sibling main checkout. Setting the env var lets the
+        user opt into the wider scope explicitly.
+        """
+        from attune.mcp.server import EmpathyMCPServer
+
+        monkeypatch.setenv("ATTUNE_MCP_WORKSPACE_ROOT", str(tmp_path))
+        server = EmpathyMCPServer()
+        assert server._workspace_root == str(tmp_path)
+
+    def test_explicit_arg_overrides_env_var(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """Explicit workspace_root argument wins over env var."""
+        from attune.mcp.server import EmpathyMCPServer
+
+        env_path = tmp_path / "from-env"
+        env_path.mkdir()
+        arg_path = tmp_path / "from-arg"
+        arg_path.mkdir()
+
+        monkeypatch.setenv("ATTUNE_MCP_WORKSPACE_ROOT", str(env_path))
+        server = EmpathyMCPServer(workspace_root=str(arg_path))
+        assert server._workspace_root == str(arg_path)
+
     def test_custom_user_id(self) -> None:
         server = _make_server(user_id="test-user")
         assert server._user_id == "test-user"

--- a/tests/unit/test_coverage_target_detection.py
+++ b/tests/unit/test_coverage_target_detection.py
@@ -1,0 +1,68 @@
+"""Tests for ``attune.utils.coverage`` — pyproject-driven --cov target detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.utils.coverage import detect_coverage_target, detect_coverage_targets
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+class TestDetectCoverageTargets:
+    def test_no_pyproject_returns_src(self, tmp_path: Path) -> None:
+        assert detect_coverage_targets(tmp_path) == ["src"]
+
+    def test_corrupt_pyproject_returns_src(self, tmp_path: Path) -> None:
+        _write(tmp_path / "pyproject.toml", "not toml {")
+        assert detect_coverage_targets(tmp_path) == ["src"]
+
+    def test_tool_coverage_run_source_wins(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "pyproject.toml",
+            "[tool.coverage.run]\nsource = ['my_pkg', 'other_pkg']\n",
+        )
+        assert detect_coverage_targets(tmp_path) == ["my_pkg", "other_pkg"]
+
+    def test_source_pkgs_alias_works(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "pyproject.toml",
+            "[tool.coverage.run]\nsource_pkgs = ['only_pkg']\n",
+        )
+        assert detect_coverage_targets(tmp_path) == ["only_pkg"]
+
+    def test_hatch_packages_when_no_coverage_section(self, tmp_path: Path) -> None:
+        """attune-gui case: hatch wheel packages from non-src layout."""
+        _write(
+            tmp_path / "pyproject.toml",
+            (
+                "[project]\nname = 'attune-gui'\n"
+                "[tool.hatch.build.targets.wheel]\n"
+                "packages = ['sidecar/attune_gui']\n"
+            ),
+        )
+        assert detect_coverage_targets(tmp_path) == ["sidecar/attune_gui"]
+
+    def test_falls_back_to_project_name_under_src(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "my_pkg").mkdir(parents=True)
+        _write(tmp_path / "pyproject.toml", "[project]\nname = 'my-pkg'\n")
+        assert detect_coverage_targets(tmp_path) == ["src/my_pkg"]
+
+    def test_falls_back_to_project_name_at_root(self, tmp_path: Path) -> None:
+        (tmp_path / "flat_pkg").mkdir()
+        _write(tmp_path / "pyproject.toml", "[project]\nname = 'flat-pkg'\n")
+        assert detect_coverage_targets(tmp_path) == ["flat_pkg"]
+
+    def test_default_when_no_signal(self, tmp_path: Path) -> None:
+        _write(tmp_path / "pyproject.toml", "[project]\nname = 'unknown'\n")
+        assert detect_coverage_targets(tmp_path) == ["src"]
+
+    def test_singular_helper_returns_first(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "pyproject.toml",
+            "[tool.coverage.run]\nsource = ['first', 'second']\n",
+        )
+        assert detect_coverage_target(tmp_path) == "first"


### PR DESCRIPTION
## Summary

Three fixes that surfaced when running `/attune-ai:release-prep` against a sibling project (attune-gui) from a git worktree, plus a stale-docstring follow-up.

- **Coverage target detection** — `--cov=src` (and the hardcoded attune-ai package list in `RealCoverageAnalyzer`) reported 0% on any project with a different layout. New `attune.utils.coverage.detect_coverage_targets()` reads `pyproject.toml` in priority order: `[tool.coverage.run] source` → `[tool.hatch.build.targets.wheel] packages` → `[project] name` resolved as `src/<name>` or `<name>` → fallback `["src"]`. Used by both `agents/release/coverage_agent.py` and `orchestration/tools/testing.py`.
- **Workspace-root override** — `EmpathyMCPServer._workspace_root` was pinned to `os.getcwd()`, raising "outside allowed directory" when the MCP launches in a worktree but operates on a sibling main checkout. Adds `ATTUNE_MCP_WORKSPACE_ROOT` env var (precedence: explicit arg > env var > cwd).
- **`final_output` dict-guard** — `_run_release_prep` AttributeError'd when `result.final_output` was a string (workflow short-circuit case, e.g. missing API key). Coerces non-dict to `{"recommendation": str(value)}`.
- **Docstring refresh** — `RealCoverageAnalyzer.analyze` docstring still claimed it was scoped to attune-specific packages.

## Test plan

- [x] 12 new unit tests across coverage detection, MCP server init, and workflow handlers
- [x] Targeted slice (`uv run pytest tests/unit/mcp/ tests/unit/agents/release/ tests/monitoring/test_mcp_path_containment.py tests/unit/test_coverage_target_detection.py`) → 434 passed, 1 skipped
- [x] Full suite (`uv run pytest`) → 16,685 passed, 7 failed, 204 skipped — all 7 failures verified pre-existing on `main` (Redis API drift + production smoke page content drift), none from this branch
- [x] `ruff check` clean on touched files
- [ ] Post-merge: bump to 6.5.5, publish, verify with `uvx --refresh attune-ai` and re-run `/attune-ai:release-prep` against attune-gui

🤖 Generated with [Claude Code](https://claude.com/claude-code)