### PR TITLE
feat(ops): workflow runner with SSE log streaming (v0.2)

### DIFF
--- a/src/attune/ops/cli.py
+++ b/src/attune/ops/cli.py
@@ -36,6 +36,11 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Don't auto-open the browser on startup",
     )
+    parser.add_argument(
+        "--allow-run",
+        action="store_true",
+        help="Enable workflow execution from the dashboard (default: read-only)",
+    )
 
 
 def cmd_ops(args: argparse.Namespace) -> int:
@@ -57,6 +62,7 @@ def cmd_ops(args: argparse.Namespace) -> int:
         project_root=args.project_root,
         host=args.host,
         port=args.port,
+        allow_run=args.allow_run,
     )
     app = create_app(config)
 
@@ -64,6 +70,7 @@ def cmd_ops(args: argparse.Namespace) -> int:
     print(f"attune ops → {url}")
     print(f"  project: {config.project_root}")
     print(f"  attune-home: {config.attune_home}")
+    print(f"  allow-run: {'on' if config.allow_run else 'off (read-only)'}")
 
     if not args.no_browser:
         try:

--- a/src/attune/ops/config.py
+++ b/src/attune/ops/config.py
@@ -15,6 +15,7 @@ class Config:
     attune_home: Path
     host: str = "127.0.0.1"
     port: int = 8765
+    allow_run: bool = False
 
     @property
     def telemetry_path(self) -> Path:
@@ -42,6 +43,7 @@ def build_config(
     *,
     host: str = "127.0.0.1",
     port: int = 8765,
+    allow_run: bool = False,
 ) -> Config:
     """Build a Config from inputs and environment defaults."""
     root = (project_root or Path.cwd()).expanduser().resolve()
@@ -50,4 +52,5 @@ def build_config(
         attune_home=attune_home(),
         host=host,
         port=port,
+        allow_run=allow_run,
     )

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -45,7 +45,14 @@ async def home(request: Request) -> HTMLResponse:
 @router.get("/workflows", response_class=HTMLResponse)
 async def workflows_page(request: Request) -> HTMLResponse:
     workflows = data.list_workflows()
-    return _render(request, "workflows.html", page="workflows", workflows=workflows)
+    cfg = request.app.state.config
+    return _render(
+        request,
+        "workflows.html",
+        page="workflows",
+        workflows=workflows,
+        allow_run=cfg.allow_run,
+    )
 
 
 @router.get("/telemetry", response_class=HTMLResponse)

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -1,0 +1,76 @@
+"""HTTP routes for workflow execution + SSE log streaming."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from attune.ops.runner import RunnerBusyError, RunnerService
+
+router = APIRouter()
+
+
+def _service(request: Request) -> RunnerService:
+    svc: RunnerService | None = getattr(request.app.state, "runner", None)
+    if svc is None:
+        raise HTTPException(status_code=500, detail="runner service unavailable")
+    return svc
+
+
+def _ensure_allowed(request: Request) -> None:
+    if not request.app.state.config.allow_run:
+        raise HTTPException(
+            status_code=403,
+            detail="workflow execution is disabled; restart attune ops with --allow-run",
+        )
+
+
+@router.post("/workflows/{name}/run")
+async def start_run(name: str, request: Request) -> JSONResponse:
+    _ensure_allowed(request)
+    svc = _service(request)
+    try:
+        run = await svc.start(name)
+    except RunnerBusyError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"message": "runner busy", "current_run_id": exc.current_run_id},
+        ) from exc
+    return JSONResponse(
+        status_code=201,
+        content={
+            "run_id": run.id,
+            "stream_url": f"/runs/{run.id}/stream",
+            "status_url": f"/runs/{run.id}",
+        },
+    )
+
+
+@router.get("/runs/{run_id}")
+async def get_run(run_id: str, request: Request) -> JSONResponse:
+    svc = _service(request)
+    run = svc.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    return JSONResponse(content=run.to_dict())
+
+
+@router.get("/runs/{run_id}/stream")
+async def stream_run(run_id: str, request: Request) -> StreamingResponse:
+    svc = _service(request)
+    run = svc.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+
+    async def event_source() -> AsyncIterator[bytes]:
+        async for kind, payload in run.subscribe():
+            yield f"event: {kind}\ndata: {json.dumps(payload)}\n\n".encode()
+
+    return StreamingResponse(
+        event_source(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -1,0 +1,194 @@
+"""In-memory workflow runner for the ops dashboard.
+
+Spawns ``attune workflow run <name>`` as a subprocess, captures merged
+stdout+stderr line-by-line, and broadcasts lines to SSE subscribers.
+
+Single concurrent run by design. History is in-memory only (last N runs).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+import sys
+import uuid
+from collections import OrderedDict
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+
+class RunnerBusyError(RuntimeError):
+    """Raised when a run is already pending/running."""
+
+    def __init__(self, current_run_id: str) -> None:
+        super().__init__(f"runner busy: run {current_run_id} is active")
+        self.current_run_id = current_run_id
+
+
+RunStatus = Literal["pending", "running", "completed", "failed"]
+EventKind = Literal["line", "done", "error"]
+Event = tuple[EventKind, object]
+
+
+@dataclass
+class Run:
+    """Single workflow execution + its broadcast state."""
+
+    id: str
+    workflow: str
+    status: RunStatus = "pending"
+    exit_code: int | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    lines: list[str] = field(default_factory=list)
+    subscribers: set[asyncio.Queue[Event]] = field(default_factory=set)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in ("completed", "failed")
+
+    @property
+    def duration_seconds(self) -> float | None:
+        if self.started_at is None or self.completed_at is None:
+            return None
+        return (self.completed_at - self.started_at).total_seconds()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "workflow": self.workflow,
+            "status": self.status,
+            "exit_code": self.exit_code,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "duration_seconds": self.duration_seconds,
+            "line_count": len(self.lines),
+        }
+
+    def _broadcast(self, event: Event) -> None:
+        for q in list(self.subscribers):
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                # INTENTIONAL: drop slow subscriber rather than block the run
+                pass
+
+    def append_line(self, line: str) -> None:
+        self.lines.append(line)
+        self._broadcast(("line", line))
+
+    def mark_done(self, exit_code: int) -> None:
+        self.exit_code = exit_code
+        self.status = "completed" if exit_code == 0 else "failed"
+        self.completed_at = datetime.now(timezone.utc)
+        self._broadcast(("done", {"exit_code": exit_code, "status": self.status}))
+
+    async def subscribe(self) -> AsyncIterator[Event]:
+        """Yield buffered + live events. Caller iterates until it sees ``done``."""
+        queue: asyncio.Queue[Event] = asyncio.Queue()
+        # Replay buffered state to this subscriber
+        for line in self.lines:
+            queue.put_nowait(("line", line))
+        if self.is_terminal:
+            queue.put_nowait(("done", {"exit_code": self.exit_code, "status": self.status}))
+        self.subscribers.add(queue)
+        try:
+            while True:
+                event = await queue.get()
+                yield event
+                if event[0] == "done":
+                    return
+        finally:
+            self.subscribers.discard(queue)
+
+
+CommandBuilder = Callable[[str], Sequence[str]]
+
+
+def _default_command(workflow: str) -> Sequence[str]:
+    """Default subprocess command — shells out to the user's `attune` CLI."""
+    return ("attune", "workflow", "run", workflow)
+
+
+class RunnerService:
+    """Owns the run history + concurrency lock."""
+
+    def __init__(
+        self,
+        *,
+        history_limit: int = 20,
+        command_builder: CommandBuilder | None = None,
+        executor: Callable[[Run], Awaitable[None]] | None = None,
+    ) -> None:
+        self._runs: OrderedDict[str, Run] = OrderedDict()
+        self._history_limit = history_limit
+        self._command_builder = command_builder or _default_command
+        self._lock = asyncio.Lock()
+        self._executor = executor or self._execute
+
+    @property
+    def current(self) -> Run | None:
+        for run in reversed(self._runs.values()):
+            if not run.is_terminal:
+                return run
+        return None
+
+    def get(self, run_id: str) -> Run | None:
+        return self._runs.get(run_id)
+
+    def recent(self, limit: int = 5) -> list[Run]:
+        return list(reversed(list(self._runs.values())))[:limit]
+
+    async def start(self, workflow: str) -> Run:
+        async with self._lock:
+            current = self.current
+            if current is not None:
+                raise RunnerBusyError(current.id)
+            run = Run(id=uuid.uuid4().hex[:12], workflow=workflow)
+            self._runs[run.id] = run
+            while len(self._runs) > self._history_limit:
+                self._runs.popitem(last=False)
+        # Fire and forget — execution streams events via the run's subscribers
+        asyncio.create_task(self._executor(run))
+        return run
+
+    async def _execute(self, run: Run) -> None:
+        run.status = "running"
+        run.started_at = datetime.now(timezone.utc)
+        cmd = list(self._command_builder(run.workflow))
+        run.append_line(f"$ {' '.join(shlex.quote(c) for c in cmd)}")
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+        except FileNotFoundError as exc:
+            run.append_line(f"[runner error] command not found: {exc}")
+            run.mark_done(-1)
+            return
+        except Exception as exc:  # noqa: BLE001
+            run.append_line(f"[runner error] {exc}")
+            run.mark_done(-1)
+            return
+
+        assert proc.stdout is not None
+        try:
+            while True:
+                raw = await proc.stdout.readline()
+                if not raw:
+                    break
+                run.append_line(raw.decode("utf-8", errors="replace").rstrip("\n"))
+            await proc.wait()
+            run.mark_done(proc.returncode if proc.returncode is not None else -1)
+        except Exception as exc:  # noqa: BLE001
+            run.append_line(f"[runner error] {exc}")
+            run.mark_done(-1)
+
+
+def echo_command_builder(workflow: str) -> Sequence[str]:
+    """Test helper: produce a portable subprocess that prints two lines + exits 0."""
+    script = f"import sys; print('starting {workflow}'); print('done {workflow}')"
+    return (sys.executable, "-c", script)

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -13,6 +13,8 @@ from fastapi.templating import Jinja2Templates
 from attune import __version__
 from attune.ops.config import Config
 from attune.ops.routes import dashboard
+from attune.ops.routes import runner as runner_routes
+from attune.ops.runner import RunnerService
 
 
 def _package_dir(name: str) -> Path:
@@ -20,7 +22,7 @@ def _package_dir(name: str) -> Path:
     return Path(str(files("attune.ops").joinpath(name)))
 
 
-def create_app(config: Config) -> FastAPI:
+def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAPI:
     """Build the FastAPI app, wiring config + templates into request state."""
     app = FastAPI(
         title="attune ops",
@@ -47,8 +49,10 @@ def create_app(config: Config) -> FastAPI:
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
     app.state.config = config
     app.state.templates = templates
+    app.state.runner = runner if runner is not None else RunnerService()
 
     app.include_router(dashboard.router)
+    app.include_router(runner_routes.router)
 
     @app.get("/api/info", response_class=JSONResponse)
     async def info(request: Request):

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -406,3 +406,49 @@ a.kpi:hover {
   font-size: 11px;
   color: var(--fg-subtle);
 }
+
+/* Workflow runner */
+.btn {
+  font: inherit;
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elev);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+.btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.btn-run {
+  font-weight: 600;
+}
+.run-status {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  min-height: 1em;
+}
+.log-pane {
+  margin-top: 8px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.log-output {
+  margin: 0;
+  padding: 10px 12px;
+  font: 12px var(--font-mono);
+  color: var(--fg);
+  max-height: 240px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -1,0 +1,77 @@
+// Minimal SSE-driven workflow runner UI.
+// No frameworks. Wires the per-row Run button to POST /workflows/<name>/run,
+// then attaches an EventSource to /runs/<id>/stream.
+(function () {
+  "use strict";
+
+  function findRow(name) {
+    return document.querySelector('tr[data-workflow="' + CSS.escape(name) + '"]');
+  }
+
+  function setStatus(row, status) {
+    var el = row.querySelector("[data-status]");
+    if (el) el.textContent = status;
+  }
+
+  function appendLine(row, line) {
+    var pre = row.querySelector("[data-log]");
+    if (!pre) return;
+    pre.textContent += line + "\n";
+    pre.scrollTop = pre.scrollHeight;
+  }
+
+  function showLogPane(row) {
+    var pane = row.querySelector("[data-log-pane]");
+    if (pane) pane.hidden = false;
+    var pre = row.querySelector("[data-log]");
+    if (pre) pre.textContent = "";
+  }
+
+  function attach(button) {
+    button.addEventListener("click", async function () {
+      var name = button.dataset.workflow;
+      var row = findRow(name);
+      if (!row) return;
+      button.disabled = true;
+      setStatus(row, "starting…");
+      showLogPane(row);
+      try {
+        var resp = await fetch("/workflows/" + encodeURIComponent(name) + "/run", {
+          method: "POST",
+        });
+        if (!resp.ok) {
+          var detail = await resp.text();
+          appendLine(row, "[error] " + resp.status + " " + detail);
+          setStatus(row, "error");
+          button.disabled = false;
+          return;
+        }
+        var body = await resp.json();
+        setStatus(row, "running");
+        var es = new EventSource(body.stream_url);
+        es.addEventListener("line", function (ev) {
+          appendLine(row, JSON.parse(ev.data));
+        });
+        es.addEventListener("done", function (ev) {
+          var info = JSON.parse(ev.data);
+          setStatus(row, info.status + " (exit " + info.exit_code + ")");
+          es.close();
+          button.disabled = false;
+        });
+        es.addEventListener("error", function () {
+          setStatus(row, "stream error");
+          es.close();
+          button.disabled = false;
+        });
+      } catch (err) {
+        appendLine(row, "[error] " + err);
+        setStatus(row, "error");
+        button.disabled = false;
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll("[data-run-button]").forEach(attach);
+  });
+})();

--- a/src/attune/ops/templates/base.html
+++ b/src/attune/ops/templates/base.html
@@ -24,6 +24,7 @@
       </div>
     </header>
     <main class="main">{% block content %}{% endblock %}</main>
+    {% block scripts %}{% endblock %}
     <footer class="footer">
       attune ops · reads from <code>{{ attune_home }}</code> · refresh page for live data
     </footer>

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -3,22 +3,30 @@
 {% block content %}
 <section class="page-head">
   <h1>Workflows</h1>
-  <p class="page-sub">{{ workflows|length }} registered. Run with <code>attune workflow run &lt;name&gt;</code>.</p>
+  <p class="page-sub">
+    {{ workflows|length }} registered.
+    {% if allow_run %}
+      Click <strong>Run</strong> to execute one. Output streams below.
+    {% else %}
+      Read-only mode — restart with <code>attune ops --allow-run</code> to run from the dashboard.
+    {% endif %}
+  </p>
 </section>
 
 {% if workflows %}
-  <table class="data-table">
+  <table class="data-table runner-table">
     <thead>
       <tr>
         <th>Name</th>
         <th class="num">Stages</th>
         <th>Tier map</th>
         <th>Description</th>
+        {% if allow_run %}<th class="num">Action</th>{% endif %}
       </tr>
     </thead>
     <tbody>
       {% for w in workflows %}
-        <tr>
+        <tr data-workflow="{{ w.name }}">
           <td><code>{{ w.name }}</code></td>
           <td class="num">{{ w.stages }}</td>
           <td>
@@ -26,12 +34,29 @@
               <span class="chip chip-{{ tier|lower }}">{{ stage }}: {{ tier }}</span>
             {% endfor %}
           </td>
-          <td>{{ w.description }}</td>
+          <td>
+            {{ w.description }}
+            <div class="run-status"><span data-status></span></div>
+            <div class="log-pane" data-log-pane hidden>
+              <pre data-log class="log-output"></pre>
+            </div>
+          </td>
+          {% if allow_run %}
+            <td class="num">
+              <button class="btn btn-run" type="button" data-run-button data-workflow="{{ w.name }}">Run</button>
+            </td>
+          {% endif %}
         </tr>
       {% endfor %}
     </tbody>
   </table>
 {% else %}
   <p class="empty">No workflows are visible. Make sure <code>attune-ai</code> is installed in the same venv as <code>attune-ops</code>.</p>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+{% if allow_run %}
+  <script src="{{ url_for('static', path='js/runner.js') }}"></script>
 {% endif %}
 {% endblock %}

--- a/tests/unit/ops/test_runner.py
+++ b/tests/unit/ops/test_runner.py
@@ -1,0 +1,203 @@
+"""Tests for the workflow runner (RunnerService + routes).
+
+These exercise the subprocess pipeline with a portable command (the python
+interpreter running a tiny inline script), so they're deterministic on every OS.
+
+The completion-dependent tests run async (with httpx.AsyncClient) because
+TestClient tears down the event loop after each request, which would orphan
+the subprocess task spawned by RunnerService.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.runner import RunnerService  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+
+def _echo_cmd(workflow: str) -> tuple[str, ...]:
+    """Two stdout lines, exits 0. Portable across linux/mac/windows."""
+    script = f"import sys; print('start {workflow}'); " f"print('end {workflow}'); sys.exit(0)"
+    return (sys.executable, "-c", script)
+
+
+def _fail_cmd(workflow: str) -> tuple[str, ...]:
+    script = f"import sys; print('boom {workflow}'); sys.exit(1)"
+    return (sys.executable, "-c", script)
+
+
+def _missing_cmd(_workflow: str) -> tuple[str, ...]:
+    return ("/nonexistent/binary/that/should/not/exist",)
+
+
+def _make_app(tmp_path, monkeypatch, *, allow_run, command_builder, executor=None):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(project_root=tmp_path, allow_run=allow_run)
+    runner = RunnerService(command_builder=command_builder, executor=executor)
+    app = create_app(config, runner=runner)
+    return app, runner
+
+
+async def _wait_terminal(runner: RunnerService, run_id: str, *, timeout: float = 5.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        run = runner.get(run_id)
+        assert run is not None
+        if run.is_terminal:
+            return run
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(f"run {run_id} did not finish within {timeout}s")
+        await asyncio.sleep(0.02)
+
+
+# --- sync (TestClient) tests: page rendering + 403/409/404 don't need lifecycle
+
+
+def test_run_disabled_returns_403(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=False, command_builder=_echo_cmd)
+    with TestClient(app) as client:
+        resp = client.post("/workflows/code-review/run")
+    assert resp.status_code == 403
+    assert "allow-run" in resp.json()["detail"]
+
+
+def test_get_run_returns_404_for_unknown(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True, command_builder=_echo_cmd)
+    with TestClient(app) as client:
+        resp = client.get("/runs/nope")
+    assert resp.status_code == 404
+
+
+def test_workflows_page_shows_run_buttons_when_enabled(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True, command_builder=_echo_cmd)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    assert "data-run-button" in resp.text
+
+
+def test_workflows_page_hides_run_buttons_when_disabled(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=False, command_builder=_echo_cmd)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    assert "data-run-button" not in resp.text
+    assert "Read-only mode" in resp.text
+
+
+def test_run_busy_returns_409(tmp_path, monkeypatch):
+    """Second POST while a run is in flight returns 409."""
+
+    async def slow_executor(run):
+        from datetime import datetime, timezone
+
+        run.status = "running"
+        run.started_at = datetime.now(timezone.utc)
+        await asyncio.sleep(0.5)
+        run.mark_done(0)
+
+    app, _ = _make_app(
+        tmp_path,
+        monkeypatch,
+        allow_run=True,
+        command_builder=lambda _: ("noop",),
+        executor=slow_executor,
+    )
+    with TestClient(app) as client:
+        first = client.post("/workflows/x/run")
+        assert first.status_code == 201
+        second = client.post("/workflows/x/run")
+    assert second.status_code == 409
+    detail = second.json()["detail"]
+    assert detail["current_run_id"] == first.json()["run_id"]
+
+
+# --- async tests: real subprocess lifecycle in a single loop
+
+
+@pytest.mark.asyncio
+async def test_run_happy_path(tmp_path, monkeypatch):
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True, command_builder=_echo_cmd)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/workflows/code-review/run")
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["stream_url"] == f"/runs/{body['run_id']}/stream"
+
+        run = await _wait_terminal(runner, body["run_id"])
+        assert run.status == "completed"
+        assert run.exit_code == 0
+        assert any("start code-review" in ln for ln in run.lines)
+        assert any("end code-review" in ln for ln in run.lines)
+
+
+@pytest.mark.asyncio
+async def test_run_failed_status_after_nonzero_exit(tmp_path, monkeypatch):
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True, command_builder=_fail_cmd)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/workflows/x/run")
+        assert resp.status_code == 201
+        run = await _wait_terminal(runner, resp.json()["run_id"])
+        assert run.status == "failed"
+        assert run.exit_code == 1
+
+
+@pytest.mark.asyncio
+async def test_run_missing_binary_marks_failed(tmp_path, monkeypatch):
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True, command_builder=_missing_cmd)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/workflows/x/run")
+        assert resp.status_code == 201
+        run = await _wait_terminal(runner, resp.json()["run_id"])
+        assert run.status == "failed"
+        assert any("runner error" in ln for ln in run.lines)
+
+
+@pytest.mark.asyncio
+async def test_stream_replays_buffered_lines(tmp_path, monkeypatch):
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True, command_builder=_echo_cmd)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        started = (await client.post("/workflows/code-review/run")).json()
+        await _wait_terminal(runner, started["run_id"])
+
+        # Connect AFTER completion: stream replays buffered lines + done.
+        async with client.stream("GET", started["stream_url"]) as resp:
+            assert resp.status_code == 200
+            events: list[tuple[str, str]] = []
+            current_event = None
+            async for raw in resp.aiter_lines():
+                if not raw:
+                    current_event = None
+                    continue
+                if raw.startswith("event: "):
+                    current_event = raw[len("event: ") :]
+                elif raw.startswith("data: ") and current_event is not None:
+                    events.append((current_event, raw[len("data: ") :]))
+                    if current_event == "done":
+                        break
+
+    kinds = [k for k, _ in events]
+    assert "line" in kinds
+    assert kinds[-1] == "done"
+    # Every payload must be JSON-decodable so the browser can JSON.parse it
+    line_payloads = [json.loads(data) for kind, data in events if kind == "line"]
+    assert any("start code-review" in s for s in line_payloads if isinstance(s, str))
+    done_payload = json.loads(events[-1][1])
+    assert done_payload["status"] == "completed"
+    assert done_payload["exit_code"] == 0


### PR DESCRIPTION
## Summary

Adds the v0.2 workflow runner: POST a workflow, watch live output stream into the dashboard via Server-Sent Events.

> **Base branch is `claude/pedantic-hodgkin-83a205` (PR #197).** Diff is v0.2-only; rebases onto `main` after #197 merges.

### What's new
- **RunnerService** — in-memory history (last 20 runs), single concurrent run, asyncio subprocess with broadcast-on-line so SSE clients can both replay buffered output and tail in real time.
- **Routes** — `POST /workflows/{name}/run` (201), `GET /runs/{id}` (status), `GET /runs/{id}/stream` (`text/event-stream`).
- **UI** — per-row Run button + collapsible log pane; ~70 LOC vanilla JS (no framework) using `EventSource`.
- **Safety** — `--allow-run` flag, default off. Read-only mode shows a banner and hides the buttons. POST returns 403 when disabled, 409 when a run is already in flight.

### Decisions (locked in)
1. Default-off (`--allow-run` opts in) — keeps v0.1's read-only promise intact.
2. Single concurrent run; second POST returns 409.
3. Tab close detaches — subprocess keeps running, accessible via `run_id`.
4. History in-memory only (last 20); persistence is a follow-up.

### Bonus fix
- `TemplateResponse(request, name, context)` for starlette 1.x — v0.1's old signature breaks with the current pin.

## Test plan

- [x] `pytest tests/unit/ops/ --no-cov -q` — 21/21 (12 v0.1 smoke + 9 new)
- [x] Live browser test: clicked Run on `bug-predict` → 201 → SSE stream tails 14 lines → status `completed (exit 0)`
- [x] No browser console errors
- [x] Pre-commit: black, ruff, bandit, secrets all green
- [ ] Reviewer: confirm 403/409 paths match expectations

## Follow-ups

- v0.3: home polish (KPI tiles, sparkline, recent runs table backed by `RunnerService.recent()`)
- Wheel packaging check (`uv build`) to confirm `static/js/*.js` ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)