### PR TITLE
feat(ops): polish home — KPI tiles, sparkline, recent runs

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -48,6 +48,72 @@ class FamilyVersion:
     source: str  # "installed" | "missing"
 
 
+@dataclass(frozen=True)
+class DailyCost:
+    """One day's cost for the home-page sparkline."""
+
+    day: str  # YYYY-MM-DD
+    events: int
+    cost: float
+
+
+@dataclass(frozen=True)
+class HomeKpis:
+    """Summary numbers shown above the fold on the home page."""
+
+    today_events: int
+    today_cost: float
+    seven_day_cost: float
+    seven_day_savings: float
+    sparkline: list[DailyCost]  # always exactly 7 entries, oldest first
+
+
+def home_kpis(summary: TelemetrySummary, *, today: date | None = None) -> HomeKpis:
+    """Derive home-page KPIs from a telemetry summary.
+
+    Always returns a 7-entry sparkline (zero-fills missing days) so the SVG
+    layout is stable even on a fresh install.
+    """
+    today = today or date.today()
+    by_day_lookup = {row[0]: (row[1], row[2]) for row in summary.by_day}
+
+    sparkline: list[DailyCost] = []
+    seven_day_cost = 0.0
+    for offset in range(6, -1, -1):
+        day = date.fromordinal(today.toordinal() - offset).isoformat()
+        events, cost = by_day_lookup.get(day, (0, 0.0))
+        seven_day_cost += cost
+        sparkline.append(DailyCost(day=day, events=events, cost=cost))
+
+    today_events, today_cost = by_day_lookup.get(today.isoformat(), (0, 0.0))
+    return HomeKpis(
+        today_events=today_events,
+        today_cost=round(today_cost, 4),
+        seven_day_cost=round(seven_day_cost, 4),
+        seven_day_savings=round(summary.total_savings, 4),
+        sparkline=sparkline,
+    )
+
+
+def sparkline_points(values: list[float], *, width: int = 240, height: int = 40) -> str:
+    """Render values as an SVG ``polyline`` ``points`` string.
+
+    Empty/all-zero values return an empty string (template renders fallback).
+    Y-axis is inverted (SVG origin is top-left); the largest value touches
+    the top of the box.
+    """
+    if not values or all(v == 0 for v in values):
+        return ""
+    n = len(values)
+    span = max(values) or 1.0
+    points: list[str] = []
+    for i, v in enumerate(values):
+        x = (i / max(n - 1, 1)) * width
+        y = height - (v / span) * height
+        points.append(f"{x:.1f},{y:.1f}")
+    return " ".join(points)
+
+
 def read_telemetry_summary(config: Config, *, recent_days: int = 7) -> TelemetrySummary:
     """Aggregate ``usage.jsonl`` into a UI-friendly summary."""
     path = config.telemetry_path

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -32,6 +32,11 @@ async def home(request: Request) -> HTMLResponse:
     summary = data.read_telemetry_summary(cfg)
     workflows = data.list_workflows()
     versions = data.family_versions()
+    kpis = data.home_kpis(summary)
+    sparkline = data.sparkline_points([d.cost for d in kpis.sparkline])
+    runner = getattr(request.app.state, "runner", None)
+    recent_runs = [r.to_dict() for r in runner.recent(limit=5)] if runner else []
+    attune_ai = next((v for v in versions if v.package == "attune-ai"), None)
     return _render(
         request,
         "home.html",
@@ -39,6 +44,10 @@ async def home(request: Request) -> HTMLResponse:
         telemetry=summary,
         workflow_count=len(workflows),
         versions=versions,
+        kpis=kpis,
+        sparkline=sparkline,
+        recent_runs=recent_runs,
+        attune_ai=attune_ai,
     )
 
 

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -452,3 +452,32 @@ a.kpi:hover {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* Home polish */
+.sparkline {
+  display: block;
+  width: 100%;
+  height: 40px;
+  color: var(--accent);
+}
+.kpi-sub {
+  color: var(--fg-subtle);
+  font-size: 12px;
+}
+.chip-completed {
+  background: var(--ok-soft);
+  color: var(--ok);
+}
+.chip-failed {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+.chip-running,
+.chip-pending {
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.started {
+  font-size: 11px;
+  color: var(--fg-subtle);
+}

--- a/src/attune/ops/templates/home.html
+++ b/src/attune/ops/templates/home.html
@@ -7,33 +7,69 @@
 </section>
 
 <section class="kpi-grid">
-  <a class="kpi" href="/workflows">
-    <div class="kpi-label">Workflows registered</div>
-    <div class="kpi-value">{{ workflow_count }}</div>
-    <div class="kpi-foot">{% if workflow_count == 0 %}attune package not importable{% else %}runnable from CLI / MCP{% endif %}</div>
+  <a class="kpi" href="/telemetry">
+    <div class="kpi-label">Today's events</div>
+    <div class="kpi-value">{{ '{:,}'.format(kpis.today_events) }}</div>
+    <div class="kpi-foot">{% if kpis.today_events == 0 %}no activity yet today{% else %}${{ '%.4f'|format(kpis.today_cost) }} spent{% endif %}</div>
   </a>
 
   <a class="kpi" href="/telemetry">
-    <div class="kpi-label">Telemetry events</div>
-    <div class="kpi-value">{{ '{:,}'.format(telemetry.total_requests) }}</div>
-    <div class="kpi-foot">spend ${{ '%.2f'|format(telemetry.total_cost) }} · saved ${{ '%.2f'|format(telemetry.total_savings) }}</div>
+    <div class="kpi-label">7-day spend</div>
+    <div class="kpi-value">${{ '%.2f'|format(kpis.seven_day_cost) }}</div>
+    <div class="kpi-foot">
+      {% if sparkline %}
+        <svg class="sparkline" viewBox="0 0 240 40" preserveAspectRatio="none" aria-hidden="true">
+          <polyline points="{{ sparkline }}" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" />
+        </svg>
+      {% else %}
+        <span class="kpi-sub">no spend in last 7 days</span>
+      {% endif %}
+    </div>
+  </a>
+
+  <a class="kpi" href="/workflows">
+    <div class="kpi-label">Workflows</div>
+    <div class="kpi-value">{{ workflow_count }}</div>
+    <div class="kpi-foot">{% if workflow_count == 0 %}attune package not importable{% else %}runnable from CLI / MCP / dashboard{% endif %}</div>
   </a>
 
   <a class="kpi" href="/releases">
-    <div class="kpi-label">Family packages</div>
-    <div class="kpi-value">{{ versions|length }}</div>
-    <div class="kpi-foot">attune-ai · author · rag · help · gui</div>
+    <div class="kpi-label">attune-ai</div>
+    <div class="kpi-value">{% if attune_ai and attune_ai.version %}v{{ attune_ai.version }}{% else %}—{% endif %}</div>
+    <div class="kpi-foot">{{ versions|length }} family packages tracked</div>
   </a>
 </section>
 
 <section class="panel">
-  <h2>Recent activity</h2>
+  <h2>Recent runs</h2>
+  {% if recent_runs %}
+    <table class="data-table">
+      <thead><tr><th>Workflow</th><th>Status</th><th class="num">Duration</th><th>Started</th><th class="num">Lines</th></tr></thead>
+      <tbody>
+        {% for r in recent_runs %}
+          <tr>
+            <td><code>{{ r.workflow }}</code></td>
+            <td><span class="chip chip-{{ r.status }}">{{ r.status }}</span></td>
+            <td class="num">{% if r.duration_seconds is not none %}{{ '%.1fs'|format(r.duration_seconds) }}{% else %}—{% endif %}</td>
+            <td><code class="started">{{ r.started_at[:19] if r.started_at else '—' }}</code></td>
+            <td class="num">{{ r.line_count }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="empty">No runs yet this session. Trigger one from <a href="/workflows">Workflows</a> with <code>attune ops --allow-run</code>.</p>
+  {% endif %}
+</section>
+
+<section class="panel">
+  <h2>Daily activity (7 days)</h2>
   {% if telemetry.by_day %}
     <table class="data-table">
       <thead><tr><th>Day</th><th class="num">Events</th><th class="num">Cost</th></tr></thead>
       <tbody>
-        {% for day, count, cost in telemetry.by_day %}
-          <tr><td><code>{{ day }}</code></td><td class="num">{{ count }}</td><td class="num">${{ '%.4f'|format(cost) }}</td></tr>
+        {% for d in kpis.sparkline %}
+          <tr><td><code>{{ d.day }}</code></td><td class="num">{{ d.events }}</td><td class="num">${{ '%.4f'|format(d.cost) }}</td></tr>
         {% endfor %}
       </tbody>
     </table>

--- a/tests/unit/ops/test_home.py
+++ b/tests/unit/ops/test_home.py
@@ -1,0 +1,146 @@
+"""Tests for the home-page polish: KPI accessor, sparkline helper, recent-runs."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops import data  # noqa: E402
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.runner import Run, RunnerService  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+
+def _empty_summary() -> data.TelemetrySummary:
+    return data.TelemetrySummary(0, 0.0, 0.0, [], [], None)
+
+
+def test_home_kpis_with_empty_summary_returns_seven_zero_days():
+    kpis = data.home_kpis(_empty_summary(), today=date(2026, 5, 6))
+    assert kpis.today_events == 0
+    assert kpis.today_cost == 0.0
+    assert kpis.seven_day_cost == 0.0
+    assert len(kpis.sparkline) == 7
+    assert kpis.sparkline[0].day == "2026-04-30"
+    assert kpis.sparkline[-1].day == "2026-05-06"
+    assert all(d.cost == 0.0 for d in kpis.sparkline)
+
+
+def test_home_kpis_zero_fills_missing_days():
+    """Days without telemetry rows must still appear at zero."""
+    summary = data.TelemetrySummary(
+        total_requests=2,
+        total_cost=0.30,
+        total_savings=0.10,
+        by_workflow=[],
+        by_day=[("2026-05-04", 1, 0.10), ("2026-05-06", 1, 0.20)],
+        last_event_at=None,
+    )
+    kpis = data.home_kpis(summary, today=date(2026, 5, 6))
+    assert kpis.today_events == 1
+    assert kpis.today_cost == 0.20
+    assert kpis.seven_day_cost == pytest.approx(0.30)
+    days = [d.day for d in kpis.sparkline]
+    assert days == [
+        "2026-04-30",
+        "2026-05-01",
+        "2026-05-02",
+        "2026-05-03",
+        "2026-05-04",
+        "2026-05-05",
+        "2026-05-06",
+    ]
+    costs = {d.day: d.cost for d in kpis.sparkline}
+    assert costs["2026-05-04"] == 0.10
+    assert costs["2026-05-06"] == 0.20
+    assert costs["2026-05-05"] == 0.0
+
+
+def test_sparkline_points_returns_normalized_polyline():
+    points = data.sparkline_points([0, 1, 2, 1, 4, 0, 0])
+    coords = [tuple(map(float, p.split(","))) for p in points.split(" ")]
+    # 7 entries, x spans width=240
+    assert len(coords) == 7
+    assert coords[0][0] == 0.0
+    assert coords[-1][0] == pytest.approx(240.0)
+    # Highest value (4) → y=0 (top); zero → y=40 (bottom)
+    ys = [c[1] for c in coords]
+    assert min(ys) == 0.0
+    assert max(ys) == 40.0
+
+
+def test_sparkline_points_empty_for_all_zero():
+    assert data.sparkline_points([0, 0, 0, 0]) == ""
+    assert data.sparkline_points([]) == ""
+
+
+def test_home_renders_with_runner_recent_runs(tmp_path, monkeypatch):
+    """Home page lists runs from the in-memory runner."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(project_root=tmp_path)
+    runner = RunnerService()
+    # Seed a completed run via the internal mapping (avoids subprocess)
+    seeded = Run(id="abc123", workflow="code-review")
+    seeded.status = "completed"
+    seeded.exit_code = 0
+    from datetime import datetime, timezone
+
+    seeded.started_at = datetime(2026, 5, 6, 12, 0, 0, tzinfo=timezone.utc)
+    seeded.completed_at = datetime(2026, 5, 6, 12, 0, 5, tzinfo=timezone.utc)
+    seeded.lines = ["line one", "line two"]
+    runner._runs[seeded.id] = seeded  # noqa: SLF001 — test-only seeding
+
+    app = create_app(config, runner=runner)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Recent runs" in resp.text
+    assert "code-review" in resp.text
+    assert "completed" in resp.text
+
+
+def test_home_shows_empty_state_when_no_runs(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(project_root=tmp_path)
+    app = create_app(config)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert "No runs yet this session" in resp.text
+
+
+def test_home_renders_sparkline_svg_when_costs_present(tmp_path, monkeypatch):
+    """SVG with polyline points appears when at least one day has cost."""
+    home = tmp_path / "attune-home"
+    (home / "telemetry").mkdir(parents=True)
+    log = home / "telemetry" / "usage.jsonl"
+    today = date.today().isoformat()
+    log.write_text(
+        f'{{"workflow": "x", "total_cost": 0.42, "timestamp": "{today}T10:00:00+00:00"}}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ATTUNE_HOME", str(home))
+    config = build_config(project_root=tmp_path)
+    app = create_app(config)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert "<polyline" in resp.text
+    assert "$0.42" in resp.text or "0.4200" in resp.text
+
+
+def test_home_renders_attune_ai_version_tile(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(project_root=tmp_path)
+    app = create_app(config)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    # Either we resolve a version (installed) or fall back to em-dash
+    assert "attune-ai" in resp.text

--- a/tests/unit/ops/test_smoke.py
+++ b/tests/unit/ops/test_smoke.py
@@ -30,7 +30,7 @@ def test_home_renders(client):
     response = client.get("/")
     assert response.status_code == 200
     assert "attune ops" in response.text.lower()
-    assert "workflows registered" in response.text.lower()
+    assert "workflows" in response.text.lower()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Replaces the v0.1 home page with a polished layout: four KPI tiles, an inline-SVG 7-day cost sparkline, and a recent-runs table backed by `RunnerService.recent()`.

> **Base branch is `feat/ops-runner-v0.2` (PR #198).** This is the third in the chain (#197 → #198 → this). Diff is home-polish-only; will rebase onto main after #197 and #198 merge.

### What's new
- **`data.home_kpis()`** — zero-fills missing days so the sparkline always has 7 entries on a fresh install (no jagged layout shifts).
- **`data.sparkline_points()`** — pure helper that converts a list of values into a `viewBox`-relative `polyline points` string. Returns empty for all-zero input so the template can render a fallback.
- **Home route** wires KPIs + sparkline + last 5 runs into the template.
- **Recent runs table** — workflow, status badge (green/red/amber chip), duration, started-at, line count.
- **Smoke test** updated for new copy ("workflows" replaces "workflows registered").

### Live verification
- 4 KPI tiles render with correct labels and values.
- Triggered `bug-predict` via the dashboard → recent-runs row appeared on reload showing `completed (1.1s, 14 lines)`.
- No browser console errors.
- Sparkline SVG renders when ≥1 day has spend; falls back to "no spend in last 7 days" otherwise.

## Test plan

- [x] `pytest tests/unit/ops/ --no-cov -q` — 29/29 (12 v0.1 + 9 runner + 8 new home)
- [x] Pre-commit hooks pass
- [x] Live browser test on real `~/.attune/` data
- [ ] Reviewer: confirm KPI copy reads naturally

## Follow-ups

- Wheel build verification (`uv build`) — check `templates/*.html`, `static/css/*.css`, `static/js/*.js` all package
- Persist run history to disk (currently in-memory only)
- Errors-today KPI — needs error signal in telemetry events (deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)