### PR TITLE
feat(telemetry): plumb Anthropic prompt-cache tokens into usage.jsonl

### DIFF
--- a/src/attune/workflows/context_proxy_mixin.py
+++ b/src/attune/workflows/context_proxy_mixin.py
@@ -103,6 +103,8 @@ class ContextProxyMixin:
         cache_hit: bool,
         cache_type: str | None,
         duration_ms: int,
+        prompt_cache_creation_tokens: int = 0,
+        prompt_cache_read_tokens: int = 0,
     ) -> None:
         """Track telemetry -- delegates to TelemetryService when ctx is provided."""
         if self._ctx and self._ctx.telemetry:
@@ -115,6 +117,8 @@ class ContextProxyMixin:
                 cache_hit=cache_hit,
                 cache_type=cache_type,
                 duration_ms=duration_ms,
+                prompt_cache_creation_tokens=prompt_cache_creation_tokens,
+                prompt_cache_read_tokens=prompt_cache_read_tokens,
             )
             return
         super()._track_telemetry(
@@ -126,6 +130,8 @@ class ContextProxyMixin:
             cache_hit,
             cache_type,
             duration_ms,
+            prompt_cache_creation_tokens=prompt_cache_creation_tokens,
+            prompt_cache_read_tokens=prompt_cache_read_tokens,
         )
 
     def _emit_call_telemetry(

--- a/src/attune/workflows/document_gen/polish_stage.py
+++ b/src/attune/workflows/document_gen/polish_stage.py
@@ -253,12 +253,12 @@ Return the complete, polished documentation with all API reference sections pres
             try:
                 step = DOC_GEN_STEPS["polish"]
                 step.max_tokens = max_tokens
-                response, input_tokens, output_tokens, cost = await self.run_step_with_executor(
+                result = await self.run_step_with_executor(
                     step=step,
                     prompt=user_message,
                     system=system,
                 )
-                return response, input_tokens, output_tokens
+                return result.content, result.input_tokens, result.output_tokens
             except Exception:  # noqa: BLE001
                 pass  # Fall through to legacy path
 

--- a/src/attune/workflows/executor_mixin.py
+++ b/src/attune/workflows/executor_mixin.py
@@ -19,6 +19,7 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +27,29 @@ from attune.models import (
     ExecutionContext,
     LLMExecutor,
 )
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Result of a single workflow step execution.
+
+    Replaces the old 4-tuple return so cache-token telemetry can flow
+    through to ``UsageTracker.track_llm_call`` without further signature
+    growth. Anthropic prompt-cache fields are zero when the underlying
+    provider didn't report them (non-Anthropic providers, older SDKs).
+    """
+
+    content: str
+    input_tokens: int
+    output_tokens: int
+    cost: float
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+
+    @property
+    def prompt_cache_hit(self) -> bool:
+        return self.cache_read_tokens > 0
+
 
 if TYPE_CHECKING:
     from .step_config import WorkflowStepConfig
@@ -137,7 +161,7 @@ class ExecutorMixin:
         prompt: str,
         system: str | None = None,
         **kwargs: Any,
-    ) -> tuple[str, int, int, float]:
+    ) -> StepResult:
         """Run a workflow step using the LLMExecutor.
 
         This method provides a unified interface for executing steps with
@@ -151,8 +175,9 @@ class ExecutorMixin:
             **kwargs: Additional arguments passed to executor
 
         Returns:
-            Tuple of (content, input_tokens, output_tokens, cost)
-
+            StepResult with content, token counts, cost, and Anthropic
+            prompt-cache stats. Cache fields are zero when the underlying
+            provider didn't report them.
         """
         executor = self._get_executor()
 
@@ -172,6 +197,15 @@ class ExecutorMixin:
         end_time = datetime.now()
         latency_ms = int((end_time - start_time).total_seconds() * 1000)
 
+        # Pull Anthropic prompt-cache stats out of the response metadata.
+        # AnthropicProvider stamps these onto LLMResponse.metadata when the
+        # SDK response carries cache_creation_input_tokens / cache_read_input_tokens.
+        # Other providers (or older SDKs) leave the keys absent, in which
+        # case we record zeros — JSONL stays clean either way.
+        meta = response.metadata or {}
+        cache_creation = int(meta.get("cache_creation_tokens", 0) or 0)
+        cache_read = int(meta.get("cache_read_tokens", 0) or 0)
+
         # Emit telemetry
         self._emit_call_telemetry(
             step_name=step.name,
@@ -185,9 +219,11 @@ class ExecutorMixin:
             success=True,
         )
 
-        return (
-            response.content,
-            response.tokens_input,
-            response.tokens_output,
-            response.cost_estimate,
+        return StepResult(
+            content=response.content,
+            input_tokens=response.tokens_input,
+            output_tokens=response.tokens_output,
+            cost=response.cost_estimate,
+            cache_creation_tokens=cache_creation,
+            cache_read_tokens=cache_read,
         )

--- a/src/attune/workflows/llm_mixin.py
+++ b/src/attune/workflows/llm_mixin.py
@@ -132,11 +132,15 @@ class LLMMixin:
         )
 
         try:
-            content, in_tokens, out_tokens, cost = await self.run_step_with_executor(
+            result = await self.run_step_with_executor(
                 step=step,
                 prompt=user_message,
                 system=system,
             )
+            content = result.content
+            in_tokens = result.input_tokens
+            out_tokens = result.output_tokens
+            cost = result.cost
 
             # Calculate duration
             duration_ms = int((time.time() - start_time) * 1000)
@@ -151,6 +155,8 @@ class LLMMixin:
                 cache_hit=False,
                 cache_type=None,
                 duration_ms=duration_ms,
+                prompt_cache_creation_tokens=result.cache_creation_tokens,
+                prompt_cache_read_tokens=result.cache_read_tokens,
             )
 
             # Store in cache using CachingMixin

--- a/src/attune/workflows/services/telemetry_service.py
+++ b/src/attune/workflows/services/telemetry_service.py
@@ -118,6 +118,8 @@ class TelemetryService:
         cache_hit: bool,
         cache_type: str | None = None,
         duration_ms: int = 0,
+        prompt_cache_creation_tokens: int = 0,
+        prompt_cache_read_tokens: int = 0,
     ) -> None:
         """Track telemetry for an LLM call.
 
@@ -127,10 +129,13 @@ class TelemetryService:
             model: Model ID used
             cost: Cost in USD
             tokens: Dictionary with "input" and "output" token counts
-            cache_hit: Whether this was a cache hit
-            cache_type: Cache type if cache hit
+            cache_hit: Whether this was a workflow-level cache hit
+            cache_type: Cache type if cache_hit is True
             duration_ms: Duration in milliseconds
-
+            prompt_cache_creation_tokens: Tokens written to Anthropic's
+                prompt cache (zero unless reported by the provider).
+            prompt_cache_read_tokens: Tokens read from Anthropic's prompt
+                cache (zero unless reported by the provider).
         """
         if not self._enabled or self._tracker is None:
             return
@@ -147,6 +152,9 @@ class TelemetryService:
                 cache_hit=cache_hit,
                 cache_type=cache_type,
                 duration_ms=duration_ms,
+                prompt_cache_hit=prompt_cache_read_tokens > 0,
+                prompt_cache_creation_tokens=prompt_cache_creation_tokens,
+                prompt_cache_read_tokens=prompt_cache_read_tokens,
             )
         except (AttributeError, TypeError, ValueError) as e:
             logger.debug(f"Failed to track telemetry (config/data): {e}")

--- a/src/attune/workflows/telemetry_mixin.py
+++ b/src/attune/workflows/telemetry_mixin.py
@@ -102,6 +102,8 @@ class TelemetryMixin:
         cache_hit: bool,
         cache_type: str | None,
         duration_ms: int,
+        prompt_cache_creation_tokens: int = 0,
+        prompt_cache_read_tokens: int = 0,
     ) -> None:
         """Track telemetry for an LLM call.
 
@@ -111,10 +113,15 @@ class TelemetryMixin:
             model: Model ID used
             cost: Cost in USD
             tokens: Dictionary with "input" and "output" token counts
-            cache_hit: Whether this was a cache hit
-            cache_type: Cache type if cache hit
+            cache_hit: Whether this was a workflow-level cache hit
+                (skipped the LLM call entirely)
+            cache_type: Cache type if cache_hit is True
             duration_ms: Duration in milliseconds
-
+            prompt_cache_creation_tokens: Tokens written to Anthropic's
+                prompt cache during this call (zero unless the provider
+                reported it; non-Anthropic providers always pass zero).
+            prompt_cache_read_tokens: Tokens read from Anthropic's prompt
+                cache during this call (zero unless reported).
         """
         if not self._enable_telemetry or self._telemetry_tracker is None:
             return
@@ -132,6 +139,9 @@ class TelemetryMixin:
                 cache_hit=cache_hit,
                 cache_type=cache_type,
                 duration_ms=duration_ms,
+                prompt_cache_hit=prompt_cache_read_tokens > 0,
+                prompt_cache_creation_tokens=prompt_cache_creation_tokens,
+                prompt_cache_read_tokens=prompt_cache_read_tokens,
             )
         except (AttributeError, TypeError, ValueError) as e:
             # INTENTIONAL: Telemetry tracking failures should never crash workflows

--- a/tests/unit/workflows/test_cache_token_telemetry.py
+++ b/tests/unit/workflows/test_cache_token_telemetry.py
@@ -1,0 +1,217 @@
+"""Cache-token telemetry plumbing.
+
+Verifies that ``cache_creation_tokens`` and ``cache_read_tokens`` flow
+from the LLM provider's ``LLMResponse.metadata`` -> ``StepResult`` ->
+``_track_telemetry`` -> ``UsageTracker.track_llm_call``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from attune.workflows.executor_mixin import StepResult
+from attune.workflows.telemetry_mixin import TelemetryMixin
+
+
+class TestStepResult:
+    def test_default_cache_fields_zero(self) -> None:
+        sr = StepResult(content="x", input_tokens=1, output_tokens=2, cost=0.0)
+        assert sr.cache_creation_tokens == 0
+        assert sr.cache_read_tokens == 0
+        assert sr.prompt_cache_hit is False
+
+    def test_prompt_cache_hit_true_when_read_tokens(self) -> None:
+        sr = StepResult(
+            content="x",
+            input_tokens=1,
+            output_tokens=2,
+            cost=0.0,
+            cache_creation_tokens=0,
+            cache_read_tokens=1024,
+        )
+        assert sr.prompt_cache_hit is True
+
+    def test_prompt_cache_hit_false_when_only_creation(self) -> None:
+        """Creation tokens alone don't count as a hit — that's a write."""
+        sr = StepResult(
+            content="x",
+            input_tokens=1,
+            output_tokens=2,
+            cost=0.0,
+            cache_creation_tokens=2048,
+            cache_read_tokens=0,
+        )
+        assert sr.prompt_cache_hit is False
+
+
+class TestTrackTelemetryForwardsCacheTokens:
+    """``_track_telemetry`` must pass cache fields through to track_llm_call."""
+
+    def _make_mixin(self) -> tuple[TelemetryMixin, MagicMock]:
+        mixin = TelemetryMixin()
+        mixin.name = "test-workflow"
+        mixin._provider_str = "anthropic"
+        tracker = MagicMock()
+        mixin._telemetry_tracker = tracker
+        return mixin, tracker
+
+    def test_zero_cache_fields_default(self) -> None:
+        """When cache fields aren't passed, tracker sees zeros + hit=False."""
+        mixin, tracker = self._make_mixin()
+        tier = MagicMock()
+        tier.value = "capable"
+
+        mixin._track_telemetry(
+            stage="s",
+            tier=tier,
+            model="m",
+            cost=0.01,
+            tokens={"input": 100, "output": 50},
+            cache_hit=False,
+            cache_type=None,
+            duration_ms=10,
+        )
+
+        call_kwargs = tracker.track_llm_call.call_args.kwargs
+        assert call_kwargs["prompt_cache_hit"] is False
+        assert call_kwargs["prompt_cache_creation_tokens"] == 0
+        assert call_kwargs["prompt_cache_read_tokens"] == 0
+
+    def test_cache_creation_only_marks_hit_false(self) -> None:
+        mixin, tracker = self._make_mixin()
+        tier = MagicMock()
+        tier.value = "capable"
+
+        mixin._track_telemetry(
+            stage="s",
+            tier=tier,
+            model="m",
+            cost=0.01,
+            tokens={"input": 100, "output": 50},
+            cache_hit=False,
+            cache_type=None,
+            duration_ms=10,
+            prompt_cache_creation_tokens=2048,
+            prompt_cache_read_tokens=0,
+        )
+
+        call_kwargs = tracker.track_llm_call.call_args.kwargs
+        assert call_kwargs["prompt_cache_hit"] is False  # creation alone is a write
+        assert call_kwargs["prompt_cache_creation_tokens"] == 2048
+        assert call_kwargs["prompt_cache_read_tokens"] == 0
+
+    def test_cache_read_marks_hit_true(self) -> None:
+        mixin, tracker = self._make_mixin()
+        tier = MagicMock()
+        tier.value = "capable"
+
+        mixin._track_telemetry(
+            stage="s",
+            tier=tier,
+            model="m",
+            cost=0.01,
+            tokens={"input": 100, "output": 50},
+            cache_hit=False,
+            cache_type=None,
+            duration_ms=10,
+            prompt_cache_creation_tokens=0,
+            prompt_cache_read_tokens=1024,
+        )
+
+        call_kwargs = tracker.track_llm_call.call_args.kwargs
+        assert call_kwargs["prompt_cache_hit"] is True
+        assert call_kwargs["prompt_cache_read_tokens"] == 1024
+
+
+class TestRunStepWithExecutorPullsCacheFromMetadata:
+    """``run_step_with_executor`` must read cache fields from
+    ``response.metadata`` and surface them on ``StepResult``."""
+
+    @pytest.mark.asyncio
+    async def test_pulls_cache_creation_and_read_tokens(self) -> None:
+        from attune.workflows.executor_mixin import ExecutorMixin
+
+        # Build a minimal host that ExecutorMixin can run on.
+        class _Host(ExecutorMixin):
+            def __init__(self) -> None:
+                self.name = "test"
+                self._executor = MagicMock()
+                self._provider_str = "anthropic"
+
+                async def _run(**_kwargs):
+                    response = MagicMock()
+                    response.content = "ok"
+                    response.tokens_input = 1500
+                    response.tokens_output = 50
+                    response.cost_estimate = 0.01
+                    response.tier = "capable"
+                    response.model_id = "claude-sonnet-4-6"
+                    response.metadata = {
+                        "cache_creation_tokens": 1200,
+                        "cache_read_tokens": 0,
+                    }
+                    return response
+
+                self._executor.run = _run
+
+            def _create_execution_context(self, **_kwargs):
+                return MagicMock()
+
+            def _emit_call_telemetry(self, **_kwargs) -> None:  # noqa: D401
+                pass
+
+        host = _Host()
+        step = MagicMock()
+        step.name = "s"
+        step.task_type = "general"
+
+        result = await host.run_step_with_executor(step=step, prompt="hi")
+
+        assert isinstance(result, StepResult)
+        assert result.content == "ok"
+        assert result.input_tokens == 1500
+        assert result.output_tokens == 50
+        assert result.cache_creation_tokens == 1200
+        assert result.cache_read_tokens == 0
+        assert result.prompt_cache_hit is False  # creation only
+
+    @pytest.mark.asyncio
+    async def test_zero_when_metadata_absent(self) -> None:
+        """No metadata key => StepResult cache fields default to zero."""
+        from attune.workflows.executor_mixin import ExecutorMixin
+
+        class _Host(ExecutorMixin):
+            def __init__(self) -> None:
+                self.name = "test"
+                self._executor = MagicMock()
+                self._provider_str = "openai"  # no cache support
+
+                async def _run(**_kwargs):
+                    response = MagicMock()
+                    response.content = "ok"
+                    response.tokens_input = 100
+                    response.tokens_output = 20
+                    response.cost_estimate = 0.001
+                    response.tier = "cheap"
+                    response.model_id = "gpt-x"
+                    response.metadata = {}  # no cache fields
+                    return response
+
+                self._executor.run = _run
+
+            def _create_execution_context(self, **_kwargs):
+                return MagicMock()
+
+            def _emit_call_telemetry(self, **_kwargs) -> None:
+                pass
+
+        host = _Host()
+        step = MagicMock()
+        step.name = "s"
+        step.task_type = "general"
+
+        result = await host.run_step_with_executor(step=step, prompt="hi")
+        assert result.cache_creation_tokens == 0
+        assert result.cache_read_tokens == 0

--- a/tests/unit/workflows/test_document_gen_polish_stage.py
+++ b/tests/unit/workflows/test_document_gen_polish_stage.py
@@ -51,7 +51,14 @@ class _FakeHost(PolishStageMixin):
 
     async def run_step_with_executor(self, step, prompt, system=None):
         """Mock executor."""
-        return "Executor polished content.", 50, 100, 0.01
+        from attune.workflows.executor_mixin import StepResult
+
+        return StepResult(
+            content="Executor polished content.",
+            input_tokens=50,
+            output_tokens=100,
+            cost=0.01,
+        )
 
     async def _polish_chunked(self, input_data, tier):
         """Mock chunked polish."""

--- a/tests/unit/workflows/test_telemetry_mixin_coverage_boost.py
+++ b/tests/unit/workflows/test_telemetry_mixin_coverage_boost.py
@@ -183,6 +183,9 @@ class TestTrackTelemetry:
             cache_hit=True,
             cache_type="semantic",
             duration_ms=500,
+            prompt_cache_hit=False,
+            prompt_cache_creation_tokens=0,
+            prompt_cache_read_tokens=0,
         )
 
     def test_track_telemetry_handles_string_tier(self):


### PR DESCRIPTION
## Summary

Closes the gap that left \`cache_creation_input_tokens\` and \`cache_read_input_tokens\` always-zero in the JSONL telemetry log, even though \`AnthropicProvider\` was already extracting them and \`UsageTracker.track_llm_call\` was already accepting them.

The workflow layer in between was dropping them on the floor.

## What's plumbed

| Layer | Before | After |
|---|---|---|
| \`AnthropicProvider\` | Extracts \`cache_creation_tokens\` / \`cache_read_tokens\` from \`response.usage\`, stamps onto \`LLMResponse.metadata\` | unchanged |
| \`run_step_with_executor\` | Returns 4-tuple \`(content, in, out, cost)\` | Returns \`StepResult\` dataclass with **two new fields** sourced from \`response.metadata\` |
| \`llm_mixin\` + \`polish_stage\` callers | Unpack 4-tuple | Use named field access on \`StepResult\` |
| \`_track_telemetry\` (mixin + proxy) | Forwards 9 kwargs to \`track_llm_call\` | Adds \`prompt_cache_creation_tokens\` and \`prompt_cache_read_tokens\` (default 0) |
| \`WorkflowsTelemetryService.track_call\` | Same forward-only proxy | Same |
| \`UsageTracker.track_llm_call\` | Accepts cache kwargs but no caller used them | Now writes \`prompt_cache\` sub-object to JSONL |

## Effect on the telemetry log

After this change, \`~/.attune/telemetry/usage.jsonl\` entries gain a \`prompt_cache\` field whenever the underlying provider reported cache activity:

\`\`\`jsonl
{
  "v": "1.0",
  "workflow": "code-review",
  "stage": "review",
  "model": "claude-sonnet-4-6",
  "cost": 0.012,
  "tokens": {"input": 1500, "output": 250},
  "prompt_cache": {
    "hit": true,
    "creation_tokens": 0,
    "read_tokens": 1024
  },
  ...
}
\`\`\`

Existing dashboard consumers read via \`.get(...)\` with defaults so they remain forward-compatible.

## Out of scope

- A "cache hit rate" tile on the ops dashboard — it's a follow-up CSS/template change once a few entries with \`prompt_cache\` accumulate.
- Non-Anthropic providers (OpenAI/Gemini) — they don't have an equivalent cache concept in their response usage object yet, so they always pass zero. The schema is forward-compatible for if/when they do.

## Test plan

- [x] **8 new tests** covering StepResult defaults, \`prompt_cache_hit\` semantics, mixin forwarding, end-to-end pull from \`response.metadata\`
- [x] **2 existing tests updated** for the wider signature + new StepResult return type
- [x] **Full workflow + ops suites: 1832 passed, 0 failed**
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)