### PR TITLE
fix(cli): default --path to cwd for workflow run

### DIFF
--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -143,7 +143,12 @@ def _add_workflow_subparsers(subparsers: argparse._SubParsersAction) -> None:
     run_parser = workflow_sub.add_parser("run", help="Run a workflow")
     run_parser.add_argument("name", help="Workflow name")
     run_parser.add_argument("--input", "-i", help="JSON input data")
-    run_parser.add_argument("--path", "-p", help="Target path")
+    run_parser.add_argument(
+        "--path",
+        "-p",
+        default=".",
+        help="Target path (defaults to current directory)",
+    )
     run_parser.add_argument("--target", "-t", help="Target value (e.g., coverage target)")
     run_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
 

--- a/tests/unit/test_cli_minimal.py
+++ b/tests/unit/test_cli_minimal.py
@@ -91,6 +91,19 @@ class TestCreateParser:
         assert args.workflow_command == "run"
         assert args.name == "wf-name"
 
+    def test_workflow_run_path_defaults_to_cwd(self, parser: argparse.ArgumentParser) -> None:
+        """``--path`` defaults to ``"."`` so workflows that need a path
+        (dependency-check, code-review, etc.) don't fail when run bare.
+        """
+        args = parser.parse_args(["workflow", "run", "dependency-check"])
+        assert args.path == "."
+
+    def test_workflow_run_path_explicit_overrides_default(
+        self, parser: argparse.ArgumentParser
+    ) -> None:
+        args = parser.parse_args(["workflow", "run", "dependency-check", "--path", "/tmp/proj"])
+        assert args.path == "/tmp/proj"
+
     def test_telemetry_show(self, parser: argparse.ArgumentParser) -> None:
         args = parser.parse_args(["telemetry", "show"])
         assert args.command == "telemetry"


### PR DESCRIPTION
Fixes "path argument is required" surfaced when running `attune workflow run dependency-check` (or code-review, security-audit, bug-predict, perf-audit) without an explicit `--path`. The 5 affected workflows all check `kwargs.get("path", "")` and abort. Defaulting at the CLI parser layer means every workflow benefits automatically; ones that don't read the kwarg ignore it.

2 new parser tests lock the default in. 90/90 CLI + workflow-command tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)