### PR TITLE
fix(ops): runner spawns attune via sys.executable, not PATH

### DIFF
--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -108,8 +108,16 @@ CommandBuilder = Callable[[str], Sequence[str]]
 
 
 def _default_command(workflow: str) -> Sequence[str]:
-    """Default subprocess command — shells out to the user's `attune` CLI."""
-    return ("attune", "workflow", "run", workflow)
+    """Default subprocess command — runs the same attune that's hosting ops.
+
+    Uses ``sys.executable -m attune.cli_minimal`` instead of bare ``attune``
+    because ``attune`` on PATH may resolve to a different install (e.g. a
+    system pyenv shim) than the one the dashboard is running. That mismatch
+    silently runs old code, which is the kind of bug that wastes 30 minutes
+    of debugging before someone notices ``which attune`` doesn't point where
+    they think it does.
+    """
+    return (sys.executable, "-m", "attune.cli_minimal", "workflow", "run", workflow)
 
 
 class RunnerService:


### PR DESCRIPTION
Bug: dashboard runner used `("attune", "workflow", "run", X)` which resolves `attune` via PATH. On the user's machine that landed on a pyenv shim — a separate install from the venv hosting the dashboard. The pyenv install had old code (no --path default), so even after #201 merged the dashboard kept failing.

Fix: use `sys.executable -m attune.cli_minimal`. Same Python = same code = no PATH ambiguity.

9/9 runner tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)