### PR TITLE
ci: auto-merge dependabot patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot auto-merge (patch only)
+
+# Auto-merges dependabot PRs that are version-update:semver-patch.
+# Minor and major updates require manual review.
+#
+# Companion to auto-approve.yml (which handles the review step).
+# Together: dependabot opens a patch PR -> auto-approved -> auto-merged
+# once CI passes (auto-merge waits for required checks).
+#
+# Prereq: repository has "Allow auto-merge" enabled (verified
+# 2026-05-09 via gh api).
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge-patch:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependabot-auto-merge.yml` — auto-merges dependabot PRs when the update-type is `version-update:semver-patch`.
- Minor and major updates still require manual review.
- Companion to existing `auto-approve.yml` (which handles the review step).

## How it works

1. Dependabot opens a PR.
2. `auto-approve.yml` approves it (existing behavior).
3. **This workflow** fetches dependabot metadata, checks the update type, and calls `gh pr merge --auto --squash` for patch updates only.
4. GitHub waits for required checks to pass, then merges.

## Why

Solo-founder workflow; patch updates rarely break things and often carry CVE fixes. Keeps you off the security-debt treadmill without manual cycles. Minors and majors (where breaking changes live) still get human review.

## Prereqs verified

- ✅ Repo has `allow_auto_merge: true` (confirmed via `gh api repos/Smart-AI-Memory/attune-ai`)
- ⚠️  Will only fire effectively once the test matrix is green again — see [`docs/specs/ci-debt/`](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/ci-debt) for parallel work.

## Test plan

- [ ] Merge this PR
- [ ] After ci-debt spec lands and CI is green, observe next dependabot patch PR auto-merging without intervention
- [ ] Confirm minor/major dependabot PRs (e.g. PR #192 streamlit minor) do NOT auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)