### PR TITLE
ci: expand [dev] extras + resolve tiktoken contract drift (Phase A)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,18 @@ dev = [
     # matches the [rag] extra so dev + runtime deps stay in
     # lock-step.
     "attune-rag>=0.1.5,<0.2",
+    # Test deps for paths that import optional runtime libs
+    # unconditionally. Without these, the unit suite fails at
+    # collection on a fresh `pip install -e .[dev]`. See
+    # docs/specs/ci-debt/ Phase A for the contract:
+    #   - redis: tests/unit/memory/test_pubsub_direct.py
+    #   - langchain-anthropic: tests/unit/agent_factory/test_langgraph_adapter.py
+    #   - tiktoken: tests/unit/models/test_token_estimator.py
+    #     (tiktoken stays optional in production; tests cover
+    #      both TIKTOKEN_AVAILABLE paths)
+    "redis>=5.0.0,<8.0.0",
+    "langchain-anthropic>=0.3.0,<1.0.0",
+    "tiktoken>=0.7.0,<1.0.0",
 ]
 
 # Individual developers - lightweight, software development focused

--- a/tests/unit/models/test_token_estimator.py
+++ b/tests/unit/models/test_token_estimator.py
@@ -543,7 +543,7 @@ class TestEstimateSingleCallCostNoModel:
 
 
 class TestGetEncodingPaths:
-    """Cover lines 40-43 in _get_encoding."""
+    """Cover lines 40-43 in _get_encoding (tiktoken-installed path)."""
 
     def test_gpt4_encoding(self):
         from attune.models import token_estimator as mod
@@ -567,6 +567,29 @@ class TestGetEncodingPaths:
         mod._get_encoding.cache_clear()
         result = mod._get_encoding("unknown-model")
         assert result is not None
+        mod._get_encoding.cache_clear()
+
+
+class TestGetEncodingPathsNoTiktoken:
+    """Cover lines 33-34 in _get_encoding (tiktoken-not-installed path).
+
+    tiktoken is optional in production (heuristic fallback exists). These
+    tests verify the no-tiktoken branch returns None so callers fall
+    through to the heuristic. Pairs with TestGetEncodingPaths above which
+    covers the tiktoken-installed branch.
+    """
+
+    def test_returns_none_when_tiktoken_unavailable(self):
+        from unittest.mock import patch
+
+        from attune.models import token_estimator as mod
+
+        mod._get_encoding.cache_clear()
+        with patch.object(mod, "TIKTOKEN_AVAILABLE", False):
+            assert mod._get_encoding("gpt-4-turbo") is None
+            assert mod._get_encoding("o1-preview") is None
+            assert mod._get_encoding("unknown-model") is None
+            assert mod._get_encoding("claude-sonnet-4-6") is None
         mod._get_encoding.cache_clear()
 
 

--- a/tests/unit/test_redis_fallback.py
+++ b/tests/unit/test_redis_fallback.py
@@ -56,10 +56,19 @@ def _redis_running() -> bool:
 class TestRedisFallbackBehavior:
     """Test that RedisShortTermMemory gracefully falls back to mock when Redis unavailable."""
 
+    @patch("attune.memory.redis_auto_detect.RedisAutoDetector")
     @patch("attune.memory.features.MemoryFeatures.check_redis", return_value=True)
     @patch("attune.memory.short_term.base.REDIS_AVAILABLE", True)
     @patch("attune.memory.short_term.base.redis.Redis")
-    def test_falls_back_to_mock_on_connection_failure(self, mock_redis_cls, _mock_feat):
+    def test_falls_back_to_mock_on_connection_failure(
+        self, mock_redis_cls, _mock_feat, mock_detector
+    ):
+        # Force auto-detect to report Redis available so the production
+        # __init__ proceeds to _create_client_with_retry() instead of
+        # short-circuiting to mock when no real Redis server runs (CI).
+        mock_detector.return_value.detect.return_value = type(
+            "DetectResult", (), {"available": True, "reason": ""}
+        )()
         """Test graceful fallback to mock storage when Redis connection fails."""
         # Mock Redis connection failure
         mock_redis_cls.side_effect = redis.ConnectionError("Connection refused")
@@ -71,11 +80,17 @@ class TestRedisFallbackBehavior:
         # Verify it attempted to connect
         assert mock_redis_cls.called
 
+    @patch("attune.memory.redis_auto_detect.RedisAutoDetector")
     @patch("attune.memory.features.MemoryFeatures.check_redis", return_value=True)
     @patch("attune.memory.short_term.base.REDIS_AVAILABLE", True)
     @patch("attune.memory.short_term.base.redis.Redis")
-    def test_falls_back_to_mock_on_auth_failure(self, mock_redis_cls, _mock_feat):
+    def test_falls_back_to_mock_on_auth_failure(self, mock_redis_cls, _mock_feat, mock_detector):
         """Test graceful fallback when Redis authentication fails."""
+        # See test_falls_back_to_mock_on_connection_failure for why
+        # auto-detect is patched.
+        mock_detector.return_value.detect.return_value = type(
+            "DetectResult", (), {"available": True, "reason": ""}
+        )()
         mock_client = Mock()
         mock_client.ping.side_effect = redis.AuthenticationError("Invalid password")
         mock_redis_cls.return_value = mock_client
@@ -84,11 +99,19 @@ class TestRedisFallbackBehavior:
         with pytest.raises(redis.AuthenticationError):
             _ = RedisShortTermMemory(host="localhost", port=6379, password="wrong")
 
+    @patch("attune.memory.redis_auto_detect.RedisAutoDetector")
     @patch("attune.memory.features.MemoryFeatures.check_redis", return_value=True)
     @patch("attune.memory.short_term.base.REDIS_AVAILABLE", True)
     @patch("attune.memory.short_term.base.redis.Redis")
-    def test_retries_connection_with_exponential_backoff(self, mock_redis_cls, _mock_feat):
+    def test_retries_connection_with_exponential_backoff(
+        self, mock_redis_cls, _mock_feat, mock_detector
+    ):
         """Test that connection retries use exponential backoff."""
+        # See test_falls_back_to_mock_on_connection_failure for why
+        # auto-detect is patched.
+        mock_detector.return_value.detect.return_value = type(
+            "DetectResult", (), {"available": True, "reason": ""}
+        )()
         mock_client = Mock()
         call_count = 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -326,6 +326,7 @@ dev = [
     { name = "coverage" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "langchain-anthropic" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -335,8 +336,10 @@ dev = [
     { name = "pytest-picked" },
     { name = "pytest-testmon" },
     { name = "pytest-xdist" },
+    { name = "redis" },
     { name = "requests" },
     { name = "ruff" },
+    { name = "tiktoken" },
     { name = "types-pyyaml" },
 ]
 developer = [
@@ -465,6 +468,7 @@ requires-dist = [
     { name = "langchain", marker = "extra == 'developer'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain", marker = "extra == 'enterprise'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain", marker = "extra == 'full'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "langchain-anthropic", marker = "extra == 'dev'", specifier = ">=0.3.0,<1.0.0" },
     { name = "langchain-core", marker = "extra == 'agents'", specifier = ">=1.2.28,<2.0.0" },
     { name = "langchain-core", marker = "extra == 'all'", specifier = ">=1.2.28,<2.0.0" },
     { name = "langchain-core", marker = "extra == 'developer'", specifier = ">=1.2.28,<2.0.0" },
@@ -548,6 +552,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'developer'", specifier = ">=6.0,<7.0" },
     { name = "pyyaml", marker = "extra == 'enterprise'", specifier = ">=6.0,<7.0" },
     { name = "pyyaml", marker = "extra == 'full'", specifier = ">=6.0,<7.0" },
+    { name = "redis", marker = "extra == 'dev'", specifier = ">=5.0.0,<8.0.0" },
     { name = "redis", marker = "extra == 'developer'", specifier = ">=5.0.0,<8.0.0" },
     { name = "redis", marker = "extra == 'memory'", specifier = ">=5.0.0,<8.0.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<8.0.0" },
@@ -559,6 +564,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'backend'", specifier = ">=0.40.0,<2.0.0" },
     { name = "starlette", marker = "extra == 'enterprise'", specifier = ">=0.40.0,<2.0.0" },
     { name = "structlog", specifier = ">=24.0.0,<26.0.0" },
+    { name = "tiktoken", marker = "extra == 'dev'", specifier = ">=0.7.0,<1.0.0" },
     { name = "typer", specifier = ">=0.9.0,<1.0.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0,<7.0" },
     { name = "typing-extensions", specifier = ">=4.0.0,<5.0.0" },
@@ -1968,6 +1974,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/47/f2/478ca9f3455b5d66402066d287eae7e8d6c722acfb8553937e06af708334/langchain-1.2.7.tar.gz", hash = "sha256:ba40e8d5b069a22f7085f54f405973da3d87cfdebf116282e77c692271432ecb", size = 556837, upload-time = "2026-01-23T15:22:10.817Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/c8/9ce37ae34870834c7d00bb14ff4876b700db31b928635e3307804dc41d74/langchain-1.2.7-py3-none-any.whl", hash = "sha256:1d643c8ca569bcde2470b853807f74f0768b3982d25d66d57db21a166aabda72", size = 108827, upload-time = "2026-01-23T15:22:09.771Z" },
+]
+
+[[package]]
+name = "langchain-anthropic"
+version = "0.3.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/26/5e02dee815a5b03b332ee2ba3a244a8266795d6bfa7a683845ae1689c991/langchain_anthropic-0.3.21.tar.gz", hash = "sha256:c6372fbc933171b2707d856215bb88e48bc480fbc8a23b3ff9652acd5646ad3e", size = 470812, upload-time = "2025-09-29T20:05:02.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/de/3b553f9a173dc6b57ec66f727ffed5131119b0ac23654e8c304decb8ded1/langchain_anthropic-0.3.21-py3-none-any.whl", hash = "sha256:459102b1bf223595d6ace70b771816c18f0adc29131151c789c1ea08f67d65e1", size = 32521, upload-time = "2025-09-29T20:05:00.545Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase A of [`docs/specs/ci-debt/`](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/ci-debt). Two intertwined root causes, one PR.

**Root cause 1: missing CI deps.** `pip install -e .[dev]` doesn't pull `redis`, `langchain-anthropic`, or `tiktoken` — but tests import them unconditionally. 16 cross-platform failures.

**Root cause 2: tiktoken contract drift.** `src/attune/models/token_estimator.py` treats tiktoken as optional (heuristic fallback). `tests/unit/models/test_token_estimator.py::TestGetEncodingPaths` asserts `result is not None` (requires tiktoken). Two contradictory contracts.

## Fix

- **Expand `[dev]` extra** in `pyproject.toml`: add `redis>=5.0.0,<8.0.0`, `langchain-anthropic>=0.3.0,<1.0.0`, `tiktoken>=0.7.0,<1.0.0`. Restores local-CI parity.
- **Resolve tiktoken contract** by testing both paths: production stays optional, new `TestGetEncodingPathsNoTiktoken` class uses `unittest.mock.patch` on `TIKTOKEN_AVAILABLE` to cover the no-tiktoken branch.

## Expected CI delta

Before: 5 jobs green, 7 failing.
After: ubuntu + macos jobs green (8 jobs); Windows still fails on encoding + path-separator. **8/12 green.**

Phases B and C (Windows fixes) follow as separate PRs.

## Test plan

- [x] Both `TestGetEncodingPaths` and `TestGetEncodingPathsNoTiktoken` pass locally (4 tests, 0.21s).
- [ ] CI: ubuntu and macos matrix jobs go green on this branch.
- [ ] CI: Windows jobs still fail on encoding + path-separator (expected — Phases B/C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)