### PR TITLE
fix(ci): SHA-pin dependabot/fetch-metadata in auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Fetch dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

PR #206 (auto-merge workflow) used `uses: dependabot/fetch-metadata@v2` — a tag, not a SHA. The repo enforces SHA-pinning via `tests/unit/ci/test_workflow_yaml.py::TestSHAPinning`, which now fails on every commit to `main`.

This is the regression that surfaced when running PR #207 (ci-debt Phase A) through CI: the `pull_request_target` merge ref tested Phase A + main, and main carries the unpinned reference.

## Fix

Pin to `v2.5.0` (latest at time of writing):
- `uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0`

## Test plan

- [x] 89 SHA-pinning tests pass locally
- [ ] Main CI goes green after merge
- [ ] PR #207 CI re-runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)