### PR TITLE
fix(hooks): force utf-8 stdout/stderr in plugin hook scripts (ci-debt Phase B)

### DIFF
--- a/plugin/hooks/_handoff_cli.py
+++ b/plugin/hooks/_handoff_cli.py
@@ -20,6 +20,14 @@ import os
 import sys
 from pathlib import Path
 
+# Force utf-8 on stdout and stderr. On Windows the default cp1252
+# encoding can't emit emoji/em-dash and would crash this hook (caught
+# by the outer try/except → silent breakage). errors='replace'
+# substitutes '?' for any stray non-encodable byte.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 _HOOKS_DIR = str(Path(__file__).resolve().parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)

--- a/plugin/hooks/compact_warning.py
+++ b/plugin/hooks/compact_warning.py
@@ -22,6 +22,14 @@ import sys
 import traceback
 from pathlib import Path
 
+# Force utf-8 on stdout and stderr. On Windows the default cp1252
+# encoding can't emit emoji/em-dash and would crash this hook (caught
+# by the outer try/except → silent breakage). errors='replace'
+# substitutes '?' for any stray non-encodable byte.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 _HOOKS_DIR = str(Path(__file__).resolve().parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)

--- a/plugin/hooks/help_freshness_check.py
+++ b/plugin/hooks/help_freshness_check.py
@@ -18,6 +18,14 @@ import sys
 import time
 from pathlib import Path
 
+# Force utf-8 on stdout and stderr. On Windows the default cp1252
+# encoding can't emit emoji/em-dash and would crash this hook (caught
+# by the outer try/except → silent breakage). errors='replace'
+# substitutes '?' for any stray non-encodable byte.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 _MAX_AGE_SECONDS = 24 * 3600  # 24 hours
 
 

--- a/plugin/hooks/help_on_error.py
+++ b/plugin/hooks/help_on_error.py
@@ -16,6 +16,14 @@ from __future__ import annotations
 import json
 import sys
 
+# Force utf-8 on stdout and stderr. On Windows the default cp1252
+# encoding can't emit emoji/em-dash and would crash this hook (caught
+# by the outer try/except → silent breakage). errors='replace'
+# substitutes '?' for any stray non-encodable byte.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 # Map error patterns to help topics.
 # Keys are substrings to match in stderr; values are
 # topic slugs for /coach.

--- a/plugin/hooks/help_post_commit.py
+++ b/plugin/hooks/help_post_commit.py
@@ -17,6 +17,14 @@ import json
 import sys
 from pathlib import Path
 
+# Force utf-8 on stdout and stderr. On Windows the default cp1252
+# encoding can't emit emoji/em-dash and would crash this hook (caught
+# by the outer try/except → silent breakage). errors='replace'
+# substitutes '?' for any stray non-encodable byte.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 
 def main() -> None:
     """Check for stale help after git commit."""

--- a/plugin/hooks/security_guard.py
+++ b/plugin/hooks/security_guard.py
@@ -22,6 +22,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
+# Force utf-8 on stdout and stderr. On Windows the default cp1252
+# encoding can't emit emoji/em-dash and would crash this hook (caught
+# by the outer try/except → silent breakage). errors='replace'
+# substitutes '?' for any stray non-encodable byte.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 logger = logging.getLogger(__name__)
 
 # Directories that must never be written to (includes macOS /private/* symlinks)

--- a/plugin/hooks/spec_orient.py
+++ b/plugin/hooks/spec_orient.py
@@ -28,6 +28,14 @@ import sys
 import traceback
 from pathlib import Path
 
+# Force utf-8 on stdout and stderr. On Windows the default cp1252
+# encoding can't emit emoji/em-dash and would crash this hook (caught
+# by the outer try/except → silent breakage). errors='replace'
+# substitutes '?' for any stray non-encodable byte.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 # Hooks are invoked as standalone scripts; ensure sibling helpers
 # resolve.
 _HOOKS_DIR = str(Path(__file__).resolve().parent)

--- a/plugin/hooks/welcome.py
+++ b/plugin/hooks/welcome.py
@@ -11,6 +11,14 @@ from __future__ import annotations
 
 import sys
 
+# Force utf-8 on stdout and stderr. On Windows the default cp1252
+# encoding can't emit emoji/em-dash and would crash this hook (caught
+# by the outer try/except → silent breakage). errors='replace'
+# substitutes '?' for any stray non-encodable byte.
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 
 def main() -> None:
     """Print welcome message to stderr (Claude Code surfaces stderr)."""


### PR DESCRIPTION
## Summary

Phase B of [`docs/specs/ci-debt/`](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/ci-debt). Resolves Windows-only encoding failures.

## Root cause

`plugin/hooks/compact_warning.py:59` emits `⚠️`. `plugin/hooks/spec_orient.py` emits em-dashes and arrows. `welcome.py` uses em-dashes. On Windows the default stdout/stderr encoding is cp1252 — these characters have no mapping → `UnicodeEncodeError`. Hook scripts are wrapped in `try/except` so the exception is swallowed; Windows users see blank output where the warning should be.

## Fix

At module load, in all 8 `plugin/hooks/*.py` scripts that write to stdout or stderr, reconfigure both streams to utf-8 with `errors="replace"`:

```python
for _stream in (sys.stdout, sys.stderr):
    if _stream.encoding and _stream.encoding.lower() != "utf-8":
        _stream.reconfigure(encoding="utf-8", errors="replace")
```

Applied uniformly across:
- `_handoff_cli.py`
- `compact_warning.py`
- `help_freshness_check.py`
- `help_on_error.py`
- `help_post_commit.py`
- `security_guard.py`
- `spec_orient.py`
- `welcome.py`

## Expected CI delta

After Phase A: ubuntu + macos jobs green, Windows still failing on encoding + path-separator.
**After this PR:** Windows jobs fail only on the path-separator test (Phase C).

## Test plan

- [x] 201 local hooks tests pass
- [ ] CI: Windows jobs no longer fail on `compact_warning` / `spec_orient`-related encoding tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)