### PR TITLE
fix(hooks): use os.pathsep for ATTUNE_AI_WORKSPACE_ROOTS (ci-debt Phase C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ and silent until they have something to say.
 - `ATTUNE_AI_COMPACT_WARNING_THRESHOLD` (default `0.70`) — fraction of context window before the warning fires.
 - `ATTUNE_AI_CHARS_PER_TOKEN` (default `4.0`) — utilization estimator's chars-to-tokens factor.
 - `ATTUNE_AI_CONTEXT_WINDOW_TOKENS` (default `200000`) — context window assumed by the estimator.
-- `ATTUNE_AI_WORKSPACE_ROOTS` (colon-separated paths) — override the workspace roots scanned for `specs/`.
+- `ATTUNE_AI_WORKSPACE_ROOTS` (`os.pathsep`-separated paths: `:` on POSIX, `;` on Windows) — override the workspace roots scanned for `specs/`.
 - `ATTUNE_AI_SENTINEL_DIR` (default `~/.attune`) — directory for the once-per-session warning sentinel.
 
 The transcript-size proxy is crude but monotonic: the warning

--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -312,13 +312,14 @@ def workspace_roots(cwd: Path | None = None) -> list[Path]:
     """Best-effort guess at workspace roots to scan for specs.
 
     Order:
-    1. ``ATTUNE_AI_WORKSPACE_ROOTS`` env var (colon-separated).
+    1. ``ATTUNE_AI_WORKSPACE_ROOTS`` env var
+       (``os.pathsep``-separated: ``:`` on POSIX, ``;`` on Windows).
     2. The given ``cwd`` (or the process cwd).
     3. ``~/attune`` if it exists and isn't already in the list.
     """
     override = os.environ.get("ATTUNE_AI_WORKSPACE_ROOTS")
     if override:
-        return [Path(p) for p in override.split(":") if p]
+        return [Path(p) for p in override.split(os.pathsep) if p]
     base = (cwd or Path.cwd()).resolve()
     roots: list[Path] = [base]
     home_workspace = Path.home() / "attune"

--- a/tests/unit/hooks/test_session_continuity_state.py
+++ b/tests/unit/hooks/test_session_continuity_state.py
@@ -247,7 +247,13 @@ class TestWorkspaceRoots:
     def test_override_takes_precedence(
         self, tmp_path: Path, state_mod, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", f"{tmp_path / 'a'}:{tmp_path / 'b'}")
+        # Use os.pathsep so this test is portable: ":" on POSIX, ";" on
+        # Windows. Hardcoding ":" caused Windows to split on the drive
+        # letter ("C:") and shred the path.
+        monkeypatch.setenv(
+            "ATTUNE_AI_WORKSPACE_ROOTS",
+            os.pathsep.join([str(tmp_path / "a"), str(tmp_path / "b")]),
+        )
         roots = state_mod.workspace_roots(cwd=tmp_path)
         assert roots == [tmp_path / "a", tmp_path / "b"]
 


### PR DESCRIPTION
## Summary

Phase C of [`docs/specs/ci-debt/`](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/ci-debt). Resolves the last Windows-only failure.

## Root cause

`workspace_roots()` in `plugin/hooks/_state.py:321` was hardcoded to split on `:` (POSIX `PATH` convention). On Windows, `tmp_path` is `C:\Users\...`, so `tmp_path / 'a'` joined with `:` produces `C:\...\a:C:\...\b`. Production parser splits on `:` and matches the drive-letter colon → `["C", "\...\a", "C", "\...\b"]`. Drive letters torn off.

## Fix

Production: `.split(":")` → `.split(os.pathsep)`. Test (`test_session_continuity_state.py:250`): `os.pathsep.join(...)` to match. Docstring + README env-var note updated.

## Expected CI delta

After Phase B: Windows jobs fail only on this one test.
**After this PR: all 12 matrix jobs green.**

## Test plan

- [x] 20 local `test_session_continuity_state.py` tests pass
- [ ] CI: Windows jobs go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)