### PR TITLE
fix(tests): restore sys.modules in token_estimator tests (unblocks #212)

### DIFF
--- a/tests/unit/models/test_token_estimator.py
+++ b/tests/unit/models/test_token_estimator.py
@@ -355,7 +355,7 @@ class TestEstimateTokensFallbacks:
 
         from attune.models import token_estimator as mod
 
-        sys.modules.pop("attune.utils.tokens", None)
+        monkeypatch.delitem(sys.modules, "attune.utils.tokens", raising=False)
 
         import builtins as _b
 
@@ -380,7 +380,7 @@ class TestEstimateTokensFallbacks:
 
         from attune.models import token_estimator as mod
 
-        sys.modules.pop("attune.utils.tokens", None)
+        monkeypatch.delitem(sys.modules, "attune.utils.tokens", raising=False)
 
         import builtins as _b
 
@@ -408,7 +408,7 @@ class TestEstimateTokensFallbacks:
 
         from attune.models import token_estimator as mod
 
-        sys.modules.pop("attune.utils.tokens", None)
+        monkeypatch.delitem(sys.modules, "attune.utils.tokens", raising=False)
 
         import builtins as _b
 


### PR DESCRIPTION
## Summary

Fixes a test-isolation bug uncovered by PR #212's pytest-timeout diagnostic. Three tests in \`tests/unit/models/test_token_estimator.py\` mutate \`sys.modules\` without restoring it, leaving stale references for any subsequent test on the same xdist worker that touches \`attune.utils.tokens\`. The visible victim is \`tests/unit/test_token_utils.py::TestCountTokens::test_api_counting_success\` and the matching \`test_api_message_counting\` — both fail in xdist runs but pass in isolation or sequentially.

## Mechanism

The 3 polluting tests do:
\`\`\`python
sys.modules.pop(\"attune.utils.tokens\", None)
\`\`\`
…to test ImportError fallback paths in \`attune.models.token_estimator\`. They never put it back.

The 2 victim tests do:
\`\`\`python
@patch(\"attune.utils.tokens._get_client\")
def test_api_counting_success(self, mock_get_client): ...
    result = count_tokens(\"Hello, world!\", use_api=True)
\`\`\`
The patch resolves \`attune.utils.tokens\` via sys.modules — but \`count_tokens\` was imported at file collection time, so \`count_tokens.__globals__\` still points to the original (popped) module. \`count_tokens()\` calls \`_get_client()\` from those original globals — bypassing the patch entirely — and the production env-var check fires:

\`\`\`
WARNING attune.utils.tokens:tokens.py:209 API token counting failed, using fallback:
ANTHROPIC_API_KEY environment variable required for API token counting
\`\`\`

The test gets a tiktoken-fallback count instead of the mocked \`10\`, and \`assert result == 10\` fails.

## Fix

Replace the 3 \`sys.modules.pop(...)\` calls with \`monkeypatch.delitem(sys.modules, \"attune.utils.tokens\", raising=False)\`. Both forms remove the cached module so the test's \`fake_import\` side_effect can fire on the next import attempt; \`monkeypatch\` additionally restores the original module entry at test teardown, killing the cross-test leak.

3 lines changed (one per test).

## Test plan

- [x] The 3 modified tests still pass: \`pytest tests/unit/models/test_token_estimator.py -k \"fallback_when_count_tokens_import_fails or fallback_with_encoding_exception or no_tiktoken_uses_heuristic\"\` → 3 passed
- [x] Full unit suite under \`-n auto\`: **5 failed, 14,122 passed → 3 failed, 14,124 passed** (+2 tests recovered, both the previously-affected token_utils tests)
- [ ] CI on this PR confirms cross-platform pass
- [ ] PR #212 (rebased on top of this) gets clean test gate

## Why this is a separate PR (not bundled into #212)

PR #212's stated goal is \"diagnose silent test hangs\" — done. This is a test-isolation bug it incidentally exposed; bundling it would conflate concerns and make bisect harder later. Small focused PRs land independently and reviewers know what each one is doing.

## Bug-log classification

Class 3 sub-pattern: **\"tests that mutate global module state without restoring it.\"** Distinct from canonical Class 3 (\"tests mocking around the bug\") because here the production code is correct — the bug is in the *test setup* leaking into other tests' assertion paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)