### PR TITLE
release: v6.7.0 — CI stabilization

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "6.3.0"
+    "version": "6.7.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
-      "description": "14 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
+      "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "6.3.0",
+      "version": "6.7.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v6.3.0
+# Attune AI Framework v6.7.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 6.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 6.7.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,121 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.7.0] - 2026-05-11
+
+### CI stabilization release — main fixes for a healthier test matrix
+
+The matrix had been hitting silent OOM crashes on Linux/macOS runners
+at ~92-98% of suite completion, masking real test failures and
+producing partial coverage. This release lands the diagnostic
+instrumentation, the fixes, and the resolution.
+
+- **`pytest-timeout` in the CI gate** (#212). Adds
+  `--timeout=60 --timeout-method=thread` so a hanging test fails
+  with a stack trace pointing at the exact line instead of letting
+  it kill an xdist worker silently. `thread` method for
+  cross-platform support — `signal`/`SIGALRM` is unreliable on
+  Windows.
+- **Integration-marked tests excluded from the CI gate** (#212).
+  4 tests in `tests/unit/orchestration/` were marked
+  `@pytest.mark.integration` but the CI filter only excluded
+  `network`. Extended to `-m "not network and not integration"`;
+  the 4 crashing-in-CI tests are now correctly out of the unit
+  gate and can be run separately via `pytest -m integration`.
+- **`sys.modules` test pollution fix** (#212). 3 tests in
+  `test_token_estimator.py` used bare `sys.modules.pop(...)`
+  without restoring, leaking module state to later xdist tests
+  that imported the same name at collection time. Replaced with
+  `monkeypatch.delitem(sys.modules, ..., raising=False)` so cleanup
+  is automatic at test teardown.
+- **Probe B memory instrumentation in CI** (#212). Background
+  monitor logs `free -m` every 30s on Linux runners. Diagnosed the
+  `[~98%] PASSED → runner shutdown` pattern as kernel OOM killer
+  harvesting xdist workers when total memory crossed the 16 GB
+  ceiling. Data ruled out coverage configuration as the dominant
+  consumer — the actual cost is heavy import chain (anthropic,
+  claude-agent-sdk, pydantic, mcp, redis, attune-*) accumulating
+  in xdist workers across thousands of tests.
+- **OOM mitigation: `-n 1` sequential in CI** (#212). Override
+  pytest.ini's `-n auto` to eliminate xdist worker multiplication.
+  Local dev keeps `-n auto`. Doubles CI wall-clock but stays
+  safely under the 16 GB Linux / 7 GB macOS ceilings.
+- **Coverage tuning**: `branch = false` in `[tool.coverage.run]`
+  plus `parallel = true` and
+  `concurrency = ["multiprocessing", "thread"]` (#212). Branch
+  coverage was set via pyproject config, so dropping
+  `--cov-branch` from the CLI alone had no effect. Disabling at
+  the config level reduces memory; parallel-mode flushing writes
+  per-worker coverage data to disk instead of accumulating in
+  RAM.
+- **`asyncio.run()` migration in `test_langgraph_adapter.py`**
+  (#212). 30 calls of
+  `asyncio.get_event_loop().run_until_complete(coro)` replaced
+  with `asyncio.run(coro)`. The deprecated form raises in Python
+  3.12+; failures were masked previously by earlier OOM crashes.
+- **`pip-audit` editable workaround** (#218). pip's editable
+  metadata handling changed around late April 2026; pip-audit
+  2.10.0's `--strict --skip-editable` started failing on every
+  PR touching `pyproject.toml` with
+  `ERROR:pip_audit._cli:attune-ai: distribution marked as editable`
+  before the skip applied. Switched to auditing a
+  `pip freeze --exclude-editable` requirements file. Same audit
+  closure, never sees the editable root.
+- **Windows runner shell fix** (#212). The new memory-monitoring
+  `run:` block uses bash syntax (`if [ ... ]; then`, `trap`, `awk`)
+  which the default PowerShell on `windows-latest` can't parse.
+  Added `shell: bash` to the step; Git Bash on Windows handles it
+  identically to Linux/macOS.
+
+### CI debt resolution (Phases A, B, C)
+
+Three follow-on PRs from the ci-debt spec that landed before the
+PR #212 stabilization work:
+
+- **Phase A** (#207): expanded `[dev]` extras + resolved tiktoken
+  contract drift.
+- **Phase B** (#210): force UTF-8 stdout/stderr in plugin hook
+  scripts. Prevents Windows `cp1252` console encoding from
+  corrupting structured hook output.
+- **Phase C** (#211): `os.pathsep`-aware
+  `ATTUNE_AI_WORKSPACE_ROOTS` parsing. Comma-separated parsing
+  broke on Windows where paths legitimately contain `:`; the env
+  var now uses the platform's path separator (`:` on POSIX, `;`
+  on Windows).
+
+### Other changes
+
+- **Dependabot patch auto-merge** (#206). PRs labeled
+  `dependabot:patch` now auto-merge once required checks pass.
+  Frees up review attention for minor/major bumps.
+- **SHA-pinned `dependabot/fetch-metadata`** (#208). Tag-based
+  pinning of GitHub Actions is vulnerable to tag-rewrite attacks;
+  this auto-merge workflow's action is now pinned by SHA.
+- **`pytest-xdist` re-enabled for local dev**. The previous `-n 0`
+  override was justified by a stale comment from before the
+  workflow refactor. Re-enabling cut suite time ~10x for local
+  dev (14k tests pass under `-n auto` in <2 min). The CI-level
+  `-n 1` cap above is separate and CI-only.
+- **Spec-driven dev infrastructure** (#213, #215, #216). Three
+  spec docs landed: redis-decoupling Phase 3A pre-flight,
+  canonical coverage pattern, and coverage exclusion policy.
+- **Help template regeneration**. 463 stale templates refreshed
+  to match current source via attune-author.
+
+### Migration notes
+
+None required. `-n auto` is still the local-dev default; the
+`-n 1` and coverage-config changes only affect CI. Branch
+coverage is off by default — re-enable in a dedicated coverage
+job with reduced `--cov=` scope if branch signal is needed.
+
+### Stats
+
+- 18,000+ unit tests passing
+- 15 auto-triggering Claude Code skills
+- 16 multi-agent workflows
+- 41 MCP tools
+
 ## [6.6.0] - 2026-05-09
 
 ### Added — session-continuity hooks + `/handoff` slash command

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Downloads](https://static.pepy.tech/badge/attune-ai)](https://pepy.tech/projects/attune-ai)
 [![Downloads/month](https://static.pepy.tech/badge/attune-ai/month)](https://pepy.tech/projects/attune-ai)
 [![Downloads/week](https://static.pepy.tech/badge/attune-ai/week)](https://pepy.tech/projects/attune-ai)
-[![Tests](https://img.shields.io/badge/tests-16%2C900%2B%20passing-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/tests.yml)
+[![Tests](https://img.shields.io/badge/tests-18%2C000%2B%20passing-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/tests.yml)
 [![Coverage](https://img.shields.io/badge/coverage-88%25-green)](https://github.com/Smart-AI-Memory/attune-ai)
 [![Security](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml/badge.svg)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml)
 [![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
@@ -16,8 +16,8 @@
 
 ---
 
-18 multi-agent workflows, 14 auto-triggering Claude Code skills, and
-36 MCP tools — specialist teams of 2–6 Claude subagents that review
+16 multi-agent workflows, 15 auto-triggering Claude Code skills, and
+41 MCP tools — specialist teams of 2–6 Claude subagents that review
 your code, surface vulnerabilities, generate tests, and plan refactors.
 The same system doubles as the authoring and assistance toolkit for
 building and maintaining knowledge bases at scale.
@@ -118,10 +118,10 @@ pip install 'attune-ai[developer]'
 
 | Capability | Plugin only | Plugin + pip |
 | ---------- | ----------- | ------------ |
-| 14 auto-triggering skills | Yes | Yes |
+| 15 auto-triggering skills | Yes | Yes |
 | Security hooks | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| 36 MCP tools | -- | Yes |
+| 41 MCP tools | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Help system maintenance | -- | Yes |
@@ -179,9 +179,9 @@ pip install 'attune-ai[developer]'
 
 ## MCP Tools
 
-36 tools organized into 4 categories:
+41 tools organized into 5 categories:
 
-### Workflow (20)
+### Workflow (21)
 
 `security_audit` `code_review` `bug_predict`
 `performance_audit` `refactor_plan` `simplify_code`
@@ -189,7 +189,7 @@ pip install 'attune-ai[developer]'
 `test_gen_parallel` `doc_gen` `doc_audit`
 `doc_orchestrator` `release_prep` `health_check`
 `dependency_check` `secure_release` `research_synthesis`
-`analyze_batch` `analyze_image`
+`analyze_batch` `analyze_image` `rag_knowledge_query`
 
 ### Help (5)
 
@@ -200,6 +200,11 @@ pip install 'attune-ai[developer]'
 
 `memory_store` `memory_retrieve` `memory_search`
 `memory_forget`
+
+### Personal Memory (4)
+
+`personal_memory_capture` `personal_memory_recall`
+`personal_memory_topics` `personal_memory_forget`
 
 ### Utility (7)
 
@@ -243,10 +248,10 @@ from retrieval. Full methodology:
 
 | | Attune AI | Static Docs | Agent Frameworks | Coding CLIs |
 | --- | --- | --- | --- | --- |
-| **Ready-to-use workflows** | 18 built-in | None | Build from scratch | None |
+| **Ready-to-use workflows** | 16 built-in | None | Build from scratch | None |
 | **Multi-agent teams** | 2–6 agents per workflow | None | Yes | No |
-| **MCP integration** | 36 native tools | None | No | No |
-| **Auto-triggering skills** | 14 skills, natural language | None | None | None |
+| **MCP integration** | 41 native tools | None | No | No |
+| **Auto-triggering skills** | 15 skills, natural language | None | None | None |
 | **Socratic discovery** | Questions before execution | None | None | None |
 | **Portable security hooks** | PreToolUse + PostToolUse | None | No | No |
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 6.3.0
+**Version:** 6.7.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1226,5 +1226,5 @@ msg = format_error(
 
 ---
 
-**Version:** 5.3.2 | **License:** Apache 2.0
+**Version:** 6.7.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "6.6.0"
+    "version": "6.7.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "6.6.0",
+      "version": "6.7.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "6.6.0"
+__version__ = "6.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "6.6.0"
+version = "6.7.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "6.6.0"
+version = "6.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Release-prep PR for **v6.7.0** — packages the CI stabilization work landing in 6.6.x-late / 6.7.x-pre and catches up significant version-string drift across the codebase.

## Version bumps (9 files)

| File | Before | After |
|---|---|---|
| `pyproject.toml` | 6.6.0 | 6.7.0 |
| `plugin/.claude-plugin/plugin.json` | 6.6.0 | 6.7.0 |
| `plugin/.claude-plugin/marketplace.json` (×2) | 6.6.0 | 6.7.0 |
| `plugin/core/__init__.py` | 6.6.0 | 6.7.0 |
| `.claude-plugin/marketplace.json` (×2) | **6.3.0** | 6.7.0 |
| `.claude/CLAUDE.md` (header + footer) | **6.3.0** | 6.7.0 |
| `docs/reference/API_REFERENCE.md` (header) | **6.3.0** | 6.7.0 |
| `docs/reference/API_REFERENCE.md` (footer) | **5.3.2** | 6.7.0 |
| `uv.lock` (auto) | 6.6.0 | 6.7.0 |

The bolded entries were stale by 4-14 minor versions per the existing "version bumps must update 7+ files" lesson. This catches them all up.

## What's in 6.7.0

The CHANGELOG entry (115 lines) covers it in detail. Highlights:

- **CI stabilization** ([#212](https://github.com/Smart-AI-Memory/attune-ai/pull/212), when merged): pytest-timeout, integration filter, sys.modules pollution fix, Probe B memory instrumentation, OOM mitigation via `-n 1` sequential + branch coverage off + parallel-mode flushing, `asyncio.run()` migration, Windows shell fix
- **pip-audit fix** ([#218](https://github.com/Smart-AI-Memory/attune-ai/pull/218)): switched to auditing a `pip freeze --exclude-editable` requirements file (editable + strict no longer plays nice in late April 2026's pip)
- **CI debt resolution** ([#207](https://github.com/Smart-AI-Memory/attune-ai/pull/207)/[#210](https://github.com/Smart-AI-Memory/attune-ai/pull/210)/[#211](https://github.com/Smart-AI-Memory/attune-ai/pull/211)): Phases A/B/C
- **Dependabot auto-merge** ([#206](https://github.com/Smart-AI-Memory/attune-ai/pull/206)) + SHA-pinning ([#208](https://github.com/Smart-AI-Memory/attune-ai/pull/208))
- **Spec docs** ([#213](https://github.com/Smart-AI-Memory/attune-ai/pull/213), [#215](https://github.com/Smart-AI-Memory/attune-ai/pull/215), [#216](https://github.com/Smart-AI-Memory/attune-ai/pull/216))

## README count refreshes (live registry verified)

| Claim | Before | After |
|---|---|---|
| Tests | 16,900+ | **18,000+** |
| Auto-triggering skills | 14 | **15** |
| MCP tools | 36 | **41** |
| Workflows | 18 | **16** (matches `list_workflows()` with-stages count) |

Also added the missing **Personal Memory (4)** category to the MCP tools listing.

## Status of merge dependencies

- ✅ #218 (pip-audit fix) — merged
- ✅ #213/#215/#216 (spec docs) — merged
- ⏳ #212 (CI stabilization) — **CI still running** for the OOM fix; this PR's content describes it as merged. If #212 doesn't land before this is merged, the CHANGELOG references it as not-yet-shipped; safe but worth noting. Rebase after #212 lands to incorporate its content into the release.
- ⏸ #209 (v7.0.0 deprecation removal) — held; not in 6.7.0

## Test plan

- [x] Local: `grep -rE "6\.6\.0|6\.3\.0|5\.3\.2"` on canonical version-claim sites returns no matches
- [x] Local: `git diff` reviewed for each file
- [ ] CI confirms pre-commit/pip-audit pass on this branch
- [ ] If #212 hasn't merged yet when this is ready to ship, rebase this on the post-#212 main

🤖 Generated with [Claude Code](https://claude.com/claude-code)