### PR TITLE
docs(specs): larger CI runners (draft)

### DIFF
--- a/docs/specs/larger-runners/decisions.md
+++ b/docs/specs/larger-runners/decisions.md
@@ -1,0 +1,114 @@
+# Decisions — Larger CI Runners
+
+**Status:** Draft (2026-05-11)
+**Owner:** Patrick
+
+---
+
+## Problem
+
+GitHub Actions' default `ubuntu-latest` runner has **4 vCPU / 16 GB
+RAM**; `macos-latest` has **3 cores / 7 GB**; `windows-latest` has
+**4 vCPU / 16 GB**. PR #212's Probe B diagnosed that attune-ai's
+14k-test suite under pytest-xdist + branch coverage peaks at
+**15.7 GB** on Linux runners — i.e., the default ceiling is
+load-bearing for our test setup. Net result: OOM-killed xdist
+workers, the `[~98%] PASSED → runner shutdown` flake pattern,
+and (most expensively) hours of engineer time spent contorting
+test-runner config to fit a 16 GB box.
+
+Patrick's local dev machine has **64 GB**. The "tests pass locally
+but fail in CI" class of confusion that follows from a much smaller
+CI ceiling has happened twice in two PRs (#207 ci-debt and now
+#212).
+
+## Decision
+
+**Move the matrix `test` job to GitHub Actions larger runners
+(8-core / 32 GB Linux variant) for `ubuntu-latest`.**
+
+Specifically:
+
+- `runs-on: ubuntu-latest` → `runs-on: ubuntu-latest-large`
+  (or equivalent — the exact label depends on what's enabled
+  for the Smart-AI-Memory org; verify with
+  `gh api repos/Smart-AI-Memory/attune-ai/actions/runs/<id>
+  --jq .runner_name` after first run)
+
+macOS and Windows runners stay on the default — they were tighter
+on memory but the import chain works there too, and the matrix
+has been mostly green on those pre-#212 anyway (modulo
+asyncio bugs and other non-memory issues).
+
+## What this lets us undo
+
+Once on 32 GB Linux runners, the following PR #212 contortions
+become unnecessary:
+
+- The dedicated `coverage:` job split — bring coverage back into
+  the matrix's ubuntu-3.11 entry as before
+- `-n 1` override — restore `-n auto` from pytest.ini for matrix
+  runs (faster wall-clock)
+- `parallel = true` + `concurrency = ["multiprocessing", "thread"]`
+  in `[tool.coverage.run]` — keep them (harmless, mildly useful)
+- mem-tick instrumentation — keep as opt-in diagnostic but no
+  longer load-bearing
+
+Probe C (investigation into "why does the suite hold 14 GB of
+process state") becomes a much smaller question: maybe still
+worth a look as a hygiene matter, but no longer release-blocking.
+
+## What this does NOT change
+
+- macOS and Windows ceilings unchanged. If `attune-ai` is ever
+  meant to run cleanly on a 7 GB macOS install, the suite still
+  needs to fit. Right now we don't gate on that — macOS matrix
+  entries are correctness checks, not memory-discipline checks.
+- The import-chain heaviness remains a real property of the
+  codebase. Larger runners are a treatment, not a cure.
+
+## Cost
+
+GitHub Actions larger runner pricing (per
+[GitHub docs](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates)):
+
+- Linux 8-core / 32 GB: **$0.016/min**
+- 75-minute timeout × 4 Python versions × ~50 PR runs/month
+  ≈ **15,000 minutes/month** worst-case
+- More realistically: ~3,000-5,000 minutes/month
+  ≈ **$50-80/month**
+
+For comparison: the PR #212 stabilization work alone consumed
+3-4 hours of engineer time. At any normal hourly rate, larger
+runners pay for themselves in <2 PRs of saved CI debugging.
+
+## Alternatives considered
+
+1. **Self-hosted runner** on a dev box or DO/Hetzner instance.
+   Lower cost ($0-20/mo), more setup, security posture review
+   needed, single point of failure. Not chosen for v1; revisit
+   if larger-runner cost becomes meaningful.
+2. **Trim the import chain** — make heavy SDKs lazy-imported in
+   tests, mock more aggressively. Real cleanup work but
+   open-ended; doesn't unblock release cadence in the
+   near term.
+3. **Cap CI parallelism aggressively forever** — what we did
+   in PR #212. Works but brittle, and each new dep makes the
+   ceiling tighter.
+4. **Accept partial coverage gating** — the current PR #212
+   compromise (continue-on-error coverage job). Ships, but
+   leaves a quality concession in place indefinitely.
+
+Choosing (current decision) over these because: minimal effort,
+minimal risk, reversible, and addresses the root cost
+(engineer time chasing memory ceilings).
+
+## Rollback
+
+Change `runs-on: ubuntu-latest-large` back to `ubuntu-latest`
+in `.github/workflows/tests.yml`. Re-apply the `-n 1` + split-
+coverage-job contortions if needed. One commit revert.
+
+---
+
+(per-phase decisions appended as work happens)

--- a/docs/specs/larger-runners/decisions.md
+++ b/docs/specs/larger-runners/decisions.md
@@ -1,11 +1,57 @@
 # Decisions — Larger CI Runners
 
-**Status:** Draft (2026-05-11)
+**Status:** Draft (2026-05-11, revised post-Probe-C)
 **Owner:** Patrick
 
 ---
 
-## Problem
+## 2026-05-11 update — post-Probe-C revision
+
+The original spec (below) was written mid-tar-pit with the
+understanding that attune-ai's 14k-test suite genuinely needed
+14+ GB of process memory. **That turned out to be wrong.** Probe C
+identified the actual cause: one missing
+`patch("threading.Thread")` in
+`tests/unit/memory/test_pubsub_direct.py` spawning a zombie
+daemon thread that allocated ~100k MagicMocks per file run. After
+the one-line fix (PR #212 commit `bcc6bdec`), the full suite peaks
+at **130 MB RSS, runs in 1.5 s sequential** — well within the
+default 16 GB ceiling.
+
+So the "rescue from OOM" framing of this spec no longer applies.
+**The case for larger runners is now smaller** but still
+defensible:
+
+1. **Headroom for future growth** — the suite is 14k tests today
+   and gaining ~1k/quarter. The next dep cycle (new SDK, more
+   workflows) could repeat the squeeze. 32 GB buys ~3-5 years
+   of runway without revisiting.
+2. **Dev parity** — Patrick's local box is 64 GB; CI at 16 GB
+   means "works locally, fails in CI" is a chronic class of
+   confusion. Larger runners narrow the gap.
+3. **Speed** — 8-core / 32 GB lets `-n auto` use more workers,
+   roughly halving matrix wall-clock again on top of Phase 4
+   of Probe C (which restores `-n auto` at 4 workers).
+
+**What the spec NO LONGER promises:**
+
+- "Lets us undo the dedicated coverage job split" — coverage job
+  now passes cleanly on default runners (post-bcc6bdec). Could
+  re-merge into matrix or keep split; lateral move.
+- "Lets us undo `-n 1`" — Probe C Phase 4 will do this on default
+  runners anyway. Larger runners just multiply available workers.
+- "Lets us undo `parallel = true / concurrency`" — keep these;
+  harmless and useful.
+- "mem-tick instrumentation no longer load-bearing" — already
+  true after bcc6bdec; the instrumentation is now diagnostic-only.
+
+**Decision still stands** because of (1)-(3) above, but priority
+drops from "blocker for tonight's release" to "nice-to-have for
+this month's release cadence."
+
+---
+
+## Problem (original framing, kept for posterity)
 
 GitHub Actions' default `ubuntu-latest` runner has **4 vCPU / 16 GB
 RAM**; `macos-latest` has **3 cores / 7 GB**; `windows-latest` has

--- a/docs/specs/larger-runners/tasks.md
+++ b/docs/specs/larger-runners/tasks.md
@@ -1,6 +1,22 @@
 # Tasks — Larger CI Runners
 
-## Phase 1 — Switch & verify (the actual work)
+**Post-Probe-C revision (2026-05-11):** with the threading-patch
+fix landed in PR #212 commit `bcc6bdec`, CI is no longer
+OOM-pressed on default 16 GB runners. The phases below are now
+about *headroom and speed*, not *rescue*. Order of operations
+also changed — Probe C Phase 4 (restore `-n auto`) is independent
+and runs first; this spec's Phase 1 stacks on top of it.
+
+Sequencing:
+
+1. **Probe C Phase 4** (separate PR) — flip `-n 1` → `-n auto`
+   on default runners. Verify green.
+2. **This spec Phase 1** — switch to larger runners; multiplies
+   the available workers (4 → 8 on Linux) and adds memory
+   headroom.
+3. **This spec Phase 2** — observe + adjust.
+
+## Phase 1 — Switch to larger runners
 
 - [ ] **1.1** Verify the org has larger runners enabled. Check
       [GitHub Actions runner groups settings](https://github.com/organizations/Smart-AI-Memory/settings/actions/runner-groups)
@@ -10,32 +26,32 @@
       - `runs-on: ubuntu-latest` → `runs-on: ubuntu-latest-large`
         on the `test` matrix job's ubuntu entries.
       - Leave macOS and Windows runners on defaults.
-- [ ] **1.3** Trigger a fresh CI run. Verify matrix completes in
-      reasonable time without OOM.
+- [ ] **1.3** Trigger a fresh CI run. Verify matrix completes
+      faster than the default-runner baseline (expectation: ~2x
+      speedup from 8 workers vs 4 with `-n auto`).
 
-## Phase 2 — Undo the workarounds (after Phase 1 confirms green)
+## Phase 2 — Observe & adjust
 
-- [ ] **2.1** Restore `-n auto` in the matrix pytest invocation
-      (remove the `-n 1` override).
-- [ ] **2.2** Re-merge the `coverage:` job back into the matrix's
-      ubuntu-3.11 entry. Or, alternative: keep the dedicated job
-      but remove `continue-on-error: true` since OOM is no longer
-      expected.
-- [ ] **2.3** Decide whether to keep mem-tick instrumentation as
-      always-on diagnostic or move it behind a workflow input flag.
-- [ ] **2.4** Close PR #212's history with a follow-up note in
-      `docs/specs/coverage-canonical-pattern/decisions.md`
-      pointing at this spec.
-
-## Phase 3 — Observe & adjust
-
-- [ ] **3.1** After one month on larger runners, check the GitHub
+- [ ] **2.1** After one month on larger runners, check the GitHub
       Actions usage report. Confirm spend is within budget
       ($50-80/month range expected).
-- [ ] **3.2** If cost exceeds expectations, evaluate self-hosted
+- [ ] **2.2** If cost exceeds expectations, evaluate self-hosted
       runner option (Alternative #1 in decisions.md).
-- [ ] **3.3** File a smaller follow-up if macOS 7 GB becomes a
+- [ ] **2.3** File a smaller follow-up if macOS 7 GB becomes a
       practical blocker for any contributor.
+
+## ~~Phase 2 — Undo the workarounds~~ (now mostly moot)
+
+The Probe C threading-patch fix already neutralized most of these:
+
+- ~~Restore `-n auto`~~ → handled by Probe C Phase 4 (separate PR)
+- ~~Re-merge `coverage:` job~~ → coverage job already passes
+  cleanly post-bcc6bdec; keeping it split is fine, no benefit
+  to re-merging
+- ~~Decide mem-tick fate~~ → already diagnostic-only post-fix;
+  keep as opt-in or retire when convenient
+- ~~Close out PR #212 history~~ → handled in
+  `docs/specs/probe-c-memory-investigation/decisions.md`
 
 ## Out of scope
 

--- a/docs/specs/larger-runners/tasks.md
+++ b/docs/specs/larger-runners/tasks.md
@@ -1,0 +1,47 @@
+# Tasks — Larger CI Runners
+
+## Phase 1 — Switch & verify (the actual work)
+
+- [ ] **1.1** Verify the org has larger runners enabled. Check
+      [GitHub Actions runner groups settings](https://github.com/organizations/Smart-AI-Memory/settings/actions/runner-groups)
+      or run a probe workflow with `runs-on: ubuntu-latest-large`
+      to confirm. Cost-attribution + billing limits should be set.
+- [ ] **1.2** Update `.github/workflows/tests.yml`:
+      - `runs-on: ubuntu-latest` → `runs-on: ubuntu-latest-large`
+        on the `test` matrix job's ubuntu entries.
+      - Leave macOS and Windows runners on defaults.
+- [ ] **1.3** Trigger a fresh CI run. Verify matrix completes in
+      reasonable time without OOM.
+
+## Phase 2 — Undo the workarounds (after Phase 1 confirms green)
+
+- [ ] **2.1** Restore `-n auto` in the matrix pytest invocation
+      (remove the `-n 1` override).
+- [ ] **2.2** Re-merge the `coverage:` job back into the matrix's
+      ubuntu-3.11 entry. Or, alternative: keep the dedicated job
+      but remove `continue-on-error: true` since OOM is no longer
+      expected.
+- [ ] **2.3** Decide whether to keep mem-tick instrumentation as
+      always-on diagnostic or move it behind a workflow input flag.
+- [ ] **2.4** Close PR #212's history with a follow-up note in
+      `docs/specs/coverage-canonical-pattern/decisions.md`
+      pointing at this spec.
+
+## Phase 3 — Observe & adjust
+
+- [ ] **3.1** After one month on larger runners, check the GitHub
+      Actions usage report. Confirm spend is within budget
+      ($50-80/month range expected).
+- [ ] **3.2** If cost exceeds expectations, evaluate self-hosted
+      runner option (Alternative #1 in decisions.md).
+- [ ] **3.3** File a smaller follow-up if macOS 7 GB becomes a
+      practical blocker for any contributor.
+
+## Out of scope
+
+- Trimming the SDK import chain (Alternative #2). Worth doing
+  someday as code hygiene; not blocking on it.
+- Self-hosted runner setup. Revisit only if cost forces it.
+- Removing `attune-rag` / `attune-help` / `attune-author` from
+  core deps to reduce test memory footprint. Architectural
+  decision, separate spec.


### PR DESCRIPTION
## Summary

Draft spec proposing we move the matrix `test` job to GitHub Actions larger runners (32 GB Linux) instead of continuing to engineer around the 16 GB default.

## Why

PR #212's Probe B established that the 14k-test suite peaks at **15.7 GB** on Linux runners with branch coverage + xdist — the default 16 GB is load-bearing. Tonight's session spent ~3-4 hours fighting the ceiling (5 iterations of OOM mitigation). Patrick's local dev box has 64 GB; the "works locally, OOMs in CI" gap has bitten us twice now (#207 ci-debt and #212).

## Proposed phases

1. **Switch & verify** — `runs-on: ubuntu-latest-large` on the test matrix Ubuntu entries
2. **Undo workarounds** — restore `-n auto`, merge coverage back into matrix, drop `continue-on-error` on coverage gate
3. **Observe** — check cost after ~1 month, revisit if budget exceeds expectations

## Cost estimate

GitHub Actions Linux 32 GB runner is **$0.016/min**. Realistic monthly spend at attune-ai PR cadence: **$50-80/month**. The PR #212 session alone (3-4 engineer-hours) already exceeded that at any normal hourly rate.

## Alternatives considered

In the spec: self-hosted runner, SDK import chain trimming, aggressive CI parallelism caps (current brittle path), partial coverage gating (#212's current compromise).

## Status

**Draft** — not for execution until #212 ships and we have a moment to breathe. Posted now so the rationale is captured while fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)