### PR TITLE
feat(ops): default to run-enabled, add --read-only opt-out

### DIFF
--- a/src/attune/ops/cli.py
+++ b/src/attune/ops/cli.py
@@ -37,9 +37,17 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="Don't auto-open the browser on startup",
     )
     parser.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Disable workflow execution from the dashboard (default: runs enabled)",
+    )
+    # Backwards-compat: --allow-run was the opt-IN flag before runs became
+    # the default. Accept it silently as a no-op so existing scripts and
+    # shell history keep working without prompting users to update.
+    parser.add_argument(
         "--allow-run",
         action="store_true",
-        help="Enable workflow execution from the dashboard (default: read-only)",
+        help=argparse.SUPPRESS,
     )
 
 
@@ -58,11 +66,15 @@ def cmd_ops(args: argparse.Namespace) -> int:
     from attune.ops.config import build_config
     from attune.ops.server import create_app
 
+    # Runs are enabled by default; --read-only opts out. The legacy
+    # --allow-run flag is accepted as a no-op (already the default).
+    allow_run = not args.read_only
+
     config = build_config(
         project_root=args.project_root,
         host=args.host,
         port=args.port,
-        allow_run=args.allow_run,
+        allow_run=allow_run,
     )
     app = create_app(config)
 

--- a/src/attune/ops/templates/home.html
+++ b/src/attune/ops/templates/home.html
@@ -58,7 +58,7 @@
       </tbody>
     </table>
   {% else %}
-    <p class="empty">No runs yet this session. Trigger one from <a href="/workflows">Workflows</a> with <code>attune ops --allow-run</code>.</p>
+    <p class="empty">No runs yet this session. Trigger one from <a href="/workflows">Workflows</a>.</p>
   {% endif %}
 </section>
 

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -8,7 +8,7 @@
     {% if allow_run %}
       Click <strong>Run</strong> to execute one. Output streams below.
     {% else %}
-      Read-only mode — restart with <code>attune ops --allow-run</code> to run from the dashboard.
+      Read-only mode — restart without <code>--read-only</code> to run from the dashboard.
     {% endif %}
   </p>
 </section>


### PR DESCRIPTION
## Summary

`attune ops` defaulted to read-only mode, requiring every interactive session that wanted to actually run a workflow to restart with `--allow-run`. That's friction for the common case.

This flips the default:

- **Runs enabled by default** — `attune ops` lands you on a working dashboard
- **`--read-only`** — new flag for opt-out (shared boxes, locked-down env)
- **`--allow-run`** — kept as a hidden no-op for backwards compat with existing scripts and shell history (it's already the new default)

## User-visible impact

| Command | Before | After |
|---|---|---|
| `attune ops` | read-only | run-enabled |
| `attune ops --allow-run` | run-enabled | run-enabled (no-op) |
| `attune ops --read-only` | n/a | read-only |

## Templates updated

The "Read-only mode — restart with `--allow-run`" hint now points at `--read-only` (since users in read-only mode now got there by passing the flag explicitly). The empty-state "trigger one from Workflows with attune ops --allow-run" message simplifies to just "trigger one from Workflows".

## Test plan

- [x] Manual: `attune ops --help` shows `--read-only`; `--allow-run` is hidden
- [x] Manual: `attune ops` defaults to allow-run
- [x] Manual: `attune ops --read-only` disables runs
- [x] Manual: `attune ops --allow-run` still works (no-op, since default)
- [ ] CI confirms no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)