### PR TITLE
docs(specs): ops-specs-features — port attune-gui spec UI to attune ops (gated draft)

### DIFF
--- a/docs/specs/ops-specs-features/decisions.md
+++ b/docs/specs/ops-specs-features/decisions.md
@@ -1,6 +1,6 @@
 # Decisions — Port spec-handling features from attune-gui to attune ops
 
-**Status:** Draft (2026-05-11) — gated on existing-features-stable
+**Status:** Approved (2026-05-11) — execution gated on existing-features-stable
 **Owner:** Patrick
 
 ---

--- a/docs/specs/ops-specs-features/decisions.md
+++ b/docs/specs/ops-specs-features/decisions.md
@@ -87,8 +87,12 @@ enough. Authoring stays in the existing tools.
 
 Phase 1 does NOT start until ALL of these are true:
 
-1. **PR #212 (CI stabilization) merged and stable** — green
-   CI for at least 1 week on default runners
+1. **PR #212 (CI stabilization) merged and stable** —
+   3 consecutive green CI runs on `main` AND no new CI-fix
+   PRs opened during that period. Measurable, not calendar-
+   based: the signal is *evidence of stability*, not *time
+   elapsed*. Could clear in a day or a week — whichever
+   demonstrates the data.
 2. **`#227` (ops default-run), `#228` (ops 409 UX)
    merged and verified** — current ops surface is rough;
    building on top of bugs is wasteful

--- a/docs/specs/ops-specs-features/decisions.md
+++ b/docs/specs/ops-specs-features/decisions.md
@@ -1,0 +1,156 @@
+# Decisions — Port spec-handling features from attune-gui to attune ops
+
+**Status:** Draft (2026-05-11) — gated on existing-features-stable
+**Owner:** Patrick
+
+---
+
+## Problem
+
+attune-gui has a fairly developed spec-handling surface
+(`sidecar/attune_gui/routes/cowork_specs.py`,
+`sidecar/attune_gui/templates/specs.html`) including:
+
+- List specs across one or more roots (federated multi-root
+  added in attune-gui PR #30)
+- Create a new spec from a slug — bootstraps
+  `requirements.md` from a Phase 1 template
+- Bootstrap subsequent phase files (`design.md`, `tasks.md`)
+  from the template, with prerequisite checks
+- Update the `**Status**:` line in any phase file
+  (`draft`/`in-review`/`approved`/`complete`/`done`)
+
+attune ops, by contrast, has Home / Workflows / Telemetry /
+Memory / Releases / Health tabs — but no specs tab. Specs live
+in the filesystem and are managed entirely from the CLI / editor.
+
+The friction:
+
+- Side-by-side use of attune ops (workflows + telemetry) and
+  attune-gui (specs + living docs) requires context-switching
+  between two dashboards
+- Spec status updates require manual file edits; the gui's
+  status-flip UX is much faster
+- Patrick uses spec-driven dev as the primary work pattern
+  (per `.claude/CLAUDE.md` session-start protocol and the
+  recently-reinforced "tar-pit trip-wire / spec-on-iter-3"
+  lesson) — specs should be first-class in the dev dashboard
+- The recent 10-hour CI tar-pit (PR #212) was partly caused by
+  reactive iteration vs spec-first work; better spec
+  accessibility makes spec-first more habitual
+
+## Why this is a spec, not an immediate build
+
+Patrick explicitly stated: *"I don't want to add features
+until we get all of our existing ones working well."* This
+spec exists to **capture the design now while the ideas are
+fresh, without committing engineering time.** Execution is
+gated.
+
+## Decision
+
+**Port the federated spec listing + status-flip UI from
+attune-gui to attune ops as a new `Specs` tab, with explicit
+scope limits and an execution gate.**
+
+### What we port (Phase 1)
+
+- **List specs** across `docs/specs/` (and any other configured
+  spec roots) — pull from attune-gui's federated multi-root
+  pattern
+- **Status display + flip** — show current status of each
+  spec's phase files; allow one-click flip between valid
+  statuses
+- **Per-spec drill-in** — view `decisions.md`, `tasks.md`,
+  `design.md`, `requirements.md` content read-only
+
+### What we explicitly do NOT port
+
+- **Spec creation from slug** (attune-gui POST endpoints)
+  — `/spec` slash command and the spec-driven workflow
+  already cover this; doubling up adds maintenance with no
+  user-facing win
+- **Phase bootstrap from template** — same reason; the
+  template lives in attune-author and the `/spec` skill
+  uses it
+- **Editor integration** — read-only viewer only. Editing
+  happens in the user's editor or via `/spec`.
+- **Living docs / corpus / template-editor surfaces** —
+  those are attune-gui's primary domain; attune ops shouldn't
+  encroach
+
+The principle: attune ops is the *developer workflow* hub.
+Specs are a developer workflow artifact. Read + status are
+enough. Authoring stays in the existing tools.
+
+## Execution gate
+
+Phase 1 does NOT start until ALL of these are true:
+
+1. **PR #212 (CI stabilization) merged and stable** — green
+   CI for at least 1 week on default runners
+2. **`#227` (ops default-run), `#228` (ops 409 UX)
+   merged and verified** — current ops surface is rough;
+   building on top of bugs is wasteful
+3. **No critical open ops bugs** — check
+   `gh issue list --label ops --state open`
+4. **Probe C Phase 4 settled** — parallel xdist restored
+   on default runners with no new failures
+5. **(Optional) `#226` larger runners** — not blocking,
+   but if landed, this work benefits from the dev-parity
+   improvement
+
+The gate is the spec's main load-bearing element. Without it,
+this spec is "yet another feature to add"; with it, this spec
+is "the work we'll do once the foundation is solid."
+
+## Alternatives considered
+
+1. **Keep two dashboards forever** — works, has the context-
+   switch cost. Acceptable if attune ops never grows a
+   significant user base; less acceptable as more developers
+   use it.
+2. **Port the full attune-gui surface to ops** — too much;
+   attune ops is workflow-focused and would lose that focus.
+3. **Move specs to attune-gui exclusively** — backwards;
+   specs are dev artifacts, not docs artifacts.
+4. **Build a new spec UI from scratch** — duplicates
+   attune-gui's working code; rejected unless attune-gui's
+   API turns out to be a poor fit for ops's frontend
+   conventions.
+
+## Acceptance criteria
+
+- A `Specs` tab in attune ops nav, between `Workflows` and
+  `Telemetry`
+- Lists specs from `docs/specs/` (configurable via
+  `--specs-root` or env var matching attune-gui's pattern)
+- Each spec shows: name, latest phase status, last-modified
+- One-click status flip with optimistic UI + server
+  confirmation
+- Read-only viewer for phase files
+- No new write endpoints beyond status updates
+- Existing attune ops tabs continue working (no regressions)
+- Tests cover the new routes at parity with existing ops
+  routes
+
+## What this spec is NOT
+
+- A commitment to start work soon. The gate is the contract.
+- A statement that attune-gui will lose its spec features.
+  Both dashboards keep working; attune ops just gains a
+  subset.
+
+## Out of scope
+
+- Mobile or external-network access to the specs UI
+  (attune ops is localhost by default; this stays)
+- Multi-user collaboration on spec edits
+- Spec analytics / trend dashboards (interesting but
+  separate)
+- Slack/email notifications on status changes
+- Diff view between phase files
+
+---
+
+(per-phase decisions appended as the gate is approached)

--- a/docs/specs/ops-specs-features/tasks.md
+++ b/docs/specs/ops-specs-features/tasks.md
@@ -1,0 +1,90 @@
+# Tasks — Port spec-handling features from attune-gui to attune ops
+
+## Phase 0 — Gate (the contract before any code)
+
+This phase is the spec's most important deliverable. Without
+the gate, this spec is just "add a feature." With it, this
+spec is "do the work when the foundation is ready."
+
+- [ ] **0.1** Verify gate conditions before starting Phase 1:
+  - [ ] PR #212 merged + 1 week of green CI
+  - [ ] PRs #227, #228 merged + verified in production
+  - [ ] No critical open `ops`-labeled issues
+  - [ ] Probe C Phase 4 settled (parallel xdist restored)
+  - [ ] (Optional) PR #226 larger runners landed
+- [ ] **0.2** Re-check decisions.md "What we port / what we
+  do NOT port" — has Patrick's usage of attune ops changed
+  in the interim such that the scope should adjust?
+
+## Phase 1 — Federated spec listing read-side
+
+Mirrors `attune-gui sidecar/attune_gui/routes/cowork_specs.py`
+GET endpoints. Backend first; frontend follows.
+
+- [ ] **1.1** Add `src/attune/ops/routes/specs.py` with:
+  - `GET /api/specs` — list all spec dirs across configured
+    roots, with phase status for each
+  - `GET /api/specs/{slug}` — return content of phase files
+    for one spec (read-only)
+- [ ] **1.2** Add `--specs-root` flag to `attune ops` CLI;
+  default to `docs/specs/` relative to `--project-root`.
+  Accept multiple values for multi-root listing (matching
+  attune-gui PR #30 pattern).
+- [ ] **1.3** Tests at parity with existing ops routes:
+  - Empty roots
+  - Single root with multiple specs
+  - Multi-root with naming collisions (later root wins?
+    error? — decide and document)
+  - Phase file missing
+  - Malformed phase file (no `**Status**:` line)
+
+## Phase 2 — Status-flip write-side
+
+- [ ] **2.1** Add `PUT /api/specs/{slug}/{phase}/status` route
+  — same body as attune-gui's
+  (`{"status": "<valid-value>"}`)
+- [ ] **2.2** Reuse attune-gui's `_STATUS_RE` and
+  `_VALID_STATUSES` patterns directly (or copy with
+  attribution comment)
+- [ ] **2.3** Honor the `--read-only` flag added in PR #227 —
+  status flip is a mutation, so blocked in read-only mode
+- [ ] **2.4** Atomic write via existing
+  `attune.ops` write helpers (or port `atomic_write` from
+  attune-gui)
+
+## Phase 3 — Frontend Specs tab
+
+- [ ] **3.1** Add `Specs` tab to nav in
+  `src/attune/ops/templates/base.html`, between
+  `Workflows` and `Telemetry`
+- [ ] **3.2** New template
+  `src/attune/ops/templates/specs.html` — pattern-match
+  attune-gui's `templates/specs.html` (160 lines, simple)
+- [ ] **3.3** Status-flip dropdown per phase with optimistic
+  UI + server-confirmation pattern (similar to runner.js
+  workflow row buttons)
+- [ ] **3.4** Per-spec drill-in showing phase file content
+  (read-only)
+
+## Phase 4 — Observe & adjust
+
+- [ ] **4.1** After 2 weeks of usage, log which features are
+  actually used (telemetry: spec listing views, status
+  flips, drill-ins)
+- [ ] **4.2** Decide whether Phase 1's read-side is enough
+  or whether to expand toward attune-gui's create/bootstrap
+  flows
+- [ ] **4.3** If usage warrants, file a follow-up spec for
+  Phase 5
+
+## Out of scope (firm — do not creep)
+
+- Spec creation from slug (`POST /api/specs`)
+- Phase bootstrap from template (`POST /api/specs/{slug}/phase`)
+- Editor / WYSIWYG / inline-markdown-editing
+- Diff view between phase files
+- Multi-user collaboration / locking
+- Notifications (slack/email/desktop)
+- Mobile access
+- Spec analytics dashboards
+- Anything from attune-gui's living-docs surface

--- a/docs/specs/ops-specs-features/tasks.md
+++ b/docs/specs/ops-specs-features/tasks.md
@@ -7,7 +7,8 @@ the gate, this spec is just "add a feature." With it, this
 spec is "do the work when the foundation is ready."
 
 - [ ] **0.1** Verify gate conditions before starting Phase 1:
-  - [ ] PR #212 merged + 1 week of green CI
+  - [ ] PR #212 merged + 3 consecutive green CI runs on `main`
+        + no new CI-fix PRs opened in that window
   - [ ] PRs #227, #228 merged + verified in production
   - [ ] No critical open `ops`-labeled issues
   - [ ] Probe C Phase 4 settled (parallel xdist restored)

--- a/docs/specs/ops-specs-features/tasks.md
+++ b/docs/specs/ops-specs-features/tasks.md
@@ -1,5 +1,9 @@
 # Tasks — Port spec-handling features from attune-gui to attune ops
 
+**Status:** Approved (2026-05-11) — execution gated on Phase 0 conditions
+
+---
+
 ## Phase 0 — Gate (the contract before any code)
 
 This phase is the spec's most important deliverable. Without


### PR DESCRIPTION
## Summary

Port a subset of attune-gui's spec-handling features (federated listing, status flip, read-only drill-in) to attune ops as a new `Specs` tab.

**This is a DRAFT spec with an explicit execution gate.** No code lands until the gate clears.

## Why now (the spec, not the build)

Patrick: *"I don't want to add features until we get all of our existing ones working well."* Exactly right — which is also exactly why the spec is the right artifact to write now:

- Specs are cheap; features are expensive
- The friction is concrete today (side-by-side use of attune-gui + attune ops); the design decays if we wait
- The gate keeps "do this someday" from becoming "do this now"

## Scope (tight)

**Port:**
- List specs across configured roots (mirrors [attune-gui PR #30](https://github.com/Smart-AI-Memory/attune-gui/pull/30) federated pattern)
- Status display + one-click flip
- Per-spec drill-in (read-only viewer for `decisions.md` / `tasks.md` / `design.md` / `requirements.md`)

**Do NOT port:**
- Spec creation from slug — `/spec` skill already covers this
- Phase bootstrap from template — same
- Editor / WYSIWYG — read-only viewer only
- Living docs / corpus / template-editor — those are attune-gui's primary domain

## Execution gate (Phase 0)

Phase 1 doesn't start until all of:

1. PR #212 (CI stabilization) merged + 1 week of green CI
2. PRs [#227](https://github.com/Smart-AI-Memory/attune-ai/pull/227), [#228](https://github.com/Smart-AI-Memory/attune-ai/pull/228) merged + verified
3. No critical open `ops`-labeled issues
4. Probe C Phase 4 settled (parallel xdist restored)
5. (Optional) [#226](https://github.com/Smart-AI-Memory/attune-ai/pull/226) larger runners landed

## Two files

- [`docs/specs/ops-specs-features/decisions.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/docs/spec-ops-specs-features/docs/specs/ops-specs-features/decisions.md)
- [`docs/specs/ops-specs-features/tasks.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/docs/spec-ops-specs-features/docs/specs/ops-specs-features/tasks.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)