### PR TITLE
docs(specs): rag-async-integration + files-api-adoption (drafts, gated)

### DIFF
--- a/docs/specs/files-api-adoption/decisions.md
+++ b/docs/specs/files-api-adoption/decisions.md
@@ -1,0 +1,94 @@
+# Decisions — Anthropic Files API adoption in attune-ai
+
+**Status:** Draft (2026-05-11) — gated on briefing-followup batch
+**Owner:** Patrick
+
+---
+
+## Problem
+
+attune-ai's perf-audit, security-audit, code-review,
+deep-review, and other workflows send code payloads to the
+Anthropic API by **inlining file contents into request
+strings.** For small codebases this is fine. For larger ones
+(multi-thousand-file repos, PDFs, large binary attachments),
+this approach:
+
+1. **Hits context-window limits** — request bodies grow with
+   the codebase
+2. **Re-uploads on every call** — no persistence; the same
+   file goes over the wire each request
+3. **Costs more** — input tokens include the full file content
+   for each call
+
+Anthropic's **Files API** addresses all three:
+
+- Upload a file once; get a `file_id`
+- Reference `file_id` in subsequent requests (saves token cost)
+- Persists across calls within the upload's lifetime
+- Works for text, code, PDFs, images
+
+Today, **zero attune-ai files import the Files API.** No
+`client.files.upload`, no `file_id` references in source.
+
+## Decision
+
+Adopt Files API in attune-ai workflows where context size is
+the bottleneck. Phased adoption per workflow:
+
+1. **Phase 1**: identify workflows hitting the inline-payload
+   ceiling (size, cost, latency)
+2. **Phase 2**: pilot Files API on ONE workflow (probably
+   `code-review` or `perf-audit` — these have the largest
+   payloads)
+3. **Phase 3**: roll out to other workflows that benefit
+4. **Phase 4**: cleanup story — uploaded files have a TTL but
+   we should explicitly delete after use to keep the account
+   tidy
+
+## What's in scope
+
+- Workflows where input payload exceeds ~50K tokens regularly
+- Multi-file payloads (whole-repo scans)
+- PDF inputs to perf-audit if those exist
+
+## What's NOT in scope
+
+- Migrating workflows whose payloads are <10K tokens (no win)
+- Image uploads to multi-modal workflows (separate concern)
+- Storing artifacts ACROSS workflows (Files API is
+  per-conversation; long-term storage is a different system)
+
+## Alternatives considered
+
+1. **Leave as-is** — works today. Cost is real on big repos
+   but not blocking. Acceptable for v6.7.x.
+2. **Use prompt caching alone** — already in use. Helps with
+   repeated calls but doesn't shrink any individual request.
+   Complements Files API rather than replacing it.
+3. **Custom client-side compression** (gzip payloads, etc.) —
+   complex, doesn't address context limit (the API decompresses
+   immediately).
+4. **Switch to streaming completions only** — orthogonal;
+   doesn't solve the upload-once problem.
+
+## Acceptance criteria
+
+- At least one workflow uses Files API end-to-end with
+  upload → reference → use → cleanup
+- Measurable token cost reduction on a representative payload
+- Cleanup pattern documented and tested (no orphan uploads
+  after CI runs)
+- Spec closed with results
+
+## Execution gate
+
+Not urgent. Don't start until:
+
+1. v6.7.x stable on PyPI
+2. Probe C Phase 4 (-n auto restore) is settled
+3. No active CI debt
+
+---
+
+(per-phase decisions appended as work happens)

--- a/docs/specs/files-api-adoption/tasks.md
+++ b/docs/specs/files-api-adoption/tasks.md
@@ -1,0 +1,56 @@
+# Tasks — Files API adoption
+
+## Phase 1 — Identify candidates
+
+- [ ] **1.1** Survey current Anthropic call sites:
+      `grep -rln "client.messages.create\|messages.create\|messages.stream" src/attune/`
+- [ ] **1.2** For each call site, estimate payload size for a
+      typical large-repo scan. Identify the top 3 by token
+      volume.
+- [ ] **1.3** Cross-reference with telemetry data (if any) to
+      confirm size estimates with actual run data
+- [ ] **1.4** Produce candidate list with priority
+
+## Phase 2 — Pilot one workflow
+
+Pick the highest-leverage candidate (likely `code-review` or
+`perf-audit`).
+
+- [ ] **2.1** Sketch the upload → reference → cleanup flow
+- [ ] **2.2** Implement upload helper in
+      `src/attune/llm/files_api.py` (or wherever the LLM
+      provider lives). Handle:
+      - file size limits (Anthropic has caps per file/account)
+      - retry on upload failure
+      - return `file_id`
+- [ ] **2.3** Add cleanup helper (`delete_file(file_id)`)
+- [ ] **2.4** Migrate the chosen workflow to use the helper
+- [ ] **2.5** Test: dry-run on a 100-file repo, confirm
+      reduced token count vs inline path
+- [ ] **2.6** Add an `--inline-payload` escape hatch flag for
+      easy revert
+
+## Phase 3 — Roll out
+
+For each remaining priority workflow from Phase 1:
+
+- [ ] **3.x.1** Migrate to Files API helper
+- [ ] **3.x.2** Verify token savings on a representative test
+- [ ] **3.x.3** Watch CI for any regression
+
+## Phase 4 — Cleanup story
+
+- [ ] **4.1** Ensure every uploaded `file_id` is paired with a
+      cleanup call (`try/finally` or context manager)
+- [ ] **4.2** Add a periodic job (cron or post-workflow) that
+      lists stale uploads and deletes them
+- [ ] **4.3** Add a metric: `files_api_orphan_count` to
+      telemetry
+
+## Out of scope
+
+- Multi-modal (image) inputs — separate spec
+- Long-term artifact storage — Files API has a TTL, not
+  intended for that
+- Files API migration for non-attune-ai consumers
+  (attune-author, attune-rag have their own concerns)

--- a/docs/specs/rag-async-integration/decisions.md
+++ b/docs/specs/rag-async-integration/decisions.md
@@ -1,0 +1,89 @@
+# Decisions — Wire attune-rag's `expand_async` into attune-ai workflows
+
+**Status:** Draft (2026-05-11) — gated on briefing-followup batch
+**Owner:** Patrick
+
+---
+
+## Problem
+
+attune-rag PR #8 added `expand_async` to `attune_rag.expander` —
+an async-aware variant of the synchronous `expand` function. It's
+been merged and is part of attune-rag 0.1.10+.
+
+In attune-ai, every consumer of attune-rag uses the **synchronous**
+path (`expand`, `pipeline.run`, etc.). The async variant has no
+consumer, so the API exists but its value isn't being captured.
+
+Concrete cost: any attune-ai workflow that's already on an asyncio
+event loop has to block-on-sync to call attune-rag, which:
+
+- Holds an event-loop slot while attune-rag's I/O completes
+- Loses concurrency on parallel RAG queries within a single
+  workflow run
+- Blocks the workflow's other async tasks (telemetry, MCP
+  pubsub, etc.)
+
+## Decision
+
+Wire `expand_async` into attune-ai workflows that already run
+async, in three phases.
+
+## What's in scope
+
+- **Phase 1**: identify which attune-ai workflows are already
+  async (the agent SDK adapter is async-friendly;
+  `rag_code_gen` workflow already uses async; some `mcp` handlers
+  too)
+- **Phase 2**: switch those call-sites to `expand_async` —
+  one call-site at a time, with a CI check between to confirm
+  no regression
+- **Phase 3**: where conversion is non-trivial (sync-only
+  workflows that would need full async migration), file a
+  separate spec rather than force the issue
+
+## What's NOT in scope
+
+- Migrating sync-only workflows to async just to use
+  `expand_async`. The cost of async migration exceeds the
+  benefit in those cases.
+- Adding `expand_async` to non-RAG paths (e.g., async pubsub,
+  async streaming). Those are separate concerns.
+- Changing attune-rag's API surface. Just consuming the
+  existing one.
+
+## Alternatives considered
+
+1. **Leave as-is** — sync path works. The cost is real but
+   not blocking. Acceptable indefinitely.
+2. **Migrate all attune-ai workflows to async** — too
+   aggressive; mixing async and sync within the orchestration
+   layer creates `asyncio.run()` reentrancy bugs.
+3. **Add a third intermediate API in attune-rag** (e.g., a
+   thread-pool-backed wrapper) — duplicates concerns; the
+   sync/async pair is the right boundary.
+
+## Acceptance criteria
+
+- At least one async attune-ai consumer calls `expand_async`
+- Benchmark shows reduced wall-clock for the chosen workflow
+  when running in parallel (e.g., a 4-query RAG run completes
+  in ~T/4 wall-clock instead of ~T)
+- No new bugs introduced; existing sync path unchanged for
+  consumers that don't migrate
+- Spec closed with a "what we migrated, what we deferred"
+  log
+
+## Execution gate
+
+This spec is **not urgent.** It's an optimization. Don't start
+execution until:
+
+1. No in-flight CI debt (Probe C resolved ✅, Windows xdist
+   queued)
+2. attune-rag stable on its current release
+3. attune-ai has bandwidth (not mid-major-release)
+
+---
+
+(per-phase decisions appended as work happens)

--- a/docs/specs/rag-async-integration/tasks.md
+++ b/docs/specs/rag-async-integration/tasks.md
@@ -1,0 +1,53 @@
+# Tasks — Wire `expand_async` into attune-ai workflows
+
+## Phase 1 — Identify async consumers
+
+- [ ] **1.1** Grep attune-ai's workflows for existing `async def`
+      / `await` patterns:
+      `grep -rln "async def\|await " src/attune/workflows/`
+- [ ] **1.2** Cross-reference with sites that call attune-rag:
+      `grep -rln "from attune_rag\|attune_rag\." src/attune/`
+- [ ] **1.3** Produce a list of candidate call-sites where
+      attune-rag is called from an async context (these are
+      the Phase 2 targets)
+- [ ] **1.4** For each candidate, record current behavior:
+      blocking? `asyncio.run()`? `loop.run_until_complete()`?
+      `asyncio.to_thread()`?
+
+## Phase 2 — Migrate call-sites (one at a time)
+
+For each candidate from 1.3, in order of estimated value:
+
+- [ ] **2.x.1** Switch the call from `expand(...)` to
+      `await expand_async(...)`
+- [ ] **2.x.2** Remove any `asyncio.run()` / `loop.*` wrapping
+      that's no longer needed
+- [ ] **2.x.3** Add a small test asserting concurrent invocations
+      complete in roughly half the time of sequential ones
+- [ ] **2.x.4** Push, watch CI, verify no regression
+- [ ] **2.x.5** Move to next call-site
+
+## Phase 3 — Defer sync-only consumers
+
+For workflows where the entire call chain is sync (not just the
+RAG site), DO NOT force-migrate. Instead:
+
+- [ ] **3.1** Identify them and record why each is sync-only
+- [ ] **3.2** File separate specs if any of those workflows
+      could benefit from full async (e.g., parallel
+      orchestration). Don't bundle here.
+
+## Phase 4 — Close
+
+- [ ] **4.1** Migration log in decisions.md: what migrated, what
+      deferred, why
+- [ ] **4.2** Mark spec **Resolved**
+
+## Out of scope
+
+- Adding new async APIs to attune-rag — just consuming
+  `expand_async`
+- Migrating any non-RAG sync-to-async paths
+- Performance optimization of attune-rag's internals
+- Coordination with attune-help / attune-author async paths
+  (separate concern)


### PR DESCRIPTION
## Summary

Two specs from the 2026-05-11 Monday-briefing followup batch.

### rag-async-integration

attune-rag PR #8 added `expand_async`; attune-ai never adopted it. Spec wires `expand_async` into already-async workflows (agent SDK adapter, rag_code_gen, async MCP handlers). Sync-only consumers explicitly deferred — don't force-migrate.

### files-api-adoption

attune-ai has zero `client.files` imports. Workflows inline file contents, hitting context limits on large repos. Spec phases adoption per workflow: pilot on code-review or perf-audit first, then roll out, with explicit cleanup story for uploaded `file_id`s.

## Both specs

- **Status: Draft, gated** — execution waits for stable CI + no active debt
- Acceptance criteria + alternatives considered + out-of-scope all defined
- No code changes in this PR

## Files

- [`rag-async-integration/decisions.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/docs/specs-batch-tuesday/docs/specs/rag-async-integration/decisions.md)
- [`rag-async-integration/tasks.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/docs/specs-batch-tuesday/docs/specs/rag-async-integration/tasks.md)
- [`files-api-adoption/decisions.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/docs/specs-batch-tuesday/docs/specs/files-api-adoption/decisions.md)
- [`files-api-adoption/tasks.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/docs/specs-batch-tuesday/docs/specs/files-api-adoption/tasks.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)