### PR TITLE
chore: weekly report 2026-05-11

### DIFF
--- a/weekly-reports/2026-05-11.md
+++ b/weekly-reports/2026-05-11.md
@@ -1,0 +1,135 @@
+# Anthropic Ecosystem Weekly — 2026-05-11
+
+## Summary
+
+The headline this week is Opus 4.7 GA (April 16) with a **new tokenizer
+that silently inflates token counts up to 35%** on the same input text —
+rate card unchanged, but real cost isn't. The Agent SDK shipped six
+releases (v0.1.74–0.1.80) with actionable changes for the stack:
+deprecated `"Skill"` in `allowed_tools`, new hook event streaming,
+`xhigh` effort, and better error surfacing from `ResultMessage`.
+
+---
+
+## Recommendations
+
+**1. Audit Opus 4.7 token budgets before routing live traffic to it**
+
+Opus 4.7's new tokenizer produces up to 35% more tokens on identical text
+vs 4.6. The rate card is the same ($5/$25 per MTok), so a workflow
+consuming 100k tokens under 4.6 may hit 135k under 4.7. Prompt cache
+entries from 4.6 are also invalidated on the first 4.7 run (cold-miss).
+
+- **Applies to:** attune-ai PREMIUM tier routing, attune-rag Claude
+  provider
+- **Action:** Check `src/attune/models/` tier config. If PREMIUM already
+  pins `claude-opus-4-7`, instrument a token-count comparison on a
+  representative workflow before enabling in prod. If still on
+  `claude-opus-4-6`, no rush — 4.6 remains available and identically
+  priced.
+- **Alternative:** Pin PREMIUM to `claude-opus-4-6` a while longer;
+  costs and capabilities are the same on paper and you avoid the
+  tokenizer surprise.
+
+**2. Replace `"Skill"` in `allowed_tools` with the `skills` option**
+
+SDK v0.1.77 (May 8) deprecated `"Skill"` in `allowed_tools` in favour of
+`ClaudeAgentOptions(skills=...)` for more granular control.
+
+- **Applies to:** any SDK-native workflow in `src/attune/workflows/` that
+  passes `allowed_tools=[..., "Skill", ...]`
+- **Action:** `grep -r '"Skill"' src/attune/workflows/` — if hits exist,
+  migrate to the `skills=` kwarg before it becomes a breaking removal.
+- **Urgency:** Low now, medium in 4–6 weeks.
+
+**3. Use the 1-hour prompt cache TTL for attune-author's polish step**
+
+`ENABLE_PROMPT_CACHING_1H` was broken until Claude Code v2.1.129 —
+requests were silently downgraded to 5-min TTL. That is fixed. Write
+cost at 1h is 2× base vs 1.25× for 5 min; break-even is 2 reads. For
+attune-author's polish pipeline (same large system prompt called N times
+across a session), 1h TTL pays off if you process ≥3 templates.
+
+- **Applies to:** attune-author PR #12 (prompt caching in flight)
+- **Action:** Add `ENABLE_PROMPT_CACHING_1H` to the PR scope and note
+  the break-even arithmetic in the PR body.
+- **Pros:** Lower per-call cost at higher session volume.
+- **Con:** 2× write cost; do not use for one-shot workflows.
+
+**4. Surface `api_error_status` from `ResultMessage` in the SDK adapter**
+
+SDK v0.1.76 added `ResultMessage.api_error_status: int | None`,
+surfacing HTTP 429/500/529 from failing agent calls.
+`src/attune/workflows/agent_sdk_adapter.py` already reads
+`ResultMessage` — a one-line check on `api_error_status` lets attune-ops
+distinguish budget exhaustion from rate-limit vs server error.
+
+- **Applies to:** `agent_sdk_adapter.py`, attune-ops dashboards
+- **Action:** Low lift; add the field to the adapter's result dict and
+  surface it in the ops UI.
+
+**5. Third-party agent subscription block is now hard enforcement**
+
+Anthropic blocked Pro/Max subscription usage by third-party agent
+frameworks (OpenClaw et al.) effective April 4. The stack already
+correctly requires `ANTHROPIC_API_KEY` for Python workflows. No
+architectural change needed, but audit any internal docs that imply Max
+plan coverage for workflow costs — those claims are now factually wrong
+and enforced.
+
+- **Applies to:** README, docs, any onboarding copy
+- **Action:** One-pass grep for "Max plan" or "subscription" in docs and
+  ensure language is "API key required."
+
+---
+
+## Carry-overs
+
+First report — no prior recommendations to track.
+
+---
+
+## Watch list
+
+- **Fast mode for Opus 4.6** (research preview): $30/$150 MTok (6×
+  standard). Only relevant if attune-rag needs low-latency Opus at
+  scale. Too expensive for general use today.
+- **Claude Managed Agents "dreaming"** (research preview):
+  self-improving cross-session memory. Conceptually overlaps with
+  attune-ai's `FeedbackLoop`/`UsageTracker`. Track whether it becomes
+  cheaper than the custom telemetry path at GA.
+- **Claude Managed Agents multiagent orchestration**: parallel specialist
+  agents from a single API call. Overlaps with `ReleasePrepTeam`. When
+  GA, compare orchestration primitives — may simplify release agent
+  architecture.
+- **SDK hook event streaming** (`include_hook_events`, v0.1.74): exposes
+  PreToolUse/PostToolUse/Stop as stream messages. Potential replacement
+  for custom hook logging in attune-ops.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Microsoft 365 add-ins GA (Excel, Word, Outlook) | No intersection with the stack |
+| Claude Design (Anthropic Labs) | Visual output tool, not a dev primitive |
+| Claude Cowork GA | Team collab feature, not an API surface |
+| Financial services agent templates | Domain-specific |
+| Claude Security public beta (Enterprise) | Stack already covers this via bandit/security workflows |
+| Compliance API | Enterprise audit logs, not applicable at current scale |
+| `ANTHROPIC_BEDROCK_SERVICE_TIER` (Bedrock flex/priority) | Stack uses direct API, not Bedrock |
+| Consumer connectors (AllTrails, Spotify, Uber, etc.) | Not applicable |
+| `claude project purge` (Claude Code) | Ops tooling, no stack impact |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/overview`
+- `code.claude.com/docs/en/changelog` (v2.1.90 – v2.1.138)
+- `github.com/anthropics/claude-agent-sdk-python/releases`
+  (v0.1.60 – v0.1.80)
+- `pypi.org/project/claude-agent-sdk/#history`
+- `platform.claude.com/docs/en/about-claude/pricing`
+- `releasebot.io/updates/anthropic` and `/claude`


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-05-11

## Summary

The headline this week is Opus 4.7 GA (April 16) with a **new tokenizer
that silently inflates token counts up to 35%** on the same input text —
rate card unchanged, but real cost isn't. The Agent SDK shipped six
releases (v0.1.74–0.1.80) with actionable changes for the stack:
deprecated `"Skill"` in `allowed_tools`, new hook event streaming,
`xhigh` effort, and better error surfacing from `ResultMessage`.

---

## Recommendations

**1. Audit Opus 4.7 token budgets before routing live traffic to it**

Opus 4.7's new tokenizer produces up to 35% more tokens on identical text
vs 4.6. The rate card is the same ($5/$25 per MTok), so a workflow
consuming 100k tokens under 4.6 may hit 135k under 4.7. Prompt cache
entries from 4.6 are also invalidated on the first 4.7 run (cold-miss).

- **Applies to:** attune-ai PREMIUM tier routing, attune-rag Claude provider
- **Action:** Check `src/attune/models/` tier config. If PREMIUM already pins `claude-opus-4-7`, instrument a token-count comparison on a representative workflow before enabling in prod. If still on `claude-opus-4-6`, no rush — 4.6 remains available and identically priced.
- **Alternative:** Pin PREMIUM to `claude-opus-4-6` a while longer; costs and capabilities are the same on paper and you avoid the tokenizer surprise.

**2. Replace `"Skill"` in `allowed_tools` with the `skills` option**

SDK v0.1.77 (May 8) deprecated `"Skill"` in `allowed_tools` in favour of
`ClaudeAgentOptions(skills=...)` for more granular control.

- **Applies to:** any SDK-native workflow in `src/attune/workflows/` that passes `allowed_tools=[..., "Skill", ...]`
- **Action:** `grep -r '"Skill"' src/attune/workflows/` — if hits exist, migrate to the `skills=` kwarg before it becomes a breaking removal.
- **Urgency:** Low now, medium in 4–6 weeks.

**3. Use the 1-hour prompt cache TTL for attune-author's polish step**

`ENABLE_PROMPT_CACHING_1H` was broken until Claude Code v2.1.129 —
requests were silently downgraded to 5-min TTL. That is fixed. Write
cost at 1h is 2× base vs 1.25× for 5 min; break-even is 2 reads.

- **Applies to:** attune-author PR #12 (prompt caching in flight)
- **Action:** Add `ENABLE_PROMPT_CACHING_1H` to the PR scope; note break-even in the PR body.
- **Pros:** Lower per-call cost at higher session volume.
- **Con:** 2× write cost; do not use for one-shot workflows.

**4. Surface `api_error_status` from `ResultMessage` in the SDK adapter**

SDK v0.1.76 added `ResultMessage.api_error_status: int | None`,
surfacing HTTP 429/500/529 from failing agent calls.

- **Applies to:** `src/attune/workflows/agent_sdk_adapter.py`, attune-ops dashboards
- **Action:** Low lift; add the field to the adapter's result dict and surface it in the ops UI.

**5. Third-party agent subscription block is now hard enforcement**

Anthropic blocked Pro/Max subscription usage by third-party agent
frameworks effective April 4. Stack is already correct (API key required),
but audit any docs that imply Max plan coverage for workflow costs.

- **Action:** Grep docs for "Max plan" / "subscription" language and correct.

---

## Carry-overs

First report — no prior recommendations to track.

---

## Watch list

- **Fast mode for Opus 4.6** (research preview): $30/$150 MTok (6× standard). Too expensive for general use; watch for GA pricing.
- **Claude Managed Agents "dreaming"** (research preview): self-improving cross-session memory. Overlaps with `FeedbackLoop`/`UsageTracker` — track GA pricing vs custom telemetry cost.
- **Claude Managed Agents multiagent orchestration**: overlaps with `ReleasePrepTeam`. Compare primitives at GA.
- **SDK hook event streaming** (`include_hook_events`, v0.1.74): potential replacement for custom hook logging in attune-ops.

---

## No-ops

| Item | Why skipped |
|---|---|
| Microsoft 365 add-ins GA | No stack intersection |
| Claude Design | Visual output tool |
| Claude Cowork GA | Team collab, not an API surface |
| Financial services templates | Domain-specific |
| Claude Security beta (Enterprise) | Stack already covers via bandit/security workflows |
| Compliance API | Enterprise audit logs |
| `ANTHROPIC_BEDROCK_SERVICE_TIER` | Stack uses direct API, not Bedrock |
| Consumer connectors (AllTrails, Spotify, etc.) | Not applicable |
| `claude project purge` (Claude Code) | Ops tooling, no stack impact |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/overview`
- `code.claude.com/docs/en/changelog` (v2.1.90 – v2.1.138)
- `github.com/anthropics/claude-agent-sdk-python/releases` (v0.1.60 – v0.1.80)
- `pypi.org/project/claude-agent-sdk/#history`
- `platform.claude.com/docs/en/about-claude/pricing`
- `releasebot.io/updates/anthropic`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xg7Tddo5W512sQNYp3y5JL)_