### PR TITLE
fix: use git rev-parse for cross-env hook paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/patrickroebuck/attune-ai && PYTHONPATH=src python src/attune/hooks/scripts/help_freshness_nudge.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && PYTHONPATH=src python src/attune/hooks/scripts/help_freshness_nudge.py",
             "timeout": 5,
             "statusMessage": "Checking .help freshness..."
           }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/patrickroebuck/attune-ai && PYTHONPATH=src python src/attune/hooks/scripts/lessons_reminder.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && PYTHONPATH=src python src/attune/hooks/scripts/lessons_reminder.py",
             "timeout": 5,
             "statusMessage": "Checking for lessons to record..."
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/patrickroebuck/attune-ai && PYTHONPATH=src python src/attune/hooks/scripts/security_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && PYTHONPATH=src python src/attune/hooks/scripts/security_guard.py",
             "timeout": 5,
             "statusMessage": "Security check..."
           }
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/patrickroebuck/attune-ai && PYTHONPATH=src python src/attune/hooks/scripts/security_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && PYTHONPATH=src python src/attune/hooks/scripts/security_guard.py",
             "timeout": 5,
             "statusMessage": "Path validation..."
           }
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/patrickroebuck/attune-ai && PYTHONPATH=src python src/attune/hooks/scripts/security_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && PYTHONPATH=src python src/attune/hooks/scripts/security_guard.py",
             "timeout": 10,
             "statusMessage": "Auto-formatting..."
           }
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd /Users/patrickroebuck/attune-ai && PYTHONPATH=src python src/attune/hooks/scripts/security_guard.py",
+            "command": "cd \"$(git rev-parse --show-toplevel)\" && PYTHONPATH=src python src/attune/hooks/scripts/security_guard.py",
             "timeout": 3,
             "statusMessage": "Recording telemetry..."
           }


### PR DESCRIPTION
## Summary

- All 6 hook commands in `.claude/settings.json` were hardcoded to `/Users/patrickroebuck/attune-ai`, which fails in the Linux web environment at `/home/user/attune-ai`
- Replace with `cd "$(git rev-parse --show-toplevel)"` — dynamically resolves the repo root at hook-run time, works on both macOS and Linux without any per-environment configuration

## Root cause

The Stop hook error `cd: can't cd to /Users/patrickroebuck/attune-ai` surfaced in the 2026-05-11 weekly-report session. The same hardcoded path also blocked all Bash, Edit, and Write tool use via PreToolUse hooks (exit code 1 from failed `cd` blocked the tools).

## Test plan

- [ ] Merge and `git pull` on Mac — verify `cd "$(git rev-parse --show-toplevel)"` resolves to `/Users/patrickroebuck/attune-ai` and hooks fire correctly
- [ ] In web session — verify Stop/SessionStart hooks no longer error, Bash/Edit/Write tools unblocked

## New CLAUDE.md lesson (add after merge)

> **Hook `cd` prefix should use `git rev-parse --show-toplevel`, not a hardcoded path**: `cd /abs/path &&` in hook commands fails when sessions run on different machines or OSes. Use `cd "$(git rev-parse --show-toplevel)" &&` — it resolves the repo root dynamically from the current working directory, works in any git checkout regardless of the absolute path, and replaces the prior lesson that said to always hardcode `/Users/patrickroebuck/attune-ai`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xg7Tddo5W512sQNYp3y5JL)_