### PR TITLE
feat(ops): Phase 3 of ops-specs-features — Specs tab frontend

### DIFF
--- a/docs/specs/ops-specs-features/tasks.md
+++ b/docs/specs/ops-specs-features/tasks.md
@@ -64,16 +64,16 @@ GET endpoints. Backend first; frontend follows.
 
 ## Phase 3 — Frontend Specs tab
 
-- [ ] **3.1** Add `Specs` tab to nav in
+- [x] **3.1** Add `Specs` tab to nav in
   `src/attune/ops/templates/base.html`, between
   `Workflows` and `Telemetry`
-- [ ] **3.2** New template
+- [x] **3.2** New template
   `src/attune/ops/templates/specs.html` — pattern-match
   attune-gui's `templates/specs.html` (160 lines, simple)
-- [ ] **3.3** Status-flip dropdown per phase with optimistic
+- [x] **3.3** Status-flip dropdown per phase with optimistic
   UI + server-confirmation pattern (similar to runner.js
   workflow row buttons)
-- [ ] **3.4** Per-spec drill-in showing phase file content
+- [x] **3.4** Per-spec drill-in showing phase file content
   (read-only)
 
 ## Phase 4 — Observe & adjust

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -76,3 +76,78 @@ async def health_page(request: Request) -> HTMLResponse:
     cfg = request.app.state.config
     snapshot = data.env_health(cfg)
     return _render(request, "health.html", page="health", snapshot=snapshot)
+
+
+@router.get("/specs", response_class=HTMLResponse)
+async def specs_page(request: Request) -> HTMLResponse:
+    """Specs tab — federated listing of all specs across configured roots.
+
+    Reuses the same root resolution + scanning logic as the JSON API so the
+    HTML view and the API can't drift.
+    """
+    from dataclasses import asdict
+
+    from attune.ops.routes.specs import _list_specs_in_root, _resolved_roots
+
+    cfg = request.app.state.config
+    roots = _resolved_roots(cfg)
+    specs = []
+    for root in roots:
+        for record in _list_specs_in_root(root):
+            specs.append(
+                {
+                    "slug": record.slug,
+                    "root": record.root,
+                    "path": record.path,
+                    "phases": [asdict(p) for p in record.phases],
+                }
+            )
+    return _render(
+        request,
+        "specs.html",
+        page="specs",
+        specs=specs,
+        roots=[str(r) for r in roots],
+        allow_run=cfg.allow_run,
+    )
+
+
+@router.get("/specs/{slug}", response_class=HTMLResponse)
+async def spec_detail_page(slug: str, request: Request) -> HTMLResponse:
+    """Drill-in for a single spec: show every phase file's content (read-only)."""
+    from fastapi import HTTPException
+
+    from attune.ops.routes.specs import _resolved_roots, _scan_spec_dir
+
+    # Slug-safety: directory name shape only, no path separators or traversal.
+    if "/" in slug or ".." in slug or "\\" in slug:
+        raise HTTPException(status_code=400, detail="invalid slug")
+
+    cfg = request.app.state.config
+    roots = _resolved_roots(cfg)
+    for root in roots:
+        spec_dir = root / slug
+        if not spec_dir.is_dir():
+            continue
+        phases = _scan_spec_dir(spec_dir)
+        contents: dict[str, str] = {}
+        for phase in phases:
+            if not phase.exists:
+                continue
+            try:
+                contents[phase.name] = (spec_dir / phase.file).read_text(encoding="utf-8")
+            except OSError:
+                # INTENTIONAL: an unreadable phase file is omitted from the
+                # contents map rather than aborting the whole drill-in.
+                continue
+        return _render(
+            request,
+            "spec_detail.html",
+            page="specs",
+            slug=slug,
+            root=str(root),
+            phases=phases,
+            contents=contents,
+            allow_run=cfg.allow_run,
+        )
+    raise HTTPException(status_code=404, detail=f"spec '{slug}' not found")

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -41,6 +41,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     templates.env.globals["nav_items"] = [
         ("/", "Home"),
         ("/workflows", "Workflows"),
+        ("/specs", "Specs"),
         ("/telemetry", "Telemetry"),
         ("/health", "Health"),
     ]

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -481,3 +481,64 @@ a.kpi:hover {
   font-size: 11px;
   color: var(--fg-subtle);
 }
+
+/* Specs tab — status-flip dropdown styled as a chip. */
+.status-select {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 22px 2px 8px;
+  border-radius: 99px;
+  border: 1px solid var(--border);
+  background-color: var(--bg-soft);
+  color: var(--fg-muted);
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+                    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position:
+    calc(100% - 12px) 50%,
+    calc(100% - 7px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+}
+.status-select:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+.status-select.chip-ok {
+  background-color: var(--ok-soft);
+  border-color: var(--ok-soft);
+  color: var(--ok);
+}
+.status-select.chip-warn {
+  background-color: var(--warn-soft);
+  border-color: var(--warn-soft);
+  color: var(--warn);
+}
+.status-select.chip-muted {
+  background-color: var(--bg-soft);
+  border-color: var(--border);
+  color: var(--fg-muted);
+}
+.status-select.flash-ok {
+  outline: 2px solid var(--ok);
+  outline-offset: 1px;
+  transition: outline 0.3s ease-out;
+}
+.status-select.flash-err {
+  outline: 2px solid var(--danger);
+  outline-offset: 1px;
+  transition: outline 0.3s ease-out;
+}
+
+/* Spec drill-in: phase body in a readable monospace block. */
+.spec-phase {
+  margin-bottom: 2rem;
+}
+.spec-phase-body {
+  max-height: 60vh;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/src/attune/ops/static/js/specs.js
+++ b/src/attune/ops/static/js/specs.js
@@ -1,0 +1,79 @@
+// Per-phase status-flip handler for the Specs tab.
+// Optimistic UI with rollback on server error. Mirrors runner.js's pattern.
+(function () {
+  "use strict";
+
+  function chipClassForStatus(status) {
+    var s = (status || "").toLowerCase();
+    if (s === "approved" || s === "complete" || s === "completed" || s === "done") {
+      return "chip-ok";
+    }
+    if (s === "in-review" || s === "review") {
+      return "chip-warn";
+    }
+    if (s === "draft") {
+      return "chip-muted";
+    }
+    return "chip";
+  }
+
+  function applyChipClass(select, status) {
+    var classes = ["status-select", chipClassForStatus(status)];
+    select.className = classes.join(" ");
+  }
+
+  function flash(select, ok) {
+    select.classList.add(ok ? "flash-ok" : "flash-err");
+    setTimeout(function () {
+      select.classList.remove("flash-ok", "flash-err");
+    }, 1200);
+  }
+
+  function attach(select) {
+    select.addEventListener("change", async function () {
+      var slug = select.dataset.slug;
+      var phase = select.dataset.phase;
+      var prev = select.dataset.original || "";
+      var next = select.value;
+      if (next === prev) return;
+      select.disabled = true;
+      applyChipClass(select, next);
+      try {
+        var resp = await fetch(
+          "/api/specs/" + encodeURIComponent(slug) +
+          "/" + encodeURIComponent(phase) + "/status",
+          {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ status: next }),
+          }
+        );
+        if (!resp.ok) {
+          var body = await resp.text();
+          console.error("status flip failed:", resp.status, body);
+          // Revert to original on failure.
+          select.value = prev;
+          applyChipClass(select, prev);
+          flash(select, false);
+          select.title = "Failed: " + resp.status + " " + body;
+        } else {
+          select.dataset.original = next;
+          flash(select, true);
+          select.title = "";
+        }
+      } catch (err) {
+        console.error("status flip exception:", err);
+        select.value = prev;
+        applyChipClass(select, prev);
+        flash(select, false);
+        select.title = "Network error: " + err;
+      } finally {
+        select.disabled = false;
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll(".status-select").forEach(attach);
+  });
+})();

--- a/src/attune/ops/templates/spec_detail.html
+++ b/src/attune/ops/templates/spec_detail.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block title %}{{ slug }} — Specs{% endblock %}
+{% block content %}
+<section class="page-head">
+  <h1><code>{{ slug }}</code></h1>
+  <p class="page-sub">
+    <a href="/specs" class="link">← Back to specs</a>
+    &nbsp;·&nbsp;
+    <code>{{ root }}/{{ slug }}/</code>
+  </p>
+</section>
+
+{% for phase in phases %}
+  <section class="spec-phase" data-phase="{{ phase.name }}">
+    <h2>
+      {{ phase.name|capitalize }}
+      {% if not phase.exists %}
+        <span class="chip chip-muted">missing</span>
+      {% elif phase.status %}
+        {% set st = phase.status|lower %}
+        {% if st in ('approved', 'complete', 'completed', 'done') %}
+          <span class="chip chip-ok">{{ phase.status }}</span>
+        {% elif st in ('in-review', 'review') %}
+          <span class="chip chip-warn">{{ phase.status }}</span>
+        {% elif st == 'draft' %}
+          <span class="chip chip-muted">{{ phase.status }}</span>
+        {% else %}
+          <span class="chip">{{ phase.status }}</span>
+        {% endif %}
+      {% else %}
+        <span class="chip chip-muted">(no status)</span>
+      {% endif %}
+    </h2>
+    {% if phase.exists %}
+      {% if contents.get(phase.name) %}
+        <pre class="log-output spec-phase-body">{{ contents[phase.name] }}</pre>
+      {% else %}
+        <p class="empty">File exists but could not be read.</p>
+      {% endif %}
+    {% else %}
+      <p class="empty"><code>{{ phase.file }}</code> doesn't exist yet.</p>
+    {% endif %}
+  </section>
+{% endfor %}
+{% endblock %}

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+{% block title %}Specs{% endblock %}
+{% block content %}
+<section class="page-head">
+  <h1>Specs</h1>
+  <p class="page-sub">
+    {{ specs|length }} spec{{ '' if specs|length == 1 else 's' }}
+    across {{ roots|length }} root{{ '' if roots|length == 1 else 's' }}.
+    {% if allow_run %}
+      Click a status chip to flip it.
+    {% else %}
+      Read-only mode — restart without <code>--read-only</code> to edit statuses.
+    {% endif %}
+  </p>
+</section>
+
+{% if roots %}
+  <p class="meta-line">
+    Reading from
+    {% for root in roots %}
+      <code>{{ root }}</code>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  </p>
+{% endif %}
+
+{% if specs %}
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Slug</th>
+        {% for phase_name in ("decisions", "requirements", "design", "tasks") %}
+          <th>{{ phase_name|capitalize }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for s in specs %}
+        <tr data-slug="{{ s.slug }}">
+          <td>
+            <a href="/specs/{{ s.slug }}" class="link"><code>{{ s.slug }}</code></a>
+          </td>
+          {% for phase in s.phases %}
+            <td data-phase="{{ phase.name }}">
+              {% if not phase.exists %}
+                <span class="chip chip-muted">—</span>
+              {% else %}
+                {% set st = (phase.status or '')|lower %}
+                {% if st in ('approved', 'complete', 'completed', 'done') %}
+                  {% set chip_cls = 'chip-ok' %}
+                {% elif st in ('in-review', 'review') %}
+                  {% set chip_cls = 'chip-warn' %}
+                {% elif st == 'draft' %}
+                  {% set chip_cls = 'chip-muted' %}
+                {% else %}
+                  {% set chip_cls = 'chip' %}
+                {% endif %}
+                {% if allow_run %}
+                  <select
+                    class="status-select {{ chip_cls }}"
+                    data-slug="{{ s.slug }}"
+                    data-phase="{{ phase.name }}"
+                    data-original="{{ phase.status or '' }}"
+                    aria-label="Status for {{ phase.name }} of {{ s.slug }}"
+                  >
+                    {% for opt in ('draft', 'in-review', 'approved', 'complete') %}
+                      <option value="{{ opt }}"{% if (phase.status or '')|lower == opt %} selected{% endif %}>{{ opt }}</option>
+                    {% endfor %}
+                    {% if phase.status and (phase.status|lower) not in ('draft', 'in-review', 'approved', 'complete') %}
+                      <option value="{{ phase.status }}" selected>{{ phase.status }}</option>
+                    {% endif %}
+                  </select>
+                {% else %}
+                  <span class="chip {{ chip_cls }}">{{ phase.status or '(no status)' }}</span>
+                {% endif %}
+              {% endif %}
+            </td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% else %}
+  <p class="empty">
+    No specs found. Configure a roots directory with
+    <code>attune ops --specs-root &lt;dir&gt;</code>, or place spec
+    folders under <code>docs/specs/</code>.
+  </p>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+{% if allow_run %}
+  <script src="{{ url_for('static', path='js/specs.js') }}"></script>
+{% endif %}
+{% endblock %}

--- a/tests/unit/ops/test_specs_dashboard.py
+++ b/tests/unit/ops/test_specs_dashboard.py
@@ -1,0 +1,221 @@
+"""Tests for the `/specs` and `/specs/{slug}` dashboard pages — Phase 3 UI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+
+def _make_spec(root: Path, slug: str, *, files: dict[str, str]) -> Path:
+    """Create a spec directory with the given phase files."""
+    spec_dir = root / slug
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (spec_dir / name).write_text(body, encoding="utf-8")
+    return spec_dir
+
+
+def _client(
+    tmp_path: Path,
+    *,
+    specs_roots: tuple[Path, ...] | None = None,
+    allow_run: bool = False,
+) -> TestClient:
+    config = build_config(
+        project_root=tmp_path,
+        specs_roots=specs_roots,
+        allow_run=allow_run,
+    )
+    return TestClient(create_app(config))
+
+
+# ---------------------------------------------------------------------------
+# GET /specs — listing page
+# ---------------------------------------------------------------------------
+
+
+def test_specs_page_renders_with_no_specs(tmp_path):
+    """No specs → empty-state copy renders without crashing."""
+    client = _client(tmp_path, specs_roots=(tmp_path / "empty",), allow_run=True)
+    r = client.get("/specs")
+    assert r.status_code == 200
+    assert "No specs found" in r.text
+
+
+def test_specs_page_lists_specs_with_status_chips(tmp_path):
+    """A spec with a status renders its name + a chip class matching the status."""
+    root = tmp_path / "specs"
+    _make_spec(
+        root,
+        "alpha",
+        files={
+            "decisions.md": "# Alpha\n\n**Status:** approved\n",
+            "tasks.md": "**Status:** draft\n",
+        },
+    )
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.get("/specs")
+    assert r.status_code == 200
+    assert "alpha" in r.text
+    # In read-only mode, statuses render as plain chips (not selects)
+    assert "approved" in r.text
+    assert "draft" in r.text
+
+
+def test_specs_page_writeable_mode_shows_dropdowns(tmp_path):
+    """allow_run=True → status renders as a <select> not a <span>."""
+    root = tmp_path / "specs"
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+    r = client.get("/specs")
+    assert r.status_code == 200
+    assert "<select" in r.text
+    assert "status-select" in r.text
+    assert 'data-slug="alpha"' in r.text
+    assert 'data-phase="tasks"' in r.text
+
+
+def test_specs_page_readonly_mode_no_dropdowns(tmp_path):
+    """allow_run=False → no <select> elements, plain chips only."""
+    root = tmp_path / "specs"
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.get("/specs")
+    assert r.status_code == 200
+    assert "<select" not in r.text
+    assert "Read-only mode" in r.text
+
+
+def test_specs_page_shows_em_dash_for_missing_phases(tmp_path):
+    """A spec with only tasks.md → other 3 phase columns show em-dash."""
+    root = tmp_path / "specs"
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.text if False else client.get("/specs").text
+    # 3 missing phases → 3 em-dashes (one per cell). We can't count exactly because
+    # the page chrome may also contain em-dashes, but we can verify the chip class.
+    assert "chip-muted" in r
+
+
+def test_specs_page_includes_specs_js_when_writeable(tmp_path):
+    """allow_run=True → specs.js loaded."""
+    root = tmp_path / "specs"
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+    r = client.get("/specs")
+    assert "/static/js/specs.js" in r.text
+
+
+def test_specs_page_omits_specs_js_when_readonly(tmp_path):
+    """allow_run=False → specs.js not loaded (no editing possible)."""
+    root = tmp_path / "specs"
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.get("/specs")
+    assert "/static/js/specs.js" not in r.text
+
+
+def test_specs_page_links_to_drill_in(tmp_path):
+    """Each spec row links to its drill-in page."""
+    root = tmp_path / "specs"
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+    r = client.get("/specs")
+    assert 'href="/specs/alpha"' in r.text
+
+
+# ---------------------------------------------------------------------------
+# GET /specs/{slug} — drill-in page
+# ---------------------------------------------------------------------------
+
+
+def test_spec_detail_renders_phase_files(tmp_path):
+    """The drill-in page shows the body content of each phase file."""
+    root = tmp_path / "specs"
+    _make_spec(
+        root,
+        "alpha",
+        files={
+            "decisions.md": "# Alpha decisions\n\n**Status:** approved\n\nWe decided X.\n",
+            "tasks.md": "**Status:** draft\n\n- [ ] Task A\n",
+        },
+    )
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.get("/specs/alpha")
+    assert r.status_code == 200
+    assert "We decided X." in r.text
+    assert "Task A" in r.text
+    assert "approved" in r.text
+    assert "draft" in r.text
+
+
+def test_spec_detail_missing_spec_returns_404(tmp_path):
+    """Slugs that don't exist → 404."""
+    root = tmp_path / "specs"
+    root.mkdir(parents=True)
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.get("/specs/does-not-exist")
+    assert r.status_code == 404
+
+
+@pytest.mark.parametrize("slug", ["../escape", "weird/slash", "back\\slash"])
+def test_spec_detail_rejects_path_traversal(tmp_path, slug):
+    """Path-traversal slugs return 400 or 404 (FastAPI may reject before handler)."""
+    root = tmp_path / "specs"
+    root.mkdir(parents=True)
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.get(f"/specs/{slug}")
+    assert r.status_code in (400, 404), f"slug={slug!r} got {r.status_code}: {r.text}"
+
+
+def test_spec_detail_shows_back_link(tmp_path):
+    """The drill-in page links back to the listing."""
+    root = tmp_path / "specs"
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.get("/specs/alpha")
+    assert r.status_code == 200
+    assert 'href="/specs"' in r.text
+
+
+def test_spec_detail_shows_missing_phase_indicator(tmp_path):
+    """Phases that don't exist show a 'missing' chip and don't crash."""
+    root = tmp_path / "specs"
+    # Only tasks.md exists — decisions/requirements/design are missing.
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=False)
+    r = client.get("/specs/alpha")
+    assert r.status_code == 200
+    assert "doesn&#39;t exist yet" in r.text or "doesn't exist yet" in r.text
+
+
+# ---------------------------------------------------------------------------
+# Nav integration
+# ---------------------------------------------------------------------------
+
+
+def test_specs_link_in_nav(tmp_path):
+    """The Specs tab appears in nav on every page."""
+    client = _client(tmp_path, allow_run=False)
+    for path in ("/", "/workflows", "/specs", "/telemetry", "/health"):
+        r = client.get(path)
+        assert r.status_code == 200, f"{path}: {r.status_code}"
+        assert 'href="/specs"' in r.text, f"{path}: no Specs nav link"
+
+
+def test_specs_nav_active_class_set_on_specs_page(tmp_path):
+    """The Specs nav link gets is-active when on /specs."""
+    client = _client(tmp_path, allow_run=False)
+    r = client.get("/specs")
+    assert r.status_code == 200
+    # Look for the active class somewhere near the Specs link
+    assert 'href="/specs" class="nav-link is-active"' in r.text


### PR DESCRIPTION
## Summary

Phase 3 of #230 (ops-specs-features) — wires the API from Phases 1 & 2 to a usable Specs tab on the ops dashboard.

**Nav:** new "Specs" entry between Workflows and Telemetry.

**`/specs` listing page:**
- One row per spec, four phase columns (decisions, requirements, design, tasks)
- Status renders as a styled `<select>` in writeable mode, or a plain chip in `--read-only` mode
- Each row links to a drill-in page

**`/specs/{slug}` drill-in:**
- Shows each phase file's full body in a scrollable monospace block
- Status chips inline per phase
- "Missing" placeholder for phase files that don't exist yet

**`specs.js`:**
- Optimistic UI on status change
- Server-confirmation via PUT `/api/specs/{slug}/{phase}/status` (the endpoint from Phase 2)
- Rollback to original on failure + flash outline feedback
- Only loaded when `allow_run=True` (no JS needed in read-only mode)

**`main.css`:**
- `.status-select` styled as a chip with chevron icon
- Per-status colors via existing `.chip-ok`/`.chip-warn`/`.chip-muted` palette
- `.flash-ok`/`.flash-err` outline feedback on PUT result
- `.spec-phase-body` for the drill-in pre block (max 60vh, scrollable)

## Test plan

- [x] `uv run --extra ops --extra dev pytest tests/unit/ops/ --no-cov` — **77 passed** (17 new for Phase 3)
- [x] `uv run ruff check src/attune/ops/ tests/unit/ops/` — clean
- [x] `pre-commit run black` — clean
- [x] Manual smoke: routes render correctly with various spec layouts (empty, single, missing phases, path traversal rejected)
- [ ] CI matrix green
- [ ] Manual UI smoke: `attune ops --specs-root docs/specs/ --allow-run` and verify status flip works end-to-end

## Spec checklist

All Phase 3 items in `docs/specs/ops-specs-features/tasks.md` checked off:

- [x] 3.1 — Specs tab in nav
- [x] 3.2 — `specs.html` template
- [x] 3.3 — Status-flip dropdown with optimistic UI
- [x] 3.4 — Per-spec drill-in (read-only file content)

## Closing

This completes Phases 1, 2, and 3 of #230. Phase 4 ("Observe & adjust") is a follow-up after live use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
