### PR TITLE
fix(tests): cross-platform path assertion in specs test

### DIFF
--- a/tests/unit/ops/test_specs_routes.py
+++ b/tests/unit/ops/test_specs_routes.py
@@ -64,9 +64,12 @@ def test_list_specs_empty_roots_returns_empty(tmp_path, monkeypatch):
     assert response.status_code == 200
     body = response.json()
     assert body["specs"] == []
-    # Default root is project_root/docs/specs even when it doesn't exist
+    # Default root is project_root/docs/specs even when it doesn't exist.
+    # Use os.sep to be cross-platform (Windows: \, POSIX: /).
+    import os
+
     assert len(body["roots"]) == 1
-    assert body["roots"][0].endswith("/docs/specs")
+    assert body["roots"][0].endswith(os.path.join("docs", "specs"))
 
 
 def test_list_specs_single_root_multiple_specs(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes a cross-platform path assertion bug in
`test_list_specs_empty_roots_returns_empty` (from Phase 1 of
ops-specs-features, #236).

The test asserted `path.endswith("/docs/specs")`. On Windows the
resolved path uses `\` separators (`C:\Users\...\docs\specs`), so
the assertion fails on every Windows lane. The bug existed since
#236 merged but went unseen because Windows lanes were still
pending when admin-merged.

Fix: use `os.path.join("docs", "specs")` for the expected suffix,
which yields the correct separator per platform.

## Discovered via

Probe-c Phase 4 testing (#242) — `-n auto` finished the Windows
lanes for the first time in a reasonable timeframe and exposed this
plus 4 other pre-existing Windows xdist issues (worker crashes,
TypeError NoneType) that the old `-n 1` cap was implicitly hiding
by being too slow to ever complete.

## Test plan

- [x] Existing 31 tests in `test_specs_routes.py` still pass
  locally (linux/macOS) — `pytest tests/unit/ops/test_specs_routes.py --no-cov`
- [ ] CI Windows lanes pass for this test
- [ ] Once merged + rebased into #242, that PR's specs-route
  failure on Windows is gone (leaving only the 4 pre-existing
  worker-crash failures for separate investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
