### PR TITLE
ci(diag): windows-memory-detection Phase 1 — capture real tracebacks

### DIFF
--- a/.github/workflows/diag-windows-memory.yml
+++ b/.github/workflows/diag-windows-memory.yml
@@ -71,6 +71,54 @@ jobs:
         pytest tests/unit/hooks/test_session_continuity_io.py::TestCompactWarning::test_above_threshold_fires_once \
           -n 1 --tb=long -v --capture=no --no-cov
 
+    # Direct reproduction: bypass pytest and call the hook from a
+    # tiny script to see exactly what subprocess.run returns.
+    - name: 1.4 deep — direct subprocess inspection
+      continue-on-error: true
+      shell: bash
+      run: |
+        python -c "
+        import json, os, subprocess, sys, tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpp = Path(tmp)
+            transcript = tmpp / 'transcript.jsonl'
+            transcript.write_text(json.dumps({'role': 'user', 'content': 'x' * 4000}) + '\n')
+            sentinel_dir = tmpp / 'sentinels'
+            sentinel_dir.mkdir()
+            hook = Path('plugin/hooks/compact_warning.py').resolve()
+            env = os.environ.copy()
+            env.update({
+                'ATTUNE_AI_SENTINEL_DIR': str(sentinel_dir),
+                'ATTUNE_AI_CONTEXT_WINDOW_TOKENS': '1000',
+                'ATTUNE_AI_COMPACT_WARNING_THRESHOLD': '0.50',
+            })
+            payload = json.dumps({
+                'session_id': 'fires-once',
+                'transcript_path': str(transcript),
+                'cwd': str(tmpp),
+            })
+            print('--- invoking hook ---')
+            print('sys.executable:', sys.executable)
+            print('hook:', hook)
+            print('hook exists:', hook.is_file())
+            result = subprocess.run(
+                [sys.executable, str(hook)],
+                input=payload,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=10,
+            )
+            print('--- result ---')
+            print('returncode:', result.returncode)
+            print('stdout type:', type(result.stdout).__name__)
+            print('stdout repr:', repr(result.stdout))
+            print('stderr type:', type(result.stderr).__name__)
+            print('stderr repr:', repr(result.stderr))
+        "
+
     # Final summary step always runs; useful for spotting "all 4
     # passed" (which would mean the failures depend on parallel
     # execution context, not the tests themselves).

--- a/.github/workflows/diag-windows-memory.yml
+++ b/.github/workflows/diag-windows-memory.yml
@@ -1,0 +1,82 @@
+# Diagnostic-only workflow — Phase 1 of
+# docs/specs/windows-memory-detection/tasks.md.
+#
+# Runs the 4 Windows-failing tests serially with full traceback to
+# capture the real exception text that xdist swallows as "worker
+# crashed". Runs on PRs to the diagnostic branch only (so it doesn't
+# spam every PR). Delete this file after the spec's Phase 4 closes.
+name: Diagnostic — windows-memory-detection Phase 1
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/diag-windows-memory.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11']  # one version is enough to see the trace
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    # Each test runs as its own step so a hard worker crash on one
+    # doesn't mask the others. `continue-on-error: true` keeps the
+    # subsequent steps firing even if a step fails.
+    - name: 1.1 — test_list_all_features_returns_dict
+      continue-on-error: true
+      shell: bash
+      run: |
+        pytest tests/unit/test_memory_features.py::TestMemoryFeatures::test_list_all_features_returns_dict \
+          -n 1 --tb=long -v --capture=no --no-cov
+
+    - name: 1.2 — test_list_all_features_structure
+      continue-on-error: true
+      shell: bash
+      run: |
+        pytest tests/unit/test_memory_features.py::TestMemoryFeatures::test_list_all_features_structure \
+          -n 1 --tb=long -v --capture=no --no-cov
+
+    - name: 1.3 — test_respects_redis_enabled_true
+      continue-on-error: true
+      shell: bash
+      run: |
+        pytest tests/unit/memory/test_redis_auto_detect.py::TestBaseOperationsBackwardCompat::test_respects_redis_enabled_true \
+          -n 1 --tb=long -v --capture=no --no-cov
+
+    - name: 1.4 — test_above_threshold_fires_once
+      continue-on-error: true
+      shell: bash
+      run: |
+        pytest tests/unit/hooks/test_session_continuity_io.py::TestCompactWarning::test_above_threshold_fires_once \
+          -n 1 --tb=long -v --capture=no --no-cov
+
+    # Final summary step always runs; useful for spotting "all 4
+    # passed" (which would mean the failures depend on parallel
+    # execution context, not the tests themselves).
+    - name: Summary
+      if: always()
+      run: |
+        echo "Phase 1 diagnostic complete. Review each step's log."
+        echo "If any step shows '1 passed' instead of a traceback, that"
+        echo "test is parallel-execution-dependent, not Windows-broken."

--- a/.github/workflows/diag-windows-memory.yml
+++ b/.github/workflows/diag-windows-memory.yml
@@ -119,6 +119,43 @@ jobs:
             print('stderr repr:', repr(result.stderr))
         "
 
+    # Isolate the None-stdout anomaly: does it happen with a trivial
+    # hello-world script, or only the real hook?
+    - name: 1.4 isolate — hello-world subprocess (no hook)
+      continue-on-error: true
+      shell: bash
+      run: |
+        python -c "
+        import subprocess, sys
+        script = 'import sys; sys.stdout.write(\"hello\"); sys.exit(0)'
+        result = subprocess.run(
+            [sys.executable, '-c', script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        print('returncode:', result.returncode)
+        print('stdout type:', type(result.stdout).__name__)
+        print('stdout repr:', repr(result.stdout))
+        print('stderr type:', type(result.stderr).__name__)
+        print('stderr repr:', repr(result.stderr))
+        "
+
+    # Isolate the reconfigure() block: bypass it and see if a
+    # minimal hook (no sys.stdout.reconfigure) returns stdout.
+    - name: 1.4 isolate — minimal hook, no reconfigure
+      continue-on-error: true
+      shell: bash
+      run: |
+        # Write the minimal hook to a file via shell heredoc so the
+        # python -c body stays single-line (avoids YAML indent issues).
+        cat > /tmp/minimal_hook.py << 'PYEOF'
+        import json, sys
+        payload = json.load(sys.stdin)
+        sys.stdout.write('ECHO ' + str(payload.get('session_id', 'none')) + chr(10))
+        PYEOF
+        python -c "import json, subprocess, sys; r = subprocess.run([sys.executable, '/tmp/minimal_hook.py'], input=json.dumps({'session_id': 'test-iso'}), capture_output=True, text=True, timeout=10); print('returncode:', r.returncode); print('stdout type:', type(r.stdout).__name__); print('stdout repr:', repr(r.stdout)); print('stderr type:', type(r.stderr).__name__); print('stderr repr:', repr(r.stderr))"
+
     # Final summary step always runs; useful for spotting "all 4
     # passed" (which would mean the failures depend on parallel
     # execution context, not the tests themselves).


### PR DESCRIPTION
## Summary

Phase 1 of `docs/specs/windows-memory-detection/` (per #244).

Adds a throwaway workflow `diag-windows-memory.yml` that runs the 4 Windows-failing tests serially on Windows with `--tb=long --capture=no` so we can see what xdist swallows as "worker crashed". Each test in its own step with `continue-on-error: true` — one crash doesn't mask the others.

Triggers on `pull_request` to main, gated by `paths: [.github/workflows/diag-windows-memory.yml]` so it only fires when this file is in the diff (won't spam any other PR). Also retains `workflow_dispatch` for manual re-runs once merged.

## Plan

1. Open this PR → trigger fires automatically → 4 Windows steps run
2. Read each step's `--tb=long` output
3. Update `docs/specs/windows-memory-detection/decisions.md` with the real root causes (promote hypotheses A and B to facts)
4. Open surgical fix PRs per spec Phase 2 & 3
5. **Do NOT merge this PR** — it's diagnostic. Close + delete the branch once the spec's Phase 4 closes.

## Why throwaway

The diagnostic command should never run on every PR — it's 4 known-failing tests in a long-form mode. The workflow file pattern self-contains: it only fires when the diagnostic workflow file itself changes, so it expires naturally with deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
