### PR TITLE
feat(ops): Tier 1 rich rendering for workflow output

### DIFF
--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -453,6 +453,44 @@ a.kpi:hover {
   word-break: break-word;
 }
 
+/* Rich-rendering tokens within .log-output (runner.js Tier 1). */
+.log-output .log-link {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.log-output .log-link:hover {
+  color: var(--accent-strong, var(--accent));
+  text-decoration-thickness: 2px;
+}
+.log-output .log-file {
+  display: inline-block;
+  padding: 0 4px;
+  margin: 0 1px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+.log-output .log-workflow {
+  display: inline-block;
+  padding: 0 6px;
+  margin: 0 2px;
+  background: var(--accent-soft, var(--bg-soft));
+  border: 1px solid var(--accent-soft, var(--border));
+  border-radius: 99px;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+}
+.log-output .log-header {
+  font-weight: 600;
+  color: var(--accent);
+}
+
 /* Home polish */
 .sparkline {
   display: block;

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -1,8 +1,52 @@
-// Minimal SSE-driven workflow runner UI.
+// SSE-driven workflow runner UI with rich line rendering.
 // No frameworks. Wires the per-row Run button to POST /workflows/<name>/run,
 // then attaches an EventSource to /runs/<id>/stream.
+//
+// Line rendering (since v6.X) parses each streamed line for URLs, file
+// paths, workflow-name mentions, and section headers; renders them as
+// clickable links / styled chips / bold headers. No innerHTML — every
+// segment becomes a real DOM node, so attacker-controlled output (file
+// paths, error messages) can't inject script.
 (function () {
   "use strict";
+
+  // Canonical workflow names — kept in sync with `attune.ops.data
+  // .list_workflows()` output. When this drifts, runner.js still works
+  // (mentions of unknown names just render as text), so no hard sync
+  // dependency, but worth a periodic glance.
+  var WORKFLOW_NAMES = [
+    "bug-predict", "code-review", "deep-review", "dependency-check",
+    "doc-audit", "doc-gen", "doc-orchestrator", "health-check",
+    "orchestrated-health-check", "perf-audit", "rag-code-gen",
+    "refactor-plan", "release-prep", "research-synthesis",
+    "secure-release", "security-audit", "simplify-code",
+    "test-audit", "test-gen"
+  ];
+
+  // Section headers (line-leader text) that get bolded/colored so users
+  // can scan workflow output quickly. Matched case-insensitively against
+  // the start of the line.
+  var SECTION_HEADERS = [
+    "Recommendations", "Recommendation",
+    "Next steps", "Next step",
+    "Issues found", "Issues", "Findings", "Finding",
+    "Summary", "Suggestions", "Suggestion",
+    "Warnings", "Warning", "Errors", "Error",
+    "Notes", "Note"
+  ];
+
+  // Build a single regex that matches a URL, file path, or workflow
+  // name. Order in the alternation is important: URLs first (they
+  // might contain dots), then file paths, then workflow names.
+  var FILE_EXTS = "py|pyi|js|jsx|ts|tsx|md|rst|txt|yml|yaml|json|toml|cfg|ini|html|css|sh|bash|zsh";
+  var TOKEN_RE = new RegExp(
+    "(https?:\\/\\/[^\\s<>\"']+)" +                                  // 1: URL
+    "|" +
+    "((?:[\\w][\\w./\\-]*\\/)?[\\w][\\w.\\-]*\\.(?:" + FILE_EXTS + ")(?::\\d+(?::\\d+)?)?)" +  // 2: file path
+    "|" +
+    "\\b(" + WORKFLOW_NAMES.map(function (n) { return n.replace(/-/g, "\\-"); }).join("|") + ")\\b",  // 3: workflow name
+    "g"
+  );
 
   function findRow(name) {
     return document.querySelector('tr[data-workflow="' + CSS.escape(name) + '"]');
@@ -13,10 +57,80 @@
     if (el) el.textContent = status;
   }
 
+  // Detect a section-header prefix on a line. Returns {header, rest} if
+  // matched, else null. Tolerates leading whitespace and bullet markers
+  // so "- Recommendations:" or "  ## Next steps" both qualify.
+  function detectSectionHeader(line) {
+    var stripped = line.replace(/^[\s\-*#>•]+/, "");
+    for (var i = 0; i < SECTION_HEADERS.length; i++) {
+      var h = SECTION_HEADERS[i];
+      var re = new RegExp("^" + h.replace(/\s/g, "\\s") + "\\s*:", "i");
+      var match = stripped.match(re);
+      if (match) {
+        var leader = line.slice(0, line.length - stripped.length) + match[0];
+        var rest = stripped.slice(match[0].length);
+        return { leader: leader, rest: rest };
+      }
+    }
+    return null;
+  }
+
+  // Append inline-parsed segments of `text` to `parent`. Each segment is
+  // either a Text node (safe by construction) or a styled child element.
+  function appendInline(parent, text) {
+    if (!text) return;
+    var lastIndex = 0;
+    var m;
+    TOKEN_RE.lastIndex = 0;
+    while ((m = TOKEN_RE.exec(text)) !== null) {
+      if (m.index > lastIndex) {
+        parent.appendChild(document.createTextNode(text.slice(lastIndex, m.index)));
+      }
+      if (m[1]) {
+        // URL
+        var a = document.createElement("a");
+        a.href = m[1];
+        a.target = "_blank";
+        a.rel = "noopener noreferrer";
+        a.className = "log-link";
+        a.textContent = m[1];
+        parent.appendChild(a);
+      } else if (m[2]) {
+        // File path with optional :line[:col] suffix
+        var span = document.createElement("span");
+        span.className = "log-file";
+        span.textContent = m[2];
+        parent.appendChild(span);
+      } else if (m[3]) {
+        // Workflow name — inert pill in Tier 1; Tier 2 will make it clickable
+        var pill = document.createElement("span");
+        pill.className = "log-workflow";
+        pill.textContent = m[3];
+        parent.appendChild(pill);
+      }
+      lastIndex = TOKEN_RE.lastIndex;
+    }
+    if (lastIndex < text.length) {
+      parent.appendChild(document.createTextNode(text.slice(lastIndex)));
+    }
+  }
+
+  // Render one streamed line into the log pane with rich segments.
   function appendLine(row, line) {
     var pre = row.querySelector("[data-log]");
     if (!pre) return;
-    pre.textContent += line + "\n";
+
+    var header = detectSectionHeader(line);
+    if (header) {
+      var leaderSpan = document.createElement("span");
+      leaderSpan.className = "log-header";
+      leaderSpan.textContent = header.leader;
+      pre.appendChild(leaderSpan);
+      appendInline(pre, header.rest);
+    } else {
+      appendInline(pre, line);
+    }
+    pre.appendChild(document.createTextNode("\n"));
     pre.scrollTop = pre.scrollHeight;
   }
 
@@ -24,7 +138,21 @@
     var pane = row.querySelector("[data-log-pane]");
     if (pane) pane.hidden = false;
     var pre = row.querySelector("[data-log]");
-    if (pre) pre.textContent = "";
+    // Clear via removing all children (faster than textContent = "" for
+    // a pre with many child nodes after rich rendering).
+    if (pre) while (pre.firstChild) pre.removeChild(pre.firstChild);
+  }
+
+  // Export internals for the test page (tests/unit/ops/static/test_runner.html).
+  // Wrapped in a check so it's a no-op in environments without window.
+  if (typeof window !== "undefined") {
+    window.__attuneRunner = {
+      detectSectionHeader: detectSectionHeader,
+      appendInline: appendInline,
+      appendLine: appendLine,
+      WORKFLOW_NAMES: WORKFLOW_NAMES,
+      SECTION_HEADERS: SECTION_HEADERS
+    };
   }
 
   // Format server error responses into something a human can read.

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -35,6 +35,17 @@
     "Notes", "Note"
   ];
 
+  // Full regex-meta escape for any string going into a RegExp. Covers
+  // every regex metacharacter including backslash, so even if
+  // WORKFLOW_NAMES is ever populated from a less-trusted source, the
+  // regex semantics stay intact (no injection bypass via embedded
+  // metacharacters). CodeQL flagged the previous one-character version
+  // as "incomplete string escaping" — fair, even though today's input
+  // is a hardcoded safe array.
+  function reEscape(s) {
+    return s.replace(/[.*+?^${}()|[\]\\-]/g, "\\$&");
+  }
+
   // Build a single regex that matches a URL, file path, or workflow
   // name. Order in the alternation is important: URLs first (they
   // might contain dots), then file paths, then workflow names.
@@ -44,7 +55,7 @@
     "|" +
     "((?:[\\w][\\w./\\-]*\\/)?[\\w][\\w.\\-]*\\.(?:" + FILE_EXTS + ")(?::\\d+(?::\\d+)?)?)" +  // 2: file path
     "|" +
-    "\\b(" + WORKFLOW_NAMES.map(function (n) { return n.replace(/-/g, "\\-"); }).join("|") + ")\\b",  // 3: workflow name
+    "\\b(" + WORKFLOW_NAMES.map(reEscape).join("|") + ")\\b",                                 // 3: workflow name
     "g"
   );
 

--- a/tests/unit/ops/test_runner_js_parsing.py
+++ b/tests/unit/ops/test_runner_js_parsing.py
@@ -1,0 +1,183 @@
+"""Tests for the rich-rendering parsing in `runner.js`.
+
+The JS itself is tested by-eye in the browser. These tests guard
+against drift between the JS regex/lists and what the Python side
+expects:
+
+- Every canonical workflow name from `attune.ops.data.list_workflows()`
+  must appear in the JS `WORKFLOW_NAMES` array. Otherwise a workflow
+  mentioned in another workflow's output wouldn't render as a pill.
+- The JS file should parse cleanly (no obvious syntax errors).
+- Representative log-line patterns we expect to render correctly:
+  match the same Python-equivalent regex (so the logic is sanity-checked
+  outside the browser).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_RUNNER_JS = (
+    Path(__file__).resolve().parents[3] / "src" / "attune" / "ops" / "static" / "js" / "runner.js"
+)
+
+
+@pytest.fixture(scope="module")
+def runner_js_text() -> str:
+    return _RUNNER_JS.read_text(encoding="utf-8")
+
+
+def test_runner_js_exists():
+    """The file is checked in and reachable."""
+    assert _RUNNER_JS.is_file(), f"missing {_RUNNER_JS}"
+
+
+def test_workflow_names_match_canonical_list(runner_js_text):
+    """JS WORKFLOW_NAMES array must include every workflow exposed by
+    `attune.ops.data.list_workflows()` — otherwise mentions in workflow
+    output wouldn't get the pill treatment.
+    """
+    pytest.importorskip("fastapi")  # ops imports need this
+    from attune.ops import data
+
+    canonical = {w.name for w in data.list_workflows()}
+    # Extract the JS array literal
+    m = re.search(r"WORKFLOW_NAMES\s*=\s*\[(.*?)\]", runner_js_text, re.DOTALL)
+    assert m, "WORKFLOW_NAMES array not found in runner.js"
+    js_names = set(re.findall(r'"([a-z][a-z0-9-]+)"', m.group(1)))
+    missing = canonical - js_names
+    assert not missing, (
+        f"Canonical workflow names missing from runner.js WORKFLOW_NAMES: {sorted(missing)}. "
+        "Update the array in runner.js so mentions of these workflows render as pills."
+    )
+
+
+def test_section_headers_includes_recommendations(runner_js_text):
+    """Common workflow-output headers must be recognized."""
+    must_have = ["Recommendations", "Next steps", "Issues", "Summary"]
+    m = re.search(r"SECTION_HEADERS\s*=\s*\[(.*?)\]", runner_js_text, re.DOTALL)
+    assert m, "SECTION_HEADERS array not found in runner.js"
+    js_headers = set(re.findall(r'"([^"]+)"', m.group(1)))
+    for required in must_have:
+        assert required in js_headers, f"missing section header: {required}"
+
+
+def test_appendline_uses_dom_nodes_not_innerhtml(runner_js_text):
+    """Tier-1 security guarantee: no innerHTML usage in the line-rendering
+    path. Each segment becomes a real DOM node so file paths / URLs /
+    error messages from workflows can never inject script."""
+    # Strip comments before searching so doc strings can mention innerHTML
+    # in a "no innerHTML" context without false-flagging.
+    without_block = re.sub(r"/\*[\s\S]*?\*/", "", runner_js_text)
+    without_comments = re.sub(r"//[^\n]*", "", without_block)
+    assert "innerHTML" not in without_comments, (
+        "innerHTML used in runner.js — Tier 1 spec requires DOM-node "
+        "construction only. Use createElement + textContent instead."
+    )
+
+
+# Python equivalent of the JS regex — kept in sync by hand. If you
+# update either, update both.
+_FILE_EXTS = "py|pyi|js|jsx|ts|tsx|md|rst|txt|yml|yaml|json|toml|cfg|ini" "|html|css|sh|bash|zsh"
+_WORKFLOW_NAMES_PY = [
+    "bug-predict",
+    "code-review",
+    "deep-review",
+    "dependency-check",
+    "doc-audit",
+    "doc-gen",
+    "doc-orchestrator",
+    "health-check",
+    "orchestrated-health-check",
+    "perf-audit",
+    "rag-code-gen",
+    "refactor-plan",
+    "release-prep",
+    "research-synthesis",
+    "secure-release",
+    "security-audit",
+    "simplify-code",
+    "test-audit",
+    "test-gen",
+]
+# Order: URL → file → workflow (same as JS)
+_TOKEN_RE = re.compile(
+    r"(https?://[^\s<>\"']+)"
+    r"|"
+    r"((?:[\w][\w./\-]*/)?[\w][\w.\-]*\.(?:" + _FILE_EXTS + r")(?::\d+(?::\d+)?)?)"
+    r"|"
+    r"\b(" + "|".join(_WORKFLOW_NAMES_PY) + r")\b"
+)
+
+
+def _classify(text: str) -> list[tuple[str, str]]:
+    """Return [(kind, value), ...] segments for `text`."""
+    out: list[tuple[str, str]] = []
+    last = 0
+    for m in _TOKEN_RE.finditer(text):
+        if m.start() > last:
+            out.append(("text", text[last : m.start()]))
+        if m.group(1):
+            out.append(("url", m.group(1)))
+        elif m.group(2):
+            out.append(("file", m.group(2)))
+        elif m.group(3):
+            out.append(("workflow", m.group(3)))
+        last = m.end()
+    if last < len(text):
+        out.append(("text", text[last:]))
+    return out
+
+
+def test_classify_url():
+    segs = _classify("see https://github.com/foo/bar/pull/1 for details")
+    kinds = [k for k, _ in segs]
+    assert "url" in kinds
+    url = next(v for k, v in segs if k == "url")
+    assert url == "https://github.com/foo/bar/pull/1"
+
+
+def test_classify_file_path():
+    segs = _classify("issue in src/attune/foo.py:42 inside main()")
+    files = [v for k, v in segs if k == "file"]
+    assert "src/attune/foo.py:42" in files
+
+
+def test_classify_workflow_name():
+    segs = _classify("recommended next: code-review then bug-predict")
+    wfs = [v for k, v in segs if k == "workflow"]
+    assert "code-review" in wfs
+    assert "bug-predict" in wfs
+
+
+def test_classify_preserves_surrounding_text():
+    segs = _classify("Run code-review on src/foo.py to check.")
+    assert segs[0] == ("text", "Run ")
+    assert ("workflow", "code-review") in segs
+    assert ("file", "src/foo.py") in segs
+    # Trailing punctuation stays in the text segment, not the file
+    last = segs[-1]
+    assert last[0] == "text"
+    assert last[1].endswith(".")
+
+
+def test_classify_no_false_positive_on_plain_text():
+    segs = _classify("Everything looks fine here.")
+    assert all(k == "text" for k, _ in segs)
+    assert len(segs) == 1
+    assert segs[0][1] == "Everything looks fine here."
+
+
+def test_classify_url_with_query_string():
+    segs = _classify("docs at https://docs.example.com/api?q=foo&bar=baz")
+    urls = [v for k, v in segs if k == "url"]
+    assert urls == ["https://docs.example.com/api?q=foo&bar=baz"]
+
+
+def test_classify_file_path_with_line_and_column():
+    segs = _classify("trace: src/foo/bar.py:123:45 here")
+    files = [v for k, v in segs if k == "file"]
+    assert "src/foo/bar.py:123:45" in files


### PR DESCRIPTION
## Summary

Tier 1 of "richer workflow result rendering" — see the user-facing rationale in the [conversation summary]. Workflow output already contains useful follow-along recommendations as plain text; this PR makes them scannable + actionable-looking.

## What renders now

| Pattern | Before | After |
|---------|--------|-------|
| `https://github.com/foo/bar` | gray text | underlined link, opens in new tab |
| `src/attune/foo.py:42` | gray text | inline chip with mono font + border |
| `code-review`, `bug-predict`, ... (19 workflow names) | gray text | accent-colored pill |
| `Recommendations:`, `Next steps:`, `Issues:`, etc. | plain | bold + accent color |

Each segment becomes a real DOM node — **no `innerHTML`** — so attacker-controlled output (file paths in error messages, etc.) can't inject script. The "no innerHTML" rule is enforced by a regression test.

## What this is NOT (deferred to Tier 2 spec)

- Workflow-name pills are **inert** here. Tier 2's spec will wire them to actually trigger the named workflow with prefilled context.
- File-path chips don't open in your editor yet.
- No persistence — log output is still session-scoped.

We ship Tier 1 today and write the Tier 2 spec with the benefit of actually using the new rendering for a day.

## Test plan

- [x] `pytest tests/unit/ops/ --no-cov` — **88 passed** (77 → 88, +11 new for the runner parsing)
- [x] `ruff check src/attune/ops/ tests/unit/ops/` — clean
- [x] `pre-commit run black` — clean
- [ ] CI matrix green
- [ ] Visual smoke — run a workflow from the dashboard, eyeball the rendering

## Drift guards

The new tests enforce three contracts:

1. **`WORKFLOW_NAMES`** in `runner.js` includes every name returned by `attune.ops.data.list_workflows()` — registry adds will fail this test and remind us to update the JS.
2. **`SECTION_HEADERS`** includes the most common output headers.
3. **No `innerHTML`** in `runner.js` (security guarantee).

Python-equivalent regex exercises representative log-line patterns so the parsing logic is sanity-checked without needing Node on every CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
