### PR TITLE
docs(specs): ops-runner-tier2 — scope picker + persistence + clickable pills

### DIFF
--- a/docs/specs/ops-runner-tier2/decisions.md
+++ b/docs/specs/ops-runner-tier2/decisions.md
@@ -1,0 +1,131 @@
+# Decisions — Ops Runner Tier 2
+
+**Status:** draft
+**Owner:** Patrick
+**Opened:** 2026-05-11
+**Predecessor:** PR #247 (Tier 1 rich rendering — workflow output gets parsed links, file chips, workflow pills, headers)
+
+---
+
+## Problem
+
+The current `/workflows` tab on the ops dashboard runs each workflow against the **whole project** with no path scoping. On a real codebase (attune-ai itself has 15k+ tests) this means:
+
+- **Slow runs.** A `code-review` over `src/attune/` takes 5–10 minutes of LLM time when the user really wanted to check `src/attune/memory/`.
+- **Diluted output.** Recommendations sprawl across unrelated areas. The "useful follow-along advice" Patrick called out (workflow X recommends running workflow Y next) gets lost in noise.
+- **Dashboard-vs-terminal habit gap.** Developers iterating on one feature run `attune workflow run code-review --path src/foo` in the terminal because the dashboard can't scope. They never come back to the dashboard for that workflow.
+
+PR #247 makes the output *prettier* — links, file chips, workflow-name pills, section headers — but the pills are inert. Clicking a recommended workflow doesn't do anything yet. The whole pattern was holding still until we knew where it should go.
+
+This spec is where it should go.
+
+---
+
+## Decision
+
+**Tier 2 turns the dashboard from a viewer into a workflow conductor.** Four headline capabilities, sequenced so each is independently shippable and reversible:
+
+1. **Scope picker per workflow row** — a feature/path dropdown sourced from `.help/features.yaml`, with a free-form `--path` fallback. Runs become *fast and focused*.
+2. **Workflow-name pills become buttons** — Tier 1's inert pills become "Run this workflow with the same scope" actions. Recommendations turn into clicks.
+3. **Output persistence** — last N runs stored per workflow, browsable inline. Returning users see prior context.
+4. **Structured recommendation channel** — workflows can emit JSON like `{"kind": "next-workflow", "name": "bug-predict", "args": {"path": "src/foo"}}` alongside their text stream; the UI renders these as proper action cards.
+
+Headline UX:
+
+```
+[ src/attune/memory/  ▼ ]  [ Run ]
+  ├─ All of project
+  ├─ specs           docs/specs/
+  ├─ ops             src/attune/ops/
+  ├─ memory          src/attune/memory/   ← selected
+  ├─ workflows       src/attune/workflows/
+  └─ Custom path…    (text input)
+```
+
+Plus a runs-history strip per workflow:
+
+```
+Recent runs:  [success • 2m ago • ops]  [failed • 1h ago • all]  [success • yesterday • memory]
+```
+
+---
+
+## Why now
+
+- PR #247 just landed visual cues that signal "this should be clickable." Leaving the pills inert beyond a brief Tier-1 trial window erodes trust.
+- `.help/features.yaml` already exists; the data is there.
+- The ops-specs-features work (#236/#239/#240) proved out the same pattern (config-driven listing + per-row actions + read-only-aware mutation). The scaffolding is reusable.
+- We just established the spec-first/tar-pit discipline in CLAUDE.md. Big UX work without a spec is exactly what that rule is for.
+
+---
+
+## Working hypotheses
+
+### H1 — `.help/features.yaml` is the right scope source
+
+The file already maps feature names to source globs (consumed by `attune-author`, `attune-help`, the doc-staleness check, etc.). Reusing it means:
+
+- Zero new metadata for users who already maintain `.help/features.yaml`
+- Graceful degradation: no `features.yaml` → only "All of project" + "Custom path…" are offered (still strictly better than today)
+- Future-proof: any improvement to the feature list flows automatically into the picker
+
+Risk: `features.yaml` is project-specific. Patrick maintains one for attune-ai but most ops users haven't. Mitigation: the dashboard's empty state explicitly tells them how to bootstrap one (`attune-author init`).
+
+### H2 — Workflow `--path` support is unevenly implemented
+
+Some workflows take `--path` (`code-review`, `bug-predict`, `simplify-code`, `perf-audit`, `test-gen`). Some don't (`release-prep`, `health-check`, `dependency-check`). The runner needs per-workflow knowledge of which arg is accepted.
+
+Investigation task: enumerate which workflows support `--path` and which don't. Disable the picker on the latter; surface a tooltip explaining the workflow runs project-wide by design.
+
+### H3 — Persistence belongs in the runner service, not a separate "Runs" tab
+
+The current `RunnerService` keeps runs in memory (last 20). Persistence means writing run metadata + truncated log to disk under `~/.attune/ops/runs/<id>.json`. The "Runs" tab idea from earlier conversation gets folded into per-workflow row history (chips next to the Run button) — simpler navigation, no extra page.
+
+### H4 — Structured recommendations should be opt-in per workflow, not retrofitted everywhere
+
+A workflow opts in by emitting an SSE event with type `recommendation` carrying a small JSON payload. The UI renders these as action cards. Workflows that don't opt in fall back to the Tier 1 regex parser — no regression. This is much safer than rewriting every workflow's output format at once.
+
+---
+
+## Out of scope
+
+- **Multi-project ops.** The dashboard scopes to one project at a time. Switching projects = restart `attune ops --project-root <other>`.
+- **Editor integration for file-path chips.** Tier 2 keeps those as visual chips. A file-path "click to open in editor" capability requires a protocol-handler or attune-gui bridge — separate spec if/when needed.
+- **Run cancellation.** The current runner doesn't support cancel; Tier 2 doesn't change that. If wanted, separate task.
+- **Sharing runs across users.** Persistence is per-user under `~/.attune/ops/`. No multi-user/server-side storage.
+- **Reorganizing the nav.** The Specs tab + Workflows tab + Telemetry tab structure stays. Tier 2 adds depth within Workflows, not breadth across tabs.
+
+---
+
+## Alternatives considered
+
+### Alternative A — Free-form path input only (no `.help/features.yaml`)
+
+Skip the feature-list integration; just give every Run button a `--path` text field. Simpler. But it loses the "menu of named scopes" UX that makes scoping discoverable. Users would have to know what paths exist in their project.
+
+Verdict: rejected. The dropdown is the discoverability story. Free-form stays as the fallback for edge cases.
+
+### Alternative B — Make Tier 1 pills clickable now, defer the scope picker
+
+Smaller scope. But clicking a pill without a scope just re-runs the same project-wide pattern that's already slow. Scope is the lever that makes the action valuable. Doing pills first means users get a "click-to-do-the-slow-thing" experience and learn to ignore the pills.
+
+Verdict: rejected. The scope picker is the prerequisite.
+
+### Alternative C — A separate "Run with scope" wizard page
+
+Dedicated multi-step page: pick workflow → pick scope → pick args → run. Maximally guided. But it shifts the dashboard from "two-click execute" to "five-click wizard" and the current users aren't asking for that — they're asking for *less* friction, not more.
+
+Verdict: rejected. Inline picker per row.
+
+---
+
+## Resolution criteria
+
+Tier 2 closes when:
+
+1. Every workflow row has a scope picker (or a tooltip explaining why it doesn't)
+2. Workflow-name pills in output trigger a follow-on run with the same scope
+3. Per-workflow recent-runs history visible inline
+4. At least one workflow demonstrates the structured-recommendation channel end-to-end
+5. PR #247's drift-guard tests + new Tier 2 tests stay green on all 12 platform lanes (windows-memory-detection spec resolved by then)
+6. Patrick has used the new dashboard for at least one real feature scope (e.g. `src/attune/memory/`) and confirmed the UX feels right

--- a/docs/specs/ops-runner-tier2/design.md
+++ b/docs/specs/ops-runner-tier2/design.md
@@ -1,0 +1,221 @@
+# Design — Ops Runner Tier 2
+
+**Status:** draft
+
+Technical shape of the work. See `requirements.md` for what we're building, `tasks.md` for the phase plan.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Browser                                                  │
+│  workflows.html  (table, row per workflow)               │
+│    ├── scope <select> + <input> per row                  │
+│    ├── runner.js (existing) + Tier 2 additions:          │
+│    │     ├── scope reader (URL → POST body)              │
+│    │     ├── pill click → POST /workflows/X/run          │
+│    │     ├── history strip renderer                      │
+│    │     └── recommendation card renderer (SSE event)    │
+│    └── CSS additions: .scope-picker, .recent-runs, ...   │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼ HTTP/SSE
+┌──────────────────────────────────────────────────────────┐
+│ FastAPI / attune.ops.server                              │
+│                                                          │
+│  routes/dashboard.py                                     │
+│    GET /workflows  → renders workflows.html              │
+│      passes features, supports_path map, recent runs     │
+│                                                          │
+│  routes/runner.py  (existing)                            │
+│    POST /workflows/{name}/run                            │
+│      body now accepts: { "path": str | null }            │
+│      validates path, builds command, kicks off run       │
+│                                                          │
+│    GET /runs/{id}/stream                                 │
+│      yields SSE: "line" + new "recommendation" events    │
+│                                                          │
+│  routes/runs_history.py  (NEW)                           │
+│    GET /api/runs/{workflow}    → recent N runs           │
+│    GET /api/runs/{workflow}/{run_id}  → full run log     │
+│                                                          │
+│  data.py                                                 │
+│    list_features() → reads .help/features.yaml           │
+│    SUPPORTS_PATH_ARG dict                                │
+│                                                          │
+│  runner.py                                               │
+│    RunnerService now writes Run to disk on completion    │
+│    Command builder uses path from request body           │
+└──────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+        ~/.attune/ops/runs/<workflow>/<run-id>.json
+        (persisted run history)
+```
+
+---
+
+## Module-by-module changes
+
+### `src/attune/ops/data.py`
+
+- **New:** `list_features(project_root: Path) -> list[Feature]` — reads `.help/features.yaml`, returns dataclasses with `name`, `paths`, `description`. Returns `[]` if file missing/malformed (logs warning).
+- **New:** `SUPPORTS_PATH_ARG: dict[str, bool]` — explicit per-workflow declaration. A drift-guard test asserts every workflow returned by `list_workflows()` has an entry.
+
+### `src/attune/ops/routes/dashboard.py`
+
+`workflows_page()` (existing) gets two more context vars:
+
+```python
+return _render(
+    request,
+    "workflows.html",
+    page="workflows",
+    workflows=workflows,
+    allow_run=cfg.allow_run,
+    features=data.list_features(cfg.project_root),
+    supports_path=data.SUPPORTS_PATH_ARG,
+)
+```
+
+### `src/attune/ops/runner.py`
+
+`RunnerService.start_run()` accepts an optional `path: str | None`. The `_default_command` becomes:
+
+```python
+def _default_command(workflow: str, path: str | None = None) -> Sequence[str]:
+    cmd = [sys.executable, "-m", "attune.cli_minimal", "workflow", "run", workflow]
+    if path:
+        cmd.extend(["--path", path])
+    return cmd
+```
+
+Persistence:
+- `Run.to_dict()` already exists; extend to include `scope` and `command` fields
+- On completion (whether success or failure), write `~/.attune/ops/runs/<workflow>/<run-id>.json` with the full record + truncated log
+- Read-only mode skips the write
+- Startup task: prune runs older than 30 days (configurable via `--runs-retention-days`)
+
+### `src/attune/ops/routes/runner.py`
+
+POST body schema (new):
+
+```python
+class RunRequest(BaseModel):
+    path: str | None = None  # validated server-side
+```
+
+If `path` is provided:
+- Apply `_validate_file_path(path, allowed_dir=config.project_root)`
+- Reject with 400 if validation fails
+
+If the workflow has `SUPPORTS_PATH_ARG[name] is False` and `path` is provided:
+- 400 with `"workflow '<name>' does not accept a --path argument"`
+
+### `src/attune/ops/routes/runs_history.py` (NEW)
+
+```python
+@router.get("/api/runs/{workflow}")
+async def list_runs(workflow: str, request: Request) -> dict:
+    """Last 20 persisted runs for a workflow, newest first."""
+    # validates workflow name against registry
+    # reads ~/.attune/ops/runs/<workflow>/*.json, sorts by started_at desc
+    # returns truncated metadata only (no logs)
+
+@router.get("/api/runs/{workflow}/{run_id}")
+async def get_run(workflow: str, run_id: str, request: Request) -> dict:
+    """Full record of one run including log."""
+    # validates run_id is hex-only (no path traversal)
+```
+
+### `src/attune/ops/templates/workflows.html`
+
+Per-row addition before the Run button:
+
+```html
+<td class="scope-cell">
+  {% if supports_path[w.name] %}
+    <select class="scope-picker" data-scope="{{ w.name }}"
+            aria-label="Scope for {{ w.name }}">
+      <option value="" selected>All of project</option>
+      <optgroup label="Features">
+        {% for f in features %}
+          <option value="{{ f.paths|join(' ') }}"
+                  title="{{ f.description or '' }}">{{ f.name }}</option>
+        {% endfor %}
+      </optgroup>
+      <option value="__custom__">Custom path…</option>
+    </select>
+    <input type="text" class="scope-custom" hidden
+           placeholder="e.g. src/foo/bar.py"
+           aria-label="Custom path for {{ w.name }}" />
+  {% else %}
+    <span class="scope-na"
+          title="{{ w.name }} runs project-wide by design (no --path)">
+      project-wide
+    </span>
+  {% endif %}
+</td>
+```
+
+Recent-runs strip below the log pane:
+
+```html
+<div class="recent-runs" data-recent-runs="{{ w.name }}"></div>
+```
+
+(Populated by JS via `GET /api/runs/{w.name}` after DOMContentLoaded.)
+
+### `src/attune/ops/static/js/runner.js`
+
+Additions:
+- `getScope(row)` — reads the picker + custom input, returns string or null
+- `setupScopePicker(row)` — wires the "Custom path…" toggle behavior
+- `setupRecentRuns(row)` — fetches `/api/runs/<name>`, renders chips
+- `setupPillHandlers()` — Tier 1 pills get a click listener that POSTs to the named workflow's row with `getScope(currentRow)` carried forward
+- `renderRecommendationCard(row, payload)` — new SSE event handler for `recommendation` events
+
+The existing `attach(button)` for the Run button is extended to read `getScope(row)` and pass it in the POST body.
+
+### `src/attune/ops/static/css/main.css`
+
+New selectors:
+- `.scope-picker`, `.scope-custom` — combobox styling matching the existing `.status-select`
+- `.scope-na` — disabled-looking inline span
+- `.recent-runs` — flex strip of chips
+- `.recent-run-chip` — clickable chip with outcome color
+- `.recommendation-card` — action card below log pane
+
+---
+
+## Failure modes & their handling
+
+| Failure | Behavior |
+|---------|----------|
+| `.help/features.yaml` missing | Picker shows only "All of project" + "Custom path…" |
+| `.help/features.yaml` malformed YAML | Same as missing + warning log line at server start |
+| `SUPPORTS_PATH_ARG` missing entry for a registered workflow | Drift-guard test fails CI; runtime falls back to "no --path" |
+| User submits custom path that fails validation | 400 with the validation error inline in the log pane |
+| Persistence dir not writable | Warning logged; runs proceed in memory only; recent-runs strip empty |
+| Workflow emits a `recommendation` event with bad payload | Server drops the event with warning; UI doesn't render anything |
+| `--read-only` flag set + pill clicked | 403 with toast: "Read-only mode: re-launch without --read-only to run workflows" |
+
+---
+
+## Security
+
+- Path validation uses existing `_validate_file_path` (covered by extensive tests)
+- Persistence writes go through the same `_validate_file_path` to ensure run_id is safe (already a UUID hex)
+- SSE `recommendation` events emitted by workflows are validated against an allowlist of `kind` values before broadcast
+- No `innerHTML` in the new JS — same security guarantee as Tier 1 (enforced by existing test)
+
+---
+
+## Backward compatibility
+
+- POST `/workflows/{name}/run` without a body: still works (path=None means project-wide)
+- Workflows that don't emit `recommendation` events: still render the Tier 1 regex parser output
+- Old in-memory run history is replaced by disk-backed; no migration needed (in-memory was per-process anyway)
+- The `--read-only` flag continues to gate all mutations

--- a/docs/specs/ops-runner-tier2/requirements.md
+++ b/docs/specs/ops-runner-tier2/requirements.md
@@ -1,0 +1,191 @@
+# Requirements — Ops Runner Tier 2
+
+**Status:** draft
+
+User-facing stories and the contracts they imply. See `decisions.md` for context, `design.md` for the technical shape, `tasks.md` for the phase plan.
+
+---
+
+## Personas
+
+- **Pat (project owner)** — runs attune ops daily against his own codebase. Wants fast iteration on one feature at a time.
+- **Casey (contributor)** — runs attune ops occasionally to triage a PR. Wants the recommendations the workflow author put there to be one click away.
+
+---
+
+## User stories
+
+### US-1 — Scope a workflow to one feature
+
+**As Pat, when I want to run `code-review` on just `src/attune/memory/`, I want to pick "memory" from a dropdown on the row and click Run.** The dropdown shows the features defined in my project's `.help/features.yaml`, plus an "All of project" default and a "Custom path…" free-form option.
+
+Acceptance:
+- The dropdown is populated from `.help/features.yaml` at server start (refreshed if the file changes)
+- The default selection is "All of project" on a fresh page load
+- Selecting a feature does NOT trigger a run — only the Run button does
+- The subprocess command becomes `attune workflow run <workflow> --path <path>` (or `--paths <p1> --paths <p2>` if the feature has multiple paths)
+- The output log shows which scope was used (header line: `Scope: memory (src/attune/memory/)`)
+
+### US-2 — Free-form path for ad-hoc scoping
+
+**As Casey, when triaging a PR, I want to scope a workflow run to the exact path the PR touches even if it isn't in `features.yaml`.** Selecting "Custom path…" opens a text input below the dropdown.
+
+Acceptance:
+- The text input accepts a single relative path or glob (e.g. `src/attune/workflows/*.py`)
+- The value is validated server-side (no path traversal, no absolute paths outside project)
+- The input persists across the page lifetime so I can run the same workflow against the same custom scope without re-typing
+
+### US-3 — Workflow doesn't support `--path` → picker disabled
+
+**As Pat, when I'm looking at a row for `release-prep` (which doesn't take `--path`), I want the picker to be visibly disabled with a tooltip explaining why.**
+
+Acceptance:
+- The picker is rendered but `disabled` with a `cursor: not-allowed` style
+- Hovering shows: "release-prep runs project-wide by design and doesn't accept a --path argument"
+- The Run button still works as before
+
+### US-4 — Workflow-name pill becomes a one-click run
+
+**As Pat, when `code-review` finishes and its output recommends running `bug-predict`, I want to click the "bug-predict" pill in the output log and have a new run kick off with the same scope.**
+
+Acceptance:
+- Pills are clickable (cursor: pointer, hover state)
+- Click triggers POST to `/workflows/<name>/run` with the current row's scope as the `path` body field
+- The new run appears in the bug-predict row (not the code-review row)
+- A subtle "↩ from code-review on memory" badge appears in the new run's output header
+
+### US-5 — Inline run history per workflow
+
+**As Pat, when I revisit the dashboard, I want to see "last 5 runs" for each workflow as a strip of clickable chips so I can see what's been happening without scrolling.**
+
+Acceptance:
+- Each row shows up to 5 most-recent chips: outcome (✓ / ✗), elapsed time, scope, age (e.g. "2m ago")
+- Clicking a chip expands the log pane showing that run's output (read-only, scrollable)
+- History persists across server restarts (writes to `~/.attune/ops/runs/<workflow>/<run-id>.json`)
+- The current "last 20 runs in memory" behavior is removed (persisted history supersedes it)
+
+### US-6 — Structured recommendations as action cards
+
+**As a workflow author, I want my workflow to be able to emit machine-readable recommendations that the dashboard renders as proper action cards (not regex-parsed prose).**
+
+Acceptance:
+- A workflow opts in by emitting an SSE event with `event: recommendation` and a JSON payload like `{"kind": "next-workflow", "name": "bug-predict", "args": {"path": "src/foo"}, "label": "Run bug-predict to verify the fix"}`
+- The dashboard renders these as cards below the log pane (not inline in the log)
+- Clicking a card runs the named workflow with the given args
+- The Tier-1 regex parser stays as a fallback for non-opted-in workflows
+
+---
+
+## Contracts
+
+### C-1 — `.help/features.yaml` source
+
+The server reads `.help/features.yaml` once at startup and on file-mtime change. Shape (Python type-hint form):
+
+```yaml
+features:
+  - name: "memory"                  # str — appears in the dropdown
+    paths: ["src/attune/memory/"]   # list[str] — passed as --path arg(s)
+    description: "Memory subsystem" # str — tooltip on hover (optional)
+  - name: "ops"
+    paths: ["src/attune/ops/"]
+    description: "Operations dashboard"
+```
+
+If the file is missing or malformed, the picker shows ONLY "All of project" + "Custom path…" — never crashes.
+
+### C-2 — Path validation server-side
+
+Custom paths must pass:
+- Relative path (no leading `/`)
+- No `..` traversal segments
+- Resolved path stays inside `config.project_root`
+- Glob characters (`*`, `?`, `[...]`) allowed
+- Result is forwarded to the subprocess as one or more `--path` arguments
+
+Reuses `_validate_file_path` already in the codebase.
+
+### C-3 — Workflow `--path` capability registry
+
+A new dict in `attune.ops.data` (or a method on the workflow info dataclass):
+
+```python
+SUPPORTS_PATH_ARG = {
+    "code-review": True,
+    "bug-predict": True,
+    "simplify-code": True,
+    "perf-audit": True,
+    "test-gen": True,
+    "doc-audit": True,
+    "security-audit": True,
+    "refactor-plan": True,
+    "release-prep": False,
+    "health-check": False,
+    "dependency-check": False,
+    "rag-code-gen": False,
+    "research-synthesis": False,
+    "test-audit": False,
+    "secure-release": False,
+    "orchestrated-health-check": False,
+    "deep-review": True,
+    "doc-gen": True,
+    "doc-orchestrator": True,
+}
+```
+
+To verify, not invent: Phase 1 of `tasks.md` is to grep each workflow's CLI handler / `execute()` signature and confirm. The registry is the SINGLE source of truth (template uses it, runner uses it, drift-guard test asserts every registered workflow appears in it).
+
+### C-4 — SSE recommendation event shape
+
+```json
+{
+  "kind": "next-workflow",       // future kinds: "open-file", "open-url", "external-action"
+  "name": "bug-predict",          // workflow name (must match registry)
+  "args": {"path": "src/foo"},    // forwarded to /workflows/<name>/run
+  "label": "Run bug-predict",     // button text in the UI
+  "rationale": "...",             // optional, shown on hover
+  "severity": "info"              // info | warn | critical, drives card color
+}
+```
+
+Validated server-side before broadcast (drops bad payloads with a warning log line).
+
+### C-5 — Persistence schema
+
+```
+~/.attune/ops/runs/<workflow>/<run-id>.json
+```
+
+```json
+{
+  "id": "abc12345",
+  "workflow": "code-review",
+  "scope": {"kind": "feature", "name": "memory", "paths": ["src/attune/memory/"]},
+  "started_at": "2026-05-11T22:00:00Z",
+  "completed_at": "2026-05-11T22:03:24Z",
+  "status": "completed",
+  "exit_code": 0,
+  "command": ["python", "-m", "attune.cli_minimal", "workflow", "run", "code-review", "--path", "src/attune/memory/"],
+  "log": "<first 200 KB of the log, then a truncation marker>"
+}
+```
+
+Read-only mode (`attune ops --read-only`) does NOT write new files but reads existing ones. Logs older than 30 days are pruned at startup.
+
+### C-6 — Read-only mode
+
+Per existing `--read-only` flag (already enforced for the Specs status-flip): all Tier 2 mutation paths must respect it.
+
+- Scope picker is shown but Run is disabled (already true in #240 pattern)
+- Workflow-name pill clicks return 403 with a friendly message
+- Recommendation cards render as visible-but-disabled
+
+---
+
+## Non-goals (named here so the spec doesn't drift)
+
+- Multi-project ops (covered in `decisions.md` Out of scope)
+- Editor integration for file-path chips (separate spec if/when)
+- Run cancellation
+- Sharing runs across users
+- Workflow scheduling (cron-like) from the dashboard

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,0 +1,124 @@
+# Tasks — Ops Runner Tier 2
+
+**Status:** draft
+
+Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
+
+---
+
+## Phase 1 — Verify `--path` capability per workflow (no code changes yet)
+
+Goal: turn hypothesis H2 ("Workflow `--path` support is unevenly implemented") into a hard fact, populating the `SUPPORTS_PATH_ARG` registry from real inspection.
+
+- [ ] **1.1** Grep each workflow class's `execute()` signature and CLI handler for `--path` / `paths` argument acceptance:
+      ```
+      for w in bug-predict code-review deep-review dependency-check doc-audit doc-gen doc-orchestrator health-check orchestrated-health-check perf-audit rag-code-gen refactor-plan release-prep research-synthesis secure-release security-audit simplify-code test-audit test-gen; do
+        echo "=== $w ==="
+        grep -l "name.*$w\|workflow.*$w" src/attune/workflows/*.py | head -1 | xargs grep -nE "path|paths" | head -5
+      done
+      ```
+- [ ] **1.2** Manually verify by running each workflow with `--help` from the CLI:
+      ```
+      python -m attune.cli_minimal workflow run <name> --help
+      ```
+- [ ] **1.3** Record findings as `SUPPORTS_PATH_ARG` dict in `src/attune/ops/data.py`. Drift-guard test in `tests/unit/ops/test_path_support_registry.py` asserts every workflow has an entry.
+
+## Phase 2 — Scope picker (headline feature)
+
+Goal: per-row dropdown that scopes the workflow run to one feature or custom path.
+
+- [ ] **2.1** Add `Feature` dataclass + `list_features()` to `src/attune/ops/data.py`. Reads `.help/features.yaml`, returns `[]` on missing/malformed. Caches result with mtime check.
+- [ ] **2.2** Pass `features` + `supports_path` to `workflows.html` from `dashboard.py`.
+- [ ] **2.3** Render the `<select>` + hidden `<input type="text">` per row in `workflows.html`. Show `<span class="scope-na">` for workflows where `supports_path[w.name] is False`.
+- [ ] **2.4** Update `RunRequest` body to accept `path: str | None` in `routes/runner.py`. Validate via `_validate_file_path`.
+- [ ] **2.5** Extend `RunnerService.start_run()` + `_default_command()` to thread `path` into the subprocess invocation.
+- [ ] **2.6** `runner.js`: add `getScope(row)`, wire the picker toggle UX (custom path input shows when "Custom path…" is selected), pass scope as POST body.
+- [ ] **2.7** CSS: `.scope-picker`, `.scope-custom`, `.scope-na` matching existing `.status-select` aesthetic.
+- [ ] **2.8** Tests:
+      - `test_list_features_*` — missing file, well-formed file, malformed YAML
+      - `test_run_with_path_arg` — POST with `path` ends up in subprocess command
+      - `test_run_rejects_invalid_path` — path traversal returns 400
+      - `test_run_rejects_path_for_no-path-workflow` — `release-prep` with path returns 400
+      - JS parsing: `test_runner_js_workflows_html_has_scope_picker` (assert the template renders the select for path-supporting workflows)
+
+## Phase 3 — Persistence (recent runs)
+
+Goal: replace in-memory run history with disk-backed per-workflow history.
+
+- [ ] **3.1** Extend `Run.to_dict()` to include `scope` and `command` fields. Add `from_dict()` for reload.
+- [ ] **3.2** On run completion, write `~/.attune/ops/runs/<workflow>/<run-id>.json`. Truncate log to first 200 KB with a `<TRUNCATED — N bytes more>` marker. Skip writes in `--read-only` mode.
+- [ ] **3.3** Startup task: prune runs older than 30 days (configurable via `--runs-retention-days`).
+- [ ] **3.4** New router `routes/runs_history.py`:
+      - `GET /api/runs/{workflow}` → list 20 newest runs (metadata only)
+      - `GET /api/runs/{workflow}/{run_id}` → full record + log
+- [ ] **3.5** `workflows.html`: add `<div class="recent-runs" data-recent-runs="{{ w.name }}">` below each log pane.
+- [ ] **3.6** `runner.js`: `setupRecentRuns(row)` fetches and renders chips. Click on a chip expands the log pane with that run's output.
+- [ ] **3.7** CSS: `.recent-runs`, `.recent-run-chip` (color by outcome: ✓ ok, ✗ danger).
+- [ ] **3.8** Tests:
+      - `test_run_persists_to_disk` — file written on completion
+      - `test_run_persists_truncates_long_log` — 1MB log → 200KB on disk + marker
+      - `test_run_skips_write_in_read_only` — `--read-only` doesn't write
+      - `test_get_recent_runs_returns_sorted` — newest first
+      - `test_get_run_rejects_path_traversal` — `run_id="../../etc/passwd"` returns 400
+      - `test_prune_old_runs` — files older than 30 days are deleted at startup
+
+## Phase 4 — Workflow-name pills become buttons
+
+Goal: Tier 1 pills (inert today) trigger a follow-on run carrying the row's scope.
+
+- [ ] **4.1** `runner.js`: attach click handlers to `.log-workflow` pills. On click:
+      - Read the row's scope via `getScope(currentRow)`
+      - Find the target workflow row by name
+      - POST `/workflows/<target>/run` with `{path: scope}`
+      - Auto-scroll to the target row, set status, attach SSE listener
+      - Render a "↩ from <source-workflow>" badge in the target row's output
+- [ ] **4.2** Handle read-only mode: pill click in `--read-only` shows a toast "Read-only mode: re-launch without --read-only to chain runs". No POST.
+- [ ] **4.3** Handle disabled target (already running): the existing 409 handler in `formatErrorDetail` already covers this; surface in the target row.
+- [ ] **4.4** CSS: pill hover state, `.pill-disabled` for `--read-only`, `.chained-from` badge styling.
+- [ ] **4.5** Tests:
+      - `test_runner_js_pills_clickable` — assert pills have `data-clickable` attribute
+      - `test_pill_click_carries_scope` (manual): visual smoke from the browser
+      - `test_read_only_pill_returns_403` — POST while `--read-only` returns 403
+
+## Phase 5 — Structured recommendation channel
+
+Goal: workflows can emit JSON recommendations rendered as action cards.
+
+- [ ] **5.1** Extend SSE event types in `routes/runner.py`. Existing: `line`, `done`. New: `recommendation`.
+- [ ] **5.2** Server-side validation: `kind` must be in allowlist (`next-workflow`, `open-url`), `name` must be a registered workflow, `args.path` must pass `_validate_file_path`. Drop bad payloads with warning log.
+- [ ] **5.3** `runner.js`: listen for `recommendation` events. Render an action card below the log pane via `renderRecommendationCard(row, payload)`.
+- [ ] **5.4** Pick ONE workflow to demonstrate end-to-end. Candidate: `code-review` emitting `{"kind": "next-workflow", "name": "bug-predict", "args": {"path": "<same scope>"}, "label": "Run bug-predict to verify"}` when it finds CWE-style issues.
+- [ ] **5.5** CSS: `.recommendation-card` action card with hover/click states + severity color.
+- [ ] **5.6** Tests:
+      - `test_recommendation_event_emitted` — workflow emits, server broadcasts
+      - `test_recommendation_event_validated` — bad payload dropped
+      - `test_recommendation_card_renders` — JS smoke
+
+## Phase 6 — Telemetry + close
+
+- [ ] **6.1** Add lightweight telemetry: pill click counts, recommendation card click counts, scope picker usage rates (in-memory only — no PII, no network). Surface in the existing `/telemetry` tab.
+- [ ] **6.2** Update `docs/COVERAGE_BUG_LOG.md` if any bugs surfaced during Phase 1–5 work.
+- [ ] **6.3** Patrick uses the new dashboard for at least one real feature scope; confirms the UX feels right.
+- [ ] **6.4** Close this spec. Open follow-up specs if any Phase 3/4 ideas surfaced (e.g. editor integration for file-path chips).
+
+---
+
+## Out of scope (parking lot)
+
+- Multi-project ops
+- Editor integration for file-path chips
+- Run cancellation
+- Sharing runs across users (multi-user persistence)
+- Workflow scheduling from the dashboard
+
+---
+
+## Rollback plan
+
+Each phase is a single squash-merge commit. Rollback = `git revert <commit>`. The spec's phasing ensures that reverting any phase leaves earlier phases working independently:
+
+- Revert Phase 5 → pills + scope picker + persistence still work, just no structured recs
+- Revert Phase 4 → pills go back to inert (Tier 1 behavior)
+- Revert Phase 3 → recent-runs strip disappears; in-memory history restored
+- Revert Phase 2 → scope picker gone; project-wide runs only (current behavior)
+- Revert Phase 1 → `SUPPORTS_PATH_ARG` removed; no other code depends on it yet


### PR DESCRIPTION
## Summary

Tier 2 spec for the ops dashboard runner, headlined by **Patrick's scope picker idea** — per-workflow feature/path filter sourced from `.help/features.yaml`. Plus the other Tier 2 ideas folded in (clickable pills, persistence, structured recommendations).

## Why now

Two converging signals from today's work:

1. **PR #247 (Tier 1 rich rendering)** just landed visual cues that signal "this should be clickable." Leaving the workflow-name pills inert beyond a brief trial window erodes trust.
2. **Patrick's scope-picker observation:** workflows currently run on the whole project, which is slow + diluted on real codebases. `.help/features.yaml` already maps feature names to paths — zero new metadata needed.

The scope picker is the **prerequisite** for clickable pills working well. Without it, clicking a pill just re-runs the same slow project-wide workflow.

## Spec contents

| File | Lines | What |
|------|-------|------|
| `decisions.md` | 131 | Problem, decision, hypotheses, alternatives considered, out-of-scope, resolution criteria |
| `requirements.md` | 191 | 6 user stories with acceptance criteria, 6 contracts (`.help/features.yaml` shape, path validation, capability registry, SSE recommendation event shape, persistence schema, read-only behavior) |
| `design.md` | 221 | Architecture diagram, module-by-module changes, failure modes, security, backward compat |
| `tasks.md` | 124 | 6 phases, each independently ship-and-revert-able |

## Phasing

```
Phase 1 — Verify --path capability per workflow (no code)
Phase 2 — Scope picker (headline)
Phase 3 — Persistence (recent runs)
Phase 4 — Clickable workflow pills (Tier 1's inert pills become actions)
Phase 5 — Structured recommendation channel
Phase 6 — Telemetry + close
```

Each phase is a single squash-merge so any can be reverted independently if it doesn't pan out.

## Predecessor

PR #247 (Tier 1 rich rendering) is in CI. Tier 2 work starts after that lands so we have real usage feedback before building on top.

## Rationale for spec-first

This is exactly the work the tar-pit / spec-first rules in CLAUDE.md are for: significant UX change with multiple data dependencies (`.help/features.yaml` location, per-workflow path-arg support, persistence schema, SSE event additions). Iterating ad-hoc would risk the same rabbit-hole pattern as Probe C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
