### PR TITLE
fix(ops/specs): preserve trailing annotation on status flip

### DIFF
--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -279,11 +279,25 @@ def _atomic_write(target: Path, text: str) -> None:
 def _rewrite_status_line(original: str, status: str) -> str:
     """Return ``original`` with its first **Status** line replaced by ``status``.
 
-    If no recognized status line exists, inserts ``**Status:** {status}`` near
-    the top (after the first ``# `` heading if present).
+    Preserves any trailing annotation after the canonical status token —
+    so ``**Status:** approved (2026-05-09) — Phase A`` flipping to
+    ``in-review`` becomes ``**Status:** in-review (2026-05-09) — Phase A``,
+    not just ``**Status:** in-review``. The annotation is whatever follows
+    the first delimiter (em-dash, hyphen-with-spaces, open-paren, or
+    comma) in the previous value.
+
+    If no recognized status line exists, inserts ``**Status:** {status}``
+    near the top (after the first ``# `` heading if present).
     """
-    if _STATUS_RE.search(original):
-        return _STATUS_RE.sub(f"**Status:** {status}", original, count=1)
+    match = _STATUS_RE.search(original)
+    if match:
+        old_value = match.group(1)
+        annotation = _extract_status_annotation(old_value)
+        new_value = (status + annotation) if annotation else status
+        # Use a lambda for sub() so the replacement is treated as a
+        # literal — `\g<...>` / numeric backrefs in annotations can't
+        # accidentally trigger expansion.
+        return _STATUS_RE.sub(lambda _m: f"**Status:** {new_value}", original, count=1)
     lines = original.splitlines()
     insert_at = 1 if lines and lines[0].startswith("# ") else 0
     lines.insert(insert_at, f"\n**Status:** {status}\n")
@@ -291,6 +305,35 @@ def _rewrite_status_line(original: str, status: str) -> str:
     if not new_text.endswith("\n"):
         new_text += "\n"
     return new_text
+
+
+def _extract_status_annotation(old_value: str) -> str:
+    """Return the trailing annotation portion of a status value.
+
+    The annotation is everything from the first delimiter onward,
+    preserving leading whitespace. Returns ``""`` if no delimiter found
+    or the annotation contains only whitespace.
+
+    Examples:
+        "draft" -> ""
+        "approved (2026-05-09)" -> " (2026-05-09)"
+        "complete (2026-05-10) — Phase A" -> " (2026-05-10) — Phase A"
+        "in-review — needs review" -> " — needs review"
+        "approved, see notes" -> ", see notes"
+    """
+    # Scan ALL delimiters and pick the EARLIEST match — otherwise
+    # "approved (2026) — Phase A" would split on " — " and lose " (2026)"
+    # from the annotation. The em-dash-vs-hyphen tie-break only matters
+    # if they're at the same position, which doesn't happen in practice.
+    earliest = -1
+    for delim in (" — ", " (", " - ", ", "):
+        idx = old_value.find(delim)
+        if idx >= 0 and (earliest < 0 or idx < earliest):
+            earliest = idx
+    if earliest < 0:
+        return ""
+    annotation = old_value[earliest:]
+    return annotation if annotation.strip() else ""
 
 
 @router.put("/{slug}/{phase}/status")

--- a/tests/unit/ops/test_specs_routes.py
+++ b/tests/unit/ops/test_specs_routes.py
@@ -415,3 +415,126 @@ def test_put_status_first_root_wins_on_collision(tmp_path, monkeypatch):
     assert (root_b / "shared" / "tasks.md").read_text(encoding="utf-8") == (
         "**Status:** approved\n"
     )
+
+
+# ---------------------------------------------------------------------------
+# PUT preserves trailing annotation on the status line (fix for lossy
+# canonical-token replacement that wiped date/note context).
+# ---------------------------------------------------------------------------
+
+
+def test_put_status_preserves_date_annotation(tmp_path, monkeypatch):
+    """`**Status:** approved (2026-05-09)` → flip to `in-review` keeps the date."""
+    monkeypatch.chdir(tmp_path)
+    root = tmp_path / "specs"
+    _make_spec(
+        root,
+        "alpha",
+        files={"tasks.md": "**Status:** approved (2026-05-09)\n"},
+    )
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+
+    r = client.put("/api/specs/alpha/tasks/status", json={"status": "in-review"})
+
+    assert r.status_code == 200, r.text
+    updated = (root / "alpha" / "tasks.md").read_text(encoding="utf-8")
+    assert "**Status:** in-review (2026-05-09)" in updated
+    assert "approved" not in updated
+
+
+def test_put_status_preserves_em_dash_annotation(tmp_path, monkeypatch):
+    """em-dash annotation (` — Phase A 68f19b90`) survives the flip."""
+    monkeypatch.chdir(tmp_path)
+    root = tmp_path / "specs"
+    _make_spec(
+        root,
+        "alpha",
+        files={"tasks.md": "**Status:** complete (2026-05-10) — Phase A 68f19b90\n"},
+    )
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+
+    r = client.put("/api/specs/alpha/tasks/status", json={"status": "in-review"})
+
+    assert r.status_code == 200, r.text
+    updated = (root / "alpha" / "tasks.md").read_text(encoding="utf-8")
+    assert "**Status:** in-review (2026-05-10) — Phase A 68f19b90" in updated
+
+
+def test_put_status_preserves_em_dash_only_annotation(tmp_path, monkeypatch):
+    """em-dash-only annotation (no parens) survives."""
+    monkeypatch.chdir(tmp_path)
+    root = tmp_path / "specs"
+    _make_spec(
+        root,
+        "alpha",
+        files={"tasks.md": "**Status:** approved — see Resolution section below\n"},
+    )
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+
+    r = client.put("/api/specs/alpha/tasks/status", json={"status": "in-review"})
+
+    assert r.status_code == 200, r.text
+    updated = (root / "alpha" / "tasks.md").read_text(encoding="utf-8")
+    assert "**Status:** in-review — see Resolution section below" in updated
+
+
+def test_put_status_preserves_comma_annotation(tmp_path, monkeypatch):
+    """Comma-delimited annotation survives."""
+    monkeypatch.chdir(tmp_path)
+    root = tmp_path / "specs"
+    _make_spec(
+        root,
+        "alpha",
+        files={"tasks.md": "**Status:** approved, owner=Patrick\n"},
+    )
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+
+    r = client.put("/api/specs/alpha/tasks/status", json={"status": "complete"})
+
+    assert r.status_code == 200, r.text
+    updated = (root / "alpha" / "tasks.md").read_text(encoding="utf-8")
+    assert "**Status:** complete, owner=Patrick" in updated
+
+
+def test_put_status_no_annotation_is_unchanged(tmp_path, monkeypatch):
+    """Bare status (no annotation) still works — annotation is just empty."""
+    monkeypatch.chdir(tmp_path)
+    root = tmp_path / "specs"
+    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+
+    r = client.put("/api/specs/alpha/tasks/status", json={"status": "approved"})
+
+    assert r.status_code == 200, r.text
+    updated = (root / "alpha" / "tasks.md").read_text(encoding="utf-8")
+    assert "**Status:** approved" in updated
+    # Make sure we didn't accidentally append extra whitespace or chars.
+    status_line = next(line for line in updated.splitlines() if line.startswith("**Status:"))
+    assert status_line == "**Status:** approved"
+
+
+def test_put_status_decorator_prefix_is_replaced(tmp_path, monkeypatch):
+    """A leading decorator like `✓ Resolved` is treated as the old token
+    and replaced — but trailing date+note are preserved.
+    Reproduces Patrick's actual scenario:
+      `**Status:** ✓ Resolved (2026-05-11) — see Resolution section below`
+      → flip to `complete`
+      → `**Status:** complete (2026-05-11) — see Resolution section below`
+    """
+    monkeypatch.chdir(tmp_path)
+    root = tmp_path / "specs"
+    _make_spec(
+        root,
+        "alpha",
+        files={
+            "tasks.md": ("**Status:** ✓ Resolved (2026-05-11) — see Resolution section below\n")
+        },
+    )
+    client = _client(tmp_path, specs_roots=(root,), allow_run=True)
+
+    r = client.put("/api/specs/alpha/tasks/status", json={"status": "complete"})
+
+    assert r.status_code == 200, r.text
+    updated = (root / "alpha" / "tasks.md").read_text(encoding="utf-8")
+    assert "**Status:** complete (2026-05-11) — see Resolution section below" in updated
+    assert "✓ Resolved" not in updated


### PR DESCRIPTION
## Summary

Surfaced by Patrick's live test of the Specs tab — flipping a status on a spec with annotated status lines was lossy:

```diff
- **Status:** ✓ Resolved (2026-05-11) — see Resolution section below
+ **Status:** complete
```

Date and reference pointer wiped. Fix preserves everything from the first delimiter onward (em-dash, paren, hyphen-with-spaces, comma).

## Before / after

| Input | Pick | Before (lossy) | After (preserves) |
|-------|------|----------------|-------------------|
| `approved (2026-05-09)` | in-review | `in-review` | `in-review (2026-05-09)` |
| `complete (2026-05-10) — Phase A 68f19b90` | in-review | `in-review` | `in-review (2026-05-10) — Phase A 68f19b90` |
| `approved — see Resolution` | in-review | `in-review` | `in-review — see Resolution` |
| `approved, owner=Patrick` | complete | `complete` | `complete, owner=Patrick` |
| `draft` (no annotation) | approved | `approved` | `approved` (unchanged) |
| `✓ Resolved (2026-05-11) — see Resolution` | complete | `complete` | `complete (2026-05-11) — see Resolution` |

Leading decorators (`✓ Resolved`) are still replaced — picking a canonical status implies you want a canonical leading token. Only *trailing* context is preserved.

## Implementation

One helper, `_extract_status_annotation(old_value: str) -> str`, finds the earliest delimiter and returns the suffix. The existing rewriter uses it to build `new_value = status + annotation`.

Subtle implementation detail: scan ALL delimiters and pick the EARLIEST, not first-by-priority. Otherwise `approved (2026) — Phase A` would split on `" — "` (which appears later) and lose `(2026)` from the annotation.

## Test plan

- [x] `pytest tests/unit/ops/ --no-cov` — **83 passed** (77 → 83, +6 preservation tests)
- [x] `ruff check` — clean
- [ ] CI matrix green
- [ ] Manual via the live dashboard: flip a status on a spec with date+note annotation, confirm both survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)
