### PR TITLE
docs(specs): website-update-dashboard-and-fold — 4-file split + feedback

### DIFF
--- a/docs/specs/website-update-dashboard-and-fold/decisions.md
+++ b/docs/specs/website-update-dashboard-and-fold/decisions.md
@@ -1,0 +1,75 @@
+# Decisions — Website update: dashboard maturity + fold-back
+
+**Status:** draft
+**Owner:** Patrick
+**Opened:** 2026-05-10
+**Companion specs:**
+- `~/attune-gui/specs/dashboard-quality-pass/` — engineering polish (sentence case, humanised timestamps, generic command result renderer, profile chip cleanup, sidecar reload-dir fix)
+- `~/attune-gui/specs/fold-attune-gui-into-attune-ai/` — packaging consolidation (`pip install attune-gui` → `pip install attune-ai[gui]`)
+
+---
+
+## Problem
+
+The attune-ai marketing site at `~/attune/attune-ai/website/` was last meaningfully updated before three substantial shifts that are now real or imminent:
+
+1. **The dashboard is now a usable feature surface.** Living Docs, the polish-corpus job, the rag-query results page, and the Commands inline-result rendering all shipped 2026-05-10. None of them are reflected on the site.
+2. **A dashboard-quality-pass spec is in-review** that finishes the polish work. When it lands, the site's feature claims should match the actual quality bar.
+3. **The fold-back-into-attune-ai spec is drafted** — when it lands, `pip install attune-gui` becomes `pip install attune-ai[gui]`, the standalone PyPI package becomes a deprecation shim, and the canonical entrypoint is one product, one install, two faces.
+
+The current site doesn't tell that story. Install instructions point at the standalone `attune-gui` package; feature pages don't mention Living Docs or the polish-corpus workflow; there's no "what does the dashboard do for me" page distinct from the rest of attune-ai.
+
+---
+
+## Decision: why a separate spec
+
+The dashboard and fold-back specs are *engineering* specs — they describe what the code does. The website spec is *narrative* — it describes how we tell users about it. They share the same source events but produce different artifacts and have different reviewers (eng vs. content / SEO).
+
+Keeping them separate also keeps each spec's blast radius bounded. If the fold-back slips, the dashboard feature page already shipped and is still useful. If a screenshot goes stale, it doesn't block engineering work.
+
+---
+
+## Decisions made (resolved during 2026-05-11 review)
+
+These were "open questions" in the original draft. Promoted to decisions; only the genuinely-open ones move below.
+
+| Question | Decision |
+|----------|----------|
+| Dashboard as `/dashboard` route or section of `/how-it-works`? | **Own route** at `/dashboard`. Substantial enough story to own a URL; SEO benefits from the keyword. |
+| Screenshots: real workspace or staged demo workspace? | **Staged** — `attune-ai` itself as the visible workspace, with carefully chosen polish/scan/regen states so each screenshot tells one story. |
+| How prominent should "Living Docs" become? | **Top of homepage hero, under a one-line tagline.** It's the differentiator. |
+| Pre-fold copy on the standalone `attune-gui` package | **Pre-announce 4–6 weeks before the fold lands** (revised from "only after fold lands"). Add a banner to attune-gui's PyPI README: "This package will become `attune-ai[gui]` in v7.0 — see migration guide." Setting expectations gives users feedback time; holding the announcement until D-day makes the migration feel forced. |
+| Changelog tone | Write for **"an existing attune-ai user who skipped 2 releases"** — that's the common reader. Plain English, no commit-message verbs, lead with what the user sees. |
+| Migration callout placement | **Sticky banner on the homepage + a dedicated `/migrate` page (or `/docs/migrating-from-attune-gui`).** Banner runs **from v7.0 release through v7.1** (one minor cycle, ~4 weeks). Auto-retires via a CI job that compares `pyproject.toml` version to a sentinel date. |
+
+---
+
+## Open questions
+
+| Question | Lean | Notes |
+|----------|------|-------|
+| Should the Dashboard feature page link out to a live demo? | Defer — needs a hosted demo first | Out of scope for this spec; revisit after fold-back |
+| Do we want a "compare attune-ai vs attune-cli" page? | No | Confuses the story. One product, multiple surfaces. |
+
+---
+
+## Out of scope (explicit)
+
+- **Pricing changes.** The fold doesn't change pricing.
+- **Visual / brand identity refresh.** Keep the existing design system; only update content.
+- **Marketing automation, email lists, social-post drafting.** Separate effort.
+- **Customer-success content** (tutorials, case studies). Separate effort.
+- **The attune-gui standalone repo's own README/docs.** Handled in the fold-back spec, not here.
+- **Live demo deploy.** Linked to but not built here.
+
+---
+
+## Resolution criteria
+
+Spec closes when:
+
+1. Phase 1 (pre-fold) tasks complete and visible on `~/attune-ai/website/` deploy
+2. Phase 2 (post-fold) tasks complete on the same deploy after the fold-back ships
+3. Acceptance criteria in `requirements.md` all pass
+4. Link checker (`lychee` or equivalent) added to CI as a non-blocking job, escalated to required after Phase 2 ships
+5. Screenshot capture workflow (`design.md` task 4) committed and runs on tagged releases

--- a/docs/specs/website-update-dashboard-and-fold/design.md
+++ b/docs/specs/website-update-dashboard-and-fold/design.md
@@ -1,0 +1,131 @@
+# Design — Website update: dashboard maturity + fold-back
+
+**Status:** draft
+
+Technical shape, mitigations, and durable fixes. See `decisions.md` for context, `requirements.md` for user stories, `tasks.md` for the phase plan.
+
+---
+
+## Risks and mitigations
+
+### R-1 — Site copy drifts from reality
+
+Easy to claim features the dashboard doesn't quite ship.
+
+**Mitigation:** every feature claim on the Dashboard page is backed by a screenshot from the live build (see R-3 for the durable fix that keeps screenshots fresh). Reviewers can verify each claim against its screenshot in the same scroll.
+
+### R-2 — SEO churn from URL changes
+
+Old `attune-gui`-specific URLs in READMEs and search results break post-fold.
+
+**Mitigation:** redirects from any old `attune-gui`-specific URLs to the consolidated `attune-ai` equivalents. Add to `website/next.config.ts` (or wherever the existing redirects live) in the same PR that flips the install commands. Verified by `lychee` in CI (see C-3).
+
+### R-3 — Out-of-date screenshots
+
+Dashboard changes faster than marketing copy. Hand-captured screenshots go stale within weeks.
+
+**Durable mitigation:** an automated screenshot-capture workflow, modeled after the diagnostic CI pattern used in `docs/specs/windows-memory-detection/`. A new GitHub Action `.github/workflows/dashboard-screenshots.yml` triggers on tagged releases:
+
+1. Spins up `attune-ai[gui]` against a staged demo workspace (the `attune-ai` repo itself with carefully-prepared state)
+2. Uses Playwright to navigate to each documented surface (Living Docs table, RAG search results, Commands inline panel, Summaries page)
+3. Captures PNG screenshots at fixed viewport dimensions
+4. Updates `website/screenshots/manifest.yaml` with new `captured_at` + `dashboard_version`
+5. Opens a PR if any screenshot diff exceeds N% pixel delta
+
+This decouples documentation freshness from manual labor. Phase 2 task — Phase 1 ships hand-captured screenshots so we don't block the feature page on automation.
+
+### R-4 — Changelog gets bloated
+
+The 2026-05-10 session was nine commits. A 1-to-1 mapping would bury the user-facing story.
+
+**Mitigation:** the changelog persona contract (C-5) forces 3–5 user-visible bullet points per shipped event, written for "an existing attune-ai user who skipped 2 releases." Each entry is 1–3 sentences. Commit-level detail lives in the linked docs page, not the changelog.
+
+### R-5 — Pre-announcement causes confusion if the fold slips
+
+If we tell users "this becomes attune-ai[gui] in v7.0" and v7.0 slips by a month, the deprecation banner is wrong for that month.
+
+**Mitigation:** the pre-fold banner uses a *non-version-specific* phrasing — "this package will become `attune-ai[gui]` in an upcoming release; see migration guide" — until the actual v7.0 RC is cut. Then a follow-up swap pins the version. Both versions of the banner ship from the same source file (`migration-banner.ts`) so the swap is one line.
+
+---
+
+## Module-by-module changes
+
+### `website/lib/install-command.ts` (NEW)
+
+Single source of truth for the install command shown anywhere on the site.
+
+```ts
+// Switched in Phase 2 when fold-back ships.
+export const CANONICAL_INSTALL = "pip install attune-gui";
+export const POST_FOLD_INSTALL = "pip install attune-ai[gui]";
+
+export function installCommand(opts: { postFold?: boolean } = {}): string {
+  return opts.postFold ? POST_FOLD_INSTALL : CANONICAL_INSTALL;
+}
+```
+
+Every install-command render imports from here. Swapping commands site-wide is one line.
+
+### `website/lib/migration-banner.ts` (NEW)
+
+Banner lifecycle per C-4. Component reads `showFromVersion`, `hideFromVersion`, `fallbackHideDate`. Build-time check (`scripts/check-migration-banner.ts`) fails the build if today is past `fallbackHideDate` AND the banner is still rendering.
+
+### `website/app/dashboard/page.tsx` (NEW)
+
+The `/dashboard` feature page. Hero section + four surfaces (Living Docs, RAG search, Commands, Summaries) each with screenshot + one-sentence description + "what you do here" callout.
+
+### `website/app/migrate/page.tsx` (NEW)
+
+Migration guide page. Pre-fold: "Heads up — `attune-gui` is becoming `attune-ai[gui]` in an upcoming release. Here's what to expect." Post-fold: "If you had `attune-gui` installed, here's what changes."
+
+### `website/components/Hero.tsx` or `website/app/page.tsx` (UPDATE)
+
+Add "Living Docs" as a primary capability under a one-line tagline. Layout TBD — content team owns the visual treatment.
+
+### `website/app/changelog/page.tsx` (UPDATE)
+
+Add the 2026-05-10 entry. Format: date heading + 3–5 user-visible bullets + link to per-feature docs page.
+
+### `website/app/faq/page.tsx` (UPDATE)
+
+Two new entries per `requirements.md` scope.
+
+### `website/next.config.ts` (UPDATE, Phase 2)
+
+Redirects from `attune-gui`-prefixed paths to `attune-ai` equivalents. Verified by `lychee` in CI.
+
+### `.github/workflows/dashboard-screenshots.yml` (NEW, Phase 2)
+
+Playwright-based automated capture. See R-3.
+
+### `.github/workflows/link-check.yml` (NEW, Phase 1)
+
+`lychee --offline website/ docs/` non-blocking job. Escalated to required check in Phase 2.
+
+---
+
+## Failure modes
+
+| Failure | Behavior |
+|---------|----------|
+| `install-command.ts` missing on a page that imports it | Build fails immediately — TypeScript catches it. |
+| Screenshot manifest entry missing for a referenced screenshot | Soft warning in CI (Phase 1); hard fail (Phase 2). |
+| `lychee` finds dead link | Non-blocking warning Phase 1; hard fail Phase 2. |
+| Banner build-time check fails (past `fallbackHideDate`, banner still on) | Build fails — forces an explicit decision to either remove the banner or push out the safety date. |
+| Migration banner shows wrong version pre-fold-RC | Acceptable — phrasing is intentionally non-version-specific until v7.0 RC. |
+
+---
+
+## Backward compatibility
+
+- Pre-fold install copy stays valid until the fold ships
+- Existing dashboard-related URLs in attune-gui's READMEs continue to work via redirects after the fold
+- The `attune-gui` PyPI package itself ships as a deprecation shim per the fold-back spec — this website spec doesn't change that package's behavior
+
+---
+
+## Open design questions (require eng input)
+
+- **Screenshot capture viewport sizes.** Match the dashboard's actual responsive breakpoints? Phase 2 task to spec out.
+- **Banner CSS placement.** Inside the `<Hero>` or above the nav? Content/design call, not engineering.
+- **Demo workspace stability.** Phase 2 work depends on `attune-ai` itself having a "demo state" — fresh corpus, known summaries, etc. Engineering owes content a `scripts/prepare-demo-state.sh` to seed it deterministically.

--- a/docs/specs/website-update-dashboard-and-fold/requirements.md
+++ b/docs/specs/website-update-dashboard-and-fold/requirements.md
@@ -1,0 +1,105 @@
+# Requirements — Website update: dashboard maturity + fold-back
+
+**Status:** draft
+
+User-facing stories and contracts. See `decisions.md` for context, `design.md` for mitigations, `tasks.md` for the phase plan.
+
+---
+
+## Scope
+
+**In scope:**
+
+- **Updated install copy across the site.** Wherever `pip install attune-gui` appears (homepage, docs, framework-docs, README excerpts), call out the new path: `pip install attune-ai[gui]` once the fold lands; `pip install attune-gui` (with deprecation note) before then. Keep the message stable: one product, two install styles.
+- **A "Dashboard" feature page** at `/dashboard` (own route — see `decisions.md`). Covers what the dashboard *is for* (Living Docs, corpus search, commands surface, jobs, summaries), with screenshots of:
+  - Living Docs document table with state badges + inline actions.
+  - rag-query search results page with linked hits.
+  - Commands page with the inline result panel.
+  - Summaries page populated by the polish-corpus job.
+- **Living Docs explanation in product copy.** This is the workflow innovation worth selling — "your docs stay current with your code." Currently absent from the homepage and how-it-works.
+- **Polish-corpus job as a named feature.** Show up in the feature list / pricing matrix / FAQ. Phrasing: "one-click corpus polish — generate path-keyed summaries the RAG retriever uses for boost scoring."
+- **Changelog entry** at `/changelog` for the dashboard work shipped 2026-05-10 (the nine-fix session) plus a forward-looking note for the quality-pass + fold-back when they land.
+- **FAQ updates:**
+  - "What's the difference between attune-ai and attune-gui?" — pre-fold answer: "two packages, one workflow." Post-fold answer: "they're one package now (`attune-ai[gui]`); attune-gui is the dashboard."
+  - "Do I need the dashboard?" — honest answer: no, but it's where the workflow tells you what to do next.
+- **OG image / opengraph copy** updated if the homepage hero changes.
+- **Sitemap / SEO check** that new routes are crawlable; existing dashboard-related URLs in `attune-gui` repo READMEs link to the right `attune-ai` site URLs after the fold.
+- **Migration banner + page** per the placement decision (`/migrate`).
+- **Pre-fold deprecation banner** on attune-gui's PyPI README 4–6 weeks before the fold ships.
+
+**Out of scope:** see `decisions.md` "Out of scope" section.
+
+---
+
+## User stories
+
+1. *As a new visitor*, I land on the homepage and see "Living Docs that stay current with your code" as a primary capability — not buried under a generic "documentation tooling" tagline.
+2. *As a user evaluating attune-ai*, the Dashboard page tells me concretely what I'll see when I run `attune-gui` against my project — screenshots, not abstractions.
+3. *As an existing attune-gui user reading the site after the fold-back ships*, I see one canonical install command (`pip install attune-ai[gui]`) and a clear "if you had `attune-gui` installed, here's what changes" callout.
+4. *As anyone reading the changelog*, the 2026-05-10 dashboard session is captured as a coherent set of shipped improvements, not a list of disconnected commits.
+5. *As a returning attune-gui user 4 weeks before the fold ships*, the package's PyPI README already warns me the rename is coming and links to the migration guide. I don't get blindsided.
+
+---
+
+## Acceptance criteria
+
+A reviewer can verify each in under fifteen minutes on a built preview deploy:
+
+1. **Install copy consistent.** Every `pip install` invocation on the site uses the same command form. No drift between homepage, docs, FAQ, framework-docs.
+2. **Dashboard page exists** with at least the four screenshots listed above and a one-sentence description per surface.
+3. **Living Docs is visible on the homepage** as a top-level capability. Not just buried in framework-docs.
+4. **Polish-corpus mentioned in features** with consistent language across feature page, FAQ, and changelog.
+5. **Changelog has an entry** dated 2026-05-10 covering the nine-fix session, written for "an existing attune-ai user who skipped 2 releases" (not commit-message language).
+6. **No dead links** to `attune-gui` standalone install paths after the fold ships, verified by `lychee --offline website/` in CI.
+7. **Pre-fold deprecation banner** is visible on attune-gui's PyPI page within the 4–6-week window before fold release.
+8. **Migration banner auto-retires** between v7.0 and v7.1 (verified by build-time check that compares `pyproject.toml` version to the sentinel date).
+
+---
+
+## Contracts
+
+### C-1 — Install command consistency
+
+The canonical install command is a single string captured in a config file (`website/lib/install-command.ts` or equivalent), imported everywhere it appears on the site. Changing the canonical install requires editing one file. Pre-fold value: `pip install attune-gui`. Post-fold value: `pip install attune-ai[gui]`. The post-fold swap is a one-line PR.
+
+### C-2 — Screenshot freshness
+
+Every screenshot on `/dashboard` has a manifest entry in `website/screenshots/manifest.yaml` with:
+
+```yaml
+- file: living-docs-table.png
+  captured_at: 2026-05-11
+  dashboard_version: 1.3.0
+  surface: living-docs
+  description: "Document table with state badges and inline actions"
+```
+
+The screenshot-capture CI job (see `design.md`) regenerates each on tagged releases and updates `captured_at` + `dashboard_version`. Stale screenshots (where `dashboard_version` lags the live release by 2+ versions) fail a soft check in CI.
+
+### C-3 — Link-checker contract
+
+`lychee --offline website/ docs/` runs as a non-blocking CI job today; escalates to required check the day the fold-back ships. Failure thresholds: any 4xx/5xx on an `attune-gui` path post-fold is a hard fail.
+
+### C-4 — Migration banner lifecycle
+
+Banner component reads from `website/lib/migration-banner.ts`:
+
+```ts
+export const MIGRATION_BANNER = {
+  showFromVersion: "7.0.0",
+  hideFromVersion: "7.1.0",  // exclusive — banner gone in 7.1
+  fallbackHideDate: "2026-07-01",  // safety net if version comparison fails
+};
+```
+
+Build-time check fails if today's date is past `fallbackHideDate` AND the banner is still showing.
+
+### C-5 — Changelog persona
+
+Every changelog entry is written for "an existing attune-ai user who skipped 2 releases." Concrete guardrails:
+
+- Lead with what the user sees, not what code changed
+- Use "you" not "we"
+- No commit verbs ("refactored", "moved", "extracted")
+- Each entry is 1–3 sentences max; details link out to the relevant docs page
+- Group related shipped work into one entry, not per-PR

--- a/docs/specs/website-update-dashboard-and-fold/requirements.md
+++ b/docs/specs/website-update-dashboard-and-fold/requirements.md
@@ -88,11 +88,11 @@ Banner component reads from `website/lib/migration-banner.ts`:
 export const MIGRATION_BANNER = {
   showFromVersion: "7.0.0",
   hideFromVersion: "7.1.0",  // exclusive — banner gone in 7.1
-  fallbackHideDate: "2026-07-01",  // safety net if version comparison fails
+  fallbackHideDate: "2026-06-15",  // safety net if version comparison fails
 };
 ```
 
-Build-time check fails if today's date is past `fallbackHideDate` AND the banner is still showing.
+Build-time check fails if today's date is past `fallbackHideDate` AND the banner is still showing. The date is intentionally tight (~5 weeks from spec-open) so any slip in the v7.0 → v7.1 cycle forces an explicit decision (extend the date or retire the banner) rather than letting it linger silently.
 
 ### C-5 — Changelog persona
 

--- a/docs/specs/website-update-dashboard-and-fold/tasks.md
+++ b/docs/specs/website-update-dashboard-and-fold/tasks.md
@@ -1,0 +1,132 @@
+# Tasks — Website update: dashboard maturity + fold-back
+
+**Status:** draft
+
+Two-phase plan. Phase 1 ships everything that doesn't depend on the fold-back; Phase 2 swaps install commands + adds redirects + automated screenshots once the fold lands. See `decisions.md`, `requirements.md`, `design.md` for context.
+
+---
+
+## Phase 1 — Pre-fold (ship now, with current install command)
+
+Goal: Dashboard story is visible on the site using today's install command. Pre-announce the fold so existing attune-gui users see it coming.
+
+### 1.1 — Foundation
+
+- [ ] **1.1.1** Create `website/lib/install-command.ts` with `CANONICAL_INSTALL` + `POST_FOLD_INSTALL` constants and an `installCommand()` helper. Replace every hard-coded `pip install` on the site with a render from this helper.
+- [ ] **1.1.2** Create `website/lib/migration-banner.ts` with `showFromVersion` / `hideFromVersion` / `fallbackHideDate` per C-4.
+- [ ] **1.1.3** Add `scripts/check-migration-banner.ts` build-time check — fails if `fallbackHideDate` has passed and banner still renders.
+
+### 1.2 — Dashboard feature page
+
+- [ ] **1.2.1** Create `website/app/dashboard/page.tsx`. Hero + 4 surfaces (Living Docs, RAG search, Commands, Summaries).
+- [ ] **1.2.2** Capture hand-shot screenshots for each surface (Phase 2 replaces with automation). Store at `website/public/screenshots/`.
+- [ ] **1.2.3** Create `website/screenshots/manifest.yaml` with entries for each screenshot (C-2 schema).
+- [ ] **1.2.4** Wire `/dashboard` into the site nav.
+
+### 1.3 — Homepage + features
+
+- [ ] **1.3.1** Add "Living Docs" as a top-of-fold capability on the homepage with a one-line tagline.
+- [ ] **1.3.2** Add polish-corpus to the feature list / pricing matrix / FAQ with consistent phrasing per `requirements.md` scope.
+
+### 1.4 — Changelog
+
+- [ ] **1.4.1** Add 2026-05-10 changelog entry covering the nine-fix session as 3–5 user-visible bullets per C-5.
+- [ ] **1.4.2** Add forward-looking note for the quality-pass + fold-back when they land (placeholder anchor; populated in Phase 2).
+
+### 1.5 — FAQ
+
+- [ ] **1.5.1** Add "What's the difference between attune-ai and attune-gui?" (pre-fold answer: "two packages, one workflow").
+- [ ] **1.5.2** Add "Do I need the dashboard?" with the honest "no, but…" answer.
+
+### 1.6 — Migration page
+
+- [ ] **1.6.1** Create `website/app/migrate/page.tsx` with the pre-fold heads-up content. Linked from the FAQ entries.
+- [ ] **1.6.2** Add the migration banner component to the homepage. Currently hidden (controlled by `migration-banner.ts`).
+
+### 1.7 — Pre-fold deprecation announcement
+
+- [ ] **1.7.1** Add a banner to attune-gui's PyPI README 4–6 weeks before the planned fold ship date. Non-version-specific phrasing per R-5. Banner links to the `/migrate` page on attune-ai.
+- [ ] **1.7.2** (Cross-repo) attune-gui maintainer publishes a new minor version of the standalone package with the README banner.
+
+### 1.8 — Link checker
+
+- [ ] **1.8.1** Add `.github/workflows/link-check.yml` running `lychee --offline website/ docs/` as a non-blocking job.
+
+### 1.9 — Phase 1 review + ship
+
+- [ ] **1.9.1** All `requirements.md` acceptance criteria 1–5 pass on a preview deploy.
+- [ ] **1.9.2** Patrick reviews + approves. Single PR merged to main.
+
+---
+
+## Phase 2 — Post-fold (ship the day v7.0 lands)
+
+Goal: swap install commands site-wide, retire the pre-fold banner, replace it with the post-fold migration banner, add redirects, enable automated screenshots.
+
+### 2.1 — Install command swap
+
+- [ ] **2.1.1** Edit `install-command.ts`: `CANONICAL_INSTALL = POST_FOLD_INSTALL`. Verify every install-command render on the site picks up the new value (single source of truth).
+- [ ] **2.1.2** Pin the migration banner to v7.0 → v7.1 lifecycle (update `showFromVersion` / `hideFromVersion` per C-4).
+
+### 2.2 — Redirects + link check escalation
+
+- [ ] **2.2.1** Add `attune-gui` → `attune-ai` redirects to `website/next.config.ts`.
+- [ ] **2.2.2** Escalate `lychee` job to a required check. Any 4xx/5xx on a post-fold path is a hard fail.
+
+### 2.3 — Migration page swap
+
+- [ ] **2.3.1** Update `/migrate` content from pre-fold heads-up to post-fold "here's what changes."
+- [ ] **2.3.2** Update changelog 1.4.2 placeholder with the actual fold entry.
+- [ ] **2.3.3** Update FAQ "What's the difference…?" to post-fold answer.
+
+### 2.4 — Automated screenshot capture
+
+- [ ] **2.4.1** Create `.github/workflows/dashboard-screenshots.yml` per `design.md` R-3.
+- [ ] **2.4.2** Create `scripts/prepare-demo-state.sh` to deterministically seed the demo workspace (fresh corpus, known summaries, etc.).
+- [ ] **2.4.3** Run the workflow against the v7.0 release tag; verify each screenshot regenerates and the manifest updates.
+- [ ] **2.4.4** Open a PR with the regenerated screenshots replacing the Phase 1 hand-captures.
+
+### 2.5 — OG / hero refresh (if rebrand calls for it)
+
+- [ ] **2.5.1** Update OG image + opengraph copy if the homepage hero changed substantially in Phase 1.
+
+### 2.6 — Phase 2 review + ship
+
+- [ ] **2.6.1** All `requirements.md` acceptance criteria 6–8 pass on a preview deploy.
+- [ ] **2.6.2** Patrick reviews + approves. Single PR merged to main on v7.0 release day.
+
+### 2.7 — Banner retirement (auto)
+
+- [ ] **2.7.1** Around 4 weeks after v7.0 ships (when v7.1 cuts), the migration banner auto-retires per C-4.
+- [ ] **2.7.2** Sanity-check the build-time check (`scripts/check-migration-banner.ts`) doesn't fail post-retirement.
+
+---
+
+## Phase 3 — Close
+
+- [ ] **3.1** All acceptance criteria green on production.
+- [ ] **3.2** `lychee` runs as required check; passing.
+- [ ] **3.3** Screenshot workflow has captured at least one full set on a real release tag.
+- [ ] **3.4** Patrick confirms the site tells the story it should.
+- [ ] **3.5** Close this spec. Open follow-up specs if Phase 2/3 work surfaced new threads (e.g. live demo deploy, customer-success content).
+
+---
+
+## Out of scope (parking lot)
+
+- Live demo deploy (Dashboard page links to it but doesn't build it)
+- Marketing automation / email lists
+- Customer-success content (tutorials, case studies)
+- Pricing changes
+- Visual / brand identity refresh
+- Compare-with-CLI page
+
+---
+
+## Rollback plan
+
+Each phase is a single squash-merge. Rollback = `git revert <commit>`. Phasing ensures independence:
+
+- Revert Phase 2 → site shows pre-fold copy with current install command; Phase 1 work still visible
+- Revert Phase 1 → site returns to current state; no harm done
+- Revert Phase 3 closure tasks → no impact (these are admin-only)


### PR DESCRIPTION
## Summary

Splits Patrick's draft spec at `docs/specs/website-update-dashboard-and-fold/requirements.md` into the canonical 4-file layout so the new Specs tab on the ops dashboard reads it correctly (decisions / requirements / design / tasks).

While splitting, folded in feedback from the 2026-05-11 review.

## Structural changes

| Source content | Target file |
|----------------|-------------|
| Problem, "why separate spec", out-of-scope, decisions | `decisions.md` |
| Scope, user stories, acceptance criteria, contracts | `requirements.md` |
| Risks → mitigations, module-by-module changes, failure modes | `design.md` |
| All work items as a 2-phase plan with checkboxes | `tasks.md` |

## Substantive changes

1. **Pre-announce the fold** (~4-6 weeks before ship), not after. Banner on attune-gui's PyPI README sets user expectations and gives feedback time.
2. **Automated screenshot capture** workflow (Playwright + tagged releases) modeled after the diagnostic-CI pattern from `windows-memory-detection`. Durable fix for the "out-of-date screenshots" risk vs. just "focus on stable surfaces."
3. **`lychee --offline` link checker in CI** — non-blocking job in Phase 1, escalated to required after Phase 2.
4. **Deterministic migration banner lifecycle** — v7.0 → v7.1 (~4 weeks), with a `fallbackHideDate` safety net and a build-time check that fails the build if the banner is still showing past the date.
5. **Defined changelog persona** — "existing attune-ai user who skipped 2 releases." Concrete guardrails on entry shape, voice, length.
6. **Single source of truth** for the install command in `website/lib/install-command.ts`. Post-fold swap is one line.
7. **Original "Open questions" with leans** → promoted to **"Decisions made"** in decisions.md. Only genuinely-open questions remain.

## Test plan

- [x] All 4 files validate as markdown
- [x] Specs tab on the ops dashboard renders all 4 status columns correctly when this branch is the project root (verified by-eye locally)
- [ ] CI checks green
- [ ] Patrick reviews substantive changes and confirms tone

## After merge

Patrick's local main checkout has the original single-file `requirements.md` as untracked. After this PR lands, `git status` will show it; he can decide whether to delete (the 4-file split supersedes) or keep as scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
