### PR TITLE
docs(specs): tier2 amendment — run-view page (#251) reshapes Phases 3-5

### DIFF
--- a/docs/specs/ops-runner-tier2/decisions.md
+++ b/docs/specs/ops-runner-tier2/decisions.md
@@ -3,7 +3,21 @@
 **Status:** draft
 **Owner:** Patrick
 **Opened:** 2026-05-11
-**Predecessor:** PR #247 (Tier 1 rich rendering — workflow output gets parsed links, file chips, workflow pills, headers)
+**Predecessors:**
+- PR #247 — Tier 1 rich rendering (workflow output gets parsed links, file chips, workflow pills, headers)
+- PR #251 — Full-page run view (output survives browser refresh; full viewport instead of cramped table-row pane)
+
+---
+
+## Amendment (2026-05-11, post-#251)
+
+The original Tier 2 spec assumed the **inline log pane** in the workflows table as the output surface for Phases 3–5. PR #251 replaced that with a dedicated `/runs/{run_id}/view` page. The spec's intent is unchanged — same phases, same outcomes — but the **rendering surface for Phases 3 (recent-runs history), 4 (pill-clicks chain runs), and 5 (recommendation cards) is now the run-view page, not the workflows-table row.**
+
+Phase 2 (the scope picker — your idea) remains on the Workflows tab. That's the launcher; scope belongs with the Run button. Once a run starts, the user navigates to `/runs/{run_id}/view` and that's where chains, history, and recommendations render.
+
+The recent-runs strip (Phase 3) appears on BOTH the workflows table (as a per-workflow history chip strip) AND the run-view page (as a "switch to another run for this workflow" navigator). Same data, two locations.
+
+See `design.md` "Run-view page integration" and `tasks.md` Phases 3–5 for the updated surfaces.
 
 ---
 

--- a/docs/specs/ops-runner-tier2/design.md
+++ b/docs/specs/ops-runner-tier2/design.md
@@ -160,33 +160,64 @@ Per-row addition before the Run button:
 </td>
 ```
 
-Recent-runs strip below the log pane:
+Recent-runs strip below each row (history chip per-workflow):
 
 ```html
 <div class="recent-runs" data-recent-runs="{{ w.name }}"></div>
 ```
 
-(Populated by JS via `GET /api/runs/{w.name}` after DOMContentLoaded.)
+(Populated by JS via `GET /api/runs/{w.name}` after DOMContentLoaded. Each chip is a link to `/runs/{run_id}/view` — the user can browse prior runs of this workflow with one click.)
 
-### `src/attune/ops/static/js/runner.js`
+### `src/attune/ops/templates/run_view.html` (Run-view page integration — post-#251)
 
-Additions:
+PR #251 introduced this page. Tier 2 extends it with three Tier 2-specific elements:
+
+```html
+<!-- Inline run-history navigator at the top of the run-view page,
+     showing the last 5 runs of THIS workflow as chips. Click a chip
+     to switch the page to that run's view. Same data source as the
+     workflows-table strip, just a different layout. -->
+<div class="run-view-history" data-recent-runs="{{ run.workflow }}"></div>
+
+<!-- Below the log pane: a slot for structured recommendation cards
+     (Phase 5). The log pane is unchanged — recommendations come from
+     a separate SSE event type ("recommendation"), not parsed from
+     the log stream. -->
+<div class="run-view-recommendations" data-recs></div>
+
+<!-- A "← from <source-workflow>" badge in the header when this run
+     was chained from a workflow-name pill click in another run.
+     Hidden by default; set by JS when the source query param is
+     present in the URL (e.g. `/runs/{id}/view?from=code-review`). -->
+<span class="chained-from" hidden></span>
+```
+
+### `src/attune/ops/static/js/runner.js` (Workflows-table launcher only)
+
+Additions on the workflows page (responsible for scope-pick + Run + recent-runs strip):
 - `getScope(row)` — reads the picker + custom input, returns string or null
 - `setupScopePicker(row)` — wires the "Custom path…" toggle behavior
-- `setupRecentRuns(row)` — fetches `/api/runs/<name>`, renders chips
-- `setupPillHandlers()` — Tier 1 pills get a click listener that POSTs to the named workflow's row with `getScope(currentRow)` carried forward
-- `renderRecommendationCard(row, payload)` — new SSE event handler for `recommendation` events
+- `setupRecentRuns(row)` — fetches `/api/runs/<name>`, renders chips that link to `/runs/<run_id>/view`
 
-The existing `attach(button)` for the Run button is extended to read `getScope(row)` and pass it in the POST body.
+The existing `attach(button)` for the Run button is extended to read `getScope(row)` and pass it in the POST body, then navigate to `/runs/<run_id>/view` (already does this since #251 — Tier 2 just adds the `?from=<workflow>` query param if this run was chained from another).
+
+### `src/attune/ops/static/js/run_view.js` (NEW — run-view page logic)
+
+PR #251 inlines a small script in `run_view.html`. Tier 2 extracts it to its own file and adds:
+- `setupPillHandlers()` — `.log-workflow` pills get a click listener that POSTs `/workflows/<target>/run` with the current scope, then navigates to `/runs/<new_run_id>/view?from=<this-workflow>`
+- `renderRecommendationCard(payload)` — appends a `.recommendation-card` to `.run-view-recommendations` when a `recommendation` SSE event arrives
+- `setupRunViewHistory()` — fetches `/api/runs/<workflow>`, renders chips in `.run-view-history`. Clicking a chip is a same-tab navigation to that run's view (browser back works).
+- `renderChainedFromBadge()` — reads `?from=` from the URL, populates `.chained-from` if present
 
 ### `src/attune/ops/static/css/main.css`
 
 New selectors:
 - `.scope-picker`, `.scope-custom` — combobox styling matching the existing `.status-select`
 - `.scope-na` — disabled-looking inline span
-- `.recent-runs` — flex strip of chips
-- `.recent-run-chip` — clickable chip with outcome color
-- `.recommendation-card` — action card below log pane
+- `.recent-runs`, `.run-view-history` — flex strip of chips (same styling, two locations)
+- `.recent-run-chip` — clickable chip with outcome color (`chip-ok`/`chip-danger`/`chip-warn`)
+- `.recommendation-card` — action card in the run-view recommendations slot, hover/click states + severity color
+- `.chained-from` — small badge in the run-view header showing the source workflow
 
 ---
 

--- a/docs/specs/ops-runner-tier2/requirements.md
+++ b/docs/specs/ops-runner-tier2/requirements.md
@@ -54,13 +54,14 @@ Acceptance:
 - The new run appears in the bug-predict row (not the code-review row)
 - A subtle "↩ from code-review on memory" badge appears in the new run's output header
 
-### US-5 — Inline run history per workflow
+### US-5 — Run history per workflow
 
 **As Pat, when I revisit the dashboard, I want to see "last 5 runs" for each workflow as a strip of clickable chips so I can see what's been happening without scrolling.**
 
 Acceptance:
-- Each row shows up to 5 most-recent chips: outcome (✓ / ✗), elapsed time, scope, age (e.g. "2m ago")
-- Clicking a chip expands the log pane showing that run's output (read-only, scrollable)
+- Each row on the Workflows tab shows up to 5 most-recent chips: outcome (✓ / ✗), elapsed time, scope, age (e.g. "2m ago")
+- The same chip strip also appears at the top of the run-view page (`/runs/<id>/view`) for the current run's workflow — lets the user switch between recent runs without leaving the page
+- Clicking any chip navigates to `/runs/<run_id>/view` (the full-page viewer from #251)
 - History persists across server restarts (writes to `~/.attune/ops/runs/<workflow>/<run-id>.json`)
 - The current "last 20 runs in memory" behavior is removed (persisted history supersedes it)
 
@@ -70,9 +71,9 @@ Acceptance:
 
 Acceptance:
 - A workflow opts in by emitting an SSE event with `event: recommendation` and a JSON payload like `{"kind": "next-workflow", "name": "bug-predict", "args": {"path": "src/foo"}, "label": "Run bug-predict to verify the fix"}`
-- The dashboard renders these as cards below the log pane (not inline in the log)
-- Clicking a card runs the named workflow with the given args
-- The Tier-1 regex parser stays as a fallback for non-opted-in workflows
+- The dashboard renders these as cards in the **run-view page**'s recommendations slot (below the log) — NOT inline in the log stream
+- Clicking a card runs the named workflow with the given args and navigates to the new run's view page
+- The Tier-1 regex parser stays as a fallback for non-opted-in workflows (parsed inline in the log)
 
 ---
 

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -51,42 +51,48 @@ Goal: replace in-memory run history with disk-backed per-workflow history.
 - [ ] **3.4** New router `routes/runs_history.py`:
       - `GET /api/runs/{workflow}` → list 20 newest runs (metadata only)
       - `GET /api/runs/{workflow}/{run_id}` → full record + log
-- [ ] **3.5** `workflows.html`: add `<div class="recent-runs" data-recent-runs="{{ w.name }}">` below each log pane.
-- [ ] **3.6** `runner.js`: `setupRecentRuns(row)` fetches and renders chips. Click on a chip expands the log pane with that run's output.
-- [ ] **3.7** CSS: `.recent-runs`, `.recent-run-chip` (color by outcome: ✓ ok, ✗ danger).
-- [ ] **3.8** Tests:
+- [ ] **3.5** `workflows.html`: add `<div class="recent-runs" data-recent-runs="{{ w.name }}">` below each workflow row. Each chip is a link to `/runs/<run_id>/view` (the per-run page from #251).
+- [ ] **3.6** `run_view.html`: add `<div class="run-view-history" data-recent-runs="{{ run.workflow }}">` at the top of the run-view page — same data, second location, makes "switch between recent runs of this workflow" a one-click navigation.
+- [ ] **3.7** JS: `setupRecentRuns()` (on workflows.html via runner.js) and the same logic on run-view via the new `run_view.js` (Phase 4.1) — both fetch `/api/runs/<workflow>` and render chips that link to the run-view page.
+- [ ] **3.8** CSS: `.recent-runs`, `.run-view-history`, `.recent-run-chip` (color by outcome: ✓ ok, ✗ danger). Same chip class in both locations.
+- [ ] **3.9** Tests:
       - `test_run_persists_to_disk` — file written on completion
       - `test_run_persists_truncates_long_log` — 1MB log → 200KB on disk + marker
       - `test_run_skips_write_in_read_only` — `--read-only` doesn't write
       - `test_get_recent_runs_returns_sorted` — newest first
       - `test_get_run_rejects_path_traversal` — `run_id="../../etc/passwd"` returns 400
       - `test_prune_old_runs` — files older than 30 days are deleted at startup
+      - `test_run_view_history_renders` — run-view page shows last-5 chips for the same workflow
 
 ## Phase 4 — Workflow-name pills become buttons
 
-Goal: Tier 1 pills (inert today) trigger a follow-on run carrying the row's scope.
+Goal: Tier 1 pills (inert today) on the run-view page trigger a follow-on run carrying the source run's scope.
 
-- [ ] **4.1** `runner.js`: attach click handlers to `.log-workflow` pills. On click:
-      - Read the row's scope via `getScope(currentRow)`
-      - Find the target workflow row by name
+**Note:** Pills now live on the **run-view page** (introduced in #251), not the workflows-table log pane. The JS for pill handling moves into a new `run_view.js` file.
+
+- [ ] **4.1** Extract the inline `<script>` block from `run_view.html` into `src/attune/ops/static/js/run_view.js`. (Currently inline as a one-off — Tier 2 needs the file for testing + multiple features.)
+- [ ] **4.2** `run_view.js`: attach click handlers to `.log-workflow` pills. On click:
+      - Read the source run's scope from the page context (server-injected as `{{ run.scope|tojson }}` once Phase 2 lands)
       - POST `/workflows/<target>/run` with `{path: scope}`
-      - Auto-scroll to the target row, set status, attach SSE listener
-      - Render a "↩ from <source-workflow>" badge in the target row's output
-- [ ] **4.2** Handle read-only mode: pill click in `--read-only` shows a toast "Read-only mode: re-launch without --read-only to chain runs". No POST.
-- [ ] **4.3** Handle disabled target (already running): the existing 409 handler in `formatErrorDetail` already covers this; surface in the target row.
-- [ ] **4.4** CSS: pill hover state, `.pill-disabled` for `--read-only`, `.chained-from` badge styling.
-- [ ] **4.5** Tests:
-      - `test_runner_js_pills_clickable` — assert pills have `data-clickable` attribute
+      - On success, navigate to `/runs/<new_run_id>/view?from=<source-workflow>`
+      - On 409 (busy), surface inline above the log without navigating
+- [ ] **4.3** `run_view.js`: `renderChainedFromBadge()` — reads `?from=` from the URL, populates `.chained-from` in the page header if present. Renders as "↩ from <source-workflow>".
+- [ ] **4.4** Handle read-only mode: pill click in `--read-only` shows a toast "Read-only mode: re-launch without --read-only to chain runs". No POST.
+- [ ] **4.5** Handle disabled target (already running): the existing 409 handler in `formatErrorDetail` already covers this; surface above the log on the source run-view page (don't navigate away from a successful prior run).
+- [ ] **4.6** CSS: `.log-workflow` pill hover state, `.pill-disabled` for `--read-only`, `.chained-from` badge styling.
+- [ ] **4.7** Tests:
+      - `test_run_view_js_exists` — file is served at `/static/js/run_view.js`
+      - `test_run_view_page_loads_run_view_js` — template references the new file
       - `test_pill_click_carries_scope` (manual): visual smoke from the browser
       - `test_read_only_pill_returns_403` — POST while `--read-only` returns 403
 
 ## Phase 5 — Structured recommendation channel
 
-Goal: workflows can emit JSON recommendations rendered as action cards.
+Goal: workflows can emit JSON recommendations rendered as action cards on the run-view page.
 
 - [ ] **5.1** Extend SSE event types in `routes/runner.py`. Existing: `line`, `done`. New: `recommendation`.
 - [ ] **5.2** Server-side validation: `kind` must be in allowlist (`next-workflow`, `open-url`), `name` must be a registered workflow, `args.path` must pass `_validate_file_path`. Drop bad payloads with warning log.
-- [ ] **5.3** `runner.js`: listen for `recommendation` events. Render an action card below the log pane via `renderRecommendationCard(row, payload)`.
+- [ ] **5.3** `run_view.js`: listen for `recommendation` events. Render an action card into the page's `.run-view-recommendations` slot via `renderRecommendationCard(payload)`.
 - [ ] **5.4** Pick ONE workflow to demonstrate end-to-end. Candidate: `code-review` emitting `{"kind": "next-workflow", "name": "bug-predict", "args": {"path": "<same scope>"}, "label": "Run bug-predict to verify"}` when it finds CWE-style issues.
 - [ ] **5.5** CSS: `.recommendation-card` action card with hover/click states + severity color.
 - [ ] **5.6** Tests:


### PR DESCRIPTION
## Summary

Doc-only amendment to the Tier 2 spec (merged in #248) reflecting that the **run-view page from #251** changed where Phases 3–5 render. The amendment was promised in #251's PR body and follow-up discussion.

## What moved

| Phase | Original assumption | After #251 |
|-------|---------------------|------------|
| Phase 3 (Persistence) | Recent-runs chip strip below the inline log pane | Strip lives in BOTH places — workflows table AND top of run-view page — same chip class. Both chips link to `/runs/<id>/view` |
| Phase 4 (Pills become buttons) | Pills in inline log pane → POST → new SSE listener on same row | Pills on the **run-view page** → POST → **navigate** to `/runs/<new_id>/view?from=<source-workflow>`. JS extracted to new `run_view.js` |
| Phase 5 (Structured recommendations) | Action cards below the inline log pane | Cards render in the run-view page's `.run-view-recommendations` slot |

Phase 2 (your scope picker idea) is **unchanged** — that lives on the Workflows tab where the Run button is.

## What didn't move

- Spec intent and outcomes — same goals, same user stories.
- Phase 1 (verify `--path` capability per workflow) — pure data work.
- Phase 6 (telemetry + close).

## Files touched

| File | Lines changed | What |
|------|---------------|------|
| `decisions.md` | +25 | New "Amendment (post-#251)" section |
| `requirements.md` | +5 / -3 | US-5 + US-6 updated for new locations |
| `design.md` | +35 / -14 | New "Run-view page integration" subsection, new `run_view.js` file |
| `tasks.md` | +22 / -18 | Phase 3.5–3.9 split, Phase 4 reworked for run-view |

## Test plan

- [x] No code changed — markdown-only diff
- [ ] CI green on the doc-checker workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
