### PR TITLE
docs(specs): ops-security-hardening — DNS-rebinding fix + cluster

### DIFF
--- a/docs/specs/ops-security-hardening/decisions.md
+++ b/docs/specs/ops-security-hardening/decisions.md
@@ -1,0 +1,89 @@
+# Decisions — Ops Dashboard Security Hardening
+
+**Status:** draft
+**Owner:** Patrick
+**Opened:** 2026-05-11
+**Trigger:** Code-review report on PR #251 (2026-05-11) flagged the ops dashboard's command-execution endpoints as vulnerable to DNS-rebinding attacks. Verified real. Not introduced by #251 — pre-existing since the ops runner shipped.
+
+---
+
+## Problem
+
+`attune ops` binds to `127.0.0.1:8766` by default. This protects against direct external network access — an attacker can't reach the dashboard from the internet. But it does NOT protect against **DNS-rebinding** attacks from any website the user visits in their browser:
+
+1. User has `attune ops` running locally.
+2. User visits `attacker.com` in another browser tab.
+3. `attacker.com` resolves to attacker's IP, serves JavaScript.
+4. JS waits, then `attacker.com` DNS-rebinds to `127.0.0.1`.
+5. JS does `fetch("http://attacker.com:8766/workflows/release-prep/run", {method: "POST"})`.
+6. Same-Origin Policy thinks this is still `attacker.com` → allows the request.
+7. The TCP connection actually lands on `localhost:8766` because of the rebind.
+8. The ops server checks the URL path (`/workflows/release-prep/run`) but **NOT the `Host:` header** (which is still `attacker.com`).
+9. Workflow executes locally. `release-prep` publishes to PyPI. `simplify-code` writes to disk. Anything.
+
+Verified by `grep -rn "Host\|TrustedHost\|allowed_host\|CORSMiddleware" src/attune/ops/` → zero matches. No defense exists today.
+
+This is the dominant risk in the recent code-review report. The other findings (unbounded subscriber queue, missing logging, gap in "output survives refresh" test) are valid but lower-severity. This spec bundles them so a single hardening pass closes the cluster.
+
+---
+
+## Decision
+
+**Add a `TrustedHost` middleware** that validates the `Host:` header against an allowlist before the request reaches any route handler. The allowlist is computed from `--host` / `--port` config so it's deterministic and matches the actual bind. DNS rebinding fails because the rebinder's `Host:` is `attacker.com`, not `localhost:8766`.
+
+Also in scope (small, defensible additions in the same PR):
+- **Bound the subscriber queue** at a sensible maxsize (e.g., 1000 events) so the `except QueueFull` block in `_broadcast` becomes live.
+- **Add structured logging** to the new run-view route (`run_view_page`) so 404s and 400s show up in the server log with run_id context.
+- **Add the "output survives refresh" integration test** — currently the replay mechanism is tested at the SSE-stream level but there's no end-to-end test for "request the /view URL after a run completes, confirm full output present."
+
+Out of this spec's scope but worth naming:
+- HTTPS / TLS — for a localhost dashboard, not warranted.
+- Authentication tokens (Bearer / cookie / OAuth) — could be a follow-up if `--host 0.0.0.0` ever becomes common. Today's bind is loopback; the TrustedHost middleware closes the realistic threat.
+- Per-workflow capability gating (e.g. "release-prep needs an extra confirmation") — interesting but separate UX question.
+
+---
+
+## Decisions made
+
+| Question | Decision |
+|----------|----------|
+| Defense layer for DNS rebinding | **Host header allowlist middleware**. CORS isn't sufficient — CORS validates the `Origin` header which the browser sets, but the same-origin GET/POST baseline allows requests to fire even when CORS would refuse them at JS-callback time. Host validation rejects at request-time before the route runs. |
+| Where the allowlist is computed | At `create_app()` time, from `config.host` + `config.port`. Default: `["localhost:<port>", "127.0.0.1:<port>"]`. CLI flag `--trusted-host` (repeatable) lets users widen for tunneled / proxied setups. |
+| What happens on rejection | Return **400 Bad Request** with a short body. Not 403 (no auth involved). Not 421 Misdirected (the request landed at the right server, just lying about Host). Log the rejected Host header for diagnosis. |
+| Queue maxsize value | **1000 events**. A reasonable run is ~1k–5k log lines; if a subscriber falls 1k events behind, dropping them is correct (the existing `except QueueFull` was the intended behavior — we just never bounded the queue to trigger it). |
+| Should rejection be configurable to disable? | **No.** A flag like `--no-host-check` would be an attractive nuisance. If a user genuinely needs to reach the dashboard from a different hostname (Tailscale, Cloudflare Tunnel), they add it to `--trusted-host`. |
+| Backward compatibility for the bind-host change | None needed. The bind defaults stay (`127.0.0.1:8765`). Existing users who run `attune ops` and `curl localhost:8765` keep working because `localhost:8765` is on the default allowlist. |
+
+---
+
+## Open questions
+
+| Question | Lean | Notes |
+|----------|------|-------|
+| Should the dashboard refuse to start if `--host 0.0.0.0` is set without an explicit `--trusted-host`? | Yes — warning level. | `0.0.0.0` means "bind on all interfaces," so without an explicit allowlist the user gave the dashboard's command surface to their LAN. Warning + suggest `--trusted-host` keeps the door open but flags the risk. |
+| Should there be a rate limit on `/workflows/<name>/run`? | Probably yes (low pri) | Even with Host check, a malicious local process could spam runs. Single-concurrent-run via `RunnerService` already partially handles this. Token-bucket on POST is a separate small task. |
+
+---
+
+## Out of scope
+
+- **TLS / HTTPS** — localhost-only by default.
+- **Auth tokens / OAuth** — requires a much larger UX story (cookie storage, signout, etc.).
+- **CSRF tokens** — Host validation closes the same threat at lower cost.
+- **Workflow capability levels** ("release-prep is dangerous; confirm twice") — UX call, separate spec if/when wanted.
+- **Audit log of all runs** — partially covered by Tier 2's persistence (Phase 3); audit-specific telemetry is a follow-up.
+- **Sandboxing the subprocess** (e.g., seccomp, container) — outside this spec.
+
+---
+
+## Resolution criteria
+
+Spec closes when:
+
+1. `TrustedHost` middleware is mounted in `create_app()` with default allowlist derived from `config.host` + `config.port`.
+2. `--trusted-host` repeatable CLI flag exists and adds to the allowlist.
+3. Subscriber queue has `maxsize=1000`; the `except QueueFull` block has at least one test asserting drop-on-overflow.
+4. `run_view_page` route logs 404 / 400 at INFO with `run_id` context (no PII leak).
+5. End-to-end test: start a run, complete it, GET `/runs/<id>/view`, parse the stream URL from the rendered HTML, connect, assert full log replays.
+6. Manual DNS-rebinding repro fails (e.g., `curl -H "Host: evil.com:8766" http://localhost:8766/api/info` returns 400).
+7. CI green on all 12 platform lanes.

--- a/docs/specs/ops-security-hardening/design.md
+++ b/docs/specs/ops-security-hardening/design.md
@@ -1,0 +1,253 @@
+# Design — Ops Dashboard Security Hardening
+
+**Status:** draft
+
+Technical shape. See `decisions.md` for context, `requirements.md` for stories, `tasks.md` for the phase plan.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Browser / attacker.com (DNS-rebound to 127.0.0.1)           │
+└─────────────────────────────────────────────────────────────┘
+                          │
+                          ▼ TCP to localhost:8766
+┌─────────────────────────────────────────────────────────────┐
+│ FastAPI app                                                 │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │ TrustedHostMiddleware (NEW)                         │    │
+│  │  - reads request.headers["host"]                    │    │
+│  │  - case-insensitive lookup in allowlist             │    │
+│  │  - allowlist = computed from config at startup      │    │
+│  │  - match → next                                     │    │
+│  │  - no match → 400 + WARN log                        │    │
+│  └─────────────────────────────────────────────────────┘    │
+│                          │                                  │
+│                          ▼                                  │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │ Existing routes (workflows, specs, runs, telemetry) │    │
+│  │ (unchanged)                                         │    │
+│  └─────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The middleware is the only new layer. Everything downstream is unchanged.
+
+---
+
+## Module-by-module changes
+
+### `src/attune/ops/config.py`
+
+Add one field to the `Config` dataclass:
+
+```python
+trusted_hosts: tuple[str, ...] = ()  # user-specified additions to the allowlist
+```
+
+Add `trusted_hosts` parameter to `build_config()`.
+
+### `src/attune/ops/cli.py`
+
+Add the `--trusted-host` flag with `action="append"` (repeatable):
+
+```python
+parser.add_argument(
+    "--trusted-host",
+    action="append",
+    default=None,
+    metavar="HOST",
+    help=(
+        "Repeatable. Hostname (optionally with :port) accepted in the "
+        "Host: header. Use when reaching the dashboard via a tunnel, "
+        "reverse proxy, or non-default hostname. Example: "
+        "--trusted-host my-tunnel.example.com"
+    ),
+)
+```
+
+In `main()`, pass `trusted_hosts=tuple(args.trusted_host or ())` to `build_config()`.
+
+Also: detect the `0.0.0.0` + no-trusted-host combination and print a yellow warning to stderr:
+
+```python
+if args.host == "0.0.0.0" and not args.trusted_host:
+    print(
+        "WARNING: Binding to 0.0.0.0 without --trusted-host means any "
+        "external hostname will be rejected by the security middleware. "
+        "Add --trusted-host <external-hostname> for each hostname you "
+        "intend to reach the dashboard at.",
+        file=sys.stderr,
+    )
+```
+
+### `src/attune/ops/middleware.py` (NEW)
+
+The middleware itself:
+
+```python
+"""Host header allowlist middleware.
+
+Defends against DNS-rebinding attacks. A browser visiting a malicious
+site can be tricked into sending requests to localhost via a DNS
+rebind, but the Host: header it sends will still be the original
+attacker domain — not localhost. This middleware rejects requests
+whose Host header isn't on the allowlist.
+
+See docs/specs/ops-security-hardening/decisions.md for the threat
+model walkthrough.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+class TrustedHostMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose Host header isn't on the allowlist.
+
+    Allowlist comparison is case-insensitive. Missing Host header
+    (HTTP/1.0 or pathological clients) is treated as untrusted.
+    """
+
+    def __init__(self, app, *, allowed_hosts: Iterable[str]) -> None:
+        super().__init__(app)
+        # Lowercase for case-insensitive compare. Frozen set for O(1) lookup.
+        self._allowed = frozenset(h.lower() for h in allowed_hosts)
+
+    async def dispatch(self, request: Request, call_next):
+        host = (request.headers.get("host") or "").lower()
+        if host not in self._allowed:
+            logger.warning(
+                "rejected request: untrusted Host header",
+                extra={"host": host[:200] or "<empty>", "path": request.url.path},
+            )
+            return JSONResponse(
+                {"detail": "untrusted Host header"},
+                status_code=400,
+            )
+        return await call_next(request)
+
+
+def compute_allowlist(host: str, port: int, extras: Iterable[str] = ()) -> set[str]:
+    """Compute the default + user-supplied Host allowlist."""
+    hosts: set[str] = {f"{host}:{port}"}
+    # Loopback aliases — make `localhost` and `127.0.0.1` interchangeable
+    # when bound to a loopback or all-interfaces address.
+    if host in ("127.0.0.1", "0.0.0.0", "localhost"):
+        hosts.add(f"localhost:{port}")
+        hosts.add(f"127.0.0.1:{port}")
+    for extra in extras:
+        hosts.add(extra)
+        if ":" not in extra:
+            # No port specified: accept both http (80) and https (443)
+            hosts.add(f"{extra}:80")
+            hosts.add(f"{extra}:443")
+    return hosts
+```
+
+### `src/attune/ops/server.py`
+
+Mount the middleware in `create_app()`:
+
+```python
+from attune.ops.middleware import TrustedHostMiddleware, compute_allowlist
+
+# Inside create_app(), after FastAPI(...) construction:
+allowed = compute_allowlist(
+    host=config.host,
+    port=config.port,
+    extras=config.trusted_hosts,
+)
+app.add_middleware(TrustedHostMiddleware, allowed_hosts=allowed)
+```
+
+Order matters: this should be ABOVE any other middleware (CORS, GZip) so untrusted requests get rejected before any other processing.
+
+### `src/attune/ops/runner.py`
+
+One-line change at line ~90:
+
+```python
+queue: asyncio.Queue[Event] = asyncio.Queue(maxsize=1000)
+```
+
+The existing `except QueueFull` block in `_broadcast` (line ~74) becomes live. No other changes.
+
+### `src/attune/ops/routes/dashboard.py`
+
+Add logging to `run_view_page`:
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+# ... inside run_view_page, in the not-found branch:
+if run is None:
+    logger.info("run_view: not found", extra={"run_id": run_id})
+    raise HTTPException(...)
+
+# In the invalid-slug branch:
+if not _re.match(...):
+    logger.warning(
+        "run_view: invalid run_id",
+        extra={"run_id_input": run_id[:64]},
+    )
+    raise HTTPException(...)
+```
+
+---
+
+## Failure modes
+
+| Failure | Behavior |
+|---------|----------|
+| Browser sends request with rebound Host header | Middleware rejects → 400 + WARN log → no workflow runs |
+| User accesses via localhost (default) | Allowlist hit → request proceeds normally |
+| User configures `--trusted-host external.example.com` | Both `external.example.com:80` and `:443` added to allowlist; tunneled access works |
+| User starts with `--host 0.0.0.0` and no `--trusted-host` | Server starts with WARNING; any non-loopback Host header is rejected |
+| Subscriber stops consuming the SSE stream | After 1000 buffered events, `put_nowait` raises `QueueFull`; existing handler drops the subscriber |
+| Subscriber drops mid-run | Subscriber's queue is bounded; no leak |
+| Direct attempt to call `/api/info` via DNS rebind | 400, never reaches the route |
+
+---
+
+## Security properties
+
+After this hardening:
+
+| Threat | Mitigated? | How |
+|--------|------------|-----|
+| Direct external network access | Already mitigated by `127.0.0.1` bind | Pre-existing |
+| DNS-rebinding attack | YES (new) | TrustedHost middleware |
+| CSRF from a same-origin attacker (impossible without compromised localhost) | N/A | Outside threat model |
+| Subprocess sandbox escape | No (out of scope) | Future spec |
+| Workflow with embedded shell injection | No (out of scope) | Workflow-author responsibility |
+| Memory exhaustion via slow subscriber | YES (new) | Queue bound |
+
+---
+
+## Backward compatibility
+
+- `attune ops` (no flags) still works — defaults bind to `127.0.0.1:8765`, default allowlist covers it.
+- All existing curl / browser requests against `localhost:<port>` continue to succeed.
+- The middleware adds ~50µs of per-request overhead (one set lookup) — negligible.
+- The queue bound is invisible to fast subscribers — the existing buffer of 1k events covers any realistic dashboard usage.
+
+---
+
+## Open design notes
+
+- **Starlette's built-in `TrustedHostMiddleware`** exists but supports only wildcard patterns and `allowed_hosts`. We need a custom one because we want to log rejections, support explicit ports, and add the loopback aliases. The custom one is ~30 LOC vs. wrapping starlette's.
+- **CORS middleware** is intentionally NOT added. Same-origin baseline lets attackers send the request anyway; CORS would only stop them reading the response. Host validation rejects the request altogether.
+- **Pre-flight (OPTIONS)** requests: ATLAS — FastAPI handles OPTIONS for any registered route. The middleware applies to OPTIONS too, so a rebound CORS preflight would also fail. Good.

--- a/docs/specs/ops-security-hardening/requirements.md
+++ b/docs/specs/ops-security-hardening/requirements.md
@@ -1,0 +1,152 @@
+# Requirements — Ops Dashboard Security Hardening
+
+**Status:** draft
+
+See `decisions.md` for context, `design.md` for the implementation shape, `tasks.md` for the phase plan.
+
+---
+
+## Scope
+
+**In scope:**
+- Host header allowlist (TrustedHost middleware)
+- `--trusted-host` repeatable CLI flag
+- Warning when `--host 0.0.0.0` is used without explicit `--trusted-host`
+- Subscriber queue bound (`maxsize=1000`) + test
+- Structured logging on the run-view route
+- End-to-end "output survives refresh" test
+
+**Out of scope:** see `decisions.md`.
+
+---
+
+## User stories
+
+### US-1 — DNS-rebinding attack fails
+
+**As Pat, when I have `attune ops` running and I visit a malicious website that attempts a DNS-rebinding attack, the website's POST to `localhost:8766/workflows/release-prep/run` fails with 400 — no workflow runs.**
+
+Acceptance:
+- The attack pattern documented in `decisions.md` is blocked at the middleware layer before the route handler runs.
+- The rejected request returns `400 Bad Request` with body `{"detail": "untrusted Host header"}` (or similar).
+- The rejection is logged at WARN with the offending `Host:` value (sanitized — no full headers).
+
+### US-2 — Loopback and default access still work
+
+**As Pat, when I run `attune ops` and visit `http://localhost:8766` or `http://127.0.0.1:8766` in my browser, the dashboard loads normally. No new friction.**
+
+Acceptance:
+- `localhost:<port>` and `127.0.0.1:<port>` are on the default allowlist.
+- `curl http://localhost:8766/api/info` works without configuration.
+- The dashboard renders all tabs without errors.
+
+### US-3 — Tunneled / proxied setups work via `--trusted-host`
+
+**As a developer accessing `attune ops` through a Cloudflare Tunnel or Tailscale or remote SSH port-forward, I can add my external hostname to the allowlist via a repeatable CLI flag.**
+
+Acceptance:
+- `attune ops --trusted-host my-tunnel.example.com --trusted-host my-other.example.com` adds both hostnames.
+- The `--trusted-host` value can include a port (`example.com:8443`) or not (defaults to standard 80/443).
+- Without a port, both http (80) and https (443) variants are accepted.
+- Help text on the flag explains the use case.
+
+### US-4 — `--host 0.0.0.0` without trust-list is loud
+
+**As Pat, when I run `attune ops --host 0.0.0.0` (binding to all interfaces) without an explicit `--trusted-host`, the startup output prints a yellow warning explaining the risk.**
+
+Acceptance:
+- Warning appears on stderr at startup, even with `--no-browser`.
+- Warning text: "Binding to 0.0.0.0 without --trusted-host means any host header is treated as untrusted. Add --trusted-host <external-hostname> for each external hostname you intend to reach the dashboard at."
+- The dashboard still starts (warning, not error).
+
+### US-5 — Subscriber queue can't grow without bound
+
+**As Pat, when a subscriber to `/runs/<id>/stream` is slow or disconnected without proper cleanup, the runner's broadcast queue does NOT grow indefinitely.**
+
+Acceptance:
+- The queue is bounded at `maxsize=1000` events.
+- When the bound is hit, the existing `except QueueFull` block in `_broadcast` fires and the slow subscriber is dropped.
+- A test exercises this: push 1000+ events to a non-consuming subscriber, assert it gets dropped.
+
+### US-6 — Run-view route is observable
+
+**As Pat, when I look at the `attune ops` server log, I can see which run_ids users tried to view that returned 404 or 400.**
+
+Acceptance:
+- `run_view_page` logs at INFO on 404 with `run_id` context.
+- `run_view_page` logs at WARN on 400 (invalid run_id) with the offending input (sanitized).
+- No PII in the log (no IP, no user identity — just run_id and what went wrong).
+
+### US-7 — "Output survives refresh" has an integration test
+
+**As a future maintainer, when I look at the test suite for the run-view feature, I can see a test that exercises the headline scenario end-to-end (start run, complete it, request /view URL, parse stream URL from HTML, attach, assert full output).**
+
+Acceptance:
+- Test exists at `tests/unit/ops/test_runner.py::test_run_view_replays_full_output_after_completion`.
+- Test runs in CI on all platforms.
+- Test fails if the replay mechanism breaks (regression guard).
+
+---
+
+## Contracts
+
+### C-1 — Allowlist resolution
+
+The Host allowlist is computed at `create_app()` time:
+
+```python
+def _compute_trusted_hosts(config: Config) -> set[str]:
+    hosts: set[str] = set()
+    # Always allow the bind address itself
+    hosts.add(f"{config.host}:{config.port}")
+    # Loopback aliases for convenience
+    if config.host in ("127.0.0.1", "0.0.0.0", "localhost"):
+        hosts.add(f"localhost:{config.port}")
+        hosts.add(f"127.0.0.1:{config.port}")
+    # User-specified additions
+    for extra in config.trusted_hosts:
+        hosts.add(extra)
+        # If no port specified, allow both 80 and 443
+        if ":" not in extra:
+            hosts.add(f"{extra}:80")
+            hosts.add(f"{extra}:443")
+    return hosts
+```
+
+The middleware compares `request.headers.get("host")` (case-insensitive) against this set. Match → pass. No match → 400.
+
+### C-2 — CLI flag shape
+
+```
+--trusted-host HOST       Repeatable. Hostname (optionally with :port) that
+                          the dashboard accepts in the Host: header. Use this
+                          when reaching the dashboard via a tunnel, reverse
+                          proxy, or non-default hostname. Examples:
+                            --trusted-host my-tunnel.example.com
+                            --trusted-host my-tunnel.example.com:8443
+```
+
+`config.trusted_hosts: tuple[str, ...] = ()` field added to `Config` dataclass.
+
+### C-3 — Queue maxsize
+
+```python
+# attune/ops/runner.py — line 90
+queue: asyncio.Queue[Event] = asyncio.Queue(maxsize=1000)
+```
+
+Single-line change. The existing `except QueueFull` block in `_broadcast` becomes live with no other code changes.
+
+### C-4 — Run-view logging
+
+```python
+# In run_view_page:
+logger.info("run_view: not found", extra={"run_id": run_id})
+# (only on 404 path; 200 path stays silent to avoid noise)
+```
+
+Standard library `logging`, namespaced `attune.ops.routes.dashboard`. No structlog dependency added — ops already uses stdlib logging elsewhere.
+
+### C-5 — Test name and location
+
+`tests/unit/ops/test_runner.py::test_run_view_replays_full_output_after_completion`. Test must NOT use real subprocess if a portable alternative exists (use the existing `_echo_cmd` fixture).

--- a/docs/specs/ops-security-hardening/tasks.md
+++ b/docs/specs/ops-security-hardening/tasks.md
@@ -1,0 +1,95 @@
+# Tasks — Ops Dashboard Security Hardening
+
+**Status:** draft
+
+Single-phase implementation (small enough to ship in one PR) plus a verification phase. See `decisions.md`, `requirements.md`, `design.md` for context.
+
+---
+
+## Phase 1 — Host header middleware (primary fix)
+
+Goal: DNS-rebinding attacks fail at the middleware layer.
+
+- [ ] **1.1** Add `trusted_hosts: tuple[str, ...] = ()` to `Config` dataclass. Add `trusted_hosts` param to `build_config()`.
+- [ ] **1.2** Add `--trusted-host` repeatable CLI flag to `cli.py`. Thread through to `build_config()`.
+- [ ] **1.3** Add startup warning for `--host 0.0.0.0` without `--trusted-host` (stderr, yellow if TTY).
+- [ ] **1.4** Create `src/attune/ops/middleware.py` with `TrustedHostMiddleware` and `compute_allowlist()`.
+- [ ] **1.5** Mount the middleware FIRST in `create_app()` (before any other middleware).
+- [ ] **1.6** Tests:
+      - `test_middleware_allows_loopback` — `Host: localhost:<port>` passes
+      - `test_middleware_allows_127_0_0_1` — `Host: 127.0.0.1:<port>` passes
+      - `test_middleware_rejects_unknown_host` — `Host: evil.com:8766` returns 400 with the expected detail
+      - `test_middleware_rejects_missing_host_header` — request without Host header → 400
+      - `test_middleware_case_insensitive` — `Host: LOCALHOST:8765` passes
+      - `test_middleware_logs_rejection` — caplog captures WARN with the host value
+      - `test_trusted_host_flag_widens_allowlist` — `--trusted-host my.tunnel.example.com` lets `Host: my.tunnel.example.com:80` and `:443` through
+      - `test_trusted_host_flag_with_port` — `--trusted-host example.com:8443` accepts that exact value
+      - `test_compute_allowlist_loopback_aliases` — binding to `0.0.0.0` adds both `localhost:<port>` and `127.0.0.1:<port>` to the allowlist
+
+## Phase 2 — Queue bound
+
+- [ ] **2.1** One-line change in `runner.py`: `asyncio.Queue(maxsize=1000)`.
+- [ ] **2.2** Test: `test_subscriber_queue_drops_slow_subscriber` — push 1001+ events to a non-consuming subscriber, assert it's removed from `self.subscribers` after the QueueFull path fires.
+- [ ] **2.3** Test: `test_subscriber_queue_does_not_block_fast_subscribers` — one slow subscriber doesn't slow down a fast one.
+
+## Phase 3 — Run-view logging
+
+- [ ] **3.1** Add `logger = logging.getLogger(__name__)` to `dashboard.py` if not present.
+- [ ] **3.2** Log at INFO on 404 path of `run_view_page` with `run_id` context.
+- [ ] **3.3** Log at WARN on invalid-run_id path with the (truncated) offending input.
+- [ ] **3.4** Test: `test_run_view_logs_404` — caplog captures the INFO line with run_id.
+- [ ] **3.5** Test: `test_run_view_logs_invalid_input` — caplog captures the WARN line with the bad input.
+
+## Phase 4 — End-to-end "output survives refresh" test
+
+- [ ] **4.1** Add `test_run_view_replays_full_output_after_completion` in `tests/unit/ops/test_runner.py`. Pattern:
+      ```python
+      # Start a run, wait for terminal, request /runs/<id>/view,
+      # parse the stream_url out of the rendered HTML, attach to the
+      # SSE stream, assert the replayed lines match the expected
+      # output, and assert we get the terminal `done` event.
+      ```
+- [ ] **4.2** Test must run async (the existing `_wait_terminal` helper expects it).
+- [ ] **4.3** Run the existing ops suite to confirm no regressions: `pytest tests/unit/ops/ --no-cov`.
+
+## Phase 5 — Manual verification
+
+- [ ] **5.1** Smoke: `curl -H "Host: evil.com:8766" http://localhost:8766/api/info` returns 400.
+- [ ] **5.2** Smoke: `curl http://localhost:8766/api/info` returns the JSON.
+- [ ] **5.3** Smoke: `curl http://127.0.0.1:8766/api/info` returns the JSON.
+- [ ] **5.4** Smoke: `attune ops --host 0.0.0.0` prints the startup warning.
+- [ ] **5.5** Smoke: `attune ops --trusted-host my.example.com` adds it to the allowlist (verify via curl with that Host).
+- [ ] **5.6** Patrick reviews the implementation in a preview deploy + browser, confirms the dashboard still loads normally.
+
+## Phase 6 — Close
+
+- [ ] **6.1** All `requirements.md` acceptance criteria pass.
+- [ ] **6.2** CI green on all 12 platform lanes.
+- [ ] **6.3** Open follow-up specs for any out-of-scope items that surfaced (rate limit on `/workflows/<name>/run`, capability levels, etc.).
+- [ ] **6.4** Add a brief mention in the next release changelog: "Hardened the ops dashboard against DNS-rebinding attacks."
+
+---
+
+## Out of scope (parking lot)
+
+- HTTPS / TLS for the dashboard
+- Auth tokens (Bearer / cookie / OAuth)
+- CSRF tokens (Host validation closes the same threat)
+- Per-workflow capability gating
+- Audit log of all runs
+- Subprocess sandboxing
+
+---
+
+## Rollback plan
+
+Each phase is a single squash-merge commit. Rollback = `git revert <commit>`.
+
+The highest-risk phase is **Phase 1** (middleware). If it inadvertently blocks legitimate access:
+- Symptom: dashboard returns 400 for `localhost:8766` requests
+- Cause: bug in `compute_allowlist` or middleware comparison
+- Mitigation: `attune ops --trusted-host localhost:8766` adds an explicit override; revert PR if widespread
+
+Phase 2 (queue bound): rollback restores unbounded queue (no change from today).
+Phase 3 (logging): pure additive; rollback removes log lines.
+Phase 4 (test): rollback removes the test only.


### PR DESCRIPTION
## Summary

Spec for the security cluster you asked me to investigate after the code-review report on PR #251 flagged the ops dashboard's command-execution endpoints as vulnerable to DNS-rebinding attacks.

Verified the vulnerability is real (zero Host/Origin/CORS validation in `src/attune/ops/`). Pre-existing — not introduced by #251 — but worth fixing before the website Phase 2 promotes the dashboard widely.

## What this spec covers

| Phase | What | Severity |
|-------|------|----------|
| 1 | TrustedHost middleware (Host header allowlist) | 🔴 High — closes DNS-rebinding |
| 2 | Subscriber queue bound (maxsize=1000) | 🟡 Medium — fixes dead-code `except QueueFull` |
| 3 | Run-view route structured logging | 🟢 Low — adds observability |
| 4 | End-to-end "output survives refresh" test | 🟢 Low — regression guard |

Bundled because they're a coherent hardening pass, not strictly because they share a root cause.

## Decisions made

| Decision | Why |
|----------|-----|
| **Host allowlist** as the defense, not CORS | CORS validates the `Origin` header at the JS callback layer; same-origin still allows the request to fire. Host check rejects at request-time before the route runs. |
| **400 Bad Request** on rejection (not 403) | No auth involved — the request is malformed (wrong Host), not unauthorized. |
| **`--trusted-host` repeatable flag** for tunnels / proxies | Hard requirement for users behind Cloudflare Tunnel, Tailscale, etc. |
| **No `--no-host-check` opt-out flag** | Would be an attractive nuisance. Users who need to widen the allowlist use `--trusted-host`. |
| **Warning** when `--host 0.0.0.0` is set without `--trusted-host` | Loud signal that the user gave the command surface to their LAN. |
| **Queue maxsize 1000** | Realistic runs are 1k–5k log lines; a subscriber 1k events behind is correctly droppable (the existing `except QueueFull` was the intended behavior — just never triggerable without a bound). |

## Test plan

- [x] Spec markdown validates
- [ ] CI checks green
- [ ] Patrick approves the spec
- [ ] Implementation PR follows (separate, lands before website Phase 2)

## What's NOT in scope

Named explicitly in `decisions.md`:
- HTTPS / TLS for a localhost dashboard
- Auth tokens / OAuth
- CSRF tokens (Host check supersedes)
- Per-workflow capability gating
- Audit log of all runs
- Subprocess sandboxing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
