### PR TITLE
release: v6.7.1 — DNS-rebinding fix for ops dashboard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "6.7.0"
+    "version": "6.7.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "6.7.0",
+      "version": "6.7.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v6.7.0
+# Attune AI Framework v6.7.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 6.7.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 6.7.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.7.1] - 2026-05-12
+
+### Security — users running `attune ops` should upgrade
+
+This release fixes a DNS-rebinding vulnerability in the local ops
+dashboard. Any website a user visited could invoke ops dashboard
+endpoints (including endpoints that trigger workflow execution) on
+the local machine by binding a controlled hostname to `127.0.0.1`
+and issuing requests against the loopback origin. The flaw has
+existed since the ops runner first shipped — it was not introduced
+by recent work — and was found while hardening the ops runner.
+
+- **DNS-rebinding fix** (#254). Validates the `Host` header on
+  every ops dashboard request and rejects anything that isn't a
+  recognized loopback address (`127.0.0.1`, `localhost`, `[::1]`).
+- **Cluster mode hardening** (#254). Additional defense-in-depth
+  for multi-worker setups; see the
+  [ops-security-hardening spec](docs/specs/ops-security-hardening/)
+  for the full design.
+
+#### Upgrade path
+
+```
+pip install --upgrade 'attune-ai'
+```
+
+If you previously pinned `attune-ai==6.7.0`, bump to `6.7.1`.
+No config changes required — the fix is on by default.
+
+### Also in this release
+
+These changes shipped between v6.7.0 and v6.7.1 and are included
+here so the patch isn't a security-only bundle:
+
+- Tier 1 rich rendering for workflow output (#247).
+- Full-page run view — workflow output now survives refresh (#251).
+- Specs tab in the ops dashboard (#236, #239, #240).
+- UX cleanup: humanized 409 responses, redundant tabs removed
+  (#228, #231).
+- `attune ops` now runs with run-enabled mode by default;
+  `--read-only` opts out (#227).
+
 ## [6.7.0] - 2026-05-11
 
 ### CI stabilization release — main fixes for a healthier test matrix

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 6.7.0
+**Version:** 6.7.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1226,5 +1226,5 @@ msg = format_error(
 
 ---
 
-**Version:** 6.7.0 | **License:** Apache 2.0
+**Version:** 6.7.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "6.7.0"
+    "version": "6.7.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "6.7.0",
+      "version": "6.7.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "6.7.0"
+__version__ = "6.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "6.7.0"
+version = "6.7.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "6.7.0"
+version = "6.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Patch release for the ops dashboard DNS-rebinding vulnerability fixed in #254, plus the UX changes that shipped between v6.7.0 and now.

**Users running `attune ops` should upgrade.** v6.7.1 fixes a DNS-rebinding vulnerability that allowed any visited website to invoke ops dashboard endpoints (including endpoints that trigger workflow execution) on the local machine. Pre-existing since the ops runner first shipped — not introduced by recent changes.

## Version bumps

- `pyproject.toml`, `uv.lock`
- `plugin/.claude-plugin/{plugin,marketplace}.json`
- `plugin/core/__init__.py`
- `.claude-plugin/marketplace.json` (root)
- `.claude/CLAUDE.md` (header + footer)
- `docs/reference/API_REFERENCE.md` (header + footer)

`test_all_versions_match` confirms parity.

## Changelog (highlights)

- **Security:** DNS-rebinding fix for ops dashboard (#254). Validates `Host` header against loopback set.
- Tier 1 rich rendering for workflow output (#247).
- Full-page run view (#251).
- Specs tab in ops dashboard (#236/#239/#240).
- UX cleanup: humanized 409s, redundant tabs removed (#228/#231).
- `attune ops` runs run-enabled by default; `--read-only` opts out (#227).

## Test plan

- [x] `pytest tests/unit/plugins/test_plugin_config_validation.py::TestVersionConsistency` passes locally
- [ ] CI green on this PR
- [ ] Tag `v6.7.1` on the merge commit after squash
- [ ] `publish-pypi.yml` approved and v6.7.1 live on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)