### PR TITLE
test(memory/security): meaningful coverage on query.py + reports.py [PoC]

### DIFF
--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,49 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — first PoC under test-quality-program spec (Opus 4.7)
+
+First module pair taken through the formalized playbook
+(`docs/specs/test-quality-program/`, spec PR #257).
+Paired PR: `memory/security/query.py` + `memory/security/reports.py`.
+Selected via rubric (top two scores in the working set: 3.99 and
+3.80, both data-handling 1.5× risk). **1 production bug surfaced.**
+
+- `memory/security/query.py` — **class 1** — a single audit log
+  line with a malformed `timestamp` aborted iteration. Inner
+  try-except caught only `JSONDecodeError`, so `ValueError` from
+  `datetime.fromisoformat()` propagated to the outer broad except
+  clause — the function logged once and returned whatever results
+  had accumulated so far. Symptom: a query with date filters
+  silently truncated its result set with no caller-visible
+  indication. Fix: per-line try/except for `(ValueError,
+  AttributeError)` inside the iteration loop, mirroring the
+  JSONDecodeError handler. Continues iteration on bad lines,
+  logs a warning per skip.
+
+**Coverage delta:**
+
+| Module | Before | After |
+|---|---|---|
+| `memory/security/query.py` | 11.2% | 100.00% |
+| `memory/security/reports.py` | 11.2% | 100.00% |
+
+**Tests:** 62 total (37 query, 25 reports). Real `AuditLogger`
+host instances against `tmp_path` — criterion-5 "real objects
+over mocks" of the meaningful-coverage definition. Determinism
+verified across 3 back-to-back runs and under `-n auto`
+alongside the full memory test subtree (1367 passed, no
+cross-test interference).
+
+**Notes on the second module:** `reports.py` surfaced no
+production bugs. Every defensive `.get(..., default)` path is
+real and reachable (the audit-log JSON shape isn't strictly
+enforced upstream so missing keys do happen in production). No
+Class 2 candidates. Demonstrates the spec's "absence of bugs is
+also data" observation from prior sessions.
+
+---
+
 ## 2026-05-09 — session 49e (Opus 4.7)
 
 Test-infrastructure spec executed (docs/specs/test-infrastructure/).

--- a/src/attune/memory/security/query.py
+++ b/src/attune/memory/security/query.py
@@ -90,13 +90,22 @@ class AuditQueryMixin:
                         if status and event.get("status") != status:
                             continue
 
-                        # Date range filtering
+                        # Date range filtering. A malformed timestamp on
+                        # one line must not abort iteration — without this
+                        # ValueError catch, a single bad event ends the
+                        # whole query and returns a silent partial result.
                         if start_date or end_date:
                             ts_raw = event.get("timestamp", "")
-                            # Handle both Z and +00:00 suffixes
-                            event_time = datetime.fromisoformat(
-                                ts_raw.replace("Z", "+00:00"),
-                            )
+                            try:
+                                event_time = datetime.fromisoformat(
+                                    ts_raw.replace("Z", "+00:00"),
+                                )
+                            except (ValueError, AttributeError):
+                                logger.warning(
+                                    "Skipping audit log line with " "malformed timestamp: %r",
+                                    ts_raw,
+                                )
+                                continue
                             if start_date and event_time < start_date:
                                 continue
                             if end_date and event_time > end_date:

--- a/tests/unit/memory/security/test_query.py
+++ b/tests/unit/memory/security/test_query.py
@@ -1,0 +1,489 @@
+"""Tests for `attune.memory.security.query.AuditQueryMixin`.
+
+Strategy: real `AuditLogger` instances against a `tmp_path` log
+file. The mixin requires `self.log_path`; constructing the real
+host class exercises the mixin in its production context with
+no mock surface to drift away from.
+
+Covers:
+- Public API: AuditQueryMixin.query() — every filter argument,
+  combinations, limit enforcement, malformed-line handling.
+- Edge cases: missing log file, empty file, unicode user_ids,
+  empty/None timestamps, mixed Z/+00:00 timezone suffixes,
+  multi-event partial matches under date filter.
+- Helper: `_apply_custom_filters` — every comparison operator
+  (gt/gte/lt/lte/ne/default), nested-key access, missing keys,
+  non-numeric operands.
+
+Copyright 2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from attune.memory.security.audit_logger import AuditLogger
+from attune.memory.security.query import _apply_custom_filters
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def logger(tmp_path: Path) -> AuditLogger:
+    """Real AuditLogger writing to a tmp_path-isolated log file."""
+    return AuditLogger(
+        log_dir=str(tmp_path),
+        log_filename="audit.jsonl",
+        enable_rotation=False,
+    )
+
+
+def _write_events(logger: AuditLogger, events: list[dict[str, Any]]) -> None:
+    """Append JSONL events directly to the logger's log file.
+
+    Bypasses AuditLogger's own write path so tests don't depend on
+    its serialization layer — we want to assert query semantics
+    against arbitrary on-disk content.
+    """
+    logger.log_path.parent.mkdir(parents=True, exist_ok=True)
+    with logger.log_path.open("a", encoding="utf-8") as f:
+        for event in events:
+            f.write(json.dumps(event) + "\n")
+
+
+def _ts(*, year: int = 2026, month: int = 5, day: int = 12, hour: int = 12) -> str:
+    """ISO timestamp helper for test event timestamps."""
+    return datetime(year, month, day, hour, tzinfo=timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# query() — file-presence edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestQueryFileEdgeCases:
+    def test_missing_log_file_returns_empty(self, logger: AuditLogger) -> None:
+        # AuditLogger.__init__ creates the log dir but not the file.
+        # If the file is missing, query() should return [], not raise.
+        if logger.log_path.exists():
+            logger.log_path.unlink()
+        assert logger.query() == []
+
+    def test_empty_log_file_returns_empty(self, logger: AuditLogger) -> None:
+        logger.log_path.write_text("", encoding="utf-8")
+        assert logger.query() == []
+
+    def test_log_with_only_blank_lines_returns_empty(self, logger: AuditLogger) -> None:
+        logger.log_path.write_text("\n\n\n", encoding="utf-8")
+        # Blank lines parse to JSON failures (json.loads("") raises);
+        # they should be skipped, returning [].
+        assert logger.query() == []
+
+
+# ---------------------------------------------------------------------------
+# query() — simple filter behaviors
+# ---------------------------------------------------------------------------
+
+
+class TestQueryFilters:
+    def test_no_filters_returns_all_events(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "llm_request", "timestamp": _ts()},
+                {"event_type": "store_pattern", "timestamp": _ts()},
+            ],
+        )
+        results = logger.query()
+        assert len(results) == 2
+
+    def test_filter_by_event_type(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "llm_request", "user_id": "alice"},
+                {"event_type": "store_pattern", "user_id": "alice"},
+                {"event_type": "llm_request", "user_id": "bob"},
+            ],
+        )
+        results = logger.query(event_type="llm_request")
+        assert len(results) == 2
+        assert all(e["event_type"] == "llm_request" for e in results)
+
+    def test_filter_by_user_id(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "llm_request", "user_id": "alice"},
+                {"event_type": "llm_request", "user_id": "bob"},
+            ],
+        )
+        results = logger.query(user_id="alice")
+        assert len(results) == 1
+        assert results[0]["user_id"] == "alice"
+
+    def test_filter_by_status(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "x", "status": "success"},
+                {"event_type": "x", "status": "failed"},
+                {"event_type": "x", "status": "blocked"},
+            ],
+        )
+        results = logger.query(status="blocked")
+        assert len(results) == 1
+        assert results[0]["status"] == "blocked"
+
+    def test_filter_combination_applies_AND(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "x", "user_id": "alice", "status": "success"},
+                {"event_type": "x", "user_id": "alice", "status": "failed"},
+                {"event_type": "y", "user_id": "alice", "status": "success"},
+            ],
+        )
+        results = logger.query(event_type="x", status="success")
+        assert len(results) == 1
+        assert results[0]["user_id"] == "alice"
+
+    def test_filter_with_no_matches_returns_empty(self, logger: AuditLogger) -> None:
+        _write_events(logger, [{"event_type": "llm_request"}])
+        assert logger.query(event_type="never_logged") == []
+
+    def test_unicode_user_id_filter(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "x", "user_id": "用户@例.com"},
+                {"event_type": "x", "user_id": "alice"},
+            ],
+        )
+        results = logger.query(user_id="用户@例.com")
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# query() — date range filtering (includes the Class 1 bug fix)
+# ---------------------------------------------------------------------------
+
+
+class TestQueryDateFilters:
+    def test_filter_by_start_date(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "x", "timestamp": _ts(day=10)},
+                {"event_type": "x", "timestamp": _ts(day=15)},
+                {"event_type": "x", "timestamp": _ts(day=20)},
+            ],
+        )
+        cutoff = datetime(2026, 5, 14, tzinfo=timezone.utc)
+        results = logger.query(start_date=cutoff)
+        assert len(results) == 2
+
+    def test_filter_by_end_date(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "x", "timestamp": _ts(day=10)},
+                {"event_type": "x", "timestamp": _ts(day=15)},
+                {"event_type": "x", "timestamp": _ts(day=20)},
+            ],
+        )
+        cutoff = datetime(2026, 5, 16, tzinfo=timezone.utc)
+        results = logger.query(end_date=cutoff)
+        assert len(results) == 2
+
+    def test_filter_by_date_range(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "x", "timestamp": _ts(day=10)},
+                {"event_type": "x", "timestamp": _ts(day=15)},
+                {"event_type": "x", "timestamp": _ts(day=20)},
+            ],
+        )
+        results = logger.query(
+            start_date=datetime(2026, 5, 12, tzinfo=timezone.utc),
+            end_date=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        )
+        assert len(results) == 1
+        # Day 15 falls inside the [12, 18] window.
+
+    def test_Z_suffix_timestamp_parses(self, logger: AuditLogger) -> None:
+        # Older audit producers wrote `2026-05-12T12:00:00Z` rather
+        # than the +00:00 form. The replace("Z", "+00:00") bridges
+        # both shapes on Python 3.10.
+        _write_events(
+            logger,
+            [{"event_type": "x", "timestamp": "2026-05-12T12:00:00Z"}],
+        )
+        results = logger.query(
+            start_date=datetime(2026, 5, 11, tzinfo=timezone.utc),
+        )
+        assert len(results) == 1
+
+    def test_malformed_timestamp_is_skipped_not_aborted(
+        self,
+        logger: AuditLogger,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Class 1 bug fix verification.
+
+        Before the fix, a single line with a malformed `timestamp`
+        raised ValueError from datetime.fromisoformat. The
+        ValueError propagated to the outer except clause, logged
+        once, and the function returned whatever results had
+        accumulated so far — silently truncating the result set.
+
+        After the fix, the malformed line is skipped and iteration
+        continues; the caller gets the complete matching set.
+        """
+        _write_events(
+            logger,
+            [
+                {"event_type": "x", "timestamp": _ts(day=10)},
+                {"event_type": "x", "timestamp": "not-a-timestamp"},
+                {"event_type": "x", "timestamp": _ts(day=20)},
+            ],
+        )
+        with caplog.at_level(logging.WARNING):
+            results = logger.query(
+                start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+        assert len(results) == 2, (
+            "the third (good) event must be reached after the bad "
+            "timestamp; pre-fix this returned 1 result, not 2"
+        )
+        assert any("malformed timestamp" in r.message for r in caplog.records)
+
+    def test_empty_string_timestamp_skipped(
+        self,
+        logger: AuditLogger,
+    ) -> None:
+        # event.get("timestamp", "") returns "" if absent; the empty
+        # string must be skipped, not raised on.
+        _write_events(
+            logger,
+            [
+                {"event_type": "x"},  # no timestamp at all
+                {"event_type": "x", "timestamp": _ts(day=15)},
+            ],
+        )
+        results = logger.query(
+            start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        assert len(results) == 1
+
+    def test_null_timestamp_skipped(self, logger: AuditLogger) -> None:
+        # JSON `null` deserializes to None; .replace() on None raises
+        # AttributeError, which the fix also catches.
+        _write_events(
+            logger,
+            [
+                {"event_type": "x", "timestamp": None},
+                {"event_type": "x", "timestamp": _ts(day=15)},
+            ],
+        )
+        results = logger.query(
+            start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# query() — limit and malformed-line handling
+# ---------------------------------------------------------------------------
+
+
+class TestQueryLimitAndRobustness:
+    def test_limit_caps_results(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [{"event_type": "x", "n": i} for i in range(10)],
+        )
+        results = logger.query(limit=3)
+        assert len(results) == 3
+
+    def test_filtered_lines_dont_count_against_limit(self, logger: AuditLogger) -> None:
+        # 10 events: 5 match, 5 don't. limit=4 means we get 4
+        # matches even though we read past 4 lines.
+        events: list[dict[str, Any]] = []
+        for i in range(10):
+            events.append({"event_type": "match" if i % 2 == 0 else "skip", "n": i})
+        _write_events(logger, events)
+        results = logger.query(event_type="match", limit=4)
+        assert len(results) == 4
+
+    def test_malformed_json_line_skipped(
+        self,
+        logger: AuditLogger,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        logger.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with logger.log_path.open("w", encoding="utf-8") as f:
+            f.write(json.dumps({"event_type": "good"}) + "\n")
+            f.write("{not valid json\n")
+            f.write(json.dumps({"event_type": "good"}) + "\n")
+        with caplog.at_level(logging.WARNING):
+            results = logger.query()
+        assert len(results) == 2
+        assert any("malformed audit log line" in r.message for r in caplog.records)
+
+    def test_io_error_returns_partial_results_not_raise(
+        self,
+        logger: AuditLogger,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Outer except handler: I/O errors on the log file must not
+        crash the query. Documented behavior is graceful degradation —
+        log the error, return whatever accumulated.
+
+        Simulating a real I/O failure cross-platform: replace
+        log_path with a directory after exists() check passes.
+        open() then raises IsADirectoryError, which the outer
+        Exception handler catches.
+        """
+        log_dir_as_file = tmp_path / "audit-as-dir"
+        log_dir_as_file.mkdir()
+        logger.log_path = log_dir_as_file
+        with caplog.at_level(logging.ERROR):
+            results = logger.query()
+        assert results == []
+        assert any("Failed to query audit logs" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _apply_custom_filters — comparison-operator dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestApplyCustomFilters:
+    def test_default_equality_match(self) -> None:
+        assert _apply_custom_filters({"status": "ok"}, {"status": "ok"})
+
+    def test_default_equality_mismatch(self) -> None:
+        assert not _apply_custom_filters({"status": "ok"}, {"status": "bad"})
+
+    def test_gt_operator(self) -> None:
+        event = {"score": 10}
+        assert _apply_custom_filters(event, {"score__gt": 5})
+        assert not _apply_custom_filters(event, {"score__gt": 10})  # not strict
+        assert not _apply_custom_filters(event, {"score__gt": 15})
+
+    def test_gte_operator(self) -> None:
+        event = {"score": 10}
+        assert _apply_custom_filters(event, {"score__gte": 10})
+        assert _apply_custom_filters(event, {"score__gte": 5})
+        assert not _apply_custom_filters(event, {"score__gte": 11})
+
+    def test_lt_operator(self) -> None:
+        event = {"score": 10}
+        assert _apply_custom_filters(event, {"score__lt": 11})
+        assert not _apply_custom_filters(event, {"score__lt": 10})  # not strict
+
+    def test_lte_operator(self) -> None:
+        event = {"score": 10}
+        assert _apply_custom_filters(event, {"score__lte": 10})
+        assert _apply_custom_filters(event, {"score__lte": 11})
+        assert not _apply_custom_filters(event, {"score__lte": 9})
+
+    def test_ne_operator(self) -> None:
+        event = {"status": "ok"}
+        assert _apply_custom_filters(event, {"status__ne": "bad"})
+        assert not _apply_custom_filters(event, {"status__ne": "ok"})
+
+    def test_nested_key_access(self) -> None:
+        event = {"security": {"pii_detected": 7}}
+        assert _apply_custom_filters(event, {"security__pii_detected": 7})
+        assert not _apply_custom_filters(event, {"security__pii_detected": 8})
+
+    def test_nested_key_with_operator(self) -> None:
+        event = {"security": {"pii_detected": 7}}
+        assert _apply_custom_filters(event, {"security__pii_detected__gt": 5})
+        assert not _apply_custom_filters(event, {"security__pii_detected__gt": 10})
+
+    def test_missing_nested_key_returns_false(self) -> None:
+        event = {"security": {}}
+        assert not _apply_custom_filters(event, {"security__pii_detected__gt": 0})
+
+    def test_missing_top_level_key_returns_false(self) -> None:
+        # event has no "security" key at all.
+        assert not _apply_custom_filters({}, {"security__pii_detected": 5})
+
+    def test_non_numeric_value_rejected_by_gt(self) -> None:
+        # gt/gte/lt/lte explicitly guard with isinstance(current,
+        # int | float). String operands return False rather than
+        # raising TypeError mid-iteration.
+        event = {"name": "alice"}
+        assert not _apply_custom_filters(event, {"name__gt": "alpha"})
+        assert not _apply_custom_filters(event, {"name__lt": "zzz"})
+
+    def test_multiple_filters_combined_AND(self) -> None:
+        event = {"a": 1, "b": 2}
+        assert _apply_custom_filters(event, {"a": 1, "b": 2})
+        assert not _apply_custom_filters(event, {"a": 1, "b": 3})
+
+    def test_empty_filters_passes(self) -> None:
+        # An event always matches an empty filter dict.
+        assert _apply_custom_filters({"anything": "here"}, {})
+
+
+# ---------------------------------------------------------------------------
+# query() — custom-filter integration with the rest of the pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestQueryWithCustomFilters:
+    def test_nested_custom_filter_via_query(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "llm_request",
+                    "security": {"pii_detected": 0},
+                },
+                {
+                    "event_type": "llm_request",
+                    "security": {"pii_detected": 8},
+                },
+            ],
+        )
+        results = logger.query(security__pii_detected__gt=5)
+        assert len(results) == 1
+        assert results[0]["security"]["pii_detected"] == 8
+
+    def test_custom_filter_combines_with_named_filters(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "llm_request",
+                    "user_id": "alice",
+                    "security": {"pii_detected": 10},
+                },
+                {
+                    "event_type": "store_pattern",
+                    "user_id": "alice",
+                    "security": {"pii_detected": 10},
+                },
+            ],
+        )
+        results = logger.query(
+            event_type="llm_request",
+            security__pii_detected__gt=5,
+        )
+        assert len(results) == 1
+        assert results[0]["event_type"] == "llm_request"

--- a/tests/unit/memory/security/test_reports.py
+++ b/tests/unit/memory/security/test_reports.py
@@ -1,0 +1,549 @@
+"""Tests for `attune.memory.security.reports.AuditReportMixin`.
+
+Strategy: real `AuditLogger` instances against a `tmp_path` log
+file. The mixin composes via `AuditLogger` which mixes in both
+`AuditQueryMixin` (for self.query()) and `AuditReportMixin`.
+
+Covers:
+- AuditReportMixin.get_violation_summary — empty log, single
+  user, multiple users, multi-severity, missing nested fields.
+- AuditReportMixin.get_compliance_report — period bounds,
+  every event_type branch (llm_request, store_pattern,
+  retrieve_pattern, security_violation), compliance metric
+  ratios, divide-by-zero guard on empty period.
+- Module-level helpers _process_llm_request,
+  _process_store_pattern, _process_retrieve_pattern,
+  _process_security_violation — direct calls so we can exercise
+  optional/missing fields without staging full event scenarios.
+
+Copyright 2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from attune.memory.security.audit_logger import AuditLogger
+from attune.memory.security.reports import (
+    _process_llm_request,
+    _process_retrieve_pattern,
+    _process_security_violation,
+    _process_store_pattern,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def logger(tmp_path: Path) -> AuditLogger:
+    return AuditLogger(
+        log_dir=str(tmp_path),
+        log_filename="audit.jsonl",
+        enable_rotation=False,
+    )
+
+
+def _write_events(logger: AuditLogger, events: list[dict[str, Any]]) -> None:
+    logger.log_path.parent.mkdir(parents=True, exist_ok=True)
+    with logger.log_path.open("a", encoding="utf-8") as f:
+        for event in events:
+            f.write(json.dumps(event) + "\n")
+
+
+def _empty_report() -> dict[str, Any]:
+    """Fresh report skeleton matching what get_compliance_report builds.
+
+    Used by the _process_* helper tests so we can exercise one
+    helper in isolation without going through the full report
+    pipeline.
+    """
+    return {
+        "llm_requests": {
+            "total": 0,
+            "with_pii_detected": 0,
+            "with_secrets_detected": 0,
+            "sanitization_applied": 0,
+        },
+        "pattern_storage": {
+            "total": 0,
+            "by_classification": {"PUBLIC": 0, "INTERNAL": 0, "SENSITIVE": 0},
+            "with_pii_scrubbed": 0,
+            "encrypted": 0,
+        },
+        "pattern_retrieval": {
+            "total": 0,
+            "by_classification": {"PUBLIC": 0, "INTERNAL": 0, "SENSITIVE": 0},
+            "access_denied": 0,
+        },
+        "security_violations": {"total": 0, "by_severity": {}, "by_type": {}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# get_violation_summary
+# ---------------------------------------------------------------------------
+
+
+class TestGetViolationSummary:
+    def test_empty_log_returns_zero_summary(self, logger: AuditLogger) -> None:
+        summary = logger.get_violation_summary()
+        assert summary == {
+            "total_violations": 0,
+            "by_type": {},
+            "by_severity": {},
+            "by_user": {},
+        }
+
+    def test_single_violation(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "security_violation",
+                    "user_id": "alice",
+                    "violation": {"type": "pii_leak", "severity": "high"},
+                },
+            ],
+        )
+        summary = logger.get_violation_summary()
+        assert summary["total_violations"] == 1
+        assert summary["by_type"] == {"pii_leak": 1}
+        assert summary["by_severity"] == {"high": 1}
+        assert summary["by_user"] == {"alice": 1}
+
+    def test_multiple_violations_aggregated(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "security_violation",
+                    "user_id": "alice",
+                    "violation": {"type": "pii_leak", "severity": "high"},
+                },
+                {
+                    "event_type": "security_violation",
+                    "user_id": "alice",
+                    "violation": {"type": "pii_leak", "severity": "medium"},
+                },
+                {
+                    "event_type": "security_violation",
+                    "user_id": "bob",
+                    "violation": {"type": "secrets", "severity": "high"},
+                },
+            ],
+        )
+        summary = logger.get_violation_summary()
+        assert summary["total_violations"] == 3
+        assert summary["by_type"] == {"pii_leak": 2, "secrets": 1}
+        assert summary["by_severity"] == {"high": 2, "medium": 1}
+        assert summary["by_user"] == {"alice": 2, "bob": 1}
+
+    def test_filter_by_user_id(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "security_violation",
+                    "user_id": "alice",
+                    "violation": {"type": "pii_leak", "severity": "high"},
+                },
+                {
+                    "event_type": "security_violation",
+                    "user_id": "bob",
+                    "violation": {"type": "secrets", "severity": "high"},
+                },
+            ],
+        )
+        summary = logger.get_violation_summary(user_id="alice")
+        assert summary["total_violations"] == 1
+        assert summary["by_user"] == {"alice": 1}
+
+    def test_non_violation_events_ignored(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {"event_type": "llm_request", "user_id": "alice"},
+                {"event_type": "store_pattern", "user_id": "alice"},
+                {
+                    "event_type": "security_violation",
+                    "user_id": "alice",
+                    "violation": {"type": "x", "severity": "low"},
+                },
+            ],
+        )
+        summary = logger.get_violation_summary()
+        assert summary["total_violations"] == 1
+
+    def test_missing_violation_subfields_default_to_unknown(self, logger: AuditLogger) -> None:
+        # Violation event with no `violation` sub-dict at all.
+        # The defensive `.get("violation", {}).get("type", "unknown")`
+        # path coerces missing fields to "unknown" rather than crashing.
+        _write_events(
+            logger,
+            [
+                {"event_type": "security_violation", "user_id": "alice"},
+            ],
+        )
+        summary = logger.get_violation_summary()
+        assert summary["total_violations"] == 1
+        assert summary["by_type"] == {"unknown": 1}
+        assert summary["by_severity"] == {"unknown": 1}
+
+    def test_non_string_violation_fields_coerced(self, logger: AuditLogger) -> None:
+        # `str(violation.get("violation", {}).get("type", "unknown"))`
+        # coerces any non-string value. Important because audit logs
+        # are JSON and could contain integer "type" codes.
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "security_violation",
+                    "user_id": "alice",
+                    "violation": {"type": 42, "severity": 1},
+                },
+            ],
+        )
+        summary = logger.get_violation_summary()
+        assert "42" in summary["by_type"]
+        assert "1" in summary["by_severity"]
+
+
+# ---------------------------------------------------------------------------
+# get_compliance_report — period bounds and structure
+# ---------------------------------------------------------------------------
+
+
+class TestComplianceReportStructure:
+    def test_empty_log_returns_zeroed_report(self, logger: AuditLogger) -> None:
+        report = logger.get_compliance_report()
+        assert report["period"] == {"start": "all_time", "end": "now"}
+        assert report["llm_requests"]["total"] == 0
+        assert report["pattern_storage"]["total"] == 0
+        assert report["pattern_retrieval"]["total"] == 0
+        assert report["security_violations"]["total"] == 0
+        # Divide-by-zero guard: rates stay 0.0 when no compliance
+        # events occurred in the period.
+        assert report["compliance_metrics"]["gdpr_compliant_rate"] == 0.0
+        assert report["compliance_metrics"]["hipaa_compliant_rate"] == 0.0
+        assert report["compliance_metrics"]["soc2_compliant_rate"] == 0.0
+
+    def test_period_uses_explicit_dates_when_given(self, logger: AuditLogger) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 6, 30, tzinfo=timezone.utc)
+        report = logger.get_compliance_report(start_date=start, end_date=end)
+        assert report["period"]["start"] == start.isoformat()
+        assert report["period"]["end"] == end.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# get_compliance_report — each event_type branch
+# ---------------------------------------------------------------------------
+
+
+class TestComplianceReportEventBranches:
+    def test_llm_request_counters(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "llm_request",
+                    "security": {
+                        "pii_detected": 2,
+                        "secrets_detected": 0,
+                        "sanitization_applied": True,
+                    },
+                },
+                {
+                    "event_type": "llm_request",
+                    "security": {
+                        "pii_detected": 0,
+                        "secrets_detected": 1,
+                        "sanitization_applied": False,
+                    },
+                },
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["llm_requests"]["total"] == 2
+        assert report["llm_requests"]["with_pii_detected"] == 1
+        assert report["llm_requests"]["with_secrets_detected"] == 1
+        assert report["llm_requests"]["sanitization_applied"] == 1
+
+    def test_store_pattern_counters(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "store_pattern",
+                    "pattern": {"classification": "SENSITIVE", "encrypted": True},
+                    "security": {"pii_scrubbed": 3},
+                },
+                {
+                    "event_type": "store_pattern",
+                    "pattern": {"classification": "PUBLIC", "encrypted": False},
+                    "security": {"pii_scrubbed": 0},
+                },
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["pattern_storage"]["total"] == 2
+        assert report["pattern_storage"]["by_classification"]["SENSITIVE"] == 1
+        assert report["pattern_storage"]["by_classification"]["PUBLIC"] == 1
+        assert report["pattern_storage"]["with_pii_scrubbed"] == 1
+        assert report["pattern_storage"]["encrypted"] == 1
+
+    def test_retrieve_pattern_counters(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "retrieve_pattern",
+                    "pattern": {"classification": "INTERNAL"},
+                    "access": {"granted": True},
+                },
+                {
+                    "event_type": "retrieve_pattern",
+                    "pattern": {"classification": "SENSITIVE"},
+                    "access": {"granted": False},
+                },
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["pattern_retrieval"]["total"] == 2
+        assert report["pattern_retrieval"]["by_classification"]["INTERNAL"] == 1
+        assert report["pattern_retrieval"]["by_classification"]["SENSITIVE"] == 1
+        assert report["pattern_retrieval"]["access_denied"] == 1
+
+    def test_retrieve_pattern_access_granted_default_true(self, logger: AuditLogger) -> None:
+        # When `access.granted` is missing, the helper defaults to
+        # True (not denying access just because the field is
+        # absent). This is an intentional defensive default.
+        _write_events(
+            logger,
+            [
+                {"event_type": "retrieve_pattern", "pattern": {}},
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["pattern_retrieval"]["access_denied"] == 0
+
+    def test_security_violation_counters(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "security_violation",
+                    "violation": {"type": "pii_leak", "severity": "high"},
+                },
+                {
+                    "event_type": "security_violation",
+                    "violation": {"type": "pii_leak", "severity": "medium"},
+                },
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["security_violations"]["total"] == 2
+        assert report["security_violations"]["by_type"]["pii_leak"] == 2
+        assert report["security_violations"]["by_severity"]["high"] == 1
+        assert report["security_violations"]["by_severity"]["medium"] == 1
+
+    def test_unknown_classification_extends_dict(self, logger: AuditLogger) -> None:
+        # Classifications outside the pre-seeded {PUBLIC, INTERNAL,
+        # SENSITIVE} should be added dynamically.
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "store_pattern",
+                    "pattern": {"classification": "CONFIDENTIAL", "encrypted": False},
+                    "security": {"pii_scrubbed": 0},
+                },
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["pattern_storage"]["by_classification"]["CONFIDENTIAL"] == 1
+
+    def test_missing_classification_defaults_to_INTERNAL(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "store_pattern",
+                    "pattern": {"encrypted": False},
+                    "security": {"pii_scrubbed": 0},
+                },
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["pattern_storage"]["by_classification"]["INTERNAL"] == 1
+
+    def test_unknown_event_type_ignored(self, logger: AuditLogger) -> None:
+        # Events with event_type not in the dispatch (llm_request,
+        # store_pattern, retrieve_pattern, security_violation) are
+        # silently skipped; only compliance fields still contribute
+        # to the rate calculation if present.
+        _write_events(
+            logger,
+            [
+                {"event_type": "future_event_type"},
+                {"event_type": "another_unknown"},
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["llm_requests"]["total"] == 0
+        assert report["pattern_storage"]["total"] == 0
+        assert report["pattern_retrieval"]["total"] == 0
+        assert report["security_violations"]["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# get_compliance_report — compliance metric rates
+# ---------------------------------------------------------------------------
+
+
+class TestComplianceMetrics:
+    def test_all_compliant_rates_are_1(self, logger: AuditLogger) -> None:
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "llm_request",
+                    "security": {},
+                    "compliance": {
+                        "gdpr_compliant": True,
+                        "hipaa_compliant": True,
+                        "soc2_compliant": True,
+                    },
+                },
+                {
+                    "event_type": "llm_request",
+                    "security": {},
+                    "compliance": {
+                        "gdpr_compliant": True,
+                        "hipaa_compliant": True,
+                        "soc2_compliant": True,
+                    },
+                },
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["compliance_metrics"]["gdpr_compliant_rate"] == 1.0
+        assert report["compliance_metrics"]["hipaa_compliant_rate"] == 1.0
+        assert report["compliance_metrics"]["soc2_compliant_rate"] == 1.0
+
+    def test_partial_compliance_rate(self, logger: AuditLogger) -> None:
+        # 2 of 4 GDPR-compliant → 0.5
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "llm_request",
+                    "security": {},
+                    "compliance": {"gdpr_compliant": True},
+                },
+                {
+                    "event_type": "llm_request",
+                    "security": {},
+                    "compliance": {"gdpr_compliant": True},
+                },
+                {
+                    "event_type": "llm_request",
+                    "security": {},
+                    "compliance": {"gdpr_compliant": False},
+                },
+                {
+                    "event_type": "llm_request",
+                    "security": {},
+                    "compliance": {"gdpr_compliant": False},
+                },
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["compliance_metrics"]["gdpr_compliant_rate"] == 0.5
+
+    def test_events_without_compliance_field_dont_count(self, logger: AuditLogger) -> None:
+        # Only events with a non-empty `compliance` dict contribute
+        # to total_compliance_checks; the rates therefore reflect
+        # actual compliance-tagged events, not all events.
+        _write_events(
+            logger,
+            [
+                {
+                    "event_type": "llm_request",
+                    "security": {},
+                    "compliance": {"gdpr_compliant": True},
+                },
+                {"event_type": "llm_request", "security": {}},
+            ],
+        )
+        report = logger.get_compliance_report()
+        assert report["compliance_metrics"]["gdpr_compliant_rate"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Module-level _process_* helpers
+# ---------------------------------------------------------------------------
+
+
+class TestProcessHelpers:
+    def test_process_llm_request_no_security_dict(self) -> None:
+        # Event has no `security` field at all — counters stay at
+        # their initial value except `total`.
+        report = _empty_report()
+        _process_llm_request(report, {"event_type": "llm_request"})
+        assert report["llm_requests"]["total"] == 1
+        assert report["llm_requests"]["with_pii_detected"] == 0
+        assert report["llm_requests"]["with_secrets_detected"] == 0
+        assert report["llm_requests"]["sanitization_applied"] == 0
+
+    def test_process_llm_request_with_zero_pii_count(self) -> None:
+        # `pii_detected: 0` must NOT increment the counter — the
+        # check is `> 0`, not truthy.
+        report = _empty_report()
+        _process_llm_request(
+            report,
+            {
+                "event_type": "llm_request",
+                "security": {"pii_detected": 0, "secrets_detected": 0},
+            },
+        )
+        assert report["llm_requests"]["with_pii_detected"] == 0
+        assert report["llm_requests"]["with_secrets_detected"] == 0
+
+    def test_process_store_pattern_no_classification(self) -> None:
+        # Missing classification defaults to "INTERNAL" via .get().
+        report = _empty_report()
+        _process_store_pattern(
+            report,
+            {"event_type": "store_pattern", "pattern": {}},
+        )
+        assert report["pattern_storage"]["by_classification"]["INTERNAL"] == 1
+
+    def test_process_retrieve_pattern_no_access_field(self) -> None:
+        # Missing `access` defaults to {}, and `.get("granted", True)`
+        # defaults to True → access NOT denied → counter unchanged.
+        report = _empty_report()
+        _process_retrieve_pattern(
+            report,
+            {"event_type": "retrieve_pattern", "pattern": {}},
+        )
+        assert report["pattern_retrieval"]["access_denied"] == 0
+        assert report["pattern_retrieval"]["total"] == 1
+
+    def test_process_security_violation_missing_subfields(self) -> None:
+        report = _empty_report()
+        _process_security_violation(
+            report,
+            {"event_type": "security_violation"},
+        )
+        assert report["security_violations"]["total"] == 1
+        assert report["security_violations"]["by_type"]["unknown"] == 1
+        assert report["security_violations"]["by_severity"]["unknown"] == 1


### PR DESCRIPTION
First proof-of-concept module taken through the test-quality-program playbook ([docs/specs/test-quality-program/](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/test-quality-program), spec PR #257). Paired PR: both files are in the same area and naturally scope together.

## Production fix

**Class 1 bug** in [`memory/security/query.py`](src/attune/memory/security/query.py): a single audit log line with a malformed `timestamp` aborted iteration. The inner try-except only caught `JSONDecodeError`, so `ValueError` from `datetime.fromisoformat()` propagated to the outer broad except clause. The function logged once and returned whatever results had accumulated so far — silently truncating the result set with no indication to the caller.

**Pre-fix reproduction:** a 3-event log with one bad timestamp returned 1 result instead of 3 under a `start_date` filter, plus a single `ERROR: Failed to query audit logs: Invalid isoformat string: 'not-a-timestamp'` on stderr.

**Fix:** wrap the date parsing in its own try/except inside the per-event loop, mirroring how `JSONDecodeError` is handled. Catch both `ValueError` (malformed string) and `AttributeError` (null timestamp from a JSON `null`). Log a warning per skip, continue iteration.

## Coverage delta

| File | Before | After |
|---|---|---|
| `memory/security/query.py` | 11.2% | **100.00%** |
| `memory/security/reports.py` | 11.2% | **100.00%** |

## Test summary

62 tests total (37 query + 25 reports). Strategy: real `AuditLogger` instances against `tmp_path` — no mocks of the mixin's host (criterion 5 of "meaningful coverage" per the spec). Events written directly as JSONL so tests assert query semantics against arbitrary on-disk content.

**`test_query.py`** covers: file-presence edge cases, every filter argument, AND combinations, unicode user_ids, date filters (start / end / range / Z-suffix), the bug-fix verification (malformed / empty / null timestamps), limit semantics, malformed-JSON skip, I/O error fallback (directory at log_path → `IsADirectoryError` → returns `[]` with logged error), `_apply_custom_filters` for every operator (gt/gte/lt/lte/ne/default), nested-key dispatch, missing-key handling, non-numeric guards.

**`test_reports.py`** covers: `get_violation_summary` empty / single / multi / user filter / missing subfields / non-string coercion; `get_compliance_report` structure / period bounds / every event_type branch / unknown classification dynamic add / unknown event_type ignored / access_granted default; compliance metric ratios (all-compliant / partial / events without compliance field); `_process_*` helpers directly for missing optional fields.

## Determinism

- 62 tests run in 0.23s solo
- 3 back-to-back full-suite runs reported identical results (zero flakes)
- Memory subdir under `-n auto`: 1367 passed, 47 skipped, 3 xfailed in 5.58s — new tests don't interfere with existing memory suite

## Test plan

- [x] Both new test files pass solo
- [x] No cross-test interference under `-n auto`
- [x] 100% line + branch coverage on both modules
- [x] Bug-fix path explicitly tested (skipped-line + warning log)
- [ ] CI matrix green across all platform combos
- [ ] Bug log entry visible in docs/COVERAGE_BUG_LOG.md

## Bug log entry

Updated `docs/COVERAGE_BUG_LOG.md` with the new session entry under "2026-05-12 — first PoC under test-quality-program spec". Records the Class 1 fix in query.py and the "0 bugs in reports.py — every defensive default is reachable" observation.

## Spec linkage

- Umbrella spec: PR #257 (still open)
- Playbook step (a)-(h) all executed; surfaced no rewrites of existing tests because there were none for these modules (only ~9 lines covered each pre-PR, all from incidental import-time loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)