### PR TITLE
test(memory/short_term): meaningful coverage on conflicts.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- **memory/short_term/conflicts.py**: meaningful coverage —
+  29 tests covering `ConflictNegotiation` (init, create, get,
+  resolve, list_active). 25.4% → 100% line + branch coverage
+  via real `BaseOperations(use_mock=True)` (no mocking of the
+  storage layer). Part of the test-quality-program (see
+  [docs/specs/test-quality-program/](docs/specs/test-quality-program/)).
+
+### Fixed
+
+- **memory/short_term/conflicts.py**: load-bearing comment in
+  `resolve_conflict` claimed resolved conflicts get a longer
+  TTL for audit; in reality active and resolved share
+  `TTLStrategy.CONFLICT_CONTEXT` (7d). Updated the comment to
+  match runtime behavior and note that long-term audit lives
+  in the stream, not Redis key TTL. Behavior unchanged.
+
 ## [6.7.1] - 2026-05-12
 
 ### Security — users running `attune ops` should upgrade

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,56 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — memory/short_term/conflicts.py (Opus 4.7)
+
+Second module through the test-quality-program playbook.
+Selected as top non-`workflows/` row in `rubric_cache.csv`
+(score 3.355, data-handling 1.5× risk, no WIP overlap, no
+dedicated test file existed). **1 Class 4 bug surfaced** —
+comment-only, behavior unchanged.
+
+- `memory/short_term/conflicts.py` — **class 4 (load-bearing
+  comment nobody re-validated)** — `resolve_conflict` had a
+  comment "Keep resolved conflicts longer for audit" above the
+  re-stash call, but the TTL passed (`TTLStrategy.CONFLICT_CONTEXT
+  = 7d`) is the same as the one used for active contexts in
+  `create_conflict_context`. No "longer" anywhere. The comment
+  would mislead an operator reasoning about audit retention into
+  thinking Redis TTL was load-bearing for that. Fix: rewrote the
+  comment to state the actual behavior (same TTL) and note that
+  long-term audit lives in the stream (`STREAM_ENTRY`), not in
+  conflict key longevity. Runtime behavior unchanged.
+
+**Coverage delta:**
+
+| Module | Before | After |
+|---|---|---|
+| `memory/short_term/conflicts.py` | 25.4% | 100.00% (55/55 stmts, 22/22 branches) |
+
+**Tests:** 29 total across 7 test classes (init, create-validation,
+create-persistence, get, resolve, list-active, end-to-end).
+Real `BaseOperations(use_mock=True)` for storage — exercises
+the actual JSON serialization, key-prefix layout, and TTL
+plumbing end-to-end. Determinism verified across 3 back-to-back
+serial runs and under `-n auto` alongside the full unit memory
+subtree (1396 passed, 47 skipped, 3 xfailed, no cross-test
+interference).
+
+**Test observations worth keeping:**
+
+- `list_active_conflicts` accepts a `credentials` arg but never
+  reads it. Documented as expected ("any tier can read") in the
+  docstring; locked in by a test that calls with `observer`.
+- `resolve_conflict` checks permissions before checking conflict
+  existence. Observer on a non-existent conflict → PermissionError,
+  not False. Locked in by `test_permission_check_runs_before_existence_check`.
+- `list_active_conflicts` silently skips empty-string values at
+  conflict-prefixed keys (`if raw:` check). Test
+  `test_skips_keys_with_falsy_raw` documents the resilience but
+  doesn't change behavior.
+
+---
+
 ## 2026-05-12 — first PoC under test-quality-program spec (Opus 4.7)
 
 First module pair taken through the formalized playbook

--- a/docs/specs/test-quality-program/NEXT_SESSION.md
+++ b/docs/specs/test-quality-program/NEXT_SESSION.md
@@ -1,0 +1,67 @@
+# Next Session — Quick Start
+
+Pickup card for the per-module loop. Pair with
+`design.md` (loop steps) and `requirements.md` (meaningful
+criteria + bug taxonomy).
+
+## Refresh the rubric
+
+Only if `rubric_cache.csv` is stale (>~2 weeks) or after a
+large refactor:
+
+```bash
+pytest tests/unit/ -n auto \
+  --cov=src/attune --cov-report=xml:/tmp/coverage.xml -q \
+  -m "not network and not integration"
+
+python3 scripts/score_test_quality.py /tmp/coverage.xml
+```
+
+Expected ~60s on a clean venv.
+
+## Pick a module
+
+Default: top non-`workflows/` row in `rubric_cache.csv`.
+
+Recommended candidates as of 2026-05-12:
+
+- `src/attune/memory/short_term/conflicts.py` — score 3.35,
+  25.4% covered, data-handling risk. No WIP overlap. No
+  dedicated test file yet.
+- `src/attune/ops/cli.py` — score 3.19, weight 5, 36.2%
+  covered. User-typed `attune ops` entry. Some coverage
+  at `tests/unit/ops/test_smoke.py`.
+
+Before picking anything under `src/attune/workflows/`,
+diff the local WIP branch — see
+`memory/project_wip_recovery_2026_05_11.md`.
+
+## Per-module loop
+
+From `design.md`:
+
+a. INVENTORY — coverage %, existing tests, markers
+b. READ — source first; identify behaviors and smells
+c. DETERMINISM — solo AND under `-n auto`
+d. FIX — production bugs (Class 1-4) + test-reliability (Class 5)
+e. TRIAGE — keep / rewrite / delete existing tests
+f. WRITE — new tests anchored to meaningful criteria
+g. VERIFY — meaningful + deterministic (3 back-to-back)
+h. SHIP — PR + CHANGELOG + `docs/COVERAGE_BUG_LOG.md` entry
+
+## Worktree gotcha
+
+`uv run attune <cmd>` serves the MAIN repo's source, not the
+worktree. When iterating on worktree code, run tests via the
+venv directly:
+
+```bash
+/Users/patrickroebuck/attune-ai/.venv/bin/python -m pytest \
+  tests/unit/<path> --no-header -q
+```
+
+## Scope guard
+
+One module per session is ambitious. One module + a real bug
+fix is the sweet spot. If a bug requires public-API change
+or touches >1 module, STOP and flag — don't fold silently.

--- a/src/attune/memory/short_term/conflicts.py
+++ b/src/attune/memory/short_term/conflicts.py
@@ -234,7 +234,9 @@ class ConflictNegotiation:
         context.resolution = resolution
 
         key = f"{self.PREFIX_CONFLICT}{conflict_id}"
-        # Keep resolved conflicts longer for audit
+        # Resolved conflicts re-stash with the same TTL as active
+        # (TTLStrategy.CONFLICT_CONTEXT = 7d). Long-term audit is
+        # delegated to the audit stream, not Redis key longevity.
         self._base._set(key, json.dumps(context.to_dict()), TTLStrategy.CONFLICT_CONTEXT.value)
 
         logger.info(

--- a/tests/unit/memory/short_term/test_conflicts.py
+++ b/tests/unit/memory/short_term/test_conflicts.py
@@ -1,0 +1,489 @@
+"""Tests for `attune.memory.short_term.conflicts.ConflictNegotiation`.
+
+Strategy: real `BaseOperations(use_mock=True)` instance for storage.
+The mock path is an in-memory dict, so we exercise the real
+serialization, TTL, and key-scan paths end-to-end without any
+network or Redis dependency. No mocking of `_get`/`_set`/`_keys`
+— if those drift, tests catch it.
+
+Covers:
+- Public API: __init__, create_conflict_context,
+  get_conflict_context, resolve_conflict, list_active_conflicts.
+- Permission paths: stage (CONTRIBUTOR+), validate (VALIDATOR+),
+  read (any tier).
+- Input validation: empty/whitespace conflict_id, non-dict
+  positions/interests.
+- Storage shape: persisted under PREFIX_CONFLICT, JSON-encoded,
+  round-trips via ConflictContext.to_dict / from_dict.
+- list_active_conflicts: filters resolved out, returns empty
+  when nothing is stored, handles other PREFIX_CONFLICT-keyed
+  entries that don't belong (defensive — _keys returns only
+  the conflict prefix so this is just round-trip).
+
+Copyright 2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from attune.memory.short_term.base import BaseOperations
+from attune.memory.short_term.conflicts import ConflictNegotiation
+from attune.memory.types import (
+    AccessTier,
+    AgentCredentials,
+    ConflictContext,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def base() -> BaseOperations:
+    """In-memory BaseOperations — no Redis required."""
+    return BaseOperations(use_mock=True)
+
+
+@pytest.fixture
+def negotiation(base: BaseOperations) -> ConflictNegotiation:
+    return ConflictNegotiation(base)
+
+
+@pytest.fixture
+def observer() -> AgentCredentials:
+    return AgentCredentials("observer_1", AccessTier.OBSERVER)
+
+
+@pytest.fixture
+def contributor() -> AgentCredentials:
+    return AgentCredentials("contributor_1", AccessTier.CONTRIBUTOR)
+
+
+@pytest.fixture
+def validator() -> AgentCredentials:
+    return AgentCredentials("validator_1", AccessTier.VALIDATOR)
+
+
+@pytest.fixture
+def steward() -> AgentCredentials:
+    return AgentCredentials("steward_1", AccessTier.STEWARD)
+
+
+def _positions() -> dict[str, str]:
+    return {"agent_a": "Use Redis", "agent_b": "Use SQLite"}
+
+
+def _interests() -> dict[str, list[str]]:
+    return {"agent_a": ["speed", "scale"], "agent_b": ["simplicity"]}
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_stores_base_reference(self, base: BaseOperations) -> None:
+        negotiation = ConflictNegotiation(base)
+        assert negotiation._base is base
+
+    def test_prefix_constant_matches_key_layout(self) -> None:
+        # The class-level prefix must keep parity with what
+        # BaseOperations namespaces conflicts under, so other
+        # callers scanning the global namespace see the same set.
+        assert ConflictNegotiation.PREFIX_CONFLICT == "empathy:conflict:"
+        assert ConflictNegotiation.PREFIX_CONFLICT == BaseOperations.PREFIX_CONFLICT
+
+
+# ---------------------------------------------------------------------------
+# create_conflict_context — validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateValidation:
+    def test_empty_id_raises_value_error(
+        self, negotiation: ConflictNegotiation, contributor: AgentCredentials
+    ) -> None:
+        with pytest.raises(ValueError, match="conflict_id cannot be empty"):
+            negotiation.create_conflict_context(
+                "", positions=_positions(), interests=_interests(), credentials=contributor
+            )
+
+    def test_whitespace_id_raises_value_error(
+        self, negotiation: ConflictNegotiation, contributor: AgentCredentials
+    ) -> None:
+        with pytest.raises(ValueError, match="conflict_id cannot be empty"):
+            negotiation.create_conflict_context(
+                "   ",
+                positions=_positions(),
+                interests=_interests(),
+                credentials=contributor,
+            )
+
+    def test_non_dict_positions_raises_type_error(
+        self, negotiation: ConflictNegotiation, contributor: AgentCredentials
+    ) -> None:
+        with pytest.raises(TypeError, match="positions must be dict"):
+            negotiation.create_conflict_context(
+                "c1",
+                positions=["agent_a", "Redis"],  # type: ignore[arg-type]
+                interests=_interests(),
+                credentials=contributor,
+            )
+
+    def test_non_dict_interests_raises_type_error(
+        self, negotiation: ConflictNegotiation, contributor: AgentCredentials
+    ) -> None:
+        with pytest.raises(TypeError, match="interests must be dict"):
+            negotiation.create_conflict_context(
+                "c1",
+                positions=_positions(),
+                interests="agent_a wants speed",  # type: ignore[arg-type]
+                credentials=contributor,
+            )
+
+    def test_observer_cannot_create(
+        self, negotiation: ConflictNegotiation, observer: AgentCredentials
+    ) -> None:
+        with pytest.raises(PermissionError, match="CONTRIBUTOR tier or higher"):
+            negotiation.create_conflict_context(
+                "c1", positions=_positions(), interests=_interests(), credentials=observer
+            )
+
+    def test_validation_order_id_before_types(
+        self, negotiation: ConflictNegotiation, contributor: AgentCredentials
+    ) -> None:
+        # Empty id is checked before positions/interests type, so
+        # an empty id with bad positions still surfaces as ValueError.
+        # Locks in the order so callers can rely on it.
+        with pytest.raises(ValueError, match="conflict_id cannot be empty"):
+            negotiation.create_conflict_context(
+                "",
+                positions="not a dict",  # type: ignore[arg-type]
+                interests=_interests(),
+                credentials=contributor,
+            )
+
+    def test_validation_order_types_before_permissions(
+        self, negotiation: ConflictNegotiation, observer: AgentCredentials
+    ) -> None:
+        # Type errors fire before permission check, so an Observer
+        # with non-dict positions gets TypeError, not PermissionError.
+        with pytest.raises(TypeError, match="positions must be dict"):
+            negotiation.create_conflict_context(
+                "c1",
+                positions="bad",  # type: ignore[arg-type]
+                interests=_interests(),
+                credentials=observer,
+            )
+
+
+# ---------------------------------------------------------------------------
+# create_conflict_context — happy path + persistence
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePersistence:
+    def test_returns_context_with_inputs(
+        self, negotiation: ConflictNegotiation, contributor: AgentCredentials
+    ) -> None:
+        context = negotiation.create_conflict_context(
+            "c1",
+            positions=_positions(),
+            interests=_interests(),
+            credentials=contributor,
+        )
+        assert context.conflict_id == "c1"
+        assert context.positions == _positions()
+        assert context.interests == _interests()
+        assert context.batna is None
+        assert context.resolved is False
+        assert context.resolution is None
+
+    def test_batna_is_stored(
+        self, negotiation: ConflictNegotiation, contributor: AgentCredentials
+    ) -> None:
+        context = negotiation.create_conflict_context(
+            "c1",
+            positions=_positions(),
+            interests=_interests(),
+            credentials=contributor,
+            batna="Use file-based storage",
+        )
+        assert context.batna == "Use file-based storage"
+
+    def test_persists_under_prefix_conflict(
+        self,
+        base: BaseOperations,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+    ) -> None:
+        negotiation.create_conflict_context(
+            "c1", positions=_positions(), interests=_interests(), credentials=contributor
+        )
+        raw = base._get("empathy:conflict:c1")
+        assert raw is not None
+        payload = json.loads(raw)
+        assert payload["conflict_id"] == "c1"
+        assert payload["positions"] == _positions()
+        assert payload["resolved"] is False
+
+    def test_validator_and_steward_can_create(
+        self,
+        negotiation: ConflictNegotiation,
+        validator: AgentCredentials,
+        steward: AgentCredentials,
+    ) -> None:
+        # Both higher tiers also satisfy can_stage().
+        negotiation.create_conflict_context(
+            "by_validator", positions=_positions(), interests=_interests(), credentials=validator
+        )
+        negotiation.create_conflict_context(
+            "by_steward", positions=_positions(), interests=_interests(), credentials=steward
+        )
+        assert negotiation.get_conflict_context("by_validator", validator) is not None
+        assert negotiation.get_conflict_context("by_steward", steward) is not None
+
+
+# ---------------------------------------------------------------------------
+# get_conflict_context
+# ---------------------------------------------------------------------------
+
+
+class TestGetConflictContext:
+    def test_missing_returns_none(
+        self, negotiation: ConflictNegotiation, observer: AgentCredentials
+    ) -> None:
+        assert negotiation.get_conflict_context("never_created", observer) is None
+
+    def test_empty_id_raises_value_error(
+        self, negotiation: ConflictNegotiation, observer: AgentCredentials
+    ) -> None:
+        with pytest.raises(ValueError, match="conflict_id cannot be empty"):
+            negotiation.get_conflict_context("", observer)
+
+    def test_whitespace_id_raises_value_error(
+        self, negotiation: ConflictNegotiation, observer: AgentCredentials
+    ) -> None:
+        with pytest.raises(ValueError, match="conflict_id cannot be empty"):
+            negotiation.get_conflict_context("\t  ", observer)
+
+    def test_round_trip_preserves_fields(
+        self,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+        observer: AgentCredentials,
+    ) -> None:
+        original = negotiation.create_conflict_context(
+            "round_trip",
+            positions=_positions(),
+            interests=_interests(),
+            credentials=contributor,
+            batna="fallback",
+        )
+        # Any tier can read.
+        fetched = negotiation.get_conflict_context("round_trip", observer)
+        assert fetched is not None
+        assert fetched.conflict_id == original.conflict_id
+        assert fetched.positions == original.positions
+        assert fetched.interests == original.interests
+        assert fetched.batna == original.batna
+        assert fetched.resolved is False
+        assert fetched.resolution is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_conflict
+# ---------------------------------------------------------------------------
+
+
+class TestResolveConflict:
+    def test_observer_cannot_resolve(
+        self,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+        observer: AgentCredentials,
+    ) -> None:
+        negotiation.create_conflict_context(
+            "c1", positions=_positions(), interests=_interests(), credentials=contributor
+        )
+        with pytest.raises(PermissionError, match="VALIDATOR tier or higher"):
+            negotiation.resolve_conflict("c1", "answer", observer)
+
+    def test_contributor_cannot_resolve(
+        self,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+    ) -> None:
+        # Contributors can create but not resolve — locks in the
+        # separation of stage vs validate access.
+        negotiation.create_conflict_context(
+            "c1", positions=_positions(), interests=_interests(), credentials=contributor
+        )
+        with pytest.raises(PermissionError, match="VALIDATOR tier or higher"):
+            negotiation.resolve_conflict("c1", "answer", contributor)
+
+    def test_permission_check_runs_before_existence_check(
+        self,
+        negotiation: ConflictNegotiation,
+        observer: AgentCredentials,
+    ) -> None:
+        # No conflict stored; observer gets PermissionError, not False.
+        # Documents the ordering: permission first, lookup second.
+        with pytest.raises(PermissionError, match="VALIDATOR tier or higher"):
+            negotiation.resolve_conflict("never_created", "answer", observer)
+
+    def test_missing_conflict_returns_false(
+        self, negotiation: ConflictNegotiation, validator: AgentCredentials
+    ) -> None:
+        assert negotiation.resolve_conflict("never_created", "answer", validator) is False
+
+    def test_resolves_and_persists(
+        self,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+        validator: AgentCredentials,
+    ) -> None:
+        negotiation.create_conflict_context(
+            "c1", positions=_positions(), interests=_interests(), credentials=contributor
+        )
+        assert negotiation.resolve_conflict("c1", "Chose Redis", validator) is True
+
+        fetched = negotiation.get_conflict_context("c1", validator)
+        assert fetched is not None
+        assert fetched.resolved is True
+        assert fetched.resolution == "Chose Redis"
+
+    def test_resolve_propagates_id_validation(
+        self, negotiation: ConflictNegotiation, validator: AgentCredentials
+    ) -> None:
+        # resolve_conflict delegates id validation to
+        # get_conflict_context. Empty id should still raise.
+        with pytest.raises(ValueError, match="conflict_id cannot be empty"):
+            negotiation.resolve_conflict("", "answer", validator)
+
+    def test_steward_can_resolve(
+        self,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+        steward: AgentCredentials,
+    ) -> None:
+        negotiation.create_conflict_context(
+            "by_contrib",
+            positions=_positions(),
+            interests=_interests(),
+            credentials=contributor,
+        )
+        assert negotiation.resolve_conflict("by_contrib", "Chose X", steward) is True
+
+
+# ---------------------------------------------------------------------------
+# list_active_conflicts
+# ---------------------------------------------------------------------------
+
+
+class TestListActiveConflicts:
+    def test_empty_when_nothing_stored(
+        self, negotiation: ConflictNegotiation, observer: AgentCredentials
+    ) -> None:
+        assert negotiation.list_active_conflicts(observer) == []
+
+    def test_returns_only_unresolved(
+        self,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+        validator: AgentCredentials,
+        observer: AgentCredentials,
+    ) -> None:
+        for cid in ("c1", "c2", "c3"):
+            negotiation.create_conflict_context(
+                cid,
+                positions=_positions(),
+                interests=_interests(),
+                credentials=contributor,
+            )
+        # Resolve c2 only.
+        negotiation.resolve_conflict("c2", "answer", validator)
+
+        active = negotiation.list_active_conflicts(observer)
+        active_ids = sorted(c.conflict_id for c in active)
+        assert active_ids == ["c1", "c3"]
+        # And every returned entry is genuinely unresolved.
+        assert all(c.resolved is False for c in active)
+
+    def test_empty_when_all_resolved(
+        self,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+        validator: AgentCredentials,
+    ) -> None:
+        negotiation.create_conflict_context(
+            "c1", positions=_positions(), interests=_interests(), credentials=contributor
+        )
+        negotiation.resolve_conflict("c1", "answer", validator)
+        assert negotiation.list_active_conflicts(validator) == []
+
+    def test_skips_keys_with_falsy_raw(
+        self,
+        base: BaseOperations,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+        validator: AgentCredentials,
+    ) -> None:
+        # A conflict-prefixed key whose value is the empty string
+        # is silently skipped by `if raw:` (line ~267). Documents
+        # the resilience: list_active_conflicts does not crash on
+        # an empty/None entry, it just drops it.
+        negotiation.create_conflict_context(
+            "c1", positions=_positions(), interests=_interests(), credentials=contributor
+        )
+        base._set("empathy:conflict:empty_value", "", ttl=60)
+
+        active = negotiation.list_active_conflicts(validator)
+        assert [c.conflict_id for c in active] == ["c1"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-method invariants
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_create_then_resolve_then_list_then_get(
+        self,
+        negotiation: ConflictNegotiation,
+        contributor: AgentCredentials,
+        validator: AgentCredentials,
+    ) -> None:
+        # Full lifecycle in one path.
+        created = negotiation.create_conflict_context(
+            "lifecycle",
+            positions=_positions(),
+            interests=_interests(),
+            credentials=contributor,
+            batna="fallback",
+        )
+        assert isinstance(created, ConflictContext)
+
+        # Not yet resolved → appears in list.
+        active_before = negotiation.list_active_conflicts(validator)
+        assert any(c.conflict_id == "lifecycle" for c in active_before)
+
+        # Resolve it.
+        assert negotiation.resolve_conflict("lifecycle", "go", validator) is True
+
+        # No longer in active list.
+        active_after = negotiation.list_active_conflicts(validator)
+        assert not any(c.conflict_id == "lifecycle" for c in active_after)
+
+        # But still fetchable, with resolution preserved.
+        fetched = negotiation.get_conflict_context("lifecycle", validator)
+        assert fetched is not None
+        assert fetched.resolved is True
+        assert fetched.resolution == "go"
+        assert fetched.batna == "fallback"


### PR DESCRIPTION
## Summary

Second module through the test-quality-program playbook ([umbrella spec](docs/specs/test-quality-program/), PR #257). First PoC was PR #259.

**Module:** `src/attune/memory/short_term/conflicts.py`
**Coverage:** 25.4% → **100%** (55/55 stmts, 22/22 branches)
**Tests added:** 29 across 7 classes (init, create-validation, create-persistence, get, resolve, list-active, end-to-end)

## Bug surfaced

One **Class 4** finding (load-bearing comment nobody re-validated). `resolve_conflict` had a comment claiming resolved conflicts get a longer TTL for audit, but the call uses the same `TTLStrategy.CONFLICT_CONTEXT` value (7d) that `create_conflict_context` uses. The comment would mislead an operator reasoning about audit retention. Rewrote the comment to state actual behavior; **runtime unchanged**.

Logged in [docs/COVERAGE_BUG_LOG.md](docs/COVERAGE_BUG_LOG.md).

## Test approach

Real `BaseOperations(use_mock=True)` for storage — no mocking of `_get`/`_set`/`_keys`. The mock path is an in-memory dict so JSON serialization, key-prefix layout, and TTL plumbing are exercised end-to-end. Matches the criterion-5 "real objects over mocks" in the meaningful-coverage definition.

Test observations now locked in:

- `list_active_conflicts` accepts `credentials` but never reads it (docstring says "any tier can read").
- `resolve_conflict` checks permissions before existence: Observer on a missing conflict → PermissionError, not False.
- `list_active_conflicts` silently skips empty-string values at conflict-prefixed keys (`if raw:`).

## Test plan

- [x] 29/29 pass solo (3x back-to-back, `-n 0`)
- [x] 1396 passed / 47 skipped / 3 xfailed in full unit memory subtree under `-n auto` (no cross-test interference)
- [x] No regression in adjacent `tests/memory/test_short_term.py` (94 passed combined)
- [x] Pre-commit clean (black, ruff, bandit, ruff BLE check)
- [x] CHANGELOG `[Unreleased]` updated
- [x] COVERAGE_BUG_LOG appended
- [x] NEXT_SESSION.md added so the per-module loop can pick up cold next time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
