### PR TITLE
test(ops/cli): meaningful coverage on attune ops entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: third module through the playbook —
+  `ops/cli.py` (`attune ops` user-typed entry point).
+  Coverage 36.2% → 100% line+branch. 19 deterministic tests
+  added under `tests/unit/ops/test_cli.py` covering argparse
+  schema, uvicorn dependency handling (`ImportError` → exit
+  code 2), happy-path config construction, `--read-only` flag,
+  `0.0.0.0` bind warning behavior, browser launch / suppression
+  / best-effort failure swallow, `main()` standalone entry.
+  Zero production bugs surfaced.
 - Test-quality-program: second module through the playbook —
   `memory/short_term/conflicts.py` (`ConflictNegotiation`).
   Coverage 25.4% → 100% line+branch. 44 deterministic tests

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,38 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — third module under test-quality-program (Opus 4.7)
+
+Third module run, first weight-5 (user-typed entry) pick. Selected
+via the rubric working set after `memory/short_term/conflicts.py`
+shipped (`ops/cli.py`, score 3.19). **0 production bugs surfaced.**
+
+- `ops/cli.py` (`attune ops` entry) — no bugs. Module is a thin
+  argparse + uvicorn launcher (151 lines). Two minor style smells
+  noted but not fixed in this PR: (a) line 82 imports uvicorn just
+  to check availability and line 135 re-imports — redundant but
+  cheap due to Python's import cache; (b) line 146
+  `parser.parse_args(["ops", *sys.argv[1:]])` could double-inject
+  "ops" if a user runs `python -m attune.ops ops --port 8000`,
+  but the case is unrealistic. Not in scope.
+
+**Coverage delta:** 36.2% → 100.00% (line + branch).
+
+**Tests:** 19 added under `tests/unit/ops/test_cli.py`. Real
+argparse, real `build_config`, real `create_app`. Only `uvicorn.run`
+(would block) and `webbrowser.open` (would open real browser)
+patched. Determinism verified across 3 back-to-back runs and under
+`-n auto` alongside the full ops test subtree (142 passed, no
+cross-test interference).
+
+**Pattern observation:** weight-5 modules surfaced no bugs while
+weight-3 data-handling modules surfaced 1 in 2 sessions. Early but
+suggestive — customer-facing entry points tend to be defensively
+written. The bug-hunt yield concentrates in composed helpers, not
+in user-typed entry points. Worth re-evaluating after 5+ modules.
+
+---
+
 ## 2026-05-12 — second module under test-quality-program (Opus 4.7)
 
 Second module run after the PoC. Selected via the rubric working

--- a/tests/unit/ops/test_cli.py
+++ b/tests/unit/ops/test_cli.py
@@ -1,0 +1,349 @@
+"""Tests for `attune.ops.cli` — the `attune ops` CLI entrypoint.
+
+Strategy: real argparse, real `build_config`, real `create_app`.
+The two unavoidable patches are:
+- `uvicorn.run` — would block the test indefinitely otherwise.
+- `webbrowser.open` — would actually open a browser tab.
+
+Covers:
+- `add_subparser`: every argument's default, type, action, and
+  repeatability. `--allow-run` accepts as a backwards-compat
+  no-op. `--specs-root` and `--trusted-host` accumulate via
+  `action="append"`.
+- `cmd_ops`: missing uvicorn → exit code 2 + stderr message;
+  happy path constructs config and invokes uvicorn.run with
+  the right host/port; --read-only flips allow_run off;
+  --host=0.0.0.0 without --trusted-host triggers the
+  middleware warning; --host=0.0.0.0 WITH --trusted-host is
+  silent; --no-browser suppresses webbrowser.open;
+  webbrowser.open failure is swallowed (best-effort).
+- `main`: dispatches to cmd_ops with "ops" injected at argv[0]
+  position. Exit code propagates.
+
+Copyright 2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from attune.ops import cli as ops_cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parser() -> argparse.ArgumentParser:
+    """Build a fresh ArgumentParser with the ops subparser attached."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    ops_cli.add_subparser(sub)
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# add_subparser — argument schema lockdown
+# ---------------------------------------------------------------------------
+
+
+class TestAddSubparser:
+    def test_defaults(self) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(["ops"])
+        assert args.host == "127.0.0.1"
+        assert args.port == 8765
+        assert args.project_root is None
+        assert args.no_browser is False
+        assert args.read_only is False
+        assert args.specs_root is None
+        assert args.trusted_host is None
+        assert args.allow_run is False
+
+    def test_port_coerced_to_int(self) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--port", "9000"])
+        assert args.port == 9000
+        assert isinstance(args.port, int)
+
+    def test_project_root_coerced_to_path(self, tmp_path: Path) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--project-root", str(tmp_path)])
+        assert args.project_root == tmp_path
+        assert isinstance(args.project_root, Path)
+
+    def test_specs_root_repeatable(self, tmp_path: Path) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--specs-root", str(a), "--specs-root", str(b)])
+        assert args.specs_root == [a, b]
+
+    def test_trusted_host_repeatable(self) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(
+            [
+                "ops",
+                "--trusted-host",
+                "tunnel.example.com",
+                "--trusted-host",
+                "other.example.com:9000",
+            ]
+        )
+        assert args.trusted_host == ["tunnel.example.com", "other.example.com:9000"]
+
+    def test_boolean_flags(self) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--no-browser", "--read-only", "--allow-run"])
+        assert args.no_browser is True
+        assert args.read_only is True
+        assert args.allow_run is True
+
+    def test_allow_run_is_hidden_in_help(self) -> None:
+        # --allow-run kept as a no-op for back-compat; SUPPRESS
+        # keeps it out of `--help` output.
+        parser = _make_parser()
+        help_text = parser.format_help()
+        assert "--allow-run" not in help_text
+
+
+# ---------------------------------------------------------------------------
+# cmd_ops — uvicorn dependency handling
+# ---------------------------------------------------------------------------
+
+
+class TestCmdOpsUvicornImport:
+    def test_missing_uvicorn_returns_2_and_prints_stderr(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Simulate uvicorn missing: monkey-patch the import to
+        # raise ImportError when the function body tries it.
+        parser = _make_parser()
+        args = parser.parse_args(["ops"])
+
+        with patch.dict(sys.modules, {"uvicorn": None}):
+            rc = ops_cli.cmd_ops(args)
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "requires extra dependencies" in err
+        assert "attune-ai[ops]" in err
+
+
+# ---------------------------------------------------------------------------
+# cmd_ops — happy path (uvicorn.run patched to no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdOpsHappyPath:
+    def test_default_run_invokes_uvicorn_with_config(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--no-browser", "--project-root", str(tmp_path)])
+
+        with patch("uvicorn.run") as mock_run:
+            rc = ops_cli.cmd_ops(args)
+
+        assert rc == 0
+        mock_run.assert_called_once()
+        # Positional `app` plus host/port kwargs.
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["host"] == "127.0.0.1"
+        assert kwargs["port"] == 8765
+        assert kwargs["log_level"] == "info"
+
+        # Banner emits the URL + config details on stdout.
+        out = capsys.readouterr().out
+        assert "http://127.0.0.1:8765" in out
+        assert "allow-run: on" in out
+
+    def test_read_only_flips_allow_run_off(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(
+            [
+                "ops",
+                "--no-browser",
+                "--read-only",
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        with patch("uvicorn.run"):
+            rc = ops_cli.cmd_ops(args)
+        assert rc == 0
+        assert "allow-run: off" in capsys.readouterr().out
+
+    def test_custom_host_and_port(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(
+            [
+                "ops",
+                "--no-browser",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "9999",
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        with patch("uvicorn.run") as mock_run:
+            ops_cli.cmd_ops(args)
+        assert mock_run.call_args.kwargs["port"] == 9999
+        assert "http://127.0.0.1:9999" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# cmd_ops — 0.0.0.0 warning
+# ---------------------------------------------------------------------------
+
+
+class TestCmdOpsBindWarning:
+    def test_zero_zero_zero_zero_without_trusted_host_warns(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(
+            [
+                "ops",
+                "--no-browser",
+                "--host",
+                "0.0.0.0",  # nosec B104
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        with patch("uvicorn.run"):
+            ops_cli.cmd_ops(args)
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "0.0.0.0" in err
+        assert "--trusted-host" in err
+
+    def test_zero_zero_zero_zero_with_trusted_host_silent(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(
+            [
+                "ops",
+                "--no-browser",
+                "--host",
+                "0.0.0.0",  # nosec B104
+                "--trusted-host",
+                "example.com",
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        with patch("uvicorn.run"):
+            ops_cli.cmd_ops(args)
+        err = capsys.readouterr().err
+        # No bind warning — user opted in by naming an external host.
+        assert "WARNING" not in err
+
+    def test_loopback_host_no_warning(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Default 127.0.0.1 should never emit the 0.0.0.0 warning,
+        # regardless of trusted-host presence.
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--no-browser", "--project-root", str(tmp_path)])
+        with patch("uvicorn.run"):
+            ops_cli.cmd_ops(args)
+        assert "WARNING" not in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# cmd_ops — browser launch
+# ---------------------------------------------------------------------------
+
+
+class TestCmdOpsBrowser:
+    def test_no_browser_flag_suppresses_open(self, tmp_path: Path) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--no-browser", "--project-root", str(tmp_path)])
+        with patch("uvicorn.run"), patch("webbrowser.open") as mock_open:
+            ops_cli.cmd_ops(args)
+        mock_open.assert_not_called()
+
+    def test_default_opens_browser(self, tmp_path: Path) -> None:
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--project-root", str(tmp_path)])
+        with patch("uvicorn.run"), patch("webbrowser.open") as mock_open:
+            ops_cli.cmd_ops(args)
+        mock_open.assert_called_once()
+        # URL passed matches the printed banner shape.
+        assert "127.0.0.1:8765" in mock_open.call_args.args[0]
+
+    def test_browser_failure_is_swallowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # `webbrowser.open` can raise on headless systems or with
+        # broken X11. The function catches Exception broadly and
+        # continues — documented as best-effort.
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--project-root", str(tmp_path)])
+        with patch("uvicorn.run"), patch("webbrowser.open", side_effect=RuntimeError("no DISPLAY")):
+            rc = ops_cli.cmd_ops(args)
+        # Crucially: function still returns 0 and reaches uvicorn.run.
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# main() — standalone entry
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_main_dispatches_to_cmd_ops(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # main() injects "ops" before sys.argv[1:]. Patch sys.argv
+        # to drive the dispatch.
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["attune-ops", "--no-browser", "--project-root", str(tmp_path)],
+        )
+        with patch("uvicorn.run") as mock_run:
+            rc = ops_cli.main()
+        assert rc == 0
+        mock_run.assert_called_once()
+
+    def test_main_propagates_exit_code(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # When uvicorn is missing, cmd_ops returns 2 — main()
+        # must surface that exit code, not swallow it.
+        monkeypatch.setattr(sys, "argv", ["attune-ops"])
+        with patch.dict(sys.modules, {"uvicorn": None}):
+            rc = ops_cli.main()
+        assert rc == 2


### PR DESCRIPTION
Third module through the test-quality-program playbook ([docs/specs/test-quality-program/](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/test-quality-program)). Selected via rubric: score 3.19 (`W=5 user-typed entry, gap=0.64, risk=1.0`). **First weight-5 module in the program.**

## Coverage delta

| File | Before | After |
|---|---|---|
| `ops/cli.py` | 36.2% | **100.00%** |

## Module

`attune ops` CLI subparser + entrypoint. 151 lines of argparse declaration + uvicorn launcher. The on-ramp every dashboard user types.

## Tests — 19 total

- **`add_subparser` schema lockdown**: defaults, type coercion (port→int, project_root→Path), --specs-root / --trusted-host repeatability, boolean flags, --allow-run hidden from --help (`SUPPRESS`).
- **uvicorn dependency**: missing uvicorn → exit 2 + stderr message containing `attune-ai[ops]`.
- **Happy path**: real argparse + real `build_config` + real `create_app`; uvicorn.run patched to capture host/port kwargs; --read-only flips allow_run banner; custom host/port.
- **0.0.0.0 warning**: triggers without --trusted-host; silent with --trusted-host; silent on loopback.
- **Browser**: --no-browser suppresses `webbrowser.open`; default calls it with the right URL; `webbrowser.open` failure swallowed (returns 0, reaches uvicorn.run).
- **`main()` standalone**: dispatches to cmd_ops; propagates exit code (uvicorn-missing case returns 2).

**Strategy:** real argparse, real `build_config`, real `create_app`. Only `uvicorn.run` (blocking) and `webbrowser.open` (real browser) patched.

## Bug findings

**0 production bugs surfaced.** Two minor style smells noted in the bug log but not fixed in this PR (redundant uvicorn re-import on line 135; unlikely double-"ops" argv injection edge case in `main()` line 146).

**Pattern observation logged:** weight-5 modules surfaced no bugs while weight-3 data-handling modules surfaced 1-in-2. Early signal but suggestive — customer-facing entry points tend to be defensively written; bug-hunt yield concentrates in composed helpers. Worth re-evaluating after 5+ modules.

## Determinism

- 19 tests in 2.5s solo
- 3 back-to-back runs identical (no flakes)
- Full ops subtree under `-n auto`: **142 passed in 2.93s** — no cross-test interference

## Spec linkage

- Umbrella spec: PR #257 (merged)
- First PoC: PR #259 (memory/security)
- Second module: PR #263 (memory/short_term/conflicts)
- Third module: this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)