### PR TITLE
test(workflows/dependency_check): meaningful coverage on Agent SDK shell

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -154,6 +154,74 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ## Lessons Learned
 
+- **Coverage omit `*/test_*.py` silently hides production
+  modules named `test_*.py`**: `pyproject.toml`'s
+  `[tool.coverage.run]` omit pattern `*/test_*.py` matches
+  any file whose basename starts with `test_` — including
+  legitimate production modules like
+  `src/attune/workflows/test_gen/test_templates.py` and
+  six `src/attune/workflows/test_*.py` workflow source
+  files. coverage.py never measures them, so the rubric
+  script reports them with `?` covered_pct and a coverage
+  gap of 1.0. Two effects: (1) genuinely uncovered code
+  passes the 85% project gate because it's not counted in
+  the denominator; (2) the test-quality-program rubric
+  promotes these `?` rows to the top of the working set
+  with spuriously-high scores. Two fixes: tighten omit to
+  `tests/test_*.py` (root-anchored) or have the rubric
+  script drop `?` covered_pct rows from the working-set
+  top before surfacing picks. Discovered during the fourth
+  test-quality-program cycle when the top 11 rubric rows
+  were all coverage-omit artifacts.
+
+- **structlog config leaks via `structlog.configure(...)`
+  break unrelated log-event tests on the same xdist
+  worker**: any test that exercises a real call to
+  `structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(WARNING))`
+  (e.g. via a CLI's `_configure_logging` function) mutates
+  the GLOBAL structlog wrapper class, and that mutation
+  persists across the rest of the worker's test session.
+  Subsequent `logger.info(...)` calls are silently
+  filtered at the wrapper layer — before the
+  `structlog.testing.capture_logs()` processor can capture
+  them — so `capture_logs()` returns `[]` and assertions
+  like `assert any(e["event"] == "..." for e in cap)` fail
+  with empty captures. The same mechanism makes the older
+  `capsys`-based pattern unreliable, but the root cause is
+  the config leak, not the capture primitive. **Fix at the
+  leak site:** add an autouse fixture in the offending
+  test class that calls `structlog.reset_defaults()` after
+  each test — keeps the global state contained. Local
+  macOS xdist usually doesn't surface this because the
+  12-worker distribution rarely puts the polluting test
+  and the assertion test on the same worker in the
+  leak-then-read order; Linux CI scheduling is different
+  enough to hit it almost deterministically. Pair lesson:
+  **`structlog.testing.capture_logs()` is still the
+  preferred capture primitive over `capsys`** because it
+  bypasses I/O entirely (capsys is also vulnerable to
+  structlog's `WriteLogger` caching `sys.stdout` at
+  logger-creation time). But `capture_logs()` alone
+  doesn't help if a leaked filtering wrapper drops the
+  event before it reaches the capture processor.
+
+- **`pytest --cov` triggers
+  `KeyError: 'pydantic.root_model'` via the workflows
+  conftest's `discover_workflows()`**: running `pytest`
+  with `--cov` enabled fails at conftest import time when
+  the project's `tests/conftest.py` calls
+  `attune.workflows.discover_workflows()`. The chain:
+  coverage instrumentation changes module import timing →
+  `mcp.types.JSONRPCMessage(RootModel[...])` triggers
+  pydantic's generic submodel creation → pydantic looks
+  up `sys.modules['pydantic.root_model']` which isn't
+  populated yet → `KeyError`. Workaround: skip
+  `pytest --cov` for ad-hoc measurement. Use
+  `coverage run -m pytest <targets>` then
+  `coverage combine && coverage report --include="..."`
+  instead — same coverage data, no instrumentation
+  interaction with conftest's lazy workflow loader.
+
 - **Windows CI encoding**: Always use `encoding="utf-8"` on
   `Path.read_text()` calls. Windows defaults to `cp1252` which
   fails on any file containing non-ASCII bytes.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -188,15 +188,29 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   like `assert any(e["event"] == "..." for e in cap)` fail
   with empty captures. The same mechanism makes the older
   `capsys`-based pattern unreliable, but the root cause is
-  the config leak, not the capture primitive. **Fix at the
-  leak site:** add an autouse fixture in the offending
-  test class that calls `structlog.reset_defaults()` after
-  each test — keeps the global state contained. Local
-  macOS xdist usually doesn't surface this because the
-  12-worker distribution rarely puts the polluting test
-  and the assertion test on the same worker in the
-  leak-then-read order; Linux CI scheduling is different
-  enough to hit it almost deterministically. Pair lesson:
+  the config leak, not the capture primitive. **Fix at
+  the READ site, not the leak site.** PR #265 spent three
+  commits trying to contain the leak (class-scoped
+  autouse → module-scoped autouse → still missed
+  `TestMain.test_main_*` which transitively calls
+  `_configure_logging` via `main()`). Each fix narrowed
+  scope but missed another caller — whack-a-mole. The
+  durable fix is in the assertion test itself: call
+  `structlog.reset_defaults()` immediately before the
+  `capture_logs()` context. That single line makes the
+  assertion resilient to ANY prior worker state — past,
+  present, and future polluting callers — and doesn't
+  require auditing every CLI entry point in the suite. As
+  belt-and-suspenders the module-level autouse in
+  `tests/unit/memory/test_control_panel_display.py`
+  stays, but the load-bearing fix is the in-test reset.
+  Local macOS xdist rarely surfaces this because the
+  12-worker distribution usually doesn't put the
+  polluting test and the assertion test on the same
+  worker in the leak-then-read order; Linux CI scheduling
+  is different enough to hit it almost
+  deterministically across all Python versions.
+  Pair lesson:
   **`structlog.testing.capture_logs()` is still the
   preferred capture primitive over `capsys`** because it
   bypasses I/O entirely (capsys is also vulnerable to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: fourth module through the playbook —
+  `workflows/dependency_check.py` (Agent SDK-native orchestrator).
+  Coverage 41.67% → 100% line+branch. 21 deterministic tests
+  added under `tests/unit/workflows/test_dependency_check_execute.py`
+  exercising the `execute()` validation/exception paths and the
+  `_run_agent_check()` async SDK loop. Real
+  `claude_agent_sdk.AssistantMessage` / `ResultMessage` /
+  `TextBlock` instances yielded by the patched `query()` so the
+  `isinstance` checks in `agent_sdk_adapter.collect_agent_output`
+  actually fire. Zero production bugs surfaced; the module is
+  a thin async SDK shell. First SDK-native workflow through the
+  program; the test pattern transfers cleanly to the three
+  sibling workflows of the same shape
+  (`bug_predict`, `perf_audit`, `refactor_plan`).
 - Test-quality-program: third module through the playbook —
   `ops/cli.py` (`attune ops` user-typed entry point).
   Coverage 36.2% → 100% line+branch. 19 deterministic tests

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,73 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — fourth module under test-quality-program (Opus 4.7)
+
+Fourth module run. First Agent SDK-native workflow through
+the program. Selected via the rubric working set after
+`ops/cli.py` shipped (`workflows/dependency_check.py`,
+score 2.685 — top entry with measured coverage data; the
+score-4.0/3.0 rows above it are coverage-omit artifacts of
+the `*/test_*.py` pattern in `pyproject.toml`, see note
+below). **0 production bugs surfaced.**
+
+- `workflows/dependency_check.py`
+  (`DependencyCheckWorkflow`) — no bugs. The module is a
+  ~230-line thin async shell around
+  `claude_agent_sdk.query()`: validates `path`, maps depth
+  → max_turns, defines two `AgentDefinition` subagents
+  (`inventory-assessor`, `update-advisor`), collects
+  `AssistantMessage` + `ResultMessage` stream output via
+  `agent_sdk_adapter.collect_agent_output`, hands the
+  result to `AgentSDKResultAdapter.from_agent_output`.
+  Each specific exception type (`ImportError`,
+  `ConnectionError`, `TimeoutError`, generic `Exception`)
+  is converted to a structured `_error_result`. The
+  catch-all `except Exception` is documented intentional
+  with `# noqa: BLE001`. No dead code; no crash paths.
+
+**Coverage delta:** 41.67% → 100.00% (line + branch).
+
+**Tests:** 21 added under
+`tests/unit/workflows/test_dependency_check_execute.py`.
+Only `claude_agent_sdk.query` is mocked (would otherwise
+make real API calls); the `AssistantMessage`,
+`ResultMessage`, and `TextBlock` instances yielded by the
+fake generator are **real SDK dataclass instances**, not
+duck-typed `MagicMock`s — per the existing CLAUDE.md
+lesson "Duck-typed test fakes fail isinstance-based
+collectors silently." Determinism verified across 3
+back-to-back runs and under `-n auto` alongside the full
+`tests/unit/workflows/` + `tests/workflows/` subtree
+(2373 passed, no cross-test interference).
+
+**Rubric note (operational, not a bug):** the rubric's
+top 11 rows above `dependency_check` all sit at `?`
+covered_pct (scores 4.0 and 3.0 across
+`workflows/test_*.py` files and
+`workflows/test_gen/test_templates.py`). These are real
+production modules but coverage.py never measures them
+because the `*/test_*.py` omit pattern in
+`pyproject.toml` matches their filenames. The rubric
+should filter `?` covered_pct rows out of the
+working-set top, or the omit pattern should be tightened
+to `tests/test_*.py` so production modules with
+"test_" in their name remain measurable. Flagged for a
+follow-up rubric refinement; not blocking this cycle's
+ship.
+
+**Pattern observation (extends prior session's note):**
+the bug-find pattern continues — composed data-handling
+helpers (memory/security/query.py) surfaced 1 class-1
+crash bug, while customer-facing entry points
+(ops/cli.py) and now SDK-native orchestrators
+(workflows/dependency_check.py) surface zero. The
+SDK-native shape is uniform across `bug_predict`,
+`perf_audit`, `refactor_plan` and the test pattern
+established here should transfer with minor renames.
+
+---
+
 ## 2026-05-12 — third module under test-quality-program (Opus 4.7)
 
 Third module run, first weight-5 (user-typed entry) pick. Selected

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -22,3 +22,48 @@ why. Any surfaced production change deferred to a sibling PR.]
 ---
 
 <!-- First entry lands here when task #8 ships. -->
+
+## workflows/dependency_check.py
+
+**Date:** 2026-05-12
+**Rubric score at pick time:** 2.685 (weight=5 × gap=0.537 × risk=1.0)
+**Picked because:** First entry with measured `covered_pct`
+after `ops/cli.py` shipped. The 11 rows above it
+(scores 4.0 / 3.0, `workflows/test_*.py` files) are
+coverage-omit artifacts of the `*/test_*.py` pattern in
+`pyproject.toml` — coverage never measures them, so the
+rubric's `?` marker is informational, not a real gap.
+**Outcome:** 1 test file added (`test_dependency_check_execute.py`,
+21 tests). Coverage 41.67% → 100% line+branch. Zero
+production bugs surfaced. Pattern is reusable for
+sibling SDK-native workflows (`bug_predict`,
+`perf_audit`, `refactor_plan`).
+**PR:** _(filled in after merge)_
+**Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
+"2026-05-12 — fourth module under test-quality-program"
+
+The module is a thin async shell around
+`claude_agent_sdk.query()`. The uncovered slice was
+the entire `execute()` body (lines 127–166) and the
+`_run_agent_check()` async loop (lines 180–229). The
+only thing mocked in the new tests is `query()` itself;
+the messages it yields are real
+`claude_agent_sdk.AssistantMessage` and
+`ResultMessage` dataclasses so the `isinstance()`
+checks in `agent_sdk_adapter.collect_agent_output`
+fire correctly (this avoids the trap documented in
+CLAUDE.md: "Duck-typed test fakes fail
+isinstance-based collectors silently"). Depth
+mapping (quick=10 / standard=20 / deep=40), each
+specific exception path (`ImportError`,
+`ConnectionError`, `TimeoutError`, generic
+`Exception`), and the empty-stream "No results
+returned" fallback are all individually covered.
+
+**Rubric refinement flagged (not done here):** the
+`*/test_*.py` omit pattern hides four `workflows/test_*.py`
+production modules from coverage entirely. Either the
+pattern should tighten to `tests/test_*.py`, or the
+rubric script should drop `?` covered_pct rows from
+the working-set top. Surfaced as a follow-up; not in
+scope for this PR.

--- a/tests/unit/memory/short_term/test_conflicts.py
+++ b/tests/unit/memory/short_term/test_conflicts.py
@@ -231,20 +231,26 @@ class TestCreateConflictContext:
         self,
         negotiation: ConflictNegotiation,
         contributor_creds: AgentCredentials,
-        capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # structlog writes to stdout by default (not Python's
-        # `logging` module), so capsys is the right capture
-        # fixture here — `caplog` returns empty records.
-        negotiation.create_conflict_context(
-            "c1",
-            {"a1": "x", "a2": "y"},
-            {},
-            credentials=contributor_creds,
-            batna="fallback",
-        )
-        captured = capsys.readouterr().out
-        assert "conflict_context_created" in captured
+        # `structlog.testing.capture_logs()` is the canonical
+        # capture primitive — bypasses I/O entirely and reads
+        # structured events directly. Earlier versions used
+        # `capsys` to read stdout, but structlog's WriteLogger
+        # caches `sys.stdout` at logger-creation time, so
+        # pytest's stdout monkey-patching (especially under
+        # `pytest-xdist` on Linux) intermittently sees empty
+        # output. The event record path is environment-stable.
+        from structlog.testing import capture_logs
+
+        with capture_logs() as cap:
+            negotiation.create_conflict_context(
+                "c1",
+                {"a1": "x", "a2": "y"},
+                {},
+                credentials=contributor_creds,
+                batna="fallback",
+            )
+        assert any(e.get("event") == "conflict_context_created" for e in cap)
 
 
 # ---------------------------------------------------------------------------
@@ -399,13 +405,15 @@ class TestResolveConflict:
         negotiation: ConflictNegotiation,
         contributor_creds: AgentCredentials,
         validator_creds: AgentCredentials,
-        capsys: pytest.CaptureFixture[str],
     ) -> None:
+        # See `test_logs_creation_event` for why `capture_logs`
+        # is preferred over `capsys` here.
+        from structlog.testing import capture_logs
+
         negotiation.create_conflict_context("c1", {}, {}, credentials=contributor_creds)
-        # Drain stdout from the create call so we only see the resolve event.
-        capsys.readouterr()
-        negotiation.resolve_conflict("c1", "done", validator_creds)
-        assert "conflict_resolved" in capsys.readouterr().out
+        with capture_logs() as cap:
+            negotiation.resolve_conflict("c1", "done", validator_creds)
+        assert any(e.get("event") == "conflict_resolved" for e in cap)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/memory/short_term/test_conflicts.py
+++ b/tests/unit/memory/short_term/test_conflicts.py
@@ -234,14 +234,17 @@ class TestCreateConflictContext:
     ) -> None:
         # `structlog.testing.capture_logs()` is the canonical
         # capture primitive — bypasses I/O entirely and reads
-        # structured events directly. Earlier versions used
-        # `capsys` to read stdout, but structlog's WriteLogger
-        # caches `sys.stdout` at logger-creation time, so
-        # pytest's stdout monkey-patching (especially under
-        # `pytest-xdist` on Linux) intermittently sees empty
-        # output. The event record path is environment-stable.
+        # structured events directly. But it can return empty
+        # if a prior test on the same xdist worker mutated
+        # structlog's global wrapper class to a filtering one
+        # (e.g. via `structlog.configure(wrapper_class=...)`
+        # in an unrelated CLI test). Reset to a known-good
+        # default in-test so this assertion is resilient to
+        # cross-worker config leaks.
+        import structlog
         from structlog.testing import capture_logs
 
+        structlog.reset_defaults()
         with capture_logs() as cap:
             negotiation.create_conflict_context(
                 "c1",
@@ -406,11 +409,13 @@ class TestResolveConflict:
         contributor_creds: AgentCredentials,
         validator_creds: AgentCredentials,
     ) -> None:
-        # See `test_logs_creation_event` for why `capture_logs`
-        # is preferred over `capsys` here.
+        # See `test_logs_creation_event` for the same
+        # structlog defaults-reset + capture_logs rationale.
+        import structlog
         from structlog.testing import capture_logs
 
         negotiation.create_conflict_context("c1", {}, {}, credentials=contributor_creds)
+        structlog.reset_defaults()
         with capture_logs() as cap:
             negotiation.resolve_conflict("c1", "done", validator_creds)
         assert any(e.get("event") == "conflict_resolved" for e in cap)

--- a/tests/unit/memory/test_control_panel_display.py
+++ b/tests/unit/memory/test_control_panel_display.py
@@ -259,6 +259,20 @@ class TestPrintHealth:
 
 @pytest.mark.unit
 class TestConfigureLogging:
+    # `_configure_logging` calls `structlog.configure(...)` which
+    # mutates global structlog state. Without a teardown, the
+    # WARNING-filter leaks into every subsequent test on the same
+    # xdist worker — silently filtering out `logger.info(...)` calls
+    # and breaking unrelated log-event assertion tests (notably
+    # `tests/unit/memory/short_term/test_conflicts.py`). Snapshot
+    # and restore.
+    @pytest.fixture(autouse=True)
+    def _restore_structlog_config(self):
+        import structlog
+
+        yield
+        structlog.reset_defaults()
+
     def test_verbose_passes_debug_to_basicconfig(self):
         import logging
 

--- a/tests/unit/memory/test_control_panel_display.py
+++ b/tests/unit/memory/test_control_panel_display.py
@@ -20,6 +20,33 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
+# ---------------------------------------------------------------------------
+# Module-level structlog state isolation
+# ---------------------------------------------------------------------------
+# Several tests in this module exercise CLI entry points that
+# internally call `_configure_logging`, which calls
+# `structlog.configure(wrapper_class=structlog.make_filtering_bound_logger(WARNING))`
+# and globally mutates structlog's wrapper class. Without a
+# teardown, that WARNING-filter leaks into every subsequent
+# test on the same xdist worker — silently filtering out
+# `logger.info(...)` calls and breaking unrelated log-event
+# assertion tests (notably `tests/unit/memory/short_term/
+# test_conflicts.py`, and any other test that uses
+# `structlog.testing.capture_logs()` on INFO events).
+#
+# An earlier scoped fixture on `TestConfigureLogging` missed
+# `TestMain` and other classes that call `main()` (which
+# transitively invokes `_configure_logging`). Module-level
+# autouse is the simplest containment that scales.
+@pytest.fixture(autouse=True)
+def _reset_structlog_after_each_test():
+    import structlog
+
+    yield
+    structlog.reset_defaults()
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -259,19 +286,10 @@ class TestPrintHealth:
 
 @pytest.mark.unit
 class TestConfigureLogging:
-    # `_configure_logging` calls `structlog.configure(...)` which
-    # mutates global structlog state. Without a teardown, the
-    # WARNING-filter leaks into every subsequent test on the same
-    # xdist worker — silently filtering out `logger.info(...)` calls
-    # and breaking unrelated log-event assertion tests (notably
-    # `tests/unit/memory/short_term/test_conflicts.py`). Snapshot
-    # and restore.
-    @pytest.fixture(autouse=True)
-    def _restore_structlog_config(self):
-        import structlog
-
-        yield
-        structlog.reset_defaults()
+    # Structlog state reset is now handled by the module-level
+    # `_reset_structlog_after_each_test` autouse fixture above,
+    # which covers both this class and `TestMain` (whose
+    # `main()` calls also reach `_configure_logging`).
 
     def test_verbose_passes_debug_to_basicconfig(self):
         import logging

--- a/tests/unit/workflows/test_dependency_check_execute.py
+++ b/tests/unit/workflows/test_dependency_check_execute.py
@@ -1,0 +1,335 @@
+"""Tests for DependencyCheckWorkflow execute() and _run_agent_check().
+
+Covers the Agent SDK execution paths. Uses real SDK message
+instances rather than duck-typed fakes so isinstance-based
+collectors in agent_sdk_adapter actually fire (per CLAUDE.md
+lesson: duck-typed test fakes fail isinstance-based collectors
+silently — construct real SDK class instances in tests).
+
+The only thing mocked is ``claude_agent_sdk.query`` itself; the
+ResultMessage / AssistantMessage / TextBlock instances yielded
+by the fake generator are constructed via the real dataclasses.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import patch
+
+import claude_agent_sdk
+import pytest
+
+from attune.workflows.agent_sdk_adapter import AgentRunResult
+from attune.workflows.base import ModelTier
+from attune.workflows.data_classes import WorkflowResult
+from attune.workflows.dependency_check import DependencyCheckWorkflow
+
+# ---------------------------------------------------------------------------
+# Fixtures — real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workflow() -> DependencyCheckWorkflow:
+    """Build a fresh DependencyCheckWorkflow."""
+    return DependencyCheckWorkflow()
+
+
+@pytest.fixture
+def assistant_message() -> claude_agent_sdk.AssistantMessage:
+    """Real AssistantMessage with a TextBlock payload."""
+    block = claude_agent_sdk.types.TextBlock(text="Inventory: 3 deps; 1 outdated.")
+    return claude_agent_sdk.AssistantMessage(
+        content=[block],
+        model="claude-opus-4-7",
+        parent_tool_use_id=None,
+    )
+
+
+@pytest.fixture
+def result_message() -> claude_agent_sdk.ResultMessage:
+    """Real ResultMessage with a final synthesis."""
+    return claude_agent_sdk.ResultMessage(
+        subtype="success",
+        duration_ms=12000,
+        duration_api_ms=10500,
+        is_error=False,
+        num_turns=4,
+        session_id="sess-deps-42",
+        total_cost_usd=0.42,
+        usage={"input_tokens": 1500, "output_tokens": 800},
+        result="## Summary\nDependency audit complete.",
+        structured_output=None,
+    )
+
+
+def _make_fake_query(messages):
+    """Build an async generator factory yielding the given messages.
+
+    The factory matches ``claude_agent_sdk.query``'s signature
+    (it accepts arbitrary kwargs and returns an async iterator).
+    """
+
+    async def fake_query(*args, **kwargs):
+        for msg in messages:
+            yield msg
+
+    return fake_query
+
+
+# ---------------------------------------------------------------------------
+# execute() — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteValidation:
+    """Empty / missing path is rejected before any SDK call."""
+
+    def test_no_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute())
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+    def test_empty_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute(path=""))
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+
+# ---------------------------------------------------------------------------
+# execute() — happy path through real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSuccess:
+    """Successful runs across the three depth profiles."""
+
+    @patch("attune.workflows.dependency_check.claude_agent_sdk.query")
+    def test_success_yields_workflow_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj", depth="standard"))
+
+        assert isinstance(result, WorkflowResult)
+        assert result.success is True
+        assert result.provider == "anthropic"
+        assert "Inventory" in result.final_output or "Summary" in result.final_output
+
+    @patch("attune.workflows.dependency_check.claude_agent_sdk.query")
+    def test_metadata_populated(self, mock_query, workflow, assistant_message, result_message):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj", depth="quick"))
+
+        # AgentSDKResultAdapter pulls metadata from ResultMessage.
+        assert result.success is True
+        # depth/path forwarded into metadata for downstream callers.
+        meta = result.metadata or {}
+        assert meta.get("depth") == "quick"
+        # path is resolved to absolute; just check it ends with our segment.
+        assert meta.get("path", "").endswith("/tmp/proj") or "tmp" in meta.get("path", "")
+        assert meta.get("max_turns") == 10
+
+    @patch("attune.workflows.dependency_check.claude_agent_sdk.query")
+    def test_result_only_no_assistant_text(self, mock_query, workflow, result_message):
+        """ResultMessage alone — exercises the `run_result = sdk_result`
+        assignment branch (line 226-227 in dependency_check.py).
+        """
+        mock_query.side_effect = _make_fake_query([result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is True
+
+    @patch("attune.workflows.dependency_check.claude_agent_sdk.query")
+    def test_empty_stream_returns_default_text(self, mock_query, workflow):
+        """Empty stream — exercises the `AgentRunResult(...="No results")`
+        initialization (line 182) being passed straight through.
+        """
+        mock_query.side_effect = _make_fake_query([])
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        # Adapter still produces a WorkflowResult; result_text defaulted.
+        assert isinstance(result, WorkflowResult)
+
+
+# ---------------------------------------------------------------------------
+# execute() — depth → max_turns mapping
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDepthMapping:
+    """``depth`` arg drives ``max_turns`` passed to the SDK."""
+
+    def _max_turns_for(self, depth, workflow, monkeypatch):
+        """Run execute(depth=...) and return the max_turns recorded."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            opts = kwargs.get("options")
+            captured["max_turns"] = opts.max_turns
+            if False:
+                yield  # make this an async generator
+
+        monkeypatch.setattr(
+            "attune.workflows.dependency_check.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/proj", depth=depth))
+        return captured.get("max_turns")
+
+    def test_quick_depth_uses_10_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("quick", workflow, monkeypatch) == 10
+
+    def test_standard_depth_uses_20_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("standard", workflow, monkeypatch) == 20
+
+    def test_deep_depth_uses_40_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("deep", workflow, monkeypatch) == 40
+
+    def test_unknown_depth_falls_back_to_20(self, workflow, monkeypatch):
+        """Undocumented depth values silently fall back to standard's 20."""
+        assert self._max_turns_for("preposterous", workflow, monkeypatch) == 20
+
+    def test_default_depth_is_standard(self, workflow, monkeypatch):
+        """No depth kwarg → standard (20)."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            captured["max_turns"] = kwargs["options"].max_turns
+            if False:
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.dependency_check.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert captured["max_turns"] == 20
+
+
+# ---------------------------------------------------------------------------
+# execute() — exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteExceptionHandling:
+    """Each specific exception type produces a structured error result."""
+
+    def _patch_query_to_raise(self, monkeypatch, exc):
+        async def raising_query(*args, **kwargs):
+            raise exc
+            if False:  # pragma: no cover
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.dependency_check.claude_agent_sdk.query",
+            raising_query,
+        )
+
+    def test_import_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ImportError("sdk missing"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "Agent SDK unavailable" in result.error
+
+    def test_connection_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ConnectionError("refused"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_timeout_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, TimeoutError("slow"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_generic_exception(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "RuntimeError" in result.error
+        assert "kaboom" in result.error
+
+
+# ---------------------------------------------------------------------------
+# _run_agent_check() — directly, bypassing execute()
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentCheckDirect:
+    """Direct invocation surfaces the SDK loop's exact behavior."""
+
+    @patch("attune.workflows.dependency_check.claude_agent_sdk.query")
+    def test_collects_assistant_and_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+
+        run_result = asyncio.run(workflow._run_agent_check("/tmp/proj", 20, "standard"))
+        assert isinstance(run_result, AgentRunResult)
+        # build_result_text prefers assistant_parts when they're at least as
+        # long as result_parts; here both are short and assistant wins by length.
+        assert "Inventory" in run_result.result_text or "Summary" in run_result.result_text
+
+    @patch("attune.workflows.dependency_check.claude_agent_sdk.query")
+    def test_no_messages_returns_default_text(self, mock_query, workflow):
+        mock_query.side_effect = _make_fake_query([])
+        run_result = asyncio.run(workflow._run_agent_check("/tmp/proj", 20))
+        assert run_result.result_text == "No results returned."
+
+    @patch("attune.workflows.dependency_check.claude_agent_sdk.query")
+    def test_passes_subagent_definitions(self, mock_query, workflow, result_message):
+        """Both subagents (inventory-assessor, update-advisor) are wired
+        into the SDK call's options.
+        """
+        captured: dict = {}
+
+        async def capturing_query(*args, **kwargs):
+            captured["options"] = kwargs.get("options")
+            captured["prompt"] = kwargs.get("prompt")
+            yield result_message
+
+        mock_query.side_effect = capturing_query
+        asyncio.run(workflow._run_agent_check("/tmp/proj", 20, "standard"))
+
+        opts = captured["options"]
+        assert "inventory-assessor" in opts.agents
+        assert "update-advisor" in opts.agents
+        # System prompt + path in task prompt.
+        assert "dependency check orchestrator" in opts.system_prompt
+        assert "/tmp/proj" in captured["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# _error_result() — inherited from BaseWorkflow but exercised here so
+# its surface stays measured even if base.py refactors break the contract.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResult:
+    """Shape of the failure WorkflowResult."""
+
+    def test_structure(self, workflow):
+        result = workflow._error_result("nope")
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert result.error == "nope"
+        assert result.total_duration_ms == 0
+        assert result.cost_report.total_cost == 0.0
+
+    def test_stage_metadata(self, workflow):
+        result = workflow._error_result("nope")
+        assert len(result.stages) == 1
+        assert result.stages[0].name == "dependency-check"
+        assert result.stages[0].tier == ModelTier.CAPABLE
+
+    def test_timestamps_bounded(self, workflow):
+        before = datetime.now()
+        result = workflow._error_result("nope")
+        after = datetime.now()
+        assert before <= result.started_at <= after
+        assert before <= result.completed_at <= after


### PR DESCRIPTION
## Summary

- Fourth module through the test-quality-program playbook
  (`docs/specs/test-quality-program/`). First SDK-native
  workflow through the program.
- Coverage **41.67% → 100% line+branch** on
  `workflows/dependency_check.py` via 21 new tests under
  `tests/unit/workflows/test_dependency_check_execute.py`.
- Zero production bugs surfaced.

## Rubric pick

Selected via the rubric working set: score **2.685**
(W=5 × gap=0.537 × risk=1.0) — top entry with measured
`covered_pct` after the three prior cycles shipped
(`memory/security/{query,reports}.py`,
`memory/short_term/conflicts.py`, `ops/cli.py`).

The 11 rows scored 4.0 / 3.0 above this one all sit at `?`
covered_pct: production modules whose filenames match the
`*/test_*.py` omit pattern in `pyproject.toml`, so coverage
never measures them. Rubric refinement flagged in
`decisions.md`, not in scope here.

## Tests added

21 tests covering:

- `execute()` arg validation
- `execute()` happy path with **real SDK message instances**
  (per CLAUDE.md: "Duck-typed test fakes fail isinstance-based
  collectors silently") — exercises both the
  `run_result = sdk_result` assignment and the
  `"No results returned."` default fallback
- depth → max_turns: quick=10 / standard=20 / deep=40, and the
  undocumented fallback for unknown depth values
- each exception path: `ImportError`, `ConnectionError`,
  `TimeoutError`, generic `Exception`
- `_run_agent_check()` direct: subagent definitions
  (`inventory-assessor`, `update-advisor`) and system prompt
  wiring, empty-stream default
- `_error_result()` structure, stage metadata, timestamp bounds

Only `claude_agent_sdk.query` is mocked; the messages it
yields are real `AssistantMessage` / `ResultMessage` /
`TextBlock` dataclasses.

## Why no bugs

Module is a thin async orchestrator: validates `path`, maps
depth → max_turns, defines two subagents, streams the SDK
output, adapts the result. Each specific exception type is
converted to a structured `_error_result`. No dead code,
no crash paths. The SDK-native shape is shared with
`bug_predict`, `perf_audit`, `refactor_plan` — the test
pattern transfers with minor renames, so future cycles on
those modules should be fast.

## Test plan

- [x] 21 new tests pass deterministically (3 back-to-back
      `-n0` runs)
- [x] `-n auto` across full
      `tests/unit/workflows/ + tests/workflows/` subtree —
      2373 passed, no cross-test interference
- [x] coverage on `workflows/dependency_check.py`:
      41.67% → 100.00% line+branch
- [x] `ruff` + `black` (pinned via pre-commit) pass

## Refs

- `docs/specs/test-quality-program/decisions.md` — entry
  added per the spec's append-only format
- `docs/COVERAGE_BUG_LOG.md` — "2026-05-12 — fourth module"
- `CHANGELOG.md` — Unreleased / Internal

🤖 Generated with [Claude Code](https://claude.com/claude-code)