### PR TITLE
test(workflows/bug_predict): meaningful coverage on Agent SDK shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: fifth module through the playbook —
+  `workflows/bug_predict.py` (Agent SDK-native orchestrator).
+  Coverage 47.3% → 97% line+branch. 21 deterministic tests
+  added under `tests/unit/workflows/test_bug_predict_execute.py`
+  matching the scaffold established by
+  `test_dependency_check_execute.py`. Same isinstance-safe
+  real-SDK-dataclass fixtures. Zero production bugs surfaced —
+  the module is a thin async shell around `query()` with three
+  subagents (`pattern-scanner`, `risk-correlator`,
+  `prevention-advisor`). Pattern transfers verbatim from
+  `dependency_check.py`; reusable for the two remaining
+  sibling workflows (`perf_audit`, `refactor_plan`).
 - Test-quality-program: fourth module through the playbook —
   `workflows/dependency_check.py` (Agent SDK-native orchestrator).
   Coverage 41.67% → 100% line+branch. 21 deterministic tests

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,65 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — fifth module under test-quality-program (Opus 4.7)
+
+Fifth module run. Second Agent SDK-native workflow through
+the program (sibling pattern to the `dependency_check`
+module shipped earlier today). Selected via the rubric
+working set: `workflows/bug_predict.py`, score 2.636 —
+top entry with measured coverage after the four `?`
+coverage-omit artifacts above it. **0 production bugs
+surfaced.**
+
+- `workflows/bug_predict.py` (`BugPredictionWorkflow`) —
+  no bugs. The module is a ~270-line thin async shell
+  around `claude_agent_sdk.query()`: validates `path`,
+  maps depth → max_turns, defines three `AgentDefinition`
+  subagents (`pattern-scanner`, `risk-correlator`,
+  `prevention-advisor`), collects `AssistantMessage` +
+  `ResultMessage` stream output via
+  `agent_sdk_adapter.collect_agent_output`, hands the
+  result to `AgentSDKResultAdapter.from_agent_output`.
+  Each specific exception type (`ImportError`,
+  `ConnectionError`, `TimeoutError`, generic `Exception`)
+  is converted to a structured `_error_result`. The
+  catch-all `except Exception` is documented intentional
+  with `# noqa: BLE001`. No dead code; no crash paths.
+  Structurally identical to `dependency_check.py` — the
+  test scaffold transferred with a one-pass rename
+  (`_run_agent_check` → `_run_agent_predict`, two
+  subagents → three, stage name "dependency-check" →
+  "bug-predict", task-prompt phrase swap).
+
+**Coverage delta:** 47.3% → 97% (line + branch). The
+one uncovered line (271) is the bottom-of-file
+`if __name__ == "__main__": main()` guard — standard
+untestable boilerplate.
+
+**Tests:** 21 added under
+`tests/unit/workflows/test_bug_predict_execute.py`,
+matching the shape established by
+`test_dependency_check_execute.py`. Only
+`claude_agent_sdk.query` is mocked; the
+`AssistantMessage`, `ResultMessage`, and `TextBlock`
+instances yielded by the fake generator are **real SDK
+dataclass instances** (per CLAUDE.md lesson on
+duck-typed fakes failing isinstance-based collectors).
+
+**Pattern observation (continues prior session):** the
+SDK-native shape is uniform across the four sibling
+workflows (`dependency_check`, `bug_predict`, plus
+unprocessed `perf_audit`, `refactor_plan`). Each ships
+zero production bugs and lifts coverage to 97-100% via
+the same test scaffold. After two consecutive cycles
+with this pattern (#265 + this PR), it's reusable
+enough to script as a per-workflow template; flagged
+for consideration but not blocking. Composed data-
+handling helpers (memory/security) remain the bug-rich
+shape; the SDK-native shells are pure plumbing.
+
+---
+
 ## 2026-05-12 — fourth module under test-quality-program (Opus 4.7)
 
 Fourth module run. First Agent SDK-native workflow through

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -67,3 +67,43 @@ pattern should tighten to `tests/test_*.py`, or the
 rubric script should drop `?` covered_pct rows from
 the working-set top. Surfaced as a follow-up; not in
 scope for this PR.
+
+## workflows/bug_predict.py
+
+**Date:** 2026-05-12
+**Rubric score at pick time:** 2.636 (weight=5 × gap=0.527 × risk=1.0)
+**Picked because:** Top entry with measured `covered_pct`
+after `dependency_check.py` shipped. Structurally
+identical SDK-native shell — the test scaffold from
+PR #265 transferred with a one-pass rename. The prior
+decision entry explicitly flagged it as the next pick.
+**Outcome:** 1 test file added (`test_bug_predict_execute.py`,
+21 tests). Coverage 47.3% → 97% line+branch (only the
+`if __name__ == "__main__"` guard at line 271 remains
+uncovered, standard untestable boilerplate). Zero
+production bugs surfaced. Two SDK-native shells now
+through the program; `perf_audit` and `refactor_plan`
+remain.
+**PR:** _(filled in after merge)_
+**Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
+"2026-05-12 — fifth module under test-quality-program"
+
+Same body shape as `dependency_check`: thin async shell
+around `claude_agent_sdk.query()`, three subagents
+(`pattern-scanner`, `risk-correlator`,
+`prevention-advisor`), depth → max_turns mapping
+(quick=10/standard=20/deep=40), specific exception
+paths each producing a structured `_error_result`. Only
+`claude_agent_sdk.query` is mocked; the messages it
+yields are real `claude_agent_sdk.AssistantMessage` and
+`ResultMessage` dataclasses so the `isinstance()`
+checks in `agent_sdk_adapter.collect_agent_output` fire
+correctly. No production changes; no sibling PR
+needed.
+
+**Reuse signal:** Two consecutive SDK-native cycles
+shipped from the same test scaffold with single-pass
+renames. The pattern is mature enough to script as a
+per-workflow template (e.g. `scripts/scaffold_sdk_workflow_tests.py`
+taking module path + subagent list as inputs). Flagged
+for the next cycle to consider; not committed.

--- a/tests/unit/workflows/test_bug_predict_execute.py
+++ b/tests/unit/workflows/test_bug_predict_execute.py
@@ -1,0 +1,329 @@
+"""Tests for BugPredictionWorkflow execute() and _run_agent_predict().
+
+Covers the Agent SDK execution paths. Uses real SDK message
+instances rather than duck-typed fakes so isinstance-based
+collectors in agent_sdk_adapter actually fire (per CLAUDE.md
+lesson: duck-typed test fakes fail isinstance-based collectors
+silently — construct real SDK class instances in tests).
+
+The only thing mocked is ``claude_agent_sdk.query`` itself; the
+ResultMessage / AssistantMessage / TextBlock instances yielded
+by the fake generator are constructed via the real dataclasses.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import patch
+
+import claude_agent_sdk
+import pytest
+
+from attune.workflows.agent_sdk_adapter import AgentRunResult
+from attune.workflows.base import ModelTier
+from attune.workflows.bug_predict import BugPredictionWorkflow
+from attune.workflows.data_classes import WorkflowResult
+
+# ---------------------------------------------------------------------------
+# Fixtures — real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workflow() -> BugPredictionWorkflow:
+    """Build a fresh BugPredictionWorkflow."""
+    return BugPredictionWorkflow()
+
+
+@pytest.fixture
+def assistant_message() -> claude_agent_sdk.AssistantMessage:
+    """Real AssistantMessage with a TextBlock payload."""
+    block = claude_agent_sdk.types.TextBlock(
+        text="Risk score: 42. Pattern: broad exception at src/foo.py:18."
+    )
+    return claude_agent_sdk.AssistantMessage(
+        content=[block],
+        model="claude-opus-4-7",
+        parent_tool_use_id=None,
+    )
+
+
+@pytest.fixture
+def result_message() -> claude_agent_sdk.ResultMessage:
+    """Real ResultMessage with a final synthesis."""
+    return claude_agent_sdk.ResultMessage(
+        subtype="success",
+        duration_ms=18000,
+        duration_api_ms=15500,
+        is_error=False,
+        num_turns=6,
+        session_id="sess-bug-7",
+        total_cost_usd=0.61,
+        usage={"input_tokens": 2100, "output_tokens": 1200},
+        result="## Summary\nBug prediction complete.",
+        structured_output=None,
+    )
+
+
+def _make_fake_query(messages):
+    """Build an async generator factory yielding the given messages.
+
+    The factory matches ``claude_agent_sdk.query``'s signature
+    (it accepts arbitrary kwargs and returns an async iterator).
+    """
+
+    async def fake_query(*args, **kwargs):
+        for msg in messages:
+            yield msg
+
+    return fake_query
+
+
+# ---------------------------------------------------------------------------
+# execute() — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteValidation:
+    """Empty / missing path is rejected before any SDK call."""
+
+    def test_no_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute())
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+    def test_empty_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute(path=""))
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+
+# ---------------------------------------------------------------------------
+# execute() — happy path through real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSuccess:
+    """Successful runs across the three depth profiles."""
+
+    @patch("attune.workflows.bug_predict.claude_agent_sdk.query")
+    def test_success_yields_workflow_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj", depth="standard"))
+
+        assert isinstance(result, WorkflowResult)
+        assert result.success is True
+        assert result.provider == "anthropic"
+        assert "Risk" in result.final_output or "Summary" in result.final_output
+
+    @patch("attune.workflows.bug_predict.claude_agent_sdk.query")
+    def test_metadata_populated(self, mock_query, workflow, assistant_message, result_message):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj", depth="quick"))
+
+        assert result.success is True
+        meta = result.metadata or {}
+        assert meta.get("depth") == "quick"
+        assert meta.get("path", "").endswith("/tmp/proj") or "tmp" in meta.get("path", "")
+        assert meta.get("max_turns") == 10
+
+    @patch("attune.workflows.bug_predict.claude_agent_sdk.query")
+    def test_result_only_no_assistant_text(self, mock_query, workflow, result_message):
+        """ResultMessage alone — exercises the ``run_result = sdk_result``
+        assignment branch inside the async loop.
+        """
+        mock_query.side_effect = _make_fake_query([result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is True
+
+    @patch("attune.workflows.bug_predict.claude_agent_sdk.query")
+    def test_empty_stream_returns_default_text(self, mock_query, workflow):
+        """Empty stream — exercises the ``AgentRunResult(...="No results")``
+        initialization being passed straight through.
+        """
+        mock_query.side_effect = _make_fake_query([])
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert isinstance(result, WorkflowResult)
+
+
+# ---------------------------------------------------------------------------
+# execute() — depth → max_turns mapping
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDepthMapping:
+    """``depth`` arg drives ``max_turns`` passed to the SDK."""
+
+    def _max_turns_for(self, depth, workflow, monkeypatch):
+        """Run execute(depth=...) and return the max_turns recorded."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            opts = kwargs.get("options")
+            captured["max_turns"] = opts.max_turns
+            if False:
+                yield  # make this an async generator
+
+        monkeypatch.setattr(
+            "attune.workflows.bug_predict.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/proj", depth=depth))
+        return captured.get("max_turns")
+
+    def test_quick_depth_uses_10_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("quick", workflow, monkeypatch) == 10
+
+    def test_standard_depth_uses_20_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("standard", workflow, monkeypatch) == 20
+
+    def test_deep_depth_uses_40_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("deep", workflow, monkeypatch) == 40
+
+    def test_unknown_depth_falls_back_to_20(self, workflow, monkeypatch):
+        """Undocumented depth values silently fall back to standard's 20."""
+        assert self._max_turns_for("preposterous", workflow, monkeypatch) == 20
+
+    def test_default_depth_is_standard(self, workflow, monkeypatch):
+        """No depth kwarg → standard (20)."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            captured["max_turns"] = kwargs["options"].max_turns
+            if False:
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.bug_predict.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert captured["max_turns"] == 20
+
+
+# ---------------------------------------------------------------------------
+# execute() — exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteExceptionHandling:
+    """Each specific exception type produces a structured error result."""
+
+    def _patch_query_to_raise(self, monkeypatch, exc):
+        async def raising_query(*args, **kwargs):
+            raise exc
+            if False:  # pragma: no cover
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.bug_predict.claude_agent_sdk.query",
+            raising_query,
+        )
+
+    def test_import_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ImportError("sdk missing"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "Agent SDK unavailable" in result.error
+
+    def test_connection_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ConnectionError("refused"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_timeout_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, TimeoutError("slow"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_generic_exception(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "RuntimeError" in result.error
+        assert "kaboom" in result.error
+
+
+# ---------------------------------------------------------------------------
+# _run_agent_predict() — directly, bypassing execute()
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentPredictDirect:
+    """Direct invocation surfaces the SDK loop's exact behavior."""
+
+    @patch("attune.workflows.bug_predict.claude_agent_sdk.query")
+    def test_collects_assistant_and_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+
+        run_result = asyncio.run(workflow._run_agent_predict("/tmp/proj", 20, "standard"))
+        assert isinstance(run_result, AgentRunResult)
+        assert "Risk" in run_result.result_text or "Summary" in run_result.result_text
+
+    @patch("attune.workflows.bug_predict.claude_agent_sdk.query")
+    def test_no_messages_returns_default_text(self, mock_query, workflow):
+        mock_query.side_effect = _make_fake_query([])
+        run_result = asyncio.run(workflow._run_agent_predict("/tmp/proj", 20))
+        assert run_result.result_text == "No results returned."
+
+    @patch("attune.workflows.bug_predict.claude_agent_sdk.query")
+    def test_passes_subagent_definitions(self, mock_query, workflow, result_message):
+        """All three subagents are wired into the SDK call's options."""
+        captured: dict = {}
+
+        async def capturing_query(*args, **kwargs):
+            captured["options"] = kwargs.get("options")
+            captured["prompt"] = kwargs.get("prompt")
+            yield result_message
+
+        mock_query.side_effect = capturing_query
+        asyncio.run(workflow._run_agent_predict("/tmp/proj", 20, "standard"))
+
+        opts = captured["options"]
+        assert "pattern-scanner" in opts.agents
+        assert "risk-correlator" in opts.agents
+        assert "prevention-advisor" in opts.agents
+        assert "bug prediction orchestrator" in opts.system_prompt
+        assert "/tmp/proj" in captured["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# _error_result() — inherited from BaseWorkflow but exercised here so
+# its surface stays measured even if base.py refactors break the contract.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResult:
+    """Shape of the failure WorkflowResult."""
+
+    def test_structure(self, workflow):
+        result = workflow._error_result("nope")
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert result.error == "nope"
+        assert result.total_duration_ms == 0
+        assert result.cost_report.total_cost == 0.0
+
+    def test_stage_metadata(self, workflow):
+        result = workflow._error_result("nope")
+        assert len(result.stages) == 1
+        assert result.stages[0].name == "bug-predict"
+        assert result.stages[0].tier == ModelTier.CAPABLE
+
+    def test_timestamps_bounded(self, workflow):
+        before = datetime.now()
+        result = workflow._error_result("nope")
+        after = datetime.now()
+        assert before <= result.started_at <= after
+        assert before <= result.completed_at <= after


### PR DESCRIPTION
## Summary

Fifth module through the [test-quality-program](docs/specs/test-quality-program/) playbook. Second SDK-native workflow after [PR #265](https://github.com/Smart-AI-Memory/attune-ai/pull/265) (`dependency_check.py`); the test scaffold transferred verbatim with a one-pass rename.

- **Coverage:** 47.3% → 97% line+branch on `workflows/bug_predict.py`. Only line 271 (`if __name__ == "__main__": main()`) remains uncovered — standard untestable boilerplate.
- **Tests:** 21 added under `tests/unit/workflows/test_bug_predict_execute.py` covering `execute()` validation/exception paths and the `_run_agent_predict()` async SDK loop.
- **Bugs surfaced:** zero. The module is a thin async shell around `claude_agent_sdk.query()` with three subagents (`pattern-scanner`, `risk-correlator`, `prevention-advisor`).

## Test design

Mocks only `claude_agent_sdk.query`; the `AssistantMessage`, `ResultMessage`, and `TextBlock` instances yielded by the fake generator are **real SDK dataclass instances** so the `isinstance` checks in `agent_sdk_adapter.collect_agent_output` actually fire (per the CLAUDE.md lesson on duck-typed fakes silently failing isinstance-based collectors).

Each specific exception path (`ImportError`, `ConnectionError`, `TimeoutError`, generic `Exception`) is exercised individually. Depth → max_turns mapping (quick=10 / standard=20 / deep=40, unknown → 20 fallback) verified by capturing the `ClaudeAgentOptions` on the patched `query()`.

## Reuse signal

Two consecutive SDK-native cycles shipped from the same test scaffold with single-pass renames. The pattern is mature enough to script as a per-workflow template (e.g. `scripts/scaffold_sdk_workflow_tests.py` taking module path + subagent list as inputs). Flagged in `decisions.md`, not committed in this PR. `perf_audit` and `refactor_plan` remain as next candidates.

## Test plan

- [x] All 21 new tests pass locally
- [x] Sibling workflow tests pass (201 collected, all green)
- [x] Black + ruff + bandit pre-commit hooks pass
- [x] Coverage measured: 97% line+branch on `bug_predict.py` (only `if __name__ == "__main__"` guard uncovered)
- [ ] CI green across matrix

## Files changed

- `tests/unit/workflows/test_bug_predict_execute.py` — 21 new tests (new file)
- `CHANGELOG.md` — Unreleased entry
- `docs/COVERAGE_BUG_LOG.md` — fifth-module entry
- `docs/specs/test-quality-program/decisions.md` — appended pick reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)