### PR TITLE
test(workflows/refactor_plan): meaningful coverage on Agent SDK shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: fifth module through the playbook —
+  `workflows/refactor_plan.py` (`RefactorPlanWorkflow`,
+  Agent SDK-native orchestrator). Coverage 44.44% → 100%
+  line+branch. 23 deterministic tests added under
+  `tests/unit/workflows/test_refactor_plan_execute.py`
+  exercising the `execute()` validation/exception paths,
+  depth → `max_turns` mapping, and the `_run_agent_plan()`
+  async SDK loop wiring three subagents (`debt-scanner`,
+  `impact-analyzer`, `plan-generator`). Real
+  `claude_agent_sdk.AssistantMessage` / `ResultMessage` /
+  `TextBlock` instances per the established pattern; only
+  `claude_agent_sdk.query` is mocked. Two tests cover the
+  workflow's `__init__` default that opts in to
+  post-simplification (`_enable_post_simplification = True`).
+  Zero production bugs surfaced — validates the cycle-four
+  prediction that the SDK-native test shape transfers
+  cleanly across `bug_predict` / `perf_audit` /
+  `refactor_plan` with rename-only changes.
 - Test-quality-program: fourth module through the playbook —
   `workflows/dependency_check.py` (Agent SDK-native orchestrator).
   Coverage 41.67% → 100% line+branch. 21 deterministic tests

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,62 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — fifth module under test-quality-program (Opus 4.7)
+
+Fifth module run. Second Agent SDK-native workflow through
+the program, riding the transfer-pattern thesis established
+in cycle four. Selected as the next sibling in the
+SDK-native orchestrator family (`bug_predict`, `perf_audit`,
+`refactor_plan`) so the dependency_check test shape could
+be validated for reuse. **0 production bugs surfaced.**
+
+- `workflows/refactor_plan.py` (`RefactorPlanWorkflow`) —
+  no bugs. Same async-shell topology as `dependency_check`:
+  validates `path`, maps depth → `max_turns` via
+  `_DEPTH_MAX_TURNS`, defines three `AgentDefinition`
+  subagents (`debt-scanner`, `impact-analyzer`,
+  `plan-generator`), collects the stream via
+  `agent_sdk_adapter.collect_agent_output`, hands result to
+  `AgentSDKResultAdapter.from_agent_output`. One
+  module-specific detail beyond the cycle-four shell: the
+  constructor opts in to post-simplification by default
+  (`kwargs.setdefault("enable_post_simplification", True)`)
+  — mixin stores the flag as
+  `self._enable_post_simplification`. Exception handling
+  identical to cycle four (specific → `_error_result`,
+  generic catch-all documented `# noqa: BLE001`). No dead
+  code; no crash paths.
+
+**Coverage delta:** 44.44% → 100.00% (line + branch).
+
+**Tests:** 23 added under
+`tests/unit/workflows/test_refactor_plan_execute.py`.
+Pattern transfers cleanly from
+`test_dependency_check_execute.py` with three rename axes
+(workflow class, subagent names, system-prompt phrase) plus
+two new tests covering the `__init__`'s
+`enable_post_simplification` default and its caller
+override. Only `claude_agent_sdk.query` is mocked; the
+`AssistantMessage`, `ResultMessage`, and `TextBlock`
+instances yielded by the fake generator are **real SDK
+dataclass instances** per the established lesson.
+
+**Transfer-pattern note (confirming cycle four's
+prediction):** the cycle-four observation that "the
+SDK-native shape is uniform across `bug_predict`,
+`perf_audit`, `refactor_plan` and the test pattern
+established here should transfer with minor renames" was
+validated empirically here. Scaffold-and-rename produced a
+running test file on the first attempt; only the
+`enable_post_simplification` attribute name (mixin-mangled
+to `_enable_post_simplification`) required one fix-up after
+running. Estimated cost: ~10 min vs. ~60 min from scratch.
+Recommend `bug_predict` and `perf_audit` as the next two
+working-set picks if the rubric agrees — same dollar of
+test labor returns the same coverage delta.
+
+---
+
 ## 2026-05-12 — fourth module under test-quality-program (Opus 4.7)
 
 Fourth module run. First Agent SDK-native workflow through

--- a/tests/unit/workflows/test_refactor_plan_execute.py
+++ b/tests/unit/workflows/test_refactor_plan_execute.py
@@ -1,0 +1,353 @@
+"""Tests for RefactorPlanWorkflow execute() and _run_agent_plan().
+
+Covers the Agent SDK execution paths. Uses real SDK message
+instances rather than duck-typed fakes so isinstance-based
+collectors in agent_sdk_adapter actually fire (per CLAUDE.md
+lesson: duck-typed test fakes fail isinstance-based collectors
+silently — construct real SDK class instances in tests).
+
+The only thing mocked is ``claude_agent_sdk.query`` itself; the
+ResultMessage / AssistantMessage / TextBlock instances yielded
+by the fake generator are constructed via the real dataclasses.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import patch
+
+import claude_agent_sdk
+import pytest
+
+from attune.workflows.agent_sdk_adapter import AgentRunResult
+from attune.workflows.base import ModelTier
+from attune.workflows.data_classes import WorkflowResult
+from attune.workflows.refactor_plan import RefactorPlanWorkflow
+
+# ---------------------------------------------------------------------------
+# Fixtures — real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workflow() -> RefactorPlanWorkflow:
+    """Build a fresh RefactorPlanWorkflow."""
+    return RefactorPlanWorkflow()
+
+
+@pytest.fixture
+def assistant_message() -> claude_agent_sdk.AssistantMessage:
+    """Real AssistantMessage with a TextBlock payload."""
+    block = claude_agent_sdk.types.TextBlock(text="Findings: 4 hotspots; 2 quick wins.")
+    return claude_agent_sdk.AssistantMessage(
+        content=[block],
+        model="claude-opus-4-7",
+        parent_tool_use_id=None,
+    )
+
+
+@pytest.fixture
+def result_message() -> claude_agent_sdk.ResultMessage:
+    """Real ResultMessage with a final synthesis."""
+    return claude_agent_sdk.ResultMessage(
+        subtype="success",
+        duration_ms=15000,
+        duration_api_ms=13500,
+        is_error=False,
+        num_turns=6,
+        session_id="sess-refactor-7",
+        total_cost_usd=0.67,
+        usage={"input_tokens": 2000, "output_tokens": 1100},
+        result="## Summary\nRefactoring plan complete.",
+        structured_output=None,
+    )
+
+
+def _make_fake_query(messages):
+    """Build an async generator factory yielding the given messages.
+
+    The factory matches ``claude_agent_sdk.query``'s signature
+    (it accepts arbitrary kwargs and returns an async iterator).
+    """
+
+    async def fake_query(*args, **kwargs):
+        for msg in messages:
+            yield msg
+
+    return fake_query
+
+
+# ---------------------------------------------------------------------------
+# __init__ — defaults
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    """RefactorPlanWorkflow's constructor opts in to post-simplification."""
+
+    def test_enables_post_simplification_by_default(self):
+        wf = RefactorPlanWorkflow()
+        # PostSimplificationMixin stores the flag as _enable_post_simplification.
+        assert wf._enable_post_simplification is True
+
+    def test_caller_can_override_post_simplification(self):
+        wf = RefactorPlanWorkflow(enable_post_simplification=False)
+        assert wf._enable_post_simplification is False
+
+
+# ---------------------------------------------------------------------------
+# execute() — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteValidation:
+    """Empty / missing path is rejected before any SDK call."""
+
+    def test_no_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute())
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+    def test_empty_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute(path=""))
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+
+# ---------------------------------------------------------------------------
+# execute() — happy path through real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSuccess:
+    """Successful runs across the three depth profiles."""
+
+    @patch("attune.workflows.refactor_plan.claude_agent_sdk.query")
+    def test_success_yields_workflow_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj", depth="standard"))
+
+        assert isinstance(result, WorkflowResult)
+        assert result.success is True
+        assert result.provider == "anthropic"
+        assert "Findings" in result.final_output or "Summary" in result.final_output
+
+    @patch("attune.workflows.refactor_plan.claude_agent_sdk.query")
+    def test_metadata_populated(self, mock_query, workflow, assistant_message, result_message):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj", depth="quick"))
+
+        # AgentSDKResultAdapter pulls metadata from ResultMessage.
+        assert result.success is True
+        # depth/path forwarded into metadata for downstream callers.
+        meta = result.metadata or {}
+        assert meta.get("depth") == "quick"
+        # path is resolved to absolute; just check it ends with our segment.
+        assert meta.get("path", "").endswith("/tmp/proj") or "tmp" in meta.get("path", "")
+        assert meta.get("max_turns") == 10
+
+    @patch("attune.workflows.refactor_plan.claude_agent_sdk.query")
+    def test_result_only_no_assistant_text(self, mock_query, workflow, result_message):
+        """ResultMessage alone — exercises the ``run_result = sdk_result``
+        assignment branch when only the terminal message arrives.
+        """
+        mock_query.side_effect = _make_fake_query([result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is True
+
+    @patch("attune.workflows.refactor_plan.claude_agent_sdk.query")
+    def test_empty_stream_returns_default_text(self, mock_query, workflow):
+        """Empty stream — adapter still produces a WorkflowResult with the
+        default ``AgentRunResult(result_text="No results returned.")``.
+        """
+        mock_query.side_effect = _make_fake_query([])
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert isinstance(result, WorkflowResult)
+
+
+# ---------------------------------------------------------------------------
+# execute() — depth → max_turns mapping
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDepthMapping:
+    """``depth`` arg drives ``max_turns`` passed to the SDK."""
+
+    def _max_turns_for(self, depth, workflow, monkeypatch):
+        """Run execute(depth=...) and return the max_turns recorded."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            opts = kwargs.get("options")
+            captured["max_turns"] = opts.max_turns
+            if False:
+                yield  # make this an async generator
+
+        monkeypatch.setattr(
+            "attune.workflows.refactor_plan.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/proj", depth=depth))
+        return captured.get("max_turns")
+
+    def test_quick_depth_uses_10_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("quick", workflow, monkeypatch) == 10
+
+    def test_standard_depth_uses_20_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("standard", workflow, monkeypatch) == 20
+
+    def test_deep_depth_uses_40_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("deep", workflow, monkeypatch) == 40
+
+    def test_unknown_depth_falls_back_to_20(self, workflow, monkeypatch):
+        """Undocumented depth values silently fall back to standard's 20."""
+        assert self._max_turns_for("preposterous", workflow, monkeypatch) == 20
+
+    def test_default_depth_is_standard(self, workflow, monkeypatch):
+        """No depth kwarg → standard (20)."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            captured["max_turns"] = kwargs["options"].max_turns
+            if False:
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.refactor_plan.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert captured["max_turns"] == 20
+
+
+# ---------------------------------------------------------------------------
+# execute() — exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteExceptionHandling:
+    """Each specific exception type produces a structured error result."""
+
+    def _patch_query_to_raise(self, monkeypatch, exc):
+        async def raising_query(*args, **kwargs):
+            raise exc
+            if False:  # pragma: no cover
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.refactor_plan.claude_agent_sdk.query",
+            raising_query,
+        )
+
+    def test_import_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ImportError("sdk missing"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "Agent SDK unavailable" in result.error
+
+    def test_connection_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ConnectionError("refused"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_timeout_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, TimeoutError("slow"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_generic_exception(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
+        result = asyncio.run(workflow.execute(path="/tmp/proj"))
+        assert result.success is False
+        assert "RuntimeError" in result.error
+        assert "kaboom" in result.error
+
+
+# ---------------------------------------------------------------------------
+# _run_agent_plan() — directly, bypassing execute()
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentPlanDirect:
+    """Direct invocation surfaces the SDK loop's exact behavior."""
+
+    @patch("attune.workflows.refactor_plan.claude_agent_sdk.query")
+    def test_collects_assistant_and_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+
+        run_result = asyncio.run(workflow._run_agent_plan("/tmp/proj", 20, "standard"))
+        assert isinstance(run_result, AgentRunResult)
+        # build_result_text prefers assistant_parts when they're at least as
+        # long as result_parts; here both are short and assistant wins by length.
+        assert "Findings" in run_result.result_text or "Summary" in run_result.result_text
+
+    @patch("attune.workflows.refactor_plan.claude_agent_sdk.query")
+    def test_no_messages_returns_default_text(self, mock_query, workflow):
+        mock_query.side_effect = _make_fake_query([])
+        run_result = asyncio.run(workflow._run_agent_plan("/tmp/proj", 20))
+        assert run_result.result_text == "No results returned."
+
+    @patch("attune.workflows.refactor_plan.claude_agent_sdk.query")
+    def test_passes_subagent_definitions(self, mock_query, workflow, result_message):
+        """All three subagents (debt-scanner, impact-analyzer,
+        plan-generator) are wired into the SDK call's options.
+        """
+        captured: dict = {}
+
+        async def capturing_query(*args, **kwargs):
+            captured["options"] = kwargs.get("options")
+            captured["prompt"] = kwargs.get("prompt")
+            yield result_message
+
+        mock_query.side_effect = capturing_query
+        asyncio.run(workflow._run_agent_plan("/tmp/proj", 20, "standard"))
+
+        opts = captured["options"]
+        assert "debt-scanner" in opts.agents
+        assert "impact-analyzer" in opts.agents
+        assert "plan-generator" in opts.agents
+        # System prompt + path in task prompt.
+        assert "refactoring plan orchestrator" in opts.system_prompt
+        assert "/tmp/proj" in captured["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# _error_result() — inherited from BaseWorkflow but exercised here so
+# its surface stays measured even if base.py refactors break the contract.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResult:
+    """Shape of the failure WorkflowResult."""
+
+    def test_structure(self, workflow):
+        result = workflow._error_result("nope")
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert result.error == "nope"
+        assert result.total_duration_ms == 0
+        assert result.cost_report.total_cost == 0.0
+
+    def test_stage_metadata(self, workflow):
+        result = workflow._error_result("nope")
+        assert len(result.stages) == 1
+        assert result.stages[0].name == "refactor-plan"
+        assert result.stages[0].tier == ModelTier.CAPABLE
+
+    def test_timestamps_bounded(self, workflow):
+        before = datetime.now()
+        result = workflow._error_result("nope")
+        after = datetime.now()
+        assert before <= result.started_at <= after
+        assert before <= result.completed_at <= after


### PR DESCRIPTION
## Summary

Fifth module through the test-quality-program playbook. Second SDK-native workflow, validating cycle-four's transfer-pattern prediction: the [`test_dependency_check_execute.py`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/tests/unit/workflows/test_dependency_check_execute.py) shape ported with rename-only changes plus two tests for the workflow's `enable_post_simplification` `__init__` default.

- **Coverage**: 44.44% → **100.00%** (line + branch) on `src/attune/workflows/refactor_plan.py`
- **Tests added**: 23 deterministic, across 7 classes (`TestInit`, `TestExecuteValidation`, `TestExecuteSuccess`, `TestExecuteDepthMapping`, `TestExecuteExceptionHandling`, `TestRunAgentPlanDirect`, `TestErrorResult`)
- **Bugs surfaced**: 0 — the module is a thin async shell around `claude_agent_sdk.query()`
- **Pattern**: only `claude_agent_sdk.query` is mocked; `AssistantMessage` / `ResultMessage` / `TextBlock` instances are real SDK dataclasses (so `isinstance` checks in `agent_sdk_adapter.collect_agent_output` fire)

## Transfer-pattern note

Cycle four predicted the SDK-native test shape would transfer across `bug_predict` / `perf_audit` / `refactor_plan` with rename-only changes. Validated empirically here — scaffold-and-rename produced a running test file on the first attempt; only the `enable_post_simplification` attribute name (mixin-mangled to `_enable_post_simplification`) needed one fix-up. ~10 min vs. ~60 min from scratch.

## Test plan

- [x] All 23 new tests pass under sequential `coverage run` (100% line+branch on target)
- [x] All 66 refactor_plan tests pass under xdist (`-n auto`): 23 new + 43 existing
- [x] Pre-commit hooks (black, ruff, ruff-bare-exception-check, bandit) all pass
- [x] CHANGELOG.md updated with Unreleased Internal note
- [x] docs/COVERAGE_BUG_LOG.md updated with fifth-module entry (0 bugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)