### PR TITLE
docs: close windows-memory-detection spec + capture lessons

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3097,21 +3097,28 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   retry would 404 because the PR is already merged.
 
 - **Restoring `-n auto` after a branch lag surfaces
-  tests landed on main under `-n 1` that aren't
-  xdist-safe**: PR #242 restored `-n auto`, was
-  rebased onto a main that had merged PR #263
-  earlier the same day. PR #263 added
-  `tests/unit/memory/short_term/test_conflicts.py`
-  with `capsys` assertions on structlog output —
-  the tests pass under `-n 1` but fail under
-  `-n auto` because structlog routing in xdist
-  workers doesn't reach the worker's `capsys`
-  stream (assertion sees empty string). Pattern:
-  ANY PR that changes parallelism mode must
-  rebase to current main AND grep the recent
-  commit range for new tests using `capsys` /
-  `caplog` / log-capture patterns — those are the
-  xdist-fragile surface. Fix template is to swap
-  `capsys` for pytest's `caplog` (xdist-aware) or
-  use a structlog-specific test capture fixture;
+  xdist-fragile tests AND can miss upstream fixes
+  for them**: PR #242 restored `-n auto`, rebased
+  onto a main that had recently merged PR #263 —
+  which originally added `test_conflicts.py` with
+  `capsys` assertions on structlog output (passes
+  under `-n 1`, fails under `-n auto` because
+  structlog routing in xdist workers doesn't reach
+  the worker's `capsys` stream). PR #265 fixed those
+  assertions to use `structlog.testing.capture_logs()`
+  with `reset_defaults()`, but #265 merged AFTER
+  #242's rebase, so the rebased branch still carried
+  the broken pre-#265 version. Two patterns:
+  (1) ANY PR that changes parallelism mode must
+  grep the recent commit range for tests using
+  `capsys` / `caplog` / log-capture and verify
+  they're using the xdist-safe variant;
+  (2) when rebasing a long-lived branch, the
+  presence of an upstream merge doesn't mean its
+  follow-ups are also in — check that any
+  test-fragility introduced by the merge has its
+  fixup commit included. Fix template for
+  structlog tests: `capture_logs()` with
+  explicit `structlog.reset_defaults()` before the
+  context manager, not `capsys`;
   do NOT skipif as the first move.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3078,3 +3078,40 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   errors="replace"` on `subprocess.run` when the
   child may emit non-ASCII. Same fix shape as the
   `Path.read_text(encoding="utf-8")` lesson.
+
+- **`gh pr merge --squash --admin` from a sub-
+  worktree exits non-zero but the remote merge
+  succeeds**: when running from
+  `.claude/worktrees/<name>/`, `gh pr merge` prints
+  `failed to run git: fatal: 'main' is already
+  used by worktree at '/Users/<...>/attune-ai'` —
+  the parent worktree owns `main` and the post-merge
+  local checkout step can't take it. The REMOTE
+  merge already succeeded by the time this error
+  fires. Distinct from the existing "fast-forward
+  warning when remote merge succeeds" lesson
+  (that's about the local fast-forward of `main`
+  failing after merge from a non-worktree). Always
+  verify with `gh pr view <PR> --json
+  state,mergedAt,mergeCommit` before retrying —
+  retry would 404 because the PR is already merged.
+
+- **Restoring `-n auto` after a branch lag surfaces
+  tests landed on main under `-n 1` that aren't
+  xdist-safe**: PR #242 restored `-n auto`, was
+  rebased onto a main that had merged PR #263
+  earlier the same day. PR #263 added
+  `tests/unit/memory/short_term/test_conflicts.py`
+  with `capsys` assertions on structlog output —
+  the tests pass under `-n 1` but fail under
+  `-n auto` because structlog routing in xdist
+  workers doesn't reach the worker's `capsys`
+  stream (assertion sees empty string). Pattern:
+  ANY PR that changes parallelism mode must
+  rebase to current main AND grep the recent
+  commit range for new tests using `capsys` /
+  `caplog` / log-capture patterns — those are the
+  xdist-fragile surface. Fix template is to swap
+  `capsys` for pytest's `caplog` (xdist-aware) or
+  use a structlog-specific test capture fixture;
+  do NOT skipif as the first move.

--- a/docs/specs/windows-memory-detection/decisions.md
+++ b/docs/specs/windows-memory-detection/decisions.md
@@ -186,3 +186,59 @@ code unchanged.
 
 Push these changes and confirm 12/12 matrix green under `-n auto`.
 All 4 documented Windows failures should now be addressed.
+
+---
+
+## 2026-05-12 (later) — PR #242 surfaces 2 new failures on rebase
+
+After PRs #260 and #261 merged, PR #242 was rebased onto the new
+main (commits `5f55a451` and `f05727fe`, force-pushed) and marked
+ready. The post-rebase CI run revealed a NEW failure pattern that
+the original 4 didn't cover:
+
+| Test | Lanes failing | Lanes passing |
+|------|--------------|---------------|
+| `tests/unit/memory/short_term/test_conflicts.py::TestCreateConflictContext::test_logs_creation_event` | Ubuntu × 4, Windows × 3 (3.11–3.13) | macOS × 4, Windows 3.10 |
+| `tests/unit/memory/short_term/test_conflicts.py::TestResolveConflict::test_logs_resolution_event` | Same as above | Same |
+
+Both assert structlog output via `capsys` (`assert "conflict_..."
+in captured` where `captured == ""`). The tests landed on main
+earlier the same day via PR #263
+(`4d8f387c test(memory/short_term): meaningful coverage on
+conflicts.py`) AFTER PR #242 was originally opened. They pass
+under `-n 1` (main's current config) but fail under `-n auto`
+(what PR #242 restores) because structlog routing in xdist
+workers doesn't reach the worker's `capsys` stream.
+
+This is the exact "5th test surfaces during rebase" scenario
+Phase 4.3 of `tasks.md` anticipated. Per the spec's discipline:
+**do NOT merge PR #242** until these are resolved.
+
+### Resolution path (next session)
+
+Three options, in order of principled-ness:
+
+1. **Fix `test_conflicts.py` to be xdist-safe**. Replace `capsys`
+   assertions with pytest's `caplog` (xdist-aware) or a
+   structlog-specific test capture fixture. ~30 min, defensible
+   on its own merits as test quality. Adds `test_conflicts.py`
+   to the spec's scope as a 5th addressed test file.
+
+2. **Block similar patterns retroactively** with a lint rule
+   that catches `capsys.readouterr()` co-located with
+   `structlog`/`logger` in the same test module, and require
+   `caplog` instead. Out of scope for this spec; file separately.
+
+3. **Skipif under xdist** (Phase 5 fallback). Pragmatic but adds
+   debt and contradicts the spec's "don't skipif as first move"
+   principle.
+
+Recommend option 1 in the next session focused on PR #242. Spec
+remains open with one outstanding criterion (resolution-criteria
+item 3: all 12 platform lanes green under `-n auto`).
+
+### Lesson captured
+
+Restoring `-n auto` after a branch lag surfaces tests landed on
+main under `-n 1` that aren't xdist-safe. Generalization captured
+in CLAUDE.md.

--- a/docs/specs/windows-memory-detection/decisions.md
+++ b/docs/specs/windows-memory-detection/decisions.md
@@ -202,36 +202,36 @@ the original 4 didn't cover:
 | `tests/unit/memory/short_term/test_conflicts.py::TestResolveConflict::test_logs_resolution_event` | Same as above | Same |
 
 Both assert structlog output via `capsys` (`assert "conflict_..."
-in captured` where `captured == ""`). The tests landed on main
-earlier the same day via PR #263
-(`4d8f387c test(memory/short_term): meaningful coverage on
-conflicts.py`) AFTER PR #242 was originally opened. They pass
-under `-n 1` (main's current config) but fail under `-n auto`
-(what PR #242 restores) because structlog routing in xdist
-workers doesn't reach the worker's `capsys` stream.
+in captured` where `captured == ""`). The capsys version was on
+PR #242's branch — added originally by PR #263 (`4d8f387c`) earlier
+the same day. They pass under `-n 1` (the configuration PR #263
+shipped under) but fail under `-n auto` (what PR #242 restores)
+because structlog routing in xdist workers doesn't reach the
+worker's `capsys` stream.
 
-This is the exact "5th test surfaces during rebase" scenario
-Phase 4.3 of `tasks.md` anticipated. Per the spec's discipline:
-**do NOT merge PR #242** until these are resolved.
+**Important correction**: main's current version of
+`test_conflicts.py` already uses the xdist-safe pattern
+(`structlog.testing.capture_logs()` with `reset_defaults()`).
+That fix landed via PR #265 (`21e7cefc`, merged 12:28 EDT today)
+AFTER PR #242's rebase ran (14:30 UTC). So PR #242's branch had
+the pre-#265 capsys version, and the rebase missed the fix
+because the rebase base predated it.
 
-### Resolution path (next session)
+This is the "5th test surfaces during rebase" scenario Phase 4.3
+of `tasks.md` anticipated, with a wrinkle: the fix already exists
+upstream; PR #242 just needs to pick it up.
 
-Three options, in order of principled-ness:
+### Resolution
 
-1. **Fix `test_conflicts.py` to be xdist-safe**. Replace `capsys`
-   assertions with pytest's `caplog` (xdist-aware) or a
-   structlog-specific test capture fixture. ~30 min, defensible
-   on its own merits as test quality. Adds `test_conflicts.py`
-   to the spec's scope as a 5th addressed test file.
+The minimal fix is to restore main's version of `test_conflicts.py`
+on PR #242's branch (`git checkout origin/main --
+tests/unit/memory/short_term/test_conflicts.py`). Committed and
+pushed as `7eef6abc` on `feat/probe-c-phase4-restore-n-auto`. CI
+should now re-run with the xdist-safe version.
 
-2. **Block similar patterns retroactively** with a lint rule
-   that catches `capsys.readouterr()` co-located with
-   `structlog`/`logger` in the same test module, and require
-   `caplog` instead. Out of scope for this spec; file separately.
-
-3. **Skipif under xdist** (Phase 5 fallback). Pragmatic but adds
-   debt and contradicts the spec's "don't skipif as first move"
-   principle.
+Alternative (cleaner but more work): re-rebase PR #242 onto current
+main, which would naturally pick up #265's fix. Skipped because the
+surgical file-restore is equivalent and avoids another force-push.
 
 Recommend option 1 in the next session focused on PR #242. Spec
 remains open with one outstanding criterion (resolution-criteria

--- a/docs/specs/windows-memory-detection/decisions.md
+++ b/docs/specs/windows-memory-detection/decisions.md
@@ -1,8 +1,9 @@
 # Decisions — Windows Memory-Feature Detection
 
-**Status:** approved
+**Status:** complete (2026-05-12)
 **Owner:** Patrick
 **Opened:** 2026-05-11
+**Closed:** 2026-05-12 (PR #242 merged `5e364653`)
 **Predecessor:** `docs/specs/probe-c-memory-investigation/` (Phase 4 deferred — see PR #242)
 
 ---
@@ -242,3 +243,35 @@ item 3: all 12 platform lanes green under `-n auto`).
 Restoring `-n auto` after a branch lag surfaces tests landed on
 main under `-n 1` that aren't xdist-safe. Generalization captured
 in CLAUDE.md.
+
+---
+
+## 2026-05-12 (final) — Spec closed
+
+PR #242 merged at `5e364653`. CI re-ran the full 12-lane matrix
+with the `test_conflicts.py` fix and all 12 lanes passed.
+
+**Resolution criteria — all satisfied:**
+
+1. ✅ Each of the 4 original failures has a root-cause line item
+   in this file (Phase 2 + 3.1 entries above).
+2. ✅ Fixes landed for all 4 — no skipif fallbacks needed.
+3. ✅ PR #242 rebased on the new main and **all 12 platform lanes
+   passed** under `-n auto`.
+4. ✅ Matrix wall time well under 10 min on the post-fix run.
+
+**PRs merged today (2026-05-12) closing this spec:**
+
+| PR | Title | Merge commit |
+|----|-------|--------------|
+| #260 | fix(ci): resolve 4 Windows-only test failures | `46492dc0` |
+| #261 | docs(lessons): three CI-debugging lessons | `9a82cbbc` |
+| #242 | ci(tests): restore `-n auto` — probe-c Phase 4 | `5e364653` |
+
+The `-n auto` win is now realized: ~3× faster CI matrix on Windows,
+~100+ compute-minutes saved per matrix run. All four Windows tests
+green, plus the late-surfacing `test_conflicts.py` capsys regression
+caught and fixed during PR #242's CI verification.
+
+Spec status: **complete**. Predecessor
+`probe-c-memory-investigation` Phase 4 also closes.

--- a/docs/specs/windows-memory-detection/tasks.md
+++ b/docs/specs/windows-memory-detection/tasks.md
@@ -1,8 +1,10 @@
 # Tasks — Windows Memory-Feature Detection
 
-**Status:** approved
+**Status:** complete (2026-05-12)
 
 Investigation + fix tasks for the 4 Windows-only failures surfaced by PR #242 (`-n auto` restore). See `decisions.md` for context.
+
+**Resolution:** PRs #260 + #242 merged 2026-05-12. All 12 platform lanes green under `-n auto`. All resolution criteria satisfied.
 
 ---
 


### PR DESCRIPTION
## Summary

End-of-session documentation bundle following the merge of [PR #260](https://github.com/Smart-AI-Memory/attune-ai/pull/260), [PR #261](https://github.com/Smart-AI-Memory/attune-ai/pull/261), and [PR #242](https://github.com/Smart-AI-Memory/attune-ai/pull/242) — all of which closed the [windows-memory-detection](docs/specs/windows-memory-detection/) spec today.

## Contents (4 commits)

1. **CLAUDE.md lessons** — two new project lessons:
   - `gh pr merge --admin` from a sub-worktree exits non-zero but the remote merge succeeds (verify with `gh pr view`)
   - Restoring `-n auto` after a branch lag surfaces xdist-fragile tests AND can miss upstream fixes for them
2. **decisions.md entry** — full timeline of PR #242's surfacing the late `test_conflicts.py` capsys regression
3. **Narrative correction** — original root-cause framing was wrong (the issue was PR #242's rebase missing PR #265's fix, not PR #263 introducing fragile tests). Corrected in both decisions.md and CLAUDE.md.
4. **Spec closure** — `windows-memory-detection` status flipped from `approved` to `complete (2026-05-12)`. All 4 resolution criteria satisfied. Closure entry summarizing the 3 merged PRs and the bonus capsys catch.

Doc-only PR — no code changes, no CI test impact.

## Test plan

- [x] pre-commit hooks all passed locally
- [ ] No CI test impact expected