### PR TITLE
docs(specs): close ignored-tests + retriage sequencing

### DIFF
--- a/docs/specs/_sequencing.md
+++ b/docs/specs/_sequencing.md
@@ -68,24 +68,6 @@ These specs feed each other; run in order.
   - [ ] Phase 3D — enforcement script + CI gate
 - Spec: [coverage-exclusion-policy](coverage-exclusion-policy/)
 
-### ignored-tests
-
-- Status: approved — 13 tasks, 0% done
-- Why here: Parent (`test-infrastructure`) is complete. Each
-  of the 4 quarantined files (88 failing tests) is
-  independently shippable, so ship them in any order once
-  Track A's coverage work is stable.
-- Tasks
-  - [ ] File 1 — triage repair/reconcile/retire
-  - [ ] File 2 — triage repair/reconcile/retire
-  - [ ] File 3 — triage repair/reconcile/retire
-  - [ ] File 4 — triage repair/reconcile/retire
-  - [ ] Update pytest.ini per-file outcomes
-  - [ ] Update decisions.md with rationale
-- Spec: [ignored-tests](ignored-tests/)
-
----
-
 ### windows-xdist-honor
 
 - Status: draft — 4-phase plan, 0% done
@@ -197,3 +179,7 @@ Windows CI is the natural next step alongside Phase 2.
 - [docs/specs/telemetry](telemetry/) — complete
 - [docs/specs/test-infrastructure](test-infrastructure/) —
   core work complete 2026-05-09 (follow-up: `ignored-tests`)
+- [docs/specs/ignored-tests](ignored-tests/) — complete
+  2026-05-09; 3 files retired, 1 reconciled (single-fixture
+  fix), pytest.ini clean, +35 tests recovered. Docs closed
+  2026-05-12.

--- a/docs/specs/_sequencing.md
+++ b/docs/specs/_sequencing.md
@@ -20,61 +20,37 @@ deleting it — the history is useful for retros.
 
 ---
 
-## Track A — Test signal (sequential, critical path)
+## Track A — Test signal (finishing up)
 
-These specs feed each other; run in order.
+windows-memory-detection and ignored-tests both closed
+2026-05-12. Only one small thread remains on this track.
 
-### windows-memory-detection (NEW priority — replaces probes)
-
-- Status: approved — 4-phase plan, Phase 1.1 done; Phase 3.1
-  partially done in this worktree (encoding fix to
-  `_run_hook` in test_session_continuity_io.py).
-- Why first: The 4 actual Windows-only CI failures on main
-  fit this spec exactly. One of them (the hook subprocess
-  bug) is named in Phase 1.3 by test ID and the encoding
-  fix matches Phase 3.1's proposed solution.
-- Tasks
-  - [x] Phase 1.1 — push diagnostic run (done via PR #245)
-  - [ ] Phase 1.2 — promote hypotheses to root-cause notes
-  - [ ] Phase 1.3 — diagnose hook subprocess failure
-        (this worktree's fix may close it; verify on Windows CI)
-  - [ ] Phase 2 — fix memory-feature worker-crash cluster
-        (3 tests: redis_auto_detect, memory_features × 2)
-  - [ ] Phase 3 — fix hook subprocess wrapper + add guard
-        test (encoding fix shipped here; add guard test)
-  - [ ] Phase 4 — unblock PR #242 (rebase, ready, merge)
-- Spec: [windows-memory-detection](windows-memory-detection/)
-
-### coverage-canonical-pattern — PAUSED 2026-05-12
-
-- Status: paused — premise invalidated. Recent main CI
-  failures are Windows-only individual test bugs, NOT the
-  `[100%] PASSED → shutdown` OOM pattern the spec was
-  designed to fix. See spec's `decisions.md`.
-- Re-open only if the OOM/shutdown pattern recurs. Probes
-  0a/0b are NOT to be executed — Probe 0a's change is
-  already in `tests.yml` and Probe 0b's hypothesis no
-  longer matches reality.
-- Spec: [coverage-canonical-pattern](coverage-canonical-pattern/)
-
-### coverage-exclusion-policy (Phases 3B–3D)
+### coverage-exclusion-policy (Phases 3B–3D) — LEAD
 
 - Status: approved — 12 tasks, ~17% done (Phase 3A landed)
-- Why here: Small. Slot between canonical-pattern phases as a
-  context-switch break. Touches the same pytest config.
+- Why lead: Last open Track A thread. Touches the same
+  `pytest.ini`/`pyproject.toml` configuration we just
+  cleaned via ignored-tests. Three small phases.
 - Tasks
   - [ ] Phase 3B — audit 3 undocumented exclusions
   - [ ] Phase 3C — document or remove each
   - [ ] Phase 3D — enforcement script + CI gate
 - Spec: [coverage-exclusion-policy](coverage-exclusion-policy/)
 
-### windows-xdist-honor
+### coverage-canonical-pattern — PAUSED 2026-05-12
+
+- Status: paused — premise invalidated. Recent main CI
+  failures were Windows-only individual test bugs, NOT the
+  `[100%] PASSED → shutdown` OOM pattern the spec was
+  designed to fix. See spec's `decisions.md`.
+- Re-open only if the OOM/shutdown pattern recurs.
+
+### windows-xdist-honor — CONDITIONAL
 
 - Status: draft — 4-phase plan, 0% done
-- Why deferred: Adjacent concern (is `-n 1` honored on
-  Windows). Address only if windows-memory-detection fixes
-  alone don't yield 11+/12 green matrix jobs. Strict
-  3-iteration cap per the tar-pit trip-wire rule.
+- Do not pre-schedule. Open only if Windows CI regresses
+  with `-n auto` not honored. Strict 3-iteration cap per
+  the tar-pit trip-wire rule.
 - Spec: [windows-xdist-honor](windows-xdist-honor/)
 
 ---
@@ -94,6 +70,20 @@ run alongside Track A.
   - [ ] Decision gate — re-scope based on findings
   - [ ] (Later) Phase B+ — implementation
 - Spec: [redis-decoupling](redis-decoupling/)
+
+### ops-specs-features (Phase 0 unblock)
+
+- Status: approved & prioritized 2026-05-11; gate condition
+  0.1b now satisfied (main green as of `bb0d8aec`,
+  2026-05-12). Phase 0.5 re-check still pending.
+- Why here: Pure verification step (re-check usage and
+  scope) gates the port-of-features implementation work.
+  Cheap to close.
+- Tasks
+  - [ ] Phase 0.1b — confirm CI condition
+  - [ ] Phase 0.5 — re-check porting scope vs current usage
+  - [ ] Phase 1+ — implementation (after gate)
+- Spec: [ops-specs-features](ops-specs-features/)
 
 ---
 
@@ -147,6 +137,40 @@ natural pause.
 
 ---
 
+## Track D — Standing umbrella (opportunistic)
+
+No start/end date. Slot a module whenever there's spare
+context between bigger work. Use the rubric to pick.
+
+### test-quality-program
+
+- Status: approved — 8 phases, 0% done; umbrella spec
+  codifying the COVERAGE_BUG_LOG playbook (~22% bug-find
+  rate across 80 prior modules).
+- Why standing: Module-by-module, not a single deliverable.
+  Re-orients prior 100%-coverage chase to "meaningful
+  coverage on customer-facing paths + test-reliability
+  hardening."
+- Cadence: One module per session, picked by rubric.
+- Spec: [test-quality-program](test-quality-program/)
+
+---
+
+## Track E — Conditional / contingent (do not pre-schedule)
+
+Open only if a trigger condition fires.
+
+### larger-runners — draft
+
+- Status: draft, post-Probe-C revision. Originally rescue
+  for OOM; now about *headroom and speed*, not rescue.
+- Trigger: CI duration becomes a constraint, or a workflow
+  consistently hits worker-memory ceilings on default
+  runners.
+- Spec: [larger-runners](larger-runners/)
+
+---
+
 ## Sequencing rationale (positive reasons)
 
 - Track A first means every later spec lands against green,
@@ -163,13 +187,10 @@ natural pause.
 
 ## Today's recommended pick
 
-**windows-memory-detection Phase 2.** Three Windows worker
-crashes (`test_redis_auto_detect`, `test_memory_features`
-×2) likely share one root cause — a Unix-only probe in
-`MemoryFeatures.list_all_features()` or `is_redis_enabled()`.
-One fix probably closes all three tests. The hook subprocess
-fix (Phase 3.1) shipped in this worktree, so verifying it on
-Windows CI is the natural next step alongside Phase 2.
+**coverage-exclusion-policy Phase 3B** — audit the three
+undocumented `[tool.coverage.run] omit` entries in
+`pyproject.toml`. Smallest unit of forward progress, finishes
+the last open Track A thread, and sets up Phase 3D's CI gate.
 
 ---
 
@@ -183,3 +204,10 @@ Windows CI is the natural next step alongside Phase 2.
   2026-05-09; 3 files retired, 1 reconciled (single-fixture
   fix), pytest.ini clean, +35 tests recovered. Docs closed
   2026-05-12.
+- [docs/specs/windows-memory-detection](windows-memory-detection/) —
+  complete 2026-05-12. Four Windows-only test failures
+  resolved (PRs #260, #261). `-n auto` restored across the
+  matrix (PR #242).
+- [docs/specs/probe-c-memory-investigation](probe-c-memory-investigation/) —
+  ✓ resolved 2026-05-11; threading-patch fix in PR #212
+  commit `bcc6bdec` closed the OOM concern.

--- a/docs/specs/ignored-tests/tasks.md
+++ b/docs/specs/ignored-tests/tasks.md
@@ -1,6 +1,6 @@
 # Spec: Resolve `--ignore`-d Test Files
 
-**Status**: approved
+**Status**: complete (2026-05-09 — see `decisions.md`)
 
 ---
 
@@ -10,8 +10,8 @@
 
 | # | Task | Layer | Status | Notes |
 |---|------|-------|--------|-------|
-| 1 | Create `docs/specs/ignored-tests/decisions.md` as an empty file with a one-line header. Each per-file resolution will append a paragraph here. | docs | todo | Append-only log; lives alongside the spec. |
-| 2 | Capture the **current** baseline: full unit suite green count under `-n auto`. Record in this spec as the reference number for Phase 3D regression checks. | test-infra | todo | Expected ~14,075 passed (2026-05-09 baseline). Re-run before starting in case anything has drifted. |
+| 1 | Create `docs/specs/ignored-tests/decisions.md` as an empty file with a one-line header. Each per-file resolution will append a paragraph here. | docs | **done** | Populated 2026-05-09 with all four per-file rationale entries. |
+| 2 | Capture the **current** baseline: full unit suite green count under `-n auto`. Record in this spec as the reference number for Phase 3D regression checks. | test-infra | **done** | Baseline 14,075 passed → final 14,110 passed (+35 recovered from composition reconcile). |
 
 ### Phase 3B — Per-file resolution
 
@@ -22,27 +22,27 @@ from the test-infrastructure audit and may need revision.
 
 | # | File | Path | Status | Notes |
 |---|------|------|--------|-------|
-| 3 | `tests/unit/workflows/test_orchestrated_release_prep.py` (5/35 fail) | **R1 REPAIR** | todo | Sample root cause from audit: `assert isinstance(result, AgentResult)` fires at `core_strategies.py:161` because real workflow execution returns non-`AgentResult`. Group all 5 failures by root cause first; if > 3 distinct causes, re-classify to R2. |
-| 4 | `tests/unit/models/test_execution_and_fallback_architecture.py` (41/52 fail) | **R3 RETIRE (with salvage)** | todo | File is explicit about being aspirational ("Coverage Target: 95%+ from 21-73%") and admits drift in code comments (`# NOTE: FallbackPolicy may not exist or have different API - Gap 3.2`). Salvage pass: walk the 8 invariants in the docstring; for each, check current production + check whether tested elsewhere. Write a small targeted file for any unique surviving invariants. |
-| 5 | `tests/unit/scaffolding/test_scaffolding_cli.py` (28/42 fail) | **R3 RETIRE (with salvage)** | todo | Re-classify after reading `src/attune/scaffolding/cli.py`. Heavy `sys.modules` mocking (`sys.modules["test_generator"] = MagicMock()`) is the smell — mocks have lost their target. If `cli.py` is small enough to test cleanly without sys.modules surgery, downgrade to R2 RECONCILE and rewrite. |
-| 6 | `tests/unit/orchestration/test_composition_patterns.py` (14/35 fail) | **R2 RECONCILE** | todo | First task: disambiguate (a) test-debt-only vs (b) production-regression. Method: `git log --oneline --since=2026-01-24 -- src/attune/orchestration/` and same for the test file. The "XFAIL TEST REMEDIATION - COMPLETED (2026-01-24)" header is the diagnostic. |
+| 3 | `tests/unit/workflows/test_orchestrated_release_prep.py` (5/35 fail) | **R3 RETIRE** (reclassified from R1) | **done** | Commit `f88afb08`. Reclassified after reading production: module is deprecated since v5.2.0 ("Remove in v6.0"); replacement `ReleasePrepTeamWorkflow` already has parallel coverage. File deleted, no salvage. See decisions.md. |
+| 4 | `tests/unit/models/test_execution_and_fallback_architecture.py` (41/52 fail) | **R3 RETIRE — no salvage** | **done** | Commit `90d33dce`. All 8 invariant categories already covered elsewhere (registry, executor, fallback, circuit breaker, cost tracking, routing, telemetry). File deleted. |
+| 5 | `tests/unit/scaffolding/test_scaffolding_cli.py` (28/42 fail) | **R3 RETIRE — no salvage** | **done** | Commit `b343fcbd`. Production CLI is deprecated (emits notice on every invocation); already excluded from coverage. Mock-driven tests had lost their targets. File deleted. |
+| 6 | `tests/unit/orchestration/test_composition_patterns.py` (14/35 fail) | **R2 RECONCILE** (confirmed) | **done** | Commit `fd80a8d0`. Single-fixture fix in `tests/unit/orchestration/conftest.py`: patch `ExecutionStrategy._execute_agent` at the class level so nested ParallelStrategy in DebateStrategy inherits the mock. All 35 tests now pass; no test method touched. |
 
 ### Phase 3C — pytest.ini cleanup
 
 | # | Task | Layer | Status | Notes |
 |---|------|-------|--------|-------|
-| 7 | After each per-file commit (#3–#6) lands, remove the corresponding `--ignore=tests/unit/...` line from `pytest.ini`. | pytest.ini | todo | Done as part of each per-file commit, not a separate commit. |
-| 8 | After all four files are resolved, update the explanatory comment block in `pytest.ini` (currently lines 29–39) to remove the audit findings and replace with a one-line note: "Only `--ignore=tests/integration/` remains — integration tests live behind their own runner. See `docs/specs/ignored-tests/`." | pytest.ini / docs | todo | Keep the comment short — it's history, not active context. |
+| 7 | After each per-file commit (#3–#6) lands, remove the corresponding `--ignore=tests/unit/...` line from `pytest.ini`. | pytest.ini | **done** | Folded into each per-file commit. |
+| 8 | After all four files are resolved, update the explanatory comment block in `pytest.ini` (currently lines 29–39) to remove the audit findings and replace with a one-line note: "Only `--ignore=tests/integration/` remains — integration tests live behind their own runner. See `docs/specs/ignored-tests/`." | pytest.ini / docs | **done** | Comment block in `pytest.ini` now points at this spec. |
 
 ### Phase 3D — Validation
 
 | # | Task | Layer | Status | Notes |
 |---|------|-------|--------|-------|
-| 9 | After each per-file commit, run `pytest tests/unit/ -n auto` and confirm: (a) the resolved file's tests now pass (or are deleted), (b) total green count is ≥ the baseline from #2, (c) zero new failures elsewhere. | manual | todo | Required before pushing each commit. Catches xdist interference (Risk 4). |
-| 10 | Final-state check: `grep -E "^\s*--ignore=tests/unit" pytest.ini` returns nothing. | manual | todo | Trivial but the canonical "are we done?" command. |
-| 11 | Final-state check: `git grep -n "import .*orchestrated_release_prep\|import .*composition_patterns\|import .*execution_and_fallback_architecture\|import .*scaffolding/cli" tests/` returns no broken imports from sibling test files. | manual | todo | If we deleted a test file that another file imported helpers from, this catches it. |
-| 12 | Update `docs/specs/test-infrastructure/tasks.md` task #10: change status from **deferred** → **done**, link to this spec's decisions.md. | docs | todo | Closes the loop with the parent spec. |
-| 13 | CI parity check: confirm CI runs are still green after the merged commits land on `main`. | CI | todo | Test debt resolution shouldn't affect CI behavior, but the sweep itself is the kind of thing that surfaces hidden coupling. |
+| 9 | After each per-file commit, run `pytest tests/unit/ -n auto` and confirm: (a) the resolved file's tests now pass (or are deleted), (b) total green count is ≥ the baseline from #2, (c) zero new failures elsewhere. | manual | **done** | Recorded inline in each commit; final count 14,110 passed. |
+| 10 | Final-state check: `grep -E "^\s*--ignore=tests/unit" pytest.ini` returns nothing. | manual | **done** | Verified 2026-05-12 — no matches. |
+| 11 | Final-state check: `git grep -n "import .*orchestrated_release_prep\|import .*composition_patterns\|import .*execution_and_fallback_architecture\|import .*scaffolding/cli" tests/` returns no broken imports from sibling test files. | manual | **done** | Verified 2026-05-12 — no matches. |
+| 12 | Update `docs/specs/test-infrastructure/tasks.md` task #10: change status from **deferred** → **done**, link to this spec's decisions.md. | docs | **done** | Commit `e872eae9`. Parent spec marked complete. |
+| 13 | CI parity check: confirm CI runs are still green after the merged commits land on `main`. | CI | **done** | All commits merged; main is clean and green as of `bb0d8aec` (2026-05-12). |
 
 ### Failure-to-deliver path
 


### PR DESCRIPTION
## Summary

- Closes the [\`ignored-tests\`](docs/specs/ignored-tests/) spec; all 13 tasks already landed on main via commits \`f88afb08\`, \`90d33dce\`, \`b343fcbd\`, \`fd80a8d0\`, \`e872eae9\`. Spec status flipped to **complete**, task rows now reference resolving SHAs.
- Retriaged [\`_sequencing.md\`](docs/specs/_sequencing.md): moved \`windows-memory-detection\` and \`probe-c-memory-investigation\` to Done, added Track D (standing umbrella) and Track E (conditional), surfaced \`ops-specs-features\` Phase 0 unblock under Track B, and rotated today's pick to \`coverage-exclusion-policy\` Phase 3B.

## Test plan

- [x] \`grep -E "^\s*--ignore=tests/unit" pytest.ini\` returns nothing
- [x] \`git grep\` for sibling imports of the retired test files returns nothing
- [x] \`pytest tests/unit/orchestration/test_composition_patterns.py\` — 35 passed
- [x] Pre-commit hooks pass on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)