### PR TITLE
docs(specs): close coverage-exclusion-policy (Phases 3B + 3C)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,3 +138,15 @@ repos:
           ^plugin/skills/.*/SKILL\.md$|
           ^src/attune/mcp/tool_schemas\.py$
         stages: [pre-commit]
+
+      # Coverage exclusion policy enforcement
+      # Every production-code entry in pyproject.toml's
+      # [tool.coverage.run] omit block must have an inline `#` comment.
+      # See docs/specs/coverage-exclusion-policy/.
+      - id: check-coverage-omits
+        name: Check coverage omit entries are documented
+        entry: python scripts/check_coverage_omits.py
+        language: system
+        pass_filenames: false
+        files: ^pyproject\.toml$
+        stages: [pre-commit]

--- a/docs/specs/coverage-exclusion-policy/decisions.md
+++ b/docs/specs/coverage-exclusion-policy/decisions.md
@@ -54,3 +54,45 @@ undocumented exclusion. See task #6.
 ---
 
 (per-entry resolutions appended below as commits land)
+
+---
+
+## Phase 3B resolution (2026-05-12)
+
+### Outcome
+
+All three undocumented entries were documented in-flight via PR #212
+(`68b4bb1c`, "CI stabilization") between the 2026-05-10 audit and
+its squash-merge to main on 2026-05-11. No new code change required
+by this spec; the verification step confirmed accuracy.
+
+### Per-entry verification
+
+| Entry | Comment as landed | Category | Verified by |
+|-------|-------------------|----------|-------------|
+| `*/hooks/scripts/help_freshness_nudge.py` | "Standalone hook script (not importable via pytest)" | 6 — standalone script | File has `#!/usr/bin/env python3` shebang and SessionStart-hook docstring. Sibling entries (`evaluate_session.py`, `session_start.py`, etc.) use the same wording. |
+| `*/meta_workflows/cli_commands/agent_commands.py` | "Interactive agent CLI (requires live Claude agent loop)" | 1 — interactive CLI | File uses `typer` + `rich`, `@meta_workflow_app.command("create-agent")`. Sibling files in same dir use "Interactive analytics / templates / config / memory" wording. |
+| `*/attune/config.py` | "Shadowed by attune/config/ package — unreachable import" | 8 — justified-other | Confirmed empirically: `import attune.config` resolves to `src/attune/config/__init__.py` (the package), not the .py file. `attune.config.__file__` ends in `/config/__init__.py`. The standalone module is dead code at the import layer. |
+
+### Compliance
+
+- 60/60 production-code `omit` entries documented = **100% compliance**.
+- Phase 3D's "all undocumented entries resolved" gate is met by inspection.
+
+### Out-of-scope follow-up
+
+`src/attune/config.py` is dead code at the import layer — Python's
+import machinery always selects the `config/` package over the
+sibling module file. The exclusion is technically correct (the file
+*can't* be reached via `import attune.config`), but the cleaner fix
+would be to delete the file entirely rather than carry a permanent
+exclusion. Flagging for a separate retirement task; not in scope
+here since this spec is about documenting exclusions, not removing
+dead code. The decisions.md from `docs/specs/deprecated-module-retirement/`
+is the natural home if it picks up this candidate.
+
+Risk to verify before deletion: grep for any module that might
+sidestep the shadowing via `importlib.import_module("attune.config")`
+plus a `__file__` lookup, or via `pkgutil.iter_modules` discovery.
+None found in a quick sweep, but worth confirming under a real
+retirement spec.

--- a/docs/specs/coverage-exclusion-policy/decisions.md
+++ b/docs/specs/coverage-exclusion-policy/decisions.md
@@ -96,3 +96,59 @@ sidestep the shadowing via `importlib.import_module("attune.config")`
 plus a `__file__` lookup, or via `pkgutil.iter_modules` discovery.
 None found in a quick sweep, but worth confirming under a real
 retirement spec.
+
+---
+
+## Phase 3C resolution (2026-05-12)
+
+### Outcome
+
+Shipped `scripts/check_coverage_omits.py` plus a pre-commit hook
+entry. Spec status flipped to `complete` in all four .md files.
+
+### What the script enforces
+
+- Locates the `[tool.coverage.run] omit = [...]` block in
+  `pyproject.toml` via line scan (resilient to comments and
+  whitespace between the section header and the `omit =` line).
+- For each quoted pattern inside the block, requires an inline
+  `#` comment on the same line *unless* the pattern is one of
+  the four meta-excludes: `*/tests/*`, `*/test_*.py`,
+  `*/__pycache__/*`, `*/site-packages/*`.
+- Exits 0 (clean), 1 (offenders listed to stderr with file:line
+  references), or 2 (block not locatable).
+
+### Side-effect of writing the enforcement: convention normalization
+
+PR #212 added the three previously-undocumented entries with their
+reasons on the *preceding* line rather than inline. That's a valid
+form of documentation but doesn't match the dominant convention
+in the file (57 of 60 production-code entries used inline) or the
+mandate in `design.md` ("inline `#` comment"). To make the
+enforcement script crisp, the three entries were normalized to
+inline form in this commit. No semantic change; identical reason
+text, just rearranged onto the same line as the pattern.
+
+### Pre-commit hook integration (D3)
+
+Added a local hook `check-coverage-omits` to
+`.pre-commit-config.yaml`. Scoped to changes in `pyproject.toml`
+only (no overhead on unrelated commits). Stage: `pre-commit` (runs
+on every commit by default, matching the surrounding hooks'
+behavior). Verified by running
+`uv run --with pre-commit pre-commit run check-coverage-omits
+--files pyproject.toml` — passes on the clean tree.
+
+### Task #9 verification
+
+Stripped the inline comment from `*/attune/config.py` as a
+deliberate violation. Script output:
+```
+Undocumented coverage-omit entries (each must have an inline
+`# reason` comment):
+  pyproject.toml:711: */attune/config.py
+
+See docs/specs/coverage-exclusion-policy/requirements.md for the
+reason-category taxonomy.
+```
+Exit 1 as expected. Comment restored; clean tree exits 0.

--- a/docs/specs/coverage-exclusion-policy/design.md
+++ b/docs/specs/coverage-exclusion-policy/design.md
@@ -1,6 +1,6 @@
 # Design: Coverage Exclusion Policy
 
-**Status**: approved
+**Status**: complete (2026-05-12)
 
 ---
 

--- a/docs/specs/coverage-exclusion-policy/requirements.md
+++ b/docs/specs/coverage-exclusion-policy/requirements.md
@@ -1,6 +1,6 @@
 # Spec: Coverage Exclusion Policy
 
-**Status**: approved
+**Status**: complete (2026-05-12)
 **Created**: 2026-05-10
 **Origin**: Surfaced during reflection on the 100%-coverage workstream
 (see COVERAGE_BUG_LOG.md). Reframed the goal from "every module at

--- a/docs/specs/coverage-exclusion-policy/tasks.md
+++ b/docs/specs/coverage-exclusion-policy/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Coverage Exclusion Policy
 
-**Status**: approved — Phase 3A done; Phase 3B verified complete (2026-05-12, no code change required); Phase 3C remaining
+**Status**: complete (2026-05-12)
 
 ---
 
@@ -12,7 +12,7 @@
 |---|------|-------|--------|-------|
 | 1 | Add inline policy comment to `pyproject.toml` `[tool.coverage.run]` block. | pyproject.toml | done | This commit. |
 | 2 | Audit all current `omit` entries for documentation. | docs | done | 64 total: 4 meta-excludes (no comment needed), 57 documented, **3 production-code entries undocumented** (see decisions.md). |
-| 3 | Write `scripts/check_coverage_omits.py` enforcement script. | scripts | todo | Phase 3B. |
+| 3 | Write `scripts/check_coverage_omits.py` enforcement script. | scripts | **done** | Shipped in Phase 3C (task #7). |
 
 ### Phase 3B — Resolve the 3 undocumented entries
 
@@ -28,17 +28,17 @@ Each is its own commit. Investigate before documenting.
 
 | # | Task | Layer | Status | Notes |
 |---|------|-------|--------|-------|
-| 7 | Add `scripts/check_coverage_omits.py` (per design.md Artifact 3). | scripts | todo | After Phase 3B so the script doesn't immediately fail on existing entries. |
-| 8 | Add pre-commit hook entry in `.pre-commit-config.yaml`. | .pre-commit-config.yaml | todo | D3 decision. Lightweight; recommended now. |
-| 9 | Verify the enforcement script catches a deliberately-undocumented entry. | manual | todo | Add a test omit entry without comment, run the script, confirm it fires. Remove the test entry. |
+| 7 | Add `scripts/check_coverage_omits.py` (per design.md Artifact 3). | scripts | **done** | Line-based scanner; allowlists 4 meta-excludes; reports each offender with line number. Exit 0/1/2. Also normalized the 3 PR-#212 entries to inline comments to match the dominant convention (57 other entries use inline; design.md mandates inline). |
+| 8 | Add pre-commit hook entry in `.pre-commit-config.yaml`. | .pre-commit-config.yaml | **done** | Local hook `check-coverage-omits`, runs on changes to `pyproject.toml` only. |
+| 9 | Verify the enforcement script catches a deliberately-undocumented entry. | manual | **done** | Stripped the inline comment from `*/attune/config.py` temporarily; script reported "pyproject.toml:711: */attune/config.py" and exited 1. Comment restored; script exits 0. |
 
 ### Phase 3D — Spec close
 
 | # | Task | Layer | Status | Notes |
 |---|------|-------|--------|-------|
-| 10 | All 3 undocumented entries from Phase 3B resolved (documented or removed). | manual | todo | |
-| 11 | `python scripts/check_coverage_omits.py` exits 0 on a clean tree. | manual | todo | |
-| 12 | Mark spec status `complete` in all 4 .md files. | docs | todo | |
+| 10 | All 3 undocumented entries from Phase 3B resolved (documented or removed). | manual | **done** | 100% compliance (60/60 production-code entries). |
+| 11 | `python scripts/check_coverage_omits.py` exits 0 on a clean tree. | manual | **done** | Verified 2026-05-12. |
+| 12 | Mark spec status `complete` in all 4 .md files. | docs | **done** | This commit. |
 
 ### Failure-to-deliver path
 

--- a/docs/specs/coverage-exclusion-policy/tasks.md
+++ b/docs/specs/coverage-exclusion-policy/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Coverage Exclusion Policy
 
-**Status**: approved (Phase 3A done in this commit)
+**Status**: approved — Phase 3A done; Phase 3B verified complete (2026-05-12, no code change required); Phase 3C remaining
 
 ---
 
@@ -20,9 +20,9 @@ Each is its own commit. Investigate before documenting.
 
 | # | Entry | Status | Notes |
 |---|-------|--------|-------|
-| 4 | `*/hooks/scripts/help_freshness_nudge.py` | todo | Likely Category 6 (standalone script). Confirm by reading the file's invocation pattern, then add `# Standalone hook script (runs as subprocess via Claude Code hook, not importable via pytest)` comment. |
-| 5 | `*/meta_workflows/cli_commands/agent_commands.py` | todo | Read the file. Sibling files in same dir are excluded with reason `# Interactive analytics`, `# Interactive templates` etc. (Category 1). If `agent_commands.py` follows the same shape, document with matching comment. If it doesn't, decision: cover with tests vs. document a non-Category-1 reason. |
-| 6 | `*/attune/config.py` | todo | **Highest-priority audit**. `config.py` is usually core production code; an undocumented exclusion here is a smell. Read the file. Three plausible outcomes: (a) it has env-var-dependent code that's not testable as-is → split file, cover the testable half, document the loader; (b) coverage was disabled during a refactor and never restored → write tests, remove from omit list; (c) the file is genuinely a thin re-export shim → document as Category 7-adjacent. |
+| 4 | `*/hooks/scripts/help_freshness_nudge.py` | **done** | Documented in PR #212 (`68b4bb1c`) as "Standalone hook script (not importable via pytest)". Category 6. Verified 2026-05-12. |
+| 5 | `*/meta_workflows/cli_commands/agent_commands.py` | **done** | Documented in PR #212 (`68b4bb1c`) as "Interactive agent CLI (requires live Claude agent loop)". Category 1, matches sibling-file wording. Verified 2026-05-12. |
+| 6 | `*/attune/config.py` | **done** | Documented in PR #212 (`68b4bb1c`) as "Shadowed by attune/config/ package — unreachable import". Verified empirically (Category 8): `import attune.config` resolves to the package's `__init__.py`, not the .py file. Out-of-scope follow-up: this is dead code at the import layer; deletion should be tracked under `deprecated-module-retirement` rather than carry a permanent exclusion. See decisions.md. |
 
 ### Phase 3C — Add enforcement
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -706,12 +706,9 @@ omit = [
     "*/core_modules/__init__.py",  # Core modules init
     # Models main entry
     "*/models/__main__.py",  # Models CLI entry point
-    # Standalone hook script (not importable via pytest)
-    "*/hooks/scripts/help_freshness_nudge.py",
-    # Interactive agent CLI (requires live Claude agent loop)
-    "*/meta_workflows/cli_commands/agent_commands.py",
-    # Shadowed by attune/config/ package — unreachable import
-    "*/attune/config.py",
+    "*/hooks/scripts/help_freshness_nudge.py",  # Standalone hook script (not importable via pytest)
+    "*/meta_workflows/cli_commands/agent_commands.py",  # Interactive agent CLI (requires live Claude agent loop)
+    "*/attune/config.py",  # Shadowed by attune/config/ package — unreachable import
 ]
 branch = true
 # parallel + concurrency: ensure xdist workers flush coverage data

--- a/scripts/check_coverage_omits.py
+++ b/scripts/check_coverage_omits.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Enforce the coverage-exclusion-policy.
+
+Every production-code entry in pyproject.toml's
+`[tool.coverage.run] omit = [...]` block must have an inline `#`
+comment stating why the file is excluded from coverage. Meta-excludes
+(test discovery patterns, build artifacts, third-party paths) are
+allowlisted and do not need a comment.
+
+See docs/specs/coverage-exclusion-policy/ for the policy and the
+allowed reason categories.
+
+Usage:
+    python scripts/check_coverage_omits.py
+
+Exit codes:
+    0 — all production-code entries documented (or only meta-excludes
+        are undocumented)
+    1 — at least one undocumented production-code entry; offenders
+        printed to stderr
+    2 — pyproject.toml or the omit block could not be located
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Meta-exclude patterns that do NOT require an inline `#` reason —
+# they are self-explanatory test/build-artifact filters.
+META_EXCLUDES: frozenset[str] = frozenset(
+    {
+        "*/tests/*",
+        "*/test_*.py",
+        "*/__pycache__/*",
+        "*/site-packages/*",
+    }
+)
+
+# Captures the first quoted pattern on a line, e.g. "*/foo/bar.py".
+_PATTERN_RE = re.compile(r'"([^"]+)"')
+
+
+def _find_omit_block(text: str) -> tuple[int, int] | None:
+    """Return (start_line_idx, end_line_idx) for the omit list body.
+
+    Indices are 0-based and reference lines *inside* the brackets
+    (i.e. the `"..."` entries), exclusive of the `omit = [` and `]`
+    delimiter lines themselves.
+
+    Returns None if the block can't be located.
+    """
+    lines = text.splitlines()
+    start: int | None = None
+    in_coverage_run = False
+    for i, raw in enumerate(lines):
+        stripped = raw.strip()
+        if stripped == "[tool.coverage.run]":
+            in_coverage_run = True
+            continue
+        # Any other section header ends the [tool.coverage.run] scope.
+        if (
+            in_coverage_run
+            and stripped.startswith("[")
+            and stripped.endswith("]")
+            and "=" not in stripped
+        ):
+            in_coverage_run = False
+        if in_coverage_run and stripped.startswith("omit"):
+            # Tolerate `omit = [` or `omit=[`.
+            if "[" in stripped:
+                start = i + 1
+                break
+    if start is None:
+        return None
+    for j in range(start, len(lines)):
+        if lines[j].strip().startswith("]"):
+            return (start, j)
+    return None
+
+
+def _is_documented(line: str, pattern: str) -> bool:
+    """Return True if the line carries a `#` comment after the quoted pattern."""
+    # Drop everything up to and including the closing quote of the pattern.
+    quoted = f'"{pattern}"'
+    idx = line.find(quoted)
+    if idx < 0:
+        return False
+    tail = line[idx + len(quoted) :]
+    return "#" in tail
+
+
+def find_undocumented(pyproject_text: str) -> list[tuple[int, str]]:
+    """Find undocumented production-code omit entries.
+
+    Returns a list of `(1-based-line-number, pattern)` tuples.
+    Meta-excludes are filtered out.
+    """
+    block = _find_omit_block(pyproject_text)
+    if block is None:
+        raise RuntimeError(
+            "Could not locate `[tool.coverage.run] omit = [...]` "
+            "block in pyproject.toml. "
+            "Has the layout changed? See "
+            "docs/specs/coverage-exclusion-policy/."
+        )
+    start, end = block
+    lines = pyproject_text.splitlines()
+    offenders: list[tuple[int, str]] = []
+    for line_idx in range(start, end):
+        line = lines[line_idx]
+        match = _PATTERN_RE.search(line)
+        if not match:
+            continue
+        pattern = match.group(1)
+        if pattern in META_EXCLUDES:
+            continue
+        if not _is_documented(line, pattern):
+            offenders.append((line_idx + 1, pattern))
+    return offenders
+
+
+def main() -> int:
+    """Check pyproject.toml's coverage omit block for documentation gaps."""
+    repo_root = Path(__file__).resolve().parent.parent
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.is_file():
+        print(f"error: {pyproject} not found", file=sys.stderr)
+        return 2
+    text = pyproject.read_text(encoding="utf-8")
+    try:
+        offenders = find_undocumented(text)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if not offenders:
+        return 0
+    print(
+        "Undocumented coverage-omit entries (each must have an " "inline `# reason` comment):",
+        file=sys.stderr,
+    )
+    for lineno, pattern in offenders:
+        print(f"  pyproject.toml:{lineno}: {pattern}", file=sys.stderr)
+    print(
+        "\nSee docs/specs/coverage-exclusion-policy/requirements.md "
+        "for the reason-category taxonomy.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the [coverage-exclusion-policy](docs/specs/coverage-exclusion-policy/) spec. Two commits:

- `7998aa11` — Phase 3B verification. All 3 entries from the 2026-05-10 audit were already documented in-flight via PR #212 (`68b4bb1c`). Confirmed each comment against the actual file.
- `d31b85ac` — Phase 3C enforcement. New `scripts/check_coverage_omits.py`, pre-commit hook entry, and convention normalization (3 entries moved from above-line to inline comments per design.md mandate).

## What landed

- `scripts/check_coverage_omits.py` — line-based scanner. Allowlists 4 meta-excludes (`*/tests/*`, `*/test_*.py`, `*/__pycache__/*`, `*/site-packages/*`); requires inline `# reason` on every other entry. Exit 0/1/2 with offender line numbers.
- `.pre-commit-config.yaml` — local hook `check-coverage-omits`, scoped to `pyproject.toml` changes only.
- `pyproject.toml` — 3 entries normalized to inline-comment form to match dominant convention.
- All 4 spec `.md` files flipped to `complete (2026-05-12)`.

## Compliance

- 60/60 production-code `omit` entries documented (100%).
- 4 meta-excludes correctly skipped by the script.

## Test plan

- [x] `python scripts/check_coverage_omits.py` exits 0 on clean tree
- [x] Deliberate violation (strip comment from `*/attune/config.py`) reproduces exit 1 with `pyproject.toml:711: */attune/config.py` offender output
- [x] `uv run --with pre-commit pre-commit run check-coverage-omits --files pyproject.toml` — passes
- [x] All pre-commit hooks pass on the commit itself (including the new hook)

## Out-of-scope follow-up

`src/attune/config.py` is dead code at the import layer (shadowed by the `attune/config/` package — verified empirically). Better fix long-term is deletion, not a permanent exclusion. Flagged in `decisions.md` for `deprecated-module-retirement` to pick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)