### PR TITLE
test(memory/short_term/caching): meaningful coverage on CacheManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: eighth module through the playbook —
+  `memory/short_term/caching.py` (`CacheManager`). Coverage
+  49.2% → 100% line+branch. 28 deterministic tests added under
+  `tests/unit/memory/short_term/test_caching.py` covering the
+  LRU eviction path (oldest `last_access` dropped on overflow),
+  disabled-mode branches (`get` / `add` / `contains`),
+  `clear()` counter reset, `get_stats()` hit-rate calculation
+  including the zero-requests guard, and the `__len__` /
+  `__contains__` dunders. Zero production bugs surfaced — the
+  module is a pure-Python LRU cache with no Redis or async
+  surface. First non-SDK cycle after four consecutive
+  SDK-native shells (`dependency_check`, `bug_predict`,
+  `perf_audit`, `refactor_plan`).
 - Test-quality-program: seventh module through the playbook —
   `workflows/refactor_plan.py` (Agent SDK-native orchestrator).
   Coverage 44.44% → 100% line+branch. 21 deterministic tests

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,51 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — eighth module under test-quality-program (Opus 4.7)
+
+Eighth module run. First non-SDK cycle in today's
+sequence after four consecutive Agent SDK shells
+(`dependency_check`, `bug_predict`, `perf_audit`,
+`refactor_plan`). Selected via the rubric working set:
+`memory/short_term/caching.py`, score 2.287.
+**0 production bugs surfaced.**
+
+- `memory/short_term/caching.py` (`CacheManager`) — no
+  bugs. The module is a 233-line pure-Python LRU cache
+  with TTL fields (timestamps tracked but never expired
+  by the cache itself — callers handle TTL semantics).
+  Two-tier strategy: local in-memory dict-backed cache
+  sitting in front of Redis. The LRU eviction path
+  (`min(self._cache, key=lambda k: self._cache[k][2])`)
+  fires only when `len(self._cache) >= self.max_size`;
+  exercised with a 3-entry cache and a deliberate
+  access-order shuffle. Disabled-mode branches in
+  `get` / `add` / `contains` all return early. No dead
+  code; no crash paths.
+
+**Coverage delta:** 49.2% → 100% line+branch.
+
+**Tests:** 28 added under
+`tests/unit/memory/short_term/test_caching.py`. No
+mocks needed — pure stdlib `time.sleep(0.001)` between
+adds to ensure `last_access` ordering for the LRU
+eviction tests. `get_stats()` hit-rate computation
+exercised both with traffic (66.67%) and with zero
+requests (the `if total > 0 else 0.0` guard).
+
+**Pattern observation:** First module today where the
+test design wasn't a single-pass rename. The
+SDK-native scaffold doesn't transfer here — pure-Python
+state-machine classes need explicit branch coverage
+(disabled-mode return-early paths, division-by-zero
+guards, LRU ordering invariants). Worth noting for
+future rubric picks: SDK-native shells cluster in
+`workflows/*`; pure data-structure modules cluster in
+`memory/short_term/*`. The test scaffold should fork
+along that boundary.
+
+---
+
 ## 2026-05-12 — seventh module under test-quality-program (Opus 4.7)
 
 Seventh module run. Fourth (and final) Agent SDK-native

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -143,3 +143,45 @@ SDK-native shells. The remaining sibling
 the inline-`main()` shape recurs there too, scripting
 a generator becomes more clearly justified than
 hand-renaming.
+
+## memory/short_term/caching.py
+
+**Date:** 2026-05-12
+**Rubric score at pick time:** 2.287 (weight=3 × gap=0.508 × risk=1.5)
+**Picked because:** Top entry with measured `covered_pct`
+after the SDK-native trio shipped today
+(`dependency_check`, `bug_predict`, `perf_audit`).
+`refactor_plan` was skipped — a parallel session had
+two open PRs on it (#267, #270); PR #270 merged
+during this cycle and took the "seventh module" slot
+in the log, so this entry is the eighth. First non-SDK
+pick in today's sequence; tests a pure-Python LRU cache.
+**Outcome:** 1 test file added (`test_caching.py`,
+28 tests). Coverage 49.2% → 100% line+branch. Zero
+production bugs surfaced.
+**PR:** _(filled in after merge)_
+**Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
+"2026-05-12 — eighth module under test-quality-program"
+
+Test design diverges from the SDK-native scaffold:
+explicit branch coverage for the disabled-mode early
+returns in `get` / `add` / `contains`, the LRU
+eviction path triggered with a deliberately small
+3-entry cache, the `get_stats()` division-by-zero
+guard, and counter resets on `clear()`. `time.sleep(0.001)`
+between adds ensures `last_access` ordering for the
+LRU tests (single-process clock resolution is
+sufficient given the dict-stored float timestamps).
+
+**Picking pattern observation (informational):**
+SDK-native shells in `workflows/*` cluster around the
+same scaffold and ship in cycles ~5 minutes each. Pure
+data-structure modules in `memory/short_term/*` need
+distinct branch-coverage tests but ship just as fast
+because they're 100-300 lines of testable surface
+each. The rubric's current ordering surfaces these
+two clusters intermixed, which is fine — but a
+future refinement could tag rows by archetype
+(`sdk-shell`, `data-structure`, `cli-entry`,
+`async-pipeline`) so picks can be batched by scaffold.
+Flagged; not committed.

--- a/tests/unit/memory/short_term/test_caching.py
+++ b/tests/unit/memory/short_term/test_caching.py
@@ -1,0 +1,287 @@
+"""Tests for CacheManager — local LRU cache layer.
+
+Pure-Python class with no Redis / SDK dependency. Targets every
+branch including the LRU eviction path (cache full → drop oldest
+by last_access).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from attune.memory.short_term.caching import CacheManager
+
+
+@pytest.fixture
+def cache() -> CacheManager:
+    """Fresh enabled cache with default size."""
+    return CacheManager(enabled=True, max_size=1000)
+
+
+@pytest.fixture
+def small_cache() -> CacheManager:
+    """Small cache for LRU-eviction scenarios."""
+    return CacheManager(enabled=True, max_size=3)
+
+
+@pytest.fixture
+def disabled_cache() -> CacheManager:
+    """Disabled cache to exercise the early-return branches."""
+    return CacheManager(enabled=False, max_size=1000)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_defaults(self):
+        c = CacheManager()
+        assert c.enabled is True
+        assert c.max_size == 1000
+        assert c.hits == 0
+        assert c.misses == 0
+        assert len(c) == 0
+
+    def test_custom_size(self):
+        c = CacheManager(enabled=True, max_size=42)
+        assert c.max_size == 42
+
+    def test_disabled_construction(self):
+        c = CacheManager(enabled=False)
+        assert c.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# get() / add() — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestGetAdd:
+    def test_get_miss_returns_none(self, cache):
+        assert cache.get("absent") is None
+        assert cache.misses == 1
+        assert cache.hits == 0
+
+    def test_add_then_get_returns_value(self, cache):
+        cache.add("k", "v")
+        assert cache.get("k") == "v"
+        assert cache.hits == 1
+        assert cache.misses == 0
+
+    def test_get_updates_last_access(self, cache):
+        """Hit should update last_access (LRU tracking)."""
+        cache.add("k", "v")
+        first_access = cache._cache["k"][2]
+        time.sleep(0.001)  # ensure clock tick
+        cache.get("k")
+        second_access = cache._cache["k"][2]
+        assert second_access >= first_access
+
+    def test_add_stores_timestamp_and_access(self, cache):
+        cache.add("k", "v")
+        value, timestamp, last_access = cache._cache["k"]
+        assert value == "v"
+        assert timestamp > 0
+        assert last_access == timestamp  # initially equal
+
+
+# ---------------------------------------------------------------------------
+# get() / add() — disabled branches
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledBranches:
+    def test_get_when_disabled_returns_none(self, disabled_cache):
+        disabled_cache._cache["k"] = ("v", time.time(), time.time())
+        assert disabled_cache.get("k") is None
+        assert disabled_cache.misses == 1
+
+    def test_add_when_disabled_is_noop(self, disabled_cache):
+        disabled_cache.add("k", "v")
+        assert "k" not in disabled_cache._cache
+        assert len(disabled_cache) == 0
+
+    def test_contains_when_disabled_returns_false(self, disabled_cache):
+        disabled_cache._cache["k"] = ("v", time.time(), time.time())
+        assert disabled_cache.contains("k") is False
+        assert "k" not in disabled_cache  # via __contains__
+
+
+# ---------------------------------------------------------------------------
+# LRU eviction
+# ---------------------------------------------------------------------------
+
+
+class TestLRUEviction:
+    def test_eviction_drops_oldest_access(self, small_cache):
+        """Filling beyond capacity drops the least-recently-accessed entry."""
+        small_cache.add("a", "1")
+        time.sleep(0.001)
+        small_cache.add("b", "2")
+        time.sleep(0.001)
+        small_cache.add("c", "3")
+        # All three present.
+        assert len(small_cache) == 3
+
+        # Touch "a" so it's the most-recently-accessed.
+        time.sleep(0.001)
+        small_cache.get("a")
+
+        # Adding a 4th should evict "b" (oldest last_access now).
+        time.sleep(0.001)
+        small_cache.add("d", "4")
+        assert "a" in small_cache
+        assert "b" not in small_cache
+        assert "c" in small_cache
+        assert "d" in small_cache
+        assert len(small_cache) == 3
+
+    def test_eviction_at_exact_capacity(self, small_cache):
+        """Adding when len == max_size triggers eviction even on first overflow."""
+        small_cache.add("a", "1")
+        small_cache.add("b", "2")
+        small_cache.add("c", "3")
+        assert len(small_cache) == small_cache.max_size
+
+        small_cache.add("d", "4")
+        assert len(small_cache) == 3
+        # Some original key was dropped.
+        kept = {k for k in ("a", "b", "c") if k in small_cache}
+        assert len(kept) == 2
+
+
+# ---------------------------------------------------------------------------
+# remove() / invalidate()
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    def test_remove_present_key(self, cache):
+        cache.add("k", "v")
+        assert cache.remove("k") is True
+        assert "k" not in cache._cache
+
+    def test_remove_absent_key(self, cache):
+        assert cache.remove("absent") is False
+
+    def test_invalidate_is_alias_for_remove(self, cache):
+        cache.add("k", "v")
+        assert cache.invalidate("k") is True
+        assert cache.invalidate("k") is False  # already gone
+
+
+# ---------------------------------------------------------------------------
+# contains() / __contains__
+# ---------------------------------------------------------------------------
+
+
+class TestContains:
+    def test_contains_present_key(self, cache):
+        cache.add("k", "v")
+        assert cache.contains("k") is True
+        assert "k" in cache  # __contains__
+
+    def test_contains_absent_key(self, cache):
+        assert cache.contains("absent") is False
+        assert "absent" not in cache
+
+    def test_contains_does_not_touch_counters(self, cache):
+        """contains() must NOT increment hits/misses."""
+        cache.add("k", "v")
+        cache.contains("k")
+        cache.contains("absent")
+        assert cache.hits == 0
+        assert cache.misses == 0
+
+
+# ---------------------------------------------------------------------------
+# clear()
+# ---------------------------------------------------------------------------
+
+
+class TestClear:
+    def test_clear_returns_count(self, cache):
+        cache.add("a", "1")
+        cache.add("b", "2")
+        cache.add("c", "3")
+        assert cache.clear() == 3
+        assert len(cache) == 0
+
+    def test_clear_empty_returns_zero(self, cache):
+        assert cache.clear() == 0
+
+    def test_clear_resets_counters(self, cache):
+        cache.add("k", "v")
+        cache.get("k")  # hit
+        cache.get("nope")  # miss
+        cache.clear()
+        assert cache.hits == 0
+        assert cache.misses == 0
+
+
+# ---------------------------------------------------------------------------
+# get_stats()
+# ---------------------------------------------------------------------------
+
+
+class TestGetStats:
+    def test_empty_cache_stats(self, cache):
+        stats = cache.get_stats()
+        assert stats["enabled"] is True
+        assert stats["size"] == 0
+        assert stats["max_size"] == 1000
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+        assert stats["hit_rate"] == 0.0
+        assert stats["total_requests"] == 0
+
+    def test_hit_rate_with_traffic(self, cache):
+        cache.add("k", "v")
+        cache.get("k")  # hit
+        cache.get("k")  # hit
+        cache.get("absent")  # miss
+        stats = cache.get_stats()
+        assert stats["hits"] == 2
+        assert stats["misses"] == 1
+        assert stats["total_requests"] == 3
+        assert stats["hit_rate"] == pytest.approx(66.666666, rel=1e-3)
+
+    def test_stats_reflect_disabled_state(self, disabled_cache):
+        stats = disabled_cache.get_stats()
+        assert stats["enabled"] is False
+
+    def test_zero_requests_hit_rate_is_zero(self, cache):
+        """Division-by-zero guard: 0 total requests → 0.0% hit rate."""
+        stats = cache.get_stats()
+        assert stats["hit_rate"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Dunders
+# ---------------------------------------------------------------------------
+
+
+class TestDunders:
+    def test_len_grows_with_adds(self, cache):
+        assert len(cache) == 0
+        cache.add("a", "1")
+        assert len(cache) == 1
+        cache.add("b", "2")
+        assert len(cache) == 2
+
+    def test_len_after_remove(self, cache):
+        cache.add("a", "1")
+        cache.remove("a")
+        assert len(cache) == 0
+
+    def test_contains_dunder_routes_through_method(self, cache):
+        cache.add("a", "1")
+        assert ("a" in cache) is True
+        assert ("b" in cache) is False


### PR DESCRIPTION
## Summary

Seventh module through the [test-quality-program](docs/specs/test-quality-program/) playbook. First non-SDK cycle today after three consecutive Agent SDK shells ([#265](https://github.com/Smart-AI-Memory/attune-ai/pull/265), [#266](https://github.com/Smart-AI-Memory/attune-ai/pull/266), [#273](https://github.com/Smart-AI-Memory/attune-ai/pull/273)).

- **Coverage:** 49.2% → 100% line+branch on `memory/short_term/caching.py`.
- **Tests:** 28 added under `tests/unit/memory/short_term/test_caching.py`.
- **Bugs surfaced:** zero.

## Why this picks differs from prior cycles

`CacheManager` is a pure-Python LRU cache — no Redis, no async, no SDK. The SDK-native scaffold doesn't transfer. Tests are designed around explicit branch coverage:

- LRU eviction path (`min(self._cache, key=...[2])`) triggered with a 3-entry cache and a deliberate access-order shuffle to verify the oldest `last_access` is dropped
- Disabled-mode early returns in `get` / `add` / `contains`
- `clear()` counter reset (hits + misses → 0)
- `get_stats()` hit-rate calculation including the zero-requests guard
- `__len__` and `__contains__` dunders

No mocks; `time.sleep(0.001)` between adds for LRU ordering.

## Test plan

- [x] All 28 new tests pass locally
- [x] Sibling `memory/short_term/` tests pass (72 collected, all green)
- [x] Black + ruff + bandit pre-commit hooks pass
- [x] Coverage measured: 100% line+branch on `caching.py`
- [ ] CI green across matrix

## Picking-pattern note

Flagged in `decisions.md`: SDK-native shells (cluster in `workflows/*`) and pure data-structure modules (cluster in `memory/short_term/*`) need distinct test scaffolds. A future rubric refinement could tag rows by archetype (`sdk-shell`, `data-structure`, `cli-entry`, `async-pipeline`) so picks batch by scaffold rather than score alone. Not committed.

## Files changed

- `tests/unit/memory/short_term/test_caching.py` — 28 new tests (new file)
- `CHANGELOG.md` — Unreleased entry
- `docs/COVERAGE_BUG_LOG.md` — seventh-module entry
- `docs/specs/test-quality-program/decisions.md` — appended pick reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)