### PR TITLE
feat(redis-decoupling)!: drop [memory] extra, slim [developer] (P2)

### DIFF
--- a/.help/templates/cli/concept.md
+++ b/.help/templates/cli/concept.md
@@ -1,43 +1,37 @@
 ---
-type: concept
 feature: cli
 depth: concept
-generated_at: 2026-05-04T02:33:52.698850+00:00
-source_hash: 8c67b256a4817afea8eb428fdc577d8217d9e0d03adf9db67b00bc30a3c490a3
+generated_at: 2026-05-12T20:01:25.941085+00:00
+source_hash: 9b280c902cb899cdf4292fc1221ba1b77cb6c199e12090acd143692bd7817bd6
 status: generated
 ---
 
-# CLI
+# Cli
 
-## What
+## How it works
 
-The CLI is attune's command-line interface for cost tracking, documentation browsing, and memory management. It combines direct command routing with intelligent input routing that learns from your usage patterns to suggest the most relevant Claude Code skills.
+Command-line interface and routing.
 
-## Why
+The main building blocks are:
 
-The CLI serves as both a traditional command interface and an adaptive learning system. Instead of forcing you to memorize exact command syntax, it watches how you work and builds routing preferences that improve over time. This matters when you need quick access to cost data, help documentation, or stored lessons without breaking your development flow.
+- **`RoutingPreference`** — User's learned routing preferences.
+- **`HybridRouter`** — Routes user input to Claude Code skill invocations.
 
-## Core responsibilities
+Under the hood, this feature spans 10 source
+files covering:
 
-The CLI handles three primary workflows:
+- Hybrid CLI Router - Skills + Natural Language
+- CLI command modules for attune.
+- CLI commands for cost tracking.
 
-**Cost tracking** — Monitor spending with `attune costs`, view daily summaries with `attune costs today`, export data for analysis, and reset tracking when needed.
+## What connects to it
 
-**Help browsing** — Access structured documentation templates through `attune help`, letting you explore concepts, tasks, references, and troubleshooting guides without leaving the terminal.
+This feature relates to: cli, commands.
 
-**Memory management** — Store and retrieve lessons with `attune remember` and `attune lessons`, plus manage cross-session memory for persistent context between Claude conversations.
+Other parts of the codebase interact with
+cli through these interfaces:
 
-## Intelligent routing
-
-The `HybridRouter` component learns your preferences as you work. When you type `attune help migration`, it remembers that you often want the task template rather than the concept. The `RoutingPreference` class tracks these patterns:
-
-- **keyword** — The term you searched for
-- **skill** — Which Claude Code skill you actually chose
-- **usage_count** — How often this preference applies
-- **confidence** — How certain the system is about this routing
-
-This creates a personalized command experience that adapts to your specific workflow patterns.
-
-## Implementation structure
-
-The CLI spans 10 source files, organizing functionality into focused command modules. Cost commands handle financial tracking, help commands bridge to the documentation system, and memory commands manage both quick lessons and persistent context storage. The routing layer sits above these modules, learning which commands you reach for most often given specific input patterns.
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `RoutingPreference` | User's learned routing preferences. | `src/attune/cli_router.py` |
+| `HybridRouter` | Routes user input to Claude Code skill invocations. | `src/attune/cli_router.py` |

--- a/.help/templates/cli/reference.md
+++ b/.help/templates/cli/reference.md
@@ -1,81 +1,67 @@
 ---
-type: reference
 feature: cli
 depth: reference
-generated_at: 2026-05-04T02:34:16.611938+00:00
-source_hash: 8c67b256a4817afea8eb428fdc577d8217d9e0d03adf9db67b00bc30a3c490a3
+generated_at: 2026-05-12T20:01:25.950502+00:00
+source_hash: 9b280c902cb899cdf4292fc1221ba1b77cb6c199e12090acd143692bd7817bd6
 status: generated
 ---
 
-# CLI reference
+# Cli reference
 
-Execute Attune commands from the terminal, manage costs, store lessons, and configure providers.
+## Classes
 
-## RoutingPreference dataclass
+| Class | Description | File |
+|-------|-------------|------|
+| `RoutingPreference` | User's learned routing preferences. | `src/attune/cli_router.py` |
+| `HybridRouter` | Routes user input to Claude Code skill invocations. | `src/attune/cli_router.py` |
 
-User's learned routing preferences.
+## Functions
 
-| Field | Type | Default |
-|-------|------|---------|
-| `keyword` | `str` | |
-| `skill` | `str` | |
-| `args` | `str` | `''` |
-| `usage_count` | `int` | `0` |
-| `confidence` | `float` | `1.0` |
+| Function | Description | File |
+|----------|-------------|------|
+| `get_version()` | Get package version. | `src/attune/cli_minimal.py` |
+| `create_parser()` | Create the argument parser. | `src/attune/cli_minimal.py` |
+| `main()` | Main entry point. | `src/attune/cli_minimal.py` |
+| `route_user_input()` | Quick routing helper. | `src/attune/cli_router.py` |
+| `is_slash_command()` | Check if text is a slash command. | `src/attune/cli_router.py` |
+| `cmd_costs()` | Show cost report for recent period. | `src/attune/cli_commands/cost_commands.py` |
+| `cmd_costs_today()` | Show today's cost summary. | `src/attune/cli_commands/cost_commands.py` |
+| `cmd_costs_export()` | Export cost data to file. | `src/attune/cli_commands/cost_commands.py` |
+| `cmd_costs_reset()` | Clear all cost tracking data. | `src/attune/cli_commands/cost_commands.py` |
+| `cmd_help()` | Handle the `attune help` command. | `src/attune/cli_commands/help_commands.py` |
+| `cmd_remember()` | Add a lesson to the lessons file. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_forget()` | Remove a lesson by line number or keyword. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_lessons()` | List current lessons with line numbers. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_memory_capture()` | Save content to personal cross-session memory. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_memory_recall()` | Search personal cross-session memory. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_memory_topics()` | List all personal memory topics. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_memory_forget_topic()` | Delete a topic (or specific kind) from personal memory. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_provider_show()` | Show current provider configuration. | `src/attune/cli_commands/provider_commands.py` |
+| `cmd_provider_set()` | Set the LLM provider. | `src/attune/cli_commands/provider_commands.py` |
+| `cmd_telemetry_show()` | Display usage summary. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_savings()` | Show cost savings from tier routing. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_export()` | Export telemetry data to file. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_routing_stats()` | Show adaptive routing statistics. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_routing_check()` | Check for tier upgrade recommendations. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_models()` | Show model performance by provider. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_agents()` | Show active agents and their status. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_signals()` | Show coordination signals. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_setup()` | Install Attune slash commands for Claude Code. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_validate()` | Validate configuration. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_version()` | Show version information. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_features()` | Show available memory and telemetry features. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_doctor()` | Run comprehensive environment health check. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_workflow_list()` | List available workflows. | `src/attune/cli_commands/workflow_commands.py` |
+| `cmd_workflow_info()` | Show workflow details. | `src/attune/cli_commands/workflow_commands.py` |
+| `cmd_workflow_run()` | Execute a workflow. | `src/attune/cli_commands/workflow_commands.py` |
 
-## HybridRouter class
 
-Routes user input to Claude Code skill invocations.
+## Source files
 
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__` | `preferences_path: str \| None = None` | | Initialize router with optional preferences file |
-| `route` | `user_input: str, context: dict[str, Any] \| None = None` | `dict[str, Any]` | Route input to appropriate skill |
-| `learn_preference` | `keyword: str, skill: str, args: str = ''` | `None` | Store routing preference for future use |
-| `get_suggestions` | `partial: str` | `list[str]` | Get command suggestions for partial input |
+- `src/attune/cli_minimal.py`
+- `src/attune/cli_router.py`
+- `src/attune/cli_commands/**`
 
-## Cost tracking functions
+## Tags
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_costs` | `args: Namespace` | `int` | Show cost report for recent period |
-| `cmd_costs_today` | `args: Namespace` | `int` | Show today's cost summary |
-| `cmd_costs_export` | `args: Namespace` | `int` | Export cost data to file |
-| `cmd_costs_reset` | `args: Namespace` | `int` | Clear all cost tracking data |
-
-## Help functions
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_help` | `args: argparse.Namespace` | `int` | Handle the `attune help` command |
-
-## Memory functions
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_remember` | `args: Namespace` | `int` | Add a lesson to the lessons file |
-| `cmd_forget` | `args: Namespace` | `int` | Remove a lesson by line number or keyword |
-| `cmd_lessons` | `args: Namespace` | `int` | List current lessons with line numbers |
-| `cmd_memory_capture` | `args: Namespace` | `int` | Save content to personal cross-session memory |
-| `cmd_memory_recall` | `args: Namespace` | `int` | Search personal cross-session memory |
-
-## Routing utilities
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `route_user_input` | | | Quick routing helper |
-| `is_slash_command` | | | Check if text is a slash command |
-
-## Core CLI functions
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `get_version` | | | Get package version |
-| `create_parser` | | | Create the argument parser |
-| `main` | | | Main entry point |
-
-## Constants
-
-| Constant | Values |
-|----------|--------|
-| `_CATEGORIES` | `'errors'`, `'warnings'`, `'tips'`, `'references'` |
+`cli`, `commands`

--- a/.help/templates/cli/task.md
+++ b/.help/templates/cli/task.md
@@ -1,57 +1,59 @@
 ---
-type: task
 feature: cli
 depth: task
-generated_at: 2026-05-04T02:34:05.644870+00:00
-source_hash: 8c67b256a4817afea8eb428fdc577d8217d9e0d03adf9db67b00bc30a3c490a3
+generated_at: 2026-05-12T20:01:25.945974+00:00
+source_hash: 9b280c902cb899cdf4292fc1221ba1b77cb6c199e12090acd143692bd7817bd6
 status: generated
 ---
 
 # Work with cli
 
-Use the attune CLI when you need to access cost tracking, documentation help, or memory management from the command line.
+Use cli when you need to command-line interface and routing.
 
 ## Prerequisites
 
 - Access to the project source code
-- Basic familiarity with Python command-line argument parsing
-- Understanding of the attune project structure
+- Familiarity with the files under src/attune/cli_minimal.py
 
 ## Steps
 
-1. **Identify the command category you need to modify.**
-   The CLI is organized into three main areas:
-   - Cost commands (`src/attune/cli_commands/cost_commands.py`) for tracking usage costs
-   - Help commands (`src/attune/cli_commands/help_commands.py`) for browsing documentation
-   - Memory commands (`src/attune/cli_commands/memory_commands.py`) for managing lessons and cross-session memory
+1. **Understand the current behavior.**
+   Read the entry points to see what cli
+   does today before making changes.
+   The primary functions are:
+   - `get_version()` in `src/attune/cli_minimal.py` — Get package version.
+   - `create_parser()` in `src/attune/cli_minimal.py` — Create the argument parser.
+   - `main()` in `src/attune/cli_minimal.py` — Main entry point.
+   - `route_user_input()` in `src/attune/cli_router.py` — Quick routing helper.
+   - `is_slash_command()` in `src/attune/cli_router.py` — Check if text is a slash command.
+2. **Locate the right function to change.**
+   Each function has a single responsibility. Read its
+   docstring, parameters, and return type to confirm it
+   owns the behavior you need to modify.
 
-2. **Locate the specific command function.**
-   Each CLI command maps to a single function with a `cmd_` prefix:
-   - `cmd_costs()` — Show cost report for recent period
-   - `cmd_costs_today()` — Show today's cost summary
-   - `cmd_costs_export()` — Export cost data to file
-   - `cmd_costs_reset()` — Clear all cost tracking data
-   - `cmd_help()` — Handle the `attune help` command
-   - `cmd_remember()` — Add a lesson to the lessons file
-   - `cmd_forget()` — Remove a lesson by line number or keyword
-   - `cmd_lessons()` — List current lessons with line numbers
+3. **Make your change.**
+   Follow existing patterns in the file — naming
+   conventions, error handling style, and logging.
 
-3. **Review the function signature and existing logic.**
-   Each command function takes an `argparse.Namespace` object and returns an integer exit code. Read the function's docstring and examine how it processes arguments and handles errors.
+4. **Run the related tests.**
+   This catches regressions before they reach other
+   developers. Target with `pytest -k "cli"`.
 
-4. **Implement your changes.**
-   Follow the established patterns in each file:
-   - Use the same argument validation approach
-   - Return `0` for success, non-zero for errors
-   - Handle exceptions gracefully with appropriate error messages
+## Key files
 
-5. **Test your command.**
-   Run the modified command directly: `python -m attune <your-command>` to verify it works as expected.
+- `src/attune/cli_minimal.py`
+- `src/attune/cli_router.py`
+- `src/attune/cli_commands/**`
 
-## Verify success
+## Common modifications
 
-Your CLI modification works correctly when:
-- The command executes without Python errors
-- The exit code is `0` for successful operations
-- Error messages are clear and actionable
-- The command behaves consistently with other attune CLI commands
+Functions you are most likely to modify:
+
+- `get_version()` in `src/attune/cli_minimal.py`
+- `create_parser()` in `src/attune/cli_minimal.py`
+- `main()` in `src/attune/cli_minimal.py`
+- `route_user_input()` in `src/attune/cli_router.py`
+- `is_slash_command()` in `src/attune/cli_router.py`
+- `cmd_costs()` in `src/attune/cli_commands/cost_commands.py`
+- `cmd_costs_today()` in `src/attune/cli_commands/cost_commands.py`
+- `cmd_costs_export()` in `src/attune/cli_commands/cost_commands.py`

--- a/.help/templates/memory/concept.md
+++ b/.help/templates/memory/concept.md
@@ -1,49 +1,43 @@
 ---
-type: concept
 feature: memory
 depth: concept
-generated_at: 2026-05-04T02:31:38.489537+00:00
-source_hash: c45e8890bff96a3bad01adc0d5e2914aa9058b01f5de4c8a1985c9b6fe4a7f0f
+generated_at: 2026-05-12T20:01:25.914500+00:00
+source_hash: f42c657508b8705e9411e006ff4a55425b1657952e6957339000b42557179ccb
 status: generated
 ---
 
 # Memory
 
-Memory is Attune AI's system for storing, retrieving, and securing conversational context and learned patterns across agent sessions.
+## How it works
 
-## Storage architecture
+Memory subsystem — storage, lookup, and security.
 
-Memory operates on three layers:
+The main building blocks are:
 
-**Short-term storage** handles session data through the `MemoryBackend` protocol. Backends like Redis store key-value pairs with TTL (time-to-live) expiration, agent-scoped namespacing, and connection pooling. The `SearchableMemoryBackend` extends this with semantic search capabilities for finding related context.
+- **`MemoryBackend`** — Protocol for short-term memory backends.
+- **`SearchableMemoryBackend`** — Extended protocol for backends with semantic search.
+- **`ClaudeMemoryConfig`** — Configuration for Claude memory integration
+- **`MemoryFile`** — Represents a loaded CLAUDE.md memory file
+- **`ClaudeMemoryLoader`** — Loads and manages Claude Code memory files (CLAUDE.md).
 
-**Claude integration** loads project-specific memory files through `ClaudeMemoryLoader`. It scans for `CLAUDE.md` files at enterprise, project, and user levels, respects import hierarchies, and validates file sizes. The `ClaudeMemoryConfig` controls which memory levels to load and sets safety limits.
+Under the hood, this feature spans 73 source
+files covering:
 
-**Long-term storage** uses the `MemDocsStorage` system with encryption, classification rules, and audit trails. Patterns are tagged as healthcare, financial, or proprietary based on content analysis, then access-controlled per user permissions.
+- Memory backend protocol for Attune AI.
+- Claude Memory Integration Module
+- Redis Configuration for Attune AI (deprecated).
 
-## Security model
+## What connects to it
 
-Memory implements defense in depth:
+This feature relates to: memory, storage.
 
-- **Classification** — Automatic tagging of sensitive content (healthcare keywords trigger HIPAA handling, financial terms enable PCI compliance)
-- **Encryption** — At-rest encryption for classified patterns with key rotation
-- **Access control** — Role-based permissions checked before retrieval
-- **Audit logging** — Complete trails of pattern access and modifications
-- **PII scrubbing** — Detection and masking of personal identifiers
-- **Secret detection** — Prevention of API keys and credentials from being stored
+Other parts of the codebase interact with
+memory through these interfaces:
 
-## Cross-session coordination
-
-The `CrossSessionCoordinator` handles conflicts when multiple agents access shared memory. It uses Redis pub/sub channels to broadcast session changes, implements optimistic locking for pattern updates, and provides conflict resolution strategies (merge, override, or user prompt).
-
-## Control and monitoring
-
-The `MemoryControlPanel` provides operational visibility:
-
-- Real-time statistics on storage usage and hit rates
-- Pattern management (list, delete, export by classification)
-- Redis health monitoring and auto-restart capabilities
-- Rate limiting and API key authentication for remote access
-- HTTP API server for web-based administration
-
-Memory backends expose standardized metrics through `get_stats()` including connection status, key counts, memory usage, and operation latencies.
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `MemoryBackend` | Protocol for short-term memory backends. | `src/attune/memory/backend.py` |
+| `SearchableMemoryBackend` | Extended protocol for backends with semantic search. | `src/attune/memory/backend.py` |
+| `ClaudeMemoryConfig` | Configuration for Claude memory integration | `src/attune/memory/claude_memory.py` |
+| `MemoryFile` | Represents a loaded CLAUDE.md memory file | `src/attune/memory/claude_memory.py` |
+| `ClaudeMemoryLoader` | Loads and manages Claude Code memory files (CLAUDE.md). | `src/attune/memory/claude_memory.py` |

--- a/.help/templates/memory/reference.md
+++ b/.help/templates/memory/reference.md
@@ -1,196 +1,159 @@
 ---
-type: reference
 feature: memory
 depth: reference
-generated_at: 2026-05-04T02:32:06.087576+00:00
-source_hash: c45e8890bff96a3bad01adc0d5e2914aa9058b01f5de8c8a1985c9b6fe4a7f0f
+generated_at: 2026-05-12T20:01:25.926122+00:00
+source_hash: f42c657508b8705e9411e006ff4a55425b1657952e6957339000b42557179ccb
 status: generated
 ---
 
 # Memory reference
 
-Store, retrieve, and manage persistent and session memory across conversations.
-
 ## Classes
 
-### Storage backends
-
-| Class | Description |
-|-------|-------------|
-| `MemoryBackend` | Protocol for short-term memory backends |
-| `SearchableMemoryBackend` | Extended protocol for backends with semantic search |
-| `RedisShortTermMemory` | Facade composing all short-term memory operations |
-| `LongTermMemory` | Simplified long-term persistent storage interface |
-| `MemDocsStorage` | Mock/Simple MemDocs storage backend |
-
-### Memory loaders and configuration
-
-| Class | Description |
-|-------|-------------|
-| `ClaudeMemoryConfig` | Configuration for Claude memory integration |
-| `MemoryFile` | Represents a loaded CLAUDE.md memory file |
-| `ClaudeMemoryLoader` | Loads and manages Claude Code memory files (CLAUDE.md) |
-| `MemoryConfig` | Configuration for unified memory system |
-| `UnifiedMemory` | Unified interface for short-term and long-term memory |
-
-### Control panel and management
-
-| Class | Description |
-|-------|-------------|
-| `ControlPanelConfig` | Configuration for control panel |
-| `MemoryControlPanel` | Enterprise control panel for Empathy memory management |
-| `MemoryAPIHandler` | HTTP request handler for Memory Control Panel API |
-| `MemoryStats` | Statistics for memory system |
-
-### Session management
-
-| Class | Description |
-|-------|-------------|
-| `FileSessionMemory` | File-based session memory with persistence |
-| `FileSessionConfig` | Configuration for file-based session memory |
-| `SessionInfo` | Information about an active session |
-| `SessionState` | Complete state of a session |
-| `CrossSessionCoordinator` | Coordinator for cross-session agent communication |
-
-### Security and classification
-
-| Class | Description |
-|-------|-------------|
-| `Classification` | Three-tier classification system for MemDocs patterns |
-| `ClassificationRules` | Security rules for each classification level |
-| `PatternMetadata` | Metadata for stored MemDocs patterns |
-| `SecurePattern` | Represents a securely stored pattern |
-| `PIIScrubber` | Comprehensive PII detection and scrubbing system |
-| `SecretsDetector` | Detects secrets in text content using pattern matching and entropy analysis |
-| `EncryptionManager` | Manages encryption/decryption for SENSITIVE patterns |
-
-### Data classes
-
-#### `ClaudeMemoryConfig`
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enabled` | `bool` | `False` | Enable Claude memory integration |
-| `load_enterprise` | `bool` | `True` | Load enterprise-level memory |
-| `load_user` | `bool` | `True` | Load user-specific memory |
-| `load_project` | `bool` | `True` | Load project-specific memory |
-| `enterprise_memory_path` | `str \| None` | `None` | Path to enterprise memory files |
-| `project_root` | `str \| None` | `None` | Root directory for project memory |
-| `max_import_depth` | `int` | `5` | Maximum depth for importing memory files |
-| `max_file_size_bytes` | `int` | `1000000` | Maximum size for memory files |
-| `validate_files` | `bool` | `True` | Validate memory files on load |
-
-#### `MemoryFile`
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `level` | `str` | | Memory level (enterprise/user/project) |
-| `path` | `str` | | File system path to memory file |
-| `content` | `str` | | Content of the memory file |
-| `imports` | `list[str]` | `[]` | List of imported memory files |
-| `load_order` | `int` | `0` | Order in which file was loaded |
-
-#### `ControlPanelConfig`
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `redis_host` | `str` | `'localhost'` | Redis server hostname |
-| `redis_port` | `int` | `6379` | Redis server port |
-| `storage_dir` | `str` | `'./memdocs_storage'` | Directory for storage files |
-| `audit_dir` | `str` | `'./logs'` | Directory for audit logs |
-| `auto_start_redis` | `bool` | `True` | Automatically start Redis if needed |
-
-#### `FileSessionConfig`
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `storage_dir` | `str` | | Directory for session storage files |
-| `auto_save` | `bool` | | Automatically save session state |
-| `compression` | `bool` | | Enable compression for session data |
+| Class | Description | File |
+|-------|-------------|------|
+| `MemoryBackend` | Protocol for short-term memory backends. | `src/attune/memory/backend.py` |
+| `SearchableMemoryBackend` | Extended protocol for backends with semantic search. | `src/attune/memory/backend.py` |
+| `ClaudeMemoryConfig` | Configuration for Claude memory integration | `src/attune/memory/claude_memory.py` |
+| `MemoryFile` | Represents a loaded CLAUDE.md memory file | `src/attune/memory/claude_memory.py` |
+| `ClaudeMemoryLoader` | Loads and manages Claude Code memory files (CLAUDE.md). | `src/attune/memory/claude_memory.py` |
+| `ControlPanelConfig` | Configuration for control panel. | `src/attune/memory/control_panel.py` |
+| `MemoryControlPanel` | Enterprise control panel for Empathy memory management. | `src/attune/memory/control_panel.py` |
+| `MemoryAPIHandler` | HTTP request handler for Memory Control Panel API. | `src/attune/memory/control_panel_api.py` |
+| `RateLimiter` | Simple in-memory rate limiter by IP address. | `src/attune/memory/control_panel_support.py` |
+| `APIKeyAuth` | Simple API key authentication. | `src/attune/memory/control_panel_support.py` |
+| `MemoryStats` | Statistics for memory system. | `src/attune/memory/control_panel_support.py` |
+| `CrossSessionCoordinator` | Coordinator for cross-session agent communication. | `src/attune/memory/cross_session/coordinator.py` |
+| `SessionType` | Type of session/agent. | `src/attune/memory/cross_session/models.py` |
+| `ConflictStrategy` | Strategy for resolving conflicts between agents. | `src/attune/memory/cross_session/models.py` |
+| `SessionInfo` | Information about an active session. | `src/attune/memory/cross_session/models.py` |
+| `ConflictResult` | Result of a conflict resolution. | `src/attune/memory/cross_session/models.py` |
+| `BackgroundService` | Background service daemon for cross-session coordination. | `src/attune/memory/cross_session/service.py` |
+| `EdgeType` | Types of relationships between nodes. | `src/attune/memory/edges.py` |
+| `Edge` | An edge connecting two nodes in the memory graph. | `src/attune/memory/edges.py` |
+| `EncryptionManager` | Manages encryption/decryption for SENSITIVE patterns. | `src/attune/memory/encryption.py` |
+| `FeatureStatus` | Status of an optional feature. | `src/attune/memory/features.py` |
+| `FeatureInfo` | Information about a memory feature. | `src/attune/memory/features.py` |
+| `MemoryFeatures` | Check availability of memory subsystem features. | `src/attune/memory/features.py` |
+| `FileSessionMemory` | File-based session memory with persistence. | `src/attune/memory/file_session.py` |
+| `FileSessionConfig` | Configuration for file-based session memory. | `src/attune/memory/file_session_models.py` |
+| `WorkingEntry` | Entry in working memory. | `src/attune/memory/file_session_models.py` |
+| `StagedPatternFile` | Pattern staged for validation (file-based version). | `src/attune/memory/file_session_models.py` |
+| `SessionState` | Complete state of a session. | `src/attune/memory/file_session_models.py` |
+| `PatternStagingMixin` | Mixin providing pattern staging operations. | `src/attune/memory/file_session_patterns.py` |
+| `PersistenceMixin` | Mixin providing session persistence operations. | `src/attune/memory/file_session_persistence.py` |
+| `MemoryGraph` | Knowledge graph for cross-workflow intelligence. | `src/attune/memory/graph.py` |
+| `LessonsManager` | Manages lessons learned from previous sessions. | `src/attune/memory/lessons.py` |
+| `SecureMemDocsIntegration` | Secure integration between Claude Memory and MemDocs. | `src/attune/memory/long_term_integration.py` |
+| `PatternOperationsMixin` | Mixin providing pattern list, delete, and statistics operations. | `src/attune/memory/long_term_operations.py` |
+| `PatternPipelineMixin` | Mixin providing store/retrieve pipeline helpers. | `src/attune/memory/long_term_pipelines.py` |
+| `Classification` | Three-tier classification system for MemDocs patterns | `src/attune/memory/long_term_types.py` |
+| `ClassificationRules` | Security rules for each classification level | `src/attune/memory/long_term_types.py` |
+| `PatternMetadata` | Metadata for stored MemDocs patterns | `src/attune/memory/long_term_types.py` |
+| `SecurePattern` | Represents a securely stored pattern | `src/attune/memory/long_term_types.py` |
+| `SecurityError` | Raised when security policy is violated | `src/attune/memory/long_term_types.py` |
+| `MemoryPermissionError` | Raised when access is denied. | `src/attune/memory/long_term_types.py` |
+| `BackendInitMixin` | Mixin providing backend initialization for UnifiedMemory. | `src/attune/memory/mixins/backend_init_mixin.py` |
+| `CapabilitiesMixin` | Mixin providing capability detection and health checks for UnifiedMemory. | `src/attune/memory/mixins/capabilities_mixin.py` |
+| `HandoffAndExportMixin` | Mixin providing session handoff and export capabilities for UnifiedMemory. | `src/attune/memory/mixins/handoff_mixin.py` |
+| `LifecycleMixin` | Mixin providing lifecycle management for UnifiedMemory. | `src/attune/memory/mixins/lifecycle_mixin.py` |
+| `LongTermOperationsMixin` | Mixin providing long-term memory operations for UnifiedMemory. | `src/attune/memory/mixins/long_term_mixin.py` |
+| `PatternPromotionMixin` | Mixin providing pattern promotion capabilities for UnifiedMemory. | `src/attune/memory/mixins/promotion_mixin.py` |
+| `ShortTermOperationsMixin` | Mixin providing short-term memory operations for UnifiedMemory. | `src/attune/memory/mixins/short_term_mixin.py` |
+| `NodeType` | Types of nodes in the memory graph. | `src/attune/memory/nodes.py` |
+| `Node` | A node in the memory graph. | `src/attune/memory/nodes.py` |
+| `BugNode` | Specialized node for bugs. | `src/attune/memory/nodes.py` |
+| `VulnerabilityNode` | Specialized node for security vulnerabilities. | `src/attune/memory/nodes.py` |
+| `PerformanceNode` | Specialized node for performance issues. | `src/attune/memory/nodes.py` |
+| `PatternNode` | Specialized node for code patterns. | `src/attune/memory/nodes.py` |
+| `PersonalMemory` | Store and retrieve personal cross-session memory. | `src/attune/memory/personal.py` |
+| `RedisDetectionResult` | Result of Redis auto-detection. | `src/attune/memory/redis_auto_detect.py` |
+| `RedisAutoDetector` | Auto-detect Redis availability and manage user preferences. | `src/attune/memory/redis_auto_detect.py` |
+| `RedisStartMethod` | Methods for starting Redis, in order of preference. | `src/attune/memory/redis_bootstrap.py` |
+| `RedisStatus` | Status of Redis connection/startup. | `src/attune/memory/redis_bootstrap.py` |
+| `AuditLogger` | Comprehensive audit logging for Attune AI. | `src/attune/memory/security/audit_logger.py` |
+| `AuditEvent` | Represents a single audit event. | `src/attune/memory/security/events.py` |
+| `SecurityViolation` | Represents a security policy violation. | `src/attune/memory/security/events.py` |
+| `AuditLogMethodsMixin` | Mixin that adds event-specific logging methods. | `src/attune/memory/security/log_methods.py` |
+| `PIIDetection` | Details about a detected PII instance. | `src/attune/memory/security/pii_scrubber.py` |
+| `PIIPattern` | Definition of a PII detection pattern. | `src/attune/memory/security/pii_scrubber.py` |
+| `PIIScrubber` | Comprehensive PII detection and scrubbing system. | `src/attune/memory/security/pii_scrubber.py` |
+| `AuditQueryMixin` | Mixin that adds query capabilities to AuditLogger. | `src/attune/memory/security/query.py` |
+| `AuditReportMixin` | Mixin that adds reporting capabilities to AuditLogger. | `src/attune/memory/security/reports.py` |
+| `SecretsDetector` | Detects secrets in text content using pattern matching and entropy analysis. | `src/attune/memory/security/secrets_detector.py` |
+| `SecretType` | Types of secrets that can be detected | `src/attune/memory/security/secrets_types.py` |
+| `Severity` | Severity levels for secret detections | `src/attune/memory/security/secrets_types.py` |
+| `SecretDetection` | Metadata about a detected secret. | `src/attune/memory/security/secrets_types.py` |
+| `BaseOperations` | Core CRUD operations and connection management. | `src/attune/memory/short_term/base.py` |
+| `BatchOperations` | Batch operations using Redis pipelines. | `src/attune/memory/short_term/batch.py` |
+| `CacheManager` | Local LRU cache manager for two-tier caching. | `src/attune/memory/short_term/caching.py` |
+| `ConflictNegotiation` | Conflict context and resolution operations. | `src/attune/memory/short_term/conflicts.py` |
+| `CrossSessionManager` | Cross-session coordination operations. | `src/attune/memory/short_term/cross_session.py` |
+| `RedisShortTermMemory` | Facade composing all short-term memory operations. | `src/attune/memory/short_term/facade.py` |
+| `Pagination` | SCAN-based pagination operations. | `src/attune/memory/short_term/pagination.py` |
+| `PatternStaging` | Pattern staging lifecycle operations. | `src/attune/memory/short_term/patterns.py` |
+| `PubSubManager` | Real-time publish/subscribe operations. | `src/attune/memory/short_term/pubsub.py` |
+| `QueueManager` | Redis list operations for task queues. | `src/attune/memory/short_term/queues.py` |
+| `DataSanitizer` | Handles data sanitization for short-term memory. | `src/attune/memory/short_term/security.py` |
+| `SessionManager` | Collaboration session operations. | `src/attune/memory/short_term/sessions.py` |
+| `StreamManager` | Redis Streams operations for audit trails and event logs. | `src/attune/memory/short_term/streams.py` |
+| `TimelineManager` | Redis sorted set operations for timeline queries. | `src/attune/memory/short_term/timelines.py` |
+| `TransactionManager` | Atomic operations using Redis transactions. | `src/attune/memory/short_term/transactions.py` |
+| `WorkingMemory` | Working memory operations for agent data storage. | `src/attune/memory/short_term/working.py` |
+| `LongTermMemory` | Simplified long-term persistent storage interface. | `src/attune/memory/simple_storage.py` |
+| `MemDocsStorage` | Mock/Simple MemDocs storage backend. | `src/attune/memory/storage_backend.py` |
+| `AgentContext` | Compact context package for sub-agent handoff. | `src/attune/memory/summary_index.py` |
+| `ConversationSummaryIndex` | Redis-backed conversation summary with topic indexing. | `src/attune/memory/summary_index.py` |
+| `AccessTier` | Role-based access tiers per EMPATHY_PHILOSOPHY.md | `src/attune/memory/types.py` |
+| `TTLStrategy` | TTL strategies for different memory types | `src/attune/memory/types.py` |
+| `RedisConfig` | Enhanced Redis configuration with SSL and retry support. | `src/attune/memory/types.py` |
+| `RedisMetrics` | Metrics for Redis operations. | `src/attune/memory/types.py` |
+| `PaginatedResult` | Result of a paginated query. | `src/attune/memory/types.py` |
+| `TimeWindowQuery` | Query parameters for time-window operations. | `src/attune/memory/types.py` |
+| `AgentCredentials` | Agent identity and access permissions | `src/attune/memory/types.py` |
+| `StagedPattern` | Pattern awaiting validation | `src/attune/memory/types.py` |
+| `ConflictContext` | Context for principled negotiation | `src/attune/memory/types.py` |
+| `SecurityError` | Raised when a security policy is violated (e.g., secrets detected in data). | `src/attune/memory/types.py` |
+| `Environment` | Deployment environment for storage configuration. | `src/attune/memory/unified.py` |
+| `MemoryConfig` | Configuration for unified memory system. | `src/attune/memory/unified.py` |
+| `UnifiedMemory` | Unified interface for short-term and long-term memory. | `src/attune/memory/unified.py` |
 
 ## Functions
 
-### Redis utilities
+| Function | Description | File |
+|----------|-------------|------|
+| `is_redis_available()` | Check if Redis subsystem is available without importing it. | `src/attune/memory/__init__.py` |
+| `create_default_project_memory()` | Create a default .claude/CLAUDE.md file for a project. | `src/attune/memory/claude_memory.py` |
+| `parse_redis_url()` | Parse Redis URL into connection parameters. | `src/attune/memory/config.py` |
+| `get_redis_config()` | Get Redis configuration from environment variables (legacy dict API). | `src/attune/memory/config.py` |
+| `get_redis_memory()` | Create a RedisShortTermMemory instance with environment-based config. | `src/attune/memory/config.py` |
+| `check_redis_connection()` | Check Redis connection and return status. | `src/attune/memory/config.py` |
+| `get_railway_redis()` | Get Redis configured for Railway deployment. | `src/attune/memory/config.py` |
+| `run_api_server()` | Run the Memory API server with security features. | `src/attune/memory/control_panel_api.py` |
+| `print_status()` | Print status in a formatted way. | `src/attune/memory/control_panel_display.py` |
+| `print_stats()` | Print statistics in a formatted way. | `src/attune/memory/control_panel_display.py` |
+| `print_health()` | Print health check in a formatted way. | `src/attune/memory/control_panel_display.py` |
+| `main()` | CLI entry point. | `src/attune/memory/control_panel_display.py` |
+| `resolve_by_priority()` | Resolve conflict using priority (access tier). | `src/attune/memory/cross_session/conflicts.py` |
+| `resolve_first_write()` | Resolve conflict using first-write-wins. | `src/attune/memory/cross_session/conflicts.py` |
+| `resolve_last_write()` | Resolve conflict using last-write-wins. | `src/attune/memory/cross_session/conflicts.py` |
+| `generate_agent_id()` | Generate a unique agent ID. | `src/attune/memory/cross_session/models.py` |
+| `check_redis_cross_session_support()` | Check if Redis supports cross-session communication. | `src/attune/memory/cross_session/service.py` |
+| `get_or_start_service()` | Get existing service or start a new one. | `src/attune/memory/cross_session/service.py` |
+| `get_file_session_memory()` | Create a file-based session memory instance. | `src/attune/memory/file_session.py` |
+| `classify_pattern()` | Auto-classify pattern based on content and type. | `src/attune/memory/long_term_classification.py` |
+| `check_access()` | Check if user has access to pattern based on classification. | `src/attune/memory/long_term_classification.py` |
+| `auto_detect_redis()` | Convenience function for auto-detecting Redis. | `src/attune/memory/redis_auto_detect.py` |
+| `ensure_redis()` | Ensure Redis is available, starting it if necessary. | `src/attune/memory/redis_bootstrap.py` |
+| `stop_redis()` | Stop Redis if we started it. | `src/attune/memory/redis_bootstrap.py` |
+| `get_redis_or_mock()` | Get a Redis connection, starting Redis if needed, or return mock. | `src/attune/memory/redis_bootstrap.py` |
+| `detect_secrets()` | Convenience function to detect secrets without creating a detector instance. | `src/attune/memory/security/secrets_detector.py` |
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `is_redis_available` | | `bool` | Check if Redis subsystem is available without importing it |
-| `get_redis_memory` | `url: str \| None = None`, `use_mock: bool \| None = None` | `RedisShortTermMemory` | Create a RedisShortTermMemory instance with environment-based config |
-| `check_redis_connection` | | `dict` | Check Redis connection and return status |
-| `get_railway_redis` | | `RedisShortTermMemory` | Get Redis configured for Railway deployment |
-| `parse_redis_url` | `url: str` | `dict` | Parse Redis URL into connection parameters |
-| `get_redis_config` | | `dict` | Get Redis configuration from environment variables (legacy dict API) |
 
-#### `get_railway_redis` raises
+## Source files
 
-| Exception | Message |
-|-----------|---------|
-| `OSError` | `'REDIS_URL not found. Make sure Redis is added to your Railway project.\nRun: railway add --database redis\nFor external access, use REDIS_PUBLIC_URL'` |
+- `src/attune/memory/**`
 
-### Memory management
+## Tags
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `create_default_project_memory` | `project_root: str`, `framework: str = 'empathy'` | | Create a default .claude/CLAUDE.md file for a project |
-| `get_file_session_memory` | | `FileSessionMemory` | Create a file-based session memory instance |
-| `classify_pattern` | | | Auto-classify pattern based on content and type |
-| `check_access` | | | Check if user has access to pattern based on classification |
-
-### Control panel
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `run_api_server` | `panel: MemoryControlPanel`, `host: str = 'localhost'`, `port: int = 8765`, `api_key: str \| None = None`, `enable_rate_limit: bool = True`, `rate_limit_requests: int = 100`, `rate_limit_window: int = 60`, `ssl_certfile: str \| None = None`, `ssl_keyfile: str \| None = None`, `allowed_origins: list[str] \| None = None` | | Run the Memory API server with security features |
-| `print_status` | `panel: MemoryControlPanel` | | Print status in a formatted way |
-| `print_stats` | `panel: MemoryControlPanel` | | Print statistics in a formatted way |
-
-### Security
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `detect_secrets` | | | Convenience function to detect secrets without creating a detector instance |
-
-### Cross-session coordination
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `generate_agent_id` | | | Generate a unique agent ID |
-| `check_redis_cross_session_support` | | | Check if Redis supports cross-session communication |
-| `get_or_start_service` | | | Get existing service or start a new one |
-
-### Redis lifecycle
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `ensure_redis` | | | Ensure Redis is available, starting it if necessary |
-| `stop_redis` | | | Stop Redis if we started it |
-| `get_redis_or_mock` | | | Get a Redis connection, starting Redis if needed, or return mock |
-| `auto_detect_redis` | | | Convenience function for auto-detecting Redis |
-
-## Constants
-
-### Cross-session keys
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `CHANNEL_SESSIONS` | `'empathy:sessions'` | Redis channel for session coordination |
-| `KEY_ACTIVE_AGENTS` | `'empathy:active_agents'` | Redis key for active agent registry |
-| `KEY_SERVICE_LOCK` | `'empathy:service_lock'` | Redis key for service coordination lock |
-| `KEY_SERVICE_HEARTBEAT` | `'empathy:service_heartbeat'` | Redis key for service heartbeat |
-
-### Security keywords
-
-| Constant | Members | Description |
-|----------|---------|-------------|
-| `HEALTHCARE_KEYWORDS` | `'patient'`, `'medical'`, `'diagnosis'`, `'treatment'`, `'healthcare'`, `'clinical'`, `'hipaa'`, `'phi'`, `'medical record'`, `'prescription'` | Keywords that trigger healthcare classification |
-| `FINANCIAL_KEYWORDS` | `'financial'`, `'payment'`, `'credit card'`, `'banking'`, `'transaction'`, `'pci dss'`, `'payment card'` | Keywords that trigger financial classification |
-| `PROPRIETARY_KEYWORDS` | `'proprietary'`, `'confidential'`, `'internal'`, `'trade secret'`, `'company confidential'`, `'restricted'` | Keywords that trigger proprietary classification |
-| `SENSITIVE_PATTERN_TYPES` | `'clinical_protocol'`, `'medical_guideline'`, `'patient_workflow'`, `'financial_procedure'` | Pattern types requiring sensitive handling |
-| `INTERNAL_PATTERN_TYPES` | `'architecture'`, `'business_logic'`, `'company_process'` | Pattern types for internal use only |
-
-### Template markers
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `_CLAUDE_MD_START` | `'<!-- attune-lessons-start -->'` | Start marker for lessons section in CLAUDE.md |
-| `_CLAUDE_MD_END` | `'<!-- attune-lessons-end -->'` | End marker for lessons section in CLAUDE.md |
+`memory`, `storage`

--- a/.help/templates/memory/task.md
+++ b/.help/templates/memory/task.md
@@ -1,64 +1,57 @@
 ---
-type: task
 feature: memory
 depth: task
-generated_at: 2026-05-04T02:31:55.138987+00:00
-source_hash: c45e8890bff96a3bad01adc0d5e2914aa9058b01f5e2914aa9058b01f5de8c8a1985c9b6fe4a7f0f
+generated_at: 2026-05-12T20:01:25.921338+00:00
+source_hash: f42c657508b8705e9411e006ff4a55425b1657952e6957339000b42557179ccb
 status: generated
 ---
 
 # Work with memory
 
-Use the memory module when you need to implement storage, retrieval, or security features for Attune AI's memory subsystem.
+Use memory when you need to memory subsystem — storage, lookup, and security.
 
 ## Prerequisites
 
 - Access to the project source code
-- Familiarity with the files under `src/attune/memory/`
-- Basic understanding of Redis configuration (if working with short-term memory)
+- Familiarity with the files under src/attune/memory/**
 
 ## Steps
 
-1. **Identify the memory component you need to modify.**
-   The memory module has four main areas:
-   - **Backends**: `MemoryBackend` and `SearchableMemoryBackend` protocols
-   - **Claude integration**: Loading and managing CLAUDE.md files
-   - **Redis configuration**: Short-term memory with Redis backends
-   - **Control panel**: Web API for memory management
+1. **Understand the current behavior.**
+   Read the entry points to see what memory
+   does today before making changes.
+   The primary functions are:
+   - `is_redis_available()` in `src/attune/memory/__init__.py` — Check if Redis subsystem is available without importing it.
+   - `create_default_project_memory()` in `src/attune/memory/claude_memory.py` — Create a default .claude/CLAUDE.md file for a project.
+   - `parse_redis_url()` in `src/attune/memory/config.py` — Parse Redis URL into connection parameters.
+   - `get_redis_config()` in `src/attune/memory/config.py` — Get Redis configuration from environment variables (legacy dict API).
+   - `get_redis_memory()` in `src/attune/memory/config.py` — Create a RedisShortTermMemory instance with environment-based config.
+2. **Locate the right function to change.**
+   Each function has a single responsibility. Read its
+   docstring, parameters, and return type to confirm it
+   owns the behavior you need to modify.
 
-2. **Choose the appropriate entry point.**
-   Based on your task, start with one of these functions:
-   - `is_redis_available()` — Check Redis subsystem availability
-   - `create_default_project_memory()` — Initialize CLAUDE.md files
-   - `get_redis_memory()` — Create Redis memory instances
-   - `run_api_server()` — Start the memory control panel
+3. **Make your change.**
+   Follow existing patterns in the file — naming
+   conventions, error handling style, and logging.
 
-3. **Examine the existing implementation.**
-   Read the function's docstring, parameters, and return type. Check how it handles errors and what patterns it follows for logging and configuration.
+4. **Run the related tests.**
+   This catches regressions before they reach other
+   developers. Target with `pytest -k "memory"`.
 
-4. **Implement your changes.**
-   Maintain consistency with the existing codebase:
-   - Use the same error handling patterns
-   - Follow established naming conventions
-   - Preserve the function's single responsibility
+## Key files
 
-5. **Verify your implementation.**
-   Run targeted tests to ensure your changes work correctly:
-   ```bash
-   pytest -k "memory"
-   ```
+- `src/attune/memory/**`
 
-## Verify success
+## Common modifications
 
-Your changes work correctly when:
-- All memory-related tests pass
-- The function returns the expected type and format
-- Error conditions are handled gracefully
-- No regressions appear in dependent functionality
+Functions you are most likely to modify:
 
-## Key files to know
-
-- `src/attune/memory/__init__.py` — Module entry points and Redis availability checking
-- `src/attune/memory/claude_memory.py` — CLAUDE.md file management
-- `src/attune/memory/config.py` — Redis configuration and connection handling
-- `src/attune/memory/control_panel_api.py` — HTTP API for memory management
+- `is_redis_available()` in `src/attune/memory/__init__.py`
+- `create_default_project_memory()` in `src/attune/memory/claude_memory.py`
+- `parse_redis_url()` in `src/attune/memory/config.py`
+- `get_redis_config()` in `src/attune/memory/config.py`
+- `get_redis_memory()` in `src/attune/memory/config.py`
+- `check_redis_connection()` in `src/attune/memory/config.py`
+- `get_railway_redis()` in `src/attune/memory/config.py`
+- `run_api_server()` in `src/attune/memory/control_panel_api.py`

--- a/.help/templates/telemetry/concept.md
+++ b/.help/templates/telemetry/concept.md
@@ -1,47 +1,43 @@
 ---
-type: concept
 feature: telemetry
 depth: concept
-generated_at: 2026-05-04T02:37:13.475757+00:00
-source_hash: ed8485991002cc1c218f67b4f33f230bcbdc4325599a2e03f2bbe584d94a5e90
+generated_at: 2026-05-12T20:01:25.969321+00:00
+source_hash: 590fd017f021732dc1cad2f715e7eaaa2a436b4e8d7cd0434769d62d180dd966
 status: generated
 ---
 
 # Telemetry
 
-Telemetry is the monitoring and coordination system that tracks agent behavior, enables inter-agent communication, and provides human oversight controls for Attune AI workflows.
+## How it works
 
-## What it tracks
+Usage tracking and feedback loops.
 
-The telemetry system monitors three layers of agent activity:
+The main building blocks are:
 
-**Agent heartbeats** track whether agents are alive and what they're doing. Each agent sends periodic status updates including current task progress and metadata. The `HeartbeatCoordinator` uses Redis TTL keys to detect when agents stop responding, providing a real-time view of the agent ecosystem's health.
+- **`CoordinationSignal`** — Coordination signal between agents.
+- **`CoordinationSignals`** — TTL-based inter-agent coordination signals.
+- **`AgentHeartbeat`** — Agent heartbeat data structure.
+- **`HeartbeatCoordinator`** — Coordinates agent heartbeats using Redis TTL keys.
+- **`ApprovalRequest`** — Approval request with context for human decision.
 
-**Inter-agent coordination** enables agents to signal each other through time-limited messages. The `CoordinationSignals` class manages TTL-based communication where agents can broadcast status updates, request assistance, or coordinate handoffs. These signals automatically expire to prevent stale coordination data.
+Under the hood, this feature spans 16 source
+files covering:
 
-**Human approval gates** pause workflows when human oversight is required. The `ApprovalGate` system presents context-rich approval requests that humans can approve or reject, with configurable timeouts to prevent workflows from hanging indefinitely.
+- Enable running telemetry as a module.
+- Agent Coordination via TTL Signals.
+- Agent Heartbeat Tracking System.
 
-## Real-time streaming
+## What connects to it
 
-Events flow through Redis Streams via the `EventStreamer`, which publishes structured events as they occur. This enables real-time monitoring dashboards and allows external systems to react to agent behavior changes immediately.
+This feature relates to: telemetry, metrics.
 
-## Cost and performance insights
+Other parts of the codebase interact with
+telemetry through these interfaces:
 
-The telemetry CLI provides operational visibility through several reporting commands:
-- Model tier fallback analysis shows cost savings from Sonnet 3.5 → Opus 3.5 degradation
-- Test execution status tracks which files have passing automation
-- Task routing reports show how work flows between agents
-- Prompt caching statistics reveal performance optimizations
-
-## Data structures
-
-All telemetry data uses structured dataclasses that serialize to/from dictionaries for Redis storage:
-
-| Class | Purpose | Key fields |
-|-------|---------|------------|
-| `CoordinationSignal` | Agent-to-agent messages | `signal_type`, `source_agent`, `target_agent`, `ttl_seconds` |
-| `AgentHeartbeat` | Agent status updates | `agent_id`, `status`, `progress`, `current_task` |
-| `ApprovalRequest` | Human approval requests | `approval_type`, `context`, `timeout_seconds` |
-| `StreamEvent` | Real-time event notifications | `event_type`, `data`, `timestamp` |
-
-This structured approach ensures telemetry data remains queryable and consistent as the agent ecosystem scales.
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `CoordinationSignal` | Coordination signal between agents. | `src/attune/telemetry/agent_coordination.py` |
+| `CoordinationSignals` | TTL-based inter-agent coordination signals. | `src/attune/telemetry/agent_coordination.py` |
+| `AgentHeartbeat` | Agent heartbeat data structure. | `src/attune/telemetry/agent_tracking.py` |
+| `HeartbeatCoordinator` | Coordinates agent heartbeats using Redis TTL keys. | `src/attune/telemetry/agent_tracking.py` |
+| `ApprovalRequest` | Approval request with context for human decision. | `src/attune/telemetry/approval_gates.py` |

--- a/.help/templates/telemetry/reference.md
+++ b/.help/templates/telemetry/reference.md
@@ -1,173 +1,56 @@
 ---
-type: reference
 feature: telemetry
 depth: reference
-generated_at: 2026-05-04T02:37:43.292955+00:00
-source_hash: ed8485991002cc1c218f67b4f33f230bcbdc4325599a2e03f2bbe584d94a5e90
+generated_at: 2026-05-12T20:01:25.978552+00:00
+source_hash: 590fd017f021732dc1cad2f715e7eaaa2a436b4e8d7cd0434769d62d180dd966
 status: generated
 ---
 
 # Telemetry reference
 
-Track agent coordination, heartbeats, approval workflows, and streaming events across Attune AI systems. Provides Redis-backed coordination signals, TTL-based agent tracking, human approval gates, and privacy-first usage telemetry.
+## Classes
 
-## Agent Coordination
+| Class | Description | File |
+|-------|-------------|------|
+| `CoordinationSignal` | Coordination signal between agents. | `src/attune/telemetry/agent_coordination.py` |
+| `CoordinationSignals` | TTL-based inter-agent coordination signals. | `src/attune/telemetry/agent_coordination.py` |
+| `AgentHeartbeat` | Agent heartbeat data structure. | `src/attune/telemetry/agent_tracking.py` |
+| `HeartbeatCoordinator` | Coordinates agent heartbeats using Redis TTL keys. | `src/attune/telemetry/agent_tracking.py` |
+| `ApprovalRequest` | Approval request with context for human decision. | `src/attune/telemetry/approval_gates.py` |
+| `ApprovalResponse` | Response to an approval request. | `src/attune/telemetry/approval_gates.py` |
+| `ApprovalGate` | Human approval gates for workflow control. | `src/attune/telemetry/approval_gates.py` |
+| `StreamEvent` | Event published to Redis Stream. | `src/attune/telemetry/event_streaming.py` |
+| `EventStreamer` | Real-time event streaming using Redis Streams. | `src/attune/telemetry/event_streaming.py` |
+| `FeatureStatus` | Status of an optional feature. | `src/attune/telemetry/features.py` |
+| `FeatureInfo` | Information about a telemetry feature. | `src/attune/telemetry/features.py` |
+| `TelemetryFeatures` | Check availability of telemetry features. | `src/attune/telemetry/features.py` |
+| `FeedbackLoop` | Agent-to-LLM feedback loop for quality-based learning. | `src/attune/telemetry/feedback_loop.py` |
+| `ModelTier` | Model tier enum matching workflows.base.ModelTier. | `src/attune/telemetry/feedback_models.py` |
+| `FeedbackEntry` | Quality feedback for an LLM response. | `src/attune/telemetry/feedback_models.py` |
+| `QualityStats` | Quality statistics for a workflow stage. | `src/attune/telemetry/feedback_models.py` |
+| `TierRecommendation` | Tier recommendation based on quality feedback. | `src/attune/telemetry/feedback_models.py` |
+| `HelpTracker` | Append-only JSONL tracker for help-system queries. | `src/attune/telemetry/help_tracker.py` |
+| `UsageTracker` | Privacy-first local telemetry tracker. | `src/attune/telemetry/usage_tracker.py` |
 
-### CoordinationSignal
+## Functions
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `signal_id` | `str` | - | Unique identifier for the signal |
-| `signal_type` | `str` | - | Type classification for filtering |
-| `source_agent` | `str` | - | ID of the sending agent |
-| `target_agent` | `str \| None` | - | ID of the receiving agent (None for broadcast) |
-| `payload` | `dict[str, Any]` | - | Signal data content |
-| `timestamp` | `datetime` | - | When the signal was created |
-| `ttl_seconds` | `int` | `60` | Time-to-live before automatic expiry |
+| Function | Description | File |
+|----------|-------------|------|
+| `main()` | Telemetry CLI entry point. | `src/attune/telemetry/__main__.py` |
+| `cmd_sonnet_opus_analysis()` | Show Sonnet 4.5 -> Opus 4.5 fallback analysis and cost savings. | `src/attune/telemetry/cli_analysis.py` |
+| `cmd_file_test_status()` | Show per-file test status. | `src/attune/telemetry/cli_analysis.py` |
+| `cmd_tier1_status()` | Show comprehensive Tier 1 automation status. | `src/attune/telemetry/cli_automation.py` |
+| `cmd_task_routing_report()` | Show detailed task routing report. | `src/attune/telemetry/cli_automation.py` |
+| `cmd_test_status()` | Show test execution status. | `src/attune/telemetry/cli_automation.py` |
+| `cmd_agent_performance()` | Show agent performance metrics. | `src/attune/telemetry/cli_automation.py` |
+| `cmd_telemetry_show()` | Show recent telemetry entries. | `src/attune/telemetry/cli_core.py` |
+| `cmd_telemetry_savings()` | Calculate and display cost savings. | `src/attune/telemetry/cli_core.py` |
+| `cmd_telemetry_cache_stats()` | Show prompt caching performance statistics. | `src/attune/telemetry/cli_core.py` |
+| `cmd_telemetry_compare()` | Compare telemetry across two time periods. | `src/attune/telemetry/cli_core.py` |
+| `cmd_telemetry_reset()` | Reset/clear all telemetry data. | `src/attune/telemetry/cli_core.py` |
+| `cmd_telemetry_export()` | Export telemetry data to JSON or CSV. | `src/attune/telemetry/cli_core.py` |
+| `get_tracker()` | Return a process-wide default HelpTracker. | `src/attune/telemetry/help_tracker.py` |
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Serialize signal to dictionary |
-| `from_dict(cls, data: dict[str, Any])` | `CoordinationSignal` | Deserialize signal from dictionary |
-
-### CoordinationSignals
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__(self, memory, agent_id, enable_streaming)` | `memory=None, agent_id: str \| None = None, enable_streaming: bool = False` | - | Initialize coordination system |
-| `signal(self, signal_type, source_agent, target_agent, payload, ttl_seconds, credentials)` | `signal_type: str, source_agent: str \| None = None, target_agent: str \| None = None, payload: dict[str, Any] \| None = None, ttl_seconds: int \| None = None, credentials: AgentCredentials \| None = None` | `str` | Send signal to specific agent |
-| `broadcast(self, signal_type, source_agent, payload, ttl_seconds, credentials)` | `signal_type: str, source_agent: str \| None = None, payload: dict[str, Any] \| None = None, ttl_seconds: int \| None = None, credentials: AgentCredentials \| None = None` | `str` | Send signal to all agents |
-| `wait_for_signal(self, signal_type, source_agent, timeout, poll_interval)` | `signal_type: str, source_agent: str \| None = None, timeout: float = 30.0, poll_interval: float = 0.5` | `CoordinationSignal \| None` | Block until signal arrives or timeout |
-| `check_signal(self, signal_type, source_agent, consume)` | `signal_type: str, source_agent: str \| None = None, consume: bool = True` | `CoordinationSignal \| None` | Non-blocking signal check |
-| `get_pending_signals(self, signal_type)` | `signal_type: str \| None = None` | `list[CoordinationSignal]` | Get all pending signals |
-| `clear_signals(self, signal_type)` | `signal_type: str \| None = None` | `int` | Remove signals and return count cleared |
-
-## Agent Tracking
-
-### AgentHeartbeat
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `agent_id` | `str` | - | Unique agent identifier |
-| `status` | `str` | - | Current agent status |
-| `progress` | `float` | - | Task completion percentage |
-| `current_task` | `str` | - | Description of current task |
-| `last_beat` | `datetime` | - | Timestamp of last heartbeat |
-| `metadata` | `dict[str, Any]` | `dict()` | Additional agent context |
-| `display_name` | `str \| None` | `None` | Human-readable agent name |
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Serialize heartbeat to dictionary |
-| `from_dict(cls, data: dict[str, Any])` | `AgentHeartbeat` | Deserialize heartbeat from dictionary |
-
-### HeartbeatCoordinator
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__(self, memory, enable_streaming)` | `memory=None, enable_streaming: bool = False` | - | Initialize heartbeat coordinator |
-| `start_heartbeat(self, agent_id, metadata, display_name)` | `agent_id: str, metadata: dict[str, Any] \| None = None, display_name: str \| None = None` | `None` | Begin heartbeat tracking |
-| `beat(self, status, progress, current_task)` | `status: str = 'running', progress: float = 0.0, current_task: str = ''` | `None` | Send heartbeat update |
-| `stop_heartbeat(self, final_status)` | `final_status: str = 'completed'` | `None` | Stop heartbeat tracking |
-| `get_active_agents(self)` | - | `list[AgentHeartbeat]` | Get all active agents |
-| `is_agent_alive(self, agent_id)` | `agent_id: str` | `bool` | Check if agent is sending heartbeats |
-| `get_agent_status(self, agent_id)` | `agent_id: str` | `AgentHeartbeat \| None` | Get specific agent status |
-| `get_stale_agents(self, threshold_seconds)` | `threshold_seconds: float = 60.0` | `list[AgentHeartbeat]` | Find agents exceeding stale threshold |
-
-## Approval Gates
-
-### ApprovalRequest
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `request_id` | `str` | - | Unique request identifier |
-| `approval_type` | `str` | - | Type of approval needed |
-| `agent_id` | `str` | - | ID of requesting agent |
-| `context` | `dict[str, Any]` | - | Request context and details |
-| `timestamp` | `datetime` | - | When request was created |
-| `timeout_seconds` | `float` | - | Request expiry timeout |
-| `status` | `str` | `'pending'` | Current request status |
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Serialize request to dictionary |
-| `from_dict(cls, data: dict[str, Any])` | `ApprovalRequest` | Deserialize request from dictionary |
-
-### ApprovalResponse
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `request_id` | `str` | - | ID of the approval request |
-| `approved` | `bool` | - | Whether request was approved |
-| `responder` | `str` | - | ID of the responding user |
-| `reason` | `str` | `''` | Explanation for the decision |
-| `timestamp` | `datetime` | `datetime.now(timezone.utc)` | When response was given |
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Serialize response to dictionary |
-| `from_dict(cls, data: dict[str, Any])` | `ApprovalResponse` | Deserialize response from dictionary |
-
-### ApprovalGate
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__(self, memory, agent_id)` | `memory=None, agent_id: str \| None = None` | - | Initialize approval gate |
-| `request_approval(self, approval_type, context, timeout)` | `approval_type: str, context: dict[str, Any] \| None = None, timeout: float \| None = None` | `ApprovalResponse` | Request human approval and wait |
-| `respond_to_approval(self, request_id, approved, responder, reason)` | `request_id: str, approved: bool, responder: str, reason: str = ''` | `bool` | Respond to pending approval request |
-| `get_pending_approvals(self, approval_type)` | `approval_type: str \| None = None` | `list[ApprovalRequest]` | Get all pending approval requests |
-| `clear_expired_requests(self)` | - | `int` | Remove expired requests and return count |
-
-## Event Streaming
-
-### StreamEvent
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `event_id` | `str` | - | Unique event identifier |
-| `event_type` | `str` | - | Type classification for filtering |
-| `timestamp` | `datetime` | - | When event occurred |
-| `data` | `dict[str, Any]` | - | Event payload |
-| `source` | `str` | `'attune'` | Source system that generated event |
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Serialize event to dictionary |
-| `from_redis_entry(cls, event_id: str, entry_data: dict[bytes, bytes])` | `StreamEvent` | Deserialize event from Redis stream entry |
-
-### EventStreamer
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__(self, memory)` | `memory=None` | - | Initialize event streamer |
-| `publish_event(self, event_type, data, source)` | `event_type: str, data: dict[str, Any], source: str = 'attune'` | `str` | Publish event to stream |
-| `consume_events(self, event_types, block_ms, count, start_id)` | `event_types: list[str] \| None = None, block_ms: int \| None = None, count: int = 10, start_id: str = '$'` | `Iterator[StreamEvent]` | Consume events from stream |
-| `get_recent_events(self, event_type, count, start_id, end_id)` | `event_type: str, count: int = 100, start_id: str = '-', end_id: str = '+'` | `list[StreamEvent]` | Get recent events by type |
-| `get_stream_info(self, event_type)` | `event_type: str` | `dict[str, Any]` | Get stream metadata and statistics |
-| `delete_stream(self, event_type)` | `event_type: str` | `bool` | Delete entire stream |
-| `trim_stream(self, event_type, max_length)` | `event_type: str, max_length: int = 1000` | `int` | Trim stream to maximum length |
-
-## CLI Commands
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main()` | - | `int` | Telemetry CLI entry point |
-| `cmd_sonnet_opus_analysis(args)` | `args: Any` | `int` | Show Sonnet 4.5 -> Opus 4.5 fallback analysis and cost savings |
-| `cmd_file_test_status(args)` | `args: Any` | `int` | Show per-file test status |
-| `cmd_tier1_status(args)` | `args: Any` | `int` | Show comprehensive Tier 1 automation status |
-| `cmd_task_routing_report(args)` | `args: Any` | `int` | Show detailed task routing report |
-| `cmd_test_status(args)` | `args: Any` | `int` | Show test execution status |
-| `cmd_agent_performance(args)` | `args: Any` | `int` | Show agent performance metrics |
-| `cmd_telemetry_show(args)` | `args: Any` | `int` | Show recent telemetry entries |
-| `cmd_telemetry_savings(args)` | `args: Any` | `int` | Calculate and display cost savings |
-| `cmd_telemetry_cache_stats(args)` | `args: Any` | `int` | Show prompt caching performance statistics |
-
-## Constants
-
-| Constant | Type | Value | Description |
-|----------|------|-------|-------------|
-| `_LOG_VERSION` | `str` | `'1.0'` | Telemetry log format version |
-| `_DEFAULT_FILE` | `str` | `'help_queries.jsonl'` | Default telemetry data filename |
 
 ## Source files
 

--- a/.help/templates/telemetry/task.md
+++ b/.help/templates/telemetry/task.md
@@ -1,93 +1,57 @@
 ---
-type: task
 feature: telemetry
 depth: task
-generated_at: 2026-05-04T02:37:27.827841+00:00
-source_hash: ed8485991002cc1c218f67b4f33f230bcbdc4325599a2e03f2bbe584d94a5e90
+generated_at: 2026-05-12T20:01:25.974335+00:00
+source_hash: 590fd017f021732dc1cad2f715e7eaaa2a436b4e8d7cd0434769d62d180dd966
 status: generated
 ---
 
 # Work with telemetry
 
-Use telemetry when you need to track agent coordination, monitor performance metrics, or implement human approval workflows in Attune AI.
+Use telemetry when you need to usage tracking and feedback loops.
 
 ## Prerequisites
 
 - Access to the project source code
-- Familiarity with the telemetry module at `src/attune/telemetry/`
-- Basic understanding of Redis for data persistence
+- Familiarity with the files under src/attune/telemetry/**
 
-## Configure telemetry components
+## Steps
 
-1. **Set up coordination signals between agents.**
-   Use `CoordinationSignals` to send TTL-based messages between agents:
-   ```python
-   from attune.telemetry import CoordinationSignals
+1. **Understand the current behavior.**
+   Read the entry points to see what telemetry
+   does today before making changes.
+   The primary functions are:
+   - `main()` in `src/attune/telemetry/__main__.py` — Telemetry CLI entry point.
+   - `cmd_sonnet_opus_analysis()` in `src/attune/telemetry/cli_analysis.py` — Show Sonnet 4.5 -> Opus 4.5 fallback analysis and cost savings.
+   - `cmd_file_test_status()` in `src/attune/telemetry/cli_analysis.py` — Show per-file test status.
+   - `cmd_tier1_status()` in `src/attune/telemetry/cli_automation.py` — Show comprehensive Tier 1 automation status.
+   - `cmd_task_routing_report()` in `src/attune/telemetry/cli_automation.py` — Show detailed task routing report.
+2. **Locate the right function to change.**
+   Each function has a single responsibility. Read its
+   docstring, parameters, and return type to confirm it
+   owns the behavior you need to modify.
 
-   coordinator = CoordinationSignals(agent_id="my_agent")
-   signal_id = coordinator.signal("task_complete", payload={"result": "success"})
-   ```
+3. **Make your change.**
+   Follow existing patterns in the file — naming
+   conventions, error handling style, and logging.
 
-2. **Initialize heartbeat monitoring.**
-   Use `HeartbeatCoordinator` to track agent health and progress:
-   ```python
-   from attune.telemetry import HeartbeatCoordinator
+4. **Run the related tests.**
+   This catches regressions before they reach other
+   developers. Target with `pytest -k "telemetry"`.
 
-   heartbeat = HeartbeatCoordinator()
-   heartbeat.start_heartbeat("agent_1", metadata={"task": "data_processing"})
-   heartbeat.beat(status="running", progress=0.5, current_task="processing file 2/4")
-   ```
+## Key files
 
-3. **Configure human approval gates.**
-   Use `ApprovalGate` for workflow control requiring human decisions:
-   ```python
-   from attune.telemetry import ApprovalGate
+- `src/attune/telemetry/**`
 
-   gate = ApprovalGate(agent_id="workflow_agent")
-   response = gate.request_approval("deploy", context={"env": "production"})
-   ```
+## Common modifications
 
-4. **Set up event streaming.**
-   Use `EventStreamer` for real-time event monitoring:
-   ```python
-   from attune.telemetry import EventStreamer
+Functions you are most likely to modify:
 
-   streamer = EventStreamer()
-   event_id = streamer.publish_event("task_started", {"agent": "worker_1"})
-   ```
-
-## Run telemetry commands
-
-1. **Check cost savings from model fallbacks.**
-   Run: `python -m attune.telemetry sonnet-opus-analysis`
-
-2. **View agent performance metrics.**
-   Run: `python -m attune.telemetry agent-performance`
-
-3. **Monitor test execution status.**
-   Run: `python -m attune.telemetry test-status`
-
-4. **Review Tier 1 automation status.**
-   Run: `python -m attune.telemetry tier1-status`
-
-5. **Generate task routing reports.**
-   Run: `python -m attune.telemetry task-routing-report`
-
-## Verify telemetry is working
-
-Check that your telemetry setup is functioning correctly:
-
-1. **Confirm agents are visible.**
-   Run `python -m attune.telemetry agent-performance` and verify your agent appears in the active list.
-
-2. **Test signal delivery.**
-   Send a test signal and verify it's received within the TTL window.
-
-3. **Validate approval workflow.**
-   Submit a test approval request and confirm it appears in pending approvals.
-
-Success indicators:
-- Agents report heartbeats without Redis connection errors
-- Coordination signals are delivered within their TTL period
-- Approval requests persist until responded to or expired
-- Event streams contain expected event types with valid timestamps
+- `main()` in `src/attune/telemetry/__main__.py`
+- `cmd_sonnet_opus_analysis()` in `src/attune/telemetry/cli_analysis.py`
+- `cmd_file_test_status()` in `src/attune/telemetry/cli_analysis.py`
+- `cmd_tier1_status()` in `src/attune/telemetry/cli_automation.py`
+- `cmd_task_routing_report()` in `src/attune/telemetry/cli_automation.py`
+- `cmd_test_status()` in `src/attune/telemetry/cli_automation.py`
+- `cmd_agent_performance()` in `src/attune/telemetry/cli_automation.py`
+- `cmd_telemetry_show()` in `src/attune/telemetry/cli_core.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   classes, pin `attune-ai<6.8.0` or copy them from the v6.7.x
   source tree.
 
+### Changed (Breaking)
+
+- `[memory]` install extra removed (now an empty no-op alias for backward
+  compatibility with `pip install 'attune-ai[memory]'`). It was redundant
+  with `[redis]` — both pulled `redis-py`. Users wanting Redis-backed
+  memory should install `'attune-ai[redis]'` (canonical opt-in for the
+  bundled `attune_redis` plugin). P2 deliverable of
+  `docs/specs/redis-decoupling/`.
+- `[developer]` extra no longer pulls `redis-py`. Users wanting the
+  bundled Redis plugin alongside the developer toolchain should install
+  `'attune-ai[developer,redis]'` explicitly.
+- User-facing install messages (in `memory/redis_auto_detect.py`,
+  `memory/features.py`, `telemetry/features.py`,
+  `cli_commands/utility_commands.py`) updated from `[memory]` to
+  `[redis]` to reflect the canonical name.
+
 ### Internal
 
 - Test-quality-program: thirteenth module through the playbook —

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -38,10 +38,10 @@ These features work without any additional dependencies beyond the base install 
 
 ## Optional Features (Require Redis)
 
-These features require Redis server and the `memory` extra:
+These features require Redis server and the `redis` extra:
 
 ```bash
-pip install 'attune-ai[memory]'
+pip install 'attune-ai[redis]'
 ```
 
 ### Memory - Redis-Enhanced
@@ -88,12 +88,12 @@ Feature                        Status          Details
 ✅ Long-term memory (file-based) Available       Core feature (always available)
 ✅ File session storage         Available       Core feature (always available)
 ⚠️ Short-term memory (Redis-based) Missing Dependency Redis package not installed
-                                Install: pip install 'attune-ai[memory]'
+                                Install: pip install 'attune-ai[redis]'
 ...
 
 💡 To enable Redis-enhanced features:
    1. Install Redis package:
-      pip install 'attune-ai[memory]'
+      pip install 'attune-ai[redis]'
 
    2. Install and start Redis server:
       • macOS: brew install redis && brew services start redis
@@ -212,7 +212,7 @@ pip install attune-ai
 
 ```bash
 # Option 1: Install with Redis support
-pip install 'attune-ai[memory]'
+pip install 'attune-ai[redis]'
 
 # Option 2: Install everything
 pip install 'attune-ai[all]'
@@ -236,7 +236,7 @@ pip install 'attune-ai[all]'
 
 | Extra | Features | Install Command |
 |-------|----------|-----------------|
-| `memory` | Redis-based short-term memory, event streaming | `pip install 'attune-ai[memory]'` |
+| `redis` | Redis-based short-term memory, event streaming | `pip install 'attune-ai[redis]'` |
 | `socratic` | Socratic workflow discovery | `pip install 'attune-ai[socratic]'` |
 | `crewai` | CrewAI integration (legacy) | `pip install 'attune-ai[crewai]'` |
 | `llm` | Anthropic LLM provider | `pip install 'attune-ai[llm]'` |
@@ -353,7 +353,7 @@ docker run -d --name attune-redis -p 6379:6379 redis:alpine
 **Solution:**
 
 ```bash
-pip install 'attune-ai[memory]'
+pip install 'attune-ai[redis]'
 ```
 
 ### "Redis server not running"
@@ -388,7 +388,7 @@ docker start attune-redis
 pip list | grep redis
 
 # If not installed, reinstall
-pip install --force-reinstall 'attune-ai[memory]'
+pip install --force-reinstall 'attune-ai[redis]'
 ```
 
 ### Connection errors
@@ -502,7 +502,7 @@ try:
 except ImportError as e:
     print(e)  # "Short-term memory requires Redis.\n
               #  Status: Redis package not installed\n
-              #  Install: pip install 'attune-ai[memory]'"
+              #  Install: pip install 'attune-ai[redis]'"
 ```
 
 **Recommended pattern:**

--- a/docs/blog/06-building-ai-memory-with-redis.md
+++ b/docs/blog/06-building-ai-memory-with-redis.md
@@ -286,7 +286,7 @@ We're exploring additional Redis capabilities:
 pip install attune-ai
 
 # Start memory server (auto-starts Redis)
-pip install 'attune-ai[memory]'
+pip install 'attune-ai[redis]'
 
 # Check status
 attune memory status

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -105,8 +105,7 @@ orchestration, and a unified memory system.
 ```bash
 pip install attune-ai                # Core
 pip install 'attune-ai[developer]'   # Developer extras
-pip install 'attune-ai[memory]'      # Memory extras
-pip install 'attune-ai[redis]'       # Redis support
+pip install 'attune-ai[redis]'       # Redis-backed memory + AMS plugin
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ dependencies = [
     "attune-rag>=0.1.5,<0.2",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
-    # NOTE: redis moved to [memory] optional - not needed for CLI/skill usage
+    # NOTE: redis is opt-in via the [redis] extra (bundled attune_redis
+    # plugin). Vanilla `pip install attune-ai` is Redis-free.
 ]
 # NOTE: CrewAI dependency removed in v3.1.3 (deprecated since v4.4.0)
 # The "Crew" workflows use EmpathyLLMExecutor (Anthropic SDK) directly.
@@ -99,10 +100,15 @@ author = [
     "attune-author>=0.6.2,<0.12",
 ]
 
-# Memory subsystem (requires Redis server 8.4+ recommended)
-memory = [
-    "redis>=5.0.0,<8.0.0",  # redis-py 5.x-7.x for Redis server 8.4 support
-]
+# `[memory]` extra removed in v6.8.0 (P2 of redis-decoupling spec).
+# It was redundant with `[redis]` — both pulled `redis-py`. Empty no-op
+# kept for backward compat with `pip install 'attune-ai[memory]'`; users
+# who actually want Redis should use `[redis]` (canonical opt-in for the
+# bundled attune_redis plugin).
+memory = []
+
+# Redis Agent Memory Server runtime deps for the bundled `attune_redis`
+# plugin. Opt-in only — vanilla `pip install attune-ai` is Redis-free.
 redis = [
     "agent-memory-client>=0.14.0",
     "redis>=5.0.0,<8.0.0",
@@ -260,8 +266,9 @@ developer = [
     # Software development plugins
     "python-docx>=0.8.11,<2.0.0",
     "pyyaml>=6.0,<7.0",
-    # Memory subsystem (Redis server 8.4+ recommended)
-    "redis>=5.0.0,<8.0.0",
+    # NOTE: redis dropped from [developer] in v6.8.0 (P2 of redis-decoupling).
+    # Users who want the bundled attune_redis plugin should install
+    # 'attune-ai[developer,redis]' explicitly.
 ]
 
 # Teams/enterprises - backend + authentication + compliance (excludes healthcare)

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -296,7 +296,7 @@ def cmd_features(args: Namespace) -> int:
     if not redis_available:
         print("\n💡 To enable Redis-enhanced features:")
         print("   1. Install Redis package:")
-        print("      pip install 'attune-ai[memory]'")
+        print("      pip install 'attune-ai[redis]'")
         print("\n   2. Install and start Redis server:")
         print("      • macOS: brew install redis && brew services start redis")
         print("      • Linux: sudo apt install redis-server")

--- a/src/attune/memory/features.py
+++ b/src/attune/memory/features.py
@@ -141,7 +141,7 @@ class MemoryFeatures:
                     name=redis_features[feature],
                     status=FeatureStatus.MISSING_DEPENDENCY,
                     message="Redis package not installed",
-                    install_command="pip install 'attune-ai[memory]'",
+                    install_command="pip install 'attune-ai[redis]'",
                 )
 
             if not MemoryFeatures.is_redis_running():
@@ -250,7 +250,7 @@ class MemoryFeatures:
                     name=display,
                     status=FeatureStatus.MISSING_DEPENDENCY,
                     message="Redis package not installed",
-                    install_command="pip install 'attune-ai[memory]'",
+                    install_command="pip install 'attune-ai[redis]'",
                 )
             if not redis_server_running:
                 return FeatureInfo(

--- a/src/attune/memory/redis_auto_detect.py
+++ b/src/attune/memory/redis_auto_detect.py
@@ -234,7 +234,7 @@ class RedisAutoDetector:
         print("  persistent session memory in Attune AI.")
         print()
         print("  Install now?")
-        print("    pip install 'attune-ai[memory]'")
+        print("    pip install 'attune-ai[redis]'")
         print()
 
         try:
@@ -246,7 +246,7 @@ class RedisAutoDetector:
         if response in ("d", "dont", "don't"):
             self._save_preference("install_declined", True)
             print("  Won't ask again. Enable later with:")
-            print("    pip install 'attune-ai[memory]'")
+            print("    pip install 'attune-ai[redis]'")
             print("=" * 60)
             print()
             return False
@@ -268,7 +268,7 @@ class RedisAutoDetector:
                     "pip",
                     "install",
                     "--quiet",
-                    "attune-ai[memory]",
+                    "attune-ai[redis]",
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -284,7 +284,7 @@ class RedisAutoDetector:
             return self._prompt_server_install()
         except subprocess.CalledProcessError as e:
             print(f"  ✗ Installation failed: {e}")
-            print("  Install manually: pip install 'attune-ai[memory]'")
+            print("  Install manually: pip install 'attune-ai[redis]'")
             print("=" * 60)
             print()
             logger.error(f"Failed to install redis package: {e}")

--- a/src/attune/telemetry/features.py
+++ b/src/attune/telemetry/features.py
@@ -93,7 +93,7 @@ class TelemetryFeatures:
                     name=redis_features[feature],
                     status=FeatureStatus.MISSING_DEPENDENCY,
                     message="Redis package not installed",
-                    install_command="pip install 'attune-ai[memory]'",
+                    install_command="pip install 'attune-ai[redis]'",
                 )
 
             return FeatureInfo(
@@ -135,7 +135,7 @@ class TelemetryFeatures:
         if not TelemetryFeatures.is_redis_available():
             raise ImportError(
                 f"{feature_name} requires Redis.\n"
-                f"Install: pip install 'attune-ai[memory]'\n"
+                f"Install: pip install 'attune-ai[redis]'\n"
                 f"See: https://redis.io/docs/install/",
             )
 

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -880,7 +880,7 @@ class TestCmdFeatures:
 
         captured = capsys.readouterr()
         assert "enable Redis-enhanced features" in captured.out
-        assert "attune-ai[memory]" in captured.out
+        assert "attune-ai[redis]" in captured.out
 
     def test_redis_available_and_running(
         self,
@@ -935,7 +935,7 @@ class TestCmdFeatures:
             name="Redis Memory",
             status="not_installed",
             message="Not available",
-            install_command="pip install 'attune-ai[memory]'",
+            install_command="pip install 'attune-ai[redis]'",
         )
 
         mock_mem = MagicMock()
@@ -950,7 +950,7 @@ class TestCmdFeatures:
 
         captured = capsys.readouterr()
         assert "Install:" in captured.out
-        assert "attune-ai[memory]" in captured.out
+        assert "attune-ai[redis]" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_memory_features.py
+++ b/tests/unit/test_memory_features.py
@@ -50,7 +50,7 @@ class TestMemoryFeatures:
             assert info.status == FeatureStatus.MISSING_DEPENDENCY
             assert info.install_command is not None
             assert "pip install" in info.install_command
-            assert "attune-ai[memory]" in info.install_command
+            assert "attune-ai[redis]" in info.install_command
 
     def test_get_feature_status_redis_feature_available(self):
         """Test Redis feature status when Redis is available and running."""

--- a/tests/unit/test_telemetry_features.py
+++ b/tests/unit/test_telemetry_features.py
@@ -51,7 +51,7 @@ class TestTelemetryFeatures:
                 assert info.status == FeatureStatus.MISSING_DEPENDENCY
                 assert "Redis package not installed" in info.message
                 assert info.install_command is not None
-                assert "attune-ai[memory]" in info.install_command
+                assert "attune-ai[redis]" in info.install_command
 
     def test_get_feature_status_redis_features_available(self):
         """Test Redis-dependent features when Redis is available."""

--- a/tests/unit/test_utility_commands.py
+++ b/tests/unit/test_utility_commands.py
@@ -577,7 +577,7 @@ class TestCmdFeatures:
 
         captured = capsys.readouterr()
         assert "pip install" in captured.out
-        assert "attune-ai[memory]" in captured.out
+        assert "attune-ai[redis]" in captured.out
 
     def test_features_redis_available_and_running(self, capsys: pytest.CaptureFixture) -> None:
         """Test cmd_features shows all-good when Redis is available and running."""
@@ -655,7 +655,7 @@ class TestCmdFeatures:
                 name="Short-term memory",
                 status=MemFeatureStatus.MISSING_DEPENDENCY,
                 message="Redis package not installed",
-                install_command="pip install 'attune-ai[memory]'",
+                install_command="pip install 'attune-ai[redis]'",
             ),
         }
 
@@ -688,7 +688,7 @@ class TestCmdFeatures:
 
         captured = capsys.readouterr()
         assert "Install:" in captured.out
-        assert "attune-ai[memory]" in captured.out
+        assert "attune-ai[redis]" in captured.out
 
     def test_features_shows_header(self, capsys: pytest.CaptureFixture) -> None:
         """Test cmd_features shows the FEATURE AVAILABILITY header."""
@@ -756,7 +756,7 @@ class TestCmdFeatures:
         else:
             short_term_status = MemFeatureStatus.MISSING_DEPENDENCY
             short_term_msg = "Redis package not installed"
-            short_term_install = "pip install 'attune-ai[memory]'"
+            short_term_install = "pip install 'attune-ai[redis]'"
 
         return {
             "short_term": FeatureInfo(
@@ -796,6 +796,6 @@ class TestCmdFeatures:
                     if redis_available
                     else "Redis package not installed"
                 ),
-                install_command=None if redis_available else "pip install 'attune-ai[memory]'",
+                install_command=None if redis_available else "pip install 'attune-ai[redis]'",
             ),
         }

--- a/uv.lock
+++ b/uv.lock
@@ -355,7 +355,6 @@ developer = [
     { name = "memdocs" },
     { name = "python-docx" },
     { name = "pyyaml" },
-    { name = "redis" },
 ]
 docs = [
     { name = "mkdocs" },
@@ -405,9 +404,6 @@ lsp = [
 ]
 memdocs = [
     { name = "memdocs" },
-]
-memory = [
-    { name = "redis" },
 ]
 ops = [
     { name = "fastapi" },
@@ -557,8 +553,6 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'enterprise'", specifier = ">=6.0,<7.0" },
     { name = "pyyaml", marker = "extra == 'full'", specifier = ">=6.0,<7.0" },
     { name = "redis", marker = "extra == 'dev'", specifier = ">=5.0.0,<8.0.0" },
-    { name = "redis", marker = "extra == 'developer'", specifier = ">=5.0.0,<8.0.0" },
-    { name = "redis", marker = "extra == 'memory'", specifier = ">=5.0.0,<8.0.0" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<8.0.0" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28.0,<3.0.0" },
     { name = "rich", specifier = ">=13.0.0,<16.0.0" },


### PR DESCRIPTION
## Summary

P2 of [`docs/specs/redis-decoupling/`](docs/specs/redis-decoupling/). Builds on [PR #278](https://github.com/Smart-AI-Memory/attune-ai/pull/278) audit and [PR #279](https://github.com/Smart-AI-Memory/attune-ai/pull/279) P1.

## ⚠️ Breaking changes

- `'attune-ai[memory]'` no longer pulls `redis-py`. Empty no-op alias kept for backward compat (existing install commands won't error).
- `'attune-ai[developer]'` no longer pulls `redis-py`. Want both? Install `'attune-ai[developer,redis]'` explicitly.
- User-facing install messages now point to `[redis]` (canonical opt-in).

## Why keep `[redis]` populated (vs spec's literal "drop both")

The audit said drop both, but the in-repo [`attune_redis/`](attune_redis/) plugin is bundled with attune-ai's wheel. Its runtime deps (`redis-py`, `agent-memory-client`) need a canonical install path. Dropping `[redis]` would break the plugin's discoverability without solving any user pain.

The original complaint was the **misleadingly-named** `[memory]` extra (sounds like memory is opt-in; actually it's core). That's the one this PR kills. `[redis]` becomes the clear, single opt-in path.

## Fresh-venv verification

```bash
# Vanilla install — Redis-free
pip install -e .                    → no redis, no agent-memory-client ✓

# Canonical Redis opt-in
pip install -e '.[redis]'           → redis 7.4.0 + agent-memory-client 0.14.0 ✓

# Backward compat — [memory] is empty alias
pip install -e '.[memory]'          → no redis (still works, just no-op) ✓
```

## Files

- `pyproject.toml` — `[memory]` → empty alias; `[developer]` drops redis; core deps comment updated
- `src/attune/{memory,telemetry,cli_commands}/...` — install messages → `[redis]`
- `tests/` — assertion strings updated
- `docs/FEATURES.md`, `docs/blog/06-...`, `docs/reference/API_REFERENCE.md` — install instructions updated
- `CHANGELOG.md` — breaking change entry
- `uv.lock` — refreshed

## Test plan

- [x] `uv run pytest tests/unit/ -n auto` → **14,425 passed**, 81 skipped, 10 xfailed
- [x] Fresh venv `pip install -e .` confirms zero Redis runtime deps
- [x] Fresh venv `pip install -e '.[redis]'` confirms Redis runtime deps land
- [x] Fresh venv `pip install -e '.[memory]'` confirms backward-compat no-op
- [x] Pre-commit hooks pass

## Status: redis-decoupling spec is now PARTIAL

- ✅ P1 ([#279](https://github.com/Smart-AI-Memory/attune-ai/pull/279)) — delete `attune.coordination/`
- ✅ P2 (this PR) — drop `[memory]`, slim `[developer]`
- ⏭️ P3 (optional follow-up) — delete `tests/unit/test_redis_fallback.py` if no longer relevant; `test_pubsub_direct.py` likely stays (PubSubManager is still reachable from `attune.memory.short_term`)

The remaining "full decoupling" work (migrating internal callers off `RedisShortTermMemory`) is deferred per the audit's recommendation — it's a memory-subsystem rewrite, not a delta on this spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)