### PR TITLE
test(workflows/doc_audit): meaningful coverage on Agent SDK shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: ninth module through the playbook —
+  `workflows/doc_audit/workflow.py` (`DocAuditWorkflow`).
+  Coverage 43.1% → 100% line+branch. 21 deterministic tests
+  added under `tests/unit/workflows/doc_audit/test_workflow_execute.py`
+  using the same SDK-native scaffold as PRs #265 / #266 / #270 /
+  #273. Subagents covered: `staleness-checker`,
+  `accuracy-reviewer`, `gap-finder`. Zero production bugs
+  surfaced. Fifth SDK-native shell through the program — the
+  scaffold continues to transfer verbatim.
 - Test-quality-program: eighth module through the playbook —
   `memory/short_term/caching.py` (`CacheManager`). Coverage
   49.2% → 100% line+branch. 28 deterministic tests added under

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,48 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — ninth module under test-quality-program (Opus 4.7)
+
+Ninth module run. Fifth Agent SDK-native workflow
+through the program — `doc_audit/workflow.py`. Same
+shell pattern as the four prior SDK cycles
+(`dependency_check`, `bug_predict`, `perf_audit`,
+`refactor_plan`). The scaffold transferred verbatim
+with a subagent-name rename. **0 production bugs
+surfaced.**
+
+- `workflows/doc_audit/workflow.py` (`DocAuditWorkflow`)
+  — no bugs. Thin async shell around
+  `claude_agent_sdk.query()` with three
+  `AgentDefinition` subagents (`staleness-checker`,
+  `accuracy-reviewer`, `gap-finder`). Validates `path`,
+  maps depth → max_turns, four-branch exception
+  handling (`ImportError` / `ConnectionError` /
+  `TimeoutError` / generic). Identical to its sibling
+  workflows.
+
+**Coverage delta:** 43.1% → 100% line+branch.
+
+**Tests:** 21 added under
+`tests/unit/workflows/doc_audit/test_workflow_execute.py`.
+Same real-SDK-dataclass fixtures pattern; only
+`claude_agent_sdk.query` mocked.
+
+**Pattern note:** This is the fifth consecutive cycle
+from the same scaffold (`dependency_check`,
+`bug_predict`, `perf_audit`, `refactor_plan`,
+`doc_audit`). The case for a generator script
+(`scripts/scaffold_sdk_workflow_tests.py` taking
+module path + subagent list as inputs) is increasingly
+strong but still flagged-not-committed — each cycle
+takes ~5 min by hand, so the script's payoff threshold
+hasn't been crossed for one-off uses. If
+`workflows/document_gen/workflow.py` (next obvious
+sibling on the rubric) follows the same shape, the
+script becomes a clear win.
+
+---
+
 ## 2026-05-12 — eighth module under test-quality-program (Opus 4.7)
 
 Eighth module run. First non-SDK cycle in today's

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -185,3 +185,42 @@ future refinement could tag rows by archetype
 (`sdk-shell`, `data-structure`, `cli-entry`,
 `async-pipeline`) so picks can be batched by scaffold.
 Flagged; not committed.
+
+## workflows/doc_audit/workflow.py
+
+**Date:** 2026-05-12
+**Rubric score at pick time:** 2.274 (weight=4 × gap=0.569 × risk=1.0)
+**Picked because:** Top entry with measured `covered_pct`
+after `memory/short_term/caching.py` shipped. Fifth
+SDK-native shell — the scaffold from PR #265 continues
+to transfer verbatim.
+**Outcome:** 1 test file added (`test_workflow_execute.py`,
+21 tests). Coverage 43.1% → 100% line+branch. Zero
+production bugs surfaced. Five SDK-native shells now
+through the program.
+**PR:** _(filled in after merge)_
+**Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
+"2026-05-12 — ninth module under test-quality-program"
+
+Same body shape as the four prior SDK-native cycles.
+Three subagents (`staleness-checker`, `accuracy-reviewer`,
+`gap-finder`). The only adaptations needed were the
+import path (workflow lives under `doc_audit/`
+subdirectory, so test import is
+`from attune.workflows.doc_audit.workflow import DocAuditWorkflow`),
+patch paths (`attune.workflows.doc_audit.workflow.claude_agent_sdk.query`),
+subagent name strings, and the system-prompt
+substring check.
+
+**Generator-script ROI threshold:** Five consecutive
+cycles from the same scaffold. Per-cycle cost is now
+~5 min (test file generation + verification +
+docs/CHANGELOG/decisions updates), so a generator
+script's payoff is one cycle of work for ~5 modules
+of automation. `document_gen/workflow.py` is the next
+obvious SDK-native sibling on the rubric — if it
+ships under the same scaffold, the generator becomes
+a clear win. Still not committed; the cost of writing
+the generator (~30 min) is higher than the marginal
+savings until there are at least three more
+candidates queued.

--- a/tests/unit/workflows/doc_audit/test_workflow_execute.py
+++ b/tests/unit/workflows/doc_audit/test_workflow_execute.py
@@ -1,0 +1,325 @@
+"""Tests for DocAuditWorkflow execute() and _run_agent_audit().
+
+Covers the Agent SDK execution paths. Uses real SDK message
+instances rather than duck-typed fakes so isinstance-based
+collectors in agent_sdk_adapter actually fire (per CLAUDE.md
+lesson: duck-typed test fakes fail isinstance-based collectors
+silently — construct real SDK class instances in tests).
+
+The only thing mocked is ``claude_agent_sdk.query`` itself; the
+ResultMessage / AssistantMessage / TextBlock instances yielded
+by the fake generator are constructed via the real dataclasses.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import patch
+
+import claude_agent_sdk
+import pytest
+
+from attune.workflows.agent_sdk_adapter import AgentRunResult
+from attune.workflows.base import ModelTier
+from attune.workflows.data_classes import WorkflowResult
+from attune.workflows.doc_audit.workflow import DocAuditWorkflow
+
+# ---------------------------------------------------------------------------
+# Fixtures — real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workflow() -> DocAuditWorkflow:
+    """Build a fresh DocAuditWorkflow."""
+    return DocAuditWorkflow()
+
+
+@pytest.fixture
+def assistant_message() -> claude_agent_sdk.AssistantMessage:
+    """Real AssistantMessage with a TextBlock payload."""
+    block = claude_agent_sdk.types.TextBlock(
+        text="Found 2 stale links, 1 outdated example at docs/api.md:42."
+    )
+    return claude_agent_sdk.AssistantMessage(
+        content=[block],
+        model="claude-opus-4-7",
+        parent_tool_use_id=None,
+    )
+
+
+@pytest.fixture
+def result_message() -> claude_agent_sdk.ResultMessage:
+    """Real ResultMessage with a final synthesis."""
+    return claude_agent_sdk.ResultMessage(
+        subtype="success",
+        duration_ms=15000,
+        duration_api_ms=13000,
+        is_error=False,
+        num_turns=5,
+        session_id="sess-doc-3",
+        total_cost_usd=0.55,
+        usage={"input_tokens": 1800, "output_tokens": 950},
+        result="## Summary\nDocumentation audit complete.",
+        structured_output=None,
+    )
+
+
+def _make_fake_query(messages):
+    """Build an async generator factory yielding the given messages."""
+
+    async def fake_query(*args, **kwargs):
+        for msg in messages:
+            yield msg
+
+    return fake_query
+
+
+# ---------------------------------------------------------------------------
+# execute() — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteValidation:
+    """Empty / missing path is rejected before any SDK call."""
+
+    def test_no_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute())
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+    def test_empty_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute(path=""))
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+
+# ---------------------------------------------------------------------------
+# execute() — happy path through real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSuccess:
+    """Successful runs across the three depth profiles."""
+
+    @patch("attune.workflows.doc_audit.workflow.claude_agent_sdk.query")
+    def test_success_yields_workflow_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/docs", depth="standard"))
+
+        assert isinstance(result, WorkflowResult)
+        assert result.success is True
+        assert result.provider == "anthropic"
+        assert "stale" in result.final_output or "Summary" in result.final_output
+
+    @patch("attune.workflows.doc_audit.workflow.claude_agent_sdk.query")
+    def test_metadata_populated(self, mock_query, workflow, assistant_message, result_message):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/docs", depth="quick"))
+
+        assert result.success is True
+        meta = result.metadata or {}
+        assert meta.get("depth") == "quick"
+        assert meta.get("path", "").endswith("/tmp/docs") or "tmp" in meta.get("path", "")
+        assert meta.get("max_turns") == 10
+
+    @patch("attune.workflows.doc_audit.workflow.claude_agent_sdk.query")
+    def test_result_only_no_assistant_text(self, mock_query, workflow, result_message):
+        """ResultMessage alone — exercises the ``run_result = sdk_result``
+        assignment branch inside the async loop.
+        """
+        mock_query.side_effect = _make_fake_query([result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/docs"))
+        assert result.success is True
+
+    @patch("attune.workflows.doc_audit.workflow.claude_agent_sdk.query")
+    def test_empty_stream_returns_default_text(self, mock_query, workflow):
+        """Empty stream — exercises the ``AgentRunResult(...="No results")``
+        initialization being passed straight through.
+        """
+        mock_query.side_effect = _make_fake_query([])
+        result = asyncio.run(workflow.execute(path="/tmp/docs"))
+        assert isinstance(result, WorkflowResult)
+
+
+# ---------------------------------------------------------------------------
+# execute() — depth → max_turns mapping
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDepthMapping:
+    """``depth`` arg drives ``max_turns`` passed to the SDK."""
+
+    def _max_turns_for(self, depth, workflow, monkeypatch):
+        """Run execute(depth=...) and return the max_turns recorded."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            opts = kwargs.get("options")
+            captured["max_turns"] = opts.max_turns
+            if False:
+                yield  # make this an async generator
+
+        monkeypatch.setattr(
+            "attune.workflows.doc_audit.workflow.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/docs", depth=depth))
+        return captured.get("max_turns")
+
+    def test_quick_depth_uses_10_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("quick", workflow, monkeypatch) == 10
+
+    def test_standard_depth_uses_20_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("standard", workflow, monkeypatch) == 20
+
+    def test_deep_depth_uses_40_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("deep", workflow, monkeypatch) == 40
+
+    def test_unknown_depth_falls_back_to_20(self, workflow, monkeypatch):
+        """Undocumented depth values silently fall back to standard's 20."""
+        assert self._max_turns_for("preposterous", workflow, monkeypatch) == 20
+
+    def test_default_depth_is_standard(self, workflow, monkeypatch):
+        """No depth kwarg → standard (20)."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            captured["max_turns"] = kwargs["options"].max_turns
+            if False:
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.doc_audit.workflow.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/docs"))
+        assert captured["max_turns"] == 20
+
+
+# ---------------------------------------------------------------------------
+# execute() — exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteExceptionHandling:
+    """Each specific exception type produces a structured error result."""
+
+    def _patch_query_to_raise(self, monkeypatch, exc):
+        async def raising_query(*args, **kwargs):
+            raise exc
+            if False:  # pragma: no cover
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.doc_audit.workflow.claude_agent_sdk.query",
+            raising_query,
+        )
+
+    def test_import_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ImportError("sdk missing"))
+        result = asyncio.run(workflow.execute(path="/tmp/docs"))
+        assert result.success is False
+        assert "Agent SDK unavailable" in result.error
+
+    def test_connection_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ConnectionError("refused"))
+        result = asyncio.run(workflow.execute(path="/tmp/docs"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_timeout_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, TimeoutError("slow"))
+        result = asyncio.run(workflow.execute(path="/tmp/docs"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_generic_exception(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
+        result = asyncio.run(workflow.execute(path="/tmp/docs"))
+        assert result.success is False
+        assert "RuntimeError" in result.error
+        assert "kaboom" in result.error
+
+
+# ---------------------------------------------------------------------------
+# _run_agent_audit() — directly, bypassing execute()
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentAuditDirect:
+    """Direct invocation surfaces the SDK loop's exact behavior."""
+
+    @patch("attune.workflows.doc_audit.workflow.claude_agent_sdk.query")
+    def test_collects_assistant_and_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+
+        run_result = asyncio.run(workflow._run_agent_audit("/tmp/docs", 20, "standard"))
+        assert isinstance(run_result, AgentRunResult)
+        assert "stale" in run_result.result_text or "Summary" in run_result.result_text
+
+    @patch("attune.workflows.doc_audit.workflow.claude_agent_sdk.query")
+    def test_no_messages_returns_default_text(self, mock_query, workflow):
+        mock_query.side_effect = _make_fake_query([])
+        run_result = asyncio.run(workflow._run_agent_audit("/tmp/docs", 20))
+        assert run_result.result_text == "No results returned."
+
+    @patch("attune.workflows.doc_audit.workflow.claude_agent_sdk.query")
+    def test_passes_subagent_definitions(self, mock_query, workflow, result_message):
+        """All three subagents are wired into the SDK call's options."""
+        captured: dict = {}
+
+        async def capturing_query(*args, **kwargs):
+            captured["options"] = kwargs.get("options")
+            captured["prompt"] = kwargs.get("prompt")
+            yield result_message
+
+        mock_query.side_effect = capturing_query
+        asyncio.run(workflow._run_agent_audit("/tmp/docs", 20, "standard"))
+
+        opts = captured["options"]
+        assert "staleness-checker" in opts.agents
+        assert "accuracy-reviewer" in opts.agents
+        assert "gap-finder" in opts.agents
+        assert "documentation audit orchestrator" in opts.system_prompt
+        assert "/tmp/docs" in captured["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# _error_result() — inherited from BaseWorkflow but exercised here so
+# its surface stays measured even if base.py refactors break the contract.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResult:
+    """Shape of the failure WorkflowResult."""
+
+    def test_structure(self, workflow):
+        result = workflow._error_result("nope")
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert result.error == "nope"
+        assert result.total_duration_ms == 0
+        assert result.cost_report.total_cost == 0.0
+
+    def test_stage_metadata(self, workflow):
+        result = workflow._error_result("nope")
+        assert len(result.stages) == 1
+        assert result.stages[0].name == "doc-audit"
+        assert result.stages[0].tier == ModelTier.CAPABLE
+
+    def test_timestamps_bounded(self, workflow):
+        before = datetime.now()
+        result = workflow._error_result("nope")
+        after = datetime.now()
+        assert before <= result.started_at <= after
+        assert before <= result.completed_at <= after


### PR DESCRIPTION
## Summary

Ninth module through the [test-quality-program](docs/specs/test-quality-program/) playbook. Fifth SDK-native workflow after [#265](https://github.com/Smart-AI-Memory/attune-ai/pull/265), [#266](https://github.com/Smart-AI-Memory/attune-ai/pull/266), [#270](https://github.com/Smart-AI-Memory/attune-ai/pull/270), [#273](https://github.com/Smart-AI-Memory/attune-ai/pull/273); the scaffold transferred verbatim with a subagent-name rename.

- **Coverage:** 43.1% → 100% line+branch on `workflows/doc_audit/workflow.py`.
- **Tests:** 21 added under `tests/unit/workflows/doc_audit/test_workflow_execute.py`.
- **Bugs surfaced:** zero. Three subagents (`staleness-checker`, `accuracy-reviewer`, `gap-finder`).

## Test plan

- [x] All 21 new tests pass locally
- [x] Sibling `doc_audit` tests pass (87 collected, all green)
- [x] Black + ruff + bandit pre-commit hooks pass
- [x] Coverage measured: 100% line+branch on `doc_audit/workflow.py`
- [ ] CI green across matrix

## Pattern note

Five consecutive SDK-native cycles from the same scaffold. The generator-script case (codifying as `scripts/scaffold_sdk_workflow_tests.py`) is flagged in `decisions.md` with a clearer ROI threshold: if `document_gen/workflow.py` (next obvious sibling on rubric) ships under the same scaffold, codifying becomes a clear win.

## Files changed

- `tests/unit/workflows/doc_audit/test_workflow_execute.py` — 21 new tests (new file)
- `CHANGELOG.md` — Unreleased entry
- `docs/COVERAGE_BUG_LOG.md` — ninth-module entry
- `docs/specs/test-quality-program/decisions.md` — appended pick reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)