### PR TITLE
test(workflows/document_gen): meaningful coverage on Agent SDK shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: tenth module through the playbook —
+  `workflows/document_gen/workflow.py` (`DocumentGenerationWorkflow`).
+  Coverage 46.4% → 100% line+branch. 24 deterministic tests
+  added under `tests/unit/workflows/document_gen/test_workflow_execute.py`.
+  Same SDK-native scaffold as the five prior shells, plus three
+  extra tests for `default_context()` — a classmethod unique to
+  this workflow that wires up `PromptService` + `ParsingService`
+  into a `WorkflowContext`. Subagents covered: `outline-planner`,
+  `content-writer`, `polish-reviewer`. Zero production bugs
+  surfaced. Sixth SDK-native shell through the program.
 - Test-quality-program: ninth module through the playbook —
   `workflows/doc_audit/workflow.py` (`DocAuditWorkflow`).
   Coverage 43.1% → 100% line+branch. 21 deterministic tests

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,47 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — tenth module under test-quality-program (Opus 4.7)
+
+Tenth module run. Sixth Agent SDK-native workflow
+through the program — `document_gen/workflow.py`.
+Same shell pattern as the five prior SDK cycles
+(`dependency_check`, `bug_predict`, `perf_audit`,
+`refactor_plan`, `doc_audit`). One small divergence:
+this workflow exposes a `default_context()` classmethod
+for `WorkflowContext` composition (wires up
+`PromptService` + `ParsingService`); three extra tests
+cover it. **0 production bugs surfaced.**
+
+- `workflows/document_gen/workflow.py`
+  (`DocumentGenerationWorkflow`) — no bugs. Thin async
+  shell around `claude_agent_sdk.query()` with three
+  subagents (`outline-planner`, `content-writer`,
+  `polish-reviewer`). The `default_context()`
+  classmethod is a real composition surface but adds
+  no behavior beyond constructing the two services
+  with the given `xml_config` kwarg.
+
+**Coverage delta:** 46.4% → 100% line+branch.
+
+**Tests:** 24 added under
+`tests/unit/workflows/document_gen/test_workflow_execute.py`
+(21 SDK-shell + 3 `default_context()`). Also added
+empty `__init__.py` for the new test sub-package to
+match the existing `doc_audit/` layout.
+
+**Generator-script ROI threshold crossed (informational):**
+Six consecutive cycles from the same scaffold. The
+generator script case is now stronger but I'm deferring
+because the next likely module on the rubric
+(`memory/control_panel.py`, weight 3, score 2.073)
+isn't an SDK shell — it's a memory subsystem. Writing
+the generator now would optimize for a pattern that's
+about to recede from the working set. Re-evaluate if
+two more SDK shells surface in a future rubric refresh.
+
+---
+
 ## 2026-05-12 — ninth module under test-quality-program (Opus 4.7)
 
 Ninth module run. Fifth Agent SDK-native workflow

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -224,3 +224,47 @@ a clear win. Still not committed; the cost of writing
 the generator (~30 min) is higher than the marginal
 savings until there are at least three more
 candidates queued.
+
+## workflows/document_gen/workflow.py
+
+**Date:** 2026-05-12
+**Rubric score at pick time:** 2.143 (weight=4 × gap=0.536 × risk=1.0)
+**Picked because:** Top entry with measured `covered_pct`
+after `doc_audit/workflow.py` shipped. Sixth SDK-native
+shell — the test scaffold continues to transfer
+verbatim with subagent + method-name renames. Also
+the threshold case for the generator-script decision
+flagged in the doc_audit cycle.
+**Outcome:** 1 test file added (`test_workflow_execute.py`,
+24 tests including 3 for `default_context()`). Empty
+`__init__.py` added to mirror the `doc_audit/` test
+sub-package layout. Coverage 46.4% → 100% line+branch.
+Zero production bugs surfaced. Six SDK-native shells
+now through the program.
+**PR:** _(filled in after merge)_
+**Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
+"2026-05-12 — tenth module under test-quality-program"
+
+Same body shape as the five prior SDK-native cycles
+with one twist: `DocumentGenerationWorkflow` exposes
+a `default_context()` classmethod that wires up
+`PromptService` and `ParsingService` into a
+`WorkflowContext` for composition use. Three extra
+tests cover it: (a) returns a `WorkflowContext`
+instance with both services set, (b) `xml_config`
+kwarg is forwarded without raising, (c) `xml_config`
+defaults to `None`. Did not introspect the services'
+internal state — that's the consumers' contract, not
+this workflow's.
+
+**Generator-script decision (deferred):** Six
+consecutive SDK-shell cycles makes the case for
+codifying the scaffold quite strong. But the next
+likely rubric pick (`memory/control_panel.py`,
+weight=3, score 2.073, 53.9% covered) is a memory
+subsystem, not an SDK shell. Writing the generator
+now would optimize for a pattern that's about to
+recede from the working set. Re-evaluate if a rubric
+refresh surfaces two more SDK shells. Until then, the
+~5-min-per-cycle cost of hand-transferring stays
+cheaper than the ~30-min generator investment.

--- a/tests/unit/workflows/document_gen/test_workflow_execute.py
+++ b/tests/unit/workflows/document_gen/test_workflow_execute.py
@@ -1,0 +1,354 @@
+"""Tests for DocumentGenerationWorkflow execute() / _run_agent_gen()
+/ default_context().
+
+Covers the Agent SDK execution paths plus the
+``default_context()`` classmethod (unique to document_gen vs the
+other SDK-native sibling workflows). Uses real SDK message
+instances rather than duck-typed fakes so isinstance-based
+collectors in agent_sdk_adapter actually fire (per CLAUDE.md
+lesson).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import patch
+
+import claude_agent_sdk
+import pytest
+
+from attune.workflows.agent_sdk_adapter import AgentRunResult
+from attune.workflows.base import ModelTier
+from attune.workflows.context import WorkflowContext
+from attune.workflows.data_classes import WorkflowResult
+from attune.workflows.document_gen.workflow import DocumentGenerationWorkflow
+
+# ---------------------------------------------------------------------------
+# Fixtures — real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workflow() -> DocumentGenerationWorkflow:
+    """Build a fresh DocumentGenerationWorkflow."""
+    return DocumentGenerationWorkflow()
+
+
+@pytest.fixture
+def assistant_message() -> claude_agent_sdk.AssistantMessage:
+    """Real AssistantMessage with a TextBlock payload."""
+    block = claude_agent_sdk.types.TextBlock(
+        text="Outline: 5 modules, 23 public APIs. Drafted intro and module overview."
+    )
+    return claude_agent_sdk.AssistantMessage(
+        content=[block],
+        model="claude-opus-4-7",
+        parent_tool_use_id=None,
+    )
+
+
+@pytest.fixture
+def result_message() -> claude_agent_sdk.ResultMessage:
+    """Real ResultMessage with a final synthesis."""
+    return claude_agent_sdk.ResultMessage(
+        subtype="success",
+        duration_ms=24000,
+        duration_api_ms=20000,
+        is_error=False,
+        num_turns=8,
+        session_id="sess-docgen-5",
+        total_cost_usd=0.84,
+        usage={"input_tokens": 2700, "output_tokens": 1700},
+        result="## Summary\nDocumentation generation complete.",
+        structured_output=None,
+    )
+
+
+def _make_fake_query(messages):
+    """Build an async generator factory yielding the given messages."""
+
+    async def fake_query(*args, **kwargs):
+        for msg in messages:
+            yield msg
+
+    return fake_query
+
+
+# ---------------------------------------------------------------------------
+# default_context() — classmethod unique to DocumentGenerationWorkflow
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultContext:
+    """The classmethod wires up PromptService + ParsingService."""
+
+    def test_returns_workflow_context(self):
+        ctx = DocumentGenerationWorkflow.default_context()
+        assert isinstance(ctx, WorkflowContext)
+        assert ctx.prompt is not None
+        assert ctx.parsing is not None
+
+    def test_passes_xml_config_through(self):
+        """xml_config kwarg is forwarded to both services."""
+        cfg = {"any": "value"}
+        ctx = DocumentGenerationWorkflow.default_context(xml_config=cfg)
+        # Both services should construct cleanly with the config —
+        # we don't inspect internal state, just verify the kwarg path
+        # didn't raise.
+        assert ctx.prompt is not None
+        assert ctx.parsing is not None
+
+    def test_default_xml_config_is_none(self):
+        """xml_config defaults to None when omitted."""
+        ctx = DocumentGenerationWorkflow.default_context()
+        assert isinstance(ctx, WorkflowContext)
+
+
+# ---------------------------------------------------------------------------
+# execute() — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteValidation:
+    """Empty / missing path is rejected before any SDK call."""
+
+    def test_no_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute())
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+    def test_empty_path_returns_error(self, workflow):
+        result = asyncio.run(workflow.execute(path=""))
+        assert result.success is False
+        assert "path argument is required" in result.error
+
+
+# ---------------------------------------------------------------------------
+# execute() — happy path through real SDK message instances
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteSuccess:
+    """Successful runs across the three depth profiles."""
+
+    @patch("attune.workflows.document_gen.workflow.claude_agent_sdk.query")
+    def test_success_yields_workflow_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/src", depth="standard"))
+
+        assert isinstance(result, WorkflowResult)
+        assert result.success is True
+        assert result.provider == "anthropic"
+        assert "Outline" in result.final_output or "Summary" in result.final_output
+
+    @patch("attune.workflows.document_gen.workflow.claude_agent_sdk.query")
+    def test_metadata_populated(self, mock_query, workflow, assistant_message, result_message):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/src", depth="quick"))
+
+        assert result.success is True
+        meta = result.metadata or {}
+        assert meta.get("depth") == "quick"
+        assert meta.get("path", "").endswith("/tmp/src") or "tmp" in meta.get("path", "")
+        assert meta.get("max_turns") == 10
+
+    @patch("attune.workflows.document_gen.workflow.claude_agent_sdk.query")
+    def test_result_only_no_assistant_text(self, mock_query, workflow, result_message):
+        """ResultMessage alone — exercises the ``run_result = sdk_result``
+        assignment branch inside the async loop.
+        """
+        mock_query.side_effect = _make_fake_query([result_message])
+        result = asyncio.run(workflow.execute(path="/tmp/src"))
+        assert result.success is True
+
+    @patch("attune.workflows.document_gen.workflow.claude_agent_sdk.query")
+    def test_empty_stream_returns_default_text(self, mock_query, workflow):
+        """Empty stream — exercises the ``AgentRunResult(...="No results")``
+        initialization being passed straight through.
+        """
+        mock_query.side_effect = _make_fake_query([])
+        result = asyncio.run(workflow.execute(path="/tmp/src"))
+        assert isinstance(result, WorkflowResult)
+
+
+# ---------------------------------------------------------------------------
+# execute() — depth → max_turns mapping
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteDepthMapping:
+    """``depth`` arg drives ``max_turns`` passed to the SDK."""
+
+    def _max_turns_for(self, depth, workflow, monkeypatch):
+        """Run execute(depth=...) and return the max_turns recorded."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            opts = kwargs.get("options")
+            captured["max_turns"] = opts.max_turns
+            if False:
+                yield  # make this an async generator
+
+        monkeypatch.setattr(
+            "attune.workflows.document_gen.workflow.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/src", depth=depth))
+        return captured.get("max_turns")
+
+    def test_quick_depth_uses_10_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("quick", workflow, monkeypatch) == 10
+
+    def test_standard_depth_uses_20_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("standard", workflow, monkeypatch) == 20
+
+    def test_deep_depth_uses_40_turns(self, workflow, monkeypatch):
+        assert self._max_turns_for("deep", workflow, monkeypatch) == 40
+
+    def test_unknown_depth_falls_back_to_20(self, workflow, monkeypatch):
+        """Undocumented depth values silently fall back to standard's 20."""
+        assert self._max_turns_for("preposterous", workflow, monkeypatch) == 20
+
+    def test_default_depth_is_standard(self, workflow, monkeypatch):
+        """No depth kwarg → standard (20)."""
+        captured: dict = {}
+
+        async def capture_query(*args, **kwargs):
+            captured["max_turns"] = kwargs["options"].max_turns
+            if False:
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.document_gen.workflow.claude_agent_sdk.query",
+            capture_query,
+        )
+        asyncio.run(workflow.execute(path="/tmp/src"))
+        assert captured["max_turns"] == 20
+
+
+# ---------------------------------------------------------------------------
+# execute() — exception handling
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteExceptionHandling:
+    """Each specific exception type produces a structured error result."""
+
+    def _patch_query_to_raise(self, monkeypatch, exc):
+        async def raising_query(*args, **kwargs):
+            raise exc
+            if False:  # pragma: no cover
+                yield
+
+        monkeypatch.setattr(
+            "attune.workflows.document_gen.workflow.claude_agent_sdk.query",
+            raising_query,
+        )
+
+    def test_import_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ImportError("sdk missing"))
+        result = asyncio.run(workflow.execute(path="/tmp/src"))
+        assert result.success is False
+        assert "Agent SDK unavailable" in result.error
+
+    def test_connection_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, ConnectionError("refused"))
+        result = asyncio.run(workflow.execute(path="/tmp/src"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_timeout_error(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, TimeoutError("slow"))
+        result = asyncio.run(workflow.execute(path="/tmp/src"))
+        assert result.success is False
+        assert "connection failed" in result.error.lower()
+
+    def test_generic_exception(self, workflow, monkeypatch):
+        self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
+        result = asyncio.run(workflow.execute(path="/tmp/src"))
+        assert result.success is False
+        assert "RuntimeError" in result.error
+        assert "kaboom" in result.error
+
+
+# ---------------------------------------------------------------------------
+# _run_agent_gen() — directly, bypassing execute()
+# ---------------------------------------------------------------------------
+
+
+class TestRunAgentGenDirect:
+    """Direct invocation surfaces the SDK loop's exact behavior."""
+
+    @patch("attune.workflows.document_gen.workflow.claude_agent_sdk.query")
+    def test_collects_assistant_and_result(
+        self, mock_query, workflow, assistant_message, result_message
+    ):
+        mock_query.side_effect = _make_fake_query([assistant_message, result_message])
+
+        run_result = asyncio.run(workflow._run_agent_gen("/tmp/src", 20, "standard"))
+        assert isinstance(run_result, AgentRunResult)
+        assert "Outline" in run_result.result_text or "Summary" in run_result.result_text
+
+    @patch("attune.workflows.document_gen.workflow.claude_agent_sdk.query")
+    def test_no_messages_returns_default_text(self, mock_query, workflow):
+        mock_query.side_effect = _make_fake_query([])
+        run_result = asyncio.run(workflow._run_agent_gen("/tmp/src", 20))
+        assert run_result.result_text == "No results returned."
+
+    @patch("attune.workflows.document_gen.workflow.claude_agent_sdk.query")
+    def test_passes_subagent_definitions(self, mock_query, workflow, result_message):
+        """All three subagents are wired into the SDK call's options."""
+        captured: dict = {}
+
+        async def capturing_query(*args, **kwargs):
+            captured["options"] = kwargs.get("options")
+            captured["prompt"] = kwargs.get("prompt")
+            yield result_message
+
+        mock_query.side_effect = capturing_query
+        asyncio.run(workflow._run_agent_gen("/tmp/src", 20, "standard"))
+
+        opts = captured["options"]
+        assert "outline-planner" in opts.agents
+        assert "content-writer" in opts.agents
+        assert "polish-reviewer" in opts.agents
+        assert "documentation generation orchestrator" in opts.system_prompt
+        assert "/tmp/src" in captured["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# _error_result() — inherited from BaseWorkflow but exercised here so
+# its surface stays measured even if base.py refactors break the contract.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorResult:
+    """Shape of the failure WorkflowResult."""
+
+    def test_structure(self, workflow):
+        result = workflow._error_result("nope")
+        assert isinstance(result, WorkflowResult)
+        assert result.success is False
+        assert result.error == "nope"
+        assert result.total_duration_ms == 0
+        assert result.cost_report.total_cost == 0.0
+
+    def test_stage_metadata(self, workflow):
+        result = workflow._error_result("nope")
+        assert len(result.stages) == 1
+        assert result.stages[0].name == "doc-gen"
+        assert result.stages[0].tier == ModelTier.CAPABLE
+
+    def test_timestamps_bounded(self, workflow):
+        before = datetime.now()
+        result = workflow._error_result("nope")
+        after = datetime.now()
+        assert before <= result.started_at <= after
+        assert before <= result.completed_at <= after


### PR DESCRIPTION
## Summary

Tenth module through the [test-quality-program](docs/specs/test-quality-program/) playbook. Sixth SDK-native workflow after [#265](https://github.com/Smart-AI-Memory/attune-ai/pull/265), [#266](https://github.com/Smart-AI-Memory/attune-ai/pull/266), [#270](https://github.com/Smart-AI-Memory/attune-ai/pull/270), [#273](https://github.com/Smart-AI-Memory/attune-ai/pull/273), [#282](https://github.com/Smart-AI-Memory/attune-ai/pull/282); scaffold transferred verbatim with one extra block of tests for `default_context()` (unique among the SDK-shell siblings).

- **Coverage:** 46.4% → 100% line+branch on `workflows/document_gen/workflow.py`.
- **Tests:** 24 added (21 SDK-shell + 3 `default_context()`).
- **Bugs surfaced:** zero. Three subagents (`outline-planner`, `content-writer`, `polish-reviewer`).

## `default_context()` divergence

This is the only SDK-shell sibling that exposes a classmethod for `WorkflowContext` composition. It constructs a `PromptService` and a `ParsingService` (with optional `xml_config` kwarg) and returns them wrapped. Three tests cover the contract: returns a `WorkflowContext`, forwards `xml_config`, and defaults to `None`. Consumer-side service state isn't introspected (that's the consumers' contract, not this workflow's).

## Generator-script decision (deferred)

Six consecutive SDK-shell cycles makes the case for codifying the scaffold strong. But the next likely rubric pick (`memory/control_panel.py`, weight=3, score 2.073) is a memory subsystem, not an SDK shell. Writing the generator now would optimize for a pattern about to recede from the working set. Re-evaluate after a rubric refresh.

## Test plan

- [x] All 24 new tests pass locally
- [x] Sibling `document_gen` + `doc_audit` tests pass (111 collected, all green)
- [x] Black + ruff pre-commit hooks pass
- [x] Coverage measured: 100% line+branch on `document_gen/workflow.py`
- [ ] CI green across matrix

## Files changed

- `tests/unit/workflows/document_gen/test_workflow_execute.py` — 24 new tests (new file)
- `tests/unit/workflows/document_gen/__init__.py` — empty package marker (new file)
- `CHANGELOG.md` — Unreleased entry
- `docs/COVERAGE_BUG_LOG.md` — tenth-module entry
- `docs/specs/test-quality-program/decisions.md` — appended pick reasoning + generator-script deferral

🤖 Generated with [Claude Code](https://claude.com/claude-code)