### PR TITLE
docs(specs): ops-runner-tier2 Phase 1 audit — three-way path-arg reality

### DIFF
--- a/docs/specs/ops-runner-tier2/audit.md
+++ b/docs/specs/ops-runner-tier2/audit.md
@@ -1,0 +1,155 @@
+# Phase 1 audit — `--path` support per workflow
+
+**Date**: 2026-05-12
+**Method**: three-step inspection per the spec's Phase 1 plan:
+1. CLI surface check (`attune workflow run --help`) — does the CLI accept `--path`?
+2. Per-workflow `execute()` signature scan
+3. Per-workflow `execute()` body scan for actual `path` consumption (kwargs.get / direct kwarg)
+4. Cross-check via `attune workflow info <name>` for the docstring's example invocation
+**Outcome**: hypothesis H2 ("Workflow `--path` support is unevenly implemented") **confirmed and refined**. The reality is three-way, not binary.
+
+---
+
+## CLI surface check
+
+```text
+$ attune workflow run --help
+usage: attune workflow run [-h] [--input INPUT] [--path PATH]
+                           [--target TARGET] [--json]
+                           name
+```
+
+`--path` is a **uniform CLI argument** for every workflow. It always
+becomes a `path=...` kwarg in `workflow.execute(**input_data)` (see
+`src/attune/cli_commands/workflow_commands.py:102-106`). Whether the
+workflow actually CONSUMES that kwarg is the real question.
+
+`--target` is a separate uniform CLI argument and is the documented
+alternative kwarg for some workflows (notably `health-check` family
+maps `target` → `project_root` at `src/attune/workflows/orchestrated_health_check.py:24-26`).
+
+---
+
+## Per-workflow categorization
+
+| Workflow | execute() signature kwargs | Path arg actually consumed | Category |
+|---|---|---|---|
+| `bug-predict` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `code-review` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `deep-review` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `dependency-check` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `doc-audit` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `doc-gen` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `perf-audit` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `refactor-plan` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `research-synthesis` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `security-audit` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `simplify-code` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `test-gen` | `**kwargs` | `kwargs.get("path", "")` | **A — direct** |
+| `release-prep` | `path: str = "."` | direct signature arg | **B — direct (signature)** |
+| `secure-release` | `path: str = "."` | direct signature arg | **B — direct (signature)** |
+| `health-check` | `project_root=None, **kwargs` | uses `project_root`; maps `target` → `project_root` at line 24-26 | **C — aliased** |
+| `orchestrated-health-check` | `project_root=None, **kwargs` | same as health-check (same source file) | **C — aliased** |
+| `doc-orchestrator` | `context, **kwargs` | uses `kwargs.get("project_root")` | **C — aliased** |
+| `test-audit` | `**kwargs` | `kwargs.get("src_path", "")` — **errors if missing** | **C — aliased** |
+| `rag-code-gen` | `**kwargs` | uses `kwargs.get("cwd")` for SDK working-dir | **C — aliased** |
+
+Totals:
+- **A + B (14 workflows)**: respond directly to the CLI `--path` arg with no rewiring.
+- **C (5 workflows)**: ignore the `--path` kwarg as-is. They take path-shaped scoping under a different name.
+
+No workflow in the audit is genuinely "project-wide by design" — every one of the 19 has SOME form of scoping argument. The spec's framing in H2 ("`release-prep`, `health-check`, `dependency-check` don't [take path]") is partially wrong:
+
+- `dependency-check` **does** take `path` (Category A).
+- `release-prep` **does** take `path` (Category B — signature-level).
+- `health-check` takes `project_root`, not `path` (Category C).
+
+---
+
+## Implication for Phase 2 (scope picker)
+
+The spec's Phase 2.3 plan was:
+
+> "Render the `<select>` + hidden `<input type="text">` per row in
+> `workflows.html`. Show `<span class="scope-na">` for workflows
+> where `supports_path[w.name] is False`."
+
+The audit suggests a **better default than scope-na**: remap Category C
+in the ops runner so the picker works for all 19 workflows.
+
+### Three implementation options for `SUPPORTS_PATH_ARG` (task 1.3)
+
+**Option 1 — Binary registry, scope-na for Category C (spec's literal plan).**
+
+```python
+SUPPORTS_PATH_ARG: dict[str, bool] = {
+    "bug-predict": True, "code-review": True, ...,  # 14 True
+    "doc-orchestrator": False, "health-check": False, ...,  # 5 False
+}
+```
+
+Tooltip on scope-na: "Runs project-wide by default." Inaccurate
+(they're path-scoped, just under a different arg) but matches the
+spec's existing prose. Simplest.
+
+**Option 2 — Three-way registry with kwarg-name remapping.**
+
+```python
+@dataclass
+class PathArgSpec:
+    kwarg: str | None  # Which kwarg name the workflow expects, or None
+    required: bool = False
+
+PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
+    "bug-predict": PathArgSpec(kwarg="path"),
+    ...
+    "health-check": PathArgSpec(kwarg="project_root"),
+    "doc-orchestrator": PathArgSpec(kwarg="project_root"),
+    "test-audit": PathArgSpec(kwarg="src_path", required=True),
+    "rag-code-gen": PathArgSpec(kwarg="cwd"),
+}
+```
+
+The ops runner reads this registry and rewrites the kwarg name before
+spawning the subprocess. All 19 workflows get the picker; the user
+never knows about the kwarg-name mismatch. **Recommended.**
+
+**Option 3 — Fix the workflows to all accept `path` (consistency).**
+
+Rewrite Category C workflows to accept `path` and forward it to their
+internal `project_root` / `src_path` / `cwd`. Cleanest long-term, but
+out of scope for this spec — it's a refactor of 5 workflow files. The
+ops runner would then need no registry at all.
+
+### Recommendation
+
+**Option 2 (three-way registry with kwarg-name remapping).** Reasons:
+- Captures the actual reality (Category C workflows ARE path-scoped,
+  just under a different name)
+- Lets the picker work for all 19 workflows without compromising UX
+- Doesn't require touching 5 workflow files (Option 3)
+- Forward-compatible: if a future workflow adds direct `path` support,
+  registry entry simplifies; if Category C workflows are unified
+  upstream, registry collapses to Category A automatically
+- `required=True` for `test-audit` ensures the picker can't submit a
+  scope-less run that the workflow would reject
+
+The drift-guard test (task 1.3, third bullet) becomes more useful too —
+it asserts every workflow has a registry entry AND that the entry's
+`kwarg` matches the actual kwarg name in the workflow source (catches
+silent renames).
+
+---
+
+## Suggested updates to `tasks.md`
+
+If this audit is accepted:
+
+- Mark task **1.1** (grep workflow source) **done**.
+- Mark task **1.2** (`--help` verification) **done** with the cross-check above.
+- Reframe task **1.3** from "Record findings as `SUPPORTS_PATH_ARG` dict" to "Add `PATH_ARG_REGISTRY` dict to `src/attune/ops/data.py` per Option 2 (three-way registry with kwarg-name remapping)." Drift-guard test asserts both presence and kwarg-name match.
+- Tasks **2.x** Phase 2 implementation can read this registry — no scope-na branch needed.
+
+The remaining work is concrete and unchanged from the spec; the audit
+mostly **expands** what Phase 2 can deliver (all 19 workflows scoped
+instead of 14).

--- a/docs/specs/ops-runner-tier2/decisions.md
+++ b/docs/specs/ops-runner-tier2/decisions.md
@@ -91,6 +91,29 @@ Some workflows take `--path` (`code-review`, `bug-predict`, `simplify-code`, `pe
 
 Investigation task: enumerate which workflows support `--path` and which don't. Disable the picker on the latter; surface a tooltip explaining the workflow runs project-wide by design.
 
+**Status (2026-05-12): CONFIRMED AND REFINED.** Phase 1 audit
+(see [audit.md](audit.md)) ran the enumeration and found the
+reality is **three-way**, not binary:
+
+- **Category A — 12 workflows** consume `kwargs.get("path", "")` directly. `--path` works as-is.
+- **Category B — 2 workflows** (`release-prep`, `secure-release`) accept `path: str = "."` as a signature kwarg. `--path` works as-is.
+- **Category C — 5 workflows** use a different kwarg name: `project_root` (health-check, orchestrated-health-check, doc-orchestrator), `src_path` (test-audit, required), `cwd` (rag-code-gen). The CLI's `path=...` kwarg lands in `**kwargs` but isn't consumed.
+
+The spec's H2 framing was partially wrong — `dependency-check`
+DOES take `--path` (Category A); `release-prep` DOES (Category B);
+only `health-check` matched the H2 prose.
+
+**Reframing for Phase 2:** Rather than a binary `supports_path[w] =
+False` with a "scope-na" UX (spec's original Phase 2.3 plan), the
+audit recommends a three-way `PATH_ARG_REGISTRY` that maps each
+Category C workflow to its actual kwarg name. The ops runner reads
+the registry and rewrites the kwarg before subprocess spawn. All 19
+workflows get the picker; users never see the inconsistency.
+
+Phase 1.3 deferred to a separate PR so reviewer can sign off on the
+shape (three-way registry vs spec's literal binary dict) before
+production code lands.
+
 ### H3 — Persistence belongs in the runner service, not a separate "Runs" tab
 
 The current `RunnerService` keeps runs in memory (last 20). Persistence means writing run metadata + truncated log to disk under `~/.attune/ops/runs/<id>.json`. The "Runs" tab idea from earlier conversation gets folded into per-workflow row history (chips next to the Run button) — simpler navigation, no extra page.

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Runner Tier 2
 
-**Status:** draft
+**Status:** Phase 1 audit done 2026-05-12 (see audit.md); Phase 1.3 + Phases 2–5 pending
 
 Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -10,18 +10,9 @@ Phased plan. Each phase is independently shippable + reversible (single-commit r
 
 Goal: turn hypothesis H2 ("Workflow `--path` support is unevenly implemented") into a hard fact, populating the `SUPPORTS_PATH_ARG` registry from real inspection.
 
-- [ ] **1.1** Grep each workflow class's `execute()` signature and CLI handler for `--path` / `paths` argument acceptance:
-      ```
-      for w in bug-predict code-review deep-review dependency-check doc-audit doc-gen doc-orchestrator health-check orchestrated-health-check perf-audit rag-code-gen refactor-plan release-prep research-synthesis secure-release security-audit simplify-code test-audit test-gen; do
-        echo "=== $w ==="
-        grep -l "name.*$w\|workflow.*$w" src/attune/workflows/*.py | head -1 | xargs grep -nE "path|paths" | head -5
-      done
-      ```
-- [ ] **1.2** Manually verify by running each workflow with `--help` from the CLI:
-      ```
-      python -m attune.cli_minimal workflow run <name> --help
-      ```
-- [ ] **1.3** Record findings as `SUPPORTS_PATH_ARG` dict in `src/attune/ops/data.py`. Drift-guard test in `tests/unit/ops/test_path_support_registry.py` asserts every workflow has an entry.
+- [x] **1.1** Grep each workflow class's `execute()` signature and CLI handler for `--path` / `paths` argument acceptance. **Done 2026-05-12** — see [audit.md](audit.md). The grep recipe in the spec needed adapting (it scoped to `src/attune/workflows/*.py` but 4 workflows live in package subdirs like `src/attune/workflows/doc_audit/workflow.py`).
+- [x] **1.2** Manually verify by running each workflow with `--help` from the CLI. **Done 2026-05-12.** Key finding: the CLI surface `attune workflow run --help` accepts `--path` UNIFORMLY for all workflows; it becomes a `path=...` kwarg in `workflow.execute(**input_data)`. Whether the workflow consumes that kwarg is the real question — answered per-workflow in audit.md.
+- [ ] **1.3** Record findings as `PATH_ARG_REGISTRY` dict (Option 2 from audit.md) in `src/attune/ops/data.py`. Drift-guard test in `tests/unit/ops/test_path_support_registry.py` asserts every workflow has an entry AND that the entry's `kwarg` matches the actual kwarg name in the workflow source. **Pending user approval** to write production code — audit complete; implementation deferred to a separate PR so reviewer can sign off on the three-way (not binary) registry shape.
 
 ## Phase 2 — Scope picker (headline feature)
 


### PR DESCRIPTION
## Summary

Phase 1 of [`docs/specs/ops-runner-tier2/`](docs/specs/ops-runner-tier2/) — verify `--path` support per workflow.

Inspected all 19 workflows' `execute()` signatures and bodies; cross-checked via `attune workflow info`. Hypothesis H2 ("Workflow `--path` support is unevenly implemented") **confirmed and refined** — the reality is three-way, not binary.

## Findings

| Category | Count | What |
|---|---|---|
| **A — direct `path` kwarg** | 12 | Consume `kwargs.get("path", "")` |
| **B — direct `path` signature** | 2 | `release-prep`, `secure-release` (signature-level `path: str = "."`) |
| **C — aliased kwarg name** | 5 | `project_root` (health-check family + doc-orchestrator), `src_path` (test-audit, required), `cwd` (rag-code-gen) |

A + B = **14 workflows** that respond to the CLI `--path` directly.
C = **5 workflows** that accept path-shaped scoping under a different kwarg name.

**The spec's H2 prose was partially wrong:**
- `dependency-check` **does** take `path` (Category A)
- `release-prep` **does** take `path` (Category B)
- Only `health-check` matches the H2 "doesn't take path" framing

No workflow is genuinely "project-wide by design" — every one has some form of scoping arg.

## Recommendation for Phase 2

The spec's Phase 2.3 planned a binary `supports_path[w] = False` with a `<span class="scope-na">` for Category C workflows.

The audit recommends **a three-way `PATH_ARG_REGISTRY`** that maps each Category C workflow to its actual kwarg name. The ops runner reads the registry and rewrites the kwarg before subprocess spawn. All 19 workflows get the picker; no scope-na fallback needed. Forward-compatible if workflows ever unify on `path`.

See `audit.md` for three implementation options and reasoning.

## What this PR does

- **`audit.md`** (new) — full classification table per workflow, three implementation options for the registry, recommendation
- **`decisions.md`** — H2 marked CONFIRMED AND REFINED with three-way detail
- **`tasks.md`** — 1.1, 1.2 marked done; 1.3 reframed and **pending user approval** before production code lands

## What this PR does NOT do

Per the Tier-1-pure-audit framing: **no production code changes.** Task 1.3 (write the `PATH_ARG_REGISTRY` dict + drift-guard test) is intentionally deferred to a separate PR so reviewer can sign off on the three-way (not binary) registry shape first.

## Test plan

- [x] All 19 workflows inspected via grep + `attune workflow info`
- [x] CLI surface (`attune workflow run --help`) confirmed uniform
- [x] Cross-check confirms Category C workflows have docstring examples with `src_path=`, `project_root=`, `cwd=` (not `path=`)
- [x] No code changes; pre-commit hooks pass

## Next step

Awaiting your nod on **Option 2 (three-way registry)** vs the spec's literal Option 1 (binary). With approval, 1.3 implementation lands in a small follow-up PR (~50 LoC: registry dict + drift-guard test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)