### PR TITLE
test(memory/control_panel): cover error-handling fallback branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: eleventh module through the playbook —
+  `memory/control_panel.py` (`MemoryControlPanel`). Existing
+  tests already covered 93% line+branch — this PR adds 7
+  targeted tests under
+  `tests/unit/memory/test_control_panel_error_paths.py` for
+  the remaining error-handling fallbacks: storage_bytes
+  `OSError` recovery (lines 229-231), long-term
+  `get_statistics()` exception handler (241-242), health_check
+  "long_term not initialized" branch (415-419), and
+  `_count_patterns()` `OSError`/`PermissionError` handler
+  (491-493). Coverage 93% → 99% (only the
+  `if __name__ == "__main__"` guard at line 497 remains).
+  Rubric data was stale: csv reported 53.9% covered, actual
+  was 93%; flagged for a rubric refresh. Zero production
+  bugs surfaced.
 - Test-quality-program: tenth module through the playbook —
   `workflows/document_gen/workflow.py` (`DocumentGenerationWorkflow`).
   Coverage 46.4% → 100% line+branch. 24 deterministic tests

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,63 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — eleventh module under test-quality-program (Opus 4.7)
+
+Eleventh module run. Second non-SDK pick after the
+six SDK-native cycles. Selected via the rubric:
+`memory/control_panel.py`, score 2.073. **0 production
+bugs surfaced.**
+
+**Rubric staleness flagged:** rubric_cache.csv from
+2026-05-12 morning reported `covered_pct=53.9` for
+this module, but at session time the existing
+`tests/memory/test_control_panel.py` (851 lines),
+`tests/memory/test_control_panel_security.py` (345),
+`tests/unit/memory/test_control_panel.py` (849), and
+`tests/unit/memory/test_control_panel_display.py`
+(678) — together 2,723 lines of existing tests —
+already gave 93% line+branch coverage. The csv
+snapshot pre-dates work that landed earlier today.
+Rubric refresh needed before the next cycle to avoid
+re-picking already-saturated modules.
+
+**Remaining 7% (this PR's target):** four
+error-handling fallback branches:
+
+- `get_statistics()` storage_bytes `Exception` →
+  fallback to 0 (lines 229-231). Exercised by patching
+  `Path.glob` to raise `OSError`.
+- `get_statistics()` long-term `get_statistics()`
+  `Exception` → log warning, leave counts at dataclass
+  defaults (241-242). Exercised by patching
+  `_get_long_term` to return a fake that raises.
+- `health_check()` long-term unavailable branch
+  (415-419). Exercised by pointing `storage_dir` at a
+  nonexistent path.
+- `_count_patterns()` `OSError`/`PermissionError`
+  handler (491-493). Exercised by patching
+  `Path.glob`.
+
+**Coverage delta:** 93% → 99% line+branch. Only line
+497 (`if __name__ == "__main__": main()`) remains
+uncovered.
+
+**Tests:** 7 added under
+`tests/unit/memory/test_control_panel_error_paths.py`.
+Uses `tmp_path` for real filesystem isolation;
+patches `Path.glob` / `_get_long_term` at strategic
+points to surface the fallback branches without
+mocking the whole subsystem.
+
+**Pattern observation:** When existing test files
+already cover the happy path well, the right move is
+a small targeted file that exercises the remaining
+error-handling branches by name (commented line
+references in the docstring). Cheaper than rewriting
+the existing tests, keeps the diff focused.
+
+---
+
 ## 2026-05-12 — tenth module under test-quality-program (Opus 4.7)
 
 Tenth module run. Sixth Agent SDK-native workflow

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -268,3 +268,44 @@ recede from the working set. Re-evaluate if a rubric
 refresh surfaces two more SDK shells. Until then, the
 ~5-min-per-cycle cost of hand-transferring stays
 cheaper than the ~30-min generator investment.
+
+## memory/control_panel.py
+
+**Date:** 2026-05-12
+**Rubric score at pick time:** 2.073 (weight=3 × gap=0.461 × risk=1.5)
+**Picked because:** Top non-SDK entry in the rubric
+working set after the six SDK-shell cycles drained
+the `workflows/*` cluster. Score reflected `covered_pct=53.9`
+in the morning csv snapshot.
+**Outcome:** 1 test file added (`test_control_panel_error_paths.py`,
+7 tests) targeting the remaining 4 error-handling
+fallback branches. Coverage **93% → 99%** line+branch.
+Rubric staleness surfaced: csv snapshot pre-dated work
+landed earlier today that brought existing coverage to
+93%, not 53.9%. Zero production bugs surfaced.
+**PR:** _(filled in after merge)_
+**Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
+"2026-05-12 — eleventh module under test-quality-program"
+
+**Rubric staleness flagged:** the rubric data is from
+this morning, but ~12 cycles have shipped since,
+plus a parallel session. Scores >12 hours old should
+be re-measured before picking. Cheap operational
+fix: re-run `scripts/score_test_quality.py` against
+fresh `coverage.xml` between cycles (or at least
+once per session). Not committed; next cycle should
+either refresh the rubric or pick from a known-fresh
+slice.
+
+**Pattern observation:** When existing tests already
+cover the happy path well (as here: 4 existing test
+files totaling 2,723 lines for a 497-line module),
+the right scaffold is NOT a wholesale rewrite — it's
+a small targeted file naming the remaining branches
+in its docstring and exercising each with focused
+patching. This kept the diff to 168 lines and
+avoided touching 2.7k lines of correct existing
+tests. Worth adding as an explicit branch in the
+playbook (design.md §Per-module loop): if existing
+coverage ≥85%, write a "fallback-paths" file rather
+than starting over.

--- a/tests/unit/memory/test_control_panel_error_paths.py
+++ b/tests/unit/memory/test_control_panel_error_paths.py
@@ -1,0 +1,155 @@
+"""Tests for MemoryControlPanel error-handling fallback branches.
+
+The existing `tests/memory/test_control_panel.py` and
+`tests/unit/memory/test_control_panel.py` cover the happy paths
+and most of the surface (93% line + branch combined). This file
+covers the remaining error-handling fallbacks discovered by the
+test-quality-program rubric pass:
+
+- storage_bytes calculation OSError fallback (line 229-231)
+- long-term `get_statistics()` exception handler (241-242)
+- health_check "long_term not initialized" branch (415-419)
+- `_count_patterns()` OSError/PermissionError handler (491-493)
+
+These are all defensive paths around real I/O — exercised via
+patched `Path.glob` / `Path.stat` / `Path.exists` and a fake
+long-term that raises on `get_statistics()`.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from attune.memory.control_panel import ControlPanelConfig, MemoryControlPanel
+
+
+@pytest.fixture
+def panel(tmp_path) -> MemoryControlPanel:
+    """Fresh panel pointing storage at tmp_path (which exists)."""
+    cfg = ControlPanelConfig(
+        storage_dir=str(tmp_path),
+        audit_dir=str(tmp_path / "audit"),
+        auto_start_redis=False,
+    )
+    return MemoryControlPanel(config=cfg)
+
+
+@pytest.fixture
+def panel_missing_storage(tmp_path) -> MemoryControlPanel:
+    """Panel with storage_dir that does NOT exist."""
+    cfg = ControlPanelConfig(
+        storage_dir=str(tmp_path / "nonexistent"),
+        audit_dir=str(tmp_path / "audit"),
+        auto_start_redis=False,
+    )
+    return MemoryControlPanel(config=cfg)
+
+
+# ---------------------------------------------------------------------------
+# get_statistics() — storage_bytes fallback (line 229-231)
+# ---------------------------------------------------------------------------
+
+
+class TestStatisticsStorageBytesFallback:
+    """When summing file sizes raises, storage_bytes falls back to 0."""
+
+    def test_storage_bytes_zero_on_glob_exception(self, panel, tmp_path):
+        """Patch Path.glob to raise; storage_bytes must end at 0."""
+        # Place at least one file so storage_path.exists() == True
+        (tmp_path / "marker.json").write_text("{}")
+
+        with patch.object(type(tmp_path), "glob", side_effect=OSError("denied")):
+            stats = panel.get_statistics()
+
+        assert stats.storage_bytes == 0
+        assert stats.long_term_available is True
+
+
+# ---------------------------------------------------------------------------
+# get_statistics() — long-term stats fallback (line 241-242)
+# ---------------------------------------------------------------------------
+
+
+class TestStatisticsLongTermFallback:
+    """When _get_long_term() / get_statistics() raises, the warning
+    branch fires and pattern counts stay at their dataclass defaults.
+    """
+
+    def test_long_term_raises_does_not_crash(self, panel, tmp_path):
+        (tmp_path / "marker.json").write_text("{}")
+
+        with patch.object(panel, "_get_long_term", side_effect=RuntimeError("lt down")):
+            stats = panel.get_statistics()
+
+        # Defaults preserved.
+        assert stats.patterns_total == 0
+        assert stats.patterns_public == 0
+        assert stats.patterns_internal == 0
+        assert stats.patterns_sensitive == 0
+        assert stats.patterns_encrypted == 0
+
+    def test_get_statistics_succeeds_when_long_term_returns_partial(self, panel, tmp_path):
+        """When get_statistics() returns a missing-key dict, the
+        ``.get(...)`` fallbacks keep things at zero without raising.
+        """
+
+        class FakeLT:
+            def get_statistics(self_inner):
+                return {}  # entirely empty
+
+        with patch.object(panel, "_get_long_term", return_value=FakeLT()):
+            stats = panel.get_statistics()
+
+        assert stats.patterns_total == 0
+        assert stats.patterns_public == 0
+        assert stats.patterns_internal == 0
+        assert stats.patterns_sensitive == 0
+        assert stats.patterns_encrypted == 0
+
+
+# ---------------------------------------------------------------------------
+# health_check() — long-term unavailable branch (line 415-419)
+# ---------------------------------------------------------------------------
+
+
+class TestHealthCheckLongTermUnavailable:
+    """When ``status['long_term']['status']`` != 'available', the
+    warning branch fires with the right recommendation.
+    """
+
+    def test_missing_storage_triggers_warn(self, panel_missing_storage):
+        result = panel_missing_storage.health_check()
+
+        long_term_check = next(c for c in result["checks"] if c["name"] == "long_term")
+        assert long_term_check["status"] == "warn"
+        assert "Storage not initialized" in long_term_check["message"]
+        assert "Initialize long-term storage directory" in result["recommendations"]
+        assert result["overall"] == "degraded"
+
+
+# ---------------------------------------------------------------------------
+# _count_patterns() — OSError/PermissionError handler (line 491-493)
+# ---------------------------------------------------------------------------
+
+
+class TestCountPatternsErrorHandler:
+    """When Path.glob raises OSError/PermissionError, _count_patterns
+    returns 0 instead of crashing.
+    """
+
+    def test_glob_oserror_returns_zero(self, panel, tmp_path):
+        with patch.object(type(tmp_path), "glob", side_effect=OSError("io")):
+            assert panel._count_patterns() == 0
+
+    def test_glob_permissionerror_returns_zero(self, panel, tmp_path):
+        with patch.object(type(tmp_path), "glob", side_effect=PermissionError("denied")):
+            assert panel._count_patterns() == 0
+
+    def test_count_patterns_zero_when_storage_missing(self, panel_missing_storage):
+        """Early-return path: storage_path.exists() is False."""
+        assert panel_missing_storage._count_patterns() == 0


### PR DESCRIPTION
## Summary

Eleventh module through the [test-quality-program](docs/specs/test-quality-program/) playbook. Pattern divergence from prior cycles: existing tests already covered 93% line+branch on this module — this PR adds a small focused file for the remaining error-handling branches rather than rewriting the existing surface.

- **Coverage:** 93% → 99% line+branch on `memory/control_panel.py`. Only the `if __name__ == "__main__": main()` guard (line 497) remains.
- **Tests:** 7 added under `tests/unit/memory/test_control_panel_error_paths.py`.
- **Bugs surfaced:** zero.

## What's covered

Four error-handling fallback branches surfaced by the rubric pass:

| Lines | Branch | Test approach |
|-------|--------|---------------|
| 229-231 | `get_statistics()` storage_bytes Exception → 0 fallback | Patch `Path.glob` to raise `OSError` |
| 241-242 | `get_statistics()` long-term Exception → log warning, defaults preserved | Patch `_get_long_term` to return fake that raises |
| 415-419 | `health_check()` long-term not-initialized branch | Point `storage_dir` at nonexistent path |
| 491-493 | `_count_patterns()` OSError/PermissionError handler | Patch `Path.glob` to raise |

Uses `tmp_path` for real filesystem isolation; patches `Path.glob` / `_get_long_term` at strategic points to surface fallback branches without mocking the whole subsystem.

## Rubric staleness flagged

`rubric_cache.csv` from this morning reported `covered_pct=53.9`, but by session time existing tests (4 files, 2,723 lines total) already covered 93%. Csv snapshot pre-dates work landed earlier today. Decisions.md notes the next cycle should re-run `scripts/score_test_quality.py` against fresh `coverage.xml`, OR pick from a known-fresh slice.

## Pattern note

When existing tests already cover ≥85%, the right scaffold is a small targeted "fallback-paths" file naming the remaining branches in its docstring — not a wholesale rewrite. Kept this PR to 168 lines and avoided touching 2.7k lines of correct existing tests. Worth adding as an explicit branch in the playbook (flagged in `decisions.md`).

## Test plan

- [x] All 7 new tests pass locally
- [x] Existing `control_panel` tests pass (210 collected, all green)
- [x] Black + ruff pre-commit hooks pass
- [x] Coverage measured: 99% line+branch on `memory/control_panel.py`
- [ ] CI green across matrix

## Files changed

- `tests/unit/memory/test_control_panel_error_paths.py` — 7 new tests (new file)
- `CHANGELOG.md` — Unreleased entry
- `docs/COVERAGE_BUG_LOG.md` — eleventh-module entry
- `docs/specs/test-quality-program/decisions.md` — appended pick reasoning + rubric staleness flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)