### PR TITLE
test(workflows/test_runner): cover Tier 1 telemetry tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: thirteenth module through the playbook —
+  `workflows/test_runner.py` (Tier 1 test execution + coverage
+  tracking). Coverage 11.7% → 92% line+branch. 24 deterministic
+  tests added under `tests/unit/workflows/test_test_runner.py`
+  covering `run_tests_with_tracking()`, `track_coverage()`,
+  `track_file_tests()` (including staleness detection), and the
+  two thin wrappers (`get_file_test_status`,
+  `get_files_needing_tests`). Mocks only `subprocess.run` (would
+  actually run pytest) and `get_telemetry_store` (would write to
+  disk); pytest-output parsing, coverage.xml parsing, and
+  FileTestRecord construction use real implementations. Remaining
+  8% is the `defusedxml` ImportError fallback (line 19-20) plus
+  three classifier branches that need precisely-shaped pytest
+  output (`errors > 0` / `skipped == total` paths). Zero
+  production bugs surfaced.
 - Test-quality-program: twelfth module through the playbook —
   `cli_commands/help_commands.py` (`attune help` CLI entry).
   Coverage 5% → 100% line+branch. **Real bug surfaced and

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,74 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — thirteenth module under test-quality-program (Opus 4.7)
+
+Thirteenth module run. Selected via the fresh
+rubric: `workflows/test_runner.py`, weight 3, score
+2.649, **11.7% covered**. **0 production bugs
+surfaced.**
+
+- `workflows/test_runner.py` (Tier 1 telemetry
+  wrappers) — no bugs. The module exposes three
+  primary functions:
+  - `run_tests_with_tracking()` — runs pytest via
+    subprocess, parses output for pass/fail/skip
+    counts, logs to `TelemetryStore`.
+  - `track_coverage()` — parses `coverage.xml`,
+    computes trend (improving/declining/stable) vs
+    previous, logs to store.
+  - `track_file_tests()` — runs per-file pytest,
+    classifies the result, detects staleness when
+    source mtime > test mtime.
+  Plus two thin wrappers (`get_file_test_status`,
+  `get_files_needing_tests`) that delegate to the
+  store.
+
+  All four exception paths (TimeoutExpired in main
+  runner, generic Exception in main runner, same
+  pair in `track_file_tests`) recover to a
+  best-effort error record without crashing.
+  Telemetry log failures are also caught with
+  warnings, never propagated — a deliberate design
+  choice given Tier 1 tracking is opt-in.
+
+**Coverage delta:** 11.7% → 92% line+branch.
+
+**Tests:** 24 added under
+`tests/unit/workflows/test_test_runner.py`. Mocks
+only `subprocess.run` (would actually run pytest)
+and `get_telemetry_store` (would write to
+`~/.attune/telemetry/...`); pytest-output parsing,
+coverage.xml parsing (via `xml.etree` /
+`defusedxml`), and `FileTestRecord` construction
+use real implementations.
+
+**Remaining 8%:** the `defusedxml` ImportError
+fallback (line 19-20) which would require
+selectively breaking defusedxml import (cross-test
+contamination risk per CLAUDE.md lesson), plus
+three classifier branches at lines 342-347
+(`errors > 0` / `skipped == total` / final else)
+that need precisely-shaped pytest output to
+trigger. Stopping at 92% — marginal cost exceeds
+marginal value for these specific branches.
+
+**Coverage-omit note (informational):** the
+`workflows/test_runner.py` filename starts with
+`test_` which the `*/test_*.py` omit pattern in
+pyproject.toml's `[tool.coverage.run]` config
+should match — but the fresh `coverage.xml` does
+record measurements for the file (line-rate
+0.1169). The omit appears to NOT match nested
+paths the way the lesson at the top of CLAUDE.md
+suggests. Either the lesson is outdated, the
+pattern matches only direct children, or coverage
+.py instruments the file but then excludes it from
+some other report path. Worth a follow-up
+investigation but not blocking this cycle.
+
+---
+
 ## 2026-05-12 — twelfth module under test-quality-program (Opus 4.7)
 
 Twelfth module run. First cycle this session that

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -363,3 +363,59 @@ and revealed `cli_commands/help_commands.py` as the
 new top pick — a module that didn't appear at all
 in the morning csv's top 10. Worth automating in a
 session-start hook for future cycles.
+
+## workflows/test_runner.py
+
+**Date:** 2026-05-12
+**Rubric score at pick time:** 2.649 (weight=3 × gap=0.883 × risk=1.0)
+**Picked because:** Top entry in the fresh rubric after
+`cli_commands/help_commands.py` shipped (post-#287
+merge). The two zero-coverage rows above it
+(`workflows/test_lifecycle.py`,
+`workflows/test_maintenance_cli.py`, both score 3.0)
+were deferred — measured at 0.0% in the csv but the
+coverage-omit pattern is ambiguous on whether they
+should be measured at all; investigation flagged but
+not blocking.
+**Outcome:** 1 test file added (`test_test_runner.py`,
+24 tests). Coverage 11.7% → 92% line+branch.
+Zero production bugs surfaced. Stopped at 92%
+because the remaining branches (defusedxml
+ImportError fallback + three pytest-output
+classifier branches) have marginal-cost > marginal-
+value.
+**PR:** _(filled in after merge)_
+**Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
+"2026-05-12 — thirteenth module under test-quality-program"
+
+This module presents a different test design than
+the prior cycles. Not an SDK shell (no
+`claude_agent_sdk.query()`) and not a pure
+data-structure (it shells out via `subprocess.run`).
+The right scaffold is "external-process tracker":
+mock the external boundary (`subprocess.run`,
+`get_telemetry_store`) and let the rest run real
+— pytest-output parsing, coverage.xml parsing,
+dataclass construction, staleness detection from
+mtimes.
+
+Three exception paths per public function:
+TimeoutExpired, generic Exception, and telemetry
+log failure — all caught with best-effort
+recovery. The pattern is consistent across the
+module's three primary functions; one fixture
+shape covers all of them.
+
+**Coverage-omit ambiguity (flagged for follow-up):**
+the `*/test_*.py` pattern in pyproject.toml's omit
+list should match `workflows/test_runner.py` per
+the CLAUDE.md lesson at line ~63, but fresh
+coverage.xml does record measurements (11.69%
+line-rate observed pre-cycle). Either the lesson
+is outdated, the pattern only matches direct
+children, or coverage.py instruments but excludes
+from certain report paths. Worth a one-cycle dive
+to clean up — the rubric's `?` entries from the
+morning csv may have been the omit firing, and
+the fresh measurements may be a recent
+configuration change. Not blocking this cycle.

--- a/tests/unit/workflows/test_test_runner.py
+++ b/tests/unit/workflows/test_test_runner.py
@@ -1,0 +1,410 @@
+"""Tests for attune.workflows.test_runner — Tier 1 test/coverage tracking.
+
+Mocks `subprocess.run` (would actually run pytest) and
+`get_telemetry_store` (would write to disk). All other paths
+(pytest output parsing, coverage.xml parsing, FileTestRecord
+construction, staleness detection) use real implementations.
+
+Note: this module's filename starts with `test_` because that's
+its production name (`workflows/test_runner.py`). The
+`*/test_*.py` coverage omit pattern in pyproject.toml does match
+it but coverage.xml still reports a measurement, so we treat it
+as a normal coverage target.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from attune.workflows.test_runner import (
+    get_file_test_status,
+    get_files_needing_tests,
+    run_tests_with_tracking,
+    track_coverage,
+    track_file_tests,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_completed_process(
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess:
+    """Build a CompletedProcess for mock side_effect."""
+    return subprocess.CompletedProcess(
+        args=["pytest"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+_PYTEST_PASSING_OUTPUT = """\
+============================= test session starts =============================
+collected 5 items
+
+tests/unit/sample_test.py .....                                         [100%]
+
+============================= 5 passed in 0.42s ===============================
+"""
+
+_PYTEST_FAILING_OUTPUT = """\
+============================= test session starts =============================
+collected 3 items
+
+tests/unit/sample_test.py .F.                                            [100%]
+
+==================================== FAILURES =================================
+________________________________ test_broken _________________________________
+def test_broken():
+>   assert 1 == 2
+E   assert 1 == 2
+
+tests/unit/sample_test.py:5: AssertionError
+========================= 1 failed, 2 passed in 0.31s =========================
+"""
+
+
+# ---------------------------------------------------------------------------
+# run_tests_with_tracking() — happy + error paths
+# ---------------------------------------------------------------------------
+
+
+class TestRunTestsWithTracking:
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner.subprocess.run")
+    def test_default_unit_suite_invokes_pytest(self, mock_run, mock_store):
+        mock_run.return_value = _make_completed_process(0, _PYTEST_PASSING_OUTPUT)
+        mock_store.return_value = MagicMock()
+
+        record = run_tests_with_tracking()
+
+        assert record.success is True
+        assert record.exit_code == 0
+        assert record.passed == 5
+        assert record.total_tests == 5
+        assert record.test_suite == "unit"
+        assert record.triggered_by == "manual"
+        # Default command targets tests/unit/
+        cmd = mock_run.call_args.args[0]
+        assert "pytest" in cmd
+        assert "tests/unit/" in cmd
+        # Logged to telemetry store
+        mock_store.return_value.log_test_execution.assert_called_once_with(record)
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner.subprocess.run")
+    def test_specific_test_files_used_in_command(self, mock_run, mock_store):
+        mock_run.return_value = _make_completed_process(0, _PYTEST_PASSING_OUTPUT)
+        mock_store.return_value = MagicMock()
+
+        record = run_tests_with_tracking(test_files=["tests/foo.py", "tests/bar.py"])
+
+        cmd = mock_run.call_args.args[0]
+        assert "tests/foo.py" in cmd
+        assert "tests/bar.py" in cmd
+        assert record.test_files == ["tests/foo.py", "tests/bar.py"]
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner.subprocess.run")
+    def test_all_suite_uses_full_pattern(self, mock_run, mock_store):
+        mock_run.return_value = _make_completed_process(0, _PYTEST_PASSING_OUTPUT)
+        mock_store.return_value = MagicMock()
+
+        run_tests_with_tracking(test_suite="all")
+        cmd = mock_run.call_args.args[0]
+        assert "tests/" in cmd
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner.subprocess.run")
+    def test_custom_command_overrides_defaults(self, mock_run, mock_store):
+        mock_run.return_value = _make_completed_process(0, _PYTEST_PASSING_OUTPUT)
+        mock_store.return_value = MagicMock()
+
+        record = run_tests_with_tracking(command="pytest -x tests/specific.py")
+        assert record.command == "pytest -x tests/specific.py"
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner.subprocess.run")
+    def test_failed_tests_parsed(self, mock_run, mock_store):
+        mock_run.return_value = _make_completed_process(1, _PYTEST_FAILING_OUTPUT)
+        mock_store.return_value = MagicMock()
+
+        record = run_tests_with_tracking()
+        assert record.success is False
+        assert record.exit_code == 1
+        assert record.failed >= 1
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner.subprocess.run")
+    def test_timeout_recorded_as_exit_124(self, mock_run, mock_store):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="pytest", timeout=600)
+        mock_store.return_value = MagicMock()
+
+        record = run_tests_with_tracking()
+        assert record.success is False
+        assert record.exit_code == 124
+        assert record.errors == 1
+        assert any("timeout" in t["name"].lower() for t in record.failed_tests)
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner.subprocess.run")
+    def test_generic_subprocess_exception(self, mock_run, mock_store):
+        mock_run.side_effect = OSError("permission denied")
+        mock_store.return_value = MagicMock()
+
+        record = run_tests_with_tracking()
+        assert record.success is False
+        assert record.exit_code == 1
+        assert record.errors == 1
+        assert any("execution_error" in t["name"] for t in record.failed_tests)
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner.subprocess.run")
+    def test_telemetry_log_failure_swallowed(self, mock_run, mock_store):
+        """If logging to the telemetry store raises, the record is
+        still returned (the run already happened — logging is
+        best-effort).
+        """
+        mock_run.return_value = _make_completed_process(0, _PYTEST_PASSING_OUTPUT)
+        store = MagicMock()
+        store.log_test_execution.side_effect = RuntimeError("disk full")
+        mock_store.return_value = store
+
+        record = run_tests_with_tracking()
+        assert record.success is True
+
+
+# ---------------------------------------------------------------------------
+# track_coverage() — happy + error paths
+# ---------------------------------------------------------------------------
+
+
+_COVERAGE_XML = """<?xml version="1.0" ?>
+<coverage version="7.0" lines-valid="1000" lines-covered="850" branches-valid="200" branches-covered="170" complexity="0" timestamp="123">
+  <packages>
+    <package name="attune" line-rate="0.85" branch-rate="0.85" complexity="0">
+      <classes>
+        <class name="example.py" filename="src/attune/example.py" line-rate="0.85" branch-rate="0.85" complexity="0">
+          <methods/>
+          <lines>
+            <line number="1" hits="1"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+"""
+
+
+class TestTrackCoverage:
+    def test_missing_file_raises_filenotfounderror(self, tmp_path):
+        missing = tmp_path / "nope.xml"
+        with pytest.raises(FileNotFoundError):
+            track_coverage(coverage_file=str(missing))
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner._get_previous_coverage", return_value=None)
+    def test_happy_path_returns_record(self, mock_prev, mock_store, tmp_path):
+        cov_file = tmp_path / "coverage.xml"
+        cov_file.write_text(_COVERAGE_XML)
+        mock_store.return_value = MagicMock()
+
+        record = track_coverage(coverage_file=str(cov_file))
+
+        assert record.overall_percentage == pytest.approx(85.0)
+        assert record.lines_total == 1000
+        assert record.lines_covered == 850
+        assert record.branches_total == 200
+        assert record.branches_covered == 170
+        assert record.trend == "stable"  # no previous
+        mock_store.return_value.log_coverage.assert_called_once_with(record)
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner._get_previous_coverage", return_value=70.0)
+    def test_trend_improving(self, mock_prev, mock_store, tmp_path):
+        cov_file = tmp_path / "coverage.xml"
+        cov_file.write_text(_COVERAGE_XML)
+        mock_store.return_value = MagicMock()
+
+        record = track_coverage(coverage_file=str(cov_file))
+        assert record.trend == "improving"  # 85% vs prior 70%
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner._get_previous_coverage", return_value=95.0)
+    def test_trend_declining(self, mock_prev, mock_store, tmp_path):
+        cov_file = tmp_path / "coverage.xml"
+        cov_file.write_text(_COVERAGE_XML)
+        mock_store.return_value = MagicMock()
+
+        record = track_coverage(coverage_file=str(cov_file))
+        assert record.trend == "declining"  # 85% vs prior 95%
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner._get_previous_coverage", return_value=85.5)
+    def test_trend_stable_within_tolerance(self, mock_prev, mock_store, tmp_path):
+        cov_file = tmp_path / "coverage.xml"
+        cov_file.write_text(_COVERAGE_XML)
+        mock_store.return_value = MagicMock()
+
+        record = track_coverage(coverage_file=str(cov_file))
+        # 85 vs 85.5 → diff 0.5 → within 1.0 tolerance → stable
+        assert record.trend == "stable"
+
+    def test_invalid_xml_raises_valueerror(self, tmp_path):
+        cov_file = tmp_path / "coverage.xml"
+        cov_file.write_text("not xml at all")
+        with pytest.raises(ValueError, match="Invalid coverage.xml"):
+            track_coverage(coverage_file=str(cov_file))
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner._get_previous_coverage", return_value=None)
+    def test_zero_lines_yields_zero_percentage(self, mock_prev, mock_store, tmp_path):
+        zero_xml = _COVERAGE_XML.replace('lines-valid="1000"', 'lines-valid="0"').replace(
+            'lines-covered="850"', 'lines-covered="0"'
+        )
+        cov_file = tmp_path / "coverage.xml"
+        cov_file.write_text(zero_xml)
+        mock_store.return_value = MagicMock()
+
+        record = track_coverage(coverage_file=str(cov_file))
+        assert record.overall_percentage == 0.0
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    @patch("attune.workflows.test_runner._get_previous_coverage", return_value=None)
+    def test_log_failure_swallowed(self, mock_prev, mock_store, tmp_path):
+        cov_file = tmp_path / "coverage.xml"
+        cov_file.write_text(_COVERAGE_XML)
+        store = MagicMock()
+        store.log_coverage.side_effect = RuntimeError("disk full")
+        mock_store.return_value = store
+
+        record = track_coverage(coverage_file=str(cov_file))
+        # Still returns the parsed record
+        assert record.overall_percentage == pytest.approx(85.0)
+
+
+# ---------------------------------------------------------------------------
+# track_file_tests()
+# ---------------------------------------------------------------------------
+
+
+class TestTrackFileTests:
+    def test_no_test_file_returns_no_tests_record(self, tmp_path):
+        source = tmp_path / "src.py"
+        source.write_text("x = 1")
+        with patch("attune.workflows.test_runner._log_file_test"):
+            record = track_file_tests(source_file=str(source))
+        assert record.last_test_result == "no_tests"
+        assert record.test_count == 0
+        assert record.is_stale is False
+
+    @patch("attune.workflows.test_runner.subprocess.run")
+    @patch("attune.workflows.test_runner._log_file_test")
+    def test_existing_test_passes(self, mock_log, mock_run, tmp_path):
+        source = tmp_path / "src.py"
+        source.write_text("x = 1")
+        tf = tmp_path / "tests" / "test_src.py"
+        tf.parent.mkdir()
+        tf.write_text("def test_x(): pass")
+
+        mock_run.return_value = _make_completed_process(0, _PYTEST_PASSING_OUTPUT)
+        record = track_file_tests(source_file=str(source), test_file=str(tf))
+
+        assert record.last_test_result == "passed"
+        assert record.test_count == 5
+        assert record.failed == 0
+        # Both source and test mtimes are recorded
+        assert record.source_modified_at is not None
+        assert record.tests_modified_at is not None
+        mock_log.assert_called_once()
+
+    @patch("attune.workflows.test_runner.subprocess.run")
+    @patch("attune.workflows.test_runner._log_file_test")
+    def test_failing_tests_classified(self, mock_log, mock_run, tmp_path):
+        source = tmp_path / "src.py"
+        source.write_text("x = 1")
+        tf = tmp_path / "test_src.py"
+        tf.write_text("def test_x(): assert False")
+
+        mock_run.return_value = _make_completed_process(1, _PYTEST_FAILING_OUTPUT)
+        record = track_file_tests(source_file=str(source), test_file=str(tf))
+        assert record.last_test_result == "failed"
+
+    @patch("attune.workflows.test_runner.subprocess.run")
+    @patch("attune.workflows.test_runner._log_file_test")
+    def test_timeout_recorded_as_error(self, mock_log, mock_run, tmp_path):
+        source = tmp_path / "src.py"
+        source.write_text("x = 1")
+        tf = tmp_path / "test_src.py"
+        tf.write_text("def test_x(): pass")
+
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="pytest", timeout=300)
+        record = track_file_tests(source_file=str(source), test_file=str(tf))
+        assert record.last_test_result == "error"
+        assert record.errors == 1
+
+    @patch("attune.workflows.test_runner.subprocess.run")
+    @patch("attune.workflows.test_runner._log_file_test")
+    def test_generic_exception_recorded_as_error(self, mock_log, mock_run, tmp_path):
+        source = tmp_path / "src.py"
+        source.write_text("x = 1")
+        tf = tmp_path / "test_src.py"
+        tf.write_text("def test_x(): pass")
+
+        mock_run.side_effect = OSError("file not found")
+        record = track_file_tests(source_file=str(source), test_file=str(tf))
+        assert record.last_test_result == "error"
+
+    @patch("attune.workflows.test_runner.subprocess.run")
+    @patch("attune.workflows.test_runner._log_file_test")
+    def test_staleness_when_source_newer_than_test(self, mock_log, mock_run, tmp_path):
+        """is_stale=True when source_modified_at > tests_modified_at."""
+        source = tmp_path / "src.py"
+        source.write_text("x = 1")
+        tf = tmp_path / "test_src.py"
+        tf.write_text("def test_x(): pass")
+
+        # Make source newer than test (artificially).
+        import os
+
+        old = (datetime.now() - timezone.utc.utcoffset(datetime.now())).timestamp() - 86400
+        os.utime(str(tf), (old, old))
+
+        mock_run.return_value = _make_completed_process(0, _PYTEST_PASSING_OUTPUT)
+        record = track_file_tests(source_file=str(source), test_file=str(tf))
+        assert record.is_stale is True
+
+
+# ---------------------------------------------------------------------------
+# get_file_test_status() / get_files_needing_tests() — thin wrappers
+# ---------------------------------------------------------------------------
+
+
+class TestStatusWrappers:
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    def test_status_returns_store_value(self, mock_store):
+        rec = MagicMock(name="record")
+        mock_store.return_value.get_latest_file_test.return_value = rec
+        assert get_file_test_status("src/foo.py") is rec
+        mock_store.return_value.get_latest_file_test.assert_called_once_with("src/foo.py")
+
+    @patch("attune.workflows.test_runner.get_telemetry_store")
+    def test_needing_tests_forwards_filters(self, mock_store):
+        mock_store.return_value.get_files_needing_tests.return_value = [1, 2, 3]
+        assert get_files_needing_tests(stale_only=True, failed_only=False) == [1, 2, 3]
+        mock_store.return_value.get_files_needing_tests.assert_called_once_with(
+            stale_only=True, failed_only=False
+        )


### PR DESCRIPTION
## Summary

Thirteenth module through the [test-quality-program](docs/specs/test-quality-program/) playbook. New scaffold archetype this cycle: **external-process tracker** — neither an SDK shell nor a pure data structure. The module shells out via `subprocess.run` and writes to a telemetry store.

- **Coverage:** 11.7% → 92% line+branch on `workflows/test_runner.py`.
- **Tests:** 24 added under `tests/unit/workflows/test_test_runner.py`.
- **Bugs surfaced:** zero.

## Test design

Mocks only the external boundaries:
- `subprocess.run` — would actually run pytest
- `get_telemetry_store` — would write to `~/.attune/telemetry/...`

Everything else uses real implementations: pytest-output parsing (real regex), coverage.xml parsing (real `xml.etree`/`defusedxml`), `FileTestRecord` dataclass construction, staleness detection from real mtimes (via `os.utime`).

Three exception paths per public function (TimeoutExpired, generic Exception, telemetry log failure) — all caught with best-effort recovery. One fixture shape covers all of them.

## Why stopped at 92%

Remaining 8%:
- `defusedxml` ImportError fallback (line 19-20) — would require selectively breaking `defusedxml` import. Cross-test contamination risk (per the CLAUDE.md lesson on `sys.modules[name] = None` sentinels).
- Three classifier branches at lines 342-347 (`errors > 0`, `skipped == total`, final else) — need precisely-shaped pytest output to trigger different return codes with no failures.

Both are marginal-cost > marginal-value; not pursued.

## Coverage-omit ambiguity flagged

The `*/test_*.py` pattern in pyproject.toml `[tool.coverage.run]` omit list should match `workflows/test_runner.py` per the CLAUDE.md lesson at line ~63, but fresh `coverage.xml` records measurements (11.69% line-rate pre-cycle). Either the lesson is outdated or the pattern matches differently than documented. Worth a one-cycle dive to clean up — flagged in `decisions.md`, not pursued here.

## Test plan

- [x] All 24 new tests pass locally
- [x] Coverage measured: 92% line+branch on `workflows/test_runner.py`
- [x] Black + ruff pre-commit hooks pass
- [ ] CI green across matrix

## Files changed

- `tests/unit/workflows/test_test_runner.py` — 24 new tests (new file)
- `CHANGELOG.md` — Unreleased entry
- `docs/COVERAGE_BUG_LOG.md` — thirteenth-module entry
- `docs/specs/test-quality-program/decisions.md` — appended pick reasoning + omit-ambiguity flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)