### PR TITLE
test(workflows/test_runner_helpers): cover helpers + flag 2 bug findings

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3369,6 +3369,167 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   fresh branch off `origin/main`, not the prior cycle's
   branch.
 
+- **Diagnostic for the rubric: low coverage + nominal
+  test file → grep for `pytest.importorskip` FIRST**:
+  three test-quality-program cycles in a row hit
+  modules where the rubric reported low coverage but
+  the gap was an artifact, not a coverage need.
+  Combined with the existing "codecov/patch 0%" and
+  "Tests for optional-dep code" lessons, the rule
+  is: when the rubric picks a module with surprisingly
+  low `covered_pct` AND a non-trivial test file
+  exists in `tests/`, run
+  `grep -l "pytest.importorskip" tests/<path>` BEFORE
+  writing new tests. If the existing tests gate the
+  whole module on an `importorskip("X")` and X isn't
+  in `[dev]`, the fix is one line in pyproject.toml
+  (add X to `[dev]`) — 16 existing tests start
+  running, coverage jumps 60+ percentage points
+  without writing anything new. Hit in PR #287
+  (`cli_commands/help_commands.py`,
+  `python-frontmatter` was only in `[author]`,
+  CI's `--extra dev --extra developer` didn't
+  install it → all 16 tests silently skipped). The
+  diagnostic also reveals "dead code wearing
+  defensive clothes" — if there's no test file at
+  all, check inbound imports (`grep -rn
+  "from ...module" src/`) before writing tests.
+
+- **Coverage rubric needs a usage signal, not just
+  a coverage-gap signal**: the formula
+  `weight × gap × risk` ranks modules purely by
+  "user value × untested surface," which is exactly
+  right for healthy code but wrong for dead/skipped
+  code. Three consecutive cycles surfaced
+  unused-or-silently-skipped modules as top picks:
+  (a) `cli_commands/help_commands.py` 16 tests
+  silently skip in CI (#287),
+  (b) `workflows/test_lifecycle.py` +
+  `test_maintenance_cli.py` 0% covered, zero
+  inbound imports outside each other, source
+  comments mark "Removed",
+  (c) `workflows/test_runner_helpers.py` 2% gap is
+  dead defensive try/except. Proposed refinement
+  (flagged in `docs/specs/test-quality-program/decisions.md`,
+  not committed): add inbound-import count to
+  `scripts/score_test_quality.py`. Modules with 0
+  external consumers should auto-flag as
+  retirement candidates rather than coverage
+  targets. The score formula should multiply by
+  `min(1.0, inbound_imports / 5)` or similar to
+  push orphan modules off the top of the working
+  set.
+
+- **Test scaffold archetype for external-process
+  trackers**: `workflows/test_runner.py` (PR #288)
+  established a third scaffold archetype after
+  "SDK shell" and "data structure". For modules
+  that shell out via `subprocess.run` and write to
+  a telemetry/persistence store, mock only those
+  two boundaries; let everything else run real
+  (pytest-output regex parsing, coverage.xml
+  parsing, dataclass construction, mtime-based
+  staleness detection via real `os.utime`).
+  Three exception paths per public function are
+  the norm: `TimeoutExpired`, generic `Exception`,
+  and telemetry log failure — all caught with
+  best-effort recovery. One fixture shape covers
+  all three. This is distinct from the SDK shell
+  pattern (where `claude_agent_sdk.query` is the
+  single mock boundary) and the data-structure
+  pattern (where no mocks are needed).
+
+- **Bug Class 2 (dead defensive code) is the most
+  common finding in modules that look like they
+  need tests but actually need cleanup**: in cycle
+  14 (PR #289), a 2% coverage gap on
+  `workflows/test_runner_helpers.py` was entirely
+  inside a `try/except (ValueError, IndexError):
+  pass` block where:
+  - `ValueError` was impossible (the surrounding
+    `if "src" in source_path.parts:` guard had
+    already confirmed presence)
+  - `IndexError` was impossible (Python's slice
+    `parts[a:b]` never raises IndexError)
+  The right action was to flag for a retirement /
+  cleanup PR, not write a test for an unreachable
+  branch. Test design rule: before writing a test
+  to close a coverage gap, prove the branch is
+  reachable. If you can't construct an input that
+  reaches it, the branch is dead — file a sibling
+  PR to delete it instead.
+
+- **Admin-merging a deletion PR without checking the
+  `build` docs check breaks main**: PR #279 deleted
+  `attune.coordination` and was admin-merged with all
+  tests green, but `docs/reference/multi-agent.md`
+  had `::: attune.coordination.ConflictResolver`
+  mkdocstrings autogen blocks. Main's `mkdocs build`
+  failed immediately, blocking the next PR in the
+  stack. The trap: every PR fails Vercel-attune-ai
+  permanently (legacy preview), so the "failures"
+  field in `gh pr view --json statusCheckRollup` is
+  always non-empty. When admin-merging a `feat!:` or
+  any deletion PR, **read each failure by name** —
+  `build`, `test (...)`, `Analyze (...)` are
+  fail-real, while `Vercel – attune-ai` is
+  fail-ignore. Concrete rule: before admin-merging a
+  deletion, also `grep -rn "::: <removed.module>"
+  docs/` and `grep -rn "<RemovedClass>" docs/` to
+  catch mkdocstrings autogen refs that won't resolve.
+  Fixing main mid-session via a hotfix branch
+  (\`hotfix/...\`) and a focused PR is the right
+  recovery path — don't try to bundle the fix into
+  the next stacked PR.
+
+- **Stacked PR rebase pattern after merging the
+  base**: when PR A and PR B both touch CHANGELOG
+  (each adding their own `### Removed (Breaking)` /
+  `### Changed (Breaking)` section under
+  `## [Unreleased]`) and A merges first, B's rebase
+  conflicts on the changelog. Resolution: keep BOTH
+  sections in the same Unreleased block, with the
+  earlier-merged PR's section first (severity-order:
+  Removed → Changed → Deprecated → Added → Fixed).
+  Same pattern works for `docs/specs/<spec>/tasks.md`
+  status rows — A's `**done**` overrides B's `todo`
+  for any row both touched. The `_sequencing.md`
+  "Today's recommended pick" section is the
+  exception: both sides are guaranteed stale by the
+  time you're resolving the conflict (the picks they
+  named both shipped). Don't pick one — replace with
+  a static pointer to "the most recent spec's
+  decisions.md."
+
+- **Batch-merging MERGEABLE PRs needs a draft filter
+  AND a fail-state read**: `gh pr list --json
+  mergeable` returns MERGEABLE for both
+  ready-to-merge AND draft PRs; the merge call
+  itself errors with "Pull Request is still a draft"
+  when you try. Filter the batch with `gh pr list
+  --json number,mergeable,isDraft --jq '.[] |
+  select(.mergeable=="MERGEABLE" and .isDraft==false)
+  | .number'` before iterating. Also: an
+  intentionally-failing diagnostic PR (like
+  `windows-memory-detection Phase 1`) marked draft
+  is a legitimate state — close, don't merge.
+  Diagnostic for "should this draft close?": does
+  the spec it served reference a closing PR? does a
+  successor PR ship the actual fix?
+
+- **Stale duplicate PRs: confirm via merged-commit
+  grep, then close with a pointer**: when two
+  parallel sessions ship the same test-quality-program
+  module, the slower one's PR ends up CONFLICTING
+  after the winner merges. Don't rebase — close with
+  a comment citing the merged commit. Verify before
+  closing: `git log --oneline --all | grep -iE
+  "<module>"` should show the winning PR's
+  merge-squash commit. If you only see the
+  duplicate's commits and no merge, the loser
+  actually has unique work — investigate before
+  closing.
+
 - **A spec's measurable premise should be probed in
   Phase 0 BEFORE implementation, even when the
   probe costs real API budget**: the Agent Surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Test-quality-program: fourteenth module through the playbook —
+  `workflows/test_runner_helpers.py` (private helpers behind the
+  Tier 1 telemetry tracker). Coverage 29.2% → 98% line+branch.
+  26 deterministic tests added under
+  `tests/unit/workflows/test_test_runner_helpers.py` covering
+  `_parse_pytest_output`, `_parse_pytest_failures`,
+  `_get_previous_coverage` (with telemetry-store mock),
+  `_analyze_coverage_files` (real XML construction), and
+  `_find_test_file` (real filesystem in tmp_path).
+  **Bug Class 2 surfaced (not fixed):** the `except (ValueError,
+  IndexError): pass` block at lines 171-172 in `_find_test_file`
+  is dead defensive code — the surrounding `if "src" in
+  source_path.parts` guard prevents `ValueError` from `.index()`,
+  and the `[src_idx + 1 : -1]` slice can't raise `IndexError`.
+  Flagged in COVERAGE_BUG_LOG; deferred to a sibling cleanup PR.
+  Also flagged **Bug Class 2 deferral:**
+  `workflows/test_lifecycle.py` and
+  `workflows/test_maintenance_cli.py` (both 0% covered, both at
+  rubric score 3.0) have zero inbound imports outside each
+  other, and `workflows/__init__.py:328` notes test-maintenance
+  was removed. Skipped this cycle — they're dead code, not
+  coverage targets.
 - Test-quality-program: thirteenth module through the playbook —
   `workflows/test_runner.py` (Tier 1 test execution + coverage
   tracking). Coverage 11.7% → 92% line+branch. 24 deterministic

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -18,6 +18,88 @@ Format: most recent session at top. Per bug: `module — class — one-liner`.
 
 ---
 
+## 2026-05-12 — fourteenth module under test-quality-program (Opus 4.7)
+
+Fourteenth module run. Selected via the fresh
+rubric: `workflows/test_runner_helpers.py`, weight 3,
+score 2.125, **29.2% covered**. **Two Bug Class 2
+findings — neither fixed inline.**
+
+- `workflows/test_runner_helpers.py` (pytest output
+  parsing + coverage XML analysis + test discovery)
+  — primarily pure functions. Three helpers
+  (`_get_previous_coverage`, `_log_file_test`) touch
+  the telemetry store, mocked. `_find_test_file`
+  walks the real filesystem in `tmp_path` via
+  `monkeypatch.chdir`.
+
+**Bug Class 2 #1 (this module):** `_find_test_file`
+at lines 165-172 has a `try/except (ValueError,
+IndexError): pass` block guarding
+`source_path.parts.index("src")` and
+`source_path.parts[src_idx + 1 : -1]`. The
+surrounding `if "src" in source_path.parts:` guard
+makes the `ValueError` impossible (we already
+confirmed "src" is in parts). The slice operation
+`parts[a:b]` never raises `IndexError` in Python.
+Dead defensive code. The right fix is to drop the
+try/except — not write a test for an unreachable
+branch. Flagged for a sibling cleanup PR.
+
+**Bug Class 2 #2 (related modules — skipped this
+cycle):** `workflows/test_lifecycle.py` (535 lines,
+0% covered) and `workflows/test_maintenance_cli.py`
+(590 lines, 0% covered) are dead code.
+`workflows/__init__.py:328` says "test-maintenance:
+Removed — utility class, not a BaseWorkflow."
+Neither module is imported anywhere outside its
+sibling. Score 3.0 each on the rubric makes them
+top picks, but writing tests for unused code is
+exactly the trap the bug-log preamble warns
+against. Flagged for a retirement PR similar to
+`scaffolding` / `orchestrated_release_prep`
+(referenced in tasks.md §Out-of-scope follow-ups).
+
+**Coverage delta:** 29.2% → 98% line+branch on
+`workflows/test_runner_helpers.py`. The 2% gap is
+the dead-code try/except branch (line 171-172)
+documented above. Will close to 100% when the dead
+code is removed.
+
+**Tests:** 26 added under
+`tests/unit/workflows/test_test_runner_helpers.py`:
+- `_parse_pytest_output` (5 tests including
+  all-passing, mixed, errors, no-summary,
+  unparseable)
+- `_parse_pytest_failures` (4 tests including
+  malformed FAILED lines + 10-entry cap)
+- `_get_previous_coverage` (4 tests — 2-or-more
+  records, single, empty, store-exception)
+- `_analyze_coverage_files` (5 tests covering
+  well-covered/critical/untested/mid-coverage
+  thresholds + 10-entry caps)
+- `_find_test_file` (6 tests — __init__ skip,
+  module dir match, standard dir match, rglob
+  fallback, no-match, no-tests-dir)
+- `_log_file_test` (2 tests — happy + store
+  exception)
+
+**Pattern observation (informational):** This is
+the second consecutive cycle where the rubric's
+top measured-coverage picks were either dead code
+or already well-covered (existing 16 silent-skip
+tests in #287, dead defensive branches here). The
+working-set picks are getting harder to
+distinguish from "modules nobody actually uses."
+A useful rubric refinement would tag modules by
+**inbound-import count** — anything with zero
+external consumers should drop off the working
+set or get a retirement flag rather than a "low
+coverage" flag. Not committing the change here;
+flagged for a future rubric script update.
+
+---
+
 ## 2026-05-12 — thirteenth module under test-quality-program (Opus 4.7)
 
 Thirteenth module run. Selected via the fresh

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -419,3 +419,47 @@ to clean up — the rubric's `?` entries from the
 morning csv may have been the omit firing, and
 the fresh measurements may be a recent
 configuration change. Not blocking this cycle.
+
+## workflows/test_runner_helpers.py
+
+**Date:** 2026-05-12
+**Rubric score at pick time:** 2.125 (weight=3 × gap=0.708 × risk=1.0)
+**Picked because:** Top entry in the fresh rubric after
+`workflows/test_runner.py` shipped (post-#288 merge).
+The two 0%-covered rows above it
+(`workflows/test_lifecycle.py`,
+`workflows/test_maintenance_cli.py`) are dead code —
+flagged for retirement, not coverage.
+**Outcome:** 1 test file added
+(`test_test_runner_helpers.py`, 26 tests). Coverage
+29.2% → 98% line+branch. **Two Bug Class 2 findings
+surfaced — neither fixed inline.**
+**PR:** _(filled in after merge)_
+**Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
+"2026-05-12 — fourteenth module under test-quality-program"
+
+**Findings (not fixed in this PR — separate PRs):**
+
+1. `_find_test_file` lines 165-172: dead defensive
+   try/except (`ValueError, IndexError`) around code
+   that can't raise either. The 2% coverage gap on
+   this module IS this dead branch. Will close to
+   100% when removed.
+
+2. `workflows/test_lifecycle.py` (535 lines, 0%) and
+   `workflows/test_maintenance_cli.py` (590 lines,
+   0%) — both orphan modules with zero inbound
+   imports outside each other. Already flagged in
+   the source as "Removed" in `workflows/__init__.py:328`.
+   Top picks on the rubric purely because the score
+   formula doesn't penalize dead code.
+
+**Rubric refinement (flagged not committed):** add an
+"inbound-import count" column to
+`scripts/score_test_quality.py`. Modules with 0
+external consumers should auto-flag as retirement
+candidates rather than coverage targets. This is the
+third cycle in a row where the working-set head
+turned out to be unused or silently-skipped — the
+rubric needs a usage signal, not just a coverage-gap
+signal.

--- a/tests/unit/workflows/test_test_runner_helpers.py
+++ b/tests/unit/workflows/test_test_runner_helpers.py
@@ -1,0 +1,279 @@
+"""Tests for attune.workflows.test_runner_helpers — private helpers.
+
+Pure functions for the most part: pytest output parsing,
+coverage XML analysis, test-file discovery. Only the telemetry
+helpers (`_get_previous_coverage`, `_log_file_test`) interact
+with state and are mocked.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from unittest.mock import MagicMock, patch
+
+from attune.models import FileTestRecord
+from attune.workflows.test_runner_helpers import (
+    _analyze_coverage_files,
+    _find_test_file,
+    _get_previous_coverage,
+    _log_file_test,
+    _parse_pytest_failures,
+    _parse_pytest_output,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_pytest_output() — pytest summary line parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParsePytestOutput:
+    def test_all_passing(self):
+        out = "============= 5 passed in 0.42s =============="
+        total, passed, failed, skipped, errors = _parse_pytest_output(out)
+        assert total == 5
+        assert passed == 5
+        assert failed == 0
+        assert skipped == 0
+        assert errors == 0
+
+    def test_mixed_results(self):
+        out = "============= 3 failed, 2 passed, 1 skipped in 1.23s ============"
+        total, passed, failed, skipped, errors = _parse_pytest_output(out)
+        assert passed == 2
+        assert failed == 3
+        assert skipped == 1
+        assert errors == 0
+        assert total == 6
+
+    def test_error_count(self):
+        out = "============= 1 failed, 2 errors in 0.5s ============"
+        total, passed, failed, skipped, errors = _parse_pytest_output(out)
+        assert errors == 2
+
+    def test_no_summary_returns_zeros(self):
+        total, passed, failed, skipped, errors = _parse_pytest_output("")
+        assert total == passed == failed == skipped == errors == 0
+
+    def test_unparseable_returns_zeros(self):
+        total, _, _, _, _ = _parse_pytest_output("garbage with no pytest line")
+        assert total == 0
+
+
+# ---------------------------------------------------------------------------
+# _parse_pytest_failures() — extracting failure entries
+# ---------------------------------------------------------------------------
+
+
+class TestParsePytestFailures:
+    def test_extracts_failed_lines(self):
+        out = (
+            "test session starts\n"
+            "FAILED tests/unit/foo.py::test_one - assertion error\n"
+            "FAILED tests/unit/bar.py::test_two - runtime error\n"
+            "===== 2 failed in 0.5s ====="
+        )
+        result = _parse_pytest_failures(out)
+        assert len(result) == 2
+        assert result[0]["file"] == "tests/unit/foo.py"
+        assert result[0]["name"] == "test_one"
+        assert result[0]["error"] == "Test failed"
+
+    def test_no_failed_lines_returns_empty(self):
+        result = _parse_pytest_failures("all good, 5 passed")
+        assert result == []
+
+    def test_caps_at_10_failures(self):
+        out = "\n".join(f"FAILED tests/f{i}.py::test_{i} - oops" for i in range(20))
+        result = _parse_pytest_failures(out)
+        assert len(result) == 10
+
+    def test_handles_missing_test_part(self):
+        """A FAILED line with no '::' is silently skipped."""
+        out = "FAILED tests/sometest.py-malformed"  # No `::` separator
+        result = _parse_pytest_failures(out)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _get_previous_coverage() — telemetry-store lookup with graceful fallback
+# ---------------------------------------------------------------------------
+
+
+class TestGetPreviousCoverage:
+    @patch("attune.workflows.test_runner_helpers.get_telemetry_store")
+    def test_two_or_more_records_returns_second_to_last(self, mock_store):
+        rec1 = MagicMock(overall_percentage=70.0)
+        rec2 = MagicMock(overall_percentage=80.0)
+        rec3 = MagicMock(overall_percentage=85.0)
+        mock_store.return_value.get_coverage_history.return_value = [rec1, rec2, rec3]
+
+        # Second-to-last is rec2.
+        assert _get_previous_coverage() == 80.0
+
+    @patch("attune.workflows.test_runner_helpers.get_telemetry_store")
+    def test_single_record_returns_it(self, mock_store):
+        rec = MagicMock(overall_percentage=60.0)
+        mock_store.return_value.get_coverage_history.return_value = [rec]
+        assert _get_previous_coverage() == 60.0
+
+    @patch("attune.workflows.test_runner_helpers.get_telemetry_store")
+    def test_empty_history_returns_none(self, mock_store):
+        mock_store.return_value.get_coverage_history.return_value = []
+        assert _get_previous_coverage() is None
+
+    @patch("attune.workflows.test_runner_helpers.get_telemetry_store")
+    def test_store_exception_returns_none(self, mock_store):
+        mock_store.side_effect = RuntimeError("store offline")
+        assert _get_previous_coverage() is None
+
+
+# ---------------------------------------------------------------------------
+# _analyze_coverage_files() — file-level coverage classification
+# ---------------------------------------------------------------------------
+
+
+def _build_coverage_root(file_specs: list[tuple[str, float]]) -> ET.Element:
+    """Build a minimal coverage XML root with the given (filename, line_rate) tuples."""
+    root = ET.Element("coverage")
+    pkg = ET.SubElement(root, "packages")
+    p = ET.SubElement(pkg, "package")
+    classes = ET.SubElement(p, "classes")
+    for filename, line_rate in file_specs:
+        c = ET.SubElement(classes, "class", filename=filename, **{"line-rate": str(line_rate)})
+        ET.SubElement(c, "methods")
+        ET.SubElement(c, "lines")
+    return root
+
+
+class TestAnalyzeCoverageFiles:
+    def test_well_covered_threshold(self):
+        root = _build_coverage_root([("a.py", 0.85)])
+        result = _analyze_coverage_files(root)
+        assert result["total"] == 1
+        assert result["well_covered"] == 1
+        assert result["critical"] == 0
+        assert result["untested"] == []
+        assert result["gaps"] == []
+
+    def test_critical_threshold(self):
+        root = _build_coverage_root([("low.py", 0.30)])
+        result = _analyze_coverage_files(root)
+        assert result["critical"] == 1
+        assert len(result["gaps"]) == 1
+        assert result["gaps"][0]["file"] == "low.py"
+        assert result["gaps"][0]["priority"] == "high"
+
+    def test_untested_collected_separately(self):
+        root = _build_coverage_root([("zero.py", 0.0)])
+        result = _analyze_coverage_files(root)
+        # 0% is both critical AND untested.
+        assert "zero.py" in result["untested"]
+        assert result["critical"] == 1
+
+    def test_mid_coverage_neither_well_nor_critical(self):
+        """50-80% range falls between thresholds."""
+        root = _build_coverage_root([("mid.py", 0.65)])
+        result = _analyze_coverage_files(root)
+        assert result["well_covered"] == 0
+        assert result["critical"] == 0
+
+    def test_caps_at_10_each(self):
+        # 11 untested files
+        root = _build_coverage_root([(f"f{i}.py", 0.0) for i in range(11)])
+        result = _analyze_coverage_files(root)
+        assert len(result["untested"]) == 10
+        assert len(result["gaps"]) == 10
+        assert result["total"] == 11
+
+
+# ---------------------------------------------------------------------------
+# _find_test_file() — test file discovery
+# ---------------------------------------------------------------------------
+
+
+class TestFindTestFile:
+    def test_init_files_have_no_dedicated_tests(self):
+        """__init__.py paths short-circuit to None."""
+        assert _find_test_file("src/attune/foo/__init__.py") is None
+
+    def test_finds_test_in_module_unit_dir(self, tmp_path, monkeypatch):
+        """src/attune/models/registry.py finds tests/unit/models/test_registry.py."""
+        monkeypatch.chdir(tmp_path)
+        target = tmp_path / "tests" / "unit" / "models" / "test_registry.py"
+        target.parent.mkdir(parents=True)
+        target.write_text("def test_x(): pass")
+
+        result = _find_test_file("src/attune/models/registry.py")
+        assert result is not None
+        assert "test_registry.py" in result
+
+    def test_finds_test_in_standard_unit_dir(self, tmp_path, monkeypatch):
+        """Falls back to tests/unit/test_foo.py when no module dir."""
+        monkeypatch.chdir(tmp_path)
+        target = tmp_path / "tests" / "unit" / "test_foo.py"
+        target.parent.mkdir(parents=True)
+        target.write_text("def test_x(): pass")
+
+        result = _find_test_file("src/attune/foo.py")
+        assert result is not None
+        assert "test_foo.py" in result
+
+    def test_returns_none_when_no_match(self, tmp_path, monkeypatch):
+        """No matching test file anywhere → None."""
+        monkeypatch.chdir(tmp_path)
+        # Create empty tests/ dir
+        (tmp_path / "tests").mkdir()
+        result = _find_test_file("src/attune/nonexistent.py")
+        assert result is None
+
+    def test_glob_fallback_finds_deeply_nested(self, tmp_path, monkeypatch):
+        """Priority 3: rglob finds test_X.py at arbitrary depth in tests/."""
+        monkeypatch.chdir(tmp_path)
+        # Put the test file at an unexpected depth — none of the
+        # explicit patterns will match, but rglob should find it.
+        deep = tmp_path / "tests" / "weird" / "deep" / "test_thing.py"
+        deep.parent.mkdir(parents=True)
+        deep.write_text("def test_x(): pass")
+
+        result = _find_test_file("src/attune/thing.py")
+        assert result is not None
+        assert result.endswith("test_thing.py")
+
+    def test_no_tests_directory(self, tmp_path, monkeypatch):
+        """No tests/ dir at all → None."""
+        monkeypatch.chdir(tmp_path)
+        result = _find_test_file("src/attune/foo.py")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _log_file_test() — telemetry logging with graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestLogFileTest:
+    @patch("attune.workflows.test_runner_helpers.get_telemetry_store")
+    def test_logs_to_store(self, mock_store):
+        rec = FileTestRecord(
+            file_path="src/foo.py",
+            timestamp="2026-05-12T00:00:00Z",
+            last_test_result="passed",
+            test_count=1,
+        )
+        _log_file_test(rec)
+        mock_store.return_value.log_file_test.assert_called_once_with(rec)
+
+    @patch("attune.workflows.test_runner_helpers.get_telemetry_store")
+    def test_store_exception_is_swallowed(self, mock_store):
+        mock_store.return_value.log_file_test.side_effect = RuntimeError("disk full")
+        rec = FileTestRecord(
+            file_path="src/foo.py",
+            timestamp="2026-05-12T00:00:00Z",
+            last_test_result="passed",
+            test_count=1,
+        )
+        # Must NOT raise.
+        _log_file_test(rec)


### PR DESCRIPTION
## Summary

Fourteenth module through the [test-quality-program](docs/specs/test-quality-program/) playbook. Two Bug Class 2 findings surfaced — neither fixed inline (deferred to sibling retirement PRs).

- **Coverage:** 29.2% → 98% line+branch on `workflows/test_runner_helpers.py`.
- **Tests:** 26 added under `tests/unit/workflows/test_test_runner_helpers.py`.
- **Bugs surfaced:** 2 (Bug Class 2 — dead defensive code, orphan modules).

## Bug Class 2 findings

### 1. Dead defensive try/except in `_find_test_file`

Lines 165-172:

```python
if "src" in source_path.parts:
    try:
        src_idx = source_path.parts.index("src")
        rel_parts = source_path.parts[src_idx + 1 : -1]
        if len(rel_parts) >= 2:
            module_name = rel_parts[-1]
    except (ValueError, IndexError):
        pass
```

- The `if "src" in source_path.parts` guard already confirms `.index("src")` cannot raise `ValueError`
- The slice `parts[a:b]` cannot raise `IndexError` in Python

Dead branches. The 2% coverage gap on this module IS this block. Will close to 100% when the try/except is removed. Flagged for a sibling cleanup PR.

### 2. Orphan modules near the top of the rubric

`workflows/test_lifecycle.py` (535 lines, 0% covered, rubric score 3.0) and `workflows/test_maintenance_cli.py` (590 lines, 0%, score 3.0) have **zero** inbound imports outside each other. `workflows/__init__.py:328` notes:

```python
# test-maintenance: Removed — utility class, not a BaseWorkflow.
```

Top rubric picks purely because the score formula doesn't penalize dead code. Skipped this cycle — writing tests for unused code is exactly the trap the COVERAGE_BUG_LOG preamble warns against. Flagged for a retirement PR similar to scaffolding/orchestrated_release_prep.

## Rubric refinement flagged

Three consecutive cycles have surfaced unused-or-skipped modules as top picks:

| PR | Module | Issue |
|----|--------|-------|
| #287 | `cli_commands/help_commands.py` | 16 silently-skipped tests masquerading as coverage |
| (this) | `test_lifecycle.py` / `test_maintenance_cli.py` | Orphan modules with zero consumers |
| (this) | `test_runner_helpers.py` | Dead defensive code (the 2% gap) |

The rubric needs a **usage signal**, not just a coverage-gap signal. Proposed refinement: add inbound-import count to `scripts/score_test_quality.py`. Modules with 0 external consumers should auto-flag as retirement candidates. Not committed in this PR.

## Test plan

- [x] All 26 new tests pass locally
- [x] Coverage measured: 98% line+branch on `workflows/test_runner_helpers.py`
- [x] Black + ruff pre-commit hooks pass
- [ ] CI green across matrix

## Files changed

- `tests/unit/workflows/test_test_runner_helpers.py` — 26 new tests (new file)
- `CHANGELOG.md` — Unreleased entry
- `docs/COVERAGE_BUG_LOG.md` — fourteenth-module entry (2 bug findings)
- `docs/specs/test-quality-program/decisions.md` — pick reasoning + rubric refinement flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)