### PR TITLE
docs(specs): ops-specs-features Phase 0 audit — spec already executed

### DIFF
--- a/docs/specs/ops-specs-features/phase0-audit.md
+++ b/docs/specs/ops-specs-features/phase0-audit.md
@@ -1,0 +1,117 @@
+# Phase 0 audit — Gate + Scope re-check
+
+**Date**: 2026-05-12
+**Method**: verify gate conditions 0.1b and 0.5; verify the
+"What we port" scope against the current `src/attune/ops/` state.
+**Outcome**: **All gate conditions met. Spec already executed in
+practice.** Phases 1–3 are shipped, tested, and live on main.
+Tasks.md has stale Phase 1 checkboxes that didn't get flipped after
+PR #236 merged.
+
+---
+
+## Gate condition 0.1b — CI status
+
+Most-recent 3 main runs of the Tests workflow:
+
+| Run | SHA | Conclusion | Notes |
+|---|---|---|---|
+| 25767167766 | `fca8c2d7` | success | PR #288 (test_runner coverage) — latest |
+| 25765740637 | `7d988f52` | success | PR #287 (help_commands coverage) |
+| 25763743950 | `9bc97bc0` | failure | PR #286 (control_panel coverage); one flaky timeout test (`test_multiple_timeout_decorators_independent` — 50ms threshold). Not the spec's named pre-existing failures, but not a new failure mode either. Subsequent runs green. |
+
+**Verdict: GATE 0.1b SATISFIED.** Two consecutive green runs on
+`main`; the one earlier failure was a known-class timing flake on a
+50ms threshold, not a new regression. The two named pre-existing
+failures (`Py 3.10 test_chain_executor`, Windows xdist `#232`) did
+not surface in these runs.
+
+---
+
+## Gate condition 0.5 — Scope re-check
+
+The spec listed (decisions.md "What we port"):
+
+1. ✅ **List specs** across `docs/specs/` — **DONE** via PR #236
+2. ✅ **Status display + flip** — **DONE** via PR #239
+3. ✅ **Per-spec drill-in (read-only view)** — **DONE** via PR #236 + #239 (templates + routes)
+
+Verified by inspecting `src/attune/ops/`:
+
+| Capability | Implementation |
+|---|---|
+| `GET /api/specs` | `src/attune/ops/routes/specs.py:159` |
+| `GET /api/specs/{slug}` | `src/attune/ops/routes/specs.py:186` |
+| `PUT /api/specs/{slug}/{phase}/status` | `src/attune/ops/routes/specs.py:339` |
+| `--specs-root` CLI flag | `src/attune/ops/cli.py:45` |
+| Multi-root config | `src/attune/ops/cli.py:117` (`specs_roots=tuple(...)`) |
+| `_STATUS_RE` + `_VALID_STATUSES` | `src/attune/ops/routes/specs.py:50,62` |
+| `--read-only` enforcement | `src/attune/ops/routes/specs.py:351-357` (403 on mutate) |
+| Atomic write | `src/attune/ops/routes/specs.py:261` (`_atomic_write`) |
+| Specs template | `src/attune/ops/templates/specs.html` |
+| Specs tab in nav | confirmed via `/specs/{slug}` links rendered in template |
+
+Tests at parity with spec's Phase 1.3 requirements:
+
+| Phase 1.3 requirement | Test |
+|---|---|
+| Empty roots | `test_list_specs_empty_roots_returns_empty` |
+| Single root with multiple specs | `test_list_specs_single_root_multiple_specs` |
+| Multi-root with naming collisions | `test_list_specs_multi_root_collision_preserved` + `test_get_spec_first_root_wins_on_collision` |
+| Phase file missing | `test_list_specs_ignores_dirs_without_phase_files` |
+| Malformed phase file (no Status line) | `test_list_specs_malformed_status_line` |
+| Path traversal rejection | `test_get_spec_rejects_path_traversal` |
+
+Full test run: `pytest tests/unit/ops/test_specs_*.py -n auto` →
+**54 passed in 3.63s**.
+
+**Verdict: GATE 0.5 SATISFIED.** Scope did not need adjustment;
+the originally-decided scope is fully implemented and matches the
+delivered code.
+
+What was NOT ported (per decisions.md):
+- Spec creation from slug — confirmed absent (no POST endpoint).
+- Phase bootstrap from template — confirmed absent.
+- Editor integration — confirmed read-only only.
+- Living docs / corpus / template-editor surfaces — confirmed absent.
+
+---
+
+## What's actually left
+
+Per tasks.md, Phase 4 (reflection cycle):
+
+- **4.1** After 2 weeks of usage, log which features are used most → pending usage data, by design
+- **4.2** Decide whether Phase 1's read-side is enough → pending usage data
+- **4.3** If usage warrants, file a follow-up spec for additional surface → pending usage data
+
+Phase 4 is **time-gated, not work-gated**. It expects 2 weeks of
+real-world usage before evaluating whether to expand scope. No
+implementation work is pending.
+
+---
+
+## Recommendation
+
+1. **Mark Phase 0 fully satisfied** in tasks.md (currently shows
+   `[ ]` on 0.1b and 0.5 — both verified above).
+2. **Mark Phase 1 tasks 1.1, 1.2, 1.3 as done** with their resolving
+   PR references (#236) — matches the existing Phase 2 / Phase 3
+   markings.
+3. **Flip spec status** from "Approved & Prioritized (2026-05-11)
+   — gate relaxed; ready when next main CI settles" to **"Phases
+   1–3 done; Phase 4 reflection cycle awaiting 2 weeks of usage
+   (target: 2026-05-25)"**. The implementation half of the spec is
+   complete; the reflection half is on a calendar.
+
+The audit does NOT recommend opening a follow-up spec yet — that
+decision is Phase 4's whole point and depends on data we don't have.
+
+---
+
+## What this audit does NOT do
+
+Per the Tier-1-pure-audit framing: **no production code changes.**
+Only updates the spec's own tracking docs. The implementation has
+been on main for days; this PR just brings the spec's checkbox
+state in line with reality.

--- a/docs/specs/ops-specs-features/tasks.md
+++ b/docs/specs/ops-specs-features/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Port spec-handling features from attune-gui to attune ops
 
-**Status:** Approved & Prioritized (2026-05-11) — gate relaxed; ready when next main CI settles
+**Status:** Phases 1–3 complete (PRs #236, #239, #249); Phase 4 reflection cycle awaiting 2 weeks of usage (target: 2026-05-25). Phase 0 gate verified 2026-05-12 — see [phase0-audit.md](phase0-audit.md).
 
 ---
 
@@ -13,40 +13,51 @@ are sized to what actually matters for ops-specs-features
 specifically.
 
 - [x] **0.1a** PR #212 merged
-- [ ] **0.1b** Most-recent merge cycle's settled CI run on `main`
+- [x] **0.1b** Most-recent merge cycle's settled CI run on `main`
       shows only known-pre-existing failures (Py 3.10
       test_chain_executor AttributeError, Windows xdist tracked
-      in #232). No new failure modes.
+      in #232). No new failure modes. **Verified 2026-05-12** —
+      runs `fca8c2d7` and `7d988f52` both green; one earlier
+      flaky-timeout failure not a new mode.
 - [x] **0.2** PRs #227, #228 merged + verified in production
 - [x] **0.3** No critical open `ops`-labeled issues
 - [x] **0.4** (Optional) PR #226 larger runners landed
-- [ ] **0.5** Re-check decisions.md "What we port / what we do
+- [x] **0.5** Re-check decisions.md "What we port / what we do
       NOT port" — has Patrick's usage of attune ops changed in
-      the interim such that the scope should adjust?
-
-When 0.1b clears, Phase 1 starts.
+      the interim such that the scope should adjust? **Verified
+      2026-05-12** — scope did NOT need adjustment; the
+      originally-decided scope was fully implemented in the
+      interim (PRs #236, #239, #249). See `phase0-audit.md`.
 
 ## Phase 1 — Federated spec listing read-side
 
 Mirrors `attune-gui sidecar/attune_gui/routes/cowork_specs.py`
 GET endpoints. Backend first; frontend follows.
 
-- [ ] **1.1** Add `src/attune/ops/routes/specs.py` with:
+- [x] **1.1** Add `src/attune/ops/routes/specs.py` with:
   - `GET /api/specs` — list all spec dirs across configured
     roots, with phase status for each
   - `GET /api/specs/{slug}` — return content of phase files
     for one spec (read-only)
-- [ ] **1.2** Add `--specs-root` flag to `attune ops` CLI;
+
+  **Shipped via PR #236** (`d6d29642`). Routes at `specs.py:159,186`.
+- [x] **1.2** Add `--specs-root` flag to `attune ops` CLI;
   default to `docs/specs/` relative to `--project-root`.
   Accept multiple values for multi-root listing (matching
   attune-gui PR #30 pattern).
-- [ ] **1.3** Tests at parity with existing ops routes:
+
+  **Shipped via PR #236.** CLI flag at `cli.py:45`; config plumbing at
+  `cli.py:117` (`specs_roots=tuple(...)`).
+- [x] **1.3** Tests at parity with existing ops routes:
   - Empty roots
   - Single root with multiple specs
-  - Multi-root with naming collisions (later root wins?
-    error? — decide and document)
+  - Multi-root with naming collisions (first-root wins,
+    documented)
   - Phase file missing
   - Malformed phase file (no `**Status**:` line)
+
+  **Shipped via PR #236.** 54 tests in `tests/unit/ops/test_specs_routes.py`
+  + `test_specs_dashboard.py` — all green as of 2026-05-12.
 
 ## Phase 2 — Status-flip write-side
 


### PR DESCRIPTION
## Summary

Phase 0 gate verification done for [`docs/specs/ops-specs-features/`](docs/specs/ops-specs-features/). Both 0.1b (CI status) and 0.5 (scope re-check) satisfied.

**Key finding: the spec is far more done than `tasks.md` showed.** Phases 1, 2, and 3 were all shipped via PRs #236, #239, #249 — but only Phase 2/3 checkboxes got flipped at the time. Phase 1's checkboxes sat as `[ ]` todo while the code lived on `main` for days.

## Verification

| Gate | Status | Evidence |
|---|---|---|
| 0.1b CI green on main | ✅ | Latest 2 runs (`fca8c2d7`, `7d988f52`) green. One earlier flaky-timeout failure not a new mode. |
| 0.5 Scope still right | ✅ | Originally-decided scope fully implemented; no adjustment needed. |
| Phase 1.1 (GET endpoints) | ✅ shipped | `specs.py:159,186` |
| Phase 1.2 (`--specs-root` CLI) | ✅ shipped | `cli.py:45,117` |
| Phase 1.3 (tests at parity) | ✅ shipped | 54 tests in `tests/unit/ops/test_specs_*.py`, all green |

## What's actually left

Phase 4 (reflection cycle) is **time-gated, not work-gated**:
- **4.1** After 2 weeks of usage, log most-used features
- **4.2** Decide whether read-side is enough
- **4.3** File follow-up spec if usage warrants

Target date for Phase 4 evaluation: **2026-05-25**.

## What this PR does

- New `phase0-audit.md` with the full verification table
- `tasks.md` checkboxes 0.1b, 0.5, 1.1, 1.2, 1.3 all flipped to `[x]` with PR references
- Spec status flipped from "Approved & Prioritized" → "Phases 1–3 complete; Phase 4 awaiting 2 weeks of usage"

## What this PR does NOT do

Per the Tier-1-pure-audit framing: **no production code changes.** The implementation has been on main for days; this PR brings the spec's tracking docs in line with reality.

## Test plan

- [x] All claims verified against `src/attune/ops/routes/specs.py` and `cli.py` directly
- [x] `pytest tests/unit/ops/test_specs_*.py -n auto` → 54 passed in 3.63s
- [x] CI history on main inspected via `gh run list`
- [x] No code changes; pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)