### PR TITLE
docs(specs): test-quality-program Phase 4 + integration-coverage draft

### DIFF
--- a/docs/specs/_sequencing.md
+++ b/docs/specs/_sequencing.md
@@ -134,6 +134,20 @@ context between bigger work. Use the rubric to pick.
 - Cadence: One module per session, picked by rubric.
 - Spec: [test-quality-program](test-quality-program/)
 
+### integration-coverage — draft
+
+- Status: draft 2026-05-13; complement to
+  test-quality-program. Phase 0 audit gates whether a
+  framework gets built at all.
+- Why standing: Per-module coverage has known structural
+  blind spots (cross-module integration, real LLM
+  behavior, concurrency, process-shaped bugs). Phase 0
+  classifies the last 30 days of bugs to test whether
+  any mechanism justifies its cost.
+- Cadence: Phase 0 is a one-shot audit (~3 hours); Phase
+  1+ designed only after the audit data lands.
+- Spec: [integration-coverage](integration-coverage/)
+
 ---
 
 ## Track E — Conditional / contingent (do not pre-schedule)

--- a/docs/specs/integration-coverage/decisions.md
+++ b/docs/specs/integration-coverage/decisions.md
@@ -1,0 +1,21 @@
+# Per-phase decisions — Integration Coverage Program
+
+Append-only log. One section per phase as it lands. See
+`requirements.md` and `tasks.md` for the framework.
+
+Format per entry:
+
+```text
+## Phase N — <title>
+
+**Date:** YYYY-MM-DD
+**Outcome:** <one-line summary>
+**Decision-doc:** <one-line summary of what got decided>
+
+[Body: data summary, rationale, and what the next phase
+(if any) needs to know.]
+```
+
+---
+
+<!-- First entry lands when Phase 0 ships. -->

--- a/docs/specs/integration-coverage/requirements.md
+++ b/docs/specs/integration-coverage/requirements.md
@@ -1,0 +1,179 @@
+# Spec: Integration Coverage Program
+
+**Status**: draft
+**Created**: 2026-05-13
+**Origin**: Complement to the `test-quality-program` umbrella
+([requirements.md](../test-quality-program/requirements.md)).
+The per-module coverage loop has known structural blind spots
+— bugs that require multiple modules wired together, real LLM
+behavior, concurrency, or external-dep changes don't surface
+through single-module unit tests. This spec frames the
+question of what fills those gaps, with a deliberate **Phase 0
+audit before design** to avoid pre-committing to the wrong
+mechanism.
+
+---
+
+## Phase 1: Requirements
+
+### Why
+
+The test-quality-program is shipping cleanly (14 modules
+processed 2026-05-12, 2 real bugs surfaced, 3 dead-code
+candidates flagged), but its design is fundamentally
+single-module-with-mocked-boundaries. By construction it
+cannot catch:
+
+1. **Integration bugs across modules.** Two units that each
+   pass their own unit tests can fail when wired together.
+   The "SDK adapter swallows subagent findings" lesson in
+   `.claude/CLAUDE.md` (later proven wrong but the original
+   misdiagnosis stood for weeks) is exactly this shape — the
+   adapter's individual tests passed, the workflow's
+   individual tests passed, the bug was in their interaction
+   under real SDK behavior.
+
+2. **Real LLM behavior.** Every SDK shell test mocks
+   `claude_agent_sdk.query()`. The actual agent loop —
+   subagent spawning, message stream collection, budget
+   enforcement, max_turns cutoff — is never exercised in CI.
+   Production bugs in this layer surface only via dogfooding
+   (already documented as a lesson in CLAUDE.md:
+   "dogfood runs catch bugs unit tests miss").
+
+3. **Concurrency / race conditions.** The Windows xdist
+   memory failures resolved by PR #260 were not surfaced by
+   coverage cycles. Single-process pytest with mocked I/O
+   cannot model multi-worker contention, socket pressure,
+   or filesystem race conditions.
+
+4. **Tests with wrong assertions.** Coverage measures
+   execution, not correctness. A test that exercises a code
+   path with `assert result == "wrong"` still hits the
+   coverage counter. Mutation testing or property-based
+   testing addresses this; line coverage does not.
+
+5. **Untouched modules.** The rubric is opportunistic
+   top-down by score; ~30% of the codebase has never been
+   picked. Bug Class 2 finds (dead code) suggest a lot more
+   rot is sitting where the rubric hasn't looked. The
+   sibling Phase 4 task in `test-quality-program/tasks.md`
+   addresses the rubric refinement (inbound-import signal),
+   but doesn't change the fundamentally per-module shape.
+
+6. **External dep changes.** `python-frontmatter` in
+   `[author]` not `[dev]` was a real bug found by accident
+   when the rubric pointed at `cli_commands/help_commands.py`
+   (PR #287). Other deps in `[author]`, `[memory]`, etc.
+   could have similar gates that won't surface until the
+   rubric drifts that way.
+
+7. **UX bugs, performance regressions, security
+   boundaries.** Out of scope for unit tests by nature.
+
+8. **Process-shaped bugs.** I admin-merged PR #279 tonight
+   without reading the `build` check's failure carefully
+   (Vercel-noise blindness), breaking main's docs build. No
+   amount of unit testing catches "human skims the failure
+   list."
+
+### What this spec is NOT
+
+- **Not a replacement for the test-quality-program.** Per-module
+  coverage work continues as the steady-state cycle; this spec
+  is a complement, not a substitute.
+- **Not a commitment to building a framework.** Phase 0
+  explicitly defers framework design until the data on actual
+  failure modes lands. The framework may end up being existing
+  tools (`tests/integration/`, dogfooding scripts, fuzz
+  harnesses) reorganized, not new infrastructure.
+- **Not a 100% integration coverage target.** Integration
+  testing has steep marginal cost (real LLM API calls,
+  real Redis, real filesystems). The right ratio of unit vs
+  integration is data-driven — see Phase 0.
+
+### Phase 0 — Audit before design
+
+The CLAUDE.md lesson "A spec's measurable premise should be
+probed in Phase 0 BEFORE implementation, even when the probe
+costs real API budget" applies directly. Before designing a
+framework, measure:
+
+**0.1 — Inventory existing integration tests.** What lives in
+`tests/integration/` today? When was it last run? Does it pass?
+What fraction of that subtree is currently `xfail` or
+`importorskip`-gated? Output: a single page summarizing
+present state.
+
+**0.2 — Classify the last 30 days of bug findings by
+catchability.**
+Sources: `docs/COVERAGE_BUG_LOG.md`, `CHANGELOG.md`
+"Internal" entries, `.claude/CLAUDE.md "Lessons Learned"`
+additions, recent CI-break root causes from PR history.
+For each entry, classify:
+
+- **unit-catchable** — a per-module unit test would have
+  caught it (the existing program handles these).
+- **integration-catchable** — required multiple modules
+  wired together, real LLM behavior, real I/O, or
+  multi-process state.
+- **process-catchable** — required a procedural change
+  (review checklist, CI gate, branch protection) rather
+  than a test.
+- **uncatchable-cheaply** — would require expensive
+  infrastructure (production traffic replay, fuzz time
+  budget, etc.) disproportionate to the impact.
+
+Output: a CSV at
+`docs/specs/integration-coverage/bug_catchability.csv` plus a
+one-paragraph summary of the distribution.
+
+**0.3 — Cost model for the most-promising mechanism.** Based
+on 0.2's distribution, pick the *one* mechanism with the
+highest impact-per-effort ratio and estimate its costs:
+
+- If integration-catchable dominates: cost of a fixture
+  framework + recorded LLM responses + CI minute budget.
+- If process-catchable dominates: cost of a PR-template
+  review-checklist update + admin-merge guardrail script.
+- If uncatchable-cheaply dominates: this spec closes as
+  "no scalable mechanism justified."
+
+Output: a `decisions.md` entry. If costs are clearly
+disproportionate to the catchability distribution, this spec
+closes here. Otherwise, **Phase 1+ are designed in a
+follow-up commit, not committed in this spec**.
+
+### Success criteria
+
+- Phase 0 audit ships within ~3 hours of focused work.
+- The decision-doc output is sharp enough that "design a
+  framework" vs "close as out-of-scope" is unambiguous.
+- The audit is reusable — next time the question recurs,
+  the script that classified the 30-day window can re-run
+  against a fresh time range without manual re-classification.
+
+### Non-goals
+
+- **Mutation testing.** Out of scope unless Phase 0 finds
+  that "tests with wrong assertions" dominates the
+  classification — unlikely.
+- **Fuzz testing.** Out of scope unless Phase 0 finds
+  uncatchable-cheaply bugs that fuzzing specifically would
+  catch — possible for security-boundary code, but a
+  separate spec.
+- **Replacing the test-quality-program.** This spec is a
+  complement.
+
+### Out-of-scope follow-ups (flagged, not committed)
+
+- **Process changes that emerged tonight.** The
+  Vercel-blindness admin-merge regression on PR #279 →
+  docs build break is a process bug. Phase 0's
+  classification will surface whether process-shaped bugs
+  dominate; if so, that's a separate spec (something like
+  `pr-merge-checklist`) rather than this one.
+- **Test framework consolidation.** If Phase 0 finds the
+  existing `tests/integration/` subtree is mostly dead, the
+  right move is a sibling retirement spec, not building
+  more on top.

--- a/docs/specs/integration-coverage/tasks.md
+++ b/docs/specs/integration-coverage/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Integration Coverage Program
+
+**Status**: draft
+
+---
+
+## Phase 0 — Audit before design
+
+| # | Task | Layer | Status | Notes |
+|---|------|-------|--------|-------|
+| 1 | Spec approval — merge requirements.md + tasks.md. | spec | todo | This PR. |
+| 2 | **0.1 Inventory existing integration tests.** Walk `tests/integration/` and produce a one-page summary at `docs/specs/integration-coverage/inventory.md`: file count, total LOC, last-modified-month histogram, fraction `xfail`-gated, fraction `importorskip`-gated, what subsystems are covered (workflows? memory? plugins? CLI?). | docs | todo | Stdlib-only walker. Don't run the tests yet — just count. |
+| 3 | **0.2a Classify 30 days of bug findings.** Parse the last ~30 days of entries from `docs/COVERAGE_BUG_LOG.md`, `CHANGELOG.md` Internal sections, `.claude/CLAUDE.md` Lessons Learned additions, and merged-PR titles. For each entry assign one of: `unit-catchable`, `integration-catchable`, `process-catchable`, `uncatchable-cheaply`. Output: `docs/specs/integration-coverage/bug_catchability.csv` with columns `date, source, summary, category, rationale`. | docs + script | todo | First pass is manual; if the volume is high (>50 entries), write a quick script to extract structured metadata from the markdown sources. |
+| 4 | **0.2b Distribution summary.** Append a one-paragraph summary to `decisions.md` reporting the category distribution and naming the top three specific bugs from each category. | decisions.md | todo | The shape of the distribution is the input to task #5. |
+| 5 | **0.3 Cost model for top-impact mechanism.** Based on the distribution from #4, identify the one mechanism with highest impact-per-effort ratio. Estimate three costs: (a) initial setup hours, (b) per-cycle CI minute cost, (c) per-bug-find expected payoff. Write to `decisions.md`. | decisions.md | todo | Single page. If the math obviously doesn't work (e.g., uncatchable-cheaply dominates), this is where this spec closes. |
+| 6 | **Phase 0 close decision.** Either: (a) mark Phase 0 done + open Phase 1 with the mechanism design as a follow-up commit, OR (b) close this spec as "no scalable mechanism justified" and document why. | spec | todo | The decision is binary by design — Phase 0 either greenlights or kills. |
+
+---
+
+## Phase 1+ — Deferred until Phase 0 lands
+
+Design and implementation tasks are intentionally **not
+specified here**. They will be added in a follow-up commit
+after Phase 0's data justifies a specific mechanism. This
+keeps the spec honest to the lesson:
+
+> A spec's measurable premise should be probed in Phase 0
+> BEFORE implementation. (CLAUDE.md, ~line 3260)
+
+Pre-committing Phase 1 design before Phase 0 data lands is
+exactly the trap the umbrella `test-quality-program` spec
+also avoided.
+
+---
+
+## Done-state
+
+This spec has two valid terminal states:
+
+- **active** → after task #6 chooses (a). Phase 1+ is then
+  designed and executed; cycles run under the new mechanism.
+- **closed (out-of-scope)** → after task #6 chooses (b). The
+  decision rationale stays in `decisions.md` for future
+  reference, so when the question resurfaces the next reader
+  can see why a framework wasn't built.

--- a/docs/specs/test-quality-program/tasks.md
+++ b/docs/specs/test-quality-program/tasks.md
@@ -30,6 +30,31 @@
 |---|------|-------|--------|-------|
 | 9+ | Per-module cycles, one per session. Each cycle: pick from working set → run loop → ship. Refresh rubric (`scripts/score_test_quality.py`) when output is >2 weeks stale or after any large refactor. | various | recurring | No closure condition. Each cycle's deliverable is a merged PR + log entry. |
 
+### Phase 4 — Rubric refinement: usage signal
+
+Three consecutive cycles on 2026-05-12 (cycles 12, 13, 14) surfaced
+unused-or-silently-skipped modules as top rubric picks:
+
+| PR | Module | Issue |
+|----|--------|-------|
+| #287 | `cli_commands/help_commands.py` | 16 silently-skipped tests via `pytest.importorskip("frontmatter")` |
+| (n/a) | `workflows/test_lifecycle.py` + `test_maintenance_cli.py` | Orphan modules with zero inbound imports; source-marked "Removed" |
+| #289 | `workflows/test_runner_helpers.py` | Dead defensive `try/except` block (the 2% coverage gap was unreachable code) |
+
+The current score formula `weight × coverage_gap × risk_multiplier`
+ranks modules by "user value × untested surface" — exactly right for
+healthy code but wrong for dead/skipped code. The program needs a
+**usage signal** to deprioritize orphan modules.
+
+| # | Task | Layer | Status | Notes |
+|---|------|-------|--------|-------|
+| 10 | Add inbound-import count to `scripts/score_test_quality.py`. For each module, count distinct importing files outside its own package (`grep -rln "from attune.<module> " src/` or `grep -rln "import attune.<module>" src/`). Output a new `inbound_imports` column in `rubric_cache.csv`. | scripts | todo | Stdlib only; ~30 lines of Python. No behavior change to the score yet — this task just measures. |
+| 11 | Add a usage-discount factor to the score formula. Proposed: `score = weight × gap × risk × min(1.0, inbound_imports / N)` where `N` is tunable (start with 5). Document the threshold choice in `design.md §Prioritization rubric`. | scripts + design.md | todo | Apply to `rubric_cache.csv` and verify the three modules flagged above drop off the top of the working set. |
+| 12 | Update playbook in `design.md §Per-module loop` with the "diagnostic for the rubric" pattern from CLAUDE.md: when a picked module has surprisingly low `covered_pct` AND a non-trivial test file exists, grep for `pytest.importorskip` BEFORE writing tests. If a test file gates the module on an `importorskip("X")` and X isn't in `[dev]`, the fix is one line in pyproject.toml. | design.md | todo | One-paragraph addition; not a full phase. |
+
+Closes once tasks 10-12 ship and the next rubric refresh shows the
+flagged modules no longer in the top 20.
+
 ### Done-state for this spec
 
 This spec is a **standing program**, not a one-shot deliverable.


### PR DESCRIPTION
## Summary

Two complementary spec additions covering the structural blind spots flagged in tonight's cycle-12-through-14 retrospective.

## (1) Phase 4 added to `test-quality-program/tasks.md`

Rubric refinement: add an inbound-import usage signal.

Three consecutive cycles surfaced unused-or-silently-skipped modules as top rubric picks because `weight × gap × risk` doesn't penalize zero-consumer code:

| PR | Module | Issue |
|----|--------|-------|
| [#287](https://github.com/Smart-AI-Memory/attune-ai/pull/287) | `cli_commands/help_commands.py` | 16 silently-skipped tests via `pytest.importorskip(\"frontmatter\")` |
| (n/a) | `workflows/test_lifecycle.py` + `test_maintenance_cli.py` | Orphan modules, zero inbound imports |
| [#289](https://github.com/Smart-AI-Memory/attune-ai/pull/289) | `workflows/test_runner_helpers.py` | Dead defensive try/except — the 2% coverage gap was unreachable code |

Three concrete tasks (10-12):
- Add `inbound_imports` column to `scripts/score_test_quality.py`
- Introduce usage-discount factor `min(1.0, inbound_imports / N)` in the score formula
- Document the \`pytest.importorskip\` diagnostic pattern in \`design.md\`

Closes once the next rubric refresh shows the three flagged modules drop off the top of the working set.

## (2) New spec `docs/specs/integration-coverage/`

Complement to test-quality-program with a deliberate **Phase 0 audit before design**.

Frames 8 structural blind spots the per-module coverage program can't address:
1. Cross-module integration bugs
2. Real LLM behavior (every SDK test mocks `query()`)
3. Concurrency / race conditions
4. Tests with wrong assertions (coverage measures execution, not correctness)
5. Untouched modules (~30% of codebase never picked)
6. External dep changes (e.g. \`python-frontmatter\` in wrong extra)
7. UX/perf/security boundaries
8. Process-shaped bugs (the Vercel-noise admin-merge regression I caused on PR #279 tonight)

Phase 0 commits to **only 3 tasks** before Phase 1+ design:
- 0.1 — inventory existing \`tests/integration/\` subtree
- 0.2 — classify last 30 days of bug findings by catchability (\`unit-catchable\` / \`integration-catchable\` / \`process-catchable\` / \`uncatchable-cheaply\`)
- 0.3 — cost model for the highest-impact mechanism

Phase 1+ is **intentionally deferred** per the existing CLAUDE.md lesson: \"A spec's measurable premise should be probed in Phase 0 BEFORE implementation.\" The spec has two valid terminal states: greenlight a framework, or close as \"no scalable mechanism justified.\"

## Sequencing wired in

Both additions registered in \`_sequencing.md\`:
- Phase 4 picks up as another test-quality-program cycle (existing Track D)
- integration-coverage joins Track D as a one-shot Phase 0 audit (~3 hours)

## Test plan

Docs-only change. No CI dependencies beyond markdown lint + mkdocs build.

- [x] markdown formatting respects existing conventions
- [x] no broken cross-spec links
- [ ] mkdocs build green
- [ ] CI green across matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)