### PR TITLE
feat(ops): ops-runner-tier2 Phase 1.3 — PATH_ARG_REGISTRY (three-way)

### DIFF
--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Runner Tier 2
 
-**Status:** Phase 1 audit done 2026-05-12 (see audit.md); Phase 1.3 + Phases 2–5 pending
+**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phases 2–5 pending
 
 Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -12,7 +12,7 @@ Goal: turn hypothesis H2 ("Workflow `--path` support is unevenly implemented") i
 
 - [x] **1.1** Grep each workflow class's `execute()` signature and CLI handler for `--path` / `paths` argument acceptance. **Done 2026-05-12** — see [audit.md](audit.md). The grep recipe in the spec needed adapting (it scoped to `src/attune/workflows/*.py` but 4 workflows live in package subdirs like `src/attune/workflows/doc_audit/workflow.py`).
 - [x] **1.2** Manually verify by running each workflow with `--help` from the CLI. **Done 2026-05-12.** Key finding: the CLI surface `attune workflow run --help` accepts `--path` UNIFORMLY for all workflows; it becomes a `path=...` kwarg in `workflow.execute(**input_data)`. Whether the workflow consumes that kwarg is the real question — answered per-workflow in audit.md.
-- [ ] **1.3** Record findings as `PATH_ARG_REGISTRY` dict (Option 2 from audit.md) in `src/attune/ops/data.py`. Drift-guard test in `tests/unit/ops/test_path_support_registry.py` asserts every workflow has an entry AND that the entry's `kwarg` matches the actual kwarg name in the workflow source. **Pending user approval** to write production code — audit complete; implementation deferred to a separate PR so reviewer can sign off on the three-way (not binary) registry shape.
+- [x] **1.3** Record findings as `PATH_ARG_REGISTRY` dict (Option 2 from audit.md) in `src/attune/ops/data.py`. Drift-guard test in `tests/unit/ops/test_path_support_registry.py` asserts every workflow has an entry AND that the entry's `kwarg` matches the actual kwarg name in the workflow source. **Shipped 2026-05-13** — 19 entries (12 Cat A + 2 Cat B + 5 Cat C), `PathArgSpec` dataclass with `kwarg: str` and `required: bool = False`. 25 drift-guard tests covering coverage drift, kwarg drift, shape invariants, and audit-doc presence. All green.
 
 ## Phase 2 — Scope picker (headline feature)
 

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -35,6 +35,69 @@ class WorkflowEntry:
 
 
 @dataclass(frozen=True)
+class PathArgSpec:
+    """How a workflow accepts a scope path on the CLI.
+
+    The CLI's ``attune workflow run --path`` always sends ``path=<value>``
+    into ``workflow.execute(**input_data)``. Most workflows consume it
+    directly. A few use a different kwarg name (``project_root``,
+    ``src_path``, ``cwd``). The ops runner uses this registry to rewrite
+    the kwarg name before subprocess spawn so the scope picker works
+    uniformly across all workflows.
+
+    Attributes:
+        kwarg: The kwarg name the workflow's ``execute()`` actually
+            consumes. ``"path"`` for the majority; one of
+            ``"project_root"``, ``"src_path"``, ``"cwd"`` for the
+            aliased minority.
+        required: True if the workflow errors when the kwarg is missing.
+            The ops runner should not submit a scope-less run for these
+            (``test-audit`` is the current example).
+    """
+
+    kwarg: str
+    required: bool = False
+
+
+# Per-workflow path-arg registry. Source: docs/specs/ops-runner-tier2/audit.md.
+#
+# Three categories surfaced by the audit:
+#   A — 12 workflows consume ``kwargs.get("path", "")`` directly.
+#   B —  2 workflows (release-prep, secure-release) declare ``path`` as a
+#         signature kwarg.
+#   C —  5 workflows use a different kwarg name.
+#
+# A + B share ``kwarg="path"`` in this registry; C carries the actual name.
+# The drift-guard test in tests/unit/ops/test_path_support_registry.py
+# asserts (a) every registered workflow has an entry, and (b) each entry's
+# kwarg name actually appears in the workflow's execute() source.
+PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
+    # Category A — kwargs.get("path", "")
+    "bug-predict": PathArgSpec(kwarg="path"),
+    "code-review": PathArgSpec(kwarg="path"),
+    "deep-review": PathArgSpec(kwarg="path"),
+    "dependency-check": PathArgSpec(kwarg="path"),
+    "doc-audit": PathArgSpec(kwarg="path"),
+    "doc-gen": PathArgSpec(kwarg="path"),
+    "perf-audit": PathArgSpec(kwarg="path"),
+    "refactor-plan": PathArgSpec(kwarg="path"),
+    "research-synthesis": PathArgSpec(kwarg="path"),
+    "security-audit": PathArgSpec(kwarg="path"),
+    "simplify-code": PathArgSpec(kwarg="path"),
+    "test-gen": PathArgSpec(kwarg="path"),
+    # Category B — direct signature kwarg ``path: str = "."``
+    "release-prep": PathArgSpec(kwarg="path"),
+    "secure-release": PathArgSpec(kwarg="path"),
+    # Category C — aliased to a different kwarg name
+    "doc-orchestrator": PathArgSpec(kwarg="project_root"),
+    "health-check": PathArgSpec(kwarg="project_root"),
+    "orchestrated-health-check": PathArgSpec(kwarg="project_root"),
+    "rag-code-gen": PathArgSpec(kwarg="cwd"),
+    "test-audit": PathArgSpec(kwarg="src_path", required=True),
+}
+
+
+@dataclass(frozen=True)
 class FamilyVersion:
     package: str
     version: str | None

--- a/tests/unit/ops/test_path_support_registry.py
+++ b/tests/unit/ops/test_path_support_registry.py
@@ -1,0 +1,171 @@
+"""Drift-guard tests for `PATH_ARG_REGISTRY`.
+
+The registry maps workflow name → kwarg name the workflow's `execute()`
+actually consumes. The ops runner uses it to rewrite the CLI's uniform
+`--path` into whatever kwarg each workflow expects.
+
+These tests catch drift in two directions:
+
+1. **Coverage drift** — every workflow returned by the workflow registry
+   has a `PATH_ARG_REGISTRY` entry. A new workflow added without a
+   registry entry fails the suite.
+2. **Kwarg drift** — every registry entry's kwarg name actually appears
+   in the workflow source's `execute()` body. A silent rename in a
+   workflow (e.g., `project_root` → `root_dir`) fails the suite.
+
+Source: docs/specs/ops-runner-tier2/audit.md (Phase 1 audit) and
+docs/specs/ops-runner-tier2/tasks.md task 1.3.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from pathlib import Path
+
+import pytest
+
+from attune.ops.data import PATH_ARG_REGISTRY, PathArgSpec
+
+
+def _workflow_source(workflow_name: str) -> str:
+    """Return the source of the workflow's class file.
+
+    The CLI workflow registry exposes `name -> "module.path:ClassName"`.
+    We import the class and read its module's source via `inspect`.
+    """
+    from attune.workflows import get_workflow
+
+    cls = get_workflow(workflow_name)
+    return inspect.getsource(inspect.getmodule(cls))
+
+
+def _registered_workflow_names() -> list[str]:
+    """Return the names every consumer sees from `list_workflows()`."""
+    from attune.workflows import list_workflows
+
+    return sorted(entry["name"] for entry in list_workflows())
+
+
+# ---------------------------------------------------------------------------
+# Coverage drift — every registered workflow has a registry entry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCoverage:
+    """Every workflow exposed via `attune workflow list` must appear in the registry."""
+
+    def test_every_registered_workflow_has_a_registry_entry(self) -> None:
+        registered = set(_registered_workflow_names())
+        registry = set(PATH_ARG_REGISTRY)
+        missing = registered - registry
+        assert not missing, (
+            f"Workflows missing PATH_ARG_REGISTRY entries: {sorted(missing)}. "
+            "Add an entry per docs/specs/ops-runner-tier2/audit.md."
+        )
+
+    def test_no_orphan_registry_entries(self) -> None:
+        registered = set(_registered_workflow_names())
+        registry = set(PATH_ARG_REGISTRY)
+        orphans = registry - registered
+        assert not orphans, (
+            f"PATH_ARG_REGISTRY entries with no matching workflow: "
+            f"{sorted(orphans)}. Likely a renamed/retired workflow — "
+            "remove the entry."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Kwarg drift — each entry's kwarg actually appears in the workflow source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "workflow_name,spec",
+    sorted(PATH_ARG_REGISTRY.items()),
+    ids=sorted(PATH_ARG_REGISTRY),
+)
+class TestRegistryKwargMatchesSource:
+    """Each registered kwarg must actually be consumed by the workflow source."""
+
+    def test_kwarg_appears_in_execute_source(self, workflow_name: str, spec: PathArgSpec) -> None:
+        source = _workflow_source(workflow_name)
+        kwarg = spec.kwarg
+
+        # Acceptable patterns:
+        # - kwargs.get("<kwarg>"  / kwargs.pop("<kwarg>"  / kwargs["<kwarg>"]
+        # - <kwarg>: <type>      (explicit signature parameter)
+        # - <kwarg>=             (explicit keyword in a call)
+        patterns = (
+            f'kwargs.get("{kwarg}"',
+            f'kwargs.pop("{kwarg}"',
+            f'kwargs["{kwarg}"]',
+            f"{kwarg}: str",
+            f"{kwarg}: Path",
+            f"{kwarg}=",
+        )
+        assert any(p in source for p in patterns), (
+            f"PATH_ARG_REGISTRY claims {workflow_name!r} consumes "
+            f"kwarg {kwarg!r}, but none of the expected source patterns "
+            f"appear in the workflow's module. Patterns checked: "
+            f"{patterns!r}. Either update the registry to match the "
+            "workflow's actual kwarg name, or update the workflow to "
+            "accept the registered name."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Sanity checks on the dataclass + categorization
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryShape:
+    """Spot-check the registry's invariants."""
+
+    def test_required_only_set_when_actually_required(self) -> None:
+        # test-audit's src_path is the only currently-required entry; the
+        # audit established that. If a new required entry is added, this
+        # test stays passing — it's a forward-reference, not a cap.
+        required = {n for n, spec in PATH_ARG_REGISTRY.items() if spec.required}
+        assert "test-audit" in required, (
+            "test-audit's src_path is required (errors if missing). "
+            "Registry must mark it required=True so the ops runner can "
+            "block scope-less submissions."
+        )
+
+    def test_kwarg_values_are_known_names(self) -> None:
+        # Defense against typos like "paht" or "Path". Add new kwarg
+        # names here as legitimate workflow patterns expand.
+        known = {"path", "project_root", "src_path", "cwd"}
+        used = {spec.kwarg for spec in PATH_ARG_REGISTRY.values()}
+        unknown = used - known
+        assert not unknown, (
+            f"PATH_ARG_REGISTRY uses unrecognized kwarg names: "
+            f"{sorted(unknown)}. If a new pattern is intentional, add "
+            "it to the `known` set in this test."
+        )
+
+    def test_data_module_exports_registry(self) -> None:
+        # Belt-and-suspenders: confirm the registry is reachable as
+        # `from attune.ops.data import PATH_ARG_REGISTRY`. Catches the
+        # accidental-rename failure mode where a downstream import
+        # breaks silently.
+        mod = importlib.import_module("attune.ops.data")
+        assert hasattr(mod, "PATH_ARG_REGISTRY")
+        assert hasattr(mod, "PathArgSpec")
+
+
+# ---------------------------------------------------------------------------
+# Documentation pointer — these tests are the contract for the audit
+# ---------------------------------------------------------------------------
+
+
+def test_audit_doc_exists() -> None:
+    """The audit doc backing this registry should be in the repo."""
+    repo_root = Path(__file__).resolve().parents[3]
+    audit = repo_root / "docs" / "specs" / "ops-runner-tier2" / "audit.md"
+    assert audit.is_file(), (
+        f"Expected audit doc at {audit} — it's the source of truth for "
+        "PATH_ARG_REGISTRY's three-way categorization. If the audit is "
+        "renamed, update this test's path."
+    )


### PR DESCRIPTION
## Summary

Implements the three-way `PATH_ARG_REGISTRY` per [PR #285](https://github.com/Smart-AI-Memory/attune-ai/pull/285)'s audit recommendation (Option 2 over the spec's literal binary).

## What landed

| File | What |
|---|---|
| `src/attune/ops/data.py` | `PathArgSpec` dataclass (`kwarg: str`, `required: bool = False`) + `PATH_ARG_REGISTRY` dict with all 19 entries |
| `tests/unit/ops/test_path_support_registry.py` | 25 drift-guard tests |
| `docs/specs/ops-runner-tier2/tasks.md` | Phase 1 marked complete |

## Registry contents

```python
PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
    # Category A — kwargs.get("path", "")  [12 workflows]
    "bug-predict": PathArgSpec(kwarg="path"),
    "code-review": PathArgSpec(kwarg="path"),
    ...
    # Category B — signature kwarg ``path: str = "."``  [2 workflows]
    "release-prep": PathArgSpec(kwarg="path"),
    "secure-release": PathArgSpec(kwarg="path"),
    # Category C — aliased  [5 workflows]
    "doc-orchestrator": PathArgSpec(kwarg="project_root"),
    "health-check": PathArgSpec(kwarg="project_root"),
    "orchestrated-health-check": PathArgSpec(kwarg="project_root"),
    "rag-code-gen": PathArgSpec(kwarg="cwd"),
    "test-audit": PathArgSpec(kwarg="src_path", required=True),
}
```

## Drift-guard tests

Two failure modes the test catches:

1. **Coverage drift** — `test_every_registered_workflow_has_a_registry_entry` fails if a new workflow appears in the registry without a `PATH_ARG_REGISTRY` entry. Inverse `test_no_orphan_registry_entries` catches retired workflows.
2. **Kwarg drift** — parametrized `test_kwarg_appears_in_execute_source` per workflow asserts the registry's kwarg name actually appears in the workflow source. Catches silent renames (`project_root` → `root_dir`).

Plus shape sanity:
- `required=True` is set on `test-audit` (the only currently-required entry)
- All kwarg values are in the known set `{"path", "project_root", "src_path", "cwd"}`
- The module exports both `PATH_ARG_REGISTRY` and `PathArgSpec` for downstream imports
- The audit doc backing this registry exists at `docs/specs/ops-runner-tier2/audit.md`

## Test plan

- [x] `pytest tests/unit/ops/test_path_support_registry.py -v` → **25 passed**
- [x] `pytest tests/unit/ops/` → **168 passed** (no regressions)
- [x] Pre-commit hooks pass

## What this PR does NOT do

No runner integration yet. The registry is the data layer; rewriting `path=<value>` → `<workflow-kwarg>=<value>` before subprocess spawn is Phase 2.5 (per `tasks.md`). This PR is the contract — Phase 2 reads from it.

## Spec status after this PR

- Phase 1 (registry verification + implementation): **complete**
- Phases 2–5 (picker UI, persistence, pills, recommendations): pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)