### PR TITLE
docs(specs): bulk status-line pass — 14 specs draft -> approved

### DIFF
--- a/docs/specs/coverage-exclusion-policy/decisions.md
+++ b/docs/specs/coverage-exclusion-policy/decisions.md
@@ -1,5 +1,8 @@
 # Per-decision log — Coverage exclusion policy
 
+**Status:** approved
+
+
 Append-only log. Phase 3A audit findings + per-entry resolution as
 Phase 3B commits land.
 

--- a/docs/specs/ignored-tests/decisions.md
+++ b/docs/specs/ignored-tests/decisions.md
@@ -1,5 +1,8 @@
 # Per-file resolution decisions — `--ignore`-d test files
 
+**Status:** approved
+
+
 Append-only log. One section per file as it's resolved. See `requirements.md`,
 `design.md`, `tasks.md` for the framework.
 

--- a/docs/specs/ops-runner-tier2/decisions.md
+++ b/docs/specs/ops-runner-tier2/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Ops Runner Tier 2
-
-**Status:** draft
+**Status:** approved
 **Owner:** Patrick
 **Opened:** 2026-05-11
 **Predecessors:**

--- a/docs/specs/ops-runner-tier2/design.md
+++ b/docs/specs/ops-runner-tier2/design.md
@@ -1,7 +1,5 @@
 # Design — Ops Runner Tier 2
-
-**Status:** draft
-
+**Status:** approved
 Technical shape of the work. See `requirements.md` for what we're building, `tasks.md` for the phase plan.
 
 ---

--- a/docs/specs/ops-runner-tier2/requirements.md
+++ b/docs/specs/ops-runner-tier2/requirements.md
@@ -1,7 +1,5 @@
 # Requirements — Ops Runner Tier 2
-
-**Status:** draft
-
+**Status:** approved
 User-facing stories and the contracts they imply. See `decisions.md` for context, `design.md` for the technical shape, `tasks.md` for the phase plan.
 
 ---

--- a/docs/specs/test-infrastructure/design.md
+++ b/docs/specs/test-infrastructure/design.md
@@ -1,7 +1,5 @@
 # Spec: Test Infrastructure Reliability
-
-**Status**: draft
-
+**Status:** approved
 ---
 
 ## Phase 2: Design

--- a/docs/specs/test-infrastructure/requirements.md
+++ b/docs/specs/test-infrastructure/requirements.md
@@ -1,7 +1,5 @@
 # Spec: Test Infrastructure Reliability
-
-**Status**: draft
-
+**Status:** approved
 ---
 
 ## Phase 1: Requirements

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -1,5 +1,8 @@
 # Per-module decisions — Test Quality Program
 
+**Status:** approved
+
+
 Append-only log. One section per module as it's worked. See
 `requirements.md`, `design.md`, `tasks.md` for the framework.
 

--- a/docs/specs/test-quality-program/design.md
+++ b/docs/specs/test-quality-program/design.md
@@ -1,7 +1,5 @@
 # Design: Test Quality Program
-
-**Status**: draft
-
+**Status:** approved
 ---
 
 ## Phase 2: Design

--- a/docs/specs/test-quality-program/tasks.md
+++ b/docs/specs/test-quality-program/tasks.md
@@ -1,7 +1,5 @@
 # Tasks: Test Quality Program
-
-**Status**: draft
-
+**Status:** approved
 ---
 
 ## Phase 3: Tasks

--- a/docs/specs/website-update-dashboard-and-fold/decisions.md
+++ b/docs/specs/website-update-dashboard-and-fold/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Website update: dashboard maturity + fold-back
-
-**Status:** draft
+**Status:** approved
 **Owner:** Patrick
 **Opened:** 2026-05-10
 **Companion specs:**

--- a/docs/specs/website-update-dashboard-and-fold/design.md
+++ b/docs/specs/website-update-dashboard-and-fold/design.md
@@ -1,7 +1,5 @@
 # Design — Website update: dashboard maturity + fold-back
-
-**Status:** draft
-
+**Status:** approved
 Technical shape, mitigations, and durable fixes. See `decisions.md` for context, `requirements.md` for user stories, `tasks.md` for the phase plan.
 
 ---

--- a/docs/specs/website-update-dashboard-and-fold/requirements.md
+++ b/docs/specs/website-update-dashboard-and-fold/requirements.md
@@ -1,7 +1,5 @@
 # Requirements — Website update: dashboard maturity + fold-back
-
-**Status:** draft
-
+**Status:** approved
 User-facing stories and contracts. See `decisions.md` for context, `design.md` for mitigations, `tasks.md` for the phase plan.
 
 ---

--- a/docs/specs/windows-xdist-honor/decisions.md
+++ b/docs/specs/windows-xdist-honor/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Windows xdist `-n 1` Honor
-
-**Status:** Draft (2026-05-11)
+**Status:** approved (2026-05-11)
 **Owner:** Patrick
 **Predecessors:** Probe B (coverage-canonical-pattern), Probe C
 (probe-c-memory-investigation)


### PR DESCRIPTION
## Summary

Replicates a prepared spec-status maintenance pass that was sitting in the parent worktree's staging area. 14 spec files get a small status-line update (mostly \`draft\` → \`approved\`) plus minor whitespace tidying around the status header.

## Conflict handling

Six staged files were **deliberately excluded** because main has more authoritative status than \`approved\`:

- \`coverage-canonical-pattern/decisions.md\` — \`paused 2026-05-12\`
- \`ops-security-hardening/*\` (4 files) — \`complete 2026-05-12, pending Phase 5 smoke\`
- \`redis-decoupling/decisions.md\` — \`partial 2026-05-12\`

Two additional files had patch conflicts on the status line because main already has a more informative status:

- \`ops-runner-tier2/tasks.md\` — main: "Phase 1 audit done 2026-05-12..."
- \`website-update-dashboard-and-fold/tasks.md\` — main: "draft — pre-Phase-1 audit done 2026-05-12..."

For both, kept main's version and skipped the simple \`approved\` flip.

## Net result

- 14 files changed, +20 / -30 lines
- Specs promoted to \`approved\`: coverage-exclusion-policy, ignored-tests, ops-runner-tier2, test-infrastructure, test-quality-program, website-update-dashboard-and-fold, windows-xdist-honor

## After merge

The 22 staged files in the parent worktree will largely become no-ops (matched by main). Running \`git pull --rebase\` in the parent then \`git diff --cached\` should show only the 6 conflict files still standing — you can \`git reset HEAD\` those without losing anything.

Doc-only — no code, no CI risk.