### PR TITLE
docs(specs): draft workflow-path-arg-unification (Option 3 follow-up)

### DIFF
--- a/docs/specs/_sequencing.md
+++ b/docs/specs/_sequencing.md
@@ -115,6 +115,22 @@ natural pause.
   - [ ] Enable automated screenshots
 - Spec: [website-update-dashboard-and-fold](website-update-dashboard-and-fold/)
 
+### workflow-path-arg-unification
+
+- Status: draft 2026-05-13 — 5 small PRs (~50 LoC each)
+- Why here: Follow-up to ops-runner-tier2 Phase 1's bridge
+  registry (PR #294). Migrates 5 workflows from
+  `project_root` / `src_path` / `cwd` → `path`. After all 5
+  land, `PATH_ARG_REGISTRY` collapses to a flat
+  `frozenset[str]`.
+- Tasks
+  - [ ] PR-1 — health-check + orchestrated-health-check
+  - [ ] PR-2 — doc-orchestrator
+  - [ ] PR-3 — test-audit (with required-flag handling)
+  - [ ] PR-4 — rag-code-gen (semantic clarification)
+  - [ ] PR-5 — registry simplification (gated)
+- Spec: [workflow-path-arg-unification](workflow-path-arg-unification/)
+
 ---
 
 ## Track D — Standing umbrella (opportunistic)

--- a/docs/specs/ops-runner-tier2/audit.md
+++ b/docs/specs/ops-runner-tier2/audit.md
@@ -121,6 +121,13 @@ internal `project_root` / `src_path` / `cwd`. Cleanest long-term, but
 out of scope for this spec — it's a refactor of 5 workflow files. The
 ops runner would then need no registry at all.
 
+**Follow-up spec drafted 2026-05-13** —
+[`workflow-path-arg-unification`](../workflow-path-arg-unification/)
+covers this work as 4 per-workflow migration PRs + a 5th
+registry-simplification PR. Bridge solution (Option 2 / PR #294) is
+in place; Option 3 is the cleanup that simplifies the registry to a
+flat `frozenset[str]`.
+
 ### Recommendation
 
 **Option 2 (three-way registry with kwarg-name remapping).** Reasons:

--- a/docs/specs/workflow-path-arg-unification/decisions.md
+++ b/docs/specs/workflow-path-arg-unification/decisions.md
@@ -1,0 +1,101 @@
+# Decisions — Workflow `path` Kwarg Unification
+
+Append-only log. Pre-flight findings and per-PR decisions appended as
+work lands.
+
+---
+
+## Origin (2026-05-13)
+
+This spec follows the [`ops-runner-tier2`](../ops-runner-tier2/) Phase 1
+audit (PR #285), which found 5 of 19 workflows use a kwarg name other
+than `path`. PR #294 shipped a three-way `PATH_ARG_REGISTRY` as a
+bridge — workable, but a workaround.
+
+Patrick raised this spec on 2026-05-13: "I still think a fix the
+workflows spec would be worth it." The bridge is the practical
+near-term, but the cleaner long-term fix is to make every workflow
+accept `path` directly. This spec is that long-term fix.
+
+---
+
+## Approach decisions
+
+### D1 — Add `path` as a kwarg, keep old kwargs as deprecated aliases
+
+**Decision**: Accept both names for one major version (v6.8 → v7.0),
+emit `DeprecationWarning` on the old name, prefer `path` when both
+are set.
+
+**Why**: We don't know how many direct API callers exist outside the
+codebase. The bridge maintains backward compat while signaling the
+migration. After v7.0, the old kwargs become hard errors.
+
+**Rejected alternatives**:
+- *Hard cutover now*: would break any external caller relying on the
+  old kwarg name. Even unlikely-but-possible cases (e.g.,
+  `attune-author` or `attune-rag` calling into `health-check` directly)
+  shouldn't bite the user on a minor bump.
+- *Forever-dual-accept*: defeats the purpose of the cleanup.
+
+### D2 — Keep old internal variable names for code clarity
+
+**Decision**: Function signature uses `path`; internal variable names
+in the body can stay as `project_root` / `src_path` / `cwd` if those
+names are more descriptive for the local logic.
+
+**Why**: Public API change is the goal. Internal variable naming is
+a code-style choice that the workflow author should pick. Forcing
+internal renames bloats the diff and risks introducing bugs.
+
+### D3 — `rag-code-gen` keeps `cwd` semantics distinct from `path`
+
+**Decision**: For `rag-code-gen`, `path` becomes a user-facing alias
+for the SDK working directory (`cwd=` in `claude_agent_sdk`). The
+internal `cwd` parameter stays for the SDK call.
+
+**Why**: `cwd` is a real SDK concept (where the agent's tools run). For
+this workflow, "scope path" and "SDK working directory" happen to be
+the same thing. Users want `path` as the consistent kwarg name; the
+SDK's internal needs are separate.
+
+**Pre-flight check needed (Phase 0 task 0.2)**: Confirm `cwd` is the
+SDK working directory, not a scope target. If they're semantically the
+same in this workflow's context, the alias is straightforward.
+
+### D4 — Drop the `required` flag from the registry post-migration
+
+**Decision**: Once `test-audit` accepts `path`, the registry no longer
+needs `required=True`. The workflow's own `execute()` body still
+validates non-empty path and returns `_error_result` — that's where
+the required-ness lives.
+
+**Why**: The `required` flag in `PATH_ARG_REGISTRY` was a hint to the
+ops runner (so the picker could enforce non-empty submission). After
+migration, the workflow's internal validation is the single source of
+truth.
+
+### D5 — `PATH_ARG_REGISTRY` collapses to `frozenset[str]`, not deleted
+
+**Decision**: Post-migration, the registry stays as a flat
+`frozenset[str]` of workflow names that accept `path`. The
+drift-guard test continues to assert every workflow is in the set.
+
+**Why**: Drop-entirely would lose the "every workflow has been
+migrated" guarantee. A `frozenset` is one line of code and gives the
+drift-guard test something to assert against. If the BaseWorkflow ever
+gets a `path: str` parameter at the class level, the registry can be
+deleted then.
+
+---
+
+## Pre-flight findings
+
+*(to be filled in by Phase 0 task 0.1 — sibling-package grep — and
+0.2 — `rag-code-gen` cwd semantics confirmation)*
+
+---
+
+## Per-PR decisions
+
+*(appended as PRs 1–5 land)*

--- a/docs/specs/workflow-path-arg-unification/design.md
+++ b/docs/specs/workflow-path-arg-unification/design.md
@@ -1,0 +1,228 @@
+# Design: Workflow `path` Kwarg Unification
+
+**Status**: draft
+
+---
+
+## Phase 2: Design
+
+### Architecture
+
+Five independent per-workflow migrations + one cleanup PR, each
+shippable in isolation:
+
+```
+PR-1: health-check + orchestrated-health-check       ← shared source file, do together
+PR-2: doc-orchestrator                               ← same pattern as PR-1
+PR-3: test-audit (path replaces required src_path)   ← deprecation warning
+PR-4: rag-code-gen (path → cwd internally)           ← semantic clarification
+PR-5: PATH_ARG_REGISTRY simplification               ← after PR-1..4 all merged
+```
+
+Each per-workflow PR is small (~30–50 LoC). The drift-guard test in
+`tests/unit/ops/test_path_support_registry.py` catches missing entries
+during the migration window — if a workflow's source kwarg changes to
+`path` but the registry isn't updated, the test fires.
+
+### The migration pattern
+
+Each Category C workflow follows the same three-step pattern in its
+`execute()` method:
+
+```python
+async def execute(self, **kwargs: Any) -> WorkflowResult:
+    # 1. Accept BOTH the new name and the legacy name.
+    path_arg: str = kwargs.get("path", "")
+    legacy_arg: str = kwargs.get("<old_name>", "")  # project_root / src_path / cwd
+
+    # 2. If only the legacy name is set, warn and forward.
+    if legacy_arg and not path_arg:
+        import warnings
+        warnings.warn(
+            f"Passing `{old_name}=` to {workflow_name} is deprecated; "
+            f"use `path=` instead. Will be removed in v8.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        path_arg = legacy_arg
+
+    # 3. Internal variable name stays as it was for code clarity.
+    # ... rest of execute() unchanged
+```
+
+The two-kwarg-accept window lasts one minor version (v6.8 → v6.9). In
+v7.0 (next major), the legacy kwargs become hard errors with a clear
+migration message.
+
+### Per-workflow specifics
+
+**`health-check` / `orchestrated-health-check` (same source file)**
+
+Current signature:
+```python
+async def execute(
+    self,
+    project_root: str | None = None,
+    context: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> WorkflowResult:
+```
+
+New signature:
+```python
+async def execute(
+    self,
+    path: str | None = None,
+    *,
+    project_root: str | None = None,   # deprecated alias
+    context: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> WorkflowResult:
+    if project_root and not path:
+        warnings.warn(...)
+        path = project_root
+    # body uses path; existing `self.project_root = Path(path).resolve()` line uses
+    # path-the-local-variable, no rename needed
+```
+
+The "Map 'target' to 'project_root' for VSCode compat" block at lines
+24-26 of the source file becomes "Map 'target' to 'path'." Backward
+compat for `target=` stays.
+
+**`doc-orchestrator`**
+
+Current signature:
+```python
+async def execute(
+    self,
+    context: dict | None = None,
+    **kwargs: Any,
+) -> WorkflowResult:
+```
+
+Body uses `kwargs.get("project_root")`. New body:
+```python
+async def execute(
+    self,
+    context: dict | None = None,
+    **kwargs: Any,
+) -> WorkflowResult:
+    path = kwargs.get("path") or kwargs.get("project_root")
+    if kwargs.get("project_root") and not kwargs.get("path"):
+        warnings.warn(...)
+    # ... rest unchanged
+```
+
+**`test-audit`**
+
+This is the only `required=True` case. Current:
+```python
+async def execute(self, **kwargs: Any) -> WorkflowResult:
+    src_path_arg: str = kwargs.get("src_path", "")
+    if not src_path_arg:
+        return self._error_result("src_path argument is required")
+```
+
+New:
+```python
+async def execute(self, **kwargs: Any) -> WorkflowResult:
+    # Accept both names; prefer `path` if both are set.
+    path_arg: str = kwargs.get("path") or kwargs.get("src_path", "")
+    if kwargs.get("src_path") and not kwargs.get("path"):
+        warnings.warn("src_path= is deprecated; use path=", DeprecationWarning)
+    if not path_arg:
+        return self._error_result("path argument is required (was: src_path)")
+    # Internal variable can stay as src_path for clarity:
+    src_path = path_arg
+    # ... rest unchanged
+```
+
+Error message updates so users see "path argument is required" rather
+than the deprecated name.
+
+**`rag-code-gen`**
+
+Two-kwarg semantic merge. Current uses `cwd` to mean "SDK working
+directory." After the migration, `path` becomes the public name and
+internal usage stays as `cwd`:
+
+```python
+async def execute(self, **kwargs: Any) -> WorkflowResult:
+    path_arg = kwargs.get("path") or kwargs.get("cwd")
+    if kwargs.get("cwd") and not kwargs.get("path"):
+        warnings.warn("cwd= is deprecated; use path=", DeprecationWarning)
+    # Forward to the SDK's cwd parameter, semantics unchanged:
+    cwd_for_sdk = path_arg or os.getcwd()
+    # ... rest unchanged
+```
+
+### PR-5: registry simplification
+
+After PRs 1–4 land, `PATH_ARG_REGISTRY` is collapsed:
+
+```python
+# Before:
+PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
+    "bug-predict": PathArgSpec(kwarg="path"),
+    "code-review": PathArgSpec(kwarg="path"),
+    ...
+    "health-check": PathArgSpec(kwarg="project_root"),
+    "test-audit": PathArgSpec(kwarg="src_path", required=True),
+    ...
+}
+
+# After:
+WORKFLOWS_ACCEPTING_PATH: frozenset[str] = frozenset({
+    "bug-predict", "code-review", "deep-review", "dependency-check",
+    "doc-audit", "doc-gen", "doc-orchestrator", "health-check",
+    "orchestrated-health-check", "perf-audit", "rag-code-gen",
+    "refactor-plan", "release-prep", "research-synthesis",
+    "secure-release", "security-audit", "simplify-code",
+    "test-audit", "test-gen",
+})
+
+# Or: drop the registry entirely and treat "accepts path" as the contract
+# that the drift-guard test enforces against EVERY workflow.
+```
+
+The `PathArgSpec` dataclass and the ops-runner kwarg-remap logic
+become deletable. Drift-guard tests in
+`tests/unit/ops/test_path_support_registry.py` simplify too:
+
+```python
+# Before — parametrized per workflow checking source kwarg name
+# After — assert every workflow has `path` in its execute() signature
+```
+
+### Risks
+
+| # | Risk | Mitigation |
+|---|---|---|
+| 1 | Downstream caller passes `project_root=path` after the deprecation window | One-major-release deprecation period (v6.8 → v7.0); CHANGELOG calls it out; the DeprecationWarning is informative |
+| 2 | Internal code in attune-* sibling packages uses old kwarg names | Pre-PR grep across `attune-author`, `attune-help`, `attune-rag`, `attune-software` for `project_root=`, `src_path=`, `cwd=` keyword usage on these workflows |
+| 3 | Workflow body keeps using the old variable name and forgets to plumb new `path` arg | Test that calls `execute(path="src/foo")` and asserts the internal path actually scopes the run |
+| 4 | `PathArgSpec.required=True` semantics get lost for test-audit | The new body still returns `_error_result` if neither `path` nor `src_path` is set; drift-guard test verifies test-audit's signature requires non-empty path |
+| 5 | Mutual exclusion: user passes BOTH `path=` and old kwarg | Document in DeprecationWarning that `path=` wins when both are set; verify in tests |
+
+### Decision points at execution time
+
+- **D1.** Should `path` be positional-or-keyword (like `release-prep`'s current `path: str = "."`) or keyword-only? Keyword-only is safer (no risk of confusing with `context`); positional-or-keyword matches the existing convention. Recommend keyword-only for all 5.
+- **D2.** Drop `PATH_ARG_REGISTRY` entirely or keep as a `frozenset` post-migration? `frozenset` preserves the drift-guard's "every workflow has an entry" check. Drop entirely if every workflow is path-accepting by construction (e.g., a BaseWorkflow assertion). Recommend `frozenset` for now.
+- **D3.** Should the deprecation period be one minor or one major? One major is more conservative; one minor matches the spec's intent and the actual blast radius (we control most callers). Recommend one major (v6.8 → v7.0).
+
+### Out-of-scope cross-references
+
+- **ops-runner-tier2 Phase 2+**: The scope picker uses `PATH_ARG_REGISTRY` today. After this spec's PR-5 lands, the picker can read from the simpler `frozenset`. No coordination needed — ops-runner-tier2 can stay on the current registry shape while this spec migrates.
+- **`attune-author` / `attune-rag` / sibling packages**: If they call any of these 5 workflows by name (unlikely but possible), they need their own minor-version bumps to switch to `path=`. Pre-PR grep flags any such call sites.
+- **MCP tool schemas**: The MCP `*` tools that wrap these workflows already pass through `path=` from their JSON schema. No MCP schema change needed.
+
+### Failure-to-deliver fallback
+
+If a Category C workflow turns out to have internal-variable-naming or sibling-package coupling that makes the migration costly:
+
+1. **Mark that workflow's PR as `deferred`** in this spec's `tasks.md`.
+2. **Keep its entry in `PATH_ARG_REGISTRY`** (the bridge stays in place for that one workflow).
+3. **PR-5 simplification is `partial`** — registry shrinks but doesn't collapse to a flat frozenset.
+4. **Document the holdout** in `decisions.md` with a follow-up note.
+
+The spec is **done** when at least 4 of the 5 workflows accept `path` AND `PATH_ARG_REGISTRY` is either flat or contains ≤1 entry.

--- a/docs/specs/workflow-path-arg-unification/requirements.md
+++ b/docs/specs/workflow-path-arg-unification/requirements.md
@@ -1,0 +1,86 @@
+# Spec: Workflow `path` Kwarg Unification
+
+**Status**: draft
+**Created**: 2026-05-13
+**Origin**: Follow-up to [`ops-runner-tier2`](../ops-runner-tier2/) Phase 1 audit. The audit (PR #285) found 5 of 19 workflows use a kwarg name other than `path` (`project_root`, `src_path`, `cwd`). PR #294 shipped a three-way `PATH_ARG_REGISTRY` as the bridge solution. This spec is the long-term cleanup that simplifies the registry to a binary.
+
+---
+
+## Phase 1: Requirements
+
+### Problem
+
+The CLI's `attune workflow run --path` accepts a uniform path argument for every workflow. Under the hood, it becomes a `path=...` kwarg in `workflow.execute(**input_data)`. But 5 workflows consume the kwarg under different names:
+
+| Workflow | Actual kwarg | Source file |
+|---|---|---|
+| `health-check` | `project_root` | `src/attune/workflows/orchestrated_health_check.py` |
+| `orchestrated-health-check` | `project_root` | (same file as above) |
+| `doc-orchestrator` | `project_root` | `src/attune/workflows/documentation_orchestrator.py` |
+| `test-audit` | `src_path` (required) | `src/attune/workflows/test_audit/workflow.py` |
+| `rag-code-gen` | `cwd` | `src/attune/workflows/rag_code_gen.py` |
+
+The current bridge solution (`PATH_ARG_REGISTRY` in `src/attune/ops/data.py`) catalogs this inconsistency so the ops runner can remap kwargs before subprocess spawn. The registry works — but it's a workaround. The cleaner long-term fix is to make every workflow accept `path` directly.
+
+### Why this is its own spec, not a delta on ops-runner-tier2
+
+Ops-runner-tier2 needs to ship the scope picker with current workflow APIs intact. Fixing the workflows is a parallel cleanup that:
+
+- Touches 5 workflow files + their tests
+- Should preserve backward compatibility (existing callers using `project_root=` / `src_path=` / `cwd=` shouldn't break)
+- Is independent of any ops-runner UI work
+- Once shipped, simplifies `PATH_ARG_REGISTRY` to "everything is `path`" (the registry can then become a sanity-check `frozenset` rather than a kwarg-remap table)
+
+### Goals
+
+- **G1.** Every workflow's `execute()` accepts `path` as a kwarg with the same semantics as the workflows that already accept it.
+- **G2.** Backward compatibility — existing direct API callers using the old kwarg names (`project_root=`, `src_path=`, `cwd=`) continue to work, with a `DeprecationWarning` for one minor release.
+- **G3.** `PATH_ARG_REGISTRY` simplifies to a `frozenset[str]` of registered workflow names (drift-guard only); the kwarg-remap logic in the ops runner becomes dead code that can be removed.
+- **G4.** Documentation in each workflow's docstring updates to show `path=` as the canonical example, with a one-line note about the legacy kwarg name.
+
+### Non-goals
+
+- **Not a rewrite.** Each workflow's `execute()` body keeps the same internal kwarg name where it makes sense (`project_root` is a clearer variable name for `health-check`'s scope; `src_path` is more accurate for `test-audit`). The contract change is at the function signature only.
+- **Not changing semantics.** `path` means the same thing across all 19 workflows: "scope this run to this directory."
+- **Not adding new validation.** The CLI's `_validate_file_path()` already runs before the kwarg lands in `execute()`. No additional check needed at the workflow level.
+- **Not touching `PATH_ARG_REGISTRY` until ALL 5 workflows are migrated.** Premature deletion would leave the ops runner without the kwarg-remap fallback during a partial migration.
+
+### Documented categories
+
+The 5 workflows split into three migration patterns:
+
+**Pattern A — Single-alias forward (3 workflows).**
+- `health-check` / `orchestrated-health-check` — accept `path=` in execute(), forward to `project_root` internally.
+- `doc-orchestrator` — same pattern (forward to `project_root`).
+
+**Pattern B — Renamed kwarg with deprecation (1 workflow).**
+- `test-audit` — accept `path=` as the new canonical name, keep `src_path=` accepting + emitting `DeprecationWarning`.
+
+**Pattern C — Semantic clarification (1 workflow).**
+- `rag-code-gen` — `cwd` is genuinely different from `path` (it's the SDK working directory, not a scope target). Two options:
+  - C1: Add `path=` as a new kwarg meaning "scope to this directory," set `cwd=path` internally.
+  - C2: Document that `path` and `cwd` are the same thing for this workflow, accept both.
+  - **C1 recommended** — clearer semantics, matches the user-facing meaning.
+
+### Public-API impact
+
+- **Direct callers** (uncommon — most users go via CLI): old kwarg names trigger `DeprecationWarning` for one minor version, then become hard errors.
+- **CLI users**: no change — they already use `--path` regardless of internal kwarg name.
+- **Ops dashboard users**: no change — the runner's kwarg remap continues to work during migration, and the user-visible picker is unchanged.
+
+### Stop-and-decide thresholds
+
+- **If any workflow's internal logic depends on the variable name** beyond signature naming (e.g., a docstring inspection looks up `self.execute.__signature__.parameters["project_root"]`), pause and reconsider — may need a wrapper instead of a rename.
+- **If the migration breaks downstream callers we don't control** (e.g., a sibling package like `attune-author` calls `health_check.execute(project_root=...)` directly), bump the deprecation window from "next minor" to "next major release."
+
+---
+
+## Acceptance criteria
+
+The spec is **done** when:
+
+1. All 5 workflows' `execute()` signatures accept `path` as a kwarg.
+2. Direct API tests confirm both `path=` (new) and old kwarg names (with `DeprecationWarning`) work.
+3. `PATH_ARG_REGISTRY` reduced to a flat `frozenset[str]` (drift-guard); the `PathArgSpec` dataclass and remap logic in the ops runner are deletable.
+4. CHANGELOG entry under `Changed` documents the deprecation window.
+5. No regressions in existing test coverage; full unit suite green.

--- a/docs/specs/workflow-path-arg-unification/tasks.md
+++ b/docs/specs/workflow-path-arg-unification/tasks.md
@@ -1,0 +1,121 @@
+# Tasks — Workflow `path` Kwarg Unification
+
+**Status**: draft
+
+Five per-workflow migrations + one registry-simplification PR. Each
+per-workflow PR is independent and shippable in any order; PR-5 is
+gated on PRs 1–4 landing.
+
+---
+
+## Phase 0 — Pre-flight (one-time, before any per-workflow PR)
+
+- [ ] **0.1** Grep `attune-author`, `attune-help`, `attune-rag`, `attune-software` (sibling packages) for keyword usage of the legacy names on these 5 workflows:
+      ```
+      git grep -nE "project_root=|src_path=|cwd=" ../attune-*/src/
+      ```
+      Document any hits in `decisions.md` — they need coordinated minor-version bumps.
+
+- [ ] **0.2** Confirm the `claude_agent_sdk` `cwd=` parameter on `rag-code-gen` is the SDK working directory (not a scope target). If they're semantically distinct (likely), the migration to `path` is a layer above `cwd` — both can coexist with `path` being the user-facing alias.
+
+---
+
+## Phase 1 — Per-workflow migrations (each is its own PR)
+
+### PR-1 — `health-check` + `orchestrated-health-check`
+
+Shared source file: `src/attune/workflows/orchestrated_health_check.py`.
+
+- [ ] **1.1** Update `execute()` signature: accept keyword-only `path: str | None = None`; keep `project_root` as deprecated alias.
+- [ ] **1.2** Emit `DeprecationWarning` when `project_root=` is set without `path=`.
+- [ ] **1.3** Update the existing "Map 'target' to 'project_root' for VSCode compat" block to map to `path` instead. Keep `target=` accepting.
+- [ ] **1.4** Update class docstring's example to use `path=`. Note legacy alias in a one-line comment.
+- [ ] **1.5** Add tests:
+      - `test_execute_accepts_path_kwarg` — `execute(path=...)` works
+      - `test_execute_legacy_project_root_warns` — `execute(project_root=...)` emits `DeprecationWarning` AND still runs
+      - `test_execute_both_kwargs_path_wins` — `execute(path="a", project_root="b")` uses `"a"`, warns
+      - `test_target_still_maps_to_path` — `execute(target=...)` still works (VSCode compat)
+- [ ] **1.6** Update `PATH_ARG_REGISTRY` entry for both workflows: change `kwarg="project_root"` → `kwarg="path"`. Drift-guard test in `tests/unit/ops/test_path_support_registry.py` then validates the migration completed.
+
+### PR-2 — `doc-orchestrator`
+
+Source file: `src/attune/workflows/documentation_orchestrator.py`.
+
+- [ ] **2.1** Update `execute()` body to read `kwargs.get("path") or kwargs.get("project_root")`, with `DeprecationWarning` on the latter.
+- [ ] **2.2** Update class docstring example.
+- [ ] **2.3** Add tests (same shape as 1.5 minus the `target` test).
+- [ ] **2.4** Update `PATH_ARG_REGISTRY` entry.
+
+### PR-3 — `test-audit`
+
+Source file: `src/attune/workflows/test_audit/workflow.py`.
+
+- [ ] **3.1** Update `execute()` body: accept `path` first, fall back to `src_path` with `DeprecationWarning`. Internal variable can stay `src_path` for code clarity — only the public kwarg name changes.
+- [ ] **3.2** Update error message: `"path argument is required"` instead of `"src_path argument is required"`. Include `(was: src_path)` to bridge the rename in the immediate window.
+- [ ] **3.3** Update class docstring example.
+- [ ] **3.4** Add tests (same shape as PR-2's, plus the `required` case — `execute()` with no path returns `_error_result`).
+- [ ] **3.5** Update `PATH_ARG_REGISTRY` entry: `kwarg="src_path"` → `kwarg="path"`; `required=True` stays.
+
+### PR-4 — `rag-code-gen`
+
+Source file: `src/attune/workflows/rag_code_gen.py`.
+
+**Decision needed at PR-author time**: option C1 (add `path` as separate kwarg meaning "scope target") vs option C2 (treat `path` as an alias for `cwd`). Default to C1 if `cwd` is genuinely the SDK working-directory (not user-scope); confirm in Phase 0 task 0.2.
+
+- [ ] **4.1** Update `execute()` body to accept both kwargs; map `path → cwd` internally for the SDK.
+- [ ] **4.2** Update class docstring.
+- [ ] **4.3** Add tests.
+- [ ] **4.4** Update `PATH_ARG_REGISTRY` entry: `kwarg="cwd"` → `kwarg="path"`.
+
+---
+
+## Phase 2 — Registry simplification (PR-5)
+
+Gated on PRs 1–4 all merged.
+
+- [ ] **5.1** Verify all 19 workflows now accept `path`: run `pytest tests/unit/ops/test_path_support_registry.py -v` and confirm every parametrized `TestRegistryKwargMatchesSource::test_kwarg_appears_in_execute_source[*]` test asserts kwarg=`"path"`.
+- [ ] **5.2** Collapse `PATH_ARG_REGISTRY: dict[str, PathArgSpec]` → `WORKFLOWS_ACCEPTING_PATH: frozenset[str]`. Drop the `PathArgSpec` dataclass entirely.
+- [ ] **5.3** Update `tests/unit/ops/test_path_support_registry.py`:
+      - Remove the parametrized kwarg-drift tests (now uniformly `path`)
+      - Keep the coverage-drift test (every workflow in the registry, no orphans)
+      - Keep the shape-invariant tests but drop `required` semantics
+- [ ] **5.4** Remove the kwarg-remap logic in the ops runner (Phase 2.5 of `ops-runner-tier2`, if landed; otherwise no-op since runner doesn't read remap yet).
+- [ ] **5.5** CHANGELOG entry under `Changed`: document the deprecation window (v6.8 → v7.0) and the new uniform `path` kwarg.
+- [ ] **5.6** Update the `ops-runner-tier2` Phase 1.3 references in `docs/specs/` to point at the simplified registry.
+
+---
+
+## Phase 3 — Spec close
+
+- [ ] **6.1** All 5 workflows accept `path`; tests green; CI green on merged commits.
+- [ ] **6.2** `PATH_ARG_REGISTRY` simplified or deleted.
+- [ ] **6.3** CHANGELOG documents the deprecation window.
+- [ ] **6.4** Mark spec status `complete` in all three .md files.
+- [ ] **6.5** Update parent spec (`ops-runner-tier2/`) tasks.md to note the simplification.
+
+---
+
+## Failure-to-deliver path
+
+If a per-workflow PR (1–4) hits unexpected coupling that makes the migration risky:
+
+1. Mark that PR's row as `deferred` with the blocker named in Notes.
+2. Keep that workflow's entry in `PATH_ARG_REGISTRY` (`PathArgSpec(kwarg="<old>", ...)`).
+3. PR-5 ships with a smaller-but-not-flat registry — still net positive (fewer aliased entries).
+4. Spec status flips to `partial`; the unfinished workflow is documented in `decisions.md`.
+
+The spec is **done** when at least 4 of the 5 workflows are migrated AND the registry has shrunk meaningfully.
+
+---
+
+## Sequencing inside Phase 1
+
+All four PRs are independent. Suggested order (smallest first):
+
+1. **PR-2 (`doc-orchestrator`)** — single workflow, no shared file, simplest case.
+2. **PR-1 (`health-check` + `orchestrated-health-check`)** — two workflows sharing a file, pattern-confirms.
+3. **PR-3 (`test-audit`)** — adds the `required` semantics case.
+4. **PR-4 (`rag-code-gen`)** — has the semantic-clarification decision (C1 vs C2) so leave for last when the pattern is well-rehearsed.
+5. **PR-5 (registry simplification)** — gated.
+
+Total estimate: 4 × ~50 LoC migrations + ~30 LoC simplification = ~230 LoC over 5 small PRs.


### PR DESCRIPTION
## Summary

Drafts the long-term cleanup for the kwarg-name inconsistency surfaced by `ops-runner-tier2`'s Phase 1 audit ([PR #285](https://github.com/Smart-AI-Memory/attune-ai/pull/285)). [PR #294](https://github.com/Smart-AI-Memory/attune-ai/pull/294) shipped a three-way `PATH_ARG_REGISTRY` as the **bridge**; this spec is **Option 3** — migrate the 5 Category C workflows to accept `path` directly so the registry collapses to a flat `frozenset[str]`.

## Approach

5 small PRs (~50 LoC each), independent:

| PR | Workflows | Pattern |
|---|---|---|
| PR-1 | `health-check` + `orchestrated-health-check` (shared source) | Forward `path` → `project_root` internally |
| PR-2 | `doc-orchestrator` | Same as PR-1 |
| PR-3 | `test-audit` | Renamed kwarg; required-flag stays in workflow body |
| PR-4 | `rag-code-gen` | `path` becomes user-facing alias for SDK `cwd` |
| PR-5 | Registry simplification | `PATH_ARG_REGISTRY` → `frozenset[str]` (gated on PRs 1–4) |

Each per-workflow PR keeps both kwarg names for one major release (v6.8 → v7.0) with `DeprecationWarning` on the old name. v7.0 makes old kwargs hard errors.

## Key decisions

| # | Decision |
|---|---|
| D1 | One-major deprecation window (not minor) — conservative for unknown direct callers |
| D2 | Internal variable names can stay (`project_root` is clearer for health-check's locals); only signature changes |
| D3 | `rag-code-gen`'s `cwd` semantics stay; `path` becomes a user-facing alias |
| D4 | Drop `required=True` flag from registry post-migration — validation moves to workflow body |
| D5 | `PATH_ARG_REGISTRY` collapses to `frozenset[str]`, not deleted — drift-guard test stays useful |

## Files

- `docs/specs/workflow-path-arg-unification/requirements.md` — problem statement + goals/non-goals
- `docs/specs/workflow-path-arg-unification/design.md` — per-workflow migration patterns + risks
- `docs/specs/workflow-path-arg-unification/tasks.md` — 5-PR phased plan + sequencing
- `docs/specs/workflow-path-arg-unification/decisions.md` — D1–D5 captured
- `docs/specs/ops-runner-tier2/audit.md` — back-link added to "Option 3" section
- `docs/specs/_sequencing.md` — new Track C entry

## What this PR does NOT do

Pure docs PR — no code changes. The actual migrations (PRs 1–5 of this spec) come later.

## Test plan

- [x] All four spec `.md` files have status `draft`
- [x] Back-link from `ops-runner-tier2/audit.md` resolves to the new spec dir
- [x] `_sequencing.md` Track C lists the new spec
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)