### PR TITLE
feat(workflows): unify health-check path kwarg (PR-1 of 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   classes, pin `attune-ai<6.8.0` or copy them from the v6.7.x
   source tree.
 
+### Deprecated
+
+- `OrchestratedHealthCheckWorkflow.execute(project_root=...)` —
+  use `execute(path=...)` instead. The legacy kwarg emits a
+  `DeprecationWarning` and will be removed in v7.0. First PR
+  of `docs/specs/workflow-path-arg-unification/` (PR-1 of 5);
+  unifies the path-arg kwarg name across all workflows for the
+  ops-runner-tier2 scope picker. The `target=` kwarg (VSCode
+  compat) still works and now maps to `path` internally.
+
 ### Changed (Breaking)
 
 - `[memory]` install extra removed (now an empty no-op alias for backward

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -90,8 +90,10 @@ PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
     "secure-release": PathArgSpec(kwarg="path"),
     # Category C — aliased to a different kwarg name
     "doc-orchestrator": PathArgSpec(kwarg="project_root"),
-    "health-check": PathArgSpec(kwarg="project_root"),
-    "orchestrated-health-check": PathArgSpec(kwarg="project_root"),
+    # health-check + orchestrated-health-check migrated to `path` in
+    # workflow-path-arg-unification PR-1 (2026-05-13).
+    "health-check": PathArgSpec(kwarg="path"),
+    "orchestrated-health-check": PathArgSpec(kwarg="path"),
     "rag-code-gen": PathArgSpec(kwarg="cwd"),
     "test-audit": PathArgSpec(kwarg="src_path", required=True),
 }

--- a/src/attune/workflows/orchestrated_health_check.py
+++ b/src/attune/workflows/orchestrated_health_check.py
@@ -28,7 +28,7 @@ Quality Criteria (weighted):
 
 Example:
     >>> workflow = OrchestratedHealthCheckWorkflow(mode="weekly")
-    >>> report = await workflow.execute(project_root=".")
+    >>> report = await workflow.execute(path=".")
     >>> print(f"{report.overall_health_score}/100 ({report.grade})")
     85/100 (B)
 
@@ -40,6 +40,7 @@ Licensed under the Apache License, Version 2.0
 import asyncio
 import logging
 import time
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -98,7 +99,7 @@ class OrchestratedHealthCheckWorkflow(BaseWorkflow):
         >>> workflow = OrchestratedHealthCheckWorkflow(
         ...     mode="weekly"
         ... )
-        >>> report = await workflow.execute(project_root=".")
+        >>> report = await workflow.execute(path=".")
         >>> if report.overall_health_score >= 80:
         ...     print("Project is healthy!")
 
@@ -177,6 +178,8 @@ class OrchestratedHealthCheckWorkflow(BaseWorkflow):
 
     async def execute(
         self,
+        path: str | None = None,
+        *,
         project_root: str | None = None,
         context: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -184,25 +187,47 @@ class OrchestratedHealthCheckWorkflow(BaseWorkflow):
         """Execute health check workflow.
 
         Args:
-            project_root: Optional project root (overrides init
-                value)
+            path: Optional project root (overrides init value).
+                Replaces the deprecated `project_root=` kwarg.
+            project_root: Deprecated alias for `path`. Emits
+                `DeprecationWarning`; will be removed in v7.0.
             context: Additional context for agents
             **kwargs: Extra parameters (ignored, for VSCode/CLI
-                compatibility)
+                compatibility). The `target=` kwarg is still
+                accepted as an alias for `path=`.
 
         Returns:
             HealthCheckReport with comprehensive health
             assessment
 
         Raises:
-            ValueError: If project_root is invalid
+            ValueError: If path is invalid
 
         """
-        # Map 'target' to 'project_root' for VSCode compat
-        if "target" in kwargs and not project_root:
-            project_root = kwargs["target"]
-        if project_root:
-            self.project_root = Path(project_root).resolve()
+        # Migrate the deprecated `project_root=` kwarg → `path=`.
+        if project_root is not None and path is None:
+            warnings.warn(
+                "OrchestratedHealthCheckWorkflow.execute(project_root=...) "
+                "is deprecated; use execute(path=...) instead. "
+                "The legacy kwarg will be removed in v7.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            path = project_root
+        elif project_root is not None and path is not None:
+            warnings.warn(
+                "OrchestratedHealthCheckWorkflow.execute(): both "
+                "`path=` and `project_root=` supplied; `path=` "
+                "takes precedence and `project_root=` is deprecated.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        # Map 'target' to 'path' for VSCode compat.
+        if "target" in kwargs and path is None:
+            path = kwargs["target"]
+        if path is not None:
+            self.project_root = Path(path).resolve()
 
         if not self.project_root.exists():
             raise ValueError(f"Project root does not exist: {self.project_root}")

--- a/tests/unit/workflows/test_orchestrated_health_check.py
+++ b/tests/unit/workflows/test_orchestrated_health_check.py
@@ -711,5 +711,98 @@ async def test_health_check_integration(tmp_path):
         assert report.grade in output
 
 
+class TestExecutePathKwarg:
+    """Tests for the `path=` kwarg migration in `execute()`.
+
+    PR-1 of workflow-path-arg-unification (2026-05-13) renames the
+    `project_root=` kwarg on `execute()` to `path=`, keeping the
+    legacy name as a deprecated alias for one major version.
+    """
+
+    @pytest.fixture
+    def _mock_strategy(self):
+        """Patch ParallelStrategy so execute() returns quickly."""
+        with patch("attune.workflows.orchestrated_health_check.ParallelStrategy") as mock_strategy:
+            mock_result = StrategyResult(
+                success=True,
+                outputs=[
+                    AgentResult(
+                        agent_id="security_auditor",
+                        success=True,
+                        output={"critical_issues": 0, "high_issues": 0, "medium_issues": 0},
+                        confidence=0.9,
+                        duration_seconds=0.1,
+                    ),
+                    AgentResult(
+                        agent_id="test_coverage_analyzer",
+                        success=True,
+                        output={"coverage_percent": 80.0},
+                        confidence=0.9,
+                        duration_seconds=0.1,
+                    ),
+                    AgentResult(
+                        agent_id="code_reviewer",
+                        success=True,
+                        output={"quality_score": 8.0},
+                        confidence=0.9,
+                        duration_seconds=0.1,
+                    ),
+                ],
+                aggregated_output={},
+                total_duration=0.3,
+            )
+            mock_strategy.return_value.execute = AsyncMock(return_value=mock_result)
+            yield mock_strategy
+
+    @pytest.mark.asyncio
+    async def test_execute_accepts_path_kwarg(self, tmp_path, _mock_strategy):
+        """execute(path=...) overrides self.project_root."""
+        other_root = tmp_path / "other"
+        other_root.mkdir()
+        workflow = OrchestratedHealthCheckWorkflow(mode="daily", project_root=str(tmp_path))
+
+        await workflow.execute(path=str(other_root))
+
+        assert workflow.project_root == other_root.resolve()
+
+    @pytest.mark.asyncio
+    async def test_execute_legacy_project_root_warns(self, tmp_path, _mock_strategy):
+        """execute(project_root=...) emits DeprecationWarning AND still runs."""
+        other_root = tmp_path / "other"
+        other_root.mkdir()
+        workflow = OrchestratedHealthCheckWorkflow(mode="daily", project_root=str(tmp_path))
+
+        with pytest.warns(DeprecationWarning, match="project_root"):
+            report = await workflow.execute(project_root=str(other_root))
+
+        assert workflow.project_root == other_root.resolve()
+        assert report.success is True
+
+    @pytest.mark.asyncio
+    async def test_execute_both_kwargs_path_wins(self, tmp_path, _mock_strategy):
+        """execute(path=A, project_root=B) uses A and warns about the conflict."""
+        path_root = tmp_path / "via_path"
+        path_root.mkdir()
+        legacy_root = tmp_path / "via_legacy"
+        legacy_root.mkdir()
+        workflow = OrchestratedHealthCheckWorkflow(mode="daily", project_root=str(tmp_path))
+
+        with pytest.warns(DeprecationWarning, match="both"):
+            await workflow.execute(path=str(path_root), project_root=str(legacy_root))
+
+        assert workflow.project_root == path_root.resolve()
+
+    @pytest.mark.asyncio
+    async def test_target_still_maps_to_path(self, tmp_path, _mock_strategy):
+        """The VSCode-compat target= kwarg still routes to path."""
+        other_root = tmp_path / "via_target"
+        other_root.mkdir()
+        workflow = OrchestratedHealthCheckWorkflow(mode="daily", project_root=str(tmp_path))
+
+        await workflow.execute(target=str(other_root))
+
+        assert workflow.project_root == other_root.resolve()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
First per-workflow migration of [docs/specs/workflow-path-arg-unification/](docs/specs/workflow-path-arg-unification/) (still in [#296](https://github.com/Smart-AI-Memory/attune-ai/pull/296) as a draft). Renames the `project_root=` kwarg on `OrchestratedHealthCheckWorkflow.execute()` to `path=`, with the old name preserved as a deprecated alias for one major version.

Covers both `health-check` and `orchestrated-health-check` registry entries in [PATH_ARG_REGISTRY](src/attune/ops/data.py) — they share a single source class.

## Audit finding worth flagging

The spec's "Sequencing inside Phase 1" listed PR-2 (`doc-orchestrator`) as the simplest first pick. While preparing PR-2, I found that `DocumentationOrchestrator.execute()` doesn't actually consume `project_root` from kwargs — it relies entirely on `self.project_root` set at `__init__`, with derived state (`self.export_path`, `self._project_index`) also baked in at construction. Applying the spec literally would add a kwarg with no runtime effect. PR-2 needs a re-scoped migration (either re-derive derived state in execute(), or treat as a no-op signature alignment). Documented for the spec follow-up; switched to PR-1 which has a clean `execute(project_root=...)` body already.

## Changes

| File | Change |
|---|---|
| [src/attune/workflows/orchestrated_health_check.py](src/attune/workflows/orchestrated_health_check.py) | Signature + body + docstrings |
| [src/attune/ops/data.py](src/attune/ops/data.py) | Registry flip: `kwarg="project_root"` → `kwarg="path"` for both entries |
| [tests/unit/workflows/test_orchestrated_health_check.py](tests/unit/workflows/test_orchestrated_health_check.py) | +4 tests in `TestExecutePathKwarg` |
| [CHANGELOG.md](CHANGELOG.md) | Entry under `Deprecated` |

## Behavior

- `execute(path="x")` — new canonical form, no warning
- `execute(project_root="x")` — works, emits `DeprecationWarning`
- `execute(path="x", project_root="y")` — uses `"x"`, emits warning about the conflict
- `execute(target="x")` — VSCode compat preserved, maps to `path` internally

## Test plan

- [x] All 4 new `TestExecutePathKwarg` tests pass locally
- [x] 110 existing health-check tests still pass (no regressions)
- [x] `tests/unit/ops/test_path_support_registry.py` drift-guard tests pass — confirms `path` is now consumed in the source
- [x] Ruff + black clean
- [ ] Full CI matrix (added by GitHub on push)

## Sequencing within the spec

This is PR-1. PR-2 (doc-orchestrator) is **blocked** pending the audit finding above — needs a spec correction. PR-3 (test-audit), PR-4 (rag-code-gen), PR-5 (registry collapse) can land in any order after PR-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)