### PR TITLE
feat(workflows): unify rag-code-gen path kwarg (PR-4 of 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (a path is still required). Error message text updated from
   "src_path argument is required" to "path argument is required
   (was: src_path)" to bridge the rename.
+- `RagCodeGenWorkflow.execute(cwd=...)` — use
+  `execute(path=...)` instead. Legacy kwarg emits a
+  `DeprecationWarning` and will be removed in v7.0. PR-4 of
+  `docs/specs/workflow-path-arg-unification/`; Phase 0.2
+  confirmed `cwd` and `path` are semantically identical for
+  this workflow (both bound the Agent SDK's filesystem-tool
+  reach via `ClaudeAgentOptions(cwd=...)`).
 
 ### Internal
 

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -94,7 +94,10 @@ PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
     # workflow-path-arg-unification PR-1 (2026-05-13).
     "health-check": PathArgSpec(kwarg="path"),
     "orchestrated-health-check": PathArgSpec(kwarg="path"),
-    "rag-code-gen": PathArgSpec(kwarg="cwd"),
+    # rag-code-gen migrated to `path` in workflow-path-arg-unification
+    # PR-4 (2026-05-13); `cwd` and `path` are semantically identical
+    # for this workflow per Phase 0.2 confirmation in #296.
+    "rag-code-gen": PathArgSpec(kwarg="path"),
     # test-audit migrated to `path` in workflow-path-arg-unification
     # PR-3 (2026-05-13); required=True preserved (workflow errors
     # when missing).

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -79,13 +79,15 @@ class RagCodeGenWorkflow(BaseWorkflow):
             records feedback on every cited template via
             ``record_template_feedback`` (Phase 4.1).
         model (str): Optional model override for generation.
-        cwd (str): Working directory passed to the Claude Agent
-            SDK for ``Read``/``Glob``/``Grep`` tool calls.
+        path (str): Working directory / scope for the Claude Agent
+            SDK's ``Read``/``Glob``/``Grep`` tool calls.
             Defaults to ``os.getcwd()`` at execute time so the
             agent cannot escape the caller's invocation
             directory via a prompt-injected path. Matches the
             ``cwd=resolved_path`` pattern used in
             ``security_audit.py``.
+        cwd (str): Deprecated alias for ``path``; emits
+            ``DeprecationWarning``. Removed in v7.0.
     """
 
     name = "rag-code-gen"
@@ -119,6 +121,8 @@ class RagCodeGenWorkflow(BaseWorkflow):
         return self._pipeline
 
     async def execute(self, **kwargs: Any) -> WorkflowResult:
+        import warnings as _warnings  # local to keep formatter from stripping
+
         query: str = kwargs.get("query", "")
         k: int = int(kwargs.get("k", 3))
         depth: str = kwargs.get("depth", "standard")
@@ -127,8 +131,29 @@ class RagCodeGenWorkflow(BaseWorkflow):
         # Default cwd to the caller's invocation directory so the
         # SDK's Read/Glob/Grep tools cannot climb outside via a
         # prompt-injected path; mirror security_audit.py's
-        # resolved-path scoping.
-        cwd: str = kwargs.get("cwd") or os.getcwd()
+        # resolved-path scoping. `path` is the new canonical kwarg
+        # name (workflow-path-arg-unification PR-4, 2026-05-13);
+        # `cwd` is preserved as a deprecated alias because they
+        # are semantically identical for this workflow.
+        legacy_cwd = kwargs.get("cwd")
+        new_path = kwargs.get("path")
+        if legacy_cwd and not new_path:
+            _warnings.warn(
+                "RagCodeGenWorkflow.execute(cwd=...) is deprecated; "
+                "use execute(path=...) instead. The legacy kwarg "
+                "will be removed in v7.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        elif legacy_cwd and new_path:
+            _warnings.warn(
+                "RagCodeGenWorkflow.execute(): both `path=` and "
+                "`cwd=` supplied; `path=` takes precedence and "
+                "`cwd=` is deprecated.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        cwd: str = new_path or legacy_cwd or os.getcwd()
 
         if not query or not query.strip():
             return self._error_result("query argument is required")

--- a/tests/unit/workflows/test_rag_code_gen_path_kwarg.py
+++ b/tests/unit/workflows/test_rag_code_gen_path_kwarg.py
@@ -1,0 +1,78 @@
+"""Tests for the `path=` kwarg migration in RagCodeGenWorkflow.
+
+PR-4 of workflow-path-arg-unification (2026-05-13) renames the
+`cwd=` kwarg on `RagCodeGenWorkflow.execute()` to `path=`, with
+`cwd=` preserved as a deprecated alias. The two are semantically
+identical for this workflow (both bound the Agent SDK's
+filesystem-tool reach via `ClaudeAgentOptions(cwd=...)`).
+
+These tests exercise just the kwarg-handling logic — the warning
+fires before the empty-query early-return, so we don't need the
+RAG pipeline wired up to validate behavior.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import warnings
+
+import pytest
+
+from attune.workflows.rag_code_gen import RagCodeGenWorkflow
+
+
+class TestExecutePathKwarg:
+    """Tests for the `path=` kwarg migration."""
+
+    def test_execute_accepts_path_kwarg_without_warning(self):
+        """execute(path=..., query="") does not emit DeprecationWarning."""
+        workflow = RagCodeGenWorkflow()
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            result = asyncio.run(workflow.execute(path="/tmp/scope", query=""))
+
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == []
+        # Empty query triggers the next guard (proves we reached the body).
+        assert result.success is False
+        assert "query argument is required" in result.error
+
+    def test_execute_legacy_cwd_warns(self):
+        """execute(cwd=...) emits DeprecationWarning AND still routes the value."""
+        workflow = RagCodeGenWorkflow()
+
+        with pytest.warns(DeprecationWarning, match="cwd"):
+            result = asyncio.run(workflow.execute(cwd="/tmp/scope", query=""))
+
+        # Workflow still proceeds past the kwarg-handling block.
+        assert result.success is False
+        assert "query argument is required" in result.error
+
+    def test_execute_both_kwargs_path_wins(self):
+        """execute(path=A, cwd=B) emits a both-supplied warning."""
+        workflow = RagCodeGenWorkflow()
+
+        with pytest.warns(DeprecationWarning, match="both"):
+            result = asyncio.run(
+                workflow.execute(path="/tmp/via_path", cwd="/tmp/via_cwd", query="")
+            )
+
+        assert result.success is False
+        assert "query argument is required" in result.error
+
+    def test_execute_no_path_or_cwd_no_warning(self):
+        """execute() with neither path nor cwd defaults to os.getcwd() silently."""
+        workflow = RagCodeGenWorkflow()
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            result = asyncio.run(workflow.execute(query=""))
+
+        deprecations = [w for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == []
+        assert result.success is False
+        assert "query argument is required" in result.error


### PR DESCRIPTION
Fourth per-workflow migration of [docs/specs/workflow-path-arg-unification/](docs/specs/workflow-path-arg-unification/) (spec draft in [#296](https://github.com/Smart-AI-Memory/attune-ai/pull/296)). Renames the `cwd=` kwarg on `RagCodeGenWorkflow.execute()` to `path=`, with `cwd=` preserved as a deprecated alias.

## Phase 0.2 audit answer: C2 (alias)

The spec left this open (C1 = separate semantics, C2 = alias). Verified by reading [rag_code_gen.py:82-88](src/attune/workflows/rag_code_gen.py:82): `cwd` is documented as the SDK working directory for `Read`/`Glob`/`Grep` tool calls, defaulted to `os.getcwd()` **for security** ("the agent cannot escape the caller's invocation directory via a prompt-injected path; mirror security_audit.py's resolved-path scoping").

The agent IS the worker; its `cwd` IS the analysis scope. There is no separate "scope target" distinct from `cwd` — they are semantically identical. **Decision C2: alias.**

Full audit posted as a comment on [#296](https://github.com/Smart-AI-Memory/attune-ai/pull/296#issuecomment-4437576632).

## Changes

| File | Change |
|---|---|
| [src/attune/workflows/rag_code_gen.py](src/attune/workflows/rag_code_gen.py) | execute() body + docstring |
| [src/attune/ops/data.py](src/attune/ops/data.py) | Registry flip: `kwarg="cwd"` → `kwarg="path"` |
| [tests/unit/workflows/test_rag_code_gen_path_kwarg.py](tests/unit/workflows/test_rag_code_gen_path_kwarg.py) | +4 tests (new file) |
| [CHANGELOG.md](CHANGELOG.md) | Entry under `Deprecated` |

## Behavior

- `execute(path="x", query="...")` — new canonical form, no warning
- `execute(cwd="x", query="...")` — works, emits `DeprecationWarning`
- `execute(path="x", cwd="y", query="...")` — uses `"x"`, emits conflict warning
- `execute(query="...")` with neither — defaults to `os.getcwd()`, no warning (security default preserved)
- Internal SDK variable stays `cwd` (matches the SDK parameter name)

## Test plan

- [x] 4 new tests pass via xdist
- [x] 21 registry drift-guard tests pass (confirms `path` is consumed in source)
- [x] Ruff + black clean
- [ ] Full CI matrix

## Notes

- Tests use the empty-query short-circuit (`query=""`) to exercise the kwarg-handling block without needing the full RAG pipeline wired up. The warning fires before the empty-query early-return, so kwarg behavior is observable from the resulting `_error_result`.
- `import warnings` scoped inside `execute()` body per the formatter-strips-imports lesson.
- Sequenced after PR-1 ([#297](https://github.com/Smart-AI-Memory/attune-ai/pull/297)) and PR-3 ([#298](https://github.com/Smart-AI-Memory/attune-ai/pull/298)). PR-2 (`doc-orchestrator`) still blocked pending the constructor-only correction described in [#296](https://github.com/Smart-AI-Memory/attune-ai/pull/296#issuecomment-4437576632). PR-5 (registry simplification) gated on 1–4 all landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)