### PR TITLE
feat(workflows): discovery-sweep Phase 1 + 2A (snapshot's design)

### DIFF
--- a/.claude/plans/discovery-sweep.md
+++ b/.claude/plans/discovery-sweep.md
@@ -1,0 +1,521 @@
+# discovery-sweep
+
+**Status:** Phase 1 complete · Phase 2A complete
+**Created:** 2026-05-13
+**Approved:** 2026-05-13
+**Phase 1 shipped:** 2026-05-13 (105 tests, engine as Python API)
+**Phase 2A shipped:** 2026-05-13 (127 tests total — PatternScanSource adapter + CLI wrapper + registry registration)
+**Phase 2B remaining:** LLM-wrapping adapters, auto-fix, retirement eval, multi-module parallelism, RAG verification
+**Owner:** Patrick + Claude (interactive)
+
+---
+
+## Context
+
+Today, code/test improvement runs interactively with Claude as
+the active driver — safe, high-quality, but doesn't scale.
+Autonomous workflows exist (bug_predict, security_audit,
+code_review, deep_review, perf_audit, test_audit) but no
+orchestrator runs them as a coordinated sweep with curated
+output. Raw output from individual workflows has known false
+positives (perf-audit `dirs[:]`, bug-predict `subprocess_exec`,
+deep-review fabrication) that make their findings untrustworthy
+for a queue without filtering.
+
+## Problem
+
+Need read-only discovery at scale: parallel agent sweep,
+verification layer that filters known false positives, curated
+output queue tagged by resolution complexity. Resolution stays
+interactive (current workflow unchanged).
+
+## Goals (Phase 1)
+
+1. Bounded-scope sweep workflow runnable foreground or as
+   background job
+2. Verification layer classifies each finding:
+   - REJECT (drop, log to rejection-log)
+   - UNSURE (batched questions file, reviewable cold)
+   - ACCEPT (queue entry)
+3. ACCEPT entries carry `resolution_complexity: routine |
+   needs_patrick` metadata
+4. Curated queue lives separately from `COVERAGE_BUG_LOG.md`
+   until Patrick promotes items
+5. Budget caps: $10 per sub-workflow invocation, $40 hard
+   ceiling per module sweep
+6. Verification rules grounded in existing CLAUDE.md lessons
+
+## End State
+
+```bash
+attune workflow run discovery-sweep --path src/attune/security/
+```
+
+Produces three artifacts:
+
+- `.claude/discovery-queue/<timestamp>-<scope>.jsonl` — ACCEPT
+  findings, tagged
+- `.claude/discovery-queue/<timestamp>-<scope>.questions.md` —
+  UNSURE findings as reviewable-cold questions
+- `.claude/discovery-queue/<timestamp>-<scope>.rejected.jsonl`
+  — REJECT findings with rule that fired (for auditing
+  verification quality)
+
+Existing interactive resolution workflow untouched. Patrick
+triages queue at his pace; promoted items flow to
+`docs/COVERAGE_BUG_LOG.md` for fixing via existing
+`crash/dead/mocked` taxonomy.
+
+## Out of Scope (Phase 1) — committed for Phase 2
+
+- Auto-fix for ROUTINE-tagged items
+- Retirement evaluation for superseded workflows (test_audit
+  prime candidate)
+- Multi-module parallelism (sweep multiple paths concurrently)
+- RAG-grounded verification (use attune-help / attune-rag to
+  check findings against documented patterns)
+
+---
+
+## Verification Rules (seed set from CLAUDE.md lessons)
+
+These become the initial denylist in Task 2. Each is grounded
+in an existing CLAUDE.md lesson — not theoretical false
+positives, but ones we've actually hit.
+
+| Pattern | Why False Positive |
+|---|---|
+| `dirs[:] = [...]` in `os.walk` loop | Required for traversal filtering — not a memory leak |
+| `create_subprocess_exec` flagged as eval | substring match against "exec" — not actual eval/exec |
+| JS `regex.exec(text)` flagged as exec | Safe regex method, not Python exec |
+| `eval()` / `exec()` inside `.write_text(...)` calls | Test fixture data, not executable code |
+| `eval()` / `exec()` inside string literals (detection code) | Scanner self-reference |
+| `except Exception` with `# noqa: BLE001` + `# INTENTIONAL:` | Documented intentional broad catch |
+| `subprocess.run(...)` in fuzz target / test | Not shell injection in this context |
+| structlog `logger.info("msg", key=value)` flagged as TypeError | Valid structlog kwargs syntax |
+| Hardcoded `"fake"` / placeholder strings flagged as secrets | Pragma allowlist applies |
+
+Verification rules are extensible — adding to the list as new
+false positives surface is a Phase 1 deliverable.
+
+---
+
+## Resolution Complexity Triggers (ACCEPT → needs_patrick)
+
+A finding flips to `needs_patrick` if any apply:
+
+- Touches 3+ files OR changes public API OR modifies shared
+  base class
+- Security-adjacent: anything in `src/attune/security/`,
+  eval/exec, path validation, webhook URLs
+- Contradicts a CLAUDE.md lesson (fix would re-introduce a
+  documented antipattern)
+- Tier/budget/cost-model change
+- "Test mocks production" smell — proposed fix would lose real
+  coverage
+- Low-confidence: verification rule fired ACCEPT but couldn't
+  name a specific failing input
+
+Otherwise: `routine`.
+
+---
+
+## Tasks
+
+<task id="1" name="finding-schema-and-file-formats">
+  <objective>
+    Define the Finding dataclass and the three output file
+    formats (queue/questions/rejected). Establish the
+    serialization contract that downstream tasks build on.
+  </objective>
+
+  <files-to-create>
+    <file path="src/attune/workflows/discovery_sweep/__init__.py">
+      Package init. Re-exports Finding, VerificationStatus,
+      ResolutionComplexity enums.
+    </file>
+    <file path="src/attune/workflows/discovery_sweep/schema.py">
+      Finding dataclass with fields:
+      - source_workflow: str (e.g. "bug_predict")
+      - file_path: str
+      - line: int | None
+      - severity: Literal["high", "medium", "low"]
+      - message: str
+      - raw_finding: dict (preserve original for audit)
+      - verification_status: Literal["accept", "reject", "unsure"]
+      - resolution_complexity: Literal["routine", "needs_patrick"] | None
+      - verification_reasoning: str
+      - sweep_id: str
+      - timestamp_utc: str (isoformat with +00:00)
+
+      VerificationStatus and ResolutionComplexity enums.
+    </file>
+    <file path="src/attune/workflows/discovery_sweep/serialization.py">
+      JSONL writers/readers for queue and rejected files.
+      Markdown writer for questions file (human-readable,
+      reviewable cold — each entry includes the original
+      finding, what made verification unsure, and which
+      sub-workflow flagged it).
+    </file>
+    <file path="tests/unit/workflows/discovery_sweep/test_schema.py">
+      Round-trip serialization tests (JSONL queue, JSONL
+      rejected, markdown questions). Schema validation tests.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>Finding dataclass round-trips JSONL without loss</check>
+    <check>Markdown questions file is parseable back to Findings</check>
+    <check>All three file formats include sweep_id for traceability</check>
+    <check>timestamps are timezone-aware (lesson: never naive datetimes)</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Schema-too-narrow risk: adding fields later is cheap
+      (dataclass) but renaming is expensive across the queue
+      file format. Mitigation: pad the schema slightly with
+      optional fields that may matter (e.g. estimated_fix_cost
+      as Optional[float]).
+    </risk>
+  </risks>
+</task>
+
+<task id="2" name="verification-rule-engine">
+  <objective>
+    Build the verification layer: a rule engine that classifies
+    Findings as ACCEPT / REJECT / UNSURE based on grounded
+    rules from CLAUDE.md lessons. This is the load-bearing
+    component — its quality determines whether the queue stays
+    signal.
+  </objective>
+
+  <files-to-create>
+    <file path="src/attune/workflows/discovery_sweep/verification.py">
+      VerificationRule protocol:
+        def classify(finding: Finding, source_text: str)
+            -> tuple[VerificationStatus, str]  # status + reasoning
+
+      VerificationEngine: runs ordered rule list against a
+      finding, returns first matching classification.
+
+      Default rule order: REJECT rules first (denylist of
+      known false positives), then ACCEPT rules, fall through
+      to UNSURE.
+    </file>
+    <file path="src/attune/workflows/discovery_sweep/rules/__init__.py">
+      Rule registry. Imports all built-in rules.
+    </file>
+    <file path="src/attune/workflows/discovery_sweep/rules/known_false_positives.py">
+      REJECT rules for the 9 patterns in the spec's seed set:
+      - DirsSliceAssignmentRule (os.walk dirs[:] pattern)
+      - SubprocessExecRule (create_subprocess_exec false-eval)
+      - JsRegexExecRule (.exec on regex objects)
+      - WriteTextEvalFixtureRule (eval/exec inside .write_text)
+      - IntentionalBroadExceptRule (# noqa: BLE001 + # INTENTIONAL:)
+      - SubprocessInFuzzTargetRule
+      - StructlogKwargsRule
+      - SecretsPragmaRule
+      Each rule reads the source line + context and decides.
+    </file>
+    <file path="tests/unit/workflows/discovery_sweep/test_verification.py">
+      For each rule, a test fixture using a real code snippet
+      from the codebase (or a minimal repro) that should be
+      REJECTED. Tests are the regression net for the
+      verification quality.
+    </file>
+    <file path="tests/unit/workflows/discovery_sweep/fixtures/false_positives/">
+      Directory of minimal source files demonstrating each
+      false positive. Tests reference these.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>Each REJECT rule fires correctly on its target false-positive fixture</check>
+    <check>Each REJECT rule does NOT fire on a control case (genuine bug with similar surface)</check>
+    <check>VerificationEngine returns UNSURE when no rule matches</check>
+    <check>Verification reasoning is human-readable (used in rejected.jsonl audit log)</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      Over-aggressive REJECT rule masks a real bug. Mitigation:
+      every REJECT rule must have a paired control test
+      (similar-looking code that IS a real bug, where the rule
+      must NOT fire). Asymmetric: false-negative on REJECT is
+      worse than false-positive on ACCEPT, because UNSURE
+      lands in the questions file (recoverable) but REJECT
+      drops to audit log (less visible).
+    </risk>
+    <risk severity="medium">
+      Rule order matters for correctness. Mitigation: rules
+      that REJECT must include source-context checks that are
+      narrow enough to not collide with ACCEPT rules. Tests
+      cover ordering.
+    </risk>
+  </risks>
+</task>
+
+<task id="3" name="resolution-complexity-classifier">
+  <objective>
+    For findings that reach ACCEPT, classify resolution
+    complexity as `routine` or `needs_patrick`. This is the
+    tag Patrick filters by when triaging the queue.
+  </objective>
+
+  <files-to-create>
+    <file path="src/attune/workflows/discovery_sweep/complexity.py">
+      ComplexityClassifier with rules:
+      - is_cross_cutting(finding) — touches 3+ files via grep
+        of message text; OR finding.file_path is in shared
+        base class registry
+      - is_security_adjacent(finding) — file path under
+        src/attune/security/, OR finding mentions eval/exec/
+        path-validation/webhook
+      - contradicts_lesson(finding) — fix would re-introduce
+        a known antipattern (cross-reference with rule
+        registry from Task 2)
+      - is_tier_or_budget_change(finding) — mentions
+        ModelTier, budget, cost
+      - is_mocks_production_smell(finding) — finding is in a
+        test file AND mentions mock/patch with a production
+        path
+      - is_low_confidence(finding) — verification reasoning
+        contains "couldn't determine" / "ambiguous" markers
+
+      Returns ResolutionComplexity (routine | needs_patrick).
+    </file>
+    <file path="tests/unit/workflows/discovery_sweep/test_complexity.py">
+      Test each trigger with a positive fixture (should be
+      needs_patrick) and negative fixture (should stay
+      routine).
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>Each trigger fires correctly on its positive fixture</check>
+    <check>Each trigger does NOT fire on its negative fixture</check>
+    <check>Routine is the default — any trigger flips to needs_patrick</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Over-tagging needs_patrick reduces throughput; under-
+      tagging risks Patrick missing items he wanted to see.
+      Mitigation: err toward needs_patrick when ambiguous;
+      Patrick can downgrade in triage.
+    </risk>
+  </risks>
+</task>
+
+<task id="4" name="sweep-workflow-orchestrator">
+  <objective>
+    Implement the DiscoverySweepWorkflow as a BaseWorkflow
+    subclass. Runs N sub-workflows on a bounded path,
+    enforces budget caps, aggregates findings, runs them
+    through verification + complexity classification, and
+    writes the three output files.
+  </objective>
+
+  <files-to-create>
+    <file path="src/attune/workflows/discovery_sweep/workflow.py">
+      DiscoverySweepWorkflow(BaseWorkflow):
+        name = "discovery-sweep"
+        description = "Orchestrated read-only discovery
+          sweep — runs N sub-workflows on a bounded path,
+          verifies findings against known-false-positive
+          rules, and produces a curated queue."
+
+      Configurable sub-workflows (default: bug_predict,
+      security_audit, code_review, perf_audit, deep_review).
+
+      Per-workflow budget: $10 (env override:
+      ATTUNE_DISCOVERY_SUBWORKFLOW_BUDGET_USD).
+      Sweep budget ceiling: $40 (env override:
+      ATTUNE_DISCOVERY_SWEEP_BUDGET_USD). Hard kill on
+      ceiling.
+
+      Output directory: .claude/discovery-queue/ (configurable
+      via --output-dir).
+    </file>
+    <file path="src/attune/workflows/discovery_sweep/budget.py">
+      BudgetTracker — tracks per-workflow + total spend,
+      raises SweepBudgetExceeded when ceiling hit.
+    </file>
+    <file path="tests/unit/workflows/discovery_sweep/test_workflow.py">
+      Tests with mocked sub-workflow results:
+      - Aggregates findings from multiple sub-workflows
+      - Verification runs on every finding
+      - Complexity classification on ACCEPT findings
+      - Writes three correct files
+      - Budget cap halts further sub-workflow invocation
+      - sweep_id is consistent across all output files
+    </file>
+  </files-to-create>
+
+  <files-to-modify>
+    <file path="src/attune/workflows/__init__.py">
+      <change location="discover_workflows registry">
+        Register DiscoverySweepWorkflow.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>attune workflow list shows discovery-sweep</check>
+    <check>Mocked end-to-end sweep produces all three output files with consistent sweep_id</check>
+    <check>Budget cap triggers SweepBudgetExceeded after threshold</check>
+    <check>Sub-workflow failure (one of N raises) does not abort sweep — failure recorded, sweep continues with remaining workflows</check>
+  </validation>
+
+  <risks>
+    <risk severity="high">
+      MCP-invoked sub-workflows lose intermediate context (per
+      "MCP-invoked SDK workflows ALREADY isolate" lesson). The
+      orchestrator must NOT rely on intermediate
+      AssistantMessage text — only final_output. Mitigation:
+      audit each sub-workflow's WorkflowResult shape before
+      consuming.
+    </risk>
+    <risk severity="medium">
+      $40 ceiling is a guess. May need adjustment after first
+      real-scope sweep. Mitigation: log per-sub-workflow spend
+      to telemetry so future tuning is data-driven.
+    </risk>
+  </risks>
+</task>
+
+<task id="5" name="python-api-and-extension-guide">
+  <objective>
+    Ship the engine as a tested Python API for Phase 1. Document
+    the ``FindingSource`` Protocol so Phase 2 adapter work is
+    cold-readable. CLI registration (``attune workflow run
+    discovery-sweep``) and real sub-workflow adapters are
+    explicit Phase 2 deliverables — registering an empty
+    workflow today would be more confusing than not registering
+    it. (Decision 2026-05-13.)
+  </objective>
+
+  <files-to-create>
+    <file path="docs/workflows/discovery-sweep.md">
+      User-facing docs:
+      - Phase 1 boundary: engine-only, Python API surface
+      - When to use (bounded scope, read-only discovery)
+      - When NOT to use (auto-fix, whole-repo)
+      - Quickstart: instantiate DiscoverySweepWorkflow with a
+        list of FindingSource instances, call .run(scope)
+      - FindingSource protocol contract and an example adapter
+      - Reading the three output files
+      - Extending verification rules and complexity triggers
+      - Phase 2 roadmap pointer (CLI + real adapters)
+    </file>
+    <file path="tests/unit/workflows/discovery_sweep/test_smoke.py">
+      End-to-end smoke test against the Python API: instantiates
+      the orchestrator with a stub FindingSource emitting a
+      known false-positive + a fresh finding, asserts the three
+      output files exist with the expected structure (one
+      REJECT, one UNSURE), and the sweep_id is consistent
+      across all files.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>Python API smoke test produces all three output files with expected counts</check>
+    <check>FindingSource protocol contract is documented with a worked example</check>
+    <check>Phase 2 roadmap pointer in docs/workflows/discovery-sweep.md links to docs/specs/discovery-sweep/phase-2.md</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Engine-only ship limits Phase 1 user value to extension
+      authors. Acceptable — Phase 1's intent was always the
+      verification + queue logic, not the adapter implementations.
+    </risk>
+  </risks>
+</task>
+
+<task id="6" name="documentation-and-phase-2-deferral-record">
+  <objective>
+    Document Phase 1 usage and create the Phase 2 deferral
+    record so the deferred items don't get lost.
+  </objective>
+
+  <files-to-create>
+    <file path="docs/specs/discovery-sweep/decisions.md">
+      Mirror of this spec file's key decisions. Records:
+      - Discovery-vs-resolution split rationale
+      - Verification-rules-grounded-in-lessons approach
+      - Resolution complexity tagging vs queue-entry gating
+        (the reframe from chat)
+      - Phase 2 commitments (auto-fix, retirement eval,
+        multi-module parallelism, RAG verification)
+    </file>
+    <file path="docs/specs/discovery-sweep/phase-2.md">
+      Phase 2 planning placeholder. Lists each deferred item
+      with a one-paragraph sketch:
+      - Auto-fix for ROUTINE-tagged items (needs reversibility
+        guarantees — likely git-stash-before-fix pattern)
+      - Workflow retirement evaluation (test_audit candidate
+        — compare sweep output vs test_audit on same scope)
+      - Multi-module parallelism (asyncio + shared budget
+        accounting)
+      - RAG-grounded verification (use attune-help/attune-rag
+        to check whether a finding contradicts documented
+        patterns)
+    </file>
+  </files-to-create>
+
+  <files-to-modify>
+    <file path="CHANGELOG.md">
+      <change location="Unreleased section">
+        Add entry: "Added: discovery-sweep workflow — read-only
+        discovery sweep with verification layer grounded in
+        CLAUDE.md lessons. Produces curated queue with
+        resolution-complexity tagging. Phase 1 of multi-phase
+        spec."
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>Phase 2 doc lists all 4 deferred items with sketches</check>
+    <check>CHANGELOG entry exists under Unreleased</check>
+    <check>docs/specs/discovery-sweep/decisions.md exists and is in markdown-formatting-rules compliance</check>
+  </validation>
+
+  <risks>
+    <risk severity="low">
+      Phase 2 sketches diverge from actual implementation.
+      Acceptable — sketches are commitments to scope, not
+      design specs.
+    </risk>
+  </risks>
+</task>
+
+---
+
+## Decisions Resolved (2026-05-13)
+
+1. **File formats:** JSONL for queue + rejected (tool
+   consumption, jq-friendly, streaming-friendly); markdown
+   for questions (human consumption, reviewable cold).
+2. **Git tracking:** `.claude/discovery-queue/` gitignored by
+   default. Patrick can opt to commit a specific queue file
+   if he wants the audit trail in git. Add to `.gitignore` in
+   Task 1.
+
+---
+
+## Out of Scope (Phase 1) — committed for Phase 2
+
+Repeated here for visibility:
+
+- **CLI registration** (`attune workflow run discovery-sweep`) —
+  pairs with the real adapters below since the workflow has no
+  built-in sources of its own
+- **Real FindingSource adapters** wrapping bug_predict,
+  security_audit, code_review, perf_audit, deep_review
+- Auto-fix for ROUTINE-tagged items
+- Retirement evaluation for superseded workflows
+- Multi-module parallelism
+- RAG-grounded verification

--- a/.gitignore
+++ b/.gitignore
@@ -252,6 +252,11 @@ dashboard/dist/
 # Generated benchmark cache (regenerates on every cache-writer run)
 .help/benchmarks/
 
+# Discovery-sweep ephemeral output (queue / rejected / questions)
+# Per .claude/plans/discovery-sweep.md — gitignored by default;
+# commit a specific queue file by-path if an audit trail is wanted.
+.claude/discovery-queue/
+
 # Test leak — tests that stringify a MagicMock into a filesystem path
 # create stray MagicMock/mock.attune_dir/<id>/ trees. Ignore them as a
 # safety net; ideally the underlying tests should be fixed to use tmp_path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `discovery-sweep` workflow (Phase 1 + Phase 2A) — read-only
+  discovery orchestrator that runs N sub-workflows on a
+  bounded path, filters findings through a verification rule
+  engine grounded in `CLAUDE.md` lessons, and produces a
+  curated queue tagged by resolution complexity. Resolution
+  stays interactive.
+  - **Phase 1** ships the engine as a Python API
+    (`DiscoverySweepEngine`) with verification rules,
+    complexity classifier, budget tracker, and serialization
+    layer.
+  - **Phase 2A** registers `discovery-sweep` in the workflow
+    registry so `attune workflow run discovery-sweep --path
+    <module>` works end-to-end. Ships the first adapter,
+    `PatternScanSource` — a deterministic, zero-LLM-cost
+    line-level scanner for bare except, dangerous-eval/exec,
+    subprocess shell=True, and TODO/FIXME markers. Its raw
+    output is filtered by the verification engine's REJECT
+    rules before reaching the queue.
+  - LLM-wrapping adapters (bug_predict, security_audit, etc.)
+    plus auto-fix, retirement evaluation, multi-module
+    parallelism, and RAG-grounded verification remain Phase
+    2B. See `docs/workflows/discovery-sweep.md` and
+    `docs/specs/discovery-sweep/`. 127 tests total.
+
 ### Deprecated
 
 - `TestAuditWorkflow.execute(src_path=...)` — use

--- a/docs/specs/_sequencing.md
+++ b/docs/specs/_sequencing.md
@@ -98,6 +98,30 @@ natural pause.
   - [ ] Phase 5 — structured recommendations
 - Spec: [ops-runner-tier2](ops-runner-tier2/)
 
+### discovery-sweep — Phase 1 + 2A shipped
+
+- Status: Phase 1 + Phase 2A shipped 2026-05-13. `attune
+  workflow run discovery-sweep --path <module>` works
+  end-to-end with the deterministic `PatternScanSource`
+  adapter. Phase 2B (LLM-wrapping adapters, retirement eval,
+  auto-fix) remains.
+- Why on Track C: New user-facing capability — a read-only
+  discovery orchestrator that fans out across sub-workflows
+  and triages findings into queue / rejected / questions
+  buckets. Independent of test-signal and audit tracks.
+- Tasks
+  - [x] Phase 1 — `DiscoverySweepEngine`, verification
+        rules, complexity classifier, budget tracker,
+        serialization, schema
+  - [x] Phase 2A — `PatternScanSource` adapter,
+        `DiscoverySweepWorkflow` BaseWorkflow wrapper,
+        registry registration, `PATH_ARG_REGISTRY` entry
+  - [ ] Phase 2B — LLM-wrapping adapters (bug_predict,
+        security_audit, …), retirement eval, auto-fix,
+        multi-module parallelism, RAG-grounded verification
+- Spec: [discovery-sweep](discovery-sweep/)
+- Plan: [.claude/plans/discovery-sweep.md](../../.claude/plans/discovery-sweep.md)
+
 ### website-update-dashboard-and-fold (Phase 1)
 
 - Status: approved — 41 tasks, 0% done

--- a/docs/specs/discovery-sweep/decisions.md
+++ b/docs/specs/discovery-sweep/decisions.md
@@ -1,0 +1,174 @@
+# discovery-sweep — decisions
+
+Mirror of key design decisions from
+`.claude/plans/discovery-sweep.md`. The plan is the executable
+spec; this file is the durable record of *why* the design landed
+where it did.
+
+## Status
+
+- **Phase 1 shipped:** 2026-05-13 — engine as Python API, six
+  tasks complete, 105 tests passing.
+- **Phase 2A shipped:** 2026-05-13 — `PatternScanSource`
+  deterministic adapter (no LLM cost), `DiscoverySweepWorkflow`
+  BaseWorkflow CLI wrapper, registered in the workflow
+  registry. `attune workflow run discovery-sweep --path
+  <module>` now produces real findings end-to-end. 127 tests
+  total (105 Phase 1 + 22 Phase 2A).
+- **Phase 2B planned:** see [phase-2.md](phase-2.md).
+
+## Decision 1 — Discovery and resolution are split
+
+Discovery (read-only scan, verification, queue write) runs
+autonomously. Resolution (actually fixing the bug) stays
+interactive with Patrick.
+
+**Why:** Agents are reliable at pattern-matching at scale,
+unreliable at judgment calls on fixes. Existing autonomous
+workflows (bug_predict, security_audit, deep_review) have
+documented false-positive patterns (perf-audit on `dirs[:]`,
+bug-predict on `subprocess_exec`, deep-review fabrication). The
+discovery half scales; the resolution half doesn't.
+
+**How to apply:** Anything that mutates code, commits, pushes,
+or otherwise leaves the read-only boundary belongs in
+resolution, not discovery.
+
+## Decision 2 — Verification rules grounded in CLAUDE.md lessons
+
+REJECT rules in the verification engine target false positives
+documented in `CLAUDE.md` lessons — not theoretical false
+positives, but ones already hit in production sessions.
+
+**Why:** Theoretical rules accumulate maintenance cost and
+risk false REJECTs. Documented lessons are pre-validated by
+historical pain.
+
+**How to apply:** When adding a REJECT rule, cite the
+`CLAUDE.md` lesson it grounds in. When a verification rule
+proves wrong in dogfood, fix the rule OR remove it; do not
+silently widen its guards.
+
+## Decision 3 — Resolution complexity is a tag, not a queue-entry gate
+
+`needs_patrick` is metadata on ACCEPTed findings (Patrick's
+triage filter), not a discovery-time decision to escalate.
+
+**Why:** Original framing had ESCALATE blocking sweep
+progression. Patrick clarified the trigger criteria were about
+the *resolution* decision (we know it's real but want
+judgment on the fix), not the *queue-entry* decision (whether
+the agent is sure it's a real bug). With that clarification:
+
+- The discovery agent's only job is real-vs-false-positive
+- Real findings always enter the queue
+- The complexity tag tells Patrick which queue items deserve
+  more attention at triage time
+
+**How to apply:** The verification engine decides
+REJECT/ACCEPT/UNSURE. The complexity classifier only runs on
+ACCEPT and only sets `routine` or `needs_patrick`. Never use
+complexity as a gate.
+
+## Decision 4 — File formats: JSONL + Markdown, by audience
+
+- Queue (`<sweep_id>.jsonl`) — JSONL, tool consumption (jq /
+  streaming)
+- Rejected (`<sweep_id>.rejected.jsonl`) — JSONL, audit log
+- Questions (`<sweep_id>.questions.md`) — Markdown,
+  human-reviewable cold
+
+**Why:** JSONL streams and pipes well for tooling; markdown
+reads well for humans without rendering. UNSURE findings need
+to be reviewable a day later without context — markdown carries
+the surrounding reasoning naturally.
+
+**How to apply:** Don't unify the three files into one format.
+The audience asymmetry is load-bearing.
+
+## Decision 5 — Output is gitignored by default
+
+`.claude/discovery-queue/` is in `.gitignore`.
+
+**Why:** Sweep output is ephemeral triage state. Most queues
+don't need durable history; the ones that do can be committed
+by-path. Tracking every sweep would bloat the repo.
+
+**How to apply:** If Patrick wants the audit trail of a
+specific sweep in git, `git add -f .claude/discovery-queue/<file>`.
+
+## Decision 6 — Phase 1 ships engine-only; CLI deferred to Phase 2
+
+`attune workflow run discovery-sweep` is NOT registered in
+Phase 1. The engine is a Python API. Real `FindingSource`
+adapters (wrapping bug_predict, security_audit, etc.) are
+Phase 2 work, and registering an empty CLI workflow that
+produces zero findings would be more confusing than not
+registering it at all.
+
+**Why:** Phase 1's intent was always the verification + queue
+logic. Adapter implementations are independent work and gate
+on the engine being stable.
+
+**How to apply:** Phase 2A brings up both CLI registration and
+the first adapter together. Until then, the documented entry
+point is `DiscoverySweepEngine(sources=[...])` Python
+instantiation.
+
+**Phase 2A outcome (2026-05-13):** CLI registration shipped
+alongside the `PatternScanSource` adapter — a deterministic,
+zero-LLM-cost scanner that emits Findings for canonical bug
+patterns (bare except, eval/exec, subprocess shell=True, TODO
+markers). The verification engine then filters its raw output.
+LLM-wrapping adapters (bug_predict, security_audit, code_review,
+perf_audit, deep_review) remain Phase 2B work — they have a
+different cost/budget profile that warrants per-adapter design.
+
+## Decision 8 — Engine vs CLI workflow split (Phase 2A rename)
+
+The Phase 1 class previously named `DiscoverySweepWorkflow`
+was renamed to `DiscoverySweepEngine` and is the pure
+orchestrator (no BaseWorkflow inheritance). A new
+`DiscoverySweepWorkflow(BaseWorkflow)` in
+`cli_workflow.py` is a thin wrapper that the workflow
+registry sees, parses `**kwargs`, and delegates to the engine.
+
+**Why:** `BaseWorkflow`'s mixin-heavy constructor is the right
+shape for LLM-routed workflows but heavy for an orchestrator
+that owns no LLM cost itself. Splitting keeps the engine's
+constructor clean (sources, output_dir, project_root) while
+still letting the CLI workflow runner dispatch normally.
+
+**How to apply:** Engine for programmatic use; CLI workflow
+for `attune workflow run discovery-sweep` and any future
+registry-driven dispatch.
+
+## Decision 7 — Budgets: $10 per sub-workflow, $40 per sweep, hard ceilings
+
+Configurable via constructor or env vars
+(`ATTUNE_DISCOVERY_SUBWORKFLOW_BUDGET_USD`,
+`ATTUNE_DISCOVERY_SWEEP_BUDGET_USD`).
+
+**Why:** "Standard" depth on a single sub-workflow runs ~$8–10
+empirically. Multi-workflow sweeps add up fast; $40 keeps a
+five-workflow sweep tractable without hard-stopping mid-run on
+typical scopes. Hard ceiling (not warning) matches the SDK's
+existing behavior — `Reached maximum budget` is an error, not
+a soft signal.
+
+**How to apply:** If a real sweep regularly hits the ceiling,
+either narrow the scope or raise the cap — but the cap should
+stay opinionated, not be auto-lifted on every overrun.
+
+## Phase 2 commitments
+
+Repeated here for visibility — see [phase-2.md](phase-2.md):
+
+- CLI registration (`attune workflow run discovery-sweep`)
+- Real `FindingSource` adapters (bug_predict, security_audit,
+  code_review, perf_audit, deep_review)
+- Auto-fix for `routine`-tagged items
+- Workflow retirement evaluation (test_audit prime candidate)
+- Multi-module parallelism
+- RAG-grounded verification (use attune-help / attune-rag to
+  check findings against documented patterns)

--- a/docs/specs/discovery-sweep/phase-2.md
+++ b/docs/specs/discovery-sweep/phase-2.md
@@ -1,0 +1,167 @@
+# discovery-sweep — Phase 2
+
+Phase 1 shipped the engine. Phase 2A shipped the
+`PatternScanSource` deterministic adapter, the
+`DiscoverySweepWorkflow(BaseWorkflow)` CLI wrapper, and
+registry registration — so `attune workflow run
+discovery-sweep --path <module>` produces real findings
+end-to-end. Phase 2B picks up the LLM-wrapping adapters and
+the remaining roadmap items below.
+
+## Phase 2A — shipped 2026-05-13
+
+- `PatternScanSource` — deterministic regex-based line scanner
+  for bare except, broad exception, eval/exec, subprocess
+  shell=True, TODO markers
+- `DiscoverySweepWorkflow(BaseWorkflow)` — thin CLI wrapper
+  that delegates to `DiscoverySweepEngine`
+- Registered in `_LAZY_WORKFLOW_IMPORTS` +
+  `_DEFAULT_WORKFLOW_NAMES`
+- 22 new tests (pattern scanner, CLI wrapper, registry
+  registration)
+
+## P2.1 — Real `FindingSource` adapters
+
+**Goal:** Wrap each existing autonomous sub-workflow as a
+`FindingSource` so sweeps produce real findings end-to-end.
+
+**Adapters to ship (priority order):**
+
+1. `BugPredictSource` — wraps `BugPredictionWorkflow`. Cheapest
+   first because bug_predict has a structured pattern-based
+   output that maps directly to `Finding`.
+2. `SecurityAuditSource` — wraps SDK-native `SecurityAuditWorkflow`.
+3. `CodeReviewSource` — wraps `CodeReviewWorkflow`.
+4. `PerfAuditSource` — wraps `PerfAuditWorkflow`.
+5. `DeepReviewSource` — wraps the multi-pass deep-review workflow.
+
+**Per-adapter checklist:**
+
+- Map sub-workflow output → `Finding` fields (file_path, line,
+  severity, message, raw_finding preserved)
+- Respect `budget_usd` ceiling — either pass to sub-workflow's
+  budget knob or short-circuit when nearly out
+- Surface real spend on `estimated_spend_usd` (read from
+  sub-workflow's cost tracker)
+- Integration test against a small fixture path with real LLM
+  calls behind a `HAS_API_KEY` skip guard
+- Unit test against a mocked sub-workflow result so the
+  adapter's translation logic is covered without API spend
+
+## P2.2 — CLI registration
+
+**Goal:** `attune workflow run discovery-sweep --path <module>`
+works.
+
+**Approach:** Either (a) make `DiscoverySweepWorkflow` a
+`BaseWorkflow` subclass so it slots into the existing registry,
+or (b) register a thin adapter that the workflow runner
+recognizes. (a) is simpler if the BaseWorkflow constructor
+isn't too noisy for the orchestrator's needs.
+
+**Flags to expose:**
+
+- `--path <scope>` (required)
+- `--sources <comma-separated names>` — defaults to all
+  registered adapters
+- `--output-dir <path>` — defaults to `.claude/discovery-queue/`
+- `--subworkflow-budget <usd>`, `--sweep-budget <usd>` —
+  override env vars
+- `--quiet` — silent mode for background-job invocation
+
+**Background-job ergonomics:**
+
+- Compatible with the existing `run_in_background` agent
+  pattern
+- Progress output goes to stderr; stdout reserved for the
+  result summary (the existing CLI convention)
+
+## P2.3 — Auto-fix for `routine`-tagged items
+
+**Goal:** Items tagged `routine` can be opted into a
+fire-and-forget fix pass that produces a PR for review.
+
+**Key design constraints:**
+
+- MUST run in a worktree (no fix touches the main checkout)
+- MUST stash before each fix (so partial-fix state is
+  recoverable)
+- MUST run the test suite after each fix; revert if anything
+  regresses
+- Resolution complexity tag stays the gate — `needs_patrick`
+  items never auto-fix
+
+**Open question for Phase 2 planning:** how to bound the
+auto-fix budget separately from the sweep budget — they should
+not share a cap.
+
+## P2.4 — Workflow retirement evaluation
+
+**Goal:** Decide which existing autonomous workflows the sweep
+supersedes.
+
+**Method:** Run the sweep and the candidate workflow on the
+same scope, compare outputs. Retirement criteria:
+
+- Sweep's queue is a strict superset of the candidate's
+  findings on representative scopes
+- Verification quality is at least as good (no new false
+  positives in sweep's REJECT output that the candidate would
+  have caught)
+- Cost-per-finding is comparable or better
+
+**Candidates (initial):** `test_audit`. Most others
+(`bug_predict`, `security_audit`, etc.) are consumed by the
+sweep as `FindingSource` adapters and retained.
+
+## P2.5 — Multi-module parallelism
+
+**Goal:** Run the sweep on N module scopes concurrently with
+shared budget accounting.
+
+**Approach:** `asyncio.gather` across `DiscoverySweepWorkflow`
+instances, with a shared `BudgetTracker` and a global ceiling
+that all instances coordinate on. Each instance produces its
+own sweep-id and output set; results aggregate at the call
+site.
+
+**Risks:**
+
+- Shared budget accounting under concurrent updates needs
+  locking
+- Combined LLM concurrency may hit rate limits — adapter-level
+  throttling required
+
+## P2.6 — RAG-grounded verification
+
+**Goal:** Verification rules consult `attune-help` /
+`attune-rag` to check whether a finding contradicts a
+documented pattern.
+
+**Approach:** A new verification rule type that queries the
+RAG index for the finding's pattern + file context. If the
+top result is a "this is intentional" lesson or template, the
+rule returns REJECT with the cited document.
+
+**Wins over the Phase 1 hard-coded denylist:**
+
+- Rule corpus grows as docs grow — no code change needed
+- Citations link findings back to their grounding doc
+- Less brittle than substring matching
+
+**Risks:**
+
+- RAG retrieval latency adds to per-finding verification time
+- Citation quality depends on attune-help corpus quality —
+  already addressed by 0.7.0 polish work but worth monitoring
+
+## Sequencing
+
+P2.1 and P2.2 should ship together — adapters without CLI are
+not useful; CLI without adapters is empty. P2.3 builds on the
+queue's complexity tag. P2.4 needs P2.1 to have a basis for
+comparison. P2.5 and P2.6 are independent and can land any
+time post-P2.1.
+
+A reasonable order: **P2.1 + P2.2 (bundled) → P2.4 → P2.3 →
+P2.6 → P2.5.**

--- a/docs/workflows/discovery-sweep.md
+++ b/docs/workflows/discovery-sweep.md
@@ -1,0 +1,217 @@
+# discovery-sweep
+
+Read-only discovery sweep that orchestrates N sub-workflows on
+a bounded scope, filters their output through a verification
+rule engine grounded in `CLAUDE.md` lessons, and produces a
+curated queue tagged by resolution complexity.
+
+Resolution stays interactive — the sweep does NOT modify code.
+Patrick triages the queue at his pace; promoted items flow to
+`docs/COVERAGE_BUG_LOG.md` for fixing via the existing
+interactive workflow.
+
+## Status
+
+Phase 1 + 2A shipped 2026-05-13. The CLI works:
+
+```bash
+attune workflow run discovery-sweep --path src/attune/security/
+```
+
+This dispatches `DiscoverySweepWorkflow` (a `BaseWorkflow`
+subclass), which wraps `DiscoverySweepEngine` (the
+orchestrator) and runs the default `PatternScanSource` adapter
+— a deterministic, zero-LLM-cost scanner for bare except,
+eval/exec, subprocess shell=True, and TODO/FIXME markers.
+
+LLM-wrapping adapters (bug_predict, security_audit, etc.) are
+Phase 2B — see
+[phase-2.md](../specs/discovery-sweep/phase-2.md).
+
+## When to use
+
+- Bounded scope, read-only audit of one module or one workflow
+  surface
+- You want a curated queue tagged by resolution complexity
+- You want a separate audit log of REJECTed findings so you
+  can track verification-rule quality over time
+
+## When NOT to use
+
+- Whole-repo sweeps (Phase 1 is single-scope only)
+- Auto-fix (resolution stays interactive)
+- Anything that needs a `FindingSource` adapter that hasn't
+  been written yet (Phase 2)
+
+## Quickstart — CLI
+
+```bash
+attune workflow run discovery-sweep --path src/attune/security/
+```
+
+Output:
+
+```text
+sweep abc123def456 | scope=/abs/path/src/attune/security/ |
+accept=3 | reject=1 | unsure=5 | spend=$0.00 |
+queue=.claude/discovery-queue/abc123def456.jsonl
+```
+
+Three artifacts in `.claude/discovery-queue/`:
+
+- `<sweep_id>.jsonl` — accepted findings (the queue)
+- `<sweep_id>.rejected.jsonl` — rejected findings (audit log)
+- `<sweep_id>.questions.md` — unsure findings (cold-readable)
+
+## Quickstart — Python API
+
+```python
+from pathlib import Path
+
+from attune.workflows.discovery_sweep import (
+    DiscoverySweepEngine,
+    Finding,
+    FindingSource,
+    PatternScanSource,
+    Severity,
+)
+
+
+class MyAdapter:
+    """A FindingSource that wraps your own sub-workflow."""
+
+    name = "my_sub_workflow"
+    estimated_spend_usd = 0.0
+
+    def discover(self, scope, budget_usd, sweep_id):
+        # Invoke your sub-workflow against `scope`, respect
+        # `budget_usd`, then translate each raw finding into a
+        # `Finding` with the canonical fields populated.
+        # Track real spend on `self.estimated_spend_usd`.
+        return [
+            Finding(
+                source_workflow=self.name,
+                file_path="src/attune/example.py",
+                line=42,
+                severity=Severity.MEDIUM,
+                message="some pattern detected",
+                raw_finding={"pattern": "scanner_internal_id"},
+                sweep_id=sweep_id,
+            )
+        ]
+
+
+engine = DiscoverySweepEngine(
+    sources=[PatternScanSource(), MyAdapter()]
+)
+result = engine.run(scope=Path("src/attune/security/"))
+print(f"accepted={result.accept_count} "
+      f"rejected={result.reject_count} "
+      f"unsure={result.unsure_count}")
+print(f"queue:     {result.queue_path}")
+print(f"rejected:  {result.rejected_path}")
+print(f"questions: {result.questions_path}")
+```
+
+## FindingSource Protocol
+
+A `FindingSource` is the adapter between an existing
+sub-workflow (bug_predict, security_audit, etc.) and the
+discovery-sweep engine. Implementations MUST:
+
+- Expose a string `name` matching the sub-workflow they wrap
+- Implement `discover(scope, budget_usd, sweep_id) -> Iterable[Finding]`
+- Expose `estimated_spend_usd` reporting actual USD spend
+  (used for budget accounting and the sweep-level cap)
+- Be side-effect free (no source-code edits, no commits)
+- Respect the `budget_usd` ceiling on a best-effort basis
+
+When `discover` raises, the orchestrator records the error in
+`SweepResult.sub_workflow_errors` and continues with the next
+source. When the sweep-level cap is exceeded, the orchestrator
+halts further sources (`SweepResult.budget_halted = True`).
+
+## Output files
+
+The sweep writes three files into the output directory
+(default: `.claude/discovery-queue/`, which is gitignored):
+
+| File | Contents |
+|---|---|
+| `<sweep_id>.jsonl` | ACCEPTed findings (the queue) |
+| `<sweep_id>.rejected.jsonl` | REJECTed findings (audit log) |
+| `<sweep_id>.questions.md` | UNSURE findings (cold-readable) |
+
+Each ACCEPTed finding carries `resolution_complexity`:
+`routine` or `needs_patrick`. Filter by the tag at triage time.
+
+## Budgets
+
+Two caps, both configurable:
+
+- **Per sub-workflow:** $10 default
+  (env: `ATTUNE_DISCOVERY_SUBWORKFLOW_BUDGET_USD`)
+- **Per sweep:** $40 default
+  (env: `ATTUNE_DISCOVERY_SWEEP_BUDGET_USD`)
+
+Crossing the sweep cap raises `SweepBudgetExceeded` internally
+and halts further sub-workflow invocation. The current
+sub-workflow's spend is still recorded for the audit log.
+
+## Verification rules
+
+The verification layer is a list of `VerificationRule` instances
+applied in order. Each rule returns one of:
+
+- `(REJECT, reasoning)` — known false positive, drop to audit log
+- `(ACCEPT, reasoning)` — strong positive signal (Phase 1 ships
+  no ACCEPT rules; everything that survives REJECT falls through)
+- `None` — rule did not match; continue to the next rule
+
+If no rule matches, the finding is classified as `UNSURE` and
+lands in the questions file.
+
+Built-in REJECT rules ship with paired control tests proving
+they do NOT fire on similar-looking REAL bugs. The control
+coverage is the regression net for the asymmetric-cost
+invariant: a false REJECT is worse than a false ACCEPT because
+REJECTed findings live in the audit log only.
+
+To add a new REJECT rule:
+
+1. Add a class to
+   `src/attune/workflows/discovery_sweep/rules/known_false_positives.py`
+2. Register it in
+   `src/attune/workflows/discovery_sweep/rules/__init__.py`
+3. Add a positive fixture +  control fixture in
+   `tests/unit/workflows/discovery_sweep/fixtures/false_positives/`
+4. Add positive + control test methods in
+   `tests/unit/workflows/discovery_sweep/test_verification.py`
+
+## Resolution complexity triggers
+
+ACCEPTed findings flip from `routine` to `needs_patrick` when
+any of these triggers apply (see
+`src/attune/workflows/discovery_sweep/complexity.py`):
+
+- `cross_cutting` — touches 3+ files OR mentions public API /
+  shared base class
+- `security_adjacent` — under `src/attune/security/` OR
+  mentions eval/exec/path-validation/webhook
+- `contradicts_lesson` — finding lands in CLAUDE.md lesson
+  territory but didn't match any REJECT rule
+- `tier_or_budget_change` — affects ModelTier, budget caps,
+  cost model
+- `mocks_production_smell` — test-file finding that suggests
+  mocking production code
+- `low_confidence` — verification reasoning includes
+  uncertainty markers
+
+Add new triggers in the same module and pass them to
+`ComplexityClassifier(triggers=[...])`.
+
+## Phase 2
+
+See [phase-2.md](../specs/discovery-sweep/phase-2.md) for the
+roadmap: real adapters, CLI registration, auto-fix for routine
+items, multi-module parallelism, RAG-grounded verification.

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -77,6 +77,7 @@ PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
     "code-review": PathArgSpec(kwarg="path"),
     "deep-review": PathArgSpec(kwarg="path"),
     "dependency-check": PathArgSpec(kwarg="path"),
+    "discovery-sweep": PathArgSpec(kwarg="path"),
     "doc-audit": PathArgSpec(kwarg="path"),
     "doc-gen": PathArgSpec(kwarg="path"),
     "perf-audit": PathArgSpec(kwarg="path"),

--- a/src/attune/workflows/__init__.py
+++ b/src/attune/workflows/__init__.py
@@ -180,6 +180,11 @@ _LAZY_WORKFLOW_IMPORTS: dict[str, tuple[str, str]] = {
     # migration.py's "progressive-test-gen" -> "test-gen" alias).
     # AgentCodeReviewWorkflow: Merged into CodeReviewWorkflow (v4.2.0)
     "DeepReviewAgentSDKWorkflow": (".deep_review", "DeepReviewAgentSDKWorkflow"),
+    # Discovery sweep orchestrator (Phase 2A)
+    "DiscoverySweepWorkflow": (
+        ".discovery_sweep.cli_workflow",
+        "DiscoverySweepWorkflow",
+    ),
     # Agent SDK adapters (v3.9.3)
     # SecurityAuditAgentSDKWorkflow: Merged into SecurityAuditWorkflow (v4.2.0)
     # PerfAuditAgentSDKWorkflow: Merged into PerformanceAuditWorkflow (v4.2.0)
@@ -291,6 +296,7 @@ _DEFAULT_WORKFLOW_NAMES: dict[str, str] = {
     "security-audit": "SecurityAuditWorkflow",
     "rag-code-gen": "RagCodeGenWorkflow",
     "perf-audit": "PerformanceAuditWorkflow",
+    "discovery-sweep": "DiscoverySweepWorkflow",
     # Generation workflows
     "test-audit": "TestAuditWorkflow",
     "test-gen": "TestGenerationWorkflow",

--- a/src/attune/workflows/discovery_sweep/__init__.py
+++ b/src/attune/workflows/discovery_sweep/__init__.py
@@ -1,0 +1,67 @@
+"""Discovery-sweep workflow package.
+
+Orchestrated read-only discovery sweep: runs N sub-workflows on
+a bounded path, filters findings through a verification rule
+engine grounded in CLAUDE.md lessons, and produces a curated
+queue tagged by resolution complexity.
+
+See ``.claude/plans/discovery-sweep.md`` for the spec.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from .budget import (
+    DEFAULT_SUBWORKFLOW_BUDGET_USD,
+    DEFAULT_SWEEP_BUDGET_USD,
+    BudgetTracker,
+    SweepBudgetExceeded,
+)
+from .cli_workflow import DiscoverySweepWorkflow
+from .complexity import ComplexityClassifier, default_triggers
+from .schema import (
+    Finding,
+    ResolutionComplexity,
+    Severity,
+    VerificationStatus,
+)
+from .serialization import (
+    read_jsonl,
+    write_jsonl,
+    write_questions_markdown,
+)
+from .sources import PatternScanSource
+from .verification import VerificationEngine
+from .workflow import (
+    DEFAULT_OUTPUT_DIR,
+    DiscoverySweepEngine,
+    FindingSource,
+    SweepResult,
+    split_findings_by_complexity,
+)
+
+__all__ = [
+    "DEFAULT_OUTPUT_DIR",
+    "DEFAULT_SUBWORKFLOW_BUDGET_USD",
+    "DEFAULT_SWEEP_BUDGET_USD",
+    "BudgetTracker",
+    "ComplexityClassifier",
+    "DiscoverySweepEngine",
+    "DiscoverySweepWorkflow",
+    "Finding",
+    "FindingSource",
+    "PatternScanSource",
+    "ResolutionComplexity",
+    "Severity",
+    "SweepBudgetExceeded",
+    "SweepResult",
+    "VerificationEngine",
+    "VerificationStatus",
+    "default_triggers",
+    "read_jsonl",
+    "split_findings_by_complexity",
+    "write_jsonl",
+    "write_questions_markdown",
+]

--- a/src/attune/workflows/discovery_sweep/budget.py
+++ b/src/attune/workflows/discovery_sweep/budget.py
@@ -1,0 +1,135 @@
+"""Budget tracker for the discovery-sweep workflow.
+
+Two ceilings: a per-sub-workflow cap (default $10) and a total
+sweep cap (default $40). Crossing the total cap raises
+``SweepBudgetExceeded`` and the orchestrator halts further
+sub-workflow invocation.
+
+Defaults can be overridden via environment variables:
+- ATTUNE_DISCOVERY_SUBWORKFLOW_BUDGET_USD
+- ATTUNE_DISCOVERY_SWEEP_BUDGET_USD
+
+Or per-instance via constructor args.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+DEFAULT_SUBWORKFLOW_BUDGET_USD = 10.0
+DEFAULT_SWEEP_BUDGET_USD = 40.0
+
+
+class SweepBudgetExceeded(RuntimeError):
+    """Raised when the sweep-level budget cap is hit."""
+
+
+@dataclass
+class BudgetReport:
+    """Per-sub-workflow spend record."""
+
+    sub_workflow: str
+    spend_usd: float
+    capped: bool = False
+
+
+@dataclass
+class BudgetTracker:
+    """Tracks per-sub-workflow + total spend across a sweep."""
+
+    subworkflow_cap_usd: float = DEFAULT_SUBWORKFLOW_BUDGET_USD
+    sweep_cap_usd: float = DEFAULT_SWEEP_BUDGET_USD
+    spend_by_subworkflow: dict[str, float] = field(default_factory=dict)
+    reports: list[BudgetReport] = field(default_factory=list)
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        subworkflow_cap_usd: float | None = None,
+        sweep_cap_usd: float | None = None,
+    ) -> BudgetTracker:
+        """Construct a tracker, honoring env-var overrides.
+
+        Explicit kwargs override env vars, which override defaults.
+        """
+
+        def _resolve(value: float | None, env_var: str, default: float) -> float:
+            if value is not None:
+                return value
+            raw = os.environ.get(env_var)
+            if raw is None:
+                return default
+            try:
+                parsed = float(raw)
+            except ValueError:
+                return default
+            return parsed
+
+        return cls(
+            subworkflow_cap_usd=_resolve(
+                subworkflow_cap_usd,
+                "ATTUNE_DISCOVERY_SUBWORKFLOW_BUDGET_USD",
+                DEFAULT_SUBWORKFLOW_BUDGET_USD,
+            ),
+            sweep_cap_usd=_resolve(
+                sweep_cap_usd,
+                "ATTUNE_DISCOVERY_SWEEP_BUDGET_USD",
+                DEFAULT_SWEEP_BUDGET_USD,
+            ),
+        )
+
+    @property
+    def total_spend_usd(self) -> float:
+        return sum(self.spend_by_subworkflow.values())
+
+    @property
+    def remaining_sweep_usd(self) -> float:
+        return max(0.0, self.sweep_cap_usd - self.total_spend_usd)
+
+    def budget_for(self, sub_workflow: str) -> float:
+        """Return the budget a sub-workflow can spend right now.
+
+        The smaller of the per-sub-workflow cap and the remaining
+        sweep budget.
+        """
+        return min(self.subworkflow_cap_usd, self.remaining_sweep_usd)
+
+    def can_run(self, sub_workflow: str) -> bool:
+        """Whether at least a token amount of budget remains."""
+        return self.remaining_sweep_usd > 0.01
+
+    def record(self, sub_workflow: str, spend_usd: float) -> BudgetReport:
+        """Record a sub-workflow's actual spend.
+
+        Raises ``SweepBudgetExceeded`` if recording this spend
+        crosses the sweep ceiling. The record is still saved
+        before the raise so the audit log captures the overrun.
+        """
+        capped = spend_usd >= self.subworkflow_cap_usd
+        self.spend_by_subworkflow[sub_workflow] = (
+            self.spend_by_subworkflow.get(sub_workflow, 0.0) + spend_usd
+        )
+        report = BudgetReport(sub_workflow=sub_workflow, spend_usd=spend_usd, capped=capped)
+        self.reports.append(report)
+
+        if self.total_spend_usd > self.sweep_cap_usd:
+            raise SweepBudgetExceeded(
+                f"sweep budget {self.sweep_cap_usd:.2f} exceeded "
+                f"(now ${self.total_spend_usd:.2f}); halting further "
+                f"sub-workflow invocation"
+            )
+        return report
+
+
+__all__ = [
+    "DEFAULT_SUBWORKFLOW_BUDGET_USD",
+    "DEFAULT_SWEEP_BUDGET_USD",
+    "BudgetReport",
+    "BudgetTracker",
+    "SweepBudgetExceeded",
+]

--- a/src/attune/workflows/discovery_sweep/cli_workflow.py
+++ b/src/attune/workflows/discovery_sweep/cli_workflow.py
@@ -1,0 +1,174 @@
+"""BaseWorkflow wrapper that exposes the engine to ``attune workflow run``.
+
+The wrapper is thin: it parses CLI/workflow-runner kwargs,
+instantiates default sources (``PatternScanSource`` by default),
+runs the engine, and packages the result as a ``WorkflowResult``
+so the existing CLI dispatch is happy.
+
+Phase 2A ships this with the deterministic pattern scanner.
+LLM-driven adapters wrapping ``BugPredictionWorkflow``,
+``SecurityAuditWorkflow``, etc. are Phase 2B work.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from attune.models import ModelTier
+from attune.workflows.base import BaseWorkflow
+from attune.workflows.data_classes import CostReport, WorkflowResult, WorkflowStage
+
+from .budget import BudgetTracker
+from .sources import PatternScanSource
+from .workflow import DiscoverySweepEngine, FindingSource, SweepResult
+
+logger = logging.getLogger(__name__)
+
+
+def _default_sources() -> list[FindingSource]:
+    """Phase 2A default — just the deterministic pattern scanner."""
+    return [PatternScanSource()]
+
+
+class DiscoverySweepWorkflow(BaseWorkflow):
+    """``attune workflow run discovery-sweep`` entry point.
+
+    Inherits from ``BaseWorkflow`` so the workflow registry,
+    workflow-runner dispatch, and CLI surface all see a familiar
+    shape. Internally delegates to ``DiscoverySweepEngine``.
+
+    Args (via ``execute(**kwargs)``):
+        path (str): Required. Directory or file to sweep.
+        output_dir (str): Optional. Override the default
+            ``.claude/discovery-queue/``.
+        subworkflow_budget_usd (float): Optional. Override the
+            ``ATTUNE_DISCOVERY_SUBWORKFLOW_BUDGET_USD`` cap.
+        sweep_budget_usd (float): Optional. Override the
+            ``ATTUNE_DISCOVERY_SWEEP_BUDGET_USD`` cap.
+        sources (list[FindingSource]): Optional. Inject custom
+            adapters in place of the Phase 2A defaults — useful
+            for tests and for early adopters wiring their own
+            adapters before Phase 2B lands.
+    """
+
+    name = "discovery-sweep"
+    description = (
+        "Read-only discovery sweep — runs N FindingSource adapters "
+        "on a bounded path, filters findings through verification "
+        "rules grounded in CLAUDE.md lessons, and produces a "
+        "curated queue tagged by resolution complexity."
+    )
+    stages = ["sweep"]
+
+    async def execute(self, **kwargs: Any) -> WorkflowResult:
+        """Run the sweep and package the result for the CLI."""
+        path_arg = kwargs.get("path", "")
+        if not path_arg:
+            return self._error_result("path argument is required")
+
+        try:
+            scope = Path(path_arg).resolve()
+        except (OSError, RuntimeError) as exc:
+            return self._error_result(f"invalid path: {exc}")
+
+        sources = kwargs.get("sources") or _default_sources()
+        if not sources:
+            return self._error_result(
+                "discovery-sweep requires at least one source; " "default is PatternScanSource"
+            )
+
+        budget = BudgetTracker.from_env(
+            subworkflow_cap_usd=kwargs.get("subworkflow_budget_usd"),
+            sweep_cap_usd=kwargs.get("sweep_budget_usd"),
+        )
+
+        output_dir = kwargs.get("output_dir")
+        engine = DiscoverySweepEngine(
+            sources=sources,
+            budget=budget,
+            output_dir=output_dir,
+        )
+
+        started_at = datetime.now(timezone.utc)
+        try:
+            sweep_result: SweepResult = engine.run(scope=scope)
+        except Exception as exc:  # noqa: BLE001
+            # INTENTIONAL: any orchestrator-level crash must surface
+            # as a WorkflowResult failure so the CLI doesn't silently
+            # swallow it.
+            logger.exception("discovery-sweep engine failed")
+            return self._error_result(f"sweep failed: {type(exc).__name__}: {exc}")
+        completed_at = datetime.now(timezone.utc)
+
+        duration_ms = int((completed_at - started_at).total_seconds() * 1000)
+        summary = _format_summary(sweep_result)
+
+        return WorkflowResult(
+            success=True,
+            stages=[
+                WorkflowStage(
+                    name="sweep",
+                    tier=ModelTier.CHEAP,
+                    description="discovery sweep",
+                    cost=sweep_result.total_spend_usd,
+                    duration_ms=duration_ms,
+                    result=summary,
+                )
+            ],
+            final_output=summary,
+            cost_report=CostReport(
+                total_cost=sweep_result.total_spend_usd,
+                baseline_cost=sweep_result.total_spend_usd,
+                savings=0.0,
+                savings_percent=0.0,
+            ),
+            started_at=started_at.replace(tzinfo=None),
+            completed_at=completed_at.replace(tzinfo=None),
+            total_duration_ms=duration_ms,
+            provider="discovery-sweep",
+            metadata={
+                "sweep_id": sweep_result.sweep_id,
+                "scope": sweep_result.scope,
+                "accept_count": sweep_result.accept_count,
+                "reject_count": sweep_result.reject_count,
+                "unsure_count": sweep_result.unsure_count,
+                "queue_path": sweep_result.queue_path,
+                "rejected_path": sweep_result.rejected_path,
+                "questions_path": sweep_result.questions_path,
+                "total_spend_usd": sweep_result.total_spend_usd,
+                "sub_workflow_spend": sweep_result.sub_workflow_spend,
+                "sub_workflow_errors": sweep_result.sub_workflow_errors,
+                "budget_halted": sweep_result.budget_halted,
+                "sweep_result": asdict(sweep_result),
+            },
+            summary=summary,
+        )
+
+
+def _format_summary(result: SweepResult) -> str:
+    """Render a CLI-friendly summary line for the WorkflowResult."""
+    parts = [
+        f"sweep {result.sweep_id}",
+        f"scope={result.scope}",
+        f"accept={result.accept_count}",
+        f"reject={result.reject_count}",
+        f"unsure={result.unsure_count}",
+        f"spend=${result.total_spend_usd:.2f}",
+    ]
+    if result.budget_halted:
+        parts.append("budget_halted=true")
+    if result.sub_workflow_errors:
+        parts.append(f"errors={len(result.sub_workflow_errors)}")
+    if result.queue_path:
+        parts.append(f"queue={result.queue_path}")
+    return " | ".join(parts)
+
+
+__all__ = ["DiscoverySweepWorkflow"]

--- a/src/attune/workflows/discovery_sweep/complexity.py
+++ b/src/attune/workflows/discovery_sweep/complexity.py
@@ -1,0 +1,244 @@
+"""Resolution-complexity classifier for the discovery-sweep workflow.
+
+Runs ONLY on findings that already have ``verification_status ==
+ACCEPT``. Decides between ``routine`` (the queue-default) and
+``needs_patrick`` (anything Patrick wants eyes on before
+resolution).
+
+Routine is the default. Any trigger flips the finding to
+``needs_patrick``. Erring toward ``needs_patrick`` on ambiguous
+cases is intentional — Patrick can downgrade in triage.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from typing import Protocol, runtime_checkable
+
+from .schema import Finding, ResolutionComplexity, VerificationStatus
+
+
+@runtime_checkable
+class ComplexityTrigger(Protocol):
+    """Returns True when the finding should flip to needs_patrick."""
+
+    name: str
+
+    def applies(self, finding: Finding) -> bool:  # pragma: no cover - protocol
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Triggers
+# ---------------------------------------------------------------------------
+
+
+class CrossCuttingTrigger:
+    """Fires when the finding looks cross-cutting.
+
+    Heuristic: message or raw_finding references three or more
+    distinct file paths, OR mentions ``public API`` / ``base
+    class`` / ``shared`` in a way that suggests broad impact.
+    """
+
+    name = "cross_cutting"
+    _BROAD_IMPACT_RE = re.compile(
+        r"\b(public api|base class|shared (?:mixin|module|interface)|" r"breaking change)\b",
+        re.IGNORECASE,
+    )
+    _PATH_RE = re.compile(r"(?:\.\./)*(?:[\w\-]+/){1,}[\w\-]+\.(?:py|js|ts|tsx|md)")
+
+    def applies(self, finding: Finding) -> bool:
+        haystack = self._collect_text(finding)
+        if self._BROAD_IMPACT_RE.search(haystack):
+            return True
+        paths = set(self._PATH_RE.findall(haystack))
+        paths.discard(finding.file_path)
+        return len(paths) >= 3
+
+    @staticmethod
+    def _collect_text(finding: Finding) -> str:
+        chunks: list[str] = [finding.message]
+        for value in finding.raw_finding.values():
+            if isinstance(value, str):
+                chunks.append(value)
+            elif isinstance(value, list):
+                chunks.extend(str(v) for v in value if isinstance(v, str | int))
+        return "\n".join(chunks)
+
+
+class SecurityAdjacentTrigger:
+    """Fires when the finding touches the security surface."""
+
+    name = "security_adjacent"
+    _SECURITY_PATH_TOKENS = (
+        "src/attune/security/",
+        "/security/",
+        "auth",
+        "credential",
+    )
+    _SECURITY_KEYWORDS_RE = re.compile(
+        r"\b(eval\(|exec\(|path traversal|path validation|webhook|"
+        r"ssrf|injection|secret|credential|cwe-)",
+        re.IGNORECASE,
+    )
+
+    def applies(self, finding: Finding) -> bool:
+        path_lower = finding.file_path.lower()
+        if any(token in path_lower for token in self._SECURITY_PATH_TOKENS):
+            return True
+        return bool(self._SECURITY_KEYWORDS_RE.search(finding.message))
+
+
+class ContradictsLessonTrigger:
+    """Fires when the finding lands in territory documented as a
+    known false-positive antipattern.
+
+    Phase 1 heuristic: the finding's message overlaps with
+    keywords from any REJECT rule's matcher (e.g. dirs[:],
+    create_subprocess_exec, structlog kwargs). Survives REJECT
+    only when the rule didn't fire — meaning Patrick should
+    look before we assume the fix is safe.
+    """
+
+    name = "contradicts_lesson"
+    _LESSON_KEYWORDS_RE = re.compile(
+        r"(dirs\[:\]|create_subprocess_exec|regex\.exec|"
+        r"\.write_text\(|noqa: ble001|structlog|pragma: allowlist secret)",
+        re.IGNORECASE,
+    )
+
+    def applies(self, finding: Finding) -> bool:
+        return bool(self._LESSON_KEYWORDS_RE.search(finding.message))
+
+
+class TierOrBudgetTrigger:
+    """Fires on findings that would change tier mapping, cost
+    model, or budget thresholds."""
+
+    name = "tier_or_budget_change"
+    _RE = re.compile(
+        r"\b(modeltier|tier_map|tier mapping|cost model|cost_tracker|"
+        r"budget(?:_| )(?:cap|ceiling|usd)|max_budget_usd|"
+        r"premium|capable tier|cheap tier)\b",
+        re.IGNORECASE,
+    )
+
+    def applies(self, finding: Finding) -> bool:
+        return bool(self._RE.search(finding.message))
+
+
+class MocksProductionTrigger:
+    """Fires when a test file's finding suggests rewriting tests
+    in a way that loses real coverage.
+
+    Heuristic: the finding is in a test path AND the message
+    mentions mocking, patching, or replacing a non-test path.
+    """
+
+    name = "mocks_production_smell"
+    _TEST_PATH_TOKENS = ("tests/", "test_", "/tests_", "/test/")
+    _MOCK_RE = re.compile(
+        r"\b(mock|patch|monkeypatch|stub|fake|replace[\w_]*)\b",
+        re.IGNORECASE,
+    )
+    _PRODUCTION_HINT_RE = re.compile(
+        r"\b(src/|attune\.[\w\.]+|production code|real (?:db|database|api|client))\b",
+        re.IGNORECASE,
+    )
+
+    def applies(self, finding: Finding) -> bool:
+        path_lower = finding.file_path.lower()
+        if not any(token in path_lower for token in self._TEST_PATH_TOKENS):
+            return False
+        return bool(
+            self._MOCK_RE.search(finding.message)
+            and self._PRODUCTION_HINT_RE.search(finding.message)
+        )
+
+
+class LowConfidenceTrigger:
+    """Fires when the verification reasoning shows the engine
+    wasn't fully confident in the ACCEPT verdict."""
+
+    name = "low_confidence"
+    _RE = re.compile(
+        r"(could not determine|ambiguous|unsure|might be|possibly|"
+        r"unable to verify|no specific input)",
+        re.IGNORECASE,
+    )
+
+    def applies(self, finding: Finding) -> bool:
+        return bool(self._RE.search(finding.verification_reasoning))
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def default_triggers() -> list[ComplexityTrigger]:
+    """Return the default trigger set."""
+    return [
+        CrossCuttingTrigger(),
+        SecurityAdjacentTrigger(),
+        ContradictsLessonTrigger(),
+        TierOrBudgetTrigger(),
+        MocksProductionTrigger(),
+        LowConfidenceTrigger(),
+    ]
+
+
+class ComplexityClassifier:
+    """Tags ACCEPTed findings with ``routine`` or ``needs_patrick``.
+
+    Returns a new Finding (the input is not mutated). Non-ACCEPT
+    findings are returned unchanged with ``resolution_complexity``
+    left None.
+    """
+
+    def __init__(self, triggers: list[ComplexityTrigger] | None = None) -> None:
+        self._triggers = triggers if triggers is not None else default_triggers()
+
+    def classify(self, finding: Finding) -> Finding:
+        if finding.verification_status != VerificationStatus.ACCEPT:
+            return finding
+
+        fired = [t.name for t in self._triggers if t.applies(finding)]
+
+        if not fired:
+            return replace(finding, resolution_complexity=ResolutionComplexity.ROUTINE)
+
+        # Append firing-trigger names to verification reasoning so
+        # the queue file carries triage hints.
+        annotation = "needs_patrick triggers: " + ", ".join(fired)
+        new_reasoning = (
+            f"{finding.verification_reasoning} | {annotation}"
+            if finding.verification_reasoning
+            else annotation
+        )
+        return replace(
+            finding,
+            resolution_complexity=ResolutionComplexity.NEEDS_PATRICK,
+            verification_reasoning=new_reasoning,
+        )
+
+    def classify_many(self, findings: list[Finding]) -> list[Finding]:
+        return [self.classify(f) for f in findings]
+
+
+__all__ = [
+    "ComplexityClassifier",
+    "ComplexityTrigger",
+    "ContradictsLessonTrigger",
+    "CrossCuttingTrigger",
+    "LowConfidenceTrigger",
+    "MocksProductionTrigger",
+    "SecurityAdjacentTrigger",
+    "TierOrBudgetTrigger",
+    "default_triggers",
+]

--- a/src/attune/workflows/discovery_sweep/rules/__init__.py
+++ b/src/attune/workflows/discovery_sweep/rules/__init__.py
@@ -1,0 +1,51 @@
+"""Rule registry for the discovery-sweep verification engine."""
+
+from __future__ import annotations
+
+from ..verification import VerificationRule
+from .known_false_positives import (
+    DirsSliceAssignmentRule,
+    IntentionalBroadExceptRule,
+    JsRegexExecRule,
+    SecretsPragmaRule,
+    StructlogKwargsRule,
+    SubprocessExecRule,
+    SubprocessInFuzzTargetRule,
+    WriteTextEvalFixtureRule,
+)
+
+
+def default_rules() -> list[VerificationRule]:
+    """Return the ordered default rule list for the engine.
+
+    REJECT rules come first. Phase 1 ships with no ACCEPT rules —
+    everything that survives the denylist falls through to UNSURE
+    and lands in the questions file for human review.
+
+    Rule order is significant: rules with stricter guards run
+    before rules with broader matchers so the more-precise rule
+    wins.
+    """
+    return [
+        DirsSliceAssignmentRule(),
+        JsRegexExecRule(),
+        WriteTextEvalFixtureRule(),
+        SubprocessExecRule(),
+        SubprocessInFuzzTargetRule(),
+        IntentionalBroadExceptRule(),
+        StructlogKwargsRule(),
+        SecretsPragmaRule(),
+    ]
+
+
+__all__ = [
+    "DirsSliceAssignmentRule",
+    "IntentionalBroadExceptRule",
+    "JsRegexExecRule",
+    "SecretsPragmaRule",
+    "StructlogKwargsRule",
+    "SubprocessExecRule",
+    "SubprocessInFuzzTargetRule",
+    "WriteTextEvalFixtureRule",
+    "default_rules",
+]

--- a/src/attune/workflows/discovery_sweep/rules/known_false_positives.py
+++ b/src/attune/workflows/discovery_sweep/rules/known_false_positives.py
@@ -1,0 +1,451 @@
+"""REJECT rules grounded in documented CLAUDE.md false positives.
+
+Each rule targets a specific historical false positive. Paired
+control tests (see ``tests/unit/workflows/discovery_sweep/
+test_verification.py``) ensure each rule does NOT fire on
+similar-looking REAL bugs.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from ..schema import Finding, VerificationStatus
+
+_REJECT = VerificationStatus.REJECT
+
+
+def _line_at(source_lines: list[str], line: int | None) -> str | None:
+    """Return the 1-indexed line, or None if out of range."""
+    if line is None or line < 1 or line > len(source_lines):
+        return None
+    return source_lines[line - 1]
+
+
+def _context_window(
+    source_lines: list[str],
+    line: int | None,
+    *,
+    before: int,
+    after: int,
+) -> list[str]:
+    """Return a window of lines around ``line`` (1-indexed)."""
+    if line is None:
+        return []
+    start = max(0, line - 1 - before)
+    end = min(len(source_lines), line + after)
+    return source_lines[start:end]
+
+
+def _find_open_call_above(
+    source_lines: list[str],
+    line: int | None,
+    *,
+    needles: tuple[str, ...],
+    max_lookback: int = 20,
+) -> int | None:
+    """Find a line above ``line`` containing any ``needles`` whose
+    enclosing call has not closed by the target line.
+
+    Returns the 1-indexed line of the matching open call, or None.
+
+    The "not closed" heuristic counts parentheses: if the number
+    of '(' from the candidate line through (line - 1) exceeds the
+    number of ')' in the same range, we treat the call as still
+    open at ``line``.
+    """
+    if line is None or line < 2:
+        return None
+    start_idx = max(0, line - 1 - max_lookback)
+    for candidate_idx in range(line - 2, start_idx - 1, -1):
+        candidate = source_lines[candidate_idx]
+        if not any(n in candidate for n in needles):
+            continue
+        between = source_lines[candidate_idx : line - 1]
+        opens = sum(s.count("(") for s in between)
+        closes = sum(s.count(")") for s in between)
+        if opens > closes:
+            return candidate_idx + 1
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: os.walk dirs[:] = [...] pattern
+# ---------------------------------------------------------------------------
+
+
+class DirsSliceAssignmentRule:
+    """REJECT memory-leak / large-list-copy findings on the
+    ``dirs[:] = [...]`` pattern inside an ``os.walk`` loop.
+
+    Lesson: this pattern is REQUIRED for in-place dirs filtering;
+    rebinding ``dirs = [...]`` would silently fail to filter.
+    """
+
+    name = "dirs_slice_assignment"
+    _TRIGGER_TOKENS = ("dirs[:]",)
+    _SUSPECT_MESSAGES = (
+        "memory_leak",
+        "large_list_copy",
+        "list_copy",
+        "unnecessary copy",
+    )
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:
+        message = finding.message.lower()
+        if not any(s in message for s in self._SUSPECT_MESSAGES):
+            return None
+
+        line_text = _line_at(source_lines, finding.line)
+        if line_text is None:
+            return None
+        if not any(t in line_text for t in self._TRIGGER_TOKENS):
+            return None
+
+        # Confirm the dirs[:] is inside an os.walk loop above.
+        lookback = _context_window(source_lines, finding.line, before=10, after=0)
+        if not any("os.walk(" in line for line in lookback):
+            return None
+
+        return (
+            _REJECT,
+            "dirs[:] inside os.walk loop is required for in-place "
+            "filtering, not a memory leak (see CLAUDE.md "
+            "os-walk-dirs-pattern lesson).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: create_subprocess_exec flagged as eval/exec
+# ---------------------------------------------------------------------------
+
+
+class SubprocessExecRule:
+    """REJECT eval/exec findings whose source line uses
+    ``create_subprocess_exec`` (substring match on 'exec' triggered
+    the scanner, but this is asyncio's safe spawn helper)."""
+
+    name = "subprocess_exec_false_eval"
+    _SAFE_TOKENS = ("create_subprocess_exec", "asyncio.subprocess.exec")
+    _SUSPECT_MESSAGES = ("dangerous_eval", "exec usage", "eval(")
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:
+        message = finding.message.lower()
+        if not any(s in message for s in self._SUSPECT_MESSAGES):
+            return None
+
+        line_text = _line_at(source_lines, finding.line)
+        if line_text is None:
+            return None
+        if not any(t in line_text for t in self._SAFE_TOKENS):
+            return None
+        # Sanity: must not actually contain raw eval(/exec( calls.
+        # Strip the safe token first so 'subprocess_exec' doesn't
+        # match 'exec(' below.
+        stripped = line_text
+        for token in self._SAFE_TOKENS:
+            stripped = stripped.replace(token, "")
+        if "eval(" in stripped or "exec(" in stripped:
+            return None
+
+        return (
+            _REJECT,
+            "create_subprocess_exec is asyncio's safe spawn helper, "
+            "not Python eval/exec (CLAUDE.md scanner-patterns lesson).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: JavaScript regex.exec() flagged as exec
+# ---------------------------------------------------------------------------
+
+
+class JsRegexExecRule:
+    """REJECT exec findings in .js/.ts/.tsx files where the call is
+    a regex ``.exec(...)`` method, not Python exec."""
+
+    name = "js_regex_exec"
+    _JS_EXTENSIONS = (".js", ".ts", ".tsx", ".jsx", ".mjs", ".cjs")
+    _SUSPECT_MESSAGES = ("dangerous_eval", "exec usage", "eval(")
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:
+        if not finding.file_path.endswith(self._JS_EXTENSIONS):
+            return None
+        message = finding.message.lower()
+        if not any(s in message for s in self._SUSPECT_MESSAGES):
+            return None
+
+        line_text = _line_at(source_lines, finding.line)
+        if line_text is None:
+            return None
+        # `.exec(` on a regex object — not standalone exec(
+        if ".exec(" not in line_text:
+            return None
+        # Reject if the line actually has a bare eval(/exec( call too.
+        # Look for tokens not preceded by '.': i.e. eval( at start of token.
+        cleaned = line_text.replace(".exec(", " ").replace(".eval(", " ")
+        if "eval(" in cleaned or " exec(" in cleaned or cleaned.lstrip().startswith("exec("):
+            return None
+
+        return (
+            _REJECT,
+            "JavaScript regex.exec() is a safe method call, not "
+            "Python exec (CLAUDE.md scanner-patterns lesson).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: eval/exec inside .write_text() / .write_bytes() fixtures
+# ---------------------------------------------------------------------------
+
+
+class WriteTextEvalFixtureRule:
+    """REJECT eval/exec findings where the line is inside a still-
+    open ``.write_text(`` or ``.write_bytes(`` call — fixture data,
+    not executable code."""
+
+    name = "write_text_eval_fixture"
+    _WRITE_CALLS = (".write_text(", ".write_bytes(", "write_text(", "write_bytes(")
+    _SUSPECT_MESSAGES = ("dangerous_eval", "exec usage", "eval(", "exec(")
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:
+        message = finding.message.lower()
+        if not any(s in message for s in self._SUSPECT_MESSAGES):
+            return None
+        line_text = _line_at(source_lines, finding.line)
+        if line_text is None:
+            return None
+        if "eval(" not in line_text and "exec(" not in line_text:
+            return None
+
+        open_call = _find_open_call_above(
+            source_lines,
+            finding.line,
+            needles=self._WRITE_CALLS,
+            max_lookback=25,
+        )
+        if open_call is None:
+            return None
+
+        return (
+            _REJECT,
+            f"eval/exec appears inside an open .write_text/.write_bytes "
+            f"call starting at line {open_call} — fixture content, not "
+            f"executable code (CLAUDE.md scanner-patterns lesson).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: Intentional broad except with # noqa: BLE001 + INTENTIONAL: marker
+# ---------------------------------------------------------------------------
+
+
+class IntentionalBroadExceptRule:
+    """REJECT broad-exception findings on lines paired with
+    ``# noqa: BLE001`` AND an ``# INTENTIONAL:`` comment within 3
+    lines (the documented graceful-degradation pattern)."""
+
+    name = "intentional_broad_except"
+    _SUSPECT_MESSAGES = ("broad_exception", "blind exception", "ble001", "broad except")
+    _NOQA = "noqa: ble001"
+    _MARKER = "intentional"
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:
+        message = finding.message.lower()
+        if not any(s in message for s in self._SUSPECT_MESSAGES):
+            return None
+        line_text = _line_at(source_lines, finding.line)
+        if line_text is None:
+            return None
+
+        window = _context_window(source_lines, finding.line, before=0, after=3)
+        window_lower = [line.lower() for line in window]
+
+        has_noqa = self._NOQA in line_text.lower() or any(
+            self._NOQA in line for line in window_lower
+        )
+        has_marker = any(self._MARKER in line for line in window_lower)
+
+        if not (has_noqa and has_marker):
+            return None
+
+        return (
+            _REJECT,
+            "broad except is paired with # noqa: BLE001 and an "
+            "INTENTIONAL: comment — documented graceful-degradation "
+            "pattern (CLAUDE.md coding-standards-index lesson).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 6: subprocess.run inside fuzz targets / clusterfuzzlite scaffolding
+# ---------------------------------------------------------------------------
+
+
+class SubprocessInFuzzTargetRule:
+    """REJECT shell-injection / subprocess findings inside fuzz
+    target files and clusterfuzzlite scaffolding — these execute
+    in an isolated build container, not in the production app."""
+
+    name = "subprocess_in_fuzz_target"
+    _SUSPECT_MESSAGES = (
+        "shell injection",
+        "subprocess",
+        "command injection",
+        "b602",
+        "b603",
+        "shell=true",
+    )
+    _FUZZ_PATH_TOKENS = (
+        ".clusterfuzzlite/",
+        "/fuzz_",
+        "/fuzzing/",
+        "fuzz_targets/",
+    )
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:
+        message = finding.message.lower()
+        if not any(s in message for s in self._SUSPECT_MESSAGES):
+            return None
+        path_lower = finding.file_path.lower()
+        if not any(token in path_lower for token in self._FUZZ_PATH_TOKENS):
+            return None
+
+        return (
+            _REJECT,
+            "subprocess call inside a fuzz target / clusterfuzzlite "
+            "scaffold runs in an isolated build container — not a "
+            "shell-injection risk in this context.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 7: structlog kwargs flagged as TypeError on stdlib Logger
+# ---------------------------------------------------------------------------
+
+
+class StructlogKwargsRule:
+    """REJECT findings that flag ``logger.info("msg", key=value)``
+    as a TypeError when the file is using structlog (where kwargs
+    are the documented syntax)."""
+
+    name = "structlog_kwargs"
+    _SUSPECT_MESSAGES = (
+        "unexpected keyword argument",
+        "got an unexpected keyword",
+        "logger.info(",
+        "typeerror",
+    )
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:
+        message = finding.message.lower()
+        if not any(s in message for s in self._SUSPECT_MESSAGES):
+            return None
+
+        # File must import or configure structlog.
+        has_structlog = any(
+            "import structlog" in line
+            or "from structlog" in line
+            or "structlog.get_logger" in line
+            or "structlog.stdlib" in line
+            for line in source_lines[:120]
+        )
+        if not has_structlog:
+            return None
+
+        # Line must be a logger call with kwargs.
+        line_text = _line_at(source_lines, finding.line)
+        if line_text is None or "logger." not in line_text:
+            return None
+        if "=" not in line_text:
+            return None
+
+        return (
+            _REJECT,
+            "logger.<level>(msg, key=value) is valid structlog "
+            "syntax — the file uses structlog (CLAUDE.md scanner-"
+            "patterns lesson on structlog kwargs).",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Rule 8: Pragma-allowlisted secret strings
+# ---------------------------------------------------------------------------
+
+
+class SecretsPragmaRule:
+    """REJECT secret findings on lines tagged
+    ``# pragma: allowlist secret`` (the detect-secrets escape
+    hatch)."""
+
+    name = "secrets_pragma_allowlist"
+    _SUSPECT_MESSAGES = (
+        "hardcoded",
+        "secret",
+        "credential",
+        "password",
+        "api key",
+        "detect-secrets",
+    )
+    _PRAGMA = "pragma: allowlist secret"
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:
+        message = finding.message.lower()
+        if not any(s in message for s in self._SUSPECT_MESSAGES):
+            return None
+        line_text = _line_at(source_lines, finding.line)
+        if line_text is None:
+            return None
+        if self._PRAGMA not in line_text.lower():
+            return None
+
+        return (
+            _REJECT,
+            "line carries # pragma: allowlist secret — documented "
+            "detect-secrets escape hatch (CLAUDE.md secrets lessons).",
+        )
+
+
+__all__ = [
+    "DirsSliceAssignmentRule",
+    "IntentionalBroadExceptRule",
+    "JsRegexExecRule",
+    "SecretsPragmaRule",
+    "StructlogKwargsRule",
+    "SubprocessExecRule",
+    "SubprocessInFuzzTargetRule",
+    "WriteTextEvalFixtureRule",
+]

--- a/src/attune/workflows/discovery_sweep/schema.py
+++ b/src/attune/workflows/discovery_sweep/schema.py
@@ -1,0 +1,134 @@
+"""Data classes for the discovery-sweep workflow.
+
+Defines the Finding dataclass and enums consumed by the
+verification rule engine, the complexity classifier, and the
+serialization layer.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+class VerificationStatus(str, Enum):
+    """Outcome of the verification layer on a single finding."""
+
+    ACCEPT = "accept"
+    REJECT = "reject"
+    UNSURE = "unsure"
+
+
+class ResolutionComplexity(str, Enum):
+    """Resolution-time tag for ACCEPTed findings.
+
+    Drives Patrick's triage filter. ``needs_patrick`` flips when
+    any complexity trigger fires (cross-cutting, security-adjacent,
+    lesson-contradicting, etc.). Default is ``routine``.
+    """
+
+    ROUTINE = "routine"
+    NEEDS_PATRICK = "needs_patrick"
+
+
+class Severity(str, Enum):
+    """Severity reported by the source sub-workflow."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+def _now_utc_iso() -> str:
+    """Timezone-aware UTC ISO timestamp."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_sweep_id() -> str:
+    """New short id for a sweep run."""
+    return uuid.uuid4().hex[:12]
+
+
+@dataclass
+class Finding:
+    """A single finding from a discovery sub-workflow.
+
+    Carries the original finding plus the verification verdict and
+    (when ACCEPTed) the resolution-complexity tag.
+
+    Fields tagged optional in the schema are populated as the
+    finding moves through the pipeline:
+      - verification_status / verification_reasoning: set by the
+        verification engine
+      - resolution_complexity: set by the complexity classifier
+        ONLY when verification_status == ACCEPT
+      - estimated_fix_cost: reserved for future cost-aware triage
+        (Phase 2); always None today
+    """
+
+    source_workflow: str
+    file_path: str
+    severity: Severity
+    message: str
+    raw_finding: dict[str, Any]
+    sweep_id: str
+
+    line: int | None = None
+    verification_status: VerificationStatus = VerificationStatus.UNSURE
+    verification_reasoning: str = ""
+    resolution_complexity: ResolutionComplexity | None = None
+    timestamp_utc: str = field(default_factory=_now_utc_iso)
+    estimated_fix_cost: float | None = None
+
+    def to_jsonl_dict(self) -> dict[str, Any]:
+        """Serialize to a JSONL-friendly dict.
+
+        Enums collapse to their string values; the dict round-trips
+        cleanly through ``from_jsonl_dict``.
+        """
+        payload = asdict(self)
+        payload["severity"] = self.severity.value
+        payload["verification_status"] = self.verification_status.value
+        payload["resolution_complexity"] = (
+            self.resolution_complexity.value if self.resolution_complexity is not None else None
+        )
+        return payload
+
+    @classmethod
+    def from_jsonl_dict(cls, data: dict[str, Any]) -> Finding:
+        """Deserialize from a JSONL-friendly dict."""
+        return cls(
+            source_workflow=data["source_workflow"],
+            file_path=data["file_path"],
+            severity=Severity(data["severity"]),
+            message=data["message"],
+            raw_finding=data["raw_finding"],
+            sweep_id=data["sweep_id"],
+            line=data.get("line"),
+            verification_status=VerificationStatus(
+                data.get("verification_status", VerificationStatus.UNSURE.value)
+            ),
+            verification_reasoning=data.get("verification_reasoning", ""),
+            resolution_complexity=(
+                ResolutionComplexity(data["resolution_complexity"])
+                if data.get("resolution_complexity") is not None
+                else None
+            ),
+            timestamp_utc=data.get("timestamp_utc", _now_utc_iso()),
+            estimated_fix_cost=data.get("estimated_fix_cost"),
+        )
+
+
+__all__ = [
+    "Finding",
+    "ResolutionComplexity",
+    "Severity",
+    "VerificationStatus",
+    "_new_sweep_id",
+]

--- a/src/attune/workflows/discovery_sweep/serialization.py
+++ b/src/attune/workflows/discovery_sweep/serialization.py
@@ -1,0 +1,139 @@
+"""Output serialization for the discovery-sweep workflow.
+
+Three artifacts are emitted per sweep:
+- ``<sweep_id>.jsonl``           — ACCEPTed findings (queue)
+- ``<sweep_id>.rejected.jsonl``  — REJECTed findings (audit log)
+- ``<sweep_id>.questions.md``    — UNSURE findings (human review)
+
+JSONL is used for tool-consumed artifacts (jq-friendly,
+streaming-friendly); markdown for the questions file so Patrick
+can review cold without needing a tool to render it.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+from attune.security.path_validation import _validate_file_path
+
+from .schema import Finding, VerificationStatus
+
+
+def write_jsonl(path: str | Path, findings: Iterable[Finding]) -> Path:
+    """Write findings to a JSONL file (one Finding per line).
+
+    Path is validated; parent directories are created if missing.
+    """
+    validated = _validate_file_path(str(path))
+    validated.parent.mkdir(parents=True, exist_ok=True)
+    with validated.open("w", encoding="utf-8") as fp:
+        for finding in findings:
+            fp.write(json.dumps(finding.to_jsonl_dict(), sort_keys=True))
+            fp.write("\n")
+    return validated
+
+
+def read_jsonl(path: str | Path) -> list[Finding]:
+    """Read findings from a JSONL file written by ``write_jsonl``."""
+    validated = _validate_file_path(str(path))
+    findings: list[Finding] = []
+    with validated.open("r", encoding="utf-8") as fp:
+        for line in fp:
+            line = line.strip()
+            if not line:
+                continue
+            findings.append(Finding.from_jsonl_dict(json.loads(line)))
+    return findings
+
+
+def _format_question_block(finding: Finding, index: int) -> str:
+    """Render one UNSURE finding as a reviewable-cold markdown block."""
+    location = finding.file_path
+    if finding.line is not None:
+        location = f"{finding.file_path}:{finding.line}"
+
+    lines = [
+        f"## {index}. {finding.source_workflow} — {location}",
+        "",
+        f"- **Severity:** {finding.severity.value}",
+        f"- **Sweep:** `{finding.sweep_id}`",
+        f"- **Captured:** {finding.timestamp_utc}",
+        "",
+        "### Finding",
+        "",
+        finding.message.strip() or "_(no message)_",
+        "",
+        "### Why verification was unsure",
+        "",
+        finding.verification_reasoning.strip()
+        or "_No verification reasoning recorded — no rule fired._",
+        "",
+        "### Raw finding (from sub-workflow)",
+        "",
+        "```json",
+        json.dumps(finding.raw_finding, indent=2, sort_keys=True),
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_questions_markdown(
+    path: str | Path,
+    findings: Iterable[Finding],
+    sweep_id: str,
+    scope: str,
+) -> Path:
+    """Write UNSURE findings as a reviewable-cold markdown file.
+
+    Only findings with ``verification_status == UNSURE`` are included.
+    Other statuses are silently filtered (call sites should pass a
+    pre-filtered list, but the filter here is defense in depth).
+    """
+    validated = _validate_file_path(str(path))
+    validated.parent.mkdir(parents=True, exist_ok=True)
+
+    unsure = [f for f in findings if f.verification_status == VerificationStatus.UNSURE]
+
+    lines = [
+        f"# Discovery sweep — UNSURE findings ({sweep_id})",
+        "",
+        f"- **Scope:** `{scope}`",
+        f"- **Sweep id:** `{sweep_id}`",
+        f"- **Count:** {len(unsure)}",
+        "",
+        "These findings could not be confidently classified by the",
+        "verification rule engine. Each block below captures the",
+        "original finding, the sub-workflow that raised it, and what",
+        "made verification ambiguous — enough context to review cold.",
+        "",
+        "---",
+        "",
+    ]
+
+    if not unsure:
+        lines.append("_No UNSURE findings in this sweep._")
+        lines.append("")
+    else:
+        for idx, finding in enumerate(unsure, start=1):
+            lines.append(_format_question_block(finding, idx))
+            lines.append("---")
+            lines.append("")
+
+    content = "\n".join(lines)
+    if not content.endswith("\n"):
+        content += "\n"
+    validated.write_text(content, encoding="utf-8")
+    return validated
+
+
+__all__ = [
+    "read_jsonl",
+    "write_jsonl",
+    "write_questions_markdown",
+]

--- a/src/attune/workflows/discovery_sweep/sources/__init__.py
+++ b/src/attune/workflows/discovery_sweep/sources/__init__.py
@@ -1,0 +1,14 @@
+"""Built-in ``FindingSource`` adapters for discovery-sweep.
+
+Phase 2A ships the deterministic pattern scanner — a fast,
+zero-LLM-cost adapter that produces line-level findings via
+regex/AST primitives. LLM-driven adapters wrapping
+``BugPredictionWorkflow``, ``SecurityAuditWorkflow``, etc. are
+Phase 2B work.
+"""
+
+from __future__ import annotations
+
+from .pattern_scan import PatternScanSource
+
+__all__ = ["PatternScanSource"]

--- a/src/attune/workflows/discovery_sweep/sources/pattern_scan.py
+++ b/src/attune/workflows/discovery_sweep/sources/pattern_scan.py
@@ -1,0 +1,185 @@
+"""``PatternScanSource`` — deterministic line-level pattern scanner.
+
+Walks ``.py`` files under a scope and emits ``Finding`` objects
+for canonical bug patterns:
+
+- bare ``except:`` clauses
+- broad ``except Exception:`` clauses
+- ``eval(`` / ``exec(`` usage
+- ``subprocess.*`` with ``shell=True``
+- TODO/FIXME markers (low severity)
+
+Zero LLM cost. The verification engine's REJECT rules filter
+the obvious false positives (intentional broad excepts,
+write_text fixtures, JS regex.exec, fuzz-target subprocess) so
+this adapter's raw output is already triaged before it reaches
+the queue.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ..schema import Finding, Severity
+
+_DEFAULT_INCLUDE_GLOB = "**/*.py"
+_DEFAULT_EXCLUDE_DIRS = frozenset(
+    {
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "node_modules",
+        ".git",
+        "build",
+        "dist",
+        ".eggs",
+        "site-packages",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _PatternSpec:
+    """One pattern the scanner looks for."""
+
+    name: str
+    severity: Severity
+    regex: re.Pattern[str]
+    message_template: str
+
+
+_PATTERNS: tuple[_PatternSpec, ...] = (
+    _PatternSpec(
+        name="bare_except",
+        severity=Severity.HIGH,
+        regex=re.compile(r"^\s*except\s*:"),
+        message_template="bare_except: catches KeyboardInterrupt and SystemExit",
+    ),
+    _PatternSpec(
+        name="broad_exception",
+        severity=Severity.MEDIUM,
+        regex=re.compile(r"^\s*except\s+Exception\s*:"),
+        message_template=("broad_exception: BLE001 blind exception — masks specific errors"),
+    ),
+    _PatternSpec(
+        name="dangerous_eval",
+        severity=Severity.HIGH,
+        regex=re.compile(r"(?<![A-Za-z0-9_.])eval\s*\("),
+        message_template="dangerous_eval: eval( call may execute arbitrary code",
+    ),
+    _PatternSpec(
+        name="dangerous_exec",
+        severity=Severity.HIGH,
+        regex=re.compile(r"(?<![A-Za-z0-9_.])exec\s*\("),
+        message_template="dangerous_eval: exec usage may execute arbitrary code",
+    ),
+    _PatternSpec(
+        name="subprocess_shell_true",
+        severity=Severity.HIGH,
+        regex=re.compile(r"subprocess\.\w+\([^)]*shell\s*=\s*True"),
+        message_template=("subprocess shell injection B602: shell=True with user input is risky"),
+    ),
+    _PatternSpec(
+        name="incomplete_code",
+        severity=Severity.LOW,
+        regex=re.compile(r"#\s*(?:TODO|FIXME)\b", re.IGNORECASE),
+        message_template="incomplete_code: TODO/FIXME marker",
+    ),
+)
+
+
+@dataclass
+class PatternScanSource:
+    """Deterministic line-level pattern scanner.
+
+    No LLM round-trips. ``estimated_spend_usd`` is always 0.0.
+    Set ``include_glob`` to restrict scope further (default
+    matches all .py files); ``exclude_dirs`` to skip vendor /
+    cache trees in addition to the built-in defaults.
+    """
+
+    name: str = "pattern_scan"
+    include_glob: str = _DEFAULT_INCLUDE_GLOB
+    exclude_dirs: frozenset[str] = _DEFAULT_EXCLUDE_DIRS
+    estimated_spend_usd: float = 0.0
+    _scanned_files: int = field(default=0, init=False, repr=False)
+
+    def discover(
+        self,
+        scope: Path,
+        budget_usd: float,
+        sweep_id: str,
+    ) -> Iterable[Finding]:
+        """Walk ``scope`` and yield Findings for matching lines.
+
+        ``budget_usd`` is honored as an advisory hint only — this
+        scanner has no real spend, so we ignore it.
+        """
+        scope_path = Path(scope).resolve()
+        if scope_path.is_file():
+            yield from self._scan_file(scope_path, sweep_id)
+            return
+        if not scope_path.is_dir():
+            return
+
+        for candidate in scope_path.rglob(self.include_glob):
+            if not candidate.is_file():
+                continue
+            if self._is_excluded(candidate, scope_path):
+                continue
+            yield from self._scan_file(candidate, sweep_id, scope_root=scope_path)
+
+    def _is_excluded(self, path: Path, scope_root: Path) -> bool:
+        try:
+            rel_parts = path.relative_to(scope_root).parts
+        except ValueError:
+            rel_parts = path.parts
+        return any(part in self.exclude_dirs for part in rel_parts)
+
+    def _scan_file(
+        self,
+        path: Path,
+        sweep_id: str,
+        scope_root: Path | None = None,
+    ) -> Iterable[Finding]:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return
+        self._scanned_files += 1
+
+        display_path = str(path.relative_to(scope_root)) if scope_root is not None else str(path)
+
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for spec in _PATTERNS:
+                if spec.regex.search(line):
+                    yield Finding(
+                        source_workflow=self.name,
+                        file_path=display_path,
+                        line=lineno,
+                        severity=spec.severity,
+                        message=spec.message_template,
+                        raw_finding={
+                            "pattern": spec.name,
+                            "matched_line": line.rstrip(),
+                        },
+                        sweep_id=sweep_id,
+                    )
+
+    @property
+    def scanned_files(self) -> int:
+        """Number of files this scanner processed in its lifetime."""
+        return self._scanned_files
+
+
+__all__ = ["PatternScanSource"]

--- a/src/attune/workflows/discovery_sweep/verification.py
+++ b/src/attune/workflows/discovery_sweep/verification.py
@@ -1,0 +1,152 @@
+"""Verification rule engine for the discovery-sweep workflow.
+
+The engine runs an ordered list of rules against each Finding.
+The first rule that fires determines the finding's
+``VerificationStatus`` (REJECT or ACCEPT). If no rule fires, the
+default is UNSURE — these findings flow to the questions file
+for human review.
+
+The asymmetry to respect: a false REJECT is worse than a false
+ACCEPT, because REJECTed findings only land in the audit log
+(less visible) while ACCEPTed findings land in the queue (visible
+and triaged). REJECT rules must be paired with control tests
+showing similar-looking real bugs that the rule does NOT fire on.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from .schema import Finding, VerificationStatus
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class VerificationRule(Protocol):
+    """Protocol for verification rules.
+
+    Implementations inspect a Finding plus the source file (as a
+    list of lines) and return a ``(status, reasoning)`` tuple when
+    the rule fires, or ``None`` to defer to subsequent rules.
+
+    Rules MUST be side-effect free.
+    """
+
+    name: str
+
+    def classify(
+        self,
+        finding: Finding,
+        source_lines: list[str],
+    ) -> tuple[VerificationStatus, str] | None:  # pragma: no cover - protocol
+        ...
+
+
+class VerificationEngine:
+    """Runs an ordered list of rules against findings.
+
+    The engine reads each finding's source file once (cached per
+    sweep run) and dispatches to rules in order. The first rule
+    that returns a non-None classification wins. If no rule matches,
+    the finding is classified as UNSURE.
+    """
+
+    def __init__(
+        self,
+        rules: Iterable[VerificationRule],
+        project_root: Path | None = None,
+    ) -> None:
+        self._rules: list[VerificationRule] = list(rules)
+        self._project_root = (project_root or Path.cwd()).resolve()
+        self._source_cache: dict[str, list[str]] = {}
+
+    def classify(self, finding: Finding) -> Finding:
+        """Return a new Finding with ``verification_status`` populated.
+
+        The input Finding is not mutated.
+        """
+        source_lines = self._load_source(finding.file_path)
+
+        for rule in self._rules:
+            try:
+                outcome = rule.classify(finding, source_lines)
+            except Exception:  # noqa: BLE001
+                # INTENTIONAL: a buggy rule must not abort the sweep.
+                # Log and skip — finding falls through to UNSURE.
+                logger.exception(
+                    "verification rule %s raised on %s:%s",
+                    getattr(rule, "name", type(rule).__name__),
+                    finding.file_path,
+                    finding.line,
+                )
+                continue
+
+            if outcome is None:
+                continue
+
+            status, reasoning = outcome
+            return _with_verdict(finding, status, reasoning)
+
+        return _with_verdict(
+            finding,
+            VerificationStatus.UNSURE,
+            "no verification rule fired; deferring to human review",
+        )
+
+    def classify_many(self, findings: Iterable[Finding]) -> list[Finding]:
+        """Classify a batch of findings."""
+        return [self.classify(f) for f in findings]
+
+    def _load_source(self, file_path: str) -> list[str]:
+        if file_path in self._source_cache:
+            return self._source_cache[file_path]
+
+        resolved = self._resolve(file_path)
+        if resolved is None or not resolved.is_file():
+            self._source_cache[file_path] = []
+            return []
+
+        try:
+            text = resolved.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            logger.debug("could not read source for %s", file_path)
+            self._source_cache[file_path] = []
+            return []
+
+        lines = text.splitlines()
+        self._source_cache[file_path] = lines
+        return lines
+
+    def _resolve(self, file_path: str) -> Path | None:
+        candidate = Path(file_path)
+        if not candidate.is_absolute():
+            candidate = self._project_root / candidate
+        try:
+            return candidate.resolve()
+        except OSError:
+            return None
+
+
+def _with_verdict(
+    finding: Finding,
+    status: VerificationStatus,
+    reasoning: str,
+) -> Finding:
+    """Return a copy of finding with the verdict applied."""
+    from dataclasses import replace
+
+    return replace(
+        finding,
+        verification_status=status,
+        verification_reasoning=reasoning,
+    )
+
+
+__all__ = ["VerificationEngine", "VerificationRule"]

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -1,0 +1,266 @@
+"""DiscoverySweepWorkflow — the orchestrator.
+
+Runs N FindingSources against a bounded scope, filters their
+output through the verification rule engine, tags ACCEPTed
+findings with resolution complexity, and writes three artifacts:
+
+- ``<sweep_id>.jsonl``           — ACCEPTed findings (queue)
+- ``<sweep_id>.rejected.jsonl``  — REJECTed findings (audit log)
+- ``<sweep_id>.questions.md``    — UNSURE findings (human review)
+
+The orchestrator is read-only: it does not modify source code.
+Patrick triages the queue at his pace; promoted items flow to
+``docs/COVERAGE_BUG_LOG.md`` for fixing via the existing
+interactive workflow.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from .budget import BudgetTracker, SweepBudgetExceeded
+from .complexity import ComplexityClassifier
+from .rules import default_rules
+from .schema import (
+    Finding,
+    ResolutionComplexity,
+    VerificationStatus,
+    _new_sweep_id,
+)
+from .serialization import write_jsonl, write_questions_markdown
+from .verification import VerificationEngine
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIR = Path(".claude") / "discovery-queue"
+
+
+@runtime_checkable
+class FindingSource(Protocol):
+    """A pluggable discovery adapter.
+
+    Implementations wrap a single sub-workflow (bug_predict,
+    security_audit, etc.) and translate its output into Finding
+    objects with ``verification_status = UNSURE`` (the verifier
+    will classify).
+
+    ``discover`` MUST be side-effect free and respect the
+    ``budget_usd`` ceiling. ``estimated_spend_usd`` reports the
+    actual spend for budget accounting.
+    """
+
+    name: str
+
+    def discover(
+        self,
+        scope: Path,
+        budget_usd: float,
+        sweep_id: str,
+    ) -> Iterable[Finding]:  # pragma: no cover - protocol
+        ...
+
+    @property
+    def estimated_spend_usd(self) -> float:  # pragma: no cover - protocol
+        ...
+
+
+@dataclass
+class SweepResult:
+    """Result of a discovery sweep run."""
+
+    sweep_id: str
+    scope: str
+    started_at: str
+    completed_at: str
+    accept_count: int
+    reject_count: int
+    unsure_count: int
+    queue_path: str | None
+    rejected_path: str | None
+    questions_path: str | None
+    total_spend_usd: float
+    sub_workflow_spend: dict[str, float]
+    sub_workflow_errors: dict[str, str] = field(default_factory=dict)
+    budget_halted: bool = False
+
+
+class DiscoverySweepEngine:
+    """Engine for the discovery-sweep pipeline.
+
+    Not a ``BaseWorkflow`` subclass — the engine doesn't need the
+    multi-tier LLM routing machinery in ``BaseWorkflow``. It
+    orchestrates ``FindingSource`` adapters, and the LLM cost (if
+    any) is owned by each adapter, not by the engine.
+
+    Phase 2A wraps this engine in a thin ``BaseWorkflow`` subclass
+    (``DiscoverySweepWorkflow`` in ``cli_workflow.py``) so that
+    ``attune workflow run discovery-sweep`` dispatches to it.
+    """
+
+    name = "discovery-sweep"
+    description = (
+        "Read-only discovery sweep: runs N sub-workflows on a "
+        "bounded path, filters findings through verification "
+        "rules grounded in CLAUDE.md lessons, produces a curated "
+        "queue tagged by resolution complexity."
+    )
+    stages = ["discover", "verify", "classify", "serialize"]
+
+    def __init__(
+        self,
+        sources: list[FindingSource],
+        *,
+        verification_engine: VerificationEngine | None = None,
+        complexity_classifier: ComplexityClassifier | None = None,
+        budget: BudgetTracker | None = None,
+        output_dir: str | Path | None = None,
+        project_root: Path | None = None,
+    ) -> None:
+        if not sources:
+            raise ValueError("DiscoverySweepEngine requires at least one source")
+        self._sources = sources
+        self._project_root = (project_root or Path.cwd()).resolve()
+        self._verification = verification_engine or VerificationEngine(
+            default_rules(), project_root=self._project_root
+        )
+        self._complexity = complexity_classifier or ComplexityClassifier()
+        self._budget = budget or BudgetTracker.from_env()
+        self._output_dir = Path(output_dir) if output_dir is not None else DEFAULT_OUTPUT_DIR
+
+    def run(self, scope: str | Path) -> SweepResult:
+        """Run the sweep against ``scope`` and write all three files.
+
+        Synchronous. Sub-workflow failures are recorded but do not
+        abort the sweep. The budget ceiling DOES abort the sweep
+        (no further sub-workflows invoked once exceeded).
+        """
+        scope_path = Path(scope).resolve()
+        sweep_id = _new_sweep_id()
+        started_at = datetime.now(timezone.utc).isoformat()
+
+        raw_findings: list[Finding] = []
+        sub_workflow_errors: dict[str, str] = {}
+        budget_halted = False
+
+        for source in self._sources:
+            if not self._budget.can_run(source.name):
+                logger.info(
+                    "skipping %s — sweep budget exhausted (sweep=%s)",
+                    source.name,
+                    sweep_id,
+                )
+                budget_halted = True
+                break
+
+            allowance = self._budget.budget_for(source.name)
+            try:
+                produced = list(source.discover(scope_path, allowance, sweep_id))
+            except Exception as exc:  # noqa: BLE001
+                # INTENTIONAL: one bad adapter must not abort the sweep.
+                # Capture the error in the result; continue with the
+                # next source.
+                logger.exception("discovery source %s failed (sweep=%s)", source.name, sweep_id)
+                sub_workflow_errors[source.name] = f"{type(exc).__name__}: {exc}"
+                continue
+
+            raw_findings.extend(produced)
+
+            try:
+                self._budget.record(source.name, source.estimated_spend_usd)
+            except SweepBudgetExceeded as exc:
+                logger.warning("sweep halted: %s", exc)
+                budget_halted = True
+                break
+
+        verified = self._verification.classify_many(raw_findings)
+        classified = self._complexity.classify_many(verified)
+
+        accepted = [f for f in classified if f.verification_status == VerificationStatus.ACCEPT]
+        rejected = [f for f in classified if f.verification_status == VerificationStatus.REJECT]
+        unsure = [f for f in classified if f.verification_status == VerificationStatus.UNSURE]
+
+        scope_str = str(scope_path)
+        queue_path, rejected_path, questions_path = self._write_outputs(
+            sweep_id=sweep_id,
+            scope=scope_str,
+            accepted=accepted,
+            rejected=rejected,
+            unsure=unsure,
+        )
+
+        completed_at = datetime.now(timezone.utc).isoformat()
+        return SweepResult(
+            sweep_id=sweep_id,
+            scope=scope_str,
+            started_at=started_at,
+            completed_at=completed_at,
+            accept_count=len(accepted),
+            reject_count=len(rejected),
+            unsure_count=len(unsure),
+            queue_path=str(queue_path) if queue_path else None,
+            rejected_path=str(rejected_path) if rejected_path else None,
+            questions_path=str(questions_path) if questions_path else None,
+            total_spend_usd=self._budget.total_spend_usd,
+            sub_workflow_spend=dict(self._budget.spend_by_subworkflow),
+            sub_workflow_errors=sub_workflow_errors,
+            budget_halted=budget_halted,
+        )
+
+    def _write_outputs(
+        self,
+        *,
+        sweep_id: str,
+        scope: str,
+        accepted: list[Finding],
+        rejected: list[Finding],
+        unsure: list[Finding],
+    ) -> tuple[Path | None, Path | None, Path | None]:
+        output_dir = self._resolve_output_dir()
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        queue_path = output_dir / f"{sweep_id}.jsonl"
+        rejected_path = output_dir / f"{sweep_id}.rejected.jsonl"
+        questions_path = output_dir / f"{sweep_id}.questions.md"
+
+        write_jsonl(queue_path, accepted)
+        write_jsonl(rejected_path, rejected)
+        write_questions_markdown(questions_path, unsure, sweep_id=sweep_id, scope=scope)
+        return queue_path, rejected_path, questions_path
+
+    def _resolve_output_dir(self) -> Path:
+        if self._output_dir.is_absolute():
+            return self._output_dir
+        return self._project_root / self._output_dir
+
+
+def split_findings_by_complexity(
+    findings: Iterable[Finding],
+) -> tuple[list[Finding], list[Finding]]:
+    """Split ACCEPTed findings into (routine, needs_patrick) lists."""
+    routine: list[Finding] = []
+    needs_patrick: list[Finding] = []
+    for finding in findings:
+        if finding.verification_status != VerificationStatus.ACCEPT:
+            continue
+        if finding.resolution_complexity == ResolutionComplexity.NEEDS_PATRICK:
+            needs_patrick.append(finding)
+        else:
+            routine.append(finding)
+    return routine, needs_patrick
+
+
+__all__ = [
+    "DEFAULT_OUTPUT_DIR",
+    "DiscoverySweepEngine",
+    "FindingSource",
+    "SweepResult",
+    "split_findings_by_complexity",
+]

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/dirs_slice_assignment.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/dirs_slice_assignment.py
@@ -1,0 +1,19 @@
+"""False-positive fixture: dirs[:] inside os.walk loop.
+
+The scanner flags ``dirs[:] = [...]`` as a memory leak / large
+list copy, but this pattern is REQUIRED for in-place dir
+filtering during os.walk traversal.
+"""
+
+import os
+
+
+def find_python_files(root: str) -> list[str]:
+    """Walk ``root`` and return all .py file paths, skipping caches."""
+    matches: list[str] = []
+    for dirpath, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in {"__pycache__", ".venv"}]
+        for f in files:
+            if f.endswith(".py"):
+                matches.append(os.path.join(dirpath, f))
+    return matches

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/dirs_slice_assignment_control.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/dirs_slice_assignment_control.py
@@ -1,0 +1,16 @@
+"""Control: dirs[:] OUTSIDE an os.walk loop.
+
+Same syntax, different context — this IS an unnecessary copy
+because the surrounding code doesn't depend on in-place
+modification. The rule must NOT fire here.
+"""
+
+
+def reverse_then_uppercase(dirs: list[str]) -> list[str]:
+    """Reverse a list of names and return upper-cased copies.
+
+    The ``dirs[:] = ...`` rebind here doesn't filter os.walk —
+    it's just a slice copy and could equally be ``dirs = ...``.
+    """
+    dirs[:] = [d.upper() for d in dirs[::-1]]
+    return dirs

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/fuzz_target.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/fuzz_target.py
@@ -1,0 +1,19 @@
+"""False-positive fixture: subprocess inside a fuzz target.
+
+Fuzz harness scaffolding runs in an isolated build container.
+Scanners flagging shell=True / B602 / B603 on this file are
+false-positive — there is no shell-injection vector reachable
+from prod.
+"""
+
+import subprocess
+import sys
+
+
+def TestOneInput(data: bytes) -> int:  # libFuzzer entrypoint
+    """libFuzzer hook — spawns the candidate binary."""
+    try:
+        subprocess.run([sys.executable, "-c", "pass"], shell=False, check=True)
+    except subprocess.CalledProcessError:
+        pass
+    return 0

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/intentional_broad_except.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/intentional_broad_except.py
@@ -1,0 +1,20 @@
+"""False-positive fixture: intentional broad except w/ noqa + INTENTIONAL.
+
+Documented graceful-degradation pattern from coding standards.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_package_version() -> str:
+    """Get package version with graceful fallback."""
+    try:
+        from importlib.metadata import version
+
+        return version("attune-ai")
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: fallback for dev installs without metadata
+        logger.debug("version metadata unavailable")
+        return "dev"

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/intentional_broad_except_control.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/intentional_broad_except_control.py
@@ -1,0 +1,16 @@
+"""Control: broad except WITHOUT noqa/INTENTIONAL markers.
+
+This is the antipattern coding-standards.md prohibits. The rule
+must NOT fire here.
+"""
+
+
+def load_config(path: str) -> dict:
+    """Load config — broad except masks real failures."""
+    try:
+        import json
+
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return {}

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/js_regex_exec.js
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/js_regex_exec.js
@@ -1,0 +1,9 @@
+// False-positive fixture: JavaScript regex.exec().
+// Scanners that don't language-distinguish flag this as Python exec.
+// It is a safe regex method.
+
+const pattern = /([a-z]+)\s+([0-9]+)/;
+const match = pattern.exec("hello 42");
+if (match) {
+    console.log(match[1], match[2]);
+}

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/js_regex_exec_control.js
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/js_regex_exec_control.js
@@ -1,0 +1,7 @@
+// Control: real eval() call in JS.
+// The rule must NOT fire here just because the file is JS.
+// eval() in JavaScript is just as dangerous as Python eval().
+
+function dangerousEval(userInput) {
+    return eval(userInput);
+}

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/normal_subprocess_control.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/normal_subprocess_control.py
@@ -1,0 +1,13 @@
+"""Control: subprocess in a normal source file (not a fuzz target).
+
+The file lives outside any fuzz path. The rule must NOT fire
+here — this IS a potential shell-injection if user input flows
+to ``cmd``.
+"""
+
+import subprocess
+
+
+def run_user_cmd(cmd: str) -> int:
+    """Run a user-supplied command. shell=True is dangerous."""
+    return subprocess.call(cmd, shell=True)

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/secrets_pragma.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/secrets_pragma.py
@@ -1,0 +1,9 @@
+"""False-positive fixture: pragma-allowlisted secret string.
+
+detect-secrets and similar scanners flag the literal as a
+hardcoded secret. The pragma comment is the documented escape
+hatch.
+"""
+
+# Test credentials — never real.
+TEST_API_KEY = "sk_live_FAKE_NOT_REAL_abc123"  # pragma: allowlist secret

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/secrets_pragma_control.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/secrets_pragma_control.py
@@ -1,0 +1,7 @@
+"""Control: hardcoded secret WITHOUT the pragma comment.
+
+This IS a real finding. The rule must NOT fire here.
+"""
+
+# Real bug — secret pinned in source without an allowlist pragma.
+LEAKED_API_KEY = "sk_live_realLookingSecret_xyz789"

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/structlog_kwargs.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/structlog_kwargs.py
@@ -1,0 +1,14 @@
+"""False-positive fixture: structlog kwargs.
+
+Scanners that assume stdlib Logger semantics flag the kwargs as
+TypeError. structlog's bound logger accepts them.
+"""
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+def record_event(user_id: str, payload: dict) -> None:
+    """Emit a structured log event with kwargs."""
+    logger.info("user.event", user_id=user_id, payload_keys=list(payload))

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/structlog_kwargs_control.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/structlog_kwargs_control.py
@@ -1,0 +1,15 @@
+"""Control: stdlib logger.info called with kwargs — real bug.
+
+The file imports stdlib logging, not structlog. ``logger.info``
+with ``user_id=...`` would raise TypeError. The rule must NOT
+fire (the file does not use structlog).
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def record_event(user_id: str) -> None:
+    """Real bug — stdlib Logger doesn't accept kwargs."""
+    logger.info("user event", user_id=user_id)

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/subprocess_exec.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/subprocess_exec.py
@@ -1,0 +1,13 @@
+"""False-positive fixture: asyncio.create_subprocess_exec.
+
+Scanners that substring-match on 'exec' flag this safe asyncio
+helper as dangerous_eval. It is NOT eval/exec.
+"""
+
+import asyncio
+
+
+async def run_ls() -> int:
+    """Spawn /bin/ls via asyncio's safe exec helper."""
+    proc = await asyncio.create_subprocess_exec("/bin/ls", "-1")
+    return await proc.wait()

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/subprocess_exec_control.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/subprocess_exec_control.py
@@ -1,0 +1,11 @@
+"""Control: real eval() call.
+
+This IS a dangerous_eval. The rule must NOT fire here just
+because the line happens to also have the word 'subprocess'
+elsewhere.
+"""
+
+
+def evaluate(expr: str, subprocess_unused: str = "") -> object:
+    """Evaluate ``expr`` with eval()."""
+    return eval(expr)

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/write_text_eval_fixture.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/write_text_eval_fixture.py
@@ -1,0 +1,21 @@
+"""False-positive fixture: eval inside a .write_text() call.
+
+The eval() appears in TEST DATA written to a temp file —
+fixture content for a scanner test. The scanner sees the
+string 'eval(' but it's not actually executable code.
+"""
+
+from pathlib import Path
+
+
+def setup_fixture(tmp_path: Path) -> Path:
+    """Write a Python source file containing eval() as test data."""
+    fixture = tmp_path / "dangerous_input.py"
+    fixture.write_text(
+        """
+def unsafe(code):
+    # Scanner should flag this in a real source file
+    return eval(code)
+"""
+    )
+    return fixture

--- a/tests/unit/workflows/discovery_sweep/fixtures/false_positives/write_text_eval_fixture_control.py
+++ b/tests/unit/workflows/discovery_sweep/fixtures/false_positives/write_text_eval_fixture_control.py
@@ -1,0 +1,10 @@
+"""Control: real eval() outside any .write_text() call.
+
+A scanner finding on the eval() line below is a true positive.
+The rule must NOT fire here.
+"""
+
+
+def evaluate_user_input(expr: str) -> object:
+    """Run eval() on caller-supplied text."""
+    return eval(expr)

--- a/tests/unit/workflows/discovery_sweep/test_cli_workflow.py
+++ b/tests/unit/workflows/discovery_sweep/test_cli_workflow.py
@@ -1,0 +1,201 @@
+"""Tests for the BaseWorkflow CLI wrapper and registry registration."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from attune.workflows.discovery_sweep import (
+    DiscoverySweepWorkflow,
+    Finding,
+    PatternScanSource,
+    Severity,
+    read_jsonl,
+)
+
+
+def _write(path: Path, lines: list[str]) -> None:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+@dataclass
+class _CannedSource:
+    """A FindingSource double that emits canned Findings."""
+
+    name: str = "canned"
+    canned: list[Finding] | None = None
+    estimated_spend_usd: float = 0.5
+
+    def discover(self, scope: Path, budget_usd: float, sweep_id: str) -> Iterable[Finding]:
+        for f in self.canned or []:
+            yield Finding(
+                source_workflow=f.source_workflow,
+                file_path=f.file_path,
+                severity=f.severity,
+                message=f.message,
+                raw_finding=f.raw_finding,
+                sweep_id=sweep_id,
+                line=f.line,
+            )
+
+
+@pytest.mark.asyncio
+async def test_execute_requires_path():
+    wf = DiscoverySweepWorkflow()
+    result = await wf.execute()
+    assert result.success is False
+    assert "path" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_default_pattern_scanner(tmp_path):
+    _write(
+        tmp_path / "fragile.py",
+        [
+            "def fragile():",
+            "    try:",
+            "        pass",
+            "    except:",
+            "        pass",
+        ],
+    )
+    wf = DiscoverySweepWorkflow()
+    result = await wf.execute(path=str(tmp_path), output_dir=str(tmp_path / "queue"))
+
+    assert result.success is True
+    assert result.metadata["sweep_id"]
+    # The bare-except finding survives REJECT (no INTENTIONAL marker) →
+    # UNSURE in the questions file.
+    assert result.metadata["unsure_count"] >= 1
+    assert result.metadata["queue_path"]
+    assert Path(result.metadata["queue_path"]).exists()
+    assert Path(result.metadata["rejected_path"]).exists()
+    assert Path(result.metadata["questions_path"]).exists()
+
+
+@pytest.mark.asyncio
+async def test_execute_with_custom_sources(tmp_path):
+    finding = Finding(
+        source_workflow="canned",
+        file_path="src/attune/whatever.py",
+        severity=Severity.MEDIUM,
+        message="some finding",
+        raw_finding={"pattern": "x"},
+        sweep_id="placeholder",
+        line=10,
+    )
+    wf = DiscoverySweepWorkflow()
+    result = await wf.execute(
+        path=str(tmp_path),
+        output_dir=str(tmp_path / "queue"),
+        sources=[_CannedSource(canned=[finding])],
+    )
+    assert result.success is True
+    # The canned finding has no matching rule → UNSURE.
+    assert result.metadata["unsure_count"] == 1
+    assert result.metadata["accept_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_budget_overrides_propagate(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_DISCOVERY_SWEEP_BUDGET_USD", "100.0")
+    wf = DiscoverySweepWorkflow()
+    result = await wf.execute(
+        path=str(tmp_path),
+        output_dir=str(tmp_path / "queue"),
+        sweep_budget_usd=2.0,
+    )
+    assert result.success is True
+    # No findings, but budget metadata is exposed via the sweep result.
+    assert "sweep_result" in result.metadata
+
+
+@pytest.mark.asyncio
+async def test_execute_writes_to_default_output_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _write(
+        tmp_path / "fragile.py",
+        ["def f():", "    try: pass", "    except: pass"],
+    )
+    wf = DiscoverySweepWorkflow()
+    result = await wf.execute(path=str(tmp_path))
+    assert result.success is True
+    assert ".claude/discovery-queue" in result.metadata["queue_path"].replace("\\", "/")
+
+
+@pytest.mark.asyncio
+async def test_execute_summary_contains_counts(tmp_path):
+    _write(
+        tmp_path / "fragile.py",
+        ["def f():", "    try: pass", "    except: pass"],
+    )
+    wf = DiscoverySweepWorkflow()
+    result = await wf.execute(path=str(tmp_path), output_dir=str(tmp_path / "out"))
+    assert result.summary is not None
+    assert "accept=" in result.summary
+    assert "reject=" in result.summary
+    assert "unsure=" in result.summary
+    assert result.metadata["sweep_id"] in result.summary
+
+
+@pytest.mark.asyncio
+async def test_real_pattern_scanner_finds_findings_in_seeded_tree(tmp_path):
+    """End-to-end: real PatternScanSource against a real fixture tree."""
+    src = tmp_path / "src"
+    src.mkdir()
+    _write(
+        src / "fragile.py",
+        [
+            "import subprocess",
+            "",
+            "def go(cmd):",
+            "    # TODO: validate cmd",
+            "    try:",
+            "        subprocess.run(cmd)",
+            "    except:",
+            "        pass",
+        ],
+    )
+
+    wf = DiscoverySweepWorkflow()
+    result = await wf.execute(
+        path=str(src),
+        output_dir=str(tmp_path / "queue"),
+        sources=[PatternScanSource()],
+    )
+    assert result.success is True
+    total = (
+        result.metadata["accept_count"]
+        + result.metadata["reject_count"]
+        + result.metadata["unsure_count"]
+    )
+    # bare_except + TODO at minimum → 2 findings.
+    assert total >= 2
+
+    # The bare_except finding lands somewhere — queue or questions.
+    rejected = read_jsonl(result.metadata["rejected_path"])
+    # No intentional-broad-except marker, so it shouldn't REJECT.
+    assert all(
+        f.raw_finding.get("pattern") != "bare_except" for f in rejected
+    ), "bare_except without INTENTIONAL should not be REJECTed"
+
+
+class TestWorkflowRegistry:
+    def test_discovery_sweep_registered(self):
+        from attune.workflows import discover_workflows
+
+        wfs = discover_workflows()
+        assert "discovery-sweep" in wfs
+        assert wfs["discovery-sweep"] is DiscoverySweepWorkflow
+
+    def test_workflow_has_required_baseworkflow_surface(self):
+        from attune.workflows.base import BaseWorkflow
+
+        assert issubclass(DiscoverySweepWorkflow, BaseWorkflow)
+        assert DiscoverySweepWorkflow.name == "discovery-sweep"
+        assert isinstance(DiscoverySweepWorkflow.description, str)
+        assert DiscoverySweepWorkflow.description
+        assert DiscoverySweepWorkflow.stages

--- a/tests/unit/workflows/discovery_sweep/test_complexity.py
+++ b/tests/unit/workflows/discovery_sweep/test_complexity.py
@@ -1,0 +1,328 @@
+"""Tests for the resolution-complexity classifier.
+
+Each trigger gets a positive fixture (must fire → needs_patrick)
+and a negative fixture (must not fire → routine).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from attune.workflows.discovery_sweep import (
+    Finding,
+    ResolutionComplexity,
+    Severity,
+    VerificationStatus,
+)
+from attune.workflows.discovery_sweep.complexity import (
+    ComplexityClassifier,
+    ContradictsLessonTrigger,
+    CrossCuttingTrigger,
+    LowConfidenceTrigger,
+    MocksProductionTrigger,
+    SecurityAdjacentTrigger,
+    TierOrBudgetTrigger,
+)
+
+
+def _make_accepted_finding(
+    *,
+    file_path: str = "src/attune/example.py",
+    message: str = "example",
+    verification_reasoning: str = "",
+    raw_finding: dict[str, Any] | None = None,
+) -> Finding:
+    return Finding(
+        source_workflow="bug_predict",
+        file_path=file_path,
+        severity=Severity.MEDIUM,
+        message=message,
+        raw_finding=raw_finding if raw_finding is not None else {"pattern": "x"},
+        sweep_id="sweep1234abcd",
+        line=10,
+        verification_status=VerificationStatus.ACCEPT,
+        verification_reasoning=verification_reasoning,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CrossCuttingTrigger
+# ---------------------------------------------------------------------------
+
+
+class TestCrossCuttingTrigger:
+    trigger = CrossCuttingTrigger()
+
+    def test_fires_on_three_or_more_paths(self):
+        finding = _make_accepted_finding(
+            message=(
+                "fix would also touch src/attune/a.py, src/attune/b.py and " "src/attune/c.py"
+            ),
+        )
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_public_api_mention(self):
+        finding = _make_accepted_finding(
+            message="changes the public API of attune.workflows.base",
+        )
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_base_class_mention(self):
+        finding = _make_accepted_finding(
+            message="modifies a shared base class signature",
+        )
+        assert self.trigger.applies(finding)
+
+    def test_does_not_fire_on_single_file_finding(self):
+        finding = _make_accepted_finding(
+            message="local refactor inside src/attune/example.py only",
+        )
+        assert not self.trigger.applies(finding)
+
+    def test_does_not_count_self_path(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/example.py",
+            message="finding in src/attune/example.py — minor cleanup",
+        )
+        assert not self.trigger.applies(finding)
+
+
+# ---------------------------------------------------------------------------
+# SecurityAdjacentTrigger
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityAdjacentTrigger:
+    trigger = SecurityAdjacentTrigger()
+
+    def test_fires_on_security_path(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/security/path_validation.py",
+            message="minor cleanup",
+        )
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_eval_keyword(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/util.py",
+            message="dangerous eval( pattern detected",
+        )
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_webhook_keyword(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/monitoring/validators.py",
+            message="webhook URL validation missing",
+        )
+        assert self.trigger.applies(finding)
+
+    def test_does_not_fire_on_unrelated(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/formatter.py",
+            message="style: prefer f-strings",
+        )
+        assert not self.trigger.applies(finding)
+
+
+# ---------------------------------------------------------------------------
+# ContradictsLessonTrigger
+# ---------------------------------------------------------------------------
+
+
+class TestContradictsLessonTrigger:
+    trigger = ContradictsLessonTrigger()
+
+    def test_fires_on_dirs_slice_mention(self):
+        finding = _make_accepted_finding(message="found dirs[:] pattern that could be simplified")
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_subprocess_exec(self):
+        finding = _make_accepted_finding(message="create_subprocess_exec usage should be audited")
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_structlog_kwargs(self):
+        finding = _make_accepted_finding(
+            message="logger.info with kwargs — verify structlog binding"
+        )
+        assert self.trigger.applies(finding)
+
+    def test_does_not_fire_on_unrelated(self):
+        finding = _make_accepted_finding(message="missing docstring on public function")
+        assert not self.trigger.applies(finding)
+
+
+# ---------------------------------------------------------------------------
+# TierOrBudgetTrigger
+# ---------------------------------------------------------------------------
+
+
+class TestTierOrBudgetTrigger:
+    trigger = TierOrBudgetTrigger()
+
+    def test_fires_on_model_tier(self):
+        finding = _make_accepted_finding(message="ModelTier.CHEAP mapping should be reconsidered")
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_budget_cap(self):
+        finding = _make_accepted_finding(
+            message="budget cap may be too tight for premium workflows"
+        )
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_cost_model(self):
+        finding = _make_accepted_finding(message="finding affects the cost model assumptions")
+        assert self.trigger.applies(finding)
+
+    def test_does_not_fire_on_unrelated(self):
+        finding = _make_accepted_finding(message="rename variable for clarity")
+        assert not self.trigger.applies(finding)
+
+
+# ---------------------------------------------------------------------------
+# MocksProductionTrigger
+# ---------------------------------------------------------------------------
+
+
+class TestMocksProductionTrigger:
+    trigger = MocksProductionTrigger()
+
+    def test_fires_when_test_file_mocks_production(self):
+        finding = _make_accepted_finding(
+            file_path="tests/unit/test_pipeline.py",
+            message="mock could replace src/attune/pipeline.py call to real DB",
+        )
+        assert self.trigger.applies(finding)
+
+    def test_does_not_fire_in_production_path(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/pipeline.py",
+            message="mock attune.example.Client to skip real API",
+        )
+        assert not self.trigger.applies(finding)
+
+    def test_does_not_fire_when_no_production_hint(self):
+        finding = _make_accepted_finding(
+            file_path="tests/unit/test_pipeline.py",
+            message="mock is named ambiguously — rename",
+        )
+        assert not self.trigger.applies(finding)
+
+
+# ---------------------------------------------------------------------------
+# LowConfidenceTrigger
+# ---------------------------------------------------------------------------
+
+
+class TestLowConfidenceTrigger:
+    trigger = LowConfidenceTrigger()
+
+    def test_fires_on_ambiguous(self):
+        finding = _make_accepted_finding(
+            verification_reasoning="rule fired but ambiguous match",
+        )
+        assert self.trigger.applies(finding)
+
+    def test_fires_on_could_not_determine(self):
+        finding = _make_accepted_finding(
+            verification_reasoning="could not determine whether the input is reachable",
+        )
+        assert self.trigger.applies(finding)
+
+    def test_does_not_fire_on_confident(self):
+        finding = _make_accepted_finding(
+            verification_reasoning="matches eval(user_input) pattern with no test surroundings",
+        )
+        assert not self.trigger.applies(finding)
+
+
+# ---------------------------------------------------------------------------
+# Classifier integration
+# ---------------------------------------------------------------------------
+
+
+class TestComplexityClassifier:
+    def test_default_for_accepted_finding_is_routine(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/util.py",
+            message="rename variable",
+        )
+        classified = ComplexityClassifier().classify(finding)
+        assert classified.resolution_complexity == ResolutionComplexity.ROUTINE
+
+    def test_security_path_flips_to_needs_patrick(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/security/path_validation.py",
+            message="cleanup",
+        )
+        classified = ComplexityClassifier().classify(finding)
+        assert classified.resolution_complexity == ResolutionComplexity.NEEDS_PATRICK
+        assert "security_adjacent" in classified.verification_reasoning
+
+    def test_unsure_finding_left_alone(self):
+        finding = Finding(
+            source_workflow="bug_predict",
+            file_path="src/attune/util.py",
+            severity=Severity.MEDIUM,
+            message="x",
+            raw_finding={},
+            sweep_id="x",
+            line=1,
+            verification_status=VerificationStatus.UNSURE,
+            verification_reasoning="r",
+        )
+        classified = ComplexityClassifier().classify(finding)
+        assert classified.resolution_complexity is None
+
+    def test_rejected_finding_left_alone(self):
+        finding = Finding(
+            source_workflow="bug_predict",
+            file_path="src/attune/util.py",
+            severity=Severity.MEDIUM,
+            message="x",
+            raw_finding={},
+            sweep_id="x",
+            line=1,
+            verification_status=VerificationStatus.REJECT,
+            verification_reasoning="known false positive",
+        )
+        classified = ComplexityClassifier().classify(finding)
+        assert classified.resolution_complexity is None
+
+    def test_multiple_triggers_concatenated_in_reasoning(self):
+        finding = _make_accepted_finding(
+            file_path="src/attune/security/x.py",
+            message="dirs[:] in a webhook handler",
+        )
+        classified = ComplexityClassifier().classify(finding)
+        assert classified.resolution_complexity == ResolutionComplexity.NEEDS_PATRICK
+        reasoning = classified.verification_reasoning
+        assert "security_adjacent" in reasoning
+        assert "contradicts_lesson" in reasoning
+
+    def test_classify_many(self):
+        routine = _make_accepted_finding(file_path="src/attune/util.py", message="rename")
+        sensitive = _make_accepted_finding(
+            file_path="src/attune/security/path_validation.py", message="cleanup"
+        )
+        out = ComplexityClassifier().classify_many([routine, sensitive])
+        assert out[0].resolution_complexity == ResolutionComplexity.ROUTINE
+        assert out[1].resolution_complexity == ResolutionComplexity.NEEDS_PATRICK
+
+
+@pytest.mark.parametrize(
+    "trigger_cls",
+    [
+        CrossCuttingTrigger,
+        SecurityAdjacentTrigger,
+        ContradictsLessonTrigger,
+        TierOrBudgetTrigger,
+        MocksProductionTrigger,
+        LowConfidenceTrigger,
+    ],
+)
+def test_trigger_name_is_str(trigger_cls):
+    trigger = trigger_cls()
+    assert isinstance(trigger.name, str)
+    assert trigger.name

--- a/tests/unit/workflows/discovery_sweep/test_pattern_scan.py
+++ b/tests/unit/workflows/discovery_sweep/test_pattern_scan.py
@@ -1,0 +1,167 @@
+"""Tests for the ``PatternScanSource`` adapter (Phase 2A)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.workflows.discovery_sweep import (
+    Finding,
+    PatternScanSource,
+    Severity,
+)
+
+
+def _write(path: Path, lines: list[str]) -> None:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _findings(source: PatternScanSource, scope: Path) -> list[Finding]:
+    return list(source.discover(scope, budget_usd=0.0, sweep_id="test01abcd23"))
+
+
+class TestPatternScanSource:
+    def test_detects_bare_except(self, tmp_path):
+        _write(
+            tmp_path / "f.py",
+            [
+                "def fragile():",
+                "    try:",
+                "        pass",
+                "    except:",
+                "        pass",
+            ],
+        )
+        findings = _findings(PatternScanSource(), tmp_path)
+        bare = [f for f in findings if f.raw_finding["pattern"] == "bare_except"]
+        assert len(bare) == 1
+        assert bare[0].line == 4
+        assert bare[0].severity == Severity.HIGH
+
+    def test_detects_broad_exception(self, tmp_path):
+        _write(
+            tmp_path / "f.py",
+            [
+                "def fragile():",
+                "    try:",
+                "        pass",
+                "    except Exception:",
+                "        pass",
+            ],
+        )
+        findings = _findings(PatternScanSource(), tmp_path)
+        broad = [f for f in findings if f.raw_finding["pattern"] == "broad_exception"]
+        assert len(broad) == 1
+        assert broad[0].severity == Severity.MEDIUM
+
+    def test_detects_subprocess_shell_true(self, tmp_path):
+        _write(
+            tmp_path / "f.py",
+            [
+                "import subprocess",
+                "def go(cmd):",
+                "    return subprocess.call(cmd, shell=True)",
+            ],
+        )
+        findings = _findings(PatternScanSource(), tmp_path)
+        shells = [f for f in findings if f.raw_finding["pattern"] == "subprocess_shell_true"]
+        assert len(shells) == 1
+        assert shells[0].severity == Severity.HIGH
+
+    def test_detects_todo_markers(self, tmp_path):
+        _write(
+            tmp_path / "f.py",
+            [
+                "def f():",
+                "    # TODO: validate input",
+                "    pass",
+            ],
+        )
+        findings = _findings(PatternScanSource(), tmp_path)
+        todos = [f for f in findings if f.raw_finding["pattern"] == "incomplete_code"]
+        assert len(todos) == 1
+        assert todos[0].severity == Severity.LOW
+
+    def test_dangerous_eval_pattern(self, tmp_path):
+        # Build the trigger via constants so the file content
+        # contains the literal eval( substring.
+        _write(
+            tmp_path / "f.py",
+            [
+                "def go(s):",
+                "    return " + "eval" + "(s)",
+            ],
+        )
+        findings = _findings(PatternScanSource(), tmp_path)
+        evals = [f for f in findings if f.raw_finding["pattern"] == "dangerous_eval"]
+        assert len(evals) == 1
+        assert evals[0].severity == Severity.HIGH
+
+    def test_does_not_fire_on_method_named_eval(self, tmp_path):
+        _write(
+            tmp_path / "f.py",
+            [
+                "class C:",
+                "    def go(self):",
+                "        return self.eval(1)",
+            ],
+        )
+        findings = _findings(PatternScanSource(), tmp_path)
+        evals = [f for f in findings if f.raw_finding["pattern"] == "dangerous_eval"]
+        assert evals == []
+
+    def test_skips_excluded_directories(self, tmp_path):
+        cache_dir = tmp_path / "__pycache__"
+        cache_dir.mkdir()
+        _write(
+            cache_dir / "f.py",
+            ["def fragile():", "    try: pass", "    except: pass"],
+        )
+        _write(
+            tmp_path / "real.py",
+            ["def fragile():", "    try:", "        pass", "    except:", "        pass"],
+        )
+        findings = _findings(PatternScanSource(), tmp_path)
+        # Only the file outside __pycache__ should contribute.
+        paths = {f.file_path for f in findings}
+        assert paths == {"real.py"}
+
+    def test_scans_single_file_when_scope_is_file(self, tmp_path):
+        target = tmp_path / "f.py"
+        _write(
+            target,
+            ["def fragile():", "    try: pass", "    except: pass"],
+        )
+        findings = _findings(PatternScanSource(), target)
+        assert len(findings) >= 1
+        # When scope is a file, display path is the absolute path.
+        assert findings[0].file_path == str(target)
+
+    def test_empty_scope_returns_no_findings(self, tmp_path):
+        findings = _findings(PatternScanSource(), tmp_path)
+        assert findings == []
+
+    def test_scanned_files_counter(self, tmp_path):
+        _write(tmp_path / "a.py", ["def f(): pass"])
+        _write(tmp_path / "b.py", ["def g(): pass"])
+        source = PatternScanSource()
+        _findings(source, tmp_path)
+        assert source.scanned_files == 2
+
+    def test_estimated_spend_is_zero(self):
+        assert PatternScanSource().estimated_spend_usd == 0.0
+
+    def test_emits_relative_paths_when_scope_is_directory(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        _write(
+            tmp_path / "sub" / "f.py",
+            ["def fragile():", "    try: pass", "    except: pass"],
+        )
+        findings = _findings(PatternScanSource(), tmp_path)
+        rel_paths = {f.file_path for f in findings}
+        assert any(p.startswith("sub") for p in rel_paths)
+
+    def test_sweep_id_propagates_to_findings(self, tmp_path):
+        _write(tmp_path / "f.py", ["    try: pass", "    except: pass"])
+        source = PatternScanSource()
+        findings = list(source.discover(tmp_path, budget_usd=0.0, sweep_id="deadbeef9999"))
+        assert all(f.sweep_id == "deadbeef9999" for f in findings)

--- a/tests/unit/workflows/discovery_sweep/test_schema.py
+++ b/tests/unit/workflows/discovery_sweep/test_schema.py
@@ -1,0 +1,230 @@
+"""Tests for the discovery-sweep schema and serialization layer."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from attune.workflows.discovery_sweep import (
+    Finding,
+    ResolutionComplexity,
+    Severity,
+    VerificationStatus,
+    read_jsonl,
+    write_jsonl,
+    write_questions_markdown,
+)
+from attune.workflows.discovery_sweep.schema import _new_sweep_id
+
+
+def _make_finding(
+    *,
+    status: VerificationStatus = VerificationStatus.UNSURE,
+    complexity: ResolutionComplexity | None = None,
+    reasoning: str = "",
+    sweep_id: str = "sweep1234abcd",
+) -> Finding:
+    return Finding(
+        source_workflow="bug_predict",
+        file_path="src/attune/example.py",
+        severity=Severity.MEDIUM,
+        message="Example finding message.",
+        raw_finding={"pattern": "example_pattern", "score": 0.7},
+        sweep_id=sweep_id,
+        line=42,
+        verification_status=status,
+        verification_reasoning=reasoning,
+        resolution_complexity=complexity,
+    )
+
+
+class TestFindingRoundTrip:
+    def test_roundtrip_minimal_finding(self):
+        original = _make_finding()
+        roundtripped = Finding.from_jsonl_dict(original.to_jsonl_dict())
+        assert roundtripped == original
+
+    def test_roundtrip_accepted_finding_with_complexity(self):
+        original = _make_finding(
+            status=VerificationStatus.ACCEPT,
+            complexity=ResolutionComplexity.NEEDS_PATRICK,
+            reasoning="touches src/attune/security/",
+        )
+        roundtripped = Finding.from_jsonl_dict(original.to_jsonl_dict())
+        assert roundtripped == original
+        assert roundtripped.resolution_complexity == ResolutionComplexity.NEEDS_PATRICK
+
+    def test_roundtrip_rejected_finding(self):
+        original = _make_finding(
+            status=VerificationStatus.REJECT,
+            reasoning="dirs[:] pattern in os.walk loop — see CLAUDE.md",
+        )
+        roundtripped = Finding.from_jsonl_dict(original.to_jsonl_dict())
+        assert roundtripped == original
+
+    def test_jsonl_dict_has_string_enum_values(self):
+        finding = _make_finding(
+            status=VerificationStatus.ACCEPT,
+            complexity=ResolutionComplexity.ROUTINE,
+        )
+        payload = finding.to_jsonl_dict()
+        assert payload["severity"] == "medium"
+        assert payload["verification_status"] == "accept"
+        assert payload["resolution_complexity"] == "routine"
+
+    def test_jsonl_dict_serializes_to_json(self):
+        finding = _make_finding()
+        payload = finding.to_jsonl_dict()
+        serialized = json.dumps(payload)
+        deserialized = json.loads(serialized)
+        roundtripped = Finding.from_jsonl_dict(deserialized)
+        assert roundtripped == finding
+
+    def test_resolution_complexity_none_roundtrips(self):
+        original = _make_finding(status=VerificationStatus.UNSURE, complexity=None)
+        roundtripped = Finding.from_jsonl_dict(original.to_jsonl_dict())
+        assert roundtripped.resolution_complexity is None
+
+
+class TestTimestamps:
+    def test_default_timestamp_is_utc_aware(self):
+        finding = _make_finding()
+        parsed = datetime.fromisoformat(finding.timestamp_utc)
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timezone.utc.utcoffset(None)
+
+    def test_no_naive_z_suffix(self):
+        finding = _make_finding()
+        assert not finding.timestamp_utc.endswith("Z+00:00")
+        assert not finding.timestamp_utc.endswith("+00:00Z")
+
+
+class TestSweepId:
+    def test_sweep_id_is_hex_short(self):
+        sweep_id = _new_sweep_id()
+        assert len(sweep_id) == 12
+        int(sweep_id, 16)
+
+    def test_sweep_ids_are_unique(self):
+        ids = {_new_sweep_id() for _ in range(50)}
+        assert len(ids) == 50
+
+
+class TestWriteReadJsonl:
+    def test_roundtrip_jsonl_file(self, tmp_path):
+        sweep_id = "abc123def456"
+        findings = [
+            _make_finding(
+                status=VerificationStatus.ACCEPT,
+                complexity=ResolutionComplexity.ROUTINE,
+                sweep_id=sweep_id,
+            ),
+            _make_finding(
+                status=VerificationStatus.ACCEPT,
+                complexity=ResolutionComplexity.NEEDS_PATRICK,
+                reasoning="cross-cutting",
+                sweep_id=sweep_id,
+            ),
+        ]
+        target = tmp_path / "queue.jsonl"
+        write_jsonl(target, findings)
+        assert target.exists()
+        roundtripped = read_jsonl(target)
+        assert roundtripped == findings
+
+    def test_write_jsonl_creates_parent_dirs(self, tmp_path):
+        target = tmp_path / "nested" / "deeper" / "queue.jsonl"
+        findings = [_make_finding()]
+        write_jsonl(target, findings)
+        assert target.exists()
+
+    def test_jsonl_one_finding_per_line(self, tmp_path):
+        target = tmp_path / "queue.jsonl"
+        findings = [_make_finding() for _ in range(3)]
+        write_jsonl(target, findings)
+        lines = target.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 3
+        for line in lines:
+            json.loads(line)
+
+    def test_empty_findings_writes_empty_file(self, tmp_path):
+        target = tmp_path / "queue.jsonl"
+        write_jsonl(target, [])
+        assert target.exists()
+        assert target.read_text(encoding="utf-8") == ""
+
+
+class TestQuestionsMarkdown:
+    def test_writes_markdown_with_only_unsure_findings(self, tmp_path):
+        accept = _make_finding(status=VerificationStatus.ACCEPT)
+        reject = _make_finding(status=VerificationStatus.REJECT)
+        unsure = _make_finding(
+            status=VerificationStatus.UNSURE,
+            reasoning="could not classify; ambiguous match",
+        )
+
+        target = tmp_path / "questions.md"
+        write_questions_markdown(
+            target,
+            [accept, reject, unsure],
+            sweep_id="sweep1234abcd",
+            scope="src/attune/example/",
+        )
+        content = target.read_text(encoding="utf-8")
+        assert "sweep1234abcd" in content
+        assert "src/attune/example/" in content
+        assert "could not classify; ambiguous match" in content
+        assert "## 1." in content
+        assert "## 2." not in content
+
+    def test_empty_unsure_writes_explicit_note(self, tmp_path):
+        target = tmp_path / "questions.md"
+        write_questions_markdown(target, [], sweep_id="sweep1234abcd", scope="src/")
+        content = target.read_text(encoding="utf-8")
+        assert "No UNSURE findings" in content
+
+    def test_markdown_includes_raw_finding_json(self, tmp_path):
+        unsure = _make_finding(status=VerificationStatus.UNSURE)
+        target = tmp_path / "questions.md"
+        write_questions_markdown(target, [unsure], sweep_id="sweep1234abcd", scope="src/")
+        content = target.read_text(encoding="utf-8")
+        assert "```json" in content
+        assert '"pattern": "example_pattern"' in content
+
+    def test_markdown_ends_with_newline(self, tmp_path):
+        target = tmp_path / "questions.md"
+        write_questions_markdown(target, [], sweep_id="sweep1234abcd", scope="src/")
+        content = target.read_text(encoding="utf-8")
+        assert content.endswith("\n")
+
+
+class TestSweepIdConsistencyAcrossFiles:
+    def test_same_sweep_id_in_all_three_files(self, tmp_path):
+        sweep_id = "feedfacecafe"
+        scope = "src/attune/security/"
+        accept = _make_finding(
+            status=VerificationStatus.ACCEPT,
+            complexity=ResolutionComplexity.NEEDS_PATRICK,
+            sweep_id=sweep_id,
+        )
+        reject = _make_finding(
+            status=VerificationStatus.REJECT,
+            reasoning="known false positive",
+            sweep_id=sweep_id,
+        )
+        unsure = _make_finding(status=VerificationStatus.UNSURE, sweep_id=sweep_id)
+
+        queue = tmp_path / f"{sweep_id}.jsonl"
+        rejected = tmp_path / f"{sweep_id}.rejected.jsonl"
+        questions = tmp_path / f"{sweep_id}.questions.md"
+
+        write_jsonl(queue, [accept])
+        write_jsonl(rejected, [reject])
+        write_questions_markdown(questions, [unsure], sweep_id=sweep_id, scope=scope)
+
+        assert all(p.exists() for p in (queue, rejected, questions))
+        for finding in read_jsonl(queue):
+            assert finding.sweep_id == sweep_id
+        for finding in read_jsonl(rejected):
+            assert finding.sweep_id == sweep_id
+        assert sweep_id in questions.read_text(encoding="utf-8")

--- a/tests/unit/workflows/discovery_sweep/test_smoke.py
+++ b/tests/unit/workflows/discovery_sweep/test_smoke.py
@@ -1,0 +1,190 @@
+"""End-to-end smoke test for the discovery-sweep Python API.
+
+Phase 1 ships the engine as a Python API; this is the
+documented smoke path: instantiate the workflow with a stub
+``FindingSource`` that emits a mix of finding kinds, run the
+sweep, and verify the three output artifacts.
+
+Real adapters wrapping bug_predict / security_audit / etc. are
+Phase 2 deliverables.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from attune.workflows.discovery_sweep import (
+    DiscoverySweepEngine,
+    Finding,
+    ResolutionComplexity,
+    Severity,
+    VerificationStatus,
+    read_jsonl,
+    split_findings_by_complexity,
+)
+
+
+@dataclass
+class _StubFindingSource:
+    """A canned FindingSource for the smoke test."""
+
+    name: str
+    canned: list[Finding]
+    estimated_spend_usd: float = 1.5
+
+    def discover(self, scope: Path, budget_usd: float, sweep_id: str) -> Iterable[Finding]:
+        return [
+            Finding(
+                source_workflow=f.source_workflow,
+                file_path=f.file_path,
+                severity=f.severity,
+                message=f.message,
+                raw_finding=f.raw_finding,
+                sweep_id=sweep_id,
+                line=f.line,
+            )
+            for f in self.canned
+        ]
+
+
+def _seed_walker_module(tmp_path: Path) -> Path:
+    """Write a real-looking module so the verification engine has
+    source text to inspect for the os.walk dirs[:] rule."""
+    target = tmp_path / "walker.py"
+    target.write_text(
+        "import os\n"
+        "\n"
+        "def find_py(root):\n"
+        "    matches = []\n"
+        "    for dirpath, dirs, files in os.walk(root):\n"
+        "        dirs[:] = [d for d in dirs if d != '.git']\n"
+        "        matches.extend(files)\n"
+        "    return matches\n"
+    )
+    return target
+
+
+def test_discovery_sweep_smoke_python_api(tmp_path):
+    """Engine smoke test: one finding REJECTs (known false positive),
+    one stays UNSURE (no rule fires)."""
+    walker = _seed_walker_module(tmp_path)
+
+    false_positive = Finding(
+        source_workflow="perf_audit",
+        file_path=str(walker.relative_to(tmp_path)),
+        severity=Severity.LOW,
+        message="memory_leak: large_list_copy on dirs[:]",
+        raw_finding={"pattern": "large_list_copy"},
+        sweep_id="placeholder",
+        line=6,
+    )
+
+    fresh_unknown = Finding(
+        source_workflow="bug_predict",
+        file_path=str(walker.relative_to(tmp_path)),
+        severity=Severity.MEDIUM,
+        message="cyclomatic complexity above threshold",
+        raw_finding={"pattern": "cyclomatic", "complexity": 12},
+        sweep_id="placeholder",
+        line=3,
+    )
+
+    source = _StubFindingSource(name="combined", canned=[false_positive, fresh_unknown])
+    workflow = DiscoverySweepEngine(
+        sources=[source],
+        output_dir=tmp_path / "queue",
+        project_root=tmp_path,
+    )
+
+    result = workflow.run(scope=tmp_path)
+
+    # File contracts: all three exist, sweep_id consistent.
+    assert result.queue_path is not None
+    assert result.rejected_path is not None
+    assert result.questions_path is not None
+    queue_path = Path(result.queue_path)
+    rejected_path = Path(result.rejected_path)
+    questions_path = Path(result.questions_path)
+    assert queue_path.exists()
+    assert rejected_path.exists()
+    assert questions_path.exists()
+    assert result.sweep_id in queue_path.name
+    assert result.sweep_id in rejected_path.name
+    assert result.sweep_id in questions_path.name
+
+    # Classification contract.
+    assert result.reject_count == 1
+    assert result.unsure_count == 1
+    assert result.accept_count == 0
+
+    rejected_findings = read_jsonl(rejected_path)
+    assert len(rejected_findings) == 1
+    assert rejected_findings[0].verification_status == VerificationStatus.REJECT
+    assert "os.walk" in rejected_findings[0].verification_reasoning
+
+    # Questions file is reviewable cold — must mention the
+    # fresh finding's message text.
+    questions_md = questions_path.read_text(encoding="utf-8")
+    assert "cyclomatic complexity above threshold" in questions_md
+    assert result.sweep_id in questions_md
+
+    # Budget tracking.
+    assert "combined" in result.sub_workflow_spend
+    assert result.total_spend_usd == 1.5
+
+
+def test_discovery_sweep_smoke_accept_is_tagged(tmp_path):
+    """When an ACCEPT rule fires (or — Phase 1 — a finding is
+    forced ACCEPTed and tagged by the complexity classifier),
+    it lands in the queue with a routine vs needs_patrick tag.
+
+    Phase 1 ships no ACCEPT rules, so this test fabricates an
+    ACCEPT finding directly to exercise the classifier path
+    inside the orchestrator.
+    """
+
+    # Stub source emits a finding pre-marked ACCEPTed. The
+    # verification engine will overwrite that status — so we
+    # bypass verification by constructing the workflow with a
+    # pass-through engine.
+    from attune.workflows.discovery_sweep.verification import VerificationEngine
+
+    class _NoopAcceptRule:
+        name = "noop_accept"
+
+        def classify(self, finding, source_lines):
+            if "promote me" in finding.message:
+                return (VerificationStatus.ACCEPT, "smoke-test ACCEPT")
+            return None
+
+    accept_finding = Finding(
+        source_workflow="bug_predict",
+        file_path="src/attune/security/auth.py",
+        severity=Severity.HIGH,
+        message="promote me — touches auth surface",
+        raw_finding={"pattern": "smoke"},
+        sweep_id="placeholder",
+        line=10,
+    )
+    source = _StubFindingSource(name="bug_predict", canned=[accept_finding])
+
+    workflow = DiscoverySweepEngine(
+        sources=[source],
+        output_dir=tmp_path / "queue",
+        project_root=tmp_path,
+        verification_engine=VerificationEngine([_NoopAcceptRule()], project_root=tmp_path),
+    )
+    result = workflow.run(scope=tmp_path)
+
+    assert result.accept_count == 1
+    queue = read_jsonl(result.queue_path)
+    assert len(queue) == 1
+    assert queue[0].verification_status == VerificationStatus.ACCEPT
+    # security_adjacent trigger should fire on the file path.
+    assert queue[0].resolution_complexity == ResolutionComplexity.NEEDS_PATRICK
+
+    routine, needs_patrick = split_findings_by_complexity(queue)
+    assert routine == []
+    assert needs_patrick == queue

--- a/tests/unit/workflows/discovery_sweep/test_verification.py
+++ b/tests/unit/workflows/discovery_sweep/test_verification.py
@@ -1,0 +1,487 @@
+"""Verification rule engine + REJECT rules.
+
+Each REJECT rule has a positive fixture (false-positive code
+where the rule MUST fire) and a control fixture (real bug with
+similar surface where the rule MUST NOT fire).
+
+The control coverage is the regression net for the spec's
+asymmetric-cost invariant: a false REJECT is worse than a false
+ACCEPT, because REJECTed findings only land in the audit log.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from attune.workflows.discovery_sweep import (
+    Finding,
+    Severity,
+    VerificationStatus,
+)
+from attune.workflows.discovery_sweep.rules import (
+    DirsSliceAssignmentRule,
+    IntentionalBroadExceptRule,
+    JsRegexExecRule,
+    SecretsPragmaRule,
+    StructlogKwargsRule,
+    SubprocessExecRule,
+    SubprocessInFuzzTargetRule,
+    WriteTextEvalFixtureRule,
+    default_rules,
+)
+from attune.workflows.discovery_sweep.verification import VerificationEngine
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "false_positives"
+
+
+def _find_line(path: Path, needle: str, *, skip_docstring: bool = True) -> int:
+    """Return the 1-indexed line containing ``needle``.
+
+    By default skips over lines that look like they live inside the
+    module docstring (a common false match because fixtures often
+    discuss the trigger pattern in their docstrings).
+    """
+    in_docstring = False
+    docstring_marker = '"""'
+    for idx, line in enumerate(path.read_text().splitlines(), start=1):
+        if skip_docstring:
+            triple_count = line.count(docstring_marker)
+            if triple_count == 1:
+                in_docstring = not in_docstring
+                continue
+            if triple_count >= 2:
+                # Opens and closes on same line — skip.
+                continue
+            if in_docstring:
+                continue
+        if needle in line:
+            return idx
+    raise AssertionError(f"needle {needle!r} not found in {path}")
+
+
+def _make_finding(
+    *,
+    file_path: Path,
+    line: int,
+    message: str,
+    source_workflow: str = "bug_predict",
+    severity: Severity = Severity.MEDIUM,
+    pattern: str = "scanner",
+    relative_to: Path | None = None,
+) -> Finding:
+    if relative_to is not None:
+        try:
+            stored_path = str(file_path.relative_to(relative_to))
+        except ValueError:
+            stored_path = str(file_path)
+    else:
+        stored_path = str(file_path)
+    return Finding(
+        source_workflow=source_workflow,
+        file_path=stored_path,
+        line=line,
+        severity=severity,
+        message=message,
+        raw_finding={"pattern": pattern, "line": line},
+        sweep_id="sweepfixture00",
+    )
+
+
+def _engine(rules: Iterable, project_root: Path | None = None) -> VerificationEngine:
+    return VerificationEngine(list(rules), project_root=project_root)
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: DirsSliceAssignmentRule
+# ---------------------------------------------------------------------------
+
+
+class TestDirsSliceAssignmentRule:
+    fixture = FIXTURE_ROOT / "dirs_slice_assignment.py"
+    control = FIXTURE_ROOT / "dirs_slice_assignment_control.py"
+
+    def test_rejects_dirs_slice_inside_os_walk(self):
+        line = _find_line(self.fixture, "dirs[:]")
+        finding = _make_finding(
+            file_path=self.fixture,
+            line=line,
+            message="memory_leak: large_list_copy on dirs[:]",
+        )
+        verdict = _engine([DirsSliceAssignmentRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+        assert "os.walk" in verdict.verification_reasoning
+
+    def test_does_not_fire_outside_os_walk(self):
+        line = _find_line(self.control, "dirs[:]")
+        finding = _make_finding(
+            file_path=self.control,
+            line=line,
+            message="memory_leak: large_list_copy on dirs[:]",
+        )
+        verdict = _engine([DirsSliceAssignmentRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+    def test_does_not_fire_on_unrelated_message(self):
+        line = _find_line(self.fixture, "dirs[:]")
+        finding = _make_finding(
+            file_path=self.fixture,
+            line=line,
+            message="style: prefer list comprehension",
+        )
+        verdict = _engine([DirsSliceAssignmentRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: SubprocessExecRule
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessExecRule:
+    fixture = FIXTURE_ROOT / "subprocess_exec.py"
+    control = FIXTURE_ROOT / "subprocess_exec_control.py"
+
+    def test_rejects_create_subprocess_exec(self):
+        line = _find_line(self.fixture, "create_subprocess_exec")
+        finding = _make_finding(
+            file_path=self.fixture,
+            line=line,
+            message="dangerous_eval: exec usage detected",
+        )
+        verdict = _engine([SubprocessExecRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+        assert "asyncio" in verdict.verification_reasoning.lower()
+
+    def test_does_not_fire_on_real_eval(self):
+        line = _find_line(self.control, "eval(expr)")
+        finding = _make_finding(
+            file_path=self.control,
+            line=line,
+            message="dangerous_eval: eval(",
+        )
+        verdict = _engine([SubprocessExecRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: JsRegexExecRule
+# ---------------------------------------------------------------------------
+
+
+class TestJsRegexExecRule:
+    fixture = FIXTURE_ROOT / "js_regex_exec.js"
+    control = FIXTURE_ROOT / "js_regex_exec_control.js"
+
+    def test_rejects_js_regex_exec(self):
+        line = _find_line(self.fixture, "pattern.exec(")
+        finding = _make_finding(
+            file_path=self.fixture,
+            line=line,
+            message="dangerous_eval: exec usage",
+        )
+        verdict = _engine([JsRegexExecRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+        assert "regex" in verdict.verification_reasoning.lower()
+
+    def test_does_not_fire_on_real_js_eval(self):
+        line = _find_line(self.control, "eval(userInput)")
+        finding = _make_finding(
+            file_path=self.control,
+            line=line,
+            message="dangerous_eval: eval(",
+        )
+        verdict = _engine([JsRegexExecRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+    def test_does_not_fire_on_python_file(self):
+        # Same .exec() pattern but in a .py file — rule must skip.
+        finding = _make_finding(
+            file_path=FIXTURE_ROOT / "subprocess_exec.py",
+            line=1,
+            message="dangerous_eval: exec usage",
+        )
+        verdict = _engine([JsRegexExecRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: WriteTextEvalFixtureRule
+# ---------------------------------------------------------------------------
+
+
+class TestWriteTextEvalFixtureRule:
+    fixture = FIXTURE_ROOT / "write_text_eval_fixture.py"
+    control = FIXTURE_ROOT / "write_text_eval_fixture_control.py"
+
+    def test_rejects_eval_inside_write_text(self):
+        # eval lives inside the .write_text(...) string literal —
+        # turn off the docstring skip so the heuristic doesn't
+        # treat that triple-quoted block as a docstring.
+        line = _find_line(self.fixture, "return eval(code)", skip_docstring=False)
+        finding = _make_finding(
+            file_path=self.fixture,
+            line=line,
+            message="dangerous_eval: eval( call",
+        )
+        verdict = _engine([WriteTextEvalFixtureRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+        assert "write_text" in verdict.verification_reasoning.lower()
+
+    def test_does_not_fire_on_real_eval_outside_write_text(self):
+        line = _find_line(self.control, "return eval(expr)")
+        finding = _make_finding(
+            file_path=self.control,
+            line=line,
+            message="dangerous_eval: eval( call",
+        )
+        verdict = _engine([WriteTextEvalFixtureRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: IntentionalBroadExceptRule
+# ---------------------------------------------------------------------------
+
+
+class TestIntentionalBroadExceptRule:
+    fixture = FIXTURE_ROOT / "intentional_broad_except.py"
+    control = FIXTURE_ROOT / "intentional_broad_except_control.py"
+
+    def test_rejects_intentional_broad_except(self):
+        line = _find_line(self.fixture, "except Exception:  # noqa: BLE001")
+        finding = _make_finding(
+            file_path=self.fixture,
+            line=line,
+            message="broad_exception: BLE001 blind exception",
+        )
+        verdict = _engine([IntentionalBroadExceptRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+        assert "intentional" in verdict.verification_reasoning.lower()
+
+    def test_does_not_fire_without_noqa_and_marker(self):
+        line = _find_line(self.control, "except Exception")
+        finding = _make_finding(
+            file_path=self.control,
+            line=line,
+            message="broad_exception: BLE001 blind exception",
+        )
+        verdict = _engine([IntentionalBroadExceptRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+
+# ---------------------------------------------------------------------------
+# Rule 6: SubprocessInFuzzTargetRule
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessInFuzzTargetRule:
+    fixture = FIXTURE_ROOT / "fuzz_target.py"
+    control = FIXTURE_ROOT / "normal_subprocess_control.py"
+
+    def test_rejects_subprocess_in_fuzz_path(self, tmp_path):
+        # Copy the fixture into a path containing /fuzz_ so the rule's
+        # path heuristic engages.
+        target_dir = tmp_path / "fuzz_targets"
+        target_dir.mkdir()
+        target = target_dir / "fuzz_demo.py"
+        target.write_text(self.fixture.read_text())
+        line = _find_line(target, "subprocess.run(")
+        finding = _make_finding(
+            file_path=target,
+            line=line,
+            message="subprocess B603: subprocess without shell injection mitigation",
+        )
+        verdict = _engine([SubprocessInFuzzTargetRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+        assert "fuzz" in verdict.verification_reasoning.lower()
+
+    def test_does_not_fire_on_normal_path(self):
+        line = _find_line(self.control, "subprocess.call(cmd, shell=True)")
+        finding = _make_finding(
+            file_path=self.control,
+            line=line,
+            message="subprocess shell injection B602 shell=True",
+        )
+        verdict = _engine([SubprocessInFuzzTargetRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+
+# ---------------------------------------------------------------------------
+# Rule 7: StructlogKwargsRule
+# ---------------------------------------------------------------------------
+
+
+class TestStructlogKwargsRule:
+    fixture = FIXTURE_ROOT / "structlog_kwargs.py"
+    control = FIXTURE_ROOT / "structlog_kwargs_control.py"
+
+    def test_rejects_logger_kwargs_in_structlog_file(self):
+        line = _find_line(self.fixture, 'logger.info("user.event"')
+        finding = _make_finding(
+            file_path=self.fixture,
+            line=line,
+            message="TypeError: logger.info got an unexpected keyword argument",
+        )
+        verdict = _engine([StructlogKwargsRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+        assert "structlog" in verdict.verification_reasoning.lower()
+
+    def test_does_not_fire_in_stdlib_logging_file(self):
+        line = _find_line(self.control, "logger.info(")
+        finding = _make_finding(
+            file_path=self.control,
+            line=line,
+            message="TypeError: logger.info got an unexpected keyword argument",
+        )
+        verdict = _engine([StructlogKwargsRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+
+# ---------------------------------------------------------------------------
+# Rule 8: SecretsPragmaRule
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsPragmaRule:
+    fixture = FIXTURE_ROOT / "secrets_pragma.py"
+    control = FIXTURE_ROOT / "secrets_pragma_control.py"
+
+    def test_rejects_pragma_allowlisted_line(self):
+        line = _find_line(self.fixture, "pragma: allowlist secret")
+        finding = _make_finding(
+            file_path=self.fixture,
+            line=line,
+            message="hardcoded credential / api key detected",
+        )
+        verdict = _engine([SecretsPragmaRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+        assert "pragma" in verdict.verification_reasoning.lower()
+
+    def test_does_not_fire_without_pragma(self):
+        line = _find_line(self.control, "LEAKED_API_KEY")
+        finding = _make_finding(
+            file_path=self.control,
+            line=line,
+            message="hardcoded credential / api key detected",
+        )
+        verdict = _engine([SecretsPragmaRule()]).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+
+# ---------------------------------------------------------------------------
+# Engine integration
+# ---------------------------------------------------------------------------
+
+
+class TestVerificationEngineIntegration:
+    def test_unsure_when_no_rule_matches(self):
+        finding = _make_finding(
+            file_path=FIXTURE_ROOT / "dirs_slice_assignment.py",
+            line=1,
+            message="totally unfamiliar message",
+        )
+        verdict = _engine(default_rules()).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+        assert "no verification rule fired" in verdict.verification_reasoning
+
+    def test_engine_reads_source_only_once_per_path(self):
+        engine = _engine(default_rules())
+        line = _find_line(FIXTURE_ROOT / "dirs_slice_assignment.py", "dirs[:]")
+        finding = _make_finding(
+            file_path=FIXTURE_ROOT / "dirs_slice_assignment.py",
+            line=line,
+            message="memory_leak: large_list_copy",
+        )
+        engine.classify(finding)
+        # Second call should hit the cache; assert the cache populated.
+        cached = engine._source_cache.get(str(FIXTURE_ROOT / "dirs_slice_assignment.py"))
+        assert cached is not None
+        assert len(cached) > 0
+
+    def test_missing_source_file_falls_through_to_unsure(self):
+        finding = _make_finding(
+            file_path=Path("/nonexistent/path/to/file.py"),
+            line=1,
+            message="memory_leak: large_list_copy on dirs[:]",
+        )
+        verdict = _engine(default_rules()).classify(finding)
+        assert verdict.verification_status == VerificationStatus.UNSURE
+
+    def test_buggy_rule_does_not_abort_sweep(self):
+        class BuggyRule:
+            name = "buggy"
+
+            def classify(self, finding, source_lines):
+                raise RuntimeError("rule blew up")
+
+        finding = _make_finding(
+            file_path=FIXTURE_ROOT / "dirs_slice_assignment.py",
+            line=_find_line(FIXTURE_ROOT / "dirs_slice_assignment.py", "dirs[:]"),
+            message="memory_leak: large_list_copy",
+        )
+        engine = _engine([BuggyRule(), DirsSliceAssignmentRule()])
+        verdict = engine.classify(finding)
+        # Despite the buggy rule, the next rule still fires.
+        assert verdict.verification_status == VerificationStatus.REJECT
+
+    def test_classify_many(self):
+        line = _find_line(FIXTURE_ROOT / "dirs_slice_assignment.py", "dirs[:]")
+        good = _make_finding(
+            file_path=FIXTURE_ROOT / "dirs_slice_assignment.py",
+            line=line,
+            message="memory_leak: large_list_copy",
+        )
+        unknown = _make_finding(
+            file_path=FIXTURE_ROOT / "dirs_slice_assignment.py",
+            line=1,
+            message="totally unknown",
+        )
+        verdicts = _engine(default_rules()).classify_many([good, unknown])
+        assert verdicts[0].verification_status == VerificationStatus.REJECT
+        assert verdicts[1].verification_status == VerificationStatus.UNSURE
+
+    def test_relative_paths_resolved_against_project_root(self, tmp_path):
+        target_dir = tmp_path / "src"
+        target_dir.mkdir()
+        target_file = target_dir / "thing.py"
+        target_file.write_text((FIXTURE_ROOT / "dirs_slice_assignment.py").read_text())
+
+        line = _find_line(target_file, "dirs[:]")
+        finding = _make_finding(
+            file_path=target_file,
+            line=line,
+            relative_to=tmp_path,
+            message="memory_leak: large_list_copy",
+        )
+        # finding.file_path is now "src/thing.py" — relative.
+        assert not Path(finding.file_path).is_absolute()
+        verdict = _engine(default_rules(), project_root=tmp_path).classify(finding)
+        assert verdict.verification_status == VerificationStatus.REJECT
+
+
+@pytest.mark.parametrize(
+    "rule_cls",
+    [
+        DirsSliceAssignmentRule,
+        SubprocessExecRule,
+        JsRegexExecRule,
+        WriteTextEvalFixtureRule,
+        IntentionalBroadExceptRule,
+        SubprocessInFuzzTargetRule,
+        StructlogKwargsRule,
+        SecretsPragmaRule,
+    ],
+)
+def test_rule_returns_none_on_missing_line(rule_cls):
+    """Every rule must gracefully return None when line is missing."""
+    rule = rule_cls()
+    finding = _make_finding(
+        file_path=Path("/tmp/fake.py"),
+        line=None if False else 99999,
+        message="something",
+    )
+    out = rule.classify(finding, source_lines=[])
+    assert out is None

--- a/tests/unit/workflows/discovery_sweep/test_workflow.py
+++ b/tests/unit/workflows/discovery_sweep/test_workflow.py
@@ -1,0 +1,385 @@
+"""Tests for the DiscoverySweepEngine orchestrator and BudgetTracker."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from attune.workflows.discovery_sweep import (
+    BudgetTracker,
+    DiscoverySweepEngine,
+    Finding,
+    ResolutionComplexity,
+    Severity,
+    SweepBudgetExceeded,
+    SweepResult,
+    VerificationEngine,
+    VerificationStatus,
+    read_jsonl,
+    split_findings_by_complexity,
+)
+from attune.workflows.discovery_sweep.rules import default_rules
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _MockSource:
+    """A FindingSource double that emits canned findings."""
+
+    name: str
+    findings: list[Finding]
+    estimated_spend_usd: float = 0.0
+    raise_on_discover: Exception | None = None
+    calls: int = 0
+
+    def discover(self, scope: Path, budget_usd: float, sweep_id: str) -> Iterable[Finding]:
+        self.calls += 1
+        if self.raise_on_discover is not None:
+            raise self.raise_on_discover
+        # Stamp the sweep_id on each emitted finding so the
+        # orchestrator's audit trail propagates.
+        return [
+            Finding(
+                source_workflow=f.source_workflow,
+                file_path=f.file_path,
+                severity=f.severity,
+                message=f.message,
+                raw_finding=f.raw_finding,
+                sweep_id=sweep_id,
+                line=f.line,
+            )
+            for f in self.findings
+        ]
+
+
+def _seed_finding(
+    *,
+    source: str = "bug_predict",
+    file_path: str = "src/attune/example.py",
+    message: str = "unknown finding",
+    line: int = 10,
+    severity: Severity = Severity.MEDIUM,
+) -> Finding:
+    return Finding(
+        source_workflow=source,
+        file_path=file_path,
+        severity=severity,
+        message=message,
+        raw_finding={"pattern": "x"},
+        sweep_id="placeholder",
+        line=line,
+    )
+
+
+# ---------------------------------------------------------------------------
+# BudgetTracker
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetTracker:
+    def test_defaults_match_spec(self):
+        tracker = BudgetTracker()
+        assert tracker.subworkflow_cap_usd == pytest.approx(10.0)
+        assert tracker.sweep_cap_usd == pytest.approx(40.0)
+
+    def test_budget_for_starts_at_subworkflow_cap(self):
+        tracker = BudgetTracker()
+        assert tracker.budget_for("any") == pytest.approx(10.0)
+
+    def test_record_accumulates_spend(self):
+        tracker = BudgetTracker()
+        tracker.record("bug_predict", 3.5)
+        tracker.record("security_audit", 2.0)
+        assert tracker.total_spend_usd == pytest.approx(5.5)
+        assert tracker.remaining_sweep_usd == pytest.approx(34.5)
+
+    def test_record_raises_when_ceiling_exceeded(self):
+        tracker = BudgetTracker(sweep_cap_usd=20.0, subworkflow_cap_usd=10.0)
+        tracker.record("a", 9.0)
+        tracker.record("b", 9.0)
+        with pytest.raises(SweepBudgetExceeded):
+            tracker.record("c", 9.0)
+        # Spend was still recorded so the audit log captures it.
+        assert tracker.total_spend_usd == pytest.approx(27.0)
+
+    def test_can_run_returns_false_after_ceiling(self):
+        tracker = BudgetTracker(sweep_cap_usd=5.0, subworkflow_cap_usd=10.0)
+        with pytest.raises(SweepBudgetExceeded):
+            tracker.record("a", 10.0)
+        assert not tracker.can_run("b")
+
+    def test_from_env_respects_overrides(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_DISCOVERY_SUBWORKFLOW_BUDGET_USD", "5.0")
+        monkeypatch.setenv("ATTUNE_DISCOVERY_SWEEP_BUDGET_USD", "15.0")
+        tracker = BudgetTracker.from_env()
+        assert tracker.subworkflow_cap_usd == pytest.approx(5.0)
+        assert tracker.sweep_cap_usd == pytest.approx(15.0)
+
+    def test_from_env_falls_back_on_invalid_value(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_DISCOVERY_SUBWORKFLOW_BUDGET_USD", "not-a-number")
+        tracker = BudgetTracker.from_env()
+        assert tracker.subworkflow_cap_usd == pytest.approx(10.0)
+
+    def test_explicit_kwargs_override_env(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_DISCOVERY_SWEEP_BUDGET_USD", "100.0")
+        tracker = BudgetTracker.from_env(sweep_cap_usd=7.5)
+        assert tracker.sweep_cap_usd == pytest.approx(7.5)
+
+
+# ---------------------------------------------------------------------------
+# DiscoverySweepEngine — orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestSweepOrchestration:
+    def test_requires_at_least_one_source(self):
+        with pytest.raises(ValueError):
+            DiscoverySweepEngine(sources=[])
+
+    def test_aggregates_findings_from_multiple_sources(self, tmp_path):
+        bug_source = _MockSource(
+            name="bug_predict",
+            findings=[
+                _seed_finding(
+                    file_path=str(tmp_path / "real_eval.py"),
+                    message="dangerous_eval detected",
+                )
+            ],
+            estimated_spend_usd=2.0,
+        )
+        sec_source = _MockSource(
+            name="security_audit",
+            findings=[
+                _seed_finding(
+                    source="security_audit",
+                    file_path=str(tmp_path / "auth.py"),
+                    message="missing path validation",
+                )
+            ],
+            estimated_spend_usd=3.0,
+        )
+
+        workflow = DiscoverySweepEngine(
+            sources=[bug_source, sec_source],
+            output_dir=tmp_path / "out",
+            project_root=tmp_path,
+        )
+        result = workflow.run(scope=tmp_path)
+
+        assert isinstance(result, SweepResult)
+        assert bug_source.calls == 1
+        assert sec_source.calls == 1
+        # Both findings flow into one of the three files; total
+        # count across the three lists matches input count.
+        assert result.accept_count + result.reject_count + result.unsure_count == 2
+
+    def test_writes_three_output_files(self, tmp_path):
+        source = _MockSource(
+            name="bug_predict",
+            findings=[_seed_finding(message="unknown pattern")],
+        )
+        workflow = DiscoverySweepEngine(
+            sources=[source],
+            output_dir=tmp_path / "queue",
+            project_root=tmp_path,
+        )
+        result = workflow.run(scope=tmp_path)
+
+        assert result.queue_path is not None
+        assert result.rejected_path is not None
+        assert result.questions_path is not None
+        assert Path(result.queue_path).exists()
+        assert Path(result.rejected_path).exists()
+        assert Path(result.questions_path).exists()
+
+    def test_sweep_id_consistent_across_files(self, tmp_path):
+        source = _MockSource(
+            name="bug_predict",
+            findings=[
+                _seed_finding(message="memory_leak: dirs[:]"),
+                _seed_finding(message="unknown finding"),
+            ],
+        )
+        workflow = DiscoverySweepEngine(
+            sources=[source],
+            output_dir=tmp_path / "queue",
+            project_root=tmp_path,
+        )
+        result = workflow.run(scope=tmp_path)
+
+        queue_findings = read_jsonl(result.queue_path)
+        rejected_findings = read_jsonl(result.rejected_path)
+        all_emitted = queue_findings + rejected_findings
+        for finding in all_emitted:
+            assert finding.sweep_id == result.sweep_id
+        # And the markdown file's header contains the sweep_id too.
+        md = Path(result.questions_path).read_text()
+        assert result.sweep_id in md
+
+    def test_one_source_failure_does_not_abort_sweep(self, tmp_path):
+        good_source = _MockSource(
+            name="bug_predict",
+            findings=[_seed_finding(message="good finding")],
+        )
+        bad_source = _MockSource(
+            name="security_audit",
+            findings=[],
+            raise_on_discover=RuntimeError("adapter exploded"),
+        )
+
+        workflow = DiscoverySweepEngine(
+            sources=[bad_source, good_source],
+            output_dir=tmp_path / "out",
+            project_root=tmp_path,
+        )
+        result = workflow.run(scope=tmp_path)
+
+        # The good source's finding still flows through.
+        assert (result.accept_count + result.reject_count + result.unsure_count) == 1
+        # The failure is recorded by source name.
+        assert "security_audit" in result.sub_workflow_errors
+        assert "adapter exploded" in result.sub_workflow_errors["security_audit"]
+
+    def test_budget_ceiling_halts_further_sources(self, tmp_path):
+        # First source spends nearly the whole sweep cap; second
+        # source should be skipped.
+        source_one = _MockSource(
+            name="bug_predict",
+            findings=[_seed_finding(message="one")],
+            estimated_spend_usd=12.0,
+        )
+        source_two = _MockSource(
+            name="security_audit",
+            findings=[_seed_finding(message="two")],
+            estimated_spend_usd=1.0,
+        )
+
+        budget = BudgetTracker(sweep_cap_usd=10.0, subworkflow_cap_usd=12.0)
+        workflow = DiscoverySweepEngine(
+            sources=[source_one, source_two],
+            output_dir=tmp_path / "out",
+            project_root=tmp_path,
+            budget=budget,
+        )
+        result = workflow.run(scope=tmp_path)
+
+        assert result.budget_halted is True
+        assert source_two.calls == 0
+        # Source one's spend is recorded, even though it crossed the cap.
+        assert "bug_predict" in result.sub_workflow_spend
+
+    def test_no_findings_still_writes_empty_files(self, tmp_path):
+        source = _MockSource(name="bug_predict", findings=[])
+        workflow = DiscoverySweepEngine(
+            sources=[source],
+            output_dir=tmp_path / "out",
+            project_root=tmp_path,
+        )
+        result = workflow.run(scope=tmp_path)
+
+        assert result.accept_count == 0
+        assert Path(result.queue_path).read_text() == ""
+        assert Path(result.rejected_path).read_text() == ""
+        assert "No UNSURE findings" in Path(result.questions_path).read_text()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end verification flow through the orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestSweepWithRealVerification:
+    """The orchestrator wires verification + complexity by default;
+    these tests confirm a finding that the rule engine REJECTs
+    lands in the rejected file (not the queue or questions)."""
+
+    def test_known_false_positive_lands_in_rejected(self, tmp_path):
+        # Synthesize a fixture file with the os.walk + dirs[:] pattern.
+        fixture = tmp_path / "walker.py"
+        fixture.write_text(
+            "import os\n"
+            "\n"
+            "def find_py(root):\n"
+            "    matches = []\n"
+            "    for dirpath, dirs, files in os.walk(root):\n"
+            "        dirs[:] = [d for d in dirs if d != '.git']\n"
+            "        matches.extend(files)\n"
+            "    return matches\n"
+        )
+        # The "scanner" emits a finding pointing at the dirs[:] line.
+        # Discovery files are stored as relative paths so the
+        # verification engine resolves them against the project root.
+        finding = _seed_finding(
+            file_path=str(fixture.relative_to(tmp_path)),
+            message="memory_leak: large_list_copy on dirs[:]",
+            line=6,  # dirs[:] line
+        )
+        source = _MockSource(name="perf_audit", findings=[finding])
+
+        workflow = DiscoverySweepEngine(
+            sources=[source],
+            output_dir=tmp_path / "out",
+            project_root=tmp_path,
+            verification_engine=VerificationEngine(default_rules(), project_root=tmp_path),
+        )
+        result = workflow.run(scope=tmp_path)
+
+        assert result.reject_count == 1
+        assert result.accept_count == 0
+        rejected = read_jsonl(result.rejected_path)
+        assert len(rejected) == 1
+        assert rejected[0].verification_status == VerificationStatus.REJECT
+        assert "os.walk" in rejected[0].verification_reasoning
+
+
+# ---------------------------------------------------------------------------
+# split_findings_by_complexity
+# ---------------------------------------------------------------------------
+
+
+class TestSplitFindingsByComplexity:
+    def test_partitions_accepts_by_tag(self):
+        routine = Finding(
+            source_workflow="bug_predict",
+            file_path="src/attune/util.py",
+            severity=Severity.MEDIUM,
+            message="x",
+            raw_finding={},
+            sweep_id="s",
+            line=1,
+            verification_status=VerificationStatus.ACCEPT,
+            resolution_complexity=ResolutionComplexity.ROUTINE,
+        )
+        sensitive = Finding(
+            source_workflow="security_audit",
+            file_path="src/attune/security/x.py",
+            severity=Severity.HIGH,
+            message="y",
+            raw_finding={},
+            sweep_id="s",
+            line=2,
+            verification_status=VerificationStatus.ACCEPT,
+            resolution_complexity=ResolutionComplexity.NEEDS_PATRICK,
+        )
+        unrelated = Finding(
+            source_workflow="bug_predict",
+            file_path="src/attune/util.py",
+            severity=Severity.LOW,
+            message="z",
+            raw_finding={},
+            sweep_id="s",
+            line=3,
+            verification_status=VerificationStatus.UNSURE,
+        )
+
+        routine_out, needs_patrick_out = split_findings_by_complexity(
+            [routine, sensitive, unrelated]
+        )
+        assert routine_out == [routine]
+        assert needs_patrick_out == [sensitive]


### PR DESCRIPTION
## Summary

Ships Phase 1 + Phase 2A of the discovery-sweep workflow per the snapshot's design (the spec docs are now the snapshot's `decisions.md` + `phase-2.md` + the 521-line plan tracker; the earlier `design.md`/`requirements.md`/`tasks.md` set is retired).

`attune workflow run discovery-sweep --path <module>` works end-to-end with the deterministic `PatternScanSource` adapter. Resolution stays interactive. LLM-wrapping adapters (Phase 2B) are out of scope.

### Why the swap

The original draft of this PR followed the older `design.md` shape (frozen `Finding` dataclass, separate `QuestionFinding`/`RejectedFinding` types, async `discover`, no on-disk output). The snapshot's design is materially different and is now canonical:

- Status embedded on `Finding` (ACCEPT/REJECT/UNSURE) via a verification engine.
- Separate `complexity.py`, `budget.py`, `schema.py`, `serialization.py`, and `rules/known_false_positives.py` modules.
- Synchronous `discover()` (engine runs sources sequentially under a budget tracker).
- Writes JSONL queue + JSONL rejected log + Markdown questions file to `.claude/discovery-queue/` (gitignored).
- REJECT rules grounded in CLAUDE.md lessons (dirs[:], js regex.exec, intentional broad-except, fuzz subprocess, secrets pragma, etc.) with paired control fixtures.

### Package contents (`src/attune/workflows/discovery_sweep/`)

- `workflow.py` — `DiscoverySweepEngine` orchestrator + `FindingSource` Protocol + `SweepResult` dataclass.
- `verification.py` — engine that runs ordered `VerificationRule`s.
- `rules/known_false_positives.py` — REJECT rules grounded in documented CLAUDE.md lessons.
- `complexity.py` — `ComplexityClassifier` tags ACCEPTed findings `routine` vs `needs_patrick`.
- `budget.py` — `BudgetTracker` with sub-workflow and sweep ceilings (env-configurable).
- `schema.py` — `Finding` / `Severity` / `VerificationStatus` / `ResolutionComplexity` enums + sweep-id helper.
- `serialization.py` — JSONL queue writer + Markdown questions writer.
- `cli_workflow.py` — `DiscoverySweepWorkflow(BaseWorkflow)` thin wrapper for `attune workflow run`.
- `sources/pattern_scan.py` — `PatternScanSource` deterministic adapter.

### Wiring + spec

- `src/attune/workflows/__init__.py` — `_LAZY_WORKFLOW_IMPORTS` + `_DEFAULT_WORKFLOW_NAMES` entries.
- `src/attune/ops/data.py` — `PATH_ARG_REGISTRY` Category A entry (`kwarg="path"`, `required=False`).
- `docs/specs/_sequencing.md` — Track C section showing Phase 1 + 2A shipped; Phase 2B remaining.
- `.gitignore` — excludes `.claude/discovery-queue/` ephemeral output.
- `docs/workflows/discovery-sweep.md` — 217-line user-facing workflow doc.

### Tests (127 in `tests/unit/workflows/discovery_sweep/`)

- `test_workflow.py` — engine plumbing, budget enforcement, source failure isolation.
- `test_verification.py` — REJECT/ACCEPT/UNSURE rule cascade.
- `test_complexity.py` — classifier coverage.
- `test_schema.py` — frozen dataclasses + sweep-id helper.
- `test_pattern_scan.py` — pattern hits + REJECT-rule pairing.
- `test_cli_workflow.py` — BaseWorkflow wrapper and result packaging.
- `test_smoke.py` — end-to-end smoke against fixture files.
- `fixtures/false_positives/` — paired bug/control pairs that document each REJECT rule.

### Test plan

- [x] Targeted suite: `uv run --extra dev --extra developer pytest tests/unit/workflows/discovery_sweep/ --no-cov -q` → 127 passed
- [x] Drift guards: `test_path_support_registry`, `test_wiring_consistency`, `test_workflow_consolidation` → 58 passed (185 total)
- [x] Pre-commit clean
- [ ] Full CI matrix on push

### Out of scope (Phase 2B+)

- LLM-wrapping adapters (`BugPredictSource`, `SecurityAuditSource`, …)
- Auto-fix
- Retirement evaluation (does discovery-sweep subsume existing workflows?)
- Multi-module parallelism
- RAG-grounded verification
- MCP tool exposure

Generated with [Claude Code](https://claude.com/claude-code)
