### PR TITLE
docs(CLAUDE.md): three session lessons from worktree cleanup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3646,3 +3646,82 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   becomes wrong the moment the version passes; treat
   migration docs as having a shelf life tied to the
   marker's target version.
+
+- **`git stash pop` after fast-forwarding to upstream
+  inverts `--ours` / `--theirs` semantics — and the
+  most common conflict shape is a spec status field
+  that upstream changed since the stash**: classic
+  flow during the "merge + restore wip" dance when
+  the main checkout has uncommitted spec edits.
+  Stash → ff merge → pop → conflicts on any file
+  where both sides edited the same line. During the
+  pop, the merge base is HEAD (the just-merged
+  upstream content), so `--ours` = upstream (HEAD),
+  `--theirs` = the stashed content. This is INVERTED
+  from a regular merge. Concretely, hit on
+  2026-05-12 with spec status field collisions —
+  upstream had moved `coverage-canonical-pattern`
+  to "paused 2026-05-12" while the stash had stale
+  "approved" edits. `git checkout --ours <file>`
+  on each conflicted file took the upstream
+  (correct) version. ALWAYS follow a deliberate-
+  discard resolution with `git stash drop` to clear
+  the stash entry — otherwise it lingers with stale
+  content and is easy to revive later by mistake.
+  The conflict shape (status fields, sometimes
+  status-line + decisions reference) is predictable
+  enough that a one-line resolution checklist works:
+  `git checkout --ours <conflicted files> && git add
+  <files> && git stash drop`.
+
+- **Scheduled-tasks display time uses Claude Code's
+  configured local timezone, NOT the timezone you
+  passed in the ISO offset — verify by reading the
+  display in the user's local time, not by trusting
+  the offset you specified**: passed
+  `fireAt="2026-05-12T19:30:00-07:00"` (intending 7:30
+  PM Pacific). Display showed "5/12/2026, 10:30:00
+  PM" — which is 7:30 PM Pacific rendered in Eastern
+  time (the user's locale). The stored ISO is
+  canonical; the display is just rendered for the
+  user. If user said "7:30 PM" and the display shows
+  a different hour, the schedule is wrong for THEIR
+  intent. Confirm user's timezone separately (their
+  daily-briefing cron `fireAt` minus the cron
+  `cronExpression` time-of-day gives the local
+  offset). Update via
+  `update_scheduled_task(fireAt="<correct-offset>")`.
+
+- **Subagent-vs-Batches questions need a Phase 0
+  measurement before drafting the full spec**: when
+  considering whether to replace a Batches API pipeline
+  with subagent fan-out (e.g., per-kind polish
+  specialization in attune-author), the prior is that
+  Batches already wins on speed/cost — 50% discount
+  plus automatic parallelism. The only axis where
+  subagents can beat Batches is *quality
+  differentiation* (different prompts, models, or
+  strategies per task type). Don't draft a full spec
+  on that prior alone. Phase 0 design: run the same
+  fixed corpus through three arms — (1) status quo
+  Batches with global prompt, (2) subagents with
+  regular API per-kind (no batching — worst case for
+  subagents, exposes the discount loss), (3) subagents
+  that each submit their own Batches call (preserves
+  discount, isolates the per-kind effect). Capture
+  wall-clock, input/output tokens, total $, and 5
+  sampled outputs per arm for quality eyeball.
+  Pre-commit a decision matrix to
+  `docs/specs/<spec>/decisions.md` BEFORE running so
+  the result routes the decision cleanly without
+  goalpost-moving (see the existing "Pre-committed
+  decision matrices survive contact with data"
+  lesson). Same pattern as the Agent Surface
+  Rebalance retirement (2026-05-12): $8.78 of
+  measurement was strictly cheaper than implementing
+  a conversion that would have saved zero bytes. Test
+  budget here is similarly cheap (~$5-15 for a 12-
+  template corpus on Sonnet). Generalize: any "swap
+  Anthropic-native infrastructure for orchestration
+  layer above it" question in this ecosystem needs
+  Phase 0 measurement first.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3725,3 +3725,30 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   Anthropic-native infrastructure for orchestration
   layer above it" question in this ecosystem needs
   Phase 0 measurement first.
+
+- **`git diff --stat` on an abandoned branch shows
+  working-tree-vs-branch-HEAD, not vs current main —
+  the insert/delete counts mislead when assessing
+  "what's worth salvaging" from a stale branch**: hit
+  during today's worktree audit on
+  `silly-shamir-a723b0` (PR #262 CLOSED, dirty). The
+  `git status` showed `M` on 3 files in
+  `.help/templates/memory/` and the `--stat` reported
+  214 inserts / 264 deletes — a substantial-looking
+  rewrite. But that diff was working-tree-vs-the-
+  branch's-OWN-old-base. The actual diff vs current
+  main was 6 lines per file: just regenerated
+  frontmatter (`generated_at` timestamp +
+  `source_hash`). Body content was identical because
+  the templates auto-regenerate from `src/attune/
+  memory/` source and main had a NEWER regeneration.
+  Pattern: when evaluating whether to "salvage"
+  uncommitted work from an abandoned branch, always
+  `diff <worktree-file> <main-file>` directly, not
+  `git diff --stat` inside the worktree. The latter
+  compares against a base that's typically weeks
+  behind main. Saved a no-op PR today. Pairs with
+  the existing "Audits with 'possibly delete if X'
+  qualifiers require verifying both X and the
+  alternative before acting" lesson — same shape,
+  different mechanism.


### PR DESCRIPTION
## Summary

Lands three session lessons that lived as **uncommitted** additions in two now-removed Claude session worktrees (`zealous-goldstine-b953ef`, `modest-hoover-8121a5`). Captured during today's worktree audit; would have been lost otherwise.

All three are append-only additions to `.claude/CLAUDE.md` — no behavior change.

### Lessons

1. **`git stash pop` after fast-forward inverts `--ours` / `--theirs`** — counterintuitive flag direction during the "merge + restore wip" dance. Includes the predictable conflict shape (spec status fields where upstream moved status since the stash was taken) and a one-line resolution recipe (`git checkout --ours <files> && git add <files> && git stash drop`).

2. **Scheduled-tasks display time uses Claude Code's configured local timezone, not the ISO offset you pass in** — passed `fireAt="2026-05-12T19:30:00-07:00"` intending 7:30 PM Pacific; display showed "10:30 PM" because the user's locale renders in Eastern. Stored ISO is canonical, display is rendered. Verify the display, not the offset.

3. **Subagent-vs-Batches questions need a Phase 0 measurement** before drafting the full spec. Three-arm test design (status-quo Batches, per-kind subagents with regular API, per-kind subagents each issuing Batches), with pre-committed decision matrix to prevent goalpost-moving. Generalization of the Agent Surface Rebalance retirement pattern ($8.78 measurement avoided implementing a zero-byte-saving conversion).

### Test plan

- [x] Pre-commit clean (no markdown rules violated, trailing-whitespace passed)
- [x] Append-only — no existing lessons modified
- [ ] CI matrix on push

Generated with [Claude Code](https://claude.com/claude-code)
