### PR TITLE
fix(ops): annotate cleanup broad-except with noqa BLE001

### DIFF
--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -271,7 +271,10 @@ def _atomic_write(target: Path, text: str) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(text)
         os.replace(tmp, target)
-    except Exception:
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: cleanup path — remove the temp file regardless of
+        # which write/replace step raised, then re-raise so the caller
+        # still sees the original failure.
         Path(tmp).unlink(missing_ok=True)
         raise
 


### PR DESCRIPTION
## Summary

- Adds `# noqa: BLE001` + `# INTENTIONAL: cleanup` annotation to the temp-file cleanup path in `_atomic_write()` at [src/attune/ops/routes/specs.py:274](src/attune/ops/routes/specs.py#L274).
- The block legitimately catches all exceptions to remove the tempfile before re-raising — it just lacked the project-required annotation pair.

## Context

This was the only real signal surfaced by the first systematic whole-tree dogfood run of the `discovery-sweep` workflow (Phase 1) against `src/attune/`. Every other queue finding (14 of 15) was a multi-line-docstring false positive — that's tracked separately as the AST-string-region filter follow-up.

Audit details: [docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md](docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md)

## Test plan

- [x] pre-commit hooks pass (black, ruff, ruff-bare-exception-check, bandit, trailing-whitespace)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)