### PR TITLE
feat(discovery-sweep): AST-based string-region filter for multi-line docstrings

### DIFF
--- a/src/attune/workflows/discovery_sweep/sources/pattern_scan.py
+++ b/src/attune/workflows/discovery_sweep/sources/pattern_scan.py
@@ -22,6 +22,7 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
+import ast
 import logging
 import re
 from dataclasses import dataclass, field
@@ -34,6 +35,66 @@ logger = logging.getLogger(__name__)
 
 _QUOTE_CHARS: frozenset[str] = frozenset({'"', "'", "`"})
 _NOQA_BLE001_RE = re.compile(r"#\s*noqa\s*:\s*[^#\n]*\bBLE001\b", re.IGNORECASE)
+
+# (start_line, start_col, end_line, end_col) — all 1-indexed lines,
+# 0-indexed columns, matching CPython's ``ast`` convention.
+_StringSpan = tuple[int, int, int, int]
+
+
+def _collect_string_spans(content: str) -> list[_StringSpan] | None:
+    """Return spans of every string literal in ``content`` via :mod:`ast`.
+
+    Each span is ``(start_line, start_col, end_line, end_col)`` using the
+    same indexing as :mod:`ast` (lines 1-indexed, cols 0-indexed). The
+    spans include single-line and multi-line strings, docstrings,
+    bytes-literals, and the literal fragments of f-strings (CPython
+    emits each f-string fragment as its own :class:`ast.Constant` child).
+
+    Returns ``None`` when ``content`` fails to parse. Callers should fall
+    back to the line-local quote walk in that case so files with syntax
+    errors still get pattern-scanned.
+    """
+    try:
+        tree = ast.parse(content)
+    except (SyntaxError, ValueError):
+        return None
+    spans: list[_StringSpan] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Constant):
+            continue
+        if not isinstance(node.value, str | bytes):
+            continue
+        if (
+            node.lineno is None
+            or node.col_offset is None
+            or node.end_lineno is None
+            or node.end_col_offset is None
+        ):
+            continue
+        spans.append((node.lineno, node.col_offset, node.end_lineno, node.end_col_offset))
+    return spans
+
+
+def _is_inside_string_span(spans: list[_StringSpan], line: int, col: int) -> bool:
+    """True if ``(line, col)`` falls inside any string span.
+
+    Linear scan over ``spans`` — fine for typical modules (a few hundred
+    string nodes at most). Lines strictly between ``start_line`` and
+    ``end_line`` of a span are always inside.
+    """
+    for start_line, start_col, end_line, end_col in spans:
+        if start_line < line < end_line:
+            return True
+        if start_line == line and end_line == line:
+            if start_col <= col < end_col:
+                return True
+        elif start_line == line:
+            if col >= start_col:
+                return True
+        elif end_line == line:
+            if col < end_col:
+                return True
+    return False
 
 
 def _is_inside_quoted_region(line: str, match_start: int) -> bool:
@@ -234,18 +295,29 @@ class PatternScanSource:
             except ValueError:
                 rel = str(file_path)
 
+        # Build a whole-file string-span map via ``ast`` so pattern tokens
+        # mentioned inside multi-line docstrings (the dominant false-
+        # positive shape from the 2026-05-13 dogfood audit) are filtered.
+        # ``None`` when the file fails to parse — the line-local fallback
+        # still applies in that case via the OR below.
+        spans = _collect_string_spans(content)
+
         findings: list[Finding] = []
         for lineno, line in enumerate(content.splitlines(), start=1):
             for spec in _PATTERNS:
                 match = spec.regex.search(line)
                 if not match:
                     continue
-                if _is_inside_quoted_region(line, match.start()):
-                    # Pattern token sits inside a string literal /
-                    # backtick code-span / docstring fragment on this
-                    # line. Skip: bug-predict's `_is_detection_code_line`
-                    # filters the same shape (see
-                    # `.claude/rules/attune/scanner-patterns.md`).
+                # Skip if EITHER the AST says the token is inside a real
+                # string literal (catches multi-line docstrings) OR the
+                # line-local quote walk says it's inside a quoted region
+                # on this line (catches same-line literals AND prose
+                # inside ``# "..."`` comment text, which AST never sees).
+                # OR semantics preserve Phase 1's comment-text filtering.
+                in_ast_string = spans is not None and _is_inside_string_span(
+                    spans, lineno, match.start()
+                )
+                if in_ast_string or _is_inside_quoted_region(line, match.start()):
                     continue
                 if spec.pattern_name == "broad_exception" and _has_noqa_ble001(line):
                     # Project coding standards waive `except Exception:`

--- a/tests/unit/workflows/discovery_sweep/test_pattern_scan_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_pattern_scan_source.py
@@ -202,6 +202,103 @@ class TestFalsePositiveFilters:
         assert len(bare) == 1
 
 
+class TestMultiLineDocstringFilter:
+    """AST-based string-region filter — added 2026-05-13.
+
+    The whole-tree dogfood audit on 2026-05-13 surfaced 14 false
+    positives where pattern keywords were mentioned in **multi-line**
+    module docstrings. The pre-existing line-local quote walk only
+    catches same-line literals — a docstring whose opening ``\"\"\"``
+    is on line 1 and whose ``eval(`` mention is on line 12 falls
+    through. The AST helper rejects those by collecting every string-
+    literal node's span up front and filtering finding coordinates
+    against the span set.
+
+    See ``docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md``.
+    """
+
+    def test_eval_inside_multiline_module_docstring_skipped(self, tmp_path: Path) -> None:
+        keyword = "ev" + "al"
+        # Module docstring opens on line 1, mentions ``eval(`` on line 4
+        # (in prose). Pre-AST filter would miss this; the AST helper
+        # treats lines 1-6 inclusive as inside-string territory.
+        (tmp_path / "a.py").write_text(
+            '"""Module docstring.\n'
+            "\n"
+            "Coding standards:\n"
+            f"- No {keyword}() or exec() usage\n"
+            "- All operators whitelisted\n"
+            '"""\n'
+            "\n"
+            "def safe(): return 1\n",
+            encoding="utf-8",
+        )
+        findings = _scan(tmp_path)
+        assert findings == [], findings
+
+    def test_exec_inside_multiline_class_docstring_skipped(self, tmp_path: Path) -> None:
+        keyword = "ex" + "ec"
+        (tmp_path / "b.py").write_text(
+            "class Foo:\n"
+            '    """One liner.\n'
+            "\n"
+            f"    Does not use {keyword}() anywhere.\n"
+            '    """\n'
+            "\n"
+            "    def bar(self):\n"
+            "        return 1\n",
+            encoding="utf-8",
+        )
+        findings = _scan(tmp_path)
+        assert findings == [], findings
+
+    def test_real_eval_outside_string_still_detected(self, tmp_path: Path) -> None:
+        """AST filter must not suppress legitimate calls."""
+        keyword = "ev" + "al"
+        (tmp_path / "c.py").write_text(
+            '"""Module docstring with no pattern keyword."""\n'
+            "\n"
+            "def unsafe(x):\n"
+            f"    return {keyword}(x)\n",
+            encoding="utf-8",
+        )
+        findings = _scan(tmp_path)
+        assert len(findings) == 1
+        assert "dangerous_eval" in findings[0].tags
+        assert findings[0].line == 4
+
+    def test_syntax_error_falls_back_to_line_local_filter(self, tmp_path: Path) -> None:
+        """Files that fail to ast.parse still get same-line filtering.
+
+        The fallback path catches same-line string literals (the
+        original Phase 1 behavior) so single-line scanner self-matches
+        keep getting filtered even when the file has invalid syntax.
+        """
+        keyword = "ev" + "al"
+        # Truly broken syntax (unbalanced bracket on a real statement)
+        # — AST will refuse to parse, scanner falls back. The string
+        # literal on the line is still recognized by the line-local
+        # quote walk.
+        (tmp_path / "d.py").write_text(
+            f'TITLE = "Use of {keyword}() bad"\n' "def broken(:\n    pass\n",
+            encoding="utf-8",
+        )
+        findings = _scan(tmp_path)
+        # Same-line string filter still applies via the fallback path.
+        assert findings == [], findings
+
+    def test_eval_in_fstring_literal_fragment_skipped(self, tmp_path: Path) -> None:
+        """f-string literal fragments are ``ast.Constant`` children and
+        should be treated as inside-string by the AST helper."""
+        keyword = "ev" + "al"
+        (tmp_path / "e.py").write_text(
+            f'def f(): return f"prose mentioning {keyword}() in middle"\n',
+            encoding="utf-8",
+        )
+        findings = _scan(tmp_path)
+        assert findings == [], findings
+
+
 class TestPathRendering:
     """Single-file scans render the bare filename, not ``.``."""
 


### PR DESCRIPTION
## Summary

- Adds `_collect_string_spans()` that parses each file with `ast.parse` and collects spans of every string-literal node (covers single-line, multi-line, byte strings, f-string fragments).
- Adds `_is_inside_string_span()` containment helper.
- `_scan_file()` now skips a finding when EITHER the AST helper OR the existing line-local quote walk says the match is inside a string. The OR preserves Phase 1's comment-text filtering behavior (line-local treats `# "..."` text as quoted; AST does not see comments).
- 5 new tests in `TestMultiLineDocstringFilter`.

## Context

The 2026-05-13 whole-tree dogfood audit on `src/attune` (PR #303 merged Phase 1; PR #306 added narrower filters) surfaced 14 false positives where pattern keywords were mentioned inside multi-line module/class docstrings. The Phase 1 line-local quote walk can't see across lines, so a docstring whose opening triple-quote is on line 1 and whose pattern-keyword mention is on line 12 fell through.

This PR is the recommended fix from the audit doc (§ Three fix options → Option 1: AST-based string-region map).

Audit: [docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md](docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md)

## Validation (re-run after this PR)

Whole-tree sweep on `src/attune` drops from 15 findings to **1** — the lone real signal in `ops/routes/specs.py:274`, which is fixed separately by [#307](https://github.com/Smart-AI-Memory/attune-ai/pull/307). When both PRs land, queue is 0.

## Design notes

- **Why OR, not gate-on-fallback**: Initial implementation gated AST as primary and line-local as fallback only when AST parsing failed. That regressed three `bug_predict_patterns.py` findings where pattern keywords appeared inside quoted text inside `#` comments. AST doesn't see comments; line-local does. OR'ing both filters means we get AST's multi-line robustness AND Phase 1's comment-text behavior.
- **F-strings**: CPython's AST emits each f-string fragment as its own `ast.Constant` child of the `ast.JoinedStr`, so walking all `Constant` nodes correctly treats literal fragments as inside-string while leaving interpolated expressions outside.
- **Files that fail `ast.parse`**: `spans is None`; the OR collapses to just the line-local walk — identical to Phase 1 behavior. Same-line literals still filtered.

## Test plan

- [x] 25 tests pass locally, including 5 new ones in `TestMultiLineDocstringFilter`
- [x] Whole-tree dogfood on `src/attune` confirms queue = 1 (the real signal)
- [x] pre-commit hooks pass (black, ruff, ruff-bare-exception-check, bandit, trailing-whitespace)
- [ ] CI green

Generated with Claude Code
