### PR TITLE
docs(discovery-sweep): mark dogfood audit resolved by #307 + #309

### DIFF
--- a/docs/specs/discovery-sweep/NEXT-SESSION.md
+++ b/docs/specs/discovery-sweep/NEXT-SESSION.md
@@ -107,7 +107,8 @@ scoped fixes to a shipped feature, not new feature work.
 - [x] PR #306 opened (draft)
 - [x] Dogfood audit run + written up
 - [x] Starter prompt written
-- [ ] PR #306 CI green (in flight when session paused)
-- [ ] PR #306 merged
-- [ ] Real-signal fix (`specs.py:274`) — next session
-- [ ] AST string-region filter — next session
+- [x] PR #306 CI green
+- [x] PR #306 merged
+- [x] Real-signal fix (`specs.py:274`) — PR #307 merged 2026-05-13
+- [x] AST string-region filter — PR #309 merged 2026-05-13
+- [x] Whole-tree dogfood re-verified: queue = 0 on `src/attune`

--- a/docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md
+++ b/docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md
@@ -133,3 +133,20 @@ the cross-package docstring shape evades it.
 - Two new lessons in `.claude/CLAUDE.md` (workflow registration
   has FOUR drift-guard gates; PatternScanSource self-match was the
   driver for #306).
+
+## Resolution
+
+**Resolved 2026-05-13** by PR
+[#307](https://github.com/Smart-AI-Memory/attune-ai/pull/307) +
+[#309](https://github.com/Smart-AI-Memory/attune-ai/pull/309).
+Whole-tree sweep on `src/attune` now returns **queue=0**.
+
+- PR #307 added the missing `# noqa: BLE001  # INTENTIONAL: cleanup`
+  annotation at [src/attune/ops/routes/specs.py:274](src/attune/ops/routes/specs.py#L274) —
+  the single real signal.
+- PR #309 added the AST-based string-region filter
+  (`_collect_string_spans` + `_is_inside_string_span`) OR'd with
+  the existing line-local quote walk, eliminating all 14 multi-
+  line-docstring false positives. The OR preserves Phase 1's
+  comment-text filtering so the three `bug_predict_patterns.py`
+  comment-text findings stay suppressed.


### PR DESCRIPTION
## Summary

- Appends a Resolution section to [docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md](docs/specs/discovery-sweep/dogfood-audit-2026-05-13.md) noting that whole-tree sweep on `src/attune` now returns queue=0.
- Checks off the remaining items in [docs/specs/discovery-sweep/NEXT-SESSION.md](docs/specs/discovery-sweep/NEXT-SESSION.md).

Verified locally post-merge of #307 + #309:

\`\`\`
queue: 0 findings
\`\`\`

## Test plan

- [x] Doc-only change; pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)