### PR TITLE
feat(discovery-sweep): Phase 1.5 — second-pass design landings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `discovery-sweep` Phase 1.5 — second-pass design landings.
+  `FindingSource` Protocol gains a `budget_multiplier: float`
+  attribute; the engine allocates `budget_usd` proportionally
+  rather than equal-split (security-audit will claim 4x, dependency-
+  check 0.5x, others 1.0–1.5x once their adapters land). Protocol
+  signature widened to `discover(paths: list[str], budget_usd:
+  float)` — the engine glob-expands the user's `--path` upstream
+  so every source sees the same concrete file list. Surface
+  evaluation reframed (not workflow retirement) and moved to
+  P2.7 (last) after all six adapters ship; test-audit joins the
+  six wrapped workflows as a distinct test-quality lens. Phase 4
+  is now CLI surface deprecation (ops-dashboard integration
+  deferred to a follow-up spec).
+
 ### Fixed
 
 - `discovery-sweep` PatternScanSource — port two false-positive

--- a/docs/specs/discovery-sweep/decisions.md
+++ b/docs/specs/discovery-sweep/decisions.md
@@ -93,26 +93,44 @@ good
 
 `discovery-sweep` is system-driven: "find everything worth flagging across all my analysis lenses, hand me back a triaged queue." It fans out, it dedupes, it triages, it surfaces questions. Different shape, different output contract.
 
-Existing workflows that share `discovery-sweep`'s "find issues" intent: `bug-predict`, `security-audit`, `dependency-check`, `perf-audit`, `doc-audit`, `test-audit`. These are the candidates for wrapping (P2.1–P2.5) and for retirement evaluation (P2.4).
+Existing workflows that share `discovery-sweep`'s "find issues" intent: `bug-predict`, `security-audit`, `dependency-check`, `perf-audit`, `doc-audit`, `test-audit`. All six get a wrapping adapter (P2.1–P2.6).
 
-> **DECIDE:** The five LLM adapters. Initial pick: bug-predict, security-audit, dependency-check, perf-audit, doc-audit. `test-audit` is excluded from the source set and instead becomes the retirement-evaluation candidate in P2.4 — the question is whether the other five collectively surface what test-audit was finding (test gaps in test files), making test-audit redundant. Alternate framing (wrap all six, retire none) is also live; revisit after P2.1 ships.
+**Resolved (2026-05-13, Phase 1.5):** Wrap **all six** audit-family workflows, including `test-audit`. Earlier framing treated `test-audit` as a retirement candidate because its scope (test files) seemed subsumable by bug-predict + doc-audit. Second-pass review concluded the test-quality lens is genuinely distinct — bug-predict scores test files the same way it scores any code (bugs/patterns), but `test-audit` scores them on test-specific dimensions (rubric coverage, dead-mock detection, fixture quality) that no other source emits. Six adapters, evaluated for surface deprecation in P2.7.
 
 ---
 
-## Why retirement evaluation is a phase, not an open question
+## Why surface evaluation runs last
 
-When `discovery-sweep` ships, individual audit workflows still exist. They have CLI entries, MCP tool exposure, ops-dashboard rows, and docs. Two failure modes if we don't evaluate retirement:
+When `discovery-sweep` ships, individual audit workflows still exist. They have CLI entries, MCP tool exposure, ops-dashboard rows, and docs. Two failure modes if we don't evaluate the CLI surface:
 
 1. **Surface bloat** — users see seven discovery-style workflows where one would do, and pick wrong.
 2. **Stale wrappers** — bug fixes in the underlying workflow have to be made twice (in the workflow + in any adapter-specific quirks).
 
-P2.4 is an empirical evaluation: run both the sweep and each candidate workflow on a real scope, compare outputs, recommend RETIRE / KEEP / DEFER per workflow. Output is a markdown doc with recommendations, not code changes. Deletion happens later (and only if the evaluation supports it) under a separate spec or PR. --sounds  like a  good recommendation
+**Resolved (2026-05-13, Phase 1.5):** This is a **surface evaluation**, not a workflow retirement. The workflow classes (`BugPredictionWorkflow`, `SecurityAuditWorkflow`, …) stay — they're what the adapters wrap. Only the standalone CLI entries (`attune workflow run bug-predict`) are candidates for deprecation in favor of `attune workflow run discovery-sweep`. The evaluation runs as **P2.7 (LAST)** after every adapter (P2.1–P2.6) has shipped so the comparison has every lens available.
+
+P2.7 is an empirical evaluation: run both the sweep and each candidate CLI entry on a real scope, compare outputs, recommend DEPRECATE / KEEP / DEFER per CLI surface. Output is a markdown doc with recommendations, not code changes. CLI deprecation (Phase 4) happens later, only if the evaluation supports it.
 
 ---
 
 ## Cost discipline
 
 `budget_usd` is hard-capped at the sweep level. The engine allocates per-source and **does not exceed the total** even if some sources come in under their share. The adapter for each LLM workflow passes its allocated budget through to the wrapped workflow's `max_budget_usd` knob.
+
+**Resolved (2026-05-13, Phase 1.5):** Per-source allocation is **proportional to a `budget_multiplier: float` attribute on the Protocol**, not equal-split. The engine sums multipliers across active sources and gives each source `budget_usd * (its_multiplier / sum_of_multipliers)`. Defaults:
+
+| Source | `budget_multiplier` | Why |
+|---|---|---|
+| `security-audit` | 4.0 | Multi-subagent fan-out, highest per-run cost |
+| `bug-predict` | 1.5 | Single agent but multi-pattern analysis |
+| `perf-audit` | 1.5 | Similar shape to bug-predict |
+| `doc-audit` | 1.0 | Single agent, narrower scope |
+| `test-audit` | 1.0 | Single agent, narrower scope |
+| `dependency-check` | 0.5 | Mostly deterministic CVE feed, low LLM cost |
+| `pattern-scan` | 0.0 | Non-LLM, no spend |
+
+Equal-split was rejected because the per-source costs differ by ~10x in practice; equal allocation either starves security-audit or wastes budget on dependency-check. Proportional allocation matches reality and stays in a single function (no per-source overrides scattered through CLI flags).
+
+**Resolved (2026-05-13, Phase 1.5):** The engine **glob-expands the user's `--path` upstream** into a `list[str]` and passes that same list to every source's `discover(paths, budget_usd)` call. Globs in `--path` (e.g. `src/**/*.py`) are resolved once; bare directory or file paths become a single-element list. This guarantees every source sees identical scope — no per-source glob-resolution drift. The Protocol signature is `discover(paths: list[str], budget_usd: float)`.
 
 For the pattern adapter (PatternScanSource, no LLM), `budget_usd` is ignored — pattern scanning is effectively free. Engine logs this for telemetry but doesn't redistribute the freed budget to LLM sources (would require a second pass; not worth it for v1).
 

--- a/docs/specs/discovery-sweep/design.md
+++ b/docs/specs/discovery-sweep/design.md
@@ -120,13 +120,19 @@ from typing import Protocol, runtime_checkable
 @runtime_checkable
 class FindingSource(Protocol):
     name: str
+    is_llm: bool
+    budget_multiplier: float
 
     async def discover(
         self,
-        path: str,
+        paths: list[str],
         budget_usd: float,
     ) -> list[Finding]:
-        """Discover findings in `path`. Must respect budget_usd.
+        """Discover findings under `paths`. Must respect budget_usd.
+
+        `paths` is a list of concrete files or directories — the engine
+        glob-expands the user's `--path` upstream so every source sees
+        the same scope.
 
         Implementations should:
         - Return early (with partial findings) if budget is exhausted
@@ -137,6 +143,8 @@ class FindingSource(Protocol):
         """
         ...
 ```
+
+`budget_multiplier` is the source's proportional claim on the total budget pool. The engine sums multipliers across active sources and allocates `budget_usd * (mult / total)` to each. Non-LLM sources set `0.0`. See `decisions.md` § Cost discipline for defaults.
 
 Adapters are constructed by `default_sources()` (or a test-only `make_sources(...)` helper). The engine never instantiates them directly — keeps source-list management out of `DiscoverySweepWorkflow`.
 
@@ -189,6 +197,12 @@ return [Finding(
 This is what guarantees engine progress even when the LLM ignores the JSON instruction: one low-confidence finding ends up in `questions`, the user sees that the adapter degraded, and the sweep moves on.
 
 > **DECIDE:** Exact JSON schema. Sketch above is a starting point — finalize during P2.1.
+
+### Prompt augmentation lives at the workflow-instance level, NEVER class
+
+Adapters must build a per-call workflow instance and append `STRUCTURED_EMIT_FOOTER` to the instance's prompt before invoking `execute()`. Mutating the workflow class's prompt template would leak into every other caller (standalone `attune workflow run bug-predict`, MCP `mcp__attune-ai__bug_predict`, the ops dashboard, etc.) and force them to parse the JSON footer they didn't ask for. The augmentation is a discovery-sweep concern; everyone else sees the unmodified workflow.
+
+Concretely: each adapter's `discover()` constructs the wrapped workflow with the augmented system prompt as an instance attribute (or kwargs to `__init__` if the workflow supports it), runs it, and discards the instance. No global state, no monkey-patching of the workflow class.
 
 ---
 
@@ -246,10 +260,11 @@ def default_sources() -> list[FindingSource]:
         DependencyCheckSource(),
         PerfAuditSource(),
         DocAuditSource(),
+        TestAuditSource(),
     ]
 ```
 
-The `--no-llm` flag filters to `[s for s in default_sources() if not isinstance(s, LLMSource)]` — relies on a marker mixin or duck-type check on a `is_llm: bool` attribute.
+All six audit-family workflows get an adapter (see `decisions.md` § "Why this isn't `code-review` or `deep-review`"). The `--no-llm` flag filters to `[s for s in default_sources() if not s.is_llm]`.
 
 > **DECIDE:** `--source <name>` filter. Cheap addition; defer if not needed.
 
@@ -293,7 +308,8 @@ src/attune/workflows/discovery_sweep/
 │   ├── security_audit.py        # SecurityAuditSource
 │   ├── dependency_check.py      # DependencyCheckSource
 │   ├── perf_audit.py            # PerfAuditSource
-│   └── doc_audit.py             # DocAuditSource
+│   ├── doc_audit.py             # DocAuditSource
+│   └── test_audit.py            # TestAuditSource
 └── llm_source_base.py           # shared parser + structured-emit prompt helper
 ```
 
@@ -314,7 +330,7 @@ src/attune/workflows/discovery_sweep/
 | `tests/unit/workflows/discovery_sweep/test_pattern_scan_source.py` | PatternScanSource on real files in `tests/fixtures/` |
 | `tests/unit/workflows/discovery_sweep/test_bug_predict_source.py` | Mocks `BugPredictionWorkflow.execute`, asserts Finding parsing |
 | `tests/unit/workflows/discovery_sweep/test_llm_source_base.py` | `parse_findings_json` happy path + malformed JSON + missing block |
-| `tests/integration/workflows/test_discovery_sweep_integration.py` | `@pytest.mark.skipif(not HAS_API_KEY)` — real sweep on a tiny fixture path |
+| `tests/integration/workflows/test_discovery_sweep_integration.py` | `@pytest.mark.integration` — real sweep on a tiny fixture path (see `tasks.md` P2.1 for the rationale: integration mark is the project-standard gate, replacing the older `HAS_API_KEY` skipif pattern that masked code regressions as Anthropic network flakes) |
 
 ---
 

--- a/docs/specs/discovery-sweep/requirements.md
+++ b/docs/specs/discovery-sweep/requirements.md
@@ -82,16 +82,17 @@ Acceptance:
 - Each finding has a stable schema (see design.md for the dataclass shape)
 - The metadata block is sufficient for cost trending without parsing the findings
 
-### US-6 — Retirement evaluation is reproducible
+### US-6 — Surface evaluation is reproducible
 
-**As Pat, when I want to know whether `test-audit` is redundant with the sweep, I want a documented procedure I can re-run when sources change.**
+**As Pat, when I want to know whether the standalone `attune workflow run bug-predict` (etc.) CLI entries are redundant now that `discovery-sweep` wraps them, I want a documented procedure I can re-run when sources change.**
 
 Acceptance:
 
-- A script or documented procedure runs both the sweep and the candidate workflow on the same path
-- Findings are cross-referenced — every candidate-workflow finding must map to one or more sweep findings (queue OR questions, not rejected)
-- Output is a markdown table per candidate with RETIRE / KEEP / DEFER recommendations
-- Lives in `docs/specs/discovery-sweep/retirement-evaluation.md` (see P2.4)
+- A script or documented procedure runs both the sweep and each candidate standalone CLI entry on the same path
+- Findings are cross-referenced — every candidate-CLI finding must map to one or more sweep findings (queue OR questions, not rejected)
+- Output is a markdown table per CLI entry with DEPRECATE / KEEP / DEFER recommendations
+- Lives in `docs/specs/discovery-sweep/surface-evaluation.md` (see P2.7) — runs LAST, after all six adapters (P2.1–P2.6) ship
+- The evaluation targets CLI surface deprecation only — the workflow classes themselves stay (adapters wrap them)
 
 ---
 
@@ -162,6 +163,6 @@ The verification rules and triage routing are deterministic code, not an LLM cal
 
 ## Open requirement questions
 
-1. Should `--path` accept globs (`src/attune/**/*.py`)? (Default: pass through to sources; some may glob-expand internally, others won't.) I'm concerned about sometimes it working and not others.
+1. ~~Should `--path` accept globs?~~ **Resolved (2026-05-13, Phase 1.5):** Yes. The engine glob-expands `--path` upstream into a `list[str]` and passes the same list to every source. No per-source glob drift — a path either matches files for every source or for none.
 2. Should the sweep accept a `--source` flag to restrict to one source? (Useful for debugging; cheap to add.) yes
-3. Should the sweep emit SSE events to the ops dashboard so progress is live? (Out of scope for v1; CLI-only.) ok out of scope
+3. Should the sweep emit SSE events to the ops dashboard so progress is live? (Out of scope for v1; CLI-only — moved to `discovery-sweep-ops-integration` follow-up spec.) ok out of scope

--- a/docs/specs/discovery-sweep/tasks.md
+++ b/docs/specs/discovery-sweep/tasks.md
@@ -50,23 +50,23 @@ Goal: wrap each audit-family workflow as a `FindingSource`. Each is an independe
 
 Each sub-task ships an adapter that:
 
-1. Inherits/conforms to `FindingSource` Protocol + `LLMSource` marker
-2. Augments the wrapped workflow's prompt with `STRUCTURED_EMIT_FOOTER`
+1. Conforms to `FindingSource` Protocol + sets `is_llm = True` and an appropriate `budget_multiplier` (see `decisions.md` § Cost discipline for defaults)
+2. Augments the wrapped workflow's prompt with `STRUCTURED_EMIT_FOOTER` **at the workflow-instance level** — see `design.md` § "Prompt augmentation lives at the workflow-instance level"
 3. Invokes the wrapped workflow (mocks-friendly — no `claude_agent_sdk` imports at module scope)
 4. Parses findings via `parse_findings_json`
 5. Adds itself to `default_sources()`
 
-- [ ] **P2.1** `BugPredictSource` wrapping `BugPredictionWorkflow` in `src/attune/workflows/bug_predict.py`. Unit tests mock `BugPredictionWorkflow.execute()`. Integration test gated on `HAS_API_KEY`. Update CHANGELOG.
-- [ ] **P2.2** `SecurityAuditSource` wrapping `SecurityAuditWorkflow` in `src/attune/workflows/security_audit.py`. Same pattern as P2.1.
-- [ ] **P2.3** `DependencyCheckSource` wrapping `DependencyCheckWorkflow`. Same pattern.
-- [ ] **P2.4** **Retirement evaluation (empirical, no code).** Run `attune workflow run discovery-sweep --path src/attune/security/` and `attune workflow run discovery-sweep --path src/attune/workflows/`. For each scope, also run candidate workflows that *might* be redundant (initial candidates: `test-audit`; later add others as P2.1–P2.3, P2.5 reveal subsumption). Cross-reference findings.
-      - Output: `docs/specs/discovery-sweep/retirement-evaluation.md` with per-workflow RETIRE / KEEP / DEFER recommendation.
-      - For RETIRE candidates, draft the deprecation path (lazy-import shim per the existing PEP 562 lesson, CHANGELOG entry, migration alias).
-      - Do NOT delete anything in this task — recommendation only. Deletion is a separate PR.
-- [ ] **P2.5** `PerfAuditSource` wrapping `PerformanceAuditWorkflow`. Same pattern as P2.1.
-- [ ] **P2.6** `DocAuditSource` wrapping `DocAuditWorkflow`. Same pattern as P2.1.
-
-> **DECIDE:** Order of P2.1–P2.6. The user's original prompts suggested P2.1=bug-predict first, then security-audit, then retirement eval (P2.4) — but the eval needs *some* LLM sources shipped to be meaningful, hence P2.4 placement here (after P2.1–P2.3 give us 3 LLM sources to evaluate). Revisit if dogfood shows the eval can run with fewer sources.
+- [ ] **P2.1** `BugPredictSource` wrapping `BugPredictionWorkflow` in `src/attune/workflows/bug_predict.py`. `budget_multiplier=1.5`. Unit tests mock `BugPredictionWorkflow.execute()`. Integration test uses `@pytest.mark.integration` (the project-standard gate) — **not** `HAS_API_KEY` skipif, which masked code regressions as Anthropic network flakes (see the `HAS_API_KEY`-gated lesson in CLAUDE.md). Update CHANGELOG.
+- [ ] **P2.2** `SecurityAuditSource` wrapping `SecurityAuditWorkflow` in `src/attune/workflows/security_audit.py`. `budget_multiplier=4.0` (multi-subagent fan-out). Same test pattern as P2.1.
+- [ ] **P2.3** `DependencyCheckSource` wrapping `DependencyCheckWorkflow`. `budget_multiplier=0.5` (mostly deterministic CVE feed). Same test pattern as P2.1.
+- [ ] **P2.4** `PerfAuditSource` wrapping `PerformanceAuditWorkflow`. `budget_multiplier=1.5`. Same test pattern as P2.1.
+- [ ] **P2.5** `DocAuditSource` wrapping `DocAuditWorkflow`. `budget_multiplier=1.0`. Same test pattern as P2.1.
+- [ ] **P2.6** `TestAuditSource` wrapping `TestAuditWorkflow`. `budget_multiplier=1.0`. Same test pattern as P2.1. (Distinct lens — see `decisions.md`: test-quality scoring is not subsumed by bug-predict or doc-audit.)
+- [ ] **P2.7** **Surface evaluation (empirical, no code) — runs LAST.** After P2.1–P2.6 have all shipped, run `attune workflow run discovery-sweep --path src/attune/security/` and `attune workflow run discovery-sweep --path src/attune/workflows/`. For each scope, also run the standalone CLI invocations of every wrapped workflow on the same path. Cross-reference findings.
+      - Output: `docs/specs/discovery-sweep/surface-evaluation.md` with per-CLI-entry DEPRECATE / KEEP / DEFER recommendation.
+      - **Surface evaluation, not workflow retirement.** The workflow classes (`BugPredictionWorkflow`, …) stay — adapters wrap them. Only the standalone CLI entries (`attune workflow run bug-predict`) are candidates for deprecation.
+      - For DEPRECATE candidates, draft the deprecation path (PEP 562 lazy-import shim, CHANGELOG entry, migration alias if needed).
+      - Do NOT delete anything in this task — recommendation only. CLI deprecation execution lives in Phase 4.
 
 ---
 
@@ -86,27 +86,27 @@ Goal: turn the markdown rendering into something pleasant and machine-readable.
 
 ---
 
-## Phase 4 — Ops dashboard integration
+## Phase 4 — CLI surface deprecation
 
-Goal: surface sweep results in the ops dashboard from ops-runner-tier2.
+Goal: act on the surface-evaluation recommendations from P2.7. Only opens if P2.7 returns any DEPRECATE recommendations.
 
-- [ ] **4.1** Discovery-sweep row in `workflows.html` honors the scope picker (already supported via `PATH_ARG_REGISTRY` from P1.7).
-- [ ] **4.2** Sweep results render as colored chips per bucket (queue/questions/rejected counts) in the row.
-- [ ] **4.3** Clicking a chip opens a detail view that lists findings (re-uses the existing run-view page).
-- [ ] **4.4** SSE event stream emits per-source progress (`source X started`, `source X finished with N findings`) so the dashboard shows a live progress bar.
+**Resolved (2026-05-13, Phase 1.5):** Old Phase 4 (ops-dashboard integration) is **deferred to a follow-up spec** — `discovery-sweep-ops-integration` — to be opened once `ops-runner-tier2` Phase 2 lands. The CLI deprecation work (previously Phase 5) is promoted to Phase 4 because it follows directly from P2.7 and ships under this spec.
 
-> **DECIDE:** Phase 4 scope. Could be deferred to a follow-up spec (`discovery-sweep-ops-integration`) if ops-runner-tier2 isn't far enough along. Revisit when Phase 3 ships.
+- [ ] **4.1** For each DEPRECATE candidate (a standalone CLI entry, e.g. `attune workflow run bug-predict`), implement the deprecation shim (PEP 562 module-level `__getattr__` with `DeprecationWarning` per the existing CLAUDE.md lesson). The underlying workflow class stays.
+- [ ] **4.2** CHANGELOG `### Deprecated` entries for each affected CLI entry.
+- [ ] **4.3** Migration alias in routing — e.g. `attune workflow run bug-predict --path X` continues to work for one release with a deprecation warning, recommending `attune workflow run discovery-sweep --path X --source bug-predict`.
+- [ ] **4.4** Update `.claude/plans/*` and `docs/specs/_sequencing.md` to reflect the deprecations.
 
 ---
 
-## Phase 5 — Retirement execution
+## Out-of-scope (follow-up spec) — Ops dashboard integration
 
-Goal: act on the retirement recommendations from P2.4. Only opens if P2.4 returns any RETIRE recommendations.
+Deferred from this spec on 2026-05-13. To land in a separate `discovery-sweep-ops-integration` spec once `ops-runner-tier2` Phase 2 ships. Originally:
 
-- [ ] **5.1** For each RETIRE candidate, implement the deprecation shim (PEP 562 module-level `__getattr__` with `DeprecationWarning` per the existing CLAUDE.md lesson).
-- [ ] **5.2** CHANGELOG `### Deprecated` entries.
-- [ ] **5.3** Migration alias in routing if the workflow had a short CLI name (e.g. `test-audit` → `discovery-sweep`).
-- [ ] **5.4** Update `.claude/plans/*` and `docs/specs/_sequencing.md` to reflect retirements.
+- Discovery-sweep row in `workflows.html` honors the scope picker (already supported via `PATH_ARG_REGISTRY` from P1.7).
+- Sweep results render as colored chips per bucket (queue/questions/rejected counts) in the row.
+- Clicking a chip opens a detail view that lists findings (re-uses the existing run-view page).
+- SSE event stream emits per-source progress so the dashboard shows a live progress bar.
 
 ---
 
@@ -114,11 +114,11 @@ Goal: act on the retirement recommendations from P2.4. Only opens if P2.4 return
 
 The spec is complete when:
 
-- Phase 1 + 2A + at least 3 of P2.1–P2.6 + Phase 3 have shipped
-- Phase 4 has either shipped OR been deferred to a named follow-up spec
-- Phase 5 has either shipped OR P2.4 returned zero RETIRE recommendations
+- Phase 1 + 1.5 + 2A + all six of P2.1–P2.6 + P2.7 + Phase 3 have shipped
+- Phase 4 (CLI deprecation) has either shipped OR P2.7 returned zero DEPRECATE recommendations
+- The ops-dashboard follow-up spec (`discovery-sweep-ops-integration`) is open or shipped
 - `discovery-sweep` appears in the `docs/specs/_sequencing.md` "Done" section
-- Phase 2 retirement evaluation is published
+- P2.7 surface evaluation is published at `docs/specs/discovery-sweep/surface-evaluation.md`
 
 ---
 

--- a/src/attune/workflows/discovery_sweep/sources/pattern_scan.py
+++ b/src/attune/workflows/discovery_sweep/sources/pattern_scan.py
@@ -235,25 +235,33 @@ class PatternScanSource:
 
     name: str = "pattern-scan"
     is_llm: bool = False
+    # Non-LLM sources don't consume budget; the engine still includes
+    # them in fan-out but allocates $0 from the total budget pool.
+    budget_multiplier: float = 0.0
     exclude_dirs: frozenset[str] = field(default_factory=lambda: _EXCLUDE_DIRS)
 
     # Surfaced for tests that need to enumerate the supported patterns
     # without parsing the regex tuple themselves.
     PATTERN_NAMES: ClassVar[tuple[str, ...]] = tuple(p.pattern_name for p in _PATTERNS)
 
-    async def discover(self, path: str, budget_usd: float) -> list[Finding]:
-        """Walk ``path`` and emit findings. ``budget_usd`` ignored."""
+    async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
+        """Walk each path in ``paths`` and emit findings.
+
+        ``budget_usd`` is ignored — pattern scanning is free. The engine
+        glob-expands the user's ``--path`` upstream so every entry in
+        ``paths`` is a concrete file or directory.
+        """
         del budget_usd  # Pattern scanning is free.
 
-        root = Path(path)
-        if not root.exists():
-            logger.warning("pattern-scan: path does not exist: %s", path)
-            return []
-
-        files = self._iter_python_files(root)
         findings: list[Finding] = []
-        for file_path in files:
-            findings.extend(self._scan_file(file_path, root))
+        for path in paths:
+            root = Path(path)
+            if not root.exists():
+                logger.warning("pattern-scan: path does not exist: %s", path)
+                continue
+            files = self._iter_python_files(root)
+            for file_path in files:
+                findings.extend(self._scan_file(file_path, root))
         return findings
 
     def _iter_python_files(self, root: Path) -> list[Path]:

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -19,6 +19,7 @@ Licensed under the Apache License, Version 2.0
 from __future__ import annotations
 
 import asyncio
+import glob as _glob
 import logging
 import time
 from dataclasses import dataclass, field
@@ -125,26 +126,40 @@ class SweepResult:
 class FindingSource(Protocol):
     """Contract every discovery-sweep source adapter implements.
 
-    Two attributes plus one async method. ``name`` is used in finding
-    metadata and CLI output; ``is_llm`` lets the engine filter sources
-    for the ``--no-llm`` flag (defaults to True for adapters that
-    spend API budget; non-LLM adapters like ``PatternScanSource`` set
-    it to False).
+    Three attributes plus one async method:
+
+    - ``name`` — surfaced in finding metadata and CLI output.
+    - ``is_llm`` — lets the engine filter sources for ``--no-llm``.
+      Non-LLM adapters (e.g. :class:`PatternScanSource`) set it False.
+    - ``budget_multiplier`` — proportional share of the total sweep
+      budget this source claims. The engine sums multipliers across
+      active sources and allocates ``budget_usd * (mult / total)`` to
+      each. Non-LLM sources set ``0.0`` (they ignore budget anyway);
+      LLM sources scale by their expected spend (1.0 default,
+      4.0 for multi-subagent security-audit, 0.5 for CVE-feed-heavy
+      dependency-check, etc.).
+
+    The engine glob-expands the user's ``--path`` upstream and passes
+    every source the same concrete ``paths`` list; sources never see
+    raw glob syntax.
     """
 
     name: str
     is_llm: bool
+    budget_multiplier: float
 
     async def discover(
         self,
-        path: str,
+        paths: list[str],
         budget_usd: float,
     ) -> list[Finding]:
-        """Discover findings in ``path``.
+        """Discover findings under ``paths``.
 
-        Implementations must respect ``budget_usd``: return partial
-        findings (with an ``info``-severity Finding noting the cap)
-        rather than overspending or raising.
+        ``paths`` is a list of concrete files or directories (glob
+        expansion happens in the engine). Implementations must respect
+        ``budget_usd``: return partial findings (with an ``info``-
+        severity Finding noting the cap) rather than overspending or
+        raising.
         """
         ...
 
@@ -214,7 +229,7 @@ def _render_markdown(result: SweepResult, *, verbose: bool = False) -> str:
 
 async def _run_source(
     source: FindingSource,
-    path: str,
+    paths: list[str],
     budget_usd: float,
 ) -> tuple[str, list[Finding] | BaseException]:
     """Wrap a single source.discover() so the gather() never raises.
@@ -225,12 +240,31 @@ async def _run_source(
     keeps source-failure rendering in one place.
     """
     try:
-        findings = await source.discover(path, budget_usd)
+        findings = await source.discover(paths, budget_usd)
     except Exception as exc:  # noqa: BLE001
         # INTENTIONAL: per spec NFR-1, source failures must not abort
         # the sweep; convert them to a questions entry downstream.
         return source.name, exc
     return source.name, findings
+
+
+_GLOB_CHARS: frozenset[str] = frozenset("*?[")
+
+
+def _expand_path(path: str) -> list[str]:
+    """Glob-expand ``path`` into a concrete list for fan-out.
+
+    The engine expands once and passes the same list to every source so
+    LLM and non-LLM adapters share an identical scope. If ``path``
+    contains no glob characters it is returned as a single-element list.
+    Recursive ``**`` is supported. Returns ``[path]`` when expansion
+    yields nothing so sources can still emit a "no files matched"
+    finding.
+    """
+    if not any(c in path for c in _GLOB_CHARS):
+        return [path]
+    matches = sorted(_glob.glob(path, recursive=True))
+    return matches if matches else [path]
 
 
 def _failure_to_question(source_name: str, exc: BaseException) -> QuestionFinding:
@@ -313,13 +347,14 @@ class DiscoverySweepWorkflow(BaseWorkflow):
         if not sources:
             return self._error_result("no sources to run (use --source or drop --no-llm)")
 
-        per_source_budget = self._allocate_budget(sources, budget_usd)
+        allocations = self._allocate_budget(sources, budget_usd)
+        paths = _expand_path(path)
 
         started_at = datetime.now()
         t0 = time.perf_counter()
 
         gathered = await asyncio.gather(
-            *(_run_source(s, path, per_source_budget) for s in sources),
+            *(_run_source(s, paths, allocations[s.name]) for s in sources),
             return_exceptions=False,
         )
 
@@ -364,18 +399,23 @@ class DiscoverySweepWorkflow(BaseWorkflow):
     def _allocate_budget(
         sources: list[FindingSource],
         budget_usd: float,
-    ) -> float:
-        """Per-source budget = total / number of LLM sources.
+    ) -> dict[str, float]:
+        """Allocate ``budget_usd`` proportionally by ``budget_multiplier``.
 
-        Non-LLM sources don't consume budget, so dividing by all
-        sources would under-allocate to the LLM ones. Falling back to
-        the full budget when there are zero LLM sources keeps the
-        signal simple (PatternScanSource ignores it anyway).
+        Each source receives
+        ``budget_usd * (its_multiplier / sum_of_multipliers)``. Non-LLM
+        adapters set ``budget_multiplier=0.0`` and receive ``$0`` (they
+        ignore budget anyway). When no source claims a positive
+        multiplier the engine passes the full budget through to every
+        source as a no-op signal so pattern-only sweeps still work.
         """
-        llm_count = sum(1 for s in sources if getattr(s, "is_llm", True))
-        if llm_count == 0:
-            return budget_usd
-        return budget_usd / llm_count
+        total_mult = sum(getattr(s, "budget_multiplier", 0.0) for s in sources)
+        if total_mult <= 0.0:
+            return {s.name: budget_usd for s in sources}
+        return {
+            s.name: budget_usd * (getattr(s, "budget_multiplier", 0.0) / total_mult)
+            for s in sources
+        }
 
     @staticmethod
     def _build_sweep_result(

--- a/tests/unit/workflows/discovery_sweep/test_engine.py
+++ b/tests/unit/workflows/discovery_sweep/test_engine.py
@@ -26,16 +26,27 @@ from attune.workflows.discovery_sweep import (
 
 @dataclass
 class FakeSource:
-    """Test double conforming structurally to FindingSource."""
+    """Test double conforming structurally to FindingSource.
+
+    ``budget_multiplier`` defaults to ``1.0`` for LLM sources and
+    ``0.0`` for non-LLM sources via ``__post_init__`` so tests can omit
+    it unless they want a specific share.
+    """
 
     name: str
     is_llm: bool = True
+    budget_multiplier: float | None = None
     findings: list[Finding] | None = None
     raises: BaseException | None = None
     received_budget: float | None = None
+    received_paths: list[str] | None = None
 
-    async def discover(self, path: str, budget_usd: float) -> list[Finding]:
-        del path
+    def __post_init__(self) -> None:
+        if self.budget_multiplier is None:
+            self.budget_multiplier = 1.0 if self.is_llm else 0.0
+
+    async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
+        self.received_paths = list(paths)
         self.received_budget = budget_usd
         if self.raises is not None:
             raise self.raises
@@ -96,6 +107,8 @@ class TestExecuteHappyPath:
 
 class TestBudgetAllocation:
     def test_per_source_budget_splits_across_llm_only(self) -> None:
+        # Two LLM sources with default multiplier=1.0; one non-LLM
+        # source with multiplier=0.0 (excluded from the pool).
         llm_a = FakeSource(name="llm-a", is_llm=True, findings=[])
         llm_b = FakeSource(name="llm-b", is_llm=True, findings=[])
         non_llm = FakeSource(name="pattern", is_llm=False, findings=[])
@@ -107,19 +120,69 @@ class TestBudgetAllocation:
                 sources=[llm_a, llm_b, non_llm],
             )
         )
-        # 10.00 / 2 LLM sources = 5.00 each. Non-LLM gets the same
-        # signal (it ignores budget_usd anyway).
+        # 10.00 * (1.0 / 2.0) = 5.00 to each LLM source.
         assert llm_a.received_budget == pytest.approx(5.0)
         assert llm_b.received_budget == pytest.approx(5.0)
+        # Non-LLM gets 0.0 — it sums to a zero share of the pool.
+        assert non_llm.received_budget == pytest.approx(0.0)
+
+    def test_proportional_allocation_by_multiplier(self) -> None:
+        # Mirrors the spec defaults: security-audit gets a 4x share,
+        # dependency-check 0.5x, default 1.0x.
+        heavy = FakeSource(name="security", is_llm=True, budget_multiplier=4.0, findings=[])
+        light = FakeSource(name="deps", is_llm=True, budget_multiplier=0.5, findings=[])
+        default = FakeSource(name="bug", is_llm=True, budget_multiplier=1.0, findings=[])
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(
+            wf.execute(path="src/", budget_usd=11.0, sources=[heavy, light, default]),
+        )
+        total = 4.0 + 0.5 + 1.0
+        assert heavy.received_budget == pytest.approx(11.0 * 4.0 / total)
+        assert light.received_budget == pytest.approx(11.0 * 0.5 / total)
+        assert default.received_budget == pytest.approx(11.0 * 1.0 / total)
 
     def test_no_llm_sources_passes_full_budget(self) -> None:
         non_llm = FakeSource(name="pattern", is_llm=False, findings=[])
         wf = DiscoverySweepWorkflow()
         asyncio.run(wf.execute(path="src/", budget_usd=7.50, sources=[non_llm]))
+        # With no positive-multiplier sources, the engine passes the
+        # full budget through as a signal — non-LLM ignores it anyway.
         assert non_llm.received_budget == pytest.approx(7.50)
 
     def test_default_budget_is_ten_dollars(self) -> None:
         assert DEFAULT_BUDGET_USD == 10.00
+
+
+class TestPathExpansion:
+    def test_non_glob_path_passed_through(self) -> None:
+        src = FakeSource(name="s", findings=[])
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(wf.execute(path="src/attune/", sources=[src]))
+        assert src.received_paths == ["src/attune/"]
+
+    def test_glob_pattern_expanded(self, tmp_path: object) -> None:
+        # Build two files matching a glob, one not.
+        from pathlib import Path as _P
+
+        base = _P(str(tmp_path))
+        (base / "a.py").write_text("x = 1\n", encoding="utf-8")
+        (base / "b.py").write_text("x = 1\n", encoding="utf-8")
+        (base / "c.txt").write_text("ignore\n", encoding="utf-8")
+
+        src = FakeSource(name="s", findings=[])
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(wf.execute(path=str(base / "*.py"), sources=[src]))
+        assert src.received_paths is not None
+        # Sorted glob result. Only .py files matched.
+        assert all(p.endswith(".py") for p in src.received_paths)
+        assert len(src.received_paths) == 2
+
+    def test_glob_with_no_matches_falls_back_to_pattern(self) -> None:
+        src = FakeSource(name="s", findings=[])
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(wf.execute(path="nonexistent/**/*.zzz", sources=[src]))
+        # Falls back to the raw pattern so sources can report it.
+        assert src.received_paths == ["nonexistent/**/*.zzz"]
 
 
 class TestSourceFiltering:

--- a/tests/unit/workflows/discovery_sweep/test_pattern_scan_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_pattern_scan_source.py
@@ -16,7 +16,7 @@ from attune.workflows.discovery_sweep.sources.pattern_scan import (
 
 
 def _scan(tmp_path: Path) -> list[Finding]:
-    return asyncio.run(PatternScanSource().discover(str(tmp_path), 0.0))
+    return asyncio.run(PatternScanSource().discover([str(tmp_path)], 0.0))
 
 
 class TestProtocolConformance:
@@ -28,6 +28,10 @@ class TestProtocolConformance:
 
     def test_name_is_pattern_scan(self) -> None:
         assert PatternScanSource().name == "pattern-scan"
+
+    def test_budget_multiplier_is_zero(self) -> None:
+        # Non-LLM sources claim no share of the budget pool.
+        assert PatternScanSource().budget_multiplier == 0.0
 
 
 class TestPatternDetection:
@@ -90,7 +94,7 @@ class TestTraversal:
 
     def test_nonexistent_path_returns_empty(self, tmp_path: Path) -> None:
         missing = tmp_path / "does-not-exist"
-        findings = asyncio.run(PatternScanSource().discover(str(missing), 0.0))
+        findings = asyncio.run(PatternScanSource().discover([str(missing)], 0.0))
         assert findings == []
 
     def test_single_file_path_scans_just_that_file(self, tmp_path: Path) -> None:
@@ -98,9 +102,29 @@ class TestTraversal:
             "def f():\n    try:\n        pass\n    except:\n        pass\n",
             encoding="utf-8",
         )
-        findings = asyncio.run(PatternScanSource().discover(str(tmp_path / "x.py"), 0.0))
+        findings = asyncio.run(PatternScanSource().discover([str(tmp_path / "x.py")], 0.0))
         assert len(findings) >= 1
         assert all(f.file is not None for f in findings)
+
+    def test_multiple_paths_all_scanned(self, tmp_path: Path) -> None:
+        # Engine glob-expands to a list; the source must visit every
+        # entry, not just the first.
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / "alpha.py").write_text(
+            "def f():\n    try:\n        pass\n    except:\n        pass\n",
+            encoding="utf-8",
+        )
+        (b / "beta.py").write_text(
+            "def f():\n    try:\n        pass\n    except:\n        pass\n",
+            encoding="utf-8",
+        )
+        findings = asyncio.run(PatternScanSource().discover([str(a), str(b)], 0.0))
+        files = {f.file for f in findings}
+        assert "alpha.py" in files
+        assert "beta.py" in files
 
 
 class TestBudget:
@@ -109,8 +133,8 @@ class TestBudget:
             "def f():\n    try:\n        pass\n    except:\n        pass\n",
             encoding="utf-8",
         )
-        zero = asyncio.run(PatternScanSource().discover(str(tmp_path), 0.0))
-        big = asyncio.run(PatternScanSource().discover(str(tmp_path), 999.0))
+        zero = asyncio.run(PatternScanSource().discover([str(tmp_path)], 0.0))
+        big = asyncio.run(PatternScanSource().discover([str(tmp_path)], 999.0))
         assert len(zero) == len(big)
 
 
@@ -307,7 +331,7 @@ class TestPathRendering:
             "def f():\n    try:\n        pass\n    except:\n        pass\n",
             encoding="utf-8",
         )
-        findings = asyncio.run(PatternScanSource().discover(str(tmp_path / "alpha.py"), 0.0))
+        findings = asyncio.run(PatternScanSource().discover([str(tmp_path / "alpha.py")], 0.0))
         assert len(findings) == 1
         assert findings[0].file == "alpha.py"
 


### PR DESCRIPTION
## Summary

Lands seven design decisions from closed PR #310 (second-pass spec
review) that weren't captured in Phase 1's `#303`/`#306`/`#308`/`#309`
ship. Spec + code move in lockstep so the docs match what runs.

## The seven decisions

| # | Decision | Touches |
|---|----------|---------|
| 1 | Wrap all SIX audit-family workflows — test-audit included as a distinct test-quality lens | decisions.md, design.md, tasks.md |
| 2 | Per-source `budget_multiplier: float` on the Protocol; engine allocates proportionally | workflow.py, decisions.md, design.md, tests |
| 3 | `discover(paths: list[str], budget_usd)` signature; engine glob-expands `--path` upstream | workflow.py, pattern_scan.py, design.md, requirements.md, tests |
| 4 | "Surface evaluation" not "retirement evaluation"; runs as P2.7 (LAST) | decisions.md, tasks.md, requirements.md |
| 5 | Phase 4 ops-dashboard deferred to follow-up spec; old Phase 5 → Phase 4 | tasks.md |
| 6 | Adapter prompt augmentation at workflow-INSTANCE level, NEVER class | design.md |
| 7 | Phase 2B adapter integration tests use `@pytest.mark.integration` not `HAS_API_KEY` skipif | tasks.md (P2.1) |

## Code (~75 LoC)

- `workflow.py`:
  - `FindingSource.discover(paths: list[str], budget_usd: float)` — list, not single path
  - New `budget_multiplier: float` Protocol attribute
  - New `_expand_path()` helper — engine glob-expands `--path` once
  - `_allocate_budget()` now returns `dict[str, float]` keyed by source name, proportional by multiplier (graceful fallback when no source has a positive multiplier)
- `sources/pattern_scan.py`:
  - `budget_multiplier: float = 0.0` (non-LLM)
  - `discover()` iterates the paths list
- Tests:
  - `FakeSource` updated for new signature; auto-defaults `budget_multiplier` to `1.0` for LLM and `0.0` for non-LLM via `__post_init__`
  - New `TestPathExpansion` (3 tests) covering non-glob, glob match, glob miss
  - New `TestBudgetAllocation::test_proportional_allocation_by_multiplier` covering the security=4 / deps=0.5 / default=1 default ratios
  - `pattern_scan` tests updated for new list signature + new `test_budget_multiplier_is_zero` + new `test_multiple_paths_all_scanned`

61 discovery_sweep tests pass. Drift-guards (workflow registry, PATH_ARG_REGISTRY, help-coverage) pass.

## Spec (~95 LoC)

- `decisions.md`: replaces DECIDE about source list with "all six adapters" resolution; renames "retirement evaluation" section to "surface evaluation"; adds resolved-callout for the proportional-multiplier allocation table and engine-side glob expansion
- `design.md`: Protocol code block updated; default_sources list adds `TestAuditSource()`; file-layout adds `test_audit.py`; new "Prompt augmentation lives at the workflow-instance level, NEVER class" subsection; tests-table updated for `@pytest.mark.integration`
- `tasks.md`: renumbers P2.4→P2.7 (surface eval moved to last); P2.5→P2.4 (PerfAuditSource); P2.6→P2.5 (DocAuditSource); new P2.6 `TestAuditSource`; P2.1 calls out `@pytest.mark.integration` + budget multipliers documented per task; old Phase 5 promoted to new Phase 4 (CLI deprecation); old Phase 4 (ops dashboard) deferred to follow-up spec
- `requirements.md`: US-6 reworked as "surface evaluation"; glob open-question resolved (engine expands upstream)

`_sequencing.md` is intentionally untouched per the brief — main's entry is current.

## Test plan

- [x] `pytest tests/unit/workflows/discovery_sweep/` — 61/61 pass
- [x] Drift-guards: `test_discovery_sweep_registered.py`, `test_path_support_registry.py`, `test_coverage_script.py` — 33/33 pass
- [x] `ruff check` + `black --check` clean
- [ ] CI: full suite

## What's NOT in this PR

- Any LLM source adapter (P2.1–P2.6) — out of scope, Phase 2 work
- Phase 2A `llm_source_base.py` shared infrastructure
- The follow-up `discovery-sweep-ops-integration` spec — separate PR after `ops-runner-tier2` Phase 2 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
