### PR TITLE
feat(discovery-sweep): Phase 2A — shared LLM adapter base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `discovery-sweep` Phase 2A — shared LLM adapter base
+  (`STRUCTURED_EMIT_FOOTER`, `parse_findings_json`, `LLMSource`).
+  No user-visible behavior change; unblocks P2.1–P2.6.
+
 - `discovery-sweep` meta-workflow (Phase 1) — fans out across audit
   sources and triages findings into three buckets: `queue` (act on),
   `questions` (need human judgment), `rejected` (filtered noise).

--- a/src/attune/workflows/discovery_sweep/llm_source_base.py
+++ b/src/attune/workflows/discovery_sweep/llm_source_base.py
@@ -1,0 +1,218 @@
+"""Shared base for LLM-backed FindingSource adapters.
+
+Three exports:
+
+* :data:`STRUCTURED_EMIT_FOOTER` — prompt augmentation appended to a
+  wrapped workflow's system prompt at the workflow-INSTANCE level
+  so the model emits a parseable ``findings`` JSON block alongside
+  its prose.
+* :func:`parse_findings_json` — tolerant parser that returns either
+  the structured findings or a single text-only-fallback Finding.
+* :class:`LLMSource` — optional marker base class setting
+  ``is_llm = True`` and ``budget_multiplier = 1.0``.
+
+Phase 2A ships infrastructure only; no per-source adapter exists yet
+and nothing is wired into :func:`default_sources`. See
+``docs/specs/discovery-sweep/design.md`` § "Structured emit (LLM
+adapters)" and § "Prompt augmentation lives at the
+workflow-instance level, NEVER class" for the contract this module
+implements.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+
+from .workflow import Finding
+
+logger = logging.getLogger(__name__)
+
+# Valid severities mirror the ``Severity`` Literal in workflow.py.
+# Kept local rather than imported so an invalid value fails into the
+# text-only fallback instead of a TypeError at Finding construction.
+_VALID_SEVERITIES = frozenset(
+    {"critical", "high", "medium", "low", "info"},
+)
+
+# Non-greedy + DOTALL per design.md so multiple blocks parse cleanly
+# and re.findall returns them in source order (we use the last).
+_JSON_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+STRUCTURED_EMIT_FOOTER = """\
+In addition to your normal prose output, emit a JSON block at the END
+of your response in the following format. The prose above is for the
+human; the JSON is for downstream tooling.
+
+```json
+{
+  "findings": [
+    {
+      "severity": "high" | "medium" | "low" | "info",
+      "title": "one-line summary",
+      "description": "1–3 sentence detail",
+      "file": "repo-relative path or null",
+      "line": <1-indexed int or null>,
+      "evidence": "exact quote from source or null",
+      "confidence": <float 0.0–1.0>,
+      "tags": ["optional", "freeform"]
+    }
+  ]
+}
+```
+"""
+
+
+def _fallback(text: str, source_name: str) -> list[Finding]:
+    """Single low-confidence finding for the failed-parse path.
+
+    Routed to ``questions`` by the engine's verification rules so the
+    user sees the adapter degraded without aborting the sweep.
+    """
+    evidence = text[:200] + "..." if len(text) > 200 else text
+    return [
+        Finding(
+            source=source_name,
+            severity="info",
+            title=f"{source_name} returned no structured findings",
+            description=(
+                f"Workflow completed but emitted no parseable JSON block. "
+                f"Raw output length: {len(text)} chars. Re-run with "
+                f"--verbose to inspect."
+            ),
+            file=None,
+            line=None,
+            evidence=evidence,
+            confidence=0.1,
+            tags=("text-only-fallback",),
+        )
+    ]
+
+
+def _finding_from_entry(entry: object, source_name: str) -> Finding:
+    """Construct a Finding from one JSON entry; raises on any defect.
+
+    The caller wraps this in try/except and converts ANY failure into
+    the text-only fallback, so we intentionally don't try to coerce
+    invalid fields here — fail loudly into the fallback path instead.
+    """
+    if not isinstance(entry, dict):
+        raise TypeError(
+            f"finding entry is {type(entry).__name__}, expected dict",
+        )
+
+    severity = entry.get("severity")
+    if severity not in _VALID_SEVERITIES:
+        raise ValueError(f"invalid severity: {severity!r}")
+
+    tags_raw = entry.get("tags") or ()
+    if not isinstance(tags_raw, list | tuple):
+        raise TypeError(
+            f"tags is {type(tags_raw).__name__}, expected list/tuple",
+        )
+
+    return Finding(
+        source=source_name,
+        severity=severity,
+        title=str(entry["title"]),
+        description=str(entry["description"]),
+        file=entry.get("file"),
+        line=entry.get("line"),
+        evidence=entry.get("evidence"),
+        confidence=float(entry["confidence"]),
+        tags=tuple(str(t) for t in tags_raw),
+    )
+
+
+def parse_findings_json(text: str, source_name: str) -> list[Finding]:
+    """Extract structured findings from an LLM response.
+
+    Tolerant parser per ``design.md`` § Structured emit. Behavior:
+
+    * Finds the LAST ```json fenced block in ``text`` (multiple blocks
+      → use last per spec P2A.2).
+    * Decodes JSON; expects ``{"findings": [{...}, ...]}``.
+    * Constructs a :class:`Finding` per entry with the adapter's
+      ``source_name``. Missing optional fields default sensibly
+      (``file=None``, ``line=None``, ``evidence=None``, ``tags=()``).
+    * On ANY failure (no block, malformed JSON, missing ``findings``
+      key, or any entry that fails construction) returns the single
+      text-only-fallback Finding and never raises.
+
+    Args:
+        text: Raw output from the wrapped workflow.
+        source_name: Name of the calling adapter — populates both the
+            constructed Finding's ``source`` field and the fallback's.
+
+    Returns:
+        List of Finding objects. Never empty: at minimum one fallback
+        finding so the engine's verification rules always have input.
+    """
+    matches = _JSON_BLOCK_RE.findall(text)
+    if not matches:
+        logger.warning(
+            "parse_findings_json: no ```json block in %s output",
+            source_name,
+        )
+        return _fallback(text, source_name)
+
+    raw_block = matches[-1]
+
+    try:
+        data = json.loads(raw_block)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "parse_findings_json: malformed JSON in %s output: %s",
+            source_name,
+            exc,
+        )
+        return _fallback(text, source_name)
+
+    if not isinstance(data, dict) or "findings" not in data:
+        logger.warning(
+            "parse_findings_json: %s output missing 'findings' key",
+            source_name,
+        )
+        return _fallback(text, source_name)
+
+    entries = data["findings"]
+    if not isinstance(entries, list):
+        logger.warning(
+            "parse_findings_json: %s 'findings' is not a list",
+            source_name,
+        )
+        return _fallback(text, source_name)
+
+    findings: list[Finding] = []
+    for entry in entries:
+        try:
+            findings.append(_finding_from_entry(entry, source_name))
+        except (TypeError, ValueError, KeyError) as exc:
+            logger.warning(
+                "parse_findings_json: %s entry construction failed "
+                "(%s); returning text-only fallback for entire response",
+                source_name,
+                exc,
+            )
+            return _fallback(text, source_name)
+
+    return findings
+
+
+class LLMSource:
+    """Optional marker base for LLM-backed FindingSource adapters.
+
+    Adapters can inherit this or set the attributes directly — the
+    engine checks them structurally via ``getattr``. ``is_llm`` lets
+    the ``--no-llm`` flag filter sources; ``budget_multiplier`` lets
+    a heavier-class adapter (e.g. an orchestrator-with-subagents)
+    request a larger share of the sweep budget.
+    """
+
+    is_llm: bool = True
+    budget_multiplier: float = 1.0

--- a/tests/unit/workflows/discovery_sweep/test_llm_source_base.py
+++ b/tests/unit/workflows/discovery_sweep/test_llm_source_base.py
@@ -1,0 +1,258 @@
+"""Tests for :mod:`attune.workflows.discovery_sweep.llm_source_base`.
+
+Covers ``parse_findings_json`` (well-formed, malformed, missing,
+multi-block, prose-wrapped, optional fields, invalid severity, bad
+shapes) plus the :class:`LLMSource` marker defaults and the
+:data:`STRUCTURED_EMIT_FOOTER` constant per spec P2A.2.
+"""
+
+from __future__ import annotations
+
+import json
+
+from attune.workflows.discovery_sweep import Finding
+from attune.workflows.discovery_sweep.llm_source_base import (
+    STRUCTURED_EMIT_FOOTER,
+    LLMSource,
+    parse_findings_json,
+)
+
+SOURCE = "fake-source"
+
+
+def _wrap(payload: dict) -> str:
+    """Helper: wrap a dict in a ```json fenced block."""
+    return f"some prose\n\n```json\n{json.dumps(payload)}\n```\n"
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_wellformed_block_returns_findings() -> None:
+    """Single well-formed block round-trips into Finding objects."""
+    text = _wrap(
+        {
+            "findings": [
+                {
+                    "severity": "high",
+                    "title": "eval() in handler",
+                    "description": "Direct eval of untrusted input.",
+                    "file": "src/handler.py",
+                    "line": 42,
+                    "evidence": "result = some_call(payload)",
+                    "confidence": 0.9,
+                    "tags": ["security", "cwe-95"],
+                }
+            ]
+        }
+    )
+
+    findings = parse_findings_json(text, SOURCE)
+
+    assert findings == [
+        Finding(
+            source=SOURCE,
+            severity="high",
+            title="eval() in handler",
+            description="Direct eval of untrusted input.",
+            file="src/handler.py",
+            line=42,
+            evidence="result = some_call(payload)",
+            confidence=0.9,
+            tags=("security", "cwe-95"),
+        )
+    ]
+
+
+def test_block_with_extra_prose_parses() -> None:
+    """Markdown prose before and after the fence doesn't confuse the regex."""
+    text = (
+        "# Audit summary\n\nWe found one issue.\n\n"
+        + _wrap(
+            {
+                "findings": [
+                    {
+                        "severity": "medium",
+                        "title": "broad except",
+                        "description": "Catches Exception unnecessarily.",
+                        "file": "src/util.py",
+                        "line": 10,
+                        "evidence": "except Exception:",
+                        "confidence": 0.6,
+                        "tags": [],
+                    }
+                ]
+            }
+        )
+        + "\n\nEnd of report."
+    )
+
+    findings = parse_findings_json(text, SOURCE)
+
+    assert len(findings) == 1
+    assert findings[0].title == "broad except"
+    assert findings[0].tags == ()
+
+
+def test_multiple_blocks_uses_last() -> None:
+    """Per P2A.2, when multiple ```json blocks appear the last wins."""
+    first = _wrap({"findings": [{"severity": "low", "title": "first"}]})
+    second = _wrap(
+        {
+            "findings": [
+                {
+                    "severity": "high",
+                    "title": "second",
+                    "description": "the winner",
+                    "confidence": 0.8,
+                }
+            ]
+        }
+    )
+
+    findings = parse_findings_json(first + "\n\n" + second, SOURCE)
+
+    assert len(findings) == 1
+    assert findings[0].title == "second"
+    assert findings[0].severity == "high"
+
+
+def test_missing_optional_fields_uses_defaults() -> None:
+    """Entries without file/line/evidence/tags get None / empty defaults."""
+    text = _wrap(
+        {
+            "findings": [
+                {
+                    "severity": "info",
+                    "title": "doc only",
+                    "description": "no location, no evidence, no tags",
+                    "confidence": 0.5,
+                }
+            ]
+        }
+    )
+
+    findings = parse_findings_json(text, SOURCE)
+
+    assert findings == [
+        Finding(
+            source=SOURCE,
+            severity="info",
+            title="doc only",
+            description="no location, no evidence, no tags",
+            file=None,
+            line=None,
+            evidence=None,
+            confidence=0.5,
+            tags=(),
+        )
+    ]
+
+
+def test_empty_findings_list_returns_empty_list() -> None:
+    """A well-formed block with an empty list is NOT a parse failure."""
+    text = _wrap({"findings": []})
+    assert parse_findings_json(text, SOURCE) == []
+
+
+# ---------------------------------------------------------------------------
+# Fallback paths
+# ---------------------------------------------------------------------------
+
+
+def _assert_is_fallback(findings: list[Finding], expected_text: str) -> None:
+    """Shared assertion for the text-only-fallback shape."""
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.source == SOURCE
+    assert only.severity == "info"
+    assert only.confidence == 0.1
+    assert only.tags == ("text-only-fallback",)
+    assert only.title == f"{SOURCE} returned no structured findings"
+    assert only.file is None
+    assert only.line is None
+    if len(expected_text) > 200:
+        assert only.evidence == expected_text[:200] + "..."
+    else:
+        assert only.evidence == expected_text
+
+
+def test_missing_block_returns_fallback() -> None:
+    """No ```json fence anywhere → single fallback finding."""
+    text = "Plain prose, no fenced block at all."
+    _assert_is_fallback(parse_findings_json(text, SOURCE), text)
+
+
+def test_malformed_json_returns_fallback() -> None:
+    """JSON syntax errors inside the fence → fallback."""
+    text = "```json\n{not valid json,,,}\n```"
+    _assert_is_fallback(parse_findings_json(text, SOURCE), text)
+
+
+def test_findings_key_missing_returns_fallback() -> None:
+    """Top-level dict without ``findings`` → fallback."""
+    text = _wrap({"results": []})
+    _assert_is_fallback(parse_findings_json(text, SOURCE), text)
+
+
+def test_findings_not_a_list_returns_fallback() -> None:
+    """``findings`` value of the wrong type → fallback."""
+    text = _wrap({"findings": "not-a-list"})
+    _assert_is_fallback(parse_findings_json(text, SOURCE), text)
+
+
+def test_invalid_severity_returns_fallback() -> None:
+    """Entry with severity outside the Literal set → fallback (no coercion)."""
+    text = _wrap(
+        {
+            "findings": [
+                {
+                    "severity": "catastrophic",
+                    "title": "bad sev",
+                    "description": "made-up severity",
+                    "confidence": 0.7,
+                }
+            ]
+        }
+    )
+    _assert_is_fallback(parse_findings_json(text, SOURCE), text)
+
+
+def test_entry_not_dict_returns_fallback() -> None:
+    """A non-dict entry inside ``findings`` → fallback for the whole response."""
+    text = _wrap({"findings": ["just a string, not an object"]})
+    _assert_is_fallback(parse_findings_json(text, SOURCE), text)
+
+
+def test_fallback_evidence_truncated_when_long() -> None:
+    """Evidence is the raw text capped at 200 chars + ``...`` when long."""
+    text = "x" * 500  # no json block → fallback
+    out = parse_findings_json(text, SOURCE)
+    assert len(out) == 1
+    assert out[0].evidence == ("x" * 200) + "..."
+
+
+# ---------------------------------------------------------------------------
+# Marker + constants
+# ---------------------------------------------------------------------------
+
+
+def test_llmsource_default_attributes() -> None:
+    """Bare subclass of LLMSource picks up is_llm=True, multiplier=1.0."""
+
+    class MyAdapter(LLMSource):
+        name = "my-adapter"
+
+    instance = MyAdapter()
+    assert instance.is_llm is True
+    assert instance.budget_multiplier == 1.0
+
+
+def test_structured_emit_footer_documents_findings_schema() -> None:
+    """Footer must include the ``findings`` array template the parser expects."""
+    assert "```json" in STRUCTURED_EMIT_FOOTER
+    assert '"findings"' in STRUCTURED_EMIT_FOOTER
+    assert '"severity"' in STRUCTURED_EMIT_FOOTER
+    assert '"confidence"' in STRUCTURED_EMIT_FOOTER


### PR DESCRIPTION
## Summary

Ships Phase 2A of `docs/specs/discovery-sweep/` — the shared LLM
adapter base. Infrastructure only; no per-source adapter exists yet
and nothing is wired into `default_sources()`. Unblocks P2.1–P2.6.

One new module exports three names:

- **`STRUCTURED_EMIT_FOOTER`** — verbatim prompt augmentation from
  `design.md` § Structured emit. Adapters append at the workflow-
  INSTANCE level, never class, per the design decision recorded in
  the spec (also widened in #312).
- **`parse_findings_json(text, source_name) -> list[Finding]`** —
  tolerant parser. Finds the LAST ```json fenced block (multiple
  blocks → last wins per P2A.2). On any failure (no block,
  malformed JSON, missing key, bad shape, or any entry that fails
  Finding construction) returns the single text-only-fallback
  Finding rather than raising. The fallback's `severity="info"`,
  `confidence=0.1`, `tags=("text-only-fallback",)` route it to
  `questions` via the existing verification rules so the engine
  always makes progress.
- **`LLMSource`** — three-line marker base setting `is_llm = True`
  and `budget_multiplier = 1.0`. Adapters may inherit or set the
  attributes directly; the engine checks structurally via
  `getattr`.

## Test plan

- [x] `pytest tests/unit/workflows/discovery_sweep/` — 69 passed
  (14 new + 55 existing)
- [x] `ruff check` clean on new files
- [x] `black --check` clean on new files
- [x] CHANGELOG `[Unreleased] ### Added` entry added
- [x] Single PR, ~480 LoC total (~140 module body + docstrings +
  footer literal, 258 tests)
- [x] No `claude_agent_sdk` or LLM API imports
- [x] No modifications to other discovery_sweep files
- [x] Branch: `claude/discovery-sweep-phase-2a` off `origin/main`

## Out of scope (per the spec)

- Per-source adapters (BugPredictSource etc.) — those are P2.1+
- Wiring `LLMSource` into `default_sources()` — no adapter exists
  to wire yet
- Modifying any other file under `discovery_sweep/`

## Notes

If #312 (Phase 1.5) merges first, no rebase needed — `LLMSource`
is a structural marker, not a Protocol implementation, and
`budget_multiplier` is forward-compat with the widened Protocol.

Spec lives at `docs/specs/discovery-sweep/`; see `tasks.md`
P2A.1–P2A.3 and `design.md` § "Structured emit (LLM adapters)" for
the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
