### PR TITLE
feat(discovery-sweep): P2.1 — BugPredictSource LLM adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `discovery-sweep` P2.1 — `BugPredictSource` LLM adapter wrapping
+  `BugPredictionWorkflow`. Constructs the wrapped workflow per call
+  with `STRUCTURED_EMIT_FOOTER` passed via a new
+  `system_prompt_suffix` kwarg on `BugPredictionWorkflow.__init__`
+  (workflow-INSTANCE level augmentation per `design.md`), invokes
+  `execute()` once per path, and parses each result's `final_output`
+  via `parse_findings_json`. Wired into `default_sources()`. Source
+  failures (raises, `success=False`, unparseable output) degrade
+  to info-findings rather than aborting the sweep. Integration
+  coverage marked `@pytest.mark.integration` per Phase 1.5 design
+  decision #7.
+
 - `discovery-sweep` Phase 2A — shared LLM adapter base
   (`STRUCTURED_EMIT_FOOTER`, `parse_findings_json`, `LLMSource`).
   No user-visible behavior change; unblocks P2.1–P2.6.

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -123,13 +123,21 @@ class BugPredictionWorkflow(BaseWorkflow):
     stages = ["agent-predict"]
     tier_map = {"agent-predict": ModelTier.CAPABLE}
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, *, system_prompt_suffix: str = "", **kwargs: Any) -> None:
         """Initialize workflow.
 
         Args:
+            system_prompt_suffix: Optional string appended to the
+                orchestrator's system prompt at call time. Lets a
+                wrapping caller (e.g. discovery-sweep's
+                ``BugPredictSource``) augment the prompt at the
+                workflow-INSTANCE level without mutating the class
+                template. Empty string (default) preserves prior
+                behavior for every other caller.
             **kwargs: Passed to BaseWorkflow.__init__().
         """
         super().__init__(**kwargs)
+        self._system_prompt_suffix = system_prompt_suffix
 
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK bug prediction.
@@ -202,10 +210,11 @@ class BugPredictionWorkflow(BaseWorkflow):
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
+        system_prompt = _SYSTEM_PROMPT + (self._system_prompt_suffix or "")
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
-                system_prompt=_SYSTEM_PROMPT,
+                system_prompt=system_prompt,
                 cwd=resolved_path,
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -210,7 +210,11 @@ class BugPredictionWorkflow(BaseWorkflow):
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
-        system_prompt = _SYSTEM_PROMPT + (self._system_prompt_suffix or "")
+        system_prompt = (
+            f"{_SYSTEM_PROMPT}\n\n{self._system_prompt_suffix}"
+            if self._system_prompt_suffix
+            else _SYSTEM_PROMPT
+        )
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(

--- a/src/attune/workflows/discovery_sweep/cli_workflow.py
+++ b/src/attune/workflows/discovery_sweep/cli_workflow.py
@@ -11,6 +11,7 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
+from .sources.bug_predict import BugPredictSource
 from .sources.pattern_scan import PatternScanSource
 from .workflow import FindingSource
 
@@ -18,12 +19,16 @@ from .workflow import FindingSource
 def default_sources() -> list[FindingSource]:
     """Return the default source list for ``attune workflow run discovery-sweep``.
 
-    Phase 1: pattern scanner only. Phase 2A+ adds LLM adapters
-    (bug-predict, security-audit, dependency-check, perf-audit,
-    doc-audit) — register them here, in spec order, when the
-    adapters land.
+    Phase 1: pattern scanner only. Phase 2 adds LLM adapters in
+    spec order (bug-predict, security-audit, dependency-check,
+    perf-audit, doc-audit, test-audit) — append here as each lands.
+    Order isn't load-bearing; verification rules dedup by location
+    regardless of source emission order.
     """
-    return [PatternScanSource()]
+    return [
+        PatternScanSource(),
+        BugPredictSource(),
+    ]
 
 
 __all__ = ["default_sources"]

--- a/src/attune/workflows/discovery_sweep/sources/bug_predict.py
+++ b/src/attune/workflows/discovery_sweep/sources/bug_predict.py
@@ -1,0 +1,149 @@
+"""``BugPredictSource`` — LLM adapter wrapping ``BugPredictionWorkflow``.
+
+Per ``docs/specs/discovery-sweep/design.md`` § "Prompt augmentation
+lives at the workflow-instance level, NEVER class": this adapter
+constructs a fresh :class:`BugPredictionWorkflow` per call with
+:data:`STRUCTURED_EMIT_FOOTER` passed as the ``system_prompt_suffix``
+kwarg, invokes ``execute()`` once per path, and parses each
+workflow's ``final_output`` via :func:`parse_findings_json`. The
+wrapped workflow is unchanged for every other caller.
+
+The ``claude_agent_sdk`` import lives inside :meth:`discover` so the
+module is mock-friendly and importing this file doesn't drag the
+SDK into the import graph of every test that touches the engine.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..workflow import Finding
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BugPredictSource(LLMSource):
+    """Discovery-sweep adapter for :class:`BugPredictionWorkflow`.
+
+    Three structural attributes (``name``, ``is_llm``,
+    ``budget_multiplier``) satisfy the :class:`FindingSource`
+    Protocol; ``LLMSource`` is inherited for the
+    ``--no-llm``-filter marker and the default ``budget_multiplier``.
+
+    ``depth`` is configurable per-instance and defaults to
+    ``"standard"`` — the same default as standalone
+    ``attune workflow run bug-predict``. Sweep callers that want a
+    cheaper pass can construct with ``depth="quick"``.
+    """
+
+    name: str = "bug-predict"
+    depth: str = "standard"
+
+    async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
+        """Run BugPredictionWorkflow on each path and parse findings.
+
+        ``budget_usd`` is informational for v1 — the wrapped workflow
+        self-limits via the SDK's own ``max_budget_usd`` derived from
+        ``depth`` (see :func:`get_max_budget_usd`). A later PR can
+        plumb the per-source share down once the wrapped workflows
+        accept an explicit per-call cap.
+        """
+        del budget_usd  # See docstring — wrapped workflow caps itself.
+
+        if not paths:
+            logger.warning("bug-predict: no paths to scan")
+            return [_empty_paths_finding(self.name)]
+
+        # Late import keeps ``claude_agent_sdk`` out of this module's
+        # import graph and lets unit tests patch the workflow class at
+        # its source module per the existing CLAUDE.md lesson.
+        from attune.workflows.bug_predict import BugPredictionWorkflow
+
+        findings: list[Finding] = []
+        for path in paths:
+            workflow = BugPredictionWorkflow(
+                system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
+            )
+            try:
+                result = await workflow.execute(path=path, depth=self.depth)
+            except Exception as exc:  # noqa: BLE001
+                # INTENTIONAL: per spec NFR-1 a single path failure
+                # must not abort the whole source — log and continue,
+                # surfacing an info-finding so the engine can route
+                # it to ``questions``.
+                logger.exception("bug-predict execute() failed for %s", path)
+                findings.append(_path_failed_finding(self.name, path, exc))
+                continue
+
+            if not getattr(result, "success", False):
+                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                continue
+
+            findings.extend(parse_findings_json(result.final_output or "", self.name))
+
+        return findings
+
+
+def _empty_paths_finding(source_name: str) -> Finding:
+    """Surfacing finding when the engine handed in an empty paths list."""
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} received no paths to scan",
+        description=(
+            "The engine passed an empty paths list to this source; "
+            "the wrapped workflow was not invoked."
+        ),
+        file=None,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )
+
+
+def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Finding:
+    """Per-path failure marker so one bad input doesn't abort the source."""
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} failed on path {path}",
+        description=(
+            f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
+            f"Other paths (if any) were still attempted."
+        ),
+        file=path,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )
+
+
+def _workflow_unsuccessful_finding(
+    source_name: str,
+    path: str,
+    result: object,
+) -> Finding:
+    """Marker for a clean WorkflowResult whose ``success`` came back False."""
+    detail = getattr(result, "final_output", "") or "(no detail returned)"
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} returned an unsuccessful result for {path}",
+        description=(
+            "Wrapped workflow completed without raising but reported "
+            f"success=False. Detail: {detail[:200]}"
+        ),
+        file=path,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )

--- a/tests/integration/test_discovery_sweep_bug_predict_integration.py
+++ b/tests/integration/test_discovery_sweep_bug_predict_integration.py
@@ -1,0 +1,71 @@
+"""Integration test for :class:`BugPredictSource`.
+
+Hits the real Anthropic API via the wrapped
+:class:`BugPredictionWorkflow`. Marked ``@pytest.mark.integration``
+per the Phase 1.5 design decision so the default ``-m "not
+integration"`` selector skips it; opt-in with::
+
+    pytest tests/integration/test_discovery_sweep_bug_predict_integration.py \\
+        -m integration
+
+The test runs against a tiny on-disk fixture so spend stays low
+(``depth="quick"`` is roughly $2 of SDK budget per the
+``_DEFAULT_BUDGET_USD["quick"]`` cap).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from attune.workflows.discovery_sweep.sources.bug_predict import BugPredictSource
+
+pytestmark = pytest.mark.integration
+
+
+_FIXTURE_BUGGY_SOURCE = textwrap.dedent(
+    '''\
+    """Fixture module — deliberately contains patterns bug-predict should flag."""
+
+
+    def parse_user_formula(formula: str):
+        # Obvious code-execution risk: trusting raw user input as a Python expression.
+        return eval(formula)  # noqa: S307
+
+
+    def read_config(path):
+        try:
+            with open(path) as fh:
+                return fh.read()
+        except Exception:  # noqa: BLE001
+            # Swallows everything including OSError/PermissionError/etc.
+            return None
+    '''
+)
+
+
+@pytest.mark.asyncio
+async def test_bug_predict_source_returns_findings_for_buggy_fixture(
+    tmp_path: Path,
+) -> None:
+    """Real sweep on a fixture file produces at least one parsed finding.
+
+    Doesn't assert specific titles or severities — the model's exact
+    wording drifts between runs. Asserts only the structural
+    contract: at least one Finding with our adapter's source name,
+    and not the text-only-fallback shape (which would indicate the
+    JSON-emit contract broke).
+    """
+    fixture = tmp_path / "buggy_module.py"
+    fixture.write_text(_FIXTURE_BUGGY_SOURCE, encoding="utf-8")
+
+    source = BugPredictSource(depth="quick")
+    findings = await source.discover([str(fixture)], budget_usd=2.0)
+
+    assert findings, "expected at least one finding from real bug-predict run"
+    assert all(f.source == "bug-predict" for f in findings)
+    assert not any(
+        "text-only-fallback" in f.tags for f in findings
+    ), "structured-emit contract failed — adapter fell back to text-only path"

--- a/tests/unit/workflows/discovery_sweep/test_bug_predict_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_bug_predict_source.py
@@ -4,7 +4,7 @@ Mocks ``BugPredictionWorkflow`` at its source module (per the
 existing CLAUDE.md lesson on deferred imports) so no
 ``claude_agent_sdk`` traffic happens during these tests. Integration
 coverage gated on a real API key lives in
-``tests/integration/workflows/test_discovery_sweep_bug_predict_integration.py``.
+``tests/integration/test_discovery_sweep_bug_predict_integration.py``.
 """
 
 from __future__ import annotations

--- a/tests/unit/workflows/discovery_sweep/test_bug_predict_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_bug_predict_source.py
@@ -1,0 +1,356 @@
+"""Unit tests for :class:`BugPredictSource`.
+
+Mocks ``BugPredictionWorkflow`` at its source module (per the
+existing CLAUDE.md lesson on deferred imports) so no
+``claude_agent_sdk`` traffic happens during these tests. Integration
+coverage gated on a real API key lives in
+``tests/integration/workflows/test_discovery_sweep_bug_predict_integration.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from unittest.mock import patch
+
+import pytest
+
+from attune.workflows.discovery_sweep import Finding
+from attune.workflows.discovery_sweep.cli_workflow import default_sources
+from attune.workflows.discovery_sweep.llm_source_base import STRUCTURED_EMIT_FOOTER
+from attune.workflows.discovery_sweep.sources.bug_predict import BugPredictSource
+
+# ---------------------------------------------------------------------------
+# Fake workflow that records constructor kwargs and execute() calls
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResult:
+    """Mirrors the shape :func:`parse_findings_json` reads from."""
+
+    success: bool = True
+    final_output: str = ""
+
+
+@dataclass
+class _RecordedCall:
+    init_kwargs: dict
+    execute_kwargs: dict
+
+
+@dataclass
+class _FakeWorkflowFactory:
+    """Hand-rolled stand-in for ``BugPredictionWorkflow``.
+
+    Records every construction + ``execute()`` call so tests can
+    assert on the augmented prompt + per-path invocation pattern.
+    Per-call results are provided as a list; the factory pops the
+    next one on each ``execute()``. ``side_effect`` lets a test
+    inject an exception instead of a result.
+    """
+
+    results: list[_FakeResult] = field(default_factory=list)
+    side_effects: list[Exception | None] = field(default_factory=list)
+    calls: list[_RecordedCall] = field(default_factory=list)
+
+    def __call__(self, **kwargs):
+        instance_index = len(self.calls)
+        recorded = _RecordedCall(init_kwargs=kwargs, execute_kwargs={})
+
+        async def _execute(**execute_kwargs):
+            recorded.execute_kwargs = execute_kwargs
+            if instance_index < len(self.side_effects):
+                exc = self.side_effects[instance_index]
+                if exc is not None:
+                    raise exc
+            if instance_index < len(self.results):
+                return self.results[instance_index]
+            return _FakeResult(success=True, final_output="")
+
+        instance = type(
+            "FakeInstance",
+            (),
+            {"execute": staticmethod(_execute)},
+        )()
+        self.calls.append(recorded)
+        return instance
+
+
+def _wrap_json(payload: dict) -> str:
+    return f"prose\n\n```json\n{json.dumps(payload)}\n```\n"
+
+
+def _wellformed_payload() -> dict:
+    return {
+        "findings": [
+            {
+                "severity": "high",
+                "title": "race on shared dict",
+                "description": "Two coroutines mutate without lock.",
+                "file": "src/handler.py",
+                "line": 88,
+                "evidence": "self._cache[key] = value",
+                "confidence": 0.85,
+                "tags": ["concurrency"],
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Source-level attributes
+# ---------------------------------------------------------------------------
+
+
+def test_source_defaults() -> None:
+    """Defaults conform to the LLMSource marker contract."""
+    source = BugPredictSource()
+    assert source.name == "bug-predict"
+    assert source.is_llm is True
+    assert source.budget_multiplier == 1.0
+    assert source.depth == "standard"
+
+
+def test_source_appears_in_default_sources() -> None:
+    """Wired into ``default_sources()`` per task P2.1 step 5."""
+    sources = default_sources()
+    bug_sources = [s for s in sources if s.name == "bug-predict"]
+    assert len(bug_sources) == 1
+    assert isinstance(bug_sources[0], BugPredictSource)
+
+
+# ---------------------------------------------------------------------------
+# discover() happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_path_returns_parsed_findings() -> None:
+    """Single path → one execute() call → parsed structured findings."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json(_wellformed_payload()))],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover(["src/"], budget_usd=1.0)
+
+    assert findings == [
+        Finding(
+            source="bug-predict",
+            severity="high",
+            title="race on shared dict",
+            description="Two coroutines mutate without lock.",
+            file="src/handler.py",
+            line=88,
+            evidence="self._cache[key] = value",
+            confidence=0.85,
+            tags=("concurrency",),
+        )
+    ]
+    assert len(factory.calls) == 1
+    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "standard"}
+
+
+@pytest.mark.asyncio
+async def test_constructor_receives_structured_emit_footer() -> None:
+    """``system_prompt_suffix`` is the augmentation channel per design.md."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json({"findings": []}))],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        await BugPredictSource().discover(["src/"], budget_usd=1.0)
+
+    assert factory.calls[0].init_kwargs == {
+        "system_prompt_suffix": STRUCTURED_EMIT_FOOTER,
+    }
+
+
+@pytest.mark.asyncio
+async def test_custom_depth_is_passed_to_execute() -> None:
+    """``depth="quick"`` reaches the wrapped workflow's execute() call."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json({"findings": []}))],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        await BugPredictSource(depth="quick").discover(["src/"], budget_usd=1.0)
+
+    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "quick"}
+
+
+@pytest.mark.asyncio
+async def test_multiple_paths_yield_per_path_calls_and_concat_findings() -> None:
+    """Each path → its own execute() call; findings concatenate in order."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "medium",
+                                "title": "first",
+                                "description": "from path 1",
+                                "confidence": 0.6,
+                            }
+                        ]
+                    }
+                ),
+            ),
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "low",
+                                "title": "second",
+                                "description": "from path 2",
+                                "confidence": 0.7,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover(["src/a/", "src/b/"], budget_usd=1.0)
+
+    assert len(factory.calls) == 2
+    assert [f.title for f in findings] == ["first", "second"]
+
+
+# ---------------------------------------------------------------------------
+# discover() degradation paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_paths_returns_source_failure_finding() -> None:
+    """Empty paths list → one info-finding, no workflow invocation."""
+    factory = _FakeWorkflowFactory()
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover([], budget_usd=1.0)
+
+    assert factory.calls == []
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.source == "bug-predict"
+    assert only.severity == "info"
+    assert only.tags == ("source-failure",)
+
+
+@pytest.mark.asyncio
+async def test_wrapped_workflow_raise_does_not_abort_other_paths() -> None:
+    """One path raises → recorded as source-failure; remaining paths run."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(),  # ignored — first instance raises
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "high",
+                                "title": "real finding",
+                                "description": "from second path",
+                                "confidence": 0.9,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ],
+        side_effects=[RuntimeError("boom"), None],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover(["bad/", "good/"], budget_usd=1.0)
+
+    # First path → source-failure marker; second path → its real finding.
+    assert len(findings) == 2
+    assert findings[0].tags == ("source-failure",)
+    assert findings[0].file == "bad/"
+    assert findings[1].title == "real finding"
+
+
+@pytest.mark.asyncio
+async def test_wrapped_workflow_returns_success_false() -> None:
+    """``WorkflowResult.success=False`` → info-finding, no parse attempt."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=False, final_output="path argument is required")],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover(["src/"], budget_usd=1.0)
+
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.tags == ("source-failure",)
+    assert only.file == "src/"
+
+
+@pytest.mark.asyncio
+async def test_unparseable_output_falls_back_to_parser_fallback() -> None:
+    """No JSON block in final_output → parse_findings_json's text-only fallback."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output="Just prose; no json block.")],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover(["src/"], budget_usd=1.0)
+
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.confidence == 0.1
+    assert only.tags == ("text-only-fallback",)
+
+
+@pytest.mark.asyncio
+async def test_empty_final_output_falls_back() -> None:
+    """``final_output`` may be None on some wrapped paths — handle defensively."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output="")],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover(["src/"], budget_usd=1.0)
+
+    assert len(findings) == 1
+    assert findings[0].tags == ("text-only-fallback",)

--- a/tests/unit/workflows/discovery_sweep/test_engine.py
+++ b/tests/unit/workflows/discovery_sweep/test_engine.py
@@ -177,12 +177,14 @@ class TestPathExpansion:
         assert all(p.endswith(".py") for p in src.received_paths)
         assert len(src.received_paths) == 2
 
-    def test_glob_with_no_matches_falls_back_to_pattern(self) -> None:
-        src = FakeSource(name="s", findings=[])
+    def test_glob_with_no_matches_does_not_run_sources(self) -> None:
+        src = FakeSource(name="s", is_llm=True, findings=[])
         wf = DiscoverySweepWorkflow()
-        asyncio.run(wf.execute(path="nonexistent/**/*.zzz", sources=[src]))
-        # Falls back to the raw pattern so sources can report it.
-        assert src.received_paths == ["nonexistent/**/*.zzz"]
+        res = asyncio.run(wf.execute(path="nonexistent/**/*.zzz", sources=[src]))
+        sweep: SweepResult = res.metadata["sweep"]
+        # An unmatched glob should not be forwarded as a raw path to sources.
+        assert src.received_paths is None
+        assert sweep.queue == []
 
 
 class TestSourceFiltering:

--- a/tests/unit/workflows/discovery_sweep/test_llm_source_base.py
+++ b/tests/unit/workflows/discovery_sweep/test_llm_source_base.py
@@ -251,8 +251,19 @@ def test_llmsource_default_attributes() -> None:
 
 
 def test_structured_emit_footer_documents_findings_schema() -> None:
-    """Footer must include the ``findings`` array template the parser expects."""
+    """Footer must include a valid JSON example matching the parser contract."""
     assert "```json" in STRUCTURED_EMIT_FOOTER
-    assert '"findings"' in STRUCTURED_EMIT_FOOTER
-    assert '"severity"' in STRUCTURED_EMIT_FOOTER
-    assert '"confidence"' in STRUCTURED_EMIT_FOOTER
+
+    _, fenced_and_rest = STRUCTURED_EMIT_FOOTER.split("```json", 1)
+    json_block, _ = fenced_and_rest.split("```", 1)
+    payload = json.loads(json_block.strip())
+
+    assert isinstance(payload, dict)
+    assert "findings" in payload
+    assert isinstance(payload["findings"], list)
+
+    if payload["findings"]:
+        first_finding = payload["findings"][0]
+        assert isinstance(first_finding, dict)
+        assert "severity" in first_finding
+        assert "confidence" in first_finding


### PR DESCRIPTION
## Summary

First LLM-backed `FindingSource` for discovery-sweep. Wraps
`BugPredictionWorkflow` without changing its behavior for any
other caller.

**Workflow-instance-level prompt augmentation.** New
`system_prompt_suffix: str = ""` kwarg on
`BugPredictionWorkflow.__init__` is appended to `_SYSTEM_PROMPT`
inside `_run_agent_predict`. Default-empty is a no-op for every
existing caller (standalone CLI, MCP `bug_predict`, ops dashboard).
Discovery-sweep's adapter passes `STRUCTURED_EMIT_FOOTER` per call.
This is the generic mechanism from Phase 1.5 design.md §
"Prompt augmentation lives at the workflow-instance level, NEVER
class" — no discovery-sweep-aware class hierarchy.

**`BugPredictSource`** (~150 LoC, inherits `LLMSource`):

1. Construct `BugPredictionWorkflow(system_prompt_suffix=
   STRUCTURED_EMIT_FOOTER)` per path
2. `await workflow.execute(path=path, depth=self.depth)`
3. Parse `final_output` via `parse_findings_json`

Degradation paths surface as info-findings (engine routes them to
`questions`, never aborts the sweep):

- Empty paths list → `_empty_paths_finding`
- Wrapped workflow raises → `_path_failed_finding`, remaining paths
  still attempted
- `WorkflowResult.success=False` → `_workflow_unsuccessful_finding`
- Unparseable `final_output` → parser's text-only-fallback

`claude_agent_sdk` import is late-bound inside `discover()` so unit
tests mock at `attune.workflows.bug_predict.BugPredictionWorkflow`
per the existing CLAUDE.md deferred-import lesson.

Wired into `default_sources()` after `PatternScanSource`.

## Stacked on (read in this order)

1. **#312** — Phase 1.5 design landings (widened Protocol,
   `budget_multiplier`, instance-augmentation rule)
2. **#313** — Phase 2A shared LLM adapter base
   (`STRUCTURED_EMIT_FOOTER`, `parse_findings_json`, `LLMSource`)
3. **This PR** — P2.1 adapter wiring

Diff against `main` includes #312 + #313 + P2.1 until those merge.
Filter for just P2.1's surface:

```
git diff main..claude/discovery-sweep-p2-1-bug-predict -- \
  src/attune/workflows/discovery_sweep/sources/bug_predict.py \
  tests/unit/workflows/discovery_sweep/test_bug_predict_source.py \
  tests/integration/test_discovery_sweep_bug_predict_integration.py \
  src/attune/workflows/bug_predict.py \
  src/attune/workflows/discovery_sweep/cli_workflow.py
```

## Test plan

- [x] 11 unit tests in `test_bug_predict_source.py` — mock the
  wrapped workflow via a hand-rolled `_FakeWorkflowFactory` that
  records construction kwargs (proves footer flows through) AND
  per-instance execute() kwargs. Covers: defaults, registry
  membership, single-path parse, augmentation channel, custom
  depth, multi-path concat, empty paths, raise mid-batch,
  `success=False`, unparseable output, empty output.
- [x] 1 `@pytest.mark.integration` test on a tiny on-disk fixture
  (`depth="quick"`, ~$2 SDK cap). Asserts structural contract only.
- [x] 133 tests across discovery_sweep + bug_predict execute +
  drift-guards pass
- [x] `ruff check` + `black --check` clean
- [x] No `claude_agent_sdk` at module scope in the adapter

## Out of scope

- Other Phase 2 adapters (P2.2–P2.7) — separate PRs
- Plumbing per-source `budget_usd` down into the wrapped workflow's
  SDK cap — v2 concern; the SDK's existing `max_budget_usd` already
  bounds each call

🤖 Generated with [Claude Code](https://claude.com/claude-code)
