### PR TITLE
feat(discovery-sweep): P2.2 — SecurityAuditSource LLM adapter + test hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `discovery-sweep` test suite — repair two tests broken by
+  Copilot Autofix commits that landed in #314's squash merge:
+  (1) `test_structured_emit_footer_documents_findings_schema`
+  was rewritten to `json.loads` the example footer, but the
+  example intentionally uses pseudo-JSON union syntax
+  (`"severity": "high" | "medium" | ...`) to document allowed
+  values and is not round-trippable — reverted to field-name
+  substring assertions; (2)
+  `test_glob_with_no_matches_does_not_run_sources` asserted
+  `received_paths is None`, but `_expand_path` documents that
+  unmatched globs are forwarded as raw paths so sources can
+  emit a "no files matched" finding — renamed to
+  `..._forwards_raw_glob_to_sources` and asserted the actual
+  contract. Broke main after #314 merged.
+
 - `discovery-sweep` PatternScanSource — port two false-positive
   filters from `bug-predict`'s
   `bug_predict_patterns.py`:
@@ -42,6 +57,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   four targets; queue noise dropped from 8 false positives to 0.
 
 ### Added
+
+- `discovery-sweep` P2.2 — `SecurityAuditSource` LLM adapter
+  wrapping `SecurityAuditWorkflow`. Same pattern as P2.1
+  (workflow-INSTANCE level `STRUCTURED_EMIT_FOOTER` via a new
+  `system_prompt_suffix` kwarg on `SecurityAuditWorkflow.__init__`)
+  with `budget_multiplier=4.0` to reflect the four-subagent spend
+  profile per Phase 1.5's default ratios (security=4 / deps=0.5 /
+  default=1). Wired into `default_sources()`. Integration
+  coverage marked `@pytest.mark.integration`.
 
 - `discovery-sweep` P2.1 — `BugPredictSource` LLM adapter wrapping
   `BugPredictionWorkflow`. Constructs the wrapped workflow per call

--- a/src/attune/workflows/discovery_sweep/cli_workflow.py
+++ b/src/attune/workflows/discovery_sweep/cli_workflow.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from .sources.bug_predict import BugPredictSource
 from .sources.pattern_scan import PatternScanSource
+from .sources.security_audit import SecurityAuditSource
 from .workflow import FindingSource
 
 
@@ -28,6 +29,7 @@ def default_sources() -> list[FindingSource]:
     return [
         PatternScanSource(),
         BugPredictSource(),
+        SecurityAuditSource(),
     ]
 
 

--- a/src/attune/workflows/discovery_sweep/sources/security_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/security_audit.py
@@ -1,0 +1,158 @@
+"""``SecurityAuditSource`` — LLM adapter wrapping ``SecurityAuditWorkflow``.
+
+Mirrors the :class:`BugPredictSource` pattern (P2.1): constructs a
+fresh :class:`SecurityAuditWorkflow` per call with
+:data:`STRUCTURED_EMIT_FOOTER` passed via ``system_prompt_suffix``
+(workflow-INSTANCE level augmentation per Phase 1.5 ``design.md``),
+invokes ``execute()`` once per path, and parses each result's
+``final_output`` via :func:`parse_findings_json`.
+
+``budget_multiplier = 4.0`` reflects the security-audit workflow's
+four specialized subagents (vuln-scanner, secret-detector,
+auth-reviewer, remediation-planner) — Phase 1.5 set the default
+ratios as ``security=4`` / ``deps=0.5`` / ``default=1`` so the
+engine allocates proportionally and security-audit gets the share
+it actually spends.
+
+The ``claude_agent_sdk`` import lives inside :meth:`discover` so
+this module is mock-friendly and doesn't drag the SDK into the
+import graph of every test that touches the engine.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..workflow import Finding
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SecurityAuditSource(LLMSource):
+    """Discovery-sweep adapter for :class:`SecurityAuditWorkflow`.
+
+    Three structural attributes (``name``, ``is_llm``,
+    ``budget_multiplier``) satisfy the :class:`FindingSource`
+    Protocol; ``LLMSource`` is inherited for the ``--no-llm``
+    filter marker. The 4.0 multiplier overrides the LLMSource
+    default of 1.0 to reflect the workflow's higher per-call spend.
+
+    ``depth`` is configurable per-instance and defaults to
+    ``"standard"`` — same default as standalone
+    ``attune workflow run security-audit``. Sweep callers that want
+    a cheaper pass can construct with ``depth="quick"``.
+    """
+
+    name: str = "security-audit"
+    budget_multiplier: float = 4.0
+    depth: str = "standard"
+
+    async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
+        """Run SecurityAuditWorkflow on each path and parse findings.
+
+        ``budget_usd`` is informational for v1 — the wrapped
+        workflow self-limits via the SDK's own ``max_budget_usd``
+        derived from ``depth``. A later PR can plumb the per-source
+        share down once the wrapped workflows accept an explicit
+        per-call cap.
+        """
+        del budget_usd  # See docstring — wrapped workflow caps itself.
+
+        if not paths:
+            logger.warning("security-audit: no paths to scan")
+            return [_empty_paths_finding(self.name)]
+
+        # Late import keeps ``claude_agent_sdk`` out of this
+        # module's import graph and lets unit tests patch the
+        # workflow class at its source module per the existing
+        # CLAUDE.md deferred-import lesson.
+        from attune.workflows.security_audit import SecurityAuditWorkflow
+
+        findings: list[Finding] = []
+        for path in paths:
+            workflow = SecurityAuditWorkflow(
+                system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
+            )
+            try:
+                result = await workflow.execute(path=path, depth=self.depth)
+            except Exception as exc:  # noqa: BLE001
+                # INTENTIONAL: per spec NFR-1 a single path failure
+                # must not abort the whole source — log and
+                # continue, surfacing an info-finding so the
+                # engine can route it to ``questions``.
+                logger.exception("security-audit execute() failed for %s", path)
+                findings.append(_path_failed_finding(self.name, path, exc))
+                continue
+
+            if not getattr(result, "success", False):
+                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                continue
+
+            findings.extend(parse_findings_json(result.final_output or "", self.name))
+
+        return findings
+
+
+def _empty_paths_finding(source_name: str) -> Finding:
+    """Surfacing finding when the engine handed in an empty paths list."""
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} received no paths to scan",
+        description=(
+            "The engine passed an empty paths list to this source; "
+            "the wrapped workflow was not invoked."
+        ),
+        file=None,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )
+
+
+def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Finding:
+    """Per-path failure marker so one bad input doesn't abort the source."""
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} failed on path {path}",
+        description=(
+            f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
+            f"Other paths (if any) were still attempted."
+        ),
+        file=path,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )
+
+
+def _workflow_unsuccessful_finding(
+    source_name: str,
+    path: str,
+    result: object,
+) -> Finding:
+    """Marker for a clean WorkflowResult whose ``success`` came back False."""
+    detail = getattr(result, "final_output", "") or "(no detail returned)"
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} returned an unsuccessful result for {path}",
+        description=(
+            "Wrapped workflow completed without raising but reported "
+            f"success=False. Detail: {detail[:200]}"
+        ),
+        file=path,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )

--- a/src/attune/workflows/security_audit.py
+++ b/src/attune/workflows/security_audit.py
@@ -104,13 +104,21 @@ class SecurityAuditWorkflow(BaseWorkflow):
     stages = ["agent-audit"]
     tier_map = {"agent-audit": ModelTier.CAPABLE}
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, *, system_prompt_suffix: str = "", **kwargs: Any) -> None:
         """Initialize workflow.
 
         Args:
+            system_prompt_suffix: Optional string appended to the
+                orchestrator's system prompt at call time. Lets a
+                wrapping caller (e.g. discovery-sweep's
+                ``SecurityAuditSource``) augment the prompt at the
+                workflow-INSTANCE level without mutating the class
+                template. Empty string (default) preserves prior
+                behavior for every other caller.
             **kwargs: Passed to BaseWorkflow.__init__().
         """
         super().__init__(**kwargs)
+        self._system_prompt_suffix = system_prompt_suffix
 
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK security audit.
@@ -212,10 +220,11 @@ class SecurityAuditWorkflow(BaseWorkflow):
             extra_opts["thinking"] = thinking
             extra_opts["effort"] = "high"
 
+        system_prompt = _SYSTEM_PROMPT + (self._system_prompt_suffix or "")
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
-                system_prompt=_SYSTEM_PROMPT,
+                system_prompt=system_prompt,
                 cwd=resolved_path,
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],

--- a/tests/integration/test_discovery_sweep_security_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_security_audit_integration.py
@@ -1,0 +1,75 @@
+"""Integration test for :class:`SecurityAuditSource`.
+
+Hits the real Anthropic API via the wrapped
+:class:`SecurityAuditWorkflow`. Marked
+``@pytest.mark.integration`` per the Phase 1.5 design decision so
+the default ``-m "not integration"`` selector skips it; opt-in
+with::
+
+    pytest tests/integration/test_discovery_sweep_security_audit_integration.py \\
+        -m integration
+
+Runs against a tiny on-disk fixture with ``depth="quick"`` so spend
+stays low (~$2 SDK cap per :func:`get_max_budget_usd`). Security
+audit's four subagents will still spend faster than bug-predict's
+three; budget accordingly when iterating.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from attune.workflows.discovery_sweep.sources.security_audit import SecurityAuditSource
+
+pytestmark = pytest.mark.integration
+
+
+_FIXTURE_VULNERABLE_SOURCE = textwrap.dedent(
+    '''\
+    """Fixture module — deliberately contains patterns security-audit should flag."""
+
+    import hashlib
+    import subprocess
+
+    # Hardcoded credential — secret-detector should flag.
+    API_KEY = "sk-live-FAKE-LOOKING-CREDENTIAL-FOR-FIXTURE"  # noqa: S105
+
+
+    def hash_password(password: str) -> str:
+        # Weak hash — vuln-scanner should flag (MD5 for credentials).
+        return hashlib.md5(password.encode()).hexdigest()
+
+
+    def run_user_command(cmd: str) -> str:
+        # Shell injection — vuln-scanner should flag (shell=True with user input).
+        return subprocess.check_output(cmd, shell=True).decode()
+    '''
+)
+
+
+@pytest.mark.asyncio
+async def test_security_audit_source_returns_findings_for_vulnerable_fixture(
+    tmp_path: Path,
+) -> None:
+    """Real sweep on a fixture file produces at least one parsed finding.
+
+    Doesn't assert specific titles or severities — the model's
+    exact wording drifts between runs. Asserts only the structural
+    contract: at least one Finding with our adapter's source name,
+    and not the text-only-fallback shape (which would indicate the
+    JSON-emit contract broke).
+    """
+    fixture = tmp_path / "vulnerable_module.py"
+    fixture.write_text(_FIXTURE_VULNERABLE_SOURCE, encoding="utf-8")
+
+    source = SecurityAuditSource(depth="quick")
+    findings = await source.discover([str(fixture)], budget_usd=4.0)
+
+    assert findings, "expected at least one finding from real security-audit run"
+    assert all(f.source == "security-audit" for f in findings)
+    assert not any(
+        "text-only-fallback" in f.tags for f in findings
+    ), "structured-emit contract failed — adapter fell back to text-only path"

--- a/tests/unit/workflows/discovery_sweep/test_engine.py
+++ b/tests/unit/workflows/discovery_sweep/test_engine.py
@@ -177,13 +177,14 @@ class TestPathExpansion:
         assert all(p.endswith(".py") for p in src.received_paths)
         assert len(src.received_paths) == 2
 
-    def test_glob_with_no_matches_does_not_run_sources(self) -> None:
+    def test_glob_with_no_matches_forwards_raw_glob_to_sources(self) -> None:
+        """Unmatched glob → raw path forwarded so sources can emit a
+        "no files matched" finding (see ``_expand_path`` docstring)."""
         src = FakeSource(name="s", is_llm=True, findings=[])
         wf = DiscoverySweepWorkflow()
         res = asyncio.run(wf.execute(path="nonexistent/**/*.zzz", sources=[src]))
         sweep: SweepResult = res.metadata["sweep"]
-        # An unmatched glob should not be forwarded as a raw path to sources.
-        assert src.received_paths is None
+        assert src.received_paths == ["nonexistent/**/*.zzz"]
         assert sweep.queue == []
 
 

--- a/tests/unit/workflows/discovery_sweep/test_llm_source_base.py
+++ b/tests/unit/workflows/discovery_sweep/test_llm_source_base.py
@@ -251,19 +251,14 @@ def test_llmsource_default_attributes() -> None:
 
 
 def test_structured_emit_footer_documents_findings_schema() -> None:
-    """Footer must include a valid JSON example matching the parser contract."""
+    """Footer must include the ``findings`` array template the parser expects.
+
+    The fenced block intentionally uses pseudo-JSON union syntax
+    (``"severity": "high" | "medium" | ...``) to document the
+    allowed values, so it is NOT round-trippable through
+    :func:`json.loads`. Assert on the field names instead.
+    """
     assert "```json" in STRUCTURED_EMIT_FOOTER
-
-    _, fenced_and_rest = STRUCTURED_EMIT_FOOTER.split("```json", 1)
-    json_block, _ = fenced_and_rest.split("```", 1)
-    payload = json.loads(json_block.strip())
-
-    assert isinstance(payload, dict)
-    assert "findings" in payload
-    assert isinstance(payload["findings"], list)
-
-    if payload["findings"]:
-        first_finding = payload["findings"][0]
-        assert isinstance(first_finding, dict)
-        assert "severity" in first_finding
-        assert "confidence" in first_finding
+    assert '"findings"' in STRUCTURED_EMIT_FOOTER
+    assert '"severity"' in STRUCTURED_EMIT_FOOTER
+    assert '"confidence"' in STRUCTURED_EMIT_FOOTER

--- a/tests/unit/workflows/discovery_sweep/test_security_audit_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_security_audit_source.py
@@ -1,0 +1,361 @@
+"""Unit tests for :class:`SecurityAuditSource`.
+
+Mocks ``SecurityAuditWorkflow`` at its source module (per the
+existing CLAUDE.md lesson on deferred imports) so no
+``claude_agent_sdk`` traffic happens during these tests.
+Integration coverage gated on
+``@pytest.mark.integration`` lives in
+``tests/integration/test_discovery_sweep_security_audit_integration.py``.
+
+Mirrors the P2.1 ``test_bug_predict_source.py`` shape — every Phase
+2B adapter should be testable from the same pattern.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from unittest.mock import patch
+
+import pytest
+
+from attune.workflows.discovery_sweep import Finding
+from attune.workflows.discovery_sweep.cli_workflow import default_sources
+from attune.workflows.discovery_sweep.llm_source_base import STRUCTURED_EMIT_FOOTER
+from attune.workflows.discovery_sweep.sources.security_audit import SecurityAuditSource
+
+SOURCE = "security-audit"
+
+
+# ---------------------------------------------------------------------------
+# Fake workflow that records constructor kwargs and execute() calls
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResult:
+    """Mirrors the shape :func:`parse_findings_json` reads from."""
+
+    success: bool = True
+    final_output: str = ""
+
+
+@dataclass
+class _RecordedCall:
+    init_kwargs: dict
+    execute_kwargs: dict
+
+
+@dataclass
+class _FakeWorkflowFactory:
+    """Hand-rolled stand-in for ``SecurityAuditWorkflow``.
+
+    Records every construction + ``execute()`` call so tests can
+    assert on the augmented prompt + per-path invocation pattern.
+    Per-call results live in ``results``; ``side_effects`` lets a
+    test inject an exception for a specific instance.
+    """
+
+    results: list[_FakeResult] = field(default_factory=list)
+    side_effects: list[Exception | None] = field(default_factory=list)
+    calls: list[_RecordedCall] = field(default_factory=list)
+
+    def __call__(self, **kwargs):
+        instance_index = len(self.calls)
+        recorded = _RecordedCall(init_kwargs=kwargs, execute_kwargs={})
+
+        async def _execute(**execute_kwargs):
+            recorded.execute_kwargs = execute_kwargs
+            if instance_index < len(self.side_effects):
+                exc = self.side_effects[instance_index]
+                if exc is not None:
+                    raise exc
+            if instance_index < len(self.results):
+                return self.results[instance_index]
+            return _FakeResult(success=True, final_output="")
+
+        instance = type(
+            "FakeInstance",
+            (),
+            {"execute": staticmethod(_execute)},
+        )()
+        self.calls.append(recorded)
+        return instance
+
+
+def _wrap_json(payload: dict) -> str:
+    return f"prose\n\n```json\n{json.dumps(payload)}\n```\n"
+
+
+def _wellformed_payload() -> dict:
+    return {
+        "findings": [
+            {
+                "severity": "critical",
+                "title": "hardcoded api key",
+                "description": "Secret committed in source.",
+                "file": "src/config.py",
+                "line": 17,
+                "evidence": "API_KEY = 'sk-real-looking-secret'",
+                "confidence": 0.95,
+                "tags": ["secret", "cwe-798"],
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Source-level attributes
+# ---------------------------------------------------------------------------
+
+
+def test_source_defaults() -> None:
+    """Defaults conform to the LLMSource marker + 4.0 budget multiplier."""
+    source = SecurityAuditSource()
+    assert source.name == SOURCE
+    assert source.is_llm is True
+    assert source.budget_multiplier == 4.0
+    assert source.depth == "standard"
+
+
+def test_source_appears_in_default_sources() -> None:
+    """Wired into ``default_sources()`` per task P2.2 step 5."""
+    sources = default_sources()
+    sec_sources = [s for s in sources if s.name == SOURCE]
+    assert len(sec_sources) == 1
+    assert isinstance(sec_sources[0], SecurityAuditSource)
+
+
+# ---------------------------------------------------------------------------
+# discover() happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_path_returns_parsed_findings() -> None:
+    """Single path → one execute() call → parsed structured findings."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json(_wellformed_payload()))],
+    )
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        findings = await SecurityAuditSource().discover(["src/"], budget_usd=4.0)
+
+    assert findings == [
+        Finding(
+            source=SOURCE,
+            severity="critical",
+            title="hardcoded api key",
+            description="Secret committed in source.",
+            file="src/config.py",
+            line=17,
+            evidence="API_KEY = 'sk-real-looking-secret'",
+            confidence=0.95,
+            tags=("secret", "cwe-798"),
+        )
+    ]
+    assert len(factory.calls) == 1
+    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "standard"}
+
+
+@pytest.mark.asyncio
+async def test_constructor_receives_structured_emit_footer() -> None:
+    """``system_prompt_suffix`` is the augmentation channel per design.md."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json({"findings": []}))],
+    )
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        await SecurityAuditSource().discover(["src/"], budget_usd=4.0)
+
+    assert factory.calls[0].init_kwargs == {
+        "system_prompt_suffix": STRUCTURED_EMIT_FOOTER,
+    }
+
+
+@pytest.mark.asyncio
+async def test_custom_depth_is_passed_to_execute() -> None:
+    """``depth="quick"`` reaches the wrapped workflow's execute() call."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json({"findings": []}))],
+    )
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        await SecurityAuditSource(depth="quick").discover(["src/"], budget_usd=4.0)
+
+    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "quick"}
+
+
+@pytest.mark.asyncio
+async def test_multiple_paths_yield_per_path_calls_and_concat_findings() -> None:
+    """Each path → its own execute() call; findings concatenate in order."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "high",
+                                "title": "sql injection",
+                                "description": "Unparameterized query.",
+                                "confidence": 0.8,
+                            }
+                        ]
+                    }
+                ),
+            ),
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "medium",
+                                "title": "weak hash",
+                                "description": "MD5 used for passwords.",
+                                "confidence": 0.7,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ],
+    )
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        findings = await SecurityAuditSource().discover(["src/a/", "src/b/"], budget_usd=4.0)
+
+    assert len(factory.calls) == 2
+    assert [f.title for f in findings] == ["sql injection", "weak hash"]
+
+
+# ---------------------------------------------------------------------------
+# discover() degradation paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_paths_returns_source_failure_finding() -> None:
+    """Empty paths list → one info-finding, no workflow invocation."""
+    factory = _FakeWorkflowFactory()
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        findings = await SecurityAuditSource().discover([], budget_usd=4.0)
+
+    assert factory.calls == []
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.source == SOURCE
+    assert only.severity == "info"
+    assert only.tags == ("source-failure",)
+
+
+@pytest.mark.asyncio
+async def test_wrapped_workflow_raise_does_not_abort_other_paths() -> None:
+    """One path raises → recorded as source-failure; remaining paths run."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(),  # ignored — first instance raises
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "high",
+                                "title": "real finding",
+                                "description": "from second path",
+                                "confidence": 0.9,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ],
+        side_effects=[RuntimeError("boom"), None],
+    )
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        findings = await SecurityAuditSource().discover(["bad/", "good/"], budget_usd=4.0)
+
+    assert len(findings) == 2
+    assert findings[0].tags == ("source-failure",)
+    assert findings[0].file == "bad/"
+    assert findings[1].title == "real finding"
+
+
+@pytest.mark.asyncio
+async def test_wrapped_workflow_returns_success_false() -> None:
+    """``WorkflowResult.success=False`` → info-finding, no parse attempt."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=False, final_output="path argument is required")],
+    )
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        findings = await SecurityAuditSource().discover(["src/"], budget_usd=4.0)
+
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.tags == ("source-failure",)
+    assert only.file == "src/"
+
+
+@pytest.mark.asyncio
+async def test_unparseable_output_falls_back_to_parser_fallback() -> None:
+    """No JSON block in final_output → parse_findings_json's text-only fallback."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output="Just prose; no json block.")],
+    )
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        findings = await SecurityAuditSource().discover(["src/"], budget_usd=4.0)
+
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.confidence == 0.1
+    assert only.tags == ("text-only-fallback",)
+
+
+@pytest.mark.asyncio
+async def test_empty_final_output_falls_back() -> None:
+    """``final_output`` may be None/empty — handle defensively."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output="")],
+    )
+
+    with patch(
+        "attune.workflows.security_audit.SecurityAuditWorkflow",
+        new=factory,
+    ):
+        findings = await SecurityAuditSource().discover(["src/"], budget_usd=4.0)
+
+    assert len(findings) == 1
+    assert findings[0].tags == ("text-only-fallback",)


### PR DESCRIPTION
## Summary

Second LLM-backed `FindingSource` for discovery-sweep. Wraps
`SecurityAuditWorkflow` using the same workflow-INSTANCE
augmentation pattern P2.1 established.

**Workflow-instance-level prompt augmentation.** New
`system_prompt_suffix: str = ""` kwarg on
`SecurityAuditWorkflow.__init__`, appended to `_SYSTEM_PROMPT`
inside `_run_agent_audit`. Default-empty is a no-op for every
existing caller (standalone CLI, MCP `security_audit`, ops
dashboard).

**`SecurityAuditSource`** (~155 LoC, inherits `LLMSource`):

1. Construct `SecurityAuditWorkflow(system_prompt_suffix=
   STRUCTURED_EMIT_FOOTER)` per path
2. `await workflow.execute(path=path, depth=self.depth)`
3. Parse `final_output` via `parse_findings_json`

`budget_multiplier = 4.0` reflects the four-subagent spend
profile (vuln-scanner + secret-detector + auth-reviewer +
remediation-planner) per Phase 1.5's default ratios
(security=4 / deps=0.5 / default=1).

Same degradation paths as P2.1 — empty paths, per-path failure,
`success=False`, unparseable output → info-findings with
`("source-failure",)` or `("text-only-fallback",)` tags. Engine
routes to `questions`, never aborts the sweep.

Wired into `default_sources()` after `BugPredictSource`.

## Inline hotfix for two tests broken on main

PR #314's squash merge bundled Copilot Autofix commits that
rewrote two tests after the CI matrix had completed, breaking
main:

- **`test_structured_emit_footer_documents_findings_schema`** —
  rewritten to `json.loads` the example footer, but the example
  intentionally uses pseudo-JSON union syntax
  (`"severity": "high" | "medium" | ...`) to document allowed
  values and isn't parseable. Reverted to field-name substring
  assertions.

- **`test_glob_with_no_matches_does_not_run_sources`** — asserted
  `received_paths is None`, contradicting `_expand_path`'s
  documented behavior of forwarding the raw glob so sources can
  emit a "no files matched" finding. Renamed to
  `..._forwards_raw_glob_to_sources` and asserted the actual
  contract.

Bundled inline rather than a separate hotfix PR to keep the merge
train moving — calling out the cross-cutting fix here so it's
visible at review.

## Test plan

- [x] 11 unit tests in `test_security_audit_source.py` (cloned
  from P2.1's pattern)
- [x] 1 `@pytest.mark.integration` test on a tiny fixture
  (hardcoded credential + weak hash + shell injection)
- [x] 97 discovery_sweep tests pass (2 previously broken now
  green)
- [x] 80 existing SecurityAudit-touching tests
  (`test_secure_release_behavioral`, `test_task_budget_wiring`,
  `test_builtin_security_wizard`) unaffected by the new kwarg
- [x] 144 tests across all touched surfaces pass
- [x] `ruff check` + `black --check` clean
- [x] No `claude_agent_sdk` at module scope in the adapter

## Out of scope

- Other Phase 2 adapters (P2.3 dependency-check, P2.4 perf-audit,
  P2.5 doc-audit, P2.6 test-audit) — separate PRs
- Plumbing per-source `budget_usd` down into the wrapped
  workflow's SDK cap — v2 concern

🤖 Generated with [Claude Code](https://claude.com/claude-code)
