### PR TITLE
feat(discovery-sweep): P2.5 — DocAuditSource LLM adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `discovery-sweep` P2.5 — `DocAuditSource` LLM adapter wrapping
+  `DocAuditWorkflow`. Same pattern as P2.1–P2.4 (workflow-INSTANCE
+  level `STRUCTURED_EMIT_FOOTER` via a new `system_prompt_suffix`
+  kwarg on `DocAuditWorkflow.__init__`) with the default
+  `budget_multiplier=1.0` from `LLMSource` (doc-audit sits at the
+  default slot in the Phase 1.5 ratios). Wired into
+  `default_sources()`. Integration coverage marked
+  `@pytest.mark.integration`.
+
 - `discovery-sweep` P2.4 — `PerfAuditSource` LLM adapter
   wrapping `PerformanceAuditWorkflow`. Same pattern as P2.1–P2.3
   (workflow-INSTANCE level `STRUCTURED_EMIT_FOOTER` via a new

--- a/src/attune/workflows/discovery_sweep/cli_workflow.py
+++ b/src/attune/workflows/discovery_sweep/cli_workflow.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from .sources.bug_predict import BugPredictSource
 from .sources.dependency_check import DependencyCheckSource
+from .sources.doc_audit import DocAuditSource
 from .sources.pattern_scan import PatternScanSource
 from .sources.perf_audit import PerfAuditSource
 from .sources.security_audit import SecurityAuditSource
@@ -34,6 +35,7 @@ def default_sources() -> list[FindingSource]:
         SecurityAuditSource(),
         DependencyCheckSource(),
         PerfAuditSource(),
+        DocAuditSource(),
     ]
 
 

--- a/src/attune/workflows/discovery_sweep/sources/doc_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/doc_audit.py
@@ -1,0 +1,157 @@
+"""``DocAuditSource`` — LLM adapter wrapping ``DocAuditWorkflow``.
+
+Mirrors the :class:`BugPredictSource` / :class:`SecurityAuditSource`
+/ :class:`DependencyCheckSource` / :class:`PerfAuditSource`
+pattern: constructs a fresh :class:`DocAuditWorkflow` per call
+with :data:`STRUCTURED_EMIT_FOOTER` passed via
+``system_prompt_suffix`` (workflow-INSTANCE level augmentation
+per Phase 1.5 ``design.md``), invokes ``execute()`` once per
+path, and parses each result's ``final_output`` via
+:func:`parse_findings_json`.
+
+``budget_multiplier = 1.0`` — doc-audit sits at the default slot
+in Phase 1.5's ratio table (security=4 / deps=0.5 / default=1).
+Inherits the marker default from :class:`LLMSource`, no override
+needed.
+
+The ``claude_agent_sdk`` import lives inside :meth:`discover` so
+this module is mock-friendly and doesn't drag the SDK into the
+import graph of every test that touches the engine.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..workflow import Finding
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DocAuditSource(LLMSource):
+    """Discovery-sweep adapter for :class:`DocAuditWorkflow`.
+
+    Three structural attributes (``name``, ``is_llm``,
+    ``budget_multiplier``) satisfy the :class:`FindingSource`
+    Protocol; ``LLMSource`` is inherited for the ``--no-llm``
+    filter marker. ``budget_multiplier`` keeps the LLMSource
+    default of 1.0.
+
+    ``depth`` is configurable per-instance and defaults to
+    ``"standard"`` — same default as standalone
+    ``attune workflow run doc-audit``. Sweep callers that want a
+    cheaper pass can construct with ``depth="quick"``.
+    """
+
+    name: str = "doc-audit"
+    depth: str = "standard"
+
+    async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
+        """Run DocAuditWorkflow on each path and parse findings.
+
+        ``budget_usd`` is informational for v1 — the wrapped
+        workflow self-limits via the SDK's own
+        ``max_budget_usd`` derived from ``depth``. A later PR can
+        plumb the per-source share down once the wrapped workflows
+        accept an explicit per-call cap.
+        """
+        del budget_usd  # See docstring — wrapped workflow caps itself.
+
+        if not paths:
+            logger.warning("doc-audit: no paths to scan")
+            return [_empty_paths_finding(self.name)]
+
+        # Late import keeps ``claude_agent_sdk`` out of this
+        # module's import graph and lets unit tests patch the
+        # workflow class at its source module per the existing
+        # CLAUDE.md deferred-import lesson.
+        from attune.workflows.doc_audit.workflow import DocAuditWorkflow
+
+        findings: list[Finding] = []
+        for path in paths:
+            workflow = DocAuditWorkflow(
+                system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
+            )
+            try:
+                result = await workflow.execute(path=path, depth=self.depth)
+            except Exception as exc:  # noqa: BLE001
+                # INTENTIONAL: per spec NFR-1 a single path failure
+                # must not abort the whole source — log and
+                # continue, surfacing an info-finding so the
+                # engine can route it to ``questions``.
+                logger.exception("doc-audit execute() failed for %s", path)
+                findings.append(_path_failed_finding(self.name, path, exc))
+                continue
+
+            if not getattr(result, "success", False):
+                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                continue
+
+            findings.extend(parse_findings_json(result.final_output or "", self.name))
+
+        return findings
+
+
+def _empty_paths_finding(source_name: str) -> Finding:
+    """Surfacing finding when the engine handed in an empty paths list."""
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} received no paths to scan",
+        description=(
+            "The engine passed an empty paths list to this source; "
+            "the wrapped workflow was not invoked."
+        ),
+        file=None,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )
+
+
+def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Finding:
+    """Per-path failure marker so one bad input doesn't abort the source."""
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} failed on path {path}",
+        description=(
+            f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
+            f"Other paths (if any) were still attempted."
+        ),
+        file=path,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )
+
+
+def _workflow_unsuccessful_finding(
+    source_name: str,
+    path: str,
+    result: object,
+) -> Finding:
+    """Marker for a clean WorkflowResult whose ``success`` came back False."""
+    detail = getattr(result, "final_output", "") or "(no detail returned)"
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} returned an unsuccessful result for {path}",
+        description=(
+            "Wrapped workflow completed without raising but reported "
+            f"success=False. Detail: {detail[:200]}"
+        ),
+        file=path,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -90,6 +90,22 @@ class DocAuditWorkflow(BaseWorkflow):
     stages = ["agent-audit"]
     tier_map = {"agent-audit": ModelTier.CAPABLE}
 
+    def __init__(self, *, system_prompt_suffix: str = "", **kwargs: Any) -> None:
+        """Initialize workflow.
+
+        Args:
+            system_prompt_suffix: Optional string appended to the
+                orchestrator's system prompt at call time. Lets a
+                wrapping caller (e.g. discovery-sweep's
+                ``DocAuditSource``) augment the prompt at the
+                workflow-INSTANCE level without mutating the class
+                template. Empty string (default) preserves prior
+                behavior for every other caller.
+            **kwargs: Passed to BaseWorkflow.__init__().
+        """
+        super().__init__(**kwargs)
+        self._system_prompt_suffix = system_prompt_suffix
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK documentation audit.
 
@@ -161,10 +177,11 @@ class DocAuditWorkflow(BaseWorkflow):
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
+        system_prompt = _SYSTEM_PROMPT + (self._system_prompt_suffix or "")
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
-                system_prompt=_SYSTEM_PROMPT,
+                system_prompt=system_prompt,
                 cwd=resolved_path,
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],

--- a/tests/integration/test_discovery_sweep_doc_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_doc_audit_integration.py
@@ -1,0 +1,81 @@
+"""Integration test for :class:`DocAuditSource`.
+
+Hits the real Anthropic API via the wrapped
+:class:`DocAuditWorkflow`. Marked
+``@pytest.mark.integration`` per the Phase 1.5 design decision so
+the default ``-m "not integration"`` selector skips it; opt-in
+with::
+
+    pytest tests/integration/test_discovery_sweep_doc_audit_integration.py \\
+        -m integration
+
+Runs against a tiny on-disk fixture with ``depth="quick"`` so
+spend stays low (~$2 SDK cap per :func:`get_max_budget_usd`).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from attune.workflows.discovery_sweep.sources.doc_audit import DocAuditSource
+
+pytestmark = pytest.mark.integration
+
+
+_FIXTURE_STALE_README = textwrap.dedent(
+    """\
+    # Fixture Project
+
+    A test project for the doc-audit integration test.
+
+    ## Installation
+
+    The recommended install command is:
+
+    ```bash
+    pip install --legacy-flag fixture-project
+    ```
+
+    > NOTE: this flag was removed in pip 22.0; the doc-audit
+    > should flag this section as stale.
+
+    ## Usage
+
+    Import the package and call `fixture.do_thing()`:
+
+    ```python
+    import fixture
+    fixture.do_thing()  # function was renamed to .run() in 2.0
+    ```
+
+    See [the API reference](./docs/api-v0.md) for details. (broken
+    link — file does not exist)
+    """
+)
+
+
+@pytest.mark.asyncio
+async def test_doc_audit_source_returns_findings_for_stale_readme(
+    tmp_path: Path,
+) -> None:
+    """Real sweep on a fixture README produces at least one parsed finding.
+
+    Doesn't assert specific titles or severities — the model's
+    exact wording drifts between runs. Asserts only the structural
+    contract: at least one Finding with our adapter's source name,
+    and not the text-only-fallback shape (which would indicate the
+    JSON-emit contract broke).
+    """
+    (tmp_path / "README.md").write_text(_FIXTURE_STALE_README, encoding="utf-8")
+
+    source = DocAuditSource(depth="quick")
+    findings = await source.discover([str(tmp_path)], budget_usd=2.0)
+
+    assert findings, "expected at least one finding from real doc-audit run"
+    assert all(f.source == "doc-audit" for f in findings)
+    assert not any(
+        "text-only-fallback" in f.tags for f in findings
+    ), "structured-emit contract failed — adapter fell back to text-only path"

--- a/tests/unit/workflows/discovery_sweep/test_doc_audit_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_doc_audit_source.py
@@ -1,0 +1,346 @@
+"""Unit tests for :class:`DocAuditSource`.
+
+Mocks ``DocAuditWorkflow`` at its source module (per the existing
+CLAUDE.md lesson on deferred imports). Integration coverage gated
+on ``@pytest.mark.integration`` lives in
+``tests/integration/test_discovery_sweep_doc_audit_integration.py``.
+
+Same shape as the P2.1–P2.4 adapter test files — every Phase 2B
+adapter is testable from this pattern.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from unittest.mock import patch
+
+import pytest
+
+from attune.workflows.discovery_sweep import Finding
+from attune.workflows.discovery_sweep.cli_workflow import default_sources
+from attune.workflows.discovery_sweep.llm_source_base import STRUCTURED_EMIT_FOOTER
+from attune.workflows.discovery_sweep.sources.doc_audit import DocAuditSource
+
+SOURCE = "doc-audit"
+
+
+@dataclass
+class _FakeResult:
+    success: bool = True
+    final_output: str = ""
+
+
+@dataclass
+class _RecordedCall:
+    init_kwargs: dict
+    execute_kwargs: dict
+
+
+@dataclass
+class _FakeWorkflowFactory:
+    """Hand-rolled stand-in for ``DocAuditWorkflow``."""
+
+    results: list[_FakeResult] = field(default_factory=list)
+    side_effects: list[Exception | None] = field(default_factory=list)
+    calls: list[_RecordedCall] = field(default_factory=list)
+
+    def __call__(self, **kwargs):
+        instance_index = len(self.calls)
+        recorded = _RecordedCall(init_kwargs=kwargs, execute_kwargs={})
+
+        async def _execute(**execute_kwargs):
+            recorded.execute_kwargs = execute_kwargs
+            if instance_index < len(self.side_effects):
+                exc = self.side_effects[instance_index]
+                if exc is not None:
+                    raise exc
+            if instance_index < len(self.results):
+                return self.results[instance_index]
+            return _FakeResult(success=True, final_output="")
+
+        instance = type(
+            "FakeInstance",
+            (),
+            {"execute": staticmethod(_execute)},
+        )()
+        self.calls.append(recorded)
+        return instance
+
+
+def _wrap_json(payload: dict) -> str:
+    return f"prose\n\n```json\n{json.dumps(payload)}\n```\n"
+
+
+def _wellformed_payload() -> dict:
+    return {
+        "findings": [
+            {
+                "severity": "medium",
+                "title": "stale install instructions",
+                "description": "README mentions deprecated CLI flag.",
+                "file": "README.md",
+                "line": 24,
+                "evidence": "pip install --legacy-flag",
+                "confidence": 0.8,
+                "tags": ["stale", "install"],
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Source-level attributes
+# ---------------------------------------------------------------------------
+
+
+def test_source_defaults() -> None:
+    """Defaults conform to LLMSource marker + default 1.0 budget multiplier."""
+    source = DocAuditSource()
+    assert source.name == SOURCE
+    assert source.is_llm is True
+    assert source.budget_multiplier == 1.0
+    assert source.depth == "standard"
+
+
+def test_source_appears_in_default_sources() -> None:
+    """Wired into ``default_sources()`` per task P2.5 step 5."""
+    sources = default_sources()
+    matched = [s for s in sources if s.name == SOURCE]
+    assert len(matched) == 1
+    assert isinstance(matched[0], DocAuditSource)
+
+
+# ---------------------------------------------------------------------------
+# discover() happy paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_path_returns_parsed_findings() -> None:
+    """Single path → one execute() call → parsed structured findings."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json(_wellformed_payload()))],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover(["docs/"], budget_usd=1.0)
+
+    assert findings == [
+        Finding(
+            source=SOURCE,
+            severity="medium",
+            title="stale install instructions",
+            description="README mentions deprecated CLI flag.",
+            file="README.md",
+            line=24,
+            evidence="pip install --legacy-flag",
+            confidence=0.8,
+            tags=("stale", "install"),
+        )
+    ]
+    assert len(factory.calls) == 1
+    assert factory.calls[0].execute_kwargs == {"path": "docs/", "depth": "standard"}
+
+
+@pytest.mark.asyncio
+async def test_constructor_receives_structured_emit_footer() -> None:
+    """``system_prompt_suffix`` is the augmentation channel per design.md."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json({"findings": []}))],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        await DocAuditSource().discover(["docs/"], budget_usd=1.0)
+
+    assert factory.calls[0].init_kwargs == {
+        "system_prompt_suffix": STRUCTURED_EMIT_FOOTER,
+    }
+
+
+@pytest.mark.asyncio
+async def test_custom_depth_is_passed_to_execute() -> None:
+    """``depth="quick"`` reaches the wrapped workflow's execute() call."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output=_wrap_json({"findings": []}))],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        await DocAuditSource(depth="quick").discover(["docs/"], budget_usd=1.0)
+
+    assert factory.calls[0].execute_kwargs == {"path": "docs/", "depth": "quick"}
+
+
+@pytest.mark.asyncio
+async def test_multiple_paths_yield_per_path_calls_and_concat_findings() -> None:
+    """Each path → its own execute() call; findings concatenate in order."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "medium",
+                                "title": "first",
+                                "description": "from path 1",
+                                "confidence": 0.6,
+                            }
+                        ]
+                    }
+                ),
+            ),
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "low",
+                                "title": "second",
+                                "description": "from path 2",
+                                "confidence": 0.7,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover(["docs/a/", "docs/b/"], budget_usd=1.0)
+
+    assert len(factory.calls) == 2
+    assert [f.title for f in findings] == ["first", "second"]
+
+
+# ---------------------------------------------------------------------------
+# discover() degradation paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_paths_returns_source_failure_finding() -> None:
+    """Empty paths list → one info-finding, no workflow invocation."""
+    factory = _FakeWorkflowFactory()
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover([], budget_usd=1.0)
+
+    assert factory.calls == []
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.source == SOURCE
+    assert only.severity == "info"
+    assert only.tags == ("source-failure",)
+
+
+@pytest.mark.asyncio
+async def test_wrapped_workflow_raise_does_not_abort_other_paths() -> None:
+    """One path raises → recorded as source-failure; remaining paths run."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(),  # ignored — first instance raises
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(
+                    {
+                        "findings": [
+                            {
+                                "severity": "high",
+                                "title": "real finding",
+                                "description": "from second path",
+                                "confidence": 0.9,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        ],
+        side_effects=[RuntimeError("boom"), None],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover(["bad-docs/", "good-docs/"], budget_usd=1.0)
+
+    assert len(findings) == 2
+    assert findings[0].tags == ("source-failure",)
+    assert findings[0].file == "bad-docs/"
+    assert findings[1].title == "real finding"
+
+
+@pytest.mark.asyncio
+async def test_wrapped_workflow_returns_success_false() -> None:
+    """``WorkflowResult.success=False`` → info-finding, no parse attempt."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=False, final_output="path argument is required")],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover(["docs/"], budget_usd=1.0)
+
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.tags == ("source-failure",)
+    assert only.file == "docs/"
+
+
+@pytest.mark.asyncio
+async def test_unparseable_output_falls_back_to_parser_fallback() -> None:
+    """No JSON block → parser's text-only-fallback finding."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output="Just prose; no json block.")],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover(["docs/"], budget_usd=1.0)
+
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.confidence == 0.1
+    assert only.tags == ("text-only-fallback",)
+
+
+@pytest.mark.asyncio
+async def test_empty_final_output_falls_back() -> None:
+    """``final_output`` may be None/empty — handle defensively."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(success=True, final_output="")],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover(["docs/"], budget_usd=1.0)
+
+    assert len(findings) == 1
+    assert findings[0].tags == ("text-only-fallback",)


### PR DESCRIPTION
## Summary

Fifth LLM-backed `FindingSource` for discovery-sweep. Wraps
`DocAuditWorkflow` using the same workflow-INSTANCE augmentation
pattern P2.1–P2.4 established.

**Workflow-instance-level prompt augmentation.** New
`system_prompt_suffix: str = ""` kwarg on
`DocAuditWorkflow.__init__` (added — the workflow previously had
no explicit `__init__`), appended to `_SYSTEM_PROMPT` inside
`_run_agent_audit`. Default-empty is a no-op for every existing
caller (standalone CLI, MCP `doc_audit`, ops dashboard).

**`DocAuditSource`** (~155 LoC, inherits `LLMSource`):

1. Construct `DocAuditWorkflow(system_prompt_suffix=
   STRUCTURED_EMIT_FOOTER)` per path
2. `await workflow.execute(path=path, depth=self.depth)`
3. Parse `final_output` via `parse_findings_json`

`budget_multiplier=1.0` (LLMSource default) — doc-audit sits at
the default slot in Phase 1.5's ratio table (security=4 /
deps=0.5 / default=1).

Same degradation paths as P2.1–P2.4 — empty paths, per-path
failure, `success=False`, unparseable output → info-findings with
`("source-failure",)` or `("text-only-fallback",)` tags. Engine
routes to `questions`, never aborts the sweep.

Wired into `default_sources()` after `PerfAuditSource`.

## Test plan

- [x] 11 unit tests in `test_doc_audit_source.py` (cloned from
  P2.1–P2.4's pattern)
- [x] 1 `@pytest.mark.integration` test on a fixture README with
  stale install flag, renamed function reference, and broken link
- [x] 188 tests pass across discovery_sweep + all
  DocAuditWorkflow consumers
- [x] `ruff check` + `black --check` clean
- [x] No `claude_agent_sdk` at module scope in the adapter

## Discovery-sweep progress

Phase 2B is now 5 of 6 adapters complete:

- ✅ Phase 1, 1.5, 2A merged
- ✅ P2.1 BugPredictSource (#314)
- ✅ P2.2 SecurityAuditSource (#315)
- ✅ P2.3 DependencyCheckSource (#316)
- ✅ P2.4 PerfAuditSource (#317)
- 🟡 **P2.5 DocAuditSource (this PR)**
- ⏳ P2.6 TestAuditSource — last of Phase 2B
- ⏳ P2.7 surface evaluation, Phase 3 polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
