### PR TITLE
feat(discovery-sweep): Phase 3 — CLI output polish + JSON mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `discovery-sweep` Phase 3 — CLI output polish + JSON mode.
+  `attune workflow run discovery-sweep` learns three new flags:
+  `--verbose` (include the rejected bucket in markdown output),
+  `--no-llm` (filter to non-LLM sources only — only
+  `PatternScanSource` survives), and `--source <name>` (run only
+  one source by name; useful for debugging single adapters).
+  Existing `--json` flag now produces a clean structured payload
+  matching `design.md` § Data model: `{"queue": [...],
+  "questions": [...], "rejected": [...], "metadata": {...}}` with
+  every Finding's tuple `tags` serialized as JSON arrays. The
+  workflow's `execute()` learns an `output_format` kwarg
+  (`"markdown"` default, `"json"` opt-in) so library callers can
+  request either rendering without going through the CLI. Phase
+  3.2 (severity-colored badges) deferred to a follow-up — the
+  spec calls it polish; the markdown rendering ships as-is.
+
 - `discovery-sweep` P2.6 — `TestAuditSource` LLM adapter wrapping
   `TestAuditWorkflow`. Final Phase 2B adapter; same pattern as
   P2.1–P2.5 (workflow-INSTANCE level `STRUCTURED_EMIT_FOOTER` via

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -110,6 +110,21 @@ def cmd_workflow_run(args: Namespace) -> int:
     if args.target:
         input_data["target"] = args.target
 
+    # Discovery-sweep flags (no-op for workflows that don't accept them
+    # since execute() takes **kwargs — extra keys are dropped silently).
+    if getattr(args, "verbose", False):
+        input_data["verbose"] = True
+    if getattr(args, "no_llm", False):
+        input_data["no_llm"] = True
+    if getattr(args, "source", None):
+        input_data["source"] = args.source
+    if getattr(args, "json", False):
+        # Let workflows that honor it render their own JSON via
+        # ``final_output`` rather than the generic ``json.dumps(result)``
+        # at the bottom of this function (which produces awkward output
+        # for nested dataclasses).
+        input_data["output_format"] = "json"
+
     print(f"\n🚀 Running workflow: {name}\n")
 
     try:
@@ -123,7 +138,15 @@ def cmd_workflow_run(args: Namespace) -> int:
 
         # Output result
         if args.json:
-            print(json.dumps(result, indent=2, default=str))
+            # Prefer the workflow's own JSON rendering in
+            # ``final_output`` when it honored ``output_format="json"``
+            # (cleaner than ``json.dumps(WorkflowResult)`` which serializes
+            # the stages/cost metadata too).
+            final_output = getattr(result, "final_output", "") or ""
+            if final_output.lstrip().startswith(("{", "[")):
+                print(final_output)
+            else:
+                print(json.dumps(result, indent=2, default=str))
         else:
             _print_workflow_result(result, workflow_name=name)
 

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -151,6 +151,22 @@ def _add_workflow_subparsers(subparsers: argparse._SubParsersAction) -> None:
     )
     run_parser.add_argument("--target", "-t", help="Target value (e.g., coverage target)")
     run_parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    run_parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Discovery-sweep: include rejected bucket in markdown output",
+    )
+    run_parser.add_argument(
+        "--no-llm",
+        dest="no_llm",
+        action="store_true",
+        help="Discovery-sweep: filter to non-LLM sources only (pattern scan)",
+    )
+    run_parser.add_argument(
+        "--source",
+        help="Discovery-sweep: run only the named source (e.g. bug-predict)",
+    )
 
 
 def _add_telemetry_subparsers(subparsers: argparse._SubParsersAction) -> None:

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -222,6 +222,26 @@ def _render_markdown(result: SweepResult, *, verbose: bool = False) -> str:
     return "\n".join(out)
 
 
+def _render_json(result: SweepResult) -> str:
+    """JSON rendering of a sweep result matching ``design.md`` § Data model.
+
+    Uses :func:`dataclasses.asdict` which recursively converts the
+    frozen Finding / QuestionFinding / RejectedFinding dataclasses
+    into plain dicts; tuple fields (notably ``Finding.tags``) become
+    JSON arrays. Top-level shape is
+    ``{"queue": [...], "questions": [...], "rejected": [...],
+    "metadata": {...}}`` — directly consumable by CI tooling and
+    the ops dashboard.
+
+    Imports are function-scoped so the existing markdown-only call
+    path doesn't pay for ``json`` / ``asdict`` at module import.
+    """
+    import json
+    from dataclasses import asdict
+
+    return json.dumps(asdict(result), indent=2, default=str)
+
+
 # ---------------------------------------------------------------------------
 # Engine
 # ---------------------------------------------------------------------------
@@ -320,15 +340,26 @@ class DiscoverySweepWorkflow(BaseWorkflow):
                 :data:`DEFAULT_BUDGET_USD` ($10.00).
             sources: Optional explicit list of :class:`FindingSource`
                 adapters; defaults to :func:`default_sources`.
-            no_llm: If True, filter to non-LLM sources only.
+            no_llm: If True, filter to non-LLM sources only
+                (``is_llm = False`` adapters survive the filter).
+            source: Optional source-name filter — only the named
+                source runs. Mutually exclusive with ``no_llm``;
+                if both are passed, ``no_llm`` applies first then
+                ``source`` filters within the survivors.
             verbose: If True, include the rejected bucket in the
                 rendered ``final_output`` markdown.
+            output_format: ``"markdown"`` (default, human-readable)
+                or ``"json"`` (machine-readable, matches design.md
+                § Data model). ``verbose`` is implied for ``"json"``
+                — JSON output always carries all three buckets.
         """
         path: str = kwargs.get("path", "")
         budget_usd: float = float(kwargs.get("budget_usd", DEFAULT_BUDGET_USD))
         sources: list[FindingSource] | None = kwargs.get("sources")
         no_llm: bool = bool(kwargs.get("no_llm", False))
+        source_filter: str | None = kwargs.get("source")
         verbose: bool = bool(kwargs.get("verbose", False))
+        output_format: str = str(kwargs.get("output_format", "markdown"))
 
         if not path:
             return self._error_result("path argument is required")
@@ -344,8 +375,13 @@ class DiscoverySweepWorkflow(BaseWorkflow):
         if no_llm:
             sources = [s for s in sources if not getattr(s, "is_llm", True)]
 
+        if source_filter:
+            sources = [s for s in sources if s.name == source_filter]
+
         if not sources:
-            return self._error_result("no sources to run (use --source or drop --no-llm)")
+            return self._error_result(
+                "no sources to run (check --source name, drop --no-llm, or both)"
+            )
 
         allocations = self._allocate_budget(sources, budget_usd)
         paths = _expand_path(path)
@@ -376,7 +412,11 @@ class DiscoverySweepWorkflow(BaseWorkflow):
                     description=self.description,
                 )
             ],
-            final_output=_render_markdown(sweep, verbose=verbose),
+            final_output=(
+                _render_json(sweep)
+                if output_format == "json"
+                else _render_markdown(sweep, verbose=verbose)
+            ),
             cost_report=CostReport(
                 total_cost=sweep.metadata.spent_usd,
                 baseline_cost=sweep.metadata.budget_usd,

--- a/tests/unit/workflows/discovery_sweep/test_engine.py
+++ b/tests/unit/workflows/discovery_sweep/test_engine.py
@@ -213,3 +213,112 @@ class TestValidation:
         res = asyncio.run(wf.execute(sources=[]))
         assert res.success is False
         assert "path argument is required" in (res.error or "")
+
+
+class TestSourceNameFilter:
+    """Phase 3 P3.5 — ``source`` kwarg narrows fan-out to one adapter."""
+
+    def test_source_filter_runs_only_named_source(self) -> None:
+        bug = FakeSource(name="bug-predict", is_llm=True, findings=[_finding()])
+        sec = FakeSource(name="security-audit", is_llm=True, findings=[_finding()])
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[bug, sec], source="bug-predict"))
+        sweep: SweepResult = res.metadata["sweep"]
+        assert sweep.metadata.sources == ["bug-predict"]
+
+    def test_source_filter_unknown_name_errors(self) -> None:
+        bug = FakeSource(name="bug-predict", is_llm=True, findings=[])
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[bug], source="missing"))
+        assert res.success is False
+        assert "no sources to run" in (res.error or "")
+
+    def test_source_and_no_llm_combine(self) -> None:
+        """``no_llm`` applies first, then ``source`` filters survivors."""
+        bug = FakeSource(name="bug-predict", is_llm=True, findings=[])
+        pat = FakeSource(name="pattern-scan", is_llm=False, findings=[])
+        wf = DiscoverySweepWorkflow()
+        # no-LLM keeps only pat; source="bug-predict" then matches nothing.
+        res = asyncio.run(
+            wf.execute(
+                path="src/",
+                sources=[bug, pat],
+                no_llm=True,
+                source="bug-predict",
+            )
+        )
+        assert res.success is False
+
+
+class TestOutputFormatJson:
+    """Phase 3 P3.1 — ``output_format='json'`` renders SweepResult as JSON."""
+
+    def test_json_output_is_parseable_with_expected_top_level(self) -> None:
+        import json as _json
+
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[_finding(severity="high", file="a.py", line=1)],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src], output_format="json"))
+        payload = _json.loads(res.final_output)
+        assert set(payload.keys()) == {"queue", "questions", "rejected", "metadata"}
+        assert len(payload["queue"]) == 1
+        assert payload["queue"][0]["severity"] == "high"
+        assert payload["queue"][0]["file"] == "a.py"
+        assert payload["metadata"]["sources"] == ["s"]
+
+    def test_json_output_serializes_tuple_tags_as_array(self) -> None:
+        import json as _json
+
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[
+                _finding(
+                    severity="medium",
+                    file="b.py",
+                    line=2,
+                    tags=("cwe-95", "review-me"),
+                )
+            ],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src], output_format="json"))
+        payload = _json.loads(res.final_output)
+        assert payload["queue"][0]["tags"] == ["cwe-95", "review-me"]
+
+    def test_markdown_is_the_default_output_format(self) -> None:
+        src = FakeSource(name="s", is_llm=False, findings=[_finding()])
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src]))
+        assert "## Queue" in res.final_output
+        assert not res.final_output.lstrip().startswith("{")
+
+
+class TestVerboseFlag:
+    """Phase 3 P3.3 — ``verbose=True`` includes rejected bucket in markdown."""
+
+    def test_verbose_false_hides_rejected_details(self) -> None:
+        # Severity below threshold (info) → routed to rejected.
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[_finding(severity="info", file="a.py", line=1)],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src]))
+        assert "use --verbose to see" in res.final_output
+
+    def test_verbose_true_shows_rejected_details(self) -> None:
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[_finding(severity="info", file="a.py", line=1)],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src], verbose=True))
+        assert "## Rejected" in res.final_output
+        assert "Rule:" in res.final_output


### PR DESCRIPTION
## Summary

Phase 3 of `docs/specs/discovery-sweep/` — CLI output polish + JSON
mode. Implements `tasks.md` **P3.1** (`--json`), **P3.3**
(`--verbose`), **P3.4** (`--no-llm`), and **P3.5** (`--source`) in
one PR. **P3.2** (severity-colored badges) deferred per the spec's
"polish" characterization — happy to revisit if you want it
bundled.

## Engine surface

`DiscoverySweepWorkflow.execute()` learns two new optional kwargs:

- **`output_format: str = "markdown"`** — accepts `"markdown"`
  (default) or `"json"`. JSON renders via new
  `_render_json(SweepResult)` using `dataclasses.asdict()` +
  `json.dumps()`. Output matches `design.md` § Data model exactly:
  ```json
  {"queue": [...], "questions": [...], "rejected": [...],
   "metadata": {...}}
  ```
  Tuple `tags` become JSON arrays via asdict's recursion.
- **`source: str | None = None`** — filters fan-out to a single
  adapter by name. Applied AFTER `no_llm` so the two compose
  cleanly.

## CLI surface

`attune workflow run <name>` adds three flags:

| Flag | Effect |
|---|---|
| `--verbose` / `-v` | `verbose=True`; markdown includes rejected bucket |
| `--no-llm` | `no_llm=True`; filters to non-LLM sources only |
| `--source <name>` | `source=name`; runs only the named adapter |

Existing `--json` / `-j` now passes `output_format="json"` so the
workflow renders its own structured JSON in `final_output` rather
than the generic `json.dumps(WorkflowResult)` fallback (which
produces awkward output for nested dataclasses). CLI detects a
JSON-like `final_output` (starts with `{` or `[`) and prints it
verbatim, preserving the workflow's chosen schema. Workflows that
don't honor `output_format` still get the legacy fallback.

End-to-end smoke test:
```
$ attune workflow run discovery-sweep --path src/attune/security/ --no-llm --json
{
  "queue": [], "questions": [], "rejected": [],
  "metadata": {"spent_usd": 0.0, "budget_usd": 10.0,
               "sources": ["pattern-scan"], "failures": [],
               "duration_ms": 1}
}
```

## Test plan

- [x] 8 new tests in `test_engine.py`:
  - `TestSourceNameFilter` (3) — single-source filter, unknown
    name, `no_llm` composition
  - `TestOutputFormatJson` (3) — parses, top-level shape, tuple
    tags as arrays, markdown still default
  - `TestVerboseFlag` (2) — rejected hidden vs shown
- [x] 355 tests pass across discovery_sweep + cli_commands
- [x] CLI smoke test on real path (`--no-llm --json` on
  `src/attune/security/`) returns clean JSON
- [x] `ruff check` + `black --check` clean
- [x] No behavior change for workflows that don't accept the new
  kwargs (no-op via `**kwargs` swallow)

## What's next in the spec

- **P3.2** — severity-colored badges + rich console formatting
  (separate PR, no API spend, pure polish)
- **P2.7** — empirical surface evaluation (run real sweeps on
  attune codebase; identify retire/keep/defer candidates)
- **Phase 4** — CLI deprecation of any P2.7 RETIRE candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
