### PR TITLE
feat(discovery-sweep): Phase 3.2 — ANSI severity badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `discovery-sweep` Phase 3.2 — severity-colored badges in
+  markdown output. Findings render with ANSI-colored
+  `[critical]` (bold red), `[high]` (red), `[medium]` (yellow),
+  `[low]` (blue), and `[info]` (dim) badges when stdout is an
+  interactive terminal. Pipes, CI logs, and file redirects get
+  plain brackets (no ANSI codes) so logs stay grep-friendly.
+  Follows no-color.org: `NO_COLOR=1` forces plain output,
+  `FORCE_COLOR=1` forces color (NO_COLOR wins on conflict). JSON
+  output (`--json` / `output_format="json"`) is unaffected — no
+  codes ever leak into structured output.
+
 - `discovery-sweep` P2.7 — surface evaluation published at
   `docs/specs/discovery-sweep/surface-evaluation.md`. Decision:
   **KEEP all six standalone audit workflows alongside

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -169,25 +169,76 @@ class FindingSource(Protocol):
 # ---------------------------------------------------------------------------
 
 
-def _render_finding_line(f: Finding) -> str:
+# ANSI severity color map. Aligned with the project's existing
+# `attune.workflows.output` pattern (high=red / medium=yellow /
+# low=blue / info=dim) with critical bumped to bold-red to
+# differentiate from high.
+_SEVERITY_ANSI: dict[str, str] = {
+    "critical": "\x1b[1;31m",  # bold red
+    "high": "\x1b[31m",  # red
+    "medium": "\x1b[33m",  # yellow
+    "low": "\x1b[34m",  # blue
+    "info": "\x1b[2m",  # dim
+}
+_ANSI_RESET = "\x1b[0m"
+
+
+def _should_color() -> bool:
+    """True when ANSI escape codes should be injected into output.
+
+    Follows the ``NO_COLOR`` env convention (no-color.org) — any
+    non-empty value disables color. ``FORCE_COLOR=1`` overrides TTY
+    detection for tests and piped invocations that want color.
+    Otherwise, attaches color only when stdout is an interactive
+    terminal.
+    """
+    import os
+    import sys
+
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    return sys.stdout.isatty()
+
+
+def _severity_badge(severity: str, *, colored: bool) -> str:
+    """Return the bracketed ``[severity]`` badge, optionally colored."""
+    label = f"[{severity}]"
+    if not colored:
+        return label
+    code = _SEVERITY_ANSI.get(severity, "")
+    if not code:
+        return label
+    return f"{code}{label}{_ANSI_RESET}"
+
+
+def _render_finding_line(f: Finding, *, colored: bool = False) -> str:
     location = f.file or "(no file)"
     if f.line is not None:
         location = f"{location}:{f.line}"
-    return f"[{f.severity}] {location}\n  {f.title}\n  Source: {f.source}"
+    return f"{_severity_badge(f.severity, colored=colored)} {location}\n  {f.title}\n  Source: {f.source}"
 
 
 def _render_markdown(result: SweepResult, *, verbose: bool = False) -> str:
     """Human-readable rendering used in ``WorkflowResult.final_output``.
 
-    The CLI surface in Phase 3 will replace this with rich formatting;
-    Phase 1 ships plain markdown so the engine works end-to-end before
-    polish work begins.
+    Severity badges (``[critical]``, ``[high]``, ``[medium]``,
+    ``[low]``, ``[info]``) are colored via ANSI escape codes when
+    stdout is a TTY (and ``NO_COLOR`` is unset). Non-TTY output —
+    pipes, CI logs, file redirects — gets plain brackets so logs
+    stay grep-friendly.
+
+    The check happens once per render via :func:`_should_color`
+    rather than per-finding, so a single tty-detection cost amortizes
+    across the whole report.
     """
+    colored = _should_color()
     out: list[str] = []
     out.append(f"## Queue ({len(result.queue)} findings)\n")
     if result.queue:
         for f in result.queue:
-            out.append(_render_finding_line(f))
+            out.append(_render_finding_line(f, colored=colored))
             if f.evidence:
                 out.append(f"  Evidence: {f.evidence}")
             out.append("")
@@ -197,7 +248,7 @@ def _render_markdown(result: SweepResult, *, verbose: bool = False) -> str:
     out.append(f"## Questions ({len(result.questions)} findings)\n")
     if result.questions:
         for q in result.questions:
-            out.append(_render_finding_line(q.finding))
+            out.append(_render_finding_line(q.finding, colored=colored))
             out.append(f"  Why a question: {q.reason}")
             out.append(f"  Next step: {q.next_step}")
             out.append("")
@@ -207,7 +258,7 @@ def _render_markdown(result: SweepResult, *, verbose: bool = False) -> str:
     if verbose:
         out.append(f"## Rejected ({len(result.rejected)} findings)\n")
         for r in result.rejected:
-            out.append(_render_finding_line(r.finding))
+            out.append(_render_finding_line(r.finding, colored=colored))
             out.append(f"  Rule: {r.rule}")
             out.append("")
     else:

--- a/tests/unit/workflows/discovery_sweep/test_engine.py
+++ b/tests/unit/workflows/discovery_sweep/test_engine.py
@@ -322,3 +322,80 @@ class TestVerboseFlag:
         res = asyncio.run(wf.execute(path="src/", sources=[src], verbose=True))
         assert "## Rejected" in res.final_output
         assert "Rule:" in res.final_output
+
+
+class TestSeverityColorBadges:
+    """Phase 3.2 — ANSI severity badges when stdout is a TTY.
+
+    ``NO_COLOR`` and ``FORCE_COLOR`` both follow no-color.org
+    convention. Tests use ``monkeypatch`` on env so they're
+    deterministic regardless of where they run (TTY-on local,
+    TTY-off CI).
+    """
+
+    def test_no_color_env_forces_plain_brackets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.delenv("FORCE_COLOR", raising=False)
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[_finding(severity="high", file="a.py", line=1)],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src]))
+        # Plain bracket with no ANSI escape codes.
+        assert "[high]" in res.final_output
+        assert "\x1b[" not in res.final_output
+
+    def test_force_color_injects_ansi_codes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[_finding(severity="high", file="a.py", line=1)],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src]))
+        # Red severity wrapped in ANSI codes.
+        assert "\x1b[31m[high]\x1b[0m" in res.final_output
+
+    def test_force_color_critical_is_bold_red(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Critical is bumped to bold-red (`\\x1b[1;31m`) to distinguish from high."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[_finding(severity="critical", file="a.py", line=1)],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src]))
+        assert "\x1b[1;31m[critical]\x1b[0m" in res.final_output
+
+    def test_no_color_takes_precedence_over_force_color(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """NO_COLOR wins (per no-color.org); FORCE_COLOR doesn't override it."""
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[_finding(severity="high", file="a.py", line=1)],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src]))
+        assert "\x1b[" not in res.final_output
+
+    def test_json_output_never_includes_ansi_codes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Even with FORCE_COLOR, the JSON path must stay clean."""
+        monkeypatch.setenv("FORCE_COLOR", "1")
+        src = FakeSource(
+            name="s",
+            is_llm=False,
+            findings=[_finding(severity="high", file="a.py", line=1)],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src], output_format="json"))
+        assert "\x1b[" not in res.final_output


### PR DESCRIPTION
## Summary

Phase 3.2 polish — severity badges now render in ANSI color when
stdout is an interactive terminal. Pipes/CI logs/file redirects
still get plain `[high]` brackets so logs stay grep-friendly.

| Severity | ANSI | Visual |
|---|---|---|
| critical | `\x1b[1;31m` | **bold red** |
| high | `\x1b[31m` | red |
| medium | `\x1b[33m` | yellow |
| low | `\x1b[34m` | blue |
| info | `\x1b[2m` | dim |

Colors align with the existing `attune.workflows.output` pattern
(high=red / medium=yellow / low=blue / info=dim); critical gets
bumped to bold-red to differentiate from high.

## TTY detection + env conventions

`_should_color()` follows no-color.org:

- **`NO_COLOR=1`** — never inject color (wins on conflict)
- **`FORCE_COLOR=1`** — force color regardless of TTY
- Otherwise, `sys.stdout.isatty()`

Tests use `monkeypatch` on both env vars so they're deterministic
whether they run locally (TTY-on) or in CI (TTY-off).

## What's NOT included

- **Rich-markup tags** (`[red]high[/red]`) — incompatible with the
  voice layer's plain `print()` final step. ANSI codes work via
  `print()` directly.
- **Clickable file:line links** — the existing `foo.py:42` format
  already auto-links in modern terminals (iTerm, VSCode, GitHub
  Actions). Spec note "already standard in attune output" confirms.
- **JSON output** (`--json` / `output_format="json"`) is unaffected.
  No ANSI codes ever leak into structured output — asserted by
  `test_json_output_never_includes_ansi_codes`.

## Test plan

- [x] 5 new tests in `TestSeverityColorBadges` cover NO_COLOR
  precedence, FORCE_COLOR, critical-bold-red, NO_COLOR wins on
  conflict, JSON-stays-clean
- [x] 154 tests pass across discovery_sweep
- [x] `ruff check` + `black --check` clean
- [x] No behavior change for callers that consume `final_output`
  outside a TTY — they get the same plain brackets as before

## Spec progression

With this PR, **Phase 3 closes 100% complete**:

- ✅ 3.1 `--json` flag (#320)
- ✅ **3.2 severity-colored badges (this PR)**
- ✅ 3.3 `--verbose` flag (#320)
- ✅ 3.4 `--no-llm` flag (#320)
- ✅ 3.5 `--source <name>` flag (#320)

Remaining discovery-sweep work: ops-dashboard integration
(separate follow-up spec, PR incoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
