### PR TITLE
feat(ops): runner-tier2 Phase 2 — scope picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,25 @@ Two follow-up beats already in flight:
   non-blocking. Spec:
   `docs/specs/discovery-sweep-ops-integration/`.
 
+- Ops dashboard scope picker (ops-runner-tier2 Phase 2) — each
+  workflow row in `/workflows` now has a per-row dropdown that
+  scopes the run to one feature (parsed from
+  `.help/features.yaml`) or a custom path. The picker passes
+  `{"path": "..."}` as the POST body to
+  `/workflows/<name>/run`; the runner threads that into
+  `--path <value>` on the subprocess invocation. Workflows
+  without a `PATH_ARG_REGISTRY` entry render an inline "n/a"
+  span instead of a picker. Path validation goes through
+  `_validate_file_path(allowed_dir=project_root)`, so traversal
+  attempts (`/etc/passwd`, `../outside`) return 400 before the
+  subprocess is spawned. `Run.path` is included in `to_dict()`
+  and replayed in the run log preamble so the executed command
+  is visible end-to-end. 20 new tests cover feature parsing
+  (well-formed, malformed, missing, glob-only edge case),
+  mtime cache invalidation, run-with-path subprocess wiring,
+  path validation rejections, no-path-workflow rejection, and
+  template rendering in both run and read-only modes.
+
 - `discovery-sweep` Phase 3.2 — severity-colored badges in
   markdown output. Findings render with ANSI-colored
   `[critical]` (bold red), `[high]` (red), `[medium]` (yellow),

--- a/docs/specs/_sequencing.md
+++ b/docs/specs/_sequencing.md
@@ -86,16 +86,18 @@ natural pause.
 
 ### ops-runner-tier2
 
-- Status: approved — 37 tasks, 0% done (largest spec)
+- Status: Phase 1 + Phase 2 shipped; Phases 3–5 pending
 - Why after security-hardening: 5 phases, each shippable.
   Phase 1 is pure inspection so it can start anytime. Phases
   3 and 4 ship together for the chaining UX.
 - Tasks
-  - [ ] Phase 1 — workflow registry verification
-  - [ ] Phase 2 — scope picker (dropdown + custom path)
+  - [x] Phase 1 — workflow registry verification (2026-05-13)
+  - [x] Phase 2 — scope picker (dropdown + custom path) (2026-05-14)
   - [ ] Phase 3 — persist recent runs
   - [ ] Phase 4 — clickable workflow-name pills
   - [ ] Phase 5 — structured recommendations
+- Phase 2 unblocks the discovery-sweep-ops-integration spec
+  (per its design dependency on the scope picker).
 - Spec: [ops-runner-tier2](ops-runner-tier2/)
 
 ### discovery-sweep — done 2026-05-13
@@ -239,19 +241,19 @@ Open only if a trigger condition fires.
 
 ## Today's recommended pick
 
-**ops-runner-tier2 Phase 1.3** — implement the
-`PATH_ARG_REGISTRY` dict per PR #285's audit. The audit
-proved hypothesis H2 right (workflow `--path` support is
-uneven) and proposed a three-way registry (Option 2) instead
-of the spec's literal binary. ~50 LoC: registry dict in
-`src/attune/ops/data.py` + drift-guard test in
-`tests/unit/ops/test_path_support_registry.py`. Once landed,
-Phases 2–5 of ops-runner-tier2 can read the registry and
-ship the scope picker.
+**ops-runner-tier2 Phase 3** — persist recent runs to disk
+so the dashboard survives a server restart without losing
+history. Bundle with Phase 4 (clickable workflow-name pills)
+for the chaining UX, per the spec's "3 and 4 ship together"
+note.
 
-Alternative: **test-quality-program** — continuous module-
-by-module work via the rubric. Slot whenever there's spare
-context between bigger work.
+Alternative: **discovery-sweep-ops-integration** — now
+unblocked by Phase 2's scope picker. Or **test-quality-program**
+as opportunistic filler.
+
+Recently shipped:
+- 2026-05-14 — ops-runner-tier2 Phase 2 (scope picker).
+- 2026-05-13 — ops-runner-tier2 Phase 1.3 (PATH_ARG_REGISTRY).
 
 ---
 

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Runner Tier 2
 
-**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phases 2–5 pending
+**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phases 3–5 pending
 
 Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -18,19 +18,26 @@ Goal: turn hypothesis H2 ("Workflow `--path` support is unevenly implemented") i
 
 Goal: per-row dropdown that scopes the workflow run to one feature or custom path.
 
-- [ ] **2.1** Add `Feature` dataclass + `list_features()` to `src/attune/ops/data.py`. Reads `.help/features.yaml`, returns `[]` on missing/malformed. Caches result with mtime check.
-- [ ] **2.2** Pass `features` + `supports_path` to `workflows.html` from `dashboard.py`.
-- [ ] **2.3** Render the `<select>` + hidden `<input type="text">` per row in `workflows.html`. Show `<span class="scope-na">` for workflows where `supports_path[w.name] is False`.
-- [ ] **2.4** Update `RunRequest` body to accept `path: str | None` in `routes/runner.py`. Validate via `_validate_file_path`.
-- [ ] **2.5** Extend `RunnerService.start_run()` + `_default_command()` to thread `path` into the subprocess invocation.
-- [ ] **2.6** `runner.js`: add `getScope(row)`, wire the picker toggle UX (custom path input shows when "Custom path…" is selected), pass scope as POST body.
-- [ ] **2.7** CSS: `.scope-picker`, `.scope-custom`, `.scope-na` matching existing `.status-select` aesthetic.
-- [ ] **2.8** Tests:
-      - `test_list_features_*` — missing file, well-formed file, malformed YAML
-      - `test_run_with_path_arg` — POST with `path` ends up in subprocess command
-      - `test_run_rejects_invalid_path` — path traversal returns 400
-      - `test_run_rejects_path_for_no-path-workflow` — `release-prep` with path returns 400
-      - JS parsing: `test_runner_js_workflows_html_has_scope_picker` (assert the template renders the select for path-supporting workflows)
+**Shipped 2026-05-14.** 20 new tests in `tests/unit/ops/test_scope_picker.py`; full ops suite (189 tests) green.
+
+- [x] **2.1** `Feature` dataclass + `list_features()` in `src/attune/ops/data.py`. Reads `.help/features.yaml`, returns `[]` on missing/malformed. Module-level mtime cache `_FEATURES_CACHE` keyed by absolute YAML path. Path-derivation prefers `/**` directory globs over single-file entries; skips mid-name globs (`code_review_*.py`) — they're not addressable scopes.
+- [x] **2.2** `dashboard.py::workflows_page` reads `cfg.project_root`, calls `data.list_features()`, and builds `supports_path = {w.name: w.name in data.PATH_ARG_REGISTRY}` so the template can render either a picker or an `n/a` span.
+- [x] **2.3** `workflows.html` renders a `<select data-scope-picker>` with Project-wide + one option per feature with a usable path + "Custom path…", plus a hidden `<input data-scope-custom>`. `<span class="scope-na">` shown when `supports_path[w.name]` is False. A new "Scope" `<th>` sits between Description and Action; both columns are gated on `allow_run` so read-only mode keeps the existing layout.
+- [x] **2.4** `routes/runner.py::start_run` reads optional `{"path": "..."}` body via a new `_read_scope()` helper. Empty body / empty string / missing key → `None` (project-wide). Path is validated via `_validate_file_path(allowed_dir=cfg.project_root)`; traversal / outside-root / non-string / malformed-JSON all return 400 BEFORE the runner is touched.
+- [x] **2.5** `Run` gained a `path: str | None` field; `to_dict()` exposes it. `RunnerService.start(workflow, *, path=None)` records the scope. `_execute` appends `--path <scope>` after `_command_builder(workflow)` — test fixtures with `(str) → Sequence[str]` signatures keep working unchanged.
+- [x] **2.6** `runner.js` adds `getScope(row)` + `wireScopePickerToggle(row)`. Click handler builds `{path: scope}` body only when scope ≠ null; project-wide POSTs stay body-less so existing endpoints don't see a behavior change. Helpers exposed on `window.__attuneRunner`.
+- [x] **2.7** CSS `.scope-picker` / `.scope-custom` / `.scope-na` in `static/css/main.css` (matched against existing `.status-select` aesthetic — same arrow glyph, `6px` radius, max-width 220px).
+- [x] **2.8** Tests:
+      - `test_list_features_*` (6 tests) — missing file, well-formed, malformed YAML, non-mapping features key, glob-only feature → `path=None`, mtime cache invalidation
+      - `test_run_with_path_threads_into_subprocess` — `--path <validated>` shows up in the recorded command line
+      - `test_run_without_body_runs_project_wide` — no body → no `--path`
+      - `test_run_rejects_invalid_path_traversal` — `/etc/passwd` → 400
+      - `test_run_rejects_path_outside_project_root` — sibling dir → 400
+      - `test_run_rejects_path_for_no_path_workflow` — workflow absent from `PATH_ARG_REGISTRY` → 400
+      - `test_run_rejects_non_string_path` / `test_run_rejects_non_object_body` / `test_run_rejects_malformed_json` — input shape rejections
+      - `test_run_treats_empty_path_as_project_wide` — empty string → 201
+      - `test_workflows_page_renders_scope_picker_for_path_workflow` / `test_workflows_page_renders_n_a_for_no_path_workflow` / `test_workflows_page_no_scope_column_when_read_only` — template surface
+      - `test_runner_js_exports_get_scope_and_toggle` / `test_runner_js_default_post_is_no_body` — JS shape
 
 ## Phase 3 — Persistence (recent runs)
 

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -11,6 +11,7 @@ import json
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from attune.ops.config import Config
@@ -101,6 +102,110 @@ PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
     # when missing).
     "test-audit": PathArgSpec(kwarg="path", required=True),
 }
+
+
+@dataclass(frozen=True)
+class Feature:
+    """One feature from ``.help/features.yaml`` for the scope picker.
+
+    ``path`` is a single representative repo-relative path derived from
+    the feature's ``files`` list: prefer a directory glob (entry ending
+    in ``/**``, stripped of the suffix); otherwise the first non-glob
+    entry. ``None`` when the feature has no addressable scope (empty
+    ``files`` or only mid-name globs like ``code_review_*.py``).
+    """
+
+    name: str
+    description: str
+    path: str | None
+    tags: tuple[str, ...] = ()
+
+
+# Per-yaml-file mtime cache: {abs_path: (mtime_ns, features)}. Keeps the
+# dashboard responsive on repeated requests within one server run.
+_FEATURES_CACHE: dict[str, tuple[int, list[Feature]]] = {}
+
+
+def _derive_feature_path(files: list[str]) -> str | None:
+    """Pick a representative scope path from a feature's files list.
+
+    Preference order:
+      1. First entry ending in ``/**`` (a directory scope) — strip the suffix.
+      2. First entry with no glob metacharacters (a single file).
+      3. ``None`` otherwise.
+    """
+    for entry in files:
+        if entry.endswith("/**"):
+            return entry[: -len("/**")]
+    for entry in files:
+        if "*" not in entry and "?" not in entry and "[" not in entry:
+            return entry
+    return None
+
+
+def list_features(project_root: Path | str) -> list[Feature]:
+    """Return features parsed from ``<project_root>/.help/features.yaml``.
+
+    Returns ``[]`` on missing file, unreadable file, or malformed YAML.
+    Result is sorted by feature name and cached by mtime so repeated
+    calls within one server run skip the YAML parse.
+    """
+    root = Path(project_root).expanduser().resolve()
+    yaml_path = root / ".help" / "features.yaml"
+    if not yaml_path.is_file():
+        return []
+
+    try:
+        mtime_ns = yaml_path.stat().st_mtime_ns
+    except OSError:
+        return []
+
+    cache_key = str(yaml_path)
+    cached = _FEATURES_CACHE.get(cache_key)
+    if cached is not None and cached[0] == mtime_ns:
+        return cached[1]
+
+    try:
+        import yaml as _yaml
+    except ImportError:
+        return []
+    try:
+        text = yaml_path.read_text(encoding="utf-8")
+        raw = _yaml.safe_load(text)
+    except (OSError, _yaml.YAMLError):
+        return []
+
+    if not isinstance(raw, dict):
+        return []
+    raw_features = raw.get("features")
+    if not isinstance(raw_features, dict):
+        return []
+
+    out: list[Feature] = []
+    for name, spec in raw_features.items():
+        if not isinstance(spec, dict):
+            continue
+        files_raw = spec.get("files") or []
+        files = (
+            [str(f) for f in files_raw if isinstance(f, str)] if isinstance(files_raw, list) else []
+        )
+        tags_raw = spec.get("tags") or []
+        tags = (
+            tuple(str(t) for t in tags_raw if isinstance(t, str))
+            if isinstance(tags_raw, list)
+            else ()
+        )
+        out.append(
+            Feature(
+                name=str(name),
+                description=str(spec.get("description") or ""),
+                path=_derive_feature_path(files),
+                tags=tags,
+            )
+        )
+    out.sort(key=lambda f: f.name)
+    _FEATURES_CACHE[cache_key] = (mtime_ns, out)
+    return out
 
 
 @dataclass(frozen=True)

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -59,12 +59,20 @@ async def home(request: Request) -> HTMLResponse:
 async def workflows_page(request: Request) -> HTMLResponse:
     workflows = data.list_workflows()
     cfg = request.app.state.config
+    features = data.list_features(cfg.project_root)
+    # supports_path[name] is True iff the workflow has a PATH_ARG_REGISTRY
+    # entry. The template uses this to render the scope picker vs an
+    # "n/a" span. Future-proofed: a new workflow without a registry
+    # entry shows as n/a until the registry is updated.
+    supports_path = {w.name: w.name in data.PATH_ARG_REGISTRY for w in workflows}
     return _render(
         request,
         "workflows.html",
         page="workflows",
         workflows=workflows,
         allow_run=cfg.allow_run,
+        features=features,
+        supports_path=supports_path,
     )
 
 

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from attune.ops import data
 from attune.ops.runner import RunnerBusyError, RunnerService
+from attune.security.path_validation import _validate_file_path
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -28,12 +33,54 @@ def _ensure_allowed(request: Request) -> None:
         )
 
 
+async def _read_scope(request: Request) -> str | None:
+    """Parse optional ``{"path": "..."}`` body. Empty body → None.
+
+    Treats an empty string the same as omitted so the picker's
+    "Project-wide" option doesn't have to send anything special.
+    """
+    body_bytes = await request.body()
+    if not body_bytes:
+        return None
+    try:
+        raw = json.loads(body_bytes)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="invalid JSON body") from exc
+    if not isinstance(raw, dict):
+        raise HTTPException(status_code=400, detail="body must be a JSON object")
+    raw_path = raw.get("path")
+    if raw_path is None or raw_path == "":
+        return None
+    if not isinstance(raw_path, str):
+        raise HTTPException(status_code=400, detail="path must be a string")
+    return raw_path
+
+
 @router.post("/workflows/{name}/run")
 async def start_run(name: str, request: Request) -> JSONResponse:
     _ensure_allowed(request)
     svc = _service(request)
+
+    scope = await _read_scope(request)
+    if scope is not None:
+        # Reject scope for workflows that don't accept a path arg. The
+        # registry is the source of truth for path-arg support; a
+        # workflow absent from the registry is treated as no-path.
+        if name not in data.PATH_ARG_REGISTRY:
+            raise HTTPException(
+                status_code=400,
+                detail=f"workflow '{name}' does not accept a path argument",
+            )
+        cfg = request.app.state.config
+        try:
+            validated = _validate_file_path(scope, allowed_dir=str(cfg.project_root))
+        except ValueError as exc:
+            logger.warning("ops.run: rejected scope path %r: %s", scope[:200], exc)
+            raise HTTPException(status_code=400, detail=f"invalid path: {exc}") from exc
+        scope = str(validated)
+
     try:
-        run = await svc.start(name)
+        run = await svc.start(name, path=scope)
     except RunnerBusyError as exc:
         raise HTTPException(
             status_code=409,

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -42,6 +42,10 @@ class Run:
     exit_code: int | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    # Optional scope path passed to the workflow as ``--path <value>``.
+    # ``None`` means the workflow runs project-wide (no ``--path`` flag).
+    # See docs/specs/ops-runner-tier2/ Phase 2.
+    path: str | None = None
     lines: list[str] = field(default_factory=list)
     subscribers: set[asyncio.Queue[Event]] = field(default_factory=set)
 
@@ -65,6 +69,7 @@ class Run:
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
             "duration_seconds": self.duration_seconds,
             "line_count": len(self.lines),
+            "path": self.path,
         }
 
     def _broadcast(self, event: Event) -> None:
@@ -126,6 +131,10 @@ def _default_command(workflow: str) -> Sequence[str]:
     silently runs old code, which is the kind of bug that wastes 30 minutes
     of debugging before someone notices ``which attune`` doesn't point where
     they think it does.
+
+    Scope (``--path``) is appended by :meth:`RunnerService._execute` after
+    the builder's output, so custom builders (test fixtures, alternative
+    CLIs) don't need to know about it.
     """
     return (sys.executable, "-m", "attune.cli_minimal", "workflow", "run", workflow)
 
@@ -159,12 +168,12 @@ class RunnerService:
     def recent(self, limit: int = 5) -> list[Run]:
         return list(reversed(list(self._runs.values())))[:limit]
 
-    async def start(self, workflow: str) -> Run:
+    async def start(self, workflow: str, *, path: str | None = None) -> Run:
         async with self._lock:
             current = self.current
             if current is not None:
                 raise RunnerBusyError(current.id)
-            run = Run(id=uuid.uuid4().hex[:12], workflow=workflow)
+            run = Run(id=uuid.uuid4().hex[:12], workflow=workflow, path=path)
             self._runs[run.id] = run
             while len(self._runs) > self._history_limit:
                 self._runs.popitem(last=False)
@@ -176,6 +185,13 @@ class RunnerService:
         run.status = "running"
         run.started_at = datetime.now(timezone.utc)
         cmd = list(self._command_builder(run.workflow))
+        # Append ``--path <scope>`` after the builder's output so test
+        # fixtures (with simple ``workflow -> command`` signatures) don't
+        # need to know about scoping. The CLI accepts ``--path`` uniformly
+        # and rewrites it into the workflow-specific kwarg via
+        # PATH_ARG_REGISTRY at the workflow layer.
+        if run.path:
+            cmd.extend(["--path", run.path])
         run.append_line(f"$ {' '.join(shlex.quote(c) for c in cmd)}")
         try:
             proc = await asyncio.create_subprocess_exec(

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -570,6 +570,55 @@ a.kpi:hover {
   transition: outline 0.3s ease-out;
 }
 
+/* Workflow scope picker (ops-runner-tier2 Phase 2). */
+.scope-cell {
+  white-space: nowrap;
+}
+.scope-picker {
+  font-size: 12px;
+  padding: 3px 22px 3px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background-color: var(--bg-soft);
+  color: var(--fg);
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+                    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position:
+    calc(100% - 12px) 50%,
+    calc(100% - 7px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  max-width: 220px;
+}
+.scope-picker:hover {
+  border-color: var(--accent);
+}
+.scope-custom {
+  display: block;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background-color: var(--bg-soft);
+  color: var(--fg);
+  width: 220px;
+  max-width: 100%;
+}
+.scope-custom:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.scope-na {
+  font-size: 12px;
+  color: var(--fg-subtle);
+  font-style: italic;
+}
+
 /* Spec drill-in: phase body in a readable monospace block. */
 .spec-phase {
   margin-bottom: 2rem;

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -161,6 +161,8 @@
       detectSectionHeader: detectSectionHeader,
       appendInline: appendInline,
       appendLine: appendLine,
+      getScope: getScope,
+      wireScopePickerToggle: wireScopePickerToggle,
       WORKFLOW_NAMES: WORKFLOW_NAMES,
       SECTION_HEADERS: SECTION_HEADERS
     };
@@ -209,6 +211,46 @@
     return function stop() { clearInterval(id); };
   }
 
+  // Read the scope the user picked for this workflow row.
+  // Returns null for "Project-wide" (default) or workflows that don't
+  // support --path (no picker in the row). Returns the string value of
+  // the dropdown for a feature pick, or the custom text input's value
+  // when the user picked "Custom path…". Trims whitespace; an empty
+  // custom value falls back to project-wide (null).
+  function getScope(row) {
+    var picker = row.querySelector("[data-scope-picker]");
+    if (!picker) return null;
+    var val = picker.value;
+    if (val === "" || val === null || val === undefined) return null;
+    if (val === "__custom__") {
+      var custom = row.querySelector("[data-scope-custom]");
+      if (!custom) return null;
+      var trimmed = (custom.value || "").trim();
+      return trimmed === "" ? null : trimmed;
+    }
+    return val;
+  }
+
+  // Toggle the custom-path text input based on the picker's value. Shown
+  // when "Custom path…" is selected, hidden otherwise.
+  function wireScopePickerToggle(row) {
+    var picker = row.querySelector("[data-scope-picker]");
+    var custom = row.querySelector("[data-scope-custom]");
+    if (!picker || !custom) return;
+    picker.addEventListener("change", function () {
+      if (picker.value === "__custom__") {
+        custom.hidden = false;
+        custom.focus();
+      } else {
+        custom.hidden = true;
+      }
+    });
+  }
+
+  // Export getScope for tests (alongside the existing rendering helpers).
+  // Note: window.__attuneRunner is populated farther below, after these
+  // helpers are defined; the assignment block lives at the same scope.
+
   function attach(button) {
     button.addEventListener("click", async function () {
       var name = button.dataset.workflow;
@@ -217,9 +259,13 @@
       button.disabled = true;
       setStatus(row, "starting…");
       try {
-        var resp = await fetch("/workflows/" + encodeURIComponent(name) + "/run", {
-          method: "POST",
-        });
+        var scope = getScope(row);
+        var fetchOpts = { method: "POST" };
+        if (scope !== null) {
+          fetchOpts.headers = { "Content-Type": "application/json" };
+          fetchOpts.body = JSON.stringify({ path: scope });
+        }
+        var resp = await fetch("/workflows/" + encodeURIComponent(name) + "/run", fetchOpts);
         if (!resp.ok) {
           var detail = await resp.text();
           // Show the inline error on the workflows page — don't navigate
@@ -248,5 +294,6 @@
 
   document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll("[data-run-button]").forEach(attach);
+    document.querySelectorAll("tr[data-workflow]").forEach(wireScopePickerToggle);
   });
 })();

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -21,6 +21,7 @@
         <th class="num">Stages</th>
         <th>Tier map</th>
         <th>Description</th>
+        {% if allow_run %}<th>Scope</th>{% endif %}
         {% if allow_run %}<th class="num">Action</th>{% endif %}
       </tr>
     </thead>
@@ -42,6 +43,24 @@
             </div>
           </td>
           {% if allow_run %}
+            <td class="scope-cell">
+              {% if supports_path[w.name] %}
+                <select class="scope-picker" data-scope-picker aria-label="Scope for {{ w.name }}">
+                  <option value="">Project-wide</option>
+                  {% for f in features %}
+                    {% if f.path %}
+                      <option value="{{ f.path }}" title="{{ f.description }}">{{ f.name }}</option>
+                    {% endif %}
+                  {% endfor %}
+                  <option value="__custom__">Custom path…</option>
+                </select>
+                <input type="text" class="scope-custom" data-scope-custom hidden
+                       placeholder="e.g. src/attune/security/"
+                       aria-label="Custom scope path for {{ w.name }}">
+              {% else %}
+                <span class="scope-na" title="This workflow doesn't accept a path argument">n/a</span>
+              {% endif %}
+            </td>
             <td class="num">
               <button class="btn btn-run" type="button" data-run-button data-workflow="{{ w.name }}">Run</button>
             </td>

--- a/tests/unit/ops/test_scope_picker.py
+++ b/tests/unit/ops/test_scope_picker.py
@@ -1,0 +1,407 @@
+"""Tests for the ops dashboard scope picker (ops-runner-tier2 Phase 2).
+
+Covers four surfaces:
+  * ``list_features()`` — reads ``.help/features.yaml`` with mtime cache.
+  * ``POST /workflows/{name}/run`` with ``{"path": ...}`` body — path
+    validation, no-path-workflow rejection, end-to-end subprocess wiring.
+  * Template rendering — scope picker / ``n/a`` span both surface.
+  * Runner.js — exports ``getScope`` and ``wireScopePickerToggle``.
+
+Companion drift-guard tests live in
+``tests/unit/ops/test_path_support_registry.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+pytest.importorskip("yaml")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from attune.ops import data  # noqa: E402
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.runner import RunnerService  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+# ----------------------------------------------------------------------
+# list_features() — file-parse + cache behavior
+# ----------------------------------------------------------------------
+
+
+def _write_features_yaml(root: Path, body: str) -> Path:
+    help_dir = root / ".help"
+    help_dir.mkdir(parents=True, exist_ok=True)
+    yaml_path = help_dir / "features.yaml"
+    yaml_path.write_text(body, encoding="utf-8")
+    return yaml_path
+
+
+@pytest.fixture(autouse=True)
+def _clear_features_cache():
+    """Reset the module-level mtime cache between tests."""
+    data._FEATURES_CACHE.clear()
+    yield
+    data._FEATURES_CACHE.clear()
+
+
+def test_list_features_missing_file_returns_empty(tmp_path):
+    """No ``.help/features.yaml`` → empty list, not an exception."""
+    assert data.list_features(tmp_path) == []
+
+
+def test_list_features_well_formed(tmp_path):
+    _write_features_yaml(
+        tmp_path,
+        """
+features:
+  security-audit:
+    description: Scan for vulns
+    files:
+      - src/attune/workflows/security_audit.py
+      - src/attune/security/**
+    tags: [security, audit]
+  perf-audit:
+    description: Performance scan
+    files:
+      - src/attune/workflows/perf_audit.py
+    tags: [perf]
+""",
+    )
+    features = data.list_features(tmp_path)
+    assert [f.name for f in features] == ["perf-audit", "security-audit"]
+    # security-audit prefers the /** glob → directory scope
+    sec = next(f for f in features if f.name == "security-audit")
+    assert sec.path == "src/attune/security"
+    assert sec.description == "Scan for vulns"
+    assert sec.tags == ("security", "audit")
+    # perf-audit has no directory glob → first file as the scope
+    perf = next(f for f in features if f.name == "perf-audit")
+    assert perf.path == "src/attune/workflows/perf_audit.py"
+
+
+def test_list_features_malformed_yaml(tmp_path):
+    """Malformed YAML → empty list (fail-soft)."""
+    _write_features_yaml(tmp_path, "features:\n  - this is\n    not: a [ mapping")
+    assert data.list_features(tmp_path) == []
+
+
+def test_list_features_features_key_not_mapping(tmp_path):
+    """Top-level shape mismatch → empty list."""
+    _write_features_yaml(tmp_path, "features:\n  - not_a_mapping\n")
+    assert data.list_features(tmp_path) == []
+
+
+def test_list_features_skips_glob_only_features(tmp_path):
+    """A feature with only mid-name globs has no addressable scope (path=None)."""
+    _write_features_yaml(
+        tmp_path,
+        """
+features:
+  code-quality:
+    description: Mixed globs only
+    files:
+      - src/attune/workflows/code_review_*.py
+    tags: [review]
+""",
+    )
+    features = data.list_features(tmp_path)
+    assert len(features) == 1
+    assert features[0].path is None
+
+
+def test_list_features_caches_by_mtime(tmp_path, monkeypatch):
+    """Repeated calls hit the cache; modifying the file invalidates it."""
+    yaml_path = _write_features_yaml(
+        tmp_path,
+        "features:\n  a:\n    description: A\n    files: [src/a.py]\n",
+    )
+    first = data.list_features(tmp_path)
+    second = data.list_features(tmp_path)
+    # Same list returned (cache hit — identity check would be too strict
+    # but the content stays equal)
+    assert first == second
+
+    # Bump mtime + change content; should re-read.
+    yaml_path.write_text(
+        "features:\n  b:\n    description: B\n    files: [src/b.py]\n",
+        encoding="utf-8",
+    )
+    # Force mtime change in case the test ran within the same nanosecond
+    import os
+    import time
+
+    new_mtime = yaml_path.stat().st_mtime + 1
+    os.utime(yaml_path, (new_mtime, new_mtime))
+    time.sleep(0.001)
+    third = data.list_features(tmp_path)
+    assert [f.name for f in third] == ["b"]
+
+
+# ----------------------------------------------------------------------
+# POST /workflows/{name}/run — path body, validation, rejection
+# ----------------------------------------------------------------------
+
+
+def _echo_cmd(workflow: str) -> tuple[str, ...]:
+    script = (
+        "import sys; print('start ' + sys.argv[1]); "
+        "[print(a) for a in sys.argv[2:]]; sys.exit(0)"
+    )
+    return (sys.executable, "-c", script, workflow)
+
+
+def _make_app(tmp_path, monkeypatch, *, allow_run=True):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=allow_run,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(command_builder=_echo_cmd)
+    app = create_app(config, runner=runner)
+    return app, runner
+
+
+async def _wait_terminal(runner, run_id, *, timeout=5.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        run = runner.get(run_id)
+        assert run is not None
+        if run.is_terminal:
+            return run
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(f"run {run_id} did not finish in {timeout}s")
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.asyncio
+async def test_run_with_path_threads_into_subprocess(tmp_path, monkeypatch):
+    """POST with ``{"path": "..."}`` adds ``--path <path>`` to the cmd."""
+    scope_dir = tmp_path / "src" / "feature"
+    scope_dir.mkdir(parents=True)
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/workflows/security-audit/run",
+            json={"path": str(scope_dir)},
+        )
+        assert resp.status_code == 201, resp.text
+        run = await _wait_terminal(runner, resp.json()["run_id"])
+    assert run.status == "completed"
+    assert run.path is not None
+    # The fixture command echoes its argv. The first line is the
+    # shell-style command preamble; later lines come from the script.
+    # The validated absolute path appears in the recorded command line.
+    cmd_line = run.lines[0]
+    assert "--path" in cmd_line
+    assert str(scope_dir.resolve()) in cmd_line
+
+
+@pytest.mark.asyncio
+async def test_run_without_body_runs_project_wide(tmp_path, monkeypatch):
+    """No body → no ``--path`` flag, no error."""
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/workflows/security-audit/run")
+        assert resp.status_code == 201, resp.text
+        run = await _wait_terminal(runner, resp.json()["run_id"])
+    assert run.path is None
+    assert "--path" not in run.lines[0]
+
+
+def test_run_rejects_invalid_path_traversal(tmp_path, monkeypatch):
+    """Path outside project_root → 400."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": "/etc/passwd"},
+        )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "invalid path" in detail.lower() or "system directory" in detail.lower()
+
+
+def test_run_rejects_path_outside_project_root(tmp_path, monkeypatch):
+    """A real path outside project_root is rejected via allowed_dir check."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    # Pick a sibling dir that definitely exists but is outside project_root
+    outsider = tmp_path.parent
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": str(outsider)},
+        )
+    assert resp.status_code == 400
+
+
+def test_run_rejects_path_for_no_path_workflow(tmp_path, monkeypatch):
+    """Workflow not in PATH_ARG_REGISTRY → 400 when path is provided.
+
+    We simulate the no-path case by patching the registry to remove
+    ``security-audit`` for the duration of the test. The validation
+    happens BEFORE registry lookup of the actual workflow, so the
+    runner never gets the call.
+    """
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    monkeypatch.delitem(data.PATH_ARG_REGISTRY, "security-audit", raising=False)
+    scope_dir = tmp_path / "src"
+    scope_dir.mkdir()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": str(scope_dir)},
+        )
+    assert resp.status_code == 400
+    assert "does not accept a path" in resp.json()["detail"]
+
+
+def test_run_rejects_non_string_path(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": 12345},
+        )
+    assert resp.status_code == 400
+
+
+def test_run_rejects_non_object_body(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            content=b"[1,2,3]",
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 400
+
+
+def test_run_rejects_malformed_json(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            content=b"not valid json {",
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 400
+
+
+def test_run_treats_empty_path_as_project_wide(tmp_path, monkeypatch):
+    """Empty-string path → same as omitted (project-wide). The picker's
+    "Project-wide" option submits ``""`` if the JS isn't filtering."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": ""},
+        )
+    assert resp.status_code == 201
+
+
+# ----------------------------------------------------------------------
+# Template rendering — workflows.html scope picker
+# ----------------------------------------------------------------------
+
+
+def test_workflows_page_renders_scope_picker_for_path_workflow(tmp_path, monkeypatch):
+    """A workflow in PATH_ARG_REGISTRY gets a ``<select data-scope-picker>``."""
+    _write_features_yaml(
+        tmp_path,
+        """
+features:
+  security-audit:
+    description: Scan
+    files: [src/attune/security/**]
+    tags: [security]
+""",
+    )
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "data-scope-picker" in body
+    assert "Project-wide" in body
+    assert "Custom path…" in body
+    assert "data-scope-custom" in body
+    # The feature dropdown option appears
+    assert ">security-audit<" in body
+
+
+def test_workflows_page_renders_n_a_for_no_path_workflow(tmp_path, monkeypatch):
+    """A workflow absent from PATH_ARG_REGISTRY shows a ``.scope-na`` span."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    # Remove one workflow so it's missing from the registry
+    monkeypatch.delitem(data.PATH_ARG_REGISTRY, "security-audit", raising=False)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    # The "n/a" span renders for the missing workflow
+    assert "scope-na" in resp.text
+
+
+def test_workflows_page_no_scope_column_when_read_only(tmp_path, monkeypatch):
+    """``--read-only`` mode: no Scope header, no picker markup."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=False)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    assert "data-scope-picker" not in resp.text
+    assert ">Scope<" not in resp.text
+
+
+# ----------------------------------------------------------------------
+# runner.js — scope helpers exported
+# ----------------------------------------------------------------------
+
+
+def test_runner_js_exports_get_scope_and_toggle():
+    js_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "runner.js"
+    )
+    text = js_path.read_text(encoding="utf-8")
+    # Both helpers exist as functions
+    assert "function getScope(" in text
+    assert "function wireScopePickerToggle(" in text
+    # Both are exposed on the test surface
+    assert "getScope: getScope" in text
+    assert "wireScopePickerToggle: wireScopePickerToggle" in text
+    # The DOMContentLoaded handler wires the toggle
+    assert "wireScopePickerToggle" in text
+    # POST body construction uses path key
+    assert "path: scope" in text or '"path": scope' in text
+
+
+def test_runner_js_default_post_is_no_body():
+    """When no scope is set, the POST should not include a body so
+    existing servers (and the test suite's no-body tests) keep working."""
+    js_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "runner.js"
+    )
+    text = js_path.read_text(encoding="utf-8")
+    # The code must guard body assignment behind a scope != null check
+    assert "scope !== null" in text


### PR DESCRIPTION
## Summary

- **Per-row scope picker** on `/workflows`. Each workflow row offers a feature dropdown (parsed from `.help/features.yaml`) + "Custom path…" fallback. Workflows without a `PATH_ARG_REGISTRY` entry render an inline "n/a" span instead.
- **Server-side path validation.** `/workflows/{name}/run` accepts an optional `{"path": "..."}` body. Validated via `_validate_file_path(allowed_dir=project_root)` before any subprocess is spawned — traversal, outside-root, non-string, malformed-JSON all return 400 with no side effect.
- **20 new tests** in `tests/unit/ops/test_scope_picker.py` covering feature parsing, mtime cache, subprocess wiring, all rejection paths, and template rendering in both run and read-only modes. Full ops suite (189) stays green.

Closes Phase 2 of `docs/specs/ops-runner-tier2/`. Phase 2 unblocks the discovery-sweep-ops-integration spec.

## What changed

| File | Change |
|---|---|
| `src/attune/ops/data.py` | Added `Feature` dataclass + `list_features()` with mtime-keyed module cache; `_derive_feature_path()` prefers `/**` directory globs over file paths, skips mid-name globs. |
| `src/attune/ops/routes/dashboard.py` | `workflows_page` reads `features` + builds `supports_path` from registry. |
| `src/attune/ops/routes/runner.py` | New `_read_scope()` helper parses the optional `{path}` body; rejects non-string / non-object / malformed JSON / missing-registry / invalid path before touching the runner. |
| `src/attune/ops/runner.py` | `Run.path: str \| None`; `RunnerService.start(..., *, path=None)`; `_execute` appends `--path <scope>` after the builder's output so test fixtures keep their `(str) → Sequence[str]` signature. |
| `src/attune/ops/templates/workflows.html` | New Scope `<th>` + `<td>` per row, gated on `allow_run`. |
| `src/attune/ops/static/js/runner.js` | `getScope(row)` + `wireScopePickerToggle(row)`; POST body only included when scope ≠ null so existing body-less endpoints don't see a behavior change. |
| `src/attune/ops/static/css/main.css` | `.scope-picker` / `.scope-custom` / `.scope-na` matching the existing `.status-select` aesthetic. |
| `tests/unit/ops/test_scope_picker.py` | 20 new tests. |
| `CHANGELOG.md`, `docs/specs/_sequencing.md`, `docs/specs/ops-runner-tier2/tasks.md` | Phase 2 marked shipped; sequencing's "Today's recommended pick" advanced to Phase 3. |

## Design notes

- **Path derivation.** `Feature.path` is a single representative scope (not a list). Algorithm: prefer the first `/**` directory glob (strip the suffix); otherwise the first non-glob file entry; otherwise `None`. Mid-name globs like `code_review_*.py` are not addressable scopes — feature falls through to `None` and won't appear in the dropdown.
- **Empty body = project-wide.** No JSON body or `{"path": ""}` both mean "no `--path` flag." The picker's "Project-wide" option submits a body-less POST so the wire shape exactly matches a no-picker workflow.
- **Validation order.** Body-shape rejections fire before registry lookup; registry-miss fires before path validation. So `release-prep` with a malformed JSON body returns 400 for the JSON error, not the registry-miss error.
- **No CommandBuilder signature change.** The runner appends `--path <scope>` itself after `_command_builder(workflow)`. Existing fixtures with the `(workflow: str) → Sequence[str]` shape (e.g., `_echo_cmd`, `_fail_cmd`, `_missing_cmd`) keep working unchanged.

## Test plan

- [x] Unit: `pytest tests/unit/ops/test_scope_picker.py` — 20/20 pass
- [x] Regression: full ops suite (189 tests) green
- [x] Manual smoke: `uv run python -m attune.ops --allow-run --port 8866` → `/workflows` renders feature dropdowns with feature descriptions in `title` tooltips; "n/a" shown when a workflow is removed from registry
- [ ] CI: full matrix on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
