### PR TITLE
test(discovery-sweep): cover _severity_badge unknown-severity fallback

### DIFF
--- a/tests/unit/workflows/discovery_sweep/test_engine.py
+++ b/tests/unit/workflows/discovery_sweep/test_engine.py
@@ -399,3 +399,17 @@ class TestSeverityColorBadges:
         wf = DiscoverySweepWorkflow()
         res = asyncio.run(wf.execute(path="src/", sources=[src], output_format="json"))
         assert "\x1b[" not in res.final_output
+
+    def test_unknown_severity_falls_back_to_plain_bracket(self) -> None:
+        """Unknown severities skip the ANSI lookup miss and return plain brackets.
+
+        ``_SEVERITY_ANSI`` only covers the five canonical levels. If a future
+        source emits a custom severity string, ``_severity_badge`` must still
+        produce a readable label rather than crashing or returning empty.
+        """
+        from attune.workflows.discovery_sweep.workflow import _severity_badge
+
+        # colored=True + severity not in the ANSI map → plain bracket (no codes).
+        assert _severity_badge("unknown", colored=True) == "[unknown]"
+        # colored=False short-circuits before the lookup, also plain.
+        assert _severity_badge("unknown", colored=False) == "[unknown]"


### PR DESCRIPTION
## Summary

- Adds the missing test for line 212 of `discovery_sweep/workflow.py` (`_severity_badge` unknown-severity fallback)
- Closes the patch-coverage gap Codecov flagged on [#322](https://github.com/Smart-AI-Memory/attune-ai/pull/322) (91.66% → 100% on those lines)
- Local coverage on `workflow.py`: 92.86% → 93.65%

## Why

Codecov on PR #322 reported `Patch coverage is 91.66% with 2 lines in your changes missing coverage`. The gap is the defensive `return label` branch in `_severity_badge` that fires when a severity isn't in `_SEVERITY_ANSI` — reached when a future source emits a non-canonical severity string. Worth covering since the branch exists specifically to handle that future case.

Test calls `_severity_badge` directly rather than threading a custom severity through the engine, because `Finding.severity` is typed `Literal["critical","high","medium","low","info"]`.

## Test plan

- [x] `pytest tests/unit/workflows/discovery_sweep/test_engine.py::TestSeverityColorBadges` (6/6 pass)
- [x] Full `tests/unit/workflows/discovery_sweep/` suite (155/155 pass)
- [x] Coverage confirms line 212 now covered + partial branch resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)
