### PR TITLE
feat(ops): runner-tier2 Phases 3 + 4 — persisted runs + chainable pills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Ops dashboard persisted run history + chainable workflow pills
+  (ops-runner-tier2 Phase 3 + Phase 4). Completed runs are now
+  written to `<attune_home>/ops/runs/<workflow>/<run-id>.json`
+  atomically (write to `.json.tmp` → `replace`) with the log
+  buffer capped at 200 KB and a `<TRUNCATED — N bytes more>`
+  marker. A startup sweep (`--runs-retention-days`, default 30,
+  `0` disables) deletes records older than the retention window.
+  Read-only mode (`--read-only`) disables persistence entirely so
+  a read-only dashboard never writes to `~/.attune/`. New
+  read-only API endpoints `GET /api/runs/{workflow}` (newest 20,
+  metadata only) and `GET /api/runs/{workflow}/{run_id}` (full
+  record including log) back a recent-runs strip below each
+  workflow row and at the top of the run-view page. The strip
+  renders one chip per run with status-colored borders + a
+  scope tooltip; clicking a chip navigates to the run-view page.
+  Phase 4 makes `.log-workflow` pills inside the streaming log
+  clickable: a click POSTs `/workflows/<target>/run` carrying the
+  source run's scope path and navigates to the new run's view
+  with `?from=<source-workflow>` so a "↩ from <name>" badge
+  shows in the header. The inline run-view script was extracted
+  to `static/js/run_view.js`; server-injected config flows
+  through a `<script type="application/json" id="run-view-data">`
+  block instead of inline JS. The global 404 handler now
+  dispatches JSON for `/api/*` paths and HTML otherwise. 32 new
+  tests cover the persistence write/read paths, log truncation,
+  pruning, the history API (in-memory + on-disk merge, bad-name
+  rejection, traversal rejection), and template + JS surface
+  shape.
 - Ops dashboard scope picker (ops-runner-tier2 Phase 2) — each
   workflow row in `/workflows` now has a per-row dropdown that
   scopes the run to one feature (parsed from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Ops dashboard scope picker (ops-runner-tier2 Phase 2) — each
+  workflow row in `/workflows` now has a per-row dropdown that
+  scopes the run to one feature (parsed from
+  `.help/features.yaml`) or a custom path. The picker passes
+  `{"path": "..."}` as the POST body to
+  `/workflows/<name>/run`; the runner threads that into
+  `--path <value>` on the subprocess invocation. Workflows
+  without a `PATH_ARG_REGISTRY` entry render an inline "n/a"
+  span instead of a picker. Path validation goes through
+  `_validate_file_path(allowed_dir=project_root)`, so traversal
+  attempts (`/etc/passwd`, `../outside`) return 400 before the
+  subprocess is spawned. `Run.path` is included in `to_dict()`
+  and replayed in the run log preamble so the executed command
+  is visible end-to-end. 20 new tests cover feature parsing
+  (well-formed, malformed, missing, glob-only edge case),
+  mtime cache invalidation, run-with-path subprocess wiring,
+  path validation rejections, no-path-workflow rejection, and
+  template rendering in both run and read-only modes.
+
 - `discovery-sweep` Phase 3.2 — severity-colored badges in
   markdown output. Findings render with ANSI-colored
   `[critical]` (bold red), `[high]` (red), `[medium]` (yellow),

--- a/docs/specs/_sequencing.md
+++ b/docs/specs/_sequencing.md
@@ -86,16 +86,17 @@ natural pause.
 
 ### ops-runner-tier2
 
-- Status: Phase 1 + Phase 2 shipped; Phases 3–5 pending
-- Why after security-hardening: 5 phases, each shippable.
+- Status: Phases 1–4 shipped; Phases 5–6 pending
+- Why after security-hardening: 6 phases, each shippable.
   Phase 1 is pure inspection so it can start anytime. Phases
-  3 and 4 ship together for the chaining UX.
+  3 and 4 shipped together (2026-05-14) for the chaining UX.
 - Tasks
   - [x] Phase 1 — workflow registry verification (2026-05-13)
   - [x] Phase 2 — scope picker (dropdown + custom path) (2026-05-14)
-  - [ ] Phase 3 — persist recent runs
-  - [ ] Phase 4 — clickable workflow-name pills
+  - [x] Phase 3 — persist recent runs (2026-05-14, with Phase 4)
+  - [x] Phase 4 — clickable workflow-name pills (2026-05-14, with Phase 3)
   - [ ] Phase 5 — structured recommendations
+  - [ ] Phase 6 — telemetry + close
 - Phase 2 unblocks the discovery-sweep-ops-integration spec
   (per its design dependency on the scope picker).
 - Spec: [ops-runner-tier2](ops-runner-tier2/)
@@ -241,17 +242,21 @@ Open only if a trigger condition fires.
 
 ## Today's recommended pick
 
-**ops-runner-tier2 Phase 3** — persist recent runs to disk
-so the dashboard survives a server restart without losing
-history. Bundle with Phase 4 (clickable workflow-name pills)
-for the chaining UX, per the spec's "3 and 4 ship together"
-note.
+**Release prep** — 16+ merges since last release (Phase 1
+PATH_ARG_REGISTRY, Phase 2 scope picker, Phase 3 persistence,
+Phase 4 chainable pills, discovery-sweep P2.x series + Phase 3).
+A minor bump on `attune-ai` is overdue.
 
-Alternative: **discovery-sweep-ops-integration** — now
-unblocked by Phase 2's scope picker. Or **test-quality-program**
-as opportunistic filler.
+Alternatives:
+- **ops-runner-tier2 Phase 5** — structured recommendation
+  channel (SSE `recommendation` events). Smaller scope; ship
+  if you'd rather keep coding than release.
+- **discovery-sweep-ops-integration** — unblocked by Phase 2.
+- **test-quality-program** — opportunistic filler.
 
 Recently shipped:
+- 2026-05-14 — ops-runner-tier2 Phase 3 + Phase 4
+  (persistence + chainable pills, shipped together).
 - 2026-05-14 — ops-runner-tier2 Phase 2 (scope picker).
 - 2026-05-13 — ops-runner-tier2 Phase 1.3 (PATH_ARG_REGISTRY).
 

--- a/docs/specs/_sequencing.md
+++ b/docs/specs/_sequencing.md
@@ -86,16 +86,18 @@ natural pause.
 
 ### ops-runner-tier2
 
-- Status: approved — 37 tasks, 0% done (largest spec)
+- Status: Phase 1 + Phase 2 shipped; Phases 3–5 pending
 - Why after security-hardening: 5 phases, each shippable.
   Phase 1 is pure inspection so it can start anytime. Phases
   3 and 4 ship together for the chaining UX.
 - Tasks
-  - [ ] Phase 1 — workflow registry verification
-  - [ ] Phase 2 — scope picker (dropdown + custom path)
+  - [x] Phase 1 — workflow registry verification (2026-05-13)
+  - [x] Phase 2 — scope picker (dropdown + custom path) (2026-05-14)
   - [ ] Phase 3 — persist recent runs
   - [ ] Phase 4 — clickable workflow-name pills
   - [ ] Phase 5 — structured recommendations
+- Phase 2 unblocks the discovery-sweep-ops-integration spec
+  (per its design dependency on the scope picker).
 - Spec: [ops-runner-tier2](ops-runner-tier2/)
 
 ### discovery-sweep — done 2026-05-13
@@ -239,19 +241,19 @@ Open only if a trigger condition fires.
 
 ## Today's recommended pick
 
-**ops-runner-tier2 Phase 1.3** — implement the
-`PATH_ARG_REGISTRY` dict per PR #285's audit. The audit
-proved hypothesis H2 right (workflow `--path` support is
-uneven) and proposed a three-way registry (Option 2) instead
-of the spec's literal binary. ~50 LoC: registry dict in
-`src/attune/ops/data.py` + drift-guard test in
-`tests/unit/ops/test_path_support_registry.py`. Once landed,
-Phases 2–5 of ops-runner-tier2 can read the registry and
-ship the scope picker.
+**ops-runner-tier2 Phase 3** — persist recent runs to disk
+so the dashboard survives a server restart without losing
+history. Bundle with Phase 4 (clickable workflow-name pills)
+for the chaining UX, per the spec's "3 and 4 ship together"
+note.
 
-Alternative: **test-quality-program** — continuous module-
-by-module work via the rubric. Slot whenever there's spare
-context between bigger work.
+Alternative: **discovery-sweep-ops-integration** — now
+unblocked by Phase 2's scope picker. Or **test-quality-program**
+as opportunistic filler.
+
+Recently shipped:
+- 2026-05-14 — ops-runner-tier2 Phase 2 (scope picker).
+- 2026-05-13 — ops-runner-tier2 Phase 1.3 (PATH_ARG_REGISTRY).
 
 ---
 

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Runner Tier 2
 
-**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phases 3–5 pending
+**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phase 3 + Phase 4 complete 2026-05-14 (persistence + chainable pills shipped together); Phase 5 + Phase 6 pending
 
 Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -41,48 +41,46 @@ Goal: per-row dropdown that scopes the workflow run to one feature or custom pat
 
 ## Phase 3 — Persistence (recent runs)
 
-Goal: replace in-memory run history with disk-backed per-workflow history.
+**Shipped 2026-05-14** alongside Phase 4 (per the spec's "Phases 3 and 4 ship together" guidance). 32 new tests in `tests/unit/ops/test_persistence_and_history.py`; full ops suite 221 green (was 189 after Phase 2).
 
-- [ ] **3.1** Extend `Run.to_dict()` to include `scope` and `command` fields. Add `from_dict()` for reload.
-- [ ] **3.2** On run completion, write `~/.attune/ops/runs/<workflow>/<run-id>.json`. Truncate log to first 200 KB with a `<TRUNCATED — N bytes more>` marker. Skip writes in `--read-only` mode.
-- [ ] **3.3** Startup task: prune runs older than 30 days (configurable via `--runs-retention-days`).
-- [ ] **3.4** New router `routes/runs_history.py`:
-      - `GET /api/runs/{workflow}` → list 20 newest runs (metadata only)
-      - `GET /api/runs/{workflow}/{run_id}` → full record + log
-- [ ] **3.5** `workflows.html`: add `<div class="recent-runs" data-recent-runs="{{ w.name }}">` below each workflow row. Each chip is a link to `/runs/<run_id>/view` (the per-run page from #251).
-- [ ] **3.6** `run_view.html`: add `<div class="run-view-history" data-recent-runs="{{ run.workflow }}">` at the top of the run-view page — same data, second location, makes "switch between recent runs of this workflow" a one-click navigation.
-- [ ] **3.7** JS: `setupRecentRuns()` (on workflows.html via runner.js) and the same logic on run-view via the new `run_view.js` (Phase 4.1) — both fetch `/api/runs/<workflow>` and render chips that link to the run-view page.
-- [ ] **3.8** CSS: `.recent-runs`, `.run-view-history`, `.recent-run-chip` (color by outcome: ✓ ok, ✗ danger). Same chip class in both locations.
-- [ ] **3.9** Tests:
-      - `test_run_persists_to_disk` — file written on completion
-      - `test_run_persists_truncates_long_log` — 1MB log → 200KB on disk + marker
-      - `test_run_skips_write_in_read_only` — `--read-only` doesn't write
-      - `test_get_recent_runs_returns_sorted` — newest first
-      - `test_get_run_rejects_path_traversal` — `run_id="../../etc/passwd"` returns 400
-      - `test_prune_old_runs` — files older than 30 days are deleted at startup
-      - `test_run_view_history_renders` — run-view page shows last-5 chips for the same workflow
+- [x] **3.1** `Run.command` field; `to_record()` / `from_record()` round-trip used by the disk writer + the reload path. `to_dict()` already carried `path` from Phase 2; persistence uses `to_record()` which adds the line buffer.
+- [x] **3.2** `_persist_run()` in `runner.py` writes `<runs_dir>/<workflow>/<run-id>.json` atomically (`.json.tmp` → `replace`). 200 KB log cap via `_truncate_lines_for_persist()` with a trailing `<TRUNCATED — N bytes more>` marker. Read-only mode is enforced at the `RunnerService` constructor level — `_build_default_runner()` in `server.py` only passes `persistence_dir` when `config.allow_run` is True.
+- [x] **3.3** `prune_old_runs()` is called at `create_app()` time when `allow_run` is True. Retention window comes from `config.runs_retention_days` (`--runs-retention-days` CLI flag, default 30). `0` disables the sweep; missing dir is a no-op.
+- [x] **3.4** New router `routes/runs_history.py` with `GET /api/runs/{workflow}` (newest 20 metadata-only) and `GET /api/runs/{workflow}/{run_id}` (full record incl. log). List combines in-memory entries (preserves live status) with disk records (dedup by id). Bad workflow names + bad run-ids return 400 BEFORE any disk lookup. The global 404 handler now dispatches JSON for `/api/*` paths so the dashboard JS can parse errors uniformly.
+- [x] **3.5** `workflows.html` adds `<div class="recent-runs" data-recent-runs="{{ w.name }}" hidden>` below each workflow's description cell. The strip stays hidden until the JS fetches and populates it.
+- [x] **3.6** `run_view.html` adds `<div class="run-view-history" data-recent-runs="{{ run.workflow }}" hidden>` at the top of the page (below the meta line, above the log).
+- [x] **3.7** `setupRecentRuns()` + `renderRecentRunsInto()` + `statusClass()` live in `runner.js`. The run-view page loads `runner.js` BEFORE `run_view.js`; `run_view.js` calls the same helper through `window.__attuneRunner.setupRecentRuns`. Failure modes (404, network) leave the strip hidden — history is best-effort and never blocks rendering. `runner.js` is now loaded unconditionally on `/workflows` (was gated on `allow_run`) so read-only users still get the recent-runs strip.
+- [x] **3.8** CSS in `static/css/main.css`: `.recent-runs` / `.run-view-history` (flex row, gap 6px) + `.recent-run-chip` (rounded pill, color by status using existing `chip-ok` / `chip-danger` / `chip-warn` / `chip-muted` palette) + `.recent-run-status` muted-text addendum. Hover state borders to `--accent`.
+- [x] **3.9** Tests:
+      - `test_run_to_record_round_trip` / `test_from_record_tolerates_missing_fields` / `test_from_record_bad_status_defaults_to_completed`
+      - `test_truncate_short_log_is_passthrough` / `test_truncate_long_log_appends_marker`
+      - `test_persist_run_writes_json` / `test_persist_run_rejects_bad_workflow_name` / `test_persist_run_rejects_bad_run_id` / `test_persist_run_truncates_long_log`
+      - `test_runner_writes_record_on_completion` (subprocess → JSON on disk) / `test_runner_skips_persistence_when_dir_is_none`
+      - `test_prune_old_runs_deletes_files_past_cutoff` / `test_prune_old_runs_zero_days_disables_sweep` / `test_prune_old_runs_missing_dir_is_noop`
+      - `test_list_persisted_runs_returns_newest_first` / `test_list_persisted_runs_rejects_bad_workflow` / `test_load_run_record_rejects_bad_run_id`
+      - `test_list_runs_rejects_bad_workflow_name` / `test_list_runs_empty_when_no_history` / `test_list_runs_combines_in_memory_and_disk`
+      - `test_get_run_record_rejects_path_traversal` / `test_get_run_record_returns_404_for_missing` / `test_get_run_record_returns_full_log`
+      - `test_read_only_mode_disables_persistence` (no writes + no `runs_dir` creation)
+      - `test_workflows_page_includes_recent_runs_strip` / `test_workflows_page_loads_runner_js_in_read_only_too`
 
 ## Phase 4 — Workflow-name pills become buttons
 
-Goal: Tier 1 pills (inert today) on the run-view page trigger a follow-on run carrying the source run's scope.
+**Shipped 2026-05-14** alongside Phase 3.
 
-**Note:** Pills now live on the **run-view page** (introduced in #251), not the workflows-table log pane. The JS for pill handling moves into a new `run_view.js` file.
+**Note:** Pills live on the **run-view page** (introduced in #251), not the workflows-table log pane. JS for pill handling lives in `static/js/run_view.js`.
 
-- [ ] **4.1** Extract the inline `<script>` block from `run_view.html` into `src/attune/ops/static/js/run_view.js`. (Currently inline as a one-off — Tier 2 needs the file for testing + multiple features.)
-- [ ] **4.2** `run_view.js`: attach click handlers to `.log-workflow` pills. On click:
-      - Read the source run's scope from the page context (server-injected as `{{ run.scope|tojson }}` once Phase 2 lands)
-      - POST `/workflows/<target>/run` with `{path: scope}`
-      - On success, navigate to `/runs/<new_run_id>/view?from=<source-workflow>`
-      - On 409 (busy), surface inline above the log without navigating
-- [ ] **4.3** `run_view.js`: `renderChainedFromBadge()` — reads `?from=` from the URL, populates `.chained-from` in the page header if present. Renders as "↩ from <source-workflow>".
-- [ ] **4.4** Handle read-only mode: pill click in `--read-only` shows a toast "Read-only mode: re-launch without --read-only to chain runs". No POST.
-- [ ] **4.5** Handle disabled target (already running): the existing 409 handler in `formatErrorDetail` already covers this; surface above the log on the source run-view page (don't navigate away from a successful prior run).
-- [ ] **4.6** CSS: `.log-workflow` pill hover state, `.pill-disabled` for `--read-only`, `.chained-from` badge styling.
-- [ ] **4.7** Tests:
-      - `test_run_view_js_exists` — file is served at `/static/js/run_view.js`
-      - `test_run_view_page_loads_run_view_js` — template references the new file
-      - `test_pill_click_carries_scope` (manual): visual smoke from the browser
-      - `test_read_only_pill_returns_403` — POST while `--read-only` returns 403
+- [x] **4.1** Extracted the inline `<script>` block from `run_view.html` into `src/attune/ops/static/js/run_view.js`. Server-injected config flows through a tagged `<script type="application/json" id="run-view-data">` block instead of inline `var STREAM_URL = {{ ... }}` statements — cleaner data/code separation, devtools-inspectable.
+- [x] **4.2** `run_view.js::handlePillClick` is wired as a delegated `click` listener on the log container. On match (closest `.log-workflow`): reads `SOURCE_PATH` from the injected config, POSTs `/workflows/<target>/run` with `{path: SOURCE_PATH}`. On 201 → navigates to `/runs/<new_run_id>/view?from=<SOURCE_WORKFLOW>`. On 409 → surfaces an inline `.run-view-error` above the log, doesn't navigate. The clicked pill gets a `.pill-disabled` class for the duration of the request to prevent double-clicks.
+- [x] **4.3** `renderChainedFromBadge()` reads `?from=` via `URLSearchParams`, validates the value against the workflow-name regex (rejects `<script>` and similar), and populates the existing `<span class="chained-from" data-chained-from>` slot in the page header with `↩ from <code>name</code>`.
+- [x] **4.4** Read-only mode (config `allow_run=False`) is passed through to the JS via the run-view-data block. The click handler short-circuits without POSTing and shows an inline error: "Read-only mode — restart attune ops without --read-only to chain runs."
+- [x] **4.5** Handled implicitly — same 409 path as 4.2's busy case, plus a 403 fallback for the rare race where allow_run flips during a session.
+- [x] **4.6** CSS: `.log-workflow` gains `cursor: pointer` + hover border + `transition`. `.pill-disabled` dims to 0.55 opacity with a progress cursor. `.run-view-error` styled with `--danger-soft`/`--danger` colors.
+- [x] **4.7** Tests:
+      - `test_run_view_page_loads_both_js_files` — template references `runner.js` + `run_view.js` and embeds the JSON data block
+      - `test_run_view_js_exists_and_exposes_helpers` — checks file presence + `handlePillClick` / `renderChainedFromBadge` / `pillTargetFromEvent` exports
+      - `test_run_view_js_validates_from_param` — confirms the regex literal is present for `?from=` validation
+      - `test_run_view_data_block_contains_allow_run_and_path` / `test_run_view_data_block_allow_run_false_in_read_only` — JSON block surfaces both keys correctly
+      - `test_read_only_mode_disables_persistence` already covers the runner-side guarantee that a pill click can't sneak in via the runner when `allow_run=False`
 
 ## Phase 5 — Structured recommendation channel
 

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Runner Tier 2
 
-**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phases 2–5 pending
+**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phases 3–5 pending
 
 Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -18,19 +18,26 @@ Goal: turn hypothesis H2 ("Workflow `--path` support is unevenly implemented") i
 
 Goal: per-row dropdown that scopes the workflow run to one feature or custom path.
 
-- [ ] **2.1** Add `Feature` dataclass + `list_features()` to `src/attune/ops/data.py`. Reads `.help/features.yaml`, returns `[]` on missing/malformed. Caches result with mtime check.
-- [ ] **2.2** Pass `features` + `supports_path` to `workflows.html` from `dashboard.py`.
-- [ ] **2.3** Render the `<select>` + hidden `<input type="text">` per row in `workflows.html`. Show `<span class="scope-na">` for workflows where `supports_path[w.name] is False`.
-- [ ] **2.4** Update `RunRequest` body to accept `path: str | None` in `routes/runner.py`. Validate via `_validate_file_path`.
-- [ ] **2.5** Extend `RunnerService.start_run()` + `_default_command()` to thread `path` into the subprocess invocation.
-- [ ] **2.6** `runner.js`: add `getScope(row)`, wire the picker toggle UX (custom path input shows when "Custom path…" is selected), pass scope as POST body.
-- [ ] **2.7** CSS: `.scope-picker`, `.scope-custom`, `.scope-na` matching existing `.status-select` aesthetic.
-- [ ] **2.8** Tests:
-      - `test_list_features_*` — missing file, well-formed file, malformed YAML
-      - `test_run_with_path_arg` — POST with `path` ends up in subprocess command
-      - `test_run_rejects_invalid_path` — path traversal returns 400
-      - `test_run_rejects_path_for_no-path-workflow` — `release-prep` with path returns 400
-      - JS parsing: `test_runner_js_workflows_html_has_scope_picker` (assert the template renders the select for path-supporting workflows)
+**Shipped 2026-05-14.** 20 new tests in `tests/unit/ops/test_scope_picker.py`; full ops suite (189 tests) green.
+
+- [x] **2.1** `Feature` dataclass + `list_features()` in `src/attune/ops/data.py`. Reads `.help/features.yaml`, returns `[]` on missing/malformed. Module-level mtime cache `_FEATURES_CACHE` keyed by absolute YAML path. Path-derivation prefers `/**` directory globs over single-file entries; skips mid-name globs (`code_review_*.py`) — they're not addressable scopes.
+- [x] **2.2** `dashboard.py::workflows_page` reads `cfg.project_root`, calls `data.list_features()`, and builds `supports_path = {w.name: w.name in data.PATH_ARG_REGISTRY}` so the template can render either a picker or an `n/a` span.
+- [x] **2.3** `workflows.html` renders a `<select data-scope-picker>` with Project-wide + one option per feature with a usable path + "Custom path…", plus a hidden `<input data-scope-custom>`. `<span class="scope-na">` shown when `supports_path[w.name]` is False. A new "Scope" `<th>` sits between Description and Action; both columns are gated on `allow_run` so read-only mode keeps the existing layout.
+- [x] **2.4** `routes/runner.py::start_run` reads optional `{"path": "..."}` body via a new `_read_scope()` helper. Empty body / empty string / missing key → `None` (project-wide). Path is validated via `_validate_file_path(allowed_dir=cfg.project_root)`; traversal / outside-root / non-string / malformed-JSON all return 400 BEFORE the runner is touched.
+- [x] **2.5** `Run` gained a `path: str | None` field; `to_dict()` exposes it. `RunnerService.start(workflow, *, path=None)` records the scope. `_execute` appends `--path <scope>` after `_command_builder(workflow)` — test fixtures with `(str) → Sequence[str]` signatures keep working unchanged.
+- [x] **2.6** `runner.js` adds `getScope(row)` + `wireScopePickerToggle(row)`. Click handler builds `{path: scope}` body only when scope ≠ null; project-wide POSTs stay body-less so existing endpoints don't see a behavior change. Helpers exposed on `window.__attuneRunner`.
+- [x] **2.7** CSS `.scope-picker` / `.scope-custom` / `.scope-na` in `static/css/main.css` (matched against existing `.status-select` aesthetic — same arrow glyph, `6px` radius, max-width 220px).
+- [x] **2.8** Tests:
+      - `test_list_features_*` (6 tests) — missing file, well-formed, malformed YAML, non-mapping features key, glob-only feature → `path=None`, mtime cache invalidation
+      - `test_run_with_path_threads_into_subprocess` — `--path <validated>` shows up in the recorded command line
+      - `test_run_without_body_runs_project_wide` — no body → no `--path`
+      - `test_run_rejects_invalid_path_traversal` — `/etc/passwd` → 400
+      - `test_run_rejects_path_outside_project_root` — sibling dir → 400
+      - `test_run_rejects_path_for_no_path_workflow` — workflow absent from `PATH_ARG_REGISTRY` → 400
+      - `test_run_rejects_non_string_path` / `test_run_rejects_non_object_body` / `test_run_rejects_malformed_json` — input shape rejections
+      - `test_run_treats_empty_path_as_project_wide` — empty string → 201
+      - `test_workflows_page_renders_scope_picker_for_path_workflow` / `test_workflows_page_renders_n_a_for_no_path_workflow` / `test_workflows_page_no_scope_column_when_read_only` — template surface
+      - `test_runner_js_exports_get_scope_and_toggle` / `test_runner_js_default_post_is_no_body` — JS shape
 
 ## Phase 3 — Persistence (recent runs)
 

--- a/src/attune/ops/cli.py
+++ b/src/attune/ops/cli.py
@@ -66,6 +66,17 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
             " Example: --trusted-host my-tunnel.example.com"
         ),
     )
+    parser.add_argument(
+        "--runs-retention-days",
+        type=int,
+        default=30,
+        metavar="DAYS",
+        help=(
+            "Delete persisted run files older than this many days at"
+            " startup. Set to 0 to disable pruning. Persisted runs"
+            " live under <attune-home>/ops/runs/. Default: 30."
+        ),
+    )
     # Backwards-compat: --allow-run was the opt-IN flag before runs became
     # the default. Accept it silently as a no-op so existing scripts and
     # shell history keep working without prompting users to update.
@@ -116,6 +127,7 @@ def cmd_ops(args: argparse.Namespace) -> int:
         allow_run=allow_run,
         specs_roots=tuple(args.specs_root) if args.specs_root else None,
         trusted_hosts=tuple(args.trusted_host) if args.trusted_host else None,
+        runs_retention_days=args.runs_retention_days,
     )
     app = create_app(config)
 

--- a/src/attune/ops/config.py
+++ b/src/attune/ops/config.py
@@ -25,10 +25,20 @@ class Config:
     # users widen for tunneled / proxied setups (Cloudflare Tunnel,
     # Tailscale, ssh -L, etc.). See docs/specs/ops-security-hardening/.
     trusted_hosts: tuple[str, ...] = ()
+    # How many days of completed runs to keep on disk under
+    # ``<attune_home>/ops/runs/``. The startup sweep deletes anything
+    # older. 30 days is enough to span a typical sprint; bump via
+    # ``--runs-retention-days`` if you want longer history.
+    runs_retention_days: int = 30
 
     @property
     def telemetry_path(self) -> Path:
         return self.attune_home / "telemetry" / "usage.jsonl"
+
+    @property
+    def runs_dir(self) -> Path:
+        """Disk root for persisted ops runs. May not exist until first write."""
+        return self.attune_home / "ops" / "runs"
 
     @property
     def memory_dir(self) -> Path:
@@ -55,6 +65,7 @@ def build_config(
     allow_run: bool = False,
     specs_roots: tuple[Path, ...] | None = None,
     trusted_hosts: tuple[str, ...] | None = None,
+    runs_retention_days: int = 30,
 ) -> Config:
     """Build a Config from inputs and environment defaults.
 
@@ -75,4 +86,5 @@ def build_config(
         allow_run=allow_run,
         specs_roots=tuple(specs_roots or ()),
         trusted_hosts=tuple(trusted_hosts or ()),
+        runs_retention_days=max(0, int(runs_retention_days)),
     )

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -11,6 +11,7 @@ import json
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from attune.ops.config import Config
@@ -101,6 +102,110 @@ PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
     # when missing).
     "test-audit": PathArgSpec(kwarg="path", required=True),
 }
+
+
+@dataclass(frozen=True)
+class Feature:
+    """One feature from ``.help/features.yaml`` for the scope picker.
+
+    ``path`` is a single representative repo-relative path derived from
+    the feature's ``files`` list: prefer a directory glob (entry ending
+    in ``/**``, stripped of the suffix); otherwise the first non-glob
+    entry. ``None`` when the feature has no addressable scope (empty
+    ``files`` or only mid-name globs like ``code_review_*.py``).
+    """
+
+    name: str
+    description: str
+    path: str | None
+    tags: tuple[str, ...] = ()
+
+
+# Per-yaml-file mtime cache: {abs_path: (mtime_ns, features)}. Keeps the
+# dashboard responsive on repeated requests within one server run.
+_FEATURES_CACHE: dict[str, tuple[int, list[Feature]]] = {}
+
+
+def _derive_feature_path(files: list[str]) -> str | None:
+    """Pick a representative scope path from a feature's files list.
+
+    Preference order:
+      1. First entry ending in ``/**`` (a directory scope) — strip the suffix.
+      2. First entry with no glob metacharacters (a single file).
+      3. ``None`` otherwise.
+    """
+    for entry in files:
+        if entry.endswith("/**"):
+            return entry[: -len("/**")]
+    for entry in files:
+        if "*" not in entry and "?" not in entry and "[" not in entry:
+            return entry
+    return None
+
+
+def list_features(project_root: Path | str) -> list[Feature]:
+    """Return features parsed from ``<project_root>/.help/features.yaml``.
+
+    Returns ``[]`` on missing file, unreadable file, or malformed YAML.
+    Result is sorted by feature name and cached by mtime so repeated
+    calls within one server run skip the YAML parse.
+    """
+    root = Path(project_root).expanduser().resolve()
+    yaml_path = root / ".help" / "features.yaml"
+    if not yaml_path.is_file():
+        return []
+
+    try:
+        mtime_ns = yaml_path.stat().st_mtime_ns
+    except OSError:
+        return []
+
+    cache_key = str(yaml_path)
+    cached = _FEATURES_CACHE.get(cache_key)
+    if cached is not None and cached[0] == mtime_ns:
+        return cached[1]
+
+    try:
+        import yaml as _yaml
+    except ImportError:
+        return []
+    try:
+        text = yaml_path.read_text(encoding="utf-8")
+        raw = _yaml.safe_load(text)
+    except (OSError, _yaml.YAMLError):
+        return []
+
+    if not isinstance(raw, dict):
+        return []
+    raw_features = raw.get("features")
+    if not isinstance(raw_features, dict):
+        return []
+
+    out: list[Feature] = []
+    for name, spec in raw_features.items():
+        if not isinstance(spec, dict):
+            continue
+        files_raw = spec.get("files") or []
+        files = (
+            [str(f) for f in files_raw if isinstance(f, str)] if isinstance(files_raw, list) else []
+        )
+        tags_raw = spec.get("tags") or []
+        tags = (
+            tuple(str(t) for t in tags_raw if isinstance(t, str))
+            if isinstance(tags_raw, list)
+            else ()
+        )
+        out.append(
+            Feature(
+                name=str(name),
+                description=str(spec.get("description") or ""),
+                path=_derive_feature_path(files),
+                tags=tags,
+            )
+        )
+    out.sort(key=lambda f: f.name)
+    _FEATURES_CACHE[cache_key] = (mtime_ns, out)
+    return out
 
 
 @dataclass(frozen=True)

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -137,6 +137,7 @@ async def run_view_page(run_id: str, request: Request) -> HTMLResponse:
         page="run-view",
         run=run.to_dict(),
         stream_url=f"/runs/{run_id}/stream",
+        allow_run=request.app.state.config.allow_run,
     )
 
 

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -59,12 +59,20 @@ async def home(request: Request) -> HTMLResponse:
 async def workflows_page(request: Request) -> HTMLResponse:
     workflows = data.list_workflows()
     cfg = request.app.state.config
+    features = data.list_features(cfg.project_root)
+    # supports_path[name] is True iff the workflow has a PATH_ARG_REGISTRY
+    # entry. The template uses this to render the scope picker vs an
+    # "n/a" span. Future-proofed: a new workflow without a registry
+    # entry shows as n/a until the registry is updated.
+    supports_path = {w.name: w.name in data.PATH_ARG_REGISTRY for w in workflows}
     return _render(
         request,
         "workflows.html",
         page="workflows",
         workflows=workflows,
         allow_run=cfg.allow_run,
+        features=features,
+        supports_path=supports_path,
     )
 
 

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from attune.ops import data
 from attune.ops.runner import RunnerBusyError, RunnerService
+from attune.security.path_validation import _validate_file_path
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -28,12 +33,54 @@ def _ensure_allowed(request: Request) -> None:
         )
 
 
+async def _read_scope(request: Request) -> str | None:
+    """Parse optional ``{"path": "..."}`` body. Empty body → None.
+
+    Treats an empty string the same as omitted so the picker's
+    "Project-wide" option doesn't have to send anything special.
+    """
+    body_bytes = await request.body()
+    if not body_bytes:
+        return None
+    try:
+        raw = json.loads(body_bytes)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="invalid JSON body") from exc
+    if not isinstance(raw, dict):
+        raise HTTPException(status_code=400, detail="body must be a JSON object")
+    raw_path = raw.get("path")
+    if raw_path is None or raw_path == "":
+        return None
+    if not isinstance(raw_path, str):
+        raise HTTPException(status_code=400, detail="path must be a string")
+    return raw_path
+
+
 @router.post("/workflows/{name}/run")
 async def start_run(name: str, request: Request) -> JSONResponse:
     _ensure_allowed(request)
     svc = _service(request)
+
+    scope = await _read_scope(request)
+    if scope is not None:
+        # Reject scope for workflows that don't accept a path arg. The
+        # registry is the source of truth for path-arg support; a
+        # workflow absent from the registry is treated as no-path.
+        if name not in data.PATH_ARG_REGISTRY:
+            raise HTTPException(
+                status_code=400,
+                detail=f"workflow '{name}' does not accept a path argument",
+            )
+        cfg = request.app.state.config
+        try:
+            validated = _validate_file_path(scope, allowed_dir=str(cfg.project_root))
+        except ValueError as exc:
+            logger.warning("ops.run: rejected scope path %r: %s", scope[:200], exc)
+            raise HTTPException(status_code=400, detail=f"invalid path: {exc}") from exc
+        scope = str(validated)
+
     try:
-        run = await svc.start(name)
+        run = await svc.start(name, path=scope)
     except RunnerBusyError as exc:
         raise HTTPException(
             status_code=409,

--- a/src/attune/ops/routes/runs_history.py
+++ b/src/attune/ops/routes/runs_history.py
@@ -1,0 +1,106 @@
+"""Read-only API for persisted run records (Phase 3).
+
+Two endpoints:
+
+  * ``GET /api/runs/{workflow}`` → up to 20 newest runs (metadata only).
+  * ``GET /api/runs/{workflow}/{run_id}`` → one record including the log.
+
+Both read from ``<attune_home>/ops/runs/<workflow>/<run-id>.json``.
+The in-memory ``RunnerService.recent()`` is consulted first so a run
+that's still in flight (no JSON on disk yet) is also visible.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from attune.ops.runner import _list_persisted_runs, _load_run_record
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# Workflow + run-id shape validators. These mirror the regexes in
+# ``runner.py`` but are duplicated here so the request-validation
+# rejection happens BEFORE any disk lookup. Pre-loaded constants are
+# fine — they never change.
+_WORKFLOW_NAME_RE = re.compile(r"^[a-z][a-z0-9-]+$")
+_RUN_ID_RE = re.compile(r"^[a-f0-9]{1,64}$")
+
+
+def _strip_lines(record: dict) -> dict:
+    """Drop the ``lines`` buffer for list responses to keep payloads small."""
+    out = dict(record)
+    out.pop("lines", None)
+    return out
+
+
+@router.get("/api/runs/{workflow}")
+async def list_runs(workflow: str, request: Request) -> JSONResponse:
+    """Return up to 20 newest runs for ``workflow``, newest first.
+
+    Combines in-memory runs (the current + recently-finished, which may
+    not be on disk yet) with persisted records. In-memory entries win
+    on id collision so an in-flight run's status stays live.
+    """
+    if not _WORKFLOW_NAME_RE.match(workflow):
+        raise HTTPException(status_code=400, detail="invalid workflow name")
+
+    runner = getattr(request.app.state, "runner", None)
+    cfg = request.app.state.config
+
+    seen_ids: set[str] = set()
+    metadata: list[dict] = []
+
+    # In-memory first — preserves live status / duration for active runs.
+    if runner is not None:
+        for run in runner.recent(limit=20):
+            if run.workflow != workflow:
+                continue
+            metadata.append(_strip_lines(run.to_record()))
+            seen_ids.add(run.id)
+
+    # Disk records second — old runs that aged out of in-memory history.
+    runs_dir = cfg.runs_dir
+    if runs_dir.is_dir():
+        for record in _list_persisted_runs(runs_dir, workflow, limit=20):
+            run_id = str(record.get("id") or "")
+            if run_id in seen_ids:
+                continue
+            metadata.append(_strip_lines(record))
+            seen_ids.add(run_id)
+
+    metadata.sort(key=lambda r: str(r.get("completed_at") or ""), reverse=True)
+    return JSONResponse(content={"workflow": workflow, "runs": metadata[:20]})
+
+
+@router.get("/api/runs/{workflow}/{run_id}")
+async def get_run_record(workflow: str, run_id: str, request: Request) -> JSONResponse:
+    """Return one persisted run record (metadata + log).
+
+    Falls back to the in-memory runner if the run isn't on disk yet
+    (e.g., still in flight, or completed but pre-persistence in
+    read-only mode).
+    """
+    if not _WORKFLOW_NAME_RE.match(workflow):
+        raise HTTPException(status_code=400, detail="invalid workflow name")
+    if not _RUN_ID_RE.match(run_id):
+        raise HTTPException(status_code=400, detail="invalid run id")
+
+    runner = getattr(request.app.state, "runner", None)
+    cfg = request.app.state.config
+
+    if runner is not None:
+        run = runner.get(run_id)
+        if run is not None and run.workflow == workflow:
+            return JSONResponse(content=run.to_record())
+
+    record = _load_run_record(cfg.runs_dir, workflow, run_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    return JSONResponse(content=record)

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -3,20 +3,47 @@
 Spawns ``attune workflow run <name>`` as a subprocess, captures merged
 stdout+stderr line-by-line, and broadcasts lines to SSE subscribers.
 
-Single concurrent run by design. History is in-memory only (last N runs).
+Single concurrent run by design. In-memory history holds the last N
+runs; completed runs may also be persisted to
+``<attune_home>/ops/runs/<workflow>/<run-id>.json`` so history survives
+a server restart. See docs/specs/ops-runner-tier2/ Phase 3.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
+import re
 import shlex
 import sys
+import time
 import uuid
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+# Log-byte cap for persisted records. Records with logs larger than this
+# get truncated and a trailing ``<TRUNCATED — N bytes more>`` marker is
+# appended so the user knows output was clipped. 200 KB is enough for
+# all observed real-world runs (the largest in telemetry was ~80 KB);
+# the cap is a defense against runaway loops filling the disk.
+_PERSIST_LOG_BUDGET_BYTES = 200_000
+
+# Workflow name shape — matches PATH_ARG_REGISTRY keys. Used to validate
+# the directory segment in the persistence path so a malformed workflow
+# name can't escape ``<runs_dir>``.
+_WORKFLOW_NAME_RE = re.compile(r"^[a-z][a-z0-9-]+$")
+
+# Run-id shape — UUID hex from ``uuid.uuid4().hex[:12]``. Validated when
+# loading records from disk so a stray file with a hostile name can't
+# bypass directory containment.
+_RUN_ID_RE = re.compile(r"^[a-f0-9]{1,64}$")
 
 
 class RunnerBusyError(RuntimeError):
@@ -30,6 +57,23 @@ class RunnerBusyError(RuntimeError):
 RunStatus = Literal["pending", "running", "completed", "failed"]
 EventKind = Literal["line", "done", "error"]
 Event = tuple[EventKind, object]
+
+
+_VALID_STATUSES: frozenset[str] = frozenset(("pending", "running", "completed", "failed"))
+
+
+def _coerce_status(value: object) -> RunStatus:
+    if isinstance(value, str) and value in _VALID_STATUSES:
+        return value  # type: ignore[return-value]
+    return "completed"
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    return None
 
 
 @dataclass
@@ -46,6 +90,10 @@ class Run:
     # ``None`` means the workflow runs project-wide (no ``--path`` flag).
     # See docs/specs/ops-runner-tier2/ Phase 2.
     path: str | None = None
+    # Full command line (argv list) the subprocess was invoked with.
+    # Captured at execute time so the persistence record can reproduce
+    # exactly what ran. ``None`` for runs that never executed.
+    command: list[str] | None = None
     lines: list[str] = field(default_factory=list)
     subscribers: set[asyncio.Queue[Event]] = field(default_factory=set)
 
@@ -70,7 +118,51 @@ class Run:
             "duration_seconds": self.duration_seconds,
             "line_count": len(self.lines),
             "path": self.path,
+            "command": list(self.command) if self.command else None,
         }
+
+    def to_record(self) -> dict[str, object]:
+        """Serialize the full record (metadata + log) for disk persistence.
+
+        Mirrors :meth:`to_dict` but adds the line buffer. Used by the
+        ``ops/runs/<workflow>/<run-id>.json`` writer in Phase 3.
+        """
+        record = self.to_dict()
+        record["lines"] = list(self.lines)
+        return record
+
+    @classmethod
+    def from_record(cls, data: dict[str, object]) -> Run:
+        """Rebuild a Run from a persisted record.
+
+        The returned Run has no subscribers (subscribers are tied to a
+        live SSE stream; replay from disk is read-only). ``started_at``
+        and ``completed_at`` are restored from ISO strings.
+        """
+
+        def _parse_dt(value: object) -> datetime | None:
+            if not isinstance(value, str) or not value:
+                return None
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return None
+
+        lines_raw = data.get("lines") or []
+        lines = [str(line) for line in lines_raw] if isinstance(lines_raw, list) else []
+        command_raw = data.get("command")
+        command = [str(c) for c in command_raw] if isinstance(command_raw, list) else None
+        return cls(
+            id=str(data.get("id", "")),
+            workflow=str(data.get("workflow", "")),
+            status=_coerce_status(data.get("status")),
+            exit_code=_coerce_int(data.get("exit_code")),
+            started_at=_parse_dt(data.get("started_at")),
+            completed_at=_parse_dt(data.get("completed_at")),
+            path=str(data["path"]) if isinstance(data.get("path"), str) else None,
+            command=command,
+            lines=lines,
+        )
 
     def _broadcast(self, event: Event) -> None:
         for q in list(self.subscribers):
@@ -140,7 +232,14 @@ def _default_command(workflow: str) -> Sequence[str]:
 
 
 class RunnerService:
-    """Owns the run history + concurrency lock."""
+    """Owns the run history + concurrency lock.
+
+    When ``persistence_dir`` is supplied, completed runs are written to
+    ``<persistence_dir>/<workflow>/<run-id>.json`` so the dashboard's
+    recent-runs strip can survive a server restart. ``None`` disables
+    persistence — used in read-only mode and tests that don't care about
+    disk side effects.
+    """
 
     def __init__(
         self,
@@ -148,12 +247,18 @@ class RunnerService:
         history_limit: int = 20,
         command_builder: CommandBuilder | None = None,
         executor: Callable[[Run], Awaitable[None]] | None = None,
+        persistence_dir: Path | None = None,
     ) -> None:
         self._runs: OrderedDict[str, Run] = OrderedDict()
         self._history_limit = history_limit
         self._command_builder = command_builder or _default_command
         self._lock = asyncio.Lock()
         self._executor = executor or self._execute
+        self._persistence_dir = persistence_dir
+
+    @property
+    def persistence_dir(self) -> Path | None:
+        return self._persistence_dir
 
     @property
     def current(self) -> Run | None:
@@ -181,6 +286,19 @@ class RunnerService:
         asyncio.create_task(self._executor(run))
         return run
 
+    def _finish_run(self, run: Run, exit_code: int) -> None:
+        """Mark a run done + persist it (best-effort) when configured.
+
+        Exactly one terminal call per run — replaces direct
+        ``run.mark_done(...)`` invocations inside ``_execute``. The
+        persistence write is synchronous on the executor's thread; it's
+        bounded (200 KB log cap, atomic-rename, JSON encode) so the
+        added latency is negligible relative to a workflow's runtime.
+        """
+        run.mark_done(exit_code)
+        if self._persistence_dir is not None:
+            _persist_run(run, self._persistence_dir)
+
     async def _execute(self, run: Run) -> None:
         run.status = "running"
         run.started_at = datetime.now(timezone.utc)
@@ -192,6 +310,7 @@ class RunnerService:
         # PATH_ARG_REGISTRY at the workflow layer.
         if run.path:
             cmd.extend(["--path", run.path])
+        run.command = list(cmd)
         run.append_line(f"$ {' '.join(shlex.quote(c) for c in cmd)}")
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -201,11 +320,11 @@ class RunnerService:
             )
         except FileNotFoundError as exc:
             run.append_line(f"[runner error] command not found: {exc}")
-            run.mark_done(-1)
+            self._finish_run(run, -1)
             return
         except Exception as exc:  # noqa: BLE001
             run.append_line(f"[runner error] {exc}")
-            run.mark_done(-1)
+            self._finish_run(run, -1)
             return
 
         assert proc.stdout is not None
@@ -216,13 +335,172 @@ class RunnerService:
                     break
                 run.append_line(raw.decode("utf-8", errors="replace").rstrip("\n"))
             await proc.wait()
-            run.mark_done(proc.returncode if proc.returncode is not None else -1)
+            self._finish_run(run, proc.returncode if proc.returncode is not None else -1)
         except Exception as exc:  # noqa: BLE001
             run.append_line(f"[runner error] {exc}")
-            run.mark_done(-1)
+            self._finish_run(run, -1)
 
 
 def echo_command_builder(workflow: str) -> Sequence[str]:
     """Test helper: produce a portable subprocess that prints two lines + exits 0."""
     script = f"import sys; print('starting {workflow}'); print('done {workflow}')"
     return (sys.executable, "-c", script)
+
+
+# ---------------------------------------------------------------------------
+# Run persistence (Phase 3) — disk read/write helpers
+# ---------------------------------------------------------------------------
+
+
+def _truncate_lines_for_persist(lines: list[str]) -> list[str]:
+    """Clamp the on-disk log to ``_PERSIST_LOG_BUDGET_BYTES``.
+
+    Keeps the FIRST N bytes (the preamble + early output where most
+    errors surface). Appends a ``<TRUNCATED — N bytes more>`` marker
+    line when bytes are dropped. Returns a NEW list — the live ``Run``
+    object is never mutated by persistence.
+    """
+    encoded = [line.encode("utf-8", errors="replace") for line in lines]
+    sizes = [len(b) + 1 for b in encoded]  # +1 for the newline separator
+    total = sum(sizes)
+    if total <= _PERSIST_LOG_BUDGET_BYTES:
+        return list(lines)
+    kept: list[str] = []
+    running = 0
+    for line, size in zip(lines, sizes, strict=False):
+        if running + size > _PERSIST_LOG_BUDGET_BYTES:
+            break
+        kept.append(line)
+        running += size
+    dropped_bytes = total - running
+    kept.append(f"<TRUNCATED — {dropped_bytes} bytes more>")
+    return kept
+
+
+def _persist_run(run: Run, runs_dir: Path) -> Path | None:
+    """Atomically write a run record under ``<runs_dir>/<workflow>/<id>.json``.
+
+    Best-effort: returns the destination path on success, ``None`` on
+    failure (logged at WARNING). Validation rejects malformed workflow
+    names and run IDs so a hostile value can't escape ``runs_dir``.
+    """
+    if not _WORKFLOW_NAME_RE.match(run.workflow):
+        logger.warning("ops.persist: refusing to write — bad workflow name %r", run.workflow)
+        return None
+    if not _RUN_ID_RE.match(run.id):
+        logger.warning("ops.persist: refusing to write — bad run id %r", run.id)
+        return None
+
+    record = run.to_record()
+    record["lines"] = _truncate_lines_for_persist(run.lines)
+    record["persisted_at"] = datetime.now(timezone.utc).isoformat()
+
+    workflow_dir = runs_dir / run.workflow
+    dest = workflow_dir / f"{run.id}.json"
+    tmp = workflow_dir / f"{run.id}.json.tmp"
+    try:
+        workflow_dir.mkdir(parents=True, exist_ok=True)
+        tmp.write_text(json.dumps(record, indent=2), encoding="utf-8")
+        tmp.replace(dest)
+    except OSError as exc:
+        logger.warning("ops.persist: write failed for %s/%s: %s", run.workflow, run.id, exc)
+        with _suppress_oserror():
+            tmp.unlink()
+        return None
+    return dest
+
+
+def _load_run_record(runs_dir: Path, workflow: str, run_id: str) -> dict | None:
+    """Load a persisted run record. Returns ``None`` on missing/malformed."""
+    if not _WORKFLOW_NAME_RE.match(workflow) or not _RUN_ID_RE.match(run_id):
+        return None
+    path = runs_dir / workflow / f"{run_id}.json"
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("ops.persist: read failed for %s: %s", path, exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _list_persisted_runs(runs_dir: Path, workflow: str, *, limit: int = 20) -> list[dict]:
+    """Return up to ``limit`` newest persisted run records for ``workflow``.
+
+    Newest first, sorted by file mtime. Malformed files are skipped with
+    a warning log. Records include the full ``lines`` buffer — callers
+    that only need metadata should drop the field.
+    """
+    if not _WORKFLOW_NAME_RE.match(workflow):
+        return []
+    workflow_dir = runs_dir / workflow
+    if not workflow_dir.is_dir():
+        return []
+    try:
+        entries = sorted(
+            workflow_dir.glob("*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return []
+    out: list[dict] = []
+    for entry in entries[: max(limit * 2, limit)]:  # over-fetch then filter
+        if not entry.is_file() or entry.name.endswith(".tmp"):
+            continue
+        run_id = entry.stem
+        if not _RUN_ID_RE.match(run_id):
+            continue
+        record = _load_run_record(runs_dir, workflow, run_id)
+        if record is None:
+            continue
+        out.append(record)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def prune_old_runs(runs_dir: Path, *, days: int) -> int:
+    """Delete persisted run files older than ``days``. Returns the deletion count.
+
+    Safe to call on a missing directory (returns 0). Errors per file
+    are logged at WARNING and don't abort the sweep.
+    """
+    if days <= 0 or not runs_dir.is_dir():
+        return 0
+    cutoff = time.time() - days * 86_400
+    deleted = 0
+    try:
+        workflow_dirs = list(runs_dir.iterdir())
+    except OSError:
+        return 0
+    for workflow_dir in workflow_dirs:
+        if not workflow_dir.is_dir():
+            continue
+        try:
+            entries = list(workflow_dir.glob("*.json"))
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    entry.unlink()
+                    deleted += 1
+            except OSError as exc:
+                logger.warning("ops.persist: prune failed for %s: %s", entry, exc)
+    return deleted
+
+
+class _suppress_oserror:
+    """Context-manager replacement for ``contextlib.suppress(OSError)``.
+
+    Inline class avoids an extra import for a 4-line cleanup path.
+    """
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return isinstance(exc, OSError)

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -42,6 +42,10 @@ class Run:
     exit_code: int | None = None
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    # Optional scope path passed to the workflow as ``--path <value>``.
+    # ``None`` means the workflow runs project-wide (no ``--path`` flag).
+    # See docs/specs/ops-runner-tier2/ Phase 2.
+    path: str | None = None
     lines: list[str] = field(default_factory=list)
     subscribers: set[asyncio.Queue[Event]] = field(default_factory=set)
 
@@ -65,6 +69,7 @@ class Run:
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
             "duration_seconds": self.duration_seconds,
             "line_count": len(self.lines),
+            "path": self.path,
         }
 
     def _broadcast(self, event: Event) -> None:
@@ -126,6 +131,10 @@ def _default_command(workflow: str) -> Sequence[str]:
     silently runs old code, which is the kind of bug that wastes 30 minutes
     of debugging before someone notices ``which attune`` doesn't point where
     they think it does.
+
+    Scope (``--path``) is appended by :meth:`RunnerService._execute` after
+    the builder's output, so custom builders (test fixtures, alternative
+    CLIs) don't need to know about it.
     """
     return (sys.executable, "-m", "attune.cli_minimal", "workflow", "run", workflow)
 
@@ -159,12 +168,12 @@ class RunnerService:
     def recent(self, limit: int = 5) -> list[Run]:
         return list(reversed(list(self._runs.values())))[:limit]
 
-    async def start(self, workflow: str) -> Run:
+    async def start(self, workflow: str, *, path: str | None = None) -> Run:
         async with self._lock:
             current = self.current
             if current is not None:
                 raise RunnerBusyError(current.id)
-            run = Run(id=uuid.uuid4().hex[:12], workflow=workflow)
+            run = Run(id=uuid.uuid4().hex[:12], workflow=workflow, path=path)
             self._runs[run.id] = run
             while len(self._runs) > self._history_limit:
                 self._runs.popitem(last=False)
@@ -176,6 +185,13 @@ class RunnerService:
         run.status = "running"
         run.started_at = datetime.now(timezone.utc)
         cmd = list(self._command_builder(run.workflow))
+        # Append ``--path <scope>`` after the builder's output so test
+        # fixtures (with simple ``workflow -> command`` signatures) don't
+        # need to know about scoping. The CLI accepts ``--path`` uniformly
+        # and rewrites it into the workflow-specific kwarg via
+        # PATH_ARG_REGISTRY at the workflow layer.
+        if run.path:
+            cmd.extend(["--path", run.path])
         run.append_line(f"$ {' '.join(shlex.quote(c) for c in cmd)}")
         try:
             proc = await asyncio.create_subprocess_exec(

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -14,8 +14,9 @@ from attune import __version__
 from attune.ops.config import Config
 from attune.ops.routes import dashboard
 from attune.ops.routes import runner as runner_routes
+from attune.ops.routes import runs_history as runs_history_routes
 from attune.ops.routes import specs as specs_routes
-from attune.ops.runner import RunnerService
+from attune.ops.runner import RunnerService, prune_old_runs
 
 
 def _package_dir(name: str) -> Path:
@@ -23,8 +24,30 @@ def _package_dir(name: str) -> Path:
     return Path(str(files("attune.ops").joinpath(name)))
 
 
+def _build_default_runner(config: Config) -> RunnerService:
+    """Construct the runner with persistence enabled when runs are allowed.
+
+    Read-only mode (``allow_run=False``) disables disk writes entirely —
+    a read-only dashboard should not modify the user's ``~/.attune``.
+    """
+    if not config.allow_run:
+        return RunnerService()
+    return RunnerService(persistence_dir=config.runs_dir)
+
+
 def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAPI:
     """Build the FastAPI app, wiring config + templates into request state."""
+    # Sweep stale persisted runs before serving any traffic. Bounded by
+    # `runs_retention_days` (CLI flag), `0` disables the sweep entirely.
+    if config.allow_run and config.runs_retention_days > 0:
+        try:
+            prune_old_runs(config.runs_dir, days=config.runs_retention_days)
+        except OSError:
+            # INTENTIONAL: best-effort sweep; never block startup on a
+            # filesystem hiccup. The helper itself swallows per-file
+            # errors; this only catches the outer iterdir failure.
+            pass
+
     app = FastAPI(
         title="attune ops",
         version=__version__,
@@ -63,10 +86,11 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
     app.state.config = config
     app.state.templates = templates
-    app.state.runner = runner if runner is not None else RunnerService()
+    app.state.runner = runner if runner is not None else _build_default_runner(config)
 
     app.include_router(dashboard.router)
     app.include_router(runner_routes.router)
+    app.include_router(runs_history_routes.router)
     app.include_router(specs_routes.router)
 
     @app.get("/api/info", response_class=JSONResponse)
@@ -80,6 +104,13 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
 
     @app.exception_handler(404)
     async def not_found(request: Request, exc):  # type: ignore[no-untyped-def]
+        # API paths get JSON so client-side error parsing works; HTML
+        # pages get the styled 404 template. ``getattr`` shields against
+        # the case where ``exc`` is a Starlette HTTPException (which has
+        # ``.detail``) vs a bare 404 (which doesn't).
+        detail = getattr(exc, "detail", None) or "not found"
+        if request.url.path.startswith("/api/"):
+            return JSONResponse(status_code=404, content={"detail": detail})
         templates = request.app.state.templates
         cfg: Config = request.app.state.config
         return HTMLResponse(

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -485,6 +485,27 @@ a.kpi:hover {
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.12s ease, background-color 0.12s ease;
+}
+.log-output .log-workflow:hover {
+  border-color: var(--accent);
+  background-color: var(--accent-soft);
+}
+.log-output .log-workflow.pill-disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+/* Inline error surfaced when a pill click can't start a run (busy,
+   read-only, etc.). Sits in the run-view-head section above the log. */
+.run-view-error {
+  margin-top: 8px;
+  padding: 6px 10px;
+  background: var(--danger-soft);
+  color: var(--danger);
+  border: 1px solid var(--danger-soft);
+  border-radius: var(--radius-sm, 6px);
+  font-size: 12px;
 }
 .log-output .log-header {
   font-weight: 600;
@@ -617,6 +638,82 @@ a.kpi:hover {
   font-size: 12px;
   color: var(--fg-subtle);
   font-style: italic;
+}
+
+/* Recent-runs strip (ops-runner-tier2 Phase 3). Shown below each
+   workflow row and at the top of the run-view page. */
+.recent-runs,
+.run-view-history {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin-top: 8px;
+  font-size: 11px;
+}
+.run-view-history {
+  margin: 12px 0 8px 0;
+}
+.recent-runs-label {
+  color: var(--fg-subtle);
+  font-style: italic;
+  margin-right: 2px;
+}
+.recent-run-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  border: 1px solid var(--border);
+  background-color: var(--bg-soft);
+  color: var(--fg);
+  text-decoration: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+.recent-run-chip:hover {
+  border-color: var(--accent);
+  background-color: var(--accent-soft, var(--bg-soft));
+  text-decoration: none;
+}
+.recent-run-chip.chip-ok {
+  border-color: var(--ok-soft);
+  background-color: var(--ok-soft);
+  color: var(--ok);
+}
+.recent-run-chip.chip-danger {
+  border-color: var(--danger-soft, var(--bg-soft));
+  background-color: var(--danger-soft, var(--bg-soft));
+  color: var(--danger);
+}
+.recent-run-chip.chip-warn {
+  border-color: var(--warn-soft);
+  background-color: var(--warn-soft);
+  color: var(--warn);
+}
+.recent-run-chip.chip-muted {
+  color: var(--fg-muted);
+}
+.recent-run-status {
+  font-size: 10px;
+  opacity: 0.7;
+  text-transform: lowercase;
+}
+.run-view-scope {
+  color: var(--fg-muted);
+}
+.chained-from {
+  font-size: 12px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  margin-left: 8px;
+}
+.chained-from a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* Spec drill-in: phase body in a readable monospace block. */

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -570,6 +570,55 @@ a.kpi:hover {
   transition: outline 0.3s ease-out;
 }
 
+/* Workflow scope picker (ops-runner-tier2 Phase 2). */
+.scope-cell {
+  white-space: nowrap;
+}
+.scope-picker {
+  font-size: 12px;
+  padding: 3px 22px 3px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background-color: var(--bg-soft);
+  color: var(--fg);
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+                    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position:
+    calc(100% - 12px) 50%,
+    calc(100% - 7px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  max-width: 220px;
+}
+.scope-picker:hover {
+  border-color: var(--accent);
+}
+.scope-custom {
+  display: block;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background-color: var(--bg-soft);
+  color: var(--fg);
+  width: 220px;
+  max-width: 100%;
+}
+.scope-custom:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.scope-na {
+  font-size: 12px;
+  color: var(--fg-subtle);
+  font-style: italic;
+}
+
 /* Spec drill-in: phase body in a readable monospace block. */
 .spec-phase {
   margin-bottom: 2rem;

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -1,0 +1,255 @@
+// Per-run page logic: SSE replay + status, recent-runs strip, chained-
+// from badge, and Phase-4 clickable workflow-name pills.
+//
+// Configuration comes from a server-injected <script
+// type="application/json" id="run-view-data"> block (see
+// templates/run_view.html). Reading from a tagged JSON block avoids
+// global-namespace pollution and keeps the data flow inspectable in
+// devtools.
+(function () {
+  "use strict";
+
+  var dataEl = document.getElementById("run-view-data");
+  if (!dataEl) return;
+
+  var DATA;
+  try {
+    DATA = JSON.parse(dataEl.textContent || "{}");
+  } catch (e) {
+    DATA = {};
+  }
+
+  var STREAM_URL = DATA.stream_url || "";
+  var INITIAL_STATUS = DATA.initial_status || "";
+  var SOURCE_WORKFLOW = DATA.workflow || "";
+  var SOURCE_PATH = DATA.path == null ? null : DATA.path;
+  var ALLOW_RUN = DATA.allow_run === true;
+
+  var pre = document.querySelector("[data-log]");
+  var statusEl = document.querySelector("[data-status]");
+  var chainedFromEl = document.querySelector("[data-chained-from]");
+  var startedAt = Date.now();
+  var tickerId = null;
+
+  function setStatus(text) {
+    if (statusEl) statusEl.textContent = text;
+  }
+
+  function setStatusClass(extra) {
+    if (!statusEl) return;
+    statusEl.className = "run-view-status chip " + (extra || "");
+  }
+
+  function appendLine(line) {
+    if (!pre) return;
+    pre.appendChild(document.createTextNode(line + "\n"));
+    pre.scrollTop = pre.scrollHeight;
+  }
+
+  function startTicker() {
+    if (tickerId) return;
+    tickerId = setInterval(function () {
+      var s = Math.floor((Date.now() - startedAt) / 1000);
+      var label;
+      if (s < 60) {
+        label = s + "s";
+      } else {
+        label = Math.floor(s / 60) + "m " + (s % 60) + "s";
+      }
+      setStatus("running " + label);
+    }, 1000);
+  }
+
+  function stopTicker() {
+    if (tickerId) {
+      clearInterval(tickerId);
+      tickerId = null;
+    }
+  }
+
+  // SSE attachment — replays buffered output for refresh-survival.
+  if (STREAM_URL) {
+    var es = new EventSource(STREAM_URL);
+
+    if (INITIAL_STATUS === "running" || INITIAL_STATUS === "pending") {
+      startTicker();
+    } else {
+      setStatusClass(
+        INITIAL_STATUS === "completed" ? "chip-ok" :
+        INITIAL_STATUS === "failed" ? "chip-danger" :
+        "chip-muted"
+      );
+    }
+
+    es.addEventListener("line", function (ev) {
+      // The raw line is broadcast verbatim; wrap in JSON.parse to
+      // unwrap the JSON-string the server emits.
+      appendLine(JSON.parse(ev.data));
+    });
+
+    es.addEventListener("done", function (ev) {
+      var info = JSON.parse(ev.data);
+      stopTicker();
+      setStatus(info.status + " (exit " + info.exit_code + ")");
+      setStatusClass(
+        info.status === "completed" ? "chip-ok" :
+        info.status === "failed" ? "chip-danger" :
+        "chip-muted"
+      );
+      es.close();
+    });
+
+    es.addEventListener("error", function () {
+      stopTicker();
+      setStatus("stream error");
+      setStatusClass("chip-danger");
+      es.close();
+    });
+  }
+
+  // ----------------------------------------------------------------
+  // Phase 4 — clickable workflow-name pills inside the log
+  // ----------------------------------------------------------------
+
+  function showInlineError(message) {
+    var section = document.querySelector(".run-view-head") || document.body;
+    var existing = section.querySelector(".run-view-error");
+    if (existing) existing.remove();
+    var box = document.createElement("div");
+    box.className = "run-view-error";
+    box.textContent = message;
+    section.appendChild(box);
+  }
+
+  function pillTargetFromEvent(ev) {
+    // Walk up to the nearest .log-workflow chip; bail if the click was
+    // somewhere else.
+    var el = ev.target;
+    while (el && el !== document) {
+      if (el.classList && el.classList.contains("log-workflow")) return el;
+      el = el.parentNode;
+    }
+    return null;
+  }
+
+  function handlePillClick(ev) {
+    var pill = pillTargetFromEvent(ev);
+    if (!pill) return;
+    ev.preventDefault();
+    var target = (pill.textContent || "").trim();
+    if (!target) return;
+    if (!ALLOW_RUN) {
+      showInlineError(
+        "Read-only mode — restart attune ops without --read-only to chain runs."
+      );
+      return;
+    }
+    var body = {};
+    if (SOURCE_PATH) body.path = SOURCE_PATH;
+    // Disable the pill to deduplicate double-clicks while the POST is
+    // in flight.
+    pill.classList.add("pill-disabled");
+    fetch("/workflows/" + encodeURIComponent(target) + "/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body)
+    })
+      .then(function (resp) {
+        return resp.text().then(function (text) {
+          return { status: resp.status, text: text };
+        });
+      })
+      .then(function (result) {
+        pill.classList.remove("pill-disabled");
+        if (result.status === 201) {
+          var parsed;
+          try { parsed = JSON.parse(result.text); } catch (e) { parsed = null; }
+          if (parsed && parsed.run_id) {
+            window.location.assign(
+              "/runs/" + encodeURIComponent(parsed.run_id) +
+              "/view?from=" + encodeURIComponent(SOURCE_WORKFLOW)
+            );
+            return;
+          }
+        }
+        if (result.status === 409) {
+          // Busy — surface inline; don't navigate away from this run.
+          var msg = "Another workflow is running. Wait for it to finish, then click again.";
+          try {
+            var parsed409 = JSON.parse(result.text);
+            if (parsed409 && parsed409.detail && parsed409.detail.message) {
+              msg = parsed409.detail.message;
+              if (parsed409.detail.current_run_id) {
+                msg += " (run " + parsed409.detail.current_run_id + ")";
+              }
+            }
+          } catch (e) { /* keep default msg */ }
+          showInlineError(msg);
+          return;
+        }
+        if (result.status === 403) {
+          showInlineError(
+            "Runs are disabled — restart attune ops without --read-only to chain runs."
+          );
+          return;
+        }
+        showInlineError("Could not start " + target + " (HTTP " + result.status + ")");
+      })
+      .catch(function (err) {
+        pill.classList.remove("pill-disabled");
+        showInlineError("Could not start " + target + ": " + err);
+      });
+  }
+
+  // Delegated listener — pills are inside the streaming log, so new
+  // ones appear over the lifetime of the page. One listener at the
+  // log container avoids per-pill wiring.
+  if (pre) {
+    pre.addEventListener("click", handlePillClick);
+  }
+
+  // ----------------------------------------------------------------
+  // Phase 4 — "↩ from <workflow>" badge driven by ?from= URL param
+  // ----------------------------------------------------------------
+
+  function renderChainedFromBadge() {
+    if (!chainedFromEl) return;
+    var params = new URLSearchParams(window.location.search);
+    var fromName = params.get("from");
+    if (!fromName) return;
+    // Strip any unexpected characters; we only want a workflow name.
+    if (!/^[a-z][a-z0-9-]+$/.test(fromName)) return;
+    while (chainedFromEl.firstChild) chainedFromEl.removeChild(chainedFromEl.firstChild);
+    chainedFromEl.appendChild(document.createTextNode("↩ from "));
+    var code = document.createElement("code");
+    code.textContent = fromName;
+    chainedFromEl.appendChild(code);
+    chainedFromEl.hidden = false;
+  }
+
+  renderChainedFromBadge();
+
+  // ----------------------------------------------------------------
+  // Phase 3 — recent-runs strip at the top of the run-view page
+  // ----------------------------------------------------------------
+  //
+  // Uses the shared helper exposed by runner.js's window.__attuneRunner.
+  // run_view.html loads runner.js before this script so the helper is
+  // available; if it's missing we no-op (history is best-effort).
+  var runner = (typeof window !== "undefined") ? window.__attuneRunner : null;
+  if (runner && typeof runner.setupRecentRuns === "function") {
+    document
+      .querySelectorAll("[data-recent-runs]")
+      .forEach(runner.setupRecentRuns);
+  }
+
+  // Expose internals for tests.
+  if (typeof window !== "undefined") {
+    window.__attuneRunView = {
+      handlePillClick: handlePillClick,
+      renderChainedFromBadge: renderChainedFromBadge,
+      pillTargetFromEvent: pillTargetFromEvent,
+      DATA: DATA
+    };
+  }
+})();

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -161,6 +161,8 @@
       detectSectionHeader: detectSectionHeader,
       appendInline: appendInline,
       appendLine: appendLine,
+      getScope: getScope,
+      wireScopePickerToggle: wireScopePickerToggle,
       WORKFLOW_NAMES: WORKFLOW_NAMES,
       SECTION_HEADERS: SECTION_HEADERS
     };
@@ -209,6 +211,46 @@
     return function stop() { clearInterval(id); };
   }
 
+  // Read the scope the user picked for this workflow row.
+  // Returns null for "Project-wide" (default) or workflows that don't
+  // support --path (no picker in the row). Returns the string value of
+  // the dropdown for a feature pick, or the custom text input's value
+  // when the user picked "Custom path…". Trims whitespace; an empty
+  // custom value falls back to project-wide (null).
+  function getScope(row) {
+    var picker = row.querySelector("[data-scope-picker]");
+    if (!picker) return null;
+    var val = picker.value;
+    if (val === "" || val === null || val === undefined) return null;
+    if (val === "__custom__") {
+      var custom = row.querySelector("[data-scope-custom]");
+      if (!custom) return null;
+      var trimmed = (custom.value || "").trim();
+      return trimmed === "" ? null : trimmed;
+    }
+    return val;
+  }
+
+  // Toggle the custom-path text input based on the picker's value. Shown
+  // when "Custom path…" is selected, hidden otherwise.
+  function wireScopePickerToggle(row) {
+    var picker = row.querySelector("[data-scope-picker]");
+    var custom = row.querySelector("[data-scope-custom]");
+    if (!picker || !custom) return;
+    picker.addEventListener("change", function () {
+      if (picker.value === "__custom__") {
+        custom.hidden = false;
+        custom.focus();
+      } else {
+        custom.hidden = true;
+      }
+    });
+  }
+
+  // Export getScope for tests (alongside the existing rendering helpers).
+  // Note: window.__attuneRunner is populated farther below, after these
+  // helpers are defined; the assignment block lives at the same scope.
+
   function attach(button) {
     button.addEventListener("click", async function () {
       var name = button.dataset.workflow;
@@ -217,9 +259,13 @@
       button.disabled = true;
       setStatus(row, "starting…");
       try {
-        var resp = await fetch("/workflows/" + encodeURIComponent(name) + "/run", {
-          method: "POST",
-        });
+        var scope = getScope(row);
+        var fetchOpts = { method: "POST" };
+        if (scope !== null) {
+          fetchOpts.headers = { "Content-Type": "application/json" };
+          fetchOpts.body = JSON.stringify({ path: scope });
+        }
+        var resp = await fetch("/workflows/" + encodeURIComponent(name) + "/run", fetchOpts);
         if (!resp.ok) {
           var detail = await resp.text();
           // Show the inline error on the workflows page — don't navigate
@@ -248,5 +294,6 @@
 
   document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll("[data-run-button]").forEach(attach);
+    document.querySelectorAll("tr[data-workflow]").forEach(wireScopePickerToggle);
   });
 })();

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -163,6 +163,9 @@
       appendLine: appendLine,
       getScope: getScope,
       wireScopePickerToggle: wireScopePickerToggle,
+      setupRecentRuns: setupRecentRuns,
+      renderRecentRunsInto: renderRecentRunsInto,
+      statusClass: statusClass,
       WORKFLOW_NAMES: WORKFLOW_NAMES,
       SECTION_HEADERS: SECTION_HEADERS
     };
@@ -247,6 +250,68 @@
     });
   }
 
+  // Fetch /api/runs/<workflow> and render up to 5 chips into the
+  // container element. Each chip is a real anchor element (no
+  // innerHTML — workflow name and run id are user-controlled enough
+  // that we'd rather treat them as untrusted, and DOM nodes are
+  // unambiguous about that).
+  function setupRecentRuns(container) {
+    if (!container) return;
+    var workflow = container.getAttribute("data-recent-runs");
+    if (!workflow) return;
+    fetch("/api/runs/" + encodeURIComponent(workflow), {
+      headers: { Accept: "application/json" }
+    })
+      .then(function (resp) {
+        if (!resp.ok) return null;
+        return resp.json();
+      })
+      .then(function (body) {
+        if (!body || !body.runs || body.runs.length === 0) return;
+        renderRecentRunsInto(container, body.runs.slice(0, 5));
+      })
+      .catch(function () {
+        // INTENTIONAL: history is a nice-to-have; a failed fetch
+        // leaves the container hidden (its default state) so the
+        // page renders normally without it.
+      });
+  }
+
+  function renderRecentRunsInto(container, runs) {
+    while (container.firstChild) container.removeChild(container.firstChild);
+    var label = document.createElement("span");
+    label.className = "recent-runs-label";
+    label.textContent = "Recent: ";
+    container.appendChild(label);
+    runs.forEach(function (run) {
+      var a = document.createElement("a");
+      a.className = "recent-run-chip chip-" + statusClass(run.status);
+      a.href = "/runs/" + encodeURIComponent(run.id) + "/view";
+      // Compact label: short id + scope marker. Status conveyed via
+      // chip color, not extra text — keeps the strip narrow.
+      var idTxt = document.createElement("code");
+      idTxt.textContent = String(run.id).slice(0, 8);
+      a.appendChild(idTxt);
+      if (run.path) {
+        a.title = "scope: " + run.path;
+      }
+      a.appendChild(document.createTextNode(" "));
+      var statusTxt = document.createElement("span");
+      statusTxt.className = "recent-run-status";
+      statusTxt.textContent = String(run.status || "?");
+      a.appendChild(statusTxt);
+      container.appendChild(a);
+    });
+    container.hidden = false;
+  }
+
+  function statusClass(status) {
+    if (status === "completed") return "ok";
+    if (status === "failed") return "danger";
+    if (status === "running" || status === "pending") return "warn";
+    return "muted";
+  }
+
   // Export getScope for tests (alongside the existing rendering helpers).
   // Note: window.__attuneRunner is populated farther below, after these
   // helpers are defined; the assignment block lives at the same scope.
@@ -295,5 +360,6 @@
   document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll("[data-run-button]").forEach(attach);
     document.querySelectorAll("tr[data-workflow]").forEach(wireScopePickerToggle);
+    document.querySelectorAll("[data-recent-runs]").forEach(setupRecentRuns);
   });
 })();

--- a/src/attune/ops/templates/run_view.html
+++ b/src/attune/ops/templates/run_view.html
@@ -8,6 +8,7 @@
   <h1>
     <code>{{ run.workflow }}</code>
     <span class="run-id-chip">run <code>{{ run.id[:12] }}</code></span>
+    <span class="chained-from" data-chained-from hidden></span>
   </h1>
   <p class="page-sub run-view-meta">
     <span class="run-view-status chip" data-status>{{ run.status }}</span>
@@ -17,7 +18,11 @@
     {% if run.started_at %}
       <span class="run-view-started">started <code>{{ run.started_at }}</code></span>
     {% endif %}
+    {% if run.path %}
+      <span class="run-view-scope">scope <code>{{ run.path }}</code></span>
+    {% endif %}
   </p>
+  <div class="run-view-history" data-recent-runs="{{ run.workflow }}" hidden></div>
 </section>
 
 <pre class="log-output run-view-log" data-log></pre>
@@ -30,91 +35,21 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-(function () {
-  "use strict";
-
-  // Server-rendered, escaped via Jinja autoescape — safe for use in JS.
-  var STREAM_URL = {{ stream_url|tojson }};
-  var INITIAL_STATUS = {{ run.status|tojson }};
-
-  var pre = document.querySelector("[data-log]");
-  var statusEl = document.querySelector("[data-status]");
-  var startedAt = Date.now();
-  var tickerId = null;
-
-  function setStatus(text) {
-    if (statusEl) statusEl.textContent = text;
-  }
-
-  function setStatusClass(extra) {
-    if (!statusEl) return;
-    statusEl.className = "run-view-status chip " + (extra || "");
-  }
-
-  function appendLine(line) {
-    pre.appendChild(document.createTextNode(line + "\n"));
-    pre.scrollTop = pre.scrollHeight;
-  }
-
-  function startTicker() {
-    if (tickerId) return;
-    tickerId = setInterval(function () {
-      var s = Math.floor((Date.now() - startedAt) / 1000);
-      var label;
-      if (s < 60) {
-        label = s + "s";
-      } else {
-        label = Math.floor(s / 60) + "m " + (s % 60) + "s";
-      }
-      setStatus("running " + label);
-    }, 1000);
-  }
-
-  function stopTicker() {
-    if (tickerId) {
-      clearInterval(tickerId);
-      tickerId = null;
-    }
-  }
-
-  // Always attach to the SSE stream. The runner replays buffered lines
-  // to new subscribers, so a refresh on an in-progress (or completed)
-  // run shows the full history before any new events.
-  var es = new EventSource(STREAM_URL);
-
-  if (INITIAL_STATUS === "running" || INITIAL_STATUS === "pending") {
-    startTicker();
-  } else {
-    setStatusClass(
-      INITIAL_STATUS === "completed" ? "chip-ok" :
-      INITIAL_STATUS === "failed" ? "chip-danger" :
-      "chip-muted"
-    );
-  }
-
-  es.addEventListener("line", function (ev) {
-    appendLine(JSON.parse(ev.data));
-  });
-
-  es.addEventListener("done", function (ev) {
-    var info = JSON.parse(ev.data);
-    stopTicker();
-    setStatus(info.status + " (exit " + info.exit_code + ")");
-    setStatusClass(
-      info.status === "completed" ? "chip-ok" :
-      info.status === "failed" ? "chip-danger" :
-      "chip-muted"
-    );
-    es.close();
-  });
-
-  es.addEventListener("error", function () {
-    stopTicker();
-    setStatus("stream error");
-    setStatusClass("chip-danger");
-    es.close();
-  });
-})();
+{# Server-injected configuration for run_view.js. Using a tagged
+   JSON block avoids global-namespace pollution and is unambiguously
+   data (not a script). #}
+<script id="run-view-data" type="application/json">
+{
+  "stream_url": {{ stream_url|tojson }},
+  "initial_status": {{ run.status|tojson }},
+  "workflow": {{ run.workflow|tojson }},
+  "path": {{ run.path|tojson }},
+  "allow_run": {{ allow_run|tojson }}
+}
 </script>
+{# runner.js provides the shared setupRecentRuns helper that
+   run_view.js calls. Loaded BEFORE run_view.js so the helper is
+   available when run_view.js initializes. #}
+<script src="{{ url_for('static', path='js/runner.js') }}"></script>
+<script src="{{ url_for('static', path='js/run_view.js') }}"></script>
 {% endblock %}

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -38,6 +38,7 @@
           <td>
             {{ w.description }}
             <div class="run-status"><span data-status></span></div>
+            <div class="recent-runs" data-recent-runs="{{ w.name }}" hidden></div>
             <div class="log-pane" data-log-pane hidden>
               <pre data-log class="log-output"></pre>
             </div>
@@ -75,7 +76,10 @@
 {% endblock %}
 
 {% block scripts %}
-{% if allow_run %}
-  <script src="{{ url_for('static', path='js/runner.js') }}"></script>
-{% endif %}
+{# runner.js is loaded unconditionally so the recent-runs strip
+   renders in both run and read-only modes. The script's
+   DOMContentLoaded handler queries for run-button / scope-picker
+   elements that only exist when allow_run is True, so the read-only
+   page sees a no-op for those features. #}
+<script src="{{ url_for('static', path='js/runner.js') }}"></script>
 {% endblock %}

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -21,6 +21,7 @@
         <th class="num">Stages</th>
         <th>Tier map</th>
         <th>Description</th>
+        {% if allow_run %}<th>Scope</th>{% endif %}
         {% if allow_run %}<th class="num">Action</th>{% endif %}
       </tr>
     </thead>
@@ -42,6 +43,24 @@
             </div>
           </td>
           {% if allow_run %}
+            <td class="scope-cell">
+              {% if supports_path[w.name] %}
+                <select class="scope-picker" data-scope-picker aria-label="Scope for {{ w.name }}">
+                  <option value="">Project-wide</option>
+                  {% for f in features %}
+                    {% if f.path %}
+                      <option value="{{ f.path }}" title="{{ f.description }}">{{ f.name }}</option>
+                    {% endif %}
+                  {% endfor %}
+                  <option value="__custom__">Custom path…</option>
+                </select>
+                <input type="text" class="scope-custom" data-scope-custom hidden
+                       placeholder="e.g. src/attune/security/"
+                       aria-label="Custom scope path for {{ w.name }}">
+              {% else %}
+                <span class="scope-na" title="This workflow doesn't accept a path argument">n/a</span>
+              {% endif %}
+            </td>
             <td class="num">
               <button class="btn btn-run" type="button" data-run-button data-workflow="{{ w.name }}">Run</button>
             </td>

--- a/tests/unit/ops/test_persistence_and_history.py
+++ b/tests/unit/ops/test_persistence_and_history.py
@@ -1,0 +1,536 @@
+"""Tests for ops-runner-tier2 Phase 3 (persistence + history API) and
+Phase 4 (clickable workflow-name pills on the run-view page).
+
+Phase 3 surfaces:
+  * ``Run.to_record`` / ``Run.from_record`` round-trip.
+  * Disk persistence: file written on completion, log truncation at the
+    200 KB budget, atomic-rename safety, malformed-name rejection.
+  * Pruning of run files older than the retention window.
+  * ``/api/runs/{workflow}`` listing (combines in-memory + on-disk).
+  * ``/api/runs/{workflow}/{run_id}`` detail endpoint.
+  * Read-only mode disables persistence entirely.
+
+Phase 4 surfaces:
+  * ``run_view.js`` exists and is referenced from ``run_view.html``.
+  * Run-view template injects the JSON config block.
+  * ``run_view.html`` includes the ``.chained-from`` slot + recent-runs strip.
+  * ``run_view.js`` exports the pill-click + chained-from helpers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+pytest.importorskip("yaml")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.runner import (  # noqa: E402
+    Run,
+    RunnerService,
+    _list_persisted_runs,
+    _load_run_record,
+    _persist_run,
+    _truncate_lines_for_persist,
+    prune_old_runs,
+)
+from attune.ops.server import create_app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Run.to_record / from_record round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_run_to_record_round_trip():
+    original = Run(
+        id="abc12345",
+        workflow="security-audit",
+        status="completed",
+        exit_code=0,
+        path="/tmp/scope",
+        command=["py", "-m", "attune", "workflow", "run", "security-audit"],
+        lines=["line one", "line two", "line three"],
+    )
+    record = original.to_record()
+    restored = Run.from_record(record)
+    assert restored.id == original.id
+    assert restored.workflow == original.workflow
+    assert restored.status == original.status
+    assert restored.exit_code == original.exit_code
+    assert restored.path == original.path
+    assert restored.command == original.command
+    assert restored.lines == original.lines
+
+
+def test_from_record_tolerates_missing_fields():
+    """A minimal record (id + workflow) still produces a usable Run."""
+    restored = Run.from_record({"id": "x", "workflow": "code-review"})
+    assert restored.id == "x"
+    assert restored.workflow == "code-review"
+    # Defaults fire for everything not in the record
+    assert restored.exit_code is None
+    assert restored.path is None
+    assert restored.command is None
+    assert restored.lines == []
+
+
+def test_from_record_bad_status_defaults_to_completed():
+    """An unknown status string falls back to 'completed' rather than crashing."""
+    restored = Run.from_record({"id": "y", "workflow": "code-review", "status": "exploded"})
+    assert restored.status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Log truncation
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_short_log_is_passthrough():
+    lines = ["one", "two", "three"]
+    assert _truncate_lines_for_persist(lines) == lines
+
+
+def test_truncate_long_log_appends_marker(monkeypatch):
+    # Build a payload that comfortably exceeds the 200 KB cap.
+    big_line = "x" * 1_000  # 1 KB per line; 250 lines → ~250 KB
+    lines = [big_line] * 250
+    out = _truncate_lines_for_persist(lines)
+    assert len(out) < len(lines)
+    assert out[-1].startswith("<TRUNCATED — ")
+    assert out[-1].endswith(" bytes more>")
+
+
+# ---------------------------------------------------------------------------
+# _persist_run write path
+# ---------------------------------------------------------------------------
+
+
+def test_persist_run_writes_json(tmp_path):
+    runs_dir = tmp_path / "runs"
+    run = Run(
+        id="aaaaaaaaaaaa",
+        workflow="security-audit",
+        status="completed",
+        exit_code=0,
+        path="/scope",
+        command=["py", "-c", "print(1)"],
+        lines=["preamble", "stdout line"],
+    )
+    dest = _persist_run(run, runs_dir)
+    assert dest is not None
+    assert dest.is_file()
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    assert data["id"] == run.id
+    assert data["workflow"] == run.workflow
+    assert data["path"] == "/scope"
+    assert data["lines"] == ["preamble", "stdout line"]
+    # ``persisted_at`` is added by the writer
+    assert "persisted_at" in data
+
+
+def test_persist_run_rejects_bad_workflow_name(tmp_path):
+    run = Run(id="abc123", workflow="bad..name", status="completed")
+    dest = _persist_run(run, tmp_path / "runs")
+    assert dest is None
+    assert not (tmp_path / "runs").exists()
+
+
+def test_persist_run_rejects_bad_run_id(tmp_path):
+    run = Run(id="../etc/passwd", workflow="security-audit", status="completed")
+    dest = _persist_run(run, tmp_path / "runs")
+    assert dest is None
+
+
+def test_persist_run_truncates_long_log(tmp_path):
+    runs_dir = tmp_path / "runs"
+    big = "x" * 1_500  # 1.5 KB per line
+    lines = [big] * 200  # ~300 KB
+    run = Run(
+        id="bbbbbbbbbbbb",
+        workflow="security-audit",
+        status="completed",
+        lines=lines,
+    )
+    dest = _persist_run(run, runs_dir)
+    assert dest is not None
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    # The truncation marker is the last line
+    assert any(line.startswith("<TRUNCATED — ") for line in data["lines"])
+    assert len(data["lines"]) < len(lines)
+
+
+# ---------------------------------------------------------------------------
+# RunnerService end-to-end persistence (uses real subprocess via echo cmd)
+# ---------------------------------------------------------------------------
+
+
+def _echo_cmd(workflow: str) -> tuple[str, ...]:
+    script = "import sys; print('start ' + sys.argv[1]); print('end ' + sys.argv[1]); sys.exit(0)"
+    return (sys.executable, "-c", script, workflow)
+
+
+async def _wait_terminal(runner, run_id, *, timeout=5.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        run = runner.get(run_id)
+        assert run is not None
+        if run.is_terminal:
+            return run
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(f"run {run_id} did not finish in {timeout}s")
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.asyncio
+async def test_runner_writes_record_on_completion(tmp_path):
+    runs_dir = tmp_path / "runs"
+    svc = RunnerService(command_builder=_echo_cmd, persistence_dir=runs_dir)
+    run = await svc.start("security-audit", path="/scope/dir")
+    await _wait_terminal(svc, run.id)
+
+    json_path = runs_dir / "security-audit" / f"{run.id}.json"
+    assert json_path.is_file()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data["status"] == "completed"
+    assert data["path"] == "/scope/dir"
+    assert data["command"][-2:] == ["--path", "/scope/dir"]
+
+
+@pytest.mark.asyncio
+async def test_runner_skips_persistence_when_dir_is_none(tmp_path):
+    """No persistence_dir → no disk writes (read-only mode)."""
+    runs_dir = tmp_path / "runs"
+    svc = RunnerService(command_builder=_echo_cmd, persistence_dir=None)
+    run = await svc.start("security-audit")
+    await _wait_terminal(svc, run.id)
+    assert not runs_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# prune_old_runs
+# ---------------------------------------------------------------------------
+
+
+def test_prune_old_runs_deletes_files_past_cutoff(tmp_path):
+    runs_dir = tmp_path / "runs"
+    workflow_dir = runs_dir / "security-audit"
+    workflow_dir.mkdir(parents=True)
+    fresh = workflow_dir / "fresh111111.json"
+    stale = workflow_dir / "stale222222.json"
+    fresh.write_text('{"id": "fresh"}', encoding="utf-8")
+    stale.write_text('{"id": "stale"}', encoding="utf-8")
+    # Backdate stale to 60 days ago
+    past = time.time() - 60 * 86_400
+    os.utime(stale, (past, past))
+
+    deleted = prune_old_runs(runs_dir, days=30)
+    assert deleted == 1
+    assert fresh.is_file()
+    assert not stale.exists()
+
+
+def test_prune_old_runs_zero_days_disables_sweep(tmp_path):
+    workflow_dir = tmp_path / "runs" / "x"
+    workflow_dir.mkdir(parents=True)
+    old = workflow_dir / "abc123.json"
+    old.write_text("{}", encoding="utf-8")
+    os.utime(old, (0, 0))  # epoch
+    assert prune_old_runs(tmp_path / "runs", days=0) == 0
+    assert old.is_file()
+
+
+def test_prune_old_runs_missing_dir_is_noop(tmp_path):
+    assert prune_old_runs(tmp_path / "does-not-exist", days=30) == 0
+
+
+# ---------------------------------------------------------------------------
+# _list_persisted_runs ordering
+# ---------------------------------------------------------------------------
+
+
+def test_list_persisted_runs_returns_newest_first(tmp_path):
+    runs_dir = tmp_path / "runs"
+    wf_dir = runs_dir / "security-audit"
+    wf_dir.mkdir(parents=True)
+    # Write 3 records and set mtimes
+    for ix, run_id in enumerate(["aaaaaa", "bbbbbb", "cccccc"]):
+        record = {
+            "id": run_id,
+            "workflow": "security-audit",
+            "status": "completed",
+            "lines": [],
+        }
+        path = wf_dir / f"{run_id}.json"
+        path.write_text(json.dumps(record), encoding="utf-8")
+        mtime = time.time() - (3 - ix) * 100  # cccccc newest
+        os.utime(path, (mtime, mtime))
+
+    records = _list_persisted_runs(runs_dir, "security-audit", limit=20)
+    ids = [r["id"] for r in records]
+    assert ids == ["cccccc", "bbbbbb", "aaaaaa"]
+
+
+def test_list_persisted_runs_rejects_bad_workflow(tmp_path):
+    assert _list_persisted_runs(tmp_path, "BAD_NAME") == []
+
+
+def test_load_run_record_rejects_bad_run_id(tmp_path):
+    runs_dir = tmp_path / "runs"
+    (runs_dir / "x").mkdir(parents=True)
+    (runs_dir / "x" / "abc.json").write_text("{}", encoding="utf-8")
+    assert _load_run_record(runs_dir, "x", "../etc/passwd") is None
+
+
+# ---------------------------------------------------------------------------
+# /api/runs/{workflow} endpoints
+# ---------------------------------------------------------------------------
+
+
+def _make_app(tmp_path, monkeypatch, *, allow_run=True):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=allow_run,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(
+        command_builder=_echo_cmd,
+        persistence_dir=config.runs_dir if allow_run else None,
+    )
+    app = create_app(config, runner=runner)
+    return app, runner, config
+
+
+def test_list_runs_rejects_bad_workflow_name(tmp_path, monkeypatch):
+    app, _, _ = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/api/runs/BAD..name")
+    assert resp.status_code == 400
+
+
+def test_list_runs_empty_when_no_history(tmp_path, monkeypatch):
+    app, _, _ = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/api/runs/security-audit")
+    assert resp.status_code == 200
+    assert resp.json() == {"workflow": "security-audit", "runs": []}
+
+
+@pytest.mark.asyncio
+async def test_list_runs_combines_in_memory_and_disk(tmp_path, monkeypatch):
+    app, runner, config = _make_app(tmp_path, monkeypatch)
+    # One run via the runner (writes to disk, also in memory)
+    run = await runner.start("security-audit", path="/scope")
+    await _wait_terminal(runner, run.id)
+
+    # Plant a second disk-only record with a fixed older id
+    wf_dir = config.runs_dir / "security-audit"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    plant_id = "ddeeff112233"
+    record = {
+        "id": plant_id,
+        "workflow": "security-audit",
+        "status": "completed",
+        "exit_code": 0,
+        "started_at": "2026-05-13T12:00:00+00:00",
+        "completed_at": "2026-05-13T12:00:05+00:00",
+        "lines": ["older"],
+    }
+    (wf_dir / f"{plant_id}.json").write_text(json.dumps(record), encoding="utf-8")
+
+    with TestClient(app) as client:
+        resp = client.get("/api/runs/security-audit")
+    assert resp.status_code == 200
+    body = resp.json()
+    ids = {r["id"] for r in body["runs"]}
+    assert run.id in ids
+    assert plant_id in ids
+    # List responses don't include the full log buffer
+    for r in body["runs"]:
+        assert "lines" not in r
+
+
+def test_get_run_record_rejects_path_traversal(tmp_path, monkeypatch):
+    app, _, _ = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/api/runs/security-audit/..%2Fetc%2Fpasswd")
+    # Either 400 from the regex check, or 404 from the path miss — both
+    # are acceptable as long as the response is non-200 and doesn't
+    # leak the file.
+    assert resp.status_code in (400, 404)
+
+
+def test_get_run_record_returns_404_for_missing(tmp_path, monkeypatch):
+    app, _, _ = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/api/runs/security-audit/aaaaaaaaaaaa")
+    assert resp.status_code == 404
+    # API path → JSON body, not HTML
+    assert resp.headers["content-type"].startswith("application/json")
+    assert resp.json()["detail"] == "run not found"
+
+
+@pytest.mark.asyncio
+async def test_get_run_record_returns_full_log(tmp_path, monkeypatch):
+    app, runner, _ = _make_app(tmp_path, monkeypatch)
+    run = await runner.start("security-audit")
+    await _wait_terminal(runner, run.id)
+    with TestClient(app) as client:
+        resp = client.get(f"/api/runs/security-audit/{run.id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == run.id
+    assert "lines" in body
+    assert len(body["lines"]) >= 2  # preamble + stdout
+
+
+def test_read_only_mode_disables_persistence(tmp_path, monkeypatch):
+    """`--read-only` (allow_run=False) → no persistence_dir → no writes
+    + the runs API works on empty data (no crash on missing runs_dir)."""
+    app, _, config = _make_app(tmp_path, monkeypatch, allow_run=False)
+    with TestClient(app) as client:
+        resp = client.get("/api/runs/security-audit")
+    assert resp.status_code == 200
+    assert resp.json()["runs"] == []
+    # Even the runs_dir itself shouldn't have been created
+    assert not config.runs_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Template + JS surface for Phase 3 / Phase 4
+# ---------------------------------------------------------------------------
+
+
+def test_workflows_page_includes_recent_runs_strip(tmp_path, monkeypatch):
+    app, _, _ = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    assert "data-recent-runs" in resp.text
+
+
+def test_workflows_page_loads_runner_js_in_read_only_too(tmp_path, monkeypatch):
+    """recent-runs strip needs runner.js loaded even in read-only mode."""
+    app, _, _ = _make_app(tmp_path, monkeypatch, allow_run=False)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    assert "/static/js/runner.js" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_run_view_page_loads_both_js_files(tmp_path, monkeypatch):
+    """run_view.html references runner.js + run_view.js + injects JSON config."""
+    app, runner, _ = _make_app(tmp_path, monkeypatch)
+    run = await runner.start("security-audit", path="/scope")
+    await _wait_terminal(runner, run.id)
+    with TestClient(app) as client:
+        resp = client.get(f"/runs/{run.id}/view")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "/static/js/runner.js" in body
+    assert "/static/js/run_view.js" in body
+    assert 'id="run-view-data"' in body
+    assert "chained-from" in body
+    assert "data-recent-runs" in body
+
+
+def test_runner_js_exports_recent_runs_helpers():
+    js_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "runner.js"
+    )
+    text = js_path.read_text(encoding="utf-8")
+    assert "function setupRecentRuns(" in text
+    assert "function renderRecentRunsInto(" in text
+    assert "setupRecentRuns: setupRecentRuns" in text
+    assert "recent-run-chip" in text
+
+
+def test_run_view_js_exists_and_exposes_helpers():
+    """Phase 4.1: extracted file is reachable + exports pill + badge helpers."""
+    js_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "run_view.js"
+    )
+    assert js_path.is_file()
+    text = js_path.read_text(encoding="utf-8")
+    assert "function handlePillClick(" in text
+    assert "function renderChainedFromBadge(" in text
+    assert "function pillTargetFromEvent(" in text
+    assert "window.__attuneRunView" in text
+    # Phase 4.4: read-only fall-through goes through showInlineError
+    assert "Read-only mode" in text
+    # Phase 4.2: 409 surfaces inline, doesn't navigate
+    assert "current_run_id" in text
+
+
+def test_run_view_js_validates_from_param():
+    """``?from=`` must match the workflow-name regex; junk is dropped."""
+    js_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "run_view.js"
+    )
+    text = js_path.read_text(encoding="utf-8")
+    # The regex literal lives in renderChainedFromBadge
+    assert "/^[a-z][a-z0-9-]+$/" in text
+
+
+@pytest.mark.asyncio
+async def test_run_view_data_block_contains_allow_run_and_path(tmp_path, monkeypatch):
+    app, runner, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    run = await runner.start("security-audit", path="/scope/value")
+    await _wait_terminal(runner, run.id)
+    with TestClient(app) as client:
+        resp = client.get(f"/runs/{run.id}/view")
+    body = resp.text
+    # Extract the JSON block content
+    start = body.index('id="run-view-data"')
+    block_open = body.index(">", start) + 1
+    block_close = body.index("</script>", block_open)
+    block = body[block_open:block_close].strip()
+    parsed = json.loads(block)
+    assert parsed["allow_run"] is True
+    assert parsed["path"] == "/scope/value"
+    assert parsed["workflow"] == "security-audit"
+
+
+@pytest.mark.asyncio
+async def test_run_view_data_block_allow_run_false_in_read_only(tmp_path, monkeypatch):
+    app, runner, _ = _make_app(tmp_path, monkeypatch, allow_run=False)
+    run = await runner.start("security-audit")
+    await _wait_terminal(runner, run.id)
+    with TestClient(app) as client:
+        resp = client.get(f"/runs/{run.id}/view")
+    body = resp.text
+    start = body.index('id="run-view-data"')
+    block_open = body.index(">", start) + 1
+    block_close = body.index("</script>", block_open)
+    block = body[block_open:block_close].strip()
+    parsed = json.loads(block)
+    assert parsed["allow_run"] is False

--- a/tests/unit/ops/test_scope_picker.py
+++ b/tests/unit/ops/test_scope_picker.py
@@ -1,0 +1,407 @@
+"""Tests for the ops dashboard scope picker (ops-runner-tier2 Phase 2).
+
+Covers four surfaces:
+  * ``list_features()`` — reads ``.help/features.yaml`` with mtime cache.
+  * ``POST /workflows/{name}/run`` with ``{"path": ...}`` body — path
+    validation, no-path-workflow rejection, end-to-end subprocess wiring.
+  * Template rendering — scope picker / ``n/a`` span both surface.
+  * Runner.js — exports ``getScope`` and ``wireScopePickerToggle``.
+
+Companion drift-guard tests live in
+``tests/unit/ops/test_path_support_registry.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+pytest.importorskip("yaml")
+
+from fastapi.testclient import TestClient  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from attune.ops import data  # noqa: E402
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.runner import RunnerService  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+# ----------------------------------------------------------------------
+# list_features() — file-parse + cache behavior
+# ----------------------------------------------------------------------
+
+
+def _write_features_yaml(root: Path, body: str) -> Path:
+    help_dir = root / ".help"
+    help_dir.mkdir(parents=True, exist_ok=True)
+    yaml_path = help_dir / "features.yaml"
+    yaml_path.write_text(body, encoding="utf-8")
+    return yaml_path
+
+
+@pytest.fixture(autouse=True)
+def _clear_features_cache():
+    """Reset the module-level mtime cache between tests."""
+    data._FEATURES_CACHE.clear()
+    yield
+    data._FEATURES_CACHE.clear()
+
+
+def test_list_features_missing_file_returns_empty(tmp_path):
+    """No ``.help/features.yaml`` → empty list, not an exception."""
+    assert data.list_features(tmp_path) == []
+
+
+def test_list_features_well_formed(tmp_path):
+    _write_features_yaml(
+        tmp_path,
+        """
+features:
+  security-audit:
+    description: Scan for vulns
+    files:
+      - src/attune/workflows/security_audit.py
+      - src/attune/security/**
+    tags: [security, audit]
+  perf-audit:
+    description: Performance scan
+    files:
+      - src/attune/workflows/perf_audit.py
+    tags: [perf]
+""",
+    )
+    features = data.list_features(tmp_path)
+    assert [f.name for f in features] == ["perf-audit", "security-audit"]
+    # security-audit prefers the /** glob → directory scope
+    sec = next(f for f in features if f.name == "security-audit")
+    assert sec.path == "src/attune/security"
+    assert sec.description == "Scan for vulns"
+    assert sec.tags == ("security", "audit")
+    # perf-audit has no directory glob → first file as the scope
+    perf = next(f for f in features if f.name == "perf-audit")
+    assert perf.path == "src/attune/workflows/perf_audit.py"
+
+
+def test_list_features_malformed_yaml(tmp_path):
+    """Malformed YAML → empty list (fail-soft)."""
+    _write_features_yaml(tmp_path, "features:\n  - this is\n    not: a [ mapping")
+    assert data.list_features(tmp_path) == []
+
+
+def test_list_features_features_key_not_mapping(tmp_path):
+    """Top-level shape mismatch → empty list."""
+    _write_features_yaml(tmp_path, "features:\n  - not_a_mapping\n")
+    assert data.list_features(tmp_path) == []
+
+
+def test_list_features_skips_glob_only_features(tmp_path):
+    """A feature with only mid-name globs has no addressable scope (path=None)."""
+    _write_features_yaml(
+        tmp_path,
+        """
+features:
+  code-quality:
+    description: Mixed globs only
+    files:
+      - src/attune/workflows/code_review_*.py
+    tags: [review]
+""",
+    )
+    features = data.list_features(tmp_path)
+    assert len(features) == 1
+    assert features[0].path is None
+
+
+def test_list_features_caches_by_mtime(tmp_path, monkeypatch):
+    """Repeated calls hit the cache; modifying the file invalidates it."""
+    yaml_path = _write_features_yaml(
+        tmp_path,
+        "features:\n  a:\n    description: A\n    files: [src/a.py]\n",
+    )
+    first = data.list_features(tmp_path)
+    second = data.list_features(tmp_path)
+    # Same list returned (cache hit — identity check would be too strict
+    # but the content stays equal)
+    assert first == second
+
+    # Bump mtime + change content; should re-read.
+    yaml_path.write_text(
+        "features:\n  b:\n    description: B\n    files: [src/b.py]\n",
+        encoding="utf-8",
+    )
+    # Force mtime change in case the test ran within the same nanosecond
+    import os
+    import time
+
+    new_mtime = yaml_path.stat().st_mtime + 1
+    os.utime(yaml_path, (new_mtime, new_mtime))
+    time.sleep(0.001)
+    third = data.list_features(tmp_path)
+    assert [f.name for f in third] == ["b"]
+
+
+# ----------------------------------------------------------------------
+# POST /workflows/{name}/run — path body, validation, rejection
+# ----------------------------------------------------------------------
+
+
+def _echo_cmd(workflow: str) -> tuple[str, ...]:
+    script = (
+        "import sys; print('start ' + sys.argv[1]); "
+        "[print(a) for a in sys.argv[2:]]; sys.exit(0)"
+    )
+    return (sys.executable, "-c", script, workflow)
+
+
+def _make_app(tmp_path, monkeypatch, *, allow_run=True):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=allow_run,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(command_builder=_echo_cmd)
+    app = create_app(config, runner=runner)
+    return app, runner
+
+
+async def _wait_terminal(runner, run_id, *, timeout=5.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        run = runner.get(run_id)
+        assert run is not None
+        if run.is_terminal:
+            return run
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(f"run {run_id} did not finish in {timeout}s")
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.asyncio
+async def test_run_with_path_threads_into_subprocess(tmp_path, monkeypatch):
+    """POST with ``{"path": "..."}`` adds ``--path <path>`` to the cmd."""
+    scope_dir = tmp_path / "src" / "feature"
+    scope_dir.mkdir(parents=True)
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/workflows/security-audit/run",
+            json={"path": str(scope_dir)},
+        )
+        assert resp.status_code == 201, resp.text
+        run = await _wait_terminal(runner, resp.json()["run_id"])
+    assert run.status == "completed"
+    assert run.path is not None
+    # The fixture command echoes its argv. The first line is the
+    # shell-style command preamble; later lines come from the script.
+    # The validated absolute path appears in the recorded command line.
+    cmd_line = run.lines[0]
+    assert "--path" in cmd_line
+    assert str(scope_dir.resolve()) in cmd_line
+
+
+@pytest.mark.asyncio
+async def test_run_without_body_runs_project_wide(tmp_path, monkeypatch):
+    """No body → no ``--path`` flag, no error."""
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/workflows/security-audit/run")
+        assert resp.status_code == 201, resp.text
+        run = await _wait_terminal(runner, resp.json()["run_id"])
+    assert run.path is None
+    assert "--path" not in run.lines[0]
+
+
+def test_run_rejects_invalid_path_traversal(tmp_path, monkeypatch):
+    """Path outside project_root → 400."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": "/etc/passwd"},
+        )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert "invalid path" in detail.lower() or "system directory" in detail.lower()
+
+
+def test_run_rejects_path_outside_project_root(tmp_path, monkeypatch):
+    """A real path outside project_root is rejected via allowed_dir check."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    # Pick a sibling dir that definitely exists but is outside project_root
+    outsider = tmp_path.parent
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": str(outsider)},
+        )
+    assert resp.status_code == 400
+
+
+def test_run_rejects_path_for_no_path_workflow(tmp_path, monkeypatch):
+    """Workflow not in PATH_ARG_REGISTRY → 400 when path is provided.
+
+    We simulate the no-path case by patching the registry to remove
+    ``security-audit`` for the duration of the test. The validation
+    happens BEFORE registry lookup of the actual workflow, so the
+    runner never gets the call.
+    """
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    monkeypatch.delitem(data.PATH_ARG_REGISTRY, "security-audit", raising=False)
+    scope_dir = tmp_path / "src"
+    scope_dir.mkdir()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": str(scope_dir)},
+        )
+    assert resp.status_code == 400
+    assert "does not accept a path" in resp.json()["detail"]
+
+
+def test_run_rejects_non_string_path(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": 12345},
+        )
+    assert resp.status_code == 400
+
+
+def test_run_rejects_non_object_body(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            content=b"[1,2,3]",
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 400
+
+
+def test_run_rejects_malformed_json(tmp_path, monkeypatch):
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            content=b"not valid json {",
+            headers={"Content-Type": "application/json"},
+        )
+    assert resp.status_code == 400
+
+
+def test_run_treats_empty_path_as_project_wide(tmp_path, monkeypatch):
+    """Empty-string path → same as omitted (project-wide). The picker's
+    "Project-wide" option submits ``""`` if the JS isn't filtering."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/security-audit/run",
+            json={"path": ""},
+        )
+    assert resp.status_code == 201
+
+
+# ----------------------------------------------------------------------
+# Template rendering — workflows.html scope picker
+# ----------------------------------------------------------------------
+
+
+def test_workflows_page_renders_scope_picker_for_path_workflow(tmp_path, monkeypatch):
+    """A workflow in PATH_ARG_REGISTRY gets a ``<select data-scope-picker>``."""
+    _write_features_yaml(
+        tmp_path,
+        """
+features:
+  security-audit:
+    description: Scan
+    files: [src/attune/security/**]
+    tags: [security]
+""",
+    )
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "data-scope-picker" in body
+    assert "Project-wide" in body
+    assert "Custom path…" in body
+    assert "data-scope-custom" in body
+    # The feature dropdown option appears
+    assert ">security-audit<" in body
+
+
+def test_workflows_page_renders_n_a_for_no_path_workflow(tmp_path, monkeypatch):
+    """A workflow absent from PATH_ARG_REGISTRY shows a ``.scope-na`` span."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    # Remove one workflow so it's missing from the registry
+    monkeypatch.delitem(data.PATH_ARG_REGISTRY, "security-audit", raising=False)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    # The "n/a" span renders for the missing workflow
+    assert "scope-na" in resp.text
+
+
+def test_workflows_page_no_scope_column_when_read_only(tmp_path, monkeypatch):
+    """``--read-only`` mode: no Scope header, no picker markup."""
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=False)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    assert "data-scope-picker" not in resp.text
+    assert ">Scope<" not in resp.text
+
+
+# ----------------------------------------------------------------------
+# runner.js — scope helpers exported
+# ----------------------------------------------------------------------
+
+
+def test_runner_js_exports_get_scope_and_toggle():
+    js_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "runner.js"
+    )
+    text = js_path.read_text(encoding="utf-8")
+    # Both helpers exist as functions
+    assert "function getScope(" in text
+    assert "function wireScopePickerToggle(" in text
+    # Both are exposed on the test surface
+    assert "getScope: getScope" in text
+    assert "wireScopePickerToggle: wireScopePickerToggle" in text
+    # The DOMContentLoaded handler wires the toggle
+    assert "wireScopePickerToggle" in text
+    # POST body construction uses path key
+    assert "path: scope" in text or '"path": scope' in text
+
+
+def test_runner_js_default_post_is_no_body():
+    """When no scope is set, the POST should not include a body so
+    existing servers (and the test suite's no-body tests) keep working."""
+    js_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "runner.js"
+    )
+    text = js_path.read_text(encoding="utf-8")
+    # The code must guard body assignment behind a scope != null check
+    assert "scope !== null" in text


### PR DESCRIPTION
**Stacked on [#324](https://github.com/Smart-AI-Memory/attune-ai/pull/324) (Phase 2).** Set base to `feat/ops-runner-tier2-phase2` for review, or merge #324 first and rebase this onto `main`.

## Summary

- **Phase 3: persisted runs + history API.** Completed runs land in `<attune_home>/ops/runs/<workflow>/<run-id>.json` atomically. Log buffer capped at 200 KB. Startup prune sweep via `--runs-retention-days` (default 30). New `GET /api/runs/{workflow}` and `GET /api/runs/{workflow}/{run_id}` endpoints back a recent-runs strip on `/workflows` and the run-view page.
- **Phase 4: clickable workflow-name pills.** A click in the streaming log POSTs `/workflows/<target>/run` carrying the source run's scope; on 201 navigates to `?from=<source>` so a "↩ from <name>" badge surfaces in the new run's header. 409 / 403 render inline without navigating away.
- **Read-only mode** disables persistence entirely — a read-only dashboard never touches `~/.attune/`. The global 404 handler now returns JSON for `/api/*` paths so the dashboard JS can parse errors uniformly.
- **32 new tests** in `tests/unit/ops/test_persistence_and_history.py`. Full ops suite **221 green** (was 189 after Phase 2).

Closes Phase 3 + Phase 4 of `docs/specs/ops-runner-tier2/`.

## What changed

| File | Change |
|---|---|
| `src/attune/ops/runner.py` | `Run.command` + `Run.to_record()/from_record()`. New module helpers: `_truncate_lines_for_persist`, `_persist_run`, `_load_run_record`, `_list_persisted_runs`, `prune_old_runs`. `RunnerService` gains `persistence_dir` constructor arg and a `_finish_run` helper that wraps `mark_done` + best-effort disk write. |
| `src/attune/ops/config.py` | `Config.runs_retention_days` (default 30); `Config.runs_dir` property. |
| `src/attune/ops/cli.py` | `--runs-retention-days DAYS` flag. |
| `src/attune/ops/server.py` | Startup prune sweep (gated on `allow_run`). New `_build_default_runner()` only attaches `persistence_dir` when runs are allowed. Mounted new `runs_history` router. 404 handler dispatches JSON for `/api/*`, HTML otherwise. |
| `src/attune/ops/routes/runs_history.py` (new) | `GET /api/runs/{workflow}` (newest 20, metadata only) and `GET /api/runs/{workflow}/{run_id}` (full record). In-memory + on-disk merge. Strict workflow + run-id regexes. |
| `src/attune/ops/routes/dashboard.py` | Passes `allow_run` to `run_view.html`. |
| `src/attune/ops/templates/workflows.html` | `data-recent-runs` strip below each row. `runner.js` now loaded unconditionally (so read-only users see the strip too). |
| `src/attune/ops/templates/run_view.html` | Replaced inline `<script>` with a JSON config block + external `runner.js` + new `run_view.js`. Added `.chained-from` slot, `.run-view-history` strip, scope chip in meta line. |
| `src/attune/ops/static/js/runner.js` | New `setupRecentRuns()` / `renderRecentRunsInto()` / `statusClass()` helpers exposed via `window.__attuneRunner`. |
| `src/attune/ops/static/js/run_view.js` (new) | Extracted SSE replay + status ticker. Adds `handlePillClick` (delegated listener on the log container) + `renderChainedFromBadge`. Reads config from `<script id="run-view-data" type="application/json">`. |
| `src/attune/ops/static/css/main.css` | `.recent-runs` / `.recent-run-chip` (color-by-status). `.log-workflow` hover/cursor/`.pill-disabled`. `.run-view-error` for inline 409/403 surfacing. `.chained-from` + `.run-view-scope` text styles. |
| `tests/unit/ops/test_persistence_and_history.py` (new) | 32 tests. |
| `CHANGELOG.md`, `docs/specs/ops-runner-tier2/tasks.md`, `docs/specs/_sequencing.md` | Phases 3 + 4 marked shipped; sequencing recommends release prep next. |

## Design notes

- **Persistence is a runner property, not a Run property.** `Run.mark_done()` stays pure; persistence lives in `RunnerService._finish_run()` so a `Run` constructed by `from_record()` for replay can't trigger another write.
- **Validation runs before any disk lookup.** `_WORKFLOW_NAME_RE` and `_RUN_ID_RE` reject malformed inputs in `routes/runs_history.py` BEFORE touching `runs_dir`. The same regexes apply at write time so a hostile workflow name can't escape its directory.
- **In-memory wins on id collision.** When the recent-runs API merges live runs with on-disk records, the in-memory entry's status takes precedence so an in-flight run never gets overwritten by its older persisted-completion record.
- **Pill click is delegated, not per-pill.** New log lines arrive over SSE; rather than re-wire on every line we attach one listener to the log container and walk up to `.log-workflow` on click.
- **Read-only is enforced at construction time.** `_build_default_runner()` decides whether to pass `persistence_dir` based on `config.allow_run`. The runner itself doesn't re-check — the `persistence_dir` either exists (persist) or doesn't (skip).

## Test plan

- [x] Unit: `pytest tests/unit/ops/test_persistence_and_history.py` — 32/32 pass
- [x] Regression: full ops suite (221) green
- [x] Manual smoke (`uv run python -m attune.ops --port 8867 --no-browser`):
  - [x] `/workflows` renders 20 recent-runs strips (`data-recent-runs` present per row)
  - [x] `/api/runs/security-audit` returns `{"workflow": "security-audit", "runs": []}` on empty
  - [x] `/api/runs/security-audit/aaaaaaaaaaaa` returns `404 application/json` (was HTML before this PR)
  - [x] `/api/runs/BAD..NAME` returns `400 {"detail": "invalid workflow name"}`
- [ ] CI: full matrix on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
