### PR TITLE
docs(help): add ops-dashboard feature entry

### DIFF
--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -77,6 +77,12 @@ features:
       - src/attune/agents/release/**
     tags: [release, publishing, quality]
 
+  ops-dashboard:
+    description: Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming
+    files:
+      - src/attune/ops/**
+    tags: [ops, dashboard, runner, workflows, scope-picker, persistence, sse]
+
   refactor-plan:
     description: Detect code smells and generate a prioritized refactoring roadmap
     files:


### PR DESCRIPTION
## Summary

- Adds `ops-dashboard` to `.help/features.yaml` — a stub entry for the 6.8.0 release's headline surface (scope picker, persistence, chainable pills).
- One-line change: `description` + `files: src/attune/ops/**` + `tags`.
- No template generation yet — that's a separate help-template freshness pass.

## Why

The ops dashboard's new 6.8.0 features have no feature entry in the help system. Three downstream effects this fixes:

1. `attune-author status` won't notice churn under `src/attune/ops/` until a feature claims those files.
2. The dashboard's own scope picker (#324) can't list `ops-dashboard` as a feature to scope future workflow runs to — the picker reads from `features.yaml`.
3. Help-template scaffolding has no slot for the new surface, so users running `/help` against ops topics get no contextual response.

## What changed

| File | Change |
|---|---|
| `.help/features.yaml` | New `ops-dashboard` entry (description + `src/attune/ops/**` + 7 tags) between `release-prep` and `refactor-plan`. |

Total feature count: 24 → 25.

## What's NOT in this PR

- Help template files (`.help/templates/ops-dashboard/concept.md` etc.) — those get generated by `attune-author` on the next freshness sweep.
- Test additions — `features.yaml` is consumed by `attune.ops.data.list_features()` (added in #324); the existing test suite there already covers the parse path.

## Test plan

- [x] `yaml.safe_load` parses; 25 features total
- [x] New entry fields (description, files, tags) shape correctly
- [ ] CI: pre-commit + Help Template Freshness check on push
- [ ] After #324 merges, the dashboard scope picker will surface `ops-dashboard` as a pickable feature (smoke verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
