### PR TITLE
docs(discovery-sweep-ops): Phase 0 audit — re-verify spec vs current runner

### DIFF
--- a/docs/specs/discovery-sweep-ops-integration/audit-2026-05-13.md
+++ b/docs/specs/discovery-sweep-ops-integration/audit-2026-05-13.md
@@ -1,0 +1,204 @@
+# Phase 0 — Re-audit against current ops-runner-tier2 surface
+
+**Date:** 2026-05-13
+**Author:** spec re-verification pass
+**Scope:** Read-only audit, no production code changes.
+**Status:** Draft — awaiting design decision before Phase 1
+implementation opens.
+
+This audit re-verifies the spec's premise against the ops-runner-tier2
+surface that is shipping in PRs #324 (Phase 2 — scope picker) and #326
+(Phases 3+4 — persistence + chainable pills), both targeted at
+`release/v6.8.0` (#328). The original spec was drafted before that
+surface was visible. Several core assumptions don't match the
+actually-shipped shape, so executing Phase 1 as written would build
+plumbing that has nowhere to publish to.
+
+---
+
+## What the spec assumed (drafted 2026-05-13)
+
+1. A **shared `GET /events` SSE stream** carrying telemetry events
+   from any running workflow, multiplexed by `sweep_id` /
+   `run_id`.
+2. The daemon **executes the workflow in-process** (importing
+   `DiscoverySweepWorkflow` and awaiting `execute(event_sink=...)`),
+   so the engine's Python-level `event_sink` callback can publish
+   directly onto the SSE stream.
+3. The daemon **persists structured sweep results** to
+   `~/.attune/ops/sweep-results/<scope-hash>.json`, indexed by
+   canonicalized scope path so the workflow list can read chip
+   counts without a fresh run.
+4. **Concurrent sweeps** on different scopes are supported and
+   correlated by `sweep_id`.
+
+## What ops-runner-tier2 actually ships
+
+| Surface | Reality (main + PR #324 + PR #326) |
+|---|---|
+| SSE stream | Per-run only: `GET /runs/{run_id}/stream`. Events are `("line", str)` and `("done", payload)` — line-oriented stdout broadcast, not structured telemetry. There is no `/events` global stream. |
+| Workflow execution | Subprocess: `RunnerService._execute` spawns `sys.executable -m attune.cli_minimal workflow run <name>` and captures merged stdout+stderr line-by-line (`src/attune/ops/runner.py:175-206`). No in-process import path. |
+| Concurrency | Single-run lock: `RunnerService.start()` raises `RunnerBusyError` if a run is in flight (`src/attune/ops/runner.py:162-173`). `sweep_id` correlation across concurrent sweeps has no use case. |
+| Persistence | PR #326 adds per-run history keyed by `run_id`, not by scope-hash. Lines stored as text; no structured sweep output is parsed or saved. |
+| Scope picker | PR #324 adds the per-row dropdown + `path` POST body → `--path <value>` subprocess flag. `PATH_ARG_REGISTRY` on main already lists `discovery-sweep` as Category A (`kwarg="path"`, `required=False`). |
+
+The engine-level `event_sink` callback proposed in spec Phase 1 lives
+inside the subprocess. Python objects do not cross the subprocess
+boundary. So `event_sink` → SSE wiring (spec Phase 2) is architecturally
+impossible without either (a) abandoning the subprocess model or
+(b) routing all engine telemetry through stdout that the parent parses.
+
+---
+
+## Mismatches by spec section
+
+### `design.md` — architecture diagram
+
+The diagram shows the daemon owning the asyncio loop and the workflow
+execution. Reality: the daemon owns the subprocess; the workflow's
+asyncio loop is inside the child process.
+
+### `design.md` — "Per-source telemetry hook in the engine"
+
+The `event_sink: EventSink | None` kwarg added to
+`DiscoverySweepWorkflow.execute()` would still be useful for in-process
+callers (tests, CLI hooks, future programmatic consumers), but it
+cannot be the channel by which the daemon hears about per-source
+progress. The daemon hears stdout. Period.
+
+### `design.md` — "Storage layout"
+
+`~/.attune/ops/sweep-results/<scope-hash>.json` is not written by
+anything today. PR #326 introduces `~/.attune/ops/runs/<run-id>.json`
+(run-keyed, not scope-keyed). If the spec wants scope-keyed storage,
+the daemon needs to write it — and the data has to come from
+somewhere the daemon can read.
+
+### `design.md` — "Detail view (drill-in)"
+
+The proposed URL `/workflows/discovery-sweep/<sweep-id>?bucket=queue`
+mixes "sweep_id" and "run_id" terminology. PR #326's run-view page is
+keyed by `run_id`. The bucket filter is achievable but the route
+shape needs to align with the run-keyed surface.
+
+### `tasks.md` — Phase 2 ("Daemon HTTP / SSE plumbing")
+
+Three of the five tasks (2.1 POST run endpoint, 2.2 SSE wiring,
+2.4 results GET) assume the in-process / shared-SSE model. They need
+re-scoping against the subprocess + stdout-parse model.
+
+---
+
+## Proposed revised design — Option A: stdout-emit + sidecar parser
+
+This is the smallest design change that delivers the spec's
+user-facing outcome (workflow-row chip counts, live per-source
+progress, drill-in to findings) without breaking the runner's
+subprocess invariant.
+
+### Wire diagram
+
+```
+┌───────────────────────────────────────────────────────────┐
+│  Dashboard (workflows.html + run_view.html)                │
+│  - workflow row: chips read GET /workflows/discovery-sweep │
+│                          /results/<scope-hash>             │
+│  - run page: subscribes to /runs/<run_id>/stream and       │
+│              parses ATTUNE_DS lines for live progress      │
+└───────────────────┬───────────────────────────────────────┘
+                    │  HTTP / SSE
+                    ▼
+┌───────────────────────────────────────────────────────────┐
+│  Ops daemon (RunnerService)                                │
+│  - existing: spawns subprocess, captures stdout line-by-   │
+│              line, broadcasts on /runs/<run_id>/stream     │
+│  - NEW: post-run hook for `discovery-sweep` workflow that  │
+│         parses ATTUNE_DS lines from `run.lines` and writes │
+│         ~/.attune/ops/sweep-results/<scope-hash>.json      │
+│  - NEW: GET /workflows/discovery-sweep/results/<hash>      │
+│         (404 if no sweep has run for that scope)           │
+└───────────────────┬───────────────────────────────────────┘
+                    │  stdout (already wired)
+                    ▼
+┌───────────────────────────────────────────────────────────┐
+│  attune workflow run discovery-sweep --path <P> --json     │
+│  - NEW: when stdout is a non-TTY, emit one line per        │
+│         per-source event in a parseable prefix:            │
+│           ATTUNE_DS source_started bug-predict ts=...      │
+│           ATTUNE_DS source_finished bug-predict count=7    │
+│         alongside today's human-readable output.           │
+│  - existing: --json flag already produces the final        │
+│              {queue, questions, rejected, metadata} blob.  │
+└───────────────────────────────────────────────────────────┘
+```
+
+### Key design properties
+
+- **No new IPC primitives.** The existing per-run SSE stream is the
+  transport for live progress events; the dashboard parses
+  `ATTUNE_DS` prefix lines client-side. No `/events` stream needed.
+- **No in-process execution.** The subprocess model is preserved.
+  The engine's optional `event_sink` kwarg (spec Phase 1) is still
+  worth adding for in-process callers and testability, but it is no
+  longer load-bearing for the dashboard surface.
+- **Scope-keyed JSON is a daemon-side concern.** The daemon parses
+  its own stdout buffer at run completion and persists. The CLI does
+  not write to `~/.attune/ops/sweep-results/` — only the daemon does
+  — which closes the race the spec's risk matrix worried about.
+- **Single-run lock survives.** No `sweep_id` correlation needed;
+  `run_id` is sufficient since concurrent sweeps don't exist.
+- **`--no-llm` static-mode path** (NFR-1) is unchanged: the CLI's
+  `--json` flag already produces dashboard-consumable output, which
+  a user can manually drop into the sweep-results dir if they want
+  the dashboard to show it without the daemon running.
+
+### What changes vs. the original spec
+
+| Spec section | Original | Revised |
+|---|---|---|
+| Phase 1 — engine event_sink | Required, load-bearing for dashboard | Still useful for in-process callers; not load-bearing for SSE. |
+| Phase 2 — daemon HTTP/SSE | New `/events` stream, in-process exec | New post-run hook on existing per-run stream, stdout parsing, scope-keyed JSON write. |
+| Phase 3 — Dashboard UI | Mostly unchanged | Reads chips from `GET /workflows/discovery-sweep/results/<hash>`; live progress parses `ATTUNE_DS` lines from the existing per-run stream. |
+| Storage | `~/.attune/ops/sweep-results/` (spec) | Same path, but daemon-owned write, scope-hash key unchanged. |
+| Identifier | `sweep_id` (new) | `run_id` (existing). |
+
+### Alternative considered: Option B — in-process execution
+
+Daemon imports `DiscoverySweepWorkflow` and awaits `execute(...)`
+directly. Pros: the `event_sink` callback is the natural fit.
+Cons: breaks the subprocess invariant for one workflow only,
+creates a precedent that every future workflow has to decide
+between subprocess vs in-process, complicates error isolation
+(an `asyncio.Task` exception inside the daemon vs a non-zero
+exit code), and forks the runner's execution model. Rejected
+unless ops-runner-tier2 owners want to flip the whole runner to
+in-process — which is a separate, much larger conversation.
+
+---
+
+## Decision required before Phase 1 opens
+
+**Q1.** Adopt Option A (stdout-emit + sidecar parser) as the
+implementation path for this spec? **Default: yes.**
+
+**Q2.** Refactor `design.md` and `tasks.md` to match Option A, or
+leave them as historical drafts and treat this audit doc as the
+canonical reference until implementation lands? **Default: refactor
+the spec docs in the same PR that opens Phase 1 implementation.**
+
+**Q3.** Keep `event_sink` in Phase 1 (in-process API surface, useful
+for tests + future programmatic callers) or drop it now that it
+isn't load-bearing? **Default: keep — it's cheap, testable, and
+preserves the option of an in-process consumer later.**
+
+---
+
+## Out of scope for this audit
+
+- Implementation of any code change. This document is a design-
+  decision artifact only.
+- Recommendations on persistence eviction / history (still post-v1,
+  same as the original spec).
+- Coordination with PR #324 / PR #326 / PR #328. Those PRs do not
+  block this audit; this audit blocks Phase 1 of *this* spec opening
+  for implementation.

--- a/docs/specs/discovery-sweep-ops-integration/tasks.md
+++ b/docs/specs/discovery-sweep-ops-integration/tasks.md
@@ -1,12 +1,18 @@
 # Tasks — Discovery-Sweep Ops Dashboard Integration
 
 **Status:** draft (2026-05-13) — not yet open for implementation
-**Spec docs:** `requirements.md`, `design.md`, `decisions.md`
-**Blocks on:** `docs/specs/ops-runner-tier2/` Phase 2
+**Spec docs:** `requirements.md`, `design.md`, `decisions.md`,
+[`audit-2026-05-13.md`](audit-2026-05-13.md)
+**Blocks on:** Decision Q1–Q3 in the audit doc (see below).
 
-> **Open this spec for implementation** when ops-runner-tier2
-> Phase 2 lands and provides the SSE event stream + the dashboard
-> workflow-list page this spec builds on.
+> **Open this spec for implementation** once the Phase 0 audit
+> ([`audit-2026-05-13.md`](audit-2026-05-13.md)) is approved.
+> The audit re-verified the spec against the actually-shipped
+> ops-runner-tier2 surface and proposes a revised design (Option A
+> — stdout-emit + sidecar parser) that the original `design.md`
+> and Phases 1–2 need to be aligned to. Until the audit's decision
+> questions are resolved, do not open implementation PRs against
+> the un-revised `tasks.md` below.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Phase 0** of `discovery-sweep-ops-integration`: read-only audit, no production code changes.
- The spec was drafted 2026-05-13 assuming ops-runner-tier2 primitives that ended up looking different in PRs #324 (scope picker) and #326 (persistence + pills) — shared `/events` SSE, in-process workflow execution, scope-keyed daemon storage.
- Actually-shipped surface: per-run `/runs/{id}/stream` SSE, subprocess execution, run-keyed history. The spec's load-bearing `event_sink` → SSE wiring is architecturally impossible across the subprocess boundary.
- Proposes **Option A (stdout-emit + sidecar parser)**: workflow emits `ATTUNE_DS` prefix lines on stdout; daemon parses its own stdout buffer at run completion and persists `~/.attune/ops/sweep-results/<scope-hash>.json`. Dashboard reads chips from a new `GET /workflows/discovery-sweep/results/<hash>`; live progress parses `ATTUNE_DS` lines from the existing per-run stream. Preserves the runner's subprocess + single-run invariants.

Per the user's instruction: this phase ships as a **draft PR with no production code**. The output is a design decision for Phase 1.

## Decision required before Phase 1 opens

1. **Q1** — Adopt Option A as the implementation path? *(default: yes)*
2. **Q2** — Refactor `design.md` / `tasks.md` in the same PR that opens Phase 1, or treat this audit as canonical until then? *(default: refactor at Phase 1 open)*
3. **Q3** — Keep `event_sink` in Phase 1 (no longer load-bearing but useful for in-process callers + tests) or drop it? *(default: keep)*

## Test plan

- [ ] No production code changes — `git diff --stat` confirms only doc files touched.
- [ ] Pre-commit hooks pass (already green at commit time — only `.md` files touched).
- [ ] Reviewer (ops-runner-tier2 owner) confirms the audit's read of PR #324 / PR #326 architecture is accurate.
- [ ] Q1–Q3 resolved in PR review; merge once approved, then open Phase 1 implementation PR.

## Notes for reviewer

- Avoided touching all conflict-prone files per worktree instructions: `src/attune/ops/runner.py`, `routes/runner.py`, `static/js/runner.js`, `static/js/run_view.js`, `templates/workflows.html`, `templates/run_view.html`.
- `audit-2026-05-13.md` is timestamped so future re-audits don't collide; pointer added to `tasks.md`.
- Builds on PR #321 (`docs/specs/discovery-sweep-ops-integration/` initial draft) and looks ahead to PRs #324 / #326 / #328 (the surface this spec depends on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)