### PR TITLE
feat(website): PR-A foundation for dashboard + fold-back spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 2026-05-10 — Dashboard becomes a real workspace
+
+If you're returning after a couple of releases, the
+`attune-gui` dashboard is now where the workflow actually
+tells you what to do next. Four user-visible changes
+shipped together:
+
+- **Living Docs** — the dashboard now shows a table of your
+  project's docs with state badges (fresh / stale / missing)
+  and inline regenerate actions. You see what's drifted
+  from the code without leaving the browser.
+- **One-click polish-corpus** — the polish job runs from
+  the dashboard and produces the path-keyed summaries the
+  RAG retriever uses for boost scoring. No more shelling
+  into a Python script.
+- **`rag-query` results page** — search a polished corpus
+  and get a results page with linked hits, scores, and
+  surrounding context. Useful both for "what does this
+  feature do?" and for sanity-checking retrieval quality.
+- **Commands inline result panel** — running a command
+  (e.g. an audit) renders the result in-page rather than
+  dumping into a separate scrollback area. Easier to copy,
+  share, and act on.
+
+### Coming next — quality polish and the fold-back
+
+Two follow-up beats already in flight:
+
+- A dashboard-quality-pass spec is in review. When it
+  lands, sentence-case copy, humanised timestamps, a
+  generic command-result renderer, and a few sidecar
+  fixes ship together.
+- The `attune-gui` package is folding back into
+  `attune-ai` as an extra. After the fold ships,
+  `pip install attune-gui` becomes
+  `pip install attune-ai[gui]`. One product, one install,
+  two faces. See `/migrate` for what changes (pre-fold
+  heads-up; post-fold details added on v7.0 release day).
+
 ### Added
 
 - `discovery-sweep` Phase 3.2 — severity-colored badges in

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -36,6 +36,32 @@ const faqData: FAQCategory[] = [
         question: 'What is Dynamic Team Composition?',
         answer: 'Dynamic Team Composition allows you to build agent teams at runtime from 13 pre-built templates or custom configurations. Teams can execute with different strategies (parallel, sequential, two-phase, delegation) and enforce quality gates. You can also compose entire workflows into teams using the WorkflowComposer.',
       },
+      {
+        question: "What's the difference between attune-ai and attune-gui?",
+        answer: (
+          <>
+            Two packages today, one workflow. <code className="font-mono">attune-ai</code> is the framework — workflows, agents, the CLI. <code className="font-mono">attune-gui</code> is the local dashboard that sits on top of it: Living Docs, RAG search, the commands surface, summaries. You install them separately right now (<code className="font-mono">pip install attune-ai</code> and <code className="font-mono">pip install attune-gui</code>) and they talk to the same project directory. In an upcoming release they fold into one install (<code className="font-mono">pip install attune-ai[gui]</code>);{' '}
+            <Link href="/migrate" className="text-[var(--primary)] hover:underline">
+              see the migration page
+            </Link>{' '}
+            for the heads-up.
+          </>
+        ),
+        answerText: "Two packages today, one workflow. attune-ai is the framework — workflows, agents, the CLI. attune-gui is the local dashboard that sits on top of it: Living Docs, RAG search, the commands surface, summaries. You install them separately right now (pip install attune-ai and pip install attune-gui) and they talk to the same project directory. In an upcoming release they fold into one install (pip install attune-ai[gui]); see /migrate for the heads-up.",
+      },
+      {
+        question: 'Do I need the dashboard?',
+        answer: (
+          <>
+            No &mdash; the CLI does everything on its own. But the dashboard is where the workflow tells you what to do next: which docs have drifted, which summaries need re-polishing, which commands you ran recently and what they produced. If you&rsquo;re just running one-off workflows, the CLI is fine. If you&rsquo;re maintaining a living help system or iterating on a corpus, the dashboard saves real time.{' '}
+            <Link href="/migrate" className="text-[var(--primary)] hover:underline">
+              Migration heads-up here
+            </Link>{' '}
+            if you have <code className="font-mono">attune-gui</code> installed today.
+          </>
+        ),
+        answerText: "No — the CLI does everything on its own. But the dashboard is where the workflow tells you what to do next: which docs have drifted, which summaries need re-polishing, which commands you ran recently and what they produced. If you're just running one-off workflows, the CLI is fine. If you're maintaining a living help system or iterating on a corpus, the dashboard saves real time. Migration heads-up at /migrate if you have attune-gui installed today.",
+      },
     ],
   },
   {

--- a/website/app/migrate/page.tsx
+++ b/website/app/migrate/page.tsx
@@ -1,0 +1,132 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Navigation from '@/components/Navigation';
+import Footer from '@/components/Footer';
+import { generateMetadata } from '@/lib/metadata';
+import { CANONICAL_INSTALL, POST_FOLD_INSTALL } from '@/lib/install-command';
+
+export const metadata: Metadata = generateMetadata({
+  title: 'Migrating from attune-gui — Attune AI',
+  description:
+    'Heads-up for current attune-gui users: the dashboard is folding back into attune-ai as an install extra. What changes, what doesn’t, and when.',
+  url: 'https://smartaimemory.com/migrate',
+  keywords: ['attune-gui migration', 'attune-ai dashboard', 'pip install attune-ai[gui]'],
+});
+
+export default function MigratePage() {
+  return (
+    <>
+      <Navigation />
+      <main id="main-content" className="min-h-screen pt-16">
+        <section className="py-20 gradient-primary text-white">
+          <div className="container">
+            <div className="max-w-3xl mx-auto text-center">
+              <h1 className="text-5xl font-bold mb-6 !text-white">
+                Heads up: <code className="font-mono">attune-gui</code> is folding into <code className="font-mono">attune-ai</code>
+              </h1>
+              <p className="text-xl !text-white opacity-90">
+                Pre-fold notice. Nothing breaks today.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16">
+          <div className="container">
+            <div className="max-w-3xl mx-auto prose prose-lg">
+              <h2>What&rsquo;s changing</h2>
+              <p>
+                Today the dashboard ships as a standalone PyPI package:
+              </p>
+              <pre><code>{CANONICAL_INSTALL}</code></pre>
+              <p>
+                In an upcoming release, it becomes an install extra on{' '}
+                <code className="font-mono">attune-ai</code> itself:
+              </p>
+              <pre><code>{POST_FOLD_INSTALL}</code></pre>
+              <p>
+                Same dashboard, same surfaces (Living Docs, RAG search,
+                Commands, Summaries). One package to install instead of two.
+              </p>
+
+              <h2>What stays the same</h2>
+              <ul>
+                <li>The dashboard URL, layout, and feature set.</li>
+                <li>Your project directory and any{' '}
+                  <code className="font-mono">.help/</code>{' '}
+                  templates / corpus state.
+                </li>
+                <li>The CLI. <code className="font-mono">attune</code>{' '}
+                  workflows continue to work unchanged.</li>
+                <li>Your existing{' '}
+                  <code className="font-mono">attune-gui</code>{' '}
+                  install keeps running until you choose to migrate.
+                </li>
+              </ul>
+
+              <h2>When does this happen</h2>
+              <p>
+                On the v7.0 release. We&rsquo;ll publish a banner here,
+                on the homepage, and on the <code className="font-mono">attune-gui</code>{' '}
+                PyPI page about 4&ndash;6 weeks before release day so you
+                aren&rsquo;t blindsided. The banner phrasing is
+                deliberately non-version-specific until the v7.0 RC cuts.
+              </p>
+
+              <h2>Do I need to do anything now?</h2>
+              <p>
+                No. This page is a heads-up. When v7.0 ships, the steps
+                will be:
+              </p>
+              <ol>
+                <li>
+                  <code className="font-mono">pip uninstall attune-gui</code>
+                </li>
+                <li>
+                  <code className="font-mono">{POST_FOLD_INSTALL}</code>
+                </li>
+              </ol>
+              <p>
+                The standalone <code className="font-mono">attune-gui</code>{' '}
+                package will continue to publish as a deprecation shim that
+                points at the new install path, so a stale install command
+                in a CI script won&rsquo;t break overnight.
+              </p>
+
+              <h2>Where to follow along</h2>
+              <ul>
+                <li>
+                  <Link href="/changelog" className="text-[var(--primary)] hover:underline">
+                    Changelog
+                  </Link>{' '}
+                  &mdash; v7.0 release notes will land here with the
+                  exact migration steps.
+                </li>
+                <li>
+                  <Link href="/faq" className="text-[var(--primary)] hover:underline">
+                    FAQ
+                  </Link>{' '}
+                  &mdash; &ldquo;What&rsquo;s the difference between attune-ai
+                  and attune-gui?&rdquo; updates on fold day.
+                </li>
+                <li>
+                  <Link
+                    href="https://github.com/Smart-AI-Memory/attune-ai/issues"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[var(--primary)] hover:underline"
+                  >
+                    GitHub issues
+                  </Link>{' '}
+                  &mdash; raise anything that surprises you in the
+                  migration.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -4,6 +4,7 @@ import Footer from '@/components/Footer';
 import GitHubStarsBadge from '@/components/GitHubStarsBadge';
 import TestsBadge from '@/components/TestsBadge';
 import { generateStructuredData } from '@/lib/metadata';
+import { installCommand } from '@/lib/install-command';
 
 // Doc-toolchain code sample. attune-ai is the parent
 // framework (headlined in the hero); the four packages
@@ -24,7 +25,7 @@ engine = HelpEngine(template_dir=".help/templates")
 print(engine.lookup("security-audit"))
 
 # 4. attune-gui — local dashboard tying it all together.
-#    pip install attune-gui && attune-gui --open`;
+#    ${installCommand()} && attune-gui --open`;
 
 export default function Home() {
   const softwareSchema = generateStructuredData('product');

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -29,6 +29,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     '/blog',
     '/changelog',
     '/contact',
+    '/migrate',
   ].map((route) => ({
     url: `${baseUrl}${route}`,
     lastModified: new Date(),

--- a/website/lib/install-command.ts
+++ b/website/lib/install-command.ts
@@ -1,0 +1,15 @@
+// Single source of truth for the GUI install command shown
+// on the site. Phase 2 (v7.0 release day) flips
+// CANONICAL_INSTALL to POST_FOLD_INSTALL in one line.
+// See docs/specs/website-update-dashboard-and-fold/.
+
+export const CANONICAL_INSTALL = 'pip install attune-gui';
+export const POST_FOLD_INSTALL = 'pip install attune-ai[gui]';
+
+export interface InstallCommandOptions {
+  postFold?: boolean;
+}
+
+export function installCommand(opts: InstallCommandOptions = {}): string {
+  return opts.postFold ? POST_FOLD_INSTALL : CANONICAL_INSTALL;
+}

--- a/website/lib/migration-banner.ts
+++ b/website/lib/migration-banner.ts
@@ -1,0 +1,34 @@
+// Migration banner lifecycle config. See contract C-4 in
+// docs/specs/website-update-dashboard-and-fold/requirements.md.
+//
+// Pre-fold (current state): banner is HIDDEN. PR-B will add
+// the component that consumes this config and renders on
+// the homepage. Phase 2 (v7.0 day) flips the pin to v7.0
+// and re-enables.
+//
+// fallbackHideDate is the safety net: if today is past
+// that date and the banner is still rendering, the
+// build-time check (scripts/check-migration-banner.ts)
+// fails the build, forcing an explicit decision.
+
+export interface MigrationBannerConfig {
+  // Show the banner when current package version is >=
+  // this value. Empty string disables the banner.
+  showFromVersion: string;
+  // Hide the banner when current package version is >=
+  // this value (exclusive — banner gone in this release).
+  hideFromVersion: string;
+  // Safety net: if today's date is past this AND the
+  // banner is still rendering, build fails.
+  fallbackHideDate: string; // ISO YYYY-MM-DD
+  // Convenience flag the component reads. Pre-fold this
+  // is false; PR-B's homepage wires it.
+  enabled: boolean;
+}
+
+export const MIGRATION_BANNER: MigrationBannerConfig = {
+  showFromVersion: '',
+  hideFromVersion: '7.1.0',
+  fallbackHideDate: '2026-06-15',
+  enabled: false,
+};

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,7 +12,6 @@
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^16.0.1",
         "@sendgrid/mail": "^8.1.6",
-        "@stripe/stripe-js": "^8.1.0",
         "bcryptjs": "^3.0.2",
         "gray-matter": "^4.0.3",
         "ioredis": "^5.8.2",
@@ -29,7 +28,6 @@
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
         "resend": "^6.5.2",
-        "stripe": "^19.1.0",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
@@ -44,6 +42,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.5.9",
         "tailwindcss": "^4",
+        "tsx": "^4.19.2",
         "typescript": "5.9.3"
       }
     },
@@ -91,6 +90,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1194,15 +1635,6 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
-    "node_modules/@stripe/stripe-js": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.1.0.tgz",
-      "integrity": "sha512-bhhi0iSHDFRa2pPVv3WOHC6x/iGEu5AZqIiAvXsT8VOucsEre9gzgsK0jFzbzfGW2eeubF+mCdTTYwNAQCMJKg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.16"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1701,7 +2133,7 @@
       "version": "20.19.22",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.22.tgz",
       "integrity": "sha512-hRnu+5qggKDSyWHlnmThnUqg62l29Aj/6vcYgUaSFL9oc7DVjeWEQN3PRgdSc6F8d9QRMWkf36CLMch1Do/+RQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2716,6 +3148,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3595,6 +4028,48 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -4341,6 +4816,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7145,6 +7635,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7623,21 +8114,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/querystringify": {
@@ -8392,6 +8868,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8411,6 +8888,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8427,6 +8905,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8445,6 +8924,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -8687,26 +9167,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stripe": {
-      "version": "19.3.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-19.3.1.tgz",
-      "integrity": "sha512-5NXhLxTZ+4uO1wnsmNysILVuyeZ1Xia7niz/8ykBkGJkCcrY2WyQZwcfYuWZmZEJtWr2+0j49JXwNC6y9CHL7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "qs": "^6.11.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@types/node": ">=16"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
       }
     },
     "node_modules/style-to-js": {
@@ -8968,6 +9428,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/website/package.json
+++ b/website/package.json
@@ -4,10 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npm run build:docs && next build",
-    "build:vercel": "next build",
-    "build:railway": "next build",
+    "build": "npm run check:migration-banner && npm run build:docs && next build",
+    "build:vercel": "npm run check:migration-banner && next build",
+    "build:railway": "npm run check:migration-banner && next build",
     "build:docs": "cd .. && mkdocs build --clean && rm -rf website/public/framework-docs && cp -r site website/public/framework-docs",
+    "check:migration-banner": "tsx scripts/check-migration-banner.ts",
     "start": "next start",
     "lint": "eslint"
   },
@@ -49,6 +50,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.9",
     "tailwindcss": "^4",
+    "tsx": "^4.19.2",
     "typescript": "5.9.3"
   }
 }

--- a/website/scripts/check-migration-banner.ts
+++ b/website/scripts/check-migration-banner.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env tsx
+// Build-time guard for the migration banner.
+//
+// Fails the build if today's date is past
+// MIGRATION_BANNER.fallbackHideDate AND the banner is
+// still enabled. Forces an explicit decision to either
+// retire the banner or push out the safety date rather
+// than letting a stale banner linger silently.
+//
+// See contract C-4 in
+// docs/specs/website-update-dashboard-and-fold/requirements.md.
+
+import { MIGRATION_BANNER } from '../lib/migration-banner';
+
+function parseDate(iso: string): Date {
+  const parsed = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(
+      `migration-banner.ts: fallbackHideDate "${iso}" is not a valid ISO date (YYYY-MM-DD).`,
+    );
+  }
+  return parsed;
+}
+
+function main(): void {
+  const fallback = parseDate(MIGRATION_BANNER.fallbackHideDate);
+  const today = new Date();
+
+  if (MIGRATION_BANNER.enabled && today > fallback) {
+    console.error(
+      [
+        '✗ Migration banner is still enabled but the fallback hide date',
+        `  (${MIGRATION_BANNER.fallbackHideDate}) has passed.`,
+        '',
+        '  Either:',
+        '    - Set MIGRATION_BANNER.enabled = false in website/lib/migration-banner.ts',
+        '    - Or push out fallbackHideDate to a new safety net.',
+      ].join('\n'),
+    );
+    process.exit(1);
+  }
+
+  console.info(
+    `✓ Migration banner check passed (enabled=${MIGRATION_BANNER.enabled}, fallbackHideDate=${MIGRATION_BANNER.fallbackHideDate}).`,
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

PR-A of the `website-update-dashboard-and-fold` spec: pre-fold foundation for the dashboard story and the v7.0 `attune-gui` → `attune-ai[gui]` fold-back. Ships the install-command helper, migration-banner config + build guard, two FAQ entries, the `/migrate` heads-up page, and a persona-styled changelog entry for the 2026-05-10 dashboard work.

PR-B (dashboard feature page, homepage updates, banner component) and Phase 2 (install swap, redirects, screenshot automation) are intentionally out of scope.

## What's in this PR

**Foundation (PR-A1)**
- [website/lib/install-command.ts](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/distracted-babbage-6f55fa/website/lib/install-command.ts) — `CANONICAL_INSTALL`, `POST_FOLD_INSTALL`, `installCommand({postFold?})` per spec C-1.
- [website/lib/migration-banner.ts](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/distracted-babbage-6f55fa/website/lib/migration-banner.ts) — banner lifecycle config (`enabled=false`, `hideFromVersion=7.1.0`, `fallbackHideDate=2026-06-15`) per C-4.
- [website/scripts/check-migration-banner.ts](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/distracted-babbage-6f55fa/website/scripts/check-migration-banner.ts) — tsx-run build guard; fails if `enabled && today > fallbackHideDate`. Wired into `build`, `build:vercel`, `build:railway`.
- [website/app/page.tsx](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/distracted-babbage-6f55fa/website/app/page.tsx) — hero code block renders `installCommand()` instead of a hard-coded `pip install attune-gui`. (Audit estimated ~10 places; the actual count of `attune-gui` install literals in `app/*.tsx` was 1 — other `pip install` strings reference different packages and are outside the helper's spec scope.)

**Content (PR-A2)**
- [CHANGELOG.md](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/distracted-babbage-6f55fa/CHANGELOG.md) — two new `[Unreleased]` subsections in C-5 persona ("existing attune-ai user who skipped 2 releases"): "2026-05-10 — Dashboard becomes a real workspace" (4 user-visible bullets: Living Docs, polish-corpus, rag-query results, Commands inline panel) and "Coming next — quality polish and the fold-back".
- [website/app/faq/page.tsx](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/distracted-babbage-6f55fa/website/app/faq/page.tsx) — two entries: "What's the difference between attune-ai and attune-gui?" (1.5.1) and "Do I need the dashboard?" (1.5.2). Both include `answerText` for FAQ structured data; both link to `/migrate`.
- [website/app/migrate/page.tsx](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/distracted-babbage-6f55fa/website/app/migrate/page.tsx) — pre-fold heads-up page (~115 lines). Imports the install constants from the helper so the page text auto-flips on the Phase 2 swap.
- [website/app/sitemap.ts](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/distracted-babbage-6f55fa/website/app/sitemap.ts) — adds `/migrate` so the new route is crawlable.

## Spec coverage

| Task | Status |
|---|---|
| 1.1.1 install helper | ✅ |
| 1.1.2 migration-banner config | ✅ |
| 1.1.3 build-time check | ✅ |
| 1.4.1 2026-05-10 changelog entry | ✅ |
| 1.4.2 forward-looking changelog note | ✅ |
| 1.5.1 FAQ: attune-ai vs attune-gui | ✅ |
| 1.5.2 FAQ: Do I need the dashboard? | ✅ |
| 1.6.1 /migrate page (pre-fold copy) | ✅ |

## Test plan

- [x] `npm run check:migration-banner` — success path
- [x] Banner check failure path verified (temporarily flipped `enabled=true` with a past date — exits 1 with the right message)
- [x] `npm run build:vercel` green; `/migrate` prerenders as static (○) at 2.35 kB / 108 kB First Load JS
- [x] `npm run lint` clean
- [ ] Vercel preview deploy renders `/migrate` with `gradient-primary` hero readable (uses `!text-white` per the project's invisible-button-class lesson)
- [ ] FAQ JSON-LD validates against Schema.org's Question/Answer types
- [ ] `/migrate` shows up in the sitemap on the preview deploy

## Out of scope (parking for follow-up PRs)

- PR-B: dashboard feature page (1.2.x), homepage Living Docs / polish-corpus surfacing (1.3.x), banner component on homepage (1.6.2). Depends on hand-shot screenshots.
- Phase 1.7: attune-gui PyPI README banner — cross-repo, lives in `~/attune-gui`.
- Phase 2: install command swap, attune-gui → attune-ai redirects, screenshot automation, banner enable — gated on v7.0 release day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
