### PR TITLE
feat(discovery-sweep): Phase 1b — ATTUNE_DS stdout side-channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `discovery-sweep` Phase 1b (ops-integration spec) — `ATTUNE_DS`
+  daemon-parseable stdout side-channel. When `ATTUNE_DS_EMIT=1`
+  is set in the environment, the engine writes a schema-version
+  line (`ATTUNE_DS_VERSION 1`) at start, one ATTUNE_DS line per
+  per-source event (`source_started` / `source_finished` /
+  `source_failed`), and a final `ATTUNE_DS final <json>` line
+  carrying the same SweepResult JSON `--json` produces. The gate
+  is an env var rather than non-TTY detection so legitimate
+  pipe-to-file invocations (`attune workflow run discovery-sweep
+  > out.md`) keep producing clean markdown. New module
+  `src/attune/workflows/discovery_sweep/ds_stdout.py` owns the
+  format + a `parse_line()` helper that round-trips the emitted
+  lines back to event dicts (used by tests today and by the
+  upcoming Phase 2 daemon-side parser). 18 new tests in
+  `tests/unit/workflows/discovery_sweep/test_ds_stdout.py` cover
+  formatter / parser round-trips, the emission gate, and engine
+  wiring (version-line-first, event ordering, final-line JSON
+  shape, co-existence with the in-process event_sink). Coverage
+  on the new module is 100%. See decision #10 in
+  `docs/specs/discovery-sweep-ops-integration/decisions.md` for
+  the env-var-vs-TTY rationale.
+
 - `discovery-sweep` Phase 1 (ops-integration spec) — engine
   `event_sink` API. `DiscoverySweepWorkflow.execute()` now accepts
   optional `event_sink` (async callback) and `sweep_id` (correlation

--- a/docs/specs/discovery-sweep-ops-integration/decisions.md
+++ b/docs/specs/discovery-sweep-ops-integration/decisions.md
@@ -188,3 +188,36 @@ sweep API for users with their own daemon, etc.).
 the daemon hears about per-source progress. The daemon hears
 stdout. `event_sink` is a parallel surface for in-process
 callers only.
+
+---
+
+## 10. Gate stdout emission on `ATTUNE_DS_EMIT=1`, not non-TTY (2026-05-13, Phase 1b)
+
+**Decision:** The Phase 1b `ATTUNE_DS` stdout side-channel is
+emitted only when the `ATTUNE_DS_EMIT` environment variable is
+set to a non-empty value. The daemon sets it when spawning the
+subprocess; nobody else does.
+
+**What the original draft said:** "Emit when `sys.stdout.isatty()`
+is False (the subprocess parent has captured stdout)." This was
+shorthand for "emit when the daemon is parsing us, but not when
+a TTY user is reading us."
+
+**Why that shorthand is wrong:** non-TTY also covers the
+legitimate user workflow of `attune workflow run discovery-sweep
+> out.md`. That redirects stdout to a file (not a TTY), but the
+user wants clean markdown in `out.md`, NOT ATTUNE_DS lines
+interleaved with the markdown. The TTY check would silently
+pollute that output.
+
+**Env-var gate is precise:** only the daemon opts in. CLI users —
+whether typing in a terminal, piping to a file, or running under
+CI capture — see exactly today's output. The env var is also
+forward-compatible: any future runner (cron job, external script)
+that wants to consume the structured stream can opt in the same
+way without negotiating a new flag.
+
+**Naming:** `ATTUNE_DS_EMIT` (not `ATTUNE_OPS_DAEMON`) so the
+toggle name describes what it does, not who flips it. A future
+non-ops consumer can use the same env var without semantic
+collision.

--- a/docs/specs/discovery-sweep-ops-integration/design.md
+++ b/docs/specs/discovery-sweep-ops-integration/design.md
@@ -66,10 +66,11 @@ per-run SSE stream — shipped via PRs #324 / #326 on `release/v6.8.0`)
 │    source_started / source_finished / source_failed events.    │
 │    In-process consumers (tests, future programmatic callers)   │
 │    pass a sink; CLI invocations get None and unchanged output. │
-│  - NEW (Phase 1b, stdout): when stdout is NOT a TTY, engine    │
-│    also writes one ATTUNE_DS line per source event so the      │
-│    daemon (which captures stdout) can parse it. TTY users see  │
-│    nothing extra.                                              │
+│  - NEW (Phase 1b, stdout): when `ATTUNE_DS_EMIT=1` is set in   │
+│    the environment, engine also writes one ATTUNE_DS line per  │
+│    source event so the daemon (which captures stdout) can      │
+│    parse it. CLI users — including pipe-to-file — see nothing  │
+│    extra. (Env-var gate, not TTY detection: see decision #10.) │
 └────────────────────────────────────────────────────────────────┘
 ```
 
@@ -214,9 +215,8 @@ race the original spec worried about can't happen.
 
 ## `ATTUNE_DS` stdout-line format (Phase 1b → Phase 2)
 
-When the engine detects a non-TTY stdout (i.e. the subprocess
-runner has captured `stdout=PIPE`), it writes one line per source
-event in this shape:
+When `ATTUNE_DS_EMIT=1` is set in the environment, the engine
+writes one line per source event in this shape:
 
 ```
 ATTUNE_DS source_started   bug-predict     ts=2026-05-13T12:34:56+00:00

--- a/docs/specs/discovery-sweep-ops-integration/tasks.md
+++ b/docs/specs/discovery-sweep-ops-integration/tasks.md
@@ -54,21 +54,26 @@ defaults to None; stdout emission gated on non-TTY detection).
       - A slow sink doesn't block other sources' execution.
 - [ ] **1.6** CHANGELOG entry under `### Added`.
 
-### Phase 1b — `ATTUNE_DS` stdout emission (deferred to follow-up PR)
+### Phase 1b — `ATTUNE_DS` stdout emission — **shipped 2026-05-13**
 
-The stdout-line format ships once the engine event_sink API is in
-place. Splitting these keeps Phase 1 a pure API addition that
-existing callers don't observe.
+New `src/attune/workflows/discovery_sweep/ds_stdout.py` module owns
+the format. Engine wires `ds_stdout.is_emission_enabled()` →
+`emit_version_line()` / `emit_event_line()` / `emit_final_line()` at
+the right points in `execute()` and `_emit_event`.
 
-- [ ] **1b.1** When `sys.stdout.isatty()` is False, also write one
-      `ATTUNE_DS <kind> <source> ts=... [findings=N|error=Cls]`
-      line per event to stdout.
-- [ ] **1b.2** Emit `ATTUNE_DS_VERSION 1` as the first line.
-- [ ] **1b.3** Emit `ATTUNE_DS final <json>` once the sweep
-      completes (carries the same JSON `--json` produces).
-- [ ] **1b.4** Tests: lines only emitted when not a TTY; format
-      matches the design.md grammar; daemon-style parser round-
-      trips the emitted lines back to the same event dicts.
+- [x] **1b.1** Emission gated on the **`ATTUNE_DS_EMIT=1`** env var
+      (not `sys.stdout.isatty()` — that would pollute the
+      legitimate `attune workflow run … > out.md` pipe-to-file
+      UX). Daemon sets the env var when spawning. See decision #10.
+- [x] **1b.2** `ATTUNE_DS_VERSION 1` emitted as the first line.
+- [x] **1b.3** `ATTUNE_DS final <json>` emitted once the sweep
+      completes (single-line; embedded newlines stripped).
+- [x] **1b.4** Tests in `test_ds_stdout.py` (18 cases): formatter /
+      parser round-trips for every event kind, emission gate
+      semantics, engine wiring (version-line-first, per-source
+      events, failed source emits source_failed, final line carries
+      SweepResult JSON, user event_sink + stdout side-channel
+      co-exist).
 
 ---
 

--- a/src/attune/workflows/discovery_sweep/ds_stdout.py
+++ b/src/attune/workflows/discovery_sweep/ds_stdout.py
@@ -1,0 +1,157 @@
+"""Daemon-parseable stdout side-channel for discovery-sweep.
+
+When the ``ATTUNE_DS_EMIT=1`` environment variable is set, the engine
+writes one ``ATTUNE_DS …`` line to stdout per per-source event plus a
+final ``ATTUNE_DS final <json>`` line with the SweepResult. The ops
+daemon (Phase 2 of ``docs/specs/discovery-sweep-ops-integration/``)
+captures these lines from the subprocess it spawns and writes a
+scope-keyed sidecar JSON the dashboard reads.
+
+Why an env var and not non-TTY detection: legitimate users pipe
+``attune workflow run discovery-sweep > out.md`` to capture markdown
+output. Non-TTY would pollute that file with ATTUNE_DS lines. The
+env var lets the daemon opt in explicitly without breaking the
+pipe-to-file UX. See ``decisions.md`` entry #10.
+
+Grammar (one event per line):
+
+    ATTUNE_DS_VERSION 1
+    ATTUNE_DS source_started   <name> ts=<iso>
+    ATTUNE_DS source_finished  <name> ts=<iso> findings=<int>
+    ATTUNE_DS source_failed    <name> ts=<iso> error=<ClassName>
+    ATTUNE_DS final <json-on-one-line>
+
+Whitespace-separated. Source names are workflow-defined identifiers
+without spaces. The final-line JSON is the same blob ``--json`` /
+``output_format="json"`` already produces.
+
+This module is import-light — no engine deps — so the ops daemon's
+parser (Phase 2) can ``from attune.workflows.discovery_sweep.ds_stdout
+import parse_line`` without pulling in the whole workflow surface.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Any
+
+EMIT_ENV = "ATTUNE_DS_EMIT"
+VERSION = 1
+
+# Regex per line kind. Anchored at start; trailing content is the value.
+_RE_VERSION = re.compile(r"^ATTUNE_DS_VERSION (\d+)$")
+_RE_STARTED = re.compile(r"^ATTUNE_DS source_started (\S+) ts=(\S+)$")
+_RE_FINISHED = re.compile(r"^ATTUNE_DS source_finished (\S+) ts=(\S+) findings=(\d+)$")
+_RE_FAILED = re.compile(r"^ATTUNE_DS source_failed (\S+) ts=(\S+) error=(\S+)$")
+_RE_FINAL = re.compile(r"^ATTUNE_DS final (.+)$")
+
+
+def is_emission_enabled() -> bool:
+    """True when ``ATTUNE_DS_EMIT`` is set to any non-empty value."""
+    return bool(os.environ.get(EMIT_ENV))
+
+
+def _write(line: str) -> None:
+    """Write a single line to stdout and flush so a subprocess parent
+    reads it in real time."""
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+def emit_version_line() -> None:
+    """Write the schema-version line. Parsers refuse unknown versions."""
+    _write(f"ATTUNE_DS_VERSION {VERSION}")
+
+
+def emit_event_line(event: dict[str, Any]) -> None:
+    """Write one ATTUNE_DS line for an engine-emitted event dict.
+
+    Unknown event kinds are silently dropped — the parser will refuse
+    them on the daemon side, so emitting a malformed line is worse
+    than skipping. Existing kinds: source_started, source_finished,
+    source_failed. The ``sweep_id`` field on each event is intentionally
+    NOT serialized — daemon-side callers correlate via ``run_id``
+    (which they own) and CLI callers leave it None; including it in
+    the wire format would just add noise.
+    """
+    kind = event.get("event")
+    source = event.get("source", "")
+    ts = event.get("ts", "")
+    if kind == "source_started":
+        _write(f"ATTUNE_DS source_started {source} ts={ts}")
+    elif kind == "source_finished":
+        n = int(event.get("findings_count", 0))
+        _write(f"ATTUNE_DS source_finished {source} ts={ts} findings={n}")
+    elif kind == "source_failed":
+        err = event.get("error", "UnknownError")
+        _write(f"ATTUNE_DS source_failed {source} ts={ts} error={err}")
+    # else: unknown kind — drop silently.
+
+
+def emit_final_line(result_json: str) -> None:
+    """Write the final ATTUNE_DS line carrying the full SweepResult JSON.
+
+    The JSON blob must be single-line; callers pass the output of
+    ``json.dumps(...)`` (no ``indent=`` arg). Multiline JSON would
+    break the one-line-per-event grammar.
+    """
+    # Defensive: strip embedded newlines if a caller passes pretty-
+    # printed JSON. Daemon parser expects one line per record.
+    single_line = result_json.replace("\n", "").replace("\r", "")
+    _write(f"ATTUNE_DS final {single_line}")
+
+
+def parse_line(line: str) -> dict[str, Any] | None:
+    """Parse one ATTUNE_DS line back into a dict. None on no match.
+
+    Returns:
+        - ``{"event": "version", "version": int}`` for the version line.
+        - ``{"event": "source_started", "source": str, "ts": str}``.
+        - ``{"event": "source_finished", "source": str, "ts": str,
+          "findings_count": int}``.
+        - ``{"event": "source_failed", "source": str, "ts": str,
+          "error": str}``.
+        - ``{"event": "final", "json": str}`` (caller does
+          ``json.loads(d["json"])``).
+        - ``None`` for any non-``ATTUNE_DS`` line or malformed entry.
+
+    Round-trips with the ``emit_*_line()`` functions in this module.
+    """
+    stripped = line.rstrip("\r\n")
+    if not stripped.startswith("ATTUNE_DS"):
+        return None
+    m = _RE_VERSION.match(stripped)
+    if m:
+        return {"event": "version", "version": int(m.group(1))}
+    m = _RE_STARTED.match(stripped)
+    if m:
+        return {
+            "event": "source_started",
+            "source": m.group(1),
+            "ts": m.group(2),
+        }
+    m = _RE_FINISHED.match(stripped)
+    if m:
+        return {
+            "event": "source_finished",
+            "source": m.group(1),
+            "ts": m.group(2),
+            "findings_count": int(m.group(3)),
+        }
+    m = _RE_FAILED.match(stripped)
+    if m:
+        return {
+            "event": "source_failed",
+            "source": m.group(1),
+            "ts": m.group(2),
+            "error": m.group(3),
+        }
+    m = _RE_FINAL.match(stripped)
+    if m:
+        return {"event": "final", "json": m.group(1)}
+    return None

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -31,7 +31,7 @@ from attune.models import ModelTier
 from attune.workflows.base import BaseWorkflow
 from attune.workflows.data_classes import CostReport, WorkflowResult, WorkflowStage
 
-from . import verification
+from . import ds_stdout, verification
 
 logger = logging.getLogger(__name__)
 
@@ -401,7 +401,16 @@ async def _run_source(
 
 
 def _emit_event(sink: EventSink | None, event: dict[str, Any]) -> None:
-    """Fire-and-forget event emission. No-op when ``sink`` is None."""
+    """Fire-and-forget event emission to the in-process sink, with an
+    optional daemon-parseable stdout side-channel (Phase 1b).
+
+    Stdout emission is gated by ``ATTUNE_DS_EMIT=1`` (see
+    :mod:`.ds_stdout`); the daemon sets that when spawning the
+    subprocess. Other invocations (CLI users piping to a file, tests,
+    in-process callers) see no extra output.
+    """
+    if ds_stdout.is_emission_enabled():
+        ds_stdout.emit_event_line(event)
     if sink is None:
         return
     asyncio.create_task(_safe_emit(sink, event))
@@ -551,6 +560,13 @@ class DiscoverySweepWorkflow(BaseWorkflow):
         allocations = self._allocate_budget(sources, budget_usd)
         paths = _expand_path(path)
 
+        # Phase 1b: write the daemon-parseable schema-version line as
+        # the first thing on stdout when emission is enabled. The
+        # daemon's parser refuses unknown versions, so the version
+        # line must precede any event line.
+        if ds_stdout.is_emission_enabled():
+            ds_stdout.emit_version_line()
+
         started_at = datetime.now()
         t0 = time.perf_counter()
 
@@ -576,6 +592,13 @@ class DiscoverySweepWorkflow(BaseWorkflow):
             budget_usd=budget_usd,
             duration_ms=duration_ms,
         )
+
+        # Phase 1b: emit the final SweepResult JSON as the last
+        # ATTUNE_DS line when emission is enabled. Always one line
+        # (newlines stripped by emit_final_line); always the same
+        # JSON shape ``--json`` / ``output_format="json"`` produces.
+        if ds_stdout.is_emission_enabled():
+            ds_stdout.emit_final_line(_render_json(sweep))
 
         return WorkflowResult(
             success=True,

--- a/tests/unit/workflows/discovery_sweep/test_ds_stdout.py
+++ b/tests/unit/workflows/discovery_sweep/test_ds_stdout.py
@@ -1,0 +1,318 @@
+"""Unit tests for the discovery-sweep ATTUNE_DS stdout side-channel.
+
+Spec: docs/specs/discovery-sweep-ops-integration/design.md
+      (Phase 1b — ATTUNE_DS stdout emission)
+
+Covers two surfaces:
+
+1. The pure formatter / parser in :mod:`ds_stdout`. Round-trips
+   verify the emitted lines parse back to event dicts so the daemon's
+   future parser (Phase 2) has a stable contract today.
+
+2. The engine wiring in :mod:`workflow`. When ``ATTUNE_DS_EMIT=1``,
+   the engine writes a version line, a started/finished/failed line
+   per source, and a final line carrying the SweepResult JSON.
+   Without the env var, stdout is unchanged (preserves the
+   pipe-to-file UX).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from attune.workflows.discovery_sweep import (
+    DiscoverySweepWorkflow,
+    Finding,
+    ds_stdout,
+)
+
+
+@dataclass
+class FakeSource:
+    """Test double — same shape as the engine tests."""
+
+    name: str
+    is_llm: bool = True
+    budget_multiplier: float | None = None
+    findings: list[Finding] | None = None
+    raises: BaseException | None = None
+
+    def __post_init__(self) -> None:
+        if self.budget_multiplier is None:
+            self.budget_multiplier = 1.0 if self.is_llm else 0.0
+
+    async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
+        if self.raises is not None:
+            raise self.raises
+        return list(self.findings or [])
+
+
+def _finding() -> Finding:
+    return Finding(
+        source="fake",
+        severity="high",
+        title="t",
+        description="d",
+        file="src/a.py",
+        line=10,
+        evidence=None,
+        confidence=0.9,
+        tags=(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatter / parser round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestFormatterParserRoundTrip:
+    def test_version_line(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ds_stdout.emit_version_line()
+        out = capsys.readouterr().out.strip()
+        assert out == f"ATTUNE_DS_VERSION {ds_stdout.VERSION}"
+        parsed = ds_stdout.parse_line(out)
+        assert parsed == {"event": "version", "version": ds_stdout.VERSION}
+
+    def test_source_started_round_trip(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ds_stdout.emit_event_line(
+            {
+                "event": "source_started",
+                "source": "bug-predict",
+                "ts": "2026-05-13T12:00:00+00:00",
+                "sweep_id": "r-1",
+            }
+        )
+        line = capsys.readouterr().out.strip()
+        parsed = ds_stdout.parse_line(line)
+        assert parsed == {
+            "event": "source_started",
+            "source": "bug-predict",
+            "ts": "2026-05-13T12:00:00+00:00",
+        }
+
+    def test_source_finished_round_trip(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ds_stdout.emit_event_line(
+            {
+                "event": "source_finished",
+                "source": "pattern-scan",
+                "ts": "2026-05-13T12:00:05+00:00",
+                "sweep_id": None,
+                "findings_count": 7,
+            }
+        )
+        line = capsys.readouterr().out.strip()
+        parsed = ds_stdout.parse_line(line)
+        assert parsed == {
+            "event": "source_finished",
+            "source": "pattern-scan",
+            "ts": "2026-05-13T12:00:05+00:00",
+            "findings_count": 7,
+        }
+
+    def test_source_failed_round_trip(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ds_stdout.emit_event_line(
+            {
+                "event": "source_failed",
+                "source": "security-audit",
+                "ts": "2026-05-13T12:00:10+00:00",
+                "sweep_id": None,
+                "error": "BudgetExceededError",
+            }
+        )
+        line = capsys.readouterr().out.strip()
+        parsed = ds_stdout.parse_line(line)
+        assert parsed == {
+            "event": "source_failed",
+            "source": "security-audit",
+            "ts": "2026-05-13T12:00:10+00:00",
+            "error": "BudgetExceededError",
+        }
+
+    def test_final_line_round_trip(self, capsys: pytest.CaptureFixture[str]) -> None:
+        payload = {"queue": [], "questions": [], "rejected": [], "metadata": {}}
+        ds_stdout.emit_final_line(json.dumps(payload))
+        line = capsys.readouterr().out.strip()
+        parsed = ds_stdout.parse_line(line)
+        assert parsed is not None
+        assert parsed["event"] == "final"
+        assert json.loads(parsed["json"]) == payload
+
+    def test_final_line_strips_embedded_newlines(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # Pretty-printed JSON would break the one-line-per-record
+        # grammar; emit_final_line must defend against that.
+        pretty = '{\n  "queue": [],\n  "metadata": {}\n}'
+        ds_stdout.emit_final_line(pretty)
+        out = capsys.readouterr().out
+        # Exactly one trailing newline written by emit_final_line.
+        assert out.count("\n") == 1
+        line = out.strip()
+        parsed = ds_stdout.parse_line(line)
+        assert parsed is not None
+        assert parsed["event"] == "final"
+        # JSON still parses after newline stripping.
+        assert json.loads(parsed["json"]) == {"queue": [], "metadata": {}}
+
+
+class TestParseLineNoMatch:
+    def test_non_attune_ds_line_returns_none(self) -> None:
+        assert ds_stdout.parse_line("hello world") is None
+        assert ds_stdout.parse_line("") is None
+        assert ds_stdout.parse_line("## Queue (0 findings)") is None
+
+    def test_malformed_event_returns_none(self) -> None:
+        # Right prefix, wrong shape.
+        assert ds_stdout.parse_line("ATTUNE_DS source_started no-ts-here") is None
+        assert ds_stdout.parse_line("ATTUNE_DS unknown_kind foo") is None
+
+    def test_unknown_event_kind_is_dropped_by_emitter(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # An unknown kind produces no line at all; the parser would
+        # refuse it on the daemon side anyway.
+        ds_stdout.emit_event_line({"event": "weird_kind", "source": "s"})
+        assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# Emission gate
+# ---------------------------------------------------------------------------
+
+
+class TestEmissionGate:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ds_stdout.EMIT_ENV, raising=False)
+        assert ds_stdout.is_emission_enabled() is False
+
+    def test_empty_value_is_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ds_stdout.EMIT_ENV, "")
+        assert ds_stdout.is_emission_enabled() is False
+
+    def test_any_truthy_value_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for value in ("1", "true", "yes", "anything"):
+            monkeypatch.setenv(ds_stdout.EMIT_ENV, value)
+            assert ds_stdout.is_emission_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Engine wiring
+# ---------------------------------------------------------------------------
+
+
+class TestEngineEmissionDisabled:
+    def test_no_atune_ds_lines_when_env_unset(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(ds_stdout.EMIT_ENV, raising=False)
+        src = FakeSource(name="s", findings=[_finding()])
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(wf.execute(path="src/", sources=[src]))
+        out = capsys.readouterr().out
+        # Strict assertion: zero ATTUNE_DS lines anywhere.
+        assert "ATTUNE_DS" not in out
+
+
+class TestEngineEmissionEnabled:
+    @pytest.fixture(autouse=True)
+    def _enable_emission(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ds_stdout.EMIT_ENV, "1")
+
+    def test_version_line_is_first(self, capsys: pytest.CaptureFixture[str]) -> None:
+        src = FakeSource(name="s", findings=[_finding()])
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(wf.execute(path="src/", sources=[src]))
+        out_lines = [ln for ln in capsys.readouterr().out.splitlines() if "ATTUNE_DS" in ln]
+        assert out_lines, "expected at least one ATTUNE_DS line"
+        assert out_lines[0] == f"ATTUNE_DS_VERSION {ds_stdout.VERSION}"
+
+    def test_per_source_events_emitted(self, capsys: pytest.CaptureFixture[str]) -> None:
+        src = FakeSource(name="alpha", findings=[_finding(), _finding()])
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(wf.execute(path="src/", sources=[src]))
+        events = [
+            ds_stdout.parse_line(ln)
+            for ln in capsys.readouterr().out.splitlines()
+            if ln.startswith("ATTUNE_DS")
+        ]
+        kinds = [e["event"] for e in events if e is not None]
+        # Expected order: version, source_started, source_finished, final.
+        assert kinds == [
+            "version",
+            "source_started",
+            "source_finished",
+            "final",
+        ]
+        # finished line carries the right count.
+        finished = next(e for e in events if e and e["event"] == "source_finished")
+        assert finished["source"] == "alpha"
+        assert finished["findings_count"] == 2
+
+    def test_failed_source_emits_source_failed(self, capsys: pytest.CaptureFixture[str]) -> None:
+        src = FakeSource(name="bad", raises=RuntimeError("boom"))
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(wf.execute(path="src/", sources=[src]))
+        events = [
+            ds_stdout.parse_line(ln)
+            for ln in capsys.readouterr().out.splitlines()
+            if ln.startswith("ATTUNE_DS")
+        ]
+        kinds = [e["event"] for e in events if e is not None]
+        assert kinds == ["version", "source_started", "source_failed", "final"]
+        failed = next(e for e in events if e and e["event"] == "source_failed")
+        assert failed["source"] == "bad"
+        assert failed["error"] == "RuntimeError"
+
+    def test_final_line_carries_sweep_result_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        src = FakeSource(name="s", findings=[_finding()])
+        wf = DiscoverySweepWorkflow()
+        asyncio.run(wf.execute(path="src/", sources=[src]))
+        events = [
+            ds_stdout.parse_line(ln)
+            for ln in capsys.readouterr().out.splitlines()
+            if ln.startswith("ATTUNE_DS")
+        ]
+        final = next(e for e in events if e and e["event"] == "final")
+        payload = json.loads(final["json"])
+        assert set(payload.keys()) >= {"queue", "questions", "rejected", "metadata"}
+        assert len(payload["queue"]) == 1
+        assert payload["queue"][0]["source"] == "fake"
+
+    def test_user_event_sink_still_fires(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # Both surfaces co-exist: an in-process user sink and the
+        # stdout side-channel fire independently. A user passing an
+        # event_sink sees their events; the daemon parses stdout.
+        seen: list[dict] = []
+
+        async def sink(event: dict) -> None:
+            seen.append(event)
+
+        src = FakeSource(name="s", findings=[_finding()])
+        wf = DiscoverySweepWorkflow()
+
+        async def runner() -> None:
+            await wf.execute(path="src/", sources=[src], event_sink=sink)
+            # Let fire-and-forget emit tasks drain.
+            for _ in range(5):
+                await asyncio.sleep(0)
+
+        asyncio.run(runner())
+
+        # User sink saw started + finished.
+        kinds = [e["event"] for e in seen]
+        assert kinds == ["source_started", "source_finished"]
+
+        # Stdout side-channel also saw the events.
+        out_kinds = [
+            ds_stdout.parse_line(ln)["event"]
+            for ln in capsys.readouterr().out.splitlines()
+            if ln.startswith("ATTUNE_DS") and ds_stdout.parse_line(ln) is not None
+        ]
+        assert "source_started" in out_kinds
+        assert "source_finished" in out_kinds
+        assert "final" in out_kinds


### PR DESCRIPTION
## Summary

- **Phase 1b** of `discovery-sweep-ops-integration` per the Option A design (audit landed in #329, Phase 1 in #331).
- New module `src/attune/workflows/discovery_sweep/ds_stdout.py` owns the structured stdout format + a `parse_line()` helper that round-trips emitted lines back to event dicts.
- Engine wiring: when `ATTUNE_DS_EMIT=1` is set, `execute()` writes `ATTUNE_DS_VERSION 1` + per-source event lines (`source_started` / `source_finished` / `source_failed`) + a final `ATTUNE_DS final <json>` line carrying the full SweepResult.
- **18 new tests**, 100% coverage on `ds_stdout.py`, full discovery_sweep suite 183 tests green.

## Design call: env-var gate, not non-TTY

The pre-audit spec text said "emit when `sys.stdout.isatty()` is False." That would pollute the legitimate pipe-to-file workflow (`attune workflow run discovery-sweep > out.md`) with `ATTUNE_DS` lines mixed into the markdown.

Phase 1b uses `ATTUNE_DS_EMIT=1` instead. Daemon (Phase 2) sets it when spawning the subprocess; CLI users — terminal, pipe-to-file, CI capture — see exactly today's output. Decision logged as `decisions.md` entry #10.

## Why this is safe

- Default behavior unchanged: env var unset → zero `ATTUNE_DS` lines on stdout (asserted by `test_no_atune_ds_lines_when_env_unset`).
- All existing discovery_sweep tests (165) still pass.
- New module `ds_stdout.py` has no engine deps — the Phase 2 daemon parser can `from attune.workflows.discovery_sweep.ds_stdout import parse_line` without pulling in the workflow surface.
- Format includes a version line so the daemon can refuse unknown versions cleanly when the format evolves.

## Test plan

- [x] `pytest tests/unit/workflows/discovery_sweep/` — 183 passed locally.
- [x] Coverage: `ds_stdout.py` 100%, `workflow.py` 93.66% (gate is 85%).
- [x] Pre-commit hooks green.
- [ ] CI matrix on push.

## Phase 2 (next)

Daemon-side parser + `~/.attune/ops/sweep-results/<scope-hash>.json` persistence, behind `ATTUNE_OPS_SWEEP_RESULTS=1` feature flag. Uses the `parse_line()` helper this PR ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)