### PR TITLE
feat(discovery-sweep): Phase 2A — sweep-results storage primitives

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3757,3 +3757,47 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   state alone**. Single-file and small-package dog-
   food can mask this — only whole-tree contact with
   real production docstrings surfaces the gap.
+
+- **`gh pr checks <PR> --watch --fail-fast` exits
+  prematurely (exit 0) on cancelled-but-tagged-"fail"
+  guard jobs**: `--fail-fast` triggers on any row
+  whose status column reads `fail`, even when the
+  underlying job conclusion is `cancelled` (zero
+  steps executed — e.g. a dependabot-only guard
+  skipping on a regular PR). On this repo `Run
+  Security Scanner` fires this pattern and made the
+  watcher exit ~1 minute into a 15-minute CI run.
+  Worst part: exit code is 0, so it looks like every
+  check passed. Two workarounds: (a) drop
+  `--fail-fast` entirely — cost is waiting the full
+  matrix even on real failures, fine at solo-dev
+  pace; (b) post-process the output to ignore rows
+  where the actual conclusion (via
+  `gh api .../jobs/<id>`) is `cancelled`. Always
+  re-fetch `gh pr checks <PR>` after a
+  `--watch --fail-fast` exits to confirm what truly
+  finished — never trust the watcher's exit code
+  alone as a "CI is done" signal.
+
+- **Daemon-parseable structured stdout should gate
+  on an explicit env var, not `sys.stdout.isatty()`**:
+  the intuitive design ("emit machine-readable lines
+  when stdout isn't a TTY; TTY users see clean
+  output") looks right but breaks legitimate
+  pipe-to-file usage — `attune workflow run … >
+  out.md` is also non-TTY, and the user wants clean
+  markdown in `out.md`, NOT structured lines mixed
+  in. Env-var gate (e.g. `ATTUNE_DS_EMIT=1`) lets
+  the daemon opt in explicitly without polluting any
+  other invocation path: terminal, pipe-to-file, CI
+  capture all stay pristine; only the daemon (which
+  controls the spawn env) sees the stream.
+  Discovered correcting the discovery-sweep Phase 1b
+  spec text in flight after noticing the pipe-to-
+  file hazard during implementation. Generalizes to
+  ANY structured-output side-channel for daemon
+  consumers — name the env var after what it does
+  (`<FEATURE>_EMIT=1`), not who flips it (avoid
+  names like `ATTUNE_OPS_DAEMON=1`), so future
+  non-daemon consumers can opt in without semantic
+  collision.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `discovery-sweep` Phase 2A (ops-integration spec) — scope-keyed
+  storage primitives. New module `src/attune/ops/sweep_results.py`
+  ships `scope_hash()` (canonicalized sha256, 16 hex chars),
+  `parse_lines()` (walks captured stdout for `ATTUNE_DS` records,
+  returns the final SweepResult JSON), `persist_result()` (atomic
+  write via tempfile + `os.replace` to
+  `~/.attune/ops/sweep-results/<hash>.json`), `read_result()`, and
+  `persist_from_lines()` (composition wrapper the upcoming Phase 2B
+  daemon hook calls). Parser refuses unknown `ATTUNE_DS_VERSION`
+  values so the daemon never persists data it might be reading
+  wrong. Feature flag `ATTUNE_OPS_SWEEP_RESULTS=1` for Phase 2B's
+  auto-persist; Phase 2A is library-only (no daemon wiring, no
+  HTTP route — both deferred until conflict-prone runner files
+  unblock). 24 new tests in `tests/unit/ops/test_sweep_results.py`
+  (92.16% coverage on the new module): persistence-flag gate,
+  scope_hash canonicalization, parse_lines round-trips + edge
+  cases, persist+read with latest-only semantics, atomic write
+  (no .tmp leftovers), and the `persist_from_lines` composition.
+  See `docs/specs/discovery-sweep-ops-integration/` Phase 2A.
+
 ### 2026-05-10 — Dashboard becomes a real workspace
 
 If you're returning after a couple of releases, the

--- a/docs/specs/discovery-sweep-ops-integration/tasks.md
+++ b/docs/specs/discovery-sweep-ops-integration/tasks.md
@@ -77,33 +77,61 @@ the right points in `execute()` and `_emit_event`.
 
 ---
 
-## Phase 2 — Daemon-side parser + scope-keyed persistence
+## Phase 2A — Sweep-results storage primitives — **shipped 2026-05-13**
 
-Goal: teach the ops daemon to recognize discovery-sweep runs,
-parse `ATTUNE_DS` lines from captured stdout, and persist a
-scope-keyed JSON the dashboard reads. **Lands behind a feature
-flag** so it's revertable to read-only mode.
+Goal: ship the scope-keyed persistence module as a pure utility
+that anyone can compose, without touching the runner. The
+auto-persist hook + HTTP route + server wiring split off into
+Phase 2B (blocked until PRs #324 / #326 / #328 land on `main` and
+unblock the conflict-prone files).
 
-- [ ] **2.1** Add a post-run hook to `RunnerService._execute`
-      keyed by workflow name. When `run.workflow ==
-      "discovery-sweep"` AND `run.exit_code == 0`, invoke the
-      `ATTUNE_DS` parser.
-- [ ] **2.2** Parser module under `src/attune/ops/` (NEW file —
-      avoids touching the conflict-prone `runner.py`). Parses
-      `run.lines` into a list of events + final JSON. Refuses
-      unknown `ATTUNE_DS_VERSION` values.
-- [ ] **2.3** Atomic write of `<scope-hash>.json` to
-      `~/.attune/ops/sweep-results/` (tempfile + os.replace).
-      `<scope-hash> = sha256(canonicalized_path)[:16]`.
-- [ ] **2.4** Add `GET /workflows/discovery-sweep/results/<hash>`
-      route in a NEW router module under `src/attune/ops/routes/`
-      (NEW file — avoids touching the conflict-prone
-      `routes/runner.py`). 404 if no sweep has run.
-- [ ] **2.5** Feature flag: `ATTUNE_OPS_SWEEP_RESULTS=1` env var
-      to enable the post-run hook and route. Off by default.
-- [ ] **2.6** Tests: parser round-trip; missing file → 404;
-      malformed sidecar → 500 with diagnostic; concurrent writes
-      to different scopes don't collide.
+- [x] **2A.1** Parser + persistence primitives in NEW file
+      `src/attune/ops/sweep_results.py`:
+      - `scope_hash(path)` — sha256 of canonicalized path, first
+        16 hex chars. Equivalent paths (`./src`, `src/`,
+        absolute) collapse to the same digest.
+      - `parse_lines(lines)` — walks captured stdout, returns the
+        final SweepResult JSON dict or `None`. Refuses unknown
+        `ATTUNE_DS_VERSION` values.
+      - `persist_result(scope_path, sweep_dict, config)` — atomic
+        write via tempfile + `os.replace` in the same dir, so a
+        partial write never corrupts the read side.
+      - `read_result(digest, config)` — reads `<hash>.json` or
+        returns `None`.
+      - `persist_from_lines(scope_path, lines, config)` —
+        composition wrapper the Phase 2B daemon hook will call.
+      - `is_persistence_enabled()` — feature flag
+        (`ATTUNE_OPS_SWEEP_RESULTS=1`).
+- [x] **2A.2** Storage layout: `~/.attune/ops/sweep-results/`,
+      one `<hash>.json` per scope. Latest-only semantics (history
+      deferred per decisions.md #3).
+- [x] **2A.3** Tests in `tests/unit/ops/test_sweep_results.py`
+      (24 cases): persistence-flag gate (3), scope_hash
+      canonicalization + collision properties (5), parse_lines
+      round-trips + edge cases (6), persist+read +
+      latest-only-semantics + atomic write (8), persist_from_lines
+      composition (2). 92.16% coverage; only defensive error
+      branches uncovered.
+
+## Phase 2B — Daemon-side wiring + HTTP route (deferred)
+
+Goal: auto-persist on run-complete + expose results via HTTP.
+**Blocked** on PRs #324 (scope picker), #326 (persistence +
+pills), #328 (release 6.8.0) merging to `main`, which unblocks
+the conflict-prone runner / template files.
+
+- [ ] **2B.1** Wire the auto-persist hook. Two options to
+      evaluate when this opens: (a) wrapper around
+      `RunnerService._executor` (modifies `runner.py`); (b)
+      external subscriber via `Run.subscribe()` spawned from the
+      POST run route (modifies `routes/runner.py`). Option (b) is
+      preferred — it's a smaller surface.
+- [ ] **2B.2** Add `GET /workflows/discovery-sweep/results/<hash>`
+      in a NEW router module `src/attune/ops/routes/sweep_results.py`.
+      404 if no sweep has run for that scope.
+- [ ] **2B.3** Register the new router in `server.py`.
+- [ ] **2B.4** Tests: end-to-end run → file lands; missing file
+      → 404; malformed sidecar → 500 with diagnostic.
 
 ---
 

--- a/src/attune/ops/sweep_results.py
+++ b/src/attune/ops/sweep_results.py
@@ -1,0 +1,234 @@
+"""Scope-keyed persistence for discovery-sweep results.
+
+Phase 2A of ``docs/specs/discovery-sweep-ops-integration/``.
+
+Stores the JSON output of a discovery-sweep run keyed by a hash of
+its canonicalized scope path, so the dashboard's workflow row can
+read the latest sweep result for a given path without re-running.
+
+Wire diagram (Option A from the Phase 0 audit):
+
+    DiscoverySweepWorkflow.execute()  (subprocess)
+        → emits ATTUNE_DS_VERSION 1
+        → emits ATTUNE_DS <event> ... lines
+        → emits ATTUNE_DS final <json>
+                                  │ stdout (captured by ops daemon)
+                                  ▼
+    RunnerService._execute()  (ops daemon)
+        → captures stdout into Run.lines
+        → on run complete + workflow == "discovery-sweep" + exit 0,
+          calls persist_from_lines() in THIS module (Phase 2B —
+          deferred until the conflict-prone runner.py unblocks)
+
+    Dashboard
+        → reads result via read_result(<scope-hash>)  (Phase 2B)
+
+Phase 2A scope is **storage primitives only**: no daemon wiring, no
+HTTP route, no automatic persistence. Anyone (a script, a future PR,
+the daemon when 2B lands) can compose these primitives:
+
+    >>> from attune.ops import sweep_results
+    >>> result = sweep_results.parse_lines(captured_stdout_lines)
+    >>> if result is not None:
+    ...     sweep_results.persist_result(scope_path, result, config)
+    >>> sweep_results.read_result(sweep_results.scope_hash(path), config)
+
+All filesystem writes are atomic (tempfile + os.replace in the same
+dir) so a partial write never corrupts the read side.
+
+Feature flag: ``ATTUNE_OPS_SWEEP_RESULTS=1`` env var. ``is_persistence_enabled()``
+returns False by default — Phase 2B wiring checks this before
+auto-persisting, so the surface stays opt-in until the user enables it.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from attune.ops.config import Config
+from attune.workflows.discovery_sweep import ds_stdout
+
+logger = logging.getLogger(__name__)
+
+ENABLE_ENV = "ATTUNE_OPS_SWEEP_RESULTS"
+RESULTS_SUBDIR = ("ops", "sweep-results")
+HASH_LENGTH = 16
+
+
+def is_persistence_enabled() -> bool:
+    """True when ``ATTUNE_OPS_SWEEP_RESULTS`` is set to a non-empty value.
+
+    Phase 2B's daemon-side auto-persist hook gates on this. Phase 2A's
+    pure utility functions ignore it — a caller that imports this
+    module is opting in explicitly, so the gate is one-level-up.
+    """
+    return bool(os.environ.get(ENABLE_ENV))
+
+
+def results_dir(config: Config) -> Path:
+    """Return ``<attune_home>/ops/sweep-results/`` (created if missing).
+
+    The directory is created with ``parents=True, exist_ok=True`` so
+    callers don't have to. Subdirectory layout is fixed by
+    ``RESULTS_SUBDIR``; users who want a different path override
+    ``ATTUNE_HOME`` via :func:`attune.ops.config.attune_home`.
+    """
+    out = config.attune_home.joinpath(*RESULTS_SUBDIR)
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def scope_hash(scope_path: str) -> str:
+    """Hash a scope path to a fixed-length hex identifier.
+
+    Canonicalizes via :meth:`Path.resolve` so ``./src``, ``src/``, and
+    the absolute path all hash to the same identifier. Returns the
+    first ``HASH_LENGTH`` (16) hex chars of sha256 — collision
+    probability across realistic scope sets is negligible.
+
+    Empty / whitespace-only paths are not canonicalized (resolve()
+    would return cwd, which is misleading); they hash directly so
+    that the empty case is at least deterministic.
+    """
+    if not scope_path or not scope_path.strip():
+        canonical = scope_path
+    else:
+        try:
+            canonical = str(Path(scope_path).resolve())
+        except (OSError, RuntimeError):
+            # Fallback to the raw string; persistence is best-effort.
+            canonical = scope_path
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return digest[:HASH_LENGTH]
+
+
+def parse_lines(lines: list[str]) -> dict[str, Any] | None:
+    """Parse a captured stdout buffer into the final SweepResult JSON.
+
+    Walks the lines looking for ATTUNE_DS records via
+    :func:`ds_stdout.parse_line`. Returns the dict from the
+    ``ATTUNE_DS final <json>`` line if found; ``None`` otherwise.
+
+    Refuses unknown ``ATTUNE_DS_VERSION`` values: if a version line
+    is present and doesn't match :data:`ds_stdout.VERSION`, returns
+    ``None`` with a logged warning so the daemon doesn't persist
+    data it might be parsing wrong. A missing version line is
+    treated as legacy / non-emitting output (returns ``None``
+    without warning).
+
+    Non-ATTUNE_DS lines are ignored — captured stdout may legitimately
+    interleave markdown rendering with the structured stream.
+    """
+    saw_version = False
+    final_json: str | None = None
+
+    for line in lines:
+        parsed = ds_stdout.parse_line(line)
+        if parsed is None:
+            continue
+        if parsed["event"] == "version":
+            saw_version = True
+            if parsed["version"] != ds_stdout.VERSION:
+                logger.warning(
+                    "discovery-sweep ATTUNE_DS version mismatch: got %s, "
+                    "expected %s — refusing to parse",
+                    parsed["version"],
+                    ds_stdout.VERSION,
+                )
+                return None
+        elif parsed["event"] == "final":
+            final_json = parsed["json"]
+
+    if not saw_version or final_json is None:
+        return None
+
+    try:
+        decoded: dict[str, Any] = json.loads(final_json)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "discovery-sweep ATTUNE_DS final line is not valid JSON: %s",
+            exc,
+        )
+        return None
+    return decoded
+
+
+def persist_result(scope_path: str, sweep_result: dict[str, Any], config: Config) -> Path:
+    """Atomically write ``sweep_result`` to ``<results_dir>/<hash>.json``.
+
+    Uses ``tempfile.NamedTemporaryFile`` + ``os.replace`` in the same
+    directory so a partial write never produces a half-readable file
+    on the read side. Overwrites the existing file for the same scope
+    (latest-only semantics; history is post-v1 per spec decisions.md).
+
+    Returns the path written.
+    """
+    digest = scope_hash(scope_path)
+    out_dir = results_dir(config)
+    target = out_dir / f"{digest}.json"
+
+    # Atomic-replace: write to a temp file in the same dir, then rename.
+    # Same-dir-tempfile is required so os.replace is atomic across
+    # mount-point boundaries (the temp dir might be on tmpfs).
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{digest}.", suffix=".json.tmp", dir=str(out_dir))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(sweep_result, f, indent=2)
+        os.replace(tmp_name, target)
+    except Exception:
+        # Best-effort cleanup if the rename never happened.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return target
+
+
+def read_result(digest: str, config: Config) -> dict[str, Any] | None:
+    """Read a previously-persisted result by its scope-hash digest.
+
+    Returns the JSON dict or ``None`` if no result has been persisted
+    for that hash. Malformed JSON on disk returns ``None`` with a
+    logged warning — the dashboard's read API should surface "no
+    data yet" rather than crashing on a partially-corrupted file
+    (atomic writes make this rare but not impossible if a user
+    edits a sidecar manually).
+    """
+    out_dir = results_dir(config)
+    target = out_dir / f"{digest}.json"
+    if not target.exists():
+        return None
+    try:
+        with target.open("r", encoding="utf-8") as f:
+            data: dict[str, Any] = json.load(f)
+        return data
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("discovery-sweep sidecar at %s is unreadable: %s", target, exc)
+        return None
+
+
+def persist_from_lines(scope_path: str, lines: list[str], config: Config) -> Path | None:
+    """Parse captured stdout lines and persist the result for ``scope_path``.
+
+    Composition of :func:`parse_lines` + :func:`persist_result`. Returns
+    the written path on success, ``None`` if the lines did not contain
+    a valid ATTUNE_DS payload (no version line, malformed JSON, version
+    mismatch).
+
+    This is the function the Phase 2B daemon-side hook calls once a
+    discovery-sweep run completes successfully.
+    """
+    result = parse_lines(lines)
+    if result is None:
+        return None
+    return persist_result(scope_path, result, config)

--- a/tests/unit/ops/test_sweep_results.py
+++ b/tests/unit/ops/test_sweep_results.py
@@ -1,0 +1,283 @@
+"""Unit tests for the discovery-sweep scope-keyed results storage.
+
+Spec: docs/specs/discovery-sweep-ops-integration/design.md
+      (Phase 2A — sweep_results storage primitives)
+
+Covers the four primitives in ``attune.ops.sweep_results``:
+
+- ``scope_hash``: canonicalization + collision properties.
+- ``parse_lines``: ATTUNE_DS round-trip from captured stdout.
+- ``persist_result`` / ``read_result``: atomic write + scope-keyed
+  read. Latest-only semantics.
+- ``persist_from_lines``: composition wrapper used by the
+  upcoming Phase 2B daemon hook.
+
+No HTTP routes, no daemon wiring — those are Phase 2B and require
+modifying conflict-prone files (runner.py, server.py, routes/runner.py).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from attune.ops import sweep_results
+from attune.ops.config import Config
+from attune.workflows.discovery_sweep import ds_stdout
+
+
+@pytest.fixture()
+def cfg(tmp_path: Path) -> Config:
+    """Config rooted at tmp_path so writes don't touch the user's home."""
+    return Config(
+        project_root=tmp_path / "project",
+        attune_home=tmp_path / "attune-home",
+    )
+
+
+def _captured_lines(
+    *, sweep_payload: dict, source: str = "fake", findings_count: int = 1
+) -> list[str]:
+    """Build a fake captured-stdout buffer matching ds_stdout's grammar."""
+    return [
+        f"ATTUNE_DS_VERSION {ds_stdout.VERSION}",
+        f"ATTUNE_DS source_started {source} ts=2026-05-13T12:00:00+00:00",
+        (
+            f"ATTUNE_DS source_finished {source} "
+            f"ts=2026-05-13T12:00:05+00:00 findings={findings_count}"
+        ),
+        f"ATTUNE_DS final {json.dumps(sweep_payload)}",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Persistence-flag gate
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceFlag:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(sweep_results.ENABLE_ENV, raising=False)
+        assert sweep_results.is_persistence_enabled() is False
+
+    def test_empty_value_is_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(sweep_results.ENABLE_ENV, "")
+        assert sweep_results.is_persistence_enabled() is False
+
+    def test_any_truthy_value_enables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for value in ("1", "true", "yes", "anything"):
+            monkeypatch.setenv(sweep_results.ENABLE_ENV, value)
+            assert sweep_results.is_persistence_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# scope_hash
+# ---------------------------------------------------------------------------
+
+
+class TestScopeHash:
+    def test_deterministic(self) -> None:
+        h1 = sweep_results.scope_hash("src/")
+        h2 = sweep_results.scope_hash("src/")
+        assert h1 == h2
+
+    def test_length_matches_constant(self) -> None:
+        h = sweep_results.scope_hash("src/")
+        assert len(h) == sweep_results.HASH_LENGTH
+
+    def test_distinct_paths_distinct_hashes(self) -> None:
+        assert sweep_results.scope_hash("src/") != sweep_results.scope_hash("tests/")
+
+    def test_canonicalizes_equivalent_paths(self, tmp_path: Path) -> None:
+        # Same resolved path through different surface forms should hash
+        # identically. The "./X" vs "X" forms are the most common
+        # equivalence the dashboard will hit.
+        (tmp_path / "src").mkdir()
+        a = sweep_results.scope_hash(str(tmp_path / "src"))
+        b = sweep_results.scope_hash(str(tmp_path / "src") + "/")
+        c = sweep_results.scope_hash(f"{tmp_path}/./src")
+        assert a == b == c
+
+    def test_empty_path_does_not_canonicalize(self) -> None:
+        # Empty path → Path.resolve() would return cwd, which would be
+        # misleading. The function hashes the empty string directly.
+        h_empty = sweep_results.scope_hash("")
+        h_dot = sweep_results.scope_hash(".")
+        assert h_empty != h_dot
+
+
+# ---------------------------------------------------------------------------
+# parse_lines
+# ---------------------------------------------------------------------------
+
+
+class TestParseLines:
+    def test_round_trip_with_valid_payload(self) -> None:
+        payload = {
+            "queue": [{"source": "x"}],
+            "questions": [],
+            "rejected": [],
+            "metadata": {"sources": ["x"]},
+        }
+        lines = _captured_lines(sweep_payload=payload)
+        result = sweep_results.parse_lines(lines)
+        assert result == payload
+
+    def test_missing_version_line_returns_none(self) -> None:
+        # No version → can't trust the wire format; refuse.
+        payload = {"queue": [], "questions": [], "rejected": [], "metadata": {}}
+        lines = [
+            f"ATTUNE_DS final {json.dumps(payload)}",
+        ]
+        assert sweep_results.parse_lines(lines) is None
+
+    def test_version_mismatch_returns_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Future version → refuse to parse so the daemon doesn't
+        # persist data it might be reading wrong.
+        payload = {"queue": [], "questions": [], "rejected": [], "metadata": {}}
+        lines = [
+            "ATTUNE_DS_VERSION 99",
+            f"ATTUNE_DS final {json.dumps(payload)}",
+        ]
+        with caplog.at_level("WARNING"):
+            assert sweep_results.parse_lines(lines) is None
+        assert any("version mismatch" in r.getMessage() for r in caplog.records)
+
+    def test_missing_final_line_returns_none(self) -> None:
+        # Version line + events, but no final blob → nothing to persist.
+        lines = [
+            f"ATTUNE_DS_VERSION {ds_stdout.VERSION}",
+            "ATTUNE_DS source_started fake ts=2026-05-13T12:00:00+00:00",
+        ]
+        assert sweep_results.parse_lines(lines) is None
+
+    def test_malformed_final_json_returns_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        lines = [
+            f"ATTUNE_DS_VERSION {ds_stdout.VERSION}",
+            "ATTUNE_DS final {not valid json",
+        ]
+        with caplog.at_level("WARNING"):
+            assert sweep_results.parse_lines(lines) is None
+        assert any("not valid JSON" in r.getMessage() for r in caplog.records)
+
+    def test_ignores_interleaved_non_attune_ds_lines(self) -> None:
+        # The subprocess stdout can carry markdown + ATTUNE_DS together
+        # (depending on output_format). parse_lines must not be fragile
+        # to interleaving.
+        payload = {"queue": [], "questions": [], "rejected": [], "metadata": {}}
+        lines = [
+            "## Queue (0 findings)",
+            f"ATTUNE_DS_VERSION {ds_stdout.VERSION}",
+            "## Questions (0 findings)",
+            "ATTUNE_DS source_started fake ts=2026-05-13T12:00:00+00:00",
+            "Some other stdout noise",
+            f"ATTUNE_DS final {json.dumps(payload)}",
+            "Spent: $0.00 / $10.00 budget",
+        ]
+        result = sweep_results.parse_lines(lines)
+        assert result == payload
+
+
+# ---------------------------------------------------------------------------
+# persist_result + read_result
+# ---------------------------------------------------------------------------
+
+
+class TestPersistAndRead:
+    def test_persist_writes_to_scope_keyed_file(self, cfg: Config) -> None:
+        payload = {
+            "queue": [{"source": "x"}],
+            "questions": [],
+            "rejected": [],
+            "metadata": {},
+        }
+        target = sweep_results.persist_result("src/", payload, cfg)
+        assert target.exists()
+        assert target.name == f"{sweep_results.scope_hash('src/')}.json"
+        assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+    def test_read_round_trip(self, cfg: Config) -> None:
+        payload = {"queue": [], "questions": [], "rejected": [], "metadata": {}}
+        sweep_results.persist_result("src/", payload, cfg)
+        digest = sweep_results.scope_hash("src/")
+        assert sweep_results.read_result(digest, cfg) == payload
+
+    def test_read_missing_returns_none(self, cfg: Config) -> None:
+        assert sweep_results.read_result("0000000000000000", cfg) is None
+
+    def test_latest_only_semantics(self, cfg: Config) -> None:
+        # Two writes for the same scope → second wins; only one file
+        # on disk for that scope. (History is post-v1 per decisions.md.)
+        first = {"queue": [{"v": 1}], "questions": [], "rejected": [], "metadata": {}}
+        second = {"queue": [{"v": 2}], "questions": [], "rejected": [], "metadata": {}}
+        sweep_results.persist_result("src/", first, cfg)
+        sweep_results.persist_result("src/", second, cfg)
+        digest = sweep_results.scope_hash("src/")
+        assert sweep_results.read_result(digest, cfg) == second
+        files = list(sweep_results.results_dir(cfg).iterdir())
+        assert [f.name for f in files] == [f"{digest}.json"]
+
+    def test_distinct_scopes_do_not_collide(self, cfg: Config) -> None:
+        a = {"queue": [{"scope": "src"}], "questions": [], "rejected": [], "metadata": {}}
+        b = {"queue": [{"scope": "tests"}], "questions": [], "rejected": [], "metadata": {}}
+        sweep_results.persist_result("src/", a, cfg)
+        sweep_results.persist_result("tests/", b, cfg)
+        assert sweep_results.read_result(sweep_results.scope_hash("src/"), cfg) == a
+        assert sweep_results.read_result(sweep_results.scope_hash("tests/"), cfg) == b
+
+    def test_read_corrupt_file_returns_none(
+        self, cfg: Config, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        out_dir = sweep_results.results_dir(cfg)
+        digest = "deadbeefdeadbeef"
+        (out_dir / f"{digest}.json").write_text("{not valid", encoding="utf-8")
+        with caplog.at_level("WARNING"):
+            assert sweep_results.read_result(digest, cfg) is None
+        assert any("unreadable" in r.getMessage() for r in caplog.records)
+
+    def test_persist_creates_results_dir(self, cfg: Config) -> None:
+        # Fresh attune_home → directory tree doesn't exist yet.
+        assert not (cfg.attune_home / "ops" / "sweep-results").exists()
+        payload = {"queue": [], "questions": [], "rejected": [], "metadata": {}}
+        sweep_results.persist_result("src/", payload, cfg)
+        assert (cfg.attune_home / "ops" / "sweep-results").is_dir()
+
+    def test_persist_is_atomic_no_tempfile_left_behind(self, cfg: Config) -> None:
+        # After a successful write the only file in the dir should be
+        # the target; no .tmp leftovers.
+        payload = {"queue": [], "questions": [], "rejected": [], "metadata": {}}
+        sweep_results.persist_result("src/", payload, cfg)
+        files = list(sweep_results.results_dir(cfg).iterdir())
+        assert len(files) == 1
+        assert not files[0].name.endswith(".tmp")
+
+
+# ---------------------------------------------------------------------------
+# persist_from_lines
+# ---------------------------------------------------------------------------
+
+
+class TestPersistFromLines:
+    def test_success_path(self, cfg: Config) -> None:
+        payload = {
+            "queue": [{"source": "x"}],
+            "questions": [],
+            "rejected": [],
+            "metadata": {},
+        }
+        lines = _captured_lines(sweep_payload=payload)
+        path = sweep_results.persist_from_lines("src/", lines, cfg)
+        assert path is not None
+        assert path.exists()
+        digest = sweep_results.scope_hash("src/")
+        assert sweep_results.read_result(digest, cfg) == payload
+
+    def test_invalid_payload_returns_none_and_writes_nothing(self, cfg: Config) -> None:
+        # No version line → parse_lines returns None → no file written.
+        lines = ["random stdout noise", "## Queue (0 findings)"]
+        result = sweep_results.persist_from_lines("src/", lines, cfg)
+        assert result is None
+        # results_dir is created by results_dir() — but it should be empty.
+        assert list(sweep_results.results_dir(cfg).iterdir()) == []


### PR DESCRIPTION
## Summary

- **Phase 2A** of `discovery-sweep-ops-integration` — ships the scope-keyed persistence module as a pure utility. NEW files only; no runner.py / templates / JS touched.
- New `src/attune/ops/sweep_results.py` exposes `scope_hash` / `parse_lines` / `persist_result` / `read_result` / `persist_from_lines` / `is_persistence_enabled`. Atomic writes via `tempfile + os.replace`. Refuses unknown `ATTUNE_DS_VERSION` values.
- **24 new tests**, 92.16% coverage on the new module (only defensive error branches uncovered).
- **Phase 2B (daemon-side auto-persist hook + HTTP route + server.py wiring) deliberately deferred** until PRs #324 / #326 / #328 land on `main` and unblock the conflict-prone runner files.

Includes a separate **first commit** with two new CLAUDE.md lessons surfaced during the Phase 0–1b work (gh pr checks --fail-fast quirk on cancelled jobs; env-var-vs-non-TTY gating for daemon stdout).

## Why split 2A/2B

PRs #324 (Phase 2 scope picker) and #326 (Phase 3+4 persistence + pills) are still open on `release/v6.8.0` and modify the runner.py / routes/runner.py / templates files. Per the session-start constraint, this PR avoids them. Phase 2B (daemon-side wiring + HTTP route) opens once those land on main.

The 2A surface is independently useful today: any script, test, or future daemon hook can compose the primitives. The library / wiring split also makes Phase 2B reviewable as a pure infrastructure change without revisiting parsing or persistence semantics.

## Why this is safe

- All new files, no production code modified — zero risk of regression.
- Feature flag `ATTUNE_OPS_SWEEP_RESULTS=1` defaults off; Phase 2B will gate its auto-persist on it. Phase 2A's pure utility functions are import-time inert.
- Reuses Phase 1b's `ds_stdout.parse_line` — single source of truth for the wire format.
- Atomic writes guarantee no half-readable files on disk.

## Test plan

- [x] `pytest tests/unit/ops/test_sweep_results.py` — 24 passed locally.
- [x] Coverage: 92.16% on `sweep_results.py` (gate 85%).
- [x] Pre-commit hooks green.
- [ ] CI matrix on push.

## Next

Phase 2B blocks on #324 / #326 / #328. Phase 3 (Dashboard UI) blocks on Phase 2B. ETA depends on the release/v6.8.0 cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)