### PR TITLE
docs(specs): reconcile discovery-sweep + ops-integration status

### DIFF
--- a/docs/specs/discovery-sweep-ops-integration/decisions.md
+++ b/docs/specs/discovery-sweep-ops-integration/decisions.md
@@ -221,3 +221,43 @@ way without negotiating a new flag.
 toggle name describes what it does, not who flips it. A future
 non-ops consumer can use the same env var without semantic
 collision.
+
+---
+
+## 11. Split Phase 2 into 2A (storage primitives) + 2B (daemon wiring) (2026-05-13)
+
+**Decision:** Ship Phase 2 in two PRs rather than one. 2A
+introduces `src/attune/ops/sweep_results.py` as a pure utility
+module (parser + scope_hash + atomic persist + read). 2B wires
+the daemon's post-run hook, the HTTP route, and the feature
+flag.
+
+**Reasoning:**
+
+- 2A is all-new files — zero risk of regression, independently
+  reviewable, can land while the conflict-prone `runner.py` and
+  `routes/runner.py` are tied up in [#324](https://github.com/Smart-AI-Memory/attune-ai/pull/324)
+  / [#326](https://github.com/Smart-AI-Memory/attune-ai/pull/326)
+  / [#328](https://github.com/Smart-AI-Memory/attune-ai/pull/328).
+- 2B touches the very files those PRs modify. Attempting both
+  in one PR would create avoidable conflicts and force re-merge
+  cycles.
+- The 2A surface is independently useful today — any script or
+  test can compose the primitives without waiting for 2B.
+- Atomic persist + read semantics are testable in isolation
+  without spinning up the daemon.
+
+**Scope confirmation:** PR [#334](https://github.com/Smart-AI-Memory/attune-ai/pull/334)
+is the 2A landing and stays within this spec (not a new spec).
+It implements `tasks.md` items 2.2 (parser), 2.3 (atomic write
+to `<scope-hash>.json`), and the prerequisite primitives for
+2.5 (feature flag exposed via `is_persistence_enabled()`).
+Items 2.1 (post-run hook), 2.4 (HTTP route), and 2.6 (end-to-
+end tests) move to a Phase 2B PR once the runner-tier2 PRs
+land.
+
+**Consequence:** `tasks.md` Phase 2 status: in progress. 2A in
+flight; 2B blocked on [#324](https://github.com/Smart-AI-Memory/attune-ai/pull/324)
+/ [#326](https://github.com/Smart-AI-Memory/attune-ai/pull/326)
+/ [#328](https://github.com/Smart-AI-Memory/attune-ai/pull/328)
+landing.

--- a/docs/specs/discovery-sweep-ops-integration/tasks.md
+++ b/docs/specs/discovery-sweep-ops-integration/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Discovery-Sweep Ops Dashboard Integration
 
-**Status:** Phase 0 audit shipped 2026-05-13; Phase 1 in progress.
+**Status:** Phase 0 audit + Phase 1 + Phase 1b shipped 2026-05-13. Phase 2 in progress — 2A (storage primitives) up as [#334](https://github.com/Smart-AI-Memory/attune-ai/pull/334); 2B (daemon wiring) blocks on [#324](https://github.com/Smart-AI-Memory/attune-ai/pull/324) / [#326](https://github.com/Smart-AI-Memory/attune-ai/pull/326) / [#328](https://github.com/Smart-AI-Memory/attune-ai/pull/328).
 **Spec docs:** `requirements.md`, `design.md`, `decisions.md`,
 [`audit-2026-05-13.md`](audit-2026-05-13.md)
 **Implementation path:** Option A (stdout-emit + sidecar parser)
@@ -30,21 +30,21 @@ Phase 3 (UI) will build on. No daemon-visible behavior change for
 existing CLI callers — both new surfaces are opt-in (event_sink
 defaults to None; stdout emission gated on non-TTY detection).
 
-- [ ] **1.1** Add an `EventSink` type alias
+- [x] **1.1** Add an `EventSink` type alias
       (`Callable[[dict[str, Any]], Awaitable[None]]`) and a
       threaded `event_sink: EventSink | None = None` kwarg through
       `DiscoverySweepWorkflow.execute()` → `_run_source()`.
-- [ ] **1.2** Add a `sweep_id: str | None = None` kwarg. Engine
+- [x] **1.2** Add a `sweep_id: str | None = None` kwarg. Engine
       doesn't generate it; daemon callers pass `run_id`; CLI
       leaves it None.
-- [ ] **1.3** Implement `source_started` / `source_finished` /
+- [x] **1.3** Implement `source_started` / `source_finished` /
       `source_failed` event emission inside `_run_source` via a
       `_safe_emit()` wrapper that catches sink exceptions and uses
       `asyncio.create_task` for fire-and-forget delivery (NFR-2).
-- [ ] **1.4** Add an `_iso_now()` helper
+- [x] **1.4** Add an `_iso_now()` helper
       (`datetime.now(timezone.utc).isoformat()`) used by all event
       timestamps.
-- [ ] **1.5** Tests in `tests/unit/workflows/discovery_sweep/test_event_sink.py`:
+- [x] **1.5** Tests in `tests/unit/workflows/discovery_sweep/test_event_sink.py`:
       - `event_sink=None` is a no-op (preserves today's behavior).
       - Sink fires exactly once per source per outcome
         (`started` + (`finished` xor `failed`)).
@@ -52,7 +52,7 @@ defaults to None; stdout emission gated on non-TTY detection).
         ts/findings_count|error).
       - A sink that raises doesn't propagate into the sweep.
       - A slow sink doesn't block other sources' execution.
-- [ ] **1.6** CHANGELOG entry under `### Added`.
+- [x] **1.6** CHANGELOG entry under `### Added`.
 
 ### Phase 1b — `ATTUNE_DS` stdout emission — **shipped 2026-05-13**
 

--- a/docs/specs/discovery-sweep/tasks.md
+++ b/docs/specs/discovery-sweep/tasks.md
@@ -1,6 +1,18 @@
 # Tasks — Discovery Sweep
 
-**Status:** approved — nothing shipped
+**Status:** feature-complete (2026-05-13) — Phase 1, 2A, 2B, 3 shipped; Phase 4 closed empty per P2.7 surface evaluation.
+
+| Phase | Status | Shipped via |
+|---|---|---|
+| Phase 1 — Engine + PatternScanSource | done | [#303](https://github.com/Smart-AI-Memory/attune-ai/pull/303), [#306](https://github.com/Smart-AI-Memory/attune-ai/pull/306) FP filter, [#309](https://github.com/Smart-AI-Memory/attune-ai/pull/309) AST filter |
+| Phase 1.5 — Second-pass design landings | done | [#312](https://github.com/Smart-AI-Memory/attune-ai/pull/312) |
+| Phase 2A — Shared LLM adapter base | done | [#313](https://github.com/Smart-AI-Memory/attune-ai/pull/313) |
+| Phase 2B — Per-source adapters (×6) | done | [#314](https://github.com/Smart-AI-Memory/attune-ai/pull/314)–[#319](https://github.com/Smart-AI-Memory/attune-ai/pull/319) |
+| Phase 2.7 — Surface evaluation | done | [#321](https://github.com/Smart-AI-Memory/attune-ai/pull/321) — KEEP all six standalones |
+| Phase 3 — Output polish + JSON | done | [#320](https://github.com/Smart-AI-Memory/attune-ai/pull/320) (3.1/3.3/3.4/3.5), [#322](https://github.com/Smart-AI-Memory/attune-ai/pull/322) (3.2 ANSI badges) |
+| Phase 4 — CLI deprecation | closed empty | P2.7 decision: zero deprecation candidates |
+
+Ops-dashboard integration (originally bundled into Phase 4) carved out to follow-up spec [`discovery-sweep-ops-integration`](../discovery-sweep-ops-integration/).
 
 Phased plan. Each phase is independently shippable. See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -12,24 +24,24 @@ Phased plan. Each phase is independently shippable. See `decisions.md`, `require
 
 Goal: prove the engine + Protocol + verification rules + CLI integration end-to-end on the cheapest source (pattern scanning). Ships a usable `attune workflow run discovery-sweep --path X --no-llm` even before any LLM adapter exists.
 
-- [ ] **1.1** Create `src/attune/workflows/discovery_sweep/` package skeleton. Empty `__init__.py`, stub `workflow.py`, stub `cli_workflow.py`, `sources/` subpackage.
-- [ ] **1.2** Define `Finding`, `QuestionFinding`, `RejectedFinding`, `SweepResult`, `SweepMetadata` dataclasses in `workflow.py`. All frozen where appropriate.
-- [ ] **1.3** Define `FindingSource` Protocol in `workflow.py` (`@runtime_checkable`, async `discover(path, budget_usd) -> list[Finding]`).
-- [ ] **1.4** Implement `verification.py` — the five routing rules from `design.md` § Verification rules. Pure functions, no I/O, no LLM. Unit tests cover each rule + interactions.
-- [ ] **1.5** Implement `DiscoverySweepWorkflow.execute()` in `workflow.py`:
+- [x] **1.1** Create `src/attune/workflows/discovery_sweep/` package skeleton. Empty `__init__.py`, stub `workflow.py`, stub `cli_workflow.py`, `sources/` subpackage.
+- [x] **1.2** Define `Finding`, `QuestionFinding`, `RejectedFinding`, `SweepResult`, `SweepMetadata` dataclasses in `workflow.py`. All frozen where appropriate.
+- [x] **1.3** Define `FindingSource` Protocol in `workflow.py` (`@runtime_checkable`, async `discover(path, budget_usd) -> list[Finding]`).
+- [x] **1.4** Implement `verification.py` — the five routing rules from `design.md` § Verification rules. Pure functions, no I/O, no LLM. Unit tests cover each rule + interactions.
+- [x] **1.5** Implement `DiscoverySweepWorkflow.execute()` in `workflow.py`:
       - Accept `path`, `budget_usd` (default 10.00), `sources` (default `None` → use `default_sources()`), `no_llm` (default False).
       - Allocate budget across sources, `asyncio.gather` with `return_exceptions=True`.
       - Run verification, build `SweepResult`.
       - Return `WorkflowResult` whose `final_output` is the human-readable markdown rendering AND whose `metadata` carries the structured `SweepResult` for JSON output.
-- [ ] **1.6** Implement `PatternScanSource` in `sources/pattern_scan.py`. Wraps existing pattern scanning (find the existing scanner — likely in `src/attune/workflows/bug_predict_patterns.py` or `src/attune/security/` — and adapt). `name = "pattern-scan"`, `is_llm = False`. Returns `Finding` objects directly. Ignores `budget_usd`.
-- [ ] **1.7** Register `DiscoverySweepWorkflow` in `src/attune/workflows/__init__.py` (lazy import + `_DEFAULT_WORKFLOW_NAMES`). Add to `PATH_ARG_REGISTRY` in `src/attune/ops/data.py` (Category A: takes `path` kwarg).
-- [ ] **1.8** CLI smoke test: `attune workflow run discovery-sweep --path tests/fixtures/ --no-llm` returns a SweepResult with at least one finding from the pattern source.
-- [ ] **1.9** Tests:
+- [x] **1.6** Implement `PatternScanSource` in `sources/pattern_scan.py`. Wraps existing pattern scanning (find the existing scanner — likely in `src/attune/workflows/bug_predict_patterns.py` or `src/attune/security/` — and adapt). `name = "pattern-scan"`, `is_llm = False`. Returns `Finding` objects directly. Ignores `budget_usd`.
+- [x] **1.7** Register `DiscoverySweepWorkflow` in `src/attune/workflows/__init__.py` (lazy import + `_DEFAULT_WORKFLOW_NAMES`). Add to `PATH_ARG_REGISTRY` in `src/attune/ops/data.py` (Category A: takes `path` kwarg).
+- [x] **1.8** CLI smoke test: `attune workflow run discovery-sweep --path tests/fixtures/ --no-llm` returns a SweepResult with at least one finding from the pattern source.
+- [x] **1.9** Tests:
       - `test_engine.py` — happy path with two fake sources, one returning findings, one raising
       - `test_verification.py` — each rule in isolation + the routing-order interaction
       - `test_pattern_scan_source.py` — runs against a fixture file with a known pattern hit
       - `test_discovery_sweep_registered.py` — drift guard: workflow appears in `list_workflows()` and `PATH_ARG_REGISTRY`
-- [ ] **1.10** Update CHANGELOG `[Unreleased]` § Added: discovery-sweep engine + PatternScanSource (no LLM).
+- [x] **1.10** Update CHANGELOG `[Unreleased]` § Added: discovery-sweep engine + PatternScanSource (no LLM).
 
 ---
 
@@ -39,12 +51,12 @@ Goal: wrap each audit-family workflow as a `FindingSource`. Each is an independe
 
 ### Phase 2A — Shared LLM adapter infrastructure
 
-- [ ] **2A.1** Implement `llm_source_base.py`:
+- [x] **2A.1** Implement `llm_source_base.py`:
       - `STRUCTURED_EMIT_FOOTER` constant (the prompt-augmentation string from design.md)
       - `parse_findings_json(text, source_name) -> list[Finding]` with text-only fallback
       - Optional `LLMSource` marker mixin (`is_llm = True`)
-- [ ] **2A.2** Tests for `parse_findings_json`: well-formed block, malformed JSON, missing block, multiple blocks (use last), block with extra prose. Each → expected Finding list.
-- [ ] **2A.3** CHANGELOG: shared LLM adapter base shipped (no user-visible behavior change).
+- [x] **2A.2** Tests for `parse_findings_json`: well-formed block, malformed JSON, missing block, multiple blocks (use last), block with extra prose. Each → expected Finding list.
+- [x] **2A.3** CHANGELOG: shared LLM adapter base shipped (no user-visible behavior change).
 
 ### Phase 2B — Per-source adapters (one PR each)
 
@@ -70,12 +82,12 @@ Each sub-task ships an adapter that:
 
 Goal: turn the markdown rendering into something pleasant and machine-readable.
 
-- [ ] **3.1** Implement `--json` flag in the CLI. Output matches the JSON schema in design.md § Data model.
-- [ ] **3.2** Improve human markdown rendering: clickable `file:line` links (already standard in attune output), severity-colored badges (use existing rich console formatting from `cli_minimal.py`).
-- [ ] **3.3** `--verbose` flag exposes rejected bucket with rule names.
-- [ ] **3.4** `--no-llm` flag filters to pattern-only sources.
-- [ ] **3.5** `--source <name>` flag (optional, defer if not needed).
-- [ ] **3.6** Tests:
+- [x] **3.1** Implement `--json` flag in the CLI. Output matches the JSON schema in design.md § Data model.
+- [x] **3.2** Improve human markdown rendering: clickable `file:line` links (already standard in attune output), severity-colored badges (use existing rich console formatting from `cli_minimal.py`).
+- [x] **3.3** `--verbose` flag exposes rejected bucket with rule names.
+- [x] **3.4** `--no-llm` flag filters to pattern-only sources.
+- [x] **3.5** `--source <name>` flag (optional, defer if not needed).
+- [x] **3.6** Tests:
       - `test_cli_json_output` — JSON parses, top-level shape matches schema
       - `test_cli_verbose_shows_rejected` — `--verbose` includes rejected bucket
       - `test_cli_no_llm_filters_sources` — only `is_llm = False` sources run


### PR DESCRIPTION
## Summary

Spec-hygiene pass after 2026-05-13's heavy delivery day. Reconciles task status to match what actually merged, and records the Phase 2A/2B split decision for the ops-integration follow-up.

- **`discovery-sweep/tasks.md`** — added phase-status table at top; marked Phase 1 (1.1–1.10), Phase 2A (2A.1–2A.3), and Phase 3 (3.1–3.6) done with PR refs. Phase 4 stays closed-empty per P2.7 surface evaluation. Cross-link to the ops-integration follow-up.
- **`discovery-sweep-ops-integration/tasks.md`** — updated top-of-file status to reflect Phase 1 + 1b shipped 2026-05-13; marked Phase 1 (1.1–1.6) done. Flagged Phase 2 as in progress: 2A via [#334](https://github.com/Smart-AI-Memory/attune-ai/pull/334), 2B blocked on #324 / #326 / #328.
- **`discovery-sweep-ops-integration/decisions.md`** — added decision #11 confirming [#334](https://github.com/Smart-AI-Memory/attune-ai/pull/334) stays within this spec (not a new one), with rationale for the 2A/2B split and the file-conflict avoidance argument.

## Why now

Several PRs landed today (#303, #306, #309, #312, #313, #314–#319, #320, #321, #322, #331, #333) but the spec task files still showed Phase 1 items unchecked. Stale task files erode trust that `tasks.md` reflects reality.

No code changes — pure documentation.

## Test plan

- [x] Pre-commit hooks green
- [x] Markdown renders correctly (phase-status table, link refs)
- [ ] CI matrix on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
