### PR TITLE
fix(docs): bump pymdown-extensions floor to >=10.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,13 +197,11 @@ docs = [
     "mkdocs-material>=9.4.0,<10.0.0",
     "mkdocstrings[python]>=0.24.0,<2.0.0",
     "mkdocs-with-pdf>=0.9.3,<1.0.0",  # PDF/ePub generation
-    "pymdown-extensions>=10.0,<11.0",
-    # Pygments 2.20 introduced a stricter html.escape() in
-    # HtmlFormatter that crashes on None filename. pymdown-
-    # extensions 10.20.x still passes title=None through as
-    # filename, so we cap pygments below 2.20 until either
-    # side ships a fix.
-    "pygments>=2.12,<2.20",
+    # pymdown-extensions 10.20.x passes title=None through as the
+    # filename kwarg, which crashes pygments 2.20+'s stricter
+    # html.escape() (AttributeError on .replace). 10.21.0 fixes
+    # the upstream bug — keep the floor pinned past it.
+    "pymdown-extensions>=10.21,<11.0",
 ]
 
 # Development dependencies
@@ -356,13 +354,11 @@ all = [
     "mkdocs-material>=9.4.0,<10.0.0",
     "mkdocstrings[python]>=0.24.0,<2.0.0",
     "mkdocs-with-pdf>=0.9.3,<1.0.0",
-    "pymdown-extensions>=10.0,<11.0",
-    # Pygments 2.20 introduced a stricter html.escape() in
-    # HtmlFormatter that crashes on None filename. pymdown-
-    # extensions 10.20.x still passes title=None through as
-    # filename, so we cap pygments below 2.20 until either
-    # side ships a fix.
-    "pygments>=2.12,<2.20",
+    # pymdown-extensions 10.20.x passes title=None through as the
+    # filename kwarg, which crashes pygments 2.20+'s stricter
+    # html.escape() (AttributeError on .replace). 10.21.0 fixes
+    # the upstream bug — keep the floor pinned past it.
+    "pymdown-extensions>=10.21,<11.0",
     # Dev tools
     "pytest>=9.0.3,<10.0",  # CVE-2025-71176 fix
     "pytest-asyncio>=0.21,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,12 @@ docs = [
     "mkdocstrings[python]>=0.24.0,<2.0.0",
     "mkdocs-with-pdf>=0.9.3,<1.0.0",  # PDF/ePub generation
     "pymdown-extensions>=10.0,<11.0",
+    # Pygments 2.20 introduced a stricter html.escape() in
+    # HtmlFormatter that crashes on None filename. pymdown-
+    # extensions 10.20.x still passes title=None through as
+    # filename, so we cap pygments below 2.20 until either
+    # side ships a fix.
+    "pygments>=2.12,<2.20",
 ]
 
 # Development dependencies
@@ -351,6 +357,12 @@ all = [
     "mkdocstrings[python]>=0.24.0,<2.0.0",
     "mkdocs-with-pdf>=0.9.3,<1.0.0",
     "pymdown-extensions>=10.0,<11.0",
+    # Pygments 2.20 introduced a stricter html.escape() in
+    # HtmlFormatter that crashes on None filename. pymdown-
+    # extensions 10.20.x still passes title=None through as
+    # filename, so we cap pygments below 2.20 until either
+    # side ships a fix.
+    "pygments>=2.12,<2.20",
     # Dev tools
     "pytest>=9.0.3,<10.0",  # CVE-2025-71176 fix
     "pytest-asyncio>=0.21,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -294,6 +294,7 @@ all = [
     { name = "opentelemetry-sdk" },
     { name = "pre-commit" },
     { name = "pygls" },
+    { name = "pygments" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pymdown-extensions" },
     { name = "pytest" },
@@ -361,6 +362,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-with-pdf" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pygments" },
     { name = "pymdown-extensions" },
 ]
 enterprise = [
@@ -524,6 +526,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.4.0,<3.0.0" },
     { name = "pygls", marker = "extra == 'all'", specifier = ">=1.0.0,<3.0.0" },
     { name = "pygls", marker = "extra == 'lsp'", specifier = ">=1.0.0,<3.0.0" },
+    { name = "pygments", marker = "extra == 'all'", specifier = ">=2.12,<2.20" },
+    { name = "pygments", marker = "extra == 'docs'", specifier = ">=2.12,<2.20" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'all'", specifier = ">=2.12.0" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'backend'", specifier = ">=2.12.0,<3.0.0" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'enterprise'", specifier = ">=2.12.0" },
@@ -3525,11 +3529,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,6 @@ all = [
     { name = "opentelemetry-sdk" },
     { name = "pre-commit" },
     { name = "pygls" },
-    { name = "pygments" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pymdown-extensions" },
     { name = "pytest" },
@@ -362,7 +361,6 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-with-pdf" },
     { name = "mkdocstrings", extra = ["python"] },
-    { name = "pygments" },
     { name = "pymdown-extensions" },
 ]
 enterprise = [
@@ -526,13 +524,11 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.4.0,<3.0.0" },
     { name = "pygls", marker = "extra == 'all'", specifier = ">=1.0.0,<3.0.0" },
     { name = "pygls", marker = "extra == 'lsp'", specifier = ">=1.0.0,<3.0.0" },
-    { name = "pygments", marker = "extra == 'all'", specifier = ">=2.12,<2.20" },
-    { name = "pygments", marker = "extra == 'docs'", specifier = ">=2.12,<2.20" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'all'", specifier = ">=2.12.0" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'backend'", specifier = ">=2.12.0,<3.0.0" },
     { name = "pyjwt", extras = ["crypto"], marker = "extra == 'enterprise'", specifier = ">=2.12.0" },
-    { name = "pymdown-extensions", marker = "extra == 'all'", specifier = ">=10.0,<11.0" },
-    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.0,<11.0" },
+    { name = "pymdown-extensions", marker = "extra == 'all'", specifier = ">=10.21,<11.0" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.21,<11.0" },
     { name = "pytest", marker = "extra == 'all'", specifier = ">=9.0.3,<10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0" },
     { name = "pytest-asyncio", marker = "extra == 'all'", specifier = ">=0.21,<2.0" },
@@ -3529,11 +3525,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -3555,15 +3551,15 @@ crypto = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.20.1"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Local \`mkdocs build\` was crashing with \`AttributeError: 'NoneType' object has no attribute 'replace'\` on the first untitled code fence. Root cause: \`pymdown-extensions 10.20.x\` passes \`title=None\` through to pygments as the \`filename\` kwarg, which crashes pygments 2.20+'s stricter \`html.escape()\`. **10.21.0 fixes the upstream bug.**

CI was already installing the fixed combo (\`pymdown-extensions 10.21.3 + pygments 2.20.0\`) cleanly on main — only the local venv was stuck on the broken 10.20.1.

This PR pins the pymdown-extensions floor past the fix instead of capping pygments. Tracks the actual root cause rather than working around it; keeps everyone on the latest pygments.

## History

Initial commit ([87710ce3](../commit/87710ce3)) capped \`pygments<2.20\` based on the incorrect premise that CI was also blocked. Replaced in [c9f6c7eb](../commit/c9f6c7eb) with the pymdown-extensions floor bump.

## Test plan

- [x] \`uv run mkdocs build\` exits 0
- [x] \`uv run mkdocs build --strict\` exits 0 (matches CI's docs.yml step)
- [x] 0 ERRORs, 0 WARNINGs
- [x] Resolved versions: \`pygments 2.20.0\` + \`pymdown-extensions 10.21.3\` (same combo CI uses)
- [x] pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)