### PR TITLE
docs(scripts/score_test_quality): document correct pytest scope

### DIFF
--- a/scripts/score_test_quality.py
+++ b/scripts/score_test_quality.py
@@ -13,7 +13,25 @@ Output:
 If coverage.xml is missing, every module gets coverage_gap=1.0.
 The relative ordering of customer_weight × risk_multiplier still
 surfaces a defensible first working set; refresh after a fresh
-`pytest --cov=src/attune --cov-report=xml` for sharper gap data.
+coverage run for sharper gap data.
+
+How to refresh coverage.xml correctly
+-------------------------------------
+
+    pytest --cov=src/attune --cov-report=xml:/tmp/coverage.xml -q \\
+      -m "not network and not integration"
+    python scripts/score_test_quality.py /tmp/coverage.xml
+
+The `pytest` invocation MUST collect from the whole `tests/`
+directory (the default via `testpaths = ["tests"]` in
+`pyproject.toml`) — NOT scoped to `tests/unit/` alone. Modules
+whose primary tests live in `tests/security/`,
+`tests/integration/`, etc. otherwise show up with spuriously-low
+`covered_pct` in the cache, and the rubric promotes already-
+well-covered modules as picks. Verified failure mode 2026-05-14:
+`memory/security/secrets_detector.py` reported 60.3% from a
+`tests/unit/`-only run, actual 90.96% under `tests/`. See
+`docs/COVERAGE_BUG_LOG.md` 2026-05-14 entry.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Adds an explicit \"How to refresh coverage.xml correctly\" section to the script's docstring after today's PR #347 revealed the previous instructions were ambiguous.

## Why

The docstring said \`pytest --cov=src/attune --cov-report=xml\` without specifying scope. Running with \`pytest tests/unit/\` instead of \`pytest tests/\` undercounts modules whose primary tests live elsewhere:

- \`tests/security/\`
- \`tests/integration/\`
- etc.

These modules then surface as picks in \`rubric_cache.csv\` with spuriously-low \`covered_pct\` — even when they're already well-covered.

## Verified case (2026-05-14)

\`memory/security/secrets_detector.py\` was selected as the next pick at score 1.79 / 60.3% covered. Running the same tests against \`tests/security/\` revealed actual coverage was **90.96%**. The cycle still shipped (PR #347, closing the remaining 9% with 9 focused tests) but the wasted-selection cost is avoidable.

## What changed

Just the docstring at the top of \`scripts/score_test_quality.py\` — adds a concrete refresh command using \`pytest --cov=src/attune --cov-report=xml:/tmp/coverage.xml -q -m \"not network and not integration\"\` (no path scope) and documents the failure mode with a back-reference to \`docs/COVERAGE_BUG_LOG.md\` 2026-05-14.

No behavior change to the script itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)