### PR TITLE
refactor: modernize asyncio.get_event_loop() callsites (Py 3.12+)

### DIFF
--- a/src/attune/agent_factory/adapters/autogen_adapter.py
+++ b/src/attune/agent_factory/adapters/autogen_adapter.py
@@ -67,7 +67,7 @@ class AutoGenAgent(BaseAgent):
 
         try:
             # AutoGen uses synchronous chat, wrap in executor
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
 
             def sync_chat():
                 """Run AutoGen generate_reply synchronously."""
@@ -137,7 +137,7 @@ class AutoGenWorkflow(BaseWorkflow):
             message = input_data.get("input", str(input_data))
 
         try:
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
 
             def sync_chat():
                 """Run AutoGen group chat synchronously."""

--- a/src/attune/agents/release/release_prep_team.py
+++ b/src/attune/agents/release/release_prep_team.py
@@ -148,7 +148,7 @@ class ReleasePrepTeam:
         logger.info(f"Starting release readiness assessment: {codebase_path}")
 
         # Execute all agents in parallel
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         tasks = [loop.run_in_executor(None, agent.process, codebase_path) for agent in self.agents]
         results: list[ReleaseAgentResult] = await asyncio.gather(*tasks)
 

--- a/src/attune/hooks/executor.py
+++ b/src/attune/hooks/executor.py
@@ -232,7 +232,7 @@ class HookExecutor:
         if asyncio.iscoroutinefunction(handler):
             return await handler(**context)
         # Run sync function in thread pool
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, lambda: handler(**context))
 
     async def _execute_webhook(

--- a/src/attune/orchestration/_strategies/advanced_strategies.py
+++ b/src/attune/orchestration/_strategies/advanced_strategies.py
@@ -11,8 +11,8 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
-import asyncio
 import logging
+import time
 from typing import Any
 
 from ..agent_templates import AgentTemplate
@@ -82,13 +82,13 @@ class ToolEnhancedStrategy(ExecutionStrategy):
             )
 
         agent = agents[0]  # Use first agent only
-        start_time = asyncio.get_event_loop().time()
+        start_time = time.monotonic()
 
         # Execute with tool access
         try:
             result = await self._execute_with_tools(agent=agent, context=context, tools=self.tools)
 
-            duration = asyncio.get_event_loop().time() - start_time
+            duration = time.monotonic() - start_time
 
             return StrategyResult(
                 success=result["success"],
@@ -106,7 +106,7 @@ class ToolEnhancedStrategy(ExecutionStrategy):
             )
         except Exception as e:  # noqa: BLE001
             logger.exception(f"Tool-enhanced execution failed: {e}")
-            duration = asyncio.get_event_loop().time() - start_time
+            duration = time.monotonic() - start_time
             return StrategyResult(
                 success=False,
                 outputs=[],
@@ -189,7 +189,7 @@ class PromptCachedSequentialStrategy(ExecutionStrategy):
         client = LLMClient()
         outputs = []
         current_output = context.get("input", {})
-        start_time = asyncio.get_event_loop().time()
+        start_time = time.monotonic()
 
         for agent in agents:
             try:
@@ -237,7 +237,7 @@ Your role: {agent.role}"""
                 )
                 outputs.append(result)
 
-        duration = asyncio.get_event_loop().time() - start_time
+        duration = time.monotonic() - start_time
 
         return StrategyResult(
             success=all(r.success for r in outputs),
@@ -314,7 +314,7 @@ class DelegationChainStrategy(ExecutionStrategy):
                 errors=["No agents provided for delegation"],
             )
 
-        start_time = asyncio.get_event_loop().time()
+        start_time = time.monotonic()
 
         # Execute coordinator (first agent)
         coordinator = agents[0]
@@ -356,7 +356,7 @@ class DelegationChainStrategy(ExecutionStrategy):
                 original_task=context.get("task", ""),
             )
 
-            duration = asyncio.get_event_loop().time() - start_time
+            duration = time.monotonic() - start_time
 
             return StrategyResult(
                 success=True,
@@ -367,7 +367,7 @@ class DelegationChainStrategy(ExecutionStrategy):
 
         except Exception as e:  # noqa: BLE001
             logger.exception(f"Delegation chain failed: {e}")
-            duration = asyncio.get_event_loop().time() - start_time
+            duration = time.monotonic() - start_time
             return StrategyResult(
                 success=False,
                 outputs=[],
@@ -435,7 +435,7 @@ Return JSON:
         from attune.models import LLMClient
 
         client = LLMClient()
-        start_time = asyncio.get_event_loop().time()
+        start_time = time.monotonic()
 
         try:
             response = await client.call(
@@ -445,7 +445,7 @@ Return JSON:
                 workflow_id=f"specialist:{specialist.agent_id}",
             )
 
-            duration = asyncio.get_event_loop().time() - start_time
+            duration = time.monotonic() - start_time
 
             return AgentResult(
                 agent_id=specialist.agent_id,
@@ -456,7 +456,7 @@ Return JSON:
             )
         except Exception as e:  # noqa: BLE001
             logger.exception(f"Specialist {specialist.agent_id} failed: {e}")
-            duration = asyncio.get_event_loop().time() - start_time
+            duration = time.monotonic() - start_time
             return AgentResult(
                 agent_id=specialist.agent_id,
                 success=False,

--- a/src/attune/socratic/mcp_server.py
+++ b/src/attune/socratic/mcp_server.py
@@ -459,11 +459,12 @@ async def run_mcp_server():
     server = SocraticMCPServer()
 
     # Read from stdin, write to stdout
+    loop = asyncio.get_running_loop()
     reader = asyncio.StreamReader()
     protocol = asyncio.StreamReaderProtocol(reader)
-    await asyncio.get_event_loop().connect_read_pipe(lambda: protocol, sys.stdin)
+    await loop.connect_read_pipe(lambda: protocol, sys.stdin)
 
-    writer_transport, writer_protocol = await asyncio.get_event_loop().connect_write_pipe(
+    writer_transport, writer_protocol = await loop.connect_write_pipe(
         asyncio.streams.FlowControlMixin,
         sys.stdout,
     )
@@ -471,7 +472,7 @@ async def run_mcp_server():
         writer_transport,
         writer_protocol,
         reader,
-        asyncio.get_event_loop(),
+        loop,
     )
 
     async def send_response(response: dict):

--- a/src/attune/workflows/orchestrated_release_prep.py
+++ b/src/attune/workflows/orchestrated_release_prep.py
@@ -41,6 +41,7 @@ Licensed under the Apache License, Version 2.0
 
 import asyncio
 import logging
+import time
 import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -347,7 +348,7 @@ class OrchestratedReleasePrepWorkflow:
             raise ValueError("path must be a non-empty string")
 
         logger.info(f"Starting orchestrated release prep for: {path}")
-        start_time = asyncio.get_event_loop().time()
+        start_time = time.monotonic()
 
         # Prepare context
         full_context = {
@@ -390,7 +391,7 @@ class OrchestratedReleasePrepWorkflow:
         report = await self._create_report(strategy_result, execution_plan.agents, full_context)
 
         # Set duration
-        end_time = asyncio.get_event_loop().time()
+        end_time = time.monotonic()
         report.total_duration = end_time - start_time
 
         logger.info(

--- a/src/attune/workflows/progress_server.py
+++ b/src/attune/workflows/progress_server.py
@@ -242,16 +242,14 @@ class ProgressServer:
 
         def callback(update: ProgressUpdate) -> None:
             """Queue a broadcast in the event loop for sync callers."""
-            # Schedule broadcast in event loop
+            # Schedule broadcast on the running loop, if any.
+            # Sync callers without a running loop are best-effort no-ops.
             try:
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    asyncio.create_task(self.broadcast(update))
-                else:
-                    loop.run_until_complete(self.broadcast(update))
+                loop = asyncio.get_running_loop()
             except RuntimeError:
-                # No event loop, skip
-                pass
+                # No running loop in this thread, skip
+                return
+            loop.create_task(self.broadcast(update))
 
         return callback
 
@@ -297,7 +295,7 @@ async def run_server(host: str = "localhost", port: int = 8766) -> None:
     server = ProgressServer(config)
 
     # Handle shutdown signals
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, lambda: asyncio.create_task(server.stop()))
 


### PR DESCRIPTION
## Summary

- Replaces 23 `asyncio.get_event_loop()` sites across 7 files with the modern equivalents required for Python 3.12+ (`get_event_loop()` outside a coroutine is deprecated and slated for removal in 3.14).
- Three replacement patterns, picked per call site:

| Pattern | Replacement | Sites |
|---|---|---|
| `loop.time()` for duration | `time.monotonic()` | 13 (`advanced_strategies.py`, `orchestrated_release_prep.py`) |
| Inside coroutine, then `run_in_executor` | `asyncio.get_running_loop()` | 4 (`autogen_adapter.py` ×2, `release_prep_team.py`, `hooks/executor.py`) |
| Async entry function | `asyncio.get_running_loop()` | 5 (`progress_server.py`, `socratic/mcp_server.py` ×3 consolidated into one local var) |
| Sync callback scheduling async | `try: get_running_loop() except RuntimeError: return` | 1 (`progress_server.py`) |

## Context

This came out of verifying a `bug-predict` report that listed five findings. Three of the five (NameError on zero-message streams in `security_audit`/`code_review`/`deep_review`, `research_synthesis` silent failure, deprecated `redis_memory*` past deadline) were false positives or already-tracked tech debt. `asyncio.get_event_loop()` was the only unambiguously real, fixable finding — so this PR scope is just that.

## Test plan

- [x] All 7 modules import cleanly (`python -c "import ..."` for each)
- [x] No `asyncio.get_event_loop()` calls remain in `src/attune/`
- [x] Targeted unit tests pass: `tests/hooks/test_executor.py`, `tests/unit/hooks/test_executor_webhook_security.py`, `tests/unit/orchestration/test_advanced_strategies.py`, `tests/unit/socratic/test_mcp_server.py`, `tests/unit/agents/test_release_prep_team.py` — **112 passed, 1 skipped**
- [ ] CI matrix green

## Behavioral notes

- One small behavioral change in `progress_server.py:get_callback()`: the previous `else: loop.run_until_complete(self.broadcast(update))` branch was dead in practice — `get_event_loop()` returning a non-running loop in a sync context is precisely the deprecated path Python 3.12+ aims to remove, and you can't call `run_until_complete` on a running loop anyway. The new code attempts `get_running_loop()` and skips on `RuntimeError`, matching the original best-effort intent without the dead branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
