### PR TITLE
feat(docs): expand ops-dashboard help corpus + wire docs into nav

### DIFF
--- a/.help/templates/ops-dashboard/comparison.md
+++ b/.help/templates/ops-dashboard/comparison.md
@@ -1,0 +1,71 @@
+---
+type: comparison
+name: ops-dashboard-comparison
+feature: ops-dashboard
+depth: comparison
+generated_at: 2026-05-14T14:43:23.578213+00:00
+source_hash: 395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42
+status: generated
+---
+
+# Comparison: Ops Dashboard vs alternatives
+
+## Context
+
+The ops dashboard is a locally-running web server (`attune ops` / `python -m attune.ops`) that combines four capabilities in one place: a per-feature scope picker backed by `.help/features.yaml`, a workflow runner with clickable stage chaining, persisted run history with configurable retention, and live SSE log streaming. Understanding what it does — and what it deliberately does not do — helps you decide whether to start it up or use a lighter alternative.
+
+## Feature comparison
+
+| Capability | Ops dashboard | Ad-hoc script | Direct CLI workflow invocation |
+|---|---|---|---|
+| **Scope picker UI** | Yes — reads `features.yaml`, resolves `Feature.path` per entry | Manual — you pass paths by hand | No — path is a positional argument |
+| **Run history & retention** | Persisted to `runs_dir`; configurable via `runs_retention_days` (default 30 days) | None unless you add it yourself | None |
+| **Live log streaming** | Server-sent events (SSE) pushed to the browser | Stdout only | Stdout only |
+| **Clickable workflow chaining** | Yes — next-stage links rendered in the UI | No | No |
+| **Telemetry & KPIs** | `HomeKpis` surfaced above the fold: today's events, cost, 7-day savings, sparkline | None | None |
+| **Host/port control** | `--host` / `--port`; default `127.0.0.1:8765` | N/A | N/A |
+| **Trusted-host enforcement** | `TrustedHostMiddleware` rejects unlisted `Host` headers | N/A | N/A |
+| **Workflow execution** | Only when `allow_run=True` (off by default) | Full control | Full control |
+| **Startup overhead** | FastAPI import deferred via `create_app()` lazy loader; still a server process | Near-zero | Near-zero |
+| **Best for** | Interactive, repeated work across multiple features | One-off or CI automation | Single workflow, no UI needed |
+
+## Tradeoffs to weigh
+
+**Ops dashboard is stronger when:**
+
+- You switch between features frequently and the scope picker saves you from re-typing paths every time.
+- You want a persistent record of what ran, when it ran, and how much it cost — without building that bookkeeping yourself.
+- You need to observe long-running workflow stages in real time through SSE, rather than tailing a log file.
+- Telemetry summaries (`TelemetrySummary`, `HomeKpis`) matter to your team.
+
+**Ops dashboard is weaker when:**
+
+- You are running a single workflow once (for example, in CI). Starting a server process, binding a port, and configuring `trusted_hosts` is more ceremony than the job warrants.
+- You need `allow_run=True` in an automated context — the flag exists but is off by default precisely because remote execution carries risk; a direct CLI call is safer and more auditable.
+- You are doing exploratory, throwaway work. Wiring up `build_config()` and launching the server for a single invocation adds friction that a plain script avoids.
+- Your environment cannot expose a local port, or `TrustedHostMiddleware` conflicts with your network setup.
+
+## Deciding which entry point to use
+
+When you have decided to use the dashboard, there are two equivalent entry points:
+
+| Entry point | Use when |
+|---|---|
+| `attune ops` (via `add_subparser`) | You are already using the `attune` CLI for other subcommands |
+| `python -m attune.ops` (`main()`) | You want to launch the dashboard standalone, without the full `attune` CLI context |
+
+Both call `cmd_ops()`, which blocks until the server exits and returns `0`.
+
+## Use the ops dashboard when…
+
+- **You work interactively across multiple features day-to-day.** The scope picker, run history, and telemetry KPIs compound in value the more you use the dashboard — they are not worth the setup cost for a single run.
+- **You need live feedback on long workflow stages.** SSE streaming is the ops dashboard's clearest advantage over any CLI alternative; nothing else in this project surfaces real-time stage output in a browser.
+- **Run history matters.** If you or your team ever ask "what ran last Tuesday and what did it cost?", the persisted `runs_dir` with `runs_retention_days` is the only option here that answers that question without custom instrumentation.
+
+Skip the ops dashboard and invoke workflows directly when the job is automated, one-shot, or running in an environment where a local web server is impractical.
+
+## Source files
+
+- `src/attune/ops/**`
+
+**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/.help/templates/ops-dashboard/error.md
+++ b/.help/templates/ops-dashboard/error.md
@@ -1,0 +1,50 @@
+---
+type: error
+name: ops-dashboard-error
+feature: ops-dashboard
+depth: error
+generated_at: 2026-05-14T14:43:23.558593+00:00
+source_hash: 395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42
+status: generated
+---
+
+# Ops Dashboard errors
+
+## Common error signatures
+
+Errors in the ops dashboard typically fall into three categories:
+
+- **Configuration errors** — `build_config()` raises when required paths are missing or environment defaults cannot be resolved. Check that `project_root` exists and that `ATTUNE_HOME` (or `~/.attune`) is readable.
+- **Server startup errors** — `cmd_ops()` or `main()` fail to bind the FastAPI server. Common causes include the configured `host`/`port` (default `127.0.0.1:8765`) already being in use, or FastAPI not being installed in the current environment.
+- **Rejected requests (`403`)** — `TrustedHostMiddleware.dispatch()` rejects any request whose `Host` header is not in the `trusted_hosts` allowlist. Add the originating host to `trusted_hosts` in your `Config`.
+- **Missing data directories** — Accessors such as `Config.runs_dir`, `Config.memory_dir`, and `Config.sessions_dir` resolve paths under `attune_home` that may not exist until the first write. Code that reads from these paths before any run has completed can raise `FileNotFoundError`.
+- **Invalid spec phase status** — Phase file readers validate `status` against `_VALID_STATUSES`. A value outside `{'draft', 'in-review', 'approved', 'complete', 'completed', 'done'}` produces a validation error surfaced in the `SpecPhase` snapshot.
+- **Missing features file** — `list_features()` and `first_feature()` parse `<project_root>/.help/features.yaml`. If that file is absent or malformed, these functions raise and the scope picker cannot populate.
+
+## Where errors originate
+
+| Entry point | What it does | Likely failure |
+|---|---|---|
+| `build_config()` | Assembles a `Config` from arguments and environment defaults | Bad paths, unresolvable `attune_home` |
+| `create_app()` | Lazily imports the FastAPI factory | `ImportError` if FastAPI is not installed |
+| `cmd_ops()` | Starts the blocking dashboard server | Port conflict, missing config values |
+| `main()` | Standalone entry (`python -m attune.ops`) | Any error from `cmd_ops()` propagates here |
+| `list_features()` / `first_feature()` | Reads `.help/features.yaml` | `FileNotFoundError`, YAML parse error |
+
+## How to diagnose
+
+1. **Read the exception type and message first.** An `ImportError` pointing at FastAPI means the dependency is missing. An `OSError` or `FileNotFoundError` points to a path problem. A `400`/`403` HTTP status from `TrustedHostMiddleware` means a host header mismatch.
+
+2. **Verify your `Config` values.** Print or log the `Config` dataclass after `build_config()` returns. Confirm that `project_root`, `attune_home`, `host`, and `port` match your environment. Remember that `runs_dir`, `memory_dir`, and `sessions_dir` are derived properties — they reflect whatever `attune_home` resolved to.
+
+3. **Check whether the data directories exist.** If `Config.runs_dir` or `Config.sessions_dir` does not exist yet, any code that tries to read from them before the first write will fail. Create the directories manually or run the dashboard at least once to let it initialize them.
+
+4. **Confirm `trusted_hosts` covers your client.** If the dashboard returns `403`, compare the `Host` header your client sends against the `trusted_hosts` tuple in your `Config`. Add the missing host or adjust your client's request headers.
+
+5. **Validate `.help/features.yaml`.** If the scope picker is blank or `list_features()` raises, open `<project_root>/.help/features.yaml` and confirm it is valid YAML. Each entry must supply at least `name` and `description`; `path` and `tags` are optional.
+
+## Source files
+
+- `src/attune/ops/**`
+
+**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/.help/templates/ops-dashboard/faq.md
+++ b/.help/templates/ops-dashboard/faq.md
@@ -1,0 +1,58 @@
+---
+type: faq
+name: ops-dashboard-faq
+feature: ops-dashboard
+depth: faq
+generated_at: 2026-05-14T14:43:23.569106+00:00
+source_hash: 395f221f9a789d9b8851995c90a8bcc4904e7c84a247bacee7036e1583b0ea42
+status: generated
+---
+
+# Ops Dashboard FAQ
+
+## What is the ops dashboard?
+
+The ops dashboard is a local web server that lets you run workflows against a specific feature scope, stream live logs over SSE, and browse persisted run history — all from a browser UI. Start it with `attune ops` or `python -m attune.ops`.
+
+## When should I use it?
+
+Use the ops dashboard when you want to run and monitor attune workflows locally — for example, to pick a feature scope, chain workflows together by clicking through the UI, or review past run history. If you're looking to automate runs non-interactively, check the other features listed in your project's `.help/features.yaml`.
+
+## What's the main entry point?
+
+Run the server with the `attune ops` CLI command. Under the hood this calls `cmd_ops()`, which is blocking. The three public symbols you're most likely to use directly are:
+
+- `create_app()` — constructs the FastAPI application (lazy-imported so that importing `attune` doesn't pull in FastAPI)
+- `build_config()` — builds a `Config` from your inputs and environment defaults (host, port, `allow_run`, retention days, etc.)
+- `Config` — the dataclass that controls where the dashboard reads project and attune state from
+
+## How do I configure the server?
+
+Pass arguments to `build_config()`, or let it pick up environment defaults. The key fields on `Config` are:
+
+| Field | Default | What it controls |
+|---|---|---|
+| `host` | `127.0.0.1` | Interface the server binds to |
+| `port` | `8765` | Port the server listens on |
+| `allow_run` | `False` | Whether the dashboard can trigger workflow runs |
+| `trusted_hosts` | `()` | Allowlist checked by `TrustedHostMiddleware` |
+| `runs_retention_days` | `30` | How long persisted run history is kept |
+
+## Where does the dashboard store its data?
+
+All data lives under the paths exposed by `Config`:
+
+- **Telemetry** — `Config.telemetry_path`
+- **Run history** — `Config.runs_dir` (created on first write)
+- **Memory** — `Config.memory_dir`
+- **Sessions** — `Config.sessions_dir`
+
+## How do I debug it?
+
+Run the related tests first with `pytest -k "ops-dashboard" -v`. If the tests pass but your code still fails, add a `logger.debug` call at the suspected failure point and re-run with logging enabled. For symptom-based diagnosis, see the troubleshooting page for this feature.
+
+## Where are the source files?
+
+All ops dashboard source files are under `src/attune/ops/`.
+
+**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/.help/templates/ops-dashboard/note.md
+++ b/.help/templates/ops-dashboard/note.md
@@ -1,0 +1,53 @@
+---
+type: note
+name: ops-dashboard-note
+feature: ops-dashboard
+depth: note
+generated_at: 2026-05-14T14:43:23.575771+00:00
+source_hash: 395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42
+status: generated
+---
+
+# Note: ops dashboard
+
+## Context
+
+`attune ops` is a local operations dashboard for the workflow OS. It provides a per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming. You can start it as a CLI command (`attune ops`) or run it directly with `python -m attune.ops`.
+
+## Public API boundary
+
+The package exposes three names at the top level (`__all__ = {'create_app', 'build_config', 'Config'}`), split between data classes and factory functions.
+
+**Data classes** (defined in `src/attune/ops/data.py` and `src/attune/ops/config.py`):
+
+| Class | Purpose |
+|---|---|
+| `Config` | Holds project root, attune home, server address, and runtime flags. Also exposes computed paths such as `runs_dir`, `memory_dir`, and `sessions_dir`. |
+| `TelemetrySummary` | Aggregated request counts, costs, and savings, broken down by workflow and by day. |
+| `WorkflowEntry` | Name, description, stage count, and tier map for a single workflow. |
+| `PathArgSpec` | Describes how a workflow accepts a scope path argument on the CLI. |
+| `Feature` | One entry from `.help/features.yaml`, used to populate the scope picker. |
+| `HomeKpis` | Today's event count and cost, seven-day cost and savings, and a sparkline list — shown above the fold on the home page. |
+
+**Factory functions** (defined in `src/attune/ops/__init__.py` and `src/attune/ops/cli.py`):
+
+| Function | Purpose |
+|---|---|
+| `create_app()` | Lazily imports the FastAPI factory, so importing `attune` does not pull in FastAPI as a side effect. |
+| `build_config()` | Constructs a `Config` from explicit arguments and environment defaults, including an env-based attune home override. |
+| `add_subparser()` | Registers the `ops` subcommand on the main `attune` CLI parser. |
+| `cmd_ops()` | Starts the dashboard server (blocking). Returns `0` on clean exit. |
+| `main()` | Standalone entry point for `python -m attune.ops`. |
+
+## Design notes
+
+- **Lazy imports.** `create_app` and `build_config` defer their imports so that `import attune` stays lightweight even when FastAPI is installed.
+- **Host allowlist.** `TrustedHostMiddleware` rejects any request whose `Host` header is not in `Config.trusted_hosts`. The default bind address is `127.0.0.1:8765`.
+- **Run retention.** Persisted ops runs live under `Config.runs_dir` and are pruned after `runs_retention_days` days (default: 30). The directory is created on first write.
+- **Scope picker.** `list_features()` parses `.help/features.yaml` relative to the project root. `first_feature()` returns the alphabetically first entry that has a renderable scope, which the dashboard uses as the default selection.
+
+## Source files
+
+- `src/attune/ops/**`
+
+**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/.help/templates/ops-dashboard/quickstart.md
+++ b/.help/templates/ops-dashboard/quickstart.md
@@ -1,0 +1,66 @@
+---
+type: quickstart
+name: ops-dashboard-quickstart
+feature: ops-dashboard
+depth: quickstart
+generated_at: 2026-05-14T14:43:23.571481+00:00
+source_hash: 395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42
+status: generated
+---
+
+# Quickstart: ops dashboard
+
+Start the local operations dashboard — a workflow runner with a per-feature scope picker, persisted run history, and live log streaming.
+
+```bash
+attune ops
+```
+
+The dashboard starts on `http://127.0.0.1:8765` by default.
+
+## Prerequisites
+
+- attune is installed and your project is cloned locally
+- You are running the command from your project root
+
+## Step 1: Build a config
+
+```python
+from attune.ops import build_config
+
+config = build_config()
+print(config.host, config.port)
+# 127.0.0.1 8765
+```
+
+`build_config()` resolves your `project_root` and `attune_home` automatically. Override the defaults with keyword arguments — for example, `port=9000` or `allow_run=True` to enable workflow execution.
+
+## Step 2: Launch the server
+
+```bash
+attune ops
+```
+
+Or from Python:
+
+```python
+from attune.ops import create_app
+
+app = create_app()   # returns the FastAPI application object
+```
+
+The server blocks until you stop it. You should see output like:
+
+```
+INFO:     Uvicorn running on http://127.0.0.1:8765 (Press CTRL+C to quit)
+```
+
+## Step 3: Open the dashboard
+
+Navigate to `http://127.0.0.1:8765` in your browser. The home page shows today's event count, today's cost, seven-day cost, and a daily cost sparkline drawn from your telemetry data.
+
+To confirm the dashboard is reading your project's features, check that the scope picker lists entries from `.help/features.yaml` in your project root.
+
+## Next:
+
+Read the `ops-dashboard` concept page to understand how telemetry summaries, run retention, and trusted-host middleware fit together — say **"what is the ops dashboard?"** to open it.

--- a/.help/templates/ops-dashboard/tip.md
+++ b/.help/templates/ops-dashboard/tip.md
@@ -1,0 +1,23 @@
+---
+type: tip
+name: ops-dashboard-tip
+feature: ops-dashboard
+depth: tip
+generated_at: 2026-05-14T14:43:23.573744+00:00
+source_hash: 395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42
+status: generated
+---
+
+# Tip: Working effectively with ops-dashboard
+
+Set `allow_run: bool = False` explicitly in your `Config` when you start the dashboard — don't rely on the default.
+
+**Why:** The `allow_run` field gates whether the dashboard can trigger workflow runs. Leaving it at its default (`False`) in production prevents the dashboard from executing workflows unintentionally, but forgetting to set it to `True` in a development environment will silently block all run attempts with no obvious error.
+
+**Tradeoff:** Hardcoding `allow_run=True` in a shared config makes your development setup convenient but increases the risk of accidentally running workflows against production data if that config leaks. Pass it as a `build_config()` argument instead of baking it into a committed file.
+
+## Source files
+
+- `src/attune/ops/**`
+
+**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/.help/templates/ops-dashboard/troubleshooting.md
+++ b/.help/templates/ops-dashboard/troubleshooting.md
@@ -1,0 +1,140 @@
+---
+type: troubleshooting
+name: ops-dashboard-troubleshooting
+feature: ops-dashboard
+depth: troubleshooting
+generated_at: 2026-05-14T14:43:23.566706+00:00
+source_hash: 395f221f9a789d9b8851995c90a8bcc4904e7c84a247bacee7036e1583b0ea42
+status: generated
+---
+
+# Troubleshoot ops dashboard
+
+The ops dashboard is a local server (`attune ops`) that serves a workflow runner with a per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming. Use this page when the dashboard fails to start, returns unexpected results, or behaves inconsistently.
+
+## Symptom table
+
+| If you observe | Check |
+|----------------|-------|
+| Dashboard won't start | Confirm the port is free: `lsof -i :8765`. Check that `project_root` and `attune_home` resolve to existing paths. |
+| `403` or connection refused from a remote host | Verify the client's `Host` header is listed in `trusted_hosts`. `TrustedHostMiddleware` rejects any host not on the allowlist. |
+| KPI numbers on the home page are missing or zero | Check that `Config.telemetry_path` exists and contains valid event records. Confirm `last_event_at` is not `None` in `TelemetrySummary`. |
+| Workflow list is empty or features don't appear | Confirm `.help/features.yaml` exists under `project_root`. Run `list_features(<project_root>)` directly in a Python shell to see what it returns. |
+| Run history is missing | Check that `Config.runs_dir` exists on disk. The directory is not created until the first write. Confirm `runs_retention_days` (default `30`) hasn't pruned entries you expect to see. |
+| SSE log stream stops or never starts | Check that `allow_run` is `True` in your config — the dashboard disables run execution when this flag is `False`. |
+| Server binds to the wrong address | `host` defaults to `127.0.0.1`. If you need LAN access, pass `--host 0.0.0.0` and add the client hostname to `trusted_hosts`. |
+| Intermittent failures after env changes | Check `ATTUNE_OPS_SWEEP_RESULTS` (`ENABLE_ENV`) and `ATTUNE_HOME`. Both are read at startup; stale values from a previous shell session can override your config. |
+
+## Diagnosis steps
+
+Work through these in order — earlier steps are faster and don't require code changes.
+
+### 1. Reproduce with the minimal command
+
+Run the dashboard directly to confirm the failure isn't caused by a wrapper or launcher:
+
+```bash
+python -m attune.ops
+```
+
+Or via the CLI:
+
+```bash
+attune ops
+```
+
+If the failure disappears, the problem is in how the surrounding context calls `cmd_ops()` or constructs its `argparse.Namespace`.
+
+### 2. Inspect the resolved config
+
+`build_config()` assembles every runtime path and flag. Print the config before the server starts to confirm all fields are what you expect:
+
+```python
+from attune.ops import build_config
+cfg = build_config()
+print(cfg)
+```
+
+Pay attention to `project_root`, `attune_home`, `host`, `port`, `allow_run`, `trusted_hosts`, and `runs_retention_days`. A wrong path here explains most startup and data-missing symptoms.
+
+### 3. Check that key directories exist
+
+The dashboard reads from several directories that may not exist until first use:
+
+```bash
+# Substitute your actual attune_home and project_root values
+ls ~/.attune/runs/
+ls ~/.attune/memory/
+ls ~/.attune/sessions/
+ls <project_root>/.help/features.yaml
+```
+
+`Config.runs_dir` and related paths are not created until the first write. Create them manually if needed:
+
+```bash
+mkdir -p ~/.attune/runs ~/.attune/memory ~/.attune/sessions
+```
+
+### 4. Enable debug logging
+
+Re-run with Python logging set to `DEBUG` to surface config resolution, middleware decisions, and telemetry reads:
+
+```bash
+PYTHONASYNCIODEBUG=1 python -m attune.ops
+```
+
+Or add this before calling `create_app()` in your own code:
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+### 5. Run the related tests
+
+```bash
+pytest -k "ops" -v
+```
+
+If a test covers the failing path, its fixtures show you the minimal valid inputs. A newly failing test after a dependency upgrade points to an external change rather than a code bug.
+
+## Common fixes
+
+**Port already in use**
+Change the port with `--port`:
+```bash
+attune ops --port 8766
+```
+Or free the existing process: `kill $(lsof -ti :8765)`.
+
+**Host rejected by `TrustedHostMiddleware`**
+Add the client's hostname or IP to `trusted_hosts` when calling `build_config()`, or pass it on the CLI if your launcher supports it. The middleware compares the `Host` request header exactly — `localhost` and `127.0.0.1` are treated as distinct values.
+
+**Features not loading from `.help/features.yaml`**
+Confirm the file exists and is valid YAML. Call `list_features()` to test parsing independently:
+```python
+from attune.ops.accessors import list_features
+print(list_features("/path/to/project"))
+```
+
+**Runs pruned unexpectedly**
+`runs_retention_days` defaults to `30`. If you need longer history, pass a higher value to `build_config()`:
+```python
+cfg = build_config(runs_retention_days=90)
+```
+
+**Sweep results not appearing**
+The `ATTUNE_OPS_SWEEP_RESULTS` environment variable (`ENABLE_ENV`) must be set for sweep result data to be read. Results are stored under `ops/sweep-results/` within `attune_home`.
+
+**Dependency version drift**
+If the dashboard worked previously without a code change, check whether a recent `pip install` changed FastAPI or a related package:
+```bash
+pip show fastapi starlette
+```
+Pin versions in your lockfile if the upgrade introduced a regression.
+
+## Source files
+
+- `src/attune/ops/**`
+
+**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/.help/templates/ops-dashboard/warning.md
+++ b/.help/templates/ops-dashboard/warning.md
@@ -1,0 +1,69 @@
+---
+type: warning
+name: ops-dashboard-warning
+feature: ops-dashboard
+depth: warning
+generated_at: 2026-05-14T14:43:23.564490+00:00
+source_hash: 395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42
+status: generated
+---
+
+# Ops Dashboard Warnings
+
+## What to watch for
+
+The `attune ops` dashboard is a blocking server process with lazy-loaded dependencies, host-allowlist enforcement, and persisted run history. The risks below apply whether you are running the dashboard directly, embedding it in another process, or writing code that imports from `attune.ops`.
+
+## Risk areas
+
+### `allow_run` defaults to `False` — workflows will not execute without it
+
+`build_config()` sets `allow_run=False` by default. If you start the dashboard without explicitly passing `allow_run=True`, the workflow runner is disabled and no runs are recorded. This is intentional as a safety default, but it is easy to miss when standing up a new environment and wondering why runs never appear in history.
+
+**Mitigation:** Pass `allow_run=True` explicitly when you intend to execute workflows, and verify the `Config` object your app receives before assuming the runner is active.
+
+---
+
+### `trusted_hosts` left empty opens the dashboard to host-header spoofing
+
+`TrustedHostMiddleware` rejects requests whose `Host` header is not on the allowlist. If you pass an empty `trusted_hosts` tuple to `build_config()`, the middleware has nothing to enforce and all `Host` values are accepted. In a network-accessible deployment this allows host-header injection attacks.
+
+**Mitigation:** Always populate `trusted_hosts` with the exact hostnames (and port, if non-standard) the dashboard should answer to. The default bind address is `127.0.0.1:8765`; if you change `host` or `port`, update `trusted_hosts` to match.
+
+---
+
+### Lazy imports in `create_app()` and `build_config()` defer errors until call time
+
+Both functions use lazy imports so that `import attune` does not pull in FastAPI or the config builder at module load. This means import errors and missing dependencies surface only when you first call the function, not when the module is imported — which can make failures appear in unexpected places during startup.
+
+**Mitigation:** Call `create_app()` and `build_config()` early in your startup path (not on first request) so any import failures surface immediately and with a clear traceback.
+
+---
+
+### `runs_dir` does not exist until the first write
+
+`Config.runs_dir` is a property that returns the disk path for persisted ops runs, but the directory is not created until the first run is written. Code that stats or lists `runs_dir` before any run has completed will encounter a missing directory.
+
+**Mitigation:** Check for existence with `runs_dir.exists()` before reading from it, or create the directory explicitly during initialization if your code depends on it being present.
+
+---
+
+### `runs_retention_days` silently drops old run history
+
+`build_config()` defaults `runs_retention_days` to `30`. Runs older than this threshold are eligible for deletion. If you lower this value in a long-running deployment, previously visible history disappears without an explicit deletion event.
+
+**Mitigation:** Treat `runs_retention_days` as a deployment-level decision and document its value alongside your other ops configuration. Avoid changing it in production without first archiving runs you want to keep.
+
+---
+
+### Private helpers and module constants can change without notice
+
+`_PHASE_FILES`, `_VALID_STATUSES`, and other underscore-prefixed names are implementation details. They are not part of the public API (see `__all__`: `create_app`, `build_config`, `Config`) and may change between releases.
+
+**Mitigation:** Depend only on the names listed in `__all__`. If you need access to phase-file names or valid status values in your own code, define them locally rather than importing the private constants.
+
+## Source files
+
+- `src/attune/ops/**`
+
+**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/docs/architecture/ops-dashboard.md
+++ b/docs/architecture/ops-dashboard.md
@@ -57,11 +57,11 @@ TrustedHostMiddleware  ──── rejects unlisted Host headers
    │    list_features() ──> Feature[]           │
    │    first_feature() ──> Feature | None      │
    │                                            │
-   │  POST /run                                 │
+   │  POST /workflows/{name}/run                │
    │    RunnerService.start()                   │
    │      ├── RunnerBusyError (409 if busy)     │
    │      └── Run (new execution)               │
-   │            └── SSE stream  (/run/{id}/log) │
+   │            └── SSE  /runs/{run_id}/stream  │
    │                                            │
    │  GET /specs                                │
    │    SpecRecord[]                            │
@@ -102,4 +102,8 @@ Workflow execution is disabled by default (`allow_run = False`). This is an expl
 - **Extend the scope picker:** add entries to `.help/features.yaml` in the project root. `list_features()` and `first_feature()` parse this file; no code changes are needed for new features.
 - **Add a new run backend:** replace or subclass `RunnerService`. The concurrency contract is: raise `RunnerBusyError` if a run is already active, return a `Run` instance otherwise. SSE consumers depend on `Run`'s broadcast interface.
 
-For usage and configuration details, see the `attune ops` reference documentation.
+## See also
+
+- [How-to: use the ops dashboard](../how-to/ops-dashboard.md) — task-focused recipes for the dashboard's core API
+- [Tutorial: ops-dashboard walkthrough](../tutorials/ops-dashboard.md) — end-to-end first run
+- [Reference: ops-dashboard CLI](../reference/ops-dashboard.md) — every command-line flag, environment variable, and exit code

--- a/docs/architecture/ops-dashboard.md
+++ b/docs/architecture/ops-dashboard.md
@@ -1,0 +1,105 @@
+# Ops Dashboard architecture
+
+Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
+
+## Purpose
+
+`attune ops` serves as the workflow OS's local web dashboard. It is responsible for: presenting home-page KPIs and cost sparklines, letting users pick a feature scope and trigger workflow runs, streaming live run output over SSE, persisting run history to disk, and enforcing trusted-host access control.
+
+It is **not** responsible for defining workflows themselves, managing the attune agent, or writing telemetry data — those concerns live outside this module. `attune ops` reads telemetry and run state; it does not produce them.
+
+## Key classes
+
+| Class | Responsibility | File |
+|-------|----------------|------|
+| `Config` | Holds all resolved paths and server settings (host, port, retention policy, trusted hosts) that the dashboard reads at startup. | `src/attune/ops/config.py` |
+| `TrustedHostMiddleware` | Rejects any request whose `Host` header is not on the configured allowlist before it reaches a route handler. | `src/attune/ops/middleware.py` |
+| `RunnerService` | Owns the run history list and the concurrency lock; enforces the one-active-run-at-a-time constraint. | `src/attune/ops/runner.py` |
+| `Run` | Represents a single workflow execution and its associated SSE broadcast state; created and managed by `RunnerService`. | `src/attune/ops/runner.py` |
+| `RunnerBusyError` | Signals that a new run was requested while one is already pending or running; raised by `RunnerService`. | `src/attune/ops/runner.py` |
+| `HomeKpis` | Aggregates today's event count, rolling 7-day cost and savings, and the sparkline data shown above the fold on the home page. | `src/attune/ops/data.py` |
+| `DailyCost` | Carries one day's event count and cost; the list of these forms the sparkline fed into `HomeKpis`. | `src/attune/ops/data.py` |
+| `TelemetrySummary` | Read-only snapshot of aggregate telemetry: total requests, cost, savings, and breakdowns by workflow and by day. | `src/attune/ops/data.py` |
+| `WorkflowEntry` | Describes one workflow available for dispatch: name, description, stage count, and CLI tier mapping. | `src/attune/ops/data.py` |
+| `PathArgSpec` | Describes how a workflow accepts a scope path on the CLI (`kwarg` name and whether it is required). | `src/attune/ops/data.py` |
+| `Feature` | Represents one entry from `.help/features.yaml`; drives the scope picker that lets users target a specific feature path. | `src/attune/ops/data.py` |
+| `FamilyVersion` | Records one package's resolved version and source; used by the dashboard to surface dependency info. | `src/attune/ops/data.py` |
+| `SpecPhase` | Snapshot of one phase file's existence and status string within a spec directory. | `src/attune/ops/routes/specs.py` |
+| `SpecRecord` | Aggregates a spec directory's path and the `SpecPhase` snapshot for each of the four phase files (`decisions.md`, `requirements.md`, `design.md`, `tasks.md`). | `src/attune/ops/routes/specs.py` |
+
+> **Note:** `Run` and `RunnerService` together do three things — execution lifecycle, SSE broadcast state, and history retention — which may be worth splitting if the runner grows more complex.
+
+## Data flow
+
+```
+CLI / browser request
+        |
+        v
+TrustedHostMiddleware  ──── rejects unlisted Host headers
+        |
+        v
+   FastAPI app  (create_app())
+   ┌────────────────────────────────────────────┐
+   │                                            │
+   │  GET /                                     │
+   │    TelemetrySummary ──> home_kpis()        │
+   │                             └──> HomeKpis  │
+   │                                   (KPI     │
+   │                                    panel + │
+   │                                    sparkline│
+   │                                    of      │
+   │                                    DailyCost)
+   │                                            │
+   │  GET /workflows                            │
+   │    WorkflowEntry[]  (scope: PathArgSpec)   │
+   │                                            │
+   │  GET /features                             │
+   │    list_features() ──> Feature[]           │
+   │    first_feature() ──> Feature | None      │
+   │                                            │
+   │  POST /run                                 │
+   │    RunnerService.start()                   │
+   │      ├── RunnerBusyError (409 if busy)     │
+   │      └── Run (new execution)               │
+   │            └── SSE stream  (/run/{id}/log) │
+   │                                            │
+   │  GET /specs                                │
+   │    SpecRecord[]                            │
+   │      └── SpecPhase × 4 per spec           │
+   └────────────────────────────────────────────┘
+        |
+        v
+  Config  (read at startup: paths, host, port,
+           trusted_hosts, runs_retention_days)
+  ├── telemetry_path  →  TelemetrySummary source
+  ├── runs_dir        →  persisted Run history
+  ├── memory_dir      →  agent memory (read-only)
+  └── sessions_dir    →  session records (read-only)
+```
+
+## Design decisions
+
+**Lazy FastAPI import via `create_app()`**
+`create_app()` and `build_config()` are thin wrappers that import FastAPI only when the dashboard is actually started. This keeps `import attune` fast for all other subcommands that don't need a web server.
+
+**One active run at a time**
+`RunnerService` holds a concurrency lock and raises `RunnerBusyError` when a second run is attempted. The alternative — queuing runs — was not chosen because the dashboard is a local single-user tool; silent queueing would obscure whether a previous run was still in progress.
+
+**`Config` as a resolved-paths dataclass, not a live reader**
+`build_config()` resolves all paths and environment variables once at startup and freezes them into a `Config` dataclass. Routes read `Config` fields directly rather than re-reading the environment on each request, so there is no ambiguity about which config values are active.
+
+**`allow_run` flag**
+Workflow execution is disabled by default (`allow_run = False`). This is an explicit opt-in so that dashboard deployments used purely for observability cannot accidentally trigger runs.
+
+**Trusted-host enforcement at middleware layer**
+`TrustedHostMiddleware` runs before any route handler, so the allowlist check cannot be bypassed by a misconfigured route. The `trusted_hosts` tuple in `Config` is the single source of truth for this list.
+
+## Extension points
+
+- **Add a new route:** register it on the FastAPI app returned by `create_app()`. Place data-shape dataclasses in `src/attune/ops/data.py` and route logic under `src/attune/ops/routes/`.
+- **Change server settings** (host, port, retention, trusted hosts): pass arguments to `build_config()` or set the corresponding environment variables — `build_config()` merges both sources.
+- **Support additional spec phase files:** add filenames to the `_PHASE_FILES` tuple in `src/attune/ops/routes/specs.py`. Valid status strings are governed by `_VALID_STATUSES` in the same file.
+- **Extend the scope picker:** add entries to `.help/features.yaml` in the project root. `list_features()` and `first_feature()` parse this file; no code changes are needed for new features.
+- **Add a new run backend:** replace or subclass `RunnerService`. The concurrency contract is: raise `RunnerBusyError` if a run is already active, return a `Run` instance otherwise. SSE consumers depend on `Run`'s broadcast interface.
+
+For usage and configuration details, see the `attune ops` reference documentation.

--- a/docs/how-to/ops-dashboard.md
+++ b/docs/how-to/ops-dashboard.md
@@ -23,7 +23,7 @@ Or launch it directly as a Python module:
 python -m attune.ops
 ```
 
-The dashboard starts a blocking server at `http://127.0.0.1:8765`. Open that URL to see the home page with today's KPIs, a cost sparkline, and the workflow catalog.
+The dashboard starts a blocking server at `http://127.0.0.1:8765`. Open that URL to see the home page with today's KPIs, a cost sparkline, and the workflow catalog. Press `Ctrl+C` in the terminal to stop the server.
 
 ## Core API
 
@@ -81,7 +81,7 @@ The `ATTUNE_OPS_SWEEP_RESULTS` environment variable must be set to a non-empty v
 
 ### Building a config and launching the app programmatically
 
-When you want to embed the dashboard inside a larger process rather than use the CLI, build a `Config` explicitly and pass it to `create_app()`:
+When you want to embed the dashboard inside a larger process rather than use the CLI, build a `Config` explicitly and pass it to `create_app()`. Keep the bind on `127.0.0.1` so the dashboard isn't reachable from outside the local machine:
 
 ```python
 from pathlib import Path
@@ -89,10 +89,9 @@ from attune.ops import build_config, create_app
 
 config = build_config(
     project_root=Path("/path/to/your/project"),
-    host="0.0.0.0",
+    host="127.0.0.1",
     port=9000,
     allow_run=True,
-    trusted_hosts=("myhost.internal",),
 )
 
 app = create_app(config)
@@ -101,6 +100,8 @@ app = create_app(config)
 import uvicorn
 uvicorn.run(app, host=config.host, port=config.port)
 ```
+
+If you genuinely need to reach the dashboard from another machine, prefer an SSH tunnel (`ssh -L 8765:127.0.0.1:8765 user@host`) or a reverse proxy that handles auth — do not bind the server to `0.0.0.0` directly. The dashboard has no built-in authentication.
 
 ### Reading telemetry and KPIs without starting the server
 
@@ -121,8 +122,8 @@ print(f"7-day savings: ${kpis.seven_day_savings:.4f}")
 
 ## See also
 
-- Concept: Template design patterns — understand how `.help/features.yaml` entries that `list_features()` reads are structured
-- Reference: attune ops CLI — complete flag listing for `attune ops`
-- How-to: Persisting sweep results — configure `ATTUNE_OPS_SWEEP_RESULTS` and use `watch_and_persist()`
+- [Tutorial: ops-dashboard walkthrough](../tutorials/ops-dashboard.md) — end-to-end first run, including the workflow runner and scope picker
+- [Reference: ops-dashboard API](../reference/ops-dashboard.md) — full symbol-by-symbol API listing
+- [Architecture: ops-dashboard](../architecture/ops-dashboard.md) — how the configuration, FastAPI app, and persistence layers fit together
 
 <!-- attune-generated: source_hash=395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42 feature=ops-dashboard kind=how-to generated_at=2026-05-14 -->

--- a/docs/how-to/ops-dashboard.md
+++ b/docs/how-to/ops-dashboard.md
@@ -1,0 +1,128 @@
+---
+type: how-to
+name: ops-dashboard
+tags: [ops, dashboard, runner, workflows, scope-picker, persistence, sse]
+source: ops-dashboard
+---
+
+# How to use the ops dashboard
+
+Use this guide when you want to launch the attune operations dashboard, configure its server settings, and work with its core APIs to surface workflow runs, telemetry, and spec status in your project.
+
+## Quick start
+
+Start the dashboard from the command line against your project root:
+
+```bash
+attune ops --project-root /path/to/your/project --port 8765
+```
+
+Or launch it directly as a Python module:
+
+```bash
+python -m attune.ops
+```
+
+The dashboard starts a blocking server at `http://127.0.0.1:8765`. Open that URL to see the home page with today's KPIs, a cost sparkline, and the workflow catalog.
+
+## Core API
+
+| Function or class | Purpose |
+|---|---|
+| `build_config(project_root, *, host, port, allow_run, ...)` | Build a `Config` from explicit inputs and environment defaults. |
+| `create_app()` | Build the FastAPI app, wiring `Config` and templates into request state. |
+| `cmd_ops(args)` | Run the dashboard server (blocking); returns `0` on clean exit. |
+| `main()` | Standalone entry point for `python -m attune.ops`. |
+| `attune_home()` | Resolve the user's attune home directory (`ATTUNE_HOME` env override → `~/.attune`). |
+| `list_features(project_root)` | Return features parsed from `<project_root>/.help/features.yaml`. |
+| `first_feature(project_root)` | Return the alphabetically first feature that has a renderable scope. |
+| `home_kpis(summary, *, today)` | Derive home-page KPI numbers from a `TelemetrySummary`. |
+| `list_workflows()` | Return the registered workflow catalog; empty list if the registry is unavailable. |
+| `env_health()` | Lightweight environment snapshot for the Health page. |
+| `family_versions()` | Resolve installed versions for every related attune package. |
+| `list_runs(workflow)` | Return up to 20 newest runs for a workflow, newest first. |
+| `prune_old_runs(days)` | Delete persisted run files older than `days`; returns the deletion count. |
+| `list_specs()` | Federated listing of specs across all configured spec roots. |
+| `update_phase_status()` | Rewrite the `**Status**` line in a named phase file. |
+| `read_telemetry_summary()` | Aggregate `usage.jsonl` into a UI-friendly `TelemetrySummary`. |
+| `compute_allowlist()` | Compute the merged default + user-supplied `Host` header allowlist. |
+| `is_persistence_enabled()` | Returns `True` when `ATTUNE_OPS_SWEEP_RESULTS` is set to a non-empty value. |
+| `persist_result()` | Atomically write a `SweepResult` to `<attune_home>/ops/sweep-results/<hash>.json`. |
+| `watch_and_persist()` | Subscribe to a discovery-sweep run and persist its result on success. |
+
+### Key dataclasses
+
+| Class | Purpose |
+|---|---|
+| `Config` | Holds all runtime configuration for the dashboard (paths, host, port, retention, etc.). |
+| `HomeKpis` | Summary numbers shown above the fold on the home page. |
+| `TelemetrySummary` | Aggregated request counts, costs, and savings by workflow and day. |
+| `WorkflowEntry` | One entry in the workflow catalog (name, description, stage count, tier map). |
+| `Feature` | One feature from `.help/features.yaml`, used by the scope picker. |
+| `SpecPhase` | Status snapshot for one phase file within a spec. |
+
+## Configuration
+
+`build_config()` accepts these parameters, all of which fall back to sensible defaults:
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `project_root` | current directory | Root of the project being inspected. |
+| `host` | `127.0.0.1` | Interface the server binds to. |
+| `port` | `8765` | Port the server listens on. |
+| `allow_run` | `False` | Enable the workflow run-trigger endpoint. |
+| `specs_roots` | `()` | Additional directories to include in the federated spec listing. |
+| `trusted_hosts` | `()` | Extra hostnames added to the `Host` header allowlist. |
+| `runs_retention_days` | `30` | How many days to keep persisted run files before `prune_old_runs()` removes them. |
+
+The `ATTUNE_OPS_SWEEP_RESULTS` environment variable must be set to a non-empty value to enable sweep-result persistence (`is_persistence_enabled()`).
+
+## Integration patterns
+
+### Building a config and launching the app programmatically
+
+When you want to embed the dashboard inside a larger process rather than use the CLI, build a `Config` explicitly and pass it to `create_app()`:
+
+```python
+from pathlib import Path
+from attune.ops import build_config, create_app
+
+config = build_config(
+    project_root=Path("/path/to/your/project"),
+    host="0.0.0.0",
+    port=9000,
+    allow_run=True,
+    trusted_hosts=("myhost.internal",),
+)
+
+app = create_app(config)
+
+# Hand `app` to any ASGI server, e.g. uvicorn:
+import uvicorn
+uvicorn.run(app, host=config.host, port=config.port)
+```
+
+### Reading telemetry and KPIs without starting the server
+
+If you only need the dashboard's data layer — for example, to pipe numbers into a CI report — you can call the reader functions directly without launching the HTTP server:
+
+```python
+from pathlib import Path
+from attune.ops import build_config, read_telemetry_summary, home_kpis
+
+config = build_config(project_root=Path("/path/to/your/project"))
+
+summary = read_telemetry_summary(config.telemetry_path)
+kpis = home_kpis(summary)
+
+print(f"Today: {kpis.today_events} events, ${kpis.today_cost:.4f}")
+print(f"7-day savings: ${kpis.seven_day_savings:.4f}")
+```
+
+## See also
+
+- Concept: Template design patterns — understand how `.help/features.yaml` entries that `list_features()` reads are structured
+- Reference: attune ops CLI — complete flag listing for `attune ops`
+- How-to: Persisting sweep results — configure `ATTUNE_OPS_SWEEP_RESULTS` and use `watch_and_persist()`
+
+<!-- attune-generated: source_hash=395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42 feature=ops-dashboard kind=how-to generated_at=2026-05-14 -->

--- a/docs/reference/ops-dashboard.md
+++ b/docs/reference/ops-dashboard.md
@@ -1,0 +1,72 @@
+# Ops Dashboard CLI reference
+
+Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
+
+## Description
+
+`attune ops` starts a blocking local web server that serves the operations dashboard UI. It reads project and attune state from a `Config` object built from your project root, host, port, and environment defaults. The dashboard exposes workflow execution, telemetry summaries, spec browsing, and run history over HTTP. You can also invoke it directly as `python -m attune.ops`.
+
+## Usage
+
+```
+attune ops [--host HOST] [--port PORT] [--allow-run] [--specs-root PATH]
+           [--trusted-host HOST] [--runs-retention-days DAYS]
+```
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--host HOST` | `127.0.0.1` | Interface address the dashboard server binds to |
+| `--port PORT` | `8765` | TCP port the dashboard server listens on |
+| `--allow-run` | `False` | Permit the dashboard to trigger workflow runs |
+| `--specs-root PATH` | — | Add a root directory to the federated spec listing; repeatable |
+| `--trusted-host HOST` | — | Add a host to the `Host`-header allowlist; repeatable |
+| `--runs-retention-days DAYS` | `30` | Delete persisted run files older than this many days |
+
+## Output
+
+`attune ops` is a blocking server process. On successful startup it prints the listening address and then runs until interrupted:
+
+```
+INFO:     Started server process [38201]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8765 (Press CTRL+C to quit)
+```
+
+The dashboard UI is then available in your browser at the printed URL. API responses from the server are JSON; for example, the home-page KPIs endpoint returns:
+
+```json
+{
+  "today_events": 14,
+  "today_cost": 0.032,
+  "seven_day_cost": 0.187,
+  "seven_day_savings": 0.054,
+  "sparkline": [
+    {"day": "2026-05-08", "events": 3, "cost": 0.021},
+    {"day": "2026-05-09", "events": 11, "cost": 0.166}
+  ]
+}
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Server shut down cleanly (process interrupted or stopped normally) |
+| `1` | Startup failed — for example, the port is already in use or a required path is invalid |
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `ATTUNE_HOME` | Overrides the default attune home directory (`~/.attune`) |
+| `ATTUNE_OPS_SWEEP_RESULTS` | When set to a non-empty value, enables persistence of discovery-sweep results under `<attune_home>/ops/sweep-results/` |
+
+## Related commands
+
+- `attune help-docs` — browse the full template library, including `--tag`-filtered searches across all 498 templates
+- `python -m attune.ops` — standalone entry point; equivalent to `attune ops` without the main CLI parser
+
+<!-- attune-generated: source_hash=395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42 feature=ops-dashboard kind=cli-reference generated_at=2026-05-14 -->

--- a/docs/reference/ops-dashboard.md
+++ b/docs/reference/ops-dashboard.md
@@ -9,8 +9,9 @@ Local operations dashboard — workflow runner with per-feature scope picker, pe
 ## Usage
 
 ```
-attune ops [--host HOST] [--port PORT] [--allow-run] [--specs-root PATH]
-           [--trusted-host HOST] [--runs-retention-days DAYS]
+attune ops [--host HOST] [--port PORT] [--project-root PATH] [--no-browser]
+           [--read-only] [--specs-root PATH] [--trusted-host HOST]
+           [--runs-retention-days DAYS]
 ```
 
 ## Options
@@ -19,10 +20,12 @@ attune ops [--host HOST] [--port PORT] [--allow-run] [--specs-root PATH]
 |--------|---------|-------------|
 | `--host HOST` | `127.0.0.1` | Interface address the dashboard server binds to |
 | `--port PORT` | `8765` | TCP port the dashboard server listens on |
-| `--allow-run` | `False` | Permit the dashboard to trigger workflow runs |
+| `--project-root PATH` | cwd | Project directory to inspect |
+| `--no-browser` | (off) | Don't auto-open a browser tab on startup |
+| `--read-only` | (off) | Disable workflow execution from the dashboard. Runs are enabled by default; pass this flag to make the dashboard purely observational. |
 | `--specs-root PATH` | — | Add a root directory to the federated spec listing; repeatable |
-| `--trusted-host HOST` | — | Add a host to the `Host`-header allowlist; repeatable |
-| `--runs-retention-days DAYS` | `30` | Delete persisted run files older than this many days |
+| `--trusted-host HOST` | — | Add a hostname (optionally `host:port`) to the `Host`-header allowlist; repeatable. Use when reaching the dashboard via a tunnel or reverse proxy. |
+| `--runs-retention-days DAYS` | `30` | Delete persisted run files older than this many days at startup. Set to `0` to disable pruning. |
 
 ## Output
 
@@ -66,7 +69,13 @@ The dashboard UI is then available in your browser at the printed URL. API respo
 
 ## Related commands
 
-- `attune help-docs` — browse the full template library, including `--tag`-filtered searches across all 498 templates
+- `attune help-docs` — browse the help template library with optional `--tag` filters
 - `python -m attune.ops` — standalone entry point; equivalent to `attune ops` without the main CLI parser
+
+## See also
+
+- [How-to: use the ops dashboard](../how-to/ops-dashboard.md) — quick start, programmatic API, and integration patterns
+- [Tutorial: ops-dashboard walkthrough](../tutorials/ops-dashboard.md) — end-to-end first run with the workflow runner and scope picker
+- [Architecture: ops-dashboard](../architecture/ops-dashboard.md) — design decisions and the data-flow diagram
 
 <!-- attune-generated: source_hash=395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42 feature=ops-dashboard kind=cli-reference generated_at=2026-05-14 -->

--- a/docs/tutorials/ops-dashboard.md
+++ b/docs/tutorials/ops-dashboard.md
@@ -1,0 +1,187 @@
+---
+type: tutorial
+name: ops-dashboard
+tags: [ops, dashboard, runner, workflows, scope-picker, persistence, sse]
+source: developer-guidance
+---
+
+# Tutorial: Ops Dashboard
+
+You are going to build a running local ops dashboard — a FastAPI-backed server that exposes a workflow runner with a per-feature scope picker, persisted run history, and live SSE log streaming. When you finish, you will have a process you can open in a browser and use to trigger attune workflows against a real project directory.
+
+## Prerequisites
+
+- Python 3.10 or newer
+- `attune` installed in your environment (`pip install attune`)
+- A project directory on disk (any folder with at least one workflow configured)
+
+## What you will build
+
+A local server started from Python that:
+
+1. Reads your project and attune state through a `Config` object
+2. Serves the ops dashboard on `http://127.0.0.1:8765`
+3. Exposes KPI numbers and a cost sparkline on the home page
+4. Lists features and workflows scoped to your project directory
+
+You will write roughly fifteen lines of Python and end up with a browser tab showing live dashboard data.
+
+---
+
+## Step 1 — Import the public API
+
+The `attune.ops` module uses lazy imports so that loading `attune` in other contexts doesn't pull FastAPI into memory. Import only what the public API exposes:
+
+```python
+from attune.ops import create_app, build_config
+```
+
+**You should see:** no import errors. If you get `ModuleNotFoundError`, confirm that `attune` is installed in the active virtual environment.
+
+---
+
+## Step 2 — Build a `Config` for your project
+
+`Config` is the single source of truth for where the dashboard reads project state and attune data. You build one with `build_config`, which resolves environment defaults for anything you leave unspecified:
+
+```python
+from pathlib import Path
+
+config = build_config(
+    project_root=Path("."),   # your project directory
+    host="127.0.0.1",
+    port=8765,
+)
+```
+
+`build_config` fills in `attune_home` automatically (checking the `ATTUNE_HOME` environment variable, then falling back to `~/.attune`), so you only need to supply values that differ from the defaults.
+
+**You should see:** a `Config` instance. Print it to confirm the paths resolved correctly:
+
+```python
+print(config.project_root)   # absolute path to your project
+print(config.attune_home)    # e.g. /home/you/.attune
+print(config.runs_dir)       # where run history will be persisted
+```
+
+---
+
+## Step 3 — Inspect what the dashboard will surface
+
+Before starting the server, confirm that the dashboard can find your project's features. This step teaches you the data model the home page is built from.
+
+`list_features` reads `.help/features.yaml` from your project root and returns a list of `Feature` objects — one per entry in that file:
+
+```python
+from attune.ops import build_config
+from attune.ops._readers import list_features, first_feature
+
+features = list_features(config.project_root)
+for f in features:
+    print(f.name, f.path, f.tags)
+
+lead = first_feature(config.project_root)
+print("Scope picker will default to:", lead)
+```
+
+Each `Feature` has a `name`, a `description`, an optional `path` (used as the scope argument), and a tuple of `tags`. The scope picker in the dashboard UI uses exactly this list.
+
+**You should see:** one line per feature defined in `.help/features.yaml`. If the file doesn't exist yet, both calls return an empty list / `None` — that's fine; the dashboard still starts.
+
+---
+
+## Step 4 — Create the FastAPI application
+
+`create_app` wraps the FastAPI factory. Calling it wires up all routes — the home page KPIs, the workflow runner endpoints, the SSE log stream, and the `TrustedHostMiddleware` that guards the server using `config.trusted_hosts`:
+
+```python
+app = create_app(config)
+```
+
+`create_app` is intentionally lazy: it imports FastAPI only at this call site, not at module import time. That is why it takes a `Config` rather than raw kwargs — all runtime decisions are already resolved before the factory runs.
+
+**You should see:** a FastAPI application object. Confirm with:
+
+```python
+print(type(app))   # <class 'fastapi.applications.FastAPI'>
+print([r.path for r in app.routes])  # list of registered URL paths
+```
+
+---
+
+## Step 5 — Start the server
+
+Use `uvicorn` to serve the app. The dashboard is a blocking process, so run this as the last statement in your script (or from the command line):
+
+```python
+import uvicorn
+
+uvicorn.run(app, host=config.host, port=config.port)
+```
+
+Alternatively, use the built-in CLI entrypoint, which does exactly the same thing:
+
+```bash
+attune ops
+```
+
+Or invoke the module directly:
+
+```bash
+python -m attune.ops
+```
+
+**You should see:** uvicorn startup lines followed by:
+
+```
+INFO:     Uvicorn running on http://127.0.0.1:8765 (Press CTRL+C to quit)
+```
+
+Open `http://127.0.0.1:8765` in a browser. The home page should display today's event count, today's cost, and a seven-day cost sparkline drawn from your telemetry data in `~/.attune`.
+
+---
+
+## Step 6 — Verify the KPI data model
+
+While the server is running, step back and look at how the home page numbers are derived. `home_kpis` takes a `TelemetrySummary` and produces a `HomeKpis` — this is what the dashboard's home-page endpoint calls internally:
+
+```python
+from datetime import date
+from attune.ops._readers import home_kpis
+from attune.ops._models import TelemetrySummary
+
+# Construct a minimal summary to see the shape of the output
+summary = TelemetrySummary(
+    total_requests=42,
+    total_cost=1.25,
+    total_savings=0.30,
+    by_workflow=[("my-workflow", 10, 0.50)],
+    by_day=[("2026-05-14", 10, 0.50)],
+    last_event_at="2026-05-14T12:00:00",
+)
+
+kpis = home_kpis(summary, today=date(2026, 5, 14))
+print(kpis.today_events)       # 10
+print(kpis.seven_day_cost)     # 0.50
+print(kpis.sparkline)          # list[DailyCost]
+```
+
+`HomeKpis.sparkline` is the list of `DailyCost` objects that the front end uses to draw the cost chart. Each `DailyCost` holds a `day` string, an `events` count, and a `cost` float.
+
+**You should see:** the printed values match what you put into `TelemetrySummary`. This confirms you understand the data flow from raw telemetry to the numbers above the fold.
+
+---
+
+## What you learned
+
+- **Step 2** — `build_config` is the single place where project paths, host/port, and attune home are resolved. You never pass raw strings to `create_app`.
+- **Step 3** — The scope picker is backed by `list_features`, which reads `.help/features.yaml`. If that file is empty or absent, the picker is empty — not broken.
+- **Step 4** — `create_app` is a lazy factory. FastAPI is imported only when you call it, keeping `attune` importable in environments that don't have FastAPI installed.
+- **Step 5** — The same server is reachable three ways: as a library (`uvicorn.run(app, ...)`), as a CLI subcommand (`attune ops`), or as a module (`python -m attune.ops`). All three paths converge on the same `Config` and `create_app`.
+- **Step 6** — `home_kpis` is a pure function. You can unit-test the KPI logic without starting a server by constructing a `TelemetrySummary` directly.
+
+## Next steps
+
+Read the `attune.ops` reference to see every `Config` field, the full `TelemetrySummary` schema, and the complete list of URL routes the dashboard registers — that's the right place to look when you need to customise retention, add trusted hosts, or integrate the dashboard into a larger application.
+
+<!-- attune-generated: source_hash=395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42 feature=ops-dashboard kind=tutorial generated_at=2026-05-14 -->

--- a/docs/tutorials/ops-dashboard.md
+++ b/docs/tutorials/ops-dashboard.md
@@ -73,8 +73,7 @@ Before starting the server, confirm that the dashboard can find your project's f
 `list_features` reads `.help/features.yaml` from your project root and returns a list of `Feature` objects — one per entry in that file:
 
 ```python
-from attune.ops import build_config
-from attune.ops._readers import list_features, first_feature
+from attune.ops.data import list_features, first_feature
 
 features = list_features(config.project_root)
 for f in features:
@@ -147,8 +146,7 @@ While the server is running, step back and look at how the home page numbers are
 
 ```python
 from datetime import date
-from attune.ops._readers import home_kpis
-from attune.ops._models import TelemetrySummary
+from attune.ops.data import home_kpis, TelemetrySummary
 
 # Construct a minimal summary to see the shape of the output
 summary = TelemetrySummary(
@@ -182,6 +180,8 @@ print(kpis.sparkline)          # list[DailyCost]
 
 ## Next steps
 
-Read the `attune.ops` reference to see every `Config` field, the full `TelemetrySummary` schema, and the complete list of URL routes the dashboard registers — that's the right place to look when you need to customise retention, add trusted hosts, or integrate the dashboard into a larger application.
+- [How-to: use the ops dashboard](../how-to/ops-dashboard.md) — task-focused recipes for the dashboard's core API
+- [Reference: ops-dashboard CLI](../reference/ops-dashboard.md) — every command-line flag, environment variable, and exit code
+- [Architecture: ops-dashboard](../architecture/ops-dashboard.md) — design decisions, key classes, and the data-flow diagram
 
 <!-- attune-generated: source_hash=395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42 feature=ops-dashboard kind=tutorial generated_at=2026-05-14 -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ exclude_docs: |
   archive/
   generated/
   architecture/
+  !architecture/ops-dashboard.md
   development-logs/
   development/
   specs/
@@ -183,6 +184,7 @@ nav:
       - tutorials/index.md
       - Build a Workflow: tutorials/build-a-workflow.md
       - Meta-Orchestration: tutorials/META_ORCHESTRATION_TUTORIAL.md
+      - Ops Dashboard: tutorials/ops-dashboard.md
       - Examples:
           - Code Review Assistant: tutorials/examples/simple-chatbot.md
           - Multi-Agent Teams: tutorials/examples/multi-agent-team-coordination.md
@@ -216,6 +218,8 @@ nav:
           - Learning and Patterns: how-to/learning-and-patterns.md
       - Observability:
           - Telemetry and Signals: how-to/telemetry-and-signals.md
+      - Operations:
+          - Ops Dashboard: how-to/ops-dashboard.md
       - Help System:
           - Maintenance: how-to/help-system-maintenance.md
       - Prerequisites: how-to/prerequisites.md
@@ -246,6 +250,7 @@ nav:
           - Multi-Agent: reference/multi-agent.md
           - Persistence: reference/persistence.md
           - LLM Toolkit: reference/llm-toolkit.md
+          - Ops Dashboard: reference/ops-dashboard.md
       - Wizards:
           - Getting Started: guides/wizards-getting-started.md
           - Architecture: guides/wizard-architecture.md
@@ -256,7 +261,9 @@ nav:
           - Glossary: reference/glossary.md
           - User Guide: reference/USER_GUIDE.md
           - Short-Term Memory: reference/SHORT_TERM_MEMORY.md
-      - Architecture: ARCHITECTURE.md
+      - Architecture:
+          - Overview: ARCHITECTURE.md
+          - Ops Dashboard: architecture/ops-dashboard.md
       - Features: FEATURES.md
 
   - Contributing:


### PR DESCRIPTION
## Summary

\`attune-author status\` flagged ops-dashboard as having an empty description column, indicating templates hadn't been generated through the standard \`--all-kinds\` pipeline. This PR runs that regen and wires the resulting project docs into the published site.

### Changes

- **\`.help/templates/ops-dashboard/\`** — adds the 8 missing template kinds (\`comparison\`, \`error\`, \`faq\`, \`note\`, \`quickstart\`, \`tip\`, \`troubleshooting\`, \`warning\`). Existing \`concept\`/\`task\`/\`reference\` from #347 are untouched.
- **\`docs/{how-to,tutorials,reference,architecture}/ops-dashboard.md\`** — four published-site pages generated by attune-author and grounded in \`src/attune/ops/\` source.
- **\`mkdocs.yml\`** — adds nav entries so the four docs/ pages are reachable from the site; consolidates \`Architecture: ARCHITECTURE.md\` into a \`Reference > Architecture > Overview\` subsection to host the new architecture page alongside it; adds a single-file negation in \`exclude_docs\` for \`architecture/ops-dashboard.md\` (the rest of \`architecture/\` stays excluded).

## Test plan

- [x] \`uv run mkdocs build --strict\` exits 0
- [x] 0 ERRORs, 0 WARNINGs
- [x] All four pages render: \`site/{how-to,tutorials,reference,architecture}/ops-dashboard/index.html\`
- [x] \`attune-author status\` now shows ops-dashboard as \"current\" with a proper description
- [x] pre-commit hooks pass

## Note

This is independent of #346 (pygments cap → pymdown-extensions floor bump). That one's still queued for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)