### PR TITLE
feat(ops): surface in-flight runs across navigation

### DIFF
--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -16,11 +16,22 @@ router = APIRouter()
 
 def _ctx(request: Request, page: str, **extra) -> dict:
     cfg = request.app.state.config
+    runner = getattr(request.app.state, "runner", None)
+    current_run = None
+    if runner is not None:
+        active = runner.current
+        if active is not None:
+            current_run = {
+                "id": active.id,
+                "workflow": active.workflow,
+                "status": active.status,
+            }
     return {
         "request": request,
         "page": page,
         "project_root": str(cfg.project_root),
         "attune_home": str(cfg.attune_home),
+        "current_run": current_run,
         **extra,
     }
 

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -140,6 +140,42 @@ a:hover {
   color: var(--accent);
 }
 
+.running-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  margin-right: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+  border: 1px solid #fcd34d;
+}
+.running-badge:hover {
+  background: #fde68a;
+  text-decoration: none;
+}
+.running-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #d97706;
+  animation: running-pulse 1.4s ease-in-out infinite;
+}
+.running-workflow {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: inherit;
+}
+@keyframes running-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
 .env {
   display: flex;
   align-items: center;

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -179,7 +179,8 @@
       wireScopeSave: wireScopeSave,
       SCOPE_STORAGE_KEY: SCOPE_STORAGE_KEY,
       WORKFLOW_NAMES: WORKFLOW_NAMES,
-      SECTION_HEADERS: SECTION_HEADERS
+      SECTION_HEADERS: SECTION_HEADERS,
+      appendBusyErrorLine: appendBusyErrorLine
     };
   }
 
@@ -201,6 +202,51 @@
       }
     }
     return rawText;
+  }
+
+  // Render a 409 "runner busy" error inline with a clickable link to the
+  // currently-running run's view page. Falls back to plain-text rendering
+  // when the payload can't be parsed or the run_id doesn't match our
+  // expected shape (defensive against injection: the href is only
+  // constructed from a value matching ``^[A-Za-z0-9_-]{1,64}$``, which
+  // mirrors the server-side validator at ``dashboard.py:run_view_page``).
+  function appendBusyErrorLine(row, rawText) {
+    var pre = row.querySelector("[data-log]");
+    if (!pre) return;
+    var msg = "another workflow is running";
+    var runId = "";
+    try {
+      var parsed = JSON.parse(rawText);
+      var detail = parsed && parsed.detail ? parsed.detail : {};
+      if (detail.message) msg = String(detail.message);
+      if (detail.current_run_id) runId = String(detail.current_run_id);
+    } catch (e) {
+      // Fall through — plain text rendering below.
+    }
+    // Strict run-id shape check before building the href. Mirrors the
+    // server-side regex; anything else degrades to a plain text run id
+    // without a clickable link.
+    var safeRunId = /^[A-Za-z0-9_-]{1,64}$/.test(runId) ? runId : "";
+    var leader = document.createElement("span");
+    leader.textContent = "[error] " + msg.charAt(0).toUpperCase() + msg.slice(1);
+    pre.appendChild(leader);
+    if (runId) {
+      pre.appendChild(document.createTextNode(" (run "));
+      if (safeRunId) {
+        var link = document.createElement("a");
+        link.href = "/runs/" + encodeURIComponent(safeRunId) + "/view";
+        link.className = "link";
+        var code = document.createElement("code");
+        code.textContent = safeRunId;
+        link.appendChild(code);
+        pre.appendChild(link);
+      } else {
+        pre.appendChild(document.createTextNode(runId));
+      }
+      pre.appendChild(document.createTextNode(")"));
+    }
+    pre.appendChild(document.createTextNode(". Wait for it to finish, then try again.\n"));
+    pre.scrollTop = pre.scrollHeight;
   }
 
   // Format an elapsed-seconds count as "Xs" or "Xm Ys" for readability.
@@ -477,7 +523,13 @@
           // away if the run never started, so the user can see why and
           // retry without losing context.
           showLogPane(row);
-          appendLine(row, "[error] " + formatErrorDetail(resp.status, detail));
+          if (resp.status === 409) {
+            // Render with a clickable link to the in-flight run so the
+            // user can jump back instead of starting a duplicate run.
+            appendBusyErrorLine(row, detail);
+          } else {
+            appendLine(row, "[error] " + formatErrorDetail(resp.status, detail));
+          }
           setStatus(row, "error");
           button.disabled = false;
           return;

--- a/src/attune/ops/templates/base.html
+++ b/src/attune/ops/templates/base.html
@@ -18,6 +18,13 @@
           <a href="{{ href }}" class="nav-link {% if request.url.path == href %}is-active{% endif %}">{{ label }}</a>
         {% endfor %}
       </nav>
+      {% if current_run %}
+        <a class="running-badge" href="/runs/{{ current_run.id }}/view" title="A workflow is running — click to view its output">
+          <span class="running-dot" aria-hidden="true"></span>
+          <span class="running-label">running</span>
+          <code class="running-workflow">{{ current_run.workflow }}</code>
+        </a>
+      {% endif %}
       <div class="env">
         <span class="env-label">project</span>
         <code class="env-value" title="{{ project_root }}">{{ project_root.split('/')[-1] }}</code>

--- a/src/attune/ops/templates/home.html
+++ b/src/attune/ops/templates/home.html
@@ -43,12 +43,13 @@
 <section class="panel">
   <h2>Recent runs</h2>
   {% if recent_runs %}
-    <table class="data-table">
-      <thead><tr><th>Workflow</th><th>Status</th><th class="num">Duration</th><th>Started</th><th class="num">Lines</th></tr></thead>
+    <table class="data-table recent-runs-table">
+      <thead><tr><th>Workflow</th><th>Run</th><th>Status</th><th class="num">Duration</th><th>Started</th><th class="num">Lines</th></tr></thead>
       <tbody>
         {% for r in recent_runs %}
           <tr>
-            <td><code>{{ r.workflow }}</code></td>
+            <td><a href="/runs/{{ r.id }}/view" class="link"><code>{{ r.workflow }}</code></a></td>
+            <td><a href="/runs/{{ r.id }}/view" class="link"><code>{{ r.id[:8] }}</code></a></td>
             <td><span class="chip chip-{{ r.status }}">{{ r.status }}</span></td>
             <td class="num">{% if r.duration_seconds is not none %}{{ '%.1fs'|format(r.duration_seconds) }}{% else %}—{% endif %}</td>
             <td><code class="started">{{ r.started_at[:19] if r.started_at else '—' }}</code></td>


### PR DESCRIPTION
## Summary

Three small fixes to close the "lost run / accidental rerun" gap on the dashboard that Patrick flagged during today's QA:

- **Home's Recent runs table**: each row is now a real link to `/runs/<id>/view`. A new **Run** column shows the short id alongside the workflow name, both clickable.
- **409 inline error on `/workflows`**: the running `run_id` is now a clickable `<a>` element pointing at the in-flight run instead of opaque text. Uses a strict regex check before constructing the href (mirrors the server-side validator at `dashboard.py:run_view_page`).
- **Top-nav "running" badge**: orange pulsing pill present on every page when `runner.current is not None`, linked to `/runs/<id>/view`. Implemented via a new `current_run` field in the shared template context.

Net effect: navigating away from a running workflow no longer hides it. The user has multiple visible affordances back to the in-flight run instead of having to remember the URL — which is how the "accidental rerun + duplicate API charge" failure mode happened.

## Test plan

- [x] Visually verified all three fixes on a live dashboard with a running `health-check` workflow (Home + Workflows + Specs + Telemetry + Health all show the badge; Home rows click through to `/runs/<id>/view`; 409 inline error renders with the run_id as a real link)
- [ ] CI green
- [ ] No regression on existing `/workflows` runner-table behavior

## Related

- Follow-up to today's ops dashboard QA pass
- Adjacent (deliberately separate, not bundled): static-JS cache-bust, `/runs/<id>/view` disk-fallback after eviction, Home's `7-day spend` always-zero bug — captured in CLAUDE.md lessons (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)