### PR TITLE
fix(ops): specs page width + compact status pills + fast tooltips

### DIFF
--- a/docs/specs/ops-dashboard-qa-2026-05-14/findings.md
+++ b/docs/specs/ops-dashboard-qa-2026-05-14/findings.md
@@ -1,0 +1,224 @@
+# Ops Dashboard QA — 2026-05-14
+
+> Punch list of defects and follow-ups surfaced during the
+> 2026-05-14 ops-dashboard polish session. Severity ranking and
+> file:line refs included so the QA session can start ranked and
+> ready.
+
+**Pages reviewed this session:** Specs (focus), Workflows (incidental
+during scope-picker debugging), Home (incidental via Recent strip).
+**Pages NOT reviewed:** Memory, Sessions, Health, Run history,
+Telemetry. Audit those before considering this list complete.
+
+---
+
+## Severity legend
+
+| Tier | Meaning |
+|---|---|
+| **Blocker** | Breaks a primary user flow on a routine action |
+| **High** | Breaks a non-primary flow OR makes a primary flow misleading |
+| **Medium** | Visible defect that degrades usability but has a workaround |
+| **Low** | Polish, consistency, or accessibility refinement |
+
+---
+
+## State-restoration bug class
+
+Three related bugs share a single root pattern: **the dashboard
+persists state and doesn't re-validate it against current workspace
+state at restore time.** Worth fixing as a class, not as individuals.
+
+### B1 — Disk-persisted run pills 404 after server restart
+
+**Severity:** High
+
+**Symptom:** Click a "Recent run" pill (e.g. `d4563e40`) in the Home
+or Workflows Recent strip → 404 with message _"run X not found. The
+runner keeps the last 20 runs in memory; older runs are pruned when
+the server restarts."_
+
+**Root cause:** `/runs/{run_id}/view` in
+[src/attune/ops/routes/dashboard.py:111](src/attune/ops/routes/dashboard.py)
+calls `runner.get(run_id)` which only checks the in-memory
+`RunnerService` history. The Recent strip sources its run list from
+`/api/runs/{workflow}` (disk-persisted via
+[src/attune/ops/routes/runs_history.py](src/attune/ops/routes/runs_history.py)),
+so it surfaces run IDs that survived a server restart — but clicking
+those IDs hits a route that doesn't see disk persistence.
+
+**Fix:** In `run_view_page`, fall back to disk on in-memory miss.
+The disk record has enough fields (`workflow`, `path`, `status`, log
+content) to render a static view. SSE stream would not reconnect
+(correct — completed run); the view should communicate this.
+
+**Effort:** ~30 lines in `dashboard.py:run_view_page` + a test that
+restarts the runner and confirms the disk record renders.
+
+---
+
+### B2 — Scope picker restores stale path from a previous worktree
+
+**Severity:** High (rendered the workflow runner non-functional in
+the affected scenario)
+
+**Symptom:** Click **Run** on a workflow → 400 _"invalid path: Path
+'X' is outside allowed directory 'Y'. Operations are restricted to
+the workspace."_ The "X" path is from a different worktree that the
+user previously had open in the dashboard.
+
+**Root cause:**
+[src/attune/ops/static/js/runner.js:restoreScopeOnLoad](src/attune/ops/static/js/runner.js)
+read the saved scope from localStorage and applied it without
+validating that the path could exist under the current workspace.
+When the user opened the dashboard in a different worktree session,
+the previous worktree's path got restored and only failed at
+run-trigger time when the server's `_validate_file_path` rejected it.
+
+**Status:** **Fixed in this PR** (#358). Server-side
+`workflows_page` now emits `workspaceRoot` in `scope-picker-config`;
+client-side `restoreScopeOnLoad` calls new `isScopeInWorkspace` to
+validate any saved absolute path, discarding stale ones with a
+`console.warn`.
+
+**Generalization:** Audit any other `localStorage`-restored state
+the dashboard owns (page-specific filters, sort orders, last-viewed
+workflow). Same shape can recur.
+
+---
+
+### B3 — Scope picker's displayed label can diverge from stored path
+
+**Severity:** Medium
+
+**Symptom:** Picker dropdown reads e.g. "All Code" but the actual
+path sent to `/workflows/{name}/run` is a different value (often a
+stale Custom path from localStorage). Diagnosed during B2 cleanup.
+
+**Root cause hypothesis (unverified):** `wireScopeSave`
+([runner.js:wireScopeSave](src/attune/ops/static/js/runner.js))
+writes to localStorage only on the picker's `change` event. If the
+picker's value is set programmatically (e.g. during
+`restoreScopeOnLoad` or via test automation) no `change` event
+fires, so localStorage doesn't update to match. Subsequent runs
+read the stale localStorage value via the `getScope` flow.
+
+**Fix:** Either
+(a) save in `restoreScopeOnLoad` so localStorage and picker always
+    agree post-restore, or
+(b) read directly from picker state in `getScope` (current behavior)
+    AND audit other call sites for the same divergence.
+
+**Effort:** ~10 lines + a test that exercises restore → custom path
+edit → run sequence.
+
+---
+
+## Cross-page consistency
+
+### C1 — Tooltip implementation differs between pages
+
+**Severity:** Low (visible during this session — Specs feels much
+snappier than Workflows because tooltips fire ~100ms vs ~500-1500ms)
+
+The Specs page got a fast CSS tooltip system (`[data-tooltip]::after`,
+~100ms reveal). Other tables (Workflows, Home, run history) still
+use native `title` attributes which have browser-controlled delays
+(Safari ~1.5s).
+
+**Fix:** Roll the CSS tooltip system out to Workflows, Home,
+Memory, etc. — the CSS already exists in `main.css`; the work is
+HTML changes only (`title="..."` → `data-tooltip="..."` plus
+keeping `aria-label` for screen readers).
+
+---
+
+### C2 — `title` attribute mixed with `data-tooltip` will double-fire
+
+If both `title` and `data-tooltip` are set on the same element,
+hover shows BOTH the native and the custom tooltip stacked. Specs
+page avoids this by stripping `title` in favor of `data-tooltip`;
+needs to be the policy everywhere.
+
+---
+
+## Specs page polish (follow-ups to PR #358)
+
+### S1 — Tooltip on phase-status pills includes status only, not phase name
+
+**Severity:** Low
+
+On hover, a pill shows e.g. `phase 0 complete + skills survey
+complete; **spec retired**` but not which phase the status belongs
+to. The cell's `data-phase` attribute carries it; the tooltip could
+prepend `[design] phase 0 complete…`.
+
+---
+
+### S2 — "Updated" relative time doesn't refresh on idle dashboard
+
+**Severity:** Low
+
+The relative time (`2h ago`, `3d ago`) renders once at page load
+via `renderMtime`. On a dashboard left open for hours, it stays
+stale. Consider a `setInterval(renderMtime, 60000)` per cell, or
+just live with the staleness (refresh fixes it).
+
+---
+
+### S3 — Empty-status custom statuses render as `(none)` rather than `—`
+
+**Severity:** Low
+
+Spec phases with a missing/empty `**Status**:` line render as
+`(none)` inside a status pill, which looks like a deliberate
+status. The em-dash `—` style used for missing-file rows
+(no `**Status**` at all) reads more clearly. Consider unifying.
+
+---
+
+## Workflows page (incidentally observed during scope-picker debug)
+
+### W1 — Long workflow descriptions may overflow on narrow viewports
+
+**Severity:** Unknown (not audited)
+
+The Workflows page renders descriptions inline. With long
+descriptions and narrow viewports, horizontal scroll may appear.
+Audit at 1280px.
+
+---
+
+## Pages NOT YET audited (open work for the QA session)
+
+- **Home** (KPIs, sparkline, Recent strip — only briefly touched)
+- **Memory** (no review this session)
+- **Sessions** (no review this session)
+- **Health** (no review this session)
+- **Telemetry** (no review this session)
+- **Run history** (the `runs-history.py` API, but no UI review)
+
+For each: width fit at 1366px and 1920px, empty states,
+long-string overflow, tooltip discoverability, keyboard navigation
+(Tab/Enter/Esc), console errors. Port 8765 has a current-main
+baseline running for visual comparison; port 8775 has the
+fix/ops-specs-page-width branch.
+
+---
+
+## How to use this list
+
+1. **Start with B-class items** — these are real defects users hit
+   on routine actions. B2 is already done in PR #358; B1 and B3
+   are the next-shortest paths to user-facing improvement.
+2. **C-class** is consistency work — ship as a follow-up PR after
+   B-class lands.
+3. **S-class** is polish that depends on Specs polish landing
+   (PR #358 itself).
+4. **W-class** and the unaudited pages are unknown — start with a
+   walkthrough at two viewport widths, capture defects with file
+   refs, then triage.
+
+**Suggested first-PR scope** after #358 merges:
+B1 (run-view disk fallback) — high impact, ~30 lines, no design
+decisions needed. Quick win to validate the QA-spec workflow.

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -91,6 +91,13 @@ async def workflows_page(request: Request) -> HTMLResponse:
         supports_path=supports_path,
         first_feature_path=first_feature_path,
         all_code_path=data.ALL_CODE_PATH,
+        # Absolute workspace root used by the scope picker to validate
+        # localStorage-restored paths. A saved scope from a previous
+        # session (possibly a different worktree) that doesn't share
+        # this prefix is treated as stale and discarded — prevents
+        # the run endpoint from getting a cross-workspace path that
+        # will only fail at validation time.
+        workspace_root=str(cfg.project_root),
     )
 
 

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -181,6 +181,7 @@ async def specs_page(request: Request) -> HTMLResponse:
                     "root": record.root,
                     "path": record.path,
                     "phases": [asdict(p) for p in record.phases],
+                    "last_modified": record.last_modified,
                 }
             )
     return _render(

--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -91,6 +91,12 @@ class SpecRecord:
     root: str  # absolute path of the containing root
     path: str  # absolute path of the spec directory
     phases: list[SpecPhase]
+    # ISO-8601 timestamp of the most recently modified *.md file in the
+    # spec directory (any kind — `decisions.md`, `_sequencing.md`,
+    # `audit.md`, etc.). None if the directory has no .md files at all
+    # (which shouldn't happen since _list_specs_in_root requires at
+    # least one canonical phase file, but handled defensively).
+    last_modified: str | None = None
 
 
 def _extract_status(text: str) -> str | None:
@@ -123,6 +129,28 @@ def _scan_spec_dir(spec_dir: Path) -> list[SpecPhase]:
     return phases
 
 
+def _newest_md_mtime(spec_dir: Path) -> str | None:
+    """Return the newest mtime across all `.md` files in the spec dir,
+    formatted as a UTC ISO-8601 string. Catches edits to canonical phase
+    files AND auxiliary content (`_sequencing.md`, `audit.md`, etc.)."""
+    from datetime import datetime, timezone
+
+    newest: float | None = None
+    try:
+        for md in spec_dir.glob("*.md"):
+            try:
+                mt = md.stat().st_mtime
+            except OSError:
+                continue
+            if newest is None or mt > newest:
+                newest = mt
+    except OSError:
+        return None
+    if newest is None:
+        return None
+    return datetime.fromtimestamp(newest, tz=timezone.utc).isoformat()
+
+
 def _list_specs_in_root(root: Path) -> list[SpecRecord]:
     """Find all spec directories under one root, with phase statuses."""
     if not root.is_dir():
@@ -142,6 +170,7 @@ def _list_specs_in_root(root: Path) -> list[SpecRecord]:
                 root=str(root),
                 path=str(child),
                 phases=_scan_spec_dir(child),
+                last_modified=_newest_md_mtime(child),
             )
         )
     return records

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -610,9 +610,11 @@ a.kpi:hover {
   padding: 6px 6px;
 }
 .specs-table .col-slug {
+  /* Let the spec column absorb whatever's left after the four fixed
+     phase columns. On wide monitors that means more readable spec
+     names; on narrow ones the min-width keeps it usable. */
   width: auto;
   min-width: 180px;
-  max-width: 320px;
 }
 .specs-table td {
   /* Needed so CSS tooltips position correctly against each cell. */
@@ -625,6 +627,27 @@ a.kpi:hover {
      Pill itself has overflow:hidden so we don't need it on the cell —
      keeping the cell overflow visible so CSS tooltips can escape. */
   width: 130px;
+}
+.specs-table .col-mtime {
+  /* Wide enough for relative strings like "2 weeks ago" without
+     wrapping. Tooltip on hover surfaces the absolute ISO timestamp. */
+  width: 110px;
+  white-space: nowrap;
+  color: var(--fg-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.spec-mtime {
+  /* Dotted-underline hover affordance (matches the dotted-underline
+     rule from feedback_color_and_hover_affordances: tooltip available,
+     non-state info, but no link color because it's not navigation). */
+  text-decoration: underline dotted;
+  text-decoration-color: var(--border-strong);
+  text-underline-offset: 2px;
+}
+.spec-mtime-empty {
+  text-decoration: none;
+  color: var(--fg-subtle);
 }
 .spec-slug {
   display: inline-block;
@@ -728,6 +751,11 @@ a.kpi:hover {
   border-radius: 6px;
   background-color: var(--bg);
   color: var(--fg);
+  /* Don't let a long "(current)" option text widen the select past
+     its cell — clip the displayed value, dropdown still shows full
+     option text when opened. */
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 /* ---------- CSS tooltips (data-tooltip="...") ----------

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -597,6 +597,185 @@ a.kpi:hover {
   background-size: 5px 5px, 5px 5px;
   background-repeat: no-repeat;
 }
+
+/* ---------- Specs page: compact status pills ---------- */
+.specs-table {
+  table-layout: fixed;
+  width: 100%;
+}
+.specs-table th,
+.specs-table td {
+  /* Tighter than the default .data-table padding so each phase
+     column can fit a ~10-char code without overlapping neighbors. */
+  padding: 6px 6px;
+}
+.specs-table .col-slug {
+  width: auto;
+  min-width: 180px;
+  max-width: 320px;
+}
+.specs-table td {
+  /* Needed so CSS tooltips position correctly against each cell. */
+  position: relative;
+}
+.specs-table .col-phase {
+  /* 130px = ~10-char truncated code (8 chars + ellipsis) +
+     dot + gap + pill padding + cell padding + breathing room.
+     Prevents inline-flex pills from spilling into adjacent cells.
+     Pill itself has overflow:hidden so we don't need it on the cell —
+     keeping the cell overflow visible so CSS tooltips can escape. */
+  width: 130px;
+}
+.spec-slug {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  font-family: var(--font-mono);
+  padding: 2px 8px;
+  border-radius: 99px;
+  background-color: var(--bg-soft);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  line-height: 1.4;
+  user-select: none;
+  /* Constrain to the cell so siblings stay aligned, but DO NOT clip
+     here — the [data-tooltip]::after pseudo-element sits above the
+     pill and would be clipped by overflow:hidden. We clip on the
+     inner .status-code span instead (with min-width:0 so the flex
+     child can actually shrink for text-overflow:ellipsis). */
+  max-width: 100%;
+  white-space: nowrap;
+}
+.status-pill .status-dot {
+  flex: 0 0 auto;
+}
+.status-pill .status-code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.status-pill .status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: currentColor;
+  opacity: 0.8;
+  flex-shrink: 0;
+}
+.status-pill .status-code {
+  letter-spacing: 0.02em;
+}
+.status-pill.chip-ok {
+  background-color: var(--ok-soft);
+  border-color: var(--ok-soft);
+  color: var(--ok);
+}
+.status-pill.chip-warn {
+  background-color: var(--warn-soft);
+  border-color: var(--warn-soft);
+  color: var(--warn);
+}
+.status-pill.chip-muted {
+  background-color: var(--bg-soft);
+  border-color: var(--border);
+  color: var(--fg-muted);
+}
+.status-pill.chip-custom {
+  background-color: var(--bg-soft);
+  border-color: var(--border);
+  color: var(--fg);
+}
+.status-pill-custom .status-code {
+  text-decoration: underline dotted;
+  text-decoration-color: var(--fg-muted);
+  text-underline-offset: 2px;
+}
+.status-pill-editable {
+  cursor: pointer;
+  transition: border-color 0.12s ease;
+}
+.status-pill-editable:hover,
+.status-pill-editable:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.status-pill.flash-ok {
+  outline: 2px solid var(--ok);
+  outline-offset: 1px;
+  transition: outline 0.3s ease-out;
+}
+.status-pill.flash-err {
+  outline: 2px solid var(--danger);
+  outline-offset: 1px;
+  transition: outline 0.3s ease-out;
+}
+.status-edit-select {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  padding: 2px 4px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background-color: var(--bg);
+  color: var(--fg);
+}
+
+/* ---------- CSS tooltips (data-tooltip="...") ----------
+   Replaces native `title` attribute for the Specs page so hover
+   feedback is fast (~100ms) and consistent across browsers. Native
+   `title` has ~500-1500ms delays depending on the browser — too slow
+   to feel responsive when scanning a table.
+   For accessibility, callers should pair `data-tooltip` with
+   `aria-label` (which screen readers read regardless of styling). */
+[data-tooltip] {
+  position: relative;
+}
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--fg);
+  color: var(--bg);
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  line-height: 1.4;
+  white-space: normal;
+  word-break: break-word;
+  max-width: 280px;
+  width: max-content;
+  text-align: center;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  z-index: 100;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: opacity 120ms ease, visibility 120ms;
+  transition-delay: 100ms;
+}
+[data-tooltip]:hover::after,
+[data-tooltip]:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+}
+/* Suppress the tooltip while the pill is in edit mode (the inline
+   <select> takes over — a competing tooltip would be confusing). */
+.status-pill[data-editing="1"]::after {
+  display: none;
+}
 .status-select:disabled {
   opacity: 0.6;
   cursor: wait;

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -340,18 +340,44 @@
   // unparseable, or malformed.
   function readScopePickerConfig() {
     var el = document.getElementById("scope-picker-config");
-    if (!el) return { firstFeaturePath: "", allCodePath: "" };
+    if (!el) return { firstFeaturePath: "", allCodePath: "", workspaceRoot: "" };
     try {
       var cfg = JSON.parse(el.textContent || "{}");
       return {
         firstFeaturePath:
           typeof cfg.firstFeaturePath === "string" ? cfg.firstFeaturePath : "",
         allCodePath:
-          typeof cfg.allCodePath === "string" ? cfg.allCodePath : ""
+          typeof cfg.allCodePath === "string" ? cfg.allCodePath : "",
+        workspaceRoot:
+          typeof cfg.workspaceRoot === "string" ? cfg.workspaceRoot : ""
       };
     } catch (e) {
-      return { firstFeaturePath: "", allCodePath: "" };
+      return { firstFeaturePath: "", allCodePath: "", workspaceRoot: "" };
     }
+  }
+
+  // Returns true if ``value`` is a scope this workspace can actually
+  // accept at run-trigger time. Catches stale localStorage from a
+  // previous session in a different worktree — the run endpoint would
+  // reject it with "outside allowed directory" anyway, but the scope
+  // picker should never restore a value that's structurally invalid
+  // for the current workspace.
+  //
+  // Rules:
+  //   - "" (Project-wide) is always valid.
+  //   - A relative path (no leading "/") is always treated as valid;
+  //     the server resolves it against project_root at run time.
+  //   - An absolute path is valid iff it equals workspaceRoot or sits
+  //     beneath it (prefix match guarded by trailing-slash to avoid
+  //     "/foo" matching "/foobar").
+  //   - If workspaceRoot is empty (server didn't emit it — old build),
+  //     accept all values to preserve previous behavior.
+  function isScopeInWorkspace(value, workspaceRoot) {
+    if (value === "" || value == null) return true;
+    if (!workspaceRoot) return true;
+    if (value.charAt(0) !== "/") return true;
+    if (value === workspaceRoot) return true;
+    return value.indexOf(workspaceRoot + "/") === 0;
   }
 
   // Apply a scope value to a single row's picker. ``value`` is:
@@ -396,12 +422,27 @@
   //   4. If even "All code" is missing — leave the picker at the
   //      template's Project-wide default (no-op).
   function restoreScopeOnLoad() {
+    var cfg = readScopePickerConfig();
     var saved = loadSavedScope();
     var value;
-    if (saved !== null) {
+    if (saved !== null && isScopeInWorkspace(saved, cfg.workspaceRoot)) {
       value = saved;
     } else {
-      var cfg = readScopePickerConfig();
+      if (saved !== null && !isScopeInWorkspace(saved, cfg.workspaceRoot)) {
+        // Stale absolute path from another worktree / workspace.
+        // Discard so the run endpoint never sees it and so the next
+        // save (after the user picks something) overwrites cleanly.
+        try {
+          window.localStorage.removeItem(SCOPE_STORAGE_KEY);
+        } catch (e) {
+          // INTENTIONAL: best-effort. If localStorage is unavailable
+          // the picker just falls back to defaults on each load.
+        }
+        console.warn(
+          "attune-ops: discarded stale scope (" + saved +
+          ") — not under workspace " + cfg.workspaceRoot
+        );
+      }
       value = cfg.firstFeaturePath || cfg.allCodePath;
     }
     if (value === "") return; // Project-wide is the template default.

--- a/src/attune/ops/static/js/specs.js
+++ b/src/attune/ops/static/js/specs.js
@@ -1,79 +1,215 @@
-// Per-phase status-flip handler for the Specs tab.
-// Optimistic UI with rollback on server error. Mirrors runner.js's pattern.
+// Specs tab: click-to-edit status pills.
+//
+// Read mode: compact pill (dot + 3-letter code) with full status in
+// title attribute. Click swaps in a <select> for editing; on change
+// or blur, PUT to /api/specs/.../status and swap back to a pill with
+// the new value. Optimistic UI with rollback on server error.
 (function () {
   "use strict";
 
-  function chipClassForStatus(status) {
-    var s = (status || "").toLowerCase();
-    if (s === "approved" || s === "complete" || s === "completed" || s === "done") {
+  var EDITABLE_OPTIONS = ["draft", "in-review", "approved", "complete"];
+
+  function statusCode(status) {
+    var s = (status || "").toLowerCase().trim();
+    if (s === "draft") return "drf";
+    if (s === "in-review" || s === "review") return "rvw";
+    if (s === "approved") return "apv";
+    if (s === "complete" || s === "completed" || s === "done") return "cpl";
+    if (s.length > 8) return s.substring(0, 8) + "…";
+    return s;
+  }
+
+  function chipClassFor(status) {
+    var s = (status || "").toLowerCase().trim();
+    if (
+      s === "approved" ||
+      s === "complete" ||
+      s === "completed" ||
+      s === "done"
+    ) {
       return "chip-ok";
     }
-    if (s === "in-review" || s === "review") {
-      return "chip-warn";
-    }
-    if (s === "draft") {
-      return "chip-muted";
-    }
-    return "chip";
+    if (s === "in-review" || s === "review") return "chip-warn";
+    if (s === "draft") return "chip-muted";
+    return "chip-custom";
   }
 
-  function applyChipClass(select, status) {
-    var classes = ["status-select", chipClassForStatus(status)];
-    select.className = classes.join(" ");
+  function isCustom(status) {
+    var s = (status || "").toLowerCase().trim();
+    if (!s) return false;
+    return [
+      "draft",
+      "in-review",
+      "review",
+      "approved",
+      "complete",
+      "completed",
+      "done",
+    ].indexOf(s) === -1;
   }
 
-  function flash(select, ok) {
-    select.classList.add(ok ? "flash-ok" : "flash-err");
+  function escapeHTML(s) {
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function flash(el, ok) {
+    el.classList.add(ok ? "flash-ok" : "flash-err");
     setTimeout(function () {
-      select.classList.remove("flash-ok", "flash-err");
+      el.classList.remove("flash-ok", "flash-err");
     }, 1200);
   }
 
-  function attach(select) {
-    select.addEventListener("change", async function () {
-      var slug = select.dataset.slug;
-      var phase = select.dataset.phase;
-      var prev = select.dataset.original || "";
-      var next = select.value;
-      if (next === prev) return;
-      select.disabled = true;
-      applyChipClass(select, next);
-      try {
-        var resp = await fetch(
-          "/api/specs/" + encodeURIComponent(slug) +
-          "/" + encodeURIComponent(phase) + "/status",
-          {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ status: next }),
-          }
-        );
-        if (!resp.ok) {
-          var body = await resp.text();
-          console.error("status flip failed:", resp.status, body);
-          // Revert to original on failure.
-          select.value = prev;
-          applyChipClass(select, prev);
-          flash(select, false);
-          select.title = "Failed: " + resp.status + " " + body;
-        } else {
-          select.dataset.original = next;
-          flash(select, true);
-          select.title = "";
+  function applyPillState(pill, status) {
+    pill.classList.remove("chip-ok", "chip-warn", "chip-muted", "chip-custom");
+    pill.classList.add(chipClassFor(status));
+    if (isCustom(status)) {
+      pill.classList.add("status-pill-custom");
+    } else {
+      pill.classList.remove("status-pill-custom");
+    }
+    pill.dataset.original = status;
+    pill.setAttribute("data-tooltip", status || "(no status)");
+    pill.setAttribute(
+      "aria-label",
+      "Status for " +
+        pill.dataset.phase +
+        " of " +
+        pill.dataset.slug +
+        ": " +
+        (status || "no status") +
+        ". Click to edit."
+    );
+    var code = statusCode(status) || "(none)";
+    pill.innerHTML =
+      '<span class="status-dot" aria-hidden="true"></span>' +
+      '<span class="status-code">' +
+      escapeHTML(code) +
+      "</span>";
+  }
+
+  async function submitChange(pill, prev, next) {
+    var slug = pill.dataset.slug;
+    var phase = pill.dataset.phase;
+    try {
+      var resp = await fetch(
+        "/api/specs/" +
+          encodeURIComponent(slug) +
+          "/" +
+          encodeURIComponent(phase) +
+          "/status",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: next }),
         }
-      } catch (err) {
-        console.error("status flip exception:", err);
-        select.value = prev;
-        applyChipClass(select, prev);
-        flash(select, false);
-        select.title = "Network error: " + err;
-      } finally {
-        select.disabled = false;
+      );
+      if (!resp.ok) {
+        var body = await resp.text();
+        console.error("status flip failed:", resp.status, body);
+        applyPillState(pill, prev);
+        flash(pill, false);
+        pill.setAttribute("data-tooltip", "Failed: " + resp.status + " " + body);
+        return false;
+      }
+      applyPillState(pill, next);
+      flash(pill, true);
+      return true;
+    } catch (err) {
+      console.error("status flip exception:", err);
+      applyPillState(pill, prev);
+      flash(pill, false);
+      pill.setAttribute("data-tooltip", "Network error: " + err);
+      return false;
+    }
+  }
+
+  function enterEditMode(pill) {
+    if (pill.dataset.editing === "1") return;
+    pill.dataset.editing = "1";
+
+    var prev = pill.dataset.original || "";
+    var pillDisplay = pill.style.display;
+    pill.style.display = "none";
+
+    var select = document.createElement("select");
+    select.className = "status-edit-select";
+    select.setAttribute("aria-label", pill.getAttribute("aria-label") || "");
+
+    var seen = false;
+    EDITABLE_OPTIONS.forEach(function (opt) {
+      var o = document.createElement("option");
+      o.value = opt;
+      o.textContent = opt;
+      if (prev.toLowerCase() === opt) {
+        o.selected = true;
+        seen = true;
+      }
+      select.appendChild(o);
+    });
+    if (!seen && prev) {
+      var custom = document.createElement("option");
+      custom.value = prev;
+      custom.textContent = prev + " (current)";
+      custom.selected = true;
+      select.appendChild(custom);
+    }
+
+    pill.parentNode.insertBefore(select, pill);
+
+    var done = false;
+    async function finish(commit) {
+      if (done) return;
+      done = true;
+      var next = select.value;
+      select.remove();
+      pill.style.display = pillDisplay;
+      pill.dataset.editing = "";
+      if (commit && next !== prev) {
+        await submitChange(pill, prev, next);
+      }
+      pill.focus();
+    }
+
+    select.addEventListener("change", function () {
+      finish(true);
+    });
+    select.addEventListener("blur", function () {
+      finish(true);
+    });
+    select.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") {
+        finish(false);
+      }
+    });
+
+    select.focus();
+    if (typeof select.showPicker === "function") {
+      try {
+        select.showPicker();
+      } catch (_) {
+        /* fall back to focus only */
+      }
+    }
+  }
+
+  function attach(pill) {
+    pill.addEventListener("click", function () {
+      enterEditMode(pill);
+    });
+    pill.addEventListener("keydown", function (e) {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        enterEditMode(pill);
       }
     });
   }
 
   document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll(".status-select").forEach(attach);
+    document.querySelectorAll(".status-pill-editable").forEach(attach);
   });
 })();

--- a/src/attune/ops/static/js/specs.js
+++ b/src/attune/ops/static/js/specs.js
@@ -154,7 +154,14 @@
     if (!seen && prev) {
       var custom = document.createElement("option");
       custom.value = prev;
-      custom.textContent = prev + " (current)";
+      // Truncate the displayed text — a long custom status like
+      // "phase 0 complete + skills survey complete; **spec retired**"
+      // would otherwise widen the <select> past its cell. The full
+      // value is still in option.value so the form submits correctly,
+      // and the title shows it on hover.
+      var label = prev.length > 12 ? prev.substring(0, 10) + "…" : prev;
+      custom.textContent = label + " (current)";
+      custom.title = prev;
       custom.selected = true;
       select.appendChild(custom);
     }
@@ -209,7 +216,68 @@
     });
   }
 
+  // Relative-time rendering for the Last-modified column.
+  // Server provides ISO 8601 UTC in data-mtime; we render "2h ago"
+  // style strings client-side so the user's local clock is the
+  // reference. data-tooltip already holds the absolute string for
+  // hover via the CSS tooltip layer.
+  function relativeTime(isoString) {
+    var then = Date.parse(isoString);
+    if (isNaN(then)) return "?";
+    var now = Date.now();
+    var secs = Math.round((now - then) / 1000);
+    if (secs < 0) return "in the future";
+    if (secs < 60) return "just now";
+    var mins = Math.round(secs / 60);
+    if (mins < 60) return mins + "m ago";
+    var hours = Math.round(mins / 60);
+    if (hours < 24) return hours + "h ago";
+    var days = Math.round(hours / 24);
+    if (days < 14) return days + "d ago";
+    var weeks = Math.round(days / 7);
+    if (weeks < 9) return weeks + "w ago";
+    var months = Math.round(days / 30);
+    if (months < 18) return months + "mo ago";
+    var years = (days / 365).toFixed(1);
+    return years + "y ago";
+  }
+
+  // Browser-localized absolute timestamp for the tooltip — replaces
+  // the raw ISO string the server emits with something readable in
+  // the user's locale, e.g. "May 12, 2026, 3:05 PM" in en-US or
+  // "12. Mai 2026 um 15:05" in de-DE. Falls back to the raw ISO if
+  // parsing fails.
+  function localizedAbsolute(isoString) {
+    var d = new Date(isoString);
+    if (isNaN(d.getTime())) return isoString;
+    try {
+      return d.toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      });
+    } catch (_) {
+      return d.toLocaleString();
+    }
+  }
+
+  function renderMtime(el) {
+    var iso = el.getAttribute("data-mtime");
+    if (!iso) return;
+    var rel = relativeTime(iso);
+    var abs = localizedAbsolute(iso);
+    el.textContent = rel;
+    // Browser-localized absolute timestamp for the hover tooltip
+    // (replaces the raw ISO that the server emitted).
+    el.setAttribute("data-tooltip", abs);
+    // Keep aria-label in sync with the visible relative time so screen
+    // readers announce "Updated 2h ago" instead of the raw ISO string.
+    // The absolute timestamp remains accessible via the datetime
+    // attribute on <time> and the data-tooltip on hover.
+    el.setAttribute("aria-label", "Updated " + rel + " (" + abs + ")");
+  }
+
   document.addEventListener("DOMContentLoaded", function () {
     document.querySelectorAll(".status-pill-editable").forEach(attach);
+    document.querySelectorAll(".spec-mtime[data-mtime]").forEach(renderMtime);
   });
 })();

--- a/src/attune/ops/templates/base.html
+++ b/src/attune/ops/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}attune ops{% endblock %} · attune ops</title>
-    <link rel="stylesheet" href="{{ url_for('static', path='css/main.css') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', path='css/main.css') }}?v={{ range(100000, 999999) | random }}" />
   </head>
   <body data-page="{{ page }}">
     <header class="topbar">

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -24,54 +24,71 @@
 {% endif %}
 
 {% if specs %}
-  <table class="data-table">
+  {# Compact status display: dot + 3-letter code for known statuses,
+     truncated text + dotted underline for custom strings. Full status
+     in title attribute (native tooltip). Click on editable pills swaps
+     to <select> via specs.js. #}
+  {% macro status_code(st) -%}
+    {%- set s = (st or '')|lower|trim -%}
+    {%- if s == 'draft' -%}drf
+    {%- elif s in ('in-review', 'review') -%}rvw
+    {%- elif s == 'approved' -%}apv
+    {%- elif s in ('complete', 'completed', 'done') -%}cpl
+    {%- elif s|length > 8 -%}{{ s[:8] }}…
+    {%- else -%}{{ s }}
+    {%- endif -%}
+  {%- endmacro %}
+  {% macro chip_cls(st) -%}
+    {%- set s = (st or '')|lower|trim -%}
+    {%- if s in ('approved', 'complete', 'completed', 'done') -%}chip-ok
+    {%- elif s in ('in-review', 'review') -%}chip-warn
+    {%- elif s == 'draft' -%}chip-muted
+    {%- else -%}chip-custom
+    {%- endif -%}
+  {%- endmacro %}
+  {% macro is_custom(st) -%}
+    {%- set s = (st or '')|lower|trim -%}
+    {%- if s and s not in ('draft', 'in-review', 'review', 'approved', 'complete', 'completed', 'done') -%}1
+    {%- else -%}0
+    {%- endif -%}
+  {%- endmacro %}
+  <table class="data-table specs-table">
     <thead>
       <tr>
-        <th>Slug</th>
+        <th class="col-slug">Slug</th>
         {% for phase_name in ("decisions", "requirements", "design", "tasks") %}
-          <th>{{ phase_name|capitalize }}</th>
+          <th class="col-phase">{{ phase_name|capitalize }}</th>
         {% endfor %}
       </tr>
     </thead>
     <tbody>
       {% for s in specs %}
         <tr data-slug="{{ s.slug }}">
-          <td>
-            <a href="/specs/{{ s.slug }}" class="link"><code>{{ s.slug }}</code></a>
+          <td class="col-slug">
+            <a href="/specs/{{ s.slug }}" class="link spec-slug" data-tooltip="{{ s.slug }}" aria-label="{{ s.slug }}"><code>{{ s.slug }}</code></a>
           </td>
           {% for phase in s.phases %}
-            <td data-phase="{{ phase.name }}">
+            <td class="col-phase" data-phase="{{ phase.name }}">
               {% if not phase.exists %}
-                <span class="chip chip-muted">—</span>
+                <span class="status-pill chip-muted" data-tooltip="No {{ phase.name }}.md file" aria-label="No {{ phase.name }}.md file">—</span>
               {% else %}
-                {% set st = (phase.status or '')|lower %}
-                {% if st in ('approved', 'complete', 'completed', 'done') %}
-                  {% set chip_cls = 'chip-ok' %}
-                {% elif st in ('in-review', 'review') %}
-                  {% set chip_cls = 'chip-warn' %}
-                {% elif st == 'draft' %}
-                  {% set chip_cls = 'chip-muted' %}
-                {% else %}
-                  {% set chip_cls = 'chip' %}
-                {% endif %}
-                {% if allow_run %}
-                  <select
-                    class="status-select {{ chip_cls }}"
-                    data-slug="{{ s.slug }}"
-                    data-phase="{{ phase.name }}"
-                    data-original="{{ phase.status or '' }}"
-                    aria-label="Status for {{ phase.name }} of {{ s.slug }}"
-                  >
-                    {% for opt in ('draft', 'in-review', 'approved', 'complete') %}
-                      <option value="{{ opt }}"{% if (phase.status or '')|lower == opt %} selected{% endif %}>{{ opt }}</option>
-                    {% endfor %}
-                    {% if phase.status and (phase.status|lower) not in ('draft', 'in-review', 'approved', 'complete') %}
-                      <option value="{{ phase.status }}" selected>{{ phase.status }}</option>
-                    {% endif %}
-                  </select>
-                {% else %}
-                  <span class="chip {{ chip_cls }}">{{ phase.status or '(no status)' }}</span>
-                {% endif %}
+                {% set cls = chip_cls(phase.status)|trim %}
+                {% set code = status_code(phase.status)|trim %}
+                {% set custom = is_custom(phase.status)|trim == '1' %}
+                <span
+                  class="status-pill {{ cls }}{% if custom %} status-pill-custom{% endif %}{% if allow_run %} status-pill-editable{% endif %}"
+                  data-tooltip="{{ phase.status or '(no status)' }}"
+                  {% if allow_run %}
+                  data-slug="{{ s.slug }}"
+                  data-phase="{{ phase.name }}"
+                  data-original="{{ phase.status or '' }}"
+                  role="button"
+                  tabindex="0"
+                  aria-label="Status for {{ phase.name }} of {{ s.slug }}: {{ phase.status or 'no status' }}. Click to edit."
+                  {% else %}
+                  aria-label="Status for {{ phase.name }} of {{ s.slug }}: {{ phase.status or 'no status' }}"
+                  {% endif %}
+                ><span class="status-dot" aria-hidden="true"></span><span class="status-code">{{ code or '(none)' }}</span></span>
               {% endif %}
             </td>
           {% endfor %}

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -55,7 +55,8 @@
   <table class="data-table specs-table">
     <thead>
       <tr>
-        <th class="col-slug">Slug</th>
+        <th class="col-slug">Spec</th>
+        <th class="col-mtime">Updated</th>
         {% for phase_name in ("decisions", "requirements", "design", "tasks") %}
           <th class="col-phase">{{ phase_name|capitalize }}</th>
         {% endfor %}
@@ -66,6 +67,20 @@
         <tr data-slug="{{ s.slug }}">
           <td class="col-slug">
             <a href="/specs/{{ s.slug }}" class="link spec-slug" data-tooltip="{{ s.slug }}" aria-label="{{ s.slug }}"><code>{{ s.slug }}</code></a>
+          </td>
+          <td class="col-mtime">
+            {% if s.last_modified %}
+              {# <time> element + datetime attr: assistive tools can recognise
+                 this as a timestamp; screen readers that support the time role
+                 announce it as a date/time. specs.js syncs aria-label to the
+                 visible relative-time on render so screen readers hear the
+                 friendly "Updated 2h ago" instead of the raw ISO string. #}
+              <time class="spec-mtime" datetime="{{ s.last_modified }}" data-mtime="{{ s.last_modified }}" data-tooltip="{{ s.last_modified }}" aria-label="Updated {{ s.last_modified }}">—</time>
+            {% else %}
+              {# aria-label replaces the visible em-dash for screen readers
+                 so the cell is announced as meaningful text, not punctuation. #}
+              <span class="spec-mtime spec-mtime-empty" aria-label="No update time recorded">—</span>
+            {% endif %}
           </td>
           {% for phase in s.phases %}
             <td class="col-phase" data-phase="{{ phase.name }}">

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -82,7 +82,7 @@
    path-bearing feature exists in features.yaml" — the JS leaves the
    picker on Project-wide in that case. #}
 <script id="scope-picker-config" type="application/json">
-{"firstFeaturePath": {{ first_feature_path | tojson }}, "allCodePath": {{ all_code_path | tojson }}}
+{"firstFeaturePath": {{ first_feature_path | tojson }}, "allCodePath": {{ all_code_path | tojson }}, "workspaceRoot": {{ workspace_root | tojson }}}
 </script>
 {# runner.js is loaded unconditionally so the recent-runs strip
    renders in both run and read-only modes. The script's

--- a/tests/unit/ops/test_specs_dashboard.py
+++ b/tests/unit/ops/test_specs_dashboard.py
@@ -72,17 +72,31 @@ def test_specs_page_lists_specs_with_status_chips(tmp_path):
     assert "draft" in r.text
 
 
-def test_specs_page_writeable_mode_shows_dropdowns(tmp_path):
-    """allow_run=True → status renders as a <select> not a <span>."""
+def test_specs_page_writeable_mode_shows_editable_pills(tmp_path):
+    """allow_run=True → status renders as an editable pill (click-to-edit).
+
+    Earlier versions rendered inline ``<select>`` dropdowns server-side.
+    PR #358 swapped that for compact status pills that swap to a select
+    on click via specs.js. We verify the writeable-mode markers
+    (status-pill-editable class, role=button, tabindex, data attributes)
+    are present, and that no inline ``<select>`` is rendered until the
+    user clicks the pill.
+    """
     root = tmp_path / "specs"
     _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
     client = _client(tmp_path, specs_roots=(root,), allow_run=True)
     r = client.get("/specs")
     assert r.status_code == 200
-    assert "<select" in r.text
-    assert "status-select" in r.text
+    # No inline <select> — that's now created client-side on click.
+    assert "<select" not in r.text
+    # Pills carry the writeable markers so specs.js can wire click-to-edit.
+    assert "status-pill-editable" in r.text
+    assert 'role="button"' in r.text
+    assert 'tabindex="0"' in r.text
+    # Per-cell data attributes feed the PUT /api/specs/.../status call.
     assert 'data-slug="alpha"' in r.text
     assert 'data-phase="tasks"' in r.text
+    assert 'data-original="draft"' in r.text
 
 
 def test_specs_page_readonly_mode_no_dropdowns(tmp_path):


### PR DESCRIPTION
## Summary

The /specs page was stretching past laptop screen widths because each status select rendered the full text (\`in-review\`, \`approved\`) and custom statuses (e.g. \`paused 2026-05-12 — premise invalidate\`) ballooned individual cells to 200+px.

### Compact status pills

- Replace \`<select>\`/chip with a dot + 3-letter code (\`drf\`/\`rvw\`/\`apv\`/\`cpl\`) for standard statuses
- Custom statuses truncate to 8 chars + ellipsis with a **dotted underline** as the "more info on hover" affordance
- Click any pill to swap in a \`<select>\` for editing (Esc cancels, change/blur commits)
- Keyboard accessible: Enter / Space activates edit mode

### Table layout

- \`table-layout: fixed\` with explicit column widths (slug 180-320px, each phase 130px)
- Pill content ellipsizes via inner span — NOT the pill itself — so the CSS tooltip pseudo-element can escape above the pill instead of being clipped (this was a real iteration during testing)

### Fast tooltips

- \`data-tooltip\` attribute + \`::after\` pseudo-element (~100ms delay vs native \`title\`'s 500-1500ms)
- Dark background, monospace, max-width 280px with word wrap so long custom statuses display readably
- \`aria-label\` preserved for screen readers (data-tooltip is visual-only)
- Suppressed during click-to-edit mode so the tooltip doesn't fight the \`<select>\`

### Plus

- Cache-buster query string on \`main.css\` since static files lack \`Cache-Control\` headers (matches the existing \`/static/*.js\` Cache-Control lesson)

## Test plan

- [x] Standard statuses render as compact dot+code pills
- [x] Custom statuses get dotted underline; tooltip shows full string
- [x] Click pill → \`<select>\` opens; Esc reverts; change commits via PUT
- [x] Table fits on 1366px laptop without horizontal scroll
- [x] Pills don't overlap adjacent cells (verified via DOM inspection)
- [x] Tooltips appear within ~100ms across Chrome/Safari/Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)