### PR TITLE
fix(ops): Home KPIs read ts field, not legacy timestamp (Phase A1)

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -357,7 +357,12 @@ def read_telemetry_summary(config: Config, *, recent_days: int = 7) -> Telemetry
                 cost = float(event.get("total_cost", event.get("cost", 0.0)) or 0.0)
                 savings = float(event.get("savings", 0.0) or 0.0)
                 workflow = str(event.get("workflow") or event.get("event_type") or "unknown")
-                ts = str(event.get("timestamp") or "")
+                # ``usage.jsonl`` events use the ``ts`` key (v1.0 schema in
+                # UsageTracker._format_entry); ``timestamp`` is kept as a
+                # legacy fallback for any rotated archives that predate the
+                # rename. Without this fallback every event silently misses
+                # the by_day bucketing and Home's KPI tiles read zero.
+                ts = str(event.get("ts") or event.get("timestamp") or "")
 
                 total_requests += 1
                 total_cost += cost

--- a/tests/unit/ops/test_telemetry_summary.py
+++ b/tests/unit/ops/test_telemetry_summary.py
@@ -1,0 +1,140 @@
+"""Regression tests for `read_telemetry_summary` field-name handling.
+
+History: Home KPI tiles and the Daily activity table silently read zero
+for months because `data.py` looked up `event.get("timestamp")` while
+the UsageTracker writer has used `ts` since the v1.0 schema. This test
+locks in the writer/reader field-name contract so the bug can't recur
+silently — if anyone renames the field on either side without
+coordinating, this test fails.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from attune.ops import data
+from attune.ops.config import Config
+
+
+def _write_jsonl(path, events):
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+def _config(tmp_path):
+    """Build an ops Config rooted in ``tmp_path``.
+
+    The fields not under test (project_root, etc.) get harmless
+    defaults; only ``attune_home`` matters because that's where
+    ``telemetry_path`` resolves to.
+    """
+    home = tmp_path / "attune_home"
+    (home / "telemetry").mkdir(parents=True)
+    return Config(
+        project_root=tmp_path,
+        attune_home=home,
+        allow_run=False,
+        specs_roots=(),
+    )
+
+
+def test_read_telemetry_summary_recognizes_ts_field(tmp_path):
+    """An event with the canonical ``ts`` key feeds the by_day bucket.
+
+    This is the field name the writer (UsageTracker._format_entry)
+    emits today. Before the fix, the reader looked up ``timestamp``
+    instead, so this event would land in totals but not by_day,
+    breaking Home's Daily activity table.
+    """
+    cfg = _config(tmp_path)
+    _write_jsonl(
+        cfg.telemetry_path,
+        [
+            {
+                "v": "1.0",
+                "ts": "2026-05-14T12:00:00+00:00",
+                "workflow": "code-review",
+                "total_cost": 0.05,
+            }
+        ],
+    )
+
+    summary = data.read_telemetry_summary(cfg)
+
+    assert summary.total_requests == 1
+    assert summary.total_cost == pytest.approx(0.05)
+    assert summary.last_event_at == "2026-05-14T12:00:00+00:00"
+    # The actual bug: by_day was empty even when events existed.
+    assert summary.by_day == [("2026-05-14", 1, 0.05)]
+
+
+def test_read_telemetry_summary_falls_back_to_legacy_timestamp(tmp_path):
+    """A rotated archive with the old ``timestamp`` field still works.
+
+    Defensive read: ``event.get("ts") or event.get("timestamp")``.
+    Without this fallback, any archived usage.YYYY-MM-DD.jsonl from
+    before the schema rename would silently fail to aggregate.
+    """
+    cfg = _config(tmp_path)
+    _write_jsonl(
+        cfg.telemetry_path,
+        [
+            {
+                "timestamp": "2026-05-14T12:00:00+00:00",
+                "workflow": "code-review",
+                "total_cost": 0.05,
+            }
+        ],
+    )
+
+    summary = data.read_telemetry_summary(cfg)
+
+    assert summary.total_requests == 1
+    assert summary.by_day == [("2026-05-14", 1, 0.05)]
+
+
+def test_read_telemetry_summary_handles_both_fields_in_same_file(tmp_path):
+    """Mixed-schema file (new + legacy events) aggregates correctly.
+
+    Concretely covers the "we just rotated mid-day" case where the
+    same file has both shapes from before and after a schema bump.
+    """
+    cfg = _config(tmp_path)
+    _write_jsonl(
+        cfg.telemetry_path,
+        [
+            {"ts": "2026-05-14T09:00:00+00:00", "workflow": "a", "total_cost": 0.01},
+            {
+                "timestamp": "2026-05-14T10:00:00+00:00",
+                "workflow": "a",
+                "total_cost": 0.02,
+            },
+            {"ts": "2026-05-15T11:00:00+00:00", "workflow": "b", "total_cost": 0.03},
+        ],
+    )
+
+    summary = data.read_telemetry_summary(cfg)
+
+    assert summary.total_requests == 3
+    assert summary.total_cost == pytest.approx(0.06)
+    by_day = {row[0]: (row[1], row[2]) for row in summary.by_day}
+    assert by_day["2026-05-14"] == (2, pytest.approx(0.03))
+    assert by_day["2026-05-15"] == (1, pytest.approx(0.03))
+
+
+def test_read_telemetry_summary_skips_event_with_no_timestamp(tmp_path):
+    """An event missing both ``ts`` and ``timestamp`` still counts in
+    totals but doesn't contribute to by_day (no date to bucket against)."""
+    cfg = _config(tmp_path)
+    _write_jsonl(
+        cfg.telemetry_path,
+        [{"workflow": "a", "total_cost": 0.01}],
+    )
+
+    summary = data.read_telemetry_summary(cfg)
+
+    assert summary.total_requests == 1
+    assert summary.total_cost == pytest.approx(0.01)
+    assert summary.by_day == []
+    assert summary.last_event_at is None


### PR DESCRIPTION
## Summary

The Home page's KPI tiles (Today's events, 7-day spend) and the
Daily activity table have been silently reading zero. Root cause:
`ops/data.py:360` looked up `event.get("timestamp")` but every
event in `~/.attune/telemetry/usage.jsonl` uses `ts` (the canonical
v1.0 schema key emitted by `UsageTracker._format_entry`). So every
event missed the `by_day` bucketing while still counting in totals
— except totals were also dropped because of how the day grouping
gates `last_event_at`. Net effect: Home shows `0` events / `$0.00`
spend and the Daily activity table renders the empty-state ("No
telemetry recorded yet") even when there are thousands of entries.

The fix is one defensive line in the reader:
`event.get("ts") or event.get("timestamp") or ""`. New events read
from the canonical `ts` field; any rotated archive
(`usage.YYYY-MM-DD.jsonl`) that predates the schema rename falls
back to the legacy name gracefully.

A note on the adjacent `memory/security/query.py:98` consumer: it
also reads `event.get("timestamp", "")` but that's correct for
it — different file (audit log), different writer
(`AuditEvent.to_dict` in `memory/security/events.py:32`), and that
writer's schema uses `timestamp`. Not touched here.

## What this resolves

- QA punch list item **PL-P1-1** in
  [docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md)
- Task **A1** in
  [docs/specs/ops-dashboard-polish/tasks.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-polish/tasks.md)
  (Phase A — Visible bug fixes)

This is the first of three Phase-A PRs sequenced to bring the
dashboard to publishable shape. Phase A items are independent and
will land as separate PRs (A2 — scope-textbox CSS, A3 — per-workflow
default scope).

## Test plan

- [x] New regression tests in `tests/unit/ops/test_telemetry_summary.py`
  - `test_read_telemetry_summary_recognizes_ts_field` — canonical
    `ts` event lands in `by_day` (this is the bug)
  - `test_read_telemetry_summary_falls_back_to_legacy_timestamp` —
    rotated archive with legacy `timestamp` still aggregates
  - `test_read_telemetry_summary_handles_both_fields_in_same_file` —
    mixed-schema file (rotation mid-day) totals correctly
  - `test_read_telemetry_summary_skips_event_with_no_timestamp` —
    event missing both fields counts in totals but not `by_day`
- [x] All 281 existing `tests/unit/ops/` tests still pass.
- [x] Verified visually against the actual user's
  `~/.attune/telemetry/usage.jsonl` (19,014 events with `ts`).
  Before the fix: KPIs show `0`. After: real numbers populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
