### PR TITLE
fix(ops): Home page daily activity reads canonical 'ts' field from usage.jsonl

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -357,7 +357,11 @@ def read_telemetry_summary(config: Config, *, recent_days: int = 7) -> Telemetry
                 cost = float(event.get("total_cost", event.get("cost", 0.0)) or 0.0)
                 savings = float(event.get("savings", 0.0) or 0.0)
                 workflow = str(event.get("workflow") or event.get("event_type") or "unknown")
-                ts = str(event.get("timestamp") or "")
+                # `ts` is the canonical field name in usage.jsonl
+                # (verified 2026-05-14: 19k+ events use `ts`, none use
+                # `timestamp`). Accept `timestamp` as a defensive fallback
+                # for any future writer that picks the other convention.
+                ts = str(event.get("ts") or event.get("timestamp") or "")
 
                 total_requests += 1
                 total_cost += cost


### PR DESCRIPTION
## Summary

Direct follow-up to merged PR #358. The lesson captured today documents the root cause:

> Home's 7-day spend / today's events always show 0 because \`read_telemetry_summary\` reads the wrong field name — \`data.py:360\` does \`event.get(\"timestamp\")\` but every entry in \`~/.attune/telemetry/usage.jsonl\` uses \`\"ts\"\` (verified 2026-05-14: 19,014 events with \`ts\`, 0 with \`timestamp\`).

\`by_day\` was always empty, so the Home page's 7-day spend / today's events KPIs always rendered as 0 and the Daily activity table fell to the "No telemetry recorded yet" empty state on every fresh server start. The Telemetry tab's per-workflow rollup was unaffected because it doesn't rely on date bucketing.

## Fix

Accept either field name, preferring \`ts\` (the actual canonical name) with \`timestamp\` as a defensive fallback for any future writer that picks the other convention.

## Test plan

- [x] Server-side: verified \`curl http://127.0.0.1:8775/ | grep '<td class=\"num\">'\` returns non-zero event counts (e.g. 150, 100) where it previously returned all zeros
- [x] No effect on Telemetry tab's per-workflow rollup (different code path)
- [x] Backwards-compat preserved — if a future writer emits \`timestamp\` instead, that still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)