### PR TITLE
spec(docs): three ops-dashboard roadmap specs — Sessions, Telemetry rethink, Path picker

### DIFF
--- a/docs/specs/ops-path-picker/decisions.md
+++ b/docs/specs/ops-path-picker/decisions.md
@@ -1,0 +1,73 @@
+# Spec: Ops Path Picker — Decisions
+
+> Pre-committed decisions captured 2026-05-14. Triggered by QA
+> punch-list item P2-7 reframed by Patrick from "fix the overflow"
+> to "give users a real path-selection affordance."
+
+---
+
+## Decision matrix
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Reuse vs net-new | **Port from attune-gui** | Patrick: "Both dashboards have good work to share." attune-gui's `fs.py` + modal JS are tested, working, and a ~200-line total port. No reason to design from scratch. |
+| Native OS dialog vs in-page modal | **In-page modal** | attune-gui tried `osascript`, switched to in-page after macOS tkinter crashes on non-main thread. Their lesson stands. |
+| File or directory | **Directory only** | Workflow scope is always a dir. File picking is Phase 2 if a future workflow needs it. |
+| Workspace boundary check | **Soft warning, not hard block** | The "outside workspace" status banner warns; user can still pick. The run endpoint enforces. Matches the existing `isScopeInWorkspace` JS we added in PR #358 — defense-in-depth pattern, not a blocker. |
+| Picker JS location | `src/attune/ops/static/js/path_picker.js` | Separate from `runner.js` because the picker is reusable across pages (Workflows now; possibly Health / Memory / a future settings page later). |
+| Picker invocation | `data-browse-target="<selector>"` on a button → opens picker pre-rooted at the selector's input | One attribute, no per-page wiring. |
+| Endpoint mount | `/api/fs` (matches attune-gui prefix) | Drift would force consumers to know which dashboard they're talking to. Same prefix = code can be reused. |
+| Endpoint contract | Identical to attune-gui's `/api/fs/browse` | Documented in attune-gui's `routes/fs.py`; the ops port matches verbatim. |
+| `annotate` parameter values | `help`, `project`, **`workspace` (new)** | First two ported from attune-gui. `workspace` is new for ops: flags entries that are inside `cfg.project_root` so the picker's "✓ inside workspace" banner has data to render. |
+| Modal styling source | Reuse existing CSS tokens (`--bg-elev`, `--shadow`, `--border`); reference markdown-body styling for visual coherence | Don't introduce a new design language. |
+| Test port | Yes — `tests/unit/ops/routes/test_fs.py` | The attune-gui tests cover the meaningful cases (lists subdirs, resolves paths, handles permission errors, hides hidden entries). Port them. |
+| Accessibility floor | Tab/Enter/Esc keyboard nav, WCAG 2.5.5 AA hit targets, `aria-modal="true"` + focus trap | Matches the standard set by the Specs page pill click-to-edit pattern. |
+
+---
+
+## Open questions (resolve during design phase)
+
+1. **`features.yaml` / project-manifest annotations.** attune-gui
+   uses these to help the user pick a `.help/` dir or project
+   root. The ops Workflows page doesn't have an equivalent
+   target (any dir under workspace is valid scope). Phase 1
+   probably doesn't need these annotations; design phase decides
+   whether to keep the support code or strip it.
+
+2. **Modal focus-trap implementation.** Native dialog vs hand-
+   rolled focus management vs lightweight library. Probably
+   hand-rolled — the existing dashboard ships no JS framework
+   and we shouldn't introduce one for a single modal.
+
+3. **Where else to mount the picker.** Workflows is the obvious
+   first consumer. Are there other inputs in the dashboard that
+   currently accept a path string and would benefit?
+   `--specs-root` is server-config (one-time), not in scope.
+   Possibly a future Memory browser or settings page.
+
+4. **Recently-used paths.** A simple localStorage list of the
+   last 5 picked paths, surfaced at the top of the modal, would
+   accelerate common usage. Phase 2 — easy add once Phase 1
+   ships and there's a body of "common paths" to surface.
+
+---
+
+## Calibration record
+
+To be filled in during implementation:
+
+- [ ] How many lines does the JS port end up being? Target ≤300.
+- [ ] Does the modal feel responsive on the dashboard, or does
+  the fetch-render cycle introduce a flash?
+- [ ] What's the typical use pattern — pick once and edit, or
+  navigate frequently? Informs whether to keep the modal open
+  or close on choose.
+
+---
+
+## Decision-change log
+
+- 2026-05-14 — Initial decisions captured. P2-7 in the
+  ops-dashboard QA punch list. Patrick reframed from "fix
+  overflow" to "give users a real picker reusing attune-gui
+  code."

--- a/docs/specs/ops-path-picker/requirements.md
+++ b/docs/specs/ops-path-picker/requirements.md
@@ -1,0 +1,140 @@
+# Spec: Ops Dashboard — Path Picker (port from attune-gui)
+
+> Replace the bare scope textbox on `/workflows` with a path-picker
+> modal patterned on attune-gui's. Reuse the existing
+> `/api/fs/browse` endpoint shape and the modal JS as a starting
+> point — both dashboards benefit from sharing this surface.
+
+---
+
+## Phase 1: Requirements
+
+**Status**: draft
+
+### Problem statement
+
+The 2026-05-14 QA punch list flagged P2-7 (run-view scope path
+overflow). Patrick reframed the underlying UX problem: the
+workflow scope picker on `/workflows` currently exposes a bare
+`<input>` with a `placeholder="e.g. src/attune/security/"` —
+users either know the path they want and type it, or guess.
+There's no discovery surface, no path validation feedback, and
+no protection against the cross-worktree path bug we just fixed
+(B2 / P0-2 adjacent).
+
+Meanwhile **attune-gui already has a working path picker**:
+- `GET /api/fs/browse?path=<dir>&annotate=<help|project>` —
+  directory listing, hidden-entry suppression, parent navigation,
+  optional manifest detection
+- A modal in `commands.html` (lazily-injected into the DOM) with
+  bread­crumb, parent button, subdir list, "Choose this directory"
+
+Both dashboards benefit from sharing this surface — same UX,
+same backend contract, no UI fragmentation.
+
+### Scope
+
+**In scope:**
+
+- Port `/api/fs/browse` endpoint from `attune-gui/sidecar/attune_gui/
+  routes/fs.py` to `src/attune/ops/routes/fs.py`. Single-file
+  endpoint, ~90 lines.
+  - `path` query param (default `~`)
+  - `annotate` query param: `help` flag dirs containing
+    `features.yaml`, `project` flags dirs containing
+    `.help/features.yaml`. For the ops dashboard we add `workspace`
+    to flag dirs that are sub-paths of `cfg.project_root` (so the
+    user sees which dirs are safely scopeable).
+  - Returns `{path, parent, entries[], has_*}` per attune-gui.
+- Port the modal JS from `attune-gui/sidecar/attune_gui/templates/
+  commands.html` (`openPathPicker(targetInput, browseHint)` and
+  helpers) into a new `src/attune/ops/static/js/path_picker.js`.
+  - Lazy DOM injection on first open
+  - Keyboard nav (Tab, Esc closes, Enter selects)
+  - Status banner ("✓ inside workspace" / "⚠ outside workspace —
+    workflow will reject" — leveraging the workspace_root we
+    already emit for scope-picker validation)
+- Wire the picker into the existing scope picker on `/workflows`:
+  the `<input class="scope-custom">` gets a `Browse…` button next
+  to it; clicking opens the modal pre-rooted at the input's
+  current value.
+- Match the styling to the dashboard's existing modal language
+  (currently none — define minimal CSS that fits the existing
+  visual system: bg-elev panel, border, shadow, dark-mode aware).
+- Path validation: on "Choose this directory", run the same
+  `isScopeInWorkspace` check we added in PR #358; if the chosen
+  path is outside the workspace, show the status banner warning
+  but still allow the choice (user may want to scope outside
+  workspace — server rejects later anyway).
+- Server-side: register the new `fs` router in `src/attune/ops/
+  server.py` mounted at `/api/fs`.
+
+**Out of scope:**
+
+- File picker (only directories — same as attune-gui's scope)
+- Recently-used paths history (Phase 2)
+- Bookmarks / favorites (Phase 2)
+- Editing the picker from inside the modal (no rename / create)
+- Cross-machine file system (local only)
+
+### Acceptance criteria
+
+1. `GET /api/fs/browse?path=/Users/patrickroebuck/attune-ai`
+   returns a JSON listing matching the attune-gui contract.
+2. The `Browse…` button on `/workflows` opens a modal centered
+   over the page.
+3. Clicking a subdir in the modal updates the breadcrumb and
+   listing. Parent button works. Esc / overlay-click closes.
+4. "Choose this directory" sets the input to the breadcrumb path
+   and closes the modal.
+5. The status banner shows "✓ inside workspace" when the
+   breadcrumb is under `cfg.project_root`, "⚠ outside workspace —
+   the run endpoint will reject this scope" otherwise.
+6. Keyboard accessible: Tab cycles through entries, Enter on a
+   subdir navigates into it, Enter on "Choose this directory"
+   confirms, Esc cancels.
+7. The picker is reusable — adding it to a future page (e.g. the
+   `--specs-root` setting on Health, or a future memory browser)
+   should be a one-line `data-browse-target` annotation, not a
+   re-wiring.
+
+### Non-goals / explicitly deferred
+
+- **Native OS file dialog.** attune-gui briefly used `osascript`;
+  switched to in-page modal because tkinter crashes on macOS
+  non-main-thread. Stick with the in-page modal.
+- **File selection.** Workflow scope is always a directory.
+- **Validation of attune-specific markers beyond workspace
+  containment.** The `has_manifest` annotations from attune-gui
+  are useful for that dashboard's command-picker use case but
+  not for ops workflow scoping. Skip the annotation params for
+  Phase 1 unless a workflow specifically benefits.
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Port of `fs.py` drifts from attune-gui's contract | Med | Copy the file verbatim and adapt only the security boundary (workspace-root); keep the response shape identical so the JS modal port works unchanged |
+| Modal styling clashes with dashboard's visual system | Low | Use existing CSS tokens (`--bg-elev`, `--shadow`, `--border`); reference the spec-detail page's recent markdown-body styling for visual coherence |
+| Permission errors on protected dirs blow up the picker | Low | attune-gui handles via 403; the modal shows an inline error and lets the user navigate away |
+| Picker reused across pages diverges in behavior | Med | Put `path_picker.js` in `src/attune/ops/static/js/` (shared); pages opt in via a single DOM attribute (e.g. `data-browse-target=".scope-custom"`) |
+
+---
+
+## Reference — attune-gui code to port
+
+**Backend:** `attune-gui/sidecar/attune_gui/routes/fs.py` (88 lines).
+The shape is small and self-contained — port verbatim, swap the
+attune-gui-specific `_has_manifest` / `_has_project_manifest`
+checks for an ops-specific `_in_workspace(cfg)` annotation.
+
+**Frontend:** `attune-gui/sidecar/attune_gui/templates/commands.html`
+lines ~585-750. Key functions:
+- `openPathPicker(targetInput, browseHint)` — entry point
+- `load(path)` — fetches /api/fs/browse and renders the modal
+- `closePicker()` — teardown
+- The lazy DOM-injection pattern (`document.getElementById('cmd-picker')`)
+  is worth keeping; rename to `attune-ops-picker` for the new context.
+
+Test file `attune-gui/sidecar/tests/test_fs.py` covers the backend
+endpoint; port those tests too (`tests/unit/ops/routes/test_fs.py`).

--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -22,6 +22,9 @@
 | Expand-on-click body | Server-side render the first user message; full transcript stays at the JSONL file on disk (no in-page transcript viewer) | Keeps the page light. Users who want the full transcript can `cat` the JSONL. |
 | Empty state | "No sessions in the last 3 days for this project. Older sessions are at `<path>`." | Tells the user where the data lives instead of pretending it doesn't. |
 | Failure mode for unreadable JSONL | Skip with WARN log, don't surface as broken row | An unreadable file is a Claude Code internal issue, not something the user can fix from the dashboard. |
+| "Resume most recent" card | **Yes — prominent top-of-page card** | Patrick approved 2026-05-14. The newest session by mtime gets full-card treatment with the full Haiku summary, a copy button, and a resume-in-new-session hint. Dedupes against the list below it. |
+| Live-session detection sources | (1) `CLAUDE_SESSION_ID` env var (if Claude Code sets one — verify during design); (2) `~/.claude/__last_session` pointer if it exists; (3) match by mtime within last 5 min as a fallback heuristic | Layered fallbacks so the feature works even when the primary signal isn't available. |
+| Live-session card behavior | "You're currently in this session" label, suppress the duplicate row in the list below | Avoids surfacing a "resume" prompt for a session that doesn't need resuming. |
 
 ---
 
@@ -43,6 +46,13 @@
    API keys, file paths, or other sensitive info. The Haiku
    summary should not echo these verbatim. Add a redaction pass
    or rely on Haiku's natural summarization to drop specifics?
+
+4. **Live-session detection mechanism — verify during design.**
+   Does Claude Code expose `CLAUDE_SESSION_ID` (or equivalent)
+   in subprocess env? Does `~/.claude/__last_session` exist as
+   a file or pointer? Run a quick check from inside a Claude
+   Code session before committing to a specific signal. The
+   mtime-based fallback (5-min window) works either way.
 
 ---
 

--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -1,0 +1,65 @@
+# Spec: Ops Sessions Page — Decisions
+
+> Pre-committed decisions captured 2026-05-14.
+
+---
+
+## Decision matrix
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Data source | `~/.claude/projects/<encoded-current-project>/*.jsonl` | Canonical Claude Code session location; no parallel store to maintain. Project-keyed encoding is `path.replace('/', '-')`. |
+| Time window | **Last 3 days** | Patrick's call. "I don't want to maintain dated and useless data." Older sessions stay on disk but aren't surfaced. |
+| Project scope | **Current project only** | Patrick's call. Cross-project resume is a power-user feature; current-project handles the 80% case. |
+| Starter-prompt generation | **Haiku-summarized** (`claude-haiku-4-5`) | Patrick's call. Sharper than heuristic. ~$0.001/session × ~10 sessions in 3-day window = ~$0.01 per uncached page load. |
+| Heuristic fallback | First user prompt + last assistant turn, both truncated to ~200 chars | Used when LLM gate is off (`ATTUNE_OPS_SESSIONS_LLM=0`) OR Haiku call errors out. |
+| Cache key | `(jsonl_filename, mtime, sha256_of_first_4kb)` | Detects edits to the file without paying for a full content hash. Cache hits are cheap on subsequent page loads. |
+| Cache location | `<attune_home>/ops/session_summaries/<session-id>.json` | Keeps session-specific data under `attune_home`, separate from `~/.claude/projects/` which we don't write to. |
+| Cache TTL | None (mtime-bound) | A file that hasn't changed since last summary doesn't need re-summarizing. |
+| Budget cap per page load | `$0.05` | Hard cap; sessions beyond the cap render heuristic-only with a "summary unavailable — over budget" marker. Configurable via `[tool.attune-ops.sessions] budget_cap_usd`. |
+| Listing route | `GET /sessions` (page) + `GET /api/sessions` (JSON) | Mirrors `/specs` + `/api/specs` and `/workflows` + `/api/runs/...`. |
+| Listing JSON shape | `{sessions: [{id, started_at, last_activity, duration_seconds, message_count, starter_prompt, source}]}` where `source` ∈ `{"heuristic", "haiku", "cached"}` | Lets the UI show a "summarized by Haiku · cached" badge for transparency. |
+| Expand-on-click body | Server-side render the first user message; full transcript stays at the JSONL file on disk (no in-page transcript viewer) | Keeps the page light. Users who want the full transcript can `cat` the JSONL. |
+| Empty state | "No sessions in the last 3 days for this project. Older sessions are at `<path>`." | Tells the user where the data lives instead of pretending it doesn't. |
+| Failure mode for unreadable JSONL | Skip with WARN log, don't surface as broken row | An unreadable file is a Claude Code internal issue, not something the user can fix from the dashboard. |
+
+---
+
+## Open questions (resolve during design phase)
+
+1. **Project-path encoding edge cases.** Some users may have
+   sessions for `~/attune-ai` (no leading `/Users/`) and
+   `/Users/patrickroebuck/attune-ai` (canonical) — same project,
+   different encoded keys. Decide whether to read multiple keys
+   or canonicalize.
+
+2. **Haiku prompt template.** The summarization prompt itself
+   needs care — what makes a good "starter prompt" vs a bad one?
+   Probably: name what was being worked on, list any open
+   threads, suggest a 1-sentence resume prompt the user can
+   paste. Calibrate against 5-10 real sessions before defaulting.
+
+3. **Active prompt-redaction.** First user messages may contain
+   API keys, file paths, or other sensitive info. The Haiku
+   summary should not echo these verbatim. Add a redaction pass
+   or rely on Haiku's natural summarization to drop specifics?
+
+---
+
+## Calibration record
+
+To be filled in during implementation:
+
+- [ ] Haiku prompt template — finalized text and 5-session test
+  snapshot
+- [ ] Average tokens per summary (in / out)
+- [ ] Average cost per session summary
+- [ ] Whether the budget cap ever fires during normal usage
+
+---
+
+## Decision-change log
+
+- 2026-05-14 — Initial decisions captured during spec draft.
+  Triggered by ops-dashboard QA punch list item P1-4. Memory
+  page explicitly dropped per Patrick.

--- a/docs/specs/ops-sessions-page/requirements.md
+++ b/docs/specs/ops-sessions-page/requirements.md
@@ -1,0 +1,97 @@
+# Spec: Ops Dashboard — Sessions Page
+
+> Add a `/sessions` page to the ops dashboard surfacing the last 3
+> days of Claude Code sessions for the **current project**, each with
+> a Haiku-summarized starter-prompt for resuming.
+
+---
+
+## Phase 1: Requirements
+
+**Status**: draft
+
+### Problem statement
+
+The 2026-05-14 QA punch list flagged that `/sessions` returns 404 —
+no template exists (P1-4). Patrick confirmed: keep Sessions, drop
+Memory, narrow scope. The use case: refreshing memory on what was
+worked on across recent Claude Code sessions, so a new session can
+start with context rather than from scratch.
+
+Existing context-recovery surface today: re-reading transcripts
+manually from `~/.claude/projects/<encoded-path>/`. Each transcript
+is a `.jsonl` file with line-delimited messages — useful but
+high-friction. A dashboard surface that lists recent sessions with
+short summaries and copy-pasteable starter prompts is the UX win.
+
+### Scope
+
+**In scope:**
+
+- New page `/sessions` in the ops dashboard.
+- Data source: `~/.claude/projects/<encoded-current-project>/*.jsonl`
+  where the encoding is the current-project absolute path with `/`
+  replaced by `-`. The dashboard's `cfg.project_root` provides the
+  unencoded path.
+- Time window: only sessions with mtime within the last **3 days**.
+- Scope: current project only (no cross-project listing).
+- Per-session display (table or card layout):
+  - Session id (short, ~8 chars of the UUID)
+  - Started timestamp (relative + absolute on hover, matching the
+    Updated column pattern on Specs)
+  - Duration (last message timestamp minus first)
+  - Message count
+  - **Starter prompt** — Haiku-summarized one-paragraph summary +
+    a suggested first prompt for resuming the session
+- Click → expand to show the first user message in full (truncated
+  to ~500 chars) plus a "Copy starter prompt to clipboard" button.
+- A "Sessions older than 3 days are hidden" footer note so users
+  understand the filter (not actively pruned from disk — Claude
+  Code owns that).
+
+**Out of scope:**
+
+- Cross-project session listing
+- Filtering / search beyond the time-window default
+- Editing sessions
+- Resuming a session in-process (just copies a starter prompt)
+- Memory page (explicitly dropped by Patrick, 2026-05-14)
+
+### Acceptance criteria
+
+1. Navigating to `/sessions` returns HTTP 200 with a list of the
+   project's sessions from the last 3 days, sorted newest first.
+2. Each session row shows id, started time, duration, message
+   count, and a Haiku-generated starter prompt.
+3. Sessions older than 3 days are not shown.
+4. Sessions with empty / unreadable JSONL files are skipped
+   (logged at WARN, not surfaced as broken rows).
+5. The Haiku summarization is gated by `ATTUNE_OPS_SESSIONS_LLM=1`
+   or an equivalent opt-in; with the gate off, a heuristic summary
+   (first user prompt + last assistant turn truncated) is used.
+6. Session summaries are cached on disk under
+   `<attune_home>/ops/session_summaries/<session-id>.json` keyed
+   by the JSONL file's mtime+sha256, so the same session isn't
+   re-summarized on every page load.
+7. Total cost per full page load (assuming cache miss on every
+   session shown) stays below `$0.05` — bounded by the 3-day
+   window and Haiku pricing.
+
+### Non-goals / explicitly deferred
+
+- **Pruning Claude Code's sessions directory.** Not our job.
+- **Live in-progress session detection.** Could be a Phase 2
+  follow-up — the currently-running Claude Code instance has a
+  PID and could be cross-referenced, but the read-only Sessions
+  page can punt.
+- **Cross-machine session sync.** Out of scope — sessions live
+  on the local machine only.
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Encoded-path heuristic doesn't always match Claude Code's logic | Med | Read `~/.claude/projects/` directly, find the dir whose name is `cfg.project_root` with `/` → `-`; fall back to any single dir if there's only one (single-project user) |
+| JSONL parsing is slow for many large sessions | Low | Only read the first line (start timestamp + first user message) and the file's mtime — no full parse for the listing view. Full parse only on expand. |
+| Haiku summarization adds visible cost | Med | Cache aggressively; opt-in flag for first release; budget cap per page load |
+| Summary quality varies | Low | Phase 1 ships heuristic + Haiku; if Haiku underperforms, fall back |

--- a/docs/specs/ops-sessions-page/requirements.md
+++ b/docs/specs/ops-sessions-page/requirements.md
@@ -48,6 +48,21 @@ short summaries and copy-pasteable starter prompts is the UX win.
 - A "Sessions older than 3 days are hidden" footer note so users
   understand the filter (not actively pruned from disk — Claude
   Code owns that).
+- **"Resume most recent" prominent action.** The single newest
+  session (by mtime) for the current project gets a dedicated
+  card at the top of the page — separate from the rest-of-list
+  treatment. Includes:
+  - The Haiku-summarized starter prompt rendered in full (not
+    truncated)
+  - A one-click "Copy starter prompt" button
+  - A "Resume in a new Claude Code session" hint that walks
+    the user through pasting the prompt into a fresh session
+  - When the in-progress Claude Code session ID is detectable
+    (via `CLAUDE_SESSION_ID` env var, `~/.claude/__last_session`
+    pointer, or equivalent — investigate during design phase),
+    the card flips to show "You're currently in this session"
+    with no starter-prompt needed; suppresses the duplicate row
+    further down the list.
 
 **Out of scope:**
 
@@ -64,6 +79,15 @@ short summaries and copy-pasteable starter prompts is the UX win.
 2. Each session row shows id, started time, duration, message
    count, and a Haiku-generated starter prompt.
 3. Sessions older than 3 days are not shown.
+3a. The newest session renders in the "Resume most recent" card
+   at the top, with its full Haiku-summarized starter prompt and
+   a copy-to-clipboard button. The same session does NOT also
+   appear in the list below.
+3b. When the dashboard is launched from inside a Claude Code
+   session and that session's id can be resolved against the
+   project's session directory, the "Resume most recent" card
+   labels itself "You're currently in this session" instead of
+   surfacing a resume prompt.
 4. Sessions with empty / unreadable JSONL files are skipped
    (logged at WARN, not surfaced as broken rows).
 5. The Haiku summarization is gated by `ATTUNE_OPS_SESSIONS_LLM=1`

--- a/docs/specs/telemetry-rethink/decisions.md
+++ b/docs/specs/telemetry-rethink/decisions.md
@@ -1,0 +1,69 @@
+# Spec: Telemetry Rethink — Decisions
+
+> Pre-committed decisions captured 2026-05-14.
+
+---
+
+## Decision matrix
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Replace vs add page | **Replace** | Patrick's call. Avoids two dashboards competing for the same mental model. CHANGELOG note covers the bookmarked-URL transition. |
+| New page identity | "Quality" or "Performance" | Final name decided at design phase. "Telemetry" is retired as a route label even if the URL stays `/telemetry` for backwards compat. |
+| URL | Keep `/telemetry` | Bookmarks survive; the new title at the top of the page sets the new expectation. |
+| Cost rollup fate | **Removed** from this page entirely | The cost data still flows through `usage.jsonl`; the Home page's KPI tiles continue showing it. Anyone who wants the rollup view can hit `/api/telemetry-summary` JSON. |
+| Redundancy clustering — Phase 1 | Exact match after normalization (trim whitespace, drop timestamps, drop absolute file paths) | Cheap, deterministic. Embedding-based clustering is Phase 2 if false negatives are common. |
+| Spendthrift formula — Phase 1 | `total_cost / run_count` per workflow | Simplest defensible formula. Document on-page so users can see what they're looking at. |
+| Latency aggregation | Median + p95 per workflow over the time window | Median resists outliers; p95 catches the tail. |
+| Latency minimum sample | ≥ 3 runs in the window | Below 3 it's noise, not signal. |
+| Faithfulness data source | `~/.attune/telemetry/rag/*.jsonl` (NEW path; attune-rag must emit) | Keeps the data structurally separate from `usage.jsonl` cost events. attune-rag's `FaithfulnessJudge` already produces these records — just needs the disk write. |
+| Empty-state policy | Each panel renders a meaningful "no data yet" message that names what would populate it | No silent zeros. |
+| Time-window default | 7 days, with "Compare to previous 7 days" delta | Matches the Home page convention. |
+| Configurable thresholds | Spendthrift `cost_per_run_threshold_usd`, latency `slow_workflow_p95_seconds`, redundancy `min_cluster_size`, faithfulness `low_score_threshold` — all under `[tool.attune-ops.telemetry]` in pyproject.toml | Lets the user calibrate to their workflow mix. |
+
+---
+
+## Open questions (resolve during design phase)
+
+1. **Page name — "Quality" vs "Performance".** Both fit. "Quality"
+   leans toward accuracy / faithfulness; "Performance" leans
+   toward latency / cost. The page covers both. Patrick picks
+   at design time.
+
+2. **Redundancy window.** A 5-minute window catches re-runs of
+   the same prompt. A longer window catches habitual rewrites.
+   Start with 60 minutes? 24 hours? Calibrate against real
+   telemetry.
+
+3. **Spendthrift signal granularity.** Per-workflow is coarse;
+   per-subagent (when SDK telemetry exposes it) would be sharper.
+   Phase 1 = per-workflow; Phase 2 considers per-subagent if the
+   data is available.
+
+4. **What "result" means for spendthrift ratio.** Cost-per-run
+   is the simplest. Patrick floated cost-per-bytes-of-output;
+   cost-per-fix-found (security-audit, code-review) would be
+   even better. Probably introduce only when there's a
+   well-defined unit per workflow.
+
+---
+
+## Calibration record
+
+To be filled in during implementation:
+
+- [ ] Redundancy window — what value lets a real user catch
+  obvious duplicates without flooding the list?
+- [ ] Latency thresholds — what's the 95th-percentile
+  workflow time across the 20 registered workflows?
+- [ ] Faithfulness baseline — what score range do real
+  attune-rag runs land in?
+
+---
+
+## Decision-change log
+
+- 2026-05-14 — Initial decisions captured during spec draft.
+  Triggered by QA review and Patrick's "moving away from cost-
+  saving-first" framing. Memory page dropped, Sessions page
+  scoped separately.

--- a/docs/specs/telemetry-rethink/requirements.md
+++ b/docs/specs/telemetry-rethink/requirements.md
@@ -1,0 +1,119 @@
+# Spec: Telemetry Rethink — Quality / Performance Dashboard
+
+> Replace the current Telemetry page with a dashboard focused on
+> **redundant API calls, spendthrift workflows, latency, and
+> accuracy / truthfulness** — the signals Patrick actually wants
+> to act on now that attune is aligned with Anthropic's solutions
+> rather than positioned as cost-saving-first.
+
+---
+
+## Phase 1: Requirements
+
+**Status**: draft
+
+### Problem statement
+
+The current `/telemetry` page renders a cost-savings rollup:
+"today's events," "7-day spend," "savings vs naive baseline,"
+"top workflows by cost." The page worked correctly for its
+original framing — "how much did the framework save me?" — but
+two things have changed:
+
+1. **Positioning shift.** Attune is no longer cost-saving-first.
+   The product is aligned with Anthropic's Agent SDK and uses
+   the API where appropriate. "Savings" is a less useful headline
+   than "where am I wasting effort?"
+2. **New quality concerns.** With RAG grounding and the
+   faithfulness work in attune-rag, accuracy / truthfulness is
+   measurable and worth surfacing on the dashboard rather than
+   left to manual spot-checks.
+
+Patrick (2026-05-14): *"I'm more concerned that you're monitoring
+redundant api calls or spendthrift practices as far as workflows
+and computer processes go, latency is also a consideration that I
+want to test. Just as I want to test the accuracy and truthfulness
+of responses now that we've done more to improve them with RAG and
+other features."*
+
+The cost rollup isn't wrong — it's just no longer the most useful
+view. Patrick's call: **replace** the current page rather than
+add a sibling page (per the QA review).
+
+### Scope
+
+**In scope: replace `/telemetry` with a Quality page**
+
+Four panels, each tied to a signal Patrick named:
+
+1. **Redundant API calls** — detect when the same prompt
+   (normalized: trimmed, stripped of timestamps and file paths)
+   was sent N times within a window. Surface the top 10 redundant
+   prompt clusters with click-through to the workflow that
+   emitted them.
+2. **Spendthrift workflows** — cost-per-result ratio. For each
+   workflow, divide total cost by some unit of work (run count,
+   bytes of output, fix count if available). Top 10 highest-
+   ratio workflows; flags candidates for prompt tuning or
+   restructuring.
+3. **Latency** — per-workflow median + p95 wall-clock time.
+   Separately, per-subagent latency where available. Surfaces
+   slow operators independently of cost.
+4. **Accuracy / faithfulness** — wire attune-rag's
+   `FaithfulnessJudge` results (already structured per the
+   2026-04-19 decision matrix) into a rolling chart. Hallucination
+   rate and faithfulness score over the last 7 / 30 days.
+
+Each panel includes:
+- A 7-day trend sparkline (or comparable visual)
+- A "What changed?" delta vs the previous 7-day window
+- Click-through to the underlying events / workflow
+
+**Out of scope:**
+
+- The original cost rollup (deprecated, deleted)
+- Per-event drilldowns (Phase 2)
+- Alerting / threshold-crossing notifications (Phase 2)
+- Cross-machine aggregation (out of scope for the local dashboard)
+
+### Acceptance criteria
+
+1. `/telemetry` now renders the Quality dashboard with four
+   panels populated from live data.
+2. Redundant-call detection catches at least one duplicate when
+   the user re-runs a workflow with the same input within ~5
+   minutes (verified manually).
+3. Spendthrift-workflow panel surfaces the workflow with the
+   highest cost-per-run when the user runs two workflows of
+   different shapes.
+4. Latency panel shows non-zero median for any workflow that
+   has run in the time window.
+5. Accuracy panel shows a faithfulness score from at least one
+   attune-rag run; renders an empty state cleanly when no
+   faithfulness telemetry exists yet.
+6. The old cost rollup is gone from the page — no "savings"
+   chip, no "7-day spend" KPI, no Daily activity table. The
+   Home page's `home_kpis` cost tile is unaffected (Home stays).
+7. The CHANGELOG documents the rename / replace as a behavior
+   change so users who bookmarked `/telemetry` know what to
+   expect.
+
+### Non-goals / explicitly deferred
+
+- **Rebuilding `read_telemetry_summary`.** The underlying
+  `usage.jsonl` reader is fine; this spec changes what we
+  AGGREGATE and PRESENT, not the storage layer.
+- **Migrating away from the cost-bucket concept entirely.** Cost
+  data still flows in; we just don't lead with it.
+- **Alerting.** A user can read the Quality page and act; we're
+  not paging them.
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| "Redundant" prompt clustering is fuzzy (when are two prompts the same?) | Med | Start with exact-match-after-normalization; add Levenshtein / embedding similarity in Phase 2 only if false negatives are common |
+| Spendthrift metric formula is contestable (what's a "unit of result"?) | Med | First pass: cost-per-run. Document the formula on the page. Iterate after Patrick uses it for a week. |
+| Faithfulness telemetry not yet wired | High | Build the empty state first; spec the data contract (`{workflow, faithfulness_score, ts}` records under `~/.attune/telemetry/rag/`); attune-rag PR follows |
+| Replacing the page surprises users who bookmarked the cost view | Low | CHANGELOG note; the existing `read_telemetry_summary` data is still queryable via the API for anyone needing it |
+| Latency panel surfaces noise if a workflow ran once with a network glitch | Low | Require ≥3 runs in the window before including a workflow; lower bar for the dev-mode dashboard |


### PR DESCRIPTION
## Summary

Three companion specs from the 2026-05-14 QA review, each Phase 1 (requirements) + pre-committed decisions matrix. Design / tasks deferred to execution sessions.

### 1. \`docs/specs/ops-sessions-page/\`

Add \`/sessions\` to the ops dashboard. Reads \`~/.claude/projects/<encoded-current-project>/*.jsonl\`, surfaces the **last 3 days** with **Haiku-summarized starter prompts**, **current project only**. Caches summaries on disk keyed by jsonl mtime+sha256 so the same session isn't re-summarized on every page load. \`$0.05\` budget cap per page load. Heuristic fallback when LLM gate is off.

Replaces QA punch list **P1-4** (Memory page explicitly dropped — "low reward").

### 2. \`docs/specs/telemetry-rethink/\`

Replace the cost-savings rollup at \`/telemetry\` with a Quality / Performance dashboard:
- Redundant API calls (cluster repeated prompts)
- Spendthrift workflows (cost-per-result ratio)
- Latency (per-workflow median + p95)
- Accuracy / faithfulness (wire attune-rag's FaithfulnessJudge output)

Cost data still flows via \`usage.jsonl\` and the Home page's KPI tiles continue showing it — only \`/telemetry\` changes.

Triggered by Patrick's positioning shift: *"moving away from being a cost saving first solution to one that is more closely aligned with Anthropic's solutions."*

### 3. \`docs/specs/ops-path-picker/\`

Replace the bare scope textbox on \`/workflows\` with a path-picker modal patterned on attune-gui's. Port verbatim:
- \`attune-gui/sidecar/attune_gui/routes/fs.py\` → \`src/attune/ops/routes/fs.py\` (~90 lines)
- attune-gui's \`commands.html\` \`openPathPicker\` modal JS → new \`src/attune/ops/static/js/path_picker.js\`

Both dashboards benefit from sharing this surface — same UX, same \`/api/fs/browse\` contract, no UI fragmentation. New \`annotate=workspace\` param flags entries inside \`cfg.project_root\` so the picker's status banner has data.

Reframes QA punch list **P2-7** (run-view scope path overflow).

## Suggested execution order

If all three approved:
1. **Sessions** first — net-new page, minimal blast radius
2. **Path picker** second — extends Workflows, no replacement
3. **Telemetry rethink** last — replaces a live page, more user-visible behavior change

Each ships as its own execution PR.

## Test plan

- [x] All three specs follow the established convention (requirements.md + decisions.md, design.md deferred)
- [x] Each requirements doc states a clear problem, scope, acceptance criteria, non-goals, and risks
- [x] Each decisions doc captures the pre-committed choices from this session's conversation
- [x] markdown lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)