### PR TITLE
fix(ops): Workflows Run button aria-label per workflow (Phase B1)

### DIFF
--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -87,7 +87,7 @@
               {% endif %}
             </td>
             <td class="num">
-              <button class="btn btn-run" type="button" data-run-button data-workflow="{{ w.name }}">Run</button>
+              <button class="btn btn-run" type="button" data-run-button data-workflow="{{ w.name }}" aria-label="Run {{ w.name }}">Run</button>
             </td>
           {% endif %}
         </tr>

--- a/tests/unit/ops/test_scope_picker.py
+++ b/tests/unit/ops/test_scope_picker.py
@@ -362,6 +362,49 @@ def test_workflows_page_no_scope_column_when_read_only(tmp_path, monkeypatch):
     assert ">Scope<" not in resp.text
 
 
+def test_workflows_run_button_has_per_workflow_aria_label(tmp_path, monkeypatch):
+    """Every Run button carries an ``aria-label`` that names the
+    workflow it triggers.
+
+    Regression guard for the QA finding where all 20 Run buttons had
+    the same accessible name ("Run") — a screen-reader user couldn't
+    distinguish "Run for bug-predict" from "Run for code-review".
+    Visible text stays "Run" (compact UI); the aria-label gives
+    assistive tech the disambiguator.
+    """
+    _write_features_yaml(
+        tmp_path,
+        """
+features:
+  security-audit:
+    description: Scan
+    files: [src/attune/security/**]
+""",
+    )
+    app, _ = _make_app(tmp_path, monkeypatch, allow_run=True)
+    with TestClient(app) as client:
+        resp = client.get("/workflows")
+    assert resp.status_code == 200
+    body = resp.text
+    # The button must carry aria-label="Run <workflow-name>" for at
+    # least one known workflow (security-audit is in the default
+    # PATH_ARG_REGISTRY so it always renders).
+    assert 'aria-label="Run security-audit"' in body
+    # Sanity: visible text didn't change — the visual "Run" label is
+    # what sighted users still see.
+    import re
+
+    button_re = re.compile(
+        r'<button[^>]*data-run-button[^>]*data-workflow="security-audit"[^>]*>([^<]*)</button>'
+    )
+    match = button_re.search(body)
+    assert match is not None, "Expected a Run button for security-audit"
+    assert match.group(1).strip() == "Run", (
+        "Visible button text should still be plain 'Run'; aria-label "
+        "carries the workflow disambiguator."
+    )
+
+
 def test_workflows_page_scope_textbox_renders_with_hidden_attr(tmp_path, monkeypatch):
     """The custom-path textbox ships with ``hidden`` set on first paint.
 


### PR DESCRIPTION
## Summary

All 20 Run buttons in the Workflows table had the same accessible
name — "Run, button" — so a screen-reader user scanning the table
couldn't distinguish "Run for `bug-predict`" from "Run for
`code-review`" without first navigating to each row's
workflow-name cell and remembering it. The visible "Run" text is
compact for sighted users; aria-label gives assistive tech the
disambiguator without affecting the visual layout.

The fix is one line: `aria-label="Run {{ w.name }}"` on the
button element. No JS, no CSS, no behavior change for sighted
users.

## What this resolves

- QA punch list item **PL-P2-1** in
  [docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md)
- Task **B1** in
  [docs/specs/ops-dashboard-polish/tasks.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-polish/tasks.md)
  (Phase B — A11y + behavioral polish, first of four remaining
  items after PR #367 absorbed B5)

PR #367 already shipped Phase B5 (Stages display) and absorbed
Phase D1 (tooltip rollout) + part of D4 (WCAG hit target), so
Phase B is down from 5 PRs to 4. B2 (Run-view 404 disk fallback),
B3 (cache-bust), B4 (Home recent-runs clickable rows) follow.

## Test plan

- [x] New `test_workflows_run_button_has_per_workflow_aria_label`
  in `tests/unit/ops/test_scope_picker.py` asserts:
  - The button's `aria-label` matches `Run <workflow-name>` for a
    known workflow (`security-audit`).
  - The visible button text is still `Run` (not `Run
    security-audit`) — catches a future regression where someone
    "fixes" the button by changing the visible label instead.
- [x] All 289 existing `tests/unit/ops/` tests still pass.
- [x] Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
