### PR TITLE
fix(ops): run-view route falls back to disk for evicted runs (Phase B2)

### DIFF
--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -154,23 +154,40 @@ async def run_view_page(run_id: str, request: Request) -> HTMLResponse:
     runner = getattr(request.app.state, "runner", None)
     if runner is None:
         raise HTTPException(status_code=503, detail="runner unavailable")
-    run = runner.get(run_id)
+    # In-memory first, then disk fallback. Distinguishing the two is
+    # load-bearing on the SSE wiring below: an in-memory Run has a live
+    # subscribers set and the executor is still streaming events;
+    # a disk-loaded Run is reconstructed without subscribers and has
+    # no live executor, so the SSE endpoint would loop indefinitely
+    # against it with nothing to stream. We render the log server-side
+    # for the disk case and signal the JS to skip EventSource.
+    in_memory_run = runner.get(run_id)
+    run = in_memory_run if in_memory_run is not None else runner.get_or_load(run_id)
     if run is None:
         logger.info("ops.run_view: run not found: run_id=%s", run_id)
         raise HTTPException(
             status_code=404,
             detail=(
-                f"run '{run_id}' not found. The runner keeps the last 20 runs "
-                "in memory; older runs are pruned when the server restarts."
+                f"run '{run_id}' not found in memory or on disk. The run "
+                "may have been pruned or never persisted."
             ),
         )
+    loaded_from_disk = in_memory_run is None
+    # SSE is only useful when the executor is live or buffered. For
+    # disk-loaded terminal runs we skip the stream entirely; the
+    # template renders the full log server-side from ``run.lines``.
+    stream_url = "" if loaded_from_disk else f"/runs/{run_id}/stream"
+    # Live runs get an empty list — the SSE replay fills the pre on
+    # subscribe. Disk-loaded runs ship their captured log inline.
+    server_rendered_lines = list(run.lines) if loaded_from_disk else []
     return _render(
         request,
         "run_view.html",
         page="run-view",
         run=run.to_dict(),
-        stream_url=f"/runs/{run_id}/stream",
+        stream_url=stream_url,
         allow_run=request.app.state.config.allow_run,
+        server_rendered_lines=server_rendered_lines,
     )
 
 

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -270,6 +270,77 @@ class RunnerService:
     def get(self, run_id: str) -> Run | None:
         return self._runs.get(run_id)
 
+    def get_or_load(self, run_id: str) -> Run | None:
+        """Return ``run_id``'s Run from memory, falling back to disk.
+
+        The dashboard's ``/runs/{id}/view`` route used to 404 whenever a
+        run was evicted from the in-memory ring buffer
+        (``_history_limit``, default 20) or after a server restart —
+        even though the recent-runs strip on Home / Workflows still
+        surfaced those runs because it reads disk directly. The disk
+        record (``<persistence_dir>/<workflow>/<run-id>.json``) holds
+        everything the route needs (status, exit_code, log lines, etc.)
+        via :meth:`Run.from_record`.
+
+        Returns ``None`` if neither the in-memory dict nor the
+        ``<persistence_dir>/*/<run-id>.json`` lookup finds the run.
+        Failures during disk read (missing perm, malformed JSON) are
+        logged at WARN and treated as cache miss — the route's 404
+        path is preferred over crashing on a corrupt record.
+
+        Note on subscribers: a Run rebuilt from disk has no
+        ``subscribers`` set and no live executor attached, so SSE
+        replay against it would loop with no events. Callers should
+        check ``run.is_terminal`` and skip the stream attempt when
+        the run is loaded from disk; the route layer does this by
+        emitting an empty ``stream_url`` when ``get()`` returns None
+        but ``get_or_load()`` finds a record.
+
+        Performance: walks
+        ``<persistence_dir>/<workflow>/<run-id>.json`` across all
+        workflow subdirectories on miss. O(workflows-with-runs) per
+        call — at the ~20-workflow scale of attune-ai this is well
+        under 1ms, so no index file is maintained. If it ever becomes
+        a hot path, the cheapest fix is a workflow-name lookup table
+        keyed by ``run_id`` populated lazily on first miss.
+        """
+        run = self._runs.get(run_id)
+        if run is not None:
+            return run
+        if self._persistence_dir is None:
+            return None
+        if not self._persistence_dir.is_dir():
+            return None
+        target_filename = f"{run_id}.json"
+        for workflow_dir in self._persistence_dir.iterdir():
+            if not workflow_dir.is_dir():
+                continue
+            candidate = workflow_dir / target_filename
+            if not candidate.is_file():
+                continue
+            try:
+                with candidate.open(encoding="utf-8") as fh:
+                    record = json.load(fh)
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "ops.runner.get_or_load: failed to read %s: %s",
+                    candidate,
+                    exc,
+                )
+                return None
+            if not isinstance(record, dict):
+                return None
+            try:
+                return Run.from_record(record)
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "ops.runner.get_or_load: malformed record %s: %s",
+                    candidate,
+                    exc,
+                )
+                return None
+        return None
+
     def recent(self, limit: int = 5) -> list[Run]:
         return list(reversed(list(self._runs.values())))[:limit]
 

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -178,6 +178,15 @@
       setStatusClass("chip-danger");
       es.close();
     });
+  } else {
+    // Disk-loaded terminal run — no SSE. The log is already rendered
+    // server-side in the <pre data-log>; we just style the status chip
+    // (the SSE-attached branch sets the chip class on terminal events).
+    setStatusClass(
+      INITIAL_STATUS === "completed" ? "chip-ok" :
+      INITIAL_STATUS === "failed" ? "chip-danger" :
+      "chip-muted"
+    );
   }
 
   // ----------------------------------------------------------------

--- a/src/attune/ops/templates/run_view.html
+++ b/src/attune/ops/templates/run_view.html
@@ -28,12 +28,23 @@
   <div class="run-view-history" data-recent-runs="{{ run.workflow }}" data-exclude-run-id="{{ run.id }}" hidden></div>
 </section>
 
-<pre class="log-output run-view-log" data-log></pre>
+{# When stream_url is empty, this run was loaded from disk (older than
+   the runner's in-memory ring buffer). Server pre-fills the log here
+   so the page renders without SSE — run_view.js detects the empty
+   stream_url and skips EventSource creation. #}
+<pre class="log-output run-view-log" data-log>{% for line in server_rendered_lines %}{{ line }}
+{% endfor %}</pre>
 
 <p class="meta run-view-foot">
-  This page reconnects to the run's stream automatically — refresh anytime
-  to see the latest output. Buffered output replays for new subscribers,
-  so you won't lose history.
+  {% if stream_url %}
+    This page reconnects to the run's stream automatically — refresh anytime
+    to see the latest output. Buffered output replays for new subscribers,
+    so you won't lose history.
+  {% else %}
+    This run was loaded from disk; the log shown above is its final
+    captured output. Live streaming is not attached because the run is
+    no longer in the runner's in-memory ring buffer.
+  {% endif %}
 </p>
 {% endblock %}
 

--- a/tests/unit/ops/test_persistence_and_history.py
+++ b/tests/unit/ops/test_persistence_and_history.py
@@ -217,6 +217,117 @@ async def test_runner_skips_persistence_when_dir_is_none(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# RunnerService.get_or_load (Phase B2: in-memory miss → disk fallback)
+# ---------------------------------------------------------------------------
+
+
+def _write_disk_record(runs_dir: Path, workflow: str, run_id: str, **fields) -> Path:
+    """Write a minimal Run record at the conventional path."""
+    workflow_dir = runs_dir / workflow
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    record = {"id": run_id, "workflow": workflow, "status": "completed", **fields}
+    path = workflow_dir / f"{run_id}.json"
+    path.write_text(json.dumps(record), encoding="utf-8")
+    return path
+
+
+def test_get_or_load_returns_in_memory_run_first(tmp_path):
+    """In-memory hit short-circuits — disk is never consulted.
+
+    Critical because the in-memory Run carries live subscribers and a
+    running executor; the from-disk reconstruction can't replace it.
+    """
+    runs_dir = tmp_path / "runs"
+    svc = RunnerService(command_builder=_echo_cmd, persistence_dir=runs_dir)
+    live = Run(id="abc12345", workflow="security-audit", status="running")
+    svc._runs[live.id] = live
+    # Disk record with a different status — proving we got the in-memory one
+    _write_disk_record(runs_dir, "security-audit", "abc12345", status="failed")
+
+    result = svc.get_or_load("abc12345")
+    assert result is live  # identity, not equality — same object
+
+
+def test_get_or_load_falls_back_to_disk_on_memory_miss(tmp_path):
+    """The bug being fixed: a run that was pruned from the 20-item
+    in-memory ring buffer is still on disk; the route should find it."""
+    runs_dir = tmp_path / "runs"
+    svc = RunnerService(command_builder=_echo_cmd, persistence_dir=runs_dir)
+    _write_disk_record(
+        runs_dir,
+        "security-audit",
+        "deadbeef0001",
+        exit_code=0,
+        lines=["finding 1", "finding 2"],
+    )
+
+    result = svc.get_or_load("deadbeef0001")
+    assert result is not None
+    assert result.id == "deadbeef0001"
+    assert result.workflow == "security-audit"
+    assert result.status == "completed"
+    assert result.lines == ["finding 1", "finding 2"]
+    # Disk-loaded runs come back without live subscribers — the route
+    # layer must skip SSE attachment because the executor is gone.
+    assert result.subscribers == set()
+
+
+def test_get_or_load_returns_none_when_both_miss(tmp_path):
+    """Genuinely-missing run → None (route turns this into 404)."""
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    svc = RunnerService(command_builder=_echo_cmd, persistence_dir=runs_dir)
+    assert svc.get_or_load("nonexistent12") is None
+
+
+def test_get_or_load_returns_none_when_no_persistence_dir(tmp_path):
+    """Read-only mode (no persistence) + memory miss → None.
+
+    Read-only mode disables disk writes entirely, so there's nothing
+    on disk to fall back to — but get_or_load should still not raise.
+    """
+    svc = RunnerService(command_builder=_echo_cmd, persistence_dir=None)
+    assert svc.get_or_load("anything") is None
+
+
+def test_get_or_load_tolerates_malformed_json(tmp_path, caplog):
+    """A corrupt record on disk → None + WARN log, not a 500."""
+    import logging
+
+    runs_dir = tmp_path / "runs"
+    workflow_dir = runs_dir / "security-audit"
+    workflow_dir.mkdir(parents=True)
+    bad = workflow_dir / "corrupt12345.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+
+    svc = RunnerService(command_builder=_echo_cmd, persistence_dir=runs_dir)
+    with caplog.at_level(logging.WARNING, logger="attune.ops.runner"):
+        assert svc.get_or_load("corrupt12345") is None
+    # WARN was logged so the operator can investigate the corrupt record
+    assert any(
+        "failed to read" in record.message.lower() or "malformed" in record.message.lower()
+        for record in caplog.records
+    )
+
+
+def test_get_or_load_walks_multiple_workflow_subdirs(tmp_path):
+    """Walks subdirectories — the run_id alone doesn't say which
+    workflow folder it lives in, so we scan."""
+    runs_dir = tmp_path / "runs"
+    # Distractor workflows
+    _write_disk_record(runs_dir, "code-review", "other000001", status="completed")
+    _write_disk_record(runs_dir, "deep-review", "other000002", status="completed")
+    # Target — should still be found
+    _write_disk_record(runs_dir, "security-audit", "target000003", status="failed")
+
+    svc = RunnerService(command_builder=_echo_cmd, persistence_dir=runs_dir)
+    result = svc.get_or_load("target000003")
+    assert result is not None
+    assert result.workflow == "security-audit"
+    assert result.status == "failed"
+
+
+# ---------------------------------------------------------------------------
 # prune_old_runs
 # ---------------------------------------------------------------------------
 
@@ -483,6 +594,14 @@ def test_run_view_js_exists_and_exposes_helpers():
     assert "Read-only mode" in text
     # Phase 4.2: 409 surfaces inline, doesn't navigate
     assert "current_run_id" in text
+    # Phase B2: disk-loaded runs ship with an empty stream_url; the JS
+    # must NOT open an EventSource against ``""``. The wrapping
+    # ``if (STREAM_URL)`` block is the gate; the ``else`` branch
+    # styles the status chip server-rendered-only.
+    assert "if (STREAM_URL)" in text
+    # And the else-branch comment markers the empty-stream-url path
+    # (so a future refactor that drops the branch loses the test).
+    assert "Disk-loaded terminal run" in text
 
 
 def test_run_view_js_validates_from_param():
@@ -534,3 +653,124 @@ async def test_run_view_data_block_allow_run_false_in_read_only(tmp_path, monkey
     block = body[block_open:block_close].strip()
     parsed = json.loads(block)
     assert parsed["allow_run"] is False
+
+
+# ---------------------------------------------------------------------------
+# Phase B2 — run-view route falls back to disk for evicted runs
+# ---------------------------------------------------------------------------
+
+
+def test_run_view_renders_disk_only_run(tmp_path, monkeypatch):
+    """The bug fix: a run that's been pruned from memory but still on
+    disk renders cleanly instead of 404'ing.
+
+    Sets up a runs/ directory with a record but does NOT register
+    anything in the runner's in-memory dict — mirrors the "older runs
+    are pruned when the server restarts" scenario from the QA punch
+    list.
+    """
+    app, _runner, config = _make_app(tmp_path, monkeypatch, allow_run=True)
+    # Pre-populate disk; runner._runs stays empty.
+    _write_disk_record(
+        config.runs_dir,
+        "security-audit",
+        "evicted00001",
+        exit_code=0,
+        started_at="2026-05-14T18:00:00+00:00",
+        completed_at="2026-05-14T18:02:30+00:00",
+        lines=["line one", "line two", "scan complete"],
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/runs/evicted00001/view")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.text
+    # Run metadata shows up
+    assert "security-audit" in body
+    assert "evicted00001"[:12] in body  # template slices id[:12]
+    # Log lines were rendered server-side (NOT just left blank for SSE)
+    assert "line one" in body
+    assert "line two" in body
+    assert "scan complete" in body
+
+
+def test_run_view_disk_run_emits_empty_stream_url(tmp_path, monkeypatch):
+    """A disk-loaded run gets ``stream_url=""`` in the JSON config
+    block so run_view.js skips EventSource creation. Without this,
+    the JS would attempt to connect to a stream that 404s and the
+    page would show a "stream error" chip."""
+    app, _runner, config = _make_app(tmp_path, monkeypatch, allow_run=True)
+    _write_disk_record(
+        config.runs_dir,
+        "code-review",
+        "evicted00002",
+        exit_code=0,
+        lines=["one"],
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/runs/evicted00002/view")
+
+    assert resp.status_code == 200
+    body = resp.text
+    start = body.index('id="run-view-data"')
+    block_open = body.index(">", start) + 1
+    block_close = body.index("</script>", block_open)
+    parsed = json.loads(body[block_open:block_close].strip())
+    assert parsed["stream_url"] == ""
+    assert parsed["workflow"] == "code-review"
+
+
+@pytest.mark.asyncio
+async def test_run_view_still_works_for_in_memory_run(tmp_path, monkeypatch):
+    """Regression guard: the disk-fallback change must not break the
+    SSE-attached behavior for currently-in-memory runs.
+
+    Starts a real subprocess so the runner has the run in _runs, then
+    requests the view. Stream URL must be populated and the log must
+    NOT be pre-rendered (SSE replay fills it client-side).
+    """
+    app, runner, _config = _make_app(tmp_path, monkeypatch, allow_run=True)
+    run = await runner.start("security-audit")
+    await _wait_terminal(runner, run.id)
+
+    with TestClient(app) as client:
+        resp = client.get(f"/runs/{run.id}/view")
+
+    assert resp.status_code == 200
+    body = resp.text
+    start = body.index('id="run-view-data"')
+    block_open = body.index(">", start) + 1
+    block_close = body.index("</script>", block_open)
+    parsed = json.loads(body[block_open:block_close].strip())
+    # In-memory runs still get a stream_url so the JS replays via SSE.
+    assert parsed["stream_url"] == f"/runs/{run.id}/stream"
+    # And the log pane is empty server-side (SSE will fill it).
+    # The <pre data-log> appears in the body but contains no log lines.
+    import re
+
+    pre_match = re.search(r"<pre[^>]*data-log[^>]*>(.*?)</pre>", body, re.DOTALL)
+    assert pre_match is not None
+    pre_content = pre_match.group(1).strip()
+    # Tolerate whitespace; assert no actual log content
+    assert "start security-audit" not in pre_content
+    assert "end security-audit" not in pre_content
+
+
+def test_run_view_404_when_neither_memory_nor_disk_has_run(tmp_path, monkeypatch):
+    """No memory + no disk → 404 (preserves the old behavior for
+    genuinely missing runs)."""
+    app, _runner, _config = _make_app(tmp_path, monkeypatch, allow_run=True)
+
+    with TestClient(app) as client:
+        resp = client.get("/runs/genuinely0000/view")
+
+    assert resp.status_code == 404
+    # NOTE: the HTTPException's ``detail`` string ("not found in memory
+    # or on disk") doesn't currently surface in the rendered HTML — the
+    # app's exception handler returns a generic 404 page. The detail is
+    # still useful in server logs but isn't visible to the browser. The
+    # generic HTML / detail-lost-on-render gap is worth a separate fix
+    # (a custom 404.html that interpolates exc.detail); not part of
+    # B2's scope. Status code is what users perceive as "not found."


### PR DESCRIPTION
## Summary

`/runs/{run_id}/view` 404'd whenever a run was pruned from the
in-memory ring buffer (`RunnerService._runs`, capped at the last
20) or after a server restart — even though the recent-runs strip
on Home / Workflows still surfaced those runs because it already
reads disk directly. Users clicking an older entry from the recent
strip hit "run not found" with no recovery path.

The fix adds a `RunnerService.get_or_load(run_id)` method that
walks `<persistence_dir>/<workflow>/<run-id>.json` on in-memory
miss and reconstructs the Run via `Run.from_record`. The route
uses it instead of `runner.get()` and distinguishes the two
sources because the SSE wiring differs:

- **In-memory run**: live executor + subscribers, SSE replays the
  buffered log (existing behavior, unchanged).
- **Disk-loaded run**: no executor, no subscribers — SSE would
  loop indefinitely. Route emits `stream_url=""` and renders the
  captured log inline in `<pre data-log>`. `run_view.js` already
  gates EventSource on `if (STREAM_URL)`; the new `else` branch
  sets the status-chip color for the no-SSE path.

## Behaviour delta

| Scenario | Before | After |
|---|---|---|
| Click an evicted run from Home's Recent strip | 404 | 200 — log rendered server-side |
| Refresh `/runs/<id>/view` after server restart | 404 | 200 — log rendered server-side |
| Click an in-memory run (recent) | 200 with SSE | Same — SSE unchanged |
| Click a never-existed run id | 404 | 404 (with "memory or on disk" detail in logs) |

## Defensive failure modes

- Persistence dir not configured (read-only mode) → memory-only,
  no disk walk.
- Persistence dir missing from filesystem → graceful `None`.
- Corrupt JSON record → logged at WARN, returns `None` (route
  turns into 404 — preferred over crashing).
- Malformed record shape rejected by `Run.from_record` → same.

## What this resolves

- QA punch list item **PL-P2-2** in
  [docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md)
- Task **B2** in
  [docs/specs/ops-dashboard-polish/tasks.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-polish/tasks.md)
  (Phase B — A11y + behavioral polish, second of four remaining
  items after PR #367 absorbed B5)

Companion to [PR #370](https://github.com/Smart-AI-Memory/attune-ai/pull/370)
(Phase B1, Run button aria-label). B3 (cache-bust) and B4 (Home
recent-runs clickable rows) follow.

## Tangentially noted

The 404 `HTTPException`'s `detail` string ("not found in memory or
on disk") isn't surfaced in the generic HTML error page the app
renders — the message is only useful in server logs. Worth a
separate fix (custom 404 template that interpolates `exc.detail`)
but out of scope for B2.

## Test plan

- [x] 6 new `get_or_load` unit tests:
  - In-memory hit short-circuits (identity check, not equality).
  - Disk fallback on memory miss returns reconstructed Run.
  - Both-miss returns `None`.
  - No persistence dir → graceful `None`.
  - Corrupt JSON → `None` + WARN log captured via caplog.
  - Walks multiple workflow subdirectories to find the run.
- [x] 3 new route tests: disk-only run renders 200 with inline
  log; JSON config block carries `stream_url=""` for disk-loaded
  runs; in-memory runs still get live SSE (regression guard).
- [x] 1 new 404 guard for the "neither memory nor disk" case.
- [x] 1 updated JS-surface test asserts the `if (STREAM_URL)`
  gate plus the disk-loaded `else`-branch marker.
- [x] All 298 ops tests pass.
- [x] Ruff + pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
