### PR TITLE
spec(test-quality): make 'delete dead code, don't test it' explicit in step (d)

### DIFF
--- a/docs/specs/test-quality-program/design.md
+++ b/docs/specs/test-quality-program/design.md
@@ -114,6 +114,23 @@ touches >1 module. If a bug requires public-API change, **stop
 and surface** — don't fold silently. Test-reliability bugs
 (Class 5) get fixed alongside.
 
+Two corollaries that follow from the Class 2 definition but
+deserve to be explicit:
+
+- **Dead defensive code → delete. Do not test it.** A Class 2
+  branch is unreachable; writing a test for it requires
+  contorting inputs in ways production code can't produce.
+  Delete the branch, re-run coverage, and accept that the
+  module's *natural ceiling* has moved up. The ceiling is
+  wherever genuinely-reachable branches end — typically
+  ~98% on modules with unreachable post-import code
+  (dotenv/tiktoken try-imports), 100% on most others.
+- **Never contort tests to hit a coverage number.** The
+  rubric optimizes meaningful coverage, not line %. Step
+  (f) writes tests for uncovered *behaviors*, not for
+  uncovered lines. If a line resists testing, it's a (d)
+  candidate (delete or fix), not an (f) candidate.
+
 **(e) Triage existing tests.**
 
 | Existing test shape | Action |


### PR DESCRIPTION
## Summary

Makes the "delete dead code, don't test it" rule explicit in the
test-quality-program playbook (step (d) FIX in `design.md`).

The rule lived in the practice and the `COVERAGE_BUG_LOG.md` /
CHANGELOG history but wasn't stated in the playbook itself. A
future contributor reading the spec cold could miss it and
dutifully write tests for the unreachable branches they were
supposed to delete — defeating the rubric's intent.

## What changed

`docs/specs/test-quality-program/design.md` — adds 17 lines after
step (d), spelling out two corollaries that already follow from
the Class 2 bug definition:

- **Dead defensive code → delete. Do not test it.** Names the
  "natural ceiling" framing the methodology already uses.
- **Never contort tests to hit a coverage number.** Step (f)
  writes tests for behaviors, not lines.

No methodology change — this codifies what the rubric already
optimizes for ("meaningful coverage, not line %"). Future
sessions get explicit guidance instead of inferring it from the
bug-class taxonomy.

## Test plan

- [x] Markdown renders correctly (verified the block in context)
- [x] No code changes — pure spec doc
- [x] CI: trivially green; no Python touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
