### PR TITLE
fix(ops): release-keyed cache-bust on static asset URLs (Phase B3)

### DIFF
--- a/src/attune/ops/templates/base.html
+++ b/src/attune/ops/templates/base.html
@@ -4,7 +4,13 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}attune ops{% endblock %} · attune ops</title>
-    <link rel="stylesheet" href="{{ url_for('static', path='css/main.css') }}?v={{ range(100000, 999999) | random }}" />
+    {# Release-keyed cache-bust: version pinning lets browsers cache the
+       file BETWEEN requests within a release while busting reliably on
+       upgrade. Replaces the previous ``random`` dev-iteration hack
+       (which busted every page render and defeated browser caching in
+       production). For dev work where the random buster was useful,
+       Cmd+Shift+R / DevTools "Disable cache" still does the job. #}
+    <link rel="stylesheet" href="{{ url_for('static', path='css/main.css') }}?v={{ attune_version }}" />
   </head>
   <body data-page="{{ page }}">
     <header class="topbar">

--- a/src/attune/ops/templates/run_view.html
+++ b/src/attune/ops/templates/run_view.html
@@ -64,6 +64,6 @@
 {# runner.js provides the shared setupRecentRuns helper that
    run_view.js calls. Loaded BEFORE run_view.js so the helper is
    available when run_view.js initializes. #}
-<script src="{{ url_for('static', path='js/runner.js') }}"></script>
-<script src="{{ url_for('static', path='js/run_view.js') }}"></script>
+<script src="{{ url_for('static', path='js/runner.js') }}?v={{ attune_version }}"></script>
+<script src="{{ url_for('static', path='js/run_view.js') }}?v={{ attune_version }}"></script>
 {% endblock %}

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -122,6 +122,6 @@
 
 {% block scripts %}
 {% if allow_run %}
-  <script src="{{ url_for('static', path='js/specs.js') }}"></script>
+  <script src="{{ url_for('static', path='js/specs.js') }}?v={{ attune_version }}"></script>
 {% endif %}
 {% endblock %}

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -114,5 +114,5 @@
    DOMContentLoaded handler queries for run-button / scope-picker
    elements that only exist when allow_run is True, so the read-only
    page sees a no-op for those features. #}
-<script src="{{ url_for('static', path='js/runner.js') }}"></script>
+<script src="{{ url_for('static', path='js/runner.js') }}?v={{ attune_version }}"></script>
 {% endblock %}

--- a/tests/unit/ops/test_smoke.py
+++ b/tests/unit/ops/test_smoke.py
@@ -126,3 +126,72 @@ def test_family_versions_at_least_attune_ai():
     versions = data.family_versions()
     names = {v.package for v in versions}
     assert "attune-ai" in names
+
+
+# ---------------------------------------------------------------------------
+# Phase B3 — release-keyed cache-bust on static asset URLs
+# ---------------------------------------------------------------------------
+
+
+def test_static_assets_have_version_cache_bust(client):
+    """Every ``<script src>`` and ``<link rel="stylesheet">`` URL on
+    the dashboard carries a ``?v=<attune_version>`` query string.
+
+    Regression guard for the dashboard-iteration problem documented
+    in CLAUDE.md: a release that updates a JS file (e.g. adding a
+    new export to runner.js) used to blank out for returning users
+    because browsers held the old cached copy with no
+    ``Cache-Control`` discipline to force a recheck. Version-keyed
+    cache-bust solves it: the URL changes on release, the cached
+    copy doesn't match, the browser fetches fresh — but stays
+    cached BETWEEN releases for snappy navigation.
+
+    The previous CSS rule used ``range(100000, 999999) | random``
+    which busted every page render — useful for dev iteration,
+    bad for production caching. That random buster is gone too.
+    """
+    import re
+
+    from attune import __version__ as attune_version
+
+    response = client.get("/workflows")
+    assert response.status_code == 200
+    body = response.text
+    # All four pages share base.html so checking one is enough for
+    # CSS; we also want JS specifically (one per page).
+    # The random-buster antipattern must not return:
+    assert "range(100000" not in body
+    # CSS link carries the version
+    css_link_re = re.compile(
+        r'<link[^>]+rel="stylesheet"[^>]+href="[^"]+/css/main\.css\?v=([^"]+)"'
+    )
+    css_match = css_link_re.search(body)
+    assert (
+        css_match is not None
+    ), "Expected <link rel=stylesheet> for main.css with ?v= query string"
+    assert css_match.group(1) == attune_version
+    # JS script tag carries the version (runner.js on the Workflows page)
+    js_script_re = re.compile(r'<script[^>]+src="[^"]+/js/runner\.js\?v=([^"]+)"')
+    js_match = js_script_re.search(body)
+    assert js_match is not None, "Expected runner.js with ?v= query string"
+    assert js_match.group(1) == attune_version
+
+
+def test_specs_page_specs_js_has_version_cache_bust(client):
+    """The Specs page's specs.js script tag carries the version too —
+    distinct from runner.js since it only loads when allow_run is
+    true on the Specs page."""
+    import re
+
+    from attune import __version__ as attune_version
+
+    response = client.get("/specs")
+    assert response.status_code == 200
+    # Only assert if specs.js shows up — read-only mode omits it.
+    if "specs.js" in response.text:
+        m = re.search(
+            r'<script[^>]+src="[^"]+/js/specs\.js\?v=([^"]+)"',
+            response.text,
+        )
+        assert m is not None, "specs.js is referenced but without a ?v= cache-bust"
+        assert m.group(1) == attune_version


### PR DESCRIPTION
## Summary

Every `<script src>` and `<link rel="stylesheet">` URL the dashboard emits now carries `?v={{ attune_version }}`. Closes the documented gap where a release that ships new JS (e.g. a new export on `runner.js`, or the per-row `data-scope-default` machinery in PR #365) blanks out for returning users because the browser holds the previous cached copy with no `Cache-Control` discipline to force a recheck.

### Mechanism

- Browser keys its cache by URL. `runner.js?v=6.8.0` ≠ `runner.js?v=6.9.0`, so a new release URL forces a fresh fetch.
- Between releases the URL is stable, so browsers cache normally for snappy navigation. **No defeat-of-caching tradeoff.**
- `attune_version` is already a Jinja global (set in `server.create_app` at module-load), so this is a pure template-side change — no route plumbing needed.

### Bonus cleanup

Also removes the previous CSS `?v={{ range(100000, 999999) | random }}` dev-iteration buster, which busted on every page render and defeated browser caching in production. The lesson on that pattern (already in CLAUDE.md) notes Cmd+Shift+R + DevTools "Disable cache" are the right tools for dev iteration; the random buster doesn't need to ship to users.

### Sites touched (4 templates, 5 references)

| File | Asset |
|---|---|
| `base.html` | `main.css` |
| `workflows.html` | `runner.js` |
| `run_view.html` | `runner.js` + `run_view.js` |
| `specs.html` | `specs.js` (conditional on `allow_run`) |

## What this resolves

- QA punch list item **PL-P2-3** in [docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md)
- Task **B3** in [docs/specs/ops-dashboard-polish/tasks.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-polish/tasks.md) (Phase B — A11y + behavioral polish, third of four remaining items after PR #367 absorbed B5)

Companions: [PR #370 (B1)](https://github.com/Smart-AI-Memory/attune-ai/pull/370) merged, [PR #371 (B2)](https://github.com/Smart-AI-Memory/attune-ai/pull/371) in CI. **B4** (Home recent-runs clickable rows) is the last remaining Phase B item.

## Test plan

- [x] Two new guards in `test_smoke.py`:
  - `test_static_assets_have_version_cache_bust` — asserts both CSS link AND runner.js carry `?v=<attune_version>` on the Workflows page; explicitly guards against re-introducing the `range(100000` random buster.
  - `test_specs_page_specs_js_has_version_cache_bust` — covers the Specs page's separate `specs.js` script tag (only loaded when `allow_run` is true).
- [x] All 301 ops tests pass.
- [x] Pre-commit + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)