### PR TITLE
fix(ops): Home Recent-runs rows are fully clickable (Phase B4)

### DIFF
--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -323,6 +323,37 @@ a.kpi:hover {
 .data-table tbody tr:hover {
   background: var(--bg-soft);
 }
+
+/* Recent-runs row click affordance (Phase B4). Each cell wraps its
+   content in an ``<a class="row-link">`` linking to the run-view
+   page; the link is display:block + fills the cell's padding (the
+   .data-table padding moves from the <td> to the <a> for these
+   rows). Result: clicking anywhere in the cell — including the
+   padding strip — opens the run. ``color: inherit`` keeps chip /
+   monospace text rendering normal; ``text-decoration: none``
+   prevents the row from looking like a row of underlined links.
+   ``cursor: pointer`` on the row signals clickability before the
+   user lands on a specific cell. Only the first per-row link is
+   in tab order (``tabindex="-1"`` on the others) so keyboard nav
+   gets ONE focus stop per run, not six. */
+.recent-runs-table tbody tr.recent-run-row {
+  cursor: pointer;
+}
+.recent-runs-table tbody tr.recent-run-row > td {
+  padding: 0;  /* moved into the <a> below so it's part of the
+                  click target */
+}
+.recent-runs-table tbody td a.row-link {
+  display: block;
+  padding: 8px 10px;
+  color: inherit;
+  text-decoration: none;
+}
+.recent-runs-table tbody td a.row-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 4px;
+}
 .data-table .num {
   text-align: right;
   font-variant-numeric: tabular-nums;

--- a/src/attune/ops/templates/home.html
+++ b/src/attune/ops/templates/home.html
@@ -43,17 +43,26 @@
 <section class="panel">
   <h2>Recent runs</h2>
   {% if recent_runs %}
+    {# Each cell wraps its content in an ``<a class="row-link">``
+       linking to ``/runs/<id>/view`` so the entire row is clickable —
+       not just the workflow-name and run-id cells. Per-cell ``<a>``
+       (rather than an absolutely-positioned overlay or a JS click
+       handler) keeps the row keyboard-accessible without scripts and
+       avoids the table-row ``position: relative`` quirks on older
+       browsers. CSS in main.css makes ``.row-link`` display:block +
+       color:inherit + text-decoration:none so the existing chip /
+       monospace styling stays visible. #}
     <table class="data-table recent-runs-table">
       <thead><tr><th>Workflow</th><th>Run</th><th>Status</th><th class="num">Duration</th><th>Started</th><th class="num">Lines</th></tr></thead>
       <tbody>
         {% for r in recent_runs %}
-          <tr>
-            <td><a href="/runs/{{ r.id }}/view" class="link"><code>{{ r.workflow }}</code></a></td>
-            <td><a href="/runs/{{ r.id }}/view" class="link"><code>{{ r.id[:8] }}</code></a></td>
-            <td><span class="chip chip-{{ r.status }}">{{ r.status }}</span></td>
-            <td class="num">{% if r.duration_seconds is not none %}{{ '%.1fs'|format(r.duration_seconds) }}{% else %}—{% endif %}</td>
-            <td><code class="started">{{ r.started_at[:19] if r.started_at else '—' }}</code></td>
-            <td class="num">{{ r.line_count }}</td>
+          <tr class="recent-run-row">
+            <td><a href="/runs/{{ r.id }}/view" class="row-link" aria-label="Open run {{ r.id[:8] }} for {{ r.workflow }}"><code>{{ r.workflow }}</code></a></td>
+            <td><a href="/runs/{{ r.id }}/view" class="row-link" tabindex="-1"><code>{{ r.id[:8] }}</code></a></td>
+            <td><a href="/runs/{{ r.id }}/view" class="row-link" tabindex="-1"><span class="chip chip-{{ r.status }}">{{ r.status }}</span></a></td>
+            <td class="num"><a href="/runs/{{ r.id }}/view" class="row-link" tabindex="-1">{% if r.duration_seconds is not none %}{{ '%.1fs'|format(r.duration_seconds) }}{% else %}—{% endif %}</a></td>
+            <td><a href="/runs/{{ r.id }}/view" class="row-link" tabindex="-1"><code class="started">{{ r.started_at[:19] if r.started_at else '—' }}</code></a></td>
+            <td class="num"><a href="/runs/{{ r.id }}/view" class="row-link" tabindex="-1">{{ r.line_count }}</a></td>
           </tr>
         {% endfor %}
       </tbody>

--- a/tests/unit/ops/test_home.py
+++ b/tests/unit/ops/test_home.py
@@ -108,6 +108,113 @@ def test_home_renders_with_runner_recent_runs(tmp_path, monkeypatch):
     assert "completed" in resp.text
 
 
+def test_home_recent_runs_each_cell_links_to_run_view(tmp_path, monkeypatch):
+    """Phase B4: every cell in a Recent-runs row is clickable.
+
+    Pre-B4, only the workflow-name and run-id cells had ``<a>``
+    wrappers — clicking the status chip, duration, started-at, or
+    line-count cells did nothing. Users who tried to "click the
+    row" missed unless they hit one of the two link cells.
+
+    Regression guard: each of the SIX cells must wrap its content
+    in an ``<a class="row-link" href="/runs/<id>/view">`` so the
+    entire row is mouse-clickable. Keyboard nav gets ONE focus
+    stop per row (the first link); the rest use ``tabindex="-1"``
+    to stay out of tab order while remaining mouse-clickable.
+    """
+    import re
+
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService()
+    seeded = Run(id="abc12345", workflow="code-review")
+    seeded.status = "completed"
+    seeded.exit_code = 0
+    from datetime import datetime, timezone
+
+    seeded.started_at = datetime(2026, 5, 6, 12, 0, 0, tzinfo=timezone.utc)
+    seeded.completed_at = datetime(2026, 5, 6, 12, 0, 5, tzinfo=timezone.utc)
+    seeded.lines = ["line one", "line two"]
+    runner._runs[seeded.id] = seeded  # noqa: SLF001
+
+    app = create_app(config, runner=runner)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    body = resp.text
+
+    # Isolate the seeded run's <tr> — we only want THIS row, not other
+    # runs the server might have surfaced. The row carries the
+    # ``recent-run-row`` class added in B4.
+    row_re = re.compile(
+        r'<tr class="recent-run-row">(.*?)</tr>',
+        re.DOTALL,
+    )
+    row_match = row_re.search(body)
+    assert row_match is not None, (
+        "Recent-runs table doesn't render a row with class "
+        "``recent-run-row`` — the B4 click-target class is missing"
+    )
+    row_html = row_match.group(1)
+    # Count <a class="row-link"> openings pointing at the run-view.
+    # Attribute order on the rendered tag is template-author-dependent
+    # (today: href first, class second), so match the tag opening then
+    # check both attributes are present inside it, rather than
+    # constraining their order in the regex.
+    a_opens = re.findall(r"<a\b[^>]*>", row_html)
+    row_links = [
+        tag for tag in a_opens if 'class="row-link"' in tag and 'href="/runs/abc12345/view"' in tag
+    ]
+    assert len(row_links) == 6, (
+        f"Expected 6 row-link <a> elements (one per cell) inside the "
+        f"seeded run's row; found {len(row_links)}. Cells: workflow, "
+        f"run id, status, duration, started, lines."
+    )
+    # Only the first link is in tab order. The other five carry
+    # ``tabindex="-1"`` so keyboard nav doesn't have to stop 6 times
+    # per row. This is the keyboard-accessibility part of the design.
+    tabindex_neg = [tag for tag in row_links if 'tabindex="-1"' in tag]
+    assert len(tabindex_neg) == 5, (
+        "Expected 5 of the 6 row-link <a>s to carry tabindex='-1' "
+        "(only the first stays in tab order); found a different count"
+    )
+    # The first cell-link is also the one carrying the descriptive
+    # aria-label that screen readers announce for the row.
+    assert (
+        'aria-label="Open run abc12345 for code-review"' in row_html
+    ), "First row-link should carry a descriptive aria-label"
+
+
+def test_home_recent_runs_css_makes_row_clickable():
+    """The CSS hook for B4 (``recent-runs-table tbody td a.row-link``)
+    must exist in main.css. The visual cue (``cursor: pointer`` on
+    the row) is part of the design promise — without it users don't
+    discover the whole-row click target."""
+    from pathlib import Path
+
+    css_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "css"
+        / "main.css"
+    )
+    text = css_path.read_text(encoding="utf-8")
+    # The cursor cue
+    assert "tr.recent-run-row" in text
+    assert "cursor: pointer" in text
+    # The link-styling rule that makes <a> fill the cell
+    assert ".recent-runs-table tbody td a.row-link" in text
+    assert "display: block" in text
+    assert "color: inherit" in text
+    assert "text-decoration: none" in text
+
+
 def test_home_shows_empty_state_when_no_runs(tmp_path, monkeypatch):
     monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
     config = build_config(


### PR DESCRIPTION
## Summary

Pre-B4, only the workflow-name and run-id cells in a Recent-runs row were clickable — the status chip, duration, started-at, and line-count cells were inert. Users who tried to "click anywhere on the row" to open a run missed unless they hit one of the two linked cells.

The fix wraps every cell's content in `<a class="row-link" href="/runs/{r.id}/view">`. Six cells, six `<a>` tags. CSS moves the cell padding from `<td>` to the `<a>` so the click target covers the whole cell (including the padding strip).

### Keyboard-accessibility tradeoff

The naive "six `<a>`s per row" gives six tab stops per run — brutal in a multi-row table. The compromise: only the **first** cell-link stays in tab order; the other five carry `tabindex="-1"` so they're mouse-clickable but skip the tab sequence. Keyboard users get one focus stop per run pointing at the workflow-name link, which carries a descriptive `aria-label="Open run <id> for <workflow>"` so screen readers announce the destination clearly.

This is option (a) from the design walkthrough — JS-free, keyboard-focusable, no `position: relative` `<tr>` fragility on older browsers, no absolute-positioned overlay `<a>` that interferes with text selection.

### Behaviour delta

| Action | Before | After |
|---|---|---|
| Click workflow name | Open run | Open run |
| Click run id | Open run | Open run |
| Click status chip | Nothing | **Open run** |
| Click duration cell | Nothing | **Open run** |
| Click started-at cell | Nothing | **Open run** |
| Click lines cell | Nothing | **Open run** |
| Hover anywhere on row | Background highlight | Background highlight + cursor:pointer |
| Tab through table | 2 stops per row | **1 stop per row** |

## What this resolves

- QA punch list item **PL-P2-4** in [docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md)
- Task **B4** in [docs/specs/ops-dashboard-polish/tasks.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-polish/tasks.md) (Phase B — A11y + behavioral polish, the **last** remaining item)

**Phase B is complete after this lands.** B1 ([#370](https://github.com/Smart-AI-Memory/attune-ai/pull/370)), B2 ([#371](https://github.com/Smart-AI-Memory/attune-ai/pull/371)), B3 ([#374](https://github.com/Smart-AI-Memory/attune-ai/pull/374)), B4 (this) — B5 was absorbed by PR #367.

## Test plan

- [x] `test_home_recent_runs_each_cell_links_to_run_view` — asserts the seeded row has exactly 6 `<a class="row-link">` elements all pointing at the seeded run's URL, plus 5 of them carry `tabindex="-1"`, plus the first carries the descriptive `aria-label`.
- [x] `test_home_recent_runs_css_makes_row_clickable` — asserts the CSS hook (`.row-link` display:block / color:inherit / text-decoration:none + the `recent-run-row` cursor cue) lives in `main.css`.
- [x] All 303 ops tests pass.
- [x] Pre-commit + ruff clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)