### PR TITLE
fix(ops): topbar project chip reads name from pyproject.toml (Phase D5)

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -282,6 +282,59 @@ def workflow_default_scope(workflow_name: str, project_root: Path | str) -> str:
     return ""
 
 
+def derive_project_name(project_root: Path | str) -> str:
+    """Return a human-readable project name for the dashboard header.
+
+    Reads the ``[project]`` table's ``name`` field from
+    ``<project_root>/pyproject.toml`` when present; falls back to the
+    directory basename otherwise. The fallback gives sensible output
+    for projects without a ``pyproject.toml`` (Node.js, plain
+    directories) while the pyproject path means worktree-launched
+    dashboards display the package name (e.g. ``attune-ai``) instead
+    of the worktree slug (e.g. ``reverent-brown-937823``).
+
+    Defensive failure modes — none of these surface to the user; the
+    dashboard just renders the basename:
+
+    - Missing ``pyproject.toml`` → basename.
+    - Unreadable file (perm error, OSError) → basename.
+    - Malformed TOML → basename.
+    - ``[project]`` table missing or ``name`` field missing → basename.
+    - Empty ``name`` value → basename (don't render blank header).
+
+    No-pyproject fallback chain isn't extended to ancestor
+    directories: the dashboard's ``--project-root`` is supposed to
+    BE the project root. Walking up could surface a parent
+    workspace's name (e.g. ``Users``) which is worse than the
+    worktree slug.
+    """
+    root = Path(project_root).expanduser().resolve()
+    pyproject = root / "pyproject.toml"
+    if pyproject.is_file():
+        try:
+            text = pyproject.read_text(encoding="utf-8")
+        except OSError:
+            return root.name
+        # Python 3.11+ ships tomllib; fall back to the stdlib parser.
+        try:
+            import tomllib
+        except ImportError:  # pragma: no cover — Python < 3.11
+            try:
+                import tomli as tomllib  # type: ignore[no-redef]
+            except ImportError:
+                return root.name
+        try:
+            parsed = tomllib.loads(text)
+        except tomllib.TOMLDecodeError:
+            return root.name
+        project_table = parsed.get("project")
+        if isinstance(project_table, dict):
+            name = project_table.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+    return root.name
+
+
 # Path passed to workflows when the user picks the "All code" picker
 # option. Hardcoded for attune-ai's ``src/`` layout. Downstream projects
 # with different code roots can override by editing this constant or by

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -30,6 +30,13 @@ def _ctx(request: Request, page: str, **extra) -> dict:
         "request": request,
         "page": page,
         "project_root": str(cfg.project_root),
+        # Human-readable project name for the topbar chip. Reads
+        # ``[project].name`` from pyproject.toml when available, falls
+        # back to the directory basename. Without this, a dashboard
+        # launched against a worktree (e.g.
+        # ``.claude/worktrees/reverent-brown-937823``) renders the
+        # worktree slug as the project name — confusing for users.
+        "project_name": data.derive_project_name(cfg.project_root),
         "attune_home": str(cfg.attune_home),
         "current_run": current_run,
         **extra,

--- a/src/attune/ops/templates/base.html
+++ b/src/attune/ops/templates/base.html
@@ -39,10 +39,17 @@
       {% endif %}
       <div class="env">
         <span class="env-label">project</span>
+        {# project_name reads ``[project].name`` from
+           ``<project_root>/pyproject.toml`` so worktree-launched
+           dashboards display the package name (``attune-ai``)
+           instead of the worktree directory's slug
+           (``reverent-brown-937823``). Falls back to the basename
+           when no pyproject is present. Tooltip + aria-label still
+           expose the full path for users who need it. #}
         <code class="env-value"
               data-tooltip="{{ project_root }}"
               data-tooltip-position="bottom"
-              aria-label="Project root: {{ project_root }}">{{ project_root.split('/')[-1] }}</code>
+              aria-label="Project root: {{ project_root }}">{{ project_name }}</code>
       </div>
     </header>
     <main class="main">{% block content %}{% endblock %}</main>

--- a/tests/unit/ops/test_smoke.py
+++ b/tests/unit/ops/test_smoke.py
@@ -195,3 +195,106 @@ def test_specs_page_specs_js_has_version_cache_bust(client):
         )
         assert m is not None, "specs.js is referenced but without a ?v= cache-bust"
         assert m.group(1) == attune_version
+
+
+# ---------------------------------------------------------------------------
+# Phase D5 — project-name derived from pyproject.toml, not basename
+# ---------------------------------------------------------------------------
+
+
+def test_derive_project_name_reads_pyproject_name(tmp_path):
+    """A ``pyproject.toml`` with ``[project].name`` returns that name,
+    not the directory basename. This is the load-bearing case: a
+    dashboard launched against a worktree should display the
+    package name (``attune-ai``) not the worktree slug
+    (``reverent-brown-937823``)."""
+    from attune.ops.data import derive_project_name
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "my-package"\nversion = "1.0.0"\n',
+        encoding="utf-8",
+    )
+    assert derive_project_name(tmp_path) == "my-package"
+
+
+def test_derive_project_name_falls_back_to_basename_without_pyproject(tmp_path):
+    """No pyproject.toml → directory basename. Sensible for Node /
+    plain directories."""
+    from attune.ops.data import derive_project_name
+
+    worktree = tmp_path / "reverent-brown-937823"
+    worktree.mkdir()
+    assert derive_project_name(worktree) == "reverent-brown-937823"
+
+
+def test_derive_project_name_handles_malformed_toml(tmp_path):
+    """Malformed pyproject.toml → basename, no crash. The dashboard
+    must keep rendering even when the project config is broken."""
+    from attune.ops.data import derive_project_name
+
+    (tmp_path / "pyproject.toml").write_text("not [ valid {{{ toml", encoding="utf-8")
+    assert derive_project_name(tmp_path) == tmp_path.name
+
+
+def test_derive_project_name_handles_missing_project_table(tmp_path):
+    """pyproject.toml with no ``[project]`` table → basename. Some
+    pyprojects exist for tooling config only (ruff, black) without
+    a package definition."""
+    from attune.ops.data import derive_project_name
+
+    (tmp_path / "pyproject.toml").write_text("[tool.ruff]\nline-length = 100\n", encoding="utf-8")
+    assert derive_project_name(tmp_path) == tmp_path.name
+
+
+def test_derive_project_name_handles_empty_name(tmp_path):
+    """``[project]`` table present but ``name`` is empty → basename
+    (rendering an empty chip would be worse than the slug)."""
+    from attune.ops.data import derive_project_name
+
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = ""\n', encoding="utf-8")
+    assert derive_project_name(tmp_path) == tmp_path.name
+
+
+def test_dashboard_topbar_chip_shows_package_name_not_slug(tmp_path, monkeypatch):
+    """End-to-end: a dashboard launched against a worktree-style path
+    (basename = slug) with a pyproject naming the package shows the
+    package name in the topbar chip, NOT the basename.
+
+    Mirrors the user-visible defect QA flagged as P3-11a.
+    """
+    worktree = tmp_path / "reverent-brown-937823"
+    worktree.mkdir()
+    (worktree / "pyproject.toml").write_text(
+        '[project]\nname = "attune-ai"\nversion = "6.8.0"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=worktree,
+        trusted_hosts=("testserver", "test"),
+    )
+    app = create_app(config)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    body = resp.text
+    # The env-value chip in base.html now renders project_name.
+    # The package name must appear inside the chip:
+    import re
+
+    chip_re = re.compile(
+        r'<code class="env-value"[^>]*>([^<]+)</code>',
+        re.DOTALL,
+    )
+    chip = chip_re.search(body)
+    assert chip is not None, "env-value chip not found in topbar"
+    assert chip.group(1).strip() == "attune-ai", (
+        f"Expected topbar chip to show 'attune-ai' (the package name), "
+        f"got {chip.group(1).strip()!r}. The worktree-slug bug is back."
+    )
+    # The tooltip / aria-label still expose the full path so users
+    # who need it can hover or screen-read.
+    assert "reverent-brown-937823" in body, (
+        "Full project path should still be visible somewhere (tooltip "
+        "/ aria-label) — only the chip's visible text is shortened"
+    )


### PR DESCRIPTION
## Summary

The topbar chip on every dashboard page derives the project name via `project_root.split('/')[-1]` — i.e. the directory basename. For a normal checkout at `/Users/patrickroebuck/attune-ai` that's fine (`attune-ai`). For a **worktree-launched dashboard** at `/Users/.../.claude/worktrees/reverent-brown-937823` the chip renders the slug (`reverent-brown-937823`), which is meaningless to anyone who isn't tracking the Cowork worktree allocation. You flagged this during the QA pass.

The fix adds a `data.derive_project_name(project_root)` helper that reads `[project].name` from `<project_root>/pyproject.toml` when present; falls back to the directory basename otherwise. Falls back, never raises, on missing/malformed/empty cases.

### Behaviour delta

| Scenario | Before | After |
|---|---|---|
| Dashboard launched at `/path/to/attune-ai` (has pyproject) | `attune-ai` | `attune-ai` (unchanged) |
| Dashboard launched at `/path/.claude/worktrees/reverent-brown-937823` (worktree, pyproject one level up) | `reverent-brown-937823` | basename (worktree dir has no pyproject) |
| Dashboard launched at worktree path **with `--project-root` pointed at the package root** | `attune-ai` (chance) | `attune-ai` (deterministic — reads pyproject) |
| Dashboard at a plain non-Python dir | basename | basename (unchanged) |
| Dashboard at a dir with malformed pyproject | crash? basename? | basename (graceful) |

(The worktree's own dir doesn't have a pyproject; `--project-root` is what determines what gets read. The user's earlier workflow already uses `--project-root /path/to/attune-ai` for this reason.)

### Wiring

- `_ctx` in `routes/dashboard.py` adds `project_name` to the template context for every page.
- `base.html` renders `{{ project_name }}` instead of the basename split.
- Tooltip + `aria-label` still expose the full `project_root` for hover / screen readers.

### Defensive failure modes — all fall back to basename, none raise

- Missing `pyproject.toml`
- Unreadable file (OSError / permission)
- Malformed TOML
- `[project]` table absent (e.g. pyproject only has `[tool.ruff]`)
- `[project].name` field missing or empty

**No ancestor walk** — `--project-root` is supposed to BE the project root. Walking up could surface a parent workspace's name (e.g. `Users`) which is worse than the slug.

## What this resolves

- QA punch list item **PL-P3-11a** in [docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md)
- Task **D5** in [docs/specs/ops-dashboard-polish/tasks.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/ops-dashboard-polish/tasks.md) (Phase D — audit pass)
- The smallest item still on the polish spec after PR #369 absorbed pieces of Phase C and the path-picker spec restructured P2-7.

## Test plan

- [x] 5 unit tests on `derive_project_name` (one per fallback path).
- [x] 1 end-to-end test: worktree-style path + pyproject inside renders the package name in the chip; full path still visible in tooltip/aria-label.
- [x] All 307 ops tests pass.
- [x] Ruff clean on touched Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)