### PR TITLE
docs(spec/ops-sessions-page): resolve open questions + pre-S3 tightening

### DIFF
--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -8,7 +8,7 @@
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Data source | `~/.claude/projects/<encoded-current-project>/*.jsonl` | Canonical Claude Code session location; no parallel store to maintain. Project-keyed encoding is `path.replace('/', '-')`. |
+| Data source | `~/.claude/projects/<encoded-canonical>*/*.jsonl` (prefix glob to catch worktree-encoded keys; see Project-key resolution below) | Canonical Claude Code session location; no parallel store to maintain. Project-keyed encoding is `path.replace('/', '-')`. |
 | Time window | **Last 3 days** | Patrick's call. "I don't want to maintain dated and useless data." Older sessions stay on disk but aren't surfaced. |
 | Project scope | **Current project only** | Patrick's call. Cross-project resume is a power-user feature; current-project handles the 80% case. |
 | Starter-prompt generation | **Haiku-summarized** (`claude-haiku-4-5`) | Patrick's call. Sharper than heuristic. ~$0.001/session × ~10 sessions in 3-day window = ~$0.01 per uncached page load. |
@@ -23,36 +23,127 @@
 | Empty state | "No sessions in the last 3 days for this project. Older sessions are at `<path>`." | Tells the user where the data lives instead of pretending it doesn't. |
 | Failure mode for unreadable JSONL | Skip with WARN log, don't surface as broken row | An unreadable file is a Claude Code internal issue, not something the user can fix from the dashboard. |
 | "Resume most recent" card | **Yes — prominent top-of-page card** | Patrick approved 2026-05-14. The newest session by mtime gets full-card treatment with the full Haiku summary, a copy button, and a resume-in-new-session hint. Dedupes against the list below it. |
-| Live-session detection sources | (1) `CLAUDE_SESSION_ID` env var (if Claude Code sets one — verify during design); (2) `~/.claude/__last_session` pointer if it exists; (3) match by mtime within last 5 min as a fallback heuristic | Layered fallbacks so the feature works even when the primary signal isn't available. |
+| Live-session detection sources | (1) **`CLAUDE_CODE_SESSION_ID` env var — verified present 2026-05-15**; (2) mtime within last 5 min on a session JSONL as a fallback | The pointer-file (`~/.claude/__last_session`) hypothesis was disproved during design probe — file does not exist. Env var name corrected from `CLAUDE_SESSION_ID` to `CLAUDE_CODE_SESSION_ID`. |
 | Live-session card behavior | "You're currently in this session" label, suppress the duplicate row in the list below | Avoids surfacing a "resume" prompt for a session that doesn't need resuming. |
 
 ---
 
-## Open questions (resolve during design phase)
+## Resolved design questions
 
-1. **Project-path encoding edge cases.** Some users may have
-   sessions for `~/attune-ai` (no leading `/Users/`) and
-   `/Users/patrickroebuck/attune-ai` (canonical) — same project,
-   different encoded keys. Decide whether to read multiple keys
-   or canonicalize.
+> All four open questions resolved 2026-05-15.
 
-2. **Haiku prompt template.** The summarization prompt itself
-   needs care — what makes a good "starter prompt" vs a bad one?
-   Probably: name what was being worked on, list any open
-   threads, suggest a 1-sentence resume prompt the user can
-   paste. Calibrate against 5-10 real sessions before defaulting.
+### 1. Project-key resolution — read multiple keys (prefix-globbed)
 
-3. **Active prompt-redaction.** First user messages may contain
-   API keys, file paths, or other sensitive info. The Haiku
-   summary should not echo these verbatim. Add a redaction pass
-   or rely on Haiku's natural summarization to drop specifics?
+**Decision: read multiple encoded keys**, not canonicalize down
+to one.
 
-4. **Live-session detection mechanism — verify during design.**
-   Does Claude Code expose `CLAUDE_SESSION_ID` (or equivalent)
-   in subprocess env? Does `~/.claude/__last_session` exist as
-   a file or pointer? Run a quick check from inside a Claude
-   Code session before committing to a specific signal. The
-   mtime-based fallback (5-min window) works either way.
+**Why.** Empirical scan of `~/.claude/projects/` on 2026-05-15
+showed the worktree-development setup produces a key per
+worktree, not per logical project. For attune-ai specifically:
+
+- Canonical `-Users-patrickroebuck-attune-ai`: 44 sessions
+- 47 distinct worktree-encoded keys
+  (`-Users-patrickroebuck-attune-ai--claude-worktrees-<slug>`):
+  57 sessions
+- **93 sessions in the last 3 days across all keys**
+
+Canonical-only lookup would miss the majority of recent
+sessions in this dev pattern. Patrick's instinct was right;
+the data forced the resolution.
+
+**Implementation.**
+
+- Compute encoded prefix from
+  `Path(project_root).expanduser().resolve()` →
+  `str.replace('/', '-')`.
+- Glob `~/.claude/projects/<encoded>*` for matching dirs.
+- Accept a dir iff its name equals `<encoded>` exactly, OR
+  starts with `<encoded>-` (the `-` separator guards against
+  sibling-project false matches like `attune-ai-something`).
+- Read all `*.jsonl` from matched dirs.
+- Dedup sessions by session-id (the JSONL filename's stem) —
+  if a session somehow appears under multiple keys, the
+  newest-mtime copy wins; log a WARN.
+
+### 2. Haiku prompt template — calibration-driven
+
+**Decision: design through a 5–10 session calibration pass
+before defaulting.**
+
+**Target output shape.** A starter prompt that:
+
+1. Names what was being worked on (1 short sentence).
+2. Lists any open threads (bullets, 0–3 items).
+3. Suggests a 1-sentence resume prompt the user can paste.
+
+**Calibration plan.** Pick 5–10 real sessions of varying
+length from `~/.claude/projects/-Users-patrickroebuck-attune-ai*`;
+run the candidate prompt against each; manually score the
+output against the target shape. Iterate the template until
+the median output is ship-worthy. The finalized prompt text
+lands in the calibration record below.
+
+### 3. Active prompt-redaction — yes, explicit pass
+
+**Decision: add a redaction pass before sending to Haiku.**
+
+**Why.** Relying on the model to "naturally summarize away"
+sensitive content is non-deterministic — one session out of
+fifty leaks a token verbatim into a cached summary and that's
+a real incident. An explicit pass is cheap and bounded.
+
+**Patterns to redact (initial set; extend as we learn).**
+
+- API key shapes:
+  `sk-ant-[a-zA-Z0-9_-]+`, `sk-[a-zA-Z0-9]{20,}`,
+  `ghp_[a-zA-Z0-9]{36}`, `gho_…`, `ghu_…`, `xoxb-…`,
+  `AKIA[0-9A-Z]{16}`, generic `[A-Za-z0-9]{40,}` tokens
+  preceded by `key|token|secret|password` within 5 chars.
+- Bearer-style headers: `Bearer [A-Za-z0-9._-]+`.
+- Absolute paths under `~` or `/Users/<name>/` — replace
+  with `<user-home>` or `<...>` (paths inside the project
+  root are kept; they're useful context).
+- IP addresses (RFC 1918 + public).
+- Email addresses outside a small allowlist (Patrick's own
+  emails per CLAUDE.md are fine; redact the rest).
+
+**Order.** Redact first, then send to Haiku, then cache the
+already-redacted summary. The cache never holds a sensitive
+prompt; subsequent reads inherit the redaction for free.
+
+### 4. Live-session detection — env var + mtime fallback
+
+**Decision: 2-layer detection, env var primary.**
+
+**Empirical findings (probed inside a Claude Code session
+2026-05-15):**
+
+- `CLAUDE_CODE_SESSION_ID` env var **is present**
+  (e.g. `accc710d-5f39-46bb-bf8b-06d779a03291`). Note: the
+  spec draft had this as `CLAUDE_SESSION_ID` — wrong name.
+  Actual variable has the `CODE_` infix. Same value the
+  JSONL file is named after.
+- `~/.claude/__last_session` (and obvious variants
+  `last_session`, `session`) **does not exist** on disk.
+  Was a guess; dropping from the design.
+- `~/.claude/sessions/` directory does exist but appears
+  unrelated to per-project session detection — out of scope
+  for this design.
+
+**Implementation.**
+
+1. Read `CLAUDE_CODE_SESSION_ID` from the dashboard's process
+   env. If present, that's the live session.
+2. Fallback: any `.jsonl` whose mtime is within the last 5
+   minutes is considered "potentially live." If exactly one
+   matches, treat as live. If multiple, no live indicator
+   (don't guess).
+
+The dashboard process inherits the env from whatever shell
+launched it, which means: when launched from inside a Claude
+Code session, the dashboard correctly detects "that
+session." When launched from a plain shell, only the mtime
+fallback fires.
 
 ---
 
@@ -73,3 +164,17 @@ To be filled in during implementation:
 - 2026-05-14 — Initial decisions captured during spec draft.
   Triggered by ops-dashboard QA punch list item P1-4. Memory
   page explicitly dropped per Patrick.
+- 2026-05-15 — All four open questions resolved before S3
+  implementation. Two empirical probes drove the resolutions:
+  (1) directory scan of `~/.claude/projects/` revealed
+  multi-key reality (worktree-per-encoded-key), confirming
+  Patrick's "read multiple keys" instinct; (2) env probe
+  inside a Claude Code session corrected the live-session
+  variable name (`CLAUDE_CODE_SESSION_ID`, not
+  `CLAUDE_SESSION_ID`) and disproved the
+  `~/.claude/__last_session` pointer-file hypothesis. Data
+  source row updated for the prefix-glob; live-session
+  detection row updated for the corrected env var. S1 + S2
+  shipped in PR #377 prior to these resolutions; the
+  multi-key fix applies to whichever future slice rewires
+  `list_recent_sessions()` (S3 design pulls it forward).

--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -11,18 +11,21 @@
 | Data source | `~/.claude/projects/<encoded-canonical>*/*.jsonl` (prefix glob to catch worktree-encoded keys; see Project-key resolution below) | Canonical Claude Code session location; no parallel store to maintain. Project-keyed encoding is `path.replace('/', '-')`. |
 | Time window | **Last 3 days** | Patrick's call. "I don't want to maintain dated and useless data." Older sessions stay on disk but aren't surfaced. |
 | Project scope | **Current project only** | Patrick's call. Cross-project resume is a power-user feature; current-project handles the 80% case. |
-| Starter-prompt generation | **Haiku-summarized** (`claude-haiku-4-5`) | Patrick's call. Sharper than heuristic. ~$0.001/session × ~10 sessions in 3-day window = ~$0.01 per uncached page load. |
+| Starter-prompt generation | **Haiku-summarized** (`claude-haiku-4-5`) | Patrick's call. Sharper than heuristic. ~$0.001/session × N=20 cap = ~$0.02/uncached load. |
 | Heuristic fallback | First user prompt + last assistant turn, both truncated to ~200 chars | Used when LLM gate is off (`ATTUNE_OPS_SESSIONS_LLM=0`) OR Haiku call errors out. |
-| Cache key | `(jsonl_filename, mtime, sha256_of_first_4kb)` | Detects edits to the file without paying for a full content hash. Cache hits are cheap on subsequent page loads. |
+| Cache key | `(jsonl_filename, mtime, sha256_of_last_4kb)` | Hashes the JSONL tail — which actually changes as the session grows — rather than the byte-identical opening block. Single seek + read. See Cache-key collision below. |
 | Cache location | `<attune_home>/ops/session_summaries/<session-id>.json` | Keeps session-specific data under `attune_home`, separate from `~/.claude/projects/` which we don't write to. |
 | Cache TTL | None (mtime-bound) | A file that hasn't changed since last summary doesn't need re-summarizing. |
-| Budget cap per page load | `$0.05` | Hard cap; sessions beyond the cap render heuristic-only with a "summary unavailable — over budget" marker. Configurable via `[tool.attune-ops.sessions] budget_cap_usd`. |
+| List cap | **N=20 most-recent sessions** | Bounds Haiku spend per page load (~$0.02 worst case). Older sessions stay on disk for `cat`, not surfaced in the list. The Resume-most-recent card is unaffected and reads independently. See Budget-cap math below. |
+| Budget cap per page load | `$0.05` | Hard cap; with N=20 it almost never fires in practice. Sessions beyond the cap render heuristic-only with a "summary unavailable — over budget" marker. Configurable via `[tool.attune-ops.sessions] budget_cap_usd`. |
 | Listing route | `GET /sessions` (page) + `GET /api/sessions` (JSON) | Mirrors `/specs` + `/api/specs` and `/workflows` + `/api/runs/...`. |
 | Listing JSON shape | `{sessions: [{id, started_at, last_activity, duration_seconds, message_count, starter_prompt, source}]}` where `source` ∈ `{"heuristic", "haiku", "cached"}` | Lets the UI show a "summarized by Haiku · cached" badge for transparency. |
 | Expand-on-click body | Server-side render the first user message; full transcript stays at the JSONL file on disk (no in-page transcript viewer) | Keeps the page light. Users who want the full transcript can `cat` the JSONL. |
 | Empty state | "No sessions in the last 3 days for this project. Older sessions are at `<path>`." | Tells the user where the data lives instead of pretending it doesn't. |
 | Failure mode for unreadable JSONL | Skip with WARN log, don't surface as broken row | An unreadable file is a Claude Code internal issue, not something the user can fix from the dashboard. |
-| "Resume most recent" card | **Yes — prominent top-of-page card** | Patrick approved 2026-05-14. The newest session by mtime gets full-card treatment with the full Haiku summary, a copy button, and a resume-in-new-session hint. Dedupes against the list below it. |
+| "Resume most recent" card | **Yes — current-worktree first, canonical fallback** | Most-recent session from the dashboard's *own* encoded key (matches "where you are right now"). If none in last 3 days under the current key, fall back to the canonical project root's key. Dedupes against the list below. See Resume-card scope below. |
+| Compare mode | `GET /sessions?compare=1` — renders heuristic + Haiku columns side-by-side for one request | Dev tool, no UI affordance. Pre-launch eyeball check that Haiku spend is buying actual quality. ~30 LOC + template tweak. |
+| Calibration harness | Committed redacted JSONL fixtures + runner emitting `tokens / cost / quality` snapshot | Lands in S3 alongside the Haiku integration. Regression signal in CI for Haiku prompt edits. See Calibration as fixture below. |
 | Live-session detection sources | (1) **`CLAUDE_CODE_SESSION_ID` env var — verified present 2026-05-15**; (2) mtime within last 5 min on a session JSONL as a fallback | The pointer-file (`~/.claude/__last_session`) hypothesis was disproved during design probe — file does not exist. Env var name corrected from `CLAUDE_SESSION_ID` to `CLAUDE_CODE_SESSION_ID`. |
 | Live-session card behavior | "You're currently in this session" label, suppress the duplicate row in the list below | Avoids surfacing a "resume" prompt for a session that doesn't need resuming. |
 
@@ -147,6 +150,167 @@ fallback fires.
 
 ---
 
+## Pre-S3 design tightening
+
+> Five additional resolutions captured 2026-05-15 after a
+> review pass. Each tightens a decision that the original
+> matrix made on incomplete information.
+
+### 5. Budget-cap math — list capped at N=20
+
+**Problem.** The original $0.05/load cap was sized for
+"~10 sessions in a 3-day window." The multi-key probe found
+**93 sessions** in the same window across all encoded keys
+— ~9× the original estimate. At ~$0.001/session that's
+~$0.09 per uncached load: already 1.8× over the cap before
+caching takes effect.
+
+**Decision.** Cap the surfaced list at **N=20 most-recent
+sessions** (sorted by `last_activity` desc). Worst-case
+uncached spend: 20 × $0.001 = $0.02 — well under the $0.05
+cap, with headroom for prompt growth or input-size variance.
+
+**What this does NOT change.** Older sessions stay on disk;
+the empty-state copy still tells users where to find them.
+The Resume-most-recent card reads independently (single
+session) and is unaffected. The N=20 limit is **list-only**.
+
+**What we declined.** Background-summarize via a worker
+would give the best UX (page never blocks on Haiku spend)
+but adds a concept the dashboard doesn't have today
+(~60 LOC + worker plumbing). Deferred — revisit in a later
+slice if N=20 becomes too restrictive in practice.
+
+### 6. Cache-key collision — hash last 4KB, not first
+
+**Problem.** Hashing the *first* 4KB of a JSONL is
+collision-prone because JSONLs grow monotonically: the
+opening block is byte-identical for the lifetime of the
+session. Two sessions whose initial prompts look similar
+share their first 4KB, and the mtime in the key is the only
+distinguishing signal — which can tick spuriously
+(filesystem touches, cleanup tools) and trigger a stale
+cache read.
+
+**Decision.** Use **last 4KB** of the file instead. The tail
+is the freshest content and changes every time the session
+does. Cache key becomes
+`(jsonl_filename, mtime, sha256_of_last_4kb)`. Single seek
+(`fh.seek(-4096, SEEK_END)`) + read; same I/O cost as
+hashing the head.
+
+**Edge case.** Files < 4KB just get fully hashed
+(short-session, rare, cheap).
+
+### 7. Resume-card scope — current worktree first
+
+**Problem.** With 47 worktree-encoded keys for attune-ai,
+"globally most recent" can surface a sibling worktree's
+session that the user has no current relationship to. The
+card's framing ("you're returning to this work") implies
+"your current stream" — but multi-worktree dev makes
+"current stream" ambiguous.
+
+**Decision.** Two-level lookup:
+
+1. Most-recent session under the encoded key matching the
+   dashboard's actual `project_root` (the worktree it was
+   launched from).
+2. If none in the last 3 days under that key, fall back to
+   the canonical project root's encoded key.
+
+If both miss, no resume card renders. The list below still
+shows the full multi-key view, so the user always has
+visibility into older worktree sessions.
+
+### 8. Calibration as committed fixture
+
+**Decision.** Land the calibration-harness infrastructure in
+S3, alongside the Haiku integration itself:
+
+- `tests/fixtures/ops/session_summaries/*.jsonl` — 10
+  redacted real-session fixtures (~50 KB total). Each is a
+  representative example: short, long, multi-thread,
+  abandoned-mid-conversation, etc.
+- `scripts/calibrate_session_summary.py` — runs the
+  candidate Haiku prompt over the fixture set, emits per-
+  fixture `{tokens_in, tokens_out, cost_usd, summary}` to a
+  snapshot file.
+- Snapshot file (`tests/fixtures/ops/session_summaries/snapshot.json`)
+  — committed; CI fails if the snapshot diverges beyond a
+  configurable tolerance (e.g. ±20% cost, length mismatch
+  on summary).
+
+**Why.** Without this, every Haiku prompt edit is a manual
+calibration pass. With it, the prompt has an objective
+regression signal — same pattern as polish-fact-check
+Phase 1 (attune-author #28).
+
+**Fixture-redaction discipline.** The fixture JSONLs are
+real session data run through the same redaction pass we
+ship for production. The fixtures **commit the redacted
+form** — original sensitive content never lands in git.
+
+### 9. Compare mode — `?compare=1` dev affordance
+
+**Decision.** A query-param-only dev tool that renders the
+session list with **both** heuristic and Haiku columns
+side-by-side for a single page load. No UI button — discoverable
+only by knowing the URL. Purpose: pre-launch eyeball
+validation that Haiku spend is actually buying improved
+output, not just different output.
+
+**Scope.** ~30 LOC + a `compare_mode` template branch.
+Doesn't bypass the budget cap; doesn't bypass redaction.
+Just renders the second column alongside the first.
+
+**Retirement plan.** Keep until S3 ships and we've validated
+Haiku in production. After that, optional to leave in (cheap
+dev tool) or remove. Documented in this row so a future
+reader knows it's not part of the user-facing surface.
+
+---
+
+## Cross-spec dependencies
+
+- **Worktree inventory** — A sibling spec at
+  `docs/specs/worktree-inventory/` consumes the same
+  multi-key project-key resolution this spec introduces.
+  Ships independently. The shared helper
+  (`enumerate_project_encoded_keys()`) lives in
+  `src/attune/ops/data.py` and serves both features.
+
+---
+
+## Ship log
+
+> Decision-row → first-implementing PR. Backfilled for
+> S1/S2. Updated as future slices land.
+
+| Decision | First PR / Commit | Status |
+|---|---|---|
+| Data source (encoded-canonical glob) | #377 (S1+S2) — `~/.claude/projects/` literal lookup | partial — multi-key resolution lands in S3 |
+| Time window (3 days) | #377 | shipped |
+| Project scope (current project only) | #377 | shipped |
+| Listing route (`GET /sessions`) | #377 (page) | partial — JSON route in S3 |
+| Listing JSON shape | #377 (template only) | partial — JSON API in S3 |
+| Empty state copy | #377 | shipped |
+| Failure mode (skip unreadable JSONL) | #377 | shipped |
+| Heuristic fallback (S2 implementation) | #377 (S2 squash a577a7e8) | shipped |
+| Cache key (last-4KB) | TBD (S3) | pending |
+| Cache location / TTL | TBD (S3) | pending |
+| List cap (N=20) | TBD (S3) | pending |
+| Starter-prompt generation (Haiku) | TBD (S3) | pending |
+| Budget cap ($0.05) | TBD (S3) | pending |
+| Source field semantics (heuristic/haiku/cached) | #377 (`heuristic` only) | partial — `haiku`/`cached` in S3 |
+| Resume card (current-worktree → canonical) | TBD (S4) | pending |
+| Live-session detection | TBD (S5) | pending |
+| Compare mode (`?compare=1`) | TBD (S3) | pending |
+| Calibration harness | TBD (S3) | pending |
+| Expand-on-click body | TBD (S4 or later) | pending |
+
+---
+
 ## Calibration record
 
 To be filled in during implementation:
@@ -178,3 +342,20 @@ To be filled in during implementation:
   shipped in PR #377 prior to these resolutions; the
   multi-key fix applies to whichever future slice rewires
   `list_recent_sessions()` (S3 design pulls it forward).
+- 2026-05-15 (later same day) — Pre-S3 design tightening
+  pass. Five more decisions captured after interactive
+  review: list cap N=20 (budget-cap math invalidated by
+  multi-key reality), cache key switched to last-4KB
+  (collision risk on monotonic JSONL growth), resume card
+  scoped to current-worktree-then-canonical (multi-key
+  noise), calibration harness as committed fixtures
+  (regression discipline), and `?compare=1` dev affordance
+  (pre-launch Haiku validation). Sixth review item
+  (worktree-inventory feature) split out to its own spec
+  at `docs/specs/worktree-inventory/`; cross-spec
+  dependency noted above. Seventh review item (ship log
+  table) added at the bottom of this file. Rows updated:
+  Starter-prompt generation (cost math), Cache key
+  (last-4KB), Budget cap (with N=20 footnote), Resume card
+  (scope), and three new rows: List cap, Compare mode,
+  Calibration harness.


### PR DESCRIPTION
## Summary

Docs-only PR. Resolves the four open design questions left in
the ops-sessions-page spec draft and captures five additional
pre-S3 tightening decisions. **No code changes.**

Lands the spec refinements independently of S3 implementation
so they can be reviewed and merged on their own. After this
merges, S3 implementation work resumes against the resolved
spec on a fresh branch off main.

## What's in here

### Two commits

- `143a0724` — Resolves the four original "Open questions"
  (project-key resolution, Haiku prompt template, prompt
  redaction, live-session detection). Two empirical probes
  drove these:
  - Directory scan of `~/.claude/projects/` (44 canonical +
    57 worktree-keyed sessions; 93 in last 3 days across
    keys) → confirmed multi-key approach.
  - Env probe inside a Claude Code session corrected the
    live-session var name (`CLAUDE_CODE_SESSION_ID`, not
    `CLAUDE_SESSION_ID`) and disproved the
    `~/.claude/__last_session` pointer-file hypothesis.

- `62117e9b` — Pre-S3 tightening pass: five more decisions
  after an interactive review.
  - **List cap N=20** — budget-cap math was invalidated by
    multi-key reality; N=20 keeps spend ~$0.02/uncached load.
  - **Cache key uses last-4KB** — first-4KB is byte-identical
    for the life of a JSONL (collision risk).
  - **Resume card scoped** to current-worktree → canonical
    fallback — avoids surfacing sibling-worktree sessions
    that aren't "where the user is right now."
  - **Calibration harness** — committed fixtures + runner +
    CI snapshot, same discipline as polish-fact-check Phase 1.
  - **Compare mode** — `?compare=1` query param, no UI
    button, pre-launch Haiku validation tool.

### New sections in `decisions.md`

- `Resolved design questions` — replaces the old "Open
  questions" block; one subsection per question with
  decision, why, and implementation notes.
- `Pre-S3 design tightening` — the five later resolutions.
- `Cross-spec dependencies` — names the shared
  `enumerate_project_encoded_keys()` helper.
- `Ship log` — Decision → First PR table; backfilled for
  #377; future slices update on merge. Hygiene addition;
  mirrors audit-doc-fidelity discipline.

### Sibling work (not in this PR)

A separate spec for worktree-inventory ships in its own PR.
It reuses the multi-key project-key resolution introduced
here. Cross-spec dependency noted in this file.

## Test plan

- [x] No code changes; lint-only files (markdown).
- [x] Pre-commit hooks clean (trim trailing whitespace,
      end-of-file fix, etc.).
- [ ] Manual review of the file for clarity.

## After merge

- Reset/rebase the `feat/ops-sessions-page-s3-haiku-summaries`
  branch onto the new main (these two commits will be in the
  squash); resume S3 implementation against the resolved spec.
