### PR TITLE
docs(spec/worktree-inventory): new spec for /sessions worktree-inventory affordance

### DIFF
--- a/docs/specs/worktree-inventory/decisions.md
+++ b/docs/specs/worktree-inventory/decisions.md
@@ -1,0 +1,91 @@
+# Spec: Worktree Inventory — Decisions
+
+> Pre-committed decisions captured 2026-05-15.
+
+---
+
+## Decision matrix
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Lives where | **Sub-section on `/sessions` page** | The data source (encoded keys under `~/.claude/projects/`) is already walked for the session list. Marginal cost is one `group_by`; no new route. Conceptually grouped with "what sessions exist" — the same set of users care about both. |
+| Data source | Reuses `enumerate_project_encoded_keys()` introduced in `ops-sessions-page/` spec | Single source of truth for "which encoded keys belong to this project." Avoids two divergent globs in the same module. |
+| Time window | **Last 3 days** (mirrors sessions list) | Same answer for the same reason: stale data isn't useful for cleanup decisions. |
+| List cap | **Top 10 by last-activity desc**; "show all" expands | Bounds the panel's vertical footprint. Worktree counts trail off after the top few; rarely meaningful beyond 10 for visual scan. |
+| Orphan detection | Decode candidate paths from the encoded key, test each for existence | The `path.replace('/', '-')` encoding is irreversible. Pragmatic candidate-test approach (replace each `-` with `/` for plausible decodings, test on disk) is good enough for a "this looks dead" signal. False-negative is fine; false-positive (flagging an alive key as orphaned) is the failure mode to avoid. |
+| Orphan rendering | Visual chip ("orphaned"), no auto-delete | Surface, don't act. Cleanup is the user's decision. |
+| Delete affordance | **Not in v1** | Out of scope. May land later as a separate feature if usage validates it. |
+| Failure modes | Silent skip + WARN log | Same discipline as ops-sessions-page: an unreadable key is Claude Code's problem, not the user's. Don't surface a broken row. |
+| Cross-project scope | Out of scope — current project only | Mirrors ops-sessions-page. Cross-project worktree inventory is a hypothetical we don't need yet. |
+| New routes | **None** | All work happens inside the existing `GET /sessions` handler. No `GET /api/worktrees` JSON endpoint in v1; can add later if a separate consumer emerges. |
+
+---
+
+## Implementation sketch
+
+Implementation lives entirely in `src/attune/ops/`:
+
+1. **`data.py`** — add a `WorktreeInventoryRow` dataclass
+   and a `list_worktree_inventory(project_root, *, days=3)`
+   function. Internally:
+   - Calls `enumerate_project_encoded_keys(project_root)`
+     (shared helper from ops-sessions-page).
+   - For each key, count session JSONLs whose mtime is
+     within the window; find the newest mtime.
+   - Resolve the canonical and worktree-slug labels from
+     the key.
+   - Test orphan status with candidate-decoding lookup.
+   - Sort and cap.
+2. **`routes/dashboard.py`** — `sessions_page()` handler
+   gets a second piece of context: `worktree_inventory =
+   data.list_worktree_inventory(cfg.project_root)`.
+   No new route.
+3. **`templates/sessions.html`** — render the panel after
+   the resume card and before the session list, only when
+   `worktree_inventory` has >1 entry (otherwise just one
+   entry = the current project, no inventory value).
+4. **Tests** — `tests/unit/ops/test_worktree_inventory.py`:
+   key enumeration, orphan detection, sort + cap, render
+   path.
+
+Total estimate: ~80 LOC source + ~150 LOC tests + small
+template block.
+
+---
+
+## Failure modes
+
+| Mode | Behavior |
+|---|---|
+| `~/.claude/projects/` doesn't exist | No panel rendered (no inventory at all). |
+| Single encoded key unreadable (perm) | Skip with WARN log; rest of inventory renders. |
+| Candidate-decoding probe hits a permission error on the candidate path | Conservatively report "exists" (avoid false orphan flag). |
+| Only one key (no worktrees yet) | Panel hidden; redundant with the session list. |
+| Many keys (>100) | Top-10 cap holds; "show all" expands the list. |
+
+---
+
+## Non-goals (v1)
+
+- No delete or rename actions.
+- No cross-project view.
+- No `GET /api/worktrees` JSON endpoint.
+- No live-tracking of worktree mutations.
+- No grouping by branch or any git-aware metadata —
+  this is an inventory of *encoded keys*, not of git
+  worktrees.
+
+---
+
+## Decision-change log
+
+- 2026-05-15 — Initial spec. Split out from the
+  ops-sessions-page spec's interactive review on the same
+  day. The original conversation suggested a worktree
+  inventory as an "opportunity" sitting on data the sessions
+  page would already load; consensus was that it should
+  ship as its own spec/PR so the ops-sessions-page spec
+  stays focused on its single concern (starter prompts +
+  resume affordance). Cross-spec dependency: this spec
+  consumes `enumerate_project_encoded_keys()` from
+  ops-sessions-page's S3 and must ship after it.

--- a/docs/specs/worktree-inventory/requirements.md
+++ b/docs/specs/worktree-inventory/requirements.md
@@ -1,0 +1,114 @@
+# Spec: Worktree Inventory
+
+> A small affordance on the ops dashboard's `/sessions`
+> page that surfaces every worktree this project has spawned
+> with Claude Code sessions in the last 3 days. Helps with
+> orphan-worktree cleanup; reuses data already loaded by the
+> sessions listing.
+
+---
+
+## Motivation
+
+A multi-worktree dev pattern (Cowork spawns, `git worktree
+add` for stacked PRs) produces dozens of encoded keys under
+`~/.claude/projects/`. attune-ai itself has 47 distinct
+worktree-encoded keys at the time this spec was drafted.
+Most are orphaned — the worktree directory was removed but
+the encoded key under `~/.claude/projects/` lingers because
+Claude Code never deletes it.
+
+The ops-sessions-page spec introduces a multi-key glob to
+surface sessions across all those keys. We're already
+walking them. The marginal work to also surface a
+"worktrees touched in the last 3 days" list is one
+`group_by` over data we have in hand.
+
+This isn't a worktree-management tool. It's a visibility
+affordance — the same way the Specs page surfaces "what's
+in-flight." Cleanup actions can come later if they prove
+useful.
+
+---
+
+## User story
+
+> As a developer who's been using worktrees aggressively, I
+> want to see which worktrees actually have recent activity
+> so I can confidently delete the ones that don't.
+
+The affordance lives where worktree-related context already
+lives — the Sessions page. No new top-level route.
+
+---
+
+## Functional requirements
+
+### F1 — Inventory section on `/sessions`
+
+A small panel near the top of `/sessions` (or near the
+bottom of the resume-card region, TBD during design)
+showing:
+
+| Worktree | Sessions (3d) | Last activity | Worktree path exists? |
+|---|---|---|---|
+| `<canonical>` (the project root itself) | N | timestamp | yes |
+| `<worktree-slug>` | N | timestamp | yes / **no — orphaned** |
+
+Rows sort by last-activity desc. Cap at, say, 10 most-
+recently-active worktrees by default; "show all" expands.
+
+### F2 — Orphan detection
+
+For each encoded key, check whether the decoded path
+exists on disk. If not, mark the row as "orphaned" with
+a visual chip. Reverse-encoding is irreversible (`/` and
+`-` both encode to `-`), so use a pragmatic check:
+candidate decodings (`-` → `/`) and test each for
+existence. If none exists, mark orphaned.
+
+### F3 — Failure modes (silent)
+
+- `~/.claude/projects/` doesn't exist → no panel rendered.
+- A single encoded key is unreadable (perm) → skip with
+  WARN log; don't surface a broken row.
+- Worktree existence check fails (perm on the candidate
+  decoded path) → conservatively report "exists" rather
+  than falsely flagging as orphaned.
+
+---
+
+## Non-goals (initial release)
+
+- No delete action. Surfacing only. Cleanup is a separate
+  decision the user makes outside the dashboard.
+- No cross-project worktree view. This is scoped to the
+  current project's encoded keys, same as ops-sessions-page.
+- No worktree-creation UI.
+- No live-tracking of worktree mutations (the panel reads
+  on page load, period).
+
+---
+
+## Cross-spec dependencies
+
+- `docs/specs/ops-sessions-page/` — introduces the
+  multi-key glob and the shared helper
+  `enumerate_project_encoded_keys()` in
+  `src/attune/ops/data.py`. This spec consumes that helper
+  and adds a `group_by(encoded_key)` pass on top of the
+  already-loaded session records. Must ship AFTER the
+  ops-sessions-page spec's S3 (which is where the helper
+  lands).
+
+---
+
+## Success criteria
+
+- The `/sessions` page renders an inventory panel
+  alongside the session list when there are >1 worktree
+  keys with sessions in the window.
+- Orphaned keys are visually distinct from active ones.
+- No new HTTP routes; reuses `/sessions`'s data.
+- Zero increase to page-load cost (the data is already
+  walked for the session list).


### PR DESCRIPTION
## Summary

Docs-only PR. New spec at
[`docs/specs/worktree-inventory/`](docs/specs/worktree-inventory/)
for a small affordance on the ops dashboard's `/sessions`
page that surfaces every worktree this project has spawned
with Claude Code sessions in the last 3 days.

Split out from the ops-sessions-page interactive design
review on 2026-05-15. That conversation surfaced this as
a free-ish feature sitting on data the sessions page would
already load — but bundling it into ops-sessions-page would
dilute that spec's single concern (starter prompts +
resume). So this gets its own spec/PR/implementation track.

## What's in the spec

### `requirements.md` (114 lines)

- Motivation — 47 worktree-encoded keys for attune-ai
  alone; most are orphaned (worktree dir gone, encoded key
  lingers under `~/.claude/projects/`).
- User story.
- Functional requirements F1–F3 (inventory panel, orphan
  detection, silent failure modes).
- Non-goals (no delete action in v1, no cross-project, no
  JSON API).
- Cross-spec dependencies — names the
  `enumerate_project_encoded_keys()` helper that lands in
  ops-sessions-page S3.
- Success criteria.

### `decisions.md` (91 lines)

- Decision matrix (where, data source, window, cap, orphan
  detection, etc.).
- Implementation sketch (~80 LOC source + ~150 LOC tests).
- Failure modes table.
- Non-goals.
- Change log.

## Sequence

Must ship **after** ops-sessions-page S3 lands, because it
consumes the `enumerate_project_encoded_keys()` helper
introduced there. Ordering:

1. PR [#380](https://github.com/Smart-AI-Memory/attune-ai/pull/380)
   — ops-sessions-page spec refinement (docs-only).
2. ops-sessions-page S3 implementation PR (TBD).
3. This spec → its own implementation PR (TBD).

## Test plan

- [x] Docs-only; no code changes.
- [x] Pre-commit hooks clean.
- [ ] Manual review for clarity.
