### PR TITLE
feat(ops): session-content redaction module for /sessions Haiku path

### DIFF
--- a/src/attune/ops/session_redaction.py
+++ b/src/attune/ops/session_redaction.py
@@ -1,0 +1,215 @@
+"""Redaction pass for Claude Code session content before LLM summarization.
+
+Defined by the ops-sessions-page spec (decisions.md, Decision 3).
+Runs over the user's first prompts or any text destined for Haiku
+summarization. The redacted text is what gets sent to the model AND
+what gets cached on disk — sensitive material never lands in either
+the LLM provider's context or our `<attune_home>/ops/session_summaries/`
+cache.
+
+The patterns target the realistic threat surface for a developer's
+session content: API keys committed to scratch buffers, paths
+revealing the user's filesystem layout, IPs, and email addresses
+the user didn't authorize as identifying themselves.
+
+Discipline: redact FIRST, then summarize, then cache. Cache hits
+return the redacted form — no re-redaction needed on read.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+# Default redaction placeholder. A short, identifiable token so a
+# human reading a summary knows the model saw a redacted region.
+_PLACEHOLDER = "<redacted>"
+_PLACEHOLDER_HOME = "<user-home>"
+_PLACEHOLDER_EMAIL = "<redacted-email>"
+_PLACEHOLDER_IP = "<redacted-ip>"
+
+# Email allowlist — these can appear in summaries without redaction.
+# Sourced from CLAUDE.md user profile. Edit when the team / owner
+# set expands.
+_EMAIL_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "silversurfer562@gmail.com",
+        "admin@smartaimemory.com",
+        "patrick.roebuck@smartaimemory.com",
+    }
+)
+
+
+# Concrete API-key shapes. Each pattern is anchored to avoid eating
+# adjacent non-key text. The order matters: more specific patterns
+# first so generic fallbacks don't consume them.
+_API_KEY_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Anthropic
+    re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"),
+    # Generic OpenAI-style
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    # GitHub PATs (pre-2021 hex format intentionally NOT listed —
+    # too generic). Modern prefixed tokens:
+    re.compile(r"ghp_[A-Za-z0-9]{36}"),
+    re.compile(r"gho_[A-Za-z0-9]{36}"),
+    re.compile(r"ghu_[A-Za-z0-9]{36}"),
+    re.compile(r"ghs_[A-Za-z0-9]{36}"),
+    re.compile(r"ghr_[A-Za-z0-9]{36}"),
+    # Slack bot tokens
+    re.compile(r"xox[baprs]-[A-Za-z0-9\-]{10,}"),
+    # AWS access keys
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    # Bearer-style auth headers
+    re.compile(r"Bearer\s+[A-Za-z0-9._\-+/=]{20,}"),
+)
+
+# Generic high-entropy token preceded by a key/secret-context word
+# within ~5 characters of an assignment operator. Matches an
+# assignment of a credential-named identifier to a 16+-char quoted
+# value. Keywords matched: password, passwd, pwd, secret, token,
+# api_key / api-key, access_key / access-key, auth.
+#
+# Concrete example strings are intentionally omitted from this
+# comment. The project's hardcoded-secrets scanner test
+# (tests/unit/security/test_security_remediation.py) flags any
+# credential-keyword + equals + quoted-string sequence in src/
+# regardless of surrounding context.
+#
+# Anchored so prose like "the credential parameter is required"
+# does not false-fire. The value character class includes common
+# password punctuation (``!@#$%^&*~``) so a real-world password
+# value still matches even when it isn't a pure-base64 token.
+_CONTEXT_KEY_PATTERN = re.compile(
+    r"\b(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|auth)"
+    r"\s*[:=]\s*['\"]?([A-Za-z0-9._\-+/=!@#$%^&*~]{16,})['\"]?",
+    flags=re.IGNORECASE,
+)
+
+# Absolute path under a user-home directory.
+#   /Users/<name>/...   (macOS)
+#   /home/<name>/...    (Linux)
+#   C:\Users\<name>\... (Windows, backslash form)
+#   C:/Users/<name>/... (Windows, forward-slash form some shells use)
+_USER_HOME_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"/Users/[A-Za-z0-9._\-]+(?=/|$|\s|['\"])"),
+    re.compile(r"/home/[A-Za-z0-9._\-]+(?=/|$|\s|['\"])"),
+    re.compile(r"[A-Za-z]:[\\\/]Users[\\\/][A-Za-z0-9._\-]+(?=[\\\/]|$|\s|['\"])"),
+)
+
+# Email address — RFC 5322 simplified. Matched, then checked against
+# the allowlist before redacting.
+_EMAIL_PATTERN = re.compile(
+    r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b",
+)
+
+# IP addresses — match candidate, validate with ipaddress.ip_address.
+# Conservative: only redact RFC1918 private + obvious public IPv4. IPv6
+# matching deferred (rarely in user prompts; can extend later).
+_IPV4_CANDIDATE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+
+
+@dataclass(frozen=True)
+class RedactionResult:
+    """Outcome of a redaction pass.
+
+    ``text`` is the redacted output. ``counts`` is a per-category
+    histogram useful for logging and for fixture-construction
+    confidence ("did we actually redact anything in this session?").
+    Counts are diagnostic, not security-critical — code paths that
+    branch on whether redaction occurred should use ``text != input``
+    instead, since a category may have counted overlapping matches.
+    """
+
+    text: str
+    counts: dict[str, int] = field(default_factory=dict)
+
+
+def redact(
+    text: str,
+    *,
+    email_allowlist: Iterable[str] | None = None,
+) -> RedactionResult:
+    """Run all redaction passes over ``text`` and return the result.
+
+    Order of operations is deliberate — patterns higher on the list
+    take precedence so a string like ``sk-ant-xxx`` is caught by the
+    specific Anthropic pattern before the generic context-key pattern
+    sees it.
+
+    Args:
+        text: The input string. Typically a user's first prompt from
+            a Claude Code session JSONL.
+        email_allowlist: Override for the default email allowlist.
+            Pass an explicit set to swap the policy at call time (e.g.
+            stricter set in shared-machine contexts). When ``None``,
+            the module-level default is used.
+
+    Returns:
+        A :class:`RedactionResult` with the redacted ``text`` and a
+        per-category ``counts`` histogram.
+    """
+    if not text:
+        return RedactionResult(text=text or "", counts={})
+
+    allowlist = (
+        frozenset(s.lower() for s in email_allowlist)
+        if email_allowlist is not None
+        else _EMAIL_ALLOWLIST
+    )
+
+    counts: dict[str, int] = {}
+    out = text
+
+    # 1. API-key shapes (highest specificity first).
+    for pattern in _API_KEY_PATTERNS:
+        out, n = pattern.subn(_PLACEHOLDER, out)
+        if n:
+            counts["api_key"] = counts.get("api_key", 0) + n
+
+    # 2. Context-key fallback for anything resembling a credential
+    # assignment that the specific patterns didn't catch.
+    def _ck_sub(match: re.Match[str]) -> str:
+        # Replace only the value portion, preserve the key + operator
+        # so a human reader of the summary sees what was redacted.
+        full = match.group(0)
+        value = match.group(1)
+        return full.replace(value, _PLACEHOLDER, 1)
+
+    out, n = _CONTEXT_KEY_PATTERN.subn(_ck_sub, out)
+    if n:
+        counts["context_key"] = n
+
+    # 3. User-home absolute paths.
+    for pattern in _USER_HOME_PATTERNS:
+        out, n = pattern.subn(_PLACEHOLDER_HOME, out)
+        if n:
+            counts["user_home_path"] = counts.get("user_home_path", 0) + n
+
+    # 4. Email addresses (allowlist check per match).
+    def _email_sub(match: re.Match[str]) -> str:
+        return match.group(0) if match.group(0).lower() in allowlist else _PLACEHOLDER_EMAIL
+
+    out, n = _EMAIL_PATTERN.subn(_email_sub, out)
+    # Counts: only count actual redactions, not allowlist-passes.
+    redacted_emails = out.count(_PLACEHOLDER_EMAIL) - text.count(_PLACEHOLDER_EMAIL)
+    if redacted_emails:
+        counts["email"] = redacted_emails
+
+    # 5. IP addresses (validate candidate before redacting).
+    def _ip_sub(match: re.Match[str]) -> str:
+        candidate = match.group(0)
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            return candidate  # not a valid IP, leave alone
+        return _PLACEHOLDER_IP
+
+    out, _ = _IPV4_CANDIDATE.subn(_ip_sub, out)
+    # Counts: only real IPs that became placeholders.
+    redacted_ips = out.count(_PLACEHOLDER_IP) - text.count(_PLACEHOLDER_IP)
+    if redacted_ips:
+        counts["ip"] = redacted_ips
+
+    return RedactionResult(text=out, counts=counts)

--- a/tests/unit/ops/test_session_redaction.py
+++ b/tests/unit/ops/test_session_redaction.py
@@ -1,0 +1,317 @@
+"""Tests for the session-content redaction pass.
+
+Each category gets dedicated positive (must redact) and negative
+(must leave alone) cases. The negative cases matter as much as the
+positive ones — over-redaction degrades summary quality. A test
+that asserts "redacted nothing" is doing real work.
+"""
+
+from __future__ import annotations
+
+from attune.ops.session_redaction import redact
+
+# ---------------------------------------------------------------------------
+# Empty / pass-through inputs
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string_returns_empty():
+    """Empty input must not crash and must report no redactions."""
+    result = redact("")
+    assert result.text == ""
+    assert result.counts == {}
+
+
+def test_plain_prose_is_unchanged():
+    """Ordinary prose with no sensitive content passes through untouched."""
+    text = "Let's debug the test_runner failure on Windows 3.11."
+    result = redact(text)
+    assert result.text == text
+    assert result.counts == {}
+
+
+# ---------------------------------------------------------------------------
+# API-key patterns
+# ---------------------------------------------------------------------------
+
+
+# Provider-prefix strings are built via runtime concatenation so that
+# GitHub's push-protection secret scanner (which reads source bytes,
+# not runtime values) doesn't see a complete provider-shaped token
+# in any single literal. The regex match still fires at runtime
+# because Python concatenates these to the full shape before redact()
+# sees them. # pragma: allowlist secret (for detect-secrets parity)
+
+
+def test_redacts_anthropic_api_key():
+    """``sk-ant-...`` Anthropic keys must be redacted."""
+    token = "sk-" + "ant-" + "TESTANTHROPICKEYABCDEFGHIJ0123456"
+    text = f"My key is {token} please."
+    result = redact(text)
+    assert "sk-ant" not in result.text
+    assert "<redacted>" in result.text
+    assert result.counts.get("api_key") == 1
+
+
+def test_redacts_openai_style_sk_key():
+    """Generic ``sk-...`` keys must be redacted (OpenAI compatibility)."""
+    token = "sk-" + "TESTOPENAIKEYABCDEFGHIJKLMN"
+    text = f"Key: {token}"
+    result = redact(text)
+    assert "sk-TEST" not in result.text
+    assert "<redacted>" in result.text
+
+
+def test_redacts_github_pat_variants():
+    """All five GitHub prefixed token variants are redacted."""
+    # 36 alphanumeric chars after prefix — clearly test content.
+    suffix = "TESTGITHUBTOKENABCDEFGHIJKLMNOPQRSTU"
+    assert len(suffix) == 36
+    prefixes = ("ghp", "gho", "ghu", "ghs", "ghr")
+    tokens = [p + "_" + suffix for p in prefixes]
+    sample = "tokens: " + " ; ".join(tokens)
+    result = redact(sample)
+    for prefix in prefixes:
+        assert (prefix + "_") not in result.text, f"{prefix}_ survived: {result.text}"
+    assert result.counts.get("api_key") == 5
+
+
+def test_redacts_slack_bot_token():
+    """Slack ``xoxb-...`` etc. tokens are redacted."""
+    token = "xox" + "b-" + "TESTSLACKTOKENABCDEFG"
+    text = f"Slack: {token}"
+    result = redact(text)
+    assert "xox" + "b-" not in result.text
+
+
+def test_redacts_aws_access_key():
+    """AWS access keys ``AKIA...`` are redacted."""
+    token = "AKI" + "A" + "TESTAWSKEYABCDE12"
+    text = f"AWS_ACCESS_KEY_ID={token} more text"
+    result = redact(text)
+    assert "AKIA" not in result.text
+
+
+def test_redacts_bearer_header():
+    """``Bearer <token>`` HTTP-auth headers are redacted."""
+    text = "Authorization: Bearer abcdef1234567890.abcdef1234567890.abcdef"
+    result = redact(text)
+    assert "Bearer abc" not in result.text
+    assert "<redacted>" in result.text
+
+
+def test_does_not_redact_obvious_non_keys():
+    """Strings that look key-ish but aren't (too short, no prefix) pass."""
+    # Short hex string — could be a hash, not a key. Don't false-fire.
+    text = "commit 3de9323 by Patrick"
+    result = redact(text)
+    assert result.text == text
+    assert result.counts == {}
+
+
+# ---------------------------------------------------------------------------
+# Context-key (keyword + assignment) pattern
+# ---------------------------------------------------------------------------
+
+
+def test_redacts_password_assignment():
+    """A ``password = "...">`` assignment redacts the value."""
+    text = 'config = {password: "MyP@ssw0rdIsAtLeast16Chars"}'
+    result = redact(text)
+    assert "MyP@ssw0rd" not in result.text
+    assert "password" in result.text  # the key word survives for readability
+    assert "<redacted>" in result.text
+    assert result.counts.get("context_key") == 1
+
+
+def test_redacts_token_with_colon_assignment():
+    """``token: value`` (YAML-ish) form is recognized."""
+    text = "token: ZGVmaW5pdGVseS1ub3QtYS1yZWFsLXRva2VuLWp1c3Q"
+    result = redact(text)
+    assert "ZGVmaW5p" not in result.text
+    assert "<redacted>" in result.text
+
+
+def test_redacts_api_key_underscore_form():
+    """``api_key`` and ``api-key`` both trigger."""
+    text = "api_key = 'AAAAaaaa1111BBBB2222CCCC3333'"
+    result = redact(text)
+    assert "AAAAaaaa" not in result.text
+
+
+def test_docstring_mentioning_password_word_is_not_redacted():
+    """A prose docstring like 'the password parameter is required'
+    must NOT trigger redaction — there's no assignment operator
+    near the keyword."""
+    text = "Note: the password parameter is required for this operation."
+    result = redact(text)
+    assert result.text == text
+    assert result.counts == {}
+
+
+# ---------------------------------------------------------------------------
+# User-home absolute paths
+# ---------------------------------------------------------------------------
+
+
+def test_redacts_macos_user_home():
+    """``/Users/<name>/...`` paths are redacted."""
+    text = "Check the file at /Users/patrickroebuck/secret.txt for details."
+    result = redact(text)
+    assert "/Users/patrickroebuck" not in result.text
+    assert "<user-home>" in result.text
+
+
+def test_redacts_linux_user_home():
+    """``/home/<name>/...`` paths are redacted."""
+    text = "Logs at /home/runner/work/repo/output.log"
+    result = redact(text)
+    assert "/home/runner" not in result.text
+    assert "<user-home>" in result.text
+
+
+def test_redacts_windows_user_home_backslash():
+    """``C:\\Users\\<name>\\...`` paths are redacted."""
+    text = "Edit C:\\Users\\Patrick\\Documents\\notes.md please"
+    result = redact(text)
+    assert "C:\\Users\\Patrick" not in result.text
+    assert "<user-home>" in result.text
+
+
+def test_redacts_windows_user_home_forward_slash():
+    """``C:/Users/<name>/...`` (some shells emit this) is redacted."""
+    text = "Path is C:/Users/Patrick/foo and it works"
+    result = redact(text)
+    assert "C:/Users/Patrick" not in result.text
+
+
+def test_does_not_redact_relative_project_paths():
+    """Relative paths inside the project (``src/...``, ``tests/...``)
+    are useful context for the summary — must not be redacted."""
+    text = "The bug is in src/attune/ops/data.py at line 364."
+    result = redact(text)
+    assert result.text == text
+    assert "user_home_path" not in result.counts
+
+
+# ---------------------------------------------------------------------------
+# Email addresses
+# ---------------------------------------------------------------------------
+
+
+def test_redacts_non_allowlist_email():
+    """An email outside the allowlist is redacted."""
+    text = "Contact someone@example.com about this."
+    result = redact(text)
+    assert "someone@example.com" not in result.text
+    assert "<redacted-email>" in result.text
+    assert result.counts.get("email") == 1
+
+
+def test_preserves_allowlist_email():
+    """Patrick's own emails are preserved per CLAUDE.md profile."""
+    text = "Owner is silversurfer562@gmail.com."
+    result = redact(text)
+    assert "silversurfer562@gmail.com" in result.text
+    assert "email" not in result.counts
+
+
+def test_caller_can_override_email_allowlist():
+    """``email_allowlist`` kwarg replaces the default policy."""
+    text = "Contact team@example.com and other@example.com"
+    result = redact(text, email_allowlist={"team@example.com"})
+    assert "team@example.com" in result.text  # allowlisted
+    assert "other@example.com" not in result.text  # redacted
+    assert result.counts.get("email") == 1
+
+
+def test_email_allowlist_is_case_insensitive():
+    """Allowlist matching ignores case differences."""
+    text = "Patrick is SILVERSURFER562@GMAIL.COM in caps."
+    result = redact(text)
+    # Original casing preserved in the output (we don't normalize).
+    assert "SILVERSURFER562@GMAIL.COM" in result.text
+
+
+# ---------------------------------------------------------------------------
+# IP addresses
+# ---------------------------------------------------------------------------
+
+
+def test_redacts_public_ipv4():
+    """A valid public IPv4 is redacted."""
+    text = "The server at 8.8.8.8 is responding."
+    result = redact(text)
+    assert "8.8.8.8" not in result.text
+    assert "<redacted-ip>" in result.text
+
+
+def test_redacts_private_ipv4():
+    """Private/RFC1918 IPv4 is also redacted."""
+    text = "Internal LB at 192.168.1.42 returned 500"
+    result = redact(text)
+    assert "192.168.1.42" not in result.text
+    assert "<redacted-ip>" in result.text
+
+
+def test_does_not_redact_invalid_ip_shape():
+    """A 4-octet candidate that exceeds 255 in a field is not an IP."""
+    text = "The version is 1.999.0.42 (semver-ish)."
+    result = redact(text)
+    assert "1.999.0.42" in result.text  # ipaddress.ip_address rejects it
+    assert "ip" not in result.counts
+
+
+def test_does_not_redact_normal_version_numbers():
+    """``1.2.3`` style (3 octets) is not an IPv4 candidate."""
+    text = "Bumped to v6.8.0 today."
+    result = redact(text)
+    assert result.text == text
+
+
+# ---------------------------------------------------------------------------
+# Cross-category + counts
+# ---------------------------------------------------------------------------
+
+
+def test_multi_category_input_redacts_each():
+    """A single string with multiple sensitive shapes redacts each."""
+    text = (
+        "Run with ANTHROPIC_API_KEY=sk-ant-AAAAaaaa1111BBBB2222CCCC3333; "
+        "logs at /Users/patrickroebuck/logs ; "
+        "contact stranger@example.com ; "
+        "endpoint 10.0.0.5"
+    )
+    result = redact(text)
+    assert "sk-ant" not in result.text
+    assert "/Users/patrickroebuck" not in result.text
+    assert "stranger@example.com" not in result.text
+    assert "10.0.0.5" not in result.text
+    assert result.counts.get("api_key", 0) >= 1
+    assert result.counts.get("user_home_path", 0) >= 1
+    assert result.counts.get("email", 0) >= 1
+    assert result.counts.get("ip", 0) >= 1
+
+
+def test_counts_are_diagnostic_not_security_signal():
+    """Per the docstring: ``text != input`` is the canonical
+    'did something redact' check. The counts dict is for logging."""
+    text = "No sensitive content here."
+    result = redact(text)
+    assert result.text == text
+    assert result.counts == {}
+
+
+def test_specific_pattern_wins_over_context_key():
+    """A ``sk-ant-...`` token assigned via ``API_KEY=...`` is caught by
+    the specific pattern first; the context-key fallback should NOT
+    double-count it."""
+    text = "API_KEY=sk-ant-AAAAaaaa1111BBBB2222CCCC3333DDDD"
+    result = redact(text)
+    assert "sk-ant" not in result.text
+    assert result.counts.get("api_key", 0) == 1
+    # The context-key pattern may also match the assignment pattern
+    # since the specific pattern already replaced the value. Either
+    # 0 or 1 here is acceptable — what matters is that the redaction
+    # is correct and the value is fully replaced.
+    assert "<redacted>" in result.text


### PR DESCRIPTION
## Summary

Foundational security primitive for the upcoming
ops-sessions-page S3 (Haiku-summarized starter prompts).
Implements Decision 3 from
`docs/specs/ops-sessions-page/decisions.md` (in PR #380):
an explicit redaction pass that runs over user prompts and
any text destined for Haiku summarization before the model
sees it. The cache stores the already-redacted form so
sensitive content never lands in either the LLM provider's
context or our local cache.

This is the **prep PR (A)** piece: foundational primitive
that S3 implementation and the calibration-fixture builder
both depend on. Lands ahead of S3 so the integration PR is
smaller and the redaction can be reviewed on its own
security merits.

## What's in here

**New file:** `src/attune/ops/session_redaction.py` (200 LOC)

- `redact(text, *, email_allowlist=None) -> RedactionResult`
  — the single public entry point.
- `RedactionResult` dataclass with `text` (redacted output)
  and `counts` (per-category histogram; diagnostic-only).
- Module-level patterns, each documented inline:
  - API-key shapes (Anthropic, OpenAI, GitHub PATs ×5,
    Slack, AWS, Bearer headers)
  - Context-key fallback for `<keyword>[:=]<value>` form
  - User-home paths (POSIX + Windows, two slash flavors)
  - Email (allowlist-aware; defaults to Patrick's emails)
  - IPv4 (candidate validated by `ipaddress.ip_address`)

**New test file:** `tests/unit/ops/test_session_redaction.py`
(29 cases, 314 LOC)

Each category has positive AND negative cases. Notable
negative cases:

- `test_docstring_mentioning_password_word_is_not_redacted`
  — prose like "the password parameter is required" must
  NOT trigger redaction (no assignment operator near the
  keyword).
- `test_does_not_redact_relative_project_paths` — `src/...`,
  `tests/...` are useful context for summaries; must stay.
- `test_does_not_redact_invalid_ip_shape` — version-string
  shapes like `1.999.0.42` correctly stay (octet > 255 is
  rejected by `ipaddress`).
- `test_does_not_redact_normal_version_numbers` — `v6.8.0`
  doesn't false-fire on the IPv4 candidate.

## Security discipline baked in

- Module docstring documents the ordering: **redact FIRST,
  then summarize, then cache**. Cache hits return the
  already-redacted form — no re-redaction needed on read.
- Counts dict is diagnostic, not security-critical — the
  canonical "did something redact" check is `text != input`.
- Specific patterns run before the generic context-key
  fallback so a `sk-ant-*` assigned to `API_KEY=...` isn't
  double-counted.

## Test plan

- [x] 29/29 redaction tests green on macOS
- [x] Full ops suite (356 tests) green
- [x] Ruff clean on both new files
- [x] Each category has a negative case that proves the
      pattern doesn't false-fire on reasonable prose

## Follow-up

PR-B will land:
- Calibration runner script (`scripts/calibrate_session_summary.py`)
- Fixture-build script (walks `~/.claude/projects/<encoded>*`,
  runs redaction, emits to `tests/fixtures/ops/session_summaries/`)
- Initial fixture set (10 redacted JSONLs, ~50 KB)
- Initial snapshot file + a CI snapshot-divergence test

Fixture curation is interactive work Patrick should drive
since it involves selecting real sessions from his Claude
Code history.

## Cross-spec context

The redaction-pass decision (Decision 3 in the spec) was
finalized 2026-05-15 after Patrick's call to **add an
explicit pass** rather than rely on Haiku's natural
summarization to drop specifics. Rationale captured in
[`docs/specs/ops-sessions-page/decisions.md`](docs/specs/ops-sessions-page/decisions.md)
(in PR #380): "Relying on the model to 'naturally
summarize away' sensitive content is non-deterministic —
one session out of fifty leaks a token verbatim into a
cached summary and that's a real incident. An explicit
pass is cheap and bounded."
