### PR TITLE
fix(ops): _encoded_project_path also strips Windows drive-letter colon

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -368,14 +368,25 @@ def _encoded_project_path(project_root: Path | str) -> str:
     still matches the on-disk encoding. Returns the encoded
     basename only — the caller prepends ``~/.claude/projects/``.
 
-    On Windows ``Path.resolve()`` produces backslash separators, so
-    both separators are mapped to ``-`` — otherwise the encoded
-    string contains a literal ``D:\\...`` that pathlib treats as an
-    absolute path on subsequent concatenation, silently discarding
-    the ``~/.claude/projects/`` prefix.
+    Three characters are mapped to ``-`` so the resulting string is
+    safe to concatenate as a single path segment on every platform:
+
+    - ``/`` — POSIX path separator (matches Claude Code's documented
+      encoding).
+    - ``\\`` — Windows path separator. ``Path.resolve()`` produces
+      backslashes on Windows.
+    - ``:`` — Windows drive-letter delimiter (``D:``). Without
+      this, the encoded string contains a literal ``D:`` prefix that
+      pathlib treats as a drive specifier on subsequent
+      ``Path / encoded`` concatenation, silently discarding the
+      ``~/.claude/projects/`` prefix and rooting the result at the
+      bogus drive.
+
+    POSIX paths never contain backslash or colon, so the two
+    Windows-only replacements are no-ops there.
     """
     resolved = str(Path(project_root).expanduser().resolve())
-    return resolved.replace("/", "-").replace("\\", "-")
+    return resolved.replace("/", "-").replace("\\", "-").replace(":", "-")
 
 
 def claude_sessions_dir(project_root: Path | str) -> Path:

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -155,7 +155,13 @@ async def sessions_page(request: Request) -> HTMLResponse:
     # rendered path matches what ``list_recent_sessions`` reads
     # from disk — naive ``str.replace("/", "-")`` here leaves
     # Windows backslashes and drive-letter colons unencoded.
-    sessions_dir = "~/" + str(data.claude_sessions_dir(cfg.project_root).relative_to(Path.home()))
+    # ``as_posix()`` so the rendered path uses ``/`` separators on every
+    # platform — on Windows ``str(Path)`` produces native backslashes,
+    # which look wrong in the UI and break tests that assert on the
+    # POSIX-style path string.
+    sessions_dir = (
+        "~/" + data.claude_sessions_dir(cfg.project_root).relative_to(Path.home()).as_posix()
+    )
     return _render(
         request,
         "sessions.html",

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
@@ -150,9 +151,11 @@ async def sessions_page(request: Request) -> HTMLResponse:
     sessions = data.list_recent_sessions(cfg.project_root, days=3)
     # Where the sessions live — surfaced in the empty-state so users
     # can ``cat`` the JSONLs directly if they want to inspect more
-    # than the page shows.
-    encoded_project = str(cfg.project_root).replace("/", "-")
-    sessions_dir = f"~/.claude/projects/{encoded_project}"
+    # than the page shows. Reuses ``claude_sessions_dir`` so the
+    # rendered path matches what ``list_recent_sessions`` reads
+    # from disk — naive ``str.replace("/", "-")`` here leaves
+    # Windows backslashes and drive-letter colons unencoded.
+    sessions_dir = "~/" + str(data.claude_sessions_dir(cfg.project_root).relative_to(Path.home()))
     return _render(
         request,
         "sessions.html",

--- a/tests/unit/ops/test_sessions.py
+++ b/tests/unit/ops/test_sessions.py
@@ -143,6 +143,26 @@ def _write_session_jsonl(
     return path
 
 
+def _patch_home(monkeypatch, home_path) -> None:
+    """Patch ``Path.home()`` to return ``home_path`` on every platform.
+
+    Python's ``pathlib.Path.home()`` consults different env vars per OS:
+
+    - POSIX: ``HOME``
+    - Windows: ``USERPROFILE`` (falls back to ``HOMEDRIVE``+``HOMEPATH``)
+
+    A test that patches only ``HOME`` will work on POSIX runners but
+    silently no-op on Windows — ``Path.home()`` will still return the
+    real user-profile directory, and any code under test that writes
+    sessions to a monkeypatched home location won't be found.
+
+    Setting both env vars covers the cross-platform case with one call.
+    """
+    home_str = str(home_path)
+    monkeypatch.setenv("HOME", home_str)
+    monkeypatch.setenv("USERPROFILE", home_str)
+
+
 def test_list_recent_sessions_returns_empty_when_dir_missing(tmp_path, monkeypatch):
     """No ``~/.claude/projects/<encoded>/`` dir → empty list, not error.
 
@@ -150,7 +170,7 @@ def test_list_recent_sessions_returns_empty_when_dir_missing(tmp_path, monkeypat
     Code from looks like this. The dashboard must render the empty
     state, not crash.
     """
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _patch_home(monkeypatch, tmp_path / "home")
     assert data.list_recent_sessions(tmp_path / "project") == []
 
 
@@ -158,7 +178,7 @@ def test_list_recent_sessions_reads_jsonl(tmp_path, monkeypatch):
     """A JSONL with one user prompt → one Session record with that
     prompt as the heuristic starter."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    _patch_home(monkeypatch, home)
     sessions_dir = data.claude_sessions_dir(tmp_path / "project")
     _write_session_jsonl(
         sessions_dir,
@@ -204,7 +224,7 @@ def test_list_recent_sessions_reads_jsonl(tmp_path, monkeypatch):
 def test_list_recent_sessions_filters_by_mtime(tmp_path, monkeypatch):
     """Files older than ``days`` are excluded by mtime."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    _patch_home(monkeypatch, home)
     sessions_dir = data.claude_sessions_dir(tmp_path / "project")
 
     now = datetime(2026, 5, 14, 12, 0, 0, tzinfo=timezone.utc)
@@ -233,7 +253,7 @@ def test_list_recent_sessions_filters_by_mtime(tmp_path, monkeypatch):
 def test_list_recent_sessions_sorts_most_recent_first(tmp_path, monkeypatch):
     """Sessions sort by ``last_activity`` desc."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    _patch_home(monkeypatch, home)
     sessions_dir = data.claude_sessions_dir(tmp_path / "project")
 
     _write_session_jsonl(
@@ -258,7 +278,7 @@ def test_list_recent_sessions_skips_malformed_lines(tmp_path, monkeypatch):
     Session record built from the good line; the parse error is
     per-line, not fatal."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    _patch_home(monkeypatch, home)
     sessions_dir = data.claude_sessions_dir(tmp_path / "project")
     sessions_dir.mkdir(parents=True)
     (sessions_dir / "mixed.jsonl").write_text(
@@ -279,7 +299,7 @@ def test_list_recent_sessions_handles_no_content_events(tmp_path, monkeypatch):
     """A session with no events that have ``content`` (e.g. dequeue-only,
     attachment-only) yields a record with placeholder starter prompt."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    _patch_home(monkeypatch, home)
     sessions_dir = data.claude_sessions_dir(tmp_path / "project")
     _write_session_jsonl(
         sessions_dir,
@@ -308,7 +328,7 @@ def test_list_recent_sessions_handles_no_content_events(tmp_path, monkeypatch):
 
 def _make_app(tmp_path, monkeypatch):
     monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _patch_home(monkeypatch, tmp_path / "home")
     config = build_config(
         project_root=tmp_path / "project",
         trusted_hosts=("testserver", "test"),

--- a/tests/unit/ops/test_sessions.py
+++ b/tests/unit/ops/test_sessions.py
@@ -41,30 +41,30 @@ def test_encoded_project_path_matches_claude_code_convention(tmp_path):
     treated as an absolute path (silently discarding the prefix).
     """
     encoded = data._encoded_project_path(tmp_path)
-    expected_suffix = str(tmp_path).replace("/", "-").replace("\\", "-")
+    expected_suffix = str(tmp_path).replace("/", "-").replace("\\", "-").replace(":", "-")
     assert encoded.endswith(expected_suffix)
     assert "/" not in encoded
     assert "\\" not in encoded
+    assert ":" not in encoded
 
 
-def test_encoded_project_path_strips_windows_backslashes():
-    """Regression test for the Windows CI failure observed 2026-05-15.
+def test_encoded_project_path_strips_windows_separators_and_colon():
+    """Regression test for the two Windows CI failures observed
+    2026-05-15: (1) PR #382 round, backslashes survived ``str
+    .replace("/", "-")`` and pathlib treated the resulting ``D:\\``
+    prefix as absolute; (2) post-#382 round, the backslash fix
+    revealed the next layer — drive-letter colons survived and
+    pathlib treated the resulting ``D:-...`` segment as a drive
+    specifier on Windows.
 
-    Passes a path string containing literal backslashes — on POSIX
-    this is a single relative filename with backslashes inside it;
-    on Windows it's a real path. Either way, the encoder must
-    return a string with NO backslashes so the caller's
-    ``Path.home() / ".claude" / "projects" / encoded`` stays a
-    single path segment.
-
-    Without the fix, the resolved POSIX form is
-    ``<cwd>/fake\\windows\\path`` and the encoder leaves backslashes
-    intact (only ``/`` → ``-``). With the fix both separators map
-    to ``-``.
+    Passes a string with both Windows separators AND a colon. On
+    POSIX the encoder still has to scrub all three so the regression
+    is catchable without a Windows runner.
     """
-    encoded = data._encoded_project_path("fake\\windows\\path")
+    encoded = data._encoded_project_path("C:\\Users\\Test\\project")
     assert "\\" not in encoded, f"backslash survived encoding: {encoded!r}"
     assert "/" not in encoded, f"forward slash survived encoding: {encoded!r}"
+    assert ":" not in encoded, f"colon survived encoding: {encoded!r}"
 
 
 def test_claude_sessions_dir_is_under_user_home(tmp_path):
@@ -75,16 +75,19 @@ def test_claude_sessions_dir_is_under_user_home(tmp_path):
 
 
 def test_claude_sessions_dir_under_user_home_with_windows_style_input():
-    """Cross-platform regression: even when project_root contains
-    backslashes (real on Windows, literal on POSIX), the resulting
-    sessions dir must still nest under ``~/.claude/projects/``.
+    """Cross-platform regression: even when project_root looks like
+    a Windows absolute path (drive letter + backslashes), the
+    resulting sessions dir must still nest under
+    ``~/.claude/projects/``.
 
-    Before the fix, the backslash-laden encoded segment was treated
-    as an absolute path on Windows path concatenation, so
-    ``sessions_dir.parent.parent.name`` was something inside the
-    tmp tree (``pytest-0`` on the failing CI run), not ``.claude``.
+    Before the colon fix, ``str(Path("C:\\Users\\X\\p").resolve())``
+    on Windows produced ``C:\\Users\\X\\p``; the backslashes mapped
+    to ``-`` but the leading ``C:`` survived. The encoded segment
+    ``C:-Users-X-p`` is treated as a drive specifier when
+    concatenated as a path part, so the result rooted at ``C:``
+    instead of under ``.claude/projects/``.
     """
-    sessions_dir = data.claude_sessions_dir("fake\\drive\\project")
+    sessions_dir = data.claude_sessions_dir("C:\\Users\\Test\\project")
     assert sessions_dir.parent.parent.name == ".claude"
     assert sessions_dir.parent.name == "projects"
 


### PR DESCRIPTION
## Summary

Second round of the Windows path-encoding fix. PR #382 handled
backslashes but missed the drive-letter colon. On Windows,
``str(Path("C:\\Users\\X\\p").resolve())`` produces
``C:\\Users\\X\\p``; after ``str.replace("/", "-").replace
("\\", "-")`` you get ``C:-Users-X-p`` — the leading ``C:``
survives.

When pathlib then concatenates ``Path.home() / ".claude" /
"projects" / "C:-Users-X-p"`` on Windows, it sees the ``C:``
and treats the whole rightmost segment as drive-relative,
silently rooting the result at ``C:`` instead of under
``~/.claude/projects/``.

## Symptom

Two tests failing on all 4 Windows lanes for every PR opened
after #382 merged:

- `test_claude_sessions_dir_under_user_home_with_windows_style
  _input` — the regression test #382 itself added; my POSIX
  input string didn't exercise the colon path so it passed
  locally and on POSIX CI but failed on real Windows runners.
- `test_sessions_page_renders_session_rows_when_data_present`
  — end-to-end render test that uses tmp_path, which on Windows
  is `C:\Users\runneradmin\AppData\Local\Temp\...`.

Currently blocking 4 open PRs: #380, #381, #383, #384.

## The fix

Three changes:

1. **`src/attune/ops/data.py`** — `_encoded_project_path` now also
   does `.replace(":", "-")`. POSIX paths never contain `\` or
   `:`, so both Windows-only replacements are no-ops on POSIX.

2. **`src/attune/ops/routes/dashboard.py`** — `sessions_page()`
   was computing the empty-state display path with a *duplicate*
   `str.replace("/", "-")` instead of using the shared helper.
   Now reuses `claude_sessions_dir()` so the rendered path
   matches what `list_recent_sessions` reads from disk on every
   platform. Single source of truth for the encoding.

3. **`tests/unit/ops/test_sessions.py`** — strengthens two
   existing tests:
   - Renames `test_encoded_project_path_strips_windows_backslashes`
     to `..._strips_windows_separators_and_colon`, adds the
     colon assertion. Cross-platform regression catcher.
   - Updates `test_claude_sessions_dir_under_user_home_with_windows
     _style_input` to use `C:\\Users\\Test\\project` (real Windows
     absolute-path shape, exercises both the backslash AND the
     colon).

## Test plan

- [x] 16/16 sessions tests green on macOS (incl. updated regressions)
- [x] Full ops suite 327/327 green
- [x] Ruff clean on changed files
- [x] Both new assertion shapes verified to fail without the fix

## Sequence

Merge this first, then rebase #380, #381, #383, #384 onto the
post-merge main. All four will pick up the fix and re-CI should
turn green across the Windows lanes.

## CLAUDE.md lesson candidate (for a future commit)

The pattern of "fix-the-Windows-thing turns out to have a deeper
layer" is now happening on two consecutive PRs:

- #382: backslashes (one Windows char)
- #383+: colons (second Windows char)

Generalizable lesson: any production code that does
`str.replace("/", X)` on a resolved `Path` is broken on Windows
in at least three ways (`/`, `\\`, `:`). Catch them all at once
or expect a follow-up PR. The right encoding is something like
`re.sub(r"[\\\\/:]", "-", resolved)` so future Windows-special
characters get caught by the same call.
