### PR TITLE
ci: workflow_dispatch Windows-only debug job for fast iteration

### DIFF
--- a/.github/workflows/windows-debug.yml
+++ b/.github/workflows/windows-debug.yml
@@ -1,0 +1,97 @@
+name: Windows debug (one-shot)
+
+# Fast-feedback channel for Windows-specific bugs. Manual-dispatch
+# only — runs ONE Windows lane against a chosen ref and a chosen
+# test path subset. Built during the 2026-05-15 ops-sessions-page
+# Windows-encoding cycle to avoid the ~13 min per-round cost of
+# the full tests.yml matrix when iterating on a path-handling fix.
+#
+# Use it like:
+#
+#   gh workflow run windows-debug.yml \
+#     --ref <branch> \
+#     -f test_path=tests/unit/ops/test_sessions.py \
+#     -f python_version=3.11
+#
+# Defaults run the whole ops-tests directory on Python 3.11 — a
+# good blast radius for path-handling regressions. Drop `test_path`
+# to a single file or test id for sub-minute iteration once you've
+# narrowed the failure.
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_path:
+        description: "Path or test id to run (e.g. tests/unit/ops/, tests/unit/ops/test_sessions.py, tests/unit/ops/test_sessions.py::test_x)"
+        required: false
+        default: "tests/unit/ops/"
+        type: string
+      python_version:
+        description: "Python version (one lane only)"
+        required: false
+        default: "3.11"
+        type: choice
+        options:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+
+permissions:
+  contents: read
+
+# No concurrency group — these are manual debug runs and the user
+# may want to fire several side-by-side against different refs or
+# test paths to compare. The cost is a few extra runner-minutes
+# during active debugging; trivial.
+
+jobs:
+  windows-test:
+    runs-on: windows-latest
+    # Tighter timeout than tests.yml's 75 min — these are targeted
+    # subsets, not the full ~16k test suite. If a debug run takes
+    # more than 20 min something is wrong with the test selection,
+    # not Windows.
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python ${{ inputs.python_version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ inputs.python_version }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Show environment
+        # One-time diagnostic block — surfaces the Windows-specific
+        # state that's often the source of "works on POSIX, fails on
+        # Windows" puzzles. Logged at job start so it's visible even
+        # if pytest crashes hard.
+        shell: pwsh
+        run: |
+          Write-Host "===== ENV ====="
+          Write-Host "OS:           $env:RUNNER_OS / $env:RUNNER_ARCH"
+          Write-Host "Python:       $(python --version)"
+          Write-Host "USERPROFILE:  $env:USERPROFILE"
+          Write-Host "HOME:         $env:HOME"
+          Write-Host "TEMP:         $env:TEMP"
+          Write-Host "Path.home():  $(python -c 'from pathlib import Path; print(Path.home())')"
+          Write-Host "cwd:          $(Get-Location)"
+          Write-Host "===== /ENV ====="
+
+      - name: Run targeted tests
+        # Same flags as tests.yml's matrix lane (--timeout=60,
+        # --timeout-method=thread, -m "not network and not
+        # integration") so behavior matches the canonical run.
+        # Difference is just the test selector — passes through the
+        # workflow input verbatim.
+        shell: bash
+        run: |
+          echo "[debug] running pytest with path: ${{ inputs.test_path }}"
+          pytest "${{ inputs.test_path }}" -n auto --timeout=60 --timeout-method=thread -m "not network and not integration" --no-cov -o addopts=


### PR DESCRIPTION
## Summary

Adds `.github/workflows/windows-debug.yml` — a manual-trigger
(`workflow_dispatch`) workflow that runs ONE Windows lane
against a chosen ref + chosen test path subset. ~5–6 min wall
clock vs ~13 min for the full `tests.yml` matrix (since only
the Windows runner spins up).

Built during the 2026-05-15 ops-sessions-page Windows-encoding
cycle. Three consecutive rounds of *"fix path bug → push →
discover next Windows quirk on the 13-min CI"* showed the
value of a fast-feedback channel. This is it.

## Why a separate workflow

`tests.yml` is the canonical full-matrix run that PRs require.
This is purely a debug tool — manual-dispatch only, no
auto-trigger, no coverage, single Python version per fire.

## Usage

```
gh workflow run windows-debug.yml \
  --ref <branch> \
  -f test_path=tests/unit/ops/test_sessions.py \
  -f python_version=3.11
```

## Features

- **Inputs**:
  - `test_path` (default `tests/unit/ops/`) — passes through
    to pytest. Directory, file, or `path::test_id`.
  - `python_version` (default `3.11`) — dropdown 3.10–3.13.
- **Single Windows lane** (no matrix).
- **20 min timeout** (vs 75 min for `tests.yml`) — targeted
  subsets, not the full ~16k test suite.
- **Diagnostic block** at job start prints `USERPROFILE`,
  `HOME`, `Path.home()`, `TEMP`, cwd. Catches the env-
  discrepancy class of bugs (like the one fixed in #385) before
  pytest even runs.
- **Same pytest flags** as `tests.yml`'s matrix lane
  (`--timeout=60`, `--timeout-method=thread`, `-m "not network
  and not integration"`) so behavior matches the canonical run.

## Cost containment

No auto-trigger. No matrix. `workflow_dispatch` runs are
chargeable runner-minutes; this design contains the cost to
explicit invocations only.

## Critical landing constraint

`workflow_dispatch` requires the workflow file to exist on the
default branch (main) before it can be dispatched against any
ref. This PR is that pre-condition — it must merge to main
before the workflow can be used on ANY branch.

## Test plan

- [x] YAML syntactically valid (`python -c "import yaml;
      yaml.safe_load(...)"`)
- [x] Action versions pinned to the same SHAs as `tests.yml`
      (actions/checkout@de0fac2e, actions/setup-python@a309ff8b)
- [x] Comments explain the rationale and usage inline
- [ ] First manual dispatch after merge to confirm end-to-end
      behavior — will fire as soon as it lands
