### PR TITLE
feat(ops): /sessions S3a — multi-key data layer + summary cache

### DIFF
--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -289,7 +289,7 @@ reader knows it's not part of the user-facing surface.
 
 | Decision | First PR / Commit | Status |
 |---|---|---|
-| Data source (encoded-canonical glob) | #377 (S1+S2) — `~/.claude/projects/` literal lookup | partial — multi-key resolution lands in S3 |
+| Data source (encoded-canonical glob) | #377 (S1+S2) — `~/.claude/projects/` literal lookup; multi-key resolution in S3a (data layer) | shipped — multi-key in S3a |
 | Time window (3 days) | #377 | shipped |
 | Project scope (current project only) | #377 | shipped |
 | Listing route (`GET /sessions`) | #377 (page) | partial — JSON route in S3 |
@@ -297,9 +297,9 @@ reader knows it's not part of the user-facing surface.
 | Empty state copy | #377 | shipped |
 | Failure mode (skip unreadable JSONL) | #377 | shipped |
 | Heuristic fallback (S2 implementation) | #377 (S2 squash a577a7e8) | shipped |
-| Cache key (last-4KB) | TBD (S3) | pending |
-| Cache location / TTL | TBD (S3) | pending |
-| List cap (N=20) | TBD (S3) | pending |
+| Cache key (last-4KB) | S3a — `session_summary_cache.compute_cache_key()` | shipped (cache module; Haiku wire-up in S3b) |
+| Cache location / TTL | S3a — `<attune_home>/ops/session_summaries/<id>.json`, mtime-bound | shipped (module); first write happens in S3b |
+| List cap (N=20) | S3a — `DEFAULT_SESSION_LIST_CAP` in `list_recent_sessions()` | shipped |
 | Starter-prompt generation (Haiku) | TBD (S3) | pending |
 | Budget cap ($0.05) | TBD (S3) | pending |
 | Source field semantics (heuristic/haiku/cached) | #377 (`heuristic` only) | partial — `haiku`/`cached` in S3 |
@@ -342,6 +342,17 @@ To be filled in during implementation:
   shipped in PR #377 prior to these resolutions; the
   multi-key fix applies to whichever future slice rewires
   `list_recent_sessions()` (S3 design pulls it forward).
+- 2026-05-15 (S3 split) — S3 implementation broken into two
+  PRs at Patrick's direction: **S3a** ships the data-layer
+  foundation (multi-key `enumerate_project_encoded_keys()`,
+  `list_recent_sessions()` rewire with newest-mtime dedup,
+  `session_summary_cache` module with last-4KB SHA-256 key,
+  `DEFAULT_SESSION_LIST_CAP = 20`) with no LLM calls. **S3b**
+  adds the Haiku summarizer + redaction wire-up + budget cap
+  (soft warning when breached) + `?compare=1` dev mode +
+  fixture-build script for calibration. Snapshot-test +
+  committed redacted fixtures defer to a post-S3 follow-up
+  pending Patrick's interactive fixture curation pass.
 - 2026-05-15 (later same day) — Pre-S3 design tightening
   pass. Five more decisions captured after interactive
   review: list cap N=20 (budget-cap math invalidated by

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -8,13 +8,17 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from attune.ops.config import Config
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -390,14 +394,71 @@ def _encoded_project_path(project_root: Path | str) -> str:
 
 
 def claude_sessions_dir(project_root: Path | str) -> Path:
-    """Return the directory Claude Code stores sessions for this project in.
+    """Return the canonical directory Claude Code stores sessions for this project in.
 
     Doesn't check existence — callers should treat a non-existent
     dir as "no sessions yet" rather than an error condition (the
     dir is created on first session, which the user may not have
     started in this project).
+
+    Note: in a worktree-heavy dev setup, Claude Code creates a separate
+    encoded-key directory per worktree. Use
+    :func:`enumerate_project_encoded_keys` to get the full set of dirs
+    that belong to this logical project. This function returns only
+    the canonical (project-root) key.
     """
     return Path.home() / ".claude" / "projects" / _encoded_project_path(project_root)
+
+
+def enumerate_project_encoded_keys(project_root: Path | str) -> list[Path]:
+    """Return all ``~/.claude/projects/`` dirs belonging to this logical project.
+
+    Claude Code encodes each project-root path as a single directory
+    name under ``~/.claude/projects/`` by replacing path separators
+    (and Windows drive-letter colons) with ``-``. In a worktree-heavy
+    development setup this produces one encoded-key dir per worktree,
+    not one per logical project. The empirical scan on attune-ai
+    2026-05-15 found 1 canonical key with 44 sessions plus 47
+    worktree-encoded keys with 57 sessions — i.e. canonical-only
+    lookup misses the majority of recent activity.
+
+    Resolution rule (matches ``docs/specs/ops-sessions-page/decisions.md``
+    Decision 1):
+
+    1. Compute encoded prefix from the resolved project root.
+    2. Scan ``~/.claude/projects/`` and accept a child dir iff its
+       name equals the encoded prefix exactly, OR starts with
+       ``<encoded>-`` (the trailing ``-`` separator guards against
+       sibling-project false matches like ``attune-ai-something``).
+
+    Returns a list of absolute :class:`Path` objects, in arbitrary
+    order — callers that need stable ordering should sort. Returns
+    ``[]`` when the parent ``~/.claude/projects/`` directory doesn't
+    exist (fresh install with no Claude Code history) or when no
+    matching keys are found.
+
+    Cross-spec note: the worktree-inventory spec at
+    ``docs/specs/worktree-inventory/`` consumes this same helper.
+    The function is exported from ``attune.ops.data`` (no leading
+    underscore) so siblings can import it without dipping into a
+    private name.
+    """
+    projects_root = Path.home() / ".claude" / "projects"
+    if not projects_root.is_dir():
+        return []
+    encoded = _encoded_project_path(project_root)
+    matches: list[Path] = []
+    try:
+        children = list(projects_root.iterdir())
+    except OSError:
+        return []
+    for child in children:
+        if not child.is_dir():
+            continue
+        name = child.name
+        if name == encoded or name.startswith(f"{encoded}-"):
+            matches.append(child)
+    return matches
 
 
 def _heuristic_starter_prompt(content: str, *, char_limit: int = 200) -> str:
@@ -489,21 +550,53 @@ def _duration_seconds(first: str | None, last: str | None) -> float:
     return max((b - a).total_seconds(), 0.0)
 
 
+# Default cap on the number of sessions surfaced on the /sessions page.
+# Sized for the budget cap math (decisions.md Decision 5): 20 × ~$0.001/session
+# Haiku spend = ~$0.02 worst case, well under the $0.05 per-load cap. Older
+# sessions stay on disk for ``cat`` but aren't surfaced. The Resume-most-recent
+# card reads independently and is unaffected by this limit.
+DEFAULT_SESSION_LIST_CAP = 20
+
+
 def list_recent_sessions(
     project_root: Path | str,
     *,
     days: int = 3,
+    limit: int | None = DEFAULT_SESSION_LIST_CAP,
     now: datetime | None = None,
+    parser: Callable[[Path], Session | None] | None = None,
 ) -> list[Session]:
     """Return Session records for this project's last ``days`` of activity.
 
-    Reads ``~/.claude/projects/<encoded-project-root>/*.jsonl`` and
-    filters to files whose mtime is within ``days`` of ``now``
-    (default: current UTC time). Sorts most-recently-active first.
+    Reads ``*.jsonl`` files from every encoded-key directory belonging
+    to this logical project (canonical key plus per-worktree keys —
+    see :func:`enumerate_project_encoded_keys`) and filters to files
+    whose mtime is within ``days`` of ``now`` (default: current UTC
+    time). Sessions are deduplicated by id (the JSONL filename's
+    stem) — when the same id appears under multiple encoded keys
+    (rare; suggests a worktree that was renamed or re-created), the
+    newest-mtime copy wins and a WARN log records the conflict.
+    Output is sorted most-recently-active first and capped at
+    ``limit`` (default :data:`DEFAULT_SESSION_LIST_CAP`).
+
+    Args:
+        project_root: The dashboard's project root. Used to compute
+            the encoded-key prefix.
+        days: Time window for filtering by JSONL mtime.
+        limit: Maximum number of sessions to return. ``None`` returns
+            all matches (unbounded — only reasonable for callers that
+            already know the size, e.g. tests). The list cap exists
+            because each session may incur an LLM-summarization spend
+            on first render; capping bounds worst-case page-load cost
+            (decisions.md Decision 5).
+        now: Override the current time (test hook).
+        parser: Override the per-file parser (test hook). Defaults to
+            :func:`_parse_session`. The parser receives the JSONL
+            :class:`Path` and returns a :class:`Session` or ``None``.
 
     Returns ``[]`` for any failure mode that doesn't raise:
-    - Sessions dir doesn't exist (user never ran Claude Code here)
-    - Sessions dir exists but is empty
+    - No matching encoded-key dirs (user never ran Claude Code here)
+    - All matched dirs are empty
     - All JSONLs are older than the cutoff
     - All JSONLs are unreadable (perm, IO)
 
@@ -520,29 +613,68 @@ def list_recent_sessions(
     # ``from datetime import ...`` is cached after first use anyway.
     from datetime import timedelta
 
-    sessions_dir = claude_sessions_dir(project_root)
-    if not sessions_dir.is_dir():
-        return []
     if now is None:
         now = datetime.now(timezone.utc)
     cutoff = now - timedelta(days=days)
-    out: list[Session] = []
-    try:
-        candidates = list(sessions_dir.glob("*.jsonl"))
-    except OSError:
+    parse = parser or _parse_session
+
+    encoded_dirs = enumerate_project_encoded_keys(project_root)
+    if not encoded_dirs:
         return []
-    for jsonl in candidates:
+
+    # Per-id newest-mtime entry. Value is (mtime_utc, jsonl_path).
+    # Build this first so dedup can choose newest-mtime before parse.
+    by_id: dict[str, tuple[datetime, Path]] = {}
+    for sessions_dir in encoded_dirs:
         try:
-            mtime = datetime.fromtimestamp(jsonl.stat().st_mtime, tz=timezone.utc)
+            candidates = list(sessions_dir.glob("*.jsonl"))
         except OSError:
             continue
-        if mtime < cutoff:
-            continue
-        session = _parse_session(jsonl)
+        for jsonl in candidates:
+            try:
+                mtime = datetime.fromtimestamp(jsonl.stat().st_mtime, tz=timezone.utc)
+            except OSError:
+                continue
+            if mtime < cutoff:
+                continue
+            session_id = jsonl.stem
+            existing = by_id.get(session_id)
+            if existing is None:
+                by_id[session_id] = (mtime, jsonl)
+                continue
+            # Duplicate session-id across encoded keys (rare). Keep newest.
+            existing_mtime, existing_path = existing
+            if mtime > existing_mtime:
+                logger.warning(
+                    "ops.sessions: duplicate session id %s — keeping newer "
+                    "%s (mtime=%s) over %s (mtime=%s)",
+                    session_id,
+                    jsonl,
+                    mtime.isoformat(),
+                    existing_path,
+                    existing_mtime.isoformat(),
+                )
+                by_id[session_id] = (mtime, jsonl)
+            else:
+                logger.warning(
+                    "ops.sessions: duplicate session id %s — keeping existing "
+                    "%s (mtime=%s) over %s (mtime=%s)",
+                    session_id,
+                    existing_path,
+                    existing_mtime.isoformat(),
+                    jsonl,
+                    mtime.isoformat(),
+                )
+
+    out: list[Session] = []
+    for _mtime, jsonl in by_id.values():
+        session = parse(jsonl)
         if session is None:
             continue
         out.append(session)
     out.sort(key=lambda s: s.last_activity or "", reverse=True)
+    if limit is not None and limit >= 0:
+        out = out[:limit]
     return out
 
 

--- a/src/attune/ops/session_summary_cache.py
+++ b/src/attune/ops/session_summary_cache.py
@@ -1,0 +1,231 @@
+"""On-disk cache for Haiku-summarized session starter prompts.
+
+Defined by the ops-sessions-page spec (decisions.md, Decisions 6 + 7).
+Keyed by ``(filename, mtime_ns, sha256_of_last_4kb)`` — the last-4KB
+hash is the freshest content in a monotonically-growing JSONL and
+changes every time the session does. Hashing the head would collide
+on the byte-identical opening block (two sessions whose opening
+prompts look similar) and rely on mtime alone for freshness, which
+ticks spuriously on filesystem touches.
+
+Cache files live at::
+
+    <attune_home>/ops/session_summaries/<session-id>.json
+
+Each holds the redaction-already-applied summary text plus the key
+it was computed against. A cache hit returns the redacted form
+directly — sensitive material never lands in either the LLM
+provider's context or this on-disk cache.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Bytes hashed from the JSONL tail to form the cache-key digest.
+# 4 KiB matches decisions.md Decision 6. Files smaller than this are
+# fully hashed (short-session edge case, rare and cheap).
+_TAIL_BYTES = 4096
+
+
+@dataclass(frozen=True)
+class CacheKey:
+    """Stable key that invalidates a cached summary when the source moves.
+
+    ``filename`` is the JSONL basename (not a full path) so a session
+    that's relocated to a different encoded-key dir still hits the
+    cache as long as its content tail matches. Two-of-three matching
+    is not enough: all three components must match for a hit.
+    """
+
+    filename: str
+    mtime_ns: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class CachedSummary:
+    """One persisted session summary plus the metadata to validate it."""
+
+    key: CacheKey
+    summary: str
+    source: str  # "haiku" | "cached" — at write time always "haiku";
+    # ``load()`` returns "cached" for hit semantics.
+    tokens_in: int
+    tokens_out: int
+    cost_usd: float
+    created_at: str  # ISO 8601 UTC
+
+
+def _hash_tail(jsonl_path: Path) -> str | None:
+    """Return the SHA-256 hex digest of the file's last ``_TAIL_BYTES``.
+
+    For files smaller than the tail size, the whole file is hashed —
+    this collapses to "hash the file" and is correct for the
+    short-session edge case. Returns ``None`` on any I/O failure
+    (callers should treat this as cache-miss-by-design).
+    """
+    try:
+        size = jsonl_path.stat().st_size
+    except OSError:
+        return None
+    try:
+        with jsonl_path.open("rb") as fh:
+            if size > _TAIL_BYTES:
+                fh.seek(size - _TAIL_BYTES)
+            data = fh.read(_TAIL_BYTES)
+    except OSError:
+        return None
+    return hashlib.sha256(data).hexdigest()
+
+
+def compute_cache_key(jsonl_path: Path) -> CacheKey | None:
+    """Build a :class:`CacheKey` for one JSONL file. ``None`` on I/O failure."""
+    try:
+        st = jsonl_path.stat()
+    except OSError:
+        return None
+    digest = _hash_tail(jsonl_path)
+    if digest is None:
+        return None
+    return CacheKey(
+        filename=jsonl_path.name,
+        mtime_ns=st.st_mtime_ns,
+        sha256=digest,
+    )
+
+
+def cache_path_for(attune_home: Path, session_id: str) -> Path:
+    """Return the on-disk cache path for one session id.
+
+    The directory is created on first ``save()``; this function does
+    not create it (callers may want to test "is there a cache for X?"
+    without forcing the dir into existence).
+    """
+    return attune_home / "ops" / "session_summaries" / f"{session_id}.json"
+
+
+def load(attune_home: Path, session_id: str, expected: CacheKey) -> CachedSummary | None:
+    """Return the cached summary iff the on-disk record matches ``expected``.
+
+    Returns ``None`` on:
+
+    - File doesn't exist
+    - File is malformed JSON
+    - Stored key doesn't match all three components of ``expected``
+    - File is missing required fields
+
+    A returned :class:`CachedSummary` always has ``source == "cached"``
+    so the caller can distinguish hits from fresh writes (which use
+    ``source == "haiku"``). The cached text itself is unchanged.
+    """
+    path = cache_path_for(attune_home, session_id)
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError:
+        logger.warning("ops.sessions.cache: malformed JSON at %s — ignoring", path)
+        return None
+    if not isinstance(raw, dict):
+        return None
+    raw_key = raw.get("key")
+    if not isinstance(raw_key, dict):
+        return None
+    try:
+        stored_key = CacheKey(
+            filename=str(raw_key["filename"]),
+            mtime_ns=int(raw_key["mtime_ns"]),
+            sha256=str(raw_key["sha256"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+    if stored_key != expected:
+        return None
+    try:
+        return CachedSummary(
+            key=stored_key,
+            summary=str(raw["summary"]),
+            source="cached",
+            tokens_in=int(raw.get("tokens_in", 0)),
+            tokens_out=int(raw.get("tokens_out", 0)),
+            cost_usd=float(raw.get("cost_usd", 0.0)),
+            created_at=str(raw.get("created_at", "")),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def save(
+    attune_home: Path,
+    session_id: str,
+    *,
+    key: CacheKey,
+    summary: str,
+    tokens_in: int,
+    tokens_out: int,
+    cost_usd: float,
+) -> Path:
+    """Write a summary to the on-disk cache, atomically.
+
+    Always writes ``source = "haiku"`` — the "cached" flavor is
+    emitted by :func:`load` to mark a hit. Returns the path the
+    record was written to. Atomic via temp-file + rename so a
+    concurrent reader never observes a half-written JSON.
+
+    Raises :class:`OSError` on filesystem errors. Callers that want
+    silent best-effort caching should wrap the call in a try/except
+    rather than burying the failure here.
+    """
+    path = cache_path_for(attune_home, session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    record = {
+        "key": asdict(key),
+        "summary": summary,
+        "source": "haiku",
+        "tokens_in": int(tokens_in),
+        "tokens_out": int(tokens_out),
+        "cost_usd": float(cost_usd),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    payload = json.dumps(record, ensure_ascii=False, indent=2) + "\n"
+
+    # Temp file in the same dir → ``Path.replace`` is atomic on POSIX
+    # and Windows (per the existing CLAUDE.md lesson about Windows'
+    # rename semantics).
+    fd, tmp_str = tempfile.mkstemp(prefix=f".{session_id}.", suffix=".tmp", dir=str(path.parent))
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        tmp_path.replace(path)
+    except OSError:
+        # Best-effort cleanup — don't mask the original error.
+        with _suppress_oserror():
+            tmp_path.unlink()
+        raise
+    return path
+
+
+class _suppress_oserror:
+    """Tiny contextlib.suppress equivalent without the import cost."""
+
+    def __enter__(self) -> None:  # noqa: D401
+        return None
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401
+        return exc_type is not None and issubclass(exc_type, OSError)

--- a/tests/unit/ops/test_session_summary_cache.py
+++ b/tests/unit/ops/test_session_summary_cache.py
@@ -1,0 +1,217 @@
+"""Tests for the on-disk session-summary cache.
+
+Covers cache-key computation (last-4KB SHA-256), load/save round-trip,
+and the cache-invalidation matrix: any of (filename, mtime, content
+tail) drifting must produce a miss.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from attune.ops import session_summary_cache as cache
+
+
+def test_cache_key_filename_is_basename(tmp_path):
+    p = tmp_path / "abc12345.jsonl"
+    p.write_text("hello", encoding="utf-8")
+    key = cache.compute_cache_key(p)
+    assert key is not None
+    assert key.filename == "abc12345.jsonl"
+
+
+def test_cache_key_short_file_hashes_whole_file(tmp_path):
+    p = tmp_path / "short.jsonl"
+    p.write_text("hi", encoding="utf-8")
+    key = cache.compute_cache_key(p)
+    assert key is not None
+    # Manually compute expected
+    import hashlib
+
+    expected = hashlib.sha256(b"hi").hexdigest()
+    assert key.sha256 == expected
+
+
+def test_cache_key_long_file_hashes_only_tail(tmp_path):
+    """Files larger than the tail size hash only the last 4 KiB."""
+    p = tmp_path / "long.jsonl"
+    head = b"H" * 10_000
+    tail = b"T" * 4096  # exactly the tail-window size
+    p.write_bytes(head + tail)
+
+    key = cache.compute_cache_key(p)
+    assert key is not None
+
+    import hashlib
+
+    expected = hashlib.sha256(tail).hexdigest()
+    assert key.sha256 == expected
+
+
+def test_cache_key_tail_changes_when_content_grows(tmp_path):
+    """Appending content (the typical JSONL growth pattern) flips the tail hash."""
+    p = tmp_path / "growing.jsonl"
+    p.write_text("a" * 5000, encoding="utf-8")
+    key1 = cache.compute_cache_key(p)
+    # Wait one tick so mtime moves too — though the tail hash alone
+    # should already differ.
+    time.sleep(0.01)
+    with p.open("a", encoding="utf-8") as fh:
+        fh.write("b" * 1000)
+    key2 = cache.compute_cache_key(p)
+    assert key1 is not None and key2 is not None
+    assert key1.sha256 != key2.sha256
+
+
+def test_compute_cache_key_returns_none_for_missing_file(tmp_path):
+    assert cache.compute_cache_key(tmp_path / "nope.jsonl") is None
+
+
+# ---------------------------------------------------------------------------
+# load / save round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def attune_home(tmp_path):
+    return tmp_path / "attune-home"
+
+
+def _make_key():
+    return cache.CacheKey(
+        filename="abc.jsonl",
+        mtime_ns=1_700_000_000_000_000_000,
+        sha256="deadbeef" * 8,
+    )
+
+
+def test_save_and_load_round_trip(attune_home):
+    key = _make_key()
+    path = cache.save(
+        attune_home,
+        "session-id-1",
+        key=key,
+        summary="A redacted summary.",
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.0012,
+    )
+    assert path.exists()
+
+    loaded = cache.load(attune_home, "session-id-1", expected=key)
+    assert loaded is not None
+    assert loaded.summary == "A redacted summary."
+    assert loaded.tokens_in == 100
+    assert loaded.tokens_out == 50
+    assert loaded.cost_usd == pytest.approx(0.0012)
+    # Source on hit is "cached", not "haiku".
+    assert loaded.source == "cached"
+    assert loaded.created_at  # non-empty ISO string
+
+
+def test_load_returns_none_when_file_missing(attune_home):
+    assert cache.load(attune_home, "no-such-id", expected=_make_key()) is None
+
+
+def test_load_returns_none_on_filename_mismatch(attune_home):
+    saved_key = _make_key()
+    cache.save(
+        attune_home,
+        "sid",
+        key=saved_key,
+        summary="x",
+        tokens_in=1,
+        tokens_out=1,
+        cost_usd=0.0,
+    )
+    drifted = cache.CacheKey(
+        filename="other.jsonl", mtime_ns=saved_key.mtime_ns, sha256=saved_key.sha256
+    )
+    assert cache.load(attune_home, "sid", expected=drifted) is None
+
+
+def test_load_returns_none_on_mtime_mismatch(attune_home):
+    saved_key = _make_key()
+    cache.save(
+        attune_home,
+        "sid",
+        key=saved_key,
+        summary="x",
+        tokens_in=1,
+        tokens_out=1,
+        cost_usd=0.0,
+    )
+    drifted = cache.CacheKey(
+        filename=saved_key.filename, mtime_ns=saved_key.mtime_ns + 1, sha256=saved_key.sha256
+    )
+    assert cache.load(attune_home, "sid", expected=drifted) is None
+
+
+def test_load_returns_none_on_sha_mismatch(attune_home):
+    saved_key = _make_key()
+    cache.save(
+        attune_home,
+        "sid",
+        key=saved_key,
+        summary="x",
+        tokens_in=1,
+        tokens_out=1,
+        cost_usd=0.0,
+    )
+    drifted = cache.CacheKey(
+        filename=saved_key.filename, mtime_ns=saved_key.mtime_ns, sha256="0" * 64
+    )
+    assert cache.load(attune_home, "sid", expected=drifted) is None
+
+
+def test_load_returns_none_on_malformed_json(attune_home):
+    path = cache.cache_path_for(attune_home, "sid")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json{{{", encoding="utf-8")
+    assert cache.load(attune_home, "sid", expected=_make_key()) is None
+
+
+def test_save_is_atomic_no_temp_files_left_behind(attune_home):
+    """After a successful save, only the final ``.json`` file should
+    exist in the cache dir — no ``.tmp`` siblings."""
+    key = _make_key()
+    cache.save(
+        attune_home,
+        "sid",
+        key=key,
+        summary="x",
+        tokens_in=1,
+        tokens_out=1,
+        cost_usd=0.0,
+    )
+    cache_dir = attune_home / "ops" / "session_summaries"
+    leftover_tmp = list(cache_dir.glob(".sid.*.tmp"))
+    assert leftover_tmp == [], f"temp files leaked: {leftover_tmp}"
+
+
+def test_cache_path_for_does_not_create_dir(attune_home):
+    """Computing the path must not have side effects on the filesystem."""
+    path = cache.cache_path_for(attune_home, "sid")
+    assert not path.parent.exists()
+    assert not path.exists()
+
+
+def test_save_persisted_record_has_haiku_source_on_disk(attune_home):
+    """The on-disk JSON records ``source: "haiku"`` even though
+    ``load()`` reports ``cached`` to callers — so a future reader can
+    distinguish "fresh write" from "cache hit" by inspecting the file."""
+    cache.save(
+        attune_home,
+        "sid",
+        key=_make_key(),
+        summary="x",
+        tokens_in=1,
+        tokens_out=1,
+        cost_usd=0.0,
+    )
+    path = cache.cache_path_for(attune_home, "sid")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["source"] == "haiku"

--- a/tests/unit/ops/test_sessions.py
+++ b/tests/unit/ops/test_sessions.py
@@ -295,6 +295,203 @@ def test_list_recent_sessions_skips_malformed_lines(tmp_path, monkeypatch):
     assert result[0].message_count == 1
 
 
+# ---------------------------------------------------------------------------
+# enumerate_project_encoded_keys — multi-key resolution
+# ---------------------------------------------------------------------------
+
+
+def test_enumerate_project_encoded_keys_returns_empty_when_projects_root_missing(
+    tmp_path, monkeypatch
+):
+    """No ``~/.claude/projects/`` dir → empty list, not error."""
+    _patch_home(monkeypatch, tmp_path / "home")
+    assert data.enumerate_project_encoded_keys(tmp_path / "project") == []
+
+
+def test_enumerate_project_encoded_keys_finds_canonical_key(tmp_path, monkeypatch):
+    """Canonical encoded-key dir is matched exactly."""
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    canonical = data.claude_sessions_dir(project_root)
+    canonical.mkdir(parents=True)
+
+    matches = data.enumerate_project_encoded_keys(project_root)
+    assert canonical in matches
+    assert len(matches) == 1
+
+
+def test_enumerate_project_encoded_keys_finds_worktree_keys(tmp_path, monkeypatch):
+    """Sibling dirs starting with ``<encoded>-`` are matched as worktree keys.
+
+    Mirrors the empirical attune-ai layout: one canonical key plus
+    several ``<encoded>--claude-worktrees-<slug>`` dirs.
+    """
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    encoded = data._encoded_project_path(project_root)
+    projects_root = tmp_path / "home" / ".claude" / "projects"
+    projects_root.mkdir(parents=True)
+
+    canonical = projects_root / encoded
+    worktree_a = projects_root / f"{encoded}--claude-worktrees-foo"
+    worktree_b = projects_root / f"{encoded}--claude-worktrees-bar"
+    canonical.mkdir()
+    worktree_a.mkdir()
+    worktree_b.mkdir()
+
+    matches = data.enumerate_project_encoded_keys(project_root)
+    assert set(matches) == {canonical, worktree_a, worktree_b}
+
+
+def test_enumerate_project_encoded_keys_rejects_sibling_project_false_match(tmp_path, monkeypatch):
+    """A dir whose name starts with ``<encoded>`` but no trailing
+    ``-`` separator (e.g. a sibling project ``attune-ai-foo`` vs
+    ``attune-ai``) must NOT match.
+
+    The trailing-dash separator is the explicit guard against this
+    in the spec (Decision 1).
+    """
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    encoded = data._encoded_project_path(project_root)
+    projects_root = tmp_path / "home" / ".claude" / "projects"
+    projects_root.mkdir(parents=True)
+
+    canonical = projects_root / encoded
+    sibling_no_dash = projects_root / f"{encoded}xyz"  # no separator
+    canonical.mkdir()
+    sibling_no_dash.mkdir()
+
+    matches = data.enumerate_project_encoded_keys(project_root)
+    assert canonical in matches
+    assert sibling_no_dash not in matches
+
+
+def test_list_recent_sessions_dedups_across_encoded_keys_newest_wins(tmp_path, monkeypatch):
+    """Same session id under canonical AND worktree key → newest mtime wins.
+
+    Rare in practice (suggests a worktree was renamed or recreated)
+    but the spec requires WARN log + newest-wins resolution.
+    """
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    encoded = data._encoded_project_path(project_root)
+    projects_root = tmp_path / "home" / ".claude" / "projects"
+    canonical = projects_root / encoded
+    worktree = projects_root / f"{encoded}--claude-worktrees-foo"
+
+    now = datetime(2026, 5, 14, 12, 0, 0, tzinfo=timezone.utc)
+    older = (now - timedelta(days=2)).timestamp()
+    newer = (now - timedelta(hours=1)).timestamp()
+
+    _write_session_jsonl(
+        canonical,
+        "shared-id",
+        events=[{"timestamp": "2026-05-12T12:00:00Z", "content": "old version"}],
+        mtime=older,
+    )
+    _write_session_jsonl(
+        worktree,
+        "shared-id",
+        events=[{"timestamp": "2026-05-14T11:00:00Z", "content": "new version"}],
+        mtime=newer,
+    )
+
+    result = data.list_recent_sessions(project_root, now=now)
+    assert len(result) == 1
+    assert result[0].id == "shared-id"
+    # The newer worktree copy should win — its prompt is the one rendered.
+    assert result[0].starter_prompt.startswith("new version")
+
+
+def test_list_recent_sessions_aggregates_across_encoded_keys(tmp_path, monkeypatch):
+    """Sessions from multiple encoded keys are aggregated into one list."""
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    encoded = data._encoded_project_path(project_root)
+    projects_root = tmp_path / "home" / ".claude" / "projects"
+    canonical = projects_root / encoded
+    worktree_a = projects_root / f"{encoded}--claude-worktrees-aaa"
+    worktree_b = projects_root / f"{encoded}--claude-worktrees-bbb"
+
+    _write_session_jsonl(
+        canonical,
+        "from-canonical",
+        events=[{"timestamp": "2026-05-14T10:00:00Z", "content": "canonical session"}],
+    )
+    _write_session_jsonl(
+        worktree_a,
+        "from-worktree-a",
+        events=[{"timestamp": "2026-05-14T10:30:00Z", "content": "worktree-a session"}],
+    )
+    _write_session_jsonl(
+        worktree_b,
+        "from-worktree-b",
+        events=[{"timestamp": "2026-05-14T11:00:00Z", "content": "worktree-b session"}],
+    )
+
+    now = datetime(2026, 5, 14, 12, 0, 0, tzinfo=timezone.utc)
+    result = data.list_recent_sessions(project_root, now=now)
+    ids = {s.id for s in result}
+    assert ids == {"from-canonical", "from-worktree-a", "from-worktree-b"}
+
+
+def test_list_recent_sessions_caps_at_default_limit(tmp_path, monkeypatch):
+    """The list cap (DEFAULT_SESSION_LIST_CAP) bounds the result size.
+
+    Decision 5 (decisions.md): cap at 20 most-recent sessions for
+    budget-cap math (~$0.02 worst case at $0.001/session).
+    """
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    sessions_dir = data.claude_sessions_dir(project_root)
+
+    # Write 25 sessions, each with a slightly different mtime so the
+    # sort is deterministic.
+    base_ts = datetime(2026, 5, 14, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+    for i in range(25):
+        _write_session_jsonl(
+            sessions_dir,
+            f"session-{i:02d}",
+            events=[
+                {
+                    "timestamp": f"2026-05-14T10:{i:02d}:00Z",
+                    "content": f"prompt {i}",
+                }
+            ],
+            mtime=base_ts + i * 60,
+        )
+
+    now = datetime(2026, 5, 14, 12, 0, 0, tzinfo=timezone.utc)
+    result = data.list_recent_sessions(project_root, now=now)
+    assert len(result) == data.DEFAULT_SESSION_LIST_CAP == 20
+    # Newest-first sort + cap → the 20 highest indexes survive.
+    surviving_ids = {s.id for s in result}
+    assert "session-24" in surviving_ids
+    assert "session-05" in surviving_ids
+    assert "session-04" not in surviving_ids
+
+
+def test_list_recent_sessions_limit_none_returns_all(tmp_path, monkeypatch):
+    """``limit=None`` disables the cap (test hook)."""
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    sessions_dir = data.claude_sessions_dir(project_root)
+
+    base_ts = datetime(2026, 5, 14, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+    for i in range(25):
+        _write_session_jsonl(
+            sessions_dir,
+            f"session-{i:02d}",
+            events=[{"timestamp": "2026-05-14T10:00:00Z", "content": f"prompt {i}"}],
+            mtime=base_ts + i * 60,
+        )
+
+    now = datetime(2026, 5, 14, 12, 0, 0, tzinfo=timezone.utc)
+    result = data.list_recent_sessions(project_root, limit=None, now=now)
+    assert len(result) == 25
+
+
 def test_list_recent_sessions_handles_no_content_events(tmp_path, monkeypatch):
     """A session with no events that have ``content`` (e.g. dequeue-only,
     attachment-only) yields a record with placeholder starter prompt."""


### PR DESCRIPTION
## Summary

PR-A of two for the [/sessions S3 spec](../tree/main/docs/specs/ops-sessions-page/decisions.md). Ships the data-layer foundation — no LLM calls in this PR. PR-B follows with the Haiku summarizer, `?compare=1` dev mode, and calibration build script.

- **Multi-key resolution**: `enumerate_project_encoded_keys()` (public export) returns all `~/.claude/projects/<encoded>*` dirs belonging to one logical project. The empirical scan on attune-ai 2026-05-15 found 47 worktree-encoded keys vs 1 canonical key — canonical-only lookup misses the majority of recent activity in a worktree-heavy dev pattern.
- **Newest-mtime dedup**: same session id appearing under multiple keys (rare; suggests worktree rename) keeps the newest copy and logs a WARN.
- **Cache module** (`session_summary_cache.py`): keyed by `(filename, mtime_ns, sha256_of_last_4kb)` per decisions.md Decision 6 — hashing the tail beats hashing the head because JSONLs grow monotonically and the opening block is byte-identical for the session's lifetime.
- **List cap N=20** (`DEFAULT_SESSION_LIST_CAP`) per decisions.md Decision 5 — bounds worst-case Haiku spend at ~$0.02/load.

## Unblocks

`enumerate_project_encoded_keys()` is the shared helper consumed by the worktree-inventory sibling spec at [`docs/specs/worktree-inventory/`](../tree/main/docs/specs/worktree-inventory/decisions.md). Public name, no leading underscore.

## Test plan

- [x] 22 new tests (`tests/unit/ops/test_sessions.py` + `tests/unit/ops/test_session_summary_cache.py`)
- [x] Full ops test suite green locally — 380 passed
- [x] Cross-platform encoding regression test holds (existing test for backslash + colon handling)
- [ ] Windows CI lanes (4) come back green
- [ ] CodeQL / push-protection scans green

## Follow-up

PR-B adds:
- Haiku summarizer wired through `attune.ops.session_redaction.redact()` first, then cache.save()
- Budget-cap soft warning ($0.05 ceiling, WARN-once on breach, keep rendering)
- `?compare=1` dev-only query param rendering heuristic + Haiku columns side-by-side
- `scripts/build_session_fixtures.py` build script (Patrick curates fixtures interactively after)
- Source field semantics: `"haiku"` (fresh) and `"cached"` (hit) populated in the route layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
