### PR TITLE
feat(ops): /sessions S3b — Haiku summarizer + compare mode (stacked on #387)

### DIFF
--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -300,13 +300,13 @@ reader knows it's not part of the user-facing surface.
 | Cache key (last-4KB) | S3a — `session_summary_cache.compute_cache_key()` | shipped (cache module; Haiku wire-up in S3b) |
 | Cache location / TTL | S3a — `<attune_home>/ops/session_summaries/<id>.json`, mtime-bound | shipped (module); first write happens in S3b |
 | List cap (N=20) | S3a — `DEFAULT_SESSION_LIST_CAP` in `list_recent_sessions()` | shipped |
-| Starter-prompt generation (Haiku) | TBD (S3) | pending |
-| Budget cap ($0.05) | TBD (S3) | pending |
-| Source field semantics (heuristic/haiku/cached) | #377 (`heuristic` only) | partial — `haiku`/`cached` in S3 |
+| Starter-prompt generation (Haiku) | S3b — `session_summary_llm.summarize()` + `session_summary.summarize_for_session()` orchestrator | shipped |
+| Budget cap ($0.05) | S3b — `BudgetTracker` soft cap, banner on breach | shipped (soft cap per Patrick 2026-05-15) |
+| Source field semantics (heuristic/haiku/cached) | #377 (`heuristic` only); S3b adds `haiku`/`cached` via route layer | shipped |
 | Resume card (current-worktree → canonical) | TBD (S4) | pending |
 | Live-session detection | TBD (S5) | pending |
-| Compare mode (`?compare=1`) | TBD (S3) | pending |
-| Calibration harness | TBD (S3) | pending |
+| Compare mode (`?compare=1`) | S3b — query-param + template branch | shipped |
+| Calibration harness | S3b — `scripts/build_session_fixtures.py`; snapshot test + committed fixtures land in a follow-up after Patrick curates | partial — build script only |
 | Expand-on-click body | TBD (S4 or later) | pending |
 
 ---

--- a/scripts/build_session_fixtures.py
+++ b/scripts/build_session_fixtures.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Build redacted Claude Code session fixtures for calibration / regression.
+
+Walks ``~/.claude/projects/<encoded-project>*`` and produces a
+small set of fixture JSONL files at
+``tests/fixtures/ops/session_summaries/``. Each fixture is a real
+session run through :func:`attune.ops.session_redaction.redact` —
+no sensitive content lands in git.
+
+**Patrick's interactive step.** This script writes candidate
+fixtures to the fixtures dir but does NOT commit them. Review
+each file by hand before staging. The intent (per the
+ops-sessions-page spec, decisions.md Decision 8):
+
+- ~10 representative sessions: short, long, multi-thread,
+  abandoned-mid-conversation.
+- Each fixture is the redacted form of a real session JSONL.
+- A snapshot test will compare Haiku output against these to
+  catch prompt drift in CI — ships in a follow-up PR after
+  fixtures are curated.
+
+Usage::
+
+    # Default: attune-ai under your CLAUDE.md project root.
+    python scripts/build_session_fixtures.py
+
+    # Custom project root (any project with Claude Code history):
+    python scripts/build_session_fixtures.py --project-root ~/other
+
+    # Larger sample (default: 12 candidates → curate down to ~10):
+    python scripts/build_session_fixtures.py --sample 20
+
+    # Different output dir:
+    python scripts/build_session_fixtures.py --out path/to/fixtures
+
+The script picks the N most-recently-active sessions across all
+matching encoded keys; you trim from there based on the
+representativeness rubric above.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Allow running from a checkout without `pip install -e .`.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from attune.ops import data, session_redaction  # noqa: E402
+
+
+def _redact_jsonl(src: Path, dst: Path) -> tuple[int, dict[str, int]]:
+    """Read ``src`` JSONL, redact each event's ``content``, write to ``dst``.
+
+    Returns ``(event_count, aggregate_counts)`` for the per-file
+    report. Aggregate counts sum per-category histogram across all
+    events in the file.
+    """
+    aggregate: dict[str, int] = {}
+    events_written = 0
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with src.open(encoding="utf-8") as r, dst.open("w", encoding="utf-8") as w:
+        for raw in r:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            content = event.get("content")
+            if isinstance(content, str) and content:
+                result = session_redaction.redact(content)
+                event["content"] = result.text
+                for k, v in result.counts.items():
+                    aggregate[k] = aggregate.get(k, 0) + v
+            w.write(json.dumps(event, ensure_ascii=False) + "\n")
+            events_written += 1
+    return events_written, aggregate
+
+
+def _pick_candidates(project_root: Path, sample: int) -> list[Path]:
+    """Find the N most-recently-active JSONLs across all encoded keys.
+
+    Sorts by mtime descending. Returns paths, not Session records —
+    the build script operates on raw files.
+    """
+    candidates: list[tuple[float, Path]] = []
+    for sessions_dir in data.enumerate_project_encoded_keys(project_root):
+        try:
+            for jsonl in sessions_dir.glob("*.jsonl"):
+                try:
+                    mt = jsonl.stat().st_mtime
+                except OSError:
+                    continue
+                candidates.append((mt, jsonl))
+        except OSError:
+            continue
+    candidates.sort(reverse=True)
+    return [p for _mt, p in candidates[:sample]]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path(os.environ.get("ATTUNE_FIXTURE_PROJECT", _REPO_ROOT)),
+        help=(
+            "Logical project root whose Claude Code sessions to harvest. "
+            "Defaults to the repo containing this script."
+        ),
+    )
+    parser.add_argument(
+        "--sample",
+        type=int,
+        default=12,
+        help=(
+            "Number of candidate sessions to harvest (default: 12). "
+            "You curate down to ~10 representative ones before committing."
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=_REPO_ROOT / "tests" / "fixtures" / "ops" / "session_summaries",
+        help="Output directory for redacted fixture JSONLs.",
+    )
+    args = parser.parse_args()
+
+    project_root = args.project_root.expanduser().resolve()
+    out_dir = args.out.expanduser().resolve()
+
+    candidates = _pick_candidates(project_root, args.sample)
+    if not candidates:
+        print(
+            f"No sessions found under any encoded key for {project_root}. "
+            "Check that ~/.claude/projects/ has matching dirs.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Harvesting {len(candidates)} fixture candidates from {project_root}"
+        f"\n  → output: {out_dir}\n"
+    )
+
+    total_redactions: dict[str, int] = {}
+    for src in candidates:
+        dst = out_dir / src.name
+        events, counts = _redact_jsonl(src, dst)
+        mtime = datetime.fromtimestamp(src.stat().st_mtime, tz=timezone.utc)
+        per_file_counts = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "0"
+        print(
+            f"  {src.name}\n"
+            f"    mtime  : {mtime.isoformat()}\n"
+            f"    events : {events}\n"
+            f"    redacts: {per_file_counts}\n"
+            f"    wrote  : {dst}\n"
+        )
+        for k, v in counts.items():
+            total_redactions[k] = total_redactions.get(k, 0) + v
+
+    print(
+        "Aggregate redactions across all candidates: "
+        + (", ".join(f"{k}={v}" for k, v in sorted(total_redactions.items())) or "0")
+    )
+    print(
+        "\nNext steps:\n"
+        f"  1. Review each fixture in {out_dir}\n"
+        "  2. Delete any that don't add representational variety\n"
+        "  3. Spot-check that redactions look clean (no leaked keys/paths)\n"
+        "  4. Stage the final set with: git add tests/fixtures/ops/session_summaries/\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_session_fixtures.py
+++ b/scripts/build_session_fixtures.py
@@ -41,7 +41,6 @@ representativeness rubric above.
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
 from datetime import datetime, timezone
@@ -54,12 +53,38 @@ sys.path.insert(0, str(_REPO_ROOT / "src"))
 from attune.ops import data, session_redaction  # noqa: E402
 
 
-def _redact_jsonl(src: Path, dst: Path) -> tuple[int, dict[str, int]]:
-    """Read ``src`` JSONL, redact each event's ``content``, write to ``dst``.
+def _redact_jsonl(
+    src: Path, dst: Path, *, max_events: int | None = None
+) -> tuple[int, dict[str, int]]:
+    """Read ``src`` JSONL, redact every line via ``redact_json_line``,
+    write the redacted form to ``dst``.
 
-    Returns ``(event_count, aggregate_counts)`` for the per-file
-    report. Aggregate counts sum per-category histogram across all
-    events in the file.
+    Uses :func:`attune.ops.session_redaction.redact_json_line` so
+    EVERY nested string in the document — including
+    ``message.content[].text``, ``toolUseResult.stdout``, arbitrary
+    tool-call payloads — gets covered. The earlier top-level-only
+    field walk left REAL Anthropic API keys and thousands of
+    unredacted home paths in the harvested fixtures (#389 fix).
+
+    Lines that fail the round-trip (redaction would have produced
+    invalid JSON — typically a JSON-escape boundary collision) are
+    dropped with a stderr warning rather than crashing the harvest.
+    Lines that fail the input parse are also skipped silently
+    (matches production reader behavior).
+
+    Args:
+        src: Source JSONL file.
+        dst: Output path. Parent dirs are created on first write.
+        max_events: When set, stop after writing N events. Real
+            Claude Code session JSONLs are megabytes; the
+            summarizer only consumes the first ~6 KB of content,
+            so a small N (e.g. 50) gives the snapshot test
+            identical input at a fraction of the git footprint.
+
+    Returns:
+        ``(events_written, per_category_counts)`` for the per-file
+        report. Per-category counts sum the redaction histogram
+        across all events in the file.
     """
     aggregate: dict[str, int] = {}
     events_written = 0
@@ -69,20 +94,24 @@ def _redact_jsonl(src: Path, dst: Path) -> tuple[int, dict[str, int]]:
             line = raw.strip()
             if not line:
                 continue
-            try:
-                event = json.loads(line)
-            except json.JSONDecodeError:
+            result = session_redaction.redact_json_line(line)
+            if result is None:
+                # Either input wasn't valid JSON (matches the
+                # production reader's per-line skip) or redaction
+                # produced invalid JSON (escape-boundary collision).
+                # Drop with a brief note so the harvest report
+                # surfaces the count.
+                print(
+                    f"  ! skipped malformed line in {src.name}",
+                    file=sys.stderr,
+                )
                 continue
-            if not isinstance(event, dict):
-                continue
-            content = event.get("content")
-            if isinstance(content, str) and content:
-                result = session_redaction.redact(content)
-                event["content"] = result.text
-                for k, v in result.counts.items():
-                    aggregate[k] = aggregate.get(k, 0) + v
-            w.write(json.dumps(event, ensure_ascii=False) + "\n")
+            for k, v in result.counts.items():
+                aggregate[k] = aggregate.get(k, 0) + v
+            w.write(result.text + "\n")
             events_written += 1
+            if max_events is not None and events_written >= max_events:
+                break
     return events_written, aggregate
 
 
@@ -133,6 +162,18 @@ def main() -> int:
         default=_REPO_ROOT / "tests" / "fixtures" / "ops" / "session_summaries",
         help="Output directory for redacted fixture JSONLs.",
     )
+    parser.add_argument(
+        "--max-events",
+        type=int,
+        default=None,
+        help=(
+            "Trim each fixture to its first N events after redaction. "
+            "Real Claude Code session JSONLs are megabytes; the summarizer "
+            "only consumes the first ~6 KB of content, so a small N (e.g. 50) "
+            "gives the snapshot test identical input at a fraction of the "
+            "git footprint. Default: no trimming (full session)."
+        ),
+    )
     args = parser.parse_args()
 
     project_root = args.project_root.expanduser().resolve()
@@ -155,7 +196,7 @@ def main() -> int:
     total_redactions: dict[str, int] = {}
     for src in candidates:
         dst = out_dir / src.name
-        events, counts = _redact_jsonl(src, dst)
+        events, counts = _redact_jsonl(src, dst, max_events=args.max_events)
         mtime = datetime.fromtimestamp(src.stat().st_mtime, tz=timezone.utc)
         per_file_counts = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "0"
         print(

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -3,16 +3,35 @@
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
-from attune.ops import data
+from attune.ops import data, session_summary
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+# Env gate for the Haiku summarizer. Defaults OFF — opt-in for the
+# first release per acceptance criterion #5 in requirements.md. When
+# off, every session row renders with its heuristic prompt (first
+# user message, truncated) and no LLM call is made.
+_LLM_GATE_ENV = "ATTUNE_OPS_SESSIONS_LLM"
+
+
+def _llm_gate_on() -> bool:
+    """Return True iff the Haiku-summarizer gate is enabled.
+
+    Accepts the canonical truthy values: ``1``, ``true``, ``yes``,
+    ``on`` (case-insensitive). Anything else (including unset)
+    keeps the gate off.
+    """
+    val = os.environ.get(_LLM_GATE_ENV, "").strip().lower()
+    return val in ("1", "true", "yes", "on")
 
 
 def _ctx(request: Request, page: str, **extra) -> dict:
@@ -132,23 +151,96 @@ async def health_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/sessions", response_class=HTMLResponse)
-async def sessions_page(request: Request) -> HTMLResponse:
+async def sessions_page(request: Request, compare: int = 0) -> HTMLResponse:
     """Sessions page — recent Claude Code sessions for this project.
 
-    S2: reads ``~/.claude/projects/<encoded-project-root>/*.jsonl``
-    and surfaces sessions whose mtime is within the last 3 days,
-    each with a heuristic starter-prompt (first user prompt,
-    truncated to ~200 chars). S3 will replace the heuristic with
-    Haiku-summarized prompts and a per-page budget cap; S4 adds the
-    resume-most-recent card; S5 marks the live session.
+    S3a (PR #387): multi-key data layer + summary cache module —
+    landed without LLM calls. S3b (this slice): wires the Haiku
+    summarizer through, gated on ``ATTUNE_OPS_SESSIONS_LLM``. With
+    the gate off (default), every row renders with the heuristic
+    starter prompt; with it on, the route walks the cap-limited
+    session list, replaces each row's prompt with the Haiku /
+    cached summary, and tracks per-page-load spend against a soft
+    budget cap (decisions.md Decision 5).
 
-    Failure modes are silent fall-throughs to the empty state: no
-    Claude Code dir, all sessions older than 3 days, all JSONLs
-    unreadable — none surface as errors. The point is to be useful
-    on a fresh install, not to debug Claude Code's internal state.
+    Compare mode: ``?compare=1`` is a dev-only query parameter that
+    renders both the heuristic and Haiku prompts side-by-side for
+    pre-launch eyeball validation. No UI affordance for it —
+    discoverable only by knowing the URL (decisions.md Decision 9).
+    Doesn't bypass the budget cap or redaction.
+
+    Failure modes are silent fall-throughs to the empty state or
+    the heuristic prompt: no Claude Code dir, all sessions older
+    than 3 days, all JSONLs unreadable, LLM call errored — none
+    surface as errors. The point is to be useful on a fresh
+    install, not to debug Claude Code's internal state.
     """
     cfg = request.app.state.config
     sessions = data.list_recent_sessions(cfg.project_root, days=3)
+
+    llm_enabled = _llm_gate_on()
+    compare_mode = bool(compare) and llm_enabled  # compare requires LLM on
+    # Heuristic-only column lives in this dict when compare mode
+    # is active. Indexed by session id. None outside compare mode.
+    heuristic_by_id: dict[str, str] | None = None
+    budget_summary: dict | None = None
+    api_key_missing = False
+
+    if llm_enabled:
+        budget = session_summary.BudgetTracker()
+        if compare_mode:
+            # Snapshot the heuristic prompt for each session before
+            # replacing the row's prompt with the Haiku summary.
+            heuristic_by_id = {s.id: s.starter_prompt for s in sessions}
+
+        # Resolve each session's JSONL path so the orchestrator can
+        # compute cache keys. data.list_recent_sessions doesn't
+        # surface paths, so re-derive from the encoded-key dirs.
+        path_by_id = _resolve_session_jsonl_paths(cfg.project_root, sessions)
+
+        upgraded: list[data.Session] = []
+        for sess in sessions:
+            jsonl_path = path_by_id.get(sess.id)
+            if jsonl_path is None:
+                upgraded.append(sess)
+                continue
+            raw_text = session_summary.extract_summarizable_text(jsonl_path)
+            if not raw_text:
+                upgraded.append(sess)
+                continue
+            try:
+                summary = session_summary.summarize_for_session(
+                    jsonl_path,
+                    raw_text,
+                    attune_home=cfg.attune_home,
+                    budget=budget,
+                )
+            except session_summary.session_summary_llm.MissingApiKeyError:
+                api_key_missing = True
+                summary = None
+            if summary is None:
+                # Heuristic fallback: keep the row's existing
+                # heuristic prompt, leave source="heuristic".
+                upgraded.append(sess)
+                continue
+            upgraded.append(
+                data.Session(
+                    id=sess.id,
+                    started_at=sess.started_at,
+                    last_activity=sess.last_activity,
+                    duration_seconds=sess.duration_seconds,
+                    message_count=sess.message_count,
+                    starter_prompt=summary.text,
+                    source=summary.source,
+                )
+            )
+        sessions = upgraded
+        budget_summary = {
+            "spend_usd": round(budget.spend_usd, 4),
+            "cap_usd": budget.cap_usd,
+            "exceeded": budget.spend_usd > budget.cap_usd,
+        }
+
     # Where the sessions live — surfaced in the empty-state so users
     # can ``cat`` the JSONLs directly if they want to inspect more
     # than the page shows. Reuses ``claude_sessions_dir`` so the
@@ -168,7 +260,47 @@ async def sessions_page(request: Request) -> HTMLResponse:
         page="sessions",
         sessions=sessions,
         sessions_dir=sessions_dir,
+        llm_enabled=llm_enabled,
+        compare_mode=compare_mode,
+        heuristic_by_id=heuristic_by_id,
+        budget_summary=budget_summary,
+        api_key_missing=api_key_missing,
     )
+
+
+def _resolve_session_jsonl_paths(project_root: Path | str, sessions: list) -> dict[str, Path]:
+    """Map each session id to its JSONL file path on disk.
+
+    Walks every encoded-key dir from
+    :func:`attune.ops.data.enumerate_project_encoded_keys` and
+    matches by filename stem. When the same session id appears
+    under multiple keys (rare; same dedup case
+    :func:`list_recent_sessions` handles), keeps the
+    newest-mtime path to align with the list ordering.
+
+    Returns an empty mapping for any session whose JSONL has
+    vanished between listing and resolution — orchestrator will
+    treat that as "skip the LLM call" via the empty-text path.
+    """
+    wanted = {s.id for s in sessions}
+    out: dict[str, Path] = {}
+    out_mtime: dict[str, float] = {}
+    for sessions_dir in data.enumerate_project_encoded_keys(project_root):
+        try:
+            for jsonl in sessions_dir.glob("*.jsonl"):
+                stem = jsonl.stem
+                if stem not in wanted:
+                    continue
+                try:
+                    mt = jsonl.stat().st_mtime
+                except OSError:
+                    continue
+                if stem not in out or mt > out_mtime[stem]:
+                    out[stem] = jsonl
+                    out_mtime[stem] = mt
+        except OSError:
+            continue
+    return out
 
 
 @router.get("/runs/{run_id}/view", response_class=HTMLResponse)

--- a/src/attune/ops/session_summary.py
+++ b/src/attune/ops/session_summary.py
@@ -1,0 +1,240 @@
+"""Orchestrator: redact → cache-or-Haiku → return summary text.
+
+Glue layer between the JSONL parser, the redaction module, the
+on-disk cache, and the Haiku summarizer. Tests cover each leg
+independently; this module wires them in the order the spec calls
+for and tracks per-page-load budget.
+
+Discipline (decisions.md Decision 3):
+
+    Redact FIRST, then summarize, then cache. The cache never holds
+    a sensitive prompt; subsequent reads inherit the redaction for
+    free.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from attune.ops import session_redaction, session_summary_cache, session_summary_llm
+
+logger = logging.getLogger(__name__)
+
+
+# Per-page-load soft budget cap. Decisions.md Decision 5 + the
+# 2026-05-15 PR-B Q1 answer: "soft warning" — once breached, keep
+# summarizing but log a WARN once per page load. The cap is sized
+# around the N=20 list limit at ~$0.001/session = ~$0.02/uncached
+# load; $0.05 has comfortable headroom.
+DEFAULT_BUDGET_CAP_USD = 0.05
+
+
+@dataclass
+class BudgetTracker:
+    """Per-page-load spend tracker for Haiku calls.
+
+    Not frozen — ``spend`` is mutated as summaries are computed.
+    Construct one tracker per page load and pass it through the
+    per-session calls; reset on each new request.
+    """
+
+    cap_usd: float = DEFAULT_BUDGET_CAP_USD
+    spend_usd: float = 0.0
+    _warned: bool = False
+
+    def charge(self, cost_usd: float) -> None:
+        """Add a call's cost to the running total. Logs once on breach."""
+        self.spend_usd += cost_usd
+        if self.spend_usd > self.cap_usd and not self._warned:
+            logger.warning(
+                "ops.sessions: per-page-load budget cap exceeded — "
+                "spend=$%.4f cap=$%.4f. Continuing to summarize "
+                "(soft cap); reduce list cap or disable "
+                "ATTUNE_OPS_SESSIONS_LLM if this recurs.",
+                self.spend_usd,
+                self.cap_usd,
+            )
+            self._warned = True
+
+
+@dataclass(frozen=True)
+class SummarizedPrompt:
+    """One session's starter prompt + provenance.
+
+    ``source`` mirrors the :class:`attune.ops.data.Session` field
+    so the dashboard's "summarized by Haiku · cached" badge can
+    distinguish a fresh Haiku call from a cache hit from the
+    pre-Haiku heuristic fallback.
+    """
+
+    text: str
+    source: str  # "heuristic" | "haiku" | "cached"
+    tokens_in: int = 0
+    tokens_out: int = 0
+    cost_usd: float = 0.0
+
+
+def summarize_for_session(
+    jsonl_path: Path,
+    raw_text: str,
+    *,
+    attune_home: Path,
+    budget: BudgetTracker,
+    api_key: str | None = None,
+    summarize_fn=None,
+    redact_fn=None,
+) -> SummarizedPrompt | None:
+    """Return a Haiku-or-cached summary, or ``None`` to signal heuristic fallback.
+
+    Sequence:
+
+    1. Compute the cache key for ``jsonl_path``. On I/O failure
+       return ``None`` and let the caller fall back to the
+       heuristic prompt.
+    2. Try the cache. On hit return the cached text marked
+       ``source="cached"``. Cache hits do NOT count against the
+       per-page budget (no fresh LLM spend incurred).
+    3. On miss, redact ``raw_text``, then call the Haiku
+       summarizer. Catch every exception from the call and return
+       ``None`` so the caller can fall back to heuristic — one bad
+       call shouldn't blank the whole page.
+    4. Charge the call's cost to ``budget``. Write the redacted
+       summary to the cache. Return marked ``source="haiku"``.
+
+    Args:
+        jsonl_path: Source JSONL file (for cache key).
+        raw_text: Pre-extracted text to summarize. Caller chooses
+            what content to send — typically the first ~6 KB of
+            user prompts + assistant turns.
+        attune_home: Cache root.
+        budget: Shared :class:`BudgetTracker` for the request.
+        api_key: Override for ``ANTHROPIC_API_KEY``. Test hook.
+        summarize_fn: Override for
+            :func:`session_summary_llm.summarize`. Test hook.
+        redact_fn: Override for
+            :func:`session_redaction.redact`. Test hook.
+
+    Returns:
+        A :class:`SummarizedPrompt` or ``None`` if anything went
+        wrong (cache-key I/O failure, missing API key, LLM error).
+        ``None`` is the explicit "use heuristic" signal.
+    """
+    do_redact = redact_fn or session_redaction.redact
+    do_summarize = summarize_fn or session_summary_llm.summarize
+
+    key = session_summary_cache.compute_cache_key(jsonl_path)
+    if key is None:
+        # Can't key the cache → no point caching the result. Fall
+        # through to heuristic; bypassing the LLM also avoids spending
+        # tokens on an unrecoverable session.
+        return None
+
+    cached = session_summary_cache.load(attune_home, jsonl_path.stem, expected=key)
+    if cached is not None:
+        return SummarizedPrompt(
+            text=cached.summary,
+            source=cached.source,  # "cached"
+            tokens_in=cached.tokens_in,
+            tokens_out=cached.tokens_out,
+            cost_usd=cached.cost_usd,
+        )
+
+    redacted = do_redact(raw_text)
+    try:
+        result = do_summarize(redacted.text, api_key=api_key)
+    except session_summary_llm.MissingApiKeyError:
+        # Re-raised by the route so it can render a one-time
+        # "config missing" banner. Distinct from runtime LLM errors
+        # which should silently fall back to heuristic.
+        raise
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: one bad LLM call falls back to heuristic for
+        # that session; the rest of the page renders normally. The
+        # alternative (raise) blanks the whole page when a single
+        # session trips a rate limit or network blip.
+        logger.exception(
+            "ops.sessions: Haiku summarize failed for %s — falling back to heuristic",
+            jsonl_path.name,
+        )
+        return None
+
+    budget.charge(result.cost_usd)
+
+    try:
+        session_summary_cache.save(
+            attune_home,
+            jsonl_path.stem,
+            key=key,
+            summary=result.text,
+            tokens_in=result.tokens_in,
+            tokens_out=result.tokens_out,
+            cost_usd=result.cost_usd,
+        )
+    except OSError:
+        # INTENTIONAL: cache write failure is non-fatal — return the
+        # fresh summary anyway. Worst case: this session re-summarizes
+        # on next page load (extra spend, no correctness impact).
+        logger.warning(
+            "ops.sessions: cache write failed for %s — summary returned uncached",
+            jsonl_path.stem,
+        )
+
+    return SummarizedPrompt(
+        text=result.text,
+        source="haiku",
+        tokens_in=result.tokens_in,
+        tokens_out=result.tokens_out,
+        cost_usd=result.cost_usd,
+    )
+
+
+def extract_summarizable_text(jsonl_path: Path, *, max_chars: int = 6000) -> str:
+    """Read the JSONL and extract the conversation text Haiku should see.
+
+    Concatenates ``content`` fields from events into a single
+    string with role hints. Caps at ``max_chars`` to keep
+    per-call cost predictable — :func:`session_summary_llm.summarize`
+    also caps internally as a defense-in-depth.
+
+    Returns an empty string on any I/O failure. Callers should
+    treat empty as "skip the LLM call, render heuristic."
+    """
+    import json
+
+    out: list[str] = []
+    total = 0
+    try:
+        with jsonl_path.open(encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                content = event.get("content")
+                if not isinstance(content, str) or not content:
+                    continue
+                # Role hint helps the LLM distinguish prompts from
+                # responses. The Claude Code JSONL we've observed
+                # only carries user prompts via queue-operation
+                # enqueue events; assistant turns are absent. We
+                # default to "user" but leave the prefix path open
+                # for when the JSONL schema gains assistant content.
+                role = event.get("role") or "user"
+                chunk = f"[{role}] {content}\n\n"
+                if total + len(chunk) > max_chars:
+                    remaining = max_chars - total
+                    if remaining > 0:
+                        out.append(chunk[:remaining])
+                    break
+                out.append(chunk)
+                total += len(chunk)
+    except OSError:
+        return ""
+    return "".join(out).strip()

--- a/src/attune/ops/session_summary_llm.py
+++ b/src/attune/ops/session_summary_llm.py
@@ -1,0 +1,198 @@
+"""Haiku-summarized starter prompts for the /sessions page.
+
+Defined by the ops-sessions-page spec (decisions.md, Decision 2 +
+Decision 3). The orchestration:
+
+    raw_session_text
+        → redact(text)               (session_redaction.py)
+        → claude-haiku-4-5 summarize (this module)
+        → cache.save(redacted summ.) (session_summary_cache.py)
+
+The summary text is what ends up in the dashboard's Starter Prompt
+column and on disk. Redaction runs FIRST so neither the LLM
+provider nor the on-disk cache ever sees sensitive material.
+
+The prompt template targets the 3-part output shape from decisions.md
+Decision 2:
+
+    1. Names what was being worked on (1 short sentence).
+    2. Lists any open threads (bullets, 0–3 items).
+    3. Suggests a 1-sentence resume prompt the user can paste.
+
+The text returned by :func:`summarize` is the LLM's verbatim output;
+no parsing or restructuring at this layer. Callers render it as-is.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Model id — Haiku 4.5. Pricing per attune.llm.providers.anthropic
+# (verified 2026-05-15): $1.00/M input, $5.00/M output.
+_MODEL = "claude-haiku-4-5-20251001"
+_INPUT_COST_PER_1M = 1.00
+_OUTPUT_COST_PER_1M = 5.00
+
+# Per-call output cap. Decisions.md Decision 2 wants a 3-part
+# summary (one sentence + ≤3 bullets + one sentence) — 400 output
+# tokens is plenty even with verbose phrasing.
+_MAX_OUTPUT_TOKENS = 400
+
+# Cap on the input text we send. A long session JSONL could easily
+# be tens of KB; we truncate to bound spend per call. The target is
+# a starter-prompt summary, not a full conversation distillation —
+# the first ~6 KB of conversation captures the original ask and a
+# few turns of context, which is the right material for a starter.
+_INPUT_TEXT_CAP_CHARS = 6000
+
+_SYSTEM_PROMPT = (
+    "You are summarizing a developer's Claude Code session into a "
+    "short starter prompt that helps them resume the work later. "
+    "Produce EXACTLY three sections, formatted as Markdown:\n\n"
+    "**What was being worked on.** One short sentence (≤25 words) "
+    "naming the task. Use concrete nouns — file paths, feature "
+    "names, bug shapes — not vague descriptors.\n\n"
+    "**Open threads.** A bulleted list of 0–3 items. Each bullet "
+    "names a specific unresolved decision, in-flight task, or "
+    "blocker visible in the conversation. Skip this section "
+    "entirely if there are no open threads — write the heading "
+    "with no bullets below it.\n\n"
+    "**Resume prompt.** One sentence (≤30 words) the user can "
+    "paste into a fresh Claude Code session to pick up where they "
+    "left off. Phrase it as a directive to Claude, not a "
+    "description of what to do.\n\n"
+    'Constraints: no preamble ("Sure, here\'s a summary..."). '
+    "No closing remarks. If the conversation is too short or "
+    "incoherent to summarize meaningfully, write a single line: "
+    '"(session too short to summarize)" and stop.'
+)
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    """One LLM call's output plus the accounting needed for caching + budget."""
+
+    text: str
+    tokens_in: int
+    tokens_out: int
+    cost_usd: float
+
+
+class MissingApiKeyError(RuntimeError):
+    """Raised when ``ANTHROPIC_API_KEY`` is required but unset.
+
+    Distinct exception type so callers can branch cleanly:
+    surface "LLM gate is on but no key" as a config error vs
+    other LLM-call failures (network, rate limit, etc.).
+    """
+
+
+def _truncate_input(text: str, *, cap: int = _INPUT_TEXT_CAP_CHARS) -> str:
+    """Bound the input character count so per-call cost is predictable.
+
+    Truncates at a paragraph or line boundary inside the last 10%
+    of the cap, falling back to a hard cut when no boundary is
+    found. Appends a sentinel so the LLM knows the input was cut.
+    """
+    if len(text) <= cap:
+        return text
+    cut = text[:cap]
+    boundary = max(cut.rfind("\n\n"), cut.rfind("\n"))
+    soft_floor = int(cap * 0.9)
+    if boundary >= soft_floor:
+        cut = cut[:boundary]
+    return cut.rstrip() + "\n\n[...session truncated for summarization...]"
+
+
+def _estimate_cost(input_tokens: int, output_tokens: int) -> float:
+    """Convert token counts to USD using Haiku 4.5 list pricing."""
+    return (
+        input_tokens / 1_000_000 * _INPUT_COST_PER_1M
+        + output_tokens / 1_000_000 * _OUTPUT_COST_PER_1M
+    )
+
+
+def summarize(
+    text: str,
+    *,
+    api_key: str | None = None,
+    client_factory=None,
+) -> SummaryResult:
+    """Send ``text`` to Haiku and return a starter-prompt summary.
+
+    Args:
+        text: Session content. **Caller is responsible for running
+            :func:`attune.ops.session_redaction.redact` first.** This
+            function does NOT redact — it would be a security
+            footgun to have two different code paths where one might
+            forget to redact. The redaction discipline lives at the
+            orchestrator layer (in the dashboard route) and applies
+            uniformly before this function is ever reached.
+        api_key: Override for ``ANTHROPIC_API_KEY``. Used by tests.
+        client_factory: Override for the ``anthropic.Anthropic``
+            constructor. Test hook — pass a callable that returns
+            a mock client. The default uses the real SDK.
+
+    Returns:
+        :class:`SummaryResult` with the LLM's verbatim text plus
+        token + cost accounting.
+
+    Raises:
+        MissingApiKeyError: ``api_key`` is None and the env var is unset.
+        Exception: Any error from the Anthropic SDK (network, rate
+            limit, malformed response). Callers should catch and fall
+            back to the heuristic prompt — the dashboard route does
+            this at the per-session level so one bad call doesn't
+            blank the whole page.
+    """
+    key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        raise MissingApiKeyError(
+            "ANTHROPIC_API_KEY not set — required when " "ATTUNE_OPS_SESSIONS_LLM is enabled."
+        )
+
+    if client_factory is None:
+        from anthropic import Anthropic
+
+        client = Anthropic(api_key=key)
+    else:
+        client = client_factory(api_key=key)
+
+    truncated = _truncate_input(text)
+    response = client.messages.create(
+        model=_MODEL,
+        max_tokens=_MAX_OUTPUT_TOKENS,
+        system=_SYSTEM_PROMPT,
+        messages=[{"role": "user", "content": truncated}],
+    )
+
+    # Anthropic returns content as a list of blocks; the first text
+    # block carries the summary. Empty content (rare) falls back to
+    # a sentinel string so the route's downstream code paths never
+    # see ``None``.
+    summary_text = ""
+    if response.content:
+        first = response.content[0]
+        summary_text = getattr(first, "text", "") or ""
+    if not summary_text:
+        summary_text = "(no summary returned)"
+
+    # Pricing: Anthropic returns input/output token counts on
+    # ``response.usage``. Token counters are integers; missing
+    # fields default to 0 so the cost calc never blows up on
+    # an unfamiliar SDK shape.
+    usage = getattr(response, "usage", None)
+    tokens_in = int(getattr(usage, "input_tokens", 0) or 0) if usage else 0
+    tokens_out = int(getattr(usage, "output_tokens", 0) or 0) if usage else 0
+    cost = _estimate_cost(tokens_in, tokens_out)
+
+    return SummaryResult(
+        text=summary_text,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        cost_usd=cost,
+    )

--- a/src/attune/ops/templates/sessions.html
+++ b/src/attune/ops/templates/sessions.html
@@ -9,14 +9,36 @@
   </p>
 </section>
 
-{# Sessions S2 — data layer. Reads Claude Code's per-project JSONL
-   logs, surfaces last-3-days sessions with a heuristic starter
-   prompt (first user message, truncated). S3 will replace the
-   heuristic with Haiku-summarized prompts; S4 lifts the most-recent
-   session into a prominent resume card; S5 marks the live session.
-   The empty-state copy below matches the spec's exact phrasing so
-   the legitimate "no sessions in 3 days" case stays clean. #}
+{# Sessions S3b — Haiku-summarized prompts gated on
+   ATTUNE_OPS_SESSIONS_LLM. With the gate off (default) every row
+   renders with the heuristic prompt. With it on the route walks
+   each row, redacts the JSONL content, calls Haiku, and writes
+   the redacted summary to the on-disk cache. ?compare=1 (dev
+   only) renders a second column with the heuristic prompt for
+   pre-launch eyeball validation. S4 lifts the most-recent
+   session into a prominent resume card; S5 marks the live
+   session. The empty-state copy below matches the spec's exact
+   phrasing so the legitimate "no sessions in 3 days" case stays
+   clean. #}
 <section class="panel">
+  {% if api_key_missing %}
+    <p class="banner banner-warn">
+      <strong>ATTUNE_OPS_SESSIONS_LLM</strong> is enabled but
+      <strong>ANTHROPIC_API_KEY</strong> is unset. Falling back to
+      heuristic prompts. Set the API key or unset the gate to
+      silence this notice.
+    </p>
+  {% endif %}
+  {% if budget_summary and budget_summary.exceeded %}
+    <p class="banner banner-warn">
+      Per-page-load Haiku spend
+      <strong>${{ '%.4f' | format(budget_summary.spend_usd) }}</strong>
+      exceeded the soft cap of
+      <strong>${{ '%.4f' | format(budget_summary.cap_usd) }}</strong>.
+      Rendering continued; consider lowering the list cap or
+      disabling <code>ATTUNE_OPS_SESSIONS_LLM</code> if this recurs.
+    </p>
+  {% endif %}
   {% if sessions %}
     <table class="data-table sessions-table">
       <thead>
@@ -26,6 +48,9 @@
           <th class="num">Duration</th>
           <th class="num">Prompts</th>
           <th>Starter prompt</th>
+          {% if compare_mode %}
+            <th>Heuristic (compare)</th>
+          {% endif %}
           <th>Source</th>
         </tr>
       </thead>
@@ -37,7 +62,10 @@
             <td class="num">{% if s.duration_seconds > 0 %}{{ '%.0fs'|format(s.duration_seconds) if s.duration_seconds < 60 else '%.0fm'|format(s.duration_seconds / 60) }}{% else %}—{% endif %}</td>
             <td class="num">{{ s.message_count }}</td>
             <td class="session-prompt">{{ s.starter_prompt }}</td>
-            <td><span class="chip chip-muted" data-tooltip="{% if s.source == 'heuristic' %}First user prompt, truncated{% else %}LLM-summarized starter prompt{% endif %}" aria-label="Source: {{ s.source }}">{{ s.source }}</span></td>
+            {% if compare_mode %}
+              <td class="session-prompt session-prompt-heuristic">{{ heuristic_by_id.get(s.id, '—') if heuristic_by_id else '—' }}</td>
+            {% endif %}
+            <td><span class="chip chip-muted" data-tooltip="{% if s.source == 'heuristic' %}First user prompt, truncated{% elif s.source == 'cached' %}Cached Haiku summary (no fresh LLM call){% else %}Fresh Haiku-summarized starter prompt{% endif %}" aria-label="Source: {{ s.source }}">{{ s.source }}</span></td>
           </tr>
         {% endfor %}
       </tbody>
@@ -45,6 +73,11 @@
     <p class="meta">
       Older sessions (beyond 3 days) stay on disk at
       <code>{{ sessions_dir }}</code> but aren't surfaced here.
+      {% if llm_enabled and budget_summary %}
+        Haiku spend this load:
+        <strong>${{ '%.4f' | format(budget_summary.spend_usd) }}</strong>
+        / ${{ '%.4f' | format(budget_summary.cap_usd) }} cap.
+      {% endif %}
     </p>
   {% else %}
     <p class="empty">

--- a/tests/unit/ops/test_session_summary.py
+++ b/tests/unit/ops/test_session_summary.py
@@ -1,0 +1,297 @@
+"""Tests for the redact→cache-or-Haiku orchestrator.
+
+Covers the three branches of :func:`summarize_for_session` — cache
+hit, cache miss with successful Haiku call, cache miss with LLM
+error — plus the budget-tracker warn-once-on-breach semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from attune.ops import (
+    session_summary,
+    session_summary_cache,
+    session_summary_llm,
+)
+
+# ---------------------------------------------------------------------------
+# BudgetTracker
+# ---------------------------------------------------------------------------
+
+
+def test_budget_tracker_accumulates_spend():
+    b = session_summary.BudgetTracker(cap_usd=0.10)
+    b.charge(0.02)
+    b.charge(0.03)
+    assert b.spend_usd == pytest.approx(0.05)
+
+
+def test_budget_tracker_warns_once_on_breach(caplog):
+    b = session_summary.BudgetTracker(cap_usd=0.05)
+    with caplog.at_level(logging.WARNING, logger="attune.ops.session_summary"):
+        b.charge(0.04)  # under cap, no warn
+        b.charge(0.03)  # breaches cap, warn
+        b.charge(0.01)  # still over, no second warn
+
+    warn_messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    over_cap_warns = [m for m in warn_messages if "budget cap exceeded" in m]
+    assert len(over_cap_warns) == 1
+
+
+# ---------------------------------------------------------------------------
+# summarize_for_session — three branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def attune_home(tmp_path):
+    return tmp_path / "attune-home"
+
+
+@pytest.fixture
+def jsonl_path(tmp_path):
+    """A small JSONL file with one prompt event."""
+    path = tmp_path / "abc12345.jsonl"
+    payload = {
+        "type": "queue-operation",
+        "operation": "enqueue",
+        "timestamp": "2026-05-15T10:00:00Z",
+        "content": "Help me fix the failing test on Windows.",
+    }
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    return path
+
+
+def _fake_summarize(text, *, api_key=None):
+    """Stand-in for session_summary_llm.summarize. Captures input."""
+    return session_summary_llm.SummaryResult(
+        text=f"SUMMARY OF: {text[:30]}",
+        tokens_in=100,
+        tokens_out=50,
+        cost_usd=0.001,
+    )
+
+
+def test_cache_miss_calls_llm_and_caches(attune_home, jsonl_path):
+    """First call: cache miss → LLM call → write cache."""
+    budget = session_summary.BudgetTracker()
+    result = session_summary.summarize_for_session(
+        jsonl_path,
+        "raw text to summarize",
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=_fake_summarize,
+    )
+    assert result is not None
+    assert result.source == "haiku"
+    assert result.text.startswith("SUMMARY OF:")
+    assert result.cost_usd == pytest.approx(0.001)
+    assert budget.spend_usd == pytest.approx(0.001)
+
+    # Cache file written.
+    cache_path = session_summary_cache.cache_path_for(attune_home, jsonl_path.stem)
+    assert cache_path.is_file()
+
+
+def test_cache_hit_skips_llm_and_does_not_charge_budget(attune_home, jsonl_path):
+    """Second call on the same file: cache hit → no LLM, no charge."""
+    budget = session_summary.BudgetTracker()
+    # Prime the cache.
+    session_summary.summarize_for_session(
+        jsonl_path,
+        "raw text",
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=_fake_summarize,
+    )
+    assert budget.spend_usd == pytest.approx(0.001)
+
+    # Second call should hit the cache.
+    def must_not_call(*a, **k):
+        raise AssertionError("LLM was called on cache hit")
+
+    result = session_summary.summarize_for_session(
+        jsonl_path,
+        "raw text",
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=must_not_call,
+    )
+    assert result is not None
+    assert result.source == "cached"
+    # Budget unchanged from the first call.
+    assert budget.spend_usd == pytest.approx(0.001)
+
+
+def test_cache_miss_on_content_change(attune_home, jsonl_path):
+    """Same session id, different content → cache miss → fresh LLM call."""
+    budget = session_summary.BudgetTracker()
+    session_summary.summarize_for_session(
+        jsonl_path,
+        "v1",
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=_fake_summarize,
+    )
+    # Modify file contents so the tail hash changes.
+    jsonl_path.write_text(
+        json.dumps({"timestamp": "2026-05-15T11:00:00Z", "content": "different"}) + "\n",
+        encoding="utf-8",
+    )
+
+    second = session_summary.summarize_for_session(
+        jsonl_path,
+        "v2",
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=_fake_summarize,
+    )
+    assert second is not None
+    assert second.source == "haiku"  # fresh write, not cached
+    # Spend doubled — second LLM call charged.
+    assert budget.spend_usd == pytest.approx(0.002)
+
+
+def test_llm_error_falls_back_to_none(attune_home, jsonl_path):
+    """A runtime LLM error returns None (caller uses heuristic)."""
+    budget = session_summary.BudgetTracker()
+
+    def failing_summarize(text, *, api_key=None):
+        raise RuntimeError("network blip")
+
+    result = session_summary.summarize_for_session(
+        jsonl_path,
+        "text",
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=failing_summarize,
+    )
+    assert result is None
+    # Budget unchanged — no successful call.
+    assert budget.spend_usd == 0.0
+    # No cache file written.
+    cache_path = session_summary_cache.cache_path_for(attune_home, jsonl_path.stem)
+    assert not cache_path.exists()
+
+
+def test_missing_api_key_propagates(attune_home, jsonl_path):
+    """``MissingApiKeyError`` is re-raised, not swallowed."""
+    budget = session_summary.BudgetTracker()
+
+    def failing_summarize(text, *, api_key=None):
+        raise session_summary_llm.MissingApiKeyError("no key")
+
+    with pytest.raises(session_summary_llm.MissingApiKeyError):
+        session_summary.summarize_for_session(
+            jsonl_path,
+            "text",
+            attune_home=attune_home,
+            budget=budget,
+            summarize_fn=failing_summarize,
+        )
+
+
+def test_cache_key_io_failure_returns_none(attune_home, tmp_path):
+    """Missing JSONL → ``compute_cache_key`` fails → caller falls back."""
+    budget = session_summary.BudgetTracker()
+    missing = tmp_path / "vanished.jsonl"
+    result = session_summary.summarize_for_session(
+        missing,
+        "text",
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=_fake_summarize,
+    )
+    assert result is None
+
+
+def test_redaction_runs_before_llm(attune_home, jsonl_path):
+    """Verifies redaction is applied to the text sent to the LLM,
+    not to the original input the caller passed."""
+    budget = session_summary.BudgetTracker()
+    captured_inputs: list[str] = []
+
+    def capturing_summarize(text, *, api_key=None):
+        captured_inputs.append(text)
+        return session_summary_llm.SummaryResult(
+            text="ok", tokens_in=1, tokens_out=1, cost_usd=0.0001
+        )
+
+    secret_text = "the key is sk-ant-abcdef1234567890abcdef1234567890"
+    result = session_summary.summarize_for_session(
+        jsonl_path,
+        secret_text,
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=capturing_summarize,
+    )
+    assert result is not None
+    assert captured_inputs, "summarize was not called"
+    sent_to_llm = captured_inputs[0]
+    assert "sk-ant-" not in sent_to_llm, f"raw key leaked to LLM: {sent_to_llm!r}"
+    assert "<redacted>" in sent_to_llm
+
+
+def test_redaction_applied_to_cache(attune_home, jsonl_path):
+    """Cached summary should be the post-redaction one (defense in depth)."""
+    budget = session_summary.BudgetTracker()
+
+    def echo_summarize(text, *, api_key=None):
+        return session_summary_llm.SummaryResult(
+            text=f"summary: {text[:60]}",
+            tokens_in=10,
+            tokens_out=10,
+            cost_usd=0.0001,
+        )
+
+    session_summary.summarize_for_session(
+        jsonl_path,
+        "leaked sk-ant-abcdef1234567890abcdef1234567890",
+        attune_home=attune_home,
+        budget=budget,
+        summarize_fn=echo_summarize,
+    )
+    cache_path = session_summary_cache.cache_path_for(attune_home, jsonl_path.stem)
+    on_disk = cache_path.read_text(encoding="utf-8")
+    assert "sk-ant-" not in on_disk
+
+
+# ---------------------------------------------------------------------------
+# extract_summarizable_text
+# ---------------------------------------------------------------------------
+
+
+def test_extract_summarizable_text_concatenates_content(tmp_path):
+    path = tmp_path / "x.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"timestamp": "t1", "content": "first prompt"}),
+                json.dumps({"timestamp": "t2", "content": "second prompt"}),
+                json.dumps({"timestamp": "t3"}),  # no content, skipped
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    text = session_summary.extract_summarizable_text(path)
+    assert "first prompt" in text
+    assert "second prompt" in text
+
+
+def test_extract_summarizable_text_returns_empty_on_missing_file(tmp_path):
+    assert session_summary.extract_summarizable_text(tmp_path / "missing.jsonl") == ""
+
+
+def test_extract_summarizable_text_respects_cap(tmp_path):
+    path = tmp_path / "big.jsonl"
+    path.write_text(
+        json.dumps({"content": "x" * 10_000}) + "\n",
+        encoding="utf-8",
+    )
+    text = session_summary.extract_summarizable_text(path, max_chars=100)
+    assert len(text) <= 100

--- a/tests/unit/ops/test_session_summary_llm.py
+++ b/tests/unit/ops/test_session_summary_llm.py
@@ -1,0 +1,220 @@
+"""Tests for the Haiku-summarizer module.
+
+Covers prompt assembly, input truncation, token + cost accounting,
+empty-response fallback, and missing-API-key signaling. Uses a
+fake client factory throughout so no real network calls are made.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from attune.ops import session_summary_llm as llm
+
+# ---------------------------------------------------------------------------
+# Fake Anthropic client — shape-compatible with the real SDK's
+# ``messages.create`` return value (content list of blocks with
+# ``.text`` plus ``usage`` with ``input_tokens`` / ``output_tokens``).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeBlock:
+    text: str
+
+
+@dataclass
+class _FakeUsage:
+    input_tokens: int
+    output_tokens: int
+
+
+@dataclass
+class _FakeResponse:
+    content: list
+    usage: _FakeUsage
+
+
+class _FakeMessages:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._response
+
+
+class _FakeClient:
+    def __init__(self, response: _FakeResponse):
+        self.messages = _FakeMessages(response)
+
+
+def _client_factory(response: _FakeResponse):
+    """Build a ``client_factory`` callable that returns the same fake every call."""
+
+    def factory(*, api_key: str):
+        return _FakeClient(response)
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# summarize() — happy path + token + cost accounting
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_returns_text_and_accounting():
+    response = _FakeResponse(
+        content=[_FakeBlock(text="**What was being worked on.** Foo.")],
+        usage=_FakeUsage(input_tokens=120, output_tokens=40),
+    )
+    result = llm.summarize(
+        "Help me with the foo bar baz.",
+        api_key="fake-key",  # pragma: allowlist secret
+        client_factory=_client_factory(response),
+    )
+    assert result.text.startswith("**What was being worked on.**")
+    assert result.tokens_in == 120
+    assert result.tokens_out == 40
+    # Cost: 120 * $1/M + 40 * $5/M = 0.00012 + 0.0002 = 0.00032
+    assert result.cost_usd == pytest.approx(0.00032, rel=1e-6)
+
+
+def test_summarize_uses_haiku_4_5_model():
+    response = _FakeResponse(
+        content=[_FakeBlock(text="ok")],
+        usage=_FakeUsage(input_tokens=10, output_tokens=10),
+    )
+    factory = _client_factory(response)
+    captured: list = []
+
+    def wrapping_factory(*, api_key: str):
+        client = factory(api_key=api_key)
+        captured.append(client)
+        return client
+
+    llm.summarize(
+        "text",
+        api_key="fake-key",  # pragma: allowlist secret
+        client_factory=wrapping_factory,
+    )
+    assert captured, "client factory was not invoked"
+    call_kwargs = captured[0].messages.calls[0]
+    assert call_kwargs["model"] == "claude-haiku-4-5-20251001"
+
+
+def test_summarize_includes_system_prompt():
+    response = _FakeResponse(
+        content=[_FakeBlock(text="ok")],
+        usage=_FakeUsage(input_tokens=1, output_tokens=1),
+    )
+    client_holder: list = []
+
+    def wrapping_factory(*, api_key: str):
+        c = _FakeClient(response)
+        client_holder.append(c)
+        return c
+
+    llm.summarize(
+        "text", api_key="fake-key", client_factory=wrapping_factory
+    )  # pragma: allowlist secret
+    call_kwargs = client_holder[0].messages.calls[0]
+    system = call_kwargs["system"]
+    # Spec Decision 2 — three-section output shape.
+    assert "What was being worked on" in system
+    assert "Open threads" in system
+    assert "Resume prompt" in system
+
+
+def test_summarize_caps_input_text():
+    """An oversized input string is truncated before being sent."""
+    response = _FakeResponse(
+        content=[_FakeBlock(text="ok")],
+        usage=_FakeUsage(input_tokens=1, output_tokens=1),
+    )
+    client_holder: list = []
+
+    def wrapping_factory(*, api_key: str):
+        c = _FakeClient(response)
+        client_holder.append(c)
+        return c
+
+    huge = "x" * 50_000
+    llm.summarize(
+        huge, api_key="fake-key", client_factory=wrapping_factory
+    )  # pragma: allowlist secret
+    sent = client_holder[0].messages.calls[0]["messages"][0]["content"]
+    assert len(sent) < len(huge)
+    assert sent.endswith("[...session truncated for summarization...]")
+
+
+def test_summarize_handles_empty_response_content():
+    """An empty content list yields a sentinel string, not a crash."""
+    response = _FakeResponse(
+        content=[],
+        usage=_FakeUsage(input_tokens=5, output_tokens=0),
+    )
+    result = llm.summarize(
+        "text",
+        api_key="fake-key",
+        client_factory=_client_factory(response),  # pragma: allowlist secret
+    )
+    assert result.text == "(no summary returned)"
+
+
+def test_summarize_missing_api_key_raises_typed_error(monkeypatch):
+    """Missing API key is a config error, distinct from runtime LLM failures."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(llm.MissingApiKeyError):
+        llm.summarize("text")
+
+
+def test_summarize_reads_api_key_from_env(monkeypatch):
+    """Env var is consulted when no explicit ``api_key`` is passed."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")  # pragma: allowlist secret
+    response = _FakeResponse(
+        content=[_FakeBlock(text="ok")],
+        usage=_FakeUsage(input_tokens=1, output_tokens=1),
+    )
+    captured_keys: list[str] = []
+
+    def factory(*, api_key: str):
+        captured_keys.append(api_key)
+        return _FakeClient(response)
+
+    llm.summarize("text", client_factory=factory)
+    assert captured_keys == ["env-key"]
+
+
+# ---------------------------------------------------------------------------
+# Cost calc — straight math sanity
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_cost_uses_haiku_pricing():
+    # 1M input + 1M output = $1.00 + $5.00 = $6.00
+    assert llm._estimate_cost(1_000_000, 1_000_000) == pytest.approx(6.00)
+    # 1000 input, 250 output = 0.001 + 0.00125 = 0.00225
+    assert llm._estimate_cost(1000, 250) == pytest.approx(0.00225)
+
+
+# ---------------------------------------------------------------------------
+# Input truncation — boundary heuristics
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_input_passes_short_text_through():
+    text = "short text"
+    assert llm._truncate_input(text, cap=100) == text
+
+
+def test_truncate_input_respects_paragraph_boundary():
+    """Truncation prefers the last paragraph break inside the soft floor."""
+    text = ("a" * 4500) + "\n\n" + ("b" * 4500)
+    result = llm._truncate_input(text, cap=5000)
+    assert result.endswith("[...session truncated for summarization...]")
+    # The b-block must be excluded — boundary cut at the \n\n.
+    assert "b" not in result, "b-block leaked past the paragraph boundary"

--- a/tests/unit/ops/test_sessions.py
+++ b/tests/unit/ops/test_sessions.py
@@ -574,3 +574,172 @@ def test_sessions_page_renders_empty_state_when_no_sessions(tmp_path, monkeypatc
     body = resp.text
     assert "No sessions in the last 3 days" in body
     assert "sessions-table" not in body
+
+
+# ---------------------------------------------------------------------------
+# /sessions route — Haiku gate, compare mode, budget banner
+# ---------------------------------------------------------------------------
+
+
+def _seed_one_session(tmp_path, project_root):
+    """Helper: write one fresh session under the canonical encoded key."""
+    sessions_dir = (
+        Path(tmp_path) / "home" / ".claude" / "projects" / data._encoded_project_path(project_root)
+    )
+    return _write_session_jsonl(
+        sessions_dir,
+        "abcdef12-c539-4057-ba26-24ce3dffec27",
+        events=[
+            {
+                "type": "queue-operation",
+                "operation": "enqueue",
+                "timestamp": "2026-05-15T10:00:00Z",
+                "content": "Help me debug the failing test on Windows.",
+            }
+        ],
+    )
+
+
+def test_sessions_page_off_by_default_uses_heuristic(tmp_path, monkeypatch):
+    """Without ATTUNE_OPS_SESSIONS_LLM set, the route never calls the LLM
+    and rows render with their heuristic prompts."""
+    monkeypatch.delenv("ATTUNE_OPS_SESSIONS_LLM", raising=False)
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _seed_one_session(tmp_path, project_root)
+
+    from attune.ops import session_summary_llm
+
+    def boom(*a, **kw):
+        raise AssertionError("LLM was called with the gate OFF")
+
+    monkeypatch.setattr(session_summary_llm, "summarize", boom)
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions")
+    assert resp.status_code == 200
+    assert "heuristic" in resp.text
+    assert "Heuristic (compare)" not in resp.text
+
+
+def test_sessions_page_with_gate_on_calls_llm_and_marks_haiku(tmp_path, monkeypatch):
+    """ATTUNE_OPS_SESSIONS_LLM=1 → LLM is invoked and rows mark source=haiku."""
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_LLM", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fa" + "ke-key")  # pragma: allowlist secret
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _seed_one_session(tmp_path, project_root)
+
+    from attune.ops import session_summary_llm
+
+    captured: list[str] = []
+
+    def fake_summarize(text, *, api_key=None):
+        captured.append(text)
+        return session_summary_llm.SummaryResult(
+            text="HAIKU SUMMARY: debug test",
+            tokens_in=200,
+            tokens_out=80,
+            cost_usd=0.0006,
+        )
+
+    monkeypatch.setattr(session_summary_llm, "summarize", fake_summarize)
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "HAIKU SUMMARY: debug test" in body
+    assert "haiku" in body
+    assert "Heuristic (compare)" not in body
+    assert captured, "summarize was not invoked"
+
+
+def test_sessions_page_compare_mode_renders_both_columns(tmp_path, monkeypatch):
+    """?compare=1 with the gate on renders heuristic AND Haiku columns."""
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_LLM", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fa" + "ke-key")  # pragma: allowlist secret
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _seed_one_session(tmp_path, project_root)
+
+    from attune.ops import session_summary_llm
+
+    monkeypatch.setattr(
+        session_summary_llm,
+        "summarize",
+        lambda text, *, api_key=None: session_summary_llm.SummaryResult(
+            text="HAIKU REPLACEMENT", tokens_in=10, tokens_out=10, cost_usd=0.0001
+        ),
+    )
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions?compare=1")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Heuristic (compare)" in body
+    assert "HAIKU REPLACEMENT" in body
+    assert "Help me debug" in body
+
+
+def test_sessions_page_compare_param_ignored_when_gate_off(tmp_path, monkeypatch):
+    """?compare=1 is a no-op when the LLM gate is off — no extra column."""
+    monkeypatch.delenv("ATTUNE_OPS_SESSIONS_LLM", raising=False)
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _seed_one_session(tmp_path, project_root)
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions?compare=1")
+    assert resp.status_code == 200
+    assert "Heuristic (compare)" not in resp.text
+
+
+def test_sessions_page_warns_on_missing_api_key(tmp_path, monkeypatch):
+    """Gate on but no API key → banner rendered, falls back to heuristic."""
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_LLM", "1")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _seed_one_session(tmp_path, project_root)
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "ANTHROPIC_API_KEY" in body
+    assert "Help me debug" in body
+    assert "heuristic" in body
+
+
+def test_sessions_page_renders_budget_banner_when_cap_exceeded(tmp_path, monkeypatch):
+    """Soft-cap breach renders a warning banner; render still succeeds."""
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_LLM", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fa" + "ke-key")  # pragma: allowlist secret
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _seed_one_session(tmp_path, project_root)
+
+    from attune.ops import session_summary_llm
+
+    # Single call with cost > $0.05 trips the soft cap.
+    monkeypatch.setattr(
+        session_summary_llm,
+        "summarize",
+        lambda text, *, api_key=None: session_summary_llm.SummaryResult(
+            text="exp", tokens_in=10, tokens_out=10, cost_usd=0.10
+        ),
+    )
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "exceeded the soft cap" in body
+    assert "exp" in body


### PR DESCRIPTION
## Summary

PR-B of two for the [/sessions S3 spec](../tree/main/docs/specs/ops-sessions-page/decisions.md). Stacked on **#387** (PR-A — multi-key data layer + summary cache module).

⚠️ **Stacked PR.** Please merge #387 first, then re-target this branch to `main` before merging (per the existing CLAUDE.md lesson on stacked PR rebase after base squash-merge).

### Wires the LLM in

- `session_summary_llm.summarize()` — direct `anthropic.Anthropic()` client, `claude-haiku-4-5-20251001`. System prompt enforces the 3-section output shape from decisions.md Decision 2.
- `session_summary.summarize_for_session()` orchestrator — redact → cache check → Haiku → cache write, in the order spec'd by Decision 3 (redact FIRST so the LLM never sees and the cache never holds sensitive content).
- `BudgetTracker` — soft cap per Patrick's 2026-05-15 decision. WARN-once on breach, render continues. Banner surfaces in the UI.
- `ATTUNE_OPS_SESSIONS_LLM` env gate (off by default — acceptance criterion #5). With it off, every row renders heuristic; the LLM module is never imported into the call path.

### `?compare=1` dev mode

Query-param-only, gate-required, no UI affordance. Renders heuristic + Haiku columns side-by-side for pre-launch eyeball validation. Doesn't bypass redaction or the budget cap.

### Calibration build script

`scripts/build_session_fixtures.py` walks `~/.claude/projects/<encoded>*` and writes redacted fixture JSONLs. Snapshot CI test + committed fixtures land in a separate follow-up after Patrick's interactive curation pass — flagged in decisions.md as "partial — build script only".

## Test plan

- [x] 24 new tests (LLM client, orchestrator, route-level gate/compare/banners)
- [x] Full ops test suite green locally — 409 passed
- [x] Pre-commit hooks pass
- [ ] Windows CI lanes green
- [ ] CodeQL / push-protection scans green
- [ ] Manual smoke: `ATTUNE_OPS_SESSIONS_LLM=1` → `/sessions` against real Claude Code data
- [ ] Manual smoke: `?compare=1` side-by-side rendering looks right

## Follow-up after this PR

1. Patrick runs `python scripts/build_session_fixtures.py`, curates ~10 representative redacted fixtures
2. Snapshot test PR adds `tests/unit/ops/test_calibration_snapshot.py` + the curated fixtures
3. S4 ships the resume-most-recent card (current-worktree → canonical fallback)
4. S5 adds live-session detection via `CLAUDE_CODE_SESSION_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
