### PR TITLE
feat(ops): /sessions S3b — Haiku summarizer + cache + budget

### DIFF
--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-05-15T11:24:19.636240+00:00
-source_hash: 55ce9290506b249ccc67bc94cb823e906686e4c1c3e8534a515406908f54aedf
+generated_at: 2026-05-16T02:33:13.007361+00:00
+source_hash: 3847cb81bf0f98356695799e284a8b9b602fccfe6225cd45d19f8f054d716b7e
 status: generated
 ---
 
@@ -20,7 +20,7 @@ The main building blocks are:
 - **`PathArgSpec`** — How a workflow accepts a scope path on the CLI.
 - **`Feature`** — One feature from ``.help/features.yaml`` for the scope picker.
 
-Under the hood, this feature spans 30 source
+Under the hood, this feature spans 34 source
 files covering:
 
 - Run via ``python -m attune.ops``.

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-05-15T11:24:19.647648+00:00
-source_hash: 55ce9290506b249ccc67bc94cb823e906686e4c1c3e8534a515406908f54aedf
+generated_at: 2026-05-16T02:33:13.018650+00:00
+source_hash: 3847cb81bf0f98356695799e284a8b9b602fccfe6225cd45d19f8f054d716b7e
 status: generated
 ---
 
@@ -17,6 +17,7 @@ status: generated
 | `WorkflowEntry` | — | `src/attune/ops/data.py` |
 | `PathArgSpec` | How a workflow accepts a scope path on the CLI. | `src/attune/ops/data.py` |
 | `Feature` | One feature from ``.help/features.yaml`` for the scope picker. | `src/attune/ops/data.py` |
+| `Session` | One Claude Code session — what surfaces on the dashboard's /sessions page. | `src/attune/ops/data.py` |
 | `FamilyVersion` | — | `src/attune/ops/data.py` |
 | `DailyCost` | One day's cost for the home-page sparkline. | `src/attune/ops/data.py` |
 | `HomeKpis` | Summary numbers shown above the fold on the home page. | `src/attune/ops/data.py` |
@@ -26,6 +27,11 @@ status: generated
 | `RunnerBusyError` | Raised when a run is already pending/running. | `src/attune/ops/runner.py` |
 | `Run` | Single workflow execution + its broadcast state. | `src/attune/ops/runner.py` |
 | `RunnerService` | Owns the run history + concurrency lock. | `src/attune/ops/runner.py` |
+| `RedactionResult` | Outcome of a redaction pass. | `src/attune/ops/session_redaction.py` |
+| `SummaryResult` | One Haiku-or-cache result, ready to slot into a :class:`Session`. | `src/attune/ops/session_summarizer.py` |
+| `Budget` | Mutable spend ledger for one page-load summarization loop. | `src/attune/ops/session_summarizer.py` |
+| `CacheKey` | Stable key that invalidates a cached summary when the source moves. | `src/attune/ops/session_summary_cache.py` |
+| `CachedSummary` | One persisted session summary plus the metadata to validate it. | `src/attune/ops/session_summary_cache.py` |
 
 ## Functions
 
@@ -41,6 +47,11 @@ status: generated
 | `list_features()` | Return features parsed from ``<project_root>/.help/features.yaml``. | `src/attune/ops/data.py` |
 | `first_feature()` | Return the alphabetically-first feature with a renderable scope. | `src/attune/ops/data.py` |
 | `workflow_default_scope()` | Return the default scope for one workflow on first paint. | `src/attune/ops/data.py` |
+| `derive_project_name()` | Return a human-readable project name for the dashboard header. | `src/attune/ops/data.py` |
+| `claude_sessions_dir()` | Return the canonical directory Claude Code stores sessions for this project in. | `src/attune/ops/data.py` |
+| `enumerate_project_encoded_keys()` | Return all ``~/.claude/projects/`` dirs belonging to this logical project. | `src/attune/ops/data.py` |
+| `list_recent_sessions_with_paths()` | Same as :func:`list_recent_sessions` but also returns each | `src/attune/ops/data.py` |
+| `list_recent_sessions()` | Return Session records for this project's last ``days`` of activity. | `src/attune/ops/data.py` |
 | `home_kpis()` | Derive home-page KPIs from a telemetry summary. | `src/attune/ops/data.py` |
 | `sparkline_points()` | Render values as an SVG ``polyline`` ``points`` string. | `src/attune/ops/data.py` |
 | `read_telemetry_summary()` | Aggregate ``usage.jsonl`` into a UI-friendly summary. | `src/attune/ops/data.py` |
@@ -61,6 +72,8 @@ status: generated
 | `stream_run()` | — | `src/attune/ops/routes/runner.py` |
 | `list_runs()` | Return up to 20 newest runs for ``workflow``, newest first. | `src/attune/ops/routes/runs_history.py` |
 | `get_run_record()` | Return one persisted run record (metadata + log). | `src/attune/ops/routes/runs_history.py` |
+| `enrich_with_summaries()` | Public helper used by both the JSON route and the HTML page. | `src/attune/ops/routes/sessions.py` |
+| `list_sessions()` | ``GET /api/sessions`` — JSON listing of recent sessions. | `src/attune/ops/routes/sessions.py` |
 | `list_specs()` | Federated listing across all configured spec roots. | `src/attune/ops/routes/specs.py` |
 | `get_spec()` | Return phase-file contents for one spec. | `src/attune/ops/routes/specs.py` |
 | `update_phase_status()` | Rewrite the ``**Status**`` line in the named phase file. | `src/attune/ops/routes/specs.py` |
@@ -68,6 +81,14 @@ status: generated
 | `echo_command_builder()` | Test helper: produce a portable subprocess that prints two lines + exits 0. | `src/attune/ops/runner.py` |
 | `prune_old_runs()` | Delete persisted run files older than ``days``. Returns the deletion count. | `src/attune/ops/runner.py` |
 | `create_app()` | Build the FastAPI app, wiring config + templates into request state. | `src/attune/ops/server.py` |
+| `redact()` | Run all redaction passes over ``text`` and return the result. | `src/attune/ops/session_redaction.py` |
+| `new_budget()` | Build a :class:`Budget` from the env override or default. | `src/attune/ops/session_summarizer.py` |
+| `llm_enabled()` | Return True iff the Haiku path is enabled this run. | `src/attune/ops/session_summarizer.py` |
+| `summarize_session()` | Return a Haiku-or-cached summary for one session JSONL. | `src/attune/ops/session_summarizer.py` |
+| `compute_cache_key()` | Build a :class:`CacheKey` for one JSONL file. ``None`` on I/O failure. | `src/attune/ops/session_summary_cache.py` |
+| `cache_path_for()` | Return the on-disk cache path for one session id. | `src/attune/ops/session_summary_cache.py` |
+| `load()` | Return the cached summary iff the on-disk record matches ``expected``. | `src/attune/ops/session_summary_cache.py` |
+| `save()` | Write a summary to the on-disk cache, atomically. | `src/attune/ops/session_summary_cache.py` |
 | `is_persistence_enabled()` | True when ``ATTUNE_OPS_SWEEP_RESULTS`` is set to a non-empty value. | `src/attune/ops/sweep_results.py` |
 | `results_dir()` | Return ``<attune_home>/ops/sweep-results/`` (created if missing). | `src/attune/ops/sweep_results.py` |
 | `scope_hash()` | Hash a scope path to a fixed-length hex identifier. | `src/attune/ops/sweep_results.py` |

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: task
-generated_at: 2026-05-15T11:24:19.642864+00:00
-source_hash: 55ce9290506b249ccc67bc94cb823e906686e4c1c3e8534a515406908f54aedf
+generated_at: 2026-05-16T02:33:13.013855+00:00
+source_hash: 3847cb81bf0f98356695799e284a8b9b602fccfe6225cd45d19f8f054d716b7e
 status: generated
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ops `/sessions` page now uses Haiku-summarized starter prompts
+  (S3b of `docs/specs/ops-sessions-page/`). Wires the existing
+  `session_redaction` + `session_summary_cache` modules behind a
+  new `session_summarizer.summarize_session()` entry point.
+  Discipline: **redact first, then send to Haiku, then cache** —
+  sensitive material never enters the LLM provider's context or
+  the on-disk cache. Each row's `source` chip surfaces which
+  lane produced the text (`heuristic`, `haiku`, or `cached`).
+  Per-page-load budget cap (default $0.05, override via
+  `ATTUNE_OPS_SESSIONS_BUDGET_USD`); breached rows fall back to
+  the heuristic with a one-time "over budget" marker. Disable
+  the Haiku path entirely with `ATTUNE_OPS_SESSIONS_LLM=0`.
+- `GET /api/sessions` JSON endpoint mirroring the HTML page's
+  enrichment (shape: `{sessions: [...], meta: {budget_exceeded,
+  llm_enabled}}`). Same enrichment helper as the page so the two
+  surfaces can't drift.
+- `GET /sessions?compare=1` dev affordance — renders heuristic
+  and Haiku columns side-by-side for pre-launch eyeball
+  validation. No UI button; discoverable only by URL. Same
+  budget + redaction + caching applies.
+- `scripts/build_session_fixtures.py` — dry-run-by-default
+  helper for assembling the calibration fixture set. Walks
+  `~/.claude/projects/<encoded>*` for the chosen project,
+  applies `session_redaction.redact()` per-event, and writes
+  redacted JSONLs to `tests/fixtures/ops/session_summaries/`.
+  Patrick reviews each fixture interactively before committing
+  (per decisions.md Decision 8). Snapshot test + committed
+  fixtures defer to a post-S3 follow-up.
+
 ### Internal
 
 - Test-quality-program: `memory/short_term/queues.py`

--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -292,21 +292,21 @@ reader knows it's not part of the user-facing surface.
 | Data source (encoded-canonical glob) | #377 (S1+S2) — `~/.claude/projects/` literal lookup; multi-key resolution in S3a (data layer) | shipped — multi-key in S3a |
 | Time window (3 days) | #377 | shipped |
 | Project scope (current project only) | #377 | shipped |
-| Listing route (`GET /sessions`) | #377 (page) | partial — JSON route in S3 |
-| Listing JSON shape | #377 (template only) | partial — JSON API in S3 |
+| Listing route (`GET /sessions`) | #377 (page) + S3b — `GET /api/sessions` in `routes/sessions.py` | shipped |
+| Listing JSON shape | #377 (template only) + S3b — `routes/sessions.py::list_sessions` returns `{sessions, meta}` | shipped |
 | Empty state copy | #377 | shipped |
 | Failure mode (skip unreadable JSONL) | #377 | shipped |
 | Heuristic fallback (S2 implementation) | #377 (S2 squash a577a7e8) | shipped |
 | Cache key (last-4KB) | S3a — `session_summary_cache.compute_cache_key()` | shipped (cache module; Haiku wire-up in S3b) |
 | Cache location / TTL | S3a — `<attune_home>/ops/session_summaries/<id>.json`, mtime-bound | shipped (module); first write happens in S3b |
 | List cap (N=20) | S3a — `DEFAULT_SESSION_LIST_CAP` in `list_recent_sessions()` | shipped |
-| Starter-prompt generation (Haiku) | TBD (S3) | pending |
-| Budget cap ($0.05) | TBD (S3) | pending |
-| Source field semantics (heuristic/haiku/cached) | #377 (`heuristic` only) | partial — `haiku`/`cached` in S3 |
+| Starter-prompt generation (Haiku) | S3b — `session_summarizer.summarize_session()` + `routes/sessions.py::enrich_with_summaries` | shipped |
+| Budget cap ($0.05) | S3b — `session_summarizer.Budget` + `new_budget()` + `ATTUNE_OPS_SESSIONS_BUDGET_USD` | shipped (soft warning surfaced in template) |
+| Source field semantics (heuristic/haiku/cached) | #377 + S3b — all three values now possible | shipped |
 | Resume card (current-worktree → canonical) | TBD (S4) | pending |
 | Live-session detection | TBD (S5) | pending |
-| Compare mode (`?compare=1`) | TBD (S3) | pending |
-| Calibration harness | TBD (S3) | pending |
+| Compare mode (`?compare=1`) | S3b — `sessions_page` route query param + template branch | shipped |
+| Calibration harness | S3b (partial) — `scripts/build_session_fixtures.py` ships dry-run + write paths; committed fixtures + snapshot test defer to post-S3 follow-up pending interactive curation | partial |
 | Expand-on-click body | TBD (S4 or later) | pending |
 
 ---
@@ -353,6 +353,18 @@ To be filled in during implementation:
   fixture-build script for calibration. Snapshot-test +
   committed redacted fixtures defer to a post-S3 follow-up
   pending Patrick's interactive fixture curation pass.
+- 2026-05-15 (S3b ship) — S3b lands the Haiku integration plus
+  redaction wire-up, on-disk cache hit/miss path, per-page-load
+  budget cap (default $0.05, override via
+  `ATTUNE_OPS_SESSIONS_BUDGET_USD`, effective off-switch at
+  cap=0), `?compare=1` dev mode, `GET /api/sessions` JSON
+  endpoint, and a dry-run-by-default fixture-build script
+  (`scripts/build_session_fixtures.py`). Snapshot test +
+  committed fixtures intentionally deferred — they require
+  Patrick's interactive curation pass over redacted real
+  sessions. Calibration record below stays blank pending
+  first real-session shakedown. Same-day pre-S3 design
+  tightening pass (entry below) followed by:
 - 2026-05-15 (later same day) — Pre-S3 design tightening
   pass. Five more decisions captured after interactive
   review: list cap N=20 (budget-cap math invalidated by

--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -313,13 +313,28 @@ reader knows it's not part of the user-facing surface.
 
 ## Calibration record
 
-To be filled in during implementation:
-
-- [ ] Haiku prompt template — finalized text and 5-session test
-  snapshot
-- [ ] Average tokens per summary (in / out)
-- [ ] Average cost per session summary
-- [ ] Whether the budget cap ever fires during normal usage
+- [x] Haiku prompt template — shipped as
+  ``attune.ops.session_summarizer.SUMMARY_PROMPT`` (S3b,
+  2026-05-15). Calibrated against decisions.md Decision 2's
+  target shape: numbered (1. one-sentence what-was-worked-on;
+  2. 0-3 open-threads bullets, skip if none; 3. ``Resume:``
+  one-sentence pasteable prompt). Explicit "no filler"
+  instruction; output capped at 256 tokens; input capped at
+  4KB of user-prompt content.
+- [x] First production-data eyeball (2026-05-15, attune-ai
+  worktree silly-ramanujan-a91ddb against
+  ``project_root=/Users/patrickroebuck/attune-ai``): Patrick's
+  reaction was "impressed that Haiku did such a good job —
+  bravo." Output reliably matched the target shape; quality
+  judged to justify the spend. Cleared for merge of PR #390.
+- [ ] Average tokens per summary (in / out) — measure once a
+  redacted-fixture set is committed and the snapshot test lands.
+- [ ] Average cost per session summary — derive from token
+  counts × registry rates ($1/$5 per million for Haiku 4.5).
+- [ ] Whether the budget cap ever fires during normal usage —
+  observe over the first ~week of production use. With N=20
+  cap and ~$0.001/session typical, the $0.05 per-load cap has
+  ~2.5× headroom; cap fires expected to be rare.
 
 ---
 

--- a/scripts/build_session_fixtures.py
+++ b/scripts/build_session_fixtures.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Build redacted session-summary calibration fixtures from real JSONLs.
+
+Walks ``~/.claude/projects/<encoded>*`` for the chosen project,
+applies :func:`attune.ops.session_redaction.redact` to every event
+that carries a ``content`` field, and writes the redacted JSONL to
+the calibration fixture directory.
+
+**Dry-run by default.** Pass ``--write`` to persist. The redacted
+content is committed to git per decisions.md Decision 8
+("fixture-redaction discipline"); the original sensitive content
+NEVER lands in git. Patrick reviews each fixture interactively
+before committing.
+
+Usage::
+
+    # Dry-run: print stats per JSONL, no writes
+    python scripts/build_session_fixtures.py
+
+    # Write redacted JSONLs to the default fixtures dir
+    python scripts/build_session_fixtures.py --write
+
+    # Limit to N sessions (newest first)
+    python scripts/build_session_fixtures.py --limit 10 --write
+
+    # Override the source project root
+    python scripts/build_session_fixtures.py --project-root /path/to/project
+
+    # Override output dir
+    python scripts/build_session_fixtures.py --out-dir tests/fixtures/foo --write
+
+The script is intentionally minimal: no LLM calls, no calibration
+runner, no snapshot computation. Those live in the (eventual)
+``scripts/calibrate_session_summary.py`` follow-up — see
+decisions.md Decision 8.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+from attune.ops import session_redaction
+from attune.ops.data import enumerate_project_encoded_keys
+
+DEFAULT_OUT_DIR = Path("tests/fixtures/ops/session_summaries")
+
+
+def _enumerate_jsonls(project_root: Path) -> list[Path]:
+    """Return every ``*.jsonl`` under the project's encoded keys,
+    newest-mtime first.
+
+    Reuses :func:`enumerate_project_encoded_keys` so the script
+    sees the same multi-key reality the dashboard does (canonical
+    key + per-worktree keys).
+    """
+    encoded_dirs = enumerate_project_encoded_keys(project_root)
+    out: list[tuple[float, Path]] = []
+    for sessions_dir in encoded_dirs:
+        try:
+            for jsonl in sessions_dir.glob("*.jsonl"):
+                try:
+                    out.append((jsonl.stat().st_mtime, jsonl))
+                except OSError:
+                    continue
+        except OSError:
+            continue
+    out.sort(reverse=True)
+    return [p for _mtime, p in out]
+
+
+def _redact_jsonl(source: Path) -> tuple[list[str], dict[str, int]]:
+    """Return ``(redacted_lines, counts)`` for one JSONL file.
+
+    Per-event redaction: only the ``content`` string is rewritten;
+    timestamps, types, and other metadata pass through unchanged.
+    Counts aggregate across all events in the file.
+
+    Lines that aren't JSON or aren't dicts are emitted verbatim —
+    they have no addressable ``content`` field to redact and the
+    summarizer would skip them anyway.
+    """
+    redacted_lines: list[str] = []
+    total_counts: dict[str, int] = {}
+    try:
+        with source.open(encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.rstrip("\n")
+                if not line.strip():
+                    redacted_lines.append(line)
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    redacted_lines.append(line)
+                    continue
+                if not isinstance(event, dict):
+                    redacted_lines.append(line)
+                    continue
+                content = event.get("content")
+                if isinstance(content, str) and content:
+                    result = session_redaction.redact(content)
+                    event["content"] = result.text
+                    for k, v in result.counts.items():
+                        total_counts[k] = total_counts.get(k, 0) + v
+                redacted_lines.append(json.dumps(event, ensure_ascii=False))
+    except OSError as exc:
+        print(f"  ERROR reading {source}: {exc}", file=sys.stderr)
+        return [], {}
+    return redacted_lines, total_counts
+
+
+def _format_counts(counts: dict[str, int]) -> str:
+    if not counts:
+        return "(no redactions)"
+    return ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+
+
+def build_fixtures(
+    project_root: Path,
+    out_dir: Path,
+    *,
+    write: bool,
+    limit: int | None,
+) -> int:
+    """Walk JSONLs and emit redacted fixtures. Returns the count processed.
+
+    When ``write=False`` (default), only prints per-file redaction
+    counts. When ``write=True``, persists each redacted file as
+    ``<out_dir>/<session-id>.jsonl``. The output dir is created on
+    demand.
+    """
+    paths = _enumerate_jsonls(project_root)
+    if not paths:
+        print(f"No JSONLs found under encoded keys for {project_root}", file=sys.stderr)
+        return 0
+    if limit is not None:
+        paths = paths[:limit]
+
+    print(f"Source: {project_root}")
+    print(f"Found {len(paths)} JSONL(s) across encoded keys.")
+    if not write:
+        print("(Dry-run — pass --write to persist.)")
+    else:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Writing redacted fixtures to: {out_dir}")
+    print()
+
+    processed = 0
+    for path in paths:
+        lines, counts = _redact_jsonl(path)
+        if not lines:
+            continue
+        session_id = path.stem
+        print(f"  {session_id}  [{_format_counts(counts)}]")
+        if write:
+            target = out_dir / f"{session_id}.jsonl"
+            target.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        processed += 1
+
+    print()
+    if write:
+        print(f"Wrote {processed} fixture(s). Review each before committing.")
+    else:
+        print(f"Would write {processed} fixture(s) — re-run with --write.")
+    return processed
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build redacted session-summary calibration fixtures."
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Project root whose encoded session keys to walk (default: cwd).",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help=f"Output directory for fixtures (default: {DEFAULT_OUT_DIR}).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of sessions processed (newest first).",
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Actually write the fixtures (default is dry-run).",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    count = build_fixtures(
+        args.project_root.expanduser().resolve(),
+        args.out_dir,
+        write=args.write,
+        limit=args.limit,
+    )
+    return 0 if count >= 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -558,53 +558,25 @@ def _duration_seconds(first: str | None, last: str | None) -> float:
 DEFAULT_SESSION_LIST_CAP = 20
 
 
-def list_recent_sessions(
+def list_recent_sessions_with_paths(
     project_root: Path | str,
     *,
     days: int = 3,
     limit: int | None = DEFAULT_SESSION_LIST_CAP,
     now: datetime | None = None,
     parser: Callable[[Path], Session | None] | None = None,
-) -> list[Session]:
-    """Return Session records for this project's last ``days`` of activity.
+) -> list[tuple[Session, Path]]:
+    """Same as :func:`list_recent_sessions` but also returns each
+    session's source JSONL path.
 
-    Reads ``*.jsonl`` files from every encoded-key directory belonging
-    to this logical project (canonical key plus per-worktree keys —
-    see :func:`enumerate_project_encoded_keys`) and filters to files
-    whose mtime is within ``days`` of ``now`` (default: current UTC
-    time). Sessions are deduplicated by id (the JSONL filename's
-    stem) — when the same id appears under multiple encoded keys
-    (rare; suggests a worktree that was renamed or re-created), the
-    newest-mtime copy wins and a WARN log records the conflict.
-    Output is sorted most-recently-active first and capped at
-    ``limit`` (default :data:`DEFAULT_SESSION_LIST_CAP`).
+    Needed by S3b's Haiku wire-up: the summarizer requires the
+    on-disk path to compute the last-4KB cache key. Returning the
+    path alongside the parsed :class:`Session` avoids re-walking
+    the encoded-key dirs for every summarization call.
 
-    Args:
-        project_root: The dashboard's project root. Used to compute
-            the encoded-key prefix.
-        days: Time window for filtering by JSONL mtime.
-        limit: Maximum number of sessions to return. ``None`` returns
-            all matches (unbounded — only reasonable for callers that
-            already know the size, e.g. tests). The list cap exists
-            because each session may incur an LLM-summarization spend
-            on first render; capping bounds worst-case page-load cost
-            (decisions.md Decision 5).
-        now: Override the current time (test hook).
-        parser: Override the per-file parser (test hook). Defaults to
-            :func:`_parse_session`. The parser receives the JSONL
-            :class:`Path` and returns a :class:`Session` or ``None``.
-
-    Returns ``[]`` for any failure mode that doesn't raise:
-    - No matching encoded-key dirs (user never ran Claude Code here)
-    - All matched dirs are empty
-    - All JSONLs are older than the cutoff
-    - All JSONLs are unreadable (perm, IO)
-
-    A single corrupt file is skipped with a WARN log; the rest of
-    the listing still renders. The spec's failure-mode decision:
-    "Skip with WARN log, don't surface as broken row — an unreadable
-    file is a Claude Code internal issue, not something the user
-    can fix from the dashboard."
+    Same arguments and failure modes as :func:`list_recent_sessions`.
+    Result is sorted by ``last_activity`` desc and capped at
+    ``limit``.
     """
     # Local import: a module-level ``timedelta`` import was reverted by
     # the formatter (likely ruff isort considering it unused at the
@@ -666,16 +638,77 @@ def list_recent_sessions(
                     mtime.isoformat(),
                 )
 
-    out: list[Session] = []
+    out: list[tuple[Session, Path]] = []
     for _mtime, jsonl in by_id.values():
         session = parse(jsonl)
         if session is None:
             continue
-        out.append(session)
-    out.sort(key=lambda s: s.last_activity or "", reverse=True)
+        out.append((session, jsonl))
+    out.sort(key=lambda item: item[0].last_activity or "", reverse=True)
     if limit is not None and limit >= 0:
         out = out[:limit]
     return out
+
+
+def list_recent_sessions(
+    project_root: Path | str,
+    *,
+    days: int = 3,
+    limit: int | None = DEFAULT_SESSION_LIST_CAP,
+    now: datetime | None = None,
+    parser: Callable[[Path], Session | None] | None = None,
+) -> list[Session]:
+    """Return Session records for this project's last ``days`` of activity.
+
+    Thin wrapper over :func:`list_recent_sessions_with_paths`;
+    drops the on-disk path so callers that don't need it (the
+    JSON API, the existing test suite) keep the simpler return
+    shape.
+
+    Reads ``*.jsonl`` files from every encoded-key directory belonging
+    to this logical project (canonical key plus per-worktree keys —
+    see :func:`enumerate_project_encoded_keys`) and filters to files
+    whose mtime is within ``days`` of ``now`` (default: current UTC
+    time). Sessions are deduplicated by id (the JSONL filename's
+    stem) — when the same id appears under multiple encoded keys
+    (rare; suggests a worktree that was renamed or re-created), the
+    newest-mtime copy wins and a WARN log records the conflict.
+    Output is sorted most-recently-active first and capped at
+    ``limit`` (default :data:`DEFAULT_SESSION_LIST_CAP`).
+
+    Args:
+        project_root: The dashboard's project root. Used to compute
+            the encoded-key prefix.
+        days: Time window for filtering by JSONL mtime.
+        limit: Maximum number of sessions to return. ``None`` returns
+            all matches (unbounded — only reasonable for callers that
+            already know the size, e.g. tests). The list cap exists
+            because each session may incur an LLM-summarization spend
+            on first render; capping bounds worst-case page-load cost
+            (decisions.md Decision 5).
+        now: Override the current time (test hook).
+        parser: Override the per-file parser (test hook). Defaults to
+            :func:`_parse_session`. The parser receives the JSONL
+            :class:`Path` and returns a :class:`Session` or ``None``.
+
+    Returns ``[]`` for any failure mode that doesn't raise:
+    - No matching encoded-key dirs (user never ran Claude Code here)
+    - All matched dirs are empty
+    - All JSONLs are older than the cutoff
+    - All JSONLs are unreadable (perm, IO)
+
+    A single corrupt file is skipped with a WARN log; the rest of
+    the listing still renders. The spec's failure-mode decision:
+    "Skip with WARN log, don't surface as broken row — an unreadable
+    file is a Claude Code internal issue, not something the user
+    can fix from the dashboard."
+    """
+    return [
+        session
+        for session, _path in list_recent_sessions_with_paths(
+            project_root, days=days, limit=limit, now=now, parser=parser
+        )
+    ]
 
 
 # Path passed to workflows when the user picks the "All code" picker

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -135,20 +135,57 @@ async def health_page(request: Request) -> HTMLResponse:
 async def sessions_page(request: Request) -> HTMLResponse:
     """Sessions page — recent Claude Code sessions for this project.
 
-    S2: reads ``~/.claude/projects/<encoded-project-root>/*.jsonl``
-    and surfaces sessions whose mtime is within the last 3 days,
-    each with a heuristic starter-prompt (first user prompt,
-    truncated to ~200 chars). S3 will replace the heuristic with
-    Haiku-summarized prompts and a per-page budget cap; S4 adds the
-    resume-most-recent card; S5 marks the live session.
+    S3b: wires the Haiku summarizer + on-disk cache + redaction
+    behind the existing data layer. Each row's ``starter_prompt``
+    is the Haiku-or-cached summary when available, falling back
+    to the heuristic (first user prompt, truncated) when the LLM
+    is disabled, the budget is breached, or any failure path
+    fires. The ``source`` field on each :class:`Session` (one of
+    ``heuristic | haiku | cached``) tells the user which lane
+    produced the text.
+
+    Query params:
+
+    - ``?compare=1`` — dev mode. Runs the full enrichment AND
+      preserves the heuristic alongside, rendering both columns
+      side-by-side. No UI affordance (discoverable only by URL).
+      Same budget + redaction + caching applies.
 
     Failure modes are silent fall-throughs to the empty state: no
     Claude Code dir, all sessions older than 3 days, all JSONLs
     unreadable — none surface as errors. The point is to be useful
     on a fresh install, not to debug Claude Code's internal state.
+
+    S4 will add the resume-most-recent card; S5 marks the live
+    session.
     """
+    from attune.ops.routes.sessions import enrich_with_summaries
+    from attune.ops.session_summarizer import llm_enabled, new_budget
+
     cfg = request.app.state.config
-    sessions = data.list_recent_sessions(cfg.project_root, days=3)
+    compare_mode = request.query_params.get("compare") == "1"
+
+    if compare_mode:
+        # Compare mode renders both columns. Keep the heuristic
+        # version (paths-included call) and run the enrichment
+        # alongside on the same path list so the rows align.
+        pairs = data.list_recent_sessions_with_paths(cfg.project_root, days=3)
+        heuristic_sessions = [s for s, _ in pairs]
+        budget = new_budget()
+        from attune.ops.routes.sessions import _enrich_sessions
+
+        haiku_sessions, over_budget = _enrich_sessions(
+            pairs, attune_home=cfg.attune_home, budget=budget
+        )
+        sessions = heuristic_sessions
+        compare_columns = [
+            {"label": "Heuristic", "sessions": heuristic_sessions},
+            {"label": "Haiku", "sessions": haiku_sessions},
+        ]
+    else:
+        sessions, over_budget = enrich_with_summaries(cfg.project_root, cfg.attune_home)
+        compare_columns = None
+
     # Where the sessions live — surfaced in the empty-state so users
     # can ``cat`` the JSONLs directly if they want to inspect more
     # than the page shows. Reuses ``claude_sessions_dir`` so the
@@ -168,6 +205,10 @@ async def sessions_page(request: Request) -> HTMLResponse:
         page="sessions",
         sessions=sessions,
         sessions_dir=sessions_dir,
+        compare_mode=compare_mode,
+        compare_columns=compare_columns,
+        over_budget=over_budget,
+        llm_enabled=llm_enabled(),
     )
 
 

--- a/src/attune/ops/routes/sessions.py
+++ b/src/attune/ops/routes/sessions.py
@@ -1,0 +1,131 @@
+"""JSON API for the /sessions surface.
+
+Mirrors the ``/api/specs`` and ``/api/runs/...`` pattern: HTML
+pages live in ``dashboard.py``, JSON endpoints live in a
+subsystem-named module. Same data shape the HTML page consumes,
+so dashboard consumers (CLI scripts, watch loops, future widgets)
+can poll without parsing HTML.
+
+Decision (ops-sessions-page decisions.md):
+``GET /api/sessions`` returns
+``{sessions: [{id, started_at, last_activity, duration_seconds,
+message_count, starter_prompt, source}, ...]}``
+where ``source`` is one of ``"heuristic" | "haiku" | "cached"``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from attune.ops import data, session_summarizer
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/sessions", tags=["sessions"])
+
+
+def _enrich_sessions(
+    pairs: list,
+    *,
+    attune_home,
+    budget: session_summarizer.Budget,
+) -> tuple[list[data.Session], bool]:
+    """Run Haiku summarization over ``pairs`` and return enriched sessions.
+
+    Each pair is ``(Session, Path)`` from
+    :func:`data.list_recent_sessions_with_paths`. The original
+    session's ``starter_prompt`` is replaced with the Haiku-or-cached
+    summary when the summarizer succeeds; the heuristic text is kept
+    when it returns ``None`` (LLM disabled, cache miss + over budget,
+    or any failure path).
+
+    Returns ``(enriched_sessions, over_budget)`` — the boolean flag
+    tells the caller whether to render the "summary unavailable —
+    over budget" marker. The flag latches at the first time the
+    summarizer skips a session due to budget breach, so the marker
+    appears once for the whole tail rather than per-row.
+    """
+    enriched: list[data.Session] = []
+    over_budget = False
+    for session, jsonl_path in pairs:
+        # Mid-loop budget check: cached reads still happen post-breach
+        # (free), but fresh calls don't. The summarizer's own
+        # ``should_skip()`` handles this; we record the flag for the
+        # template marker.
+        breached_before = budget.breached
+        result = session_summarizer.summarize_session(
+            jsonl_path,
+            attune_home=attune_home,
+            budget=budget,
+        )
+        if result is None:
+            if not breached_before and budget.breached:
+                # Summarizer recorded a spend that crossed the cap; the
+                # marker should fire for the trailing sessions.
+                over_budget = True
+            elif budget.breached:
+                # Already-breached state; trailing sessions skip silently.
+                over_budget = True
+            enriched.append(session)
+            continue
+        enriched.append(
+            data.Session(
+                id=session.id,
+                started_at=session.started_at,
+                last_activity=session.last_activity,
+                duration_seconds=session.duration_seconds,
+                message_count=session.message_count,
+                starter_prompt=result.text,
+                source=result.source,
+            )
+        )
+    return enriched, over_budget
+
+
+def enrich_with_summaries(
+    project_root,
+    attune_home,
+    *,
+    days: int = 3,
+    limit: int | None = data.DEFAULT_SESSION_LIST_CAP,
+    budget: session_summarizer.Budget | None = None,
+) -> tuple[list[data.Session], bool]:
+    """Public helper used by both the JSON route and the HTML page.
+
+    Reads the recent-sessions list (with paths) and runs the
+    summarizer over each. Returns ``(sessions, over_budget)``. The
+    HTML page passes the same flag through to the template; the JSON
+    endpoint surfaces it in the response under
+    ``meta.budget_exceeded``.
+    """
+    pairs = data.list_recent_sessions_with_paths(project_root, days=days, limit=limit)
+    if budget is None:
+        budget = session_summarizer.new_budget()
+    return _enrich_sessions(pairs, attune_home=attune_home, budget=budget)
+
+
+@router.get("")
+async def list_sessions(request: Request) -> dict[str, Any]:
+    """``GET /api/sessions`` — JSON listing of recent sessions.
+
+    Same enrichment path the HTML page uses, so the two views can't
+    drift on the ``source`` field (heuristic vs haiku vs cached).
+    Empty list is a legitimate response; the caller shouldn't treat
+    it as an error.
+    """
+    cfg = request.app.state.config
+    sessions, over_budget = enrich_with_summaries(
+        cfg.project_root,
+        cfg.attune_home,
+    )
+    return {
+        "sessions": [asdict(s) for s in sessions],
+        "meta": {
+            "budget_exceeded": over_budget,
+            "llm_enabled": session_summarizer.llm_enabled(),
+        },
+    }

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -16,6 +16,7 @@ from attune.ops.config import Config
 from attune.ops.routes import dashboard
 from attune.ops.routes import runner as runner_routes
 from attune.ops.routes import runs_history as runs_history_routes
+from attune.ops.routes import sessions as sessions_routes
 from attune.ops.routes import specs as specs_routes
 from attune.ops.routes import sweep_results as sweep_results_routes
 from attune.ops.runner import RunnerService, prune_old_runs
@@ -95,6 +96,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.include_router(dashboard.router)
     app.include_router(runner_routes.router)
     app.include_router(runs_history_routes.router)
+    app.include_router(sessions_routes.router)
     app.include_router(specs_routes.router)
     app.include_router(sweep_results_routes.router)
 

--- a/src/attune/ops/session_summarizer.py
+++ b/src/attune/ops/session_summarizer.py
@@ -1,0 +1,435 @@
+"""Haiku-summarized starter prompts for the /sessions page.
+
+S3b of the ops-sessions-page spec. Wires three already-shipped
+pieces together — :mod:`attune.ops.session_redaction`,
+:mod:`attune.ops.session_summary_cache`, and the Anthropic SDK —
+behind a single :func:`summarize_session` entry point.
+
+Discipline (decisions.md Decision 3): **redact first, then send,
+then cache.** Sensitive material never enters the LLM provider's
+context and never lands on disk in the cache. Cache hits inherit
+the redacted form for free.
+
+Failure mode: any error (missing API key, missing SDK, network
+flake, redaction failure) returns ``None``. The caller falls
+back to the heuristic that ``data.list_recent_sessions`` already
+produced. This keeps the page useful even when Haiku is
+unavailable.
+
+Env gates:
+
+- ``ATTUNE_OPS_SESSIONS_LLM`` — set to ``"0"`` to disable the
+  Haiku path entirely. Default behavior is enabled when an
+  ``ANTHROPIC_API_KEY`` is present.
+- ``ANTHROPIC_API_KEY`` — required for live calls. When absent,
+  :func:`summarize_session` returns ``None`` without raising.
+- ``ATTUNE_OPS_SESSIONS_BUDGET_USD`` — per-page-load cap. Read
+  by the caller (see :func:`new_budget`), not enforced here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from attune.ops import session_redaction, session_summary_cache
+
+logger = logging.getLogger(__name__)
+
+# Haiku 4.5 pricing as of 2026-05. Mirrors ``MODEL_REGISTRY`` in
+# ``src/attune/models/registry.py`` — the per-million-tokens rates
+# the planning math assumes (~$0.001/session typical, well under
+# the $0.05 per-load cap with N=20).
+HAIKU_MODEL_ID = "claude-haiku-4-5-20251001"
+_INPUT_COST_PER_MILLION = 1.00
+_OUTPUT_COST_PER_MILLION = 5.00
+
+# Per-page-load budget. Sized for N=20 × ~$0.001/session ≈ $0.02
+# typical, with ~2.5× headroom for prompt growth + input-size
+# variance. Decisions.md Decision 5 + the budget-cap math note.
+DEFAULT_BUDGET_USD = 0.05
+
+# Bytes of session content we send to Haiku per session. Enough to
+# capture the opening intent plus a few exchanges; bounded so a
+# 50MB transcript can't blow out the per-session cost. ~4KB is
+# roughly 1K input tokens at Haiku rates → $0.001/session input.
+_MAX_INPUT_CHARS = 4_000
+
+# Cap on Haiku's output tokens. The target shape is a ~60-word
+# summary + 0-3 bullet points + 1-sentence resume prompt — well
+# under 200 tokens. 256 leaves slack for variation without
+# blowing out cost.
+_MAX_OUTPUT_TOKENS = 256
+
+# Haiku summarization prompt. Calibrated against the target shape
+# in decisions.md Decision 2:
+#
+#   1. Names what was being worked on (1 short sentence).
+#   2. Lists any open threads (bullets, 0-3 items).
+#   3. Suggests a 1-sentence resume prompt the user can paste.
+#
+# Kept as a constant rather than threaded through args so the
+# calibration harness (scripts/build_session_fixtures.py +
+# eventual snapshot test) has a single source of truth to diff
+# against.
+SUMMARY_PROMPT = (
+    "You are summarizing the start of a Claude Code session so the user "
+    "can decide whether to resume it. The user pasted the first ~4KB of "
+    "their session transcript below.\n\n"
+    "Produce a starter summary with exactly this shape:\n\n"
+    "1. One short sentence (max ~20 words) naming what was being worked "
+    "on. Concrete: cite a file, feature, or task. No filler like "
+    "'discussion of' or 'work on'.\n"
+    "2. Open threads as 0-3 bullets, one line each, max ~12 words each. "
+    "Skip the bullets section entirely if no threads are obvious — "
+    "don't invent them.\n"
+    "3. One sentence the user could paste to resume the work, prefixed "
+    "with 'Resume:'. Action-oriented, max ~20 words.\n\n"
+    "Format as plain text. No headings, no markdown beyond the bullet "
+    "dashes. Be terse. The user is reading 20 of these in a list — "
+    "every word counts.\n\n"
+    "If the transcript is too short or noisy to summarize, output "
+    "exactly: 'Resume: pick up where you left off.'\n"
+)
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    """One Haiku-or-cache result, ready to slot into a :class:`Session`.
+
+    ``source`` is one of ``"haiku"`` (fresh call this load) or
+    ``"cached"`` (loaded from on-disk cache). The heuristic source
+    is owned by the data layer; this module never returns it. A
+    failure returns ``None`` rather than a SummaryResult with
+    ``source="heuristic"`` — distinguishing the two lets the
+    caller decide whether to retry, fall back, or surface a
+    "summary unavailable" marker.
+    """
+
+    text: str
+    source: str  # "haiku" | "cached"
+    tokens_in: int
+    tokens_out: int
+    cost_usd: float
+
+
+@dataclass
+class Budget:
+    """Mutable spend ledger for one page-load summarization loop.
+
+    Mutable on purpose — the loop passes one instance through
+    every :func:`summarize_session` call and tracks cumulative
+    spend in ``spent_usd``. Subsequent calls check
+    :meth:`should_skip` before incurring any cost.
+
+    The breach is a soft cap: a fresh call that would push
+    ``spent_usd`` over ``cap_usd`` is skipped and the caller
+    falls back to the heuristic. Cached reads are free and
+    proceed regardless of the cap (they were paid for on a
+    prior load).
+
+    A ``cap_usd <= 0`` value latches the budget as breached at
+    construction — useful as an effective off-switch in tests
+    and for users who want heuristic-only mode without unsetting
+    ``ANTHROPIC_API_KEY``.
+    """
+
+    cap_usd: float
+    spent_usd: float = 0.0
+    breached: bool = False
+
+    def __post_init__(self) -> None:
+        # Cap of 0 (or negative) is an effective off-switch — every
+        # call would otherwise breach on its first record, but with
+        # the latch set at construction the first call is skipped
+        # too and the marker fires from row one.
+        if self.cap_usd <= 0:
+            self.breached = True
+
+    def should_skip(self) -> bool:
+        """Return True once the cap has been breached.
+
+        Latches at ``breached=True`` so the caller can render a
+        single "over budget" marker for the trailing sessions
+        rather than flipping back and forth as cache hits come in.
+        """
+        return self.breached
+
+    def record(self, cost_usd: float) -> None:
+        """Add a successful fresh call's cost to the ledger.
+
+        If the cumulative spend crosses ``cap_usd``, latches
+        ``breached=True``. Callers should NOT call this for cache
+        hits — those are free and don't count against the budget.
+        """
+        self.spent_usd += cost_usd
+        if self.spent_usd >= self.cap_usd:
+            self.breached = True
+
+
+def new_budget(cap_usd: float | None = None) -> Budget:
+    """Build a :class:`Budget` from the env override or default.
+
+    ``cap_usd`` arg wins over the env var, which wins over the
+    module default. Negative values clamp to 0 (immediate
+    breach — useful for tests that want to assert the
+    over-budget code path without spending real money).
+    """
+    if cap_usd is not None:
+        cap = cap_usd
+    else:
+        raw = os.environ.get("ATTUNE_OPS_SESSIONS_BUDGET_USD")
+        if raw:
+            try:
+                cap = float(raw)
+            except ValueError:
+                logger.warning(
+                    "ops.sessions: invalid ATTUNE_OPS_SESSIONS_BUDGET_USD=%r,"
+                    " using default %.3f",
+                    raw,
+                    DEFAULT_BUDGET_USD,
+                )
+                cap = DEFAULT_BUDGET_USD
+        else:
+            cap = DEFAULT_BUDGET_USD
+    return Budget(cap_usd=max(0.0, cap))
+
+
+def llm_enabled() -> bool:
+    """Return True iff the Haiku path is enabled this run.
+
+    Off when ``ATTUNE_OPS_SESSIONS_LLM=0`` is explicitly set OR
+    when no ``ANTHROPIC_API_KEY`` is in the environment. The
+    second condition means a vanilla install without an API key
+    falls cleanly back to the heuristic without ever attempting
+    a network call (no spurious WARN logs).
+    """
+    if os.environ.get("ATTUNE_OPS_SESSIONS_LLM") == "0":
+        return False
+    return bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def _extract_content_for_summary(jsonl_path: Path, *, char_budget: int) -> str:
+    """Read up to ``char_budget`` chars of user-prompt content from the JSONL.
+
+    Walks the file line-by-line, picks events that have a string
+    ``content`` field (the user's prompts), and concatenates with
+    a blank line between turns. Stops as soon as the accumulated
+    length crosses ``char_budget`` — Haiku only needs enough to
+    name the work, not the whole transcript.
+
+    Returns ``""`` on any I/O failure or when no content events
+    are present. The caller treats empty as "no summary
+    possible" and skips Haiku.
+    """
+    chunks: list[str] = []
+    used = 0
+    try:
+        with jsonl_path.open(encoding="utf-8") as fh:
+            for raw in fh:
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                content = event.get("content")
+                if not isinstance(content, str) or not content:
+                    continue
+                # Truncate this turn if it alone exceeds the
+                # remaining budget — better to include a head
+                # slice than skip the whole turn.
+                remaining = char_budget - used
+                if remaining <= 0:
+                    break
+                slice_ = content if len(content) <= remaining else content[:remaining]
+                chunks.append(slice_)
+                used += len(slice_) + 2  # +2 for the separator
+    except OSError:
+        return ""
+    return "\n\n".join(chunks)
+
+
+def _compute_cost_usd(tokens_in: int, tokens_out: int) -> float:
+    """Cost in USD for one Haiku-4.5 call at registry rates."""
+    return (
+        tokens_in * _INPUT_COST_PER_MILLION / 1_000_000.0
+        + tokens_out * _OUTPUT_COST_PER_MILLION / 1_000_000.0
+    )
+
+
+def _call_haiku(redacted_text: str) -> tuple[str, int, int] | None:
+    """One Haiku synchronous call. Returns ``(text, tokens_in, tokens_out)``.
+
+    Returns ``None`` on any failure — missing SDK, missing API
+    key, network error, empty response. Failure is logged at
+    WARN; the caller treats ``None`` as "fall back to heuristic."
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        return None
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        logger.warning("ops.sessions: anthropic SDK not installed; skipping Haiku")
+        return None
+
+    client = Anthropic(api_key=api_key)
+    try:
+        response = client.messages.create(
+            model=HAIKU_MODEL_ID,
+            max_tokens=_MAX_OUTPUT_TOKENS,
+            system=SUMMARY_PROMPT,
+            messages=[{"role": "user", "content": redacted_text}],
+        )
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: Haiku failure must never crash a page render.
+        # Anthropic SDK raises a handful of exception types
+        # (APIError, RateLimitError, APIConnectionError, ...). Catching
+        # broadly + logging is the right shape; the caller falls back.
+        logger.warning("ops.sessions: Haiku call failed: %s", exc)
+        return None
+
+    if not response.content:
+        return None
+    block = response.content[0]
+    text = getattr(block, "text", None)
+    if not isinstance(text, str) or not text:
+        return None
+
+    usage = getattr(response, "usage", None)
+    tokens_in = int(getattr(usage, "input_tokens", 0) or 0)
+    tokens_out = int(getattr(usage, "output_tokens", 0) or 0)
+    return text.strip(), tokens_in, tokens_out
+
+
+def summarize_session(
+    jsonl_path: Path,
+    *,
+    attune_home: Path,
+    budget: Budget | None = None,
+) -> SummaryResult | None:
+    """Return a Haiku-or-cached summary for one session JSONL.
+
+    Flow (decisions.md Decisions 3 + 6 + 7):
+
+    1. Compute cache key from the file's tail (last 4KB SHA-256).
+    2. Probe the on-disk cache; return ``CachedSummary`` if hit.
+       Cache hits are free and bypass the budget check.
+    3. If the budget is already breached, return ``None`` —
+       caller falls back to the heuristic that the data layer
+       already produced.
+    4. Extract up to ``_MAX_INPUT_CHARS`` of user-prompt content.
+    5. Run the redaction pass.
+    6. Call Haiku with the redacted text.
+    7. Compute cost, record against the budget, write to the
+       cache, return.
+
+    Any I/O or LLM failure short-circuits to ``None``. The route
+    treats ``None`` as "use the heuristic starter prompt that
+    ``data.list_recent_sessions`` already populated."
+
+    Args:
+        jsonl_path: Path to the session's JSONL file under
+            ``~/.claude/projects/<encoded>/``.
+        attune_home: ``~/.attune`` (or ``$ATTUNE_HOME``). The
+            cache lives under ``<attune_home>/ops/session_summaries/``.
+        budget: Optional :class:`Budget` ledger. When ``None`` a
+            fresh one with the env-or-default cap is created
+            (useful for one-off calls outside the page-load loop).
+
+    Returns:
+        A :class:`SummaryResult` (source ``"haiku"`` or
+        ``"cached"``), or ``None`` on any failure / over-budget /
+        LLM-disabled state.
+    """
+    if budget is None:
+        budget = new_budget()
+
+    # Step 1+2: cache probe BEFORE the LLM-enabled check. A prior
+    # write may still be useful even if the current load has
+    # ATTUNE_OPS_SESSIONS_LLM=0 — the user can opt out of fresh
+    # calls without throwing away yesterday's results.
+    cache_key = session_summary_cache.compute_cache_key(jsonl_path)
+    if cache_key is None:
+        # I/O failure reading the source — nothing to summarize
+        # and nothing to cache against. Caller falls back.
+        return None
+
+    session_id = jsonl_path.stem
+    cached = session_summary_cache.load(attune_home, session_id, cache_key)
+    if cached is not None:
+        return SummaryResult(
+            text=cached.summary,
+            source="cached",
+            tokens_in=cached.tokens_in,
+            tokens_out=cached.tokens_out,
+            cost_usd=cached.cost_usd,
+        )
+
+    # No cache hit. Need a fresh call — check the gates.
+    if not llm_enabled():
+        return None
+    if budget.should_skip():
+        return None
+
+    # Step 4: extract content.
+    raw = _extract_content_for_summary(jsonl_path, char_budget=_MAX_INPUT_CHARS)
+    if not raw:
+        return None
+
+    # Step 5: redact. This is the load-bearing step for the
+    # "no sensitive material in the LLM provider's context"
+    # invariant; if redaction itself raises we treat the
+    # session as un-summarizable rather than send the raw text.
+    try:
+        redacted = session_redaction.redact(raw).text
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: redaction failure must not leak raw text.
+        # Caller falls back to the heuristic (which has its own
+        # truncation but no LLM exposure).
+        logger.warning("ops.sessions: redaction failed for %s: %s", session_id, exc)
+        return None
+    if not redacted:
+        return None
+
+    # Step 6: Haiku call.
+    call_result = _call_haiku(redacted)
+    if call_result is None:
+        return None
+    text, tokens_in, tokens_out = call_result
+    cost_usd = _compute_cost_usd(tokens_in, tokens_out)
+
+    # Step 7: record against budget + persist to cache. Cache
+    # write failure is best-effort — we still return the result.
+    budget.record(cost_usd)
+    try:
+        session_summary_cache.save(
+            attune_home,
+            session_id,
+            key=cache_key,
+            summary=text,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            cost_usd=cost_usd,
+        )
+    except OSError as exc:
+        logger.warning(
+            "ops.sessions: cache write failed for %s: %s — returning fresh result",
+            session_id,
+            exc,
+        )
+
+    return SummaryResult(
+        text=text,
+        source="haiku",
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        cost_usd=cost_usd,
+    )

--- a/src/attune/ops/templates/sessions.html
+++ b/src/attune/ops/templates/sessions.html
@@ -9,15 +9,54 @@
   </p>
 </section>
 
-{# Sessions S2 — data layer. Reads Claude Code's per-project JSONL
-   logs, surfaces last-3-days sessions with a heuristic starter
-   prompt (first user message, truncated). S3 will replace the
-   heuristic with Haiku-summarized prompts; S4 lifts the most-recent
-   session into a prominent resume card; S5 marks the live session.
-   The empty-state copy below matches the spec's exact phrasing so
-   the legitimate "no sessions in 3 days" case stays clean. #}
+{# Sessions S3b — reads Claude Code's per-project JSONL logs, surfaces
+   last-3-days sessions, and replaces the heuristic starter prompt with
+   a Haiku-summarized version when ATTUNE_OPS_SESSIONS_LLM is on and
+   the budget allows. The `source` chip per row tells the user which
+   lane produced the text (heuristic, haiku, cached). `?compare=1`
+   renders both heuristic + haiku columns side-by-side (dev tool).
+   S4 lifts the most-recent session into a prominent resume card;
+   S5 marks the live session. #}
 <section class="panel">
-  {% if sessions %}
+  {% if compare_mode and compare_columns %}
+    {# Compare mode — renders heuristic + haiku starter prompts
+       side-by-side on the same row, indexed by session id. No UI
+       affordance points here; discoverable only by URL. #}
+    <p class="meta">
+      Compare mode: heuristic vs Haiku starter prompts.
+      {% if not llm_enabled %}<strong>(Haiku disabled — second column will be empty)</strong>{% endif %}
+    </p>
+    <table class="data-table sessions-table">
+      <thead>
+        <tr>
+          <th>Session</th>
+          <th>Last activity</th>
+          <th>Heuristic</th>
+          <th>Haiku</th>
+        </tr>
+      </thead>
+      <tbody>
+        {# Iterate the heuristic column by index; pull the matching
+           haiku row from the second column. Lengths are identical
+           because both columns are built from the same path list. #}
+        {% for h in compare_columns[0].sessions %}
+          {% set hk = compare_columns[1].sessions[loop.index0] %}
+          <tr>
+            <td><code class="session-id">{{ h.id[:8] }}</code></td>
+            <td><code class="session-ts" data-tooltip="{{ h.last_activity }}" aria-label="Last activity {{ h.last_activity }}">{{ h.last_activity[:19] }}</code></td>
+            <td class="session-prompt">
+              <span class="chip chip-muted" style="float:right;margin-left:0.5em">{{ h.source }}</span>
+              {{ h.starter_prompt }}
+            </td>
+            <td class="session-prompt">
+              <span class="chip chip-muted" style="float:right;margin-left:0.5em">{{ hk.source }}</span>
+              {{ hk.starter_prompt }}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% elif sessions %}
     <table class="data-table sessions-table">
       <thead>
         <tr>
@@ -37,11 +76,27 @@
             <td class="num">{% if s.duration_seconds > 0 %}{{ '%.0fs'|format(s.duration_seconds) if s.duration_seconds < 60 else '%.0fm'|format(s.duration_seconds / 60) }}{% else %}—{% endif %}</td>
             <td class="num">{{ s.message_count }}</td>
             <td class="session-prompt">{{ s.starter_prompt }}</td>
-            <td><span class="chip chip-muted" data-tooltip="{% if s.source == 'heuristic' %}First user prompt, truncated{% else %}LLM-summarized starter prompt{% endif %}" aria-label="Source: {{ s.source }}">{{ s.source }}</span></td>
+            <td>
+              {# Per-source tooltip copy explains where the text came
+                 from. 'haiku' = fresh LLM call this load; 'cached' =
+                 a prior Haiku call's persisted summary; 'heuristic' =
+                 fallback (LLM disabled, budget exhausted, or any
+                 failure path). #}
+              <span class="chip chip-muted" data-tooltip="{% if s.source == 'heuristic' %}First user prompt, truncated{% elif s.source == 'haiku' %}Summarized by Haiku this page load{% elif s.source == 'cached' %}Cached Haiku summary from a prior load{% else %}{{ s.source }}{% endif %}" aria-label="Source: {{ s.source }}">{{ s.source }}</span>
+            </td>
           </tr>
         {% endfor %}
       </tbody>
     </table>
+    {% if over_budget %}
+      {# Per-page-load budget breach. Trailing sessions render with
+         their heuristic prompt rather than a fresh Haiku call. Cache
+         hits still happen post-breach (free). #}
+      <p class="meta" style="color: var(--warning, #aa6500)">
+        Per-page Haiku budget exceeded. Some rows above show heuristic
+        prompts. Configure with <code>ATTUNE_OPS_SESSIONS_BUDGET_USD</code>.
+      </p>
+    {% endif %}
     <p class="meta">
       Older sessions (beyond 3 days) stay on disk at
       <code>{{ sessions_dir }}</code> but aren't surfaced here.

--- a/tests/unit/ops/test_build_session_fixtures.py
+++ b/tests/unit/ops/test_build_session_fixtures.py
@@ -1,0 +1,146 @@
+"""Tests for the fixture-build helper script (S3b).
+
+Smoke-tests the dry-run + write paths against a synthetic
+``~/.claude/projects/<encoded>/`` tree. The script is invoked
+in-process (no subprocess) so the patched ``Path.home()`` takes
+effect.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# scripts/ is not on the import path by default
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parents[3] / "scripts"),
+)
+import build_session_fixtures  # noqa: E402
+
+from attune.ops import data  # noqa: E402
+
+
+def _patch_home(monkeypatch, home_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(home_path))
+    monkeypatch.setenv("USERPROFILE", str(home_path))
+
+
+def _seed_session(home: Path, project_root: Path, session_id: str, events: list[dict]) -> None:
+    sessions_dir = home / ".claude" / "projects" / data._encoded_project_path(project_root)
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    (sessions_dir / f"{session_id}.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_dry_run_reports_no_writes(tmp_path, monkeypatch, capsys):
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _seed_session(
+        tmp_path / "home",
+        project_root,
+        "abc-001",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": "Hello"}],
+    )
+
+    out_dir = tmp_path / "fixtures"
+    count = build_session_fixtures.build_fixtures(
+        project_root=project_root.resolve(),
+        out_dir=out_dir,
+        write=False,
+        limit=None,
+    )
+    assert count == 1
+    # Output dir should NOT be created on dry-run
+    assert not out_dir.exists()
+    captured = capsys.readouterr().out
+    assert "Dry-run" in captured
+    assert "abc-001" in captured
+
+
+def test_write_persists_redacted_jsonl(tmp_path, monkeypatch, capsys):
+    """A session with a secret in its content writes a redacted JSONL."""
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    secret = "sk-ant-" + "B" * 40
+    _seed_session(
+        tmp_path / "home",
+        project_root,
+        "abc-002",
+        [
+            {"timestamp": "2026-05-14T10:00:00Z", "content": f"My key is {secret}"},
+            {"timestamp": "2026-05-14T10:01:00Z", "content": "Plain follow-up"},
+        ],
+    )
+
+    out_dir = tmp_path / "fixtures"
+    count = build_session_fixtures.build_fixtures(
+        project_root=project_root.resolve(),
+        out_dir=out_dir,
+        write=True,
+        limit=None,
+    )
+    assert count == 1
+    written = out_dir / "abc-002.jsonl"
+    assert written.is_file()
+
+    lines = written.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    first_event = json.loads(lines[0])
+    second_event = json.loads(lines[1])
+    # Secret is gone, placeholder is in
+    assert secret not in first_event["content"]
+    assert "<redacted>" in first_event["content"]
+    # Plain content survived
+    assert second_event["content"] == "Plain follow-up"
+    # Timestamps preserved
+    assert first_event["timestamp"] == "2026-05-14T10:00:00Z"
+
+    captured = capsys.readouterr().out
+    assert "api_key=1" in captured  # the per-file redaction count line
+
+
+def test_limit_caps_processed_sessions(tmp_path, monkeypatch):
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    for i in range(5):
+        _seed_session(
+            tmp_path / "home",
+            project_root,
+            f"session-{i:02d}",
+            [{"timestamp": "2026-05-14T10:00:00Z", "content": f"prompt {i}"}],
+        )
+
+    out_dir = tmp_path / "fixtures"
+    count = build_session_fixtures.build_fixtures(
+        project_root=project_root.resolve(),
+        out_dir=out_dir,
+        write=True,
+        limit=2,
+    )
+    assert count == 2
+    written = sorted(out_dir.glob("*.jsonl"))
+    assert len(written) == 2
+
+
+def test_empty_source_dir_reports_zero(tmp_path, monkeypatch, capsys):
+    _patch_home(monkeypatch, tmp_path / "home")
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    out_dir = tmp_path / "fixtures"
+    count = build_session_fixtures.build_fixtures(
+        project_root=project_root.resolve(),
+        out_dir=out_dir,
+        write=True,
+        limit=None,
+    )
+    assert count == 0
+    captured = capsys.readouterr()
+    assert "No JSONLs found" in captured.err

--- a/tests/unit/ops/test_session_summarizer.py
+++ b/tests/unit/ops/test_session_summarizer.py
@@ -1,0 +1,479 @@
+"""Tests for the Haiku summarizer wire-up (S3b of ops-sessions-page).
+
+All Anthropic SDK calls are mocked — no real API hits in CI. The
+tests cover:
+
+- Env gates: LLM disabled, no API key, explicit ``ATTUNE_OPS_SESSIONS_LLM=0``
+- Cache lifecycle: miss -> Haiku -> save -> hit returns ``source=cached``
+- Redaction is called BEFORE the LLM (decisions.md Decision 3)
+- Budget enforcement: breach skips fresh calls but allows cache reads
+- Failure paths: missing SDK, SDK exception, empty response → ``None``
+- Cost computation matches the registry rates
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from attune.ops import session_summarizer, session_summary_cache
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> Path:
+    """Write a JSONL file with the given events; create parents."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(e) for e in events) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _fake_haiku_response(text: str, *, tokens_in: int = 100, tokens_out: int = 50):
+    """Build a mock ``anthropic`` response object with the expected shape."""
+    content_block = types.SimpleNamespace(text=text, type="text")
+    usage = types.SimpleNamespace(input_tokens=tokens_in, output_tokens=tokens_out)
+    return types.SimpleNamespace(content=[content_block], usage=usage)
+
+
+def _install_fake_anthropic(monkeypatch, *, response=None, exception=None):
+    """Install a fake ``anthropic`` module on sys.modules.
+
+    The fake exposes ``Anthropic(api_key=...)`` returning a client
+    whose ``messages.create(...)`` returns ``response`` or raises
+    ``exception``. Captures the call args on the messages mock so
+    tests can assert that the redacted text was the one sent.
+    """
+    messages_create = MagicMock()
+    if exception is not None:
+        messages_create.side_effect = exception
+    else:
+        messages_create.return_value = response or _fake_haiku_response("(default)")
+
+    client = types.SimpleNamespace(messages=types.SimpleNamespace(create=messages_create))
+
+    class _FakeAnthropic:
+        def __init__(self, *, api_key):
+            assert api_key  # sanity — the summarizer must pass the key
+
+        def __new__(cls, *, api_key):
+            return client
+
+    fake_module = types.ModuleType("anthropic")
+    fake_module.Anthropic = _FakeAnthropic
+    monkeypatch.setitem(sys.modules, "anthropic", fake_module)
+    return messages_create
+
+
+# ---------------------------------------------------------------------------
+# Env gates
+# ---------------------------------------------------------------------------
+
+
+def test_llm_enabled_false_without_api_key(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ATTUNE_OPS_SESSIONS_LLM", raising=False)
+    assert session_summarizer.llm_enabled() is False
+
+
+def test_llm_enabled_true_with_api_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    monkeypatch.delenv("ATTUNE_OPS_SESSIONS_LLM", raising=False)
+    assert session_summarizer.llm_enabled() is True
+
+
+def test_llm_enabled_false_when_explicitly_disabled(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_LLM", "0")
+    assert session_summarizer.llm_enabled() is False
+
+
+def test_summarize_returns_none_when_llm_disabled(tmp_path, monkeypatch):
+    """No LLM available + no cache → None (caller falls back to heuristic)."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    jsonl = _write_jsonl(
+        tmp_path / "session.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": "Test prompt content."}],
+    )
+    result = session_summarizer.summarize_session(jsonl, attune_home=tmp_path / "attune-home")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------------
+
+
+def test_new_budget_uses_default():
+    monkeypatch_clean = pytest.MonkeyPatch()
+    try:
+        monkeypatch_clean.delenv("ATTUNE_OPS_SESSIONS_BUDGET_USD", raising=False)
+        b = session_summarizer.new_budget()
+        assert b.cap_usd == session_summarizer.DEFAULT_BUDGET_USD
+        assert b.spent_usd == 0.0
+        assert b.breached is False
+    finally:
+        monkeypatch_clean.undo()
+
+
+def test_new_budget_reads_env(monkeypatch):
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_BUDGET_USD", "0.25")
+    b = session_summarizer.new_budget()
+    assert b.cap_usd == 0.25
+
+
+def test_new_budget_falls_back_on_invalid_env(monkeypatch):
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_BUDGET_USD", "not-a-float")
+    b = session_summarizer.new_budget()
+    assert b.cap_usd == session_summarizer.DEFAULT_BUDGET_USD
+
+
+def test_new_budget_arg_wins_over_env(monkeypatch):
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_BUDGET_USD", "0.25")
+    b = session_summarizer.new_budget(cap_usd=0.10)
+    assert b.cap_usd == 0.10
+
+
+def test_budget_latches_breached_on_record():
+    b = session_summarizer.Budget(cap_usd=0.05)
+    b.record(0.03)
+    assert b.breached is False
+    b.record(0.03)  # cumulative 0.06 > 0.05
+    assert b.breached is True
+    # Should stay latched even if a subsequent record is small
+    b.record(0.001)
+    assert b.breached is True
+
+
+def test_budget_should_skip_returns_breached_state():
+    # cap=0 is an effective off-switch: latched as breached at
+    # construction so the FIRST call also skips.
+    b = session_summarizer.Budget(cap_usd=0.0)
+    assert b.should_skip() is True
+
+    # Normal cap: starts un-breached, becomes breached after record.
+    b2 = session_summarizer.Budget(cap_usd=0.05)
+    assert b2.should_skip() is False
+    b2.record(0.10)
+    assert b2.should_skip() is True
+
+
+# ---------------------------------------------------------------------------
+# Happy path: Haiku call + cache write + redaction
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_runs_haiku_and_writes_cache(tmp_path, monkeypatch):
+    """Cache miss → redact → call Haiku → cache write → return haiku result."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    create_mock = _install_fake_anthropic(
+        monkeypatch,
+        response=_fake_haiku_response(
+            "Worked on auth. Resume: finish JWT.", tokens_in=500, tokens_out=20
+        ),
+    )
+
+    jsonl = _write_jsonl(
+        tmp_path / "abc12345-c539-4057-ba26-24ce3dffec27.jsonl",
+        [
+            {"timestamp": "2026-05-14T10:00:00Z", "content": "Help me with auth"},
+            {"timestamp": "2026-05-14T10:05:00Z", "content": "Try JWT"},
+        ],
+    )
+    attune_home = tmp_path / "attune-home"
+
+    result = session_summarizer.summarize_session(jsonl, attune_home=attune_home)
+
+    assert result is not None
+    assert result.source == "haiku"
+    assert result.text == "Worked on auth. Resume: finish JWT."
+    assert result.tokens_in == 500
+    assert result.tokens_out == 20
+    # Cost = (500 * 1.00 + 20 * 5.00) / 1_000_000 = 0.0006
+    assert result.cost_usd == pytest.approx(0.0006, abs=1e-6)
+
+    # Cache file should exist with the haiku source
+    cache_path = session_summary_cache.cache_path_for(
+        attune_home, "abc12345-c539-4057-ba26-24ce3dffec27"
+    )
+    assert cache_path.is_file()
+    cached_raw = json.loads(cache_path.read_text())
+    assert cached_raw["source"] == "haiku"
+    assert cached_raw["summary"] == "Worked on auth. Resume: finish JWT."
+
+    # The Anthropic call was made exactly once
+    assert create_mock.call_count == 1
+
+
+def test_summarize_returns_cached_on_second_call(tmp_path, monkeypatch):
+    """Second call with the same file (mtime + tail unchanged) → cache hit."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    create_mock = _install_fake_anthropic(
+        monkeypatch,
+        response=_fake_haiku_response("Summary.", tokens_in=100, tokens_out=10),
+    )
+
+    jsonl = _write_jsonl(
+        tmp_path / "session-001.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": "Hello"}],
+    )
+    attune_home = tmp_path / "attune-home"
+
+    first = session_summarizer.summarize_session(jsonl, attune_home=attune_home)
+    assert first is not None and first.source == "haiku"
+
+    second = session_summarizer.summarize_session(jsonl, attune_home=attune_home)
+    assert second is not None
+    assert second.source == "cached"
+    assert second.text == first.text
+    # The LLM was called exactly once total — second was a cache hit.
+    assert create_mock.call_count == 1
+
+
+def test_summarize_redacts_before_sending(tmp_path, monkeypatch):
+    """The text sent to Haiku must have secrets redacted (Decision 3)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    create_mock = _install_fake_anthropic(
+        monkeypatch,
+        response=_fake_haiku_response("Summary.", tokens_in=10, tokens_out=5),
+    )
+
+    secret_token = "sk-ant-" + "A" * 40  # Anthropic key shape
+    jsonl = _write_jsonl(
+        tmp_path / "session-002.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": f"Here is my key: {secret_token}"}],
+    )
+
+    session_summarizer.summarize_session(jsonl, attune_home=tmp_path / "attune-home")
+
+    # Inspect what got sent
+    assert create_mock.call_count == 1
+    call_kwargs = create_mock.call_args.kwargs
+    sent_text = call_kwargs["messages"][0]["content"]
+    assert secret_token not in sent_text, "secret leaked into LLM call!"
+    assert "<redacted>" in sent_text
+
+
+# ---------------------------------------------------------------------------
+# Budget enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_skips_fresh_call_when_budget_breached(tmp_path, monkeypatch):
+    """Cache miss + budget breached → None (no LLM call)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    create_mock = _install_fake_anthropic(
+        monkeypatch,
+        response=_fake_haiku_response("Summary."),
+    )
+
+    jsonl = _write_jsonl(
+        tmp_path / "session-003.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": "Hello"}],
+    )
+
+    budget = session_summarizer.Budget(cap_usd=0.0)
+    budget.record(0.001)  # immediate breach
+    assert budget.breached
+
+    result = session_summarizer.summarize_session(
+        jsonl, attune_home=tmp_path / "attune-home", budget=budget
+    )
+    assert result is None
+    # The LLM was NOT called.
+    assert create_mock.call_count == 0
+
+
+def test_summarize_returns_cached_even_when_budget_breached(tmp_path, monkeypatch):
+    """A cache hit bypasses the budget — free reads are always allowed."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    _install_fake_anthropic(
+        monkeypatch,
+        response=_fake_haiku_response("Cached!", tokens_in=50, tokens_out=5),
+    )
+
+    jsonl = _write_jsonl(
+        tmp_path / "session-004.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": "Hello"}],
+    )
+    attune_home = tmp_path / "attune-home"
+
+    # Prime the cache with a fresh budget
+    fresh_budget = session_summarizer.Budget(cap_usd=1.0)
+    first = session_summarizer.summarize_session(
+        jsonl, attune_home=attune_home, budget=fresh_budget
+    )
+    assert first is not None and first.source == "haiku"
+
+    # Now blow the budget on a SECOND budget and re-summarize
+    breached_budget = session_summarizer.Budget(cap_usd=0.0)
+    breached_budget.record(0.01)
+    assert breached_budget.breached
+
+    second = session_summarizer.summarize_session(
+        jsonl, attune_home=attune_home, budget=breached_budget
+    )
+    assert second is not None
+    assert second.source == "cached"
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_returns_none_on_sdk_exception(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    _install_fake_anthropic(monkeypatch, exception=RuntimeError("API rate limited"))
+
+    jsonl = _write_jsonl(
+        tmp_path / "session-005.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": "Hello"}],
+    )
+    result = session_summarizer.summarize_session(jsonl, attune_home=tmp_path / "attune-home")
+    assert result is None
+
+
+def test_summarize_returns_none_when_anthropic_module_missing(tmp_path, monkeypatch):
+    """ModuleNotFoundError on ``import anthropic`` → None (no crash)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    # Sentinel: setting sys.modules entry to None makes import raise.
+    monkeypatch.setitem(sys.modules, "anthropic", None)
+
+    jsonl = _write_jsonl(
+        tmp_path / "session-006.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": "Hello"}],
+    )
+    result = session_summarizer.summarize_session(jsonl, attune_home=tmp_path / "attune-home")
+    assert result is None
+
+
+def test_summarize_returns_none_on_empty_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    empty = types.SimpleNamespace(
+        content=[], usage=types.SimpleNamespace(input_tokens=0, output_tokens=0)
+    )
+    _install_fake_anthropic(monkeypatch, response=empty)
+
+    jsonl = _write_jsonl(
+        tmp_path / "session-007.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "content": "Hello"}],
+    )
+    result = session_summarizer.summarize_session(jsonl, attune_home=tmp_path / "attune-home")
+    assert result is None
+
+
+def test_summarize_returns_none_when_no_content_in_jsonl(tmp_path, monkeypatch):
+    """JSONL with no ``content`` fields → no text to summarize → None."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    create_mock = _install_fake_anthropic(
+        monkeypatch, response=_fake_haiku_response("Should not see this")
+    )
+
+    jsonl = _write_jsonl(
+        tmp_path / "session-008.jsonl",
+        [{"timestamp": "2026-05-14T10:00:00Z", "type": "queue-operation"}],
+    )
+    result = session_summarizer.summarize_session(jsonl, attune_home=tmp_path / "attune-home")
+    assert result is None
+    # LLM should NOT have been called
+    assert create_mock.call_count == 0
+
+
+def test_summarize_returns_none_when_jsonl_path_unreadable(tmp_path, monkeypatch):
+    """Missing JSONL → None (cache key computation fails)."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    _install_fake_anthropic(monkeypatch, response=_fake_haiku_response("Hi"))
+    result = session_summarizer.summarize_session(
+        tmp_path / "does-not-exist.jsonl", attune_home=tmp_path / "attune-home"
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Cost computation
+# ---------------------------------------------------------------------------
+
+
+def test_compute_cost_matches_registry_rates():
+    """1M input + 1M output at $1/$5 per million = $6.00 total."""
+    cost = session_summarizer._compute_cost_usd(1_000_000, 1_000_000)
+    assert cost == pytest.approx(6.00, abs=1e-9)
+
+
+def test_compute_cost_zero_tokens():
+    assert session_summarizer._compute_cost_usd(0, 0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Content extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_content_collects_user_prompts(tmp_path):
+    jsonl = _write_jsonl(
+        tmp_path / "session.jsonl",
+        [
+            {"content": "First"},
+            {"timestamp": "skip me"},  # no content
+            {"content": "Second"},
+            {"content": "Third"},
+        ],
+    )
+    text = session_summarizer._extract_content_for_summary(jsonl, char_budget=1000)
+    assert "First" in text
+    assert "Second" in text
+    assert "Third" in text
+
+
+def test_extract_content_respects_char_budget(tmp_path):
+    jsonl = _write_jsonl(
+        tmp_path / "session.jsonl",
+        [{"content": "X" * 100} for _ in range(20)],
+    )
+    text = session_summarizer._extract_content_for_summary(jsonl, char_budget=300)
+    # Should stop accumulating once budget is exhausted; allowing for the
+    # 2-char separator inflation, length stays close to budget.
+    assert len(text) <= 320
+
+
+def test_extract_content_returns_empty_on_missing_file(tmp_path):
+    assert (
+        session_summarizer._extract_content_for_summary(
+            tmp_path / "missing.jsonl", char_budget=1000
+        )
+        == ""
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cache module integration smoke test
+# ---------------------------------------------------------------------------
+
+
+@patch.object(session_summary_cache, "save", side_effect=OSError("disk full"))
+def test_cache_write_failure_does_not_crash(mock_save, tmp_path, monkeypatch):
+    """Cache save errors are best-effort — summarizer still returns the result."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    _install_fake_anthropic(
+        monkeypatch,
+        response=_fake_haiku_response("Summary.", tokens_in=10, tokens_out=5),
+    )
+    jsonl = _write_jsonl(
+        tmp_path / "session.jsonl",
+        [{"content": "Hello"}],
+    )
+    result = session_summarizer.summarize_session(jsonl, attune_home=tmp_path / "attune-home")
+    assert result is not None
+    assert result.source == "haiku"
+    # Save was attempted (and failed)
+    assert mock_save.call_count == 1

--- a/tests/unit/ops/test_sessions_route_s3b.py
+++ b/tests/unit/ops/test_sessions_route_s3b.py
@@ -1,0 +1,268 @@
+"""Tests for S3b dashboard wire-up: HTML compare mode + JSON API.
+
+The deterministic S2/S3a tests already cover the data-layer
+heuristic. These tests cover:
+
+- ``/api/sessions`` returns the spec'd JSON shape
+- ``?compare=1`` renders both heuristic and haiku columns
+- Over-budget marker appears when the budget is exhausted
+- Source chips render correctly (heuristic vs haiku vs cached)
+
+Anthropic calls are mocked; no real LLM hits in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops import data  # noqa: E402
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Shared fixtures + helpers (mirror tests/unit/ops/test_sessions.py)
+# ---------------------------------------------------------------------------
+
+
+def _patch_home(monkeypatch, home_path: Path) -> None:
+    """Patch ``Path.home()`` to ``home_path`` on every platform.
+
+    Mirrors the helper in test_sessions.py — must set both env vars
+    so the test works on Windows runners too.
+    """
+    home_str = str(home_path)
+    monkeypatch.setenv("HOME", home_str)
+    monkeypatch.setenv("USERPROFILE", home_str)
+
+
+def _write_session(home: Path, project_root: Path, session_id: str, content: str) -> Path:
+    sessions_dir = home / ".claude" / "projects" / data._encoded_project_path(project_root)
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    path = sessions_dir / f"{session_id}.jsonl"
+    path.write_text(
+        json.dumps({"timestamp": "2026-05-14T10:00:00Z", "content": content}) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _install_fake_anthropic(monkeypatch, *, summary_text: str = "Worked on X. Resume: continue."):
+    """Install a fake ``anthropic`` module that returns ``summary_text``."""
+    from unittest.mock import MagicMock
+
+    content_block = types.SimpleNamespace(text=summary_text, type="text")
+    usage = types.SimpleNamespace(input_tokens=100, output_tokens=20)
+    response = types.SimpleNamespace(content=[content_block], usage=usage)
+
+    create_mock = MagicMock(return_value=response)
+    client = types.SimpleNamespace(messages=types.SimpleNamespace(create=create_mock))
+
+    class _FakeAnthropic:
+        def __new__(cls, *, api_key):
+            return client
+
+    fake_module = types.ModuleType("anthropic")
+    fake_module.Anthropic = _FakeAnthropic
+    monkeypatch.setitem(sys.modules, "anthropic", fake_module)
+    return create_mock
+
+
+def _make_app(tmp_path: Path, monkeypatch) -> object:
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    _patch_home(monkeypatch, tmp_path / "home")
+    config = build_config(
+        project_root=tmp_path / "project",
+        trusted_hosts=("testserver", "test"),
+    )
+    return create_app(config)
+
+
+# ---------------------------------------------------------------------------
+# /api/sessions JSON
+# ---------------------------------------------------------------------------
+
+
+def test_api_sessions_returns_spec_shape_with_haiku(tmp_path, monkeypatch):
+    """``GET /api/sessions`` returns ``{sessions: [...], meta: {...}}``
+    with each session carrying the source field.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    _install_fake_anthropic(monkeypatch, summary_text="Worked on auth.")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_session(tmp_path / "home", project_root, "abc12345-def", "Help with auth")
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/api/sessions")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "sessions" in body
+    assert "meta" in body
+    assert body["meta"]["llm_enabled"] is True
+    assert body["meta"]["budget_exceeded"] is False
+
+    assert len(body["sessions"]) == 1
+    row = body["sessions"][0]
+    expected_keys = {
+        "id",
+        "started_at",
+        "last_activity",
+        "duration_seconds",
+        "message_count",
+        "starter_prompt",
+        "source",
+    }
+    assert expected_keys.issubset(row.keys())
+    assert row["id"] == "abc12345-def"
+    assert row["source"] == "haiku"
+    assert row["starter_prompt"] == "Worked on auth."
+
+
+def test_api_sessions_returns_heuristic_when_llm_disabled(tmp_path, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_LLM", "0")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_session(tmp_path / "home", project_root, "xyz-001", "Heuristic prompt content")
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/api/sessions")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meta"]["llm_enabled"] is False
+    assert len(body["sessions"]) == 1
+    row = body["sessions"][0]
+    assert row["source"] == "heuristic"
+    assert "Heuristic prompt content" in row["starter_prompt"]
+
+
+def test_api_sessions_returns_empty_on_no_data(tmp_path, monkeypatch):
+    """No sessions dir → empty list, 200 OK (not 404)."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/api/sessions")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sessions"] == []
+
+
+# ---------------------------------------------------------------------------
+# Cached source field on second load
+# ---------------------------------------------------------------------------
+
+
+def test_api_sessions_second_load_returns_cached_source(tmp_path, monkeypatch):
+    """First load runs Haiku; second load (cache hit) reports source=cached."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    create_mock = _install_fake_anthropic(monkeypatch, summary_text="Auth work.")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_session(tmp_path / "home", project_root, "session-cached-001", "Help with auth")
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        first = client.get("/api/sessions").json()
+        second = client.get("/api/sessions").json()
+
+    assert first["sessions"][0]["source"] == "haiku"
+    assert second["sessions"][0]["source"] == "cached"
+    # Cache hit means only one LLM call across two HTTP requests.
+    assert create_mock.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# ?compare=1 dev mode
+# ---------------------------------------------------------------------------
+
+
+def test_sessions_page_compare_mode_renders_both_columns(tmp_path, monkeypatch):
+    """``?compare=1`` renders Heuristic and Haiku side-by-side."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    _install_fake_anthropic(monkeypatch, summary_text="HAIKU_SUMMARY_TEXT")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_session(tmp_path / "home", project_root, "abc12345-cmp", "ORIGINAL_PROMPT_TEXT")
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions?compare=1")
+
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Compare mode" in body
+    # Heuristic column header
+    assert "Heuristic" in body
+    # Haiku column header
+    assert "Haiku" in body
+    # Both prompts present
+    assert "ORIGINAL_PROMPT_TEXT" in body
+    assert "HAIKU_SUMMARY_TEXT" in body
+
+
+def test_sessions_page_normal_mode_does_not_show_compare_chrome(tmp_path, monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_session(tmp_path / "home", project_root, "abc12345-norm", "Test prompt")
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions")
+
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Compare mode" not in body
+
+
+# ---------------------------------------------------------------------------
+# Over-budget marker
+# ---------------------------------------------------------------------------
+
+
+def test_sessions_page_renders_over_budget_marker(tmp_path, monkeypatch):
+    """Setting the budget to 0 forces a breach on the first call →
+    the over-budget marker appears in the rendered page.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")  # pragma: allowlist secret
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_BUDGET_USD", "0.0")
+    _install_fake_anthropic(monkeypatch, summary_text="Should not appear")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    # Write 2 sessions; the first call would breach with cap=0, so
+    # both rows render heuristic. The marker fires once.
+    _write_session(tmp_path / "home", project_root, "s-001", "First prompt")
+    _write_session(tmp_path / "home", project_root, "s-002", "Second prompt")
+
+    app = _make_app(tmp_path, monkeypatch)
+    with TestClient(app) as client:
+        resp = client.get("/sessions")
+
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Per-page Haiku budget exceeded" in body
+    # Heuristic content survived
+    assert "First prompt" in body
+    assert "Second prompt" in body


### PR DESCRIPTION
## Summary

- Wires the Haiku summarizer into the /sessions page, gated on `ATTUNE_OPS_SESSIONS_LLM` + `ANTHROPIC_API_KEY`. Per-row `source` chip surfaces which lane produced the text (`heuristic` | `haiku` | `cached`).
- Discipline (decisions.md Decision 3): **redact first, then send, then cache** — `session_redaction.redact()` runs over the JSONL content slice before any LLM call, and the cache persists the already-redacted summary so cache hits inherit the redaction.
- Per-page-load budget cap (`ATTUNE_OPS_SESSIONS_BUDGET_USD`, default $0.05). Breached rows fall back to the heuristic with a one-time "over budget" marker. `cap=0` is the effective off-switch — latched as breached at construction.
- New `GET /api/sessions` JSON endpoint mirroring the HTML page's enrichment helper. Shape: `{sessions: [...], meta: {budget_exceeded, llm_enabled}}`.
- New `?compare=1` dev affordance — renders heuristic and Haiku columns side-by-side. No UI button; discoverable only by URL.
- New `scripts/build_session_fixtures.py` — dry-run-by-default helper that walks `~/.claude/projects/<encoded>*`, redacts each event's `content`, and writes redacted JSONLs to `tests/fixtures/ops/session_summaries/`. Patrick reviews each before committing (per decisions.md Decision 8).

Stretches the existing `session_summary_cache` + `session_redaction` modules shipped in S3a (#387) and the redaction shipped in #384.

Resume-card scope (S4) and live-session detection (S5) intentionally deferred. Snapshot test + committed redacted fixtures defer to a post-S3 follow-up pending interactive curation.

## Ship-log updates (docs/specs/ops-sessions-page/decisions.md)

- Starter-prompt generation (Haiku) → **shipped**
- Budget cap → **shipped** (soft warning surfaced in template)
- Source field semantics → **shipped**
- Compare mode → **shipped**
- Listing JSON shape → **shipped**
- Calibration harness → **partial** (script ships; fixtures + snapshot test defer)

## Test plan

- [x] `pytest tests/unit/ops/` — 417 pass (61 new: summarizer 35, route 7, script 11, supporting smokes)
- [x] ruff + black + bandit + detect-secrets clean on the changed surface (pre-commit pass)
- [x] No real LLM hits in CI — all Anthropic SDK calls mocked via `sys.modules["anthropic"]` injection
- [ ] Manual eyeball: `/sessions?compare=1` with `ANTHROPIC_API_KEY` set against this branch — pre-launch validation that Haiku spend is actually buying improved output (Patrick's interactive review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
