### PR TITLE
docs(scripts/score_test_quality): document correct pytest scope

### DIFF
--- a/scripts/score_test_quality.py
+++ b/scripts/score_test_quality.py
@@ -13,7 +13,25 @@ Output:
 If coverage.xml is missing, every module gets coverage_gap=1.0.
 The relative ordering of customer_weight × risk_multiplier still
 surfaces a defensible first working set; refresh after a fresh
-`pytest --cov=src/attune --cov-report=xml` for sharper gap data.
+coverage run for sharper gap data.
+
+How to refresh coverage.xml correctly
+-------------------------------------
+
+    pytest --cov=src/attune --cov-report=xml:/tmp/coverage.xml -q \\
+      -m "not network and not integration"
+    python scripts/score_test_quality.py /tmp/coverage.xml
+
+The `pytest` invocation MUST collect from the whole `tests/`
+directory (the default via `testpaths = ["tests"]` in
+`pyproject.toml`) — NOT scoped to `tests/unit/` alone. Modules
+whose primary tests live in `tests/security/`,
+`tests/integration/`, etc. otherwise show up with spuriously-low
+`covered_pct` in the cache, and the rubric promotes already-
+well-covered modules as picks. Verified failure mode 2026-05-14:
+`memory/security/secrets_detector.py` reported 60.3% from a
+`tests/unit/`-only run, actual 90.96% under `tests/`. See
+`docs/COVERAGE_BUG_LOG.md` 2026-05-14 entry.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Adds an explicit "How to refresh coverage.xml correctly" section to the docstring of \`scripts/score_test_quality.py\`. The key constraint:

> Run \`pytest tests/\` (the default via \`testpaths = ["tests"]\` in \`pyproject.toml\`), NOT \`pytest tests/unit/\`.

The narrower scope omits \`tests/security/\`, \`tests/integration/\`, etc. and produces **spuriously-low \`covered_pct\` values** in \`rubric_cache.csv\` — which then promotes already-well-covered modules as picks for the test-quality-program.

## Motivation

Triggered by the 2026-05-14 \`memory/security/secrets_detector.py\` cycle ([PR #347](https://github.com/Smart-AI-Memory/attune-ai/pull/347)):

- Rubric reported the module at **60.3% covered**
- Actual coverage was **90.96%**
- The refresh command had narrowed scope to \`tests/unit/\`, missing the security tests that exercise the module

See \`docs/COVERAGE_BUG_LOG.md\` 2026-05-14 entry for full diagnosis.

## Test plan

- [x] Docstring renders correctly in \`--help\` output
- [x] No behavior changes — pure documentation
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)