### PR TITLE
fix(scripts): build_session_fixtures uses recursive redact_json_line()

### DIFF
--- a/scripts/build_session_fixtures.py
+++ b/scripts/build_session_fixtures.py
@@ -2,9 +2,14 @@
 """Build redacted session-summary calibration fixtures from real JSONLs.
 
 Walks ``~/.claude/projects/<encoded>*`` for the chosen project,
-applies :func:`attune.ops.session_redaction.redact` to every event
-that carries a ``content`` field, and writes the redacted JSONL to
-the calibration fixture directory.
+applies :func:`attune.ops.session_redaction.redact_json_line` to
+every line, and writes the redacted JSONL to the calibration
+fixture directory. ``redact_json_line`` covers EVERY nested string
+in any tree shape (``message.content[].text``,
+``toolUseResult.stdout``, arbitrary tool-call payloads), not just
+top-level ``event["content"]`` — load-bearing per the security fix
+in #389 (real Anthropic API key + thousands of unredacted home
+paths nearly leaked from a top-level-only walk).
 
 **Dry-run by default.** Pass ``--write`` to persist. The redacted
 content is committed to git per decisions.md Decision 8
@@ -38,7 +43,6 @@ decisions.md Decision 8.
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from collections.abc import Iterable
 from pathlib import Path
@@ -75,13 +79,19 @@ def _enumerate_jsonls(project_root: Path) -> list[Path]:
 def _redact_jsonl(source: Path) -> tuple[list[str], dict[str, int]]:
     """Return ``(redacted_lines, counts)`` for one JSONL file.
 
-    Per-event redaction: only the ``content`` string is rewritten;
-    timestamps, types, and other metadata pass through unchanged.
-    Counts aggregate across all events in the file.
+    Uses :func:`attune.ops.session_redaction.redact_json_line` so
+    EVERY nested string in the document gets covered — including
+    ``message.content[].text``, ``toolUseResult.stdout``, and
+    arbitrary tool-call payloads where Claude Code's session JSONLs
+    nest the conversation content. The earlier top-level-only
+    ``event["content"]`` walk left REAL Anthropic API keys + 12,623
+    unredacted home paths in the harvest 2026-05-15 (#389).
 
-    Lines that aren't JSON or aren't dicts are emitted verbatim —
-    they have no addressable ``content`` field to redact and the
-    summarizer would skip them anyway.
+    Lines that fail the round-trip (invalid JSON in, or redaction
+    breaking a JSON escape boundary on the way out) are dropped
+    with a stderr warning rather than emitted verbatim — emitting
+    a line that failed redaction defeats the purpose. Counts
+    aggregate across all events in the file.
     """
     redacted_lines: list[str] = []
     total_counts: dict[str, int] = {}
@@ -92,21 +102,21 @@ def _redact_jsonl(source: Path) -> tuple[list[str], dict[str, int]]:
                 if not line.strip():
                     redacted_lines.append(line)
                     continue
-                try:
-                    event = json.loads(line)
-                except json.JSONDecodeError:
-                    redacted_lines.append(line)
+                result = session_redaction.redact_json_line(line)
+                if result is None:
+                    # Either the input wasn't valid JSON or
+                    # redaction would have produced invalid JSON
+                    # (escape-boundary collision). Drop the line
+                    # rather than ship a malformed fixture or
+                    # leave a leak in.
+                    print(
+                        f"  ! skipped malformed line in {source.name}",
+                        file=sys.stderr,
+                    )
                     continue
-                if not isinstance(event, dict):
-                    redacted_lines.append(line)
-                    continue
-                content = event.get("content")
-                if isinstance(content, str) and content:
-                    result = session_redaction.redact(content)
-                    event["content"] = result.text
-                    for k, v in result.counts.items():
-                        total_counts[k] = total_counts.get(k, 0) + v
-                redacted_lines.append(json.dumps(event, ensure_ascii=False))
+                for k, v in result.counts.items():
+                    total_counts[k] = total_counts.get(k, 0) + v
+                redacted_lines.append(result.text)
     except OSError as exc:
         print(f"  ERROR reading {source}: {exc}", file=sys.stderr)
         return [], {}


### PR DESCRIPTION
## Summary

**Hotfix.** The build script that shipped via [#390](https://github.com/Smart-AI-Memory/attune-ai/pull/390) calls `session_redaction.redact()` on top-level `event["content"]` only — the same naive walk that triggered [#389](https://github.com/Smart-AI-Memory/attune-ai/pull/389)'s near-miss (real Anthropic API key + 12,623 unredacted home paths leaked during harvest because Claude Code session JSONLs nest content under `message.content[].text` and `toolUseResult.stdout`, not at the top level).

If anyone runs `python scripts/build_session_fixtures.py` against real sessions today, **the output will leak secrets**.

## The fix

Swap `_redact_jsonl()` to call `session_redaction.redact_json_line()` (added in #389) which operates on the JSON-serialized form so every nested string gets covered. Lines that fail the round-trip (invalid JSON in or escape-boundary breakage out) are dropped with a stderr warning rather than emitted verbatim.

## Smoke test against 2 real sessions

| Session | Redactions counted (was 0 with top-level walk) |
|---------|------------------------------------------------|
| `389eb901` | api_key=17, context_key=2, email=8, ip=5, user_home_path=1306 |
| `2b0a6775` | ip=24, user_home_path=800 |

Post-redaction scan against the 6-pattern secret panel: **0 leaks** in either output file.

## Backstops

- Committed fixtures from [#393](https://github.com/Smart-AI-Memory/attune-ai/pull/393) are unaffected — they were harvested with the recursive redaction in (closed) #388 and re-scanned clean before commit
- The CI snapshot test from #393 (`test_session_redaction_snapshot.py`) catches any future regression to top-level walking by asserting committed fixtures contain zero leaked secrets

## Test plan

- [x] Smoke test verified output is leak-free across the 6-pattern panel
- [x] Pre-commit hooks pass
- [ ] Windows CI lanes green (script change is platform-independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)