### PR TITLE
feat(ops): /sessions calibration harness — Haiku cost/length snapshot CI gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `scripts/calibrate_session_summary.py` + companion CI gate
+  `tests/unit/ops/test_calibration_snapshot.py` — closes the
+  calibration loop for the `/sessions` Haiku summarizer. The
+  script runs Haiku over every committed fixture in
+  `tests/fixtures/ops/session_summaries/*.jsonl` and emits a
+  per-fixture `{tokens_in, tokens_out, cost_usd, summary,
+  summary_chars}` snapshot. Default mode regenerates the
+  snapshot; `--check` mode fails on drift past configurable
+  tolerances (±10% input tokens, ±50% output tokens, ±20% cost
+  per decisions.md Decision 8, ±50% summary length); `--dry-run`
+  lists fixtures + prompt fingerprint without API calls. The
+  CI test does **not** make real Haiku calls — it asserts the
+  committed snapshot is structurally sound + within plausible
+  cost bands + hash-consistent with the current
+  `SUMMARY_PROMPT`. Skips cleanly when the snapshot is absent
+  (fresh clone before first calibration). Runbook at
+  `docs/specs/ops-sessions-page/calibration-runbook.md`.
+
 - Ops `/sessions` page now uses Haiku-summarized starter prompts
   (S3b of `docs/specs/ops-sessions-page/`). Wires the existing
   `session_redaction` + `session_summary_cache` modules behind a

--- a/docs/specs/ops-sessions-page/calibration-runbook.md
+++ b/docs/specs/ops-sessions-page/calibration-runbook.md
@@ -1,0 +1,174 @@
+# Calibration runbook
+
+> How to seed and maintain
+> `tests/fixtures/ops/session_summaries/snapshot.json` — the
+> regression gate for the Haiku starter-prompt summarizer.
+
+---
+
+## Background
+
+The `/sessions` page calls Haiku-4.5 to summarize each session's
+opening prompt. The output is sensitive to two things:
+
+1. The exact text of `attune.ops.session_summarizer.SUMMARY_PROMPT`
+2. The model itself (Anthropic ships new Haiku revisions
+   periodically)
+
+A change to either can quietly regress output quality, length, or
+cost. The committed `snapshot.json` is the regression gate — it
+holds one row per fixture with the Haiku tokens, cost, and summary
+text from the last accepted calibration run.
+
+---
+
+## When to re-run the calibrator
+
+- You edited `SUMMARY_PROMPT` in `src/attune/ops/session_summarizer.py`
+- You added or removed a fixture in
+  `tests/fixtures/ops/session_summaries/*.jsonl`
+- You bumped the Haiku model ID (the snapshot stores the model id,
+  so a mismatch fails the test)
+- Periodic re-baseline against the current Haiku release (quarterly
+  is plenty; the snapshot is a regression gate, not a quality
+  benchmark)
+
+You do **not** need to re-run for:
+
+- Pure refactors of `session_summarizer.py` that don't change the
+  prompt
+- Cache module changes (the calibrator uses a fresh tempdir cache)
+- Changes elsewhere in the codebase
+
+---
+
+## Run the calibrator
+
+```bash
+# From the repo root, with ANTHROPIC_API_KEY in your env
+ATTUNE_OPS_SESSIONS_LLM=1 \
+  python scripts/calibrate_session_summary.py
+```
+
+Output:
+
+```text
+Model:         claude-haiku-4-5-20251001
+Prompt hash:   b837f64e77aa
+Fixtures:      12 from tests/fixtures/ops/session_summaries
+Snapshot:      tests/fixtures/ops/session_summaries/snapshot.json
+
+Fresh totals:  {'fixtures': 12, 'succeeded': 12, 'tokens_in': ...,
+                'tokens_out': ..., 'cost_usd': 0.0xxx}
+
+Snapshot written to tests/fixtures/ops/session_summaries/snapshot.json
+Total cost:    $0.0xxx
+
+Review the diff and commit when satisfied:
+  git diff tests/fixtures/ops/session_summaries/snapshot.json
+```
+
+Cost is typically ~$0.02 (12 fixtures × ~$0.001 each). The
+calibrator uses a fresh tempdir cache, so every fixture incurs a
+real Haiku call — no cache hits inflate the "this seems free"
+illusion.
+
+---
+
+## Inspect + commit
+
+```bash
+git diff tests/fixtures/ops/session_summaries/snapshot.json
+```
+
+Look for:
+
+- **Tokens / cost** — drift past ±20% on `cost_usd` is the
+  threshold the `--check` mode flags. A larger drift means
+  something material changed (prompt got chattier, fixture got
+  longer, model got more verbose).
+- **Summary samples** — random-spot-check 2-3 to make sure the
+  output still matches decisions.md Decision 2 (one short
+  sentence, optional 0-3 bullets, `Resume:` line). If a recent
+  prompt edit dropped the structural rules, you'll see it here.
+- **Prompt hash** — should match the new `SUMMARY_PROMPT` you
+  edited. The test asserts this so a stale snapshot can't sneak
+  in.
+
+When you're satisfied:
+
+```bash
+git add tests/fixtures/ops/session_summaries/snapshot.json
+git commit -m "calib(session-summary): regen snapshot after prompt edit"
+```
+
+---
+
+## Check mode (CI-style dry-run)
+
+Use `--check` to verify a fresh run matches the committed
+snapshot without overwriting it. Useful as a pre-PR sanity check
+or in a nightly cron:
+
+```bash
+ATTUNE_OPS_SESSIONS_LLM=1 \
+  python scripts/calibrate_session_summary.py --check
+```
+
+Per-field tolerances:
+
+| Field | Tolerance | Why |
+|-------|-----------|-----|
+| `tokens_in` | ±10% | Input is the redacted text; mostly stable |
+| `tokens_out` | ±50% | Haiku output length varies more |
+| `cost_usd` | ±20% | Per decisions.md Decision 8 |
+| `summary_chars` | ±50% | Sanity check; catches empty / runaway |
+
+Exit code is 1 if any fixture drifts past its tolerance; the
+report lists every drifting fixture + field + observed ratio.
+
+---
+
+## Dry-run (no API calls)
+
+```bash
+python scripts/calibrate_session_summary.py --dry-run
+```
+
+Lists the fixture set + prints the current prompt fingerprint
+(SHA-256[:12]). Useful for "I just want to know what the prompt
+hash is right now" — e.g. to compare against what's in the
+committed snapshot before deciding whether a re-run is needed.
+
+---
+
+## CI gate
+
+`tests/unit/ops/test_calibration_snapshot.py` runs on every CI
+build. It does **not** make Haiku calls — it asserts the
+committed snapshot is:
+
+- Structurally sound (right top-level fields, model id matches,
+  one row per fixture on disk)
+- Within plausible cost bands (per-fixture ≤ $0.05, total ≤ $0.10)
+- Hash-consistent with the current `SUMMARY_PROMPT`
+
+When the snapshot is absent (fresh clone before first
+calibration), every test in the file skips — no false failures
+during initial setup.
+
+---
+
+## Open boxes the snapshot fills
+
+Once you've run the calibrator and committed the snapshot, the
+following items in `decisions.md`'s calibration record stop being
+"to fill in" boxes and become reportable facts:
+
+- Average tokens per summary (in / out) — read from
+  `snapshot.json` `totals.tokens_in / totals.fixtures`
+- Average cost per session summary — `totals.cost_usd /
+  totals.fixtures`
+- Whether the budget cap ever fires during normal usage — observe
+  over the first week of production use; the snapshot's
+  per-fixture max cost is the proxy

--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -306,7 +306,7 @@ reader knows it's not part of the user-facing surface.
 | Resume card (current-worktree → canonical) | TBD (S4) | pending |
 | Live-session detection | TBD (S5) | pending |
 | Compare mode (`?compare=1`) | S3b — `sessions_page` route query param + template branch | shipped |
-| Calibration harness | S3b (partial) — `scripts/build_session_fixtures.py` ships dry-run + write paths; committed fixtures + snapshot test defer to post-S3 follow-up pending interactive curation | partial |
+| Calibration harness | S3b — `scripts/build_session_fixtures.py` (build), #393 — 12 committed redacted fixtures + `tests/unit/ops/test_session_redaction_snapshot.py` (redaction gate), post-S3 follow-up — `scripts/calibrate_session_summary.py` + `tests/unit/ops/test_calibration_snapshot.py` (Haiku cost/length gate) + `docs/specs/ops-sessions-page/calibration-runbook.md` | shipped |
 | Expand-on-click body | TBD (S4 or later) | pending |
 
 ---

--- a/scripts/calibrate_session_summary.py
+++ b/scripts/calibrate_session_summary.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Calibration harness for the /sessions Haiku summarizer.
+
+Runs ``attune.ops.session_summarizer.summarize_session()`` over every
+committed fixture at ``tests/fixtures/ops/session_summaries/*.jsonl``
+and emits a per-fixture record of
+``{tokens_in, tokens_out, cost_usd, summary, summary_chars}`` to
+``tests/fixtures/ops/session_summaries/snapshot.json``. The snapshot
+is committed so future Haiku-prompt edits surface as a visible diff
+the developer must review (and re-commit) before landing.
+
+**Default mode** — regenerates the snapshot:
+
+    ATTUNE_OPS_SESSIONS_LLM=1 python scripts/calibrate_session_summary.py
+
+Requires ``ANTHROPIC_API_KEY`` in the environment. Uses a fresh
+tempdir for the on-disk cache so every fixture incurs a real Haiku
+call (no cache hits). Total spend per run: ~$0.02 at $0.001/fixture
+× 12 fixtures.
+
+**``--check`` mode** — fails on drift past the configured tolerance.
+Compares a fresh run against the committed snapshot and exits 1 if
+any fixture drifts more than:
+
+- ``±10%`` on ``tokens_in`` (input is the redacted text, mostly stable)
+- ``±50%`` on ``tokens_out`` (Haiku output length varies more)
+- ``±20%`` on ``cost_usd`` (per decisions.md Decision 8)
+- ``±50%`` on ``summary_chars`` (length-of-summary sanity)
+
+Useful for developers who edit ``session_summarizer.SUMMARY_PROMPT``
+and want to verify the prompt change doesn't blow up cost or
+output shape before re-committing the snapshot.
+
+**``--dry-run`` mode** — lists what would be summarized + the
+fingerprint of the current prompt, without calling Haiku. Free.
+
+The harness intentionally does NOT run inside CI's pytest suite —
+that would require ``ANTHROPIC_API_KEY`` in CI secrets and burn
+~$0.02 per build. The sibling ``tests/unit/ops/test_calibration_snapshot.py``
+provides the CI gate (asserts the committed snapshot is structurally
+sound + costs are within plausible ranges).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# scripts/ is not on the import path by default; add src/ relative
+# to this file's location (scripts/ sits next to src/).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from attune.ops import session_summarizer  # noqa: E402
+
+DEFAULT_FIXTURE_DIR = (
+    Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "ops" / "session_summaries"
+)
+DEFAULT_SNAPSHOT = DEFAULT_FIXTURE_DIR / "snapshot.json"
+
+# Drift tolerances for --check mode. Tighter on inputs (deterministic
+# given a stable prompt), looser on outputs (Haiku varies). See module
+# docstring for rationale.
+_TOLERANCE = {
+    "tokens_in": 0.10,
+    "tokens_out": 0.50,
+    "cost_usd": 0.20,
+    "summary_chars": 0.50,
+}
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """One fixture's drift result."""
+
+    fixture: str
+    failures: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+def _hash_prompt() -> str:
+    """SHA-256 of the current SUMMARY_PROMPT — first 12 hex chars.
+
+    Bundled into the snapshot so a prompt-only edit (which is what
+    the snapshot is designed to catch) shows up as a visible diff
+    in the snapshot JSON, separately from the per-fixture changes.
+    """
+    h = hashlib.sha256(session_summarizer.SUMMARY_PROMPT.encode("utf-8"))
+    return h.hexdigest()[:12]
+
+
+def _summarize_one(fixture: Path, attune_home: Path) -> dict:
+    """Run the summarizer against one fixture; return a snapshot row.
+
+    Returns ``{"error": "..."}`` if the summarizer returns None
+    (LLM disabled, redaction failure, etc.) so the snapshot still
+    records that the fixture was attempted.
+    """
+    # Fresh budget per fixture so a hypothetical breach in one
+    # doesn't affect the next. Cap is generous ($10) — the budget
+    # belongs in production-render code paths, not here.
+    budget = session_summarizer.Budget(cap_usd=10.0)
+    result = session_summarizer.summarize_session(fixture, attune_home=attune_home, budget=budget)
+    if result is None:
+        return {"error": "summarize_session returned None"}
+    return {
+        "source": result.source,
+        "tokens_in": result.tokens_in,
+        "tokens_out": result.tokens_out,
+        "cost_usd": round(result.cost_usd, 6),
+        "summary": result.text,
+        "summary_chars": len(result.text),
+    }
+
+
+def _build_snapshot(fixtures: list[Path], attune_home: Path) -> dict:
+    """Run the summarizer over every fixture, build the snapshot dict."""
+    per_fixture = {f.name: _summarize_one(f, attune_home) for f in sorted(fixtures)}
+    succeeded = [v for v in per_fixture.values() if "error" not in v]
+    totals = {
+        "fixtures": len(per_fixture),
+        "succeeded": len(succeeded),
+        "tokens_in": sum(v["tokens_in"] for v in succeeded),
+        "tokens_out": sum(v["tokens_out"] for v in succeeded),
+        "cost_usd": round(sum(v["cost_usd"] for v in succeeded), 6),
+    }
+    return {
+        "model": session_summarizer.HAIKU_MODEL_ID,
+        "prompt_hash": _hash_prompt(),
+        "totals": totals,
+        "fixtures": per_fixture,
+    }
+
+
+def _compute_drift(
+    committed: dict,
+    fresh: dict,
+    *,
+    tolerance: dict[str, float] = _TOLERANCE,
+) -> list[DriftReport]:
+    """Compare two snapshots per-fixture; return per-fixture drift reports.
+
+    A missing fixture in either side counts as a drift failure for
+    that fixture so a developer can't silently remove a fixture from
+    the calibration set by re-running the calibrator without --check.
+    """
+    reports: list[DriftReport] = []
+    committed_fx = committed.get("fixtures", {})
+    fresh_fx = fresh.get("fixtures", {})
+
+    for name in sorted(set(committed_fx) | set(fresh_fx)):
+        failures: list[str] = []
+        c = committed_fx.get(name)
+        f = fresh_fx.get(name)
+        if c is None:
+            failures.append("fixture present in fresh run but not committed snapshot")
+            reports.append(DriftReport(fixture=name, failures=failures))
+            continue
+        if f is None:
+            failures.append("fixture present in committed snapshot but not fresh run")
+            reports.append(DriftReport(fixture=name, failures=failures))
+            continue
+        if "error" in c or "error" in f:
+            if c.get("error") != f.get("error"):
+                failures.append(
+                    f"error status changed: committed={c.get('error')!r}, "
+                    f"fresh={f.get('error')!r}"
+                )
+            reports.append(DriftReport(fixture=name, failures=failures))
+            continue
+        for field, tol in tolerance.items():
+            c_val = float(c.get(field, 0))
+            f_val = float(f.get(field, 0))
+            if c_val == 0:
+                # Avoid div-by-zero. Treat 0→nonzero as a drift.
+                if f_val != 0:
+                    failures.append(
+                        f"{field}: committed=0, fresh={f_val} (any change from zero is a drift)"
+                    )
+                continue
+            ratio = abs(f_val - c_val) / c_val
+            if ratio > tol:
+                failures.append(
+                    f"{field}: committed={c_val}, fresh={f_val}, "
+                    f"drift={ratio:.1%} (tolerance ±{tol:.0%})"
+                )
+        reports.append(DriftReport(fixture=name, failures=failures))
+    return reports
+
+
+def _format_drift_summary(reports: list[DriftReport]) -> str:
+    """Human-readable drift summary for --check mode output."""
+    failing = [r for r in reports if not r.ok]
+    if not failing:
+        return "OK — snapshot matches within tolerance."
+    lines = [f"DRIFT — {len(failing)} of {len(reports)} fixtures failed:"]
+    for r in failing:
+        lines.append(f"  {r.fixture}:")
+        for failure in r.failures:
+            lines.append(f"    - {failure}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Calibration harness for the /sessions Haiku summarizer.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Regenerate snapshot (requires ANTHROPIC_API_KEY)\n"
+            "  python scripts/calibrate_session_summary.py\n\n"
+            "  # Check fresh run against committed snapshot — fail on drift\n"
+            "  python scripts/calibrate_session_summary.py --check\n\n"
+            "  # Dry-run — show prompt fingerprint, no API calls\n"
+            "  python scripts/calibrate_session_summary.py --dry-run\n"
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compare fresh run to committed snapshot; exit 1 on drift.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print prompt fingerprint + fixture list; no Haiku calls.",
+    )
+    parser.add_argument(
+        "--fixtures",
+        type=Path,
+        default=DEFAULT_FIXTURE_DIR,
+        help=f"Fixture directory (default: {DEFAULT_FIXTURE_DIR})",
+    )
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        default=DEFAULT_SNAPSHOT,
+        help=f"Snapshot file (default: {DEFAULT_SNAPSHOT})",
+    )
+    parser.add_argument(
+        "--attune-home",
+        type=Path,
+        default=None,
+        help="Cache dir (default: fresh tempdir each run so every call is real).",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if not args.fixtures.is_dir():
+        print(f"ERROR: fixture dir not found: {args.fixtures}", file=sys.stderr)
+        return 1
+    fixtures = sorted(args.fixtures.glob("*.jsonl"))
+    if not fixtures:
+        print(f"ERROR: no *.jsonl fixtures in {args.fixtures}", file=sys.stderr)
+        return 1
+
+    prompt_hash = _hash_prompt()
+    print(f"Model:         {session_summarizer.HAIKU_MODEL_ID}")
+    print(f"Prompt hash:   {prompt_hash}")
+    print(f"Fixtures:      {len(fixtures)} from {args.fixtures}")
+    print(f"Snapshot:      {args.snapshot}")
+    print()
+
+    if args.dry_run:
+        for f in fixtures:
+            print(f"  {f.name}")
+        print()
+        print("Dry-run — no Haiku calls made.")
+        return 0
+
+    # Live runs need the LLM gate flipped + a key in the env. The
+    # summarizer's own llm_enabled() check would otherwise return
+    # None on every fixture and the snapshot would be all errors.
+    if not session_summarizer.llm_enabled():
+        print(
+            "ERROR: Haiku path disabled. Need ANTHROPIC_API_KEY in env "
+            "AND ATTUNE_OPS_SESSIONS_LLM not set to '0'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Fresh tempdir for the cache means every fixture incurs a real
+    # call (no cache hits from a prior run). Override via --attune-home
+    # if you want to inspect the cache files afterward.
+    cleanup_tempdir = False
+    if args.attune_home is None:
+        attune_home = Path(tempfile.mkdtemp(prefix="attune-calib-"))
+        cleanup_tempdir = True
+    else:
+        attune_home = args.attune_home
+        attune_home.mkdir(parents=True, exist_ok=True)
+
+    try:
+        fresh = _build_snapshot(fixtures, attune_home)
+    finally:
+        if cleanup_tempdir:
+            # Best-effort cleanup. Tempdir contents are just cached
+            # summary JSONs — small, won't accumulate.
+            import shutil
+
+            shutil.rmtree(attune_home, ignore_errors=True)
+
+    print(f"Fresh totals:  {fresh['totals']}")
+    print()
+
+    if args.check:
+        if not args.snapshot.is_file():
+            print(
+                f"ERROR: no snapshot at {args.snapshot} to check against. "
+                "Run without --check to generate one.",
+                file=sys.stderr,
+            )
+            return 1
+        committed = json.loads(args.snapshot.read_text(encoding="utf-8"))
+        drift_reports = _compute_drift(committed, fresh)
+        print(_format_drift_summary(drift_reports))
+        failing = [r for r in drift_reports if not r.ok]
+        return 1 if failing else 0
+
+    # Default mode: write the snapshot.
+    args.snapshot.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(fresh, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    args.snapshot.write_text(payload, encoding="utf-8")
+    print(f"Snapshot written to {args.snapshot}")
+    print(f"Total cost:    ${fresh['totals']['cost_usd']:.6f}")
+    print()
+    print("Review the diff and commit when satisfied:")
+    print(
+        f"  git diff {args.snapshot.relative_to(Path.cwd()) if args.snapshot.is_absolute() else args.snapshot}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    # Don't propagate ATTUNE_OPS_SESSIONS_LLM=0 from a parent shell
+    # that may have disabled it. Caller can still override via env if
+    # they really want the script to no-op (see --dry-run instead).
+    if (
+        os.environ.get("ATTUNE_OPS_SESSIONS_LLM") == "0"
+        and "--dry-run" not in sys.argv
+        and "--check" not in sys.argv
+    ):
+        print(
+            "WARNING: ATTUNE_OPS_SESSIONS_LLM=0 is set. The summarizer "
+            "will return None for every fixture and the snapshot will "
+            "contain only errors. Unset the env var or use --dry-run.",
+            file=sys.stderr,
+        )
+    raise SystemExit(main())

--- a/tests/unit/ops/test_calibration_snapshot.py
+++ b/tests/unit/ops/test_calibration_snapshot.py
@@ -1,0 +1,274 @@
+"""Snapshot regression CI gate for the /sessions Haiku calibration.
+
+Companion to ``scripts/calibrate_session_summary.py``. The script
+runs Haiku over every committed fixture and emits a JSON snapshot
+at ``tests/fixtures/ops/session_summaries/snapshot.json``. THIS
+test asserts the committed snapshot is structurally sound — same
+fixture set the redaction snapshot covers, plausible per-fixture
+cost/length, totals within the spec'd budget cap.
+
+What this test does NOT do:
+
+- It does **not** make real Haiku calls. CI has no
+  ``ANTHROPIC_API_KEY`` and burning ~$0.02 per build would be a
+  poor trade for the structural verification we get here for free.
+- It does **not** assert summary CONTENT equality. Haiku output is
+  non-deterministic; comparing text would noise-fail every run.
+
+The actual regression signal for prompt edits comes from the
+``--check`` mode of the calibrator script. A developer changing
+``session_summarizer.SUMMARY_PROMPT`` is expected to:
+
+1. Re-run ``python scripts/calibrate_session_summary.py``
+2. Inspect the snapshot diff (cost, length, summary samples)
+3. If satisfied, ``git add`` the updated snapshot
+
+This test catches the OTHER failure modes — a developer removed a
+fixture, edited the snapshot by hand, or the snapshot diverged
+from the fixture set on disk.
+
+Skipped (not failed) when the snapshot file is absent so a fresh
+clone of the repo without the snapshot doesn't break CI before
+Patrick's first calibration run lands the file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_FIXTURE_DIR = (
+    Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "ops" / "session_summaries"
+)
+_SNAPSHOT_PATH = _FIXTURE_DIR / "snapshot.json"
+
+# Plausible per-fixture cost band. Hard lower bound at $0.0001 catches
+# accidentally-zeroed entries (would indicate a snapshot generated with
+# the LLM disabled — only error rows). Upper bound at $0.05 matches
+# the per-page-load budget cap; any single fixture above it means the
+# input slice or output cap leaked something unreasonable.
+_PER_FIXTURE_COST_BAND = (1e-4, 0.05)
+
+# Plausible summary length in characters. Lower bound rules out empty
+# or "Resume:" placeholder output. Upper bound catches a prompt that
+# silently dropped the "be terse" instruction and lets Haiku ramble.
+_SUMMARY_CHARS_BAND = (20, 2000)
+
+# Plausible total spend across the fixture set. With 12 fixtures and
+# ~$0.001 typical, $0.10 leaves 8× headroom for output variance + the
+# occasional longer session.
+_TOTAL_COST_CAP = 0.10
+
+
+def _snapshot_or_skip() -> dict:
+    if not _SNAPSHOT_PATH.is_file():
+        pytest.skip(
+            f"calibration snapshot absent at {_SNAPSHOT_PATH}; "
+            "run scripts/calibrate_session_summary.py to generate"
+        )
+    return json.loads(_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+
+def _fixture_names() -> set[str]:
+    if not _FIXTURE_DIR.is_dir():
+        return set()
+    return {p.name for p in _FIXTURE_DIR.glob("*.jsonl")}
+
+
+# ---------------------------------------------------------------------------
+# Top-level shape
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_has_required_top_level_fields():
+    """Snapshot must carry model id, prompt hash, totals, per-fixture rows."""
+    snap = _snapshot_or_skip()
+    assert set(snap.keys()) >= {"model", "prompt_hash", "totals", "fixtures"}
+    assert isinstance(snap["model"], str) and snap["model"]
+    assert isinstance(snap["prompt_hash"], str) and len(snap["prompt_hash"]) == 12
+    assert isinstance(snap["totals"], dict)
+    assert isinstance(snap["fixtures"], dict)
+
+
+def test_snapshot_model_is_haiku_4_5():
+    """Snapshot must come from claude-haiku-4-5; a different model means
+    the cost math + token assumptions are off and the snapshot needs a
+    regen."""
+    snap = _snapshot_or_skip()
+    assert snap["model"].startswith("claude-haiku-4-5"), (
+        f"snapshot was built with {snap['model']!r}; expected a "
+        "claude-haiku-4-5 variant. Re-run scripts/calibrate_session_summary.py."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-fixture invariants
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_fixtures_match_fixture_dir():
+    """Snapshot must have exactly one entry per *.jsonl in the fixture dir.
+
+    A developer who removed a fixture and forgot to re-run the
+    calibrator gets a clear failure here. Same for the reverse —
+    adding a fixture without re-running the calibrator.
+    """
+    snap = _snapshot_or_skip()
+    snapshot_names = set(snap["fixtures"].keys())
+    on_disk = _fixture_names()
+    missing_in_snapshot = on_disk - snapshot_names
+    extra_in_snapshot = snapshot_names - on_disk
+    assert not missing_in_snapshot, (
+        f"fixtures on disk but not in snapshot: {sorted(missing_in_snapshot)}; "
+        "re-run scripts/calibrate_session_summary.py"
+    )
+    assert not extra_in_snapshot, (
+        f"fixtures in snapshot but not on disk: {sorted(extra_in_snapshot)}; "
+        "re-run scripts/calibrate_session_summary.py (the snapshot is stale)"
+    )
+
+
+def test_snapshot_records_have_required_fields():
+    """Every per-fixture row must carry the calibration metrics.
+
+    Error rows ({\"error\": \"...\"}) are tolerated here — a fixture
+    that legitimately failed to summarize records the failure rather
+    than vanishing. Per-row drift assertions live in the script's
+    --check mode, not this CI gate.
+    """
+    snap = _snapshot_or_skip()
+    for name, row in snap["fixtures"].items():
+        assert isinstance(row, dict), f"{name}: row must be a dict"
+        if "error" in row:
+            continue
+        required = {"source", "tokens_in", "tokens_out", "cost_usd", "summary", "summary_chars"}
+        missing = required - set(row.keys())
+        assert not missing, f"{name}: missing required fields {sorted(missing)}"
+
+
+def test_snapshot_costs_within_per_fixture_band():
+    """Per-fixture cost stays inside the plausible band.
+
+    Catches snapshots accidentally generated with LLM disabled
+    (every row would have cost_usd=0) or with a runaway prompt
+    that blew out the per-call cost.
+    """
+    snap = _snapshot_or_skip()
+    low, high = _PER_FIXTURE_COST_BAND
+    for name, row in snap["fixtures"].items():
+        if "error" in row:
+            continue
+        cost = float(row["cost_usd"])
+        assert low <= cost <= high, (
+            f"{name}: cost ${cost:.6f} outside plausible band "
+            f"${low:.4f}-${high:.4f}. Re-run scripts/calibrate_session_summary.py."
+        )
+
+
+def test_snapshot_summary_chars_within_band():
+    """Per-fixture summary length stays inside the plausible band."""
+    snap = _snapshot_or_skip()
+    low, high = _SUMMARY_CHARS_BAND
+    for name, row in snap["fixtures"].items():
+        if "error" in row:
+            continue
+        chars = int(row["summary_chars"])
+        assert low <= chars <= high, (
+            f"{name}: summary_chars={chars} outside plausible band "
+            f"{low}-{high}. Either the prompt dropped its "
+            "terseness instruction or Haiku returned an empty/stub response."
+        )
+
+
+def test_snapshot_source_is_haiku_not_cached():
+    """Calibration runs use a fresh tempdir cache; every row should be
+    source=haiku. A row with source=cached means the calibrator ran
+    against a non-tempdir cache and didn't measure fresh model output."""
+    snap = _snapshot_or_skip()
+    for name, row in snap["fixtures"].items():
+        if "error" in row:
+            continue
+        assert row["source"] == "haiku", (
+            f"{name}: source={row['source']!r}; calibration must use a fresh "
+            "cache so every fixture incurs a real Haiku call. "
+            "Drop the cache dir or omit --attune-home from the calibrator call."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Totals
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_total_cost_below_cap():
+    """Total spend across the fixture set must stay below the global cap.
+
+    With 12 fixtures and ~$0.001 typical, $0.10 (~8× headroom) is a
+    soft ceiling. A snapshot above this means either: (a) a prompt
+    edit made Haiku much chattier, or (b) the fixture set grew
+    without re-tuning the cap.
+    """
+    snap = _snapshot_or_skip()
+    total = float(snap["totals"]["cost_usd"])
+    assert total <= _TOTAL_COST_CAP, (
+        f"total snapshot cost ${total:.4f} exceeds soft cap "
+        f"${_TOTAL_COST_CAP:.4f}. Inspect the snapshot diff for a "
+        "Haiku-output explosion or re-tune the cap if the fixture "
+        "set legitimately grew."
+    )
+
+
+def test_snapshot_totals_match_per_fixture_sums():
+    """``totals.cost_usd`` must equal the sum of per-fixture costs.
+
+    Drift here means the snapshot was hand-edited rather than
+    regenerated via the script — the totals were left stale.
+    """
+    snap = _snapshot_or_skip()
+    summed = sum(float(row["cost_usd"]) for row in snap["fixtures"].values() if "error" not in row)
+    total = float(snap["totals"]["cost_usd"])
+    # Allow tiny rounding noise from the script's per-fixture round().
+    assert abs(total - summed) < 0.01, (
+        f"totals.cost_usd={total:.6f} but per-fixture sum is "
+        f"{summed:.6f}. Snapshot was likely hand-edited; re-run the "
+        "calibrator to regenerate."
+    )
+
+
+def test_snapshot_totals_count_matches_fixture_dir():
+    """``totals.fixtures`` must equal the number of *.jsonl files on disk."""
+    snap = _snapshot_or_skip()
+    on_disk = len(_fixture_names())
+    assert snap["totals"]["fixtures"] == on_disk, (
+        f"totals.fixtures={snap['totals']['fixtures']} but on-disk count is "
+        f"{on_disk}; snapshot is stale relative to the fixture dir"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt-hash consistency
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_prompt_hash_matches_current_prompt():
+    """``prompt_hash`` must match the SHA-256[:12] of the current
+    ``session_summarizer.SUMMARY_PROMPT``.
+
+    A mismatch means the prompt has been edited since the snapshot
+    was generated. The developer must re-run the calibrator to
+    update the snapshot before the change can land.
+    """
+    snap = _snapshot_or_skip()
+    import hashlib
+
+    from attune.ops import session_summarizer
+
+    expected = hashlib.sha256(session_summarizer.SUMMARY_PROMPT.encode("utf-8")).hexdigest()[:12]
+    assert snap["prompt_hash"] == expected, (
+        f"snapshot prompt_hash={snap['prompt_hash']!r} but current "
+        f"SUMMARY_PROMPT hashes to {expected!r}. The prompt has been "
+        "edited since the snapshot was generated — re-run "
+        "scripts/calibrate_session_summary.py and commit the new snapshot."
+    )


### PR DESCRIPTION
## Summary

Closes the calibration loop deferred from S3b ([PR #390](https://github.com/Smart-AI-Memory/attune-ai/pull/390)). [PR #393](https://github.com/Smart-AI-Memory/attune-ai/pull/393) already landed the 12 redacted fixtures + a redaction snapshot test. This PR adds the **Haiku-output** side — cost + length drift detection.

### `scripts/calibrate_session_summary.py`

Runs Haiku over every fixture in `tests/fixtures/ops/session_summaries/*.jsonl` and writes per-fixture `{tokens_in, tokens_out, cost_usd, summary, summary_chars}` to `snapshot.json`. Three modes:

- **default** — regenerate the snapshot (Patrick runs this once with `ANTHROPIC_API_KEY` to seed the file, ~$0.02 spend)
- **`--check`** — re-run and fail on drift past tolerances (input ±10%, output ±50%, cost ±20% per decisions.md Decision 8, summary length ±50%). Useful as a pre-PR sanity check or in a nightly cron.
- **`--dry-run`** — list fixtures + print prompt fingerprint, no API calls. Free.

Uses a fresh tempdir cache so every fixture incurs a real Haiku call — no cache-hit illusion that the calibrator runs for free.

### `tests/unit/ops/test_calibration_snapshot.py`

CI gate. **Does NOT make real Haiku calls** — CI has no API key and burning $0.02 per build is a poor trade. Asserts the committed snapshot is:

- Structurally sound (right top-level fields, model id matches, one row per fixture on disk)
- Within plausible cost bands (per-fixture < $0.05, total < $0.10)
- `source=haiku` on every row (not `cached` — would mean the calibrator didn't measure fresh model output)
- Hash-consistent with the current `SUMMARY_PROMPT` (a prompt edit forces a snapshot re-run)

Skips cleanly when the snapshot is absent so a fresh clone doesn't break CI before the first calibration run lands.

### `docs/specs/ops-sessions-page/calibration-runbook.md`

When to re-run, how to invoke, what to look for in the diff, how the CI gate fits in.

### Ship-log update

`decisions.md` calibration-harness row flips from **partial** → **shipped**. Three remaining open boxes in the calibration record (token averages, cost averages, budget-cap firing frequency) get answered once you seed `snapshot.json` + a week of production data accumulates.

## Patrick's next step after merge

```bash
ATTUNE_OPS_SESSIONS_LLM=1 python scripts/calibrate_session_summary.py
git diff tests/fixtures/ops/session_summaries/snapshot.json
git add tests/fixtures/ops/session_summaries/snapshot.json
git commit -m "calib(session-summary): seed snapshot with first Haiku baseline"
```

Once that lands, the CI gate flips from "all skip" to "all assert" automatically.

## Test plan

- [x] All 478 ops tests pass; 11 calibration tests skip (expected — no snapshot yet)
- [x] `--dry-run` smoke-tested against the 12 committed fixtures locally
- [x] Pre-commit clean (ruff, black, bandit, detect-secrets)
- [ ] Patrick seeds `snapshot.json` via the runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
