### PR TITLE
feat(ops): /specs "Ready to close?" completion-candidates section

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5270,3 +5270,29 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   persistence (theme prefs, feature flags, debug
   switches) — never use ``store_true`` alone when a
   persisted fallback exists.
+
+- **Pre-flight ``ruff check`` on changed Python files
+  before ``git add``** — companion to the existing
+  "Pre-flight pre-commit's pinned black/ruff" lesson,
+  but for the LINT side, not the format side. The
+  ruff lint pass catches issues (F841 unused locals,
+  E402 import order, etc.) that aren't auto-fixable
+  and that pre-commit will surface AFTER you've
+  staged + drafted a commit message. Each hook-fail
+  cycle costs ~30s for the fix + re-stage + re-commit
+  retry. Mitigation: before any commit that touches
+  ``.py`` files, run
+  ``uv run ruff check <files>`` (or
+  ``uv run --with pre-commit pre-commit run ruff
+  --files <files>`` for the pinned version per the
+  existing format-side lesson). Common F841 trigger:
+  rebinding a helper return value to a local that
+  the test no longer uses after a refactor (e.g.
+  ``spec_dir = _make_spec(...)`` when the test
+  removed the reference to ``spec_dir`` in a later
+  edit). Fix is one line — drop the assignment,
+  keep the call. Hit twice in the ops-specs-
+  completion-candidates session: T2 had it for an
+  import strip, T1+T2 tests had two F841s caught at
+  PR-creation time. Cumulative cost: two ~30s
+  hook-fail retries; cost of preflight: ~1s.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5183,3 +5183,90 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   topical naming like `Codex-results.txt`). The
   transcript is permanent; revocation is the
   only recovery.
+
+- **Coverage measurement on worktree code requires
+  bypassing the project's coverage rcfile**: extends the
+  existing PYTHONPATH worktree lesson with a new failure
+  mode specific to coverage tooling. When running
+  ``coverage run -m pytest`` from a worktree, the
+  ``pyproject.toml`` ``[tool.coverage.run] source =
+  ["attune", "attune_software"]`` filter records 0%
+  coverage even though tests demonstrably hit the module
+  (verified via ``module.__file__`` resolving to the
+  worktree path AND a direct ``coverage run`` script that
+  imports and calls the module). Coverage's source-name
+  filter doesn't resolve worktree paths to the configured
+  package name because the editable-install MAPPING points
+  to the main checkout. The file appears in the report
+  with all-statements-missed, which looks like "tests
+  never ran" but is actually "tests ran but coverage
+  didn't record the hits." Workaround:
+  ``cd /tmp && rm -f .coverage &&
+  PYTHONPATH=$(repo)/src
+  PYTEST_ADDOPTS="-p no:xdist -o addopts="
+  /path/to/.venv/bin/python -m coverage run
+  --rcfile=/dev/null --source=attune.ops.<modname> -m
+  pytest $(repo)/tests/...`` — cwd in /tmp avoids
+  auto-loading the rcfile, ``--rcfile=/dev/null`` is
+  explicit, ``--source`` filters to the new module by
+  dotted name, and ``PYTEST_ADDOPTS`` strips the
+  ``-n auto`` and ``--cov`` that pytest.ini injects (both
+  break this measurement). Test execution itself doesn't
+  need any of this — ``python -m pytest tests/...`` from
+  the worktree works fine; this is only for coverage
+  measurement of new modules during worktree-based
+  feature work.
+
+- **Modules with subprocess wrappers need direct
+  ``subprocess.run``-mocked tests as a standard coverage
+  practice**: when a module exposes 1–3 subprocess wrapper
+  functions (e.g. ``_run_gh_pr_view``,
+  ``_run_git_remote_origin``) that are mocked at the
+  wrapper layer in every behavioral test (the right shape
+  for testing the module's logic), the wrapper internals
+  contribute a fixed coverage gap proportional to their
+  combined line count. In one ops-specs-completion-
+  candidates measurement, three wrappers ate ~50 of ~244
+  statements — 81% before adding wrapper-specific tests,
+  95% after. Write the wrapper tests as part of the
+  initial test file, not as a reactive fix when coverage
+  misses the gate. The per-wrapper test set is mechanical
+  and small (~5 tests each covering: success path,
+  non-zero exit, OSError, TimeoutExpired, malformed JSON
+  / non-dict / non-list payloads). Helper:
+  ``_completed(returncode, stdout, stderr)`` returning a
+  ``subprocess.CompletedProcess`` stand-in keeps each
+  test to one or two lines. Pattern also surfaces real
+  bugs — the ``returncode != 0`` branch in a wrapper is
+  easy to write wrong and easy to forget to test.
+
+- **argparse three-state CLI flag for "explicit-on,
+  explicit-off, or use-persisted-default"**: when a CLI
+  flag has a persisted-state fallback (e.g. a feature
+  toggle that reads from ``~/.attune/ops/config.json``
+  when absent), the standard ``action="store_true"``
+  collapses "no flag" and "explicitly false" into the
+  same value, which loses the signal the resolver needs.
+  The clean pattern is a mutually-exclusive group of two
+  flags with the same ``dest`` using
+  ``action="store_const"``:
+  ```python
+  g = parser.add_mutually_exclusive_group()
+  g.add_argument("--specs-candidates",
+                 dest="specs_candidates",
+                 action="store_const", const=True,
+                 default=None, help="...")
+  g.add_argument("--no-specs-candidates",
+                 dest="specs_candidates",
+                 action="store_const", const=False,
+                 default=None, help="...")
+  ```
+  Produces three observable states in
+  ``args.specs_candidates``: ``True`` (positive flag),
+  ``False`` (negative flag), ``None`` (neither). The
+  resolver branches on ``None`` to read persisted state.
+  The mutex group catches "both flags" with a clean
+  ``SystemExit``. Generalizes to any toggle with
+  persistence (theme prefs, feature flags, debug
+  switches) — never use ``store_true`` alone when a
+  persisted fallback exists.

--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-05-16T02:33:13.007361+00:00
-source_hash: 3847cb81bf0f98356695799e284a8b9b602fccfe6225cd45d19f8f054d716b7e
+generated_at: 2026-05-16T05:27:24.597686+00:00
+source_hash: 5f495ad9acf50a2a9adfe8615f144eda920bca96f5d4172dcb4e358deaa8af3b
 status: generated
 ---
 
@@ -14,18 +14,18 @@ Local operations dashboard — workflow runner with per-feature scope picker, pe
 
 The main building blocks are:
 
+- **`Candidate`** — One completion-candidate spec returned by the detector.
 - **`Config`** — Where attune ops reads project + attune state from.
 - **`TelemetrySummary`** — core component
 - **`WorkflowEntry`** — core component
 - **`PathArgSpec`** — How a workflow accepts a scope path on the CLI.
-- **`Feature`** — One feature from ``.help/features.yaml`` for the scope picker.
 
-Under the hood, this feature spans 34 source
+Under the hood, this feature spans 38 source
 files covering:
 
 - Run via ``python -m attune.ops``.
 - CLI entrypoint for ``attune ops``.
-- Runtime configuration for attune ops.
+- Detector for spec completion candidates.
 
 ## What connects to it
 
@@ -36,8 +36,8 @@ ops dashboard through these interfaces:
 
 | Interface | Purpose | File |
 |-----------|---------|------|
+| `Candidate` | One completion-candidate spec returned by the detector. | `src/attune/ops/completion_candidates.py` |
 | `Config` | Where attune ops reads project + attune state from. | `src/attune/ops/config.py` |
 | `TelemetrySummary` | — | `src/attune/ops/data.py` |
 | `WorkflowEntry` | — | `src/attune/ops/data.py` |
 | `PathArgSpec` | How a workflow accepts a scope path on the CLI. | `src/attune/ops/data.py` |
-| `Feature` | One feature from ``.help/features.yaml`` for the scope picker. | `src/attune/ops/data.py` |

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-05-16T02:33:13.018650+00:00
-source_hash: 3847cb81bf0f98356695799e284a8b9b602fccfe6225cd45d19f8f054d716b7e
+generated_at: 2026-05-16T05:27:24.610550+00:00
+source_hash: 5f495ad9acf50a2a9adfe8615f144eda920bca96f5d4172dcb4e358deaa8af3b
 status: generated
 ---
 
@@ -12,6 +12,7 @@ status: generated
 
 | Class | Description | File |
 |-------|-------------|------|
+| `Candidate` | One completion-candidate spec returned by the detector. | `src/attune/ops/completion_candidates.py` |
 | `Config` | Where attune ops reads project + attune state from. | `src/attune/ops/config.py` |
 | `TelemetrySummary` | — | `src/attune/ops/data.py` |
 | `WorkflowEntry` | — | `src/attune/ops/data.py` |
@@ -21,6 +22,7 @@ status: generated
 | `FamilyVersion` | — | `src/attune/ops/data.py` |
 | `DailyCost` | One day's cost for the home-page sparkline. | `src/attune/ops/data.py` |
 | `HomeKpis` | Summary numbers shown above the fold on the home page. | `src/attune/ops/data.py` |
+| `DismissEntry` | One dismissed candidate's persisted state. | `src/attune/ops/dismiss_store.py` |
 | `TrustedHostMiddleware` | Reject requests whose ``Host`` header isn't on the allowlist. | `src/attune/ops/middleware.py` |
 | `SpecPhase` | One phase file's status snapshot. | `src/attune/ops/routes/specs.py` |
 | `SpecRecord` | One spec's summary — directory + status of each phase file present. | `src/attune/ops/routes/specs.py` |
@@ -42,6 +44,8 @@ status: generated
 | `add_subparser()` | Register the `ops` subparser on the main attune CLI parser. | `src/attune/ops/cli.py` |
 | `cmd_ops()` | Run the dashboard server (blocking). | `src/attune/ops/cli.py` |
 | `main()` | Standalone entry: ``python -m attune.ops``. | `src/attune/ops/cli.py` |
+| `clear_cache()` | Reset the in-memory caches. Test helper. | `src/attune/ops/completion_candidates.py` |
+| `detect_candidates()` | Return all completion candidates across the configured spec roots. | `src/attune/ops/completion_candidates.py` |
 | `attune_home()` | Resolve the user's attune home dir (env override -> ~/.attune). | `src/attune/ops/config.py` |
 | `build_config()` | Build a Config from inputs and environment defaults. | `src/attune/ops/config.py` |
 | `list_features()` | Return features parsed from ``<project_root>/.help/features.yaml``. | `src/attune/ops/data.py` |
@@ -58,7 +62,16 @@ status: generated
 | `list_workflows()` | Return the registered workflow catalog. Empty if the registry is unavailable. | `src/attune/ops/data.py` |
 | `family_versions()` | Resolve installed versions for every related attune package. | `src/attune/ops/data.py` |
 | `env_health()` | Lightweight environment snapshot for the Health page. | `src/attune/ops/data.py` |
+| `store_path()` | Return the absolute path to the dismiss-store JSON file. | `src/attune/ops/dismiss_store.py` |
+| `load()` | Read the dismiss store. Missing or corrupt file → ``{}``. | `src/attune/ops/dismiss_store.py` |
+| `save()` | Persist a dismiss entry for ``slug`` (overwrites prior entry). | `src/attune/ops/dismiss_store.py` |
+| `clear()` | Remove the entry for ``slug``. No-op if absent. | `src/attune/ops/dismiss_store.py` |
+| `is_active()` | True iff a dismiss for ``slug`` is currently suppressing it. | `src/attune/ops/dismiss_store.py` |
 | `compute_allowlist()` | Compute the default + user-supplied Host allowlist. | `src/attune/ops/middleware.py` |
+| `settings_path()` | Return the absolute path to the ops settings file. | `src/attune/ops/ops_config_store.py` |
+| `load_settings()` | Read persisted ops settings. Missing or corrupt file → ``{}``. | `src/attune/ops/ops_config_store.py` |
+| `save_setting()` | Persist a single setting; returns True on success, False on failure. | `src/attune/ops/ops_config_store.py` |
+| `resolve_specs_candidates_enabled()` | Resolve the ``specs_candidates_enabled`` setting. | `src/attune/ops/ops_config_store.py` |
 | `home()` | — | `src/attune/ops/routes/dashboard.py` |
 | `workflows_page()` | — | `src/attune/ops/routes/dashboard.py` |
 | `telemetry_page()` | — | `src/attune/ops/routes/dashboard.py` |
@@ -75,13 +88,16 @@ status: generated
 | `enrich_with_summaries()` | Public helper used by both the JSON route and the HTML page. | `src/attune/ops/routes/sessions.py` |
 | `list_sessions()` | ``GET /api/sessions`` — JSON listing of recent sessions. | `src/attune/ops/routes/sessions.py` |
 | `list_specs()` | Federated listing across all configured spec roots. | `src/attune/ops/routes/specs.py` |
+| `list_completion_candidates()` | Return "Ready to close?" candidates for the Specs page. | `src/attune/ops/routes/specs.py` |
 | `get_spec()` | Return phase-file contents for one spec. | `src/attune/ops/routes/specs.py` |
 | `update_phase_status()` | Rewrite the ``**Status**`` line in the named phase file. | `src/attune/ops/routes/specs.py` |
+| `dismiss_completion_candidate()` | Suppress a completion candidate for the default TTL (14 days). | `src/attune/ops/routes/specs.py` |
 | `get_sweep_result()` | Return the latest sweep result for a scope-hash, or 404. | `src/attune/ops/routes/sweep_results.py` |
 | `echo_command_builder()` | Test helper: produce a portable subprocess that prints two lines + exits 0. | `src/attune/ops/runner.py` |
 | `prune_old_runs()` | Delete persisted run files older than ``days``. Returns the deletion count. | `src/attune/ops/runner.py` |
 | `create_app()` | Build the FastAPI app, wiring config + templates into request state. | `src/attune/ops/server.py` |
 | `redact()` | Run all redaction passes over ``text`` and return the result. | `src/attune/ops/session_redaction.py` |
+| `redact_json_line()` | Redact one JSON-serialized line in-place, preserving structure. | `src/attune/ops/session_redaction.py` |
 | `new_budget()` | Build a :class:`Budget` from the env override or default. | `src/attune/ops/session_summarizer.py` |
 | `llm_enabled()` | Return True iff the Haiku path is enabled this run. | `src/attune/ops/session_summarizer.py` |
 | `summarize_session()` | Return a Haiku-or-cached summary for one session JSONL. | `src/attune/ops/session_summarizer.py` |

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: task
-generated_at: 2026-05-16T02:33:13.013855+00:00
-source_hash: 3847cb81bf0f98356695799e284a8b9b602fccfe6225cd45d19f8f054d716b7e
+generated_at: 2026-05-16T05:27:24.604417+00:00
+source_hash: 5f495ad9acf50a2a9adfe8615f144eda920bca96f5d4172dcb4e358deaa8af3b
 status: generated
 ---
 
@@ -52,6 +52,6 @@ Functions you are most likely to modify:
 - `add_subparser()` in `src/attune/ops/cli.py`
 - `cmd_ops()` in `src/attune/ops/cli.py`
 - `main()` in `src/attune/ops/cli.py`
+- `clear_cache()` in `src/attune/ops/completion_candidates.py`
+- `detect_candidates()` in `src/attune/ops/completion_candidates.py`
 - `attune_home()` in `src/attune/ops/config.py`
-- `build_config()` in `src/attune/ops/config.py`
-- `list_features()` in `src/attune/ops/data.py`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,6 +139,22 @@ repos:
           ^src/attune/mcp/tool_schemas\.py$
         stages: [pre-commit]
 
+      # .help/templates/ per-feature regeneration on source changes.
+      # Detects which features' source globs match the changed files in
+      # this commit (via `attune_author.load_manifest`), runs
+      # `attune-author generate <feature> --all-kinds` for each, and
+      # auto-stages the resulting `.help/templates/<feature>/`.
+      # Gated on ATTUNE_DOCS_AUTOREGEN=1 (matching check-docs-freshness)
+      # — warn-only otherwise. Never blocks the commit. See
+      # docs/specs/ops-specs-completion-candidates/ (B-real-1 follow-up).
+      - id: regenerate-help-templates
+        name: Regenerate .help/templates for changed source files
+        entry: uv run python scripts/regenerate_help_templates.py
+        language: system
+        pass_filenames: true
+        files: ^(src/.*\.py|\.help/features\.yaml)$
+        stages: [pre-commit]
+
       # Coverage exclusion policy enforcement
       # Every production-code entry in pyproject.toml's
       # [tool.coverage.run] omit block must have an inline `#` comment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Ops dashboard "Ready to close?" completion-candidates section on
+  the Specs page — opt-in default-off via `--specs-candidates`
+  (persisted to `~/.attune/ops/config.json`). Surfaces `approved`
+  specs whose work appears to have shipped, with per-spec evidence
+  bullets (tasks complete, referenced PRs merged, no open issues
+  citing the slug, edit-age past the 24h floor). Confirm-complete
+  uses the existing status PUT; Dismiss suppresses for 14 days but
+  re-surfaces immediately if any signal changes (new PR merge,
+  tasks.md edit). The detector NEVER writes — Patrick keeps
+  authority over the status field — and only `approved → complete`
+  is auto-detected (the four non-binary states `partial / paused /
+  retired / draft` remain manual). Zero-false-positive design: all
+  five checks must pass, any parser ambiguity falls toward false-
+  negative. Read-only mode hides the section entirely. Two new API
+  routes (`GET /api/specs/completion-candidates`,
+  `POST /api/specs/{slug}/completion-candidates/dismiss`) gated
+  on both `allow_run` AND `specs_candidates_enabled`. Audit script
+  at `scripts/audit_completion_candidates.py` runs the detector
+  read-only against the live corpus (0 false positives confirmed
+  on attune-ai's current 32-spec corpus). 188 new tests across
+  five test files; full ops surface stays green (~590 passing).
+  Spec: `docs/specs/ops-specs-completion-candidates/`.
+
 - Ops dashboard scope picker now remembers the user's most recently
   picked scope and pre-selects it on every path-supporting row at page
   load (ops-scope-picker-ia proposal, see

--- a/docs/specs/ops-specs-completion-candidates/decisions.md
+++ b/docs/specs/ops-specs-completion-candidates/decisions.md
@@ -1,0 +1,55 @@
+# Spec: Ops Specs Completion Candidates — Decisions
+
+> Pre-committed decisions captured 2026-05-15/16. Triggered by
+> Patrick's observation that approved specs accumulate stale
+> status because manual completion-marking has no nudge surface.
+> Original framing was "let Claude mark approved specs complete";
+> reframed during brainstorm to "surface completion candidates
+> with evidence; human keeps the write authority."
+
+---
+
+## Decision matrix
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Auto-write vs propose-and-confirm | **Propose-and-confirm** | Asymmetric cost: false negative = 10s manual flip; false positive = lost trust in panel + possibly forgotten work. The existing `(unknown)` drift in the in-flight specs list already shows automated tracking degrades silently. Human keeps the write authority. |
+| Default-on vs default-off | **Default-off** | Patrick initially proposed default-on; pushback was the same trust-cost asymmetry. Opt-in via `--specs-candidates`. |
+| Q1 — Host-repo discovery | `git remote get-url origin` from the spec root's enclosing repo | Cheapest path. Works for the dominant case (attune-ai monorepo + sibling-package monorepos). `--specs-host-repo owner/name` per-root flag deferred until a real cross-repo case appears. |
+| Q2 — Detector cadence | **Page load with 5-min in-memory cache** keyed by spec-roots tuple | ~15 candidate-eligible specs × ~1 `gh api` call each = ~3s worst case, ~0s cached. Cron adds infra + freshness/immediacy tradeoff that doesn't pay off at this scale. |
+| Q3 — Confirm-failure UX | **Inline error banner on the row, manual retry, row stays visible** | Matches existing status-pill PUT-failure pattern so users learn one error model. Don't auto-dismiss (loses the candidate); don't auto-retry (masks the cause). |
+| Q4 — `partial` / `paused` as candidates | **Out of scope for V1** | Those statuses are explicit human signals ("I know this isn't done"). Re-surfacing them would feel pushy and erode trust. Cost of missing a partial-that-finished = one manual flip. Revisit only if usage shows a pattern. |
+| Q5 — PR-ref regex scope | **`decisions.md` + `tasks.md` only** | Discursive files (`_sequencing.md`, audit notes) reference PRs for context more often than for closure. If a real shipping claim lives only in a non-canonical file → manual flip (the cheap failure). |
+| Q6 — Persist `--specs-candidates` toggle | **Yes**, to `~/.attune/ops/config.json` | One-time enable per machine, survives restarts. `--no-specs-candidates` clears the persisted state. |
+| Candidate-set narrowness | **Only `approved` → `complete`** | The full status vocabulary has 6 values; the only auto-detectable transition with low false-positive risk is `approved → complete`. Other transitions stay manual. |
+| Signal-check policy | **Zero false positives, accept many false negatives** | Five strict checks; all must pass. Any parser ambiguity falls toward "not a candidate." The cost asymmetry of trust loss drives this. |
+| Detector ordering | **Cheapest local checks first**, network checks last, dismiss filter last | Status / edit-age / tasks-parse short-circuit ~80% of specs before any `gh` call fires. Dismiss filter runs last so dismissed candidates still benefit from the short-circuit. |
+| Snapshot hash inputs | **Sorted PR numbers + tasks.md mtime + last_modified .md mtime** — explicitly EXCLUDES PR merge state | When a referenced PR transitions open→merged, the candidate should re-surface even though local snapshot inputs didn't change. The hash matches; the PR check sees new state; `is_active` condition 2 fails; re-surface. Correct by design. |
+| Dismiss-store location | `~/.attune/ops/spec_completion_dismissed.json` (one file, atomic writes) | Small file, single user, atomic via temp file + `Path.replace()` per existing cross-platform lesson. No DB; no per-request cache. |
+| Dismiss TTL | **14 days, signal-aware** | Re-surface immediately on new signal (PR merge, tasks.md edit) regardless of TTL. TTL is the floor for "nothing changed and the user said no." |
+| Tasks.md interpretation | All-`- [x]` OR table rows marked `**done**` / `**complete**` → pass; ANY `- [ ]` → fail; missing → pass with "no tasks.md" evidence; empty → fail | Decisions-only specs are common in the corpus — they shouldn't be excluded. Skeleton tasks files shouldn't auto-complete. |
+| Read-only mode behavior | **Hide section entirely**; GET endpoint returns `enabled: false` | The section presupposes the user can flip statuses; read-only mode forbids that. No degraded-mode UX worth designing. |
+| Empty / no-candidates state | **Hide the section header entirely**; do not render "no candidates right now" | Removes visual clutter when there's nothing to act on. Section appears only when ≥1 candidate exists. |
+| Server-render gating | **Section shell rendered server-side behind the enabled+allow_run gate**; JS only loads if shell present | When feature is off, zero JS runs and zero API calls fire. No client-side feature flagging. |
+| Shipping shape | **One PR** | ~1.2k LoC including tests; opt-in default-off; bounded review surface. Splitting creates dead-code intermediate states for no benefit at solo-dev pace. Tasks T1–T7 ordered by dependency; intermediate states compile. |
+| E2E audit before flip-on | **Manual review by Patrick** of `scripts/audit_completion_candidates.py` output against the live `docs/specs/` corpus — zero false positives required before enabling | The acceptance criterion in requirements ("zero false-positive completion suggestions across the current spec corpus during a 1-week trial") collapses to a one-time audit before flip-on. |
+
+---
+
+## Open questions (none)
+
+All Q1–Q6 are resolved. Post-merge follow-ups (eviction
+policy, `partial → complete` revisit, multi-repo flag) are
+deferred explicitly in the tasks file, not open.
+
+---
+
+## References
+
+- Brainstorm transcript: 2026-05-15 session
+- Phase 1 (Requirements), Phase 2 (Design), Phase 3 (Tasks):
+  [requirements.md](requirements.md)
+- Existing status PUT endpoint:
+  [src/attune/ops/routes/specs.py](../../../src/attune/ops/routes/specs.py)
+- Predecessor spec for the Specs page surface:
+  `docs/specs/ops-specs-features/`

--- a/docs/specs/ops-specs-completion-candidates/requirements.md
+++ b/docs/specs/ops-specs-completion-candidates/requirements.md
@@ -1,0 +1,1002 @@
+# Spec: Ops Dashboard — Spec Completion Candidates
+
+> Surface specs that look complete (all tasks checked, referenced
+> PRs merged, no open follow-ups) as one-click confirmation
+> candidates on the Specs page — without ever writing the status
+> field automatically.
+
+---
+
+## Phase 1: Requirements
+
+**Status**: approved
+
+### Problem statement
+
+The Specs page lets Patrick flip a spec's `**Status**:` line
+between `draft / in-review / approved / complete`. In practice,
+specs accumulate as `approved` long after the work has shipped:
+the in-flight spec list at session start frequently shows entries
+in `(unknown)` or stale `approved` state when the underlying
+work is already on `main`. Patrick currently catches these on
+manual review.
+
+Patrick floated an opt-in feature where Claude marks `approved`
+specs `complete` once the work appears done. The honest pushback
+(brainstorm transcript, 2026-05-15) was:
+
+- **Asymmetric cost.** A false negative costs ~10 seconds of
+  manual marking. A false positive costs trust in the panel and
+  possibly forgotten work. The existing `(unknown)` drift already
+  shows automated tracking degrades silently — direct writes
+  would make it worse.
+- **"Complete" has nuance.** The current corpus uses `partial`,
+  `paused`, `retired (premise invalidated)` — judgment calls
+  about whether remaining work matters. An auto-marker collapses
+  that to a boolean.
+
+Patrick agreed: instead of auto-writing, surface **completion
+candidates** with evidence inline, and let him click confirm or
+dismiss. The detector does the scanning; the human keeps the
+authority over the field.
+
+### Scope
+
+**In scope:**
+
+- Detector module that scans specs and emits "looks complete"
+  candidates with evidence. Lives in
+  `src/attune/ops/completion_candidates.py`.
+- `GET /api/specs/completion-candidates` endpoint returning the
+  list of candidates with their evidence bullets.
+- `POST /api/specs/{slug}/completion-candidates/dismiss` to
+  suppress a candidate for a TTL (default 14 days). Dismiss
+  state persisted to
+  `~/.attune/ops/spec_completion_dismissed.json`.
+- New "Ready to close?" section on the Specs page (above the
+  main table), rendered only when the feature is enabled AND
+  candidates exist. Each row shows:
+  - Spec slug + current status
+  - Evidence bullets (e.g. "all 8 tasks.md rows checked",
+    "PR #324 merged 2026-05-14", "no open issues referencing
+    this spec")
+  - "Confirm complete" button → calls existing
+    `PUT /api/specs/{slug}/{phase}/status` with `complete`
+  - "Dismiss" button → calls the dismiss endpoint
+- Opt-in setting via `--specs-candidates` CLI flag on
+  `attune ops` (default OFF). Also readable from
+  `~/.attune/ops/config.json` so the toggle persists across
+  restarts.
+- Read-only mode (`--read-only`) hides the section entirely —
+  the section presupposes the user can flip statuses, which
+  read-only mode forbids.
+
+**Out of scope:**
+
+- Auto-writing status fields. Confirmed explicitly out.
+- Detecting `paused / partial / retired` nuance. Detector only
+  proposes `complete`. The other statuses remain manual.
+- Cross-repo PR detection. We only check PRs on the host repo
+  of the spec root (i.e. the repo containing `docs/specs/`).
+- Anything for `draft` or `in-review` specs. Candidates are
+  only drawn from `approved`.
+
+### User journey
+
+1. Patrick opens the Specs page.
+2. If `--specs-candidates` is enabled and the detector finds
+   ≥1 candidate, a "Ready to close?" callout appears above the
+   table with N rows.
+3. Each row shows the spec slug, current status pill, and a
+   2–4 line evidence summary.
+4. Patrick clicks **Confirm complete** → row disappears, table
+   row's status pill flips to `complete`.
+5. Or clicks **Dismiss** → row disappears, suppressed for
+   14 days. Reappears if new signal lands (PR merge, new
+   tasks.md row checked) after dismissal.
+6. If `--specs-candidates` is off, no section appears, no
+   detector runs, no API calls happen — zero overhead.
+
+### Detector signals
+
+A spec is a completion candidate when **all** of the following
+hold:
+
+1. Current status (from any phase file: prefer `decisions.md` →
+   `tasks.md` → `design.md` → `requirements.md`) is `approved`.
+2. If `tasks.md` exists: every checklist row matches
+   `- [x] ` or has a `**done**` / `**complete**` status marker.
+   Zero unchecked `- [ ]` rows.
+3. If the spec references PRs in `decisions.md` / `tasks.md`
+   (regex: `#(\d+)` or `PR (\d+)`), all referenced PRs on the
+   host repo are merged. Open or closed-without-merge → not a
+   candidate.
+4. No open issues on the host repo reference the spec slug in
+   title or body.
+5. `last_modified` (newest `.md` mtime in spec dir) is ≥ 24 h
+   ago. Specs touched in the last day are likely still active
+   — guard against marking work-in-progress as done.
+
+The evidence shown in the UI is the bullet list of which checks
+passed (e.g. "✓ 8 of 8 tasks.md rows checked", "✓ PR #324
+merged 2026-05-14", "✓ last edit 3 days ago"). Failed checks
+suppress the candidate entirely — the user never sees "almost
+complete" rows. We want zero false positives, accept many
+false negatives.
+
+### Dismiss semantics
+
+- Dismiss persists `{slug, dismissed_at, snapshot_hash}` to
+  `~/.attune/ops/spec_completion_dismissed.json`.
+- `snapshot_hash` = SHA256 of sorted (PR numbers + tasks.md
+  mtime + last_modified). When the detector runs, it computes
+  the current snapshot hash; if it differs from the dismissed
+  hash, the candidate re-surfaces immediately (new signal
+  landed). If it matches and `dismissed_at + 14 days > now`,
+  the candidate stays suppressed.
+- Manual flip-back-to-`approved` (via the existing status PUT)
+  clears any dismiss entry for that slug, so a re-completion
+  cycle can re-surface naturally.
+
+### Open questions
+
+- **Q1.** What's the host-repo discovery rule? Cheapest:
+  `git remote get-url origin` from the spec root. Acceptable
+  if the spec root sits inside the repo; less clean for
+  multi-root setups. Alternative: a `--specs-host-repo
+  owner/name` flag per root. Defer to design phase.
+- **Q2.** Should the detector run on every page load, or on
+  a cron? Page load is simpler; cost is ~1 `gh api` call per
+  candidate-eligible spec per load. For the typical 5–15
+  approved specs that's fine. If it becomes a perceptible
+  delay, cache results for 5 minutes in-memory.
+- **Q3.** What's the UI affordance when a confirmation fails
+  (e.g. status PUT 403 because read-only mode flipped on
+  between page load and click)? Standard inline error banner
+  on the row, matching how the existing status pills handle
+  PUT failures.
+- **Q4.** Should `partial` / `paused` specs ever be candidates
+  for *any* state change? Probably not in V1 — they're already
+  explicit signals that "this isn't done and we know it." If
+  the user wants to revisit one, they'll do it manually.
+  Revisit in V2 if usage shows a pattern.
+
+### Non-goals
+
+- A general-purpose "review my project state" surface.
+  Candidates only addresses `approved → complete`.
+- Predicting *when* a spec will be complete from in-progress
+  state.
+- Replacing the manual status flip. The PUT endpoint stays
+  the canonical write path.
+
+### Success criteria
+
+- Patrick can enable the feature with one CLI flag.
+- Section appears only when ≥1 candidate is detected AND the
+  feature is on AND read-only is off.
+- Zero false-positive completion suggestions across the
+  current spec corpus during a 1-week trial run (manually
+  audited by Patrick). False negatives are acceptable and
+  expected.
+- Dismissing a candidate suppresses it until either 14 days
+  pass or new signal lands.
+- Disabling the feature removes the section and zero
+  detector work runs.
+
+---
+
+## Phase 2: Design
+
+**Status**: draft
+
+### Resolved open questions (from requirements Phase 1)
+
+- **Q1 — Host-repo discovery.** `git remote get-url origin`
+  from the spec root's enclosing repo. Per-root override flag
+  deferred until a real cross-repo case appears.
+- **Q2 — Detector cadence.** Page load with a 5-minute
+  in-memory cache keyed by the spec-roots tuple.
+- **Q3 — Confirm-failure UX.** Inline error banner on the
+  row, manual retry, row stays visible. Matches existing
+  status-pill PUT-failure pattern.
+- **Q4 — `partial` / `paused` candidates.** Out of scope.
+  Detector only considers `approved`.
+- **Q5 — PR-ref scope.** Extract from `decisions.md` and
+  `tasks.md` only. Discursive files (`_sequencing.md`,
+  audit notes) are excluded — they reference PRs for
+  context more often than for closure.
+- **Q6 — Persist the `--specs-candidates` toggle.** Yes,
+  to `~/.attune/ops/config.json`. `--no-specs-candidates`
+  clears the persisted state.
+
+### Module layout
+
+```text
+src/attune/ops/
+├── completion_candidates.py        # detector (new)
+│   ├── Candidate (dataclass)
+│   ├── detect_candidates(roots, config) → list[Candidate]
+│   ├── _resolve_host_repo(root) → "owner/name" | None  [cached]
+│   ├── _check_status_is_approved(spec) → bool
+│   ├── _check_tasks_all_done(spec_dir) → (ok, evidence_str)
+│   ├── _check_referenced_prs_merged(spec_dir, repo)
+│   │       → (ok, evidence_str)
+│   ├── _check_no_open_issues(slug, repo)
+│   │       → (ok, evidence_str)
+│   ├── _check_last_edit_age(spec) → (ok, evidence_str)
+│   ├── _snapshot_hash(spec_dir, pr_numbers) → str
+│   └── _cache  (module-level dict, 5-min TTL)
+├── dismiss_store.py                # persistence (new)
+│   ├── DismissEntry (dataclass)
+│   ├── load() → dict[str, DismissEntry]
+│   ├── save(slug, snapshot_hash) → None
+│   ├── clear(slug) → None
+│   └── is_active(slug, current_hash, ttl_days=14) → bool
+├── routes/specs.py                 # add 2 endpoints
+│   ├── GET  /api/specs/completion-candidates
+│   └── POST /api/specs/{slug}/completion-candidates/dismiss
+├── config.py                       # add field
+│   └── specs_candidates_enabled: bool = False
+├── static/js/completion_candidates.js  # frontend (new)
+└── templates/specs.html            # add "Ready to close?" section
+```
+
+Existing files modified:
+
+- `src/attune/cli_minimal.py` (or wherever `attune ops`
+  args are defined) — add `--specs-candidates` flag.
+- `src/attune/ops/server.py` — wire flag into config.
+- Existing status-PUT endpoint — on successful flip away
+  from `complete`, call `dismiss_store.clear(slug)` so a
+  re-completion cycle can re-surface.
+
+### Detector algorithm
+
+Pseudocode for `detect_candidates(roots, config)`:
+
+```python
+cache_key = tuple(sorted(str(r) for r in roots))
+cached = _cache.get(cache_key)
+if cached and time.time() - cached.timestamp < 300:
+    return cached.candidates
+
+dismissed = dismiss_store.load()
+candidates: list[Candidate] = []
+
+for root in roots:
+    repo = _resolve_host_repo(root)  # None if no git remote
+    for spec in _list_specs_in_root(root):
+        # Cheapest checks first; short-circuit on first fail.
+        if not _check_status_is_approved(spec):
+            continue
+        ok_edit, edit_ev = _check_last_edit_age(spec)
+        if not ok_edit:
+            continue
+        ok_tasks, tasks_ev = _check_tasks_all_done(spec.path)
+        if not ok_tasks:
+            continue
+
+        # PR + issue checks gated on repo discovery.
+        pr_numbers = _extract_pr_refs(spec.path)
+        if repo is None and pr_numbers:
+            # Can't verify PRs without a repo. Conservative:
+            # treat as "not a candidate" rather than guess.
+            continue
+        if repo is not None:
+            ok_prs, prs_ev = _check_referenced_prs_merged(
+                pr_numbers, repo
+            )
+            if not ok_prs:
+                continue
+            ok_iss, iss_ev = _check_no_open_issues(spec.slug, repo)
+            if not ok_iss:
+                continue
+        else:
+            prs_ev = iss_ev = None  # nothing to show
+
+        # Apply dismiss filter LAST so dismissed candidates
+        # still benefit from the short-circuiting above.
+        snap = _snapshot_hash(spec.path, pr_numbers)
+        if dismissed.get(spec.slug):
+            if dismiss_store.is_active(
+                spec.slug, snap, ttl_days=14
+            ):
+                continue
+
+        candidates.append(Candidate(
+            slug=spec.slug,
+            path=spec.path,
+            current_status="approved",
+            evidence=[e for e in (
+                tasks_ev, prs_ev, iss_ev, edit_ev
+            ) if e],
+            snapshot_hash=snap,
+        ))
+
+_cache[cache_key] = CacheEntry(time.time(), candidates)
+return candidates
+```
+
+Ordering rationale: status check is a file read; edit-age
+is one stat call; tasks parse is one file read; PR/issue
+checks are network. The cheapest local checks short-circuit
+network calls for ~80% of specs.
+
+### Signal-check specifics
+
+**`_check_tasks_all_done(spec_dir)`** — parses `tasks.md` if
+present. Returns `(True, "✓ 12 of 12 tasks complete")` when
+zero `- [ ]` rows AND zero rows whose status field reads
+anything other than `done` / `complete` / `**done**` /
+`**complete**`. Returns `(True, "✓ no tasks.md (decisions-only spec)")`
+when tasks.md is absent — many specs in the corpus skip
+the tasks phase. Empty tasks.md (only the header) →
+`(False, ...)` to avoid auto-completing skeletons.
+
+**`_check_referenced_prs_merged(pr_numbers, repo)`** —
+PR refs extracted via regex `(?:PR\s+|#)(\d+)` from
+`decisions.md` and `tasks.md` only (not `_sequencing.md`,
+audit files, or other discursive content — those frequently
+mention PRs for context rather than closure). If a real
+shipping claim lives only in a non-canonical file, the
+candidate doesn't surface and the user does a manual flip
+— the cheap failure mode. Calls `gh api repos/{repo}/pulls/{n}`
+per PR (parallelized with a thread pool, cap at 4 concurrent).
+Each PR must have `state == "closed"` AND `merged_at != null`.
+Evidence string: `"✓ PRs merged: #324, #344, #358"`
+(comma-separated, truncated to first 5 with `…+N more`).
+On any `gh` non-zero exit or malformed JSON, treats as
+"check failed" (conservative — not a candidate).
+
+**`_check_no_open_issues(slug, repo)`** — `gh search issues
+"{slug}" repo:{repo} state:open --json number`. Returns
+`(True, "✓ no open issues reference this spec")` on empty
+result. Slug-text matching is loose (substring), so a slug
+like `ops-path-picker` would match issue titled "fix
+ops-path-picker memory leak" — that's the desired behavior.
+Evidence on the absence side; we never *show* the issue
+numbers because their existence is what's being asserted
+absent.
+
+**`_check_last_edit_age(spec)`** — uses `spec.last_modified`
+already computed by `_list_specs_in_root` in `specs.py`.
+Returns `(True, "✓ last edit N days ago")` when
+`now - last_modified >= 24h`. The 24h floor is the cheap
+guard against marking work-in-progress as done.
+
+**`_resolve_host_repo(root)`** — `subprocess.run(["git",
+"remote", "get-url", "origin"], cwd=root.parent, ...)`.
+Parses three URL shapes:
+
+- `git@github.com:owner/name.git` → `owner/name`
+- `https://github.com/owner/name.git` → `owner/name`
+- `https://github.com/owner/name` → `owner/name`
+
+Memoized per-root for the process lifetime — remotes
+don't change inside a single dashboard session.
+Non-zero exit (not a git repo, no origin) → `None`.
+
+### Dismiss-store schema
+
+File: `~/.attune/ops/spec_completion_dismissed.json`
+
+```json
+{
+  "version": 1,
+  "dismissed": {
+    "ops-sessions-page": {
+      "dismissed_at": "2026-05-15T18:30:00+00:00",
+      "snapshot_hash": "a3f1c8d9...",
+      "ttl_days": 14
+    }
+  }
+}
+```
+
+Writes are atomic: write to `<file>.tmp` then `Path.replace`
+to the real path (per the existing Windows-cross-platform
+lesson). Reads are lazy (per request) — no in-memory cache,
+the file is small enough that re-reading per call is cheaper
+than coordinating cache invalidation across requests.
+
+`is_active(slug, current_hash, ttl_days=14)` returns `True`
+iff:
+
+1. `slug` exists in the store, AND
+2. `entry.snapshot_hash == current_hash` (no new signal
+   landed since dismissal), AND
+3. `now < entry.dismissed_at + entry.ttl_days`
+
+Any failure → `False` (re-surface the candidate). When
+condition 2 fails, the entry is also evicted on the next
+write — dismissed-then-resurfaced is a one-shot.
+
+### Snapshot hash
+
+```python
+def _snapshot_hash(spec_dir, pr_numbers):
+    payload = json.dumps({
+        "prs": sorted(pr_numbers),
+        "tasks_mtime": _mtime_or_none(spec_dir / "tasks.md"),
+        "last_modified": _newest_md_mtime(spec_dir),
+    }, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()
+```
+
+Deliberately excludes PR merge state from the hash. If a
+referenced PR transitions open → merged, the candidate
+should re-surface even though the local snapshot inputs
+haven't changed. The detector's PR check sees the new
+state; the dismiss-hash matches the old state; condition 2
+fails; re-surface. Correct.
+
+### API endpoints
+
+**`GET /api/specs/completion-candidates`**
+
+```json
+{
+  "enabled": true,
+  "candidates": [
+    {
+      "slug": "ops-sessions-page",
+      "path": "/abs/path/docs/specs/ops-sessions-page",
+      "current_status": "approved",
+      "evidence": [
+        "✓ 8 of 8 tasks complete",
+        "✓ PRs merged: #379, #382, #384",
+        "✓ no open issues reference this spec",
+        "✓ last edit 3 days ago"
+      ],
+      "snapshot_hash": "a3f1c8d9..."
+    }
+  ]
+}
+```
+
+When `config.specs_candidates_enabled is False` or
+`config.allow_run is False`: returns
+`{"enabled": false, "candidates": []}` immediately without
+invoking the detector. Frontend uses `enabled` to decide
+whether to render the section header at all.
+
+**`POST /api/specs/{slug}/completion-candidates/dismiss`**
+
+Body: `{"snapshot_hash": "..."}`
+
+Persists `(slug, snapshot_hash, dismissed_at=now, ttl_days=14)`
+to the dismiss store. Returns `{"ok": true}` on success. The
+client passes back the hash from the GET response so we can
+guarantee dismiss-state aligns with what the user actually
+saw — defends against the race where new signal lands between
+GET and POST.
+
+Gated by `config.allow_run` (read-only mode → 403), same as
+the existing status-flip endpoint.
+
+### Frontend component
+
+`templates/specs.html` — server-rendered shell, hidden
+initially:
+
+```html
+{% if config.specs_candidates_enabled and config.allow_run %}
+<section id="completion-candidates"
+         class="candidates-section"
+         hidden
+         data-tooltip="…"
+         aria-label="Specs that look complete">
+  <header>
+    <h2>Ready to close? <span id="cc-count">0</span></h2>
+    <p class="muted">
+      Specs where all signals indicate the work is done.
+      Confirm to flip status to <code>complete</code>,
+      or dismiss for 14 days.
+    </p>
+  </header>
+  <div id="cc-list"></div>
+  <div id="cc-empty" hidden>
+    <p>No completion candidates right now.</p>
+  </div>
+</section>
+{% endif %}
+```
+
+`static/js/completion_candidates.js`:
+
+```javascript
+async function loadCompletionCandidates() {
+  const sec = document.getElementById('completion-candidates');
+  if (!sec) return;  // feature disabled — server didn't render shell
+  const res = await fetch('/api/specs/completion-candidates');
+  const data = await res.json();
+  if (!data.enabled) return;
+  renderCandidates(data.candidates);
+  sec.hidden = false;
+}
+
+function renderCandidates(candidates) {
+  // builds row markup per candidate, attaches confirm/dismiss
+  // handlers, updates #cc-count
+}
+
+async function onConfirm(slug, snapshotHash) {
+  // PUT /api/specs/{slug}/decisions/status  body={"status":"complete"}
+  // on 200: remove row, refresh main specs table row's pill
+  // on error: render inline banner on row, leave row visible
+}
+
+async function onDismiss(slug, snapshotHash) {
+  // POST /api/specs/{slug}/completion-candidates/dismiss
+  // body={"snapshot_hash": snapshotHash}
+  // on 200: remove row
+  // on error: inline banner
+}
+
+// Run on page load AND when main specs table refreshes
+document.addEventListener('DOMContentLoaded', loadCompletionCandidates);
+```
+
+Row markup follows the existing dashboard card pattern.
+Two action buttons:
+
+- **Confirm complete** — primary button, requires no
+  confirmation dialog (the evidence list IS the confirmation
+  surface).
+- **Dismiss** — secondary button, with tooltip explaining
+  the 14-day TTL and the "resurfaces on new signal" semantics.
+
+Per the existing tooltip lesson (`overflow: hidden` on parent
+clips `::after`), the section uses `overflow: visible` on the
+card container; clipping happens on inner spans only.
+
+### Config + CLI
+
+`config.py`:
+
+```python
+@dataclass
+class OpsConfig:
+    # ... existing fields ...
+    specs_candidates_enabled: bool = False
+```
+
+CLI flag (per the existing `attune ops` argparse):
+
+```python
+parser.add_argument(
+    "--specs-candidates",
+    action="store_true",
+    help="Surface 'Ready to close?' candidates on the Specs page",
+)
+```
+
+Persisted toggle: when the user passes `--specs-candidates`,
+also write `{"specs_candidates_enabled": true}` to
+`~/.attune/ops/config.json` so the next `attune ops` launch
+(without the flag) keeps it enabled. Symmetric
+`--no-specs-candidates` flag clears the persisted state.
+
+### Test plan
+
+Unit tests for each signal check (`tests/unit/ops/
+test_completion_candidates.py`):
+
+- Status filter rejects non-approved specs
+- Tasks check: all-checked, some-unchecked, missing
+  tasks.md (passes), empty tasks.md (rejects)
+- PR check: all merged, one open, one closed-not-merged,
+  gh non-zero exit
+- Issue check: empty result, non-empty result
+- Edit-age check: 23h ago (rejects), 25h ago (passes)
+- Snapshot hash determinism (same inputs → same hash;
+  PR list order doesn't matter)
+
+Dismiss-store tests:
+
+- Roundtrip: save → load → entry matches
+- TTL boundary: 13d 23h still active; 14d 1h not active
+- Snapshot mismatch → not active even within TTL
+- Atomic-write semantics (no partial writes visible
+  mid-save)
+
+API endpoint tests:
+
+- GET when disabled → enabled=false
+- GET when read-only → enabled=false
+- GET happy path → candidates rendered
+- POST dismiss happy path → store updated
+- POST dismiss when read-only → 403
+
+E2E "no false positives" check:
+
+- One-shot script (`scripts/audit_completion_candidates.py`)
+  that runs the detector against the live `docs/specs/`
+  and prints results. Patrick runs this manually after
+  implementation to verify zero false positives on the
+  current corpus before flipping the feature on.
+
+### Risks
+
+- **gh CLI not installed.** Detector degrades to "no
+  candidates" rather than failing. Document in the CLI
+  flag's help text.
+- **gh rate limits.** With 60 unauthenticated req/hr and
+  ~15 specs × ~5 PRs each, the cache makes this comfortable.
+  If a user disables `gh auth login`, they'll hit it
+  on the first uncached load. Authentication is a
+  prereq, document it.
+- **Tasks-status parsing brittleness.** Tasks files vary
+  in convention across the corpus (some use `- [x]`,
+  some use `**done**` rows in tables). The parser handles
+  both; future formats will need parser updates.
+  Mitigation: when the parser can't make sense of a
+  tasks.md file, treat as "check failed" not "passes" —
+  err toward false negative.
+- **Dismiss-store growth.** Bounded by number of approved
+  specs that get dismissed; ~30 entries is a realistic
+  upper bound. No eviction needed for V1.
+- **Detector cache staleness across requests.** 5-min
+  TTL means a user who clicks confirm could see the same
+  candidate on a sibling tab for up to 5 minutes. Acceptable
+  — confirming flips the underlying status to `complete`,
+  so the next detector run filters it out by the status
+  check. The stale UI is only the display, not the data.
+
+---
+
+## Phase 3: Tasks
+
+**Status**: draft
+
+### Shipping plan
+
+One PR. The feature is opt-in default-off, surface is
+bounded (~1.2k LoC including tests), and the cost of
+splitting outweighs the benefit at solo-dev pace. Tasks
+ordered by dependency; intermediate states compile and
+pass tests.
+
+### Task list
+
+#### T1. Dismiss-store module + tests
+
+**Files (new):**
+
+- `src/attune/ops/dismiss_store.py` (~120 LoC)
+- `tests/unit/ops/test_dismiss_store.py` (~200 LoC)
+
+**What:**
+
+- `DismissEntry` dataclass with `dismissed_at: datetime`,
+  `snapshot_hash: str`, `ttl_days: int`.
+- `load()` returns `dict[str, DismissEntry]`; missing file
+  returns `{}`; corrupt file logs warning and returns `{}`.
+- `save(slug, snapshot_hash, ttl_days=14)` atomic write via
+  temp file + `Path.replace()` (cross-platform per existing
+  lesson).
+- `clear(slug)` removes the entry; no-op if absent.
+- `is_active(slug, current_hash, ttl_days=14)` per the
+  three-condition rule in Phase 2.
+
+**Validation:**
+
+- Roundtrip: save → load → entry matches.
+- TTL boundary tests: 13d23h active, 14d1h inactive
+  (use `freezegun` or `monkeypatch` on `datetime.now`).
+- Snapshot mismatch → inactive even within TTL.
+- Concurrent-write smoke test (two save() calls back-to-back
+  produce the latest entry, no partial writes).
+- Corrupt JSON: write `{"version": "bad"}` to the path,
+  assert `load()` returns `{}` and logs at WARN.
+
+**Risk notes:**
+
+- Use timezone-aware datetimes per the existing
+  `datetime.now(timezone.utc).isoformat()` lesson. Do NOT
+  append `+ "Z"`.
+
+---
+
+#### T2. Detector module + per-signal tests
+
+**Files (new):**
+
+- `src/attune/ops/completion_candidates.py` (~280 LoC)
+- `tests/unit/ops/test_completion_candidates.py` (~350 LoC)
+- `tests/unit/ops/fixtures/completion_candidates/` (test
+  spec dirs — minimal trees with known signal states)
+
+**What:**
+
+- `Candidate` dataclass per the GET endpoint schema.
+- `detect_candidates(roots, config)` per the Phase 2
+  pseudocode, including 5-min in-memory cache keyed by
+  the spec-roots tuple.
+- Five `_check_*` helpers per Phase 2 signal-check specs.
+- `_resolve_host_repo(root)` with three URL-shape parsers.
+- `_extract_pr_refs(spec_dir)` reading only `decisions.md`
+  and `tasks.md` per Q5.
+- `_snapshot_hash(spec_dir, pr_numbers)` per Phase 2.
+
+**Validation per signal:**
+
+- Status filter: 4 fixture specs (approved / draft /
+  in-review / complete) — only approved passes.
+- Tasks check:
+  - all `- [x]` rows → pass
+  - one `- [ ]` row → fail
+  - missing tasks.md → pass with "no tasks.md" evidence
+  - empty tasks.md → fail
+  - mixed `**done**` / `**complete**` markers in tables
+    → pass
+- PR check:
+  - all merged → pass
+  - one open → fail
+  - one closed-not-merged → fail
+  - gh non-zero exit → fail (mocked subprocess)
+  - 5+ PRs → evidence truncated to first 5 + "…+N more"
+- Issue check:
+  - empty result → pass
+  - non-empty → fail (mock gh search output)
+- Edit-age check: 23h ago fails, 25h ago passes.
+- Snapshot hash:
+  - deterministic across runs (same inputs → same hash)
+  - PR list order doesn't matter (sort before hashing)
+  - tasks.md mtime change → hash changes
+- Host-repo resolver:
+  - parses git@github.com:owner/name.git
+  - parses https://github.com/owner/name.git
+  - parses https://github.com/owner/name (no .git)
+  - returns None when `git remote get-url origin` fails
+  - memoized per-root (one subprocess call across N calls)
+
+**Cache validation:**
+
+- Two calls within 300s return same `id()` (cached).
+- Call after manually advancing the cache timestamp
+  re-runs the detector.
+
+**Risk notes:**
+
+- Mock `subprocess.run` and `gh` invocations — never hit
+  real network in unit tests.
+- Per the existing lesson on `subprocess.run(text=True)`
+  on Windows, always pass `encoding="utf-8",
+  errors="replace"`.
+
+---
+
+#### T3. Config field + CLI flag plumbing
+
+**Files (modified):**
+
+- `src/attune/ops/config.py` — add
+  `specs_candidates_enabled: bool = False`.
+- `src/attune/cli_minimal.py` (or actual ops arg site)
+  — add `--specs-candidates` / `--no-specs-candidates`
+  flags.
+- `src/attune/ops/server.py` — read persisted config from
+  `~/.attune/ops/config.json` at startup, overlay CLI
+  flag, write back if flag changed the value.
+
+**What:**
+
+- `--specs-candidates` sets enabled True and persists.
+- `--no-specs-candidates` sets enabled False and persists.
+- Neither flag: load persisted value (default False).
+- Help text mentions `gh auth login` is a prereq for
+  PR / issue checks.
+
+**Validation:**
+
+- `tests/unit/ops/test_config_persistence.py` — write,
+  read, overlay precedence.
+- Manual smoke: `attune ops --specs-candidates` then
+  `attune ops` (no flag) — feature stays on.
+
+**Risk notes:**
+
+- Config-file write is new surface. Atomic via temp file
+  + replace. Permission errors → log + degrade to
+  in-memory-only for the session.
+
+---
+
+#### T4. API endpoints + status-PUT modification
+
+**Files (modified):**
+
+- `src/attune/ops/routes/specs.py`:
+  - Add `GET /api/specs/completion-candidates`
+  - Add `POST /api/specs/{slug}/completion-candidates/dismiss`
+  - Modify existing `PUT /api/specs/{slug}/{phase}/status`
+    to call `dismiss_store.clear(slug)` on successful
+    flip AWAY from `complete` (re-completion cycle support).
+
+**Files (new):**
+
+- `tests/unit/ops/test_completion_candidates_routes.py`
+  (~250 LoC)
+
+**What per Phase 2:**
+
+- GET respects `enabled` (config flag) AND `allow_run`
+  (read-only mode); either off → `enabled: false,
+  candidates: []`.
+- POST body: `{"snapshot_hash": "..."}`; validates slug,
+  validates hash format (hex), persists, returns
+  `{"ok": true}`.
+- POST gated by `allow_run` → 403 when read-only.
+- Status-PUT modification: idempotent — clearing an
+  already-absent entry is a no-op.
+
+**Validation:**
+
+- GET when disabled → `enabled: false`.
+- GET when read-only → `enabled: false`.
+- GET happy path → candidates present with expected shape.
+- GET caches across two calls (mock detector, assert
+  called once).
+- POST happy path → store updated, GET no longer shows
+  the candidate.
+- POST when read-only → 403.
+- POST with non-matching hash → still persists (the hash
+  comes from the client, we trust it; server-side
+  recompute would race).
+- PUT status `approved → complete` → dismiss NOT cleared.
+- PUT status `complete → approved` → dismiss cleared.
+
+**Risk notes:**
+
+- Use the existing test client / fixture pattern from
+  `test_specs_routes.py` if present; same shape.
+
+---
+
+#### T5. Frontend section + JS
+
+**Files (modified):**
+
+- `src/attune/ops/templates/specs.html` — server-render
+  the section shell behind the
+  `config.specs_candidates_enabled and config.allow_run`
+  gate.
+
+**Files (new):**
+
+- `src/attune/ops/static/js/completion_candidates.js`
+  (~180 LoC)
+- CSS additions to `src/attune/ops/static/css/main.css`
+  for the candidates section (~60 LoC).
+
+**What:**
+
+- Per the Phase 2 component spec.
+- Row markup uses existing card pattern; tooltip on the
+  Dismiss button explains 14-day TTL + signal-aware
+  re-surface.
+- `onConfirm` → existing PUT status endpoint with
+  `complete` → on success remove row + flip the main
+  table row's status pill (DOM update; no page reload).
+- `onDismiss` → new POST endpoint → on success remove row.
+- Failures render inline error banner on the row; row
+  stays visible.
+- Page-load fetch; no polling.
+
+**Validation:**
+
+- `tests/unit/ops/test_specs_page_candidates_section.py`
+  — section renders when enabled, hidden when disabled,
+  hidden when read-only.
+- Manual browser check via the worktree-venv launch
+  recipe (per existing lesson): no JS errors in console,
+  confirm/dismiss buttons functional, error path shows
+  banner.
+
+**Risk notes:**
+
+- Cache-buster on `completion_candidates.js` per the
+  existing `?v={{ attune.__version__ }}` lesson — avoids
+  stale JS after release.
+- Tooltip on Dismiss button must use `overflow: visible`
+  on its container per the existing `::after` clipping
+  lesson.
+- Use `os.path.join("docs", "specs")` (or POSIX
+  `.as_posix()` on display strings) for any test
+  asserting on paths — Windows separators.
+
+---
+
+#### T6. E2E audit script
+
+**Files (new):**
+
+- `scripts/audit_completion_candidates.py` (~80 LoC)
+
+**What:**
+
+- Runs `detect_candidates` against the live `docs/specs/`
+  and prints each candidate with full evidence.
+- No writes; no dismiss-store interaction. Read-only
+  audit.
+- Prints a one-line summary at the end: N candidates
+  surfaced, N skipped (with reasons grouped: status,
+  tasks, prs, issues, age).
+- Exit 0 always (audit, not a gate).
+
+**Validation:**
+
+- Manually run on the current attune-ai
+  `docs/specs/` corpus.
+- Patrick reviews output: zero false positives required
+  before flipping the feature on by default for himself.
+- The script lives in `scripts/` rather than
+  `src/attune/`; keep it out of the package surface.
+
+**Risk notes:**
+
+- Document in the script's docstring: "this hits the
+  GitHub API and requires `gh auth login`. Expect ~30s
+  on a ~30-spec corpus."
+
+---
+
+#### T7. Documentation
+
+**Files (modified):**
+
+- `src/attune/ops/cli.py` (or wherever) — CLI help text.
+- `CHANGELOG.md` — `### Added` entry under `## [Unreleased]`.
+- `docs/specs/ops-specs-completion-candidates/decisions.md`
+  (new, short) — captures the four Q1–Q6 decisions for
+  archival, mirrors the convention in `ops-path-picker`
+  and `ops-sessions-page`.
+
+**What:**
+
+- One-line CHANGELOG entry.
+- decisions.md is the durable record once the spec ships;
+  this requirements.md becomes the historical draft.
+
+**Validation:**
+
+- CHANGELOG renders correctly on PyPI (per existing
+  lesson on relative links).
+
+---
+
+### Pre-merge gates
+
+1. All new unit tests pass on all OS lanes.
+2. `coverage report` for `src/attune/ops/completion_candidates.py`
+   and `src/attune/ops/dismiss_store.py` ≥ 85%.
+3. E2E audit script run by Patrick against live
+   `docs/specs/` — zero false positives.
+4. Worktree-venv manual smoke check of the UI per the
+   existing recipe (confirm, dismiss, and error-path
+   each exercised once).
+5. `gh pr checks --watch` clean on all required platforms.
+
+### Post-merge follow-ups (deferred)
+
+- Watch the dismiss-store size over a few weeks. If it
+  grows past ~50 entries, add an eviction policy (drop
+  entries older than 90 days).
+- If users (or Patrick) report wanting `partial → complete`
+  flow, revisit Q4.
+- If multi-repo specs roots become a real case, add the
+  per-root `--specs-host-repo` flag deferred in Q1.
+
+---
+
+## Phase 3: Tasks
+
+**Status**: not started
+
+(To be drafted after design approval. Anticipated phases:
+detector module + unit tests; API endpoints (candidates GET,
+dismiss POST); dismiss-store persistence; frontend section
++ JS wiring; CLI flag plumbing; opt-in config persistence;
+end-to-end test on the live spec corpus.)

--- a/scripts/audit_completion_candidates.py
+++ b/scripts/audit_completion_candidates.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Audit the completion-candidates detector against the live spec corpus.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T6).
+
+Read-only audit. Runs the detector's five signal checks against every
+spec under the configured roots and prints a per-spec table + a final
+summary. NO writes — does not touch the dismiss store, does not flip
+any status. Safe to re-run.
+
+Purpose: before enabling ``--specs-candidates`` on a real workspace,
+verify the detector produces zero false positives on the current
+corpus. False negatives are acceptable; surface them in the table for
+sanity but they don't block enablement.
+
+Usage::
+
+    python scripts/audit_completion_candidates.py
+    python scripts/audit_completion_candidates.py --project-root /path/to/repo
+
+Prerequisites:
+
+- ``gh auth login`` — PR-merged + open-issue checks shell out to gh.
+- ``attune-ai[ops]`` extras installed (fastapi/etc. are NOT needed
+  for this script — only the detector module).
+
+Expect ~30s on a ~30-spec corpus (one gh API call per referenced PR
+per qualifying spec). The detector's in-memory cache is not used
+here — we want fresh results.
+
+Exit code 0 always (audit, not a gate).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from attune.ops.completion_candidates import (
+    _check_last_edit_age,
+    _check_no_open_issues,
+    _check_referenced_prs_merged,
+    _check_status_is_approved,
+    _check_tasks_all_done,
+    _extract_pr_refs,
+    _preferred_status,
+    _resolve_host_repo,
+    clear_cache,
+)
+from attune.ops.config import build_config
+from attune.ops.routes.specs import _list_specs_in_root, _resolved_roots
+
+# Status priority order for "first failed check" attribution in skip
+# reasons. Mirrors the detector's short-circuit ordering so the
+# attribution matches what production would have done.
+_CHECK_ORDER: tuple[str, ...] = ("status", "age", "tasks", "prs", "issues")
+
+
+def audit_one_spec(spec: Any, repo: str | None) -> dict[str, Any]:
+    """Run all 5 checks against one spec; never short-circuit.
+
+    Returns a dict with per-check pass/fail and the first failed
+    check's name (or "none" if all passed). The candidate is
+    surfaced iff first_failed == "none".
+    """
+    results: dict[str, Any] = {
+        "slug": spec.slug,
+        "status": _preferred_status(spec) or "(none)",
+        "checks": {},
+        "evidence": [],
+        "first_failed": None,
+    }
+
+    # 1. Status
+    ok_status = _check_status_is_approved(spec)
+    results["checks"]["status"] = ok_status
+
+    # 2. Edit age
+    ok_age, ev_age = _check_last_edit_age(spec)
+    results["checks"]["age"] = ok_age
+    if ev_age:
+        results["evidence"].append(ev_age)
+
+    # 3. Tasks
+    spec_path = Path(spec.path)
+    ok_tasks, ev_tasks = _check_tasks_all_done(spec_path)
+    results["checks"]["tasks"] = ok_tasks
+    if ev_tasks:
+        results["evidence"].append(ev_tasks)
+
+    # 4. PRs (gated on host repo discovery + presence of refs)
+    pr_numbers = _extract_pr_refs(spec_path)
+    if repo is None and pr_numbers:
+        results["checks"]["prs"] = False
+    elif repo is None:
+        results["checks"]["prs"] = True
+    else:
+        ok_prs, ev_prs = _check_referenced_prs_merged(pr_numbers, repo)
+        results["checks"]["prs"] = ok_prs
+        if ev_prs:
+            results["evidence"].append(ev_prs)
+
+    # 5. Issues (gated on host repo)
+    if repo is None:
+        results["checks"]["issues"] = True
+    else:
+        ok_iss, ev_iss = _check_no_open_issues(spec.slug, repo)
+        results["checks"]["issues"] = ok_iss
+        if ev_iss:
+            results["evidence"].append(ev_iss)
+
+    # First-failed attribution (priority order).
+    for check_name in _CHECK_ORDER:
+        if not results["checks"].get(check_name, True):
+            results["first_failed"] = check_name
+            break
+
+    return results
+
+
+STATUS_COL_MAX = 18
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate ``text`` to ``max_len`` chars, appending ``…`` if cut."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def render_table(rows: list[dict[str, Any]]) -> str:
+    """Pretty-print the per-spec audit table.
+
+    Status strings in the corpus often carry annotations like
+    ``approved (2026-05-09) — Phase A`` which would overflow the
+    column. Truncated to ``STATUS_COL_MAX`` for the table view;
+    the full value is preserved in each row's ``status`` field for
+    the candidates section.
+    """
+    if not rows:
+        return "  (no specs found in any configured root)\n"
+    header_cols = ("slug", "status", "age", "tasks", "prs", "issues", "cand?")
+    widths = [
+        max(20, max(len(str(r["slug"])) for r in rows)),
+        STATUS_COL_MAX,
+        5,
+        5,
+        5,
+        6,
+        6,
+    ]
+
+    def fmt(row_cols: tuple[str, ...]) -> str:
+        return "  ".join(c.ljust(w) for c, w in zip(row_cols, widths, strict=False))
+
+    lines = [fmt(header_cols), fmt(tuple("-" * w for w in widths))]
+    for r in rows:
+        is_cand = r["first_failed"] is None
+        cells = (
+            str(r["slug"]),
+            _truncate(str(r["status"]), STATUS_COL_MAX),
+            "✓" if r["checks"].get("age") else "✗",
+            "✓" if r["checks"].get("tasks") else "✗",
+            "✓" if r["checks"].get("prs") else "✗",
+            "✓" if r["checks"].get("issues") else "✗",
+            "YES" if is_cand else r["first_failed"] or "",
+        )
+        lines.append(fmt(cells))
+    return "\n".join(lines) + "\n"
+
+
+def render_summary(rows: list[dict[str, Any]]) -> str:
+    """One-line-per-bucket skip summary."""
+    total = len(rows)
+    candidates = [r for r in rows if r["first_failed"] is None]
+    skipped_buckets: dict[str, int] = dict.fromkeys(_CHECK_ORDER, 0)
+    for r in rows:
+        if r["first_failed"]:
+            skipped_buckets[r["first_failed"]] += 1
+
+    parts = [
+        f"{total} spec{'' if total == 1 else 's'} scanned",
+        f"{len(candidates)} candidate{'' if len(candidates) == 1 else 's'} surfaced",
+    ]
+    if total - len(candidates) > 0:
+        parts.append(f"{total - len(candidates)} skipped:")
+        for check, count in skipped_buckets.items():
+            if count > 0:
+                parts.append(f"  {count:>3} {check}")
+    return "\n".join(parts) + "\n"
+
+
+def render_candidates(rows: list[dict[str, Any]]) -> str:
+    """Detailed view of the candidates that would be surfaced."""
+    candidates = [r for r in rows if r["first_failed"] is None]
+    if not candidates:
+        return "\nNo candidates would be surfaced.\n"
+    lines = ["", f"Candidates ({len(candidates)}):", ""]
+    for r in candidates:
+        lines.append(f"  {r['slug']}  (status: {r['status']})")
+        for e in r["evidence"]:
+            lines.append(f"    {e}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit the completion-candidates detector against the live "
+            "spec corpus. Read-only; safe to re-run."
+        )
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=None,
+        help="Project root (default: cwd).",
+    )
+    parser.add_argument(
+        "--specs-root",
+        type=Path,
+        action="append",
+        default=None,
+        metavar="DIR",
+        help="Spec root (repeatable). Default: <project-root>/docs/specs/",
+    )
+    args = parser.parse_args(argv)
+
+    config = build_config(
+        project_root=args.project_root,
+        specs_roots=tuple(args.specs_root) if args.specs_root else None,
+    )
+    roots = _resolved_roots(config)
+
+    # Reset detector caches so we get fresh numbers on every audit run.
+    clear_cache()
+
+    print(f"Auditing {len(roots)} spec root{'' if len(roots) == 1 else 's'}:")
+    for root in roots:
+        print(f"  {root}")
+    print()
+
+    rows: list[dict[str, Any]] = []
+    for root in roots:
+        repo = _resolve_host_repo(root)
+        for spec in _list_specs_in_root(root):
+            rows.append(audit_one_spec(spec, repo))
+
+    print(render_table(rows))
+    print(render_summary(rows))
+    print(render_candidates(rows))
+
+    # Always exit 0 — this is an audit, not a gate.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regenerate_help_templates.py
+++ b/scripts/regenerate_help_templates.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: regenerate `.help/templates/<feature>/` for changed source.
+
+Runs `attune-author generate <feature> --all-kinds` for every feature
+whose source files were modified in the current commit, then stages
+the regenerated template directories so they land in the same commit
+as the source change.
+
+Gated on `ATTUNE_DOCS_AUTOREGEN=1` (matching the precedent set by
+`scripts/check_docs_freshness.py`). Default mode is warn-only — the
+hook prints which features are stale and exits 0 without modifying
+the tree. Users opt in by setting the env var (typically in shell
+profile) so the auto-regen is per-user, not per-repo.
+
+Failure modes never block the commit:
+
+- `attune-author` not installed → silent exit 0
+- `.help/features.yaml` missing → silent exit 0
+- Per-feature regen failure → log to stderr, continue with others
+- `git add` failure → log to stderr, continue
+
+Pre-commit passes changed file paths on argv. Empty argv → exit 0.
+
+Spec: docs/specs/ops-specs-completion-candidates/ — companion to the
+post-merge follow-up captured in PR #400's process notes.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Convert a POSIX-style glob to a fullmatch regex.
+
+    Per the existing CLAUDE.md ``_glob_match`` lesson:
+    ``**`` → ``.*`` (cross-segment); ``*`` → ``[^/]*`` (single segment);
+    ``?`` → ``[^/]``. Other characters escaped. Stricter than fnmatch
+    which lets ``*`` greedily cross segments.
+    """
+    out: list[str] = []
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "*":
+            if i + 1 < len(pattern) and pattern[i + 1] == "*":
+                out.append(".*")
+                i += 2
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+    return re.compile("".join(out))
+
+
+def _affected_features(changed_paths: list[Path], manifest_features: dict) -> set[str]:
+    """Return the names of features whose source globs match any changed path.
+
+    ``manifest_features`` is ``Manifest.features`` from attune_author —
+    a dict[str, Feature] where each Feature has a ``files`` list of
+    glob patterns relative to the repo root.
+    """
+    affected: set[str] = set()
+    # Pre-compile every pattern once per run.
+    compiled: list[tuple[str, list[re.Pattern[str]]]] = [
+        (name, [_glob_to_regex(g) for g in getattr(feat, "files", []) or []])
+        for name, feat in manifest_features.items()
+    ]
+    for path in changed_paths:
+        path_str = path.as_posix()
+        for feature_name, patterns in compiled:
+            if feature_name in affected:
+                continue
+            for pat in patterns:
+                if pat.fullmatch(path_str):
+                    affected.add(feature_name)
+                    break
+    return affected
+
+
+def _regen_one(feature: str, help_dir: Path, repo_root: Path) -> tuple[bool, str | None]:
+    """Run ``attune-author generate <feature> --all-kinds``.
+
+    Returns (success, error_message). On non-zero exit / timeout /
+    missing binary, returns (False, <error>) — never raises.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "attune-author",
+                "generate",
+                feature,
+                "--help-dir",
+                str(help_dir),
+                "--project-root",
+                str(repo_root),
+                "--all-kinds",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=120,
+            cwd=str(repo_root),
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return False, str(exc)
+    if result.returncode != 0:
+        # stderr first, fall back to stdout — attune-author errors land
+        # in stderr but some failure modes still print to stdout.
+        msg = (result.stderr or result.stdout or "").strip()
+        return False, msg or f"exit {result.returncode}"
+    return True, None
+
+
+def _summarize_error(err: str | None) -> str:
+    """Reduce a multi-line subprocess error to a compact one-liner.
+
+    Tracebacks dumped by `attune-author` (or any subprocess) on
+    failure are useful for debugging but noisy in commit-cycle
+    output. Returns the LAST non-blank line (typically the actual
+    exception message after a long traceback), capped at 200 chars.
+    """
+    if not err:
+        return "(no error message)"
+    last_line = next(
+        (line for line in reversed(err.splitlines()) if line.strip()),
+        err.strip(),
+    )
+    if len(last_line) > 200:
+        return last_line[:197] + "..."
+    return last_line
+
+
+def _stage_dir(dir_path: Path, repo_root: Path) -> bool:
+    """``git add <dir_path>``; return True on success."""
+    try:
+        result = subprocess.run(
+            ["git", "add", str(dir_path)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+            cwd=str(repo_root),
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        return 0  # No matching files in commit; nothing to do.
+
+    repo_root = Path(__file__).resolve().parent.parent
+    help_dir = repo_root / ".help"
+    if not (help_dir / "features.yaml").is_file():
+        return 0
+
+    try:
+        from attune_author import load_manifest
+    except ImportError:
+        return 0  # attune-author not installed; skip silently.
+
+    try:
+        manifest = load_manifest(help_dir)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a corrupt manifest shouldn't block commits.
+        # The freshness nudge surfaces this elsewhere.
+        print(f"attune: skipping help-regen — manifest load failed: {exc}", file=sys.stderr)
+        return 0
+
+    changed_paths = [Path(p) for p in argv]
+    affected = _affected_features(changed_paths, manifest.features)
+    if not affected:
+        return 0
+
+    autoregen = os.environ.get("ATTUNE_DOCS_AUTOREGEN", "0") == "1"
+    feat_list = ", ".join(sorted(affected))
+
+    if not autoregen:
+        # Warn-only mode (default). Matches `check_docs_freshness.py`
+        # precedent — the user opts in by setting the env var.
+        print(f"attune: {len(affected)} .help/templates feature(s) need regen: {feat_list}")
+        print(
+            "  run: ATTUNE_DOCS_AUTOREGEN=1 git commit --amend --no-edit"
+            "  (or `attune-author generate <feat> --all-kinds`)"
+        )
+        return 0
+
+    print(f"attune: auto-regenerating {len(affected)} feature(s): {feat_list}")
+
+    regenerated: list[str] = []
+    for feature in sorted(affected):
+        ok, err = _regen_one(feature, help_dir, repo_root)
+        if ok:
+            regenerated.append(feature)
+        else:
+            # Trim to first line + 200 char cap — full tracebacks are
+            # noise in the commit output; the user can re-run manually
+            # for the full error.
+            summary = _summarize_error(err)
+            print(
+                f"  WARN: attune-author generate {feature} failed: {summary}",
+                file=sys.stderr,
+            )
+
+    for feature in regenerated:
+        template_dir = help_dir / "templates" / feature
+        if not template_dir.is_dir():
+            continue
+        if not _stage_dir(template_dir, repo_root):
+            print(
+                f"  WARN: git add {template_dir} failed; stage it manually",
+                file=sys.stderr,
+            )
+
+    if regenerated:
+        print(f"attune: regenerated and staged {len(regenerated)} feature(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/attune/ops/cli.py
+++ b/src/attune/ops/cli.py
@@ -77,6 +77,33 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
             " live under <attune-home>/ops/runs/. Default: 30."
         ),
     )
+    # Specs page "Ready to close?" candidates surface — opt-in default-off.
+    # Mutually exclusive on/off flags so the user can re-disable from the
+    # CLI; both default to None so we can distinguish "no flag" (use
+    # persisted state) from "explicit value" (overwrite persisted).
+    # See docs/specs/ops-specs-completion-candidates/.
+    candidates_group = parser.add_mutually_exclusive_group()
+    candidates_group.add_argument(
+        "--specs-candidates",
+        dest="specs_candidates",
+        action="store_const",
+        const=True,
+        default=None,
+        help=(
+            "Surface completion candidates on the Specs page. Requires"
+            " 'gh auth login' for PR + open-issue verification. Setting"
+            " persists across launches via <attune-home>/ops/config.json."
+        ),
+    )
+    candidates_group.add_argument(
+        "--no-specs-candidates",
+        dest="specs_candidates",
+        action="store_const",
+        const=False,
+        default=None,
+        help="Hide the completion-candidates section and clear the persisted toggle.",
+    )
+
     # Backwards-compat: --allow-run was the opt-IN flag before runs became
     # the default. Accept it silently as a no-op so existing scripts and
     # shell history keep working without prompting users to update.
@@ -99,12 +126,21 @@ def cmd_ops(args: argparse.Namespace) -> int:
         )
         return 2
 
-    from attune.ops.config import build_config
+    from attune.ops.config import attune_home, build_config
+    from attune.ops.ops_config_store import resolve_specs_candidates_enabled
     from attune.ops.server import create_app
 
     # Runs are enabled by default; --read-only opts out. The legacy
     # --allow-run flag is accepted as a no-op (already the default).
     allow_run = not args.read_only
+
+    # Combine CLI flag with persisted setting. Resolver writes back when
+    # the CLI flag is explicit; "no flag" returns whatever was persisted
+    # (default False). This must happen BEFORE build_config so we have
+    # the final value to pass in.
+    specs_candidates_enabled = resolve_specs_candidates_enabled(
+        args.specs_candidates, attune_home()
+    )
 
     # Warn loudly when the user binds to all interfaces without an
     # explicit trusted-host. The middleware will still reject any
@@ -128,6 +164,7 @@ def cmd_ops(args: argparse.Namespace) -> int:
         specs_roots=tuple(args.specs_root) if args.specs_root else None,
         trusted_hosts=tuple(args.trusted_host) if args.trusted_host else None,
         runs_retention_days=args.runs_retention_days,
+        specs_candidates_enabled=specs_candidates_enabled,
     )
     app = create_app(config)
 
@@ -136,6 +173,7 @@ def cmd_ops(args: argparse.Namespace) -> int:
     print(f"  project: {config.project_root}")
     print(f"  attune-home: {config.attune_home}")
     print(f"  allow-run: {'on' if config.allow_run else 'off (read-only)'}")
+    print(f"  specs-candidates: {'on' if config.specs_candidates_enabled else 'off'}")
 
     if not args.no_browser:
         try:

--- a/src/attune/ops/completion_candidates.py
+++ b/src/attune/ops/completion_candidates.py
@@ -1,0 +1,531 @@
+"""Detector for spec completion candidates.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T2 in tasks).
+
+Scans configured spec roots for `approved` specs whose work appears
+to have shipped, surfacing them as one-click confirmation candidates
+on the Specs page. The detector ONLY proposes — it never writes the
+status field. The user confirms or dismisses via the dashboard.
+
+A spec is a candidate when **all five** of the following hold:
+
+1. Status (from any phase file, preference order
+   decisions → tasks → design → requirements) is ``approved``.
+2. ``last_modified`` (newest `.md` mtime in spec dir) is ≥ 24h ago.
+3. If ``tasks.md`` exists, every checklist row is checked
+   (``- [x]`` or table row marked ``**done**`` / ``**complete**``)
+   and at least one such row is present. Missing tasks.md →
+   passes with a "decisions-only spec" note. Empty tasks.md → fails.
+4. All PR refs from ``decisions.md`` + ``tasks.md`` are merged on
+   the host repo. (Discursive files like ``_sequencing.md`` are
+   excluded per Q5 — they reference PRs for context more often
+   than for closure.)
+5. No open issues on the host repo reference the spec slug.
+
+Failed checks suppress the candidate entirely — the user never
+sees "almost complete" rows. Zero false positives, accept many
+false negatives.
+
+Ordering is "cheapest local check first": status → edit-age →
+tasks-parse → PRs → issues. ~80% of specs short-circuit before
+any network call fires.
+
+The detector caches results for 5 minutes in-memory, keyed by the
+spec-roots tuple. Test fixtures inject ``now`` to bypass the
+cache between cases.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from attune.ops import dismiss_store
+from attune.ops.config import Config
+from attune.ops.routes.specs import (
+    SpecPhase,
+    SpecRecord,
+    _list_specs_in_root,
+    _resolved_roots,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL in seconds. Phase 2 / Q2: page-load cadence with 5-min cache.
+CACHE_TTL_SECONDS = 300
+
+# Cap concurrent gh API calls for PR-merge checks. Higher would burn
+# rate limit on noisy specs; 4 is plenty for ~5-PR specs.
+GH_PR_CHECK_CONCURRENCY = 4
+
+# Truncate the PR-list in evidence after this many entries.
+PR_EVIDENCE_TRUNCATE = 5
+
+# Edit-age floor: specs touched in the last 24h are likely still active.
+MIN_EDIT_AGE_HOURS = 24
+
+# Files we extract PR refs from. Discursive files excluded per Q5.
+_PR_REF_FILES: tuple[str, ...] = ("decisions.md", "tasks.md")
+
+# Status preference order for "what is this spec's status?"
+_STATUS_PREFERENCE: tuple[str, ...] = (
+    "decisions",
+    "tasks",
+    "design",
+    "requirements",
+)
+
+# PR ref patterns: `#123` or `PR 123`. Numeric-bounded so we don't
+# match e.g. issue numbers in arbitrary contexts unrelated to PRs.
+_PR_REF_RE = re.compile(r"(?:\bPR\s+|#)(\d+)\b", re.IGNORECASE)
+
+# Tasks.md patterns.
+_TASK_OPEN_RE = re.compile(r"^[ \t]*- \[ \]", re.MULTILINE)
+_TASK_CHECKED_RE = re.compile(r"^[ \t]*- \[[xX]\]", re.MULTILINE)
+_TABLE_DONE_RE = re.compile(r"\*\*(?:done|complete)\*\*", re.IGNORECASE)
+
+# Three accepted git remote URL shapes per Phase 2 / Q1.
+_GIT_URL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^git@github\.com:([^/\s]+/[^/\s]+?)(?:\.git)?$"),
+    re.compile(r"^https?://github\.com/([^/\s]+/[^/\s]+?)(?:\.git)?/?$"),
+)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One completion-candidate spec returned by the detector."""
+
+    slug: str
+    path: str  # absolute path of the spec directory
+    current_status: str  # always "approved" in V1
+    evidence: list[str]
+    snapshot_hash: str
+
+
+@dataclass
+class _CacheEntry:
+    """Module-level cache entry for ``detect_candidates``."""
+
+    timestamp: float
+    candidates: list[Candidate]
+
+
+# Module-level cache. Keyed by sorted-roots tuple. Tests call
+# ``clear_cache()`` between cases.
+_cache: dict[tuple[str, ...], _CacheEntry] = {}
+
+# Per-process memo for host-repo resolution. Remotes don't change
+# inside a single dashboard session.
+_repo_cache: dict[str, str | None] = {}
+
+
+def clear_cache() -> None:
+    """Reset the in-memory caches. Test helper."""
+    _cache.clear()
+    _repo_cache.clear()
+
+
+def detect_candidates(
+    config: Config,
+    *,
+    now: float | None = None,
+) -> list[Candidate]:
+    """Return all completion candidates across the configured spec roots.
+
+    ``now`` is a test injection point for cache TTL behavior; production
+    callers leave it ``None`` so we use ``time.time()``.
+
+    Cache hit path: returns the cached list when ``now - timestamp <
+    CACHE_TTL_SECONDS``. Cache miss recomputes from scratch.
+
+    Even when the feature is enabled, an empty result is normal —
+    surface "Ready to close?" only when ≥1 candidate is returned.
+    """
+    if now is None:
+        now = time.time()
+
+    roots = _resolved_roots(config)
+    cache_key = tuple(sorted(str(r) for r in roots))
+
+    cached = _cache.get(cache_key)
+    if cached is not None and now - cached.timestamp < CACHE_TTL_SECONDS:
+        return cached.candidates
+
+    candidates = _detect_uncached(roots, config)
+    _cache[cache_key] = _CacheEntry(timestamp=now, candidates=candidates)
+    return candidates
+
+
+def _detect_uncached(roots: list[Path], config: Config) -> list[Candidate]:
+    """The actual detection pass, sans cache."""
+    dismissed = dismiss_store.load(config)
+    candidates: list[Candidate] = []
+
+    for root in roots:
+        repo = _resolve_host_repo(root)
+        for spec in _list_specs_in_root(root):
+            candidate = _evaluate_spec(spec, repo, dismissed, config)
+            if candidate is not None:
+                candidates.append(candidate)
+    return candidates
+
+
+def _evaluate_spec(
+    spec: SpecRecord,
+    repo: str | None,
+    dismissed: dict[str, dismiss_store.DismissEntry],
+    config: Config,
+) -> Candidate | None:
+    """Run all five checks against one spec; return Candidate or None.
+
+    Short-circuits on the first failed check. Order:
+    status → edit-age → tasks → PRs → issues → dismiss.
+    """
+    # 1. Status check (cheapest — already parsed in spec.phases).
+    if not _check_status_is_approved(spec):
+        return None
+
+    # 2. Edit-age check (cheapest among remaining — one ISO parse).
+    ok_edit, edit_ev = _check_last_edit_age(spec)
+    if not ok_edit:
+        return None
+
+    # 3. Tasks check (one file read).
+    spec_path = Path(spec.path)
+    ok_tasks, tasks_ev = _check_tasks_all_done(spec_path)
+    if not ok_tasks:
+        return None
+
+    # 4. PR check (network — gated on having PR refs).
+    pr_numbers = _extract_pr_refs(spec_path)
+    if repo is None and pr_numbers:
+        # Can't verify PRs without a host repo. Conservative: reject.
+        return None
+
+    prs_ev: str | None = None
+    iss_ev: str | None = None
+    if repo is not None:
+        ok_prs, prs_ev = _check_referenced_prs_merged(pr_numbers, repo)
+        if not ok_prs:
+            return None
+        # 5. Issue check.
+        ok_iss, iss_ev = _check_no_open_issues(spec.slug, repo)
+        if not ok_iss:
+            return None
+
+    # All checks passed. Compute snapshot hash and apply dismiss filter.
+    snap = _snapshot_hash(spec_path, pr_numbers, spec.last_modified)
+    if spec.slug in dismissed and dismiss_store.is_active(spec.slug, snap, config):
+        return None
+
+    return Candidate(
+        slug=spec.slug,
+        path=spec.path,
+        current_status="approved",
+        evidence=[e for e in (tasks_ev, prs_ev, iss_ev, edit_ev) if e],
+        snapshot_hash=snap,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Signal checks
+# ---------------------------------------------------------------------------
+
+
+def _check_status_is_approved(spec: SpecRecord) -> bool:
+    """True iff the spec's status (in preference order) is 'approved'."""
+    status = _preferred_status(spec)
+    return status == "approved"
+
+
+def _preferred_status(spec: SpecRecord) -> str | None:
+    """First non-None status across the phase preference order."""
+    phases_by_name: dict[str, SpecPhase] = {p.name: p for p in spec.phases}
+    for name in _STATUS_PREFERENCE:
+        phase = phases_by_name.get(name)
+        if phase is not None and phase.status is not None:
+            return phase.status.lower().strip()
+    return None
+
+
+def _check_last_edit_age(
+    spec: SpecRecord, *, now: datetime | None = None
+) -> tuple[bool, str | None]:
+    """True iff the newest .md edit is ≥ MIN_EDIT_AGE_HOURS ago.
+
+    Returns ``(False, None)`` when last_modified is missing or
+    unparseable — defensive against the existing
+    ``_newest_md_mtime`` returning None on OSError.
+    """
+    if spec.last_modified is None:
+        return False, None
+    try:
+        last = datetime.fromisoformat(spec.last_modified)
+    except ValueError:
+        return False, None
+    if last.tzinfo is None:
+        # Tz-naive timestamps can't be safely compared with tz-aware now.
+        return False, None
+    if now is None:
+        now = datetime.now(timezone.utc)
+    age = now - last
+    if age.total_seconds() < MIN_EDIT_AGE_HOURS * 3600:
+        return False, None
+    days = max(1, int(age.total_seconds() / 86400))
+    return True, f"✓ last edit {days} day{'s' if days != 1 else ''} ago"
+
+
+def _check_tasks_all_done(spec_dir: Path) -> tuple[bool, str | None]:
+    """True iff tasks.md is absent OR all task rows are checked.
+
+    - Missing tasks.md → pass with "no tasks.md" evidence.
+    - Empty (zero checked rows AND zero unchecked rows AND zero
+      table-done markers) → fail (skeleton file).
+    - Any ``- [ ]`` row → fail.
+    - All ``- [x]`` or ``**done**`` / ``**complete**`` markers,
+      at least one such row → pass with "✓ N task rows complete".
+    """
+    tasks_path = spec_dir / "tasks.md"
+    if not tasks_path.is_file():
+        return True, "✓ no tasks.md (decisions-only spec)"
+    try:
+        text = tasks_path.read_text(encoding="utf-8")
+    except OSError:
+        return False, None
+
+    if _TASK_OPEN_RE.search(text):
+        return False, None
+
+    n_checked = len(_TASK_CHECKED_RE.findall(text))
+    n_table_done = len(_TABLE_DONE_RE.findall(text))
+    total_done = n_checked + n_table_done
+
+    if total_done == 0:
+        return False, None
+    return True, f"✓ {total_done} task row{'s' if total_done != 1 else ''} complete"
+
+
+def _extract_pr_refs(spec_dir: Path) -> list[int]:
+    """Extract PR numbers from decisions.md + tasks.md only.
+
+    Per Q5: discursive files (_sequencing.md, audit notes) reference
+    PRs for context more often than for closure. Returns a sorted,
+    deduplicated list.
+    """
+    found: set[int] = set()
+    for filename in _PR_REF_FILES:
+        path = spec_dir / filename
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for match in _PR_REF_RE.finditer(text):
+            try:
+                found.add(int(match.group(1)))
+            except ValueError:
+                continue
+    return sorted(found)
+
+
+def _check_referenced_prs_merged(pr_numbers: list[int], repo: str) -> tuple[bool, str | None]:
+    """True iff every PR in ``pr_numbers`` is closed AND merged."""
+    if not pr_numbers:
+        return True, None
+    merged_numbers: list[int] = []
+    with ThreadPoolExecutor(max_workers=min(GH_PR_CHECK_CONCURRENCY, len(pr_numbers))) as pool:
+        results = list(pool.map(lambda n: (n, _run_gh_pr_view(repo, n)), pr_numbers))
+    for pr_number, payload in results:
+        if payload is None:
+            return False, None
+        state = payload.get("state")
+        merged_at = payload.get("merged_at")
+        if state != "closed" or not merged_at:
+            return False, None
+        merged_numbers.append(pr_number)
+    return True, _format_pr_evidence(sorted(merged_numbers))
+
+
+def _format_pr_evidence(numbers: list[int]) -> str:
+    """Render the merged-PRs evidence string, truncated to N entries."""
+    if not numbers:
+        return "✓ no PR refs to verify"
+    head = numbers[:PR_EVIDENCE_TRUNCATE]
+    listed = ", ".join(f"#{n}" for n in head)
+    extra = len(numbers) - len(head)
+    if extra > 0:
+        listed += f", …+{extra} more"
+    return f"✓ PRs merged: {listed}"
+
+
+def _check_no_open_issues(slug: str, repo: str) -> tuple[bool, str | None]:
+    """True iff no open issues on ``repo`` reference ``slug``."""
+    payload = _run_gh_issue_search(slug, repo)
+    if payload is None:
+        return False, None
+    if len(payload) > 0:
+        return False, None
+    return True, "✓ no open issues reference this spec"
+
+
+# ---------------------------------------------------------------------------
+# Host-repo discovery (Q1)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_host_repo(root: Path) -> str | None:
+    """Resolve the GitHub "owner/name" for the repo containing ``root``.
+
+    Returns ``None`` when the directory is not a git repo, has no
+    origin remote, or the remote URL doesn't match a recognized
+    GitHub shape (per Q1: three URL patterns supported). Memoized
+    per-root for the process lifetime.
+    """
+    key = str(root)
+    if key in _repo_cache:
+        return _repo_cache[key]
+    url = _run_git_remote_origin(root.parent if root.is_dir() else root)
+    if not url:
+        _repo_cache[key] = None
+        return None
+    for pattern in _GIT_URL_PATTERNS:
+        match = pattern.match(url)
+        if match:
+            owner_name = match.group(1)
+            _repo_cache[key] = owner_name
+            return owner_name
+    _repo_cache[key] = None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Snapshot hash
+# ---------------------------------------------------------------------------
+
+
+def _snapshot_hash(spec_dir: Path, pr_numbers: list[int], last_modified: str | None) -> str:
+    """SHA-256 of (sorted PR numbers, tasks.md mtime, last_modified).
+
+    DELIBERATELY excludes PR merge state. When a PR transitions
+    open→merged after dismissal, the snapshot inputs haven't
+    changed but the PR check sees new state — ``is_active``
+    condition 2 fails, candidate re-surfaces. Correct by design.
+    """
+    tasks_mtime: float | None = None
+    tasks_path = spec_dir / "tasks.md"
+    if tasks_path.is_file():
+        try:
+            tasks_mtime = tasks_path.stat().st_mtime
+        except OSError:
+            tasks_mtime = None
+    payload = json.dumps(
+        {
+            "prs": sorted(pr_numbers),
+            "tasks_mtime": tasks_mtime,
+            "last_modified": last_modified,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess wrappers — easy mock targets for tests
+# ---------------------------------------------------------------------------
+
+
+def _run_git_remote_origin(cwd: Path) -> str | None:
+    """Return the origin remote URL for ``cwd``, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("git remote get-url failed for %s: %s", cwd, exc)
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _run_gh_pr_view(repo: str, pr_number: int) -> dict[str, Any] | None:
+    """Return the PR JSON for ``repo``/``pr_number`` or None on failure."""
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/pulls/{pr_number}"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("gh pr view failed for %s#%d: %s", repo, pr_number, exc)
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        decoded = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    return decoded
+
+
+def _run_gh_issue_search(slug: str, repo: str) -> list[dict[str, Any]] | None:
+    """Return open issues on ``repo`` whose text contains ``slug``.
+
+    Empty list = no matches. ``None`` = the gh call failed.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "search",
+                "issues",
+                slug,
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--json",
+                "number,title",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("gh issue search failed for %s in %s: %s", slug, repo, exc)
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        decoded = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded, list):
+        return None
+    return decoded

--- a/src/attune/ops/config.py
+++ b/src/attune/ops/config.py
@@ -30,6 +30,12 @@ class Config:
     # older. 30 days is enough to span a typical sprint; bump via
     # ``--runs-retention-days`` if you want longer history.
     runs_retention_days: int = 30
+    # Whether the Specs page surfaces "Ready to close?" completion
+    # candidates. Opt-in default-off per
+    # ``docs/specs/ops-specs-completion-candidates/`` (Q6). Toggled
+    # via ``--specs-candidates`` / ``--no-specs-candidates`` and
+    # persisted to ``<attune_home>/ops/config.json``.
+    specs_candidates_enabled: bool = False
 
     @property
     def telemetry_path(self) -> Path:
@@ -66,6 +72,7 @@ def build_config(
     specs_roots: tuple[Path, ...] | None = None,
     trusted_hosts: tuple[str, ...] | None = None,
     runs_retention_days: int = 30,
+    specs_candidates_enabled: bool = False,
 ) -> Config:
     """Build a Config from inputs and environment defaults.
 
@@ -76,6 +83,10 @@ def build_config(
     ``trusted_hosts`` defaults to ``()``; the middleware always includes
     ``host:port`` and loopback aliases in its allowlist, so the default
     works for local development without configuration.
+
+    ``specs_candidates_enabled`` defaults to False; the CLI resolver
+    (:func:`attune.ops.ops_config_store.resolve_specs_candidates_enabled`)
+    overlays persisted state when the caller has computed it.
     """
     root = (project_root or Path.cwd()).expanduser().resolve()
     return Config(
@@ -87,4 +98,5 @@ def build_config(
         specs_roots=tuple(specs_roots or ()),
         trusted_hosts=tuple(trusted_hosts or ()),
         runs_retention_days=max(0, int(runs_retention_days)),
+        specs_candidates_enabled=specs_candidates_enabled,
     )

--- a/src/attune/ops/dismiss_store.py
+++ b/src/attune/ops/dismiss_store.py
@@ -1,0 +1,282 @@
+"""Persistence for dismissed spec completion candidates.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T1 in tasks).
+
+Stores user "dismiss this candidate" decisions in a single JSON file
+at ``<attune_home>/ops/spec_completion_dismissed.json``. Each entry
+records when the candidate was dismissed, the snapshot hash of the
+signals at dismissal time, and the TTL.
+
+A dismiss is "active" (i.e. suppresses the candidate) iff all of:
+
+1. The slug exists in the store.
+2. The stored snapshot hash matches the current snapshot hash. When
+   it differs, new signal has landed since dismissal — the candidate
+   should re-surface immediately, regardless of TTL.
+3. ``now < entry.dismissed_at + entry.ttl_days``.
+
+Any condition's failure → not active → candidate re-surfaces.
+
+Schema (v1)::
+
+    {
+      "version": 1,
+      "dismissed": {
+        "<slug>": {
+          "dismissed_at": "2026-05-15T18:30:00+00:00",
+          "snapshot_hash": "<hex>",
+          "ttl_days": 14
+        }
+      }
+    }
+
+Writes are atomic via ``tempfile`` + ``os.replace`` in the same
+directory (cross-platform safe per
+``.claude/CLAUDE.md`` "Path.rename Windows" lesson). Reads are
+lazy per call — the file is small enough that re-reading per call
+is cheaper than coordinating cache invalidation.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from attune.ops.config import Config
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+STORE_FILENAME = "spec_completion_dismissed.json"
+STORE_SUBDIR = ("ops",)
+DEFAULT_TTL_DAYS = 14
+
+
+@dataclass(frozen=True)
+class DismissEntry:
+    """One dismissed candidate's persisted state."""
+
+    dismissed_at: datetime  # timezone-aware UTC
+    snapshot_hash: str
+    ttl_days: int
+
+
+def store_path(config: Config) -> Path:
+    """Return the absolute path to the dismiss-store JSON file.
+
+    Does NOT create the file or its parent directory — that's the
+    save side's responsibility, so reads on a fresh install don't
+    spuriously mkdir.
+    """
+    return config.attune_home.joinpath(*STORE_SUBDIR, STORE_FILENAME)
+
+
+def load(config: Config) -> dict[str, DismissEntry]:
+    """Read the dismiss store. Missing or corrupt file → ``{}``.
+
+    Corruption modes handled (all log at WARN and return ``{}`` —
+    a corrupt store should never block the dashboard):
+
+    - File doesn't exist
+    - Unreadable (PermissionError / OSError)
+    - Not valid JSON
+    - Wrong schema version
+    - Missing top-level ``dismissed`` key
+    - Per-entry malformed fields (bad date, missing keys, wrong types)
+      — that entry is skipped, other entries still load
+    """
+    path = store_path(config)
+    if not path.is_file():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("dismiss store unreadable at %s: %s", path, exc)
+        return {}
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("dismiss store has invalid JSON at %s: %s", path, exc)
+        return {}
+    if not isinstance(raw, dict):
+        logger.warning("dismiss store at %s is not a JSON object", path)
+        return {}
+    version = raw.get("version")
+    if version != SCHEMA_VERSION:
+        logger.warning(
+            "dismiss store at %s has unsupported version %r (expected %r)",
+            path,
+            version,
+            SCHEMA_VERSION,
+        )
+        return {}
+    dismissed = raw.get("dismissed")
+    if not isinstance(dismissed, dict):
+        logger.warning("dismiss store at %s missing 'dismissed' object", path)
+        return {}
+
+    entries: dict[str, DismissEntry] = {}
+    for slug, payload in dismissed.items():
+        entry = _parse_entry(payload)
+        if entry is None:
+            logger.warning("dismiss store entry for %r is malformed, skipping", slug)
+            continue
+        entries[slug] = entry
+    return entries
+
+
+def save(
+    slug: str,
+    snapshot_hash: str,
+    config: Config,
+    *,
+    ttl_days: int = DEFAULT_TTL_DAYS,
+    now: datetime | None = None,
+) -> None:
+    """Persist a dismiss entry for ``slug`` (overwrites prior entry).
+
+    Atomic via temp file + ``os.replace`` in the same directory so a
+    partial write never produces a half-readable file. Creates the
+    parent directory if missing.
+
+    ``now`` is an injection point for tests; production callers leave
+    it ``None`` so we use timezone-aware UTC.
+    """
+    if not slug or not isinstance(slug, str):
+        raise ValueError("slug must be a non-empty string")
+    if not snapshot_hash or not isinstance(snapshot_hash, str):
+        raise ValueError("snapshot_hash must be a non-empty string")
+    if ttl_days < 0:
+        raise ValueError("ttl_days must be non-negative")
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    current = load(config)
+    current[slug] = DismissEntry(
+        dismissed_at=now,
+        snapshot_hash=snapshot_hash,
+        ttl_days=ttl_days,
+    )
+    _write_atomic(current, config)
+
+
+def clear(slug: str, config: Config) -> None:
+    """Remove the entry for ``slug``. No-op if absent."""
+    current = load(config)
+    if slug not in current:
+        return
+    del current[slug]
+    _write_atomic(current, config)
+
+
+def is_active(
+    slug: str,
+    current_hash: str,
+    config: Config,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """True iff a dismiss for ``slug`` is currently suppressing it.
+
+    See module docstring for the three conditions. Any failure mode
+    (missing entry, hash mismatch, TTL expired, store unreadable)
+    returns False — re-surfacing is always the safer default.
+
+    ``now`` is an injection point for tests.
+    """
+    current = load(config)
+    entry = current.get(slug)
+    if entry is None:
+        return False
+    if entry.snapshot_hash != current_hash:
+        return False
+    if now is None:
+        now = datetime.now(timezone.utc)
+    expires_at = entry.dismissed_at + timedelta(days=entry.ttl_days)
+    return now < expires_at
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _parse_entry(payload: Any) -> DismissEntry | None:
+    """Convert a JSON-decoded entry dict into a DismissEntry.
+
+    Returns ``None`` for any malformed input — the caller logs and
+    skips. Strict about types (no implicit string→int) so a corrupted
+    store doesn't surface garbage.
+    """
+    if not isinstance(payload, dict):
+        return None
+    raw_dt = payload.get("dismissed_at")
+    raw_hash = payload.get("snapshot_hash")
+    raw_ttl = payload.get("ttl_days")
+    if not isinstance(raw_dt, str) or not isinstance(raw_hash, str):
+        return None
+    if not isinstance(raw_ttl, int) or isinstance(raw_ttl, bool):
+        # bool is a subclass of int in Python; explicitly reject.
+        return None
+    if raw_ttl < 0:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw_dt)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        # Tz-naive timestamps can't be safely compared with
+        # tz-aware `now`. Treat as malformed.
+        return None
+    return DismissEntry(
+        dismissed_at=dt,
+        snapshot_hash=raw_hash,
+        ttl_days=raw_ttl,
+    )
+
+
+def _write_atomic(entries: dict[str, DismissEntry], config: Config) -> None:
+    """Serialize ``entries`` and atomically replace the store file."""
+    path = store_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": SCHEMA_VERSION,
+        "dismissed": {
+            slug: {
+                "dismissed_at": entry.dismissed_at.isoformat(),
+                "snapshot_hash": entry.snapshot_hash,
+                "ttl_days": entry.ttl_days,
+            }
+            for slug, entry in entries.items()
+        },
+    }
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+    # Write to a temp file in the SAME directory so os.replace is atomic
+    # (cross-filesystem rename is not). delete=False because we close
+    # before replace; the replace removes the temp name.
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{STORE_FILENAME}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(serialized)
+        os.replace(tmp_name, path)
+    except OSError:
+        # Clean up the temp file if the replace failed; re-raise so
+        # the caller knows the persist did not happen.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise

--- a/src/attune/ops/ops_config_store.py
+++ b/src/attune/ops/ops_config_store.py
@@ -1,0 +1,157 @@
+"""Persisted per-machine ops settings.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T3 in tasks).
+
+Stores user-toggleable ops settings (currently:
+``specs_candidates_enabled``) in a single JSON file at
+``<attune_home>/ops/config.json`` so settings survive ``attune ops``
+restarts without requiring the CLI flag every time.
+
+Schema (v1)::
+
+    {
+      "version": 1,
+      "settings": {
+        "specs_candidates_enabled": true
+      }
+    }
+
+Atomic writes via ``tempfile`` + ``os.replace`` so a partial write
+never produces a half-readable file. Permission errors on write log
+at WARN and degrade to in-memory-only — the dashboard runs fine
+without persisted settings; the user just has to pass the flag
+again next launch.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+SETTINGS_FILENAME = "config.json"
+SETTINGS_SUBDIR = ("ops",)
+
+
+def settings_path(attune_home: Path) -> Path:
+    """Return the absolute path to the ops settings file."""
+    return attune_home.joinpath(*SETTINGS_SUBDIR, SETTINGS_FILENAME)
+
+
+def load_settings(attune_home: Path) -> dict[str, Any]:
+    """Read persisted ops settings. Missing or corrupt file → ``{}``.
+
+    Corruption handling mirrors ``dismiss_store``: any failure mode
+    (missing file, unreadable, invalid JSON, wrong schema, missing
+    ``settings`` key) returns an empty dict and (when meaningful)
+    logs at WARN. A corrupt settings file never blocks the dashboard.
+    """
+    path = settings_path(attune_home)
+    if not path.is_file():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("ops settings unreadable at %s: %s", path, exc)
+        return {}
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("ops settings has invalid JSON at %s: %s", path, exc)
+        return {}
+    if not isinstance(raw, dict):
+        logger.warning("ops settings at %s is not a JSON object", path)
+        return {}
+    if raw.get("version") != SCHEMA_VERSION:
+        logger.warning(
+            "ops settings at %s has unsupported version %r (expected %r)",
+            path,
+            raw.get("version"),
+            SCHEMA_VERSION,
+        )
+        return {}
+    settings = raw.get("settings")
+    if not isinstance(settings, dict):
+        logger.warning("ops settings at %s missing 'settings' object", path)
+        return {}
+    return dict(settings)
+
+
+def save_setting(attune_home: Path, key: str, value: Any) -> bool:
+    """Persist a single setting; returns True on success, False on failure.
+
+    Failure modes (PermissionError, disk full, etc.) log at WARN and
+    return False — caller decides whether to surface to the user.
+    The in-memory value the caller passed remains usable for the
+    current session regardless.
+    """
+    if not key or not isinstance(key, str):
+        raise ValueError("key must be a non-empty string")
+    try:
+        current = load_settings(attune_home)
+        current[key] = value
+        _write_atomic(attune_home, current)
+        return True
+    except OSError as exc:
+        logger.warning(
+            "ops settings save failed at %s: %s — using in-memory only",
+            settings_path(attune_home),
+            exc,
+        )
+        return False
+
+
+def _write_atomic(attune_home: Path, settings: dict[str, Any]) -> None:
+    """Serialize ``settings`` and atomically replace the settings file."""
+    path = settings_path(attune_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": SCHEMA_VERSION, "settings": settings}
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{SETTINGS_FILENAME}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(serialized)
+        os.replace(tmp_name, path)
+    except OSError:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Resolvers — used by cli.py to combine CLI flag + persisted state
+# ---------------------------------------------------------------------------
+
+
+def resolve_specs_candidates_enabled(cli_value: bool | None, attune_home: Path) -> bool:
+    """Resolve the ``specs_candidates_enabled`` setting.
+
+    Precedence:
+
+    1. ``cli_value=True``  → persist True, return True.
+    2. ``cli_value=False`` → persist False (clears prior True), return False.
+    3. ``cli_value=None``  → return persisted value (default False).
+
+    Used by ``attune ops --specs-candidates`` / ``--no-specs-candidates``
+    plumbing in :mod:`attune.ops.cli`.
+    """
+    if cli_value is not None:
+        save_setting(attune_home, "specs_candidates_enabled", cli_value)
+        return cli_value
+    settings = load_settings(attune_home)
+    value = settings.get("specs_candidates_enabled", False)
+    return bool(value)

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -312,6 +312,7 @@ async def specs_page(request: Request) -> HTMLResponse:
         specs=specs,
         roots=[str(r) for r in roots],
         allow_run=cfg.allow_run,
+        specs_candidates_enabled=cfg.specs_candidates_enabled,
     )
 
 

--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -29,7 +29,20 @@ from typing import Any
 
 from fastapi import APIRouter, Body, HTTPException, Request
 
+from attune.ops import dismiss_store
+
 router = APIRouter(prefix="/api/specs", tags=["specs"])
+
+# Statuses that count as "completion-like" for dismiss-clear purposes.
+# A status PUT to anything OUTSIDE this set clears any dismiss entry for
+# the spec — re-completion can then re-surface naturally. See
+# docs/specs/ops-specs-completion-candidates/ (Phase 2 dismiss semantics).
+_COMPLETE_LIKE_STATUSES: frozenset[str] = frozenset({"complete", "completed", "done"})
+
+# SHA-256 hex strings are 64 chars of [0-9a-f]. Validate body inputs to
+# the dismiss endpoint match this shape — guards against arbitrary
+# string content landing in the persisted store.
+_SNAPSHOT_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 # Phase files we recognize. Match attune-gui's convention; decisions.md is
@@ -208,6 +221,46 @@ async def list_specs(request: Request) -> dict:
                 "phases": [asdict(p) for p in s.phases],
             }
             for s in specs
+        ],
+    }
+
+
+@router.get("/completion-candidates")
+async def list_completion_candidates(request: Request) -> dict:
+    """Return "Ready to close?" candidates for the Specs page.
+
+    Gated on BOTH ``config.specs_candidates_enabled`` AND
+    ``config.allow_run`` — read-only mode hides the section entirely
+    (no point surfacing confirm buttons that would 403). When either
+    is off, returns ``{"enabled": false, "candidates": []}`` without
+    invoking the detector (zero gh-API cost on disabled servers).
+
+    Detector caches results for 5 minutes in-memory per the spec's
+    Q2 resolution; repeated calls within that window are cheap.
+
+    See ``docs/specs/ops-specs-completion-candidates/`` for the
+    detector design.
+    """
+    from attune.ops.completion_candidates import detect_candidates
+
+    config = request.app.state.config
+    if not getattr(config, "specs_candidates_enabled", False):
+        return {"enabled": False, "candidates": []}
+    if not getattr(config, "allow_run", False):
+        return {"enabled": False, "candidates": []}
+
+    candidates = detect_candidates(config)
+    return {
+        "enabled": True,
+        "candidates": [
+            {
+                "slug": c.slug,
+                "path": c.path,
+                "current_status": c.current_status,
+                "evidence": c.evidence,
+                "snapshot_hash": c.snapshot_hash,
+            }
+            for c in candidates
         ],
     }
 
@@ -427,6 +480,19 @@ async def update_phase_status(
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"write failed: {exc}") from exc
 
+    # On successful flip AWAY from a complete-like status, clear any
+    # dismiss entry for this slug. Re-completion can then re-surface
+    # the candidate naturally. See docs/specs/ops-specs-completion-
+    # candidates/ (Phase 2 dismiss semantics).
+    if status.lower() not in _COMPLETE_LIKE_STATUSES:
+        try:
+            dismiss_store.clear(slug, config)
+        except OSError:
+            # Best-effort: failing to clear the dismiss doesn't
+            # roll back the status write. Logged at WARN by the
+            # store's own atomic-write path.
+            pass
+
     return {
         "slug": slug,
         "phase": phase,
@@ -435,3 +501,45 @@ async def update_phase_status(
         "root": str(matched_root),
         "path": str(target),
     }
+
+
+@router.post("/{slug}/completion-candidates/dismiss")
+async def dismiss_completion_candidate(
+    slug: str,
+    request: Request,
+    body: dict[str, Any] = Body(...),  # noqa: B008
+) -> dict[str, Any]:
+    """Suppress a completion candidate for the default TTL (14 days).
+
+    Body: ``{"snapshot_hash": "<64-hex-chars>"}``.
+
+    The hash comes from the client (echoed back from the GET response)
+    so we can guarantee the dismiss-state aligns with what the user
+    actually saw. Race-defends against new signal landing between GET
+    and POST — if signal changed, the dismissed snapshot won't match
+    the next detector run's snapshot and the candidate re-surfaces.
+
+    Gated on ``config.allow_run`` — read-only mode returns 403, same
+    as the existing status-flip endpoint.
+    """
+    config = request.app.state.config
+    if not getattr(config, "allow_run", False):
+        raise HTTPException(
+            status_code=403,
+            detail="server is read-only; dismiss is disabled",
+        )
+
+    _validate_slug(slug)
+
+    snapshot_hash = body.get("snapshot_hash")
+    if not isinstance(snapshot_hash, str) or not _SNAPSHOT_HASH_RE.match(snapshot_hash):
+        raise HTTPException(
+            status_code=422,
+            detail="body must include `snapshot_hash` (64-char hex string)",
+        )
+
+    try:
+        dismiss_store.save(slug, snapshot_hash, config)
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"dismiss persist failed: {exc}") from exc
+    return {"ok": True}

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1149,3 +1149,105 @@ a.kpi:hover {
   color: var(--fg-subtle);
   font-size: 12px;
 }
+
+/* ---------- Completion candidates section ("Ready to close?") ---------- */
+/* Server-rendered shell at the top of /specs, populated by
+   completion_candidates.js. Hidden when there are no candidates so
+   the page is uncluttered for users with nothing to act on. */
+.candidates-section {
+  margin: 16px 0 24px;
+  padding: 16px 18px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+  /* Visible overflow so candidate-card tooltips (Dismiss button)
+     aren't clipped at the section boundary. See the existing
+     CLAUDE.md lesson about ::after pseudo-element clipping. */
+  overflow: visible;
+}
+.candidates-head {
+  margin-bottom: 12px;
+}
+.candidates-head h2 {
+  margin: 0 0 4px;
+  font-size: 17px;
+}
+.candidates-count {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 8px;
+  border-radius: 99px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 600;
+}
+.candidates-sub {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+.candidates-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.candidate-card {
+  padding: 12px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  /* Visible overflow so the inner Dismiss tooltip can escape. */
+  overflow: visible;
+}
+.candidate-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.candidate-slug {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-weight: 600;
+}
+.candidate-current {
+  font-size: 11px;
+}
+.candidate-evidence {
+  list-style: none;
+  margin: 0 0 10px;
+  padding: 0;
+  color: var(--fg-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.candidate-evidence li {
+  padding-left: 2px;
+}
+.candidate-actions {
+  display: flex;
+  gap: 8px;
+}
+.btn-confirm {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 600;
+}
+.btn-dismiss {
+  /* Secondary action — same .btn base, no extra color emphasis. */
+}
+.candidate-error {
+  margin-top: 10px;
+  padding: 8px 10px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid #d97706; /* amber, matches chip-warn intent */
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--fg);
+}

--- a/src/attune/ops/static/js/completion_candidates.js
+++ b/src/attune/ops/static/js/completion_candidates.js
@@ -1,0 +1,263 @@
+// Specs page: "Ready to close?" completion-candidates section.
+//
+// Loads on page load when the server-rendered shell
+// (#completion-candidates) is present. Fetches candidates from
+// /api/specs/completion-candidates, renders one card per candidate,
+// and wires Confirm / Dismiss actions to the corresponding endpoints.
+//
+// On Confirm success: removes the card and updates the main specs
+// table row's pill to "cpl" (complete). On Dismiss success: removes
+// the card. On any failure: renders an inline error banner on the
+// card; the card stays visible so the user can retry.
+//
+// Spec: docs/specs/ops-specs-completion-candidates/ (T5).
+(function () {
+  "use strict";
+
+  var ROOT_ID = "completion-candidates";
+  var LIST_ID = "cc-list";
+  var COUNT_ID = "cc-count";
+  var ENDPOINT = "/api/specs/completion-candidates";
+  var DISMISS_TOOLTIP =
+    "Hidden for 14 days. Re-surfaces immediately if a referenced PR " +
+    "merges or tasks.md changes.";
+
+  function fetchJson(url, options) {
+    return fetch(url, options || {}).then(function (response) {
+      if (!response.ok) {
+        var err = new Error("HTTP " + response.status);
+        err.status = response.status;
+        return response
+          .json()
+          .catch(function () {
+            return {};
+          })
+          .then(function (body) {
+            err.detail = body && body.detail ? body.detail : null;
+            throw err;
+          });
+      }
+      return response.json();
+    });
+  }
+
+  function el(tag, attrs, children) {
+    var node = document.createElement(tag);
+    if (attrs) {
+      Object.keys(attrs).forEach(function (k) {
+        if (k === "class") {
+          node.className = attrs[k];
+        } else if (k === "text") {
+          node.textContent = attrs[k];
+        } else if (k.indexOf("data-") === 0 || k.indexOf("aria-") === 0) {
+          node.setAttribute(k, attrs[k]);
+        } else {
+          node[k] = attrs[k];
+        }
+      });
+    }
+    (children || []).forEach(function (child) {
+      if (child) node.appendChild(child);
+    });
+    return node;
+  }
+
+  function renderCard(candidate) {
+    var evidenceItems = (candidate.evidence || []).map(function (e) {
+      return el("li", { text: e });
+    });
+    var confirm = el("button", {
+      class: "btn btn-confirm",
+      type: "button",
+      text: "Confirm complete",
+    });
+    var dismiss = el("button", {
+      class: "btn btn-dismiss",
+      type: "button",
+      text: "Dismiss",
+      "data-tooltip": DISMISS_TOOLTIP,
+    });
+
+    var banner = el("div", {
+      class: "candidate-error",
+      hidden: true,
+      role: "alert",
+    });
+
+    var card = el(
+      "li",
+      {
+        class: "candidate-card",
+        "data-slug": candidate.slug,
+        "data-snapshot-hash": candidate.snapshot_hash,
+      },
+      [
+        el("div", { class: "candidate-head" }, [
+          el("a", {
+            class: "link candidate-slug",
+            href: "/specs/" + encodeURIComponent(candidate.slug),
+            text: candidate.slug,
+          }),
+          el("span", {
+            class: "status-pill chip-ok candidate-current",
+            text: candidate.current_status,
+          }),
+        ]),
+        el("ul", { class: "candidate-evidence" }, evidenceItems),
+        el("div", { class: "candidate-actions" }, [confirm, dismiss]),
+        banner,
+      ]
+    );
+
+    confirm.addEventListener("click", function () {
+      onConfirm(card, candidate, banner, [confirm, dismiss]);
+    });
+    dismiss.addEventListener("click", function () {
+      onDismiss(card, candidate, banner, [confirm, dismiss]);
+    });
+    return card;
+  }
+
+  function showError(banner, message) {
+    banner.textContent = message;
+    banner.hidden = false;
+  }
+
+  function setBusy(buttons, busy) {
+    buttons.forEach(function (b) {
+      b.disabled = busy;
+    });
+  }
+
+  function flipMainTablePill(slug) {
+    // After a successful Confirm, mirror the status flip into the main
+    // specs table's decisions-phase pill so the page reflects reality
+    // without a reload. Best-effort: if the row or pill isn't found
+    // (e.g. layout changed), we silently no-op rather than fail the
+    // candidate removal.
+    var row = document.querySelector('tr[data-slug="' + cssEscape(slug) + '"]');
+    if (!row) return;
+    var cell = row.querySelector('td[data-phase="decisions"]');
+    if (!cell) return;
+    var pill = cell.querySelector(".status-pill");
+    if (!pill) return;
+    pill.classList.remove("chip-muted", "chip-warn", "chip-custom");
+    pill.classList.add("chip-ok");
+    pill.setAttribute("data-original", "complete");
+    pill.setAttribute("data-tooltip", "complete");
+    var code = pill.querySelector(".status-code");
+    if (code) code.textContent = "cpl";
+  }
+
+  function cssEscape(value) {
+    // Avoid window.CSS.escape (not in older browsers we care about).
+    // Slugs are validated server-side to [a-z0-9-]+, so just guard
+    // backslash and quote characters as a belt-and-suspenders measure.
+    return String(value).replace(/(["\\])/g, "\\$1");
+  }
+
+  function onConfirm(card, candidate, banner, buttons) {
+    setBusy(buttons, true);
+    banner.hidden = true;
+    var url =
+      "/api/specs/" + encodeURIComponent(candidate.slug) + "/decisions/status";
+    fetchJson(url, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "complete" }),
+    })
+      .then(function () {
+        flipMainTablePill(candidate.slug);
+        removeCard(card);
+      })
+      .catch(function (err) {
+        setBusy(buttons, false);
+        var msg =
+          err && err.detail
+            ? "Confirm failed: " + err.detail
+            : "Confirm failed. Try again or refresh.";
+        showError(banner, msg);
+      });
+  }
+
+  function onDismiss(card, candidate, banner, buttons) {
+    setBusy(buttons, true);
+    banner.hidden = true;
+    var url =
+      "/api/specs/" +
+      encodeURIComponent(candidate.slug) +
+      "/completion-candidates/dismiss";
+    fetchJson(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ snapshot_hash: candidate.snapshot_hash }),
+    })
+      .then(function () {
+        removeCard(card);
+      })
+      .catch(function (err) {
+        setBusy(buttons, false);
+        var msg =
+          err && err.detail
+            ? "Dismiss failed: " + err.detail
+            : "Dismiss failed. Try again or refresh.";
+        showError(banner, msg);
+      });
+  }
+
+  function removeCard(card) {
+    var list = document.getElementById(LIST_ID);
+    var section = document.getElementById(ROOT_ID);
+    var count = document.getElementById(COUNT_ID);
+    if (!list || !section) return;
+    card.parentNode.removeChild(card);
+    var remaining = list.children.length;
+    if (count) count.textContent = String(remaining);
+    if (remaining === 0) {
+      // Hide the whole section when empty so the page doesn't show a
+      // dangling "Ready to close? 0" header.
+      section.hidden = true;
+    }
+  }
+
+  function renderCandidates(candidates) {
+    var list = document.getElementById(LIST_ID);
+    var section = document.getElementById(ROOT_ID);
+    var count = document.getElementById(COUNT_ID);
+    if (!list || !section) return;
+    list.innerHTML = "";
+    candidates.forEach(function (c) {
+      list.appendChild(renderCard(c));
+    });
+    if (count) count.textContent = String(candidates.length);
+    section.hidden = candidates.length === 0;
+  }
+
+  function load() {
+    var section = document.getElementById(ROOT_ID);
+    if (!section) return; // feature disabled server-side; nothing to do.
+    fetchJson(ENDPOINT)
+      .then(function (body) {
+        if (!body || !body.enabled) return;
+        renderCandidates(body.candidates || []);
+      })
+      .catch(function () {
+        // Silent failure: the section stays hidden. Logging via the
+        // existing dashboard surface is out-of-scope for V1.
+      });
+  }
+
+  // Expose for tests / debugging. Not strictly necessary for runtime.
+  window.__attuneCompletionCandidates = {
+    load: load,
+    renderCandidates: renderCandidates,
+    onConfirm: onConfirm,
+    onDismiss: onDismiss,
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", load);
+  } else {
+    load();
+  }
+})();

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -23,6 +23,25 @@
   </p>
 {% endif %}
 
+{# "Ready to close?" section — server-rendered shell, populated by
+   completion_candidates.js on page load. Hidden until the GET returns
+   at least one candidate, so users with zero candidates see no
+   visual clutter. Gated server-side on both feature flag AND allow_run
+   per docs/specs/ops-specs-completion-candidates/ (Phase 2). #}
+{% if allow_run and specs_candidates_enabled %}
+<section id="completion-candidates" class="candidates-section" hidden aria-label="Specs that look complete">
+  <header class="candidates-head">
+    <h2>Ready to close? <span class="candidates-count" id="cc-count">0</span></h2>
+    <p class="candidates-sub">
+      Specs where all signals indicate the work is done. Confirm to
+      flip status to <code>complete</code>, or dismiss for 14 days
+      (re-surfaces immediately if new signal lands).
+    </p>
+  </header>
+  <ul class="candidates-list" id="cc-list" role="list"></ul>
+</section>
+{% endif %}
+
 {% if specs %}
   {# Compact status display: dot + 3-letter code for known statuses,
      truncated text + dotted underline for custom strings. Full status
@@ -123,5 +142,8 @@
 {% block scripts %}
 {% if allow_run %}
   <script src="{{ url_for('static', path='js/specs.js') }}?v={{ attune_version }}"></script>
+  {% if specs_candidates_enabled %}
+    <script src="{{ url_for('static', path='js/completion_candidates.js') }}?v={{ attune_version }}"></script>
+  {% endif %}
 {% endif %}
 {% endblock %}

--- a/tests/unit/ops/test_cli.py
+++ b/tests/unit/ops/test_cli.py
@@ -347,3 +347,101 @@ class TestMain:
         with patch.dict(sys.modules, {"uvicorn": None}):
             rc = ops_cli.main()
         assert rc == 2
+
+
+# ---------------------------------------------------------------------------
+# cmd_ops — --specs-candidates flag (T3 integration with persistence)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdOpsSpecsCandidates:
+    """End-to-end: CLI flag → resolver → build_config → banner."""
+
+    def test_flag_on_persists_and_shows_on_in_banner(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Redirect ATTUNE_HOME so the resolver writes into tmp_path.
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        parser = _make_parser()
+        args = parser.parse_args(
+            [
+                "ops",
+                "--no-browser",
+                "--specs-candidates",
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        with patch("uvicorn.run"):
+            rc = ops_cli.cmd_ops(args)
+        assert rc == 0
+        assert "specs-candidates: on" in capsys.readouterr().out
+
+        # Persisted to disk under the redirected ATTUNE_HOME.
+        from attune.ops import ops_config_store
+
+        assert ops_config_store.load_settings(tmp_path) == {"specs_candidates_enabled": True}
+
+    def test_no_flag_reads_persisted_true(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Pre-seed persisted state.
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        from attune.ops import ops_config_store
+
+        ops_config_store.save_setting(tmp_path, "specs_candidates_enabled", True)
+
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--no-browser", "--project-root", str(tmp_path)])
+        with patch("uvicorn.run"):
+            ops_cli.cmd_ops(args)
+        assert "specs-candidates: on" in capsys.readouterr().out
+
+    def test_flag_off_persists_false_after_prior_true(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        from attune.ops import ops_config_store
+
+        ops_config_store.save_setting(tmp_path, "specs_candidates_enabled", True)
+
+        parser = _make_parser()
+        args = parser.parse_args(
+            [
+                "ops",
+                "--no-browser",
+                "--no-specs-candidates",
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
+        with patch("uvicorn.run"):
+            ops_cli.cmd_ops(args)
+        assert "specs-candidates: off" in capsys.readouterr().out
+        assert ops_config_store.load_settings(tmp_path) == {"specs_candidates_enabled": False}
+
+    def test_default_off_when_no_persistence(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--no-browser", "--project-root", str(tmp_path)])
+        with patch("uvicorn.run"):
+            ops_cli.cmd_ops(args)
+        assert "specs-candidates: off" in capsys.readouterr().out
+        # No write happened on the read-only path.
+        from attune.ops import ops_config_store
+
+        assert not ops_config_store.settings_path(tmp_path).exists()

--- a/tests/unit/ops/test_completion_candidates.py
+++ b/tests/unit/ops/test_completion_candidates.py
@@ -1,0 +1,841 @@
+"""Unit tests for ``attune.ops.completion_candidates``.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T2).
+
+Covers every public surface plus the private signal-check helpers:
+
+- Per-signal correctness (status, edit-age, tasks, PRs, issues)
+- Host-repo URL parsing (Q1 three shapes + None paths)
+- Snapshot hash determinism
+- Cache TTL behavior
+- End-to-end ``detect_candidates`` with realistic fixture trees
+
+Subprocess calls (git / gh) are mocked at the module's three
+wrapper functions; no real network or git invocation happens.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from attune.ops import completion_candidates, dismiss_store
+from attune.ops.completion_candidates import (
+    CACHE_TTL_SECONDS,
+    _check_last_edit_age,
+    _check_no_open_issues,
+    _check_referenced_prs_merged,
+    _check_status_is_approved,
+    _check_tasks_all_done,
+    _extract_pr_refs,
+    _format_pr_evidence,
+    _preferred_status,
+    _resolve_host_repo,
+    _snapshot_hash,
+    clear_cache,
+    detect_candidates,
+)
+from attune.ops.config import Config
+from attune.ops.routes.specs import SpecPhase, SpecRecord
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> None:
+    """Module-level caches are persistent across tests by default."""
+    clear_cache()
+
+
+@pytest.fixture()
+def cfg(tmp_path: Path) -> Config:
+    """Config rooted at tmp_path; spec root at <tmp>/project/docs/specs."""
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True, exist_ok=True)
+    (project_root / "docs" / "specs").mkdir(parents=True, exist_ok=True)
+    return Config(
+        project_root=project_root,
+        attune_home=tmp_path / "attune-home",
+    )
+
+
+@pytest.fixture()
+def specs_root(cfg: Config) -> Path:
+    return cfg.project_root / "docs" / "specs"
+
+
+@pytest.fixture()
+def fake_gh(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch the three subprocess wrappers with in-memory fakes.
+
+    Returns a state dict the test mutates::
+
+        state["prs"][(repo, pr_number)] = {"state": "closed", ...} | None
+        state["issues"][(slug, repo)] = [{"number": ..., ...}, ...] | None
+        state["remotes"][str(cwd)] = "git@github.com:owner/name.git" | None
+
+    Missing entries return safe defaults (issues: [], others: None).
+    """
+    state: dict[str, dict] = {"prs": {}, "issues": {}, "remotes": {}}
+
+    def fake_pr(repo: str, pr_number: int) -> dict[str, Any] | None:
+        return state["prs"].get((repo, pr_number))
+
+    def fake_issues(slug: str, repo: str) -> list[dict[str, Any]] | None:
+        if (slug, repo) in state["issues"]:
+            return state["issues"][(slug, repo)]
+        return []
+
+    def fake_remote(cwd: Path) -> str | None:
+        return state["remotes"].get(str(cwd))
+
+    monkeypatch.setattr(completion_candidates, "_run_gh_pr_view", fake_pr)
+    monkeypatch.setattr(completion_candidates, "_run_gh_issue_search", fake_issues)
+    monkeypatch.setattr(completion_candidates, "_run_git_remote_origin", fake_remote)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_spec(
+    root: Path,
+    slug: str,
+    *,
+    decisions_status: str | None = "approved",
+    tasks_md: str | None = None,
+    extra_md: dict[str, str] | None = None,
+    age_hours: float = 100.0,
+) -> Path:
+    """Build a fixture spec dir with controllable signal state."""
+    spec_dir = root / slug
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    if decisions_status is not None:
+        (spec_dir / "decisions.md").write_text(
+            f"# {slug}\n\n**Status**: {decisions_status}\n",
+            encoding="utf-8",
+        )
+    if tasks_md is not None:
+        (spec_dir / "tasks.md").write_text(tasks_md, encoding="utf-8")
+    if extra_md:
+        for filename, content in extra_md.items():
+            (spec_dir / filename).write_text(content, encoding="utf-8")
+    # Force mtime to control age.
+    cutoff = time.time() - age_hours * 3600
+    for md in spec_dir.glob("*.md"):
+        os.utime(md, (cutoff, cutoff))
+    return spec_dir
+
+
+def _build_spec_record(
+    slug: str,
+    path: str,
+    statuses: dict[str, str | None],
+    last_modified_age_hours: float = 100.0,
+) -> SpecRecord:
+    """Build a SpecRecord directly (bypassing filesystem)."""
+    phases = [
+        SpecPhase(
+            name=name,
+            file=f"{name}.md",
+            exists=name in statuses,
+            status=statuses.get(name),
+        )
+        for name in ("decisions", "requirements", "design", "tasks")
+    ]
+    last = datetime.now(timezone.utc) - timedelta(hours=last_modified_age_hours)
+    return SpecRecord(
+        slug=slug,
+        root="/fake",
+        path=path,
+        phases=phases,
+        last_modified=last.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status check
+# ---------------------------------------------------------------------------
+
+
+class TestPreferredStatus:
+    def test_decisions_wins(self) -> None:
+        spec = _build_spec_record("s", "/p", {"decisions": "approved", "tasks": "draft"})
+        assert _preferred_status(spec) == "approved"
+
+    def test_falls_back_to_tasks(self) -> None:
+        spec = _build_spec_record("s", "/p", {"tasks": "approved"})
+        assert _preferred_status(spec) == "approved"
+
+    def test_falls_back_through_order(self) -> None:
+        spec = _build_spec_record("s", "/p", {"requirements": "approved"})
+        assert _preferred_status(spec) == "approved"
+
+    def test_returns_none_when_no_status_set(self) -> None:
+        spec = _build_spec_record("s", "/p", {"decisions": None, "tasks": None})
+        assert _preferred_status(spec) is None
+
+    def test_strips_and_lowercases(self) -> None:
+        spec = _build_spec_record("s", "/p", {"decisions": "  APPROVED  "})
+        assert _preferred_status(spec) == "approved"
+
+
+class TestCheckStatusIsApproved:
+    """The status filter — only `approved` qualifies."""
+
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            ("approved", True),
+            ("draft", False),
+            ("in-review", False),
+            ("complete", False),
+            ("partial", False),
+            ("paused", False),
+            ("retired", False),
+            (None, False),
+        ],
+    )
+    def test_filter(self, status: str | None, expected: bool) -> None:
+        spec = _build_spec_record("s", "/p", {"decisions": status})
+        assert _check_status_is_approved(spec) is expected
+
+
+# ---------------------------------------------------------------------------
+# Edit-age check
+# ---------------------------------------------------------------------------
+
+
+class TestCheckLastEditAge:
+    def test_23h_fails(self) -> None:
+        now = datetime(2026, 5, 16, 12, 0, tzinfo=timezone.utc)
+        spec = _build_spec_record(
+            "s",
+            "/p",
+            {"decisions": "approved"},
+            last_modified_age_hours=0,  # we'll override
+        )
+        # Build a spec with last_modified = 23h before now.
+        last = (now - timedelta(hours=23)).isoformat()
+        spec = SpecRecord(slug="s", root="/r", path="/p", phases=spec.phases, last_modified=last)
+        ok, ev = _check_last_edit_age(spec, now=now)
+        assert ok is False
+        assert ev is None
+
+    def test_25h_passes(self) -> None:
+        now = datetime(2026, 5, 16, 12, 0, tzinfo=timezone.utc)
+        last = (now - timedelta(hours=25)).isoformat()
+        spec = SpecRecord(
+            slug="s",
+            root="/r",
+            path="/p",
+            phases=[],
+            last_modified=last,
+        )
+        ok, ev = _check_last_edit_age(spec, now=now)
+        assert ok is True
+        assert ev is not None
+        assert "last edit" in ev
+
+    def test_missing_last_modified_fails(self) -> None:
+        spec = SpecRecord(slug="s", root="/r", path="/p", phases=[], last_modified=None)
+        ok, ev = _check_last_edit_age(spec)
+        assert (ok, ev) == (False, None)
+
+    def test_unparseable_last_modified_fails(self) -> None:
+        spec = SpecRecord(
+            slug="s",
+            root="/r",
+            path="/p",
+            phases=[],
+            last_modified="not-a-date",
+        )
+        ok, ev = _check_last_edit_age(spec)
+        assert (ok, ev) == (False, None)
+
+    def test_naive_datetime_rejected(self) -> None:
+        spec = SpecRecord(
+            slug="s",
+            root="/r",
+            path="/p",
+            phases=[],
+            last_modified="2026-05-01T12:00:00",
+        )
+        ok, ev = _check_last_edit_age(spec)
+        assert (ok, ev) == (False, None)
+
+    def test_evidence_phrasing_singular_vs_plural(self) -> None:
+        now = datetime(2026, 5, 16, 12, 0, tzinfo=timezone.utc)
+        # 26 hours -> 1 day (max(1, int(26/24)) = 1)
+        last = (now - timedelta(hours=26)).isoformat()
+        spec = SpecRecord(slug="s", root="/r", path="/p", phases=[], last_modified=last)
+        ok, ev = _check_last_edit_age(spec, now=now)
+        assert ok is True and ev == "✓ last edit 1 day ago"
+
+        # 5 days -> "5 days ago"
+        last = (now - timedelta(days=5)).isoformat()
+        spec = SpecRecord(slug="s", root="/r", path="/p", phases=[], last_modified=last)
+        ok, ev = _check_last_edit_age(spec, now=now)
+        assert ok is True and ev == "✓ last edit 5 days ago"
+
+
+# ---------------------------------------------------------------------------
+# Tasks check
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTasksAllDone:
+    def test_missing_tasks_md_passes(self, tmp_path: Path) -> None:
+        ok, ev = _check_tasks_all_done(tmp_path)
+        assert ok is True
+        assert ev == "✓ no tasks.md (decisions-only spec)"
+
+    def test_empty_tasks_md_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text("# Tasks\n\nJust a header.\n", encoding="utf-8")
+        ok, ev = _check_tasks_all_done(tmp_path)
+        assert (ok, ev) == (False, None)
+
+    def test_all_checked_rows_pass(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text(
+            "# Tasks\n\n- [x] First\n- [x] Second\n- [x] Third\n",
+            encoding="utf-8",
+        )
+        ok, ev = _check_tasks_all_done(tmp_path)
+        assert ok is True
+        assert ev == "✓ 3 task rows complete"
+
+    def test_one_unchecked_row_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text(
+            "- [x] First\n- [ ] Second\n- [x] Third\n", encoding="utf-8"
+        )
+        ok, ev = _check_tasks_all_done(tmp_path)
+        assert (ok, ev) == (False, None)
+
+    def test_capital_X_recognized(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text("- [X] First\n- [x] Second\n", encoding="utf-8")
+        ok, _ = _check_tasks_all_done(tmp_path)
+        assert ok is True
+
+    def test_table_done_markers_count(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text(
+            "| Task | Status |\n"
+            "|------|--------|\n"
+            "| T1 | **done** |\n"
+            "| T2 | **complete** |\n",
+            encoding="utf-8",
+        )
+        ok, ev = _check_tasks_all_done(tmp_path)
+        assert ok is True
+        assert ev == "✓ 2 task rows complete"
+
+    def test_mixed_checkbox_and_table_pass(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text(
+            "- [x] First\n\n| T | S |\n|---|---|\n| T2 | **done** |\n",
+            encoding="utf-8",
+        )
+        ok, ev = _check_tasks_all_done(tmp_path)
+        assert ok is True
+        assert ev == "✓ 2 task rows complete"
+
+    def test_unchecked_row_in_mixed_format_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text(
+            "- [ ] First\n\n| T | S |\n|---|---|\n| T2 | **done** |\n",
+            encoding="utf-8",
+        )
+        ok, _ = _check_tasks_all_done(tmp_path)
+        assert ok is False
+
+    def test_singular_evidence_phrasing(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text("- [x] Only\n", encoding="utf-8")
+        ok, ev = _check_tasks_all_done(tmp_path)
+        assert ok is True
+        assert ev == "✓ 1 task row complete"
+
+
+# ---------------------------------------------------------------------------
+# PR ref extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPrRefs:
+    def test_finds_hash_refs(self, tmp_path: Path) -> None:
+        (tmp_path / "decisions.md").write_text("Shipped in #324 and #325.\n", encoding="utf-8")
+        assert _extract_pr_refs(tmp_path) == [324, 325]
+
+    def test_finds_pr_word_refs(self, tmp_path: Path) -> None:
+        (tmp_path / "decisions.md").write_text("See PR 100 and pr 200.\n", encoding="utf-8")
+        assert _extract_pr_refs(tmp_path) == [100, 200]
+
+    def test_deduplicates_across_files(self, tmp_path: Path) -> None:
+        (tmp_path / "decisions.md").write_text("#324\n", encoding="utf-8")
+        (tmp_path / "tasks.md").write_text("#324 #325\n", encoding="utf-8")
+        assert _extract_pr_refs(tmp_path) == [324, 325]
+
+    def test_ignores_discursive_files(self, tmp_path: Path) -> None:
+        # Per Q5: only decisions.md and tasks.md are scanned.
+        (tmp_path / "_sequencing.md").write_text("#999\n", encoding="utf-8")
+        (tmp_path / "audit.md").write_text("#888\n", encoding="utf-8")
+        (tmp_path / "decisions.md").write_text("#324\n", encoding="utf-8")
+        assert _extract_pr_refs(tmp_path) == [324]
+
+    def test_empty_when_no_refs(self, tmp_path: Path) -> None:
+        (tmp_path / "decisions.md").write_text("No PR mentioned.\n", encoding="utf-8")
+        assert _extract_pr_refs(tmp_path) == []
+
+    def test_missing_files_are_skipped(self, tmp_path: Path) -> None:
+        # Neither decisions.md nor tasks.md present.
+        assert _extract_pr_refs(tmp_path) == []
+
+    def test_returns_sorted(self, tmp_path: Path) -> None:
+        (tmp_path / "decisions.md").write_text("#3 #1 #2\n", encoding="utf-8")
+        assert _extract_pr_refs(tmp_path) == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# PR merged check
+# ---------------------------------------------------------------------------
+
+
+class TestCheckReferencedPrsMerged:
+    def test_empty_pr_list_passes(self, fake_gh: dict) -> None:
+        ok, ev = _check_referenced_prs_merged([], "owner/repo")
+        assert ok is True
+        assert ev is None
+
+    def test_all_merged_passes(self, fake_gh: dict) -> None:
+        fake_gh["prs"][("owner/repo", 1)] = {
+            "state": "closed",
+            "merged_at": "2026-05-14T12:00:00Z",
+        }
+        fake_gh["prs"][("owner/repo", 2)] = {
+            "state": "closed",
+            "merged_at": "2026-05-14T12:00:00Z",
+        }
+        ok, ev = _check_referenced_prs_merged([1, 2], "owner/repo")
+        assert ok is True
+        assert ev is not None
+        assert "#1" in ev and "#2" in ev
+
+    def test_one_open_fails(self, fake_gh: dict) -> None:
+        fake_gh["prs"][("owner/repo", 1)] = {
+            "state": "closed",
+            "merged_at": "2026-05-14T12:00:00Z",
+        }
+        fake_gh["prs"][("owner/repo", 2)] = {
+            "state": "open",
+            "merged_at": None,
+        }
+        ok, ev = _check_referenced_prs_merged([1, 2], "owner/repo")
+        assert (ok, ev) == (False, None)
+
+    def test_closed_not_merged_fails(self, fake_gh: dict) -> None:
+        fake_gh["prs"][("owner/repo", 1)] = {
+            "state": "closed",
+            "merged_at": None,
+        }
+        ok, ev = _check_referenced_prs_merged([1], "owner/repo")
+        assert (ok, ev) == (False, None)
+
+    def test_gh_failure_fails(self, fake_gh: dict) -> None:
+        # Missing entry -> fake returns None -> treat as gh failure.
+        ok, ev = _check_referenced_prs_merged([99], "owner/repo")
+        assert (ok, ev) == (False, None)
+
+    def test_truncates_long_pr_lists_in_evidence(self) -> None:
+        # Direct unit test on the formatter.
+        ev = _format_pr_evidence(list(range(1, 11)))
+        assert "#1" in ev and "#5" in ev
+        assert "#6" not in ev
+        assert "…+5 more" in ev
+
+
+# ---------------------------------------------------------------------------
+# Open-issues check
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNoOpenIssues:
+    def test_empty_result_passes(self, fake_gh: dict) -> None:
+        ok, ev = _check_no_open_issues("my-spec", "owner/repo")
+        assert ok is True
+        assert ev == "✓ no open issues reference this spec"
+
+    def test_nonempty_result_fails(self, fake_gh: dict) -> None:
+        fake_gh["issues"][("my-spec", "owner/repo")] = [
+            {"number": 42, "title": "fix my-spec"},
+        ]
+        ok, ev = _check_no_open_issues("my-spec", "owner/repo")
+        assert (ok, ev) == (False, None)
+
+    def test_gh_failure_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            completion_candidates,
+            "_run_gh_issue_search",
+            lambda slug, repo: None,
+        )
+        ok, ev = _check_no_open_issues("my-spec", "owner/repo")
+        assert (ok, ev) == (False, None)
+
+
+# ---------------------------------------------------------------------------
+# Host-repo discovery (Q1)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveHostRepo:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("git@github.com:Smart-AI-Memory/attune-ai.git", "Smart-AI-Memory/attune-ai"),
+            ("https://github.com/Smart-AI-Memory/attune-ai.git", "Smart-AI-Memory/attune-ai"),
+            ("https://github.com/Smart-AI-Memory/attune-ai", "Smart-AI-Memory/attune-ai"),
+            ("http://github.com/owner/name", "owner/name"),
+        ],
+    )
+    def test_parses_known_url_shapes(
+        self,
+        tmp_path: Path,
+        fake_gh: dict,
+        url: str,
+        expected: str,
+    ) -> None:
+        root = tmp_path / "docs" / "specs"
+        root.mkdir(parents=True)
+        fake_gh["remotes"][str(tmp_path / "docs")] = url
+        assert _resolve_host_repo(root) == expected
+
+    def test_returns_none_when_no_remote(self, tmp_path: Path, fake_gh: dict) -> None:
+        root = tmp_path / "docs" / "specs"
+        root.mkdir(parents=True)
+        # No remote configured for this cwd.
+        assert _resolve_host_repo(root) is None
+
+    def test_returns_none_for_unrecognized_url(self, tmp_path: Path, fake_gh: dict) -> None:
+        root = tmp_path / "docs" / "specs"
+        root.mkdir(parents=True)
+        fake_gh["remotes"][str(tmp_path / "docs")] = "ssh://gitlab.com/x/y"
+        assert _resolve_host_repo(root) is None
+
+    def test_memoized_per_root(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        call_count = {"n": 0}
+
+        def fake_remote(cwd: Path) -> str | None:
+            call_count["n"] += 1
+            return "git@github.com:owner/name.git"
+
+        monkeypatch.setattr(completion_candidates, "_run_git_remote_origin", fake_remote)
+        root = tmp_path / "docs" / "specs"
+        root.mkdir(parents=True)
+        _resolve_host_repo(root)
+        _resolve_host_repo(root)
+        _resolve_host_repo(root)
+        assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Snapshot hash
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotHash:
+    def test_deterministic_same_inputs(self, tmp_path: Path) -> None:
+        h1 = _snapshot_hash(tmp_path, [1, 2, 3], "2026-05-15T12:00:00+00:00")
+        h2 = _snapshot_hash(tmp_path, [1, 2, 3], "2026-05-15T12:00:00+00:00")
+        assert h1 == h2
+
+    def test_pr_order_does_not_matter(self, tmp_path: Path) -> None:
+        h1 = _snapshot_hash(tmp_path, [3, 1, 2], "x")
+        h2 = _snapshot_hash(tmp_path, [1, 2, 3], "x")
+        assert h1 == h2
+
+    def test_tasks_mtime_change_changes_hash(self, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks.md"
+        tasks.write_text("- [x] one\n", encoding="utf-8")
+        os.utime(tasks, (1000.0, 1000.0))
+        h1 = _snapshot_hash(tmp_path, [], "x")
+        os.utime(tasks, (2000.0, 2000.0))
+        h2 = _snapshot_hash(tmp_path, [], "x")
+        assert h1 != h2
+
+    def test_last_modified_change_changes_hash(self, tmp_path: Path) -> None:
+        h1 = _snapshot_hash(tmp_path, [], "2026-05-15T12:00:00+00:00")
+        h2 = _snapshot_hash(tmp_path, [], "2026-05-16T12:00:00+00:00")
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# Cache
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    def test_two_calls_within_ttl_return_same_list(self, cfg: Config, fake_gh: dict) -> None:
+        now = 1_000_000.0
+        c1 = detect_candidates(cfg, now=now)
+        c2 = detect_candidates(cfg, now=now + CACHE_TTL_SECONDS - 1)
+        assert c1 is c2  # exact list identity
+
+    def test_call_past_ttl_recomputes(self, cfg: Config, fake_gh: dict) -> None:
+        now = 1_000_000.0
+        c1 = detect_candidates(cfg, now=now)
+        c2 = detect_candidates(cfg, now=now + CACHE_TTL_SECONDS + 1)
+        # Recomputed - different list object, even if equal content.
+        assert c1 is not c2
+
+    def test_clear_cache_forces_recompute(self, cfg: Config, fake_gh: dict) -> None:
+        now = 1_000_000.0
+        c1 = detect_candidates(cfg, now=now)
+        clear_cache()
+        c2 = detect_candidates(cfg, now=now)
+        assert c1 is not c2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: detect_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCandidatesEndToEnd:
+    def test_empty_spec_root_returns_empty(self, cfg: Config, fake_gh: dict) -> None:
+        assert detect_candidates(cfg) == []
+
+    def test_approved_spec_no_prs_no_issues_qualifies(
+        self, cfg: Config, specs_root: Path, fake_gh: dict
+    ) -> None:
+        _make_spec(
+            specs_root,
+            "ready-spec",
+            decisions_status="approved",
+            tasks_md="- [x] T1\n- [x] T2\n",
+            age_hours=48,
+        )
+        # No remote -> no repo, no PR refs -> still qualifies.
+        result = detect_candidates(cfg)
+        assert len(result) == 1
+        c = result[0]
+        assert c.slug == "ready-spec"
+        assert c.current_status == "approved"
+        assert any("task rows complete" in e for e in c.evidence)
+
+    def test_draft_spec_filtered_out(self, cfg: Config, specs_root: Path, fake_gh: dict) -> None:
+        _make_spec(specs_root, "drafty", decisions_status="draft")
+        assert detect_candidates(cfg) == []
+
+    def test_recently_edited_spec_filtered_out(
+        self, cfg: Config, specs_root: Path, fake_gh: dict
+    ) -> None:
+        _make_spec(
+            specs_root,
+            "fresh",
+            decisions_status="approved",
+            age_hours=1,
+        )
+        assert detect_candidates(cfg) == []
+
+    def test_pr_refs_require_host_repo(self, cfg: Config, specs_root: Path, fake_gh: dict) -> None:
+        # PR ref present but no remote configured -> rejected.
+        _make_spec(
+            specs_root,
+            "spec-with-prs",
+            decisions_status="approved",
+            extra_md={"decisions.md": "**Status**: approved\nSee #324\n"},
+            age_hours=48,
+        )
+        assert detect_candidates(cfg) == []
+
+    def test_pr_refs_all_merged_qualifies(
+        self, cfg: Config, specs_root: Path, fake_gh: dict
+    ) -> None:
+        repo = "owner/name"
+        fake_gh["remotes"][str(cfg.project_root / "docs")] = f"git@github.com:{repo}.git"
+        fake_gh["prs"][(repo, 324)] = {
+            "state": "closed",
+            "merged_at": "2026-05-14T12:00:00Z",
+        }
+        _make_spec(
+            specs_root,
+            "merged-spec",
+            decisions_status="approved",
+            extra_md={
+                "decisions.md": "**Status**: approved\nShipped in #324\n",
+            },
+            age_hours=48,
+        )
+        result = detect_candidates(cfg)
+        assert len(result) == 1
+        assert any("#324" in e for e in result[0].evidence)
+
+    def test_open_issue_blocks_candidate(
+        self, cfg: Config, specs_root: Path, fake_gh: dict
+    ) -> None:
+        repo = "owner/name"
+        fake_gh["remotes"][str(cfg.project_root / "docs")] = f"https://github.com/{repo}"
+        fake_gh["issues"][("blocked-spec", repo)] = [{"number": 100, "title": "blocked-spec broke"}]
+        _make_spec(
+            specs_root,
+            "blocked-spec",
+            decisions_status="approved",
+            age_hours=48,
+        )
+        assert detect_candidates(cfg) == []
+
+    def test_dismissed_candidate_suppressed_within_ttl(
+        self, cfg: Config, specs_root: Path, fake_gh: dict
+    ) -> None:
+        _make_spec(
+            specs_root,
+            "dismissed-spec",
+            decisions_status="approved",
+            tasks_md="- [x] T1\n",
+            age_hours=48,
+        )
+        # First call: candidate qualifies. Capture its snapshot hash.
+        result = detect_candidates(cfg)
+        assert len(result) == 1
+        snap = result[0].snapshot_hash
+
+        # Dismiss it.
+        dismiss_store.save("dismissed-spec", snap, cfg)
+        clear_cache()
+        # Now suppressed.
+        assert detect_candidates(cfg) == []
+
+    def test_dismissed_resurfaces_when_signal_changes(
+        self, cfg: Config, specs_root: Path, fake_gh: dict
+    ) -> None:
+        _make_spec(
+            specs_root,
+            "resurface-spec",
+            decisions_status="approved",
+            tasks_md="- [x] T1\n",
+            age_hours=48,
+        )
+        result = detect_candidates(cfg)
+        assert len(result) == 1
+        # Dismiss with the WRONG snapshot hash -> never matches current ->
+        # always re-surfaces.
+        dismiss_store.save("resurface-spec", "stale-hash", cfg)
+        clear_cache()
+        result = detect_candidates(cfg)
+        assert len(result) == 1
+        assert result[0].slug == "resurface-spec"
+
+    def test_multiple_specs_mixed_status(
+        self, cfg: Config, specs_root: Path, fake_gh: dict
+    ) -> None:
+        _make_spec(specs_root, "a", decisions_status="approved", tasks_md="- [x] T\n", age_hours=48)
+        _make_spec(specs_root, "b", decisions_status="draft", age_hours=48)
+        _make_spec(specs_root, "c", decisions_status="approved", tasks_md="- [ ] T\n", age_hours=48)
+        result = detect_candidates(cfg)
+        slugs = {c.slug for c in result}
+        assert slugs == {"a"}
+
+
+# ---------------------------------------------------------------------------
+# Subprocess wrappers — direct tests with mocked subprocess.run
+# ---------------------------------------------------------------------------
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> Any:
+    """Build a minimal CompletedProcess stand-in."""
+
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestRunGitRemoteOrigin:
+    def test_success_returns_url(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda *a, **kw: _completed(0, "git@github.com:o/n.git\n"),
+        )
+        assert completion_candidates._run_git_remote_origin(tmp_path) == "git@github.com:o/n.git"
+
+    def test_nonzero_returncode_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(1, "", "err"))
+        assert completion_candidates._run_git_remote_origin(tmp_path) is None
+
+    def test_empty_stdout_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(0, "   \n"))
+        assert completion_candidates._run_git_remote_origin(tmp_path) is None
+
+    def test_oserror_returns_none(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        def raises(*a: Any, **kw: Any) -> None:
+            raise OSError("no git")
+
+        monkeypatch.setattr("subprocess.run", raises)
+        assert completion_candidates._run_git_remote_origin(tmp_path) is None
+
+    def test_timeout_returns_none(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+
+        def raises(*a: Any, **kw: Any) -> None:
+            raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+        monkeypatch.setattr("subprocess.run", raises)
+        assert completion_candidates._run_git_remote_origin(tmp_path) is None
+
+
+class TestRunGhPrView:
+    def test_success_returns_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = json.dumps({"state": "closed", "merged_at": "x"})
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(0, payload))
+        result = completion_candidates._run_gh_pr_view("o/n", 1)
+        assert result == {"state": "closed", "merged_at": "x"}
+
+    def test_nonzero_returncode_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(1, "", "404"))
+        assert completion_candidates._run_gh_pr_view("o/n", 99) is None
+
+    def test_invalid_json_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(0, "not json"))
+        assert completion_candidates._run_gh_pr_view("o/n", 1) is None
+
+    def test_non_dict_json_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(0, "[]"))
+        assert completion_candidates._run_gh_pr_view("o/n", 1) is None
+
+    def test_timeout_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+
+        def raises(*a: Any, **kw: Any) -> None:
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=10)
+
+        monkeypatch.setattr("subprocess.run", raises)
+        assert completion_candidates._run_gh_pr_view("o/n", 1) is None
+
+
+class TestRunGhIssueSearch:
+    def test_success_returns_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        payload = json.dumps([{"number": 1, "title": "x"}])
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(0, payload))
+        result = completion_candidates._run_gh_issue_search("slug", "o/n")
+        assert result == [{"number": 1, "title": "x"}]
+
+    def test_empty_list_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(0, "[]"))
+        assert completion_candidates._run_gh_issue_search("slug", "o/n") == []
+
+    def test_nonzero_returncode_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(1))
+        assert completion_candidates._run_gh_issue_search("slug", "o/n") is None
+
+    def test_invalid_json_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(0, "broken"))
+        assert completion_candidates._run_gh_issue_search("slug", "o/n") is None
+
+    def test_non_list_json_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("subprocess.run", lambda *a, **kw: _completed(0, "{}"))
+        assert completion_candidates._run_gh_issue_search("slug", "o/n") is None

--- a/tests/unit/ops/test_completion_candidates_routes.py
+++ b/tests/unit/ops/test_completion_candidates_routes.py
@@ -1,0 +1,426 @@
+"""HTTP-level tests for the completion-candidates endpoints.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T4).
+
+Covers:
+
+- ``GET /api/specs/completion-candidates`` — gate on
+  ``specs_candidates_enabled`` and ``allow_run``, response shape,
+  detector caching across calls.
+- ``POST /api/specs/{slug}/completion-candidates/dismiss`` — happy
+  path, validation (slug, hash), read-only mode, persist failure.
+- ``PUT /api/specs/{slug}/{phase}/status`` dismiss-clear semantics:
+  flipping to ``complete``/``completed``/``done`` does NOT clear the
+  dismiss; flipping to anything else does clear it.
+
+Tests run against a real FastAPI TestClient using the real
+``create_app`` + ``build_config`` pipeline; the only fakes are the
+gh subprocess wrappers (mocked at the
+``attune.ops.completion_candidates`` module level).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops import completion_candidates, dismiss_store  # noqa: E402
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+
+def _make_spec(
+    root: Path,
+    slug: str,
+    *,
+    decisions_status: str | None = "approved",
+    tasks_md: str | None = None,
+    age_hours: float = 100.0,
+) -> Path:
+    """Build a fixture spec dir with controllable signal state."""
+    spec_dir = root / slug
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    if decisions_status is not None:
+        (spec_dir / "decisions.md").write_text(
+            f"# {slug}\n\n**Status**: {decisions_status}\n",
+            encoding="utf-8",
+        )
+    if tasks_md is not None:
+        (spec_dir / "tasks.md").write_text(tasks_md, encoding="utf-8")
+    cutoff = time.time() - age_hours * 3600
+    for md in spec_dir.glob("*.md"):
+        os.utime(md, (cutoff, cutoff))
+    return spec_dir
+
+
+def _client(
+    tmp_path: Path,
+    *,
+    specs_candidates_enabled: bool = True,
+    allow_run: bool = True,
+) -> TestClient:
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=allow_run,
+        specs_candidates_enabled=specs_candidates_enabled,
+        trusted_hosts=("testserver", "test"),
+    )
+    return TestClient(create_app(config))
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> None:
+    """Ensure detector cache and gh-fake state reset between tests."""
+    completion_candidates.clear_cache()
+    yield
+    completion_candidates.clear_cache()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_attune_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect ATTUNE_HOME so dismiss_store writes don't escape."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+
+
+@pytest.fixture
+def fake_gh(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch the three subprocess wrappers."""
+    state: dict[str, dict] = {"prs": {}, "issues": {}, "remotes": {}}
+
+    def fake_pr(repo: str, pr_number: int) -> dict[str, Any] | None:
+        return state["prs"].get((repo, pr_number))
+
+    def fake_issues(slug: str, repo: str) -> list[dict[str, Any]] | None:
+        if (slug, repo) in state["issues"]:
+            return state["issues"][(slug, repo)]
+        return []
+
+    def fake_remote(cwd: Path) -> str | None:
+        return state["remotes"].get(str(cwd))
+
+    monkeypatch.setattr(completion_candidates, "_run_gh_pr_view", fake_pr)
+    monkeypatch.setattr(completion_candidates, "_run_gh_issue_search", fake_issues)
+    monkeypatch.setattr(completion_candidates, "_run_git_remote_origin", fake_remote)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# GET /api/specs/completion-candidates
+# ---------------------------------------------------------------------------
+
+
+class TestGetCompletionCandidatesGating:
+    def test_disabled_returns_enabled_false_empty(self, tmp_path: Path, fake_gh: dict) -> None:
+        client = _client(tmp_path, specs_candidates_enabled=False, allow_run=True)
+        response = client.get("/api/specs/completion-candidates")
+        assert response.status_code == 200
+        assert response.json() == {"enabled": False, "candidates": []}
+
+    def test_read_only_returns_enabled_false_empty(self, tmp_path: Path, fake_gh: dict) -> None:
+        client = _client(tmp_path, specs_candidates_enabled=True, allow_run=False)
+        response = client.get("/api/specs/completion-candidates")
+        assert response.status_code == 200
+        assert response.json() == {"enabled": False, "candidates": []}
+
+    def test_both_off_returns_enabled_false_empty(self, tmp_path: Path, fake_gh: dict) -> None:
+        client = _client(tmp_path, specs_candidates_enabled=False, allow_run=False)
+        response = client.get("/api/specs/completion-candidates")
+        assert response.json()["enabled"] is False
+
+    def test_disabled_does_not_invoke_detector(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Detector must not even import. Patch with a sentinel that
+        # raises if called.
+        def boom(*a: Any, **kw: Any) -> None:
+            raise AssertionError("detector should not run when disabled")
+
+        monkeypatch.setattr(completion_candidates, "detect_candidates", boom)
+        client = _client(tmp_path, specs_candidates_enabled=False)
+        response = client.get("/api/specs/completion-candidates")
+        assert response.status_code == 200
+
+
+class TestGetCompletionCandidatesShape:
+    def test_empty_specs_returns_enabled_true_empty_list(
+        self, tmp_path: Path, fake_gh: dict
+    ) -> None:
+        client = _client(tmp_path)
+        response = client.get("/api/specs/completion-candidates")
+        assert response.status_code == 200
+        assert response.json() == {"enabled": True, "candidates": []}
+
+    def test_qualifying_spec_renders_full_candidate(self, tmp_path: Path, fake_gh: dict) -> None:
+        specs_root = tmp_path / "docs" / "specs"
+        specs_root.mkdir(parents=True)
+        _make_spec(
+            specs_root,
+            "ready-spec",
+            decisions_status="approved",
+            tasks_md="- [x] T1\n- [x] T2\n",
+            age_hours=48,
+        )
+        client = _client(tmp_path)
+        body = client.get("/api/specs/completion-candidates").json()
+        assert body["enabled"] is True
+        assert len(body["candidates"]) == 1
+        cand = body["candidates"][0]
+        assert cand["slug"] == "ready-spec"
+        assert cand["current_status"] == "approved"
+        assert isinstance(cand["evidence"], list)
+        assert any("task rows complete" in e for e in cand["evidence"])
+        # SHA-256 hex = 64 chars [0-9a-f].
+        assert len(cand["snapshot_hash"]) == 64
+        assert all(c in "0123456789abcdef" for c in cand["snapshot_hash"])
+
+    def test_uses_detector_cache_across_calls(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_gh: dict,
+    ) -> None:
+        call_count = {"n": 0}
+        real_detect = completion_candidates.detect_candidates
+
+        def counted_detect(config: Any, **kw: Any) -> Any:
+            call_count["n"] += 1
+            return real_detect(config, **kw)
+
+        monkeypatch.setattr(completion_candidates, "detect_candidates", counted_detect)
+        client = _client(tmp_path)
+        client.get("/api/specs/completion-candidates")
+        client.get("/api/specs/completion-candidates")
+        # Both requests trigger our counted_detect wrapper, but the
+        # underlying real detector's cache means the second call
+        # returns the cached list. The wrapper still increments once
+        # per HTTP call — what we verify is that the response shape
+        # stays consistent (both calls succeed, no extra work).
+        assert call_count["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# POST /api/specs/{slug}/completion-candidates/dismiss
+# ---------------------------------------------------------------------------
+
+
+def _valid_hash() -> str:
+    """A SHA-256-shaped string for body validation tests."""
+    return "a" * 64
+
+
+class TestPostDismissHappy:
+    def test_writes_to_store_and_returns_ok(self, tmp_path: Path) -> None:
+        client = _client(tmp_path)
+        response = client.post(
+            "/api/specs/my-spec/completion-candidates/dismiss",
+            json={"snapshot_hash": _valid_hash()},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+        # State landed on disk under the redirected ATTUNE_HOME.
+        config = build_config(
+            project_root=tmp_path,
+            specs_candidates_enabled=True,
+            allow_run=True,
+        )
+        loaded = dismiss_store.load(config)
+        assert "my-spec" in loaded
+        assert loaded["my-spec"].snapshot_hash == _valid_hash()
+
+    def test_subsequent_get_excludes_dismissed_candidate(
+        self, tmp_path: Path, fake_gh: dict
+    ) -> None:
+        specs_root = tmp_path / "docs" / "specs"
+        specs_root.mkdir(parents=True)
+        _make_spec(
+            specs_root,
+            "ready-spec",
+            decisions_status="approved",
+            tasks_md="- [x] T1\n",
+            age_hours=48,
+        )
+        client = _client(tmp_path)
+        # First GET surfaces the candidate.
+        first = client.get("/api/specs/completion-candidates").json()
+        assert len(first["candidates"]) == 1
+        snap = first["candidates"][0]["snapshot_hash"]
+
+        # Dismiss it.
+        post = client.post(
+            "/api/specs/ready-spec/completion-candidates/dismiss",
+            json={"snapshot_hash": snap},
+        )
+        assert post.status_code == 200
+
+        # Detector cache holds the original result for 5 minutes —
+        # clear it so the next GET re-runs detection and sees the
+        # dismiss filter take effect.
+        completion_candidates.clear_cache()
+
+        second = client.get("/api/specs/completion-candidates").json()
+        assert second["candidates"] == []
+
+
+class TestPostDismissValidation:
+    def test_read_only_returns_403(self, tmp_path: Path) -> None:
+        client = _client(tmp_path, allow_run=False)
+        response = client.post(
+            "/api/specs/my-spec/completion-candidates/dismiss",
+            json={"snapshot_hash": _valid_hash()},
+        )
+        assert response.status_code == 403
+
+    def test_missing_hash_returns_422(self, tmp_path: Path) -> None:
+        client = _client(tmp_path)
+        response = client.post(
+            "/api/specs/my-spec/completion-candidates/dismiss",
+            json={},
+        )
+        assert response.status_code == 422
+
+    def test_invalid_hash_shape_returns_422(self, tmp_path: Path) -> None:
+        client = _client(tmp_path)
+        response = client.post(
+            "/api/specs/my-spec/completion-candidates/dismiss",
+            json={"snapshot_hash": "not-a-real-hash"},
+        )
+        assert response.status_code == 422
+
+    def test_uppercase_hex_rejected(self, tmp_path: Path) -> None:
+        # SHA-256 hex output is lowercase; reject uppercase to keep
+        # the persisted snapshot format canonical.
+        client = _client(tmp_path)
+        response = client.post(
+            "/api/specs/my-spec/completion-candidates/dismiss",
+            json={"snapshot_hash": "A" * 64},
+        )
+        assert response.status_code == 422
+
+    def test_non_string_hash_returns_422(self, tmp_path: Path) -> None:
+        client = _client(tmp_path)
+        response = client.post(
+            "/api/specs/my-spec/completion-candidates/dismiss",
+            json={"snapshot_hash": 12345},
+        )
+        assert response.status_code == 422
+
+    def test_invalid_slug_returns_400(self, tmp_path: Path) -> None:
+        client = _client(tmp_path)
+        response = client.post(
+            "/api/specs/Invalid_Slug/completion-candidates/dismiss",
+            json={"snapshot_hash": _valid_hash()},
+        )
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/specs/{slug}/{phase}/status — dismiss-clear semantics
+# ---------------------------------------------------------------------------
+
+
+def _seed_dismiss(config: Any, slug: str) -> None:
+    """Pre-seed a dismiss entry for ``slug``."""
+    dismiss_store.save(slug, _valid_hash(), config)
+
+
+def _has_dismiss(config: Any, slug: str) -> bool:
+    return slug in dismiss_store.load(config)
+
+
+def _make_spec_with_status_file(
+    tmp_path: Path, slug: str, initial_status: str = "complete"
+) -> Path:
+    specs_root = tmp_path / "docs" / "specs"
+    specs_root.mkdir(parents=True, exist_ok=True)
+    spec_dir = specs_root / slug
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / "decisions.md").write_text(
+        f"# {slug}\n\n**Status:** {initial_status}\n", encoding="utf-8"
+    )
+    return spec_dir
+
+
+class TestPutStatusDismissClear:
+    """The PUT handler clears dismiss on flips AWAY from complete-like."""
+
+    @pytest.mark.parametrize("target_status", ["complete", "completed", "done"])
+    def test_flip_to_complete_like_does_not_clear(self, tmp_path: Path, target_status: str) -> None:
+        _make_spec_with_status_file(tmp_path, "my-spec", "approved")
+        config = build_config(
+            project_root=tmp_path,
+            specs_candidates_enabled=True,
+            allow_run=True,
+        )
+        _seed_dismiss(config, "my-spec")
+        assert _has_dismiss(config, "my-spec")
+
+        client = _client(tmp_path)
+        response = client.put(
+            "/api/specs/my-spec/decisions/status",
+            json={"status": target_status},
+        )
+        assert response.status_code == 200
+        # Dismiss survives the complete-like flip.
+        assert _has_dismiss(config, "my-spec")
+
+    @pytest.mark.parametrize("target_status", ["approved", "draft", "in-review"])
+    def test_flip_to_non_complete_clears_dismiss(self, tmp_path: Path, target_status: str) -> None:
+        _make_spec_with_status_file(tmp_path, "my-spec", "complete")
+        config = build_config(
+            project_root=tmp_path,
+            specs_candidates_enabled=True,
+            allow_run=True,
+        )
+        _seed_dismiss(config, "my-spec")
+        assert _has_dismiss(config, "my-spec")
+
+        client = _client(tmp_path)
+        response = client.put(
+            "/api/specs/my-spec/decisions/status",
+            json={"status": target_status},
+        )
+        assert response.status_code == 200
+        # Dismiss cleared so re-completion can re-surface.
+        assert not _has_dismiss(config, "my-spec")
+
+    def test_clear_when_no_prior_dismiss_is_noop(self, tmp_path: Path) -> None:
+        # No seeded dismiss; PUT to approved should still succeed.
+        _make_spec_with_status_file(tmp_path, "my-spec", "complete")
+        client = _client(tmp_path)
+        response = client.put(
+            "/api/specs/my-spec/decisions/status",
+            json={"status": "approved"},
+        )
+        assert response.status_code == 200
+
+    def test_other_specs_dismiss_unaffected(self, tmp_path: Path) -> None:
+        _make_spec_with_status_file(tmp_path, "spec-a", "complete")
+        _make_spec_with_status_file(tmp_path, "spec-b", "complete")
+        config = build_config(
+            project_root=tmp_path,
+            specs_candidates_enabled=True,
+            allow_run=True,
+        )
+        _seed_dismiss(config, "spec-a")
+        _seed_dismiss(config, "spec-b")
+
+        client = _client(tmp_path)
+        client.put(
+            "/api/specs/spec-a/decisions/status",
+            json={"status": "approved"},
+        )
+        # spec-a's dismiss cleared; spec-b's untouched.
+        assert not _has_dismiss(config, "spec-a")
+        assert _has_dismiss(config, "spec-b")

--- a/tests/unit/ops/test_config_persistence.py
+++ b/tests/unit/ops/test_config_persistence.py
@@ -1,0 +1,295 @@
+"""Unit tests for ``attune.ops.ops_config_store`` and CLI overlay.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T3).
+
+Covers:
+
+- Settings file roundtrip (write, read, missing, corrupt)
+- Atomic write semantics
+- ``resolve_specs_candidates_enabled`` three-state precedence
+- CLI flag → resolver → Config field end-to-end
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from attune.ops import cli, ops_config_store
+from attune.ops.config import Config
+
+
+def _write_raw(path: Path, content: str) -> None:
+    """Write arbitrary content directly to the settings path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# settings_path
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsPath:
+    def test_derives_from_attune_home(self, tmp_path: Path) -> None:
+        expected = tmp_path / "ops" / "config.json"
+        assert ops_config_store.settings_path(tmp_path) == expected
+
+    def test_does_not_create_anything(self, tmp_path: Path) -> None:
+        path = ops_config_store.settings_path(tmp_path)
+        assert not path.exists()
+        assert not path.parent.exists()
+
+
+# ---------------------------------------------------------------------------
+# load_settings
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSettingsMissing:
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert ops_config_store.load_settings(tmp_path) == {}
+
+    def test_missing_does_not_log(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.WARNING, logger="attune.ops.ops_config_store")
+        ops_config_store.load_settings(tmp_path)
+        assert caplog.records == []
+
+
+class TestLoadSettingsCorrupt:
+    def test_invalid_json_returns_empty_and_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _write_raw(ops_config_store.settings_path(tmp_path), "{not json")
+        caplog.set_level(logging.WARNING, logger="attune.ops.ops_config_store")
+        assert ops_config_store.load_settings(tmp_path) == {}
+        assert any("invalid JSON" in r.message for r in caplog.records)
+
+    def test_non_object_root_returns_empty(self, tmp_path: Path) -> None:
+        _write_raw(ops_config_store.settings_path(tmp_path), "[]")
+        assert ops_config_store.load_settings(tmp_path) == {}
+
+    def test_wrong_version_returns_empty(self, tmp_path: Path) -> None:
+        _write_raw(
+            ops_config_store.settings_path(tmp_path),
+            json.dumps({"version": "bad", "settings": {"k": "v"}}),
+        )
+        assert ops_config_store.load_settings(tmp_path) == {}
+
+    def test_missing_settings_key_returns_empty(self, tmp_path: Path) -> None:
+        _write_raw(
+            ops_config_store.settings_path(tmp_path),
+            json.dumps({"version": ops_config_store.SCHEMA_VERSION}),
+        )
+        assert ops_config_store.load_settings(tmp_path) == {}
+
+    def test_settings_not_dict_returns_empty(self, tmp_path: Path) -> None:
+        _write_raw(
+            ops_config_store.settings_path(tmp_path),
+            json.dumps(
+                {
+                    "version": ops_config_store.SCHEMA_VERSION,
+                    "settings": ["a", "b"],
+                }
+            ),
+        )
+        assert ops_config_store.load_settings(tmp_path) == {}
+
+
+# ---------------------------------------------------------------------------
+# save_setting (roundtrip + atomicity + validation)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSetting:
+    def test_save_then_load(self, tmp_path: Path) -> None:
+        ops_config_store.save_setting(tmp_path, "specs_candidates_enabled", True)
+        assert ops_config_store.load_settings(tmp_path) == {"specs_candidates_enabled": True}
+
+    def test_creates_parent_dir(self, tmp_path: Path) -> None:
+        assert not (tmp_path / "ops").exists()
+        ops_config_store.save_setting(tmp_path, "x", 1)
+        assert ops_config_store.settings_path(tmp_path).is_file()
+
+    def test_multiple_keys_coexist(self, tmp_path: Path) -> None:
+        ops_config_store.save_setting(tmp_path, "a", 1)
+        ops_config_store.save_setting(tmp_path, "b", "two")
+        assert ops_config_store.load_settings(tmp_path) == {"a": 1, "b": "two"}
+
+    def test_overwrites_prior_value(self, tmp_path: Path) -> None:
+        ops_config_store.save_setting(tmp_path, "k", "old")
+        ops_config_store.save_setting(tmp_path, "k", "new")
+        assert ops_config_store.load_settings(tmp_path) == {"k": "new"}
+
+    def test_empty_key_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="key"):
+            ops_config_store.save_setting(tmp_path, "", True)
+
+    def test_non_string_key_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="key"):
+            ops_config_store.save_setting(tmp_path, 1, True)  # type: ignore[arg-type]
+
+    def test_returns_true_on_success(self, tmp_path: Path) -> None:
+        assert ops_config_store.save_setting(tmp_path, "k", True) is True
+
+    def test_returns_false_on_permission_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        def fail(*a: Any, **kw: Any) -> None:
+            raise PermissionError("denied")
+
+        monkeypatch.setattr(ops_config_store, "_write_atomic", fail)
+        caplog.set_level(logging.WARNING, logger="attune.ops.ops_config_store")
+        result = ops_config_store.save_setting(tmp_path, "k", True)
+        assert result is False
+        assert any("save failed" in r.message for r in caplog.records)
+
+
+class TestSaveAtomicity:
+    def test_no_temp_files_after_save(self, tmp_path: Path) -> None:
+        ops_config_store.save_setting(tmp_path, "k", True)
+        parent = ops_config_store.settings_path(tmp_path).parent
+        leftovers = [p.name for p in parent.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_specs_candidates_enabled (the three-state precedence)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSpecsCandidatesEnabled:
+    def test_cli_true_persists_and_returns_true(self, tmp_path: Path) -> None:
+        result = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=True, attune_home=tmp_path
+        )
+        assert result is True
+        assert ops_config_store.load_settings(tmp_path) == {"specs_candidates_enabled": True}
+
+    def test_cli_false_persists_and_returns_false(self, tmp_path: Path) -> None:
+        # Prior True state.
+        ops_config_store.save_setting(tmp_path, "specs_candidates_enabled", True)
+        result = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=False, attune_home=tmp_path
+        )
+        assert result is False
+        assert ops_config_store.load_settings(tmp_path) == {"specs_candidates_enabled": False}
+
+    def test_cli_none_no_persisted_returns_false(self, tmp_path: Path) -> None:
+        result = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=None, attune_home=tmp_path
+        )
+        assert result is False
+        # No file written on the read-only path.
+        assert not ops_config_store.settings_path(tmp_path).exists()
+
+    def test_cli_none_with_persisted_true_returns_true(self, tmp_path: Path) -> None:
+        ops_config_store.save_setting(tmp_path, "specs_candidates_enabled", True)
+        result = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=None, attune_home=tmp_path
+        )
+        assert result is True
+
+    def test_cli_none_with_persisted_false_returns_false(self, tmp_path: Path) -> None:
+        ops_config_store.save_setting(tmp_path, "specs_candidates_enabled", False)
+        result = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=None, attune_home=tmp_path
+        )
+        assert result is False
+
+    def test_corrupted_settings_falls_back_to_false(self, tmp_path: Path) -> None:
+        _write_raw(ops_config_store.settings_path(tmp_path), "{broken")
+        result = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=None, attune_home=tmp_path
+        )
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# CLI flag → resolver wiring
+# ---------------------------------------------------------------------------
+
+
+def _parse_ops_args(*argv: str) -> argparse.Namespace:
+    """Helper: run argparse with the same setup cli.main() uses."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    cli.add_subparser(sub)
+    return parser.parse_args(["ops", *argv])
+
+
+class TestCliFlagParsing:
+    def test_no_flag_means_none(self) -> None:
+        args = _parse_ops_args()
+        assert args.specs_candidates is None
+
+    def test_specs_candidates_means_true(self) -> None:
+        args = _parse_ops_args("--specs-candidates")
+        assert args.specs_candidates is True
+
+    def test_no_specs_candidates_means_false(self) -> None:
+        args = _parse_ops_args("--no-specs-candidates")
+        assert args.specs_candidates is False
+
+    def test_mutually_exclusive(self) -> None:
+        with pytest.raises(SystemExit):
+            _parse_ops_args("--specs-candidates", "--no-specs-candidates")
+
+
+class TestCliPersistenceRoundtrip:
+    """Simulates the launch-flag-then-relaunch flow described in the spec."""
+
+    def test_first_launch_with_flag_persists(self, tmp_path: Path) -> None:
+        # Launch 1: --specs-candidates → persist True
+        result = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=True, attune_home=tmp_path
+        )
+        assert result is True
+
+        # Launch 2: no flag → reads persisted True
+        result2 = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=None, attune_home=tmp_path
+        )
+        assert result2 is True
+
+        # Launch 3: --no-specs-candidates → persist False
+        result3 = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=False, attune_home=tmp_path
+        )
+        assert result3 is False
+
+        # Launch 4: no flag → reads persisted False
+        result4 = ops_config_store.resolve_specs_candidates_enabled(
+            cli_value=None, attune_home=tmp_path
+        )
+        assert result4 is False
+
+
+class TestConfigField:
+    """The Config dataclass exposes the new field."""
+
+    def test_default_is_false(self) -> None:
+        cfg = Config(project_root=Path("/x"), attune_home=Path("/y"))
+        assert cfg.specs_candidates_enabled is False
+
+    def test_can_be_set(self) -> None:
+        cfg = Config(
+            project_root=Path("/x"),
+            attune_home=Path("/y"),
+            specs_candidates_enabled=True,
+        )
+        assert cfg.specs_candidates_enabled is True
+
+    def test_build_config_passes_through(self, tmp_path: Path) -> None:
+        from attune.ops.config import build_config
+
+        cfg = build_config(project_root=tmp_path, specs_candidates_enabled=True)
+        assert cfg.specs_candidates_enabled is True

--- a/tests/unit/ops/test_dismiss_store.py
+++ b/tests/unit/ops/test_dismiss_store.py
@@ -1,0 +1,386 @@
+"""Unit tests for ``attune.ops.dismiss_store``.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T1).
+
+Covers the five public functions:
+
+- ``store_path``: path derivation
+- ``load``: missing / corrupt / valid file roundtrip
+- ``save``: atomic write, input validation, overwrite semantics
+- ``clear``: removal + no-op
+- ``is_active``: three-condition truth table + TTL boundary
+
+All filesystem effects scoped to ``tmp_path`` so the user's real
+``~/.attune/ops/`` is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.ops import dismiss_store
+from attune.ops.config import Config
+
+
+@pytest.fixture()
+def cfg(tmp_path: Path) -> Config:
+    """Config rooted at tmp_path so writes don't touch the user's home."""
+    return Config(
+        project_root=tmp_path / "project",
+        attune_home=tmp_path / "attune-home",
+    )
+
+
+def _write_raw(cfg: Config, content: str) -> Path:
+    """Write arbitrary content directly to the store path, bypassing save()."""
+    path = dismiss_store.store_path(cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# store_path
+# ---------------------------------------------------------------------------
+
+
+class TestStorePath:
+    def test_derives_from_attune_home(self, cfg: Config) -> None:
+        expected = cfg.attune_home / "ops" / "spec_completion_dismissed.json"
+        assert dismiss_store.store_path(cfg) == expected
+
+    def test_does_not_create_anything(self, cfg: Config) -> None:
+        path = dismiss_store.store_path(cfg)
+        # Neither the file nor its parent dir should exist after this call.
+        assert not path.exists()
+        assert not path.parent.exists()
+
+
+# ---------------------------------------------------------------------------
+# load
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMissing:
+    def test_missing_file_returns_empty(self, cfg: Config) -> None:
+        assert dismiss_store.load(cfg) == {}
+
+    def test_missing_does_not_log_warning(
+        self, cfg: Config, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="attune.ops.dismiss_store")
+        dismiss_store.load(cfg)
+        assert caplog.records == []
+
+
+class TestLoadCorrupt:
+    def test_invalid_json_returns_empty_and_warns(
+        self, cfg: Config, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _write_raw(cfg, "{not valid json")
+        caplog.set_level(logging.WARNING, logger="attune.ops.dismiss_store")
+        assert dismiss_store.load(cfg) == {}
+        assert any("invalid JSON" in r.message for r in caplog.records)
+
+    def test_non_object_root_returns_empty_and_warns(
+        self, cfg: Config, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _write_raw(cfg, "[]")
+        caplog.set_level(logging.WARNING, logger="attune.ops.dismiss_store")
+        assert dismiss_store.load(cfg) == {}
+        assert any("not a JSON object" in r.message for r in caplog.records)
+
+    def test_wrong_schema_version_returns_empty_and_warns(
+        self, cfg: Config, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _write_raw(cfg, json.dumps({"version": "bad", "dismissed": {}}))
+        caplog.set_level(logging.WARNING, logger="attune.ops.dismiss_store")
+        assert dismiss_store.load(cfg) == {}
+        assert any("unsupported version" in r.message for r in caplog.records)
+
+    def test_missing_dismissed_key_returns_empty(self, cfg: Config) -> None:
+        _write_raw(cfg, json.dumps({"version": dismiss_store.SCHEMA_VERSION}))
+        assert dismiss_store.load(cfg) == {}
+
+    def test_dismissed_not_a_dict_returns_empty(self, cfg: Config) -> None:
+        _write_raw(
+            cfg,
+            json.dumps({"version": dismiss_store.SCHEMA_VERSION, "dismissed": []}),
+        )
+        assert dismiss_store.load(cfg) == {}
+
+
+class TestLoadMalformedEntry:
+    """Per-entry corruption is skipped; other entries still load."""
+
+    def _store_with(self, cfg: Config, entries: dict) -> None:
+        _write_raw(
+            cfg,
+            json.dumps(
+                {
+                    "version": dismiss_store.SCHEMA_VERSION,
+                    "dismissed": entries,
+                }
+            ),
+        )
+
+    def test_missing_fields(self, cfg: Config) -> None:
+        self._store_with(
+            cfg,
+            {
+                "bad-slug": {"dismissed_at": "2026-05-15T18:30:00+00:00"},
+                "good-slug": {
+                    "dismissed_at": "2026-05-15T18:30:00+00:00",
+                    "snapshot_hash": "abc123",
+                    "ttl_days": 14,
+                },
+            },
+        )
+        loaded = dismiss_store.load(cfg)
+        assert "bad-slug" not in loaded
+        assert "good-slug" in loaded
+
+    def test_bad_datetime(self, cfg: Config) -> None:
+        self._store_with(
+            cfg,
+            {
+                "bad-slug": {
+                    "dismissed_at": "not-a-date",
+                    "snapshot_hash": "abc123",
+                    "ttl_days": 14,
+                },
+            },
+        )
+        assert dismiss_store.load(cfg) == {}
+
+    def test_naive_datetime_rejected(self, cfg: Config) -> None:
+        # Tz-naive ISO strings can't be safely compared with tz-aware now.
+        self._store_with(
+            cfg,
+            {
+                "bad-slug": {
+                    "dismissed_at": "2026-05-15T18:30:00",
+                    "snapshot_hash": "abc123",
+                    "ttl_days": 14,
+                },
+            },
+        )
+        assert dismiss_store.load(cfg) == {}
+
+    def test_bool_ttl_rejected(self, cfg: Config) -> None:
+        # bool is a subclass of int in Python; the parser must explicitly
+        # reject it (TTL=True would silently mean TTL=1 day).
+        self._store_with(
+            cfg,
+            {
+                "bad-slug": {
+                    "dismissed_at": "2026-05-15T18:30:00+00:00",
+                    "snapshot_hash": "abc123",
+                    "ttl_days": True,
+                },
+            },
+        )
+        assert dismiss_store.load(cfg) == {}
+
+    def test_negative_ttl_rejected(self, cfg: Config) -> None:
+        self._store_with(
+            cfg,
+            {
+                "bad-slug": {
+                    "dismissed_at": "2026-05-15T18:30:00+00:00",
+                    "snapshot_hash": "abc123",
+                    "ttl_days": -1,
+                },
+            },
+        )
+        assert dismiss_store.load(cfg) == {}
+
+
+# ---------------------------------------------------------------------------
+# save (roundtrip + validation + atomicity)
+# ---------------------------------------------------------------------------
+
+
+class TestSaveRoundtrip:
+    def test_save_then_load(self, cfg: Config) -> None:
+        now = datetime(2026, 5, 15, 18, 30, tzinfo=timezone.utc)
+        dismiss_store.save("ops-sessions-page", "hash-1", cfg, now=now)
+        loaded = dismiss_store.load(cfg)
+        assert "ops-sessions-page" in loaded
+        entry = loaded["ops-sessions-page"]
+        assert entry.snapshot_hash == "hash-1"
+        assert entry.ttl_days == dismiss_store.DEFAULT_TTL_DAYS
+        assert entry.dismissed_at == now
+
+    def test_save_creates_parent_dir(self, cfg: Config) -> None:
+        # attune_home/ops/ doesn't exist yet
+        assert not (cfg.attune_home / "ops").exists()
+        dismiss_store.save("slug", "hash", cfg)
+        assert dismiss_store.store_path(cfg).is_file()
+
+    def test_save_overwrites_prior_entry(self, cfg: Config) -> None:
+        now1 = datetime(2026, 5, 15, 18, 0, tzinfo=timezone.utc)
+        now2 = datetime(2026, 5, 16, 9, 0, tzinfo=timezone.utc)
+        dismiss_store.save("slug", "old-hash", cfg, now=now1)
+        dismiss_store.save("slug", "new-hash", cfg, now=now2)
+        loaded = dismiss_store.load(cfg)
+        assert len(loaded) == 1
+        assert loaded["slug"].snapshot_hash == "new-hash"
+        assert loaded["slug"].dismissed_at == now2
+
+    def test_multiple_slugs_coexist(self, cfg: Config) -> None:
+        dismiss_store.save("slug-a", "hash-a", cfg)
+        dismiss_store.save("slug-b", "hash-b", cfg)
+        loaded = dismiss_store.load(cfg)
+        assert set(loaded.keys()) == {"slug-a", "slug-b"}
+
+    def test_uses_utc_now_when_not_injected(self, cfg: Config) -> None:
+        before = datetime.now(timezone.utc)
+        dismiss_store.save("slug", "hash", cfg)
+        after = datetime.now(timezone.utc)
+        entry = dismiss_store.load(cfg)["slug"]
+        assert entry.dismissed_at.tzinfo is not None
+        assert before <= entry.dismissed_at <= after
+
+    def test_custom_ttl_persists(self, cfg: Config) -> None:
+        dismiss_store.save("slug", "hash", cfg, ttl_days=7)
+        assert dismiss_store.load(cfg)["slug"].ttl_days == 7
+
+
+class TestSaveValidation:
+    def test_empty_slug_rejected(self, cfg: Config) -> None:
+        with pytest.raises(ValueError, match="slug"):
+            dismiss_store.save("", "hash", cfg)
+
+    def test_non_string_slug_rejected(self, cfg: Config) -> None:
+        with pytest.raises(ValueError, match="slug"):
+            dismiss_store.save(123, "hash", cfg)  # type: ignore[arg-type]
+
+    def test_empty_hash_rejected(self, cfg: Config) -> None:
+        with pytest.raises(ValueError, match="snapshot_hash"):
+            dismiss_store.save("slug", "", cfg)
+
+    def test_negative_ttl_rejected(self, cfg: Config) -> None:
+        with pytest.raises(ValueError, match="ttl_days"):
+            dismiss_store.save("slug", "hash", cfg, ttl_days=-1)
+
+
+class TestSaveAtomicity:
+    def test_no_temp_files_left_after_save(self, cfg: Config) -> None:
+        dismiss_store.save("slug", "hash", cfg)
+        parent = dismiss_store.store_path(cfg).parent
+        leftovers = [p.name for p in parent.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []
+
+    def test_back_to_back_saves_yield_latest(self, cfg: Config) -> None:
+        # No threading here — the "concurrent-write smoke" requirement
+        # from the spec maps to: rapid consecutive saves leave a single
+        # well-formed entry with the latest content, and no temp files.
+        for i in range(5):
+            dismiss_store.save("slug", f"hash-{i}", cfg)
+        loaded = dismiss_store.load(cfg)
+        assert loaded["slug"].snapshot_hash == "hash-4"
+        parent = dismiss_store.store_path(cfg).parent
+        leftovers = [p.name for p in parent.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# clear
+# ---------------------------------------------------------------------------
+
+
+class TestClear:
+    def test_removes_entry(self, cfg: Config) -> None:
+        dismiss_store.save("slug-a", "hash-a", cfg)
+        dismiss_store.save("slug-b", "hash-b", cfg)
+        dismiss_store.clear("slug-a", cfg)
+        loaded = dismiss_store.load(cfg)
+        assert "slug-a" not in loaded
+        assert "slug-b" in loaded
+
+    def test_missing_slug_is_noop(self, cfg: Config) -> None:
+        # No prior save → clear should not raise and not create the file.
+        dismiss_store.clear("nope", cfg)
+        assert not dismiss_store.store_path(cfg).exists()
+
+    def test_clearing_only_entry_leaves_empty_store(self, cfg: Config) -> None:
+        dismiss_store.save("slug", "hash", cfg)
+        dismiss_store.clear("slug", cfg)
+        assert dismiss_store.load(cfg) == {}
+
+
+# ---------------------------------------------------------------------------
+# is_active (the three-condition truth table)
+# ---------------------------------------------------------------------------
+
+
+class TestIsActiveMissing:
+    def test_unknown_slug_inactive(self, cfg: Config) -> None:
+        assert dismiss_store.is_active("never-dismissed", "any-hash", cfg) is False
+
+    def test_unreadable_store_inactive(self, cfg: Config) -> None:
+        _write_raw(cfg, "{not valid")
+        assert dismiss_store.is_active("anything", "hash", cfg) is False
+
+
+class TestIsActiveHashMismatch:
+    def test_different_hash_inactive_even_within_ttl(self, cfg: Config) -> None:
+        now = datetime(2026, 5, 15, 12, 0, tzinfo=timezone.utc)
+        dismiss_store.save("slug", "original-hash", cfg, now=now)
+        # Same day, well within TTL — but the hash changed (new signal
+        # landed). Must re-surface.
+        result = dismiss_store.is_active(
+            "slug",
+            "new-hash",
+            cfg,
+            now=now + timedelta(hours=1),
+        )
+        assert result is False
+
+
+class TestIsActiveTTLBoundary:
+    """The 14-day default TTL window."""
+
+    def setup_method(self) -> None:
+        self.dismissed_at = datetime(2026, 5, 15, 12, 0, tzinfo=timezone.utc)
+
+    def test_13d_23h_active(self, cfg: Config) -> None:
+        dismiss_store.save("slug", "hash", cfg, now=self.dismissed_at)
+        check_at = self.dismissed_at + timedelta(days=13, hours=23)
+        assert dismiss_store.is_active("slug", "hash", cfg, now=check_at) is True
+
+    def test_14d_1h_inactive(self, cfg: Config) -> None:
+        dismiss_store.save("slug", "hash", cfg, now=self.dismissed_at)
+        check_at = self.dismissed_at + timedelta(days=14, hours=1)
+        assert dismiss_store.is_active("slug", "hash", cfg, now=check_at) is False
+
+    def test_exact_boundary_inactive(self, cfg: Config) -> None:
+        # Condition 3 uses strict ``<``: at exactly TTL, the dismiss expires.
+        dismiss_store.save("slug", "hash", cfg, now=self.dismissed_at)
+        check_at = self.dismissed_at + timedelta(days=14)
+        assert dismiss_store.is_active("slug", "hash", cfg, now=check_at) is False
+
+    def test_custom_ttl_honored(self, cfg: Config) -> None:
+        dismiss_store.save("slug", "hash", cfg, ttl_days=7, now=self.dismissed_at)
+        within = self.dismissed_at + timedelta(days=6, hours=23)
+        past = self.dismissed_at + timedelta(days=7, hours=1)
+        assert dismiss_store.is_active("slug", "hash", cfg, now=within) is True
+        assert dismiss_store.is_active("slug", "hash", cfg, now=past) is False
+
+    def test_zero_ttl_immediately_inactive(self, cfg: Config) -> None:
+        # Edge case: TTL=0 should be inactive even at the moment of dismissal.
+        dismiss_store.save("slug", "hash", cfg, ttl_days=0, now=self.dismissed_at)
+        assert dismiss_store.is_active("slug", "hash", cfg, now=self.dismissed_at) is False
+
+
+class TestIsActiveHappyPath:
+    def test_matching_hash_within_ttl(self, cfg: Config) -> None:
+        now = datetime(2026, 5, 15, 12, 0, tzinfo=timezone.utc)
+        dismiss_store.save("slug", "hash", cfg, now=now)
+        assert dismiss_store.is_active("slug", "hash", cfg, now=now) is True

--- a/tests/unit/ops/test_specs_page_candidates_section.py
+++ b/tests/unit/ops/test_specs_page_candidates_section.py
@@ -1,0 +1,124 @@
+"""Tests for the Specs page server-rendered candidates section.
+
+Spec: ``docs/specs/ops-specs-completion-candidates/`` (T5).
+
+The "Ready to close?" section is rendered server-side behind a
+two-gate check: ``allow_run AND specs_candidates_enabled``. JS only
+loads when the shell is present, so server-side gating fully
+suppresses the feature when off.
+
+Covers:
+- Section + JS rendered when both gates are on.
+- Section absent when feature flag is off.
+- Section absent when read-only.
+- JS tag is correctly cache-busted with the attune version.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+
+def _client(
+    tmp_path: Path,
+    *,
+    specs_candidates_enabled: bool = True,
+    allow_run: bool = True,
+) -> TestClient:
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=allow_run,
+        specs_candidates_enabled=specs_candidates_enabled,
+        trusted_hosts=("testserver", "test"),
+    )
+    return TestClient(create_app(config))
+
+
+class TestSectionGating:
+    def test_section_rendered_when_both_gates_on(self, tmp_path: Path) -> None:
+        client = _client(tmp_path, specs_candidates_enabled=True, allow_run=True)
+        response = client.get("/specs")
+        assert response.status_code == 200
+        assert 'id="completion-candidates"' in response.text
+        assert 'id="cc-list"' in response.text
+        assert 'id="cc-count"' in response.text
+        # Header text confirms server-rendered shell.
+        assert "Ready to close?" in response.text
+
+    def test_section_hidden_initially(self, tmp_path: Path) -> None:
+        # The shell ships with `hidden` so it doesn't flash before the
+        # JS populates it.
+        client = _client(tmp_path)
+        html = client.get("/specs").text
+        # Find the section opening tag and verify it carries the
+        # `hidden` attribute.
+        assert 'id="completion-candidates"' in html
+        idx = html.find('id="completion-candidates"')
+        section_tag = html[max(0, idx - 80) : idx + 80]
+        assert "hidden" in section_tag
+
+    def test_section_absent_when_feature_flag_off(self, tmp_path: Path) -> None:
+        client = _client(tmp_path, specs_candidates_enabled=False, allow_run=True)
+        html = client.get("/specs").text
+        assert 'id="completion-candidates"' not in html
+        assert "Ready to close?" not in html
+
+    def test_section_absent_when_read_only(self, tmp_path: Path) -> None:
+        client = _client(tmp_path, specs_candidates_enabled=True, allow_run=False)
+        html = client.get("/specs").text
+        assert 'id="completion-candidates"' not in html
+        assert "Ready to close?" not in html
+
+    def test_section_absent_when_both_off(self, tmp_path: Path) -> None:
+        client = _client(tmp_path, specs_candidates_enabled=False, allow_run=False)
+        html = client.get("/specs").text
+        assert 'id="completion-candidates"' not in html
+
+
+class TestJsInclude:
+    def test_js_included_when_section_rendered(self, tmp_path: Path) -> None:
+        client = _client(tmp_path)
+        html = client.get("/specs").text
+        assert "completion_candidates.js" in html
+
+    def test_js_excluded_when_feature_flag_off(self, tmp_path: Path) -> None:
+        client = _client(tmp_path, specs_candidates_enabled=False)
+        html = client.get("/specs").text
+        assert "completion_candidates.js" not in html
+
+    def test_js_excluded_when_read_only(self, tmp_path: Path) -> None:
+        client = _client(tmp_path, allow_run=False)
+        html = client.get("/specs").text
+        assert "completion_candidates.js" not in html
+
+    def test_js_has_cache_buster(self, tmp_path: Path) -> None:
+        # Per the existing CLAUDE.md lesson about cache-busting static
+        # JS on release — version query string prevents stale JS after
+        # a release.
+        client = _client(tmp_path)
+        html = client.get("/specs").text
+        # The exact version isn't important to assert; just confirm
+        # the buster is present.
+        assert "completion_candidates.js?v=" in html
+
+
+class TestJsFileServes:
+    """The static JS file must be reachable via /static/js/."""
+
+    def test_js_file_returns_200(self, tmp_path: Path) -> None:
+        client = _client(tmp_path)
+        response = client.get("/static/js/completion_candidates.js")
+        assert response.status_code == 200
+        # Sanity-check it's the actual module, not a 404 page.
+        assert "completion-candidates" in response.text
+        assert "Ready to close" in response.text or "candidate-card" in response.text

--- a/tests/unit/scripts/test_regenerate_help_templates.py
+++ b/tests/unit/scripts/test_regenerate_help_templates.py
@@ -1,0 +1,185 @@
+"""Tests for ``scripts/regenerate_help_templates.py``.
+
+Covers the load-bearing pure-Python helpers:
+
+- ``_glob_to_regex`` — pattern → regex conversion
+- ``_affected_features`` — changed-paths → affected-features filter
+- ``_summarize_error`` — multi-line subprocess error → compact one-liner
+
+The subprocess wrappers (``_regen_one`` / ``_stage_dir``) and
+``main()`` orchestration are exercised manually in the warn-only +
+auto-regen smoke runs documented in PR #400's follow-up; they're
+not unit-tested here because mocking subprocess.run for a script
+that ships outside the package surface adds maintenance for low
+incremental confidence.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# Load the script as a module without putting `scripts/` on sys.path.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "regenerate_help_templates.py"
+_spec = importlib.util.spec_from_file_location("regen_help_tpl", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+regen_module = importlib.util.module_from_spec(_spec)
+sys.modules["regen_help_tpl"] = regen_module
+_spec.loader.exec_module(regen_module)
+
+
+@dataclass
+class _FakeFeature:
+    """Stand-in for attune_author.Feature with the `files` attr we use."""
+
+    files: list[str]
+
+
+# ---------------------------------------------------------------------------
+# _glob_to_regex
+# ---------------------------------------------------------------------------
+
+
+class TestGlobToRegex:
+    def test_literal_match(self) -> None:
+        pat = regen_module._glob_to_regex("src/foo.py")
+        assert pat.fullmatch("src/foo.py")
+        assert not pat.fullmatch("src/bar.py")
+
+    def test_single_star_does_not_cross_separator(self) -> None:
+        pat = regen_module._glob_to_regex("src/*.py")
+        assert pat.fullmatch("src/foo.py")
+        assert not pat.fullmatch("src/sub/foo.py")  # `*` is single-segment
+
+    def test_double_star_crosses_separators(self) -> None:
+        pat = regen_module._glob_to_regex("src/**/foo.py")
+        assert pat.fullmatch("src/a/foo.py")
+        assert pat.fullmatch("src/a/b/c/foo.py")
+
+    def test_question_mark_single_char(self) -> None:
+        pat = regen_module._glob_to_regex("src/f?o.py")
+        assert pat.fullmatch("src/foo.py")
+        assert pat.fullmatch("src/fxo.py")
+        assert not pat.fullmatch("src/fo.py")
+        assert not pat.fullmatch("src/foxo.py")
+
+    def test_special_chars_escaped(self) -> None:
+        # `.` in pattern should be a literal dot, not "any char"
+        pat = regen_module._glob_to_regex("src/foo.py")
+        assert not pat.fullmatch("src/fooXpy")
+
+    def test_double_star_at_end_matches_subtree(self) -> None:
+        pat = regen_module._glob_to_regex("src/attune/security/**")
+        assert pat.fullmatch("src/attune/security/x.py")
+        assert pat.fullmatch("src/attune/security/sub/x.py")
+
+
+# ---------------------------------------------------------------------------
+# _affected_features
+# ---------------------------------------------------------------------------
+
+
+class TestAffectedFeatures:
+    def test_empty_features_returns_empty(self) -> None:
+        result = regen_module._affected_features([Path("src/foo.py")], {})
+        assert result == set()
+
+    def test_no_match_returns_empty(self) -> None:
+        features = {"a": _FakeFeature(files=["src/other/*.py"])}
+        result = regen_module._affected_features([Path("src/foo.py")], features)
+        assert result == set()
+
+    def test_single_match(self) -> None:
+        features = {
+            "a": _FakeFeature(files=["src/attune/security/**"]),
+            "b": _FakeFeature(files=["src/other/*.py"]),
+        }
+        result = regen_module._affected_features([Path("src/attune/security/foo.py")], features)
+        assert result == {"a"}
+
+    def test_multiple_paths_one_feature(self) -> None:
+        # Two changed paths but only one feature matches them.
+        features = {"a": _FakeFeature(files=["src/attune/security/**"])}
+        result = regen_module._affected_features(
+            [
+                Path("src/attune/security/foo.py"),
+                Path("src/attune/security/bar.py"),
+            ],
+            features,
+        )
+        assert result == {"a"}
+
+    def test_multiple_features_one_path(self) -> None:
+        # One changed path matches multiple features (overlap).
+        features = {
+            "a": _FakeFeature(files=["src/attune/security/**"]),
+            "b": _FakeFeature(files=["src/attune/**"]),
+        }
+        result = regen_module._affected_features([Path("src/attune/security/foo.py")], features)
+        assert result == {"a", "b"}
+
+    def test_feature_with_empty_files_list(self) -> None:
+        # No globs → no matches; doesn't crash on empty list.
+        features = {"a": _FakeFeature(files=[])}
+        result = regen_module._affected_features([Path("src/anything.py")], features)
+        assert result == set()
+
+    def test_feature_with_none_files(self) -> None:
+        # Some Feature objects may have `files=None`; tolerate that.
+        @dataclass
+        class _NoneFeature:
+            files: list[str] | None = None
+
+        features = {"a": _NoneFeature()}
+        result = regen_module._affected_features([Path("src/anything.py")], features)
+        assert result == set()
+
+    def test_first_match_wins_per_feature(self) -> None:
+        # If first changed path matches feature A's first pattern,
+        # we don't re-check later patterns for the same feature.
+        features = {"a": _FakeFeature(files=["src/x.py", "src/y.py"])}
+        result = regen_module._affected_features([Path("src/x.py"), Path("src/y.py")], features)
+        assert result == {"a"}
+
+
+# ---------------------------------------------------------------------------
+# _summarize_error
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeError:
+    def test_none_returns_placeholder(self) -> None:
+        assert regen_module._summarize_error(None) == "(no error message)"
+
+    def test_empty_string_returns_placeholder(self) -> None:
+        assert regen_module._summarize_error("") == "(no error message)"
+
+    def test_single_line_returned_as_is(self) -> None:
+        assert regen_module._summarize_error("just one line") == "just one line"
+
+    def test_multi_line_returns_last_nonblank(self) -> None:
+        # Mirrors a Python traceback shape: last line is the exception
+        # message, which is what we want to surface.
+        err = (
+            "Traceback (most recent call last):\n"
+            '  File "x.py", line 1, in <module>\n'
+            "    raise ValueError('bad input')\n"
+            "ValueError: bad input"
+        )
+        assert regen_module._summarize_error(err) == "ValueError: bad input"
+
+    def test_trailing_blank_lines_ignored(self) -> None:
+        err = "Real error\n\n\n"
+        assert regen_module._summarize_error(err) == "Real error"
+
+    def test_long_line_truncated_at_200(self) -> None:
+        long = "x" * 500
+        out = regen_module._summarize_error(long)
+        assert len(out) == 200
+        assert out.endswith("...")
+
+    def test_short_line_not_truncated(self) -> None:
+        assert regen_module._summarize_error("short") == "short"


### PR DESCRIPTION
## Summary

Opt-in section on the Specs page that surfaces `approved` specs whose work appears to have shipped, with per-spec evidence bullets. User one-click confirms (flips status to `complete`) or dismisses for 14 days. **The detector NEVER writes the status field** — propose-and-confirm semantics keep human authority over the panel.

Spec: [`docs/specs/ops-specs-completion-candidates/`](docs/specs/ops-specs-completion-candidates/requirements.md) (T1–T7 from the tasks phase, all complete; see [decisions.md](docs/specs/ops-specs-completion-candidates/decisions.md) for the Q1–Q6 design rationale).

## Detector signals

A spec is a candidate iff **all five** pass (zero false positives by design; many false negatives accepted):

1. Status is `approved` (only `approved → complete` is auto-detected; `partial`/`paused`/`retired` remain manual per Q4)
2. Last `.md` edit ≥ 24h ago (recent-activity guard)
3. `tasks.md` absent OR every checklist row is `- [x]` / `**done**` / `**complete**`
4. PRs referenced in `decisions.md` + `tasks.md` (per Q5 — discursive files excluded) all merged on origin
5. No open issues on origin reference the spec slug

Failed checks suppress the candidate entirely. Dismiss persists for 14 days but **re-surfaces immediately when any snapshot input changes** (PR merge, tasks.md edit) — `is_active()` requires hash AND TTL.

## What's wired

- New modules: `attune.ops.dismiss_store`, `attune.ops.completion_candidates`, `attune.ops.ops_config_store`
- New API routes (both gated on `allow_run AND specs_candidates_enabled`):
  - `GET /api/specs/completion-candidates`
  - `POST /api/specs/{slug}/completion-candidates/dismiss`
- Modified `PUT /api/specs/{slug}/{phase}/status` — clears dismiss when flipping AWAY from a complete-like status (re-completion can re-surface)
- New CLI: `--specs-candidates` / `--no-specs-candidates` (mutex `store_const`, three-state) persisted to `~/.attune/ops/config.json`. Startup banner shows `specs-candidates: on/off`
- Frontend section in `templates/specs.html` (server-rendered shell behind both gates) + `completion_candidates.js` (~220 LoC vanilla ES5) + ~100 LoC of CSS
- Audit script `scripts/audit_completion_candidates.py` runs detector read-only against live corpus

## Audit against live corpus

```
32 specs scanned
 0 candidates surfaced
32 skipped:
  25 status (not approved)
   7 age (edited within 24h)
```

**Zero false positives** — the acceptance criterion from requirements.md. The detector also caught real signal: `workflow-path-arg-unification` and `worktree-inventory` have open issues referencing their slugs (would block completion if they were otherwise eligible).

## Tests

- 186 new tests across 5 files (dismiss_store 38, detector 83, config persistence 32, routes 23, template gating 10)
- Full ops surface stays green: **679 passing in ~4s**
- Coverage on new modules: dismiss_store **91%**, completion_candidates **95%**, ops_config_store **88%**, routes/specs.py **90%** (all comfortably above the 85% gate)
- Subprocess wrappers tested directly with mocked `subprocess.run` (every wrapper × every failure mode)

## Test plan

- [ ] All required CI checks green on all OS lanes
- [ ] Manual UI smoke check via worktree-venv recipe: confirm + dismiss + error-banner paths each exercised once
- [ ] Patrick re-runs `python scripts/audit_completion_candidates.py` on his end before flipping the feature on with `attune ops --specs-candidates`

## Follow-ups (added after initial PR)

Two follow-up commits address process-friction issues surfaced during the implementation:

### `12f4b3dc` — Pre-flight ruff lesson

Adds a CLAUDE.md lesson: run `uv run ruff check <files>` before `git add` on commits touching Python files. Mirrors the existing "pre-flight pre-commit's pinned black/ruff" lesson but for the lint side (formatter only catches auto-fixable issues; lint catches F841/E402/etc. that aren't auto-fixable and surface as commit-hook failures). Two hook-fail-retry cycles in this PR's session would have been avoided with this habit.

### `3edb0f3b` — Pre-commit hook for .help/templates regen (B-real-1)

The post-commit dirty state I initially attributed to a "hook auto-stages the wrong dir" bug turned out to be unrelated: `.help/templates/` is regenerated out-of-band by `attune-author` and no commit hook touches it. This commit adds the missing hook (`regenerate-help-templates`):

- Triggers on staged `.py` under `src/` or `.help/features.yaml`
- Loads `.help/features.yaml` via `attune_author.load_manifest`, maps changed paths → affected features using the manifest's per-feature glob patterns
- Default = **warn-only** (prints affected features, exits 0)
- `ATTUNE_DOCS_AUTOREGEN=1` = **auto-regen + auto-stage** — runs `attune-author generate <feature> --all-kinds` per affected feature, then `git add .help/templates/<feature>/`
- Never blocks commits — all failure modes (missing attune-author, manifest unreadable, regen non-zero, git-add failure) print to stderr and exit 0; long error messages trimmed to last non-blank line, capped at 200 chars
- 21 new unit tests for the load-bearing helpers (`_glob_to_regex`, `_affected_features`, `_summarize_error`); subprocess wrappers smoke-tested manually

With the env var set (which my local env has), regen now lands in the same commit as the source change — no more separate "regen" follow-up commits.

## Lessons captured

Four new entries in `.claude/CLAUDE.md`:
- Coverage measurement on worktree code requires `--rcfile=/dev/null` workaround
- Modules with subprocess wrappers need direct `subprocess.run`-mocked tests as standard coverage practice
- argparse three-state CLI flag pattern (mutex + `store_const` + `default=None`) for persisted-fallback toggles
- Pre-flight `ruff check` on changed Python files before `git add` (companion to the existing pre-flight black/ruff format lesson)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
