### PR TITLE
fix(workflows): resolve cwd for file-path inputs across 15 SDK workflows

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2271,24 +2271,36 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   / attune-help all share attune-help as a transitive
   dep with sometimes-divergent cap ranges.
 
-- **`attune workflow run code-review` and
-  `security-audit` require a DIRECTORY for `--path`, not
-  a single file — passing a file raises
-  `NotADirectoryError` deep inside the Claude Agent SDK
-  call**: discovered while trying to deep-review two
-  specific files (`rag_hook.py`, `rag_code_gen.py`).
-  Direct file paths fail after a few seconds of
-  spurious SDK spin-up (wasted API budget). Two ways to
-  adapt: (a) pass the parent directory and filter the
-  workflow's findings back down to your target file in
-  post-processing — noisy, scanner reports issues in
-  adjacent files as if they were in your scope; (b)
-  abandon the workflow for single-file reviews and do
-  direct reading + `grep`-based analysis — cheaper and
-  more precise. For targeted reviews of 1–3 files,
-  option (b) is strictly better. Reserve the workflow
-  for directory-scoped passes (module, package,
-  subsystem).
+- **SDK workflows accepting a file path used to crash
+  silently with `Command failed with exit code 1` —
+  fixed 2026-05-16 via `resolve_cwd_for_path()`
+  helper, but the underlying gotcha is broader**: the
+  Claude Agent SDK's `ClaudeAgentOptions(cwd=...)`
+  must be an existing directory; passing a file raises
+  `CLIConnectionError: [Errno 20] Not a directory` at
+  subprocess startup, which the SDK message reader
+  bubbles as the opaque `Command failed with exit
+  code 1` (no other diagnostic). All 15 SDK-native
+  workflows (`security_audit`, `code_review`,
+  `bug_predict`, `test_gen`, etc.) had the
+  `cwd=resolved_path` antipattern. Fix: every workflow
+  now wraps with `resolve_cwd_for_path(resolved_path)`
+  from `attune.workflows.agent_sdk_adapter`, which
+  returns `path.parent` when `path.is_file()` else
+  `path` unchanged. A drift-guard test
+  (`tests/unit/workflows/test_agent_sdk_adapter.py::
+  TestSdkWorkflowsUseCwdHelper`) asserts the
+  antipattern stays absent. The broader gotcha for
+  any future code calling `claude_agent_sdk.query()`:
+  always use `resolve_cwd_for_path()` for
+  user-supplied paths, even when the path "looks
+  like" a directory at the docstring level —
+  user invocations vary. Companion observation: when
+  workflows fail with `Command failed with exit
+  code 1` and `Cost & Time` shows `$0.0000 | 0.0s`,
+  the failure is at subprocess startup (cwd, auth,
+  CLI binary missing) — NOT a runtime budget/turn
+  issue. The `$0.0` is the diagnostic.
 
 - **Citation-forced prompting and prompt-injection
   resistance are separate threat models — solving one

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -14,6 +14,7 @@ import os
 import re
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import claude_agent_sdk
@@ -494,6 +495,27 @@ def get_max_budget_usd(depth: str = "standard") -> float | None:
         val = float(override)
         return val if val > 0 else None
     return _DEFAULT_BUDGET_USD.get(depth, 10.00)
+
+
+def resolve_cwd_for_path(path: str | Path) -> Path:
+    """Return a directory path suitable for the Agent SDK ``cwd=`` arg.
+
+    The Claude Agent SDK's ``cwd`` must be an existing directory.
+    Passing a file raises ``CLIConnectionError: Not a directory``
+    at subprocess startup, which the SDK surfaces opaquely as
+    ``Command failed with exit code 1``. When the caller's path
+    targets a single file (e.g. a per-module workflow run), the
+    file's parent directory is the correct ``cwd``.
+
+    Args:
+        path: File or directory path the workflow is targeting.
+
+    Returns:
+        ``Path(path).parent`` when ``path`` is an existing file;
+        otherwise ``Path(path)`` unchanged.
+    """
+    p = Path(path)
+    return p.parent if p.is_file() else p
 
 
 # Role-keyword to model mapping for subagents

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -28,6 +28,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -223,7 +224,7 @@ class BugPredictionWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=system_prompt,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/code_review.py
+++ b/src/attune/workflows/code_review.py
@@ -32,6 +32,7 @@ from .agent_sdk_adapter import (
     get_subagent_model,
     get_task_budget,
     get_thinking_config,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -236,7 +237,7 @@ class CodeReviewWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=_SYSTEM_PROMPT,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/deep_review.py
+++ b/src/attune/workflows/deep_review.py
@@ -34,6 +34,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -281,7 +282,7 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=_SYSTEM_PROMPT,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/dependency_check.py
+++ b/src/attune/workflows/dependency_check.py
@@ -24,6 +24,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -205,7 +206,7 @@ class DependencyCheckWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=system_prompt,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -24,6 +24,7 @@ from ..agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
@@ -182,7 +183,7 @@ class DocAuditWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=system_prompt,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/document_gen/workflow.py
+++ b/src/attune/workflows/document_gen/workflow.py
@@ -23,6 +23,7 @@ from ..agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
 )
 from ..base import BaseWorkflow, ModelTier
 from ..context import WorkflowContext
@@ -187,7 +188,7 @@ class DocumentGenerationWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=_SYSTEM_PROMPT,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/perf_audit.py
+++ b/src/attune/workflows/perf_audit.py
@@ -28,6 +28,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -205,7 +206,7 @@ class PerformanceAuditWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=system_prompt,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -32,6 +32,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_task_budget,
     get_thinking_config,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -275,7 +276,7 @@ class RagCodeGenWorkflow(BaseWorkflow):
             "allowed_tools": ["Read", "Glob", "Grep"],
             "permission_mode": "default",
             "max_turns": max_turns,
-            "cwd": cwd,
+            "cwd": resolve_cwd_for_path(cwd),
         }
         if model:
             options_kwargs["model"] = model

--- a/src/attune/workflows/refactor_plan.py
+++ b/src/attune/workflows/refactor_plan.py
@@ -26,6 +26,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -205,7 +206,7 @@ class RefactorPlanWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=_SYSTEM_PROMPT,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -23,6 +23,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -179,7 +180,7 @@ class ReleasePreparationWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=_SYSTEM_PROMPT,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/research_synthesis.py
+++ b/src/attune/workflows/research_synthesis.py
@@ -29,6 +29,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -203,7 +204,7 @@ class ResearchSynthesisWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=_SYSTEM_PROMPT,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/security_audit.py
+++ b/src/attune/workflows/security_audit.py
@@ -33,6 +33,7 @@ from .agent_sdk_adapter import (
     get_subagent_model,
     get_task_budget,
     get_thinking_config,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -229,7 +230,7 @@ class SecurityAuditWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=system_prompt,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/simplify_code.py
+++ b/src/attune/workflows/simplify_code.py
@@ -29,6 +29,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
@@ -197,7 +198,7 @@ class SimplifyCodeWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=_SYSTEM_PROMPT,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -25,6 +25,7 @@ from ..agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
@@ -212,7 +213,7 @@ class TestAuditWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(src_path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=system_prompt,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
                 permission_mode="default",

--- a/src/attune/workflows/test_gen/workflow.py
+++ b/src/attune/workflows/test_gen/workflow.py
@@ -30,6 +30,7 @@ from ..agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
@@ -189,7 +190,7 @@ class TestGenerationWorkflow(BaseWorkflow):
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
                 system_prompt=_SYSTEM_PROMPT,
-                cwd=resolved_path,
+                cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -20,6 +20,7 @@ from attune.workflows.agent_sdk_adapter import (
     AgentSDKResultAdapter,
     get_max_budget_usd,
     get_subagent_model,
+    resolve_cwd_for_path,
     sdk_error_message,
 )
 from attune.workflows.data_classes import (
@@ -580,6 +581,84 @@ class TestSdkErrorMessage:
         exc = Exception(self.EXIT_1_RAW)
         msg = sdk_error_message(exc, duration_seconds=60.0, depth="standard")
         assert "subscription" in msg.lower()
+
+
+@pytest.mark.unit
+class TestResolveCwdForPath:
+    """Regression tests for resolve_cwd_for_path().
+
+    The Claude Agent SDK's ``cwd=`` arg must be an existing
+    directory; passing a file path crashes the SDK subprocess
+    with ``CLIConnectionError: Not a directory`` (surfaced
+    opaquely as ``Command failed with exit code 1``). This
+    helper unblocks single-file workflow invocations.
+    """
+
+    def test_file_returns_parent_directory(self, tmp_path) -> None:
+        """Given a file path, returns its parent directory."""
+        file_path = tmp_path / "mod.py"
+        file_path.write_text("x = 1\n")
+        assert resolve_cwd_for_path(file_path) == tmp_path
+
+    def test_directory_returns_itself_unchanged(self, tmp_path) -> None:
+        """Given a directory path, returns it unchanged."""
+        assert resolve_cwd_for_path(tmp_path) == tmp_path
+
+    def test_accepts_string_input(self, tmp_path) -> None:
+        """Given a str path, coerces to Path and applies same rule."""
+        file_path = tmp_path / "mod.py"
+        file_path.write_text("x = 1\n")
+        assert resolve_cwd_for_path(str(file_path)) == tmp_path
+
+    def test_nonexistent_path_returned_unchanged(self, tmp_path) -> None:
+        """Given a nonexistent path, returns it unchanged (not a file)."""
+        ghost = tmp_path / "does_not_exist"
+        assert resolve_cwd_for_path(ghost) == ghost
+
+
+@pytest.mark.unit
+class TestSdkWorkflowsUseCwdHelper:
+    """Drift-guard: every SDK workflow's cwd= must use the helper.
+
+    Without this guard, a future workflow author would naturally
+    write ``cwd=resolved_path``, reintroducing the silent file-
+    path crash. Asserts the antipattern is absent across all 15
+    SDK-native workflows that take a path argument.
+    """
+
+    _SDK_WORKFLOW_FILES = [
+        "src/attune/workflows/bug_predict.py",
+        "src/attune/workflows/code_review.py",
+        "src/attune/workflows/deep_review.py",
+        "src/attune/workflows/dependency_check.py",
+        "src/attune/workflows/perf_audit.py",
+        "src/attune/workflows/rag_code_gen.py",
+        "src/attune/workflows/release_prep.py",
+        "src/attune/workflows/research_synthesis.py",
+        "src/attune/workflows/security_audit.py",
+        "src/attune/workflows/refactor_plan.py",
+        "src/attune/workflows/simplify_code.py",
+        "src/attune/workflows/document_gen/workflow.py",
+        "src/attune/workflows/doc_audit/workflow.py",
+        "src/attune/workflows/test_audit/workflow.py",
+        "src/attune/workflows/test_gen/workflow.py",
+    ]
+
+    def test_no_workflow_uses_raw_resolved_path_as_cwd(self) -> None:
+        """No SDK workflow may write ``cwd=resolved_path`` directly."""
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[3]
+        offenders: list[str] = []
+        for rel in self._SDK_WORKFLOW_FILES:
+            text = (repo_root / rel).read_text(encoding="utf-8")
+            if "cwd=resolved_path," in text:
+                offenders.append(rel)
+        assert not offenders, (
+            f"Workflows passing file paths as cwd to the Agent SDK "
+            f"crash at subprocess startup. Wrap with "
+            f"resolve_cwd_for_path(). Offenders: {offenders}"
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- **Root cause:** `ClaudeAgentOptions(cwd=...)` requires an existing directory; passing a file raises `CLIConnectionError: [Errno 20] Not a directory` at subprocess startup, which the SDK message reader bubbles as the opaque `Command failed with exit code 1` (with `$0 cost / 0s duration` — the diagnostic that the failure is at subprocess startup, not in the agent run).
- **Fix:** New `resolve_cwd_for_path()` helper in `agent_sdk_adapter.py` returns `path.parent` when `path.is_file()` else `path` unchanged. All 15 SDK-native workflows (`security_audit`, `code_review`, `bug_predict`, `test_gen`, `deep_review`, `dependency_check`, `perf_audit`, `rag_code_gen`, `release_prep`, `research_synthesis`, `refactor_plan`, `simplify_code`, `doc_audit`, `document_gen`, `test_audit`) now wrap their `cwd=` arg with the helper. Unblocks per-file invocations (per-module audits, targeted test generation, file-scoped reviews).
- **Drift-guard:** `TestSdkWorkflowsUseCwdHelper` in `test_agent_sdk_adapter.py` greps each SDK workflow source and asserts the antipattern is absent.
- **Lesson:** Replaced the CLAUDE.md "workflows require a DIRECTORY for --path" workaround note with the fix + broader gotcha (the `$0.0` cost is the subprocess-startup-failure signal).

## Test plan

- [x] 64/64 tests in `tests/unit/workflows/test_agent_sdk_adapter.py` pass (was 59, +5 new: 4 helper unit tests + 1 drift-guard)
- [x] All 16 patched modules import cleanly
- [x] End-to-end validation: `attune workflow run test-gen --input '{"path":"src/attune/agent_factory/adapters/autogen_adapter.py","depth":"standard"}'` completes successfully (686s, $6.97) where it previously crashed with the opaque exit-1 error at $0
- [ ] CI matrix green across Ubuntu / macOS / Windows × Py 3.10-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)