### PR TITLE
fix(workflows): gate task_budget on CLI --task-budget flag support

### DIFF
--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shutil
+import subprocess
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -295,6 +297,63 @@ _DEFAULT_TASK_BUDGET_TOKENS: dict[str, int] = {
 }
 
 
+# Cache for the CLI's --task-budget support probe. None = not yet
+# probed; True/False = result. Probe is lazy + once-per-process.
+_CLI_SUPPORTS_TASK_BUDGET: bool | None = None
+
+
+def _cli_supports_task_budget() -> bool:
+    """Return True iff the resolved ``claude`` CLI accepts ``--task-budget``.
+
+    The SDK appends ``--task-budget <N>`` to the CLI command when
+    ``ClaudeAgentOptions.task_budget`` is set. Older CLI binaries
+    (including the bundled one in ``claude-agent-sdk`` 0.1.63 and
+    the system ``claude`` 2.1.x) don't recognize the flag and exit
+    with code 1 at startup — surfaced to the workflow as an
+    opaque ``Command failed with exit code 1`` with ``$0 cost /
+    1-2s elapsed``. This probe gates the feature off until both
+    sides catch up.
+
+    Probes by running ``<cli> --help`` once and grepping for
+    ``--task-budget``. Result is cached in
+    ``_CLI_SUPPORTS_TASK_BUDGET`` so the subprocess fires at most
+    once per Python process.
+
+    The CLI is resolved using the same precedence as the SDK
+    transport: prefer the SDK's bundled CLI when present,
+    fall back to ``shutil.which("claude")``.
+    """
+    global _CLI_SUPPORTS_TASK_BUDGET
+    if _CLI_SUPPORTS_TASK_BUDGET is not None:
+        return _CLI_SUPPORTS_TASK_BUDGET
+
+    # SDK's bundled CLI takes precedence over PATH.
+    sdk_dir = Path(claude_agent_sdk.__file__).resolve().parent
+    bundled = sdk_dir / "_bundled" / "claude"
+    cli_path = str(bundled) if bundled.is_file() else shutil.which("claude")
+
+    if not cli_path:
+        _CLI_SUPPORTS_TASK_BUDGET = False
+        return False
+
+    try:
+        result = subprocess.run(
+            [cli_path, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        _CLI_SUPPORTS_TASK_BUDGET = "--task-budget" in (result.stdout + result.stderr)
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning(
+            "task-budget CLI probe failed (%s); disabling task_budget",
+            type(exc).__name__,
+        )
+        _CLI_SUPPORTS_TASK_BUDGET = False
+    return _CLI_SUPPORTS_TASK_BUDGET
+
+
 def get_task_budget(depth: str = "standard") -> Any:
     """Build a token-aware ``TaskBudget`` for a workflow depth.
 
@@ -308,11 +367,17 @@ def get_task_budget(depth: str = "standard") -> Any:
     ``ATTUNE_TASK_BUDGET_TOKENS`` env var (positive integer;
     unset or 0 falls back to the depth default).
 
-    Returns ``None`` when the installed SDK doesn't expose
-    ``TaskBudget`` so callers can treat it as a no-op field.
+    Returns ``None`` when (a) the installed SDK doesn't expose
+    ``TaskBudget``, or (b) the resolved ``claude`` CLI doesn't
+    accept the ``--task-budget`` flag (SDK transport appends it
+    unconditionally; older CLIs reject the unknown arg and
+    exit 1 at subprocess startup). Callers can treat None as a
+    no-op field.
     """
     budget_cls = getattr(claude_agent_sdk, "TaskBudget", None)
     if budget_cls is None:
+        return None
+    if not _cli_supports_task_budget():
         return None
     override = os.environ.get("ATTUNE_TASK_BUDGET_TOKENS")
     if override:

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -662,6 +662,119 @@ class TestSdkWorkflowsUseCwdHelper:
 
 
 @pytest.mark.unit
+class TestGetTaskBudgetCliProbe:
+    """Regression tests for the task_budget CLI feature-probe.
+
+    The SDK appends ``--task-budget <N>`` to the CLI command when
+    ``ClaudeAgentOptions.task_budget`` is set. Older CLIs (bundled
+    in claude-agent-sdk 0.1.63 and system ``claude`` 2.1.x) don't
+    recognize the flag and exit 1 at startup, surfacing as the
+    opaque ``Command failed with exit code 1``. ``get_task_budget``
+    now probes ``<cli> --help`` once and returns ``None`` when the
+    flag is absent.
+    """
+
+    def setup_method(self) -> None:
+        """Reset the module-level cache before each test."""
+        import attune.workflows.agent_sdk_adapter as mod
+
+        mod._CLI_SUPPORTS_TASK_BUDGET = None
+
+    def test_returns_none_when_cli_lacks_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Given a CLI whose --help omits --task-budget, returns None."""
+        import attune.workflows.agent_sdk_adapter as mod
+
+        fake_help = (
+            "Usage: claude [options]\n"
+            "  --max-budget-usd <amount>  Max dollars\n"
+            "  --print                    Non-interactive\n"
+        )
+
+        def fake_run(cmd, **kwargs):
+            class _R:
+                stdout = fake_help
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/local/bin/claude")
+        # Avoid the bundled-CLI path so the shutil.which() fake is used.
+        monkeypatch.setattr(mod.Path, "is_file", lambda self: False)
+
+        assert mod._cli_supports_task_budget() is False
+        assert mod.get_task_budget("standard") is None
+
+    def test_returns_budget_when_cli_supports_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Given a CLI whose --help mentions --task-budget, returns a TaskBudget."""
+        import attune.workflows.agent_sdk_adapter as mod
+
+        fake_help = "  --task-budget <tokens>  Token cap per task\n"
+
+        def fake_run(cmd, **kwargs):
+            class _R:
+                stdout = fake_help
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/local/bin/claude")
+        monkeypatch.setattr(mod.Path, "is_file", lambda self: False)
+
+        assert mod._cli_supports_task_budget() is True
+        budget = mod.get_task_budget("standard")
+        assert budget is not None
+        assert budget["total"] == 80_000
+
+    def test_probe_result_is_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Probe runs at most once per process; subsequent calls hit cache."""
+        import attune.workflows.agent_sdk_adapter as mod
+
+        call_count = {"n": 0}
+
+        def fake_run(cmd, **kwargs):
+            call_count["n"] += 1
+
+            class _R:
+                stdout = "  --task-budget X\n"
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/local/bin/claude")
+        monkeypatch.setattr(mod.Path, "is_file", lambda self: False)
+
+        mod._cli_supports_task_budget()
+        mod._cli_supports_task_budget()
+        mod._cli_supports_task_budget()
+        assert call_count["n"] == 1
+
+    def test_probe_timeout_disables_feature(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If the probe times out, treat the CLI as unsupported."""
+        import attune.workflows.agent_sdk_adapter as mod
+
+        def fake_run(cmd, **kwargs):
+            raise mod.subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(mod.shutil, "which", lambda _: "/usr/local/bin/claude")
+        monkeypatch.setattr(mod.Path, "is_file", lambda self: False)
+
+        assert mod._cli_supports_task_budget() is False
+
+    def test_missing_cli_disables_feature(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When no CLI is found anywhere, return False without probing."""
+        import attune.workflows.agent_sdk_adapter as mod
+
+        monkeypatch.setattr(mod.shutil, "which", lambda _: None)
+        monkeypatch.setattr(mod.Path, "is_file", lambda self: False)
+
+        assert mod._cli_supports_task_budget() is False
+
+
+@pytest.mark.unit
 class TestGetSubagentModel:
     """Test per-agent model selection helper."""
 

--- a/tests/unit/workflows/test_task_budget_wiring.py
+++ b/tests/unit/workflows/test_task_budget_wiring.py
@@ -16,6 +16,23 @@ import pytest
 pytest.importorskip("claude_agent_sdk")
 
 
+@pytest.fixture(autouse=True)
+def _force_cli_supports_task_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the CLI feature-probe to return True for wiring tests.
+
+    ``get_task_budget()`` returns ``None`` when the resolved ``claude``
+    CLI doesn't accept ``--task-budget`` (current bundled CLI doesn't).
+    These tests are checking that workflows FORWARD ``task_budget`` to
+    the SDK when the helper returns a value — they should not depend
+    on which CLI happens to be installed. Override both the function
+    and the cached result so any code path returns True.
+    """
+    import attune.workflows.agent_sdk_adapter as mod
+
+    monkeypatch.setattr(mod, "_CLI_SUPPORTS_TASK_BUDGET", True)
+    monkeypatch.setattr(mod, "_cli_supports_task_budget", lambda: True)
+
+
 # --- Pure helper tests ----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- **Root cause:** The SDK's subprocess transport appends `--task-budget <N>` to the `claude` CLI command when `ClaudeAgentOptions.task_budget` is set, but neither the bundled CLI (in `claude-agent-sdk` 0.1.63's `_bundled/claude`) nor the system `claude` 2.1.x supports the flag. CLI rejects the unknown arg and exits 1 at subprocess startup, surfacing as the opaque `Command failed with exit code 1` with `$0 cost / 1-2s elapsed`. Affected workflows: **`code-review`, `security-audit`, `rag-code-gen`**.
- **Why the old feature-detect missed it:** `get_task_budget()` only checked `getattr(claude_agent_sdk, "TaskBudget", None)` — but `TaskBudget` is a TypedDict that always exists in 0.1.63, so the symbol-presence check was a false positive. Symbol existence ≠ end-to-end support.
- **Fix:** Add `_cli_supports_task_budget()` that probes the resolved CLI (bundled first, then `shutil.which("claude")`) by running `--help` once and grepping for `--task-budget`. Result cached at module level so the subprocess fires at most once per process. `get_task_budget()` returns `None` when the probe fails, treating the field as a no-op until SDK and CLI versions converge.
- **Drift-guard:** 5 new regression tests in `TestGetTaskBudgetCliProbe` cover supported / unsupported / cached / timeout / missing-CLI paths.

## Test plan

- [x] 5/5 new probe tests pass
- [x] All 16 patched modules from #401 still import cleanly
- [x] **End-to-end validation:** `code-review --path <single-file>` used to fail with `$0 cost / 1.7s elapsed` (instant subprocess exit-1). After the fix, the workflow runs ~35s of real subagent work before hitting an unrelated budget-cap surface — **20x improvement in useful execution time**. The remaining failure is the standard budget-cap diagnostic that the voice layer already surfaces (`ATTUNE_MAX_BUDGET_USD=0`).
- [ ] CI matrix green across Ubuntu / macOS / Windows × Py 3.10-3.13

## Related

- Pairs with #401 (resolve_cwd_for_path): same shape of opaque-exit-1 diagnostic, different root cause (cwd-is-a-file vs unknown-CLI-flag).
- The remaining `exit 1` after `ResultMessage` delivery (when CLI subprocess terminates non-zero on max_turns/budget hit) is a separate SDK-level issue — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)