### PR TITLE
docs(specs): draft sibling-package subscription-auth spec

### DIFF
--- a/docs/specs/sibling-subscription-auth/decisions.md
+++ b/docs/specs/sibling-subscription-auth/decisions.md
@@ -1,0 +1,54 @@
+# Spec: Subscription-First Auth for Sibling Packages — Decisions
+
+> Pre-committed decisions per the existing lesson "Pre-committed
+> decision matrices survive contact with data." Phase 0's
+> findings populate the empty rows before Phase 1 starts;
+> Phase 1+ rows get filled as implementation progresses.
+
+---
+
+## Decision matrix
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Phase 0 deliverable shape | A single `findings.md` doc plus a runnable probe script committed to `scripts/probe_subscription_routing.py` | The probe is reusable: if the routing mechanism changes upstream, re-running tells us so. A doc alone goes stale. |
+| Phase 0 success criterion | The four open design questions in `design.md` have explicit yes/no answers (or "not yet determined, follow-up needed") | Soft "we learned a lot" deliverables are how investigation phases die. |
+| Design option (A/B/C) | _TBD — pre-commit after Phase 0_ | The choice is determined by whether subscription auth is inheritable across a subprocess boundary. |
+| Detection default for subscribers | _TBD — pre-commit after Phase 0_ | Lean toward opt-in (`ATTUNE_AUTHOR_AUTH_MODE=auto` not the default initially) to avoid surprising users until the routing is proven stable. Revisit after the first month of real use. |
+| CLI flag name | `--auth-mode={auto,api,sub}` on `attune-author generate`, `regenerate`, `attune-rag eval` | Three discrete values map clean to argparse `choices=`; matches existing `--fact-check={off,soft,strict}` style. |
+| Env var names | `ATTUNE_AUTHOR_AUTH_MODE` (attune-author scope) and `ATTUNE_RAG_AUTH_MODE` (attune-rag scope) | Per-package env vars; users with both packages can override independently. Avoids a single global `ATTUNE_AUTH_MODE` that overrides everything at once. |
+| Status command | `attune-author auth status` (and matching `attune-rag auth status`) | Mirrors `attune-ai`'s existing `attune auth status`. Output format intentionally parallel so users get the same diagnostic surface across packages. |
+| Telemetry cost annotation format | `estimated cost $0.0000 (subscription)` and `$0.0150 (API)` | One line, no schema change for existing telemetry consumers. The parenthetical tag is grep-able. |
+| Fallback order when both auths are available | Subscription, then API key | A subscriber paying $200/mo for Max should be the first beneficiary; API-key takes over only when subscription explicitly fails or is forced off. |
+| Behavior when neither auth is available | Raise a clear error pointing the user at both setup paths | No silent fallback to a "no auth" mode that just emits Jinja drafts. Polish failures already have that lenient path; auth failures should not pile onto it. |
+| Cycle prevention if Option B chosen | Place the public auth helper in `attune-ai`'s top-level package surface (`attune.auth.get_authenticated_completer`) with **no transitive attune-ai dependencies** | Siblings can then import a minimal shim without dragging in attune-ai's workflow/MCP/wizard surface. |
+| Cross-package release coordination | Land Phase 1 (attune-author) and Phase 2 (attune-rag) in separate PRs; coordinate release in same week if both ship | Independent shipping reduces risk; coordinated release date keeps the user-facing story consistent. |
+
+---
+
+## Calibration record
+
+To be filled in during Phase 0 implementation:
+
+- [ ] Phase 0 finding: `claude_agent_sdk.query()` inside Claude Code
+      without env key: _TBD_
+- [ ] Phase 0 finding: same from a child subprocess of Claude Code:
+      _TBD_
+- [ ] Phase 0 finding: detection signal Claude Code exposes
+      (env var, file, or none): _TBD_
+- [ ] Phase 0 finding: total sibling-package count making direct
+      API calls (today's known set: attune-author, attune-rag —
+      audit may surface more): _TBD_
+
+---
+
+## Decision-change log
+
+> Append entries here when a decision above is revised.
+> Reference the PR that revised it.
+
+- 2026-05-16 — Initial decisions captured during spec draft.
+  Motivating trigger: polish-fact-check Phase 3 (attune-author
+  PR #36) added a second LLM-call path that requires
+  `ANTHROPIC_API_KEY`, making the cumulative API-key dependency
+  in sibling packages tangible enough to warrant fixing.

--- a/docs/specs/sibling-subscription-auth/design.md
+++ b/docs/specs/sibling-subscription-auth/design.md
@@ -1,0 +1,183 @@
+# Spec: Subscription-First Auth for Sibling Packages — Design
+
+**Status**: draft
+
+---
+
+## Phase 2: Design
+
+### Open question driving the design
+
+How does a Claude Code subscription actually route an LLM call so
+no API token is consumed?
+
+The honest answer at draft time: it appears to be a property of
+the Claude Agent SDK when invoked inside a Claude Code session
+context. The SDK reads authentication from the session rather
+than from `ANTHROPIC_API_KEY`. This needs Phase 0 verification
+before any of the options below get implemented.
+
+The three design options assume Phase 0 confirms the
+SDK-context-routing model. If Phase 0 surfaces a different
+mechanism, the design will be revised before implementation.
+
+---
+
+### Option A: Agent-SDK shim in each sibling
+
+Each sibling package gains a small adapter that prefers
+`claude_agent_sdk.query()` over the direct
+`anthropic.Anthropic` client when:
+
+1. The Agent SDK is importable, AND
+2. A subscription session is detectable (env var or session
+   probe), AND
+3. The caller hasn't explicitly forced API mode.
+
+Pseudocode:
+
+```python
+def get_llm_client():
+    if _running_under_subscription():
+        return AgentSDKClientAdapter()  # uses claude_agent_sdk.query
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return AnthropicSDKClient()
+    raise NoCredentialsError(...)
+```
+
+**Pros:** No new package; each sibling owns its routing.
+**Cons:** Duplicate adapters across siblings (DRY violation);
+each sibling decides "what counts as subscription" separately;
+two LLM SDKs become a coupling surface.
+
+---
+
+### Option B: Publish `attune_ai.auth` as a public helper
+
+`attune-ai` exposes a function siblings can import that returns
+an LLM-call callable already wired for the right mode:
+
+```python
+# in attune-ai
+def get_authenticated_completer(
+    *,
+    fallback_to_api: bool = True,
+) -> Callable[..., str]:
+    """Return a `(messages, **kwargs) -> str` callable that uses
+    whichever mode AuthStrategy recommends."""
+    ...
+
+# in attune-author / attune-rag
+from attune_ai.auth import get_authenticated_completer
+complete = get_authenticated_completer()
+text = complete(messages=[...], model="claude-haiku-4-5", ...)
+```
+
+**Pros:** Single source of truth; siblings get
+recommendation-driven routing "for free"; matches how
+attune-ai's own workflows already work.
+**Cons:** `attune-author` and `attune-rag` gain a runtime
+dependency on `attune-ai`. Today they're consumed-by-but-not-
+dependent-on. Reversing that direction has packaging
+implications (cycle risk, install size, version pinning).
+
+---
+
+### Option C: Shared `attune-auth` package
+
+Extract the auth-routing layer into its own tiny PyPI package
+that all four consumers depend on:
+
+```
+attune-auth/         # ~150 LOC; exposes get_authenticated_completer
+├── attune-ai
+├── attune-author
+└── attune-rag
+```
+
+**Pros:** Cleanest dependency graph; no cycle risk; each
+consumer pins independently.
+**Cons:** New package to maintain, version, publish, release-
+cadence-align. Possibly overkill for what may end up being a
+50-line adapter.
+
+---
+
+### Recommendation
+
+Defer the decision until Phase 0 finishes. Likely outcome:
+
+- If subscription routing turns out to be a `claude_agent_sdk`
+  context inheritance — and that inheritance works from a child
+  subprocess of Claude Code — then **Option A** is sufficient.
+  Each sibling gets a ~30-line adapter that detects + uses the
+  Agent SDK when present, falls back to the Anthropic SDK
+  otherwise. Duplication is acceptable at this scale.
+- If subscription routing requires nontrivial setup the auth
+  strategy already encodes (token estimation, tier-aware mode
+  selection, cost reporting), then **Option B** wins: import
+  the existing logic instead of reimplementing it. The
+  dependency direction concern is solvable by keeping the auth
+  helper in a thin `attune-ai.auth` module that has no transitive
+  attune-ai deps.
+- **Option C** is the right call only if a 4th consumer needs
+  the same plumbing — premature today.
+
+---
+
+### User-facing surface (independent of option)
+
+Regardless of mechanism, the siblings need:
+
+1. **Auto-detection.** `attune-author generate` and the Phase 3
+   judge should "just work" for subscribers without env vars.
+2. **Explicit override.** `--auth-mode=api` / `--auth-mode=sub`
+   CLI flags + `ATTUNE_AUTH_MODE` env var, for cases where the
+   user wants to force one path (e.g., CI lanes with an API key
+   and no subscription, or vice versa).
+3. **Status command.** `attune-author auth status` reports
+   which mode would fire for a hypothetical call right now,
+   including which credentials are available. Eliminates the
+   "did it actually route?" debugging.
+4. **Telemetry parity.** The existing Phase 3 telemetry log
+   (`Faithfulness judge: 3 calls, 0 skipped, estimated cost
+   $0.0150`) should annotate whether costs were
+   subscription-covered or billed — e.g.
+   `estimated cost $0.0000 (subscription)` vs
+   `$0.0150 (API)`.
+
+---
+
+### Failure modes to design around
+
+- **Subscription expires mid-run.** Token / session expires
+  between calls during a multi-feature regen. Should fall
+  through to API-key if available; surface a clear message if
+  not.
+- **Mixed authentication on the same machine.** Some users
+  have BOTH a subscription AND an `ANTHROPIC_API_KEY` set. The
+  mode flag (or `AuthStrategy.default_mode`) is the
+  tie-breaker; without an explicit setting, prefer subscription.
+- **Sibling invoked from non-Claude-Code shell.** A subscriber
+  running `attune-author generate` from a plain terminal won't
+  have a session-level subscription to inherit. The detection
+  must not false-positive in this case; the fallback to
+  `ANTHROPIC_API_KEY` (or a graceful "no auth" error) is the
+  expected path.
+
+---
+
+### Open design questions (resolve before Phase 1 implementation)
+
+1. **Does `claude_agent_sdk` inherit a Claude Code session's
+   auth when run from a subprocess?** Phase 0 task #1.
+2. **Is there an env var or file that Claude Code sets to
+   advertise its session presence?** Phase 0 task #2.
+3. **Should detection be opt-in (`ATTUNE_AUTH_MODE=auto`
+   default-off) or opt-out (default-on, env to disable)?**
+   Pre-commit a default in `decisions.md` before Phase 1.
+4. **For attune-rag, does the judge's async API change at
+   all?** The Agent SDK is async-native; the existing
+   `FaithfulnessJudge.score` is already async — clean fit.
+   But if Option A picks the Agent SDK, the AsyncAnthropic
+   construction needs replacing, not just augmenting.

--- a/docs/specs/sibling-subscription-auth/requirements.md
+++ b/docs/specs/sibling-subscription-auth/requirements.md
@@ -1,0 +1,117 @@
+# Spec: Subscription-First Auth for Sibling Packages
+
+**Status**: draft
+**Created**: 2026-05-16
+**Sibling spec**: `docs/specs/polish-fact-check/` (motivating
+trigger — Phase 3 made attune-author's API-key dependency
+visibly tangible by adding a second LLM-call path)
+
+---
+
+## Phase 1: Requirements
+
+### Problem statement
+
+`attune-author` and `attune-rag` both make direct Anthropic API
+calls and require `ANTHROPIC_API_KEY` in the environment.
+
+- `attune_author.doc_gen._anthropic.call_anthropic` constructs a
+  sync `anthropic.Anthropic(api_key=...)` client.
+- `attune_rag.eval.faithfulness.FaithfulnessJudge.__init__`
+  constructs `anthropic.AsyncAnthropic(api_key=...)` directly.
+
+`attune-ai` ships an auth strategy
+(`attune.models.auth_strategy.AuthStrategy`) that recommends
+subscription-vs-API mode based on subscription tier + module
+size. Its own workflows route LLM calls through
+`claude_agent_sdk.query()` which CAN consume a Claude Code
+subscription when run in the appropriate context. But that
+routing capability isn't exposed to sibling packages, so users
+who have a Claude Code subscription still pay full API cost when
+attune-author polishes templates or attune-rag's judge scores
+faithfulness.
+
+### Why this matters
+
+1. **Duplicate billing.** A Pro/Max subscriber pays $20–$200/month
+   for Claude Code AND pays per-token to Anthropic for the same
+   model when attune-author runs polish or attune-rag runs the
+   judge. The two paths use different SDKs so the subscription
+   discount doesn't apply.
+2. **First-run friction.** New attune-ai users today get told
+   "install attune-ai, run a command" and it works. The moment
+   they try `attune-author generate` or enable the Phase 3
+   faithfulness judge, they hit an API-key requirement that the
+   rest of attune-ai didn't make them think about. The UX seam
+   breaks the zero-config story.
+3. **Cost surprise.** Without a subscription path, faithfulness
+   scoring at default rates (~$0.03 per 3-kind feature) is
+   inexpensive but unbounded: a full regen of 30 features at
+   11 kinds each is ~$3 per pass. With subscription routing the
+   incremental cost is zero.
+
+### Scope
+
+In scope:
+
+- `attune_author.doc_gen._anthropic` (polish-pass API calls).
+- `attune_rag.eval.faithfulness.FaithfulnessJudge` (judge calls).
+- Any other sibling package that makes direct Anthropic API
+  calls — `attune-help`, `attune-lite` — discovered during
+  Phase 0 audit.
+
+Out of scope:
+
+- attune-ai's own workflows (already route through
+  `claude_agent_sdk`).
+- The recommendation logic in `AuthStrategy` (which mode to
+  pick); this spec is about execution, not policy.
+- Anthropic's own SDK behavior or pricing.
+
+### What "subscription routing" actually means (open question)
+
+The Phase 0 research task answers this: today's `AuthStrategy`
+returns recommendations (`AuthMode.SUBSCRIPTION` vs
+`AuthMode.API`) but the code path that converts a "use the
+subscription" recommendation into an actual non-billed LLM call
+is not obvious from a five-minute read of
+`src/attune/models/`. The most likely mechanism is
+`claude_agent_sdk.query()` invoked from inside a Claude Code
+session, where the SDK inherits the session's authentication
+context. If that's the mechanism, sibling packages need either:
+
+1. A way to detect "I'm running under Claude Code" and route
+   through `claude_agent_sdk` instead of the direct Anthropic
+   SDK, OR
+2. A shared auth-routing helper that exposes the choice as a
+   library call.
+
+### Success criteria
+
+- A Pro/Max-subscription user can run `attune-author generate`
+  and `attune-author regenerate` end-to-end **without setting
+  `ANTHROPIC_API_KEY`** (when their Claude Code session has
+  valid auth).
+- Same for the Phase 3 faithfulness judge: a subscriber-only
+  user can flip `[tool.attune-author.fact-check.faithfulness]
+  enabled = true` and the judge runs against their subscription.
+- API-key-only users (no Claude Code subscription, or running
+  outside a Claude Code session) keep working unchanged — the
+  fallback to `ANTHROPIC_API_KEY` stays first-class.
+- No behavior change for users running attune-ai's existing
+  workflows (the change is additive at the sibling-package
+  layer).
+- A diagnostic command — likely an extension of
+  `attune-author auth status` or a new
+  `attune-author auth diagnose` — that prints which mode is
+  actually being used for a real call, so users can confirm
+  routing is working without scraping logs.
+
+### Non-goals
+
+- Modifying the subscription/API recommendation logic.
+- Building a separate `attune-auth` PyPI package (considered
+  in the design but deferred unless a 4th sibling needs the
+  same plumbing).
+- Caching, batching, or cost reporting beyond what already
+  exists in attune-ai's telemetry.

--- a/docs/specs/sibling-subscription-auth/tasks.md
+++ b/docs/specs/sibling-subscription-auth/tasks.md
@@ -1,0 +1,136 @@
+# Spec: Subscription-First Auth for Sibling Packages — Tasks
+
+**Status**: draft
+
+> Phase 0 is mandatory and lands before any implementation. The
+> design rests on assumptions about how `claude_agent_sdk` and
+> Claude Code subscriptions interact; the implementation phases
+> are gated on those assumptions surviving contact with reality.
+
+---
+
+## Phase 0: Research
+
+**Target PR scope:** ~100 LOC of probe scripts + a written
+findings doc. No production code changes.
+
+| # | Task | Layer | Status | Notes |
+|---|------|-------|--------|-------|
+| 0.1 | Probe: does `claude_agent_sdk.query()` work inside Claude Code without `ANTHROPIC_API_KEY`? | attune-ai | todo | Write the probe as a one-shot script under `scripts/probe_subscription_routing.py`. Run inside Claude Code; capture whether the call succeeds and what auth context it uses. |
+| 0.2 | Probe: same as 0.1, but from a child subprocess spawned by Claude Code (mimicking attune-author being invoked from Claude Code) | attune-ai | todo | Critical: confirms whether subscription auth is inherited across a process boundary or only available inside Claude Code's own process. |
+| 0.3 | Probe: identify env vars / config files Claude Code sets that advertise its presence | attune-ai | todo | Look for `CLAUDE_CODE_*`, `~/.claude/`, etc. Findings inform the detection step. |
+| 0.4 | Audit: list every sibling package that makes direct Anthropic API calls | attune-ai | todo | Grep `attune-author`, `attune-rag`, `attune-help`, `attune-lite`, `attune-software` for `anthropic.Anthropic`, `anthropic.AsyncAnthropic`. Confirm scope. |
+| 0.5 | Write `findings.md` in this spec dir | attune-ai | todo | One page; covers what the probes returned + which design option (A/B/C) the data supports. |
+| 0.6 | Pre-commit Phase 1 design decisions in `decisions.md` | attune-ai | todo | Detection default (opt-in vs opt-out), CLI/env-var override naming, telemetry message format. |
+
+### Phase 0 exit checklist
+
+- [ ] `scripts/probe_subscription_routing.py` lands and is
+      runnable both inside and outside Claude Code
+- [ ] `findings.md` answers the four open design questions
+      from `design.md`
+- [ ] `decisions.md` has a pre-committed decision row for each
+      open question
+- [ ] Spec status moves from `draft` to `approved` (or `paused`
+      if findings invalidate the premise)
+
+---
+
+## Phase 1: Shim layer in attune-author (smallest blast radius)
+
+**Target PR scope:** ~300 LOC including tests. Depends on Phase 0.
+
+| # | Task | Layer | Status | Notes |
+|---|------|-------|--------|-------|
+| 1.1 | Pick design option (A/B/C) from Phase 0 findings | attune-author | todo | Document in this spec's decisions.md |
+| 1.2 | Implement the chosen adapter / wrapper in attune-author | attune-author | todo | Lives under `src/attune_author/auth/` or extends `doc_gen/_anthropic.py` |
+| 1.3 | Wire the adapter into `polish._call_llm` | attune-author | todo | Drop-in replacement for the current direct `get_client()` call |
+| 1.4 | Add `--auth-mode={auto,api,sub}` to `attune-author generate` and `regenerate` | attune-author | todo | Plus `ATTUNE_AUTHOR_AUTH_MODE` env var (explicit override always wins over auto) |
+| 1.5 | Add `attune-author auth status` CLI command | attune-author | todo | Report which mode would fire right now; list available credentials |
+| 1.6 | Telemetry: annotate cost as `(subscription)` or `(API)` in the regen summary log | attune-author | todo | Matches the Phase 3 telemetry log format |
+| 1.7 | Tests: routing under each mode (auto-sub, auto-api, forced-sub, forced-api, no-creds) | attune-author | todo | Mock the SDK at the adapter boundary, not the wire |
+| 1.8 | Tests: failure modes (subscription expires mid-run, mixed auth) | attune-author | todo | |
+| 1.9 | Update CHANGELOG + README | attune-author | todo | Document zero-config subscriber UX |
+
+### Phase 1 exit checklist
+
+- [ ] Tasks 1.1–1.9 done
+- [ ] A subscriber can run `attune-author generate <feat>`
+      without `ANTHROPIC_API_KEY` and see "(subscription)"
+      cost in the log
+- [ ] An API-key-only user sees no behavior change
+- [ ] `auth status` correctly reports the active mode
+
+---
+
+## Phase 2: Same for attune-rag (faithfulness judge)
+
+**Target PR scope:** ~250 LOC. Depends on Phase 1 (reuses the
+adapter shape; may extract to a shared helper).
+
+| # | Task | Layer | Status | Notes |
+|---|------|-------|--------|-------|
+| 2.1 | Mirror Phase 1's adapter inside attune-rag (or import from a shared package per Option B/C) | attune-rag | todo | Async-native — `claude_agent_sdk.query()` matches `FaithfulnessJudge.score`'s async shape |
+| 2.2 | Wire into `FaithfulnessJudge.__init__` so callers don't pass api_key when subscription is detected | attune-rag | todo | Existing `client: AsyncAnthropic | None` keyword stays for explicit injection |
+| 2.3 | Update `attune-rag eval` CLI commands with the same `--auth-mode` flag | attune-rag | todo | Parity with attune-author |
+| 2.4 | Tests: judge routing under each mode | attune-rag | todo | |
+| 2.5 | Telemetry: annotate `subscription` vs `API` cost in attune-author's faithfulness summary log | attune-author | todo | Cross-package; depends on Phase 2 being merged |
+| 2.6 | Update CHANGELOG + README in attune-rag | attune-rag | todo | |
+
+### Phase 2 exit checklist
+
+- [ ] Tasks 2.1–2.6 done
+- [ ] Polish-fact-check Phase 3 judge runs against subscription
+      without an API key
+- [ ] attune-rag's standalone CLI honors the same flags as
+      attune-author
+
+---
+
+## Phase 3 (optional): Extract shared helper
+
+**Target PR scope:** ~200 LOC. Only happens if Phase 1 + 2
+shake out enough duplication to justify a separate package.
+
+| # | Task | Layer | Status | Notes |
+|---|------|-------|--------|-------|
+| 3.1 | Decide: ship as `attune-ai.auth` public API (Option B) or new `attune-auth` package (Option C) | spec | todo | Driven by whether a 4th consumer (attune-help, attune-lite) needs it |
+| 3.2 | Extract the adapter | varies | todo | |
+| 3.3 | Update attune-author and attune-rag to consume the shared helper | attune-author + attune-rag | todo | |
+| 3.4 | Deprecate the duplicate adapters in each sibling | varies | todo | Keep the duplicate as a deprecation shim for one release cycle |
+| 3.5 | CHANGELOGs + READMEs in all affected packages | all | todo | |
+
+### Phase 3 exit checklist
+
+- [ ] Single source of truth for sibling auth routing
+- [ ] Each consumer's `auth/` module has shrunk to a re-export
+- [ ] Umbrella spec status moves to `complete`
+
+---
+
+## Cross-phase notes
+
+### Testing strategy
+
+- No mocking of LLM calls in integration tests. Mock at the SDK
+  client boundary (`anthropic.Anthropic` and
+  `claude_agent_sdk.query`) per the regen-pipeline pattern.
+- Each adapter has a test that constructs it in each of the four
+  states: subscription-available, api-key-available, both,
+  neither. The four states cover every routing decision the
+  adapter has to make.
+
+### Rollback strategy
+
+Each phase has its own `--auth-mode=api` opt-out. If
+subscription routing causes unexpected breakage in production
+regens, the operator can pin `ATTUNE_AUTHOR_AUTH_MODE=api` in
+`pyproject.toml` or env without touching code. The behavior
+returns to pre-spec semantics.
+
+### Sequencing within the broader spec backlog
+
+This spec is independent of `polish-fact-check` Phase 3 — that
+PR ships now with `ANTHROPIC_API_KEY` as the only credential
+path. The current spec retroactively makes the key optional for
+subscribers; it doesn't gate the Phase 3 ship.


### PR DESCRIPTION
## Summary

- Draft a spec for routing sibling-package LLM calls (attune-author polish + attune-rag faithfulness judge) through a Claude Code subscription so subscribers stop paying per-token on top of their subscription.
- Motivated by [attune-author#36](https://github.com/Smart-AI-Memory/attune-author/pull/36) (polish-fact-check Phase 3 faithfulness judge) which made the cumulative `ANTHROPIC_API_KEY` requirement in sibling packages tangible enough to fix.
- Status: **draft**. Phase 0 is mandatory research before any production code lands.

## What's in the spec

Four files, 490 lines total under [`docs/specs/sibling-subscription-auth/`](docs/specs/sibling-subscription-auth/):

- **[requirements.md](docs/specs/sibling-subscription-auth/requirements.md)** — problem statement (duplicate billing, first-run friction, cost surprise), scope, success criteria, non-goals
- **[design.md](docs/specs/sibling-subscription-auth/design.md)** — three implementation options with trade-offs:
  - **Option A**: Per-sibling Agent-SDK shim (~30 LOC per consumer; duplication acceptable)
  - **Option B**: Public `attune.auth` helper that siblings import (single source of truth; introduces a runtime dependency from sibling → attune-ai)
  - **Option C**: New shared `attune-auth` PyPI package (cleanest deps; new release cadence to maintain)
  - Four open design questions Phase 0 must answer first
- **[tasks.md](docs/specs/sibling-subscription-auth/tasks.md)** — Phase 0 (mandatory research with concrete probe scripts) + Phases 1-3 (implementation), gated on Phase 0 findings
- **[decisions.md](docs/specs/sibling-subscription-auth/decisions.md)** — pre-committed decisions (CLI flag names, env-var names `ATTUNE_AUTHOR_AUTH_MODE` / `ATTUNE_RAG_AUTH_MODE`, telemetry annotation format, fallback order) + TBD rows that Phase 0 fills

## Why Phase 0 is mandatory

The spec rests on the assumption that subscription routing rides on `claude_agent_sdk` session-context inheritance. That's a five-minute-read guess at how the existing `AuthStrategy` recommendation engine actually executes its recommendations. Mirrors the [Agent Surface Rebalance retirement](https://github.com/Smart-AI-Memory/attune-ai/blob/main/.claude/CLAUDE.md#:~:text=Agent%20Surface%20Rebalance) lesson where $8.78 of measurement was strictly cheaper than implementing a conversion that would have saved zero bytes.

Phase 0 ships a runnable probe script (`scripts/probe_subscription_routing.py`) plus a written `findings.md`. If the routing mechanism turns out to be different, the design doc gets revised before Phase 1 starts.

## What this PR is NOT

- Not an implementation. Zero code changes.
- Not blocking the polish-fact-check phase PRs ([attune-author#35](https://github.com/Smart-AI-Memory/attune-author/pull/35), [#36](https://github.com/Smart-AI-Memory/attune-author/pull/36), [#37](https://github.com/Smart-AI-Memory/attune-author/pull/37)) — those ship with the current API-key requirement; this spec retroactively makes the key optional for subscribers.

## Test plan

- [x] Spec follows the conventional 4-file shape (`requirements.md` / `design.md` / `tasks.md` / `decisions.md`) matching `docs/specs/redis-decoupling/`, `polish-fact-check/`, etc.
- [x] Phase 0 deliverables are concrete (runnable probe + written findings doc, not "we learned a lot")
- [x] Decisions matrix has pre-committed rows AND TBD rows clearly distinguished
- [ ] User review of the framing before Phase 0 work begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
