### PR TITLE
docs(spec/website-update-dashboard-and-fold): flip status draft → approved

### DIFF
--- a/docs/specs/website-update-dashboard-and-fold/tasks.md
+++ b/docs/specs/website-update-dashboard-and-fold/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Website update: dashboard maturity + fold-back
 
-**Status:** draft — pre-Phase-1 audit done 2026-05-12 ([phase0-audit.md](phase0-audit.md))
+**Status:** approved — pre-Phase-1 audit done 2026-05-12 ([phase0-audit.md](phase0-audit.md))
 
 Two-phase plan. Phase 1 ships everything that doesn't depend on the fold-back; Phase 2 swaps install commands + adds redirects + automated screenshots once the fold lands. See `decisions.md`, `requirements.md`, `design.md` for context, and `phase0-audit.md` for the current-state inventory + three implementation nuances the spec didn't flag (narrow `pip install` replacement scope, dashboard-mention reuse on homepage, changelog lives in root `CHANGELOG.md`).
 


### PR DESCRIPTION
## Summary

One-line spec status change. Phase 0 audit completed 2026-05-12; design and acceptance criteria have been reviewed and signed off. Marking the spec approved so Phase 1 tasks are now actionable.

This was sitting uncommitted in the \`distracted-babbage-6f55fa\` worktree — surfaced during a Phase 3 / dashboard-work audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)