### PR TITLE
feat(ops): scope picker renders in read-only mode (closes ops-scope-picker-ia AC-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Workflows page renders the scope picker in read-only mode
+  (`--read-only`). Closes AC-6 of
+  [`docs/specs/ops-scope-picker-ia/`](docs/specs/ops-scope-picker-ia/proposal.md):
+  the saved scope now pre-selects on every load regardless of
+  run mode, so a user who toggles back into run mode keeps the
+  scope they picked. Only the Action column (Run button) hides
+  in read-only — the picker's state stays observable and is
+  persisted via the existing `attune-ops:lastScope` localStorage
+  entry. The template drops the `{% if allow_run %}` wrap on
+  the Scope column and the row's `data-scope-default`
+  attribute; the JS layer was already scope-mode-agnostic
+  (`restoreScopeOnLoad` + `wireScopeSave` no-op cleanly when
+  the picker is absent), so no runner.js changes were needed.
+
 ### Added
 
 - `scripts/calibrate_session_summary.py` + companion CI gate

--- a/docs/specs/ops-scope-picker-ia/proposal.md
+++ b/docs/specs/ops-scope-picker-ia/proposal.md
@@ -1,8 +1,19 @@
 # Proposal: Ops dashboard scope-picker — remember last-used scope
 
-**Status:** Draft (2026-05-14)
+**Status:** Implemented (2026-05-16)
 **Author:** Patrick (with Claude as drafter)
 **Scope:** `src/attune/ops/` — workflow scope picker UX
+
+**Shipping history:**
+
+- AC-1 through AC-5 landed in PRs #344 (initial), #363, #365 (Phase A3,
+  per-workflow defaults from `features.yaml`).
+- AC-6 (picker renders in read-only mode) closed in the follow-up
+  `feat/ops-scope-picker-ia-impl` PR — template now drops the
+  `{% if allow_run %}` wrap on the Scope column and the row's
+  `data-scope-default` attribute. Only the Action column hides; the
+  picker observes and remembers state for when the user re-enables
+  runs.
 
 ---
 

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -21,7 +21,7 @@
         <th class="num">Stages</th>
         <th>Tier map</th>
         <th>Description</th>
-        {% if allow_run %}<th>Scope</th>{% endif %}
+        <th>Scope</th>
         {% if allow_run %}<th class="num">Action</th>{% endif %}
       </tr>
     </thead>
@@ -35,7 +35,7 @@
            workflows like release-prep / health-check that don't map
            to a single feature. #}
         <tr data-workflow="{{ w.name }}"
-            data-scope-default="{{ default_scopes[w.name] if allow_run and supports_path[w.name] else '' }}">
+            data-scope-default="{{ default_scopes[w.name] if supports_path[w.name] else '' }}">
           <td><code>{{ w.name }}</code></td>
           {# Stages=0 means the workflow doesn't expose a stages array
              (typical for meta-orchestration workflows that compose
@@ -64,28 +64,32 @@
               <pre data-log class="log-output"></pre>
             </div>
           </td>
+          {# Scope cell renders in both run and read-only modes (AC-6).
+             In read-only mode the picker still pre-selects the saved
+             scope so the choice persists for when the user enables
+             runs; only the Action column hides. #}
+          <td class="scope-cell">
+            {% if supports_path[w.name] %}
+              <select class="scope-picker" data-scope-picker aria-label="Scope for {{ w.name }}">
+                <option value="">Project-wide</option>
+                {% for f in features %}
+                  {% if f.path %}
+                    <option value="{{ f.path }}" title="{{ f.description }}">{{ f.name }}</option>
+                  {% endif %}
+                {% endfor %}
+                <option value="{{ all_code_path }}" title="All source code under {{ all_code_path }}">All code ({{ all_code_path }})</option>
+                <option value="__custom__">Custom path…</option>
+              </select>
+              <input type="text" class="scope-custom" data-scope-custom hidden
+                     placeholder="e.g. src/attune/security/"
+                     aria-label="Custom scope path for {{ w.name }}">
+            {% else %}
+              <span class="scope-na"
+                    data-tooltip="This workflow doesn't accept a path argument"
+                    aria-label="This workflow doesn't accept a path argument">n/a</span>
+            {% endif %}
+          </td>
           {% if allow_run %}
-            <td class="scope-cell">
-              {% if supports_path[w.name] %}
-                <select class="scope-picker" data-scope-picker aria-label="Scope for {{ w.name }}">
-                  <option value="">Project-wide</option>
-                  {% for f in features %}
-                    {% if f.path %}
-                      <option value="{{ f.path }}" title="{{ f.description }}">{{ f.name }}</option>
-                    {% endif %}
-                  {% endfor %}
-                  <option value="{{ all_code_path }}" title="All source code under {{ all_code_path }}">All code ({{ all_code_path }})</option>
-                  <option value="__custom__">Custom path…</option>
-                </select>
-                <input type="text" class="scope-custom" data-scope-custom hidden
-                       placeholder="e.g. src/attune/security/"
-                       aria-label="Custom scope path for {{ w.name }}">
-              {% else %}
-                <span class="scope-na"
-                      data-tooltip="This workflow doesn't accept a path argument"
-                      aria-label="This workflow doesn't accept a path argument">n/a</span>
-              {% endif %}
-            </td>
             <td class="num">
               <button class="btn btn-run" type="button" data-run-button data-workflow="{{ w.name }}" aria-label="Run {{ w.name }}">Run</button>
             </td>

--- a/tests/unit/ops/test_scope_picker.py
+++ b/tests/unit/ops/test_scope_picker.py
@@ -352,14 +352,38 @@ def test_workflows_page_renders_n_a_for_no_path_workflow(tmp_path, monkeypatch):
     assert "scope-na" in resp.text
 
 
-def test_workflows_page_no_scope_column_when_read_only(tmp_path, monkeypatch):
-    """``--read-only`` mode: no Scope header, no picker markup."""
+def test_workflows_page_renders_scope_picker_in_read_only_mode(tmp_path, monkeypatch):
+    """AC-6: ``--read-only`` mode still renders the scope picker so the
+    saved default pre-selects on every load. Only the Run button (and
+    its Action column) hides — the picker's state is observed and
+    remembered for when the user enables runs.
+    """
+    _write_features_yaml(
+        tmp_path,
+        """
+features:
+  security-audit:
+    description: Scan
+    files: [src/attune/security/**]
+""",
+    )
     app, _ = _make_app(tmp_path, monkeypatch, allow_run=False)
     with TestClient(app) as client:
         resp = client.get("/workflows")
     assert resp.status_code == 200
-    assert "data-scope-picker" not in resp.text
-    assert ">Scope<" not in resp.text
+    body = resp.text
+    # Scope column + picker markup must be present in read-only mode.
+    assert ">Scope<" in body
+    assert "data-scope-picker" in body
+    assert "Project-wide" in body
+    assert "Custom path…" in body
+    # The per-row default scope wires through regardless of run mode so
+    # that the saved-scope restore path works on first paint.
+    assert 'data-scope-default="src/attune/security"' in body
+    # The Run button + Action column stay hidden — read-only suppresses
+    # execution surfaces but preserves the picker's observability.
+    assert "data-run-button" not in body
+    assert ">Action<" not in body
 
 
 def test_workflows_run_button_has_per_workflow_aria_label(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Closes the last open acceptance criterion (**AC-6**) of
[`docs/specs/ops-scope-picker-ia/`](docs/specs/ops-scope-picker-ia/proposal.md).

**Audit context:** the step-4 sequencing plan ([#408](https://github.com/Smart-AI-Memory/attune-ai/pull/408)) listed this spec as "production implementation not started." The audit was stale — AC-1 through AC-5 already shipped via [#344](https://github.com/Smart-AI-Memory/attune-ai/pull/344), [#363](https://github.com/Smart-AI-Memory/attune-ai/pull/363), and [#365](https://github.com/Smart-AI-Memory/attune-ai/pull/365), with 41 passing tests in `tests/unit/ops/test_scope_picker.py`. The only real gap was AC-6: render the picker in read-only mode with the saved scope pre-selected. This PR closes it.

## Change

- `src/attune/ops/templates/workflows.html`: drop the `{% if allow_run %}` guard on the **Scope** column header, the row's `data-scope-default` attribute, and the scope `<td>`. The picker now renders in both modes; only the **Action** column (Run button) stays gated on `allow_run`.
- `tests/unit/ops/test_scope_picker.py`: replace `test_workflows_page_no_scope_column_when_read_only` (the old contract) with `test_workflows_page_renders_scope_picker_in_read_only_mode` — asserts the picker + per-row default render in read-only mode and the Run button + Action column remain hidden.
- `docs/specs/ops-scope-picker-ia/proposal.md`: flip Status → **Implemented (2026-05-16)** with shipping history pointing at the merged PRs.
- `CHANGELOG.md`: entry under `[Unreleased] ### Changed`.

No `runner.js` changes — the JS layer was already scope-mode-agnostic (`restoreScopeOnLoad` + `wireScopeSave` no-op cleanly when the picker is absent), so the existing wiring lights up automatically once the template renders the markup.

## Test plan

- [x] `pytest tests/unit/ops/test_scope_picker.py` — 41 passed.
- [x] `pytest tests/unit/ops/ tests/unit/help/` — 1,068 passed (no regressions across the broader ops + help test corpora).
- [ ] Smoke `/workflows` page in browser, `python -m attune.ops --read-only` — confirm picker renders + saved scope round-trips.
- [ ] Smoke same page without `--read-only` — confirm Run button + saved scope still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)