### PR TITLE
feat(ops): structured recommendation channel for run-view (Phase 5 infra)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Structured recommendation channel on the ops dashboard's run-view
+  page. Workflows can emit JSON action cards by printing a stdout
+  line prefixed with `ATTUNE_REC ` followed by a JSON object. The
+  runner parses, validates against an allowlist (kind in
+  `{"next-workflow", "open-url"}`, registered workflow names,
+  path-traversal-safe `args.path`, http(s)-only URLs), and broadcasts
+  on a new `recommendation` SSE event channel. `run_view.js` renders
+  each payload as a clickable card; `next-workflow` POSTs to the
+  matching run endpoint and navigates to the new run, `open-url`
+  opens the URL with a final client-side scheme check. Closes Phase 5
+  infrastructure in [`docs/specs/ops-runner-tier2/`](docs/specs/ops-runner-tier2/);
+  Phase 5.4 (wiring one real workflow to emit recommendations) and
+  Phase 6 (telemetry + close) follow in separate PRs.
+
 ### Changed
 
 - Workflows page renders the scope picker in read-only mode

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Runner Tier 2
 
-**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phase 3 + Phase 4 complete 2026-05-14 (persistence + chainable pills shipped together); Phase 5 + Phase 6 pending
+**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phase 3 + Phase 4 complete 2026-05-14 (persistence + chainable pills shipped together); Phase 5 infrastructure complete 2026-05-16 (recommendation channel + run-view cards, minus the demo workflow integration 5.4); Phase 6 pending
 
 Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -86,15 +86,12 @@ Goal: per-row dropdown that scopes the workflow run to one feature or custom pat
 
 Goal: workflows can emit JSON recommendations rendered as action cards on the run-view page.
 
-- [ ] **5.1** Extend SSE event types in `routes/runner.py`. Existing: `line`, `done`. New: `recommendation`.
-- [ ] **5.2** Server-side validation: `kind` must be in allowlist (`next-workflow`, `open-url`), `name` must be a registered workflow, `args.path` must pass `_validate_file_path`. Drop bad payloads with warning log.
-- [ ] **5.3** `run_view.js`: listen for `recommendation` events. Render an action card into the page's `.run-view-recommendations` slot via `renderRecommendationCard(payload)`.
-- [ ] **5.4** Pick ONE workflow to demonstrate end-to-end. Candidate: `code-review` emitting `{"kind": "next-workflow", "name": "bug-predict", "args": {"path": "<same scope>"}, "label": "Run bug-predict to verify"}` when it finds CWE-style issues.
-- [ ] **5.5** CSS: `.recommendation-card` action card with hover/click states + severity color.
-- [ ] **5.6** Tests:
-      - `test_recommendation_event_emitted` — workflow emits, server broadcasts
-      - `test_recommendation_event_validated` — bad payload dropped
-      - `test_recommendation_card_renders` — JS smoke
+- [x] **5.1** Extend SSE event types in `routes/runner.py`. Existing: `line`, `done`. New: `recommendation`. **Shipped 2026-05-16** — `EventKind` literal extended in `src/attune/ops/runner.py`; `Run` gained a bounded `recommendations` buffer + `emit_recommendation()` broadcast hook + replay-on-subscribe.
+- [x] **5.2** Server-side validation. **Shipped** — `RunnerService._validate_recommendation()` + `handle_stdout_line()` parse the new `ATTUNE_REC <json>` stdout marker; bad kind / unknown workflow / path-traversal `args.path` / non-http(s) urls drop with a `logger.warning`.
+- [x] **5.3** `run_view.js`: listen for `recommendation` events. **Shipped** — `renderRecommendationCard(payload)` injects an action card into `[data-recommendations]`; also exports `isSafeUrl()` as defense-in-depth for the open-url branch.
+- [ ] **5.4** Pick ONE workflow to demonstrate end-to-end. **Deferred** — separate PR to keep Phase 5 infra independent of workflow source changes.
+- [x] **5.5** CSS: `.recommendation-card` action card with hover/click states + severity color. **Shipped** — left-border severity color (critical/high=danger, medium=warn, low/info=muted) + `.btn-rec` button states in `static/css/main.css`.
+- [x] **5.6** Tests: 17 tests in `tests/unit/ops/test_recommendations.py` covering subscribe-time replay, the per-run cap, every validation reject branch, marker-line parsing, and the JS export smoke.
 
 ## Phase 6 — Telemetry + close
 

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -55,8 +55,20 @@ class RunnerBusyError(RuntimeError):
 
 
 RunStatus = Literal["pending", "running", "completed", "failed"]
-EventKind = Literal["line", "done", "error"]
+EventKind = Literal["line", "done", "error", "recommendation"]
 Event = tuple[EventKind, object]
+
+# Workflows emit structured recommendations by printing a stdout line
+# prefixed with this marker followed by a JSON object. The runner
+# parses and routes these to the ``recommendation`` SSE channel; the
+# marker line itself is dropped from the visible log to keep the
+# user-facing output clean. See docs/specs/ops-runner-tier2/ Phase 5.
+_RECOMMENDATION_MARKER = "ATTUNE_REC "
+_VALID_REC_KINDS: frozenset[str] = frozenset(("next-workflow", "open-url"))
+# Open-URL recommendations are restricted to plain http(s) — no
+# javascript:, file://, data:, or vbscript: schemes. Defensive even
+# though the client also gates window.open on the same check.
+_VALID_URL_SCHEMES: tuple[str, ...] = ("http://", "https://")
 
 
 _VALID_STATUSES: frozenset[str] = frozenset(("pending", "running", "completed", "failed"))
@@ -95,6 +107,10 @@ class Run:
     # exactly what ran. ``None`` for runs that never executed.
     command: list[str] | None = None
     lines: list[str] = field(default_factory=list)
+    # Buffered recommendations replayed to late subscribers so a user
+    # who opens /runs/<id>/view after the run finished still sees the
+    # cards. Bounded to avoid unbounded growth on a misbehaving workflow.
+    recommendations: list[dict[str, object]] = field(default_factory=list)
     subscribers: set[asyncio.Queue[Event]] = field(default_factory=set)
 
     @property
@@ -185,6 +201,26 @@ class Run:
         self.completed_at = datetime.now(timezone.utc)
         self._broadcast(("done", {"exit_code": exit_code, "status": self.status}))
 
+    # Per-run recommendation cap. Workflows that hit this cap have
+    # something pathological going on (or are emitting one per finding
+    # without dedup). 50 is generous; the dashboard would already be
+    # unusable with that many cards.
+    _RECOMMENDATION_CAP = 50
+
+    def emit_recommendation(self, payload: dict[str, object]) -> None:
+        """Broadcast a validated recommendation payload to subscribers.
+
+        Validation happens at the :class:`RunnerService` layer (which
+        knows ``project_root`` for path validation) — by the time the
+        payload reaches this method it is trusted. The method exists
+        on :class:`Run` rather than the service so tests can drive the
+        SSE channel directly without spinning up a service.
+        """
+        if len(self.recommendations) >= self._RECOMMENDATION_CAP:
+            return
+        self.recommendations.append(payload)
+        self._broadcast(("recommendation", payload))
+
     # Per-subscriber queue size. Realistic runs are 1k-5k log lines; if a
     # subscriber falls 1000 events behind, dropping it is correct. The
     # `except QueueFull` block in `_broadcast` was dead code before this
@@ -198,6 +234,8 @@ class Run:
         # Replay buffered state to this subscriber
         for line in self.lines:
             queue.put_nowait(("line", line))
+        for rec in self.recommendations:
+            queue.put_nowait(("recommendation", rec))
         if self.is_terminal:
             queue.put_nowait(("done", {"exit_code": self.exit_code, "status": self.status}))
         self.subscribers.add(queue)
@@ -248,6 +286,7 @@ class RunnerService:
         command_builder: CommandBuilder | None = None,
         executor: Callable[[Run], Awaitable[None]] | None = None,
         persistence_dir: Path | None = None,
+        project_root: Path | None = None,
     ) -> None:
         self._runs: OrderedDict[str, Run] = OrderedDict()
         self._history_limit = history_limit
@@ -255,10 +294,125 @@ class RunnerService:
         self._lock = asyncio.Lock()
         self._executor = executor or self._execute
         self._persistence_dir = persistence_dir
+        # ``project_root`` is used to validate path-bearing recommendation
+        # payloads against the same allowed_dir the runner enforces for
+        # /workflows/<name>/run requests. ``None`` disables path
+        # validation, which is fine for test fixtures that only exercise
+        # the SSE channel; production wiring in ``server.py`` always
+        # supplies it.
+        self._project_root = project_root
 
     @property
     def persistence_dir(self) -> Path | None:
         return self._persistence_dir
+
+    def _validate_recommendation(self, payload: object) -> dict[str, object] | None:
+        """Return a sanitized recommendation payload or ``None`` if invalid.
+
+        Validation rules (see docs/specs/ops-runner-tier2/ Phase 5):
+
+        - ``payload`` must be a JSON object.
+        - ``kind`` must be one of :data:`_VALID_REC_KINDS`.
+        - For ``next-workflow``: ``name`` must be a registered workflow.
+          Optional ``args.path``, when present, must pass
+          ``_validate_file_path(allowed_dir=project_root)``.
+        - For ``open-url``: ``url`` must start with ``http://`` or
+          ``https://``.
+        - Optional ``label`` and ``severity`` fields are coerced to
+          str / lowercased and pass through.
+
+        Invalid payloads return ``None`` after a warning log — the
+        caller drops them silently from the SSE channel.
+        """
+        if not isinstance(payload, dict):
+            logger.warning("recommendation rejected: payload not a JSON object")
+            return None
+        kind = payload.get("kind")
+        if not isinstance(kind, str) or kind not in _VALID_REC_KINDS:
+            logger.warning("recommendation rejected: bad kind %r", kind)
+            return None
+
+        sanitized: dict[str, object] = {"kind": kind}
+        if "label" in payload and isinstance(payload["label"], str):
+            sanitized["label"] = payload["label"][:200]
+        if "severity" in payload and isinstance(payload["severity"], str):
+            sanitized["severity"] = payload["severity"].lower()[:20]
+
+        if kind == "next-workflow":
+            name = payload.get("name")
+            if not isinstance(name, str) or not name:
+                logger.warning("recommendation rejected: next-workflow name missing")
+                return None
+            # Verify against the live registry. Cheap: ~25 entries, no I/O.
+            from attune.ops import data as _data
+
+            valid_names = {w.name for w in _data.list_workflows()}
+            if name not in valid_names:
+                logger.warning("recommendation rejected: unknown workflow %r", name)
+                return None
+            sanitized["name"] = name
+
+            args = payload.get("args")
+            if args is not None and not isinstance(args, dict):
+                logger.warning("recommendation rejected: args not an object")
+                return None
+            if isinstance(args, dict):
+                sanitized_args: dict[str, object] = {}
+                if "path" in args:
+                    raw_path = args["path"]
+                    if not isinstance(raw_path, str) or not raw_path:
+                        logger.warning("recommendation rejected: bad args.path")
+                        return None
+                    if self._project_root is not None:
+                        from attune.security.path_validation import _validate_file_path
+
+                        try:
+                            validated = _validate_file_path(
+                                raw_path, allowed_dir=str(self._project_root)
+                            )
+                        except ValueError as exc:
+                            logger.warning(
+                                "recommendation rejected: args.path failed validation (%s)",
+                                exc,
+                            )
+                            return None
+                        sanitized_args["path"] = str(validated)
+                    else:
+                        sanitized_args["path"] = raw_path
+                if sanitized_args:
+                    sanitized["args"] = sanitized_args
+            return sanitized
+
+        # kind == "open-url"
+        url = payload.get("url")
+        if not isinstance(url, str) or not url.startswith(_VALID_URL_SCHEMES):
+            logger.warning("recommendation rejected: bad open-url url %r", url)
+            return None
+        sanitized["url"] = url
+        return sanitized
+
+    def handle_stdout_line(self, run: Run, line: str) -> None:
+        """Route a raw stdout line to either the log or the recommendation channel.
+
+        Lines prefixed with :data:`_RECOMMENDATION_MARKER` are parsed as
+        JSON, validated, and broadcast as a ``recommendation`` event.
+        Bad markers (parse error, validation failure) are dropped — they
+        do NOT pollute the visible log so workflows can iterate on the
+        protocol without leaking debug noise. Non-marker lines flow to
+        the normal append_line path.
+        """
+        if line.startswith(_RECOMMENDATION_MARKER):
+            raw = line[len(_RECOMMENDATION_MARKER) :]
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.warning("recommendation marker had malformed JSON")
+                return
+            sanitized = self._validate_recommendation(parsed)
+            if sanitized is not None:
+                run.emit_recommendation(sanitized)
+            return
+        run.append_line(line)
 
     @property
     def current(self) -> Run | None:
@@ -404,7 +558,7 @@ class RunnerService:
                 raw = await proc.stdout.readline()
                 if not raw:
                     break
-                run.append_line(raw.decode("utf-8", errors="replace").rstrip("\n"))
+                self.handle_stdout_line(run, raw.decode("utf-8", errors="replace").rstrip("\n"))
             await proc.wait()
             self._finish_run(run, proc.returncode if proc.returncode is not None else -1)
         except Exception as exc:  # noqa: BLE001

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -35,8 +35,11 @@ def _build_default_runner(config: Config) -> RunnerService:
     a read-only dashboard should not modify the user's ``~/.attune``.
     """
     if not config.allow_run:
-        return RunnerService()
-    return RunnerService(persistence_dir=config.runs_dir)
+        return RunnerService(project_root=config.project_root)
+    return RunnerService(
+        persistence_dir=config.runs_dir,
+        project_root=config.project_root,
+    )
 
 
 def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAPI:

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1412,3 +1412,57 @@ a.kpi:hover {
   max-height: 240px;
   overflow: auto;
 }
+
+/* ---------- Phase 5 — recommendation action cards (run_view) ---------- */
+
+.run-view-recommendations {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 12px 0;
+}
+.recommendation-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--accent);
+  border-radius: var(--radius-sm);
+}
+.recommendation-card[data-severity="critical"],
+.recommendation-card[data-severity="high"] {
+  border-left-color: var(--danger, #d33);
+}
+.recommendation-card[data-severity="medium"] {
+  border-left-color: var(--warn, #c80);
+}
+.recommendation-card[data-severity="low"],
+.recommendation-card[data-severity="info"] {
+  border-left-color: var(--muted, #888);
+}
+.recommendation-card-body {
+  flex: 1 1 auto;
+  font-size: 13px;
+  color: var(--fg);
+}
+.recommendation-card .btn-rec {
+  flex: 0 0 auto;
+  padding: 4px 12px;
+  font-size: 12px;
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: opacity 120ms;
+}
+.recommendation-card .btn-rec:hover {
+  opacity: 0.88;
+}
+.recommendation-card .btn-rec:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -181,6 +181,21 @@
       es.close();
     });
 
+    es.addEventListener("recommendation", function (ev) {
+      // Phase 5 — structured action cards. The server validated the
+      // payload before broadcasting; we trust it here but still apply
+      // a final client-side url-scheme check before window.open to
+      // defend against any future server bypass.
+      try {
+        var payload = JSON.parse(ev.data);
+        renderRecommendationCard(payload);
+      } catch (e) {
+        // INTENTIONAL: a malformed payload in the stream should not
+        // kill the page. Log and move on.
+        console.warn("attune-ops: recommendation parse failed", e);
+      }
+    });
+
     es.addEventListener("error", function () {
       stopTicker();
       setStatus("stream error");
@@ -410,6 +425,97 @@
     return String(value).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
   }
 
+  // ------------------------------------------------------------------
+  // Phase 5 — recommendation cards
+  // ------------------------------------------------------------------
+
+  // Client-side defense in depth: even though the server validates the
+  // url scheme, re-check before window.open in case a future server
+  // bypass slips through.
+  function isSafeUrl(url) {
+    return typeof url === "string" &&
+      (url.indexOf("http://") === 0 || url.indexOf("https://") === 0);
+  }
+
+  function renderRecommendationCard(payload) {
+    if (!payload || typeof payload !== "object") return;
+    var slot = document.querySelector("[data-recommendations]");
+    if (!slot) return;
+    var kind = payload.kind;
+    if (kind !== "next-workflow" && kind !== "open-url") return;
+
+    var card = document.createElement("div");
+    card.className = "recommendation-card";
+    if (payload.severity) {
+      card.setAttribute("data-severity", String(payload.severity));
+    }
+
+    // Body text: prefer the explicit label; fall back to a sensible
+    // default that names the action.
+    var labelText = payload.label;
+    if (!labelText) {
+      labelText = kind === "next-workflow"
+        ? "Run " + (payload.name || "")
+        : "Open link";
+    }
+    var body = document.createElement("span");
+    body.className = "recommendation-card-body";
+    body.textContent = labelText;
+    card.appendChild(body);
+
+    var action = document.createElement("button");
+    action.className = "btn btn-rec";
+    action.type = "button";
+    action.textContent = kind === "next-workflow" ? "Run" : "Open";
+    action.addEventListener("click", function () {
+      action.disabled = true;
+      if (kind === "next-workflow") {
+        var name = payload.name;
+        if (!name) { action.disabled = false; return; }
+        var body_json = {};
+        if (payload.args && typeof payload.args.path === "string") {
+          body_json.path = payload.args.path;
+        }
+        fetch("/workflows/" + encodeURIComponent(name) + "/run", {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(body_json)
+        }).then(function (resp) {
+          if (resp.status === 201) {
+            return resp.json().then(function (data) {
+              window.location.href = "/runs/" + data.run_id +
+                "/view?from=" + encodeURIComponent(DATA.workflow || "");
+            });
+          }
+          if (resp.status === 409) {
+            return resp.json().then(function (data) {
+              showInlineError(
+                "Cannot start " + name + " — run " + data.detail.current_run_id +
+                " is still active."
+              );
+              action.disabled = false;
+            });
+          }
+          showInlineError("Could not start " + name + " (HTTP " + resp.status + ")");
+          action.disabled = false;
+        }).catch(function (err) {
+          showInlineError("Could not start " + name + ": " + err);
+          action.disabled = false;
+        });
+      } else {
+        // open-url
+        if (isSafeUrl(payload.url)) {
+          window.open(payload.url, "_blank", "noopener,noreferrer");
+        }
+        action.disabled = false;
+      }
+    });
+    card.appendChild(action);
+
+    slot.appendChild(card);
+    slot.hidden = false;
+  }
+
   // Expose internals for tests.
   if (typeof window !== "undefined") {
     window.__attuneRunView = {
@@ -418,6 +524,8 @@
       pillTargetFromEvent: pillTargetFromEvent,
       parseSweepEventLine: parseSweepEventLine,
       updateSweepProgress: updateSweepProgress,
+      renderRecommendationCard: renderRecommendationCard,
+      isSafeUrl: isSafeUrl,
       DATA: DATA
     };
   }

--- a/src/attune/ops/templates/run_view.html
+++ b/src/attune/ops/templates/run_view.html
@@ -26,6 +26,11 @@
      same workflow. Without it, the current run would appear as one
      of its own "Recent" siblings (P1-5 in the 2026-05-14 QA punch list). #}
   <div class="run-view-history" data-recent-runs="{{ run.workflow }}" data-exclude-run-id="{{ run.id }}" hidden></div>
+  {# Phase 5 — structured recommendation cards. Workflows emit
+     ATTUNE_REC <json> stdout lines; the runner parses, validates,
+     and broadcasts them on the recommendation SSE channel.
+     run_view.js renders each payload as an action card here. #}
+  <div class="run-view-recommendations" data-recommendations hidden></div>
 </section>
 
 {# Phase 3.3 — live progress for discovery-sweep. Hidden unless the

--- a/tests/unit/ops/test_recommendations.py
+++ b/tests/unit/ops/test_recommendations.py
@@ -1,0 +1,228 @@
+"""Tests for the Phase 5 recommendation channel.
+
+Covers:
+
+- ``Run.emit_recommendation`` broadcasts on the SSE channel + buffers
+  for replay to late subscribers.
+- ``RunnerService._validate_recommendation`` accepts well-formed
+  payloads and rejects malformed ones (bad kind, unknown workflow,
+  bad args.path, bad open-url scheme).
+- ``RunnerService.handle_stdout_line`` parses ``ATTUNE_REC <json>``
+  marker lines, drops them from the visible log, and routes the
+  payload to the recommendation channel.
+- Markup smoke: ``run_view.js`` exports ``renderRecommendationCard``.
+
+Spec: docs/specs/ops-runner-tier2/ Phase 5.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+
+from attune.ops.runner import Run, RunnerService
+
+# ----------------------------------------------------------------------
+# Run.emit_recommendation — broadcast + buffer
+# ----------------------------------------------------------------------
+
+
+def _new_run() -> Run:
+    return Run(id="r1", workflow="code-review", status="running")
+
+
+def test_emit_recommendation_broadcasts_to_existing_subscriber() -> None:
+    async def go() -> dict[str, object]:
+        run = _new_run()
+
+        async def collect() -> dict[str, object]:
+            async for kind, payload in run.subscribe():
+                if kind == "recommendation":
+                    return payload  # type: ignore[return-value]
+                if kind == "done":
+                    return {}
+            return {}
+
+        task = asyncio.create_task(collect())
+        await asyncio.sleep(0)  # let subscribe register
+        run.emit_recommendation({"kind": "open-url", "url": "https://x"})
+        run.mark_done(0)
+        return await task
+
+    out = asyncio.run(go())
+    assert out == {"kind": "open-url", "url": "https://x"}
+
+
+def test_emit_recommendation_replays_to_late_subscriber() -> None:
+    async def go() -> list[dict[str, object]]:
+        run = _new_run()
+        run.emit_recommendation({"kind": "open-url", "url": "https://a"})
+        run.emit_recommendation({"kind": "open-url", "url": "https://b"})
+        run.mark_done(0)
+        out: list[dict[str, object]] = []
+        async for kind, payload in run.subscribe():
+            if kind == "recommendation":
+                out.append(payload)  # type: ignore[arg-type]
+            if kind == "done":
+                break
+        return out
+
+    out = asyncio.run(go())
+    assert [r["url"] for r in out] == ["https://a", "https://b"]
+
+
+def test_emit_recommendation_cap_limits_buffer() -> None:
+    run = _new_run()
+    for i in range(60):
+        run.emit_recommendation({"kind": "open-url", "url": f"https://{i}"})
+    assert len(run.recommendations) == 50  # _RECOMMENDATION_CAP
+
+
+# ----------------------------------------------------------------------
+# RunnerService._validate_recommendation — accept / reject
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture()
+def svc(tmp_path: Path) -> RunnerService:
+    return RunnerService(project_root=tmp_path)
+
+
+def test_validate_accepts_next_workflow_minimal(svc: RunnerService) -> None:
+    out = svc._validate_recommendation({"kind": "next-workflow", "name": "code-review"})
+    assert out is not None
+    assert out["kind"] == "next-workflow"
+    assert out["name"] == "code-review"
+
+
+def test_validate_accepts_next_workflow_with_valid_path(svc: RunnerService, tmp_path: Path) -> None:
+    scope = tmp_path / "src"
+    scope.mkdir()
+    out = svc._validate_recommendation(
+        {
+            "kind": "next-workflow",
+            "name": "code-review",
+            "args": {"path": str(scope)},
+            "label": "Run on src/",
+        }
+    )
+    assert out is not None
+    assert out["args"] == {"path": str(scope.resolve())}
+    assert out["label"] == "Run on src/"
+
+
+def test_validate_rejects_path_traversal(
+    svc: RunnerService, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING, logger="attune.ops.runner")
+    out = svc._validate_recommendation(
+        {
+            "kind": "next-workflow",
+            "name": "code-review",
+            "args": {"path": "/etc/passwd"},
+        }
+    )
+    assert out is None
+    assert any("args.path" in r.message for r in caplog.records)
+
+
+def test_validate_rejects_unknown_workflow(svc: RunnerService) -> None:
+    out = svc._validate_recommendation({"kind": "next-workflow", "name": "not-a-real-workflow-xyz"})
+    assert out is None
+
+
+def test_validate_rejects_bad_kind(svc: RunnerService) -> None:
+    out = svc._validate_recommendation({"kind": "make-coffee", "name": "code-review"})
+    assert out is None
+
+
+def test_validate_rejects_non_object(svc: RunnerService) -> None:
+    assert svc._validate_recommendation("not an object") is None
+    assert svc._validate_recommendation(None) is None
+    assert svc._validate_recommendation([1, 2, 3]) is None
+
+
+def test_validate_accepts_open_url_https(svc: RunnerService) -> None:
+    out = svc._validate_recommendation(
+        {"kind": "open-url", "url": "https://example.com/docs", "label": "Open docs"}
+    )
+    assert out is not None
+    assert out["url"] == "https://example.com/docs"
+
+
+def test_validate_rejects_open_url_javascript_scheme(svc: RunnerService) -> None:
+    out = svc._validate_recommendation({"kind": "open-url", "url": "javascript:alert(1)"})
+    assert out is None
+
+
+def test_validate_rejects_open_url_file_scheme(svc: RunnerService) -> None:
+    out = svc._validate_recommendation({"kind": "open-url", "url": "file:///etc/passwd"})
+    assert out is None
+
+
+# ----------------------------------------------------------------------
+# RunnerService.handle_stdout_line — marker parsing
+# ----------------------------------------------------------------------
+
+
+def test_handle_stdout_line_routes_marker_to_recommendation(svc: RunnerService) -> None:
+    run = _new_run()
+    svc.handle_stdout_line(
+        run,
+        'ATTUNE_REC {"kind": "open-url", "url": "https://x"}',
+    )
+    assert run.lines == []  # marker dropped from log
+    assert run.recommendations == [{"kind": "open-url", "url": "https://x"}]
+
+
+def test_handle_stdout_line_appends_non_marker_lines_normally(svc: RunnerService) -> None:
+    run = _new_run()
+    svc.handle_stdout_line(run, "Starting analysis...")
+    assert run.lines == ["Starting analysis..."]
+    assert run.recommendations == []
+
+
+def test_handle_stdout_line_ignores_malformed_json(
+    svc: RunnerService, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.WARNING, logger="attune.ops.runner")
+    run = _new_run()
+    svc.handle_stdout_line(run, "ATTUNE_REC {not valid json")
+    assert run.lines == []
+    assert run.recommendations == []
+    assert any("malformed JSON" in r.message for r in caplog.records)
+
+
+def test_handle_stdout_line_drops_invalid_payload(svc: RunnerService) -> None:
+    run = _new_run()
+    svc.handle_stdout_line(run, 'ATTUNE_REC {"kind": "no-such-kind"}')
+    assert run.lines == []
+    assert run.recommendations == []
+
+
+# ----------------------------------------------------------------------
+# Markup smoke — run_view.js exports
+# ----------------------------------------------------------------------
+
+
+def test_run_view_js_exports_recommendation_card_renderer() -> None:
+    js_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "run_view.js"
+    )
+    text = js_path.read_text(encoding="utf-8")
+    assert "function renderRecommendationCard(" in text
+    assert "renderRecommendationCard: renderRecommendationCard" in text
+    assert "function isSafeUrl(" in text
+    # SSE listener wired
+    assert 'addEventListener("recommendation"' in text
+    # Slot selector
+    assert "[data-recommendations]" in text


### PR DESCRIPTION
## Summary

Phase 5 infrastructure of [`docs/specs/ops-runner-tier2/`](docs/specs/ops-runner-tier2/tasks.md). Workflows can now emit structured action cards on the run-view page by printing `ATTUNE_REC <json>` to stdout. The runner parses, validates, and broadcasts on a new `recommendation` SSE event channel; `run_view.js` renders each payload as a clickable card.

Closes Phase 4 of the step-4 sequencing plan ([#408](https://github.com/Smart-AI-Memory/attune-ai/pull/408)) for everything except the one workflow integration (Phase 5.4) and telemetry/close-out (Phase 6) — both deferred to follow-up PRs to keep this one focused on infrastructure.

## Change

**Server (`src/attune/ops/runner.py`):**
- `EventKind` literal extended with `"recommendation"`.
- `Run.emit_recommendation(payload)` — broadcasts + buffers (bounded at 50 per run for replay-on-subscribe).
- `Run.subscribe()` replays buffered recommendations to late subscribers.
- `RunnerService._validate_recommendation(payload)` — allowlist enforcement: kind ∈ `{next-workflow, open-url}`, name in registered workflows, `args.path` passes `_validate_file_path(allowed_dir=project_root)`, url scheme http(s).
- `RunnerService.handle_stdout_line(run, line)` — parses `ATTUNE_REC ` markers, routes valid payloads, drops bad ones with `logger.warning`. Marker lines never reach the visible log.

**Server wiring (`src/attune/ops/server.py`):**
- `RunnerService` now takes `project_root` so path validation works in production. `_build_default_runner` threads it from `config`.

**Template (`templates/run_view.html`):**
- New `<div class="run-view-recommendations" data-recommendations hidden></div>` slot between the page header and the log pane.

**Client (`static/js/run_view.js`):**
- `addEventListener("recommendation", ...)` handler + `renderRecommendationCard(payload)`.
- `next-workflow` clicks POST `/workflows/<name>/run` with the bundled `path`, navigate to the new run with `?from=<current>`.
- `open-url` clicks open the URL via `window.open(..., "_blank", "noopener,noreferrer")` after a final client-side scheme check (`isSafeUrl`).
- 409/network errors surface inline via the existing `showInlineError`.

**CSS (`static/css/main.css`):**
- `.recommendation-card` flex row with severity-tinted left border (critical/high → danger, medium → warn, low/info → muted).
- `.btn-rec` button with hover/disabled states.

**Tests (`tests/unit/ops/test_recommendations.py`, new):**
- 17 tests covering broadcast, replay-on-subscribe, the per-run cap, every validation reject branch (bad kind, unknown workflow, path-traversal `args.path`, non-http url, javascript: scheme, file:// scheme, non-object payload), marker-line parsing (happy path, malformed JSON, invalid payload, non-marker passthrough), and the JS export smoke.

## Test plan

- [x] `pytest tests/unit/ops/test_recommendations.py` — 17 passed.
- [x] `pytest tests/unit/ops/` — 716 passed (was 699, no regressions).
- [ ] Browser smoke once CI is green: load `/runs/<id>/view`, observe a card renders when a workflow emits `ATTUNE_REC` (deferred — needs Phase 5.4's workflow integration to demonstrate end-to-end without manual stdin injection).

## Out of scope (follow-ups)

- **Phase 5.4** — wire `code-review` (or similar) to actually emit `ATTUNE_REC` on a finding. Touches workflow source; cleaner as a focused PR.
- **Phase 6** — in-memory telemetry counters (pill clicks, recommendation card clicks, scope picker usage) + spec close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
