### PR TITLE
feat(workflows): code-review emits ATTUNE_REC on security findings (Phase 5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `code-review` workflow now emits an `ATTUNE_REC` recommendation
+  suggesting a `bug-predict` run on the same scope when its synthesized
+  output mentions CWE/CVE identifiers, common vulnerability classes
+  (SQL/command injection, path traversal, XSS, CSRF, hardcoded
+  secrets, insecure deserialization/random), or direct `eval(`/`exec(`
+  calls. The ops dashboard's run-view page surfaces this as a
+  clickable action card per the channel shipped in [#413](https://github.com/Smart-AI-Memory/attune-ai/pull/413).
+  Closes Phase 5.4 of [`docs/specs/ops-runner-tier2/`](docs/specs/ops-runner-tier2/tasks.md);
+  Phase 6 (telemetry + close) follows.
+
 - Structured recommendation channel on the ops dashboard's run-view
   page. Workflows can emit JSON action cards by printing a stdout
   line prefixed with `ATTUNE_REC ` followed by a JSON object. The

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Runner Tier 2
 
-**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phase 3 + Phase 4 complete 2026-05-14 (persistence + chainable pills shipped together); Phase 5 infrastructure complete 2026-05-16 (recommendation channel + run-view cards, minus the demo workflow integration 5.4); Phase 6 pending
+**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phase 3 + Phase 4 complete 2026-05-14 (persistence + chainable pills shipped together); Phase 5 complete 2026-05-16 (recommendation channel + run-view cards + `code-review` demo integration); Phase 6 pending
 
 Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -89,7 +89,7 @@ Goal: workflows can emit JSON recommendations rendered as action cards on the ru
 - [x] **5.1** Extend SSE event types in `routes/runner.py`. Existing: `line`, `done`. New: `recommendation`. **Shipped 2026-05-16** — `EventKind` literal extended in `src/attune/ops/runner.py`; `Run` gained a bounded `recommendations` buffer + `emit_recommendation()` broadcast hook + replay-on-subscribe.
 - [x] **5.2** Server-side validation. **Shipped** — `RunnerService._validate_recommendation()` + `handle_stdout_line()` parse the new `ATTUNE_REC <json>` stdout marker; bad kind / unknown workflow / path-traversal `args.path` / non-http(s) urls drop with a `logger.warning`.
 - [x] **5.3** `run_view.js`: listen for `recommendation` events. **Shipped** — `renderRecommendationCard(payload)` injects an action card into `[data-recommendations]`; also exports `isSafeUrl()` as defense-in-depth for the open-url branch.
-- [ ] **5.4** Pick ONE workflow to demonstrate end-to-end. **Deferred** — separate PR to keep Phase 5 infra independent of workflow source changes.
+- [x] **5.4** Pick ONE workflow to demonstrate end-to-end. **Shipped 2026-05-16** — `code-review` (`src/attune/workflows/code_review.py`) gained `_emit_security_recommendation_if_warranted()`, called at the end of `execute()`. Scans the synthesized review for CWE/CVE ids + common vulnerability-class phrases (SQL/command injection, path traversal, XSS, CSRF, hardcoded secrets, insecure deserialization/random, `eval(`/`exec(`); on a hit it prints an `ATTUNE_REC` marker suggesting `bug-predict` on the same scope. 26 tests in `tests/unit/workflows/test_code_review_recommendations.py` including a runner-validation round-trip.
 - [x] **5.5** CSS: `.recommendation-card` action card with hover/click states + severity color. **Shipped** — left-border severity color (critical/high=danger, medium=warn, low/info=muted) + `.btn-rec` button states in `static/css/main.css`.
 - [x] **5.6** Tests: 17 tests in `tests/unit/ops/test_recommendations.py` covering subscribe-time replay, the per-run cap, every validation reject branch, marker-line parsing, and the JS export smoke.
 

--- a/src/attune/workflows/code_review.py
+++ b/src/attune/workflows/code_review.py
@@ -14,7 +14,10 @@ Copyright 2025-2026 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
 
+import json
 import logging
+import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -55,6 +58,71 @@ _SUBAGENT_NAMES = [
     "perf-reviewer",
     "architect-reviewer",
 ]
+
+# Phase 5.4 — When the synthesized review mentions any of these terms,
+# emit an ATTUNE_REC recommending a bug-predict run on the same scope.
+# Picked as terms that signal "this finding is worth a deeper look,"
+# not "any incidental security mention." The regex is case-insensitive
+# and word-bounded to avoid matching code that just imports something
+# named "injection" or "xss". A single hit on any term triggers one
+# recommendation per run (the runner caps at 50 anyway).
+_SECURITY_TRIGGERS = re.compile(
+    r"\b(CWE-\d+|CVE-\d+|"
+    r"sql\s*injection|command\s*injection|path\s*traversal|"
+    r"xss|cross[- ]site\s*scripting|csrf|"
+    r"hardcoded\s*(secret|credential|password|token|api\s*key)|"
+    r"insecure\s*(deserializ|random)|"
+    r"eval\(|exec\()",
+    re.IGNORECASE,
+)
+
+
+def _emit_security_recommendation_if_warranted(
+    result_text: str | None,
+    scope_path: str,
+    *,
+    output_stream: Any = None,
+) -> bool:
+    """Print an ``ATTUNE_REC`` line to stdout when the review surfaces
+    security-shaped findings.
+
+    Suggests running ``bug-predict`` on the same scope — bug-predict's
+    pattern scanner catches eval/exec/path-traversal that code-review
+    might call out narratively without locating the exact line. The
+    two workflows complement each other: code-review reads, bug-predict
+    pinpoints. The runner parses ``ATTUNE_REC`` markers on the SSE
+    channel and renders an action card on the run-view page (Phase 5
+    infrastructure, PR #413).
+
+    Args:
+        result_text: The synthesized review output. ``None`` / empty
+            skips emission.
+        scope_path: The ``--path`` that code-review ran against; passed
+            through to bug-predict so the recommendation lands on the
+            same files.
+        output_stream: Stream to print to. Defaults to ``sys.stdout``
+            so the runner's stdout reader captures it. Override in
+            tests to capture without monkeypatching.
+
+    Returns:
+        True iff a recommendation was emitted. Useful for tests + as
+        a signal for upstream telemetry hooks.
+    """
+    if not result_text or not scope_path:
+        return False
+    if not _SECURITY_TRIGGERS.search(result_text):
+        return False
+    payload: dict[str, Any] = {
+        "kind": "next-workflow",
+        "name": "bug-predict",
+        "args": {"path": scope_path},
+        "label": "Run bug-predict to locate the specific lines",
+        "severity": "high",
+    }
+    stream = output_stream if output_stream is not None else sys.stdout
+    print("ATTUNE_REC " + json.dumps(payload), file=stream, flush=True)
+    return True
+
 
 _SYSTEM_PROMPT = """\
 You are a senior code review orchestrator. You coordinate four \
@@ -171,6 +239,12 @@ class CodeReviewWorkflow(BaseWorkflow):
                     if base_text and base_text != "No results returned."
                     else f"## Subagent findings\n\n{rendered_transcripts}"
                 )
+
+            # Phase 5.4 — emit an ATTUNE_REC marker when the synthesized
+            # review surfaces security/CWE-shaped findings, suggesting
+            # a bug-predict run on the same scope. The ops dashboard's
+            # runner parses this and renders an action card.
+            _emit_security_recommendation_if_warranted(run_result.result_text, resolved_path)
 
             return AgentSDKResultAdapter.from_agent_output(
                 result_text=run_result.result_text,

--- a/tests/unit/workflows/test_code_review_recommendations.py
+++ b/tests/unit/workflows/test_code_review_recommendations.py
@@ -1,0 +1,137 @@
+"""Tests for Phase 5.4 — code-review emits ATTUNE_REC recommendations.
+
+Covers the `_emit_security_recommendation_if_warranted` helper:
+
+- Fires on each documented security-trigger phrase (CWE/CVE id, SQL/
+  command injection, path traversal, XSS/CSRF, hardcoded secrets,
+  insecure deserialization / random, eval/exec).
+- Does NOT fire on benign reviews (style nits, missing docstrings).
+- Skipped when path or result_text is empty.
+- Emits a well-formed ATTUNE_REC line that the ops runner's
+  `handle_stdout_line` accepts.
+
+Spec: docs/specs/ops-runner-tier2/ Phase 5.4.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from attune.workflows.code_review import _emit_security_recommendation_if_warranted
+
+
+def _capture(result_text: str, scope: str = "src/foo") -> str:
+    buf = io.StringIO()
+    fired = _emit_security_recommendation_if_warranted(result_text, scope, output_stream=buf)
+    captured = buf.getvalue()
+    if fired:
+        assert captured.startswith("ATTUNE_REC ")
+    else:
+        assert captured == ""
+    return captured
+
+
+@pytest.mark.parametrize(
+    "trigger",
+    [
+        "Found a SQL injection in models.py",
+        "Possible command injection at line 42",
+        "Path traversal via user-controlled filename",
+        "XSS sink in template rendering",
+        "Reflective cross-site scripting on the search endpoint",
+        "CSRF token not validated on POST",
+        "Hardcoded secret in config.py",
+        "Hardcoded API key found",
+        "Insecure deserialization of user input",
+        "Insecure random used for session id",
+        "Found a CWE-79 vulnerability",
+        "Matches CVE-2024-1234",
+        "Uses eval( on user-controlled string",
+        "Calls exec( with concatenated SQL",
+    ],
+)
+def test_trigger_emits_recommendation(trigger: str) -> None:
+    out = _capture(trigger)
+    assert out, f"expected emission for trigger: {trigger!r}"
+    payload = json.loads(out.removeprefix("ATTUNE_REC ").strip())
+    assert payload == {
+        "kind": "next-workflow",
+        "name": "bug-predict",
+        "args": {"path": "src/foo"},
+        "label": "Run bug-predict to locate the specific lines",
+        "severity": "high",
+    }
+
+
+@pytest.mark.parametrize(
+    "benign",
+    [
+        "Missing docstring on function foo()",
+        "Variable naming could be clearer",
+        "Consider extracting this into a helper",
+        "Style nit: trailing whitespace",
+        "Performance: this loop is O(n^2)",
+        "Architectural concern: tight coupling between modules",
+        # Adjacent words that should NOT trigger
+        "The injection point of this dependency is the constructor.",
+    ],
+)
+def test_benign_review_does_not_emit(benign: str) -> None:
+    assert _capture(benign) == ""
+
+
+def test_skip_when_result_text_empty() -> None:
+    assert _capture("") == ""
+
+
+def test_skip_when_result_text_none() -> None:
+    buf = io.StringIO()
+    fired = _emit_security_recommendation_if_warranted(None, "src/foo", output_stream=buf)
+    assert fired is False
+    assert buf.getvalue() == ""
+
+
+def test_skip_when_scope_empty() -> None:
+    buf = io.StringIO()
+    fired = _emit_security_recommendation_if_warranted(
+        "Found a SQL injection", "", output_stream=buf
+    )
+    assert fired is False
+    assert buf.getvalue() == ""
+
+
+def test_payload_passes_runner_validation() -> None:
+    """End-to-end: the emitted marker line must validate against
+    RunnerService._validate_recommendation so the dashboard accepts it."""
+    from pathlib import Path
+
+    from attune.ops.runner import RunnerService
+
+    # project_root needs to exist so _validate_file_path accepts paths
+    # under it. Use the repo root — code-review's resolved path will
+    # be inside it for any real run.
+    repo_root = Path(__file__).resolve().parents[3]
+    svc = RunnerService(project_root=repo_root)
+    scope = str(repo_root / "src" / "attune" / "workflows")
+
+    buf = io.StringIO()
+    _emit_security_recommendation_if_warranted("Found SQL injection", scope, output_stream=buf)
+    line = buf.getvalue().rstrip("\n")
+    assert line.startswith("ATTUNE_REC ")
+    payload = json.loads(line.removeprefix("ATTUNE_REC "))
+    sanitized = svc._validate_recommendation(payload)
+    assert sanitized is not None
+    assert sanitized["name"] == "bug-predict"
+    assert sanitized["args"] == {"path": scope}
+
+
+def test_only_one_emission_per_call_even_with_multiple_triggers() -> None:
+    """The helper emits at most one recommendation per call. Real
+    reviews often mention multiple issues; we don't want to flood the
+    card list with duplicates."""
+    text = "Found SQL injection AND a hardcoded secret AND XSS in three files."
+    out = _capture(text)
+    assert out.count("ATTUNE_REC ") == 1


### PR DESCRIPTION
## Summary

Phase 5.4 of [`docs/specs/ops-runner-tier2/`](docs/specs/ops-runner-tier2/tasks.md) — wires `code-review` to emit an `ATTUNE_REC` recommendation when its synthesized output surfaces security/CWE-shaped findings. This is the end-to-end demonstration of the recommendation channel infrastructure shipped in [#413](https://github.com/Smart-AI-Memory/attune-ai/pull/413).

The two workflows complement each other:
- **code-review** reads narratively ("found a SQL injection in models.py")
- **bug-predict** pinpoints lines via its pattern scanner

When code-review names a finding without locating it, the action card on the run-view page lets the user kick off bug-predict on the same scope with one click.

## Change

**`src/attune/workflows/code_review.py`** (+~80 LOC)
- New `_SECURITY_TRIGGERS` regex matching CWE/CVE ids, common vulnerability-class phrases (SQL/command injection, path traversal, XSS, CSRF, hardcoded secrets, insecure deserialization/random), and direct `eval(`/`exec(` calls. Case-insensitive, word-bounded.
- New `_emit_security_recommendation_if_warranted(result_text, scope_path)` helper. On match, prints `ATTUNE_REC <json>` to stdout with a `next-workflow` payload pointing at `bug-predict` with the same `args.path`. Takes an `output_stream` kwarg so tests can capture without monkeypatching.
- Called at the end of `execute()` right before `AgentSDKResultAdapter.from_agent_output(...)`.

**`tests/unit/workflows/test_code_review_recommendations.py`** (new, 26 tests)
- Parametrized over 14 trigger phrases → all emit a well-formed marker.
- Parametrized over 7 benign phrases (style nits, perf, architecture, narrative use of "injection") → no emission.
- Skip cases: empty result_text, None result_text, empty scope.
- One-emission-per-call guarantee (multi-trigger paragraph).
- Round-trip: emitted payload passes `RunnerService._validate_recommendation` — proves the dashboard will actually accept it.

## Test plan

- [x] `pytest tests/unit/workflows/test_code_review_recommendations.py` — 26 passed.
- [x] `pytest tests/unit/workflows/test_code_review_workflow.py tests/unit/workflows/test_code_review_agent_sdk.py tests/unit/ops/` — 742 passed (716 ops + 26 new).
- [ ] Browser smoke: run code-review against a file with `eval(...)` and confirm an action card renders on `/runs/<id>/view`. Best done end-to-end now that both halves of the channel are live.

## Out of scope

- **Phase 6** — in-memory telemetry counters (pill clicks, recommendation card clicks, scope picker usage) + spec close. Last remaining item in ops-runner-tier2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
