### PR TITLE
chore: add deprecation marker enforcement + bump 6 stale v4.0.0 markers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -166,3 +166,15 @@ repos:
         pass_filenames: false
         files: ^pyproject\.toml$
         stages: [pre-commit]
+
+      # Deprecation marker enforcement
+      # Modules tagged "REMOVE IN vX.Y.Z" must be removed before the
+      # codebase ships major X. Fails when any marker has rotted past
+      # the current major. See scripts/check_deprecation_markers.py.
+      - id: check-deprecation-markers
+        name: Check deprecation markers aren't past due
+        entry: python scripts/check_deprecation_markers.py
+        language: system
+        pass_filenames: false
+        files: ^(src/.*\.py|pyproject\.toml)$
+        stages: [pre-commit]

--- a/scripts/check_deprecation_markers.py
+++ b/scripts/check_deprecation_markers.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Enforce deprecation-marker version contracts.
+
+Modules and call sites tagged ``REMOVE IN vX.Y.Z`` must be removed
+before the codebase ships version ``X``. This script reads the
+current version from ``pyproject.toml`` and scans the source tree
+for markers whose major version is *less than or equal to* the
+current major. Any match means a previously-scheduled deletion has
+silently rotted past its deadline.
+
+Background: lesson in ``.claude/CLAUDE.md`` ("Past-due deprecations
+are deletion targets, not implementation targets") and the
+attune-ai 6.x cleanup that surfaced six ``REMOVE IN v4.0.0`` markers
+three majors overdue.
+
+Usage:
+    python scripts/check_deprecation_markers.py
+    python scripts/check_deprecation_markers.py --root src/
+
+Exit codes:
+    0 — every marker is scheduled for a future major
+    1 — at least one marker is past due (offenders printed to stderr)
+    2 — pyproject.toml could not be read or the marker syntax is bad
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Match REMOVE IN v<MAJOR>.<MINOR>.<PATCH> on any line. Permissive about
+# preceding text so we catch markers in module docstrings, sphinx
+# ``.. deprecated::`` blocks, and inline ``# REMOVE IN`` comments.
+MARKER_RE = re.compile(r"REMOVE IN v(\d+)\.(\d+)\.(\d+)")
+
+# Files to ignore even if they contain marker-like text (this script
+# itself defines the pattern; the lessons file documents the rule).
+SELF_REFERENTIAL: frozenset[str] = frozenset(
+    {
+        "scripts/check_deprecation_markers.py",
+        ".claude/CLAUDE.md",
+        "tests/unit/test_deprecation_markers.py",
+    }
+)
+
+
+def _read_current_major(pyproject: Path) -> int:
+    """Return the current major version from pyproject.toml."""
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(f"cannot read {pyproject}: {exc}") from exc
+
+    match = re.search(r'^version\s*=\s*"(\d+)\.(\d+)\.(\d+)"', text, re.MULTILINE)
+    if not match:
+        raise SystemExit(f"could not parse version from {pyproject}")
+    return int(match.group(1))
+
+
+def _iter_files(root: Path) -> list[Path]:
+    """Yield .py and .md files under ``root`` that we should scan."""
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix not in {".py", ".md"}:
+            continue
+        if any(part in {"__pycache__", ".venv", "node_modules"} for part in path.parts):
+            continue
+        rel = path.relative_to(root.parent if root.name == "src" else root)
+        if str(rel).replace("\\", "/") in SELF_REFERENTIAL:
+            continue
+        files.append(path)
+    return files
+
+
+def scan(root: Path, current_major: int) -> list[tuple[Path, int, str, tuple[int, int, int]]]:
+    """Return list of past-due markers as (path, lineno, line, (M, m, p))."""
+    offenders: list[tuple[Path, int, str, tuple[int, int, int]]] = []
+    for path in _iter_files(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            match = MARKER_RE.search(line)
+            if not match:
+                continue
+            major, minor, patch = (int(g) for g in match.groups())
+            if major <= current_major:
+                offenders.append((path, lineno, line.strip(), (major, minor, patch)))
+    return offenders
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("src"),
+        help="directory to scan (default: src/)",
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="path to pyproject.toml (default: pyproject.toml)",
+    )
+    args = parser.parse_args(argv)
+
+    current_major = _read_current_major(args.pyproject)
+    offenders = scan(args.root, current_major)
+
+    if not offenders:
+        print(
+            f"[deprecation-markers] OK — no past-due markers under "
+            f"{args.root} (current major: v{current_major}.x.x)"
+        )
+        return 0
+
+    print(
+        f"[deprecation-markers] FAIL — {len(offenders)} marker(s) past "
+        f"due (current major: v{current_major}.x.x):",
+        file=sys.stderr,
+    )
+    for path, lineno, line, version in offenders:
+        major, minor, patch = version
+        print(
+            f"  {path}:{lineno}  REMOVE IN v{major}.{minor}.{patch}  " f"({line[:80]})",
+            file=sys.stderr,
+        )
+    print(
+        "\nFix: either delete the deprecated code and its marker, or "
+        "bump the marker to a future major (and update the migration "
+        "plan that gates the deletion).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/attune/memory/config.py
+++ b/src/attune/memory/config.py
@@ -8,7 +8,7 @@ Copyright 2025 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0
 """
 
-# REMOVE IN v4.0.0 — see docs/migration/redis-plugin-migration.md
+# REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
 
 import os
 from urllib.parse import urlparse

--- a/src/attune/redis_config.py
+++ b/src/attune/redis_config.py
@@ -1,6 +1,6 @@
 """Redis Configuration for Attune AI (deprecated).
 
-REMOVE IN v4.0.0 — see docs/migration/redis-plugin-migration.md
+REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
 
 .. deprecated::
     Use ``attune_redis.config.RedisPluginConfig`` for new code.

--- a/src/attune/redis_memory.py
+++ b/src/attune/redis_memory.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis.AMSMemoryBackend.
 
-REMOVE IN v4.0.0 — see docs/migration/redis-plugin-migration.md
+REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
 
 Legacy facade for RedisShortTermMemory. Kept for backward
 compatibility. New code should use the ``attune_redis``

--- a/src/attune/redis_memory_coordination.py
+++ b/src/attune/redis_memory_coordination.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis for coordination.
 
-REMOVE IN v4.0.0 — see docs/migration/redis-plugin-migration.md
+REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
 
 Legacy coordination mixins kept for backward compatibility.
 New code should use ``attune_redis.signals.RedisSignalBus``.

--- a/src/attune/redis_memory_patterns.py
+++ b/src/attune/redis_memory_patterns.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis for pattern promotion.
 
-REMOVE IN v4.0.0 — see docs/migration/redis-plugin-migration.md
+REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
 
 Legacy pattern staging mixins kept for backward
 compatibility. New code should use

--- a/src/attune/redis_memory_storage.py
+++ b/src/attune/redis_memory_storage.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis.AMSMemoryBackend.
 
-REMOVE IN v4.0.0 — see docs/migration/redis-plugin-migration.md
+REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
 
 Legacy storage engine kept for backward compatibility.
 New code should use ``attune_redis.memory.AMSMemoryBackend``.

--- a/tests/unit/test_deprecation_markers.py
+++ b/tests/unit/test_deprecation_markers.py
@@ -1,0 +1,85 @@
+"""Smoke tests for scripts/check_deprecation_markers.py.
+
+The script is a CI gate, so we test the scan function directly with
+synthetic file trees rather than spawning a subprocess.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def check_module():
+    """Load scripts/check_deprecation_markers.py as a module."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "check_deprecation_markers.py"
+    spec = importlib.util.spec_from_file_location("_check_dep_markers", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_check_dep_markers"] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop("_check_dep_markers", None)
+
+
+def test_scan_finds_past_due_marker(check_module, tmp_path: Path) -> None:
+    """A marker for a major <= current should be returned."""
+    target = tmp_path / "legacy.py"
+    target.write_text(
+        '"""Old module.\n\nREMOVE IN v4.0.0 — see migration.md\n"""\n',
+        encoding="utf-8",
+    )
+    offenders = check_module.scan(tmp_path, current_major=6)
+    assert len(offenders) == 1
+    path, lineno, _, version = offenders[0]
+    assert path == target
+    assert lineno == 3
+    assert version == (4, 0, 0)
+
+
+def test_scan_ignores_future_marker(check_module, tmp_path: Path) -> None:
+    """A marker scheduled for a future major must not be flagged."""
+    (tmp_path / "modern.py").write_text(
+        '"""# REMOVE IN v9.0.0 — gated on future spec\n"""\n',
+        encoding="utf-8",
+    )
+    assert check_module.scan(tmp_path, current_major=6) == []
+
+
+def test_scan_handles_equal_major_as_past_due(check_module, tmp_path: Path) -> None:
+    """Equal majors mean we're already shipping the version that was
+    supposed to have deleted the code — count as past due."""
+    (tmp_path / "edge.py").write_text(
+        "# REMOVE IN v6.0.0 — same major as current\n", encoding="utf-8"
+    )
+    offenders = check_module.scan(tmp_path, current_major=6)
+    assert len(offenders) == 1
+
+
+def test_scan_ignores_non_python_non_markdown(check_module, tmp_path: Path) -> None:
+    """Files outside .py/.md should be skipped."""
+    (tmp_path / "skipme.txt").write_text(
+        "REMOVE IN v4.0.0 — but in a .txt file\n", encoding="utf-8"
+    )
+    assert check_module.scan(tmp_path, current_major=99) == []
+
+
+def test_repo_state_is_clean(check_module) -> None:
+    """Regression guard: the live repo must have no past-due markers.
+
+    If this fails, either delete the deprecated code that's past its
+    target version, or bump the marker to a realistic future major.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    pyproject = repo_root / "pyproject.toml"
+    current_major = check_module._read_current_major(pyproject)
+    src = repo_root / "src"
+    offenders = check_module.scan(src, current_major)
+    assert offenders == [], (
+        f"Past-due deprecation markers found: " f"{[(str(p), v) for p, _, _, v in offenders]}"
+    )


### PR DESCRIPTION
## Summary

The six `REMOVE IN v4.0.0` markers in `src/attune/redis_*.py` and `src/attune/memory/config.py` were three majors overdue (current is v6.8.0). Per the CLAUDE.md lesson — **"Without enforcement, 'we'll delete this later' becomes 'this lives forever'"** — aspirational markers without a CI gate rot silently.

## What's in this PR

1. **`scripts/check_deprecation_markers.py`** — scans `.py` + `.md` under `src/` for `REMOVE IN vX.Y.Z` patterns. Reads current version from `pyproject.toml` and fails when any marker's major ≤ current major. Exits 0 / 1 / 2 matching the project's existing check-script convention.

2. **Pre-commit hook** — wired in alongside `check-coverage-omits`. Fires on `src/**.py` or `pyproject.toml` changes.

3. **5 smoke tests** including a `test_repo_state_is_clean` regression guard that fails CI if any past-due marker ever lands on main.

4. **Marker bumps**: 6 files bumped `v4.0.0` → `v8.0.0 — gated on redis-decoupling spec P3` to make the future deletion contract explicit and enforceable.

## Out of scope

Actual deletion of the deprecated modules. Each has live consumers — `core.py`, `memory/short_term/base.py`, `agents/book_production/pipeline.py`, 7 test files, 5 doc files, `attune_redis/tests/` — that need migration first. That work belongs in `docs/specs/redis-decoupling/` Phase 3+, not this enforcement PR.

## Test plan

- [ ] CI green (script self-check should pass with bumped markers)
- [ ] `pre-commit run check-deprecation-markers --all-files` passes locally
- [ ] `pytest tests/unit/test_deprecation_markers.py` passes (all 5 tests, including repo-state regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)