### PR TITLE
docs(CLAUDE.md): macOS Claude.app session-leak lesson

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5349,3 +5349,47 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   --project-root . --all-kinds`. Parallel regens
   via `&` background jobs work fine; the env is
   inherited by the children of the same Bash call.
+
+- **Claude.app on macOS leaks ~6 processes per closed
+  Claude Code session — the launcher chain is never
+  reaped**: each Claude Code session spawns the chain
+  `Claude.app/Helpers/disclaimer → claude-code/.../claude
+  → uv tool uvx → uv run → python -m attune.mcp.server`
+  (the MCP server itself often spawns a second python
+  child). When the user closes a session, Claude.app
+  does NOT terminate this chain — every process stays
+  alive indefinitely, parented to the still-running
+  Claude.app root (`/Applications/Claude.app/Contents/
+  MacOS/Claude`). On 2026-05-14 a single host had 144
+  `attune.mcp.server` processes across 38 dead sessions
+  (~6 processes per session). Detection: `pgrep -f
+  attune.mcp.server | wc -l` — anything materially above
+  the count of currently-open Claude Code sessions × 2
+  is leaked. Cleanup approach (use carefully — the
+  agent's earlier ancestry-walking heuristic was denied
+  by the permission system for misclassification risk):
+  enumerate live launcher PIDs by inspecting MCP server
+  processes you KNOW belong to live sessions, trace
+  ancestry to find their `claude-code/.../claude`
+  launcher PIDs, build the set of dead launcher PIDs as
+  `(all claude-code launchers) - (known-live launchers)`,
+  BFS each dead launcher to collect all descendants,
+  then `kill -TERM` the lot. PPID=1 filtering catches
+  ZERO of them because the chain stays attached to the
+  live Claude.app root, not reparented to init. Two
+  scripting traps hit during the cleanup: (1) zsh
+  doesn't word-split unquoted variables by default, so
+  `for p in $list` in zsh treats `$list` as a single
+  value — run cleanup via explicit `bash -c '...'` to
+  get bash splitting semantics; (2) `pgrep -f
+  "claude-code/.*claude\.app/MacOS/claude "` matches
+  BOTH the launcher process AND its `disclaimer` parent
+  (which passes the launcher path as argv), so the match
+  returns pairs and you must protect both PIDs per live
+  session, not one. Final caveat: a new Claude Code
+  session opened between scan and kill won't be in the
+  protected set — verify after cleanup that all
+  currently-live sessions still respond to `kill -0`,
+  and accept that any survivors you didn't enumerate
+  upfront are likely additional live sessions, not
+  leaks.


### PR DESCRIPTION
## Summary

Adds one CLAUDE.md lesson salvaged from `stash@{3}` (recursing-montalcini WIP) during the 2026-05-16 stash safety triage. The lesson documents a real-world detection + cleanup pattern for the Claude.app launcher-chain process leak observed 2026-05-14 (144 `attune.mcp.server` processes across 38 dead sessions on a single host).

## What the lesson covers

- The launcher chain shape: `Claude.app/Helpers/disclaimer → claude-code/.../claude → uv tool uvx → uv run → python -m attune.mcp.server`.
- Why `PPID=1` filtering misses every leaked process (the chain stays parented to the live Claude.app root, not reparented to init when the session dies).
- Cleanup approach: enumerate live launcher PIDs from known-live MCP servers, derive dead launcher set as `(all launchers) - (live launchers)`, BFS each dead launcher for descendants, then `kill -TERM`.
- Two scripting traps: zsh word-splitting semantics break `for p in $list`; `pgrep -f` matches both the launcher AND its `disclaimer` parent so you must protect both PIDs per session.
- Final caveat: a new session opened between scan and kill won't be in the protected set; verify with `kill -0` after.

## Why a separate PR

The lesson is net-new content (verified via `grep -c "Claude.app on macOS leaks"` returning 0 on `main`) and orthogonal to the other in-flight work. Keeping it as its own PR means the docs change is easy to review and doesn't pile onto unrelated spec / salvage work.

## Test plan

- [ ] CI green on docs-only diff (single file, append-only).
- [ ] Reviewer agrees the lesson reflects an actual reproducible pattern (not theoretical) — content is based on the 2026-05-14 host scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
