### PR TITLE
feat(ops): suggestion chips parsed from "What I'd Do Next" log lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Suggestion chips on the run-view page. The "What I'd Do Next" lines
+  every SDK-native workflow emits as plain text (e.g. "I'd run
+  `attune workflow run security-audit` next — …") now render as
+  clickable chips below the run header. Clicking a chip POSTs to
+  `/workflows/<name>/run` with the same scope path the current run
+  used and navigates to the new run with `?from=<source>` so the
+  chained-from badge fires. Both the live-SSE branch and the
+  disk-loaded run-view branch render chips, so completed runs viewed
+  later get the same affordance. Header marker is anchored to
+  `attune.voice.personality.HEADER_NEXT_STEPS` — a drift-guard test
+  fails if either side renames. Complements the `ATTUNE_REC`
+  recommendation cards shipped in [#413](https://github.com/Smart-AI-Memory/attune-ai/pull/413)
+  + [#415](https://github.com/Smart-AI-Memory/attune-ai/pull/415):
+  recommendations are workflow-emitted structured signals; chips are
+  parsed from existing voice-layer output and require no workflow
+  changes to surface.
+
 - `code-review` workflow now emits an `ATTUNE_REC` recommendation
   suggesting a `bug-predict` run on the same scope when its synthesized
   output mentions CWE/CVE identifiers, common vulnerability classes

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1466,3 +1466,47 @@ a.kpi:hover {
   opacity: 0.55;
   cursor: progress;
 }
+
+/* ---------- Suggestion chips ("What I'd Do Next" parsed from log) ---------- */
+
+.suggestion-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+}
+.suggestion-row-label {
+  color: var(--muted, #888);
+  margin-right: 4px;
+}
+.suggestion-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  font-size: 12px;
+  font-family: inherit;
+  background: transparent;
+  color: var(--fg);
+  border: 1px dotted var(--accent);
+  border-radius: 99px;
+  cursor: pointer;
+  transition: background 120ms, color 120ms, border-style 120ms;
+}
+.suggestion-chip:hover {
+  background: var(--accent);
+  color: #fff;
+  border-style: solid;
+}
+.suggestion-chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.suggestion-chip:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -178,6 +178,11 @@
           "chip-muted"
         );
       }
+      // Scan the captured log for "What I'd Do Next" suggestions and
+      // render each as a clickable chip alongside any ATTUNE_REC cards.
+      // The marker pattern is stable across all SDK-native workflows
+      // (defined in attune.voice.personality.HEADER_NEXT_STEPS).
+      renderSuggestionChipsFromLog(logBuffer);
       es.close();
     });
 
@@ -211,6 +216,13 @@
       INITIAL_STATUS === "failed" ? "chip-danger" :
       "chip-muted"
     );
+    // Same suggestion-chip pass as the SSE "done" handler — disk-loaded
+    // runs should still surface "What I'd Do Next" suggestions from
+    // their pre-rendered <pre data-log> content.
+    var preEl = document.querySelector("[data-log]");
+    if (preEl) {
+      renderSuggestionChipsFromLog(preEl.textContent || "");
+    }
   }
 
   // ----------------------------------------------------------------
@@ -516,6 +528,126 @@
     slot.hidden = false;
   }
 
+  // ------------------------------------------------------------------
+  // Suggestion chips parsed from "What I'd Do Next" log lines
+  // ------------------------------------------------------------------
+
+  // Pattern: lines look like
+  //   I'd run `attune workflow run security-audit` next — Your spec ...
+  // The backtick-wrapped workflow name is the parsable signal. Free-form
+  // explanation after the em-dash is kept as the chip's tooltip text.
+  var _NEXT_STEP_RE = /attune workflow run\s+([a-z][a-z0-9-]+)/i;
+  var _VALID_WORKFLOW_NAME_RE = /^[a-z][a-z0-9-]+$/;
+
+  function parseSuggestions(logText) {
+    if (!logText || typeof logText !== "string") return [];
+    var lines = logText.split(/\r?\n/);
+    var inNextSteps = false;
+    var out = [];
+    var seen = {};
+    for (var i = 0; i < lines.length; i++) {
+      var raw = lines[i];
+      var line = raw.trim();
+      if (!line) continue;
+      // The voice layer emits the header literally as "What I'd Do Next".
+      if (line === "What I'd Do Next") {
+        inNextSteps = true;
+        continue;
+      }
+      if (!inNextSteps) continue;
+      // Other section headers end the block (e.g. "Cost & Time" appears
+      // BEFORE NextSteps, but a future workflow might emit another
+      // markdown heading after — guard defensively).
+      if (line.charAt(0) === "#") break;
+      var m = _NEXT_STEP_RE.exec(line);
+      if (!m) continue;
+      var name = m[1];
+      if (!_VALID_WORKFLOW_NAME_RE.test(name)) continue;
+      if (seen[name]) continue;
+      seen[name] = true;
+      // Tooltip: everything after the em-dash if present, else the
+      // whole line trimmed of the "I'd run … next —" preamble.
+      var emIdx = line.indexOf("—");
+      var tooltip = emIdx >= 0
+        ? line.substring(emIdx + 1).trim()
+        : line.replace(/^I'd run\s+`[^`]+`\s+next\s*—?\s*/i, "");
+      out.push({ name: name, tooltip: tooltip });
+    }
+    return out;
+  }
+
+  function renderSuggestionChipsFromLog(logText) {
+    var suggestions = parseSuggestions(logText);
+    if (!suggestions.length) return;
+    var slot = document.querySelector("[data-recommendations]");
+    if (!slot) return;
+    // Render under a single header so multi-suggestion runs feel like
+    // one group rather than N standalone cards.
+    var existing = slot.querySelector("[data-suggestion-row]");
+    if (existing) existing.remove();
+    var row = document.createElement("div");
+    row.className = "suggestion-row";
+    row.setAttribute("data-suggestion-row", "");
+    var label = document.createElement("span");
+    label.className = "suggestion-row-label";
+    label.textContent = "What I'd do next:";
+    row.appendChild(label);
+    for (var i = 0; i < suggestions.length; i++) {
+      row.appendChild(buildSuggestionChip(suggestions[i]));
+    }
+    slot.appendChild(row);
+    slot.hidden = false;
+  }
+
+  function buildSuggestionChip(suggestion) {
+    var chip = document.createElement("button");
+    chip.className = "suggestion-chip";
+    chip.type = "button";
+    chip.setAttribute("data-suggestion-chip", suggestion.name);
+    chip.textContent = suggestion.name;
+    if (suggestion.tooltip) {
+      chip.setAttribute("data-tooltip", suggestion.tooltip);
+      chip.setAttribute("aria-label", "Run " + suggestion.name + " — " + suggestion.tooltip);
+    } else {
+      chip.setAttribute("aria-label", "Run " + suggestion.name);
+    }
+    chip.addEventListener("click", function () {
+      chip.disabled = true;
+      var body = {};
+      if (DATA && typeof DATA.path === "string" && DATA.path) {
+        body.path = DATA.path;
+      }
+      fetch("/workflows/" + encodeURIComponent(suggestion.name) + "/run", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(body)
+      }).then(function (resp) {
+        if (resp.status === 201) {
+          return resp.json().then(function (data) {
+            window.location.href = "/runs/" + data.run_id +
+              "/view?from=" + encodeURIComponent(DATA.workflow || "");
+          });
+        }
+        if (resp.status === 409) {
+          return resp.json().then(function (data) {
+            showInlineError(
+              "Cannot start " + suggestion.name + " — run " +
+              data.detail.current_run_id + " is still active."
+            );
+            chip.disabled = false;
+          });
+        }
+        showInlineError("Could not start " + suggestion.name +
+          " (HTTP " + resp.status + ")");
+        chip.disabled = false;
+      }).catch(function (err) {
+        showInlineError("Could not start " + suggestion.name + ": " + err);
+        chip.disabled = false;
+      });
+    });
+    return chip;
+  }
+
   // Expose internals for tests.
   if (typeof window !== "undefined") {
     window.__attuneRunView = {
@@ -526,6 +658,9 @@
       updateSweepProgress: updateSweepProgress,
       renderRecommendationCard: renderRecommendationCard,
       isSafeUrl: isSafeUrl,
+      parseSuggestions: parseSuggestions,
+      renderSuggestionChipsFromLog: renderSuggestionChipsFromLog,
+      buildSuggestionChip: buildSuggestionChip,
       DATA: DATA
     };
   }

--- a/tests/unit/ops/test_run_view_suggestion_chips.py
+++ b/tests/unit/ops/test_run_view_suggestion_chips.py
@@ -1,0 +1,170 @@
+"""Tests for the "What I'd Do Next" suggestion-chip renderer in run_view.js.
+
+The chip renderer parses workflow report output (the voice layer's
+"What I'd Do Next" section) and emits clickable chips on the run-view
+page. Tests live at the JS-source-grep level (no DOM emulator) since
+the production logic is single-file and the parsing rules are
+documented in source comments.
+
+Spec context: Patrick's request 2026-05-17 — surface the textual
+"I'd run X next" suggestions as one-click chips so users don't have
+to copy-paste workflow names into the terminal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_RUN_VIEW_JS = (
+    Path(__file__).resolve().parents[3] / "src" / "attune" / "ops" / "static" / "js" / "run_view.js"
+)
+
+
+def _read_js() -> str:
+    return _RUN_VIEW_JS.read_text(encoding="utf-8")
+
+
+def test_parser_helper_exists() -> None:
+    """``parseSuggestions`` and ``renderSuggestionChipsFromLog`` are
+    the two public entry points the SSE handler + disk-loaded branch
+    call into. Both must be exported."""
+    text = _read_js()
+    assert "function parseSuggestions(" in text
+    assert "function renderSuggestionChipsFromLog(" in text
+    assert "function buildSuggestionChip(" in text
+    assert "parseSuggestions: parseSuggestions" in text
+    assert "renderSuggestionChipsFromLog: renderSuggestionChipsFromLog" in text
+    assert "buildSuggestionChip: buildSuggestionChip" in text
+
+
+def test_parser_anchored_on_voice_layer_header() -> None:
+    """The header literal must match ``HEADER_NEXT_STEPS`` in
+    ``attune.voice.personality``. If either side drifts, the chips
+    silently stop rendering."""
+    text = _read_js()
+    assert 'line === "What I\'d Do Next"' in text
+
+    # Confirm the producer side still emits the same string.
+    personality = (
+        Path(__file__).resolve().parents[3] / "src" / "attune" / "voice" / "personality.py"
+    )
+    py_text = personality.read_text(encoding="utf-8")
+    assert 'HEADER_NEXT_STEPS = "What I\'d Do Next"' in py_text
+
+
+def test_parser_workflow_name_regex_matches_canonical_shape() -> None:
+    """The workflow-name regex matches the same shape used by the
+    runner's ``_WORKFLOW_NAME_RE`` — lowercase letters, digits, and
+    hyphens, starting with a letter."""
+    text = _read_js()
+    # JS-side
+    assert "/^[a-z][a-z0-9-]+$/" in text
+    # The "attune workflow run X" extractor
+    assert "/attune workflow run\\s+([a-z][a-z0-9-]+)/i" in text
+
+
+def test_done_handler_invokes_renderer() -> None:
+    """After the SSE ``done`` event fires and the status chip is set,
+    the handler scans the buffered log for suggestions."""
+    text = _read_js()
+    done_idx = text.find('addEventListener("done"')
+    assert done_idx > 0
+    # Helper called inside the done body (anywhere before the next
+    # addEventListener).
+    next_handler = text.find("addEventListener(", done_idx + 1)
+    done_body = text[done_idx:next_handler]
+    assert "renderSuggestionChipsFromLog(logBuffer)" in done_body
+
+
+def test_disk_loaded_branch_invokes_renderer() -> None:
+    """Disk-loaded runs (no SSE — server pre-rendered <pre>) also
+    render chips by reading the existing <pre data-log> textContent."""
+    text = _read_js()
+    # The else branch: STREAM_URL absent path. Both invocations live
+    # below the SSE block; assert both function references are present.
+    assert 'querySelector("[data-log]")' in text
+    assert "renderSuggestionChipsFromLog(preEl.textContent" in text
+
+
+def test_chip_button_carries_workflow_name_data_attribute() -> None:
+    """Each chip is a <button> with data-suggestion-chip="<name>" so
+    drift-guard tests + accessibility tooling can locate it."""
+    text = _read_js()
+    assert 'chip.setAttribute("data-suggestion-chip"' in text
+    assert 'chip.className = "suggestion-chip"' in text
+    assert 'chip.type = "button"' in text
+
+
+def test_chip_click_posts_with_inherited_scope_path() -> None:
+    """A suggestion chip POSTs to ``/workflows/<name>/run`` with the
+    current run's path threaded through as the body's ``path`` key.
+    No path = body-less POST, matching the runner's project-wide
+    semantics."""
+    text = _read_js()
+    # The fetch target and the path-inheritance branch
+    assert '"/workflows/" + encodeURIComponent(suggestion.name) + "/run"' in text
+    assert 'if (DATA && typeof DATA.path === "string" && DATA.path)' in text
+    assert "body.path = DATA.path" in text
+
+
+def test_chip_409_surfaces_inline_error() -> None:
+    """A 409 (runner busy) response surfaces the inline error already
+    used by Phase 4 pill clicks — same pattern, same UI."""
+    text = _read_js()
+    # Find the suggestion-chip handler body. The next TOP-LEVEL function
+    # definition (two-space indent inside the IIFE) bounds the chip
+    # function; nested ``function () { ... }`` fetch callbacks share
+    # the keyword but with different indentation.
+    chip_idx = text.find("function buildSuggestionChip(")
+    next_top = text.find("\n  function ", chip_idx + 1)
+    body = text[chip_idx : next_top if next_top != -1 else len(text)]
+    assert "resp.status === 409" in body
+    assert "showInlineError(" in body
+
+
+def test_chip_201_navigates_with_from_param() -> None:
+    """Successful chip click navigates to the new run with
+    ``?from=<source-workflow>`` so the chained-from badge renders."""
+    text = _read_js()
+    chip_idx = text.find("function buildSuggestionChip(")
+    next_top = text.find("\n  function ", chip_idx + 1)
+    body = text[chip_idx : next_top if next_top != -1 else len(text)]
+    assert "resp.status === 201" in body
+    # The literal includes "/view?from=" — match the unique suffix.
+    assert '?from=" + encodeURIComponent(DATA.workflow || "")' in body
+
+
+def test_parser_skips_lines_outside_next_steps_section() -> None:
+    """The parser only activates inside the "What I'd Do Next" block.
+    A backtick-wrapped workflow name elsewhere in the log (e.g. the
+    initial command line, or a description that happens to mention
+    a workflow) must not produce a chip."""
+    text = _read_js()
+    # The implementation uses `inNextSteps = false` as the initial gate
+    # and flips to true only on the header line.
+    assert "var inNextSteps = false;" in text
+    assert "inNextSteps = true;" in text
+
+
+def test_parser_dedupes_repeated_workflow_names() -> None:
+    """Workflow reports occasionally repeat the same suggestion (e.g.
+    the same workflow appears with two different justification
+    strings). The chip row should show each name once."""
+    text = _read_js()
+    # The implementation tracks seen names in a flat object map.
+    assert "var seen = {};" in text
+    assert "if (seen[name]) continue;" in text
+
+
+def test_css_styles_suggestion_chip() -> None:
+    """The chip styles ship with hover + focus-visible + disabled
+    states. The base style is a dotted-outline pill (matches Patrick's
+    color/hover affordance preference: dotted underline / dotted
+    border for clickability)."""
+    css_path = _RUN_VIEW_JS.parent.parent / "css" / "main.css"
+    text = css_path.read_text(encoding="utf-8")
+    assert ".suggestion-chip" in text
+    assert ".suggestion-chip:hover" in text
+    assert ".suggestion-chip:focus-visible" in text
+    assert ".suggestion-chip:disabled" in text
+    assert "border: 1px dotted" in text


### PR DESCRIPTION
## Summary

Surfaces every SDK-native workflow's **"What I'd Do Next"** suggestions as clickable chips on the run-view page. These are the textual "I'd run `attune workflow run security-audit` next — …" lines the voice layer emits today — currently invisible as anything other than text. With this PR they become one-click runs.

Companions the `ATTUNE_REC` recommendation channel from [#413](https://github.com/Smart-AI-Memory/attune-ai/pull/413) + [#415](https://github.com/Smart-AI-Memory/attune-ai/pull/415):
- **Recommendation cards** = workflow-emitted structured signals (`ATTUNE_REC <json>` stdout markers). Require workflow changes to surface anything.
- **Suggestion chips** = parsed from existing voice-layer output. Require no workflow changes — every SDK-native workflow already emits "What I'd Do Next" lines, so this lights up on day one across the board.

## Change

**`src/attune/ops/static/js/run_view.js`** (~140 LOC)
- `parseSuggestions(logText)` — walks the log, activates inside the `"What I'd Do Next"` section, extracts workflow names from `attune workflow run <name>` patterns, captures the post-em-dash explanation as tooltip text. Deduplicates by name.
- `renderSuggestionChipsFromLog(logText)` — appends a chip row to `[data-recommendations]` (same slot the recommendation cards use). Re-render-safe: replaces any prior `[data-suggestion-row]`.
- `buildSuggestionChip(suggestion)` — builds the chip `<button>` with `data-suggestion-chip` attribute, tooltip, and click handler. Click POSTs `/workflows/<name>/run` with the current run's scope, navigates to the new run with `?from=<source>`. Same 201/409/error behavior as Phase 4 pill clicks.
- Wired into both the SSE `done` handler and the disk-loaded branch so completed runs viewed later get the same affordance.

**`src/attune/ops/static/css/main.css`** (~45 LOC)
- `.suggestion-row` flex container, `.suggestion-row-label` muted prefix, `.suggestion-chip` dotted-border pill matching Patrick's color/hover affordance preference (dotted underline / dotted border for clickability).
- Hover, focus-visible, and disabled states.

**`tests/unit/ops/test_run_view_suggestion_chips.py`** (new, 12 tests)
- Helper exports + drift guard tying the JS header literal to `attune.voice.personality.HEADER_NEXT_STEPS`.
- Workflow-name regex matches the canonical `_WORKFLOW_NAME_RE` shape.
- SSE `done` handler + disk-loaded branch both invoke the renderer.
- Chip carries `data-suggestion-chip="<name>"` for drift guards.
- Click POSTs with inherited scope; 201 navigates with `?from=`; 409 surfaces inline error.
- Parser only activates inside the section, dedupes by name.
- CSS hover / focus / disabled states present.

## Test plan

- [x] `pytest tests/unit/ops/test_run_view_suggestion_chips.py` — 12 passed.
- [x] `pytest tests/unit/ops/` — 728 passed (was 716, no regressions).
- [ ] Browser smoke: load any completed code-review / security-audit / bug-predict run-view page and verify the chips appear, click one and verify it kicks off a new run with the inherited scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
