### PR TITLE
release: v7.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "6.8.0"
+    "version": "7.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "6.8.0",
+      "version": "7.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v6.8.0
+# Attune AI Framework v7.0.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 6.8.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 7.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 
@@ -5326,6 +5326,56 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   `TelemetrySummary`, `HomeKpis`,
   `TrustedHostMiddleware` with full prose
   explaining their roles.
+
+- **`/api/runs/<workflow>` returns a LIST; `/runs/<id>` (NOT
+  `/api/runs/<id>`) returns a SINGLE run — endpoint paths are
+  asymmetric and the wrong one fails silently in poll loops**:
+  the ops dashboard exposes `GET /api/runs/{workflow_name}`
+  (returns `{"workflow": ..., "runs": [...]}` — list of runs for
+  that workflow) AND `GET /runs/{run_id}` (returns one run by id).
+  A script polling `/api/runs/<run_id>` doesn't 404 — it matches
+  the workflow-list route on a workflow-name slug that happens to
+  resemble the id (e.g. the workflow runner accepted "f8ed53713add"
+  as a "workflow name" and returned an empty `runs:[]` list, no
+  `status` field). The poll's `.get("status", "")` then returns
+  empty forever, the loop hits its time cap, and the script moves
+  on while the actual workflow is still running — causing every
+  subsequent POST to return 409 "runner busy" because the previous
+  run never finished from the script's perspective. Hit during
+  the v7.0.0 workflows-tab review (2026-05-17) — first two runs
+  burned their full 8-min poll cap unnecessarily, then five more
+  workflows were skipped on 409. Fix: use `/runs/<id>` (singular,
+  no `/api/` prefix) for per-run status. Pre-flight with
+  `curl -s "$BASE/runs/$RID" | jq .status` before relying on the
+  endpoint in a script. Same shape as the existing "run_view_page
+  route returns 404 for disk-persisted runs after server restart"
+  lesson but a different failure mode (silent empty payload, not
+  404) — both are about the asymmetry between the workflow-list
+  and the per-id endpoints.
+
+- **`attune workflow run` on a mismatched input type (HTML to
+  code-review, etc.) exits 0 with a 2-second traceback that the
+  dashboard chip classifies as success**: a concrete instance of
+  the existing "exits 0 even when WorkflowResult.success is
+  False" lesson. Running code-review on
+  `src/attune/ops/templates/workflows.html` finished in 2.6s with
+  `exit_code: 0`; the persisted log shows
+  `ERROR:claude_agent_sdk._internal.query: Command failed with
+  exit code 1` followed by `code_review.py:226` raising in
+  `_run_agent_review`. The dashboard's defense-in-depth log-scan
+  (PR #366) should downgrade these to warn-yellow chips, but the
+  failure surfaces in <3 seconds with `exit_code=0` so a casual
+  glance at the recent-runs strip will see green. **Diagnostic
+  shortcut for "is this run a real run or a silent failure":
+  duration < 5 seconds on any LLM-backed workflow is essentially
+  always a startup failure.** Real workflow runs ALWAYS take at
+  least ~10s for the SDK handshake even on tiny inputs. Pair with
+  the existing "Workflow run-view route returns 404 ..." lesson:
+  both are dashboard surfaces where exit code 0 lies about real
+  success. Workflow operator preflight: before queueing a
+  code-review / doc-audit / test-audit run, eyeball the path
+  extension — these workflows assume Python source and will
+  silent-fail on `.html`, `.css`, `.md`, `.json`, etc.
 
 - **attune-author CLI does NOT auto-load
   `~/.attune/anthropic.env` — every shell

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5377,6 +5377,54 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   extension — these workflows assume Python source and will
   silent-fail on `.html`, `.css`, `.md`, `.json`, etc.
 
+- **API quota exhaustion masquerades as SDK startup failure
+  with $0.00 / 0.0s — the workflow's "What Went Wrong" lists
+  three plausible-but-wrong causes and never names the real
+  one**: extends the existing "Command failed with exit code
+  1 + $0.0000 | 0.0s = subprocess startup failure" lesson with
+  a fourth root cause to consider. When the symptom shape is
+  `claude_agent_sdk.query()` failing in 2.6 seconds with
+  exit_code 0 at the CLI boundary, the workflow's voice-layer
+  suggests "ANTHROPIC_API_KEY unset/expired, claude CLI not
+  on PATH, claude-agent-sdk version incompatible" — but the
+  actual fourth cause is **API account usage cap reached**.
+  The SDK swallows the underlying 400
+  `invalid_request_error: "You have reached your specified
+  API usage limits. You will regain access on YYYY-MM-DD..."`
+  into the generic `Exception: Command failed`. Diagnosis
+  shortcut: call `claude` directly with the same flags the
+  SDK passes (`echo "" | claude --json-schema '<minimal-schema>'
+  -p "say hi"`). If the direct call returns the 400 quota
+  message, you've found the root cause. The
+  three-listed-causes are red herrings; auth + PATH + SDK
+  version are all fine. This drove ~15 minutes of misdiagnosis
+  on 2026-05-17 — and is the exact trigger for the
+  [`sdk-error-message-fidelity`](../../../docs/specs/sdk-error-message-fidelity/requirements.md)
+  spec.
+
+- **Pre-commit's `.help` template regen creates a
+  stash-and-reappear dance — every commit touching source
+  files that bump a feature's source_hash spawns a follow-up
+  commit for the regenerated `.help/templates/<feature>/*.md`
+  frontmatter**: hit twice in one session on 2026-05-17.
+  Commit 1 changed CLAUDE.md → pre-commit's
+  help-template-freshness hook regenerated
+  `.help/templates/plugin/{concept,reference,task}.md` →
+  these landed in the working tree AFTER commit 1 because
+  pre-commit's stash/restore cycle (stash unstaged before
+  hook run, restore after) merges hook output back as
+  unstaged changes. Same pattern hit again when commit 2
+  changed `src/attune/ops/*` → ops-dashboard templates
+  regenerated. Result: 3 commits planned became 5
+  (chore→regen→feat→docs→regen). Two cleaner alternatives
+  for the next session: (a) preempt the hook by running
+  `attune-author generate <feature>` manually before
+  `git add`, so the regenerated frontmatter is part of the
+  source commit; (b) batch the source-file commits and let
+  one trailing `chore(.help)` commit pick up all hash bumps
+  at once. Don't be surprised when committing source files
+  produces "free" follow-up commits — plan for them.
+
 - **attune-author CLI does NOT auto-load
   `~/.attune/anthropic.env` — every shell
   invocation needs an inline source**: the existing

--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,53 +1,43 @@
 ---
-type: concept
-name: ops-dashboard-concept
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-05-16T06:19:45.785146+00:00
-source_hash: 882177b61c372bb6753c706430edfcc0df951fa4fae4106cb76ff02fca34a836
+generated_at: 2026-05-17T18:28:27.048023+00:00
+source_hash: 848a51e7aabcd39ac987255bff940539153d7b544651bdec566acd763432d775
 status: generated
 ---
 
 # Ops Dashboard
 
-The ops dashboard is a local web server that gives you a live view of your attune workflows — showing cost telemetry, session history, and run logs — and lets you trigger workflow runs scoped to a specific feature or path.
+## How it works
 
-## How the pieces fit together
+Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
 
-When you run `attune ops` (or `python -m attune.ops`), the CLI builds a `Config` object and starts a FastAPI server bound to `127.0.0.1:8765` by default. Everything the dashboard reads and renders flows through that config:
+The main building blocks are:
 
-- **`Config`** anchors the server to your `project_root` and `attune_home`. It also determines where persisted data lives: `runs_dir` holds the history of past workflow executions, `sessions_dir` holds Claude Code session records, and `telemetry_path` points to the cost event log. None of those directories need to exist before first use.
-- **`TelemetrySummary`** aggregates the telemetry log into the numbers the dashboard surfaces — total requests, total cost, total savings, a per-workflow breakdown, and a per-day breakdown — so the home page can show you spend at a glance without reading raw event files.
-- **`HomeKpis`** and **`DailyCost`** feed the above-the-fold summary: today's event count, today's cost, seven-day cost, seven-day savings, and the sparkline that visualizes daily cost over time.
-- **`WorkflowEntry`** describes each workflow the dashboard can run: its name, description, number of stages, and the tier map that governs which model tier each stage uses.
-- **`Feature`** represents one entry from `.help/features.yaml`. The scope picker on the workflow runner page lists your project's features so you can target a workflow at a specific part of the codebase rather than running it over everything.
-- **`PathArgSpec`** tells the dashboard how a given workflow accepts a path argument on the CLI — which keyword argument to use and whether it is required — so the scope picker can construct the correct invocation.
-- **`Session`** represents one Claude Code session as it appears on the `/sessions` page: start time, duration, message count, and an AI-generated starter summary so you can decide whether to resume it.
-- **`TrustedHostMiddleware`** rejects any request whose `Host` header is not on the `trusted_hosts` allowlist, keeping the local server from being reachable by unexpected callers even when `allow_run` is enabled.
+- **`Candidate`** — One completion-candidate spec returned by the detector.
+- **`Config`** — Where attune ops reads project + attune state from.
+- **`TelemetrySummary`** — core component
+- **`WorkflowEntry`** — core component
+- **`PathArgSpec`** — How a workflow accepts a scope path on the CLI.
 
-## When the dashboard matters
+Under the hood, this feature spans 40 source
+files covering:
 
-The dashboard is most useful in three situations:
+- Run via ``python -m attune.ops``.
+- CLI entrypoint for ``attune ops``.
+- Detector for spec completion candidates.
 
-1. **Monitoring cost.** `TelemetrySummary` and `HomeKpis` turn raw telemetry events into a readable spend summary. If a workflow is consuming unexpectedly many tokens, the per-workflow breakdown shows it immediately.
-2. **Running workflows with a specific scope.** Without the dashboard, you pass a path argument directly on the CLI. With it, the scope picker reads your `.help/features.yaml` via `list_features()` and `first_feature()`, presents your features by name, and constructs the correct invocation — no need to remember argument names or paths.
-3. **Reviewing session history.** The `/sessions` page surfaces past Claude Code sessions with AI-generated summaries (produced by the `SUMMARY_PROMPT` logic) so you can orient yourself before resuming work.
+## What connects to it
 
-## Key configuration options
+This feature relates to: ops, dashboard, runner, workflows, scope-picker, persistence, sse.
 
-`build_config()` accepts these values, all of which have defaults so you can start the server with no arguments:
+Other parts of the codebase interact with
+ops dashboard through these interfaces:
 
-| Option | Default | Effect |
-|---|---|---|
-| `host` | `127.0.0.1` | Interface the server binds to |
-| `port` | `8765` | Port the server listens on |
-| `allow_run` | `False` | Whether workflow execution is permitted from the UI |
-| `runs_retention_days` | `30` | How many days of run history to keep on disk |
-| `specs_roots` | `()` | Additional directories to scan for workflow specs |
-| `trusted_hosts` | `()` | Host header allowlist enforced by `TrustedHostMiddleware` |
-
-## Related topics
-
-- **Reference**: Ops dashboard — all `Config` fields, data structures, and CLI flags
-- **Quickstart**: Ops dashboard — start the server and run your first scoped workflow
-- **Concept**: Template design patterns — how `.help/features.yaml` feature entries are structured
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `Candidate` | One completion-candidate spec returned by the detector. | `src/attune/ops/completion_candidates.py` |
+| `Config` | Where attune ops reads project + attune state from. | `src/attune/ops/config.py` |
+| `TelemetrySummary` | — | `src/attune/ops/data.py` |
+| `WorkflowEntry` | — | `src/attune/ops/data.py` |
+| `PathArgSpec` | How a workflow accepts a scope path on the CLI. | `src/attune/ops/data.py` |

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,255 +1,128 @@
 ---
-type: reference
-name: ops-dashboard-reference
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-05-16T06:19:45.796093+00:00
-source_hash: 882177b61c372bb6753c706430edfcc0df951fa4fae4106cb76ff02fca34a836
+generated_at: 2026-05-17T18:28:27.059758+00:00
+source_hash: 848a51e7aabcd39ac987255bff940539153d7b544651bdec566acd763432d775
 status: generated
 ---
 
 # Ops Dashboard reference
 
-Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
-
-Run via `python -m attune.ops` or the `attune ops` CLI subcommand. The public surface exported from `attune.ops` is `create_app`, `build_config`, and `Config`.
-
 ## Classes
 
-| Class | Description |
-|-------|-------------|
-| `Config` | Where attune ops reads project + attune state from. |
-| `TelemetrySummary` | Aggregated telemetry totals and breakdowns for the dashboard. |
-| `WorkflowEntry` | One entry in the registered workflow catalog. |
-| `PathArgSpec` | How a workflow accepts a scope path on the CLI. |
-| `Feature` | One feature from `.help/features.yaml` for the scope picker. |
-| `Session` | One Claude Code session — what surfaces on the dashboard's `/sessions` page. |
-| `FamilyVersion` | Installed version record for one related attune package. |
-| `DailyCost` | One day's cost for the home-page sparkline. |
-| `HomeKpis` | Summary numbers shown above the fold on the home page. |
-| `TrustedHostMiddleware` | Reject requests whose `Host` header isn't on the allowlist. |
-
-### `Config` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `project_root` | `Path` | — |
-| `attune_home` | `Path` | — |
-| `host` | `str` | `'127.0.0.1'` |
-| `port` | `int` | `8765` |
-| `allow_run` | `bool` | `False` |
-| `specs_roots` | `tuple[Path, ...]` | `()` |
-| `trusted_hosts` | `tuple[str, ...]` | `()` |
-| `runs_retention_days` | `int` | `30` |
-
-### `Config` properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `telemetry_path` | `Path` | Path to the telemetry data file. |
-| `runs_dir` | `Path` | Disk root for persisted ops runs. May not exist until first write. |
-| `memory_dir` | `Path` | Path to the attune memory directory. |
-| `sessions_dir` | `Path` | Path to the sessions directory. |
-
-### `TelemetrySummary` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `total_requests` | `int` | — |
-| `total_cost` | `float` | — |
-| `total_savings` | `float` | — |
-| `by_workflow` | `list[tuple[str, int, float]]` | — |
-| `by_day` | `list[tuple[str, int, float]]` | — |
-| `last_event_at` | `str | None` | — |
-
-### `WorkflowEntry` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `name` | `str` | — |
-| `description` | `str` | — |
-| `stages` | `int` | — |
-| `tier_map` | `dict[str, str]` | — |
-
-### `PathArgSpec` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `kwarg` | `str` | — |
-| `required` | `bool` | `False` |
-
-### `Feature` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `name` | `str` | — |
-| `description` | `str` | — |
-| `path` | `str | None` | — |
-| `tags` | `tuple[str, ...]` | `()` |
-
-### `Session` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `id` | `str` | — |
-| `started_at` | `str` | — |
-| `last_activity` | `str` | — |
-| `duration_seconds` | `float` | — |
-| `message_count` | `int` | — |
-| `starter_prompt` | `str` | — |
-| `source` | `str` | `'heuristic'` |
-
-### `FamilyVersion` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `package` | `str` | — |
-| `version` | `str | None` | — |
-| `source` | `str` | — |
-
-### `DailyCost` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `day` | `str` | — |
-| `events` | `int` | — |
-| `cost` | `float` | — |
-
-### `HomeKpis` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `today_events` | `int` | — |
-| `today_cost` | `float` | — |
-| `seven_day_cost` | `float` | — |
-| `seven_day_savings` | `float` | — |
-| `sparkline` | `list[DailyCost]` | — |
-
-### `TrustedHostMiddleware` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__` | `app: object, *, allowed_hosts: Iterable[str]` | `None` | Construct the middleware with an explicit host allowlist. |
-| `dispatch` | `request: Request, call_next: Callable[[Request], Awaitable[Response]]` | `Response` | Enforce the allowlist; pass through or reject each request. |
+| Class | Description | File |
+|-------|-------------|------|
+| `Candidate` | One completion-candidate spec returned by the detector. | `src/attune/ops/completion_candidates.py` |
+| `Config` | Where attune ops reads project + attune state from. | `src/attune/ops/config.py` |
+| `TelemetrySummary` | — | `src/attune/ops/data.py` |
+| `WorkflowEntry` | — | `src/attune/ops/data.py` |
+| `PathArgSpec` | How a workflow accepts a scope path on the CLI. | `src/attune/ops/data.py` |
+| `Feature` | One feature from ``.help/features.yaml`` for the scope picker. | `src/attune/ops/data.py` |
+| `Session` | One Claude Code session — what surfaces on the dashboard's /sessions page. | `src/attune/ops/data.py` |
+| `FamilyVersion` | — | `src/attune/ops/data.py` |
+| `DailyCost` | One day's cost for the home-page sparkline. | `src/attune/ops/data.py` |
+| `HomeKpis` | Summary numbers shown above the fold on the home page. | `src/attune/ops/data.py` |
+| `SweepChipCounts` | Per-bucket counts loaded from a persisted discovery-sweep result. | `src/attune/ops/data.py` |
+| `DismissEntry` | One dismissed candidate's persisted state. | `src/attune/ops/dismiss_store.py` |
+| `TrustedHostMiddleware` | Reject requests whose ``Host`` header isn't on the allowlist. | `src/attune/ops/middleware.py` |
+| `SpecPhase` | One phase file's status snapshot. | `src/attune/ops/routes/specs.py` |
+| `SpecRecord` | One spec's summary — directory + status of each phase file present. | `src/attune/ops/routes/specs.py` |
+| `RunnerBusyError` | Raised when a run is already pending/running. | `src/attune/ops/runner.py` |
+| `Run` | Single workflow execution + its broadcast state. | `src/attune/ops/runner.py` |
+| `RunnerService` | Owns the run history + concurrency lock. | `src/attune/ops/runner.py` |
+| `RedactionResult` | Outcome of a redaction pass. | `src/attune/ops/session_redaction.py` |
+| `SummaryResult` | One Haiku-or-cache result, ready to slot into a :class:`Session`. | `src/attune/ops/session_summarizer.py` |
+| `Budget` | Mutable spend ledger for one page-load summarization loop. | `src/attune/ops/session_summarizer.py` |
+| `CacheKey` | Stable key that invalidates a cached summary when the source moves. | `src/attune/ops/session_summary_cache.py` |
+| `CachedSummary` | One persisted session summary plus the metadata to validate it. | `src/attune/ops/session_summary_cache.py` |
 
 ## Functions
 
-### Configuration
+| Function | Description | File |
+|----------|-------------|------|
+| `create_app()` | Lazy-import the FastAPI factory so importing attune doesn't pull FastAPI. | `src/attune/ops/__init__.py` |
+| `build_config()` | Lazy import of the config builder. | `src/attune/ops/__init__.py` |
+| `add_subparser()` | Register the `ops` subparser on the main attune CLI parser. | `src/attune/ops/cli.py` |
+| `cmd_ops()` | Run the dashboard server (blocking). | `src/attune/ops/cli.py` |
+| `main()` | Standalone entry: ``python -m attune.ops``. | `src/attune/ops/cli.py` |
+| `clear_cache()` | Reset the in-memory caches. Test helper. | `src/attune/ops/completion_candidates.py` |
+| `detect_candidates()` | Return all completion candidates across the configured spec roots. | `src/attune/ops/completion_candidates.py` |
+| `attune_home()` | Resolve the user's attune home dir (env override -> ~/.attune). | `src/attune/ops/config.py` |
+| `build_config()` | Build a Config from inputs and environment defaults. | `src/attune/ops/config.py` |
+| `list_features()` | Return features parsed from ``<project_root>/.help/features.yaml``. | `src/attune/ops/data.py` |
+| `first_feature()` | Return the alphabetically-first feature with a renderable scope. | `src/attune/ops/data.py` |
+| `workflow_default_scope()` | Return the default scope for one workflow on first paint. | `src/attune/ops/data.py` |
+| `derive_project_name()` | Return a human-readable project name for the dashboard header. | `src/attune/ops/data.py` |
+| `claude_sessions_dir()` | Return the canonical directory Claude Code stores sessions for this project in. | `src/attune/ops/data.py` |
+| `enumerate_project_encoded_keys()` | Return all ``~/.claude/projects/`` dirs belonging to this logical project. | `src/attune/ops/data.py` |
+| `list_recent_sessions_with_paths()` | Same as :func:`list_recent_sessions` but also returns each | `src/attune/ops/data.py` |
+| `list_recent_sessions()` | Return Session records for this project's last ``days`` of activity. | `src/attune/ops/data.py` |
+| `home_kpis()` | Derive home-page KPIs from a telemetry summary. | `src/attune/ops/data.py` |
+| `sparkline_points()` | Render values as an SVG ``polyline`` ``points`` string. | `src/attune/ops/data.py` |
+| `read_telemetry_summary()` | Aggregate ``usage.jsonl`` into a UI-friendly summary. | `src/attune/ops/data.py` |
+| `read_sweep_chip_counts()` | Read the latest persisted sweep result for ``scope_path`` and tally chips. | `src/attune/ops/data.py` |
+| `list_workflows()` | Return the registered workflow catalog. Empty if the registry is unavailable. | `src/attune/ops/data.py` |
+| `family_versions()` | Resolve installed versions for every related attune package. | `src/attune/ops/data.py` |
+| `env_health()` | Lightweight environment snapshot for the Health page. | `src/attune/ops/data.py` |
+| `store_path()` | Return the absolute path to the dismiss-store JSON file. | `src/attune/ops/dismiss_store.py` |
+| `load()` | Read the dismiss store. Missing or corrupt file → ``{}``. | `src/attune/ops/dismiss_store.py` |
+| `save()` | Persist a dismiss entry for ``slug`` (overwrites prior entry). | `src/attune/ops/dismiss_store.py` |
+| `clear()` | Remove the entry for ``slug``. No-op if absent. | `src/attune/ops/dismiss_store.py` |
+| `is_active()` | True iff a dismiss for ``slug`` is currently suppressing it. | `src/attune/ops/dismiss_store.py` |
+| `compute_allowlist()` | Compute the default + user-supplied Host allowlist. | `src/attune/ops/middleware.py` |
+| `settings_path()` | Return the absolute path to the ops settings file. | `src/attune/ops/ops_config_store.py` |
+| `load_settings()` | Read persisted ops settings. Missing or corrupt file → ``{}``. | `src/attune/ops/ops_config_store.py` |
+| `save_setting()` | Persist a single setting; returns True on success, False on failure. | `src/attune/ops/ops_config_store.py` |
+| `resolve_specs_candidates_enabled()` | Resolve the ``specs_candidates_enabled`` setting. | `src/attune/ops/ops_config_store.py` |
+| `home()` | — | `src/attune/ops/routes/dashboard.py` |
+| `workflows_page()` | — | `src/attune/ops/routes/dashboard.py` |
+| `telemetry_page()` | — | `src/attune/ops/routes/dashboard.py` |
+| `health_page()` | — | `src/attune/ops/routes/dashboard.py` |
+| `sessions_page()` | Sessions page — recent Claude Code sessions for this project. | `src/attune/ops/routes/dashboard.py` |
+| `run_view_page()` | Full-page view for one workflow run. | `src/attune/ops/routes/dashboard.py` |
+| `specs_page()` | Specs tab — federated listing of all specs across configured roots. | `src/attune/ops/routes/dashboard.py` |
+| `spec_detail_page()` | Drill-in for a single spec: show every phase file's content (read-only). | `src/attune/ops/routes/dashboard.py` |
+| `start_run()` | — | `src/attune/ops/routes/runner.py` |
+| `get_run()` | — | `src/attune/ops/routes/runner.py` |
+| `stream_run()` | — | `src/attune/ops/routes/runner.py` |
+| `list_runs()` | Return up to 20 newest runs for ``workflow``, newest first. | `src/attune/ops/routes/runs_history.py` |
+| `get_run_record()` | Return one persisted run record (metadata + log). | `src/attune/ops/routes/runs_history.py` |
+| `enrich_with_summaries()` | Public helper used by both the JSON route and the HTML page. | `src/attune/ops/routes/sessions.py` |
+| `list_sessions()` | ``GET /api/sessions`` — JSON listing of recent sessions. | `src/attune/ops/routes/sessions.py` |
+| `list_specs()` | Federated listing across all configured spec roots. | `src/attune/ops/routes/specs.py` |
+| `list_completion_candidates()` | Return "Ready to close?" candidates for the Specs page. | `src/attune/ops/routes/specs.py` |
+| `get_spec()` | Return phase-file contents for one spec. | `src/attune/ops/routes/specs.py` |
+| `update_phase_status()` | Rewrite the ``**Status**`` line in the named phase file. | `src/attune/ops/routes/specs.py` |
+| `dismiss_completion_candidate()` | Suppress a completion candidate for the default TTL (14 days). | `src/attune/ops/routes/specs.py` |
+| `get_sweep_result()` | Return the latest sweep result for a scope-hash, or 404. | `src/attune/ops/routes/sweep_results.py` |
+| `get_sweep_chips()` | Return chip counts for an arbitrary scope path. | `src/attune/ops/routes/sweep_results.py` |
+| `sweep_detail_page()` | Scope-keyed detail page for the latest discovery-sweep result. | `src/attune/ops/routes/sweep_results.py` |
+| `echo_command_builder()` | Test helper: produce a portable subprocess that prints two lines + exits 0. | `src/attune/ops/runner.py` |
+| `prune_old_runs()` | Delete persisted run files older than ``days``. Returns the deletion count. | `src/attune/ops/runner.py` |
+| `create_app()` | Build the FastAPI app, wiring config + templates into request state. | `src/attune/ops/server.py` |
+| `redact()` | Run all redaction passes over ``text`` and return the result. | `src/attune/ops/session_redaction.py` |
+| `redact_json_line()` | Redact one JSON-serialized line in-place, preserving structure. | `src/attune/ops/session_redaction.py` |
+| `new_budget()` | Build a :class:`Budget` from the env override or default. | `src/attune/ops/session_summarizer.py` |
+| `llm_enabled()` | Return True iff the Haiku path is enabled this run. | `src/attune/ops/session_summarizer.py` |
+| `summarize_session()` | Return a Haiku-or-cached summary for one session JSONL. | `src/attune/ops/session_summarizer.py` |
+| `compute_cache_key()` | Build a :class:`CacheKey` for one JSONL file. ``None`` on I/O failure. | `src/attune/ops/session_summary_cache.py` |
+| `cache_path_for()` | Return the on-disk cache path for one session id. | `src/attune/ops/session_summary_cache.py` |
+| `load()` | Return the cached summary iff the on-disk record matches ``expected``. | `src/attune/ops/session_summary_cache.py` |
+| `save()` | Write a summary to the on-disk cache, atomically. | `src/attune/ops/session_summary_cache.py` |
+| `is_persistence_enabled()` | True when ``ATTUNE_OPS_SWEEP_RESULTS`` is set to a non-empty value. | `src/attune/ops/sweep_results.py` |
+| `results_dir()` | Return ``<attune_home>/ops/sweep-results/`` (created if missing). | `src/attune/ops/sweep_results.py` |
+| `scope_hash()` | Hash a scope path to a fixed-length hex identifier. | `src/attune/ops/sweep_results.py` |
+| `parse_lines()` | Parse a captured stdout buffer into the final SweepResult JSON. | `src/attune/ops/sweep_results.py` |
+| `persist_result()` | Atomically write ``sweep_result`` to ``<results_dir>/<hash>.json``. | `src/attune/ops/sweep_results.py` |
+| `read_result()` | Read a previously-persisted result by its scope-hash digest. | `src/attune/ops/sweep_results.py` |
+| `persist_from_lines()` | Parse captured stdout lines and persist the result for ``scope_path``. | `src/attune/ops/sweep_results.py` |
+| `watch_and_persist()` | Subscribe to a discovery-sweep run; persist its result on success. | `src/attune/ops/sweep_results_watcher.py` |
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `attune_home` | — | `Path` | Resolve the user's attune home dir (env override → `~/.attune`). |
-| `build_config` | `project_root: Path \| None = None, *, host: str = '127.0.0.1', port: int = 8765, allow_run: bool = False, specs_roots: tuple[Path, ...] \| None = None, trusted_hosts: tuple[str, ...] \| None = None, runs_retention_days: int = 30` | `Config` | Build a `Config` from inputs and environment defaults. |
 
-### CLI and entry points
+## Source files
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `add_subparser` | `subparsers: argparse._SubParsersAction` | `None` | Register the `ops` subparser on the main attune CLI parser. |
-| `cmd_ops` | `args: argparse.Namespace` | `int` | Run the dashboard server (blocking). Returns `0` on clean exit. |
-| `main` | — | `int` | Standalone entry point: `python -m attune.ops`. |
+- `src/attune/ops/**`
 
-### App factory
+## Tags
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `create_app` | `config: Config, *, runner: RunnerService \| None = None` | `FastAPI` | Build the FastAPI app, wiring config + templates into request state. |
-
-### Feature and workflow data
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `list_features` | `project_root: Path \| str` | `list[Feature]` | Return features parsed from `<project_root>/.help/features.yaml`. |
-| `first_feature` | `project_root: Path \| str` | `Feature \| None` | Return the alphabetically-first feature with a renderable scope. |
-| `workflow_default_scope` | `workflow_name: str, project_root: Path \| str` | `str` | Return the default scope for one workflow on first paint. Returns `''` when no default applies. |
-| `list_workflows` | — | `list[WorkflowEntry]` | Return the registered workflow catalog. Empty if the registry is unavailable. |
-| `derive_project_name` | `project_root: Path \| str` | `str` | Return a human-readable project name for the dashboard header. |
-
-### Session data
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `claude_sessions_dir` | `project_root: Path \| str` | `Path` | Return the canonical directory Claude Code stores sessions for this project in. |
-| `enumerate_project_encoded_keys` | `project_root: Path \| str` | `list[Path]` | Return all `~/.claude/projects/` dirs belonging to this logical project. |
-| `list_recent_sessions` | `project_root: Path \| str, *, days: int = 3, limit: int \| None = DEFAULT_SESSION_LIST_CAP, now: datetime \| None = None, parser: Callable[[Path], Session \| None] \| None = None` | `list[Session]` | Return `Session` records for this project's last `days` of activity. |
-| `list_recent_sessions_with_paths` | `project_root: Path \| str, *, days: int = 3, limit: int \| None = DEFAULT_SESSION_LIST_CAP, now: datetime \| None = None, parser: Callable[[Path], Session \| None] \| None = None` | `list[tuple[Session, Path]]` | Same as `list_recent_sessions` but also returns each session's source path. |
-
-### Telemetry and KPIs
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `read_telemetry_summary` | `config: Config, *, recent_days: int = 7` | `TelemetrySummary` | Aggregate `usage.jsonl` into a UI-friendly summary. |
-| `home_kpis` | `summary: TelemetrySummary, *, today: date \| None = None` | `HomeKpis` | Derive home-page KPIs from a telemetry summary. |
-| `sparkline_points` | `values: list[float], *, width: int = 240, height: int = 40` | `str` | Render values as an SVG `polyline` `points` string. |
-| `family_versions` | — | `list[FamilyVersion]` | Resolve installed versions for every related attune package. |
-| `env_health` | `config: Config` | `dict[str, Any]` | Lightweight environment snapshot for the Health page. |
-
-### Middleware
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `compute_allowlist` | `host: str, port: int, extras: Iterable[str] = ()` | `set[str]` | Compute the default + user-supplied Host allowlist. |
-
-### Dashboard routes
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `home` | `request: Request` | `HTMLResponse` | Render the dashboard home page. |
-| `workflows_page` | `request: Request` | `HTMLResponse` | Render the workflows listing page. |
-| `telemetry_page` | `request: Request` | `HTMLResponse` | Render the telemetry page. |
-| `health_page` | `request: Request` | `HTMLResponse` | Render the health page. |
-| `sessions_page` | `request: Request` | `HTMLResponse` | Sessions page — recent Claude Code sessions for this project. |
-| `run_view_page` | `run_id: str, request: Request` | `HTMLResponse` | Full-page view for one workflow run. |
-| `specs_page` | `request: Request` | `HTMLResponse` | Specs tab — federated listing of all specs across configured roots. |
-| `spec_detail_page` | `slug: str, request: Request` | `HTMLResponse` | Drill-in for a single spec: show every phase file's content (read-only). |
-
-### Runner routes
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `start_run` | `name: str, request: Request` | `JSONResponse` | Start a named workflow run. |
-| `get_run` | `run_id: str, request: Request` | `JSONResponse` | Return current state for one run. |
-| `stream_run` | `run_id: str, request: Request` | `StreamingResponse` | Stream live SSE log output for one run. |
-
-### Run history routes
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `list_runs` | `workflow: str, request: Request` | `JSONResponse` | Return up to 20 newest runs for `workflow`, newest first. |
-| `get_run_record` | `workflow: str, run_id: str, request: Request` | `JSONResponse` | Return one persisted run record (metadata + log). |
-
-### Sessions route helpers
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `enrich_with_summaries` | `project_root, attune_home, *, days: int = 3, limit: int \| None = data.DEFAULT_SESSION_LIST_CAP, budget: session_summarizer.Budget \| None = None` | `tuple[list[data.Session], bool]` | Attach Haiku-or-cached summaries to a batch of sessions; used by both the JSON route and the HTML page. |
-| `list_sessions` | `request: Request` | `dict[str, Any]` | `GET /api/sessions` — JSON listing of recent sessions. |
-
-### Spec routes
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `list_specs` | `request: Request` | `dict` | Federated listing across all configured spec roots. |
-| `get_spec` | `slug: str, request: Request` | `dict` | Return phase-file contents for one spec. |
-| `update_phase_status` | `slug: str, phase: str, request: Request, body: dict[str, Any] = Body(...)` | `dict[str, Any]` | Rewrite the `**Status**` line in the named phase file. |
-
-### Sweep results
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `get_sweep_result` | `scope_hash: str, request: Request` | `JSONResponse` | Return the latest sweep result for a scope-hash, or 404. |
-| `is_persistence_enabled` | — | `bool` | True when `ATTUNE_OPS_SWEEP_RESULTS` is set to a non-empty value. |
-| `results_dir` | `config: Config` | `Path` | Return `<attune_home>/ops/sweep-results/` (created if missing). |
-| `scope_hash` | `scope_path: str` | `str` | Hash a scope path to a fixed-length hex identifier. |
-| `parse_lines` | `lines: list[str]` | `dict[str, Any] \| None` | Parse a captured stdout buffer into the final SweepResult JSON. |
-| `persist_result` | `scope_path: str, sweep_result: dict[str, Any], config: Config` | `Path` | Atomically write `sweep_result` to `<results_dir>/<hash>.json`. |
-| `read_result` | `digest: str, config: Config` | `dict[str, Any] \| None` | Read a previously-persisted result by its scope-hash digest. |
-| `persist_from_lines` | `scope_path: str, lines: list[str], config: Config` | `Path \| None` | Parse captured stdout lines and persist the result for `scope_path`. |
-| `watch_and_persist` | `run: Run, config: Config` | `None` | Subscribe to a discovery-sweep run; persist its result on success. |
-
-### Runner utilities
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `echo_command_builder` | `workflow: str` | `Sequence[str]` | Test helper: produce a portable subprocess that prints two lines and exits 0. |
-| `prune_old_runs` |
+`ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,71 +1,57 @@
 ---
-type: task
-name: ops-dashboard-task
 feature: ops-dashboard
 depth: task
-generated_at: 2026-05-16T06:19:45.791431+00:00
-source_hash: 882177b61c372bb6753c706430edfcc0df951fa4fae4106cb76ff02fca34a836
+generated_at: 2026-05-17T18:28:27.054846+00:00
+source_hash: 848a51e7aabcd39ac987255bff940539153d7b544651bdec566acd763432d775
 status: generated
 ---
 
-# Work with the ops dashboard
+# Work with ops dashboard
 
-Use the ops dashboard when you need to start, configure, or extend the local operations dashboard — a workflow runner with a per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
+Use ops dashboard when you need to local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live sse log streaming.
 
 ## Prerequisites
 
-- Read access to `src/attune/ops/`
-- The `attune` CLI installed and on your `PATH`
+- Access to the project source code
+- Familiarity with the files under src/attune/ops/**
 
 ## Steps
 
-1. **Identify the entry point that owns the behavior you want to change.**
+1. **Understand the current behavior.**
+   Read the entry points to see what ops dashboard
+   does today before making changes.
+   The primary functions are:
+   - `create_app()` in `src/attune/ops/__init__.py` — Lazy-import the FastAPI factory so importing attune doesn't pull FastAPI.
+   - `build_config()` in `src/attune/ops/__init__.py` — Lazy import of the config builder.
+   - `add_subparser()` in `src/attune/ops/cli.py` — Register the `ops` subparser on the main attune CLI parser.
+   - `cmd_ops()` in `src/attune/ops/cli.py` — Run the dashboard server (blocking).
+   - `main()` in `src/attune/ops/cli.py` — Standalone entry: ``python -m attune.ops``.
+2. **Locate the right function to change.**
+   Each function has a single responsibility. Read its
+   docstring, parameters, and return type to confirm it
+   owns the behavior you need to modify.
 
-   The dashboard is split across three modules. Match your goal to the responsible function:
+3. **Make your change.**
+   Follow existing patterns in the file — naming
+   conventions, error handling style, and logging.
 
-   | Goal | Function | File |
-   |---|---|---|
-   | Change how the FastAPI app is constructed | `create_app()` | `src/attune/ops/__init__.py` |
-   | Change host, port, or retention defaults | `build_config()` | `src/attune/ops/config.py` |
-   | Add or rename a CLI flag | `add_subparser()` | `src/attune/ops/cli.py` |
-   | Change server startup behavior | `cmd_ops()` | `src/attune/ops/cli.py` |
-   | Change the standalone module entry point | `main()` | `src/attune/ops/cli.py` |
-   | Change how the attune home directory is resolved | `attune_home()` | `src/attune/ops/config.py` |
-   | Change how features are loaded for the scope picker | `list_features()` | `src/attune/ops/data.py` |
+4. **Run the related tests.**
+   This catches regressions before they reach other
+   developers. Target with `pytest -k "ops-dashboard"`.
 
-2. **Read the function's docstring, parameters, and return type** before editing. Confirm the function owns the behavior end-to-end — some behavior spans `build_config()` in both `__init__.py` (a lazy re-export) and `config.py` (the real implementation).
+## Key files
 
-3. **Edit the target function.** Keep changes consistent with the module's naming conventions, error-handling style, and logging patterns. For example:
-   - `build_config()` resolves paths against `project_root` and `attune_home`; pass `Path` objects, not raw strings.
-   - `TrustedHostMiddleware` reads `trusted_hosts` from `Config`; update `Config.trusted_hosts` if you need to change the allowlist.
-   - `list_features()` reads `<project_root>/.help/features.yaml`; changes to feature loading belong there, not in the app factory.
+- `src/attune/ops/**`
 
-4. **Start the dashboard and verify your change.**
+## Common modifications
 
-   Run the server locally:
+Functions you are most likely to modify:
 
-   ```bash
-   attune ops
-   ```
-
-   Or run it as a standalone module:
-
-   ```bash
-   python -m attune.ops
-   ```
-
-   The server binds to `127.0.0.1:8765` by default. Open `http://127.0.0.1:8765` in a browser and confirm the dashboard loads and your change behaves as expected.
-
-5. **Run the test suite** to catch regressions before they reach other developers:
-
-   ```bash
-   pytest -k "ops"
-   ```
-
-## Verify success
-
-The task is complete when:
-
-- `attune ops` starts without errors and the terminal shows the server address.
-- The dashboard home page loads in your browser and displays the KPI summary (today's events, cost, and the 7-day sparkline).
-- `pytest -k "ops"` passes with no new failures.
+- `create_app()` in `src/attune/ops/__init__.py`
+- `build_config()` in `src/attune/ops/__init__.py`
+- `add_subparser()` in `src/attune/ops/cli.py`
+- `cmd_ops()` in `src/attune/ops/cli.py`
+- `main()` in `src/attune/ops/cli.py`
+- `clear_cache()` in `src/attune/ops/completion_candidates.py`
+- `detect_candidates()` in `src/attune/ops/completion_candidates.py`
+- `attune_home()` in `src/attune/ops/config.py`

--- a/.help/templates/plugin/concept.md
+++ b/.help/templates/plugin/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: concept
-generated_at: 2026-05-14T00:09:29.490567+00:00
-source_hash: dad4ff4d931be93483178512f305df4124786c91adacb4cc3420e7e53450f49d
+generated_at: 2026-05-17T18:27:08.904228+00:00
+source_hash: 7c317f125965385a2a8e8ed6605ef6bd454625bc8fded43149d47d64438b73b0
 status: generated
 ---
 

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: reference
-generated_at: 2026-05-14T00:09:29.502628+00:00
-source_hash: dad4ff4d931be93483178512f305df4124786c91adacb4cc3420e7e53450f49d
+generated_at: 2026-05-17T18:27:08.915959+00:00
+source_hash: 7c317f125965385a2a8e8ed6605ef6bd454625bc8fded43149d47d64438b73b0
 status: generated
 ---
 

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: task
-generated_at: 2026-05-14T00:09:29.497930+00:00
-source_hash: dad4ff4d931be93483178512f305df4124786c91adacb4cc3420e7e53450f49d
+generated_at: 2026-05-17T18:27:08.911339+00:00
+source_hash: 7c317f125965385a2a8e8ed6605ef6bd454625bc8fded43149d47d64438b73b0
 status: generated
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,34 @@ All notable changes to Attune AI (formerly Empathy Framework) will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.0.0] — 2026-05-16
+
+### Removed — BREAKING
+
+Two long-deprecated modules whose tests were retired in the
+ignored-tests cleanup (2026-05-09), leaving them with zero coverage
+and zero internal callers. See
+`docs/specs/deprecated-module-retirement/` for the full retirement
+spec and rationale.
+
+- **`attune.workflows.orchestrated_release_prep`** (entire module).
+  Deprecated since v5.2.0; scheduled for removal in v6.0; six minor
+  versions overdue.
+  *Migration*: use `ReleasePrepTeamWorkflow` from
+  `attune.agents.release` (drop-in replacement: same constructor,
+  same `execute()` signature, same `ReleaseReadinessReport` return
+  type). The CLI path `attune workflow run release-prep` already
+  invokes the new workflow.
+  Symbols removed from `attune.workflows.__all__`:
+  `OrchestratedReleasePrepWorkflow`, `ReleaseReadinessReport`.
+  (`ReleaseReadinessReport` remains exported from
+  `attune.agents.release`.)
+- **`attune.scaffolding`** (entire CLI package). Deprecated since
+  2026-02-21 (commit 3833d5d6, PR #60); `__main__.py` has emitted
+  a runtime deprecation notice on every invocation.
+  *Migration*: use `attune workflow run <workflow-name>` instead of
+  `python -m attune.scaffolding create ...`. There is no Python-API
+  replacement; the scaffolding surface was always a CLI.
 
 ### Added
 
@@ -982,35 +1009,6 @@ job with reduced `--cov=` scope if branch signal is needed.
 - 15 auto-triggering Claude Code skills
 - 16 multi-agent workflows
 - 41 MCP tools
-
-## [7.0.0] - planned (couples with the 100%-coverage milestone release)
-
-### Removed — BREAKING
-
-Two long-deprecated modules whose tests were retired in the
-ignored-tests cleanup (2026-05-09), leaving them with zero coverage
-and zero internal callers. See
-`docs/specs/deprecated-module-retirement/` for the full retirement
-spec and rationale.
-
-- **`attune.workflows.orchestrated_release_prep`** (entire module).
-  Deprecated since v5.2.0; scheduled for removal in v6.0; six minor
-  versions overdue.
-  *Migration*: use `ReleasePrepTeamWorkflow` from
-  `attune.agents.release` (drop-in replacement: same constructor,
-  same `execute()` signature, same `ReleaseReadinessReport` return
-  type). The CLI path `attune workflow run release-prep` already
-  invokes the new workflow.
-  Symbols removed from `attune.workflows.__all__`:
-  `OrchestratedReleasePrepWorkflow`, `ReleaseReadinessReport`.
-  (`ReleaseReadinessReport` remains exported from
-  `attune.agents.release`.)
-- **`attune.scaffolding`** (entire CLI package). Deprecated since
-  2026-02-21 (commit 3833d5d6, PR #60); `__main__.py` has emitted
-  a runtime deprecation notice on every invocation.
-  *Migration*: use `attune workflow run <workflow-name>` instead of
-  `python -m attune.scaffolding create ...`. There is no Python-API
-  replacement; the scaffolding surface was always a CLI.
 
 ## [6.6.0] - 2026-05-09
 
@@ -4440,7 +4438,7 @@ This release combines **Phase 2 optimizations** (Redis caching, memory efficienc
   - 4 smart_router tests - pre-existing failures
   - Does not affect production functionality
 
-## [Unreleased - Previous]
+## [Historical pre-release notes]
 
 ### Added
 
@@ -5763,7 +5761,7 @@ print(result.generate_report())
 - Resolved 2 Ruff issues (F841, B007)
 - Added workflow execution timeout
 
-## [Unreleased]
+## [Historical pre-release notes — docs sprint]
 
 ### Added
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 6.8.0
+**Version:** 7.0.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 6.8.0 | **License:** Apache 2.0
+**Version:** 7.0.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/docs/specs/agent-surface-rebalance/decisions.md
+++ b/docs/specs/agent-surface-rebalance/decisions.md
@@ -1,6 +1,5 @@
 # Decisions
-
-**Status**: phase 0 complete + skills survey complete; **spec retired**
+**Status:** in-review
 **Decided**: 2026-05-12
 
 ---

--- a/docs/specs/bulletin-curator/requirements.md
+++ b/docs/specs/bulletin-curator/requirements.md
@@ -1,0 +1,258 @@
+# Spec: Bulletin Curator
+
+> An Opus-tier agent that reads the bulletin + adjacent
+> surfaces, ranks what needs attention, produces an executive
+> summary, and dispatches focused follow-ups via
+> `AskUserQuestion`. Fires on-demand when Patrick opens the
+> bulletin — not continuously.
+
+**Status:** draft
+**Created:** 2026-05-17
+**Owner:** TBD
+**Related:**
+- [`multi-actor-bulletin`](../multi-actor-bulletin/requirements.md) — provides the bulletin data surface this agent reads
+- [`pipeline-learner`](../pipeline-learner/requirements.md) — sibling consumer of the bulletin's archived history
+- [`project_bulletin_and_pipeline_learner.md`](~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/project_bulletin_and_pipeline_learner.md) — high-level synthesis
+
+---
+
+## Problem statement
+
+Today the dashboard's surfaces are **passive**: `/sessions`,
+`/specs`, `/workflows`, completion-candidates, discovery-sweep
+findings, telemetry. Each shows what's there. None of them
+**rank** items, **synthesize across them**, or **pull Patrick
+into a focused decision**. The result is that important things
+sit in plain sight without surfacing — the user has to know to
+go looking.
+
+What's missing is a **briefing layer** that distills the
+underlying state into "here are the top N things that need your
+attention right now, here's why each ranks where it does, and
+here's the one question that would unblock the next step."
+
+The bulletin board (separate spec) provides one piece of data
+the curator needs: who-is-running-what across actors. The
+curator is the agent that synthesizes *across* the bulletin and
+the other surfaces to produce ranked, actionable output.
+
+---
+
+## Goals
+
+1. **On-demand executive summary** — when Patrick opens the
+   bulletin (or hits a `/curator` route, or invokes
+   `attune curator`), an Opus-tier agent reads the available
+   sources and returns a fresh 2–3 paragraph summary of what's
+   notable.
+2. **Ranked attention list** — the same call returns a
+   prioritized list of N items with a short rationale per item
+   (severity, age, blocking-something-else, etc.).
+3. **Focused follow-ups** — for items that need a decision
+   (approve / dismiss / dig deeper), the curator emits an
+   `AskUserQuestion`-shaped payload that the dashboard renders
+   as an actionable card. Patrick's choice routes back into the
+   right next workflow or status update.
+4. **No hallucinated facts** — every claim in the summary
+   traces to a specific source row (run id, spec slug, finding
+   id) that's clickable in the rendered output.
+
+## Non-goals
+
+- **Replacing the underlying surfaces.** `/sessions`, `/specs`,
+  etc. stay. The curator distills; it doesn't displace.
+- **Always-on agent.** No continuous polling, no background
+  daemon. Fire on-demand, cache for ~5 minutes, refresh on
+  next open.
+- **Writing status fields.** The curator can suggest
+  transitions (e.g. "this spec looks ready to mark complete")
+  but never writes to the status field directly. Patrick's
+  authority is preserved per the existing
+  completion-candidates discipline.
+- **Cross-host / multi-tenant.** Same-host, single-user v1.
+- **A separate "agent personality"** beyond a clear system
+  prompt. The curator is a Claude Opus invocation with a
+  curation role, not a new persona to maintain.
+
+---
+
+## Design
+
+### Sources read
+
+| Source | What | Read via |
+|---|---|---|
+| Bulletin (now-running) | Active runs across actors | `attune.bulletin.read_active()` |
+| Bulletin (archive) | Recent terminal-status entries | `attune.bulletin.read_archive(since=...)` |
+| `/specs` data | Open / draft / approved / complete specs + completion-candidates | `attune.ops.data.list_specs()` |
+| Discovery-sweep findings | Queue / questions / rejected buckets | `attune.workflows.discovery_sweep.read_buckets()` |
+| Telemetry | Recent cost spikes, error spikes, p95 anomalies | `attune.telemetry` summary functions |
+| ATTUNE_REC | Pending recommendation cards on recent runs | `attune.ops.recommendations.pending()` |
+| `git status` + recent commits | Uncommitted work, branch state | `subprocess.run(["git", ...])` |
+
+### Curator agent invocation
+
+```python
+# Pseudocode — actual interface TBD
+from attune.curator import run_curator
+
+result = await run_curator(
+    project_root=Path("."),
+    max_items=5,
+    cache_ttl_seconds=300,
+)
+# result.summary: str (2-3 paragraphs)
+# result.items: list[CuratorItem]
+# result.questions: list[AskUserQuestionPayload]
+# result.sources_consulted: list[str]
+# result.cost_usd: float
+```
+
+The invocation:
+
+1. Reads all sources in parallel (most are local file/IO; fast).
+2. Builds a compact context block per source (bullet summaries,
+   not raw dumps — controls token spend).
+3. Invokes `claude_agent_sdk.query()` with an Opus model and a
+   curator system prompt.
+4. Forces structured output via `output_format` (the same
+   `WORKFLOW_OUTPUT_SCHEMA` pattern used by code-review /
+   security-audit, adapted for curator items).
+5. Caches the result for 5 minutes keyed on the source-state
+   hash so refresh-spam doesn't re-spend budget.
+
+### Curator item shape
+
+```json
+{
+  "id": "spec-X-completion-candidate",
+  "title": "deprecated-module-retirement looks ready to mark complete",
+  "severity": "info | nudge | warn | block",
+  "rationale": "all 3 tasks marked done; PR #209 merged; no open issues citing this slug; edit-age 6 days",
+  "sources": ["docs/specs/deprecated-module-retirement/tasks.md", "PR #209"],
+  "suggested_action": {
+    "kind": "ask | open | run | dismiss",
+    "payload": "..."
+  }
+}
+```
+
+`suggested_action.kind`:
+
+- `ask` — emit an `AskUserQuestion` payload (e.g. *"Mark this
+  spec complete? \[Yes / Not yet / Dismiss for 14 days\]"*)
+- `open` — link to the deep-dive surface (`/specs/<slug>`,
+  `/runs/<id>/view`, etc.)
+- `run` — propose a workflow run with pre-filled scope
+- `dismiss` — suppress this item for N days
+
+### Dashboard surface
+
+New `/curator` route. Renders the executive summary at the top,
+ranked items as cards below, and surfaces any
+`AskUserQuestion`-shaped payloads as inline actionable forms.
+A "Refresh" button forces a re-curate, bypassing the 5-min
+cache. The bulletin's "Now running across actors" strip
+(from the multi-actor-bulletin spec) gets a "View briefing"
+link that jumps to `/curator`.
+
+CLI equivalent: `attune curator` prints the summary +
+top items + any questions to stdout. Useful for terminal-first
+workflows where Patrick isn't in the browser.
+
+### Tier + cost model
+
+- Model: Opus (current generation — currently `claude-opus-4-7`).
+  Synthesis quality matters; this is the highest-leverage
+  invocation in the dashboard, not a hot path.
+- Cost cap per call: $0.50 (well above expected; controls
+  catastrophic prompt-bloat).
+- Cache TTL: 5 min, keyed on source-state hash. A no-change
+  refresh is free.
+- Expected per-call cost: $0.05–$0.15 based on similar
+  Opus synthesis tasks. Patrick's daily curator usage at this
+  cost = trivial.
+
+---
+
+## Acceptance criteria
+
+1. **Honest synthesis** — fabricate a fixture state with 3
+   known items (a stale spec, a queued sweep finding, a failed
+   run with ATTUNE_REC). Run the curator. The returned items
+   include all three with correct titles and rationales drawn
+   from the source data, no invented entries.
+2. **Actionable follow-ups** — at least one item in the
+   fixture surfaces an `AskUserQuestion` payload that the
+   dashboard renders correctly as a clickable card.
+3. **Source clickability** — every claim in the summary
+   resolves to at least one source row that produces a
+   valid clickable link in the rendered output.
+4. **Cache works** — two refreshes within 5 min without
+   source-state change hit the cache (cost: $0). Source-state
+   change invalidates.
+5. **CLI equivalence** — `attune curator` produces the same
+   summary + items + questions as the web `/curator`.
+6. **Honest empty state** — when no items rank above the
+   noise threshold, the curator says so cleanly ("nothing
+   pressing right now") rather than padding with low-value
+   filler.
+
+---
+
+## Tasks (phased)
+
+### Phase 1 — Source readers + cache scaffolding (~3h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 1 | `attune.curator.sources` module — one reader per source listed above | 1.5h |
+| 2 | Source-state hash for cache invalidation | 30m |
+| 3 | Mock fixtures for each source (used by tests) | 1h |
+
+### Phase 2 — Agent invocation + structured output (~3h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 4 | Curator system prompt + output schema | 1h |
+| 5 | `attune.curator.run_curator()` async entry point | 1h |
+| 6 | Cost cap + cache-key plumbing | 30m |
+| 7 | Unit tests against fixtures (deterministic — mock the SDK) | 30m |
+
+### Phase 3 — Dashboard `/curator` + CLI (~3h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 8 | `/curator` route + template (summary + cards + AskUserQuestion forms) | 1.5h |
+| 9 | CLI `attune curator` subcommand | 1h |
+| 10 | Bulletin → curator cross-link | 30m |
+
+### Phase 4 — Live verification (~1h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 11 | Run against real attune-ai state, eyeball output, iterate prompt | 1h |
+
+**Total estimated:** 10h. Phases 1+2 deliver the headless API;
+Phase 3 makes it visible. Each phase is independently shippable.
+
+---
+
+## Open questions
+
+1. **Source weighting.** Should each source carry an explicit
+   weight in the ranker prompt, or trust the LLM to balance
+   them? Lean: no explicit weights in v1; document the prompt's
+   ranking heuristics in the system prompt and iterate based on
+   what Patrick consistently down-votes.
+2. **Down-vote mechanism.** When Patrick dismisses an item with
+   *"this isn't actually important"*, where does that signal
+   live? Per-item suppression for N days is simple. Learning
+   what *kinds* of items he down-votes is the v2 idea (probably
+   a small classifier or a preference file the curator reads as
+   another source).
+3. **Curator-of-the-curator.** Patrick has multiple projects.
+   Does each project get its own curator output, or is there a
+   meta-curator across projects? Lean: per-project for v1; the
+   bulletin board's actor-id already gives us
+   "project = working directory" as a natural boundary.

--- a/docs/specs/coverage-exclusion-policy/design.md
+++ b/docs/specs/coverage-exclusion-policy/design.md
@@ -1,7 +1,5 @@
 # Design: Coverage Exclusion Policy
-
-**Status**: complete (2026-05-12)
-
+**Status:** complete (2026-05-12)
 ---
 
 ## Phase 2: Design

--- a/docs/specs/coverage-exclusion-policy/requirements.md
+++ b/docs/specs/coverage-exclusion-policy/requirements.md
@@ -1,6 +1,5 @@
 # Spec: Coverage Exclusion Policy
-
-**Status**: complete (2026-05-12)
+**Status:** complete (2026-05-12)
 **Created**: 2026-05-10
 **Origin**: Surfaced during reflection on the 100%-coverage workstream
 (see COVERAGE_BUG_LOG.md). Reframed the goal from "every module at

--- a/docs/specs/coverage-exclusion-policy/tasks.md
+++ b/docs/specs/coverage-exclusion-policy/tasks.md
@@ -1,7 +1,5 @@
 # Tasks: Coverage Exclusion Policy
-
-**Status**: complete (2026-05-12)
-
+**Status:** complete (2026-05-12)
 ---
 
 ## Phase 3: Tasks

--- a/docs/specs/multi-actor-bulletin/decisions.md
+++ b/docs/specs/multi-actor-bulletin/decisions.md
@@ -1,0 +1,105 @@
+# Decisions: Multi-Actor Bulletin Board
+
+**Status:** approved
+
+
+Resolutions on open questions, captured as Patrick reviewed the
+[`requirements.md`](requirements.md) draft.
+
+---
+
+## 2026-05-17 — Open questions resolved
+
+### Heartbeat cadence — 30s beat / 90s GC, **emitted by the wrapper process**
+
+**Decision:** keep 30s heartbeat / 90s GC. **Decouple heartbeat
+emission from workflow progress.** The actor's wrapper process
+(dashboard `RunnerService`, CLI dispatcher, MCP handler, etc.)
+runs an independent `asyncio` task that ticks every 30s
+regardless of what the workflow is doing internally.
+
+**Why:** Patrick's only concern on the cadence was truncation of
+healthy long-running work — some SDK calls can block >60s
+inside `claude_agent_sdk.query()` without progress signals
+reaching the wrapper. Decoupling solves that: as long as the
+wrapper process is alive, heartbeats fire. A GC'd entry then
+truly indicates a dead wrapper (crash, machine sleep, terminal
+closed), not slow work.
+
+**How to apply:**
+
+- Heartbeat task lives in the wrapper, started before the
+  workflow's `execute()` call and cancelled on terminal status.
+- Wrapper failures (uncaught exceptions, OS-level kills) stop
+  the task naturally — `asyncio.CancelledError` or process exit.
+- Workflow loop itself does not emit heartbeats. Workflows
+  don't need to know the bulletin exists.
+
+### Actor ID stability — best-judgment scheme per actor kind
+
+**Decision:** Patrick deferred. Going with:
+
+| Actor kind | Actor ID format |
+|---|---|
+| Claude Code session | `cc-session-${CLAUDE_CODE_SESSION_ID}` |
+| Dashboard process | `dashboard-${hostname}-${port}-${start_iso_date}` |
+| Raw CLI (one-shot) | `cli-${hostname}-${pid}-${start_iso_date}` |
+| ATTUNE_REC auto-trigger | inherits parent actor ID + `triggered_by_run_id` field |
+| Scheduled task | `scheduled-${task_id}` |
+
+**Why:** the design constraint is "stable enough to be useful
+on a single host within a single working day, with no extra
+state to track." Hostname + PID + date for CLIs gives that
+without a persistent ID file. Claude Code sessions get a
+genuinely stable ID for free. Scheduled tasks already have a
+durable identifier.
+
+**How to apply:** centralize the derivation in
+`attune.bulletin.actor.derive_actor_id(kind)` so we have one
+place to change if the scheme proves wrong.
+
+### Privacy / multi-user — file permissions for v1
+
+**Decision:** rely on `0700` directory perms on
+`~/.attune/bulletin/` and `0600` on individual files. No
+per-workflow or per-scope opt-out tag in v1.
+
+**Why:** Patrick: *"for now I'm inclined to rely on file
+permissions but am open to pushback."* I don't have pushback —
+file perms match how the rest of `~/.attune/` already works
+(telemetry, memory, ops runs), and the bulletin is per-user
+either way. The privacy concern only escalates if the bulletin
+ever becomes a shared store (Phase 3 Redis Streams with
+cross-host access). Revisit then.
+
+**How to apply:**
+
+- On first write to `~/.attune/bulletin/`, set directory to
+  `0700` and individual files to `0600`. Match the pattern
+  already used in `attune.memory` modules.
+- Phase 3 Redis backend will need its own privacy story
+  (auth, ACLs, namespacing per user); flag at that phase.
+
+### Rule authoring — YAML for v1
+
+**Decision:** rules live in `~/.attune/bulletin/rules.yaml`,
+loaded at runtime. No Python rules in v1.
+
+**Why:** Patrick agreed. YAML is the right authoring surface
+for v1 — declarative, easy to share, harder to weaponize than
+Python. If users hit the YAML ceiling we'll know via specific
+unmet asks, and a Python escape hatch can be added incrementally.
+
+**How to apply:**
+
+- `attune.bulletin.rules.load(path)` returns a list of `Rule`
+  objects parsed from YAML.
+- Each rule has `id`, `block_if` (a small DSL expression), and
+  `message` (a template with `{other_actor}`, `{other_workflow}`,
+  etc. substitutions).
+- The DSL surface is intentionally minimal — a fixed set of
+  predicates (`any_actor_running_on_parent_or_self`,
+  `count_running_expensive`, `account_budget_remaining_usd`)
+  rather than arbitrary expressions. Predicates compose with
+  `and`/`or`/`not`. Adding a new predicate is a Python change,
+  not a config change.

--- a/docs/specs/multi-actor-bulletin/requirements.md
+++ b/docs/specs/multi-actor-bulletin/requirements.md
@@ -1,0 +1,278 @@
+# Spec: Multi-Actor Bulletin Board
+
+> Shared, real-time view of which workflows are running and who
+> started them — so multiple Claude Code sessions can collaborate
+> as a team rather than colliding as solos.
+**Status:** approved
+**Created:** 2026-05-17
+**Owner:** TBD
+**Related:**
+- [`bulletin_and_pipeline_learner` memory](~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/project_bulletin_and_pipeline_learner.md) — high-level synthesis
+- Future spec: `bulletin-curator` (executive-summary agent — separate scope)
+- Future spec: `pipeline-learner` (mines bulletin history for canonicalization candidates)
+
+---
+
+## Problem statement
+
+The current runner is **single-actor aware**. `RunnerService._runs`
+holds the dashboard's in-flight runs in one Python process; CLI
+invocations, `ATTUNE_REC` auto-triggers, scheduled tasks, and
+other Claude Code sessions are invisible to each other. Three
+concrete consequences observed today (2026-05-17):
+
+1. **Cross-actor overlap can't be diagnosed.** A `bug-predict`
+   run on `demo_eval_vuln.py` overlapped with my queue's
+   `health-check`. The overlap *looked* like a busy-lock race
+   for ~30 minutes of investigation. Forensic on the persisted
+   JSON revealed it was a different actor (likely the
+   ATTUNE_REC code-review→bug-predict flow), not a race. A
+   bulletin would have shown the second actor immediately.
+
+2. **No sequencing rules can be enforced.** "Don't run two
+   large-scope workflows simultaneously" or "refuse new starts
+   when the account API budget is below threshold" both require
+   observability the runner doesn't have.
+
+3. **Multi-session collaboration is solo work in parallel.**
+   Patrick reports juggling multiple Claude Code sessions as a
+   normal pattern and wants it to feel like teamwork — but
+   each session is blind to the others. The shape today is
+   "ensemble of solos", not a coordinated team.
+
+The earlier whiteboard concepts (bulletin board + pipeline
+learner) presupposed this coordination substrate. This spec
+delivers it.
+
+---
+
+## Goals
+
+1. Every actor (dashboard, CLI, ATTUNE_REC trigger, scheduled
+   task, other Claude Code session) writes its in-flight run
+   state to a shared store every other actor can read.
+2. The dashboard renders a "Now running" panel showing all
+   in-flight runs across actors, with `actor_id`, workflow,
+   scope, started_at, and current status.
+3. A small **sequencing rules** module reads the bulletin and
+   can block a new start with a clear reason (e.g. *"another
+   actor is already running security-audit on a parent of this
+   scope"*).
+4. Pluggable backend: file-based by default, Redis-Streams as
+   an opt-in upgrade via `attune-redis`.
+
+## Non-goals (out of scope for this spec)
+
+- **Curator agent / executive summary.** Lives in a separate
+  `bulletin-curator` spec. This spec gives the curator a data
+  surface to read from.
+- **Pipeline-learner mining workflow.** Reads the bulletin's
+  history; defined separately.
+- **AMS / semantic-search backed bulletin.** v3 idea; not v1
+  or v2.
+- **Cross-host coordination.** Same-host multi-actor is the
+  v1/v2 scope. Distributed teams across machines is a future
+  problem (and the Redis-Streams backend naturally extends
+  there).
+- **Replacement of `RunnerService._runs`.** That stays as the
+  dashboard's in-memory cache. The bulletin is additive — every
+  actor writes its events; the dashboard's view layer reads from
+  the bulletin alongside its own cache.
+
+---
+
+## Design
+
+### Data model
+
+A bulletin entry is the minimum needed to answer "who is doing
+what right now":
+
+```json
+{
+  "actor_id": "claude-code-session-<uuid>",
+  "actor_kind": "claude-code-session | cli | dashboard | scheduled | attune-rec",
+  "workflow": "code-review",
+  "scope": "src/attune/ops/",
+  "run_id": "5e506b3386ab",
+  "started_at": "2026-05-17T15:08:07.129158+00:00",
+  "current_status": "running | completed | failed | cancelled",
+  "last_heartbeat": "2026-05-17T15:09:42.000000+00:00",
+  "hostname": "patrick-mbp"
+}
+```
+
+Each actor writes a **start record** on workflow start, a
+**heartbeat** every 30s while running, and a **finish record**
+on terminal status. Stale entries (no heartbeat for > 90s) are
+GC'd by readers; readers don't trust the writer to clean up
+after a crash.
+
+### Backends
+
+```
+                           +-------------------+
+                           |  BulletinProtocol |
+                           +-------------------+
+                                    ^
+                  -------------------+-------------------
+                  |                                     |
+       +------------------------+         +-------------------------+
+       |  FileBulletinBackend   |         |  RedisStreamBulletin    |
+       |  ~/.attune/bulletin/   |         |  XADD attune:bulletin   |
+       |    active.jsonl        |         |  XREAD consumer groups  |
+       |    archive/YYYY-MM-DD/ |         |  via attune-redis       |
+       +------------------------+         +-------------------------+
+                v1 default                   v2, opt-in via extra
+```
+
+**v1 (file):** `~/.attune/bulletin/active.jsonl` — append-only.
+Readers tail + dedupe by `run_id` + drop stale heartbeats.
+Daily rotation into `archive/YYYY-MM-DD/` keeps the hot file
+small. Concurrent write safety via fcntl advisory lock around
+each append. Zero new dependencies.
+
+**v2 (Redis Streams):** uses the existing `attune-redis` plugin
++ `agent-memory-client` machinery. Stream name `attune:bulletin`.
+Consumer groups: `dashboard`, `cli`, `curator`. Cross-host
+ready as a natural side effect. Opt-in via
+`pip install 'attune-ai[bulletin-redis]'` (new extra) or by
+having `attune-redis` already installed.
+
+**v3 (AMS-backed history, future):** archive entries flow into
+Redis Agent Memory Server for the pipeline-learner's
+"find runs similar to this one" query.
+
+### Sequencing rules
+
+A small policy module (`attune.bulletin.rules`) loads a rule
+set from `~/.attune/bulletin/rules.yaml` and provides
+`can_start(workflow, scope) -> (bool, reason)`:
+
+```yaml
+# Example rules
+rules:
+  - id: no-parent-scope-overlap
+    block_if: any_actor_running_on_parent_or_self(scope)
+    message: "{other_actor} is already running {other_workflow} on {parent_scope}"
+
+  - id: global-large-scope-throttle
+    block_if: >
+      workflow.is_expensive and
+      count_running_expensive() >= 1
+    message: "another expensive workflow is in flight; queue and try again in a minute"
+
+  - id: api-budget-floor
+    block_if: account_budget_remaining_usd() < 1.00
+    message: "Anthropic API budget below $1.00 floor; raise the cap or wait"
+```
+
+Rules are advisory (the dashboard and CLI consult before
+starting), not enforced at the SDK boundary. A future spec
+could make them hard.
+
+### Wiring per actor
+
+| Actor | Start writes | Heartbeat | Finish writes |
+|---|---|---|---|
+| **Dashboard `RunnerService.start`** | ✓ | from existing SSE tick | ✓ |
+| **CLI `attune workflow run`** | ✓ | from workflow loop | ✓ |
+| **ATTUNE_REC auto-trigger** | ✓ (inherited via dashboard) | inherited | inherited |
+| **Scheduled task** | ✓ | from task wrapper | ✓ |
+| **Other Claude Code session via MCP `code_review` etc.** | ✓ (new) | from MCP handler | ✓ (new) |
+
+The MCP-handler wiring is the only one that's genuinely new
+code-path work. The others are 5–10 lines of "write your record
+where you already log to disk".
+
+### Dashboard surface
+
+The Workflows tab gains a "Now running across actors" strip
+above the workflow table when the bulletin shows any non-self
+in-flight runs. Each entry is a chip with `actor_id` (short
+form), workflow, scope, and a tooltip showing started_at and
+last_heartbeat. Stale entries (heartbeat older than 90s but
+not yet GC'd) render as muted with a "stale" marker.
+
+The existing recent-runs strip per workflow stays unchanged.
+
+---
+
+## Acceptance criteria
+
+1. **Cross-actor visibility:** start a workflow from a CLI in
+   one terminal, open the dashboard in another browser. The
+   dashboard shows the CLI's run in the "Now running" strip
+   within 5 seconds.
+2. **Sequencing rule fires:** with the example rule
+   `no-parent-scope-overlap` enabled, start `security-audit`
+   on `src/attune/` from actor A. From actor B, attempt
+   `code-review` on `src/attune/security/`. Actor B receives
+   a clean rejection with the rule's message.
+3. **Stale GC:** kill actor A's process during a run.
+   90 seconds later, the bulletin no longer shows that run.
+   No other actor needed to clean it up — readers GC.
+4. **Backend swap is invisible:** flipping the config from
+   `file` to `redis-stream` requires no code changes in
+   workflows or the dashboard.
+5. **Reasonable failure modes:** if `~/.attune/bulletin/` is
+   unwritable, the workflow still runs (bulletin is advisory,
+   not gating). Logged at WARN.
+6. **No regression:** existing single-actor flows behave
+   identically. The bulletin is a new surface; it doesn't
+   replace `RunnerService._runs`.
+
+---
+
+## Tasks (phased)
+
+### Phase 1 — File backend, dashboard visibility (~6h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 1 | `BulletinProtocol` + `FileBulletinBackend` (append, read, GC) | 2h |
+| 2 | Actor-ID derivation (Claude Code session env, CLI auto-id, dashboard host) | 30m |
+| 3 | Wire write-on-start/heartbeat/finish into `RunnerService` and CLI dispatcher | 1h |
+| 4 | "Now running across actors" strip in Workflows tab template + SSE refresh | 1h |
+| 5 | Unit tests + integration test with two concurrent writers | 1.5h |
+
+### Phase 2 — Sequencing rules (~3h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 6 | `attune.bulletin.rules` module + YAML loader | 1h |
+| 7 | `can_start()` consultation in `RunnerService.start` and CLI | 30m |
+| 8 | Three default rules (parent-scope-overlap, expensive-throttle, api-budget-floor) | 1h |
+| 9 | Rule tests | 30m |
+
+### Phase 3 — Redis Streams backend (~4h, opt-in)
+
+| # | Task | Effort |
+|---|------|--------|
+| 10 | `RedisStreamBulletinBackend` using `agent-memory-client` or direct redis-py | 2h |
+| 11 | Backend selection via config (`~/.attune/bulletin/config.yaml`) | 30m |
+| 12 | Cross-host test scenario (two machines) | 1h |
+| 13 | Docs / migration guide for opt-in | 30m |
+
+### Phase 4 — MCP handler wiring (~2h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 14 | Wrap each MCP workflow tool to write bulletin entries | 1.5h |
+| 15 | Integration test: two Claude Code sessions see each other's MCP-triggered work | 30m |
+
+**Total estimated:** 15h. v1 ships in Phase 1+2 (~9h); Phases 3
+and 4 are independent follow-ups.
+
+---
+
+## Open questions
+
+All four initial open questions resolved 2026-05-17 — see
+[`decisions.md`](decisions.md). The load-bearing resolution is
+the heartbeat: emitted by the wrapper process (not the workflow
+loop), which eliminates the truncation risk and lets 90s GC stay
+conservative without killing healthy long-running work.
+
+Remaining unknowns surface during implementation, captured in
+`decisions.md` as they're resolved.

--- a/docs/specs/pipeline-learner/requirements.md
+++ b/docs/specs/pipeline-learner/requirements.md
@@ -1,0 +1,283 @@
+# Spec: Pipeline Learner
+
+> A mining workflow that reads workflow run history + bulletin
+> archive, identifies common multi-step sequences, and offers
+> to canonicalize them as declarative pipelines. The bottom-up
+> path to pipeline authoring — songs that emerge from what
+> we've actually played.
+
+**Status:** draft
+**Created:** 2026-05-17
+**Owner:** TBD
+**Related:**
+- [`multi-actor-bulletin`](../multi-actor-bulletin/requirements.md) — provides the archived run history this workflow mines
+- [`bulletin-curator`](../bulletin-curator/requirements.md) — sibling consumer; the curator surfaces this learner's output to Patrick
+- [`project_bulletin_and_pipeline_learner.md`](~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/project_bulletin_and_pipeline_learner.md) — high-level synthesis
+
+---
+
+## Problem statement
+
+The current state of pipeline authoring in attune-ai:
+**top-down only.** Songs (`release-prep`, `secure-release`,
+`doc-orchestrator`) are hardcoded as Python workflow classes.
+There's no way for anyone — Patrick, downstream users, or me —
+to look at the working patterns that actually emerge in real
+use and canonicalize them as named, declarative pipelines.
+
+The persisted run history in `~/.attune/ops/runs/<wf>/*.json`
+contains thousands of runs going back months. Patterns are in
+there — *"after security-audit on $path, code-review on the
+same path runs within 30 min, 80% of the time"* — but nothing
+mines them. They stay implicit in Patrick's working memory,
+which means:
+
+1. **They're not transferable.** New users (downstream) can't
+   benefit from working patterns Patrick has discovered.
+2. **They're not version-controlled.** A great working pattern
+   today can be forgotten next quarter.
+3. **They can't be automated.** Without a canonical name,
+   nothing can invoke "the security-then-review pattern" as a
+   first-class thing.
+
+This spec defines the workflow that mines the history and
+proposes canonicalization candidates. Acceptance — turning a
+candidate into a real pipeline file — stays with Patrick (the
+detector never writes; the writer never decides).
+
+---
+
+## Goals
+
+1. **Mine run history** for common multi-step sequences with
+   minimum-support thresholds.
+2. **Rank candidates** by signal strength (frequency,
+   consistency, recency, time-window tightness).
+3. **Surface candidates** through the bulletin-curator's
+   ranked-attention list as *"Save this as a named pipeline?"*
+   items.
+4. **Generate scaffolding** when accepted — write a candidate
+   YAML pipeline file to `docs/specs/pipelines/<slug>.yaml`
+   that Patrick can edit and commit.
+5. **Stay opt-in.** No silent canonicalization. The learner
+   proposes; Patrick disposes.
+
+## Non-goals
+
+- **Executing pipelines.** That's a separate concern handled by
+  whatever pipeline runner lands later (the
+  hybrid-with-decision-nodes design from the chord→song
+  whiteboard discussion).
+- **Reading semantic meaning** of workflow purposes. The miner
+  works on observable patterns (workflow name, scope, timing),
+  not on what the workflows do.
+- **Predicting the next workflow** in real-time. That's the
+  ATTUNE_REC channel's job. The learner mines *retrospectively*
+  for patterns worth promoting.
+- **Auto-applying canonical pipelines** as ATTUNE_REC
+  suggestions. Possible v2; not v1.
+- **Cross-host / multi-project mining.** Same-host, same-project
+  in v1. Cross-project mining is a follow-up that depends on
+  the Phase 3 Redis Streams bulletin backend (cross-host data
+  source).
+
+---
+
+## Design
+
+### Input: the corpus
+
+Two source pools, merged:
+
+1. `~/.attune/ops/runs/<wf>/*.json` — every persisted dashboard
+   run since the dashboard started recording. Already has
+   `workflow`, `scope`, `started_at`, `completed_at`, `status`,
+   `actor` (after the bulletin spec lands).
+2. `~/.attune/bulletin/archive/YYYY-MM-DD/*.jsonl` — daily
+   rotated bulletin entries. Same shape; covers CLI / MCP /
+   scheduled actors the dashboard doesn't see.
+
+Both pools merge into a flat list of "actor X ran workflow Y on
+scope Z, starting at T, completing at T+D, status S".
+
+### Mining algorithm
+
+A simple **temporal-sequence frequent-pattern mining** pass.
+For each pair `(A, B)` of distinct workflows, count how often:
+
+- Workflow A completed successfully on scope `P_A`
+- Workflow B then ran on a scope `P_B` where `P_B ⊆ P_A` or
+  `P_A ⊆ P_B`
+- Both within the same actor's timeline (or same project, in v2)
+- Within a configurable time window (default: 30 min)
+
+Yields pair-frequency counts. Filter by minimum support (e.g.
+`count ≥ 5 AND ratio_when_A_runs ≥ 0.5`). Extend to triples /
+n-grams in a second pass; pair-mining is the v1 deliverable.
+
+The thing being mined is **operator behavior** — when Patrick
+manually runs A then B, that's signal. When ATTUNE_REC
+auto-runs B from A, that's *different* signal (it's already a
+canonicalized edge in the source code); the miner should
+**weight manual sequences higher** because those represent
+genuine emergent patterns, not encoded suggestions.
+
+### Candidate output shape
+
+For each above-threshold pair (or n-gram), emit:
+
+```json
+{
+  "candidate_id": "security-audit_then_code-review",
+  "sequence": [
+    {"workflow": "security-audit", "scope_relation": "self_or_parent"},
+    {"workflow": "code-review", "scope_relation": "from_predecessor"}
+  ],
+  "support": {
+    "occurrences": 14,
+    "first_seen": "2026-04-03",
+    "last_seen": "2026-05-16",
+    "ratio_when_first_step_runs": 0.78,
+    "manual_vs_attune_rec": "12 manual / 2 attune-rec",
+    "actors_observed": ["cc-session-abc", "dashboard-localhost-..."]
+  },
+  "confidence_score": 0.82,
+  "suggested_pipeline_yaml": "docs/specs/pipelines/security-audit_then_code-review.yaml",
+  "rationale": "Manual sequence emerged 12 times across 6 weeks; same-or-narrower scope on follow-up; 78% follow-rate."
+}
+```
+
+The `confidence_score` is a weighted blend of frequency,
+ratio, recency, and manual-fraction. Tuned later; sensible v1
+defaults baked in.
+
+### YAML pipeline scaffolding
+
+When Patrick accepts a candidate (via the curator's
+`AskUserQuestion` card), the learner writes a starter pipeline
+YAML to `docs/specs/pipelines/<slug>.yaml`:
+
+```yaml
+# Auto-generated 2026-05-17 by pipeline-learner.
+# Supporting evidence in docs/specs/pipelines/<slug>.evidence.json
+# Edit freely. Original support metrics preserved in the evidence file.
+
+name: security-audit_then_code-review
+summary: "Run security-audit then code-review on the same scope."
+pipeline:
+  - workflow: security-audit
+    scope: ${input.scope}
+  - workflow: code-review
+    scope: ${prev.scope}
+```
+
+Plus a sibling `.evidence.json` with the full support metrics
+so the pipeline's provenance is auditable. Patrick edits the
+YAML to taste, commits it, and the pipeline becomes a
+first-class song.
+
+### Invocation model
+
+`pipeline-learner` is itself a workflow registered in the
+existing workflow registry. Runs on-demand (`attune workflow
+run pipeline-learner`) or on a schedule (weekly cron). Outputs
+its candidates to:
+
+1. `~/.attune/pipeline-learner/candidates.jsonl` — durable
+   output the curator reads as one of its sources.
+2. The dashboard's `/specs` or a new `/pipelines/candidates`
+   surface.
+
+Mining is CPU-bound, not LLM-backed in v1 (deterministic
+algorithm; no agent calls needed). v2 might add an LLM pass to
+generate human-readable pipeline names and summaries, but the
+core mining is pure algorithm.
+
+---
+
+## Acceptance criteria
+
+1. **Surfaces a known pattern.** Seed the corpus with 10
+   fixture runs that contain the security-audit →
+   code-review pattern 7 times. Run the learner. The candidate
+   appears with `occurrences: 7` and a sensible confidence
+   score.
+2. **Filters noise.** Same fixture also contains 2 isolated
+   workflow runs that aren't part of any pattern. They do not
+   appear as candidates.
+3. **Manual vs auto weighting.** Add 3 ATTUNE_REC-triggered
+   security-audit → bug-predict pairs. The candidate scores
+   them with `manual_vs_attune_rec: "0 manual / 3 attune-rec"`
+   and confidence is lower than an equivalent-count manual
+   pattern.
+4. **Scaffolding lands.** Acceptance via the curator's
+   AskUserQuestion writes a non-empty
+   `docs/specs/pipelines/<slug>.yaml` + sibling evidence file.
+5. **Idempotent re-runs.** Running the learner twice in a row
+   without new corpus data produces identical candidates.
+6. **No silent writes.** The learner never writes to
+   `docs/specs/pipelines/` without an explicit acceptance
+   signal.
+
+---
+
+## Tasks (phased)
+
+### Phase 1 — Corpus reader + mining algorithm (~4h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 1 | `attune.pipeline_learner.corpus` — merge dashboard runs + bulletin archive | 1h |
+| 2 | Pair-mining algorithm with scope-relation logic | 2h |
+| 3 | Confidence scoring (frequency / ratio / recency / manual-weight) | 1h |
+
+### Phase 2 — Workflow registration + outputs (~2h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 4 | `PipelineLearnerWorkflow` class registered in `_DEFAULT_WORKFLOW_NAMES` | 30m |
+| 5 | Persist candidates to `~/.attune/pipeline-learner/candidates.jsonl` | 30m |
+| 6 | Wire into the four registry drift-guard gates (per CLAUDE.md lesson) | 30m |
+| 7 | Unit tests against fixture corpora | 30m |
+
+### Phase 3 — Curator integration + scaffolding (~2h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 8 | Curator reads candidates as one of its sources | 30m |
+| 9 | `AskUserQuestion` acceptance handler writes the YAML + evidence file | 1h |
+| 10 | End-to-end test: fixture corpus → mine → curator → accept → YAML lands | 30m |
+
+### Phase 4 — Triples / n-grams (~2h, deferrable)
+
+| # | Task | Effort |
+|---|------|--------|
+| 11 | Extend mining to 3-step sequences with cohesion threshold | 1.5h |
+| 12 | Tests | 30m |
+
+**Total estimated:** 8h for v1 (Phases 1–3); +2h for triples.
+
+---
+
+## Open questions
+
+1. **Scope-relation logic.** Subset-relations are easy on
+   absolute paths (`src/attune/security/` ⊂ `src/attune/`). But
+   the bulletin allows custom scope strings, and discovery-sweep
+   uses scope hashes. Lean: treat unrecognized scope strings
+   as "scope: opaque" and only mine pairs where the scope
+   relationship is determinable. Document the limitation.
+2. **What counts as the same "operator behavior"?** Within a
+   Claude Code session, sequential runs are clearly the same
+   operator. Across sessions, less clear. Lean: same actor_id
+   AND same project for v1. The bulletin-curator can later
+   merge cross-session candidates if signals agree.
+3. **Threshold tuning.** Defaults: 5 occurrences, 0.5 ratio.
+   These are guesses; iterate based on what surfaces. The
+   confidence score deliberately separates the inputs so we
+   can re-weight without rerunning the miner.
+4. **Negative evidence.** When Patrick dismisses a candidate
+   ("not a real pattern"), the learner should suppress it
+   from future surfacings. Per-candidate suppression for N
+   days is simple; lean that for v1. Learning to *predict*
+   which candidates will be dismissed is a v2 problem.

--- a/docs/specs/sdk-error-message-fidelity/requirements.md
+++ b/docs/specs/sdk-error-message-fidelity/requirements.md
@@ -1,0 +1,209 @@
+# Spec: SDK Error Message Fidelity
+
+> When `claude_agent_sdk.query()` fails, surface the real cause
+> from the `claude` CLI's stderr instead of a generic
+> "Command failed with exit code 1" wrapped in a list of plausible-
+> but-wrong remediation suggestions.
+
+**Status:** draft
+**Created:** 2026-05-17
+**Owner:** TBD
+**Related:** [`workflow-failure-exit-propagation`](../workflow-failure-exit-propagation/) (sibling — same surface, exit-code side)
+
+---
+
+## Problem statement
+
+When a workflow's `claude_agent_sdk.query()` call fails, three
+distinct layers of error masking collapse the real cause into an
+unhelpful message:
+
+1. **SDK layer:** `claude_agent_sdk._internal.query` catches the
+   subprocess failure and raises a bare
+   `Exception: Command failed with exit code 1 (exit code: 1)
+   Error output: Check stderr output for details`. The actual
+   stderr (which contains the real cause) is not attached to the
+   exception.
+
+2. **Workflow layer:** the workflow's catch wrapper calls a
+   shared `sdk_error_message()` helper that presents a fixed
+   menu of three plausible-but-often-wrong causes:
+   ```
+   - `ANTHROPIC_API_KEY` is unset, expired, or invalid
+   - The `claude` CLI isn't installed or isn't on PATH
+   - `claude-agent-sdk` version is incompatible
+   ```
+   None of these may be the actual cause.
+
+3. **CLI layer:** `attune workflow run` exits `0` and prints the
+   "What Went Wrong" voice-layer block as if the workflow
+   completed normally. *(Tracked separately by
+   [`workflow-failure-exit-propagation`](../workflow-failure-exit-propagation/);
+   this spec focuses on layers 1 and 2.)*
+
+### Concrete trigger (2026-05-17)
+
+The Anthropic account's API usage cap was hit during a workflow
+queue. Running `code-review` from the CLI:
+
+- Real error from `claude --json-schema ...` direct call:
+  ```
+  API Error: 400 ... "You have reached your specified API
+  usage limits. You will regain access on 2026-06-01 at
+  00:00 UTC."
+  ```
+- What the user saw in the workflow output:
+  ```
+  - ANTHROPIC_API_KEY is unset, expired, or invalid
+  - The `claude` CLI isn't installed or isn't on PATH
+  - claude-agent-sdk version is incompatible
+  ```
+
+The diagnostic cost without this fix: ~15 minutes of probing
+auth, PATH, and SDK version before someone thought to call
+`claude` directly. The fix should make the real cause visible
+in the first user-facing error.
+
+### Affected workflows
+
+Any workflow that calls `claude_agent_sdk.query()`. The structured-
+output workflows hit this most visibly because they exercise the
+`--json-schema` flag the SDK passes to `claude`:
+
+- `code_review` (`src/attune/workflows/code_review.py`)
+- `security_audit` (`src/attune/workflows/security_audit.py`)
+- All other SDK-backed workflows (`test_audit`, `doc_audit`,
+  `refactor_plan`, `perf_audit`, `bug_predict` SDK shells,
+  `dependency_check` SDK shells, `document_gen`,
+  `discovery_sweep`, plus the deep-review / secure-release
+  pipelines).
+
+---
+
+## Scope
+
+### In scope
+
+- Capture the `claude` subprocess stderr inside the SDK
+  invocation surface (where we own the call, not the SDK).
+- Surface the captured stderr in the workflow's error result,
+  visible in:
+  - The CLI's "What Went Wrong" voice-layer block
+  - The persisted run JSON (`~/.attune/ops/runs/<wf>/<id>.json`)
+  - The dashboard's `/runs/<id>/view` page
+- Add a small classification helper that recognizes a handful of
+  common error shapes and short-labels them in the chip / voice
+  output:
+  - API quota exceeded → "API quota reached (regains 2026-06-01)"
+    or similar
+  - Auth missing / 401 → "Anthropic auth invalid or missing"
+  - Rate limit (429) → "Rate-limited by Anthropic; retry shortly"
+  - Subprocess not found → "claude CLI not on PATH"
+  - Schema rejected → "Output schema not accepted by claude CLI"
+  - Unknown → fall through to "see stderr below" + full text
+
+### Out of scope
+
+- Changing the SDK itself. We layer on top, not fork.
+- Exit-code propagation — covered by
+  [`workflow-failure-exit-propagation`](../workflow-failure-exit-propagation/).
+- Retry / backoff logic on transient errors. Surface the cause;
+  let the user retry.
+- Predicting every possible error class. Five-ish known shapes
+  + "see stderr" fallback is sufficient.
+
+---
+
+## Approach (sketch — to be refined in `decisions.md`)
+
+The SDK's `subprocess_cli.py` builds the `claude` invocation and
+captures the subprocess via `anyio`. We don't own that file.
+**Two implementation paths**, both reasonable; pick during design:
+
+### Path A — Wrap the SDK call site
+
+In each workflow's `_run_agent_*` method (or in the shared
+`agent_sdk_adapter`), wrap the `async for message in
+claude_agent_sdk.query(...)` loop with a try/except that, on the
+generic `Exception: Command failed ...`:
+
+1. Re-runs the `claude` CLI with the same flags but in a
+   capture-stderr mode (`subprocess.run` with `capture_output=True`)
+   to extract the real error.
+2. Re-raises as a typed `SdkSubprocessError(message, stderr,
+   classified_kind)`.
+
+Pro: contained to our code, no SDK fork.
+Con: double-spend on the second invocation (could be expensive
+on rate-limited paths; cheap on quota-exhausted paths since the
+second call also fails fast).
+
+### Path B — Monkeypatch the SDK transport
+
+Patch `claude_agent_sdk._internal.transport.subprocess_cli` at
+import time to capture stderr and stash it on the raised
+exception. Workflow catch blocks read it from
+`exc.__cause__.stderr` (or similar attr).
+
+Pro: single subprocess call, real stderr available everywhere.
+Con: fragile across SDK upgrades, monkey-patch smell, harder to
+test.
+
+**Recommendation:** Path A. Cheaper to maintain. The double-call
+cost only fires on failure paths and the second call exits in
+sub-second.
+
+---
+
+## Acceptance criteria
+
+1. Reproduce today's symptom: cap the account API quota (or use
+   an invalid API key, or any other consistent failure). Run
+   `attune workflow run code-review --path <some.py>`. The
+   workflow output's "What Went Wrong" block names the **actual
+   cause** (API quota, invalid auth, etc.), not the three-cause
+   menu.
+2. The persisted run JSON contains a `sdk_stderr` field (or
+   equivalent) with the captured text.
+3. The dashboard's `/runs/<id>/view` page renders the captured
+   stderr in a collapsible block.
+4. Unit test: mock `claude_agent_sdk.query` to raise
+   `Exception("Command failed ...")` and ensure the wrapper
+   re-invokes capture-mode and surfaces the real error.
+5. Integration test: end-to-end with `ANTHROPIC_API_KEY=invalid`,
+   the workflow surfaces "Anthropic auth invalid or missing"
+   rather than the generic three-cause list.
+6. No regression on the happy path — workflows that succeed
+   still produce the existing structured output.
+
+---
+
+## Tasks (rough)
+
+| # | Task | Effort |
+|---|------|--------|
+| 1 | Add `SdkSubprocessError` exception + classifier helper in `agent_sdk_adapter.py` | 1h |
+| 2 | Replace `sdk_error_message()` in code-review + security-audit + four other SDK shells with the new classifier output | 1h |
+| 3 | Persist `sdk_stderr` in run JSON; thread through `RunnerService` | 30m |
+| 4 | Render captured stderr in `/runs/<id>/view` (collapsible) | 30m |
+| 5 | Unit tests for each classifier branch + happy-path regression | 1h |
+| 6 | Manual verification: 2-3 induced failure modes | 30m |
+
+**Estimated total:** 4–5 hours.
+
+---
+
+## Open questions
+
+1. Should the classifier be table-driven (regex map in a config
+   file) or hard-coded? Table-driven adds extensibility; hard-
+   coded is one less thing to maintain. Lean hard-coded for v1;
+   table-driven if the list grows past ~8 shapes.
+2. Should the captured stderr be redacted (per the
+   `session_redaction` module's rules) before persisting? It
+   could carry API keys in some configurations. Lean yes —
+   reuse the existing redactor.
+3. Does the chip-classifier defense-in-depth (PR #366) get
+   simplified once this lands? It currently scans log text for
+   `Traceback` / `What Went Wrong`; with structured stderr
+   capture, it could read the typed classification instead.

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "6.8.0"
+    "version": "7.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "6.8.0",
+      "version": "7.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "6.8.0",
+  "version": "7.0.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "6.8.0"
+__version__ = "7.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "6.8.0"
+version = "7.0.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -719,6 +719,27 @@ def list_recent_sessions(
 ALL_CODE_PATH = "src/"
 
 
+# Friendly chip labels for the Workflows tab. The Tier-map column on
+# ``workflows.html`` renders ``{stage}: {tier}`` chips; the raw stage
+# names (``agent-review``, ``sweep``) and lowercase tier identifiers
+# (``cheap``, ``capable``, ``premium``) read like internal jargon.
+# ``TIER_LABEL`` maps each tier to a human-readable descriptor;
+# ``TIER_TOOLTIP`` explains the descriptor plus the underlying model
+# class in a hover affordance per the dashboard's tooltip-positive
+# UX rule.
+TIER_LABEL: dict[str, str] = {
+    "cheap": "Light",
+    "capable": "Standard",
+    "premium": "Deep",
+}
+
+TIER_TOOLTIP: dict[str, str] = {
+    "cheap": "Light tier — fast, lowest cost. Uses Haiku.",
+    "capable": "Standard tier — balanced quality and cost. Uses Sonnet.",
+    "premium": "Deep tier — highest quality, slowest, most expensive. Uses Opus.",
+}
+
+
 @dataclass(frozen=True)
 class FamilyVersion:
     package: str

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -115,6 +115,8 @@ async def workflows_page(request: Request) -> HTMLResponse:
         supports_path=supports_path,
         default_scopes=default_scopes,
         all_code_path=data.ALL_CODE_PATH,
+        tier_label=data.TIER_LABEL,
+        tier_tooltip=data.TIER_TOOLTIP,
         sweep_chips=sweep_chips,
         # Absolute workspace root used by the scope picker to validate
         # localStorage-restored paths. A saved scope from a previous

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1005,6 +1005,9 @@ a.kpi:hover {
 .recent-run-chip.chip-muted {
   color: var(--fg-muted);
 }
+.recent-run-date {
+  font-variant-numeric: tabular-nums;
+}
 .recent-run-status {
   font-size: 10px;
   opacity: 0.7;

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -517,6 +517,41 @@
       });
   }
 
+  // Render an ISO 8601 timestamp as a compact relative label:
+  //   - same calendar day  -> "h:MM AM/PM" (12h)
+  //   - previous day       -> "Yesterday"
+  //   - within last 7 days -> "Sun" .. "Sat"
+  //   - older              -> "May 14"
+  // Returns "?" for missing/unparseable input. Falls back to UTC date
+  // pieces if Date methods throw (defensive; shouldn't happen in
+  // practice for well-formed ISO inputs from the server).
+  function formatRunDate(isoString) {
+    if (!isoString) return "?";
+    var d = new Date(isoString);
+    if (isNaN(d.getTime())) return "?";
+    var now = new Date();
+    var sameDay = d.toDateString() === now.toDateString();
+    if (sameDay) {
+      var h = d.getHours();
+      var ampm = h >= 12 ? "PM" : "AM";
+      var h12 = h % 12;
+      if (h12 === 0) h12 = 12;
+      var mm = String(d.getMinutes()).padStart(2, "0");
+      return h12 + ":" + mm + " " + ampm;
+    }
+    var yesterday = new Date(now);
+    yesterday.setDate(now.getDate() - 1);
+    if (d.toDateString() === yesterday.toDateString()) {
+      return "Yesterday";
+    }
+    var daysAgo = Math.floor((now.getTime() - d.getTime()) / 86400000);
+    if (daysAgo >= 0 && daysAgo < 7) {
+      return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][d.getDay()];
+    }
+    var months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    return months[d.getMonth()] + " " + d.getDate();
+  }
+
   function renderRecentRunsInto(container, runs) {
     while (container.firstChild) container.removeChild(container.firstChild);
     var label = document.createElement("span");
@@ -527,22 +562,28 @@
       var a = document.createElement("a");
       a.className = "recent-run-chip chip-" + statusClass(run.status);
       a.href = "/runs/" + encodeURIComponent(run.id) + "/view";
-      // Compact label: short id + scope marker. Status conveyed via
-      // chip color, not extra text — keeps the strip narrow.
-      var idTxt = document.createElement("code");
-      idTxt.textContent = String(run.id).slice(0, 8);
-      a.appendChild(idTxt);
-      if (run.path) {
-        // Fast CSS tooltip (matches the system used on Specs and
-        // the topbar — P2-1 rollout).
-        a.setAttribute("data-tooltip", "scope: " + run.path);
-        a.setAttribute("aria-label", "scope: " + run.path);
-      }
+      // Visible label: date · status. The short run-id used to live
+      // here but conveyed nothing actionable; it's preserved in the
+      // tooltip alongside the full ISO timestamp and scope path so
+      // power users can still see it on hover.
+      var dateTxt = document.createElement("span");
+      dateTxt.className = "recent-run-date";
+      dateTxt.textContent = formatRunDate(run.started_at);
+      a.appendChild(dateTxt);
       a.appendChild(document.createTextNode(" "));
       var statusTxt = document.createElement("span");
       statusTxt.className = "recent-run-status";
       statusTxt.textContent = String(run.status || "?");
       a.appendChild(statusTxt);
+      // Tooltip carries the previously-visible run id plus full
+      // timestamp + scope. Matches the dashboard's tooltip-positive
+      // UX rule — supplemental detail on hover, compact label always.
+      var tipParts = [];
+      if (run.started_at) tipParts.push(run.started_at);
+      tipParts.push("id " + String(run.id).slice(0, 8));
+      if (run.path) tipParts.push("scope: " + run.path);
+      a.setAttribute("data-tooltip", tipParts.join(" · "));
+      a.setAttribute("aria-label", tipParts.join(", "));
       container.appendChild(a);
     });
     container.hidden = false;

--- a/src/attune/ops/static/preview-recent-runs.html
+++ b/src/attune/ops/static/preview-recent-runs.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Preview · recent-runs chips</title>
+  <link rel="stylesheet" href="/static/css/main.css">
+  <style>
+    body { padding: 24px 32px; max-width: 980px; }
+    h1 { font-size: 18px; margin: 0 0 4px 0; }
+    .preview-sub { color: var(--fg-muted); margin: 0 0 24px 0; font-size: 13px; }
+    .preview-section { margin-bottom: 28px; }
+    .preview-section h2 {
+      font-size: 13px; text-transform: uppercase; letter-spacing: 0.04em;
+      color: var(--fg-muted); margin: 0 0 8px 0;
+    }
+    .preview-description {
+      font-size: 14px; line-height: 1.5; margin: 0 0 8px 0;
+    }
+    .preview-row {
+      display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+      padding: 8px 0; border-bottom: 1px dashed var(--border);
+    }
+    .preview-row:last-child { border-bottom: none; }
+    .preview-meta {
+      font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
+      min-width: 220px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Recent-runs chip preview</h1>
+  <p class="preview-sub">
+    Static preview of every state the chip strip can render —
+    builds the same DOM the dashboard does, with mock run data, so
+    you can eyeball date/status pairs without waiting for real runs
+    to accumulate. Hover any chip to see the tooltip carrying the
+    run id + full ISO timestamp + scope.
+  </p>
+
+  <div class="preview-section">
+    <h2>Description-column context (mock workflow row)</h2>
+    <p class="preview-description">
+      Generate documentation from source code — docstrings,
+      READMEs, API references.
+    </p>
+    <div class="recent-runs" id="preview-strip"></div>
+  </div>
+
+  <div class="preview-section">
+    <h2>One chip per (date, status) pair</h2>
+    <div id="preview-grid"></div>
+  </div>
+
+  <script src="/static/js/runner.js?v=preview"></script>
+  <script>
+    // Mock runs spanning every date bucket the formatter knows
+    // about (today / yesterday / weekday / older) crossed with
+    // every status color (completed / failed / running / pending /
+    // other).
+    var now = new Date();
+    function iso(daysAgo, hours, minutes) {
+      var d = new Date(now);
+      d.setDate(d.getDate() - daysAgo);
+      if (typeof hours === "number") d.setHours(hours, minutes || 0, 0, 0);
+      return d.toISOString();
+    }
+    var mockRuns = [
+      { id: "b39613fd6195", status: "completed", path: "src/attune/security/", started_at: iso(0, 14, 2) },
+      { id: "089f60fe6411", status: "failed",    path: "src/attune/workflows/code_review.py", started_at: iso(0, 11, 15) },
+      { id: "d6ae69ee4aff", status: "running",   path: "src/attune/ops/", started_at: iso(0, 9, 30) },
+      { id: "222810456f50", status: "completed", path: "src/attune/", started_at: iso(1, 16, 45) },
+      { id: "f8ed53713add", status: "completed", path: "src/attune/memory/", started_at: iso(3, 10, 20) }
+    ];
+
+    // Hook into the runner.js export surface to render with the
+    // real codepath (not a duplicate) — guarantees this preview
+    // shows exactly what the dashboard will render.
+    window.__attuneRunner.renderRecentRunsInto(
+      document.getElementById("preview-strip"),
+      mockRuns
+    );
+
+    // Second section: one chip per scenario in isolation so each
+    // (date, status) pair has its own row with a label.
+    var scenarios = [
+      { label: "today  2:02 PM   completed", run: { id: "aaa11111aaaa", status: "completed", path: "src/", started_at: iso(0, 14, 2) } },
+      { label: "today  9:30 AM   running",   run: { id: "bbb22222bbbb", status: "running",   path: "src/", started_at: iso(0, 9, 30) } },
+      { label: "today  11:15 AM  failed",    run: { id: "ccc33333cccc", status: "failed",    path: "src/", started_at: iso(0, 11, 15) } },
+      { label: "today  12:00 AM  pending",   run: { id: "ddd44444dddd", status: "pending",   path: "src/", started_at: iso(0, 0, 0) } },
+      { label: "today  12:00 PM  completed", run: { id: "eee55555eeee", status: "completed", path: "src/", started_at: iso(0, 12, 0) } },
+      { label: "Yesterday        failed",    run: { id: "fff66666ffff", status: "failed",    path: "src/", started_at: iso(1, 16, 45) } },
+      { label: "Sat (3 days ago) completed", run: { id: "ggg77777gggg", status: "completed", path: "src/", started_at: iso(3, 10, 20) } },
+      { label: "Wed (5 days ago) failed",    run: { id: "hhh88888hhhh", status: "failed",    path: "src/", started_at: iso(5, 8, 0) } },
+      { label: "May 14 (older)   completed", run: { id: "iii99999iiii", status: "completed", path: "src/", started_at: iso(15, 13, 0) } },
+      { label: "Apr 22 (older)   completed", run: { id: "jjj00000jjjj", status: "completed", path: "src/", started_at: iso(45, 8, 0) } },
+      { label: "today  unknown   ?",         run: { id: "kkkaaaaakkkk", status: "weird",     path: "src/", started_at: iso(0, 7, 0) } }
+    ];
+    var grid = document.getElementById("preview-grid");
+    scenarios.forEach(function (s) {
+      var row = document.createElement("div");
+      row.className = "preview-row";
+      var meta = document.createElement("span");
+      meta.className = "preview-meta";
+      meta.textContent = s.label;
+      row.appendChild(meta);
+      var slot = document.createElement("div");
+      slot.className = "recent-runs";
+      row.appendChild(slot);
+      window.__attuneRunner.renderRecentRunsInto(slot, [s.run]);
+      grid.appendChild(row);
+    });
+  </script>
+</body>
+</html>

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -18,7 +18,6 @@
     <thead>
       <tr>
         <th>Name</th>
-        <th class="num">Stages</th>
         <th>Tier map</th>
         <th>Description</th>
         <th>Scope</th>
@@ -37,24 +36,25 @@
         <tr data-workflow="{{ w.name }}"
             data-scope-default="{{ default_scopes[w.name] if supports_path[w.name] else '' }}">
           <td><code>{{ w.name }}</code></td>
-          {# Stages=0 means the workflow doesn't expose a stages array
-             (typical for meta-orchestration workflows that compose
-             other workflows rather than declaring an explicit pipeline).
-             Render '—' with a tooltip so users don't read it as
-             "this workflow has zero stages" (P2-4 in the QA punch list). #}
-          <td class="num">
-            {% if w.stages > 0 %}
-              {{ w.stages }}
-            {% else %}
-              <span class="muted"
-                    data-tooltip="Workflow doesn't expose a stages array. Meta-orchestration workflows compose other workflows rather than declaring an explicit pipeline."
-                    aria-label="Stages not declared">—</span>
-            {% endif %}
-          </td>
+          {# Chip text: humanized stage name + friendly tier descriptor.
+             - Stage names like ``agent-review`` strip the ``agent-`` prefix
+               and title-case for readability (``Review``).
+             - Tier names like ``capable`` map through TIER_LABEL to
+               ``Standard``; the underlying Claude model class is
+               surfaced in the tooltip via TIER_TOOLTIP so the chip stays
+               compact while the hover affordance carries the detail. #}
           <td>
             {% for stage, tier in w.tier_map.items() %}
-              <span class="chip chip-{{ tier|lower }}">{{ stage }}: {{ tier }}</span>
+              {% set stage_label = stage.replace('agent-', '').replace('-', ' ').replace('_', ' ').title() %}
+              <span class="chip chip-{{ tier|lower }}"
+                    data-tooltip="{{ tier_tooltip.get(tier|lower, tier) }}"
+                    aria-label="{{ stage_label }} stage, {{ tier_label.get(tier|lower, tier) }} tier">{{ stage_label }} {{ tier_label.get(tier|lower, tier) }}</span>
             {% endfor %}
+            {% if not w.tier_map %}
+              <span class="muted"
+                    data-tooltip="Meta-orchestration workflow — composes other workflows rather than declaring its own stages."
+                    aria-label="Meta-orchestration workflow">—</span>
+            {% endif %}
           </td>
           <td>
             {{ w.description }}
@@ -100,13 +100,18 @@
           <td class="scope-cell">
             {% if supports_path[w.name] %}
               <select class="scope-picker" data-scope-picker aria-label="Scope for {{ w.name }}">
-                <option value="">Project-wide</option>
+                {# "All code" is the top option and the catch-all default
+                   for workflows without a specific feature mapping (the
+                   per-row ``data-scope-default=""`` still signals "no path
+                   argument" to the runner — the visible label just
+                   replaces the misleading "Project-wide" with what the
+                   workflow actually scans). #}
+                <option value="" title="All source code under {{ all_code_path }} — broad scan, no path argument passed">All code ({{ all_code_path }})</option>
                 {% for f in features %}
                   {% if f.path %}
                     <option value="{{ f.path }}" title="{{ f.description }}">{{ f.name }}</option>
                   {% endif %}
                 {% endfor %}
-                <option value="{{ all_code_path }}" title="All source code under {{ all_code_path }}">All code ({{ all_code_path }})</option>
                 <option value="__custom__">Custom path…</option>
               </select>
               <input type="text" class="scope-custom" data-scope-custom hidden

--- a/tests/unit/ops/test_scope_picker.py
+++ b/tests/unit/ops/test_scope_picker.py
@@ -333,7 +333,9 @@ features:
     assert resp.status_code == 200
     body = resp.text
     assert "data-scope-picker" in body
-    assert "Project-wide" in body
+    # v7.0.0: "All code (src/)" replaces "Project-wide" as the top
+    # (no-path-argument) option. The value="" mechanic is preserved.
+    assert "All code (src/)" in body
     assert "Custom path…" in body
     assert "data-scope-custom" in body
     # The feature dropdown option appears
@@ -375,7 +377,9 @@ features:
     # Scope column + picker markup must be present in read-only mode.
     assert ">Scope<" in body
     assert "data-scope-picker" in body
-    assert "Project-wide" in body
+    # v7.0.0: "All code (src/)" replaces "Project-wide" as the top
+    # (no-path-argument) option. The value="" mechanic is preserved.
+    assert "All code (src/)" in body
     assert "Custom path…" in body
     # The per-row default scope wires through regardless of run mode so
     # that the saved-scope restore path works on first paint.
@@ -757,9 +761,12 @@ def test_workflows_page_scope_picker_config_no_longer_carries_fallback_paths(tmp
 
 
 def test_workflows_page_renders_all_code_option(tmp_path, monkeypatch):
-    """The picker carries an "All code" option positioned between the
-    feature list and Custom path…, with the configured path as its
-    value and a descriptive label."""
+    """v7.0.0: "All code (src/)" is the top option on the picker and
+    carries ``value=""`` (the no-path-argument default the runner
+    already understands). It replaced the previous "Project-wide"
+    label in that slot; the prior separate "All code" option with
+    ``value="src/"`` between features and Custom was dropped to
+    eliminate the duplicate."""
     _write_features_yaml(
         tmp_path,
         "features:\n  feat:\n    description: x\n    files: [src/feat/**]\n",
@@ -768,16 +775,23 @@ def test_workflows_page_renders_all_code_option(tmp_path, monkeypatch):
     with TestClient(app) as client:
         resp = client.get("/workflows")
     assert resp.status_code == 200
-    # Option exists with the configured path as its value.
-    assert '<option value="src/"' in resp.text
+    # The empty-value "All code" option exists and carries the
+    # descriptive title attribute (the source-of-truth for the
+    # broad-scan semantics).
     assert "All code (src/)" in resp.text
-    # And precedes Custom path… in the markup (bottom-of-fixed-options
-    # placement; Custom path stays as the input-toggle anchor at the
-    # very end).
+    assert "All source code under src/" in resp.text
+    # Ordering: "All code" is the first <option> in the picker, above
+    # the feature list AND above Custom path…
     all_code_idx = resp.text.find("All code (src/)")
+    feat_idx = resp.text.find(">feat<")
     custom_idx = resp.text.find("Custom path")
-    assert all_code_idx > 0 and custom_idx > 0
+    assert all_code_idx > 0 and feat_idx > 0 and custom_idx > 0
+    assert all_code_idx < feat_idx
     assert all_code_idx < custom_idx
+    # The old separate ``<option value="src/">`` "All code" option was
+    # removed; the v7.0.0 picker has no such option (the broad-scan
+    # value="" replaced it).
+    assert '<option value="src/"' not in resp.text
 
 
 # ----------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "6.8.0"
+version = "7.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- **Version bump: 6.8.0 → 7.0.0** across all 8 canonical files (pyproject, plugin manifests, root marketplace, plugin core, CLAUDE.md, API_REFERENCE, uv.lock).
- **BREAKING removals** carried over from the previously-planned [7.0.0] draft: `attune.workflows.orchestrated_release_prep` and `attune.scaffolding`. Both deprecated since v5.2.0 / 2026-02-21 respectively; migration notes in CHANGELOG point at the replacements.
- **Workflows tab UI redesign** on the ops dashboard (interactive review on 2026-05-17): dropped Stages column, humanized tier-map chips (`Review Standard` + tooltip naming Haiku/Sonnet/Opus), replaced "Project-wide" with "All code (src/)" as the top scope option, redesigned recent-runs chips from `<run-id> <status>` to `<date> <status>` (12h AM/PM today, "Yesterday", weekday, then "May 14"), full tooltip carries the run-id + ISO + scope.
- **Four new post-7.0.0 specs** drafted from the same session: `sdk-error-message-fidelity`, `multi-actor-bulletin` (approved), `bulletin-curator`, `pipeline-learner`. The bulletin/curator/learner trio implements the bulletin-board + pipeline-learner whiteboard synthesis.
- **Two new lessons** in CLAUDE.md: API quota exhaustion masquerading as SDK startup failure, and pre-commit's `.help` template regen stash-and-reappear dance.

## Breaking changes

| Module | Replacement | Deprecated since |
|---|---|---|
| `attune.workflows.orchestrated_release_prep` | `ReleasePrepTeamWorkflow` from `attune.agents.release` (drop-in) | v5.2.0 |
| `attune.scaffolding` | `attune workflow run <name>` (no Python API replacement) | 2026-02-21 |

The CLI path `attune workflow run release-prep` already routed to the new workflow before this release, so user-visible impact on that path is zero.

## Test plan

- [ ] CI matrix (12 cells) passes
- [ ] Plugin config drift-guard tests (29/29 already verified locally)
- [ ] CHANGELOG renders cleanly on PyPI
- [ ] Post-merge: tag `v7.0.0` lands on the squash commit
- [ ] Post-merge: `publish-pypi.yml` workflow run via `--ref main` (per the existing lesson about tag-triggered publishes being rejected by the `pypi` env)
- [ ] Post-publish: `pip install attune-ai==7.0.0` resolves on PyPI; smoke-test import

🤖 Generated with [Claude Code](https://claude.com/claude-code)
