### PR TITLE
feat(ops): Copy report button on the run-view page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Attune AI (formerly Empathy Framework) will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Copy-report button on the ops dashboard's run-view page. Renders
+  as a compact dotted-pill chip in the run header next to the run
+  ID; one click copies the full rendered report (the `<pre
+  data-log>` contents) to the clipboard via
+  `navigator.clipboard.writeText`. Works on both live-SSE runs and
+  disk-loaded completed runs since it reads from the canonical
+  `[data-log]` element. Flashes "Copied ✓" / "Copy failed" /
+  "Nothing to copy" for 1.5s with matching state classes so the
+  user gets immediate feedback. Graceful degradation when
+  `navigator.clipboard` is unavailable (old browsers, insecure
+  contexts) — surfaces the error rather than silently failing.
+
 ## [7.0.0] — 2026-05-16
 
 ### Removed — BREAKING

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1513,3 +1513,40 @@ a.kpi:hover {
   opacity: 0.55;
   cursor: progress;
 }
+
+/* ---------- Copy-report button (run-view header) ---------- */
+
+.btn-copy-report {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 12px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: inherit;
+  background: transparent;
+  color: var(--fg-muted, #888);
+  border: 1px dotted var(--border, #ccc);
+  border-radius: 99px;
+  cursor: pointer;
+  vertical-align: middle;
+  transition: background 120ms, color 120ms, border-style 120ms;
+}
+.btn-copy-report:hover {
+  background: var(--bg-soft, #f3f4f6);
+  color: var(--fg, #111);
+  border-style: solid;
+}
+.btn-copy-report:focus-visible {
+  outline: 2px solid var(--accent, #4f46e5);
+  outline-offset: 2px;
+}
+.btn-copy-report.is-copied {
+  color: var(--ok, #047857);
+  border-color: var(--ok, #047857);
+  border-style: solid;
+}
+.btn-copy-report.is-failed {
+  color: var(--danger, #b91c1c);
+  border-color: var(--danger, #b91c1c);
+  border-style: solid;
+}

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -648,6 +648,73 @@
     return chip;
   }
 
+  // ------------------------------------------------------------------
+  // Copy report — clipboard handler for the [data-copy-report] button
+  // ------------------------------------------------------------------
+
+  function readReportText() {
+    var preEl = document.querySelector("[data-log]");
+    return preEl ? (preEl.textContent || "") : "";
+  }
+
+  function flashCopyState(btn, message, ok) {
+    var label = btn.querySelector(".btn-copy-report-label");
+    if (!label) return;
+    var prev = label.textContent;
+    label.textContent = message;
+    btn.classList.toggle("is-copied", !!ok);
+    btn.classList.toggle("is-failed", !ok);
+    setTimeout(function () {
+      label.textContent = prev;
+      btn.classList.remove("is-copied");
+      btn.classList.remove("is-failed");
+    }, 1500);
+  }
+
+  function copyReportToClipboard(btn) {
+    var text = readReportText();
+    if (!text) {
+      flashCopyState(btn, "Nothing to copy", false);
+      return Promise.resolve(false);
+    }
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+      // Graceful fallback for old browsers / insecure contexts:
+      // surface the error so the user knows to retry over HTTPS or
+      // in a modern browser. We don't attempt the legacy
+      // execCommand("copy") path because it requires document.execCommand
+      // which is itself deprecated and security-conscious users have
+      // disabled clipboard JS API for a reason.
+      flashCopyState(btn, "Clipboard unavailable", false);
+      return Promise.resolve(false);
+    }
+    return navigator.clipboard.writeText(text).then(
+      function () {
+        flashCopyState(btn, "Copied ✓", true);
+        return true;
+      },
+      function () {
+        flashCopyState(btn, "Copy failed", false);
+        return false;
+      }
+    );
+  }
+
+  function wireCopyReportButton() {
+    var btn = document.querySelector("[data-copy-report]");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      copyReportToClipboard(btn);
+    });
+  }
+
+  if (typeof document !== "undefined") {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", wireCopyReportButton);
+    } else {
+      wireCopyReportButton();
+    }
+  }
+
   // Expose internals for tests.
   if (typeof window !== "undefined") {
     window.__attuneRunView = {
@@ -661,6 +728,9 @@
       parseSuggestions: parseSuggestions,
       renderSuggestionChipsFromLog: renderSuggestionChipsFromLog,
       buildSuggestionChip: buildSuggestionChip,
+      readReportText: readReportText,
+      copyReportToClipboard: copyReportToClipboard,
+      wireCopyReportButton: wireCopyReportButton,
       DATA: DATA
     };
   }

--- a/src/attune/ops/templates/run_view.html
+++ b/src/attune/ops/templates/run_view.html
@@ -9,6 +9,18 @@
     <code>{{ run.workflow }}</code>
     <span class="run-id-chip">run <code>{{ run.id[:12] }}</code></span>
     <span class="chained-from" data-chained-from hidden></span>
+    {# Copy-report button — copies the full report text (the <pre
+       data-log> contents) to the clipboard. Lives in the H1 so it
+       sits near the run identity, where users naturally look when
+       they want to share/save a report. Disabled gracefully when
+       navigator.clipboard is unavailable. #}
+    <button type="button"
+            class="btn-copy-report"
+            data-copy-report
+            data-tooltip="Copy the full report to clipboard"
+            aria-label="Copy report to clipboard">
+      <span class="btn-copy-report-label">Copy report</span>
+    </button>
   </h1>
   <p class="page-sub run-view-meta">
     <span class="run-view-status chip" data-status>{{ run.status }}</span>

--- a/tests/unit/ops/test_run_view_copy_report.py
+++ b/tests/unit/ops/test_run_view_copy_report.py
@@ -1,0 +1,141 @@
+"""Tests for the run-view "Copy report" button.
+
+The button copies the rendered report (`<pre data-log>` contents) to
+the clipboard via `navigator.clipboard.writeText`. Tests live at the
+source-grep level since the production logic is single-file JS and
+the DOM/clipboard interactions don't lend themselves to a Python
+emulator. Behavioral coverage at the browser level is tracked in the
+PR's manual-smoke test plan.
+
+Spec context: Patrick's request 2026-05-17 — one-click copy of any
+workflow run's report for sharing/pasting into other tools.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_TEMPLATE = (
+    Path(__file__).resolve().parents[3] / "src" / "attune" / "ops" / "templates" / "run_view.html"
+)
+_JS = (
+    Path(__file__).resolve().parents[3] / "src" / "attune" / "ops" / "static" / "js" / "run_view.js"
+)
+_CSS = (
+    Path(__file__).resolve().parents[3] / "src" / "attune" / "ops" / "static" / "css" / "main.css"
+)
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def test_template_renders_copy_report_button() -> None:
+    """The run-view header includes a button tagged with
+    ``data-copy-report`` so the JS wirer can locate it."""
+    text = _read(_TEMPLATE)
+    assert "data-copy-report" in text
+    assert 'class="btn-copy-report"' in text
+    assert "Copy report" in text
+    # The button should be inside the run-view-head section.
+    head_idx = text.find("run-view-head")
+    btn_idx = text.find("data-copy-report")
+    assert (
+        head_idx >= 0 and btn_idx > head_idx
+    ), "Copy-report button should live inside .run-view-head"
+
+
+def test_template_button_has_tooltip_and_aria_label() -> None:
+    """Compact UI — the icon-style button needs a tooltip for
+    discoverability and an aria-label for screen readers."""
+    text = _read(_TEMPLATE)
+    assert "data-tooltip=" in text
+    assert "Copy the full report to clipboard" in text
+    assert 'aria-label="Copy report to clipboard"' in text
+
+
+def test_js_exports_copy_helpers() -> None:
+    """``readReportText``, ``copyReportToClipboard``, and
+    ``wireCopyReportButton`` are the three public entry points the
+    DOMContentLoaded handler and tests need."""
+    text = _read(_JS)
+    assert "function readReportText(" in text
+    assert "function copyReportToClipboard(" in text
+    assert "function wireCopyReportButton(" in text
+    assert "readReportText: readReportText" in text
+    assert "copyReportToClipboard: copyReportToClipboard" in text
+    assert "wireCopyReportButton: wireCopyReportButton" in text
+
+
+def test_js_reads_from_data_log() -> None:
+    """The copy helper reads from the canonical ``[data-log]``
+    element so it picks up the live SSE-streamed log AND the
+    server-pre-rendered disk-loaded log without branching."""
+    text = _read(_JS)
+    assert 'querySelector("[data-log]")' in text
+    # Read via textContent (not innerHTML — we want the literal text
+    # the user sees, not the markup).
+    assert "textContent" in text
+
+
+def test_js_uses_navigator_clipboard_api() -> None:
+    """Modern clipboard API — must check feature availability before
+    invoking (gracefully degrades on insecure contexts / old browsers
+    that disable the API)."""
+    text = _read(_JS)
+    assert "navigator.clipboard" in text
+    assert "navigator.clipboard.writeText" in text
+    # Feature-detection guard
+    assert "!navigator.clipboard" in text or "navigator.clipboard ||" in text
+
+
+def test_js_flashes_visual_feedback_on_copy_state() -> None:
+    """Successful and failed copies both flash a brief label
+    change + class toggle so the user gets immediate feedback.
+    Classes are restored to the default state after ~1.5s."""
+    text = _read(_JS)
+    assert "is-copied" in text
+    assert "is-failed" in text
+    # The flash helper schedules a cleanup via setTimeout
+    assert "setTimeout" in text
+    assert "flashCopyState" in text
+
+
+def test_js_handles_empty_report() -> None:
+    """When the report is empty (e.g. SSE hasn't populated yet, or
+    the disk record has zero lines), the copy attempt surfaces a
+    'Nothing to copy' message rather than calling writeText with
+    an empty string."""
+    text = _read(_JS)
+    assert "Nothing to copy" in text
+
+
+def test_js_wires_button_on_dom_ready() -> None:
+    """The wirer attaches the click listener at DOMContentLoaded
+    (or immediately if the document is already past loading state)
+    so the button works on both the live-run and disk-loaded
+    branches without depending on the SSE stream."""
+    text = _read(_JS)
+    wire_idx = text.find("wireCopyReportButton")
+    assert wire_idx > 0
+    # The boot block checks document.readyState and either attaches
+    # the DOMContentLoaded listener OR calls the wirer immediately.
+    assert 'document.readyState === "loading"' in text
+    assert "DOMContentLoaded" in text
+
+
+def test_css_styles_copy_report_button_states() -> None:
+    """Base + hover + focus-visible + is-copied + is-failed —
+    dotted-border-becomes-solid-on-hover matches Patrick's existing
+    color/hover affordance preference for clickable chips."""
+    text = _read(_CSS)
+    assert ".btn-copy-report" in text
+    assert ".btn-copy-report:hover" in text
+    assert ".btn-copy-report:focus-visible" in text
+    assert ".btn-copy-report.is-copied" in text
+    assert ".btn-copy-report.is-failed" in text
+    # Dotted-border-on-rest, solid-on-hover (matches suggestion-chip
+    # in the parallel ops-suggestion-chips PR).
+    assert "border: 1px dotted" in text
+    # Hover transition exists
+    assert "transition:" in text


### PR DESCRIPTION
## Summary

Adds a **Copy report** button to the run-view page header. One click copies the full rendered report (`<pre data-log>` contents) to the clipboard. Closes Patrick's second ask from 2026-05-17.

## Change

**`src/attune/ops/templates/run_view.html`**
- Compact `<button class="btn-copy-report" data-copy-report>` chip rendered in the `<h1>` next to the run-id chip. Tooltip + aria-label for discoverability + screen-reader support.

**`src/attune/ops/static/js/run_view.js`** (~70 LOC)
- `readReportText()` — reads `[data-log].textContent` (works for both live-SSE and disk-loaded branches).
- `copyReportToClipboard(btn)` — feature-detects `navigator.clipboard`, calls `writeText`, flashes status on the button. Returns a Promise<boolean>.
- `flashCopyState(btn, message, ok)` — temporary label change + state class toggle, restored after 1.5s.
- `wireCopyReportButton()` — attaches the click handler. Boots from `DOMContentLoaded` OR immediately if the document is already loaded.
- Three new test exports on `window.__attuneRunView`.

**`src/attune/ops/static/css/main.css`** (~40 LOC)
- `.btn-copy-report` dotted-pill base + hover (solid border, slightly tinted bg) + focus-visible + `.is-copied` (green) + `.is-failed` (red). Matches Patrick's color/hover affordance preference and the suggestion-chip aesthetic from the parallel PR.

**`tests/unit/ops/test_run_view_copy_report.py`** (new, 9 tests)
- Template renders the button with `data-copy-report`, tooltip, aria-label, inside `.run-view-head`.
- JS exports the three helpers and reads from `[data-log].textContent` (not innerHTML).
- Uses `navigator.clipboard.writeText` with feature-detection.
- Flashes `is-copied`/`is-failed` state classes with `setTimeout` cleanup.
- Handles empty-report case with a "Nothing to copy" message.
- Wires on `DOMContentLoaded` AND on already-loaded docs.
- CSS rules: base + hover + focus-visible + is-copied + is-failed, dotted-border-on-rest.

## Test plan

- [x] `pytest tests/unit/ops/test_run_view_copy_report.py` — 9 passed.
- [x] `pytest tests/unit/ops/` — 725 passed (was 716, no regressions).
- [ ] Browser smoke: load any completed run page, click the Copy report button, paste into another app to confirm the report text matches. Verify "Copied ✓" flashes green for ~1.5s and reverts to "Copy report".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
