### PR TITLE
feat(ops): in-memory UI interaction counters on /telemetry

### DIFF
--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-05-17T18:28:27.048023+00:00
-source_hash: 848a51e7aabcd39ac987255bff940539153d7b544651bdec566acd763432d775
+generated_at: 2026-05-18T05:24:12.363229+00:00
+source_hash: b6ca0aef7a04a6f5122f0108db8941b3fcbbd161578c24f5d23838793ec43ec1
 status: generated
 ---
 
@@ -20,7 +20,7 @@ The main building blocks are:
 - **`WorkflowEntry`** — core component
 - **`PathArgSpec`** — How a workflow accepts a scope path on the CLI.
 
-Under the hood, this feature spans 40 source
+Under the hood, this feature spans 42 source
 files covering:
 
 - Run via ``python -m attune.ops``.

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-05-17T18:28:27.059758+00:00
-source_hash: 848a51e7aabcd39ac987255bff940539153d7b544651bdec566acd763432d775
+generated_at: 2026-05-18T05:24:12.375039+00:00
+source_hash: b6ca0aef7a04a6f5122f0108db8941b3fcbbd161578c24f5d23838793ec43ec1
 status: generated
 ---
 
@@ -24,7 +24,9 @@ status: generated
 | `HomeKpis` | Summary numbers shown above the fold on the home page. | `src/attune/ops/data.py` |
 | `SweepChipCounts` | Per-bucket counts loaded from a persisted discovery-sweep result. | `src/attune/ops/data.py` |
 | `DismissEntry` | One dismissed candidate's persisted state. | `src/attune/ops/dismiss_store.py` |
+| `InteractionCounters` | Process-lifetime counters for dashboard UI interactions. | `src/attune/ops/interaction_counters.py` |
 | `TrustedHostMiddleware` | Reject requests whose ``Host`` header isn't on the allowlist. | `src/attune/ops/middleware.py` |
+| `InteractionEvent` | Request body for ``POST /api/telemetry/interaction``. | `src/attune/ops/routes/interaction_counters.py` |
 | `SpecPhase` | One phase file's status snapshot. | `src/attune/ops/routes/specs.py` |
 | `SpecRecord` | One spec's summary — directory + status of each phase file present. | `src/attune/ops/routes/specs.py` |
 | `RunnerBusyError` | Raised when a run is already pending/running. | `src/attune/ops/runner.py` |
@@ -82,6 +84,8 @@ status: generated
 | `run_view_page()` | Full-page view for one workflow run. | `src/attune/ops/routes/dashboard.py` |
 | `specs_page()` | Specs tab — federated listing of all specs across configured roots. | `src/attune/ops/routes/dashboard.py` |
 | `spec_detail_page()` | Drill-in for a single spec: show every phase file's content (read-only). | `src/attune/ops/routes/dashboard.py` |
+| `record_interaction()` | Increment a UI interaction counter. | `src/attune/ops/routes/interaction_counters.py` |
+| `read_interactions()` | Return the full counter snapshot + per-event totals. | `src/attune/ops/routes/interaction_counters.py` |
 | `start_run()` | — | `src/attune/ops/routes/runner.py` |
 | `get_run()` | — | `src/attune/ops/routes/runner.py` |
 | `stream_run()` | — | `src/attune/ops/routes/runner.py` |

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: task
-generated_at: 2026-05-17T18:28:27.054846+00:00
-source_hash: 848a51e7aabcd39ac987255bff940539153d7b544651bdec566acd763432d775
+generated_at: 2026-05-18T05:24:12.370158+00:00
+source_hash: b6ca0aef7a04a6f5122f0108db8941b3fcbbd161578c24f5d23838793ec43ec1
 status: generated
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Ops dashboard now tracks in-memory UI interaction counters (pill
+  clicks, recommendation-card clicks, scope-picker changes) and
+  surfaces them under a new "Dashboard interactions (this session)"
+  panel on the `/telemetry` tab. Counters are process-lifetime — no
+  PII, no disk write, no network — and reset on dashboard restart.
+  Wired via a new `POST /api/telemetry/interaction` endpoint plus
+  `GET /api/telemetry/interactions` for the JSON snapshot. Closes
+  Phase 6.1 of the ops-runner-tier2 spec.
 - Copy-report button on the ops dashboard's run-view page. Renders
   as a compact dotted-pill chip in the run header next to the run
   ID; one click copies the full rendered report (the `<pre

--- a/docs/specs/ops-runner-tier2/tasks.md
+++ b/docs/specs/ops-runner-tier2/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Runner Tier 2
 
-**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phase 3 + Phase 4 complete 2026-05-14 (persistence + chainable pills shipped together); Phase 5 complete 2026-05-16 (recommendation channel + run-view cards + `code-review` demo integration); Phase 6 pending
+**Status:** Phase 1 complete 2026-05-13 (audit + registry shipped); Phase 2 complete 2026-05-14 (scope picker shipped); Phase 3 + Phase 4 complete 2026-05-14 (persistence + chainable pills shipped together); Phase 5 complete 2026-05-16 (recommendation channel + run-view cards + `code-review` demo integration); Phase 6.1 complete 2026-05-18 (in-memory interaction counters on `/telemetry`); 6.2–6.4 pending
 
 Phased plan. Each phase is independently shippable + reversible (single-commit revert). See `decisions.md`, `requirements.md`, `design.md` for context.
 
@@ -95,7 +95,7 @@ Goal: workflows can emit JSON recommendations rendered as action cards on the ru
 
 ## Phase 6 — Telemetry + close
 
-- [ ] **6.1** Add lightweight telemetry: pill click counts, recommendation card click counts, scope picker usage rates (in-memory only — no PII, no network). Surface in the existing `/telemetry` tab.
+- [x] **6.1** **Shipped 2026-05-18** — process-lifetime in-memory counters for pill clicks, recommendation-card clicks, and scope-picker changes. Backend: `src/attune/ops/interaction_counters.py` (counter store with thread-safe `Counter` buckets + target normalization) + `src/attune/ops/routes/interaction_counters.py` (`POST /api/telemetry/interaction`, `GET /api/telemetry/interactions`). Frontend: `recordInteraction()` helper on `window.__attuneRunner`, called from `handlePillClick`, recommendation-card action handler, and `wireScopeSave`. Telemetry page gains a "Dashboard interactions (this session)" section with three KPI tiles + top-N tables. 22 tests in `tests/unit/ops/test_interaction_counters.py` cover counter store unit behavior, HTTP API edge cases (unknown event → 204, HTML target → bucketed as `(unknown)`, missing event → 422), and the rendered HTML.
 - [ ] **6.2** Update `docs/COVERAGE_BUG_LOG.md` if any bugs surfaced during Phase 1–5 work.
 - [ ] **6.3** Patrick uses the new dashboard for at least one real feature scope; confirms the UX feels right.
 - [ ] **6.4** Close this spec. Open follow-up specs if any Phase 3/4 ideas surfaced (e.g. editor integration for file-path chips).

--- a/src/attune/ops/interaction_counters.py
+++ b/src/attune/ops/interaction_counters.py
@@ -1,0 +1,141 @@
+"""In-memory dashboard interaction counters.
+
+Phase 6.1 of ops-runner-tier2. Tracks three user-driven UI events
+across the lifetime of the dashboard process so we can answer
+"is anyone using the pill/recommendation/scope features?" without
+shipping a network endpoint or writing PII to disk.
+
+Counters reset on dashboard restart. No persistence, no network,
+no PII — just per-process tallies surfaced on the /telemetry tab.
+
+Bucket layout
+-------------
+
+- ``pill_clicks`` — keyed by the *target* workflow (the pill the
+  user clicked, not the source page). Empty/unknown target is
+  bucketed as ``"(unknown)"``.
+- ``rec_card_clicks`` — keyed by the recommendation card kind
+  (``"next-workflow"`` or ``"open-url"``). Unknown kinds bucket
+  as ``"(unknown)"``.
+- ``scope_picker_changes`` — keyed by the *source* workflow whose
+  scope picker the user touched. Empty/unknown source bucket as
+  ``"(unknown)"``.
+
+Targets are length-capped (64 chars) and stripped to a conservative
+charset (workflow-name shape + a few separators). The cap protects
+the in-memory map from a runaway client that POSTs many distinct
+targets; the charset filter keeps the rendered HTML safe even if
+the template ever stops escaping. Unparseable inputs bucket as
+``"(unknown)"`` rather than raising.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from collections import Counter
+from dataclasses import dataclass, field
+
+# Allowed UI events. New events should be added here AND mapped in
+# ``_BUCKET_FOR_EVENT`` below.
+EVENTS: tuple[str, ...] = (
+    "pill_click",
+    "rec_card_click",
+    "scope_picker_change",
+)
+
+# Conservative target charset. Workflow names are lowercase
+# kebab-case but we also accept underscore, dot, and slash so a
+# future scope-picker call site can pass a path-like target without
+# raising. Anything else collapses to "(unknown)".
+_TARGET_RE = re.compile(r"^[A-Za-z0-9_./-]{1,64}$")
+
+_UNKNOWN = "(unknown)"
+
+
+def _normalize_target(target: str | None) -> str:
+    """Return a safe-to-bucket key for ``target``.
+
+    Empty string, ``None``, or anything that doesn't match the
+    conservative charset collapses to the ``"(unknown)"`` sentinel
+    so we still record the event without trusting the input.
+    """
+    if not target:
+        return _UNKNOWN
+    if not isinstance(target, str):
+        return _UNKNOWN
+    if not _TARGET_RE.match(target):
+        return _UNKNOWN
+    return target
+
+
+@dataclass
+class InteractionCounters:
+    """Process-lifetime counters for dashboard UI interactions.
+
+    Thread-safe via a single lock. We use ``collections.Counter``
+    per bucket so increments are cheap and read-out can sort by
+    count without extra structure.
+    """
+
+    pill_clicks: Counter[str] = field(default_factory=Counter)
+    rec_card_clicks: Counter[str] = field(default_factory=Counter)
+    scope_picker_changes: Counter[str] = field(default_factory=Counter)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def record(self, event: str, target: str | None = None) -> bool:
+        """Increment the bucket for ``event`` keyed by ``target``.
+
+        Returns ``True`` if the event was recorded, ``False`` if
+        the event name is unrecognized (caller may want to log).
+        Never raises.
+        """
+        bucket = self._bucket_for(event)
+        if bucket is None:
+            return False
+        key = _normalize_target(target)
+        with self._lock:
+            bucket[key] += 1
+        return True
+
+    def snapshot(self) -> dict[str, dict[str, int]]:
+        """Return a deep copy of all buckets for rendering.
+
+        Returns ordered top-down so the JSON / template renders are
+        deterministic across calls.
+        """
+        with self._lock:
+            return {
+                "pill_clicks": dict(self.pill_clicks),
+                "rec_card_clicks": dict(self.rec_card_clicks),
+                "scope_picker_changes": dict(self.scope_picker_changes),
+            }
+
+    def totals(self) -> dict[str, int]:
+        """Return the total count per event type (not per target)."""
+        with self._lock:
+            return {
+                "pill_clicks": sum(self.pill_clicks.values()),
+                "rec_card_clicks": sum(self.rec_card_clicks.values()),
+                "scope_picker_changes": sum(self.scope_picker_changes.values()),
+            }
+
+    def top(self, event: str, limit: int = 10) -> list[tuple[str, int]]:
+        """Top-N targets for ``event``, descending by count.
+
+        Returns an empty list for unrecognized events.
+        """
+        bucket = self._bucket_for(event)
+        if bucket is None:
+            return []
+        with self._lock:
+            return bucket.most_common(limit)
+
+    def _bucket_for(self, event: str) -> Counter[str] | None:
+        if event == "pill_click":
+            return self.pill_clicks
+        if event == "rec_card_click":
+            return self.rec_card_clicks
+        if event == "scope_picker_change":
+            return self.scope_picker_changes
+        return None

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -132,7 +132,26 @@ async def workflows_page(request: Request) -> HTMLResponse:
 async def telemetry_page(request: Request) -> HTMLResponse:
     cfg = request.app.state.config
     summary = data.read_telemetry_summary(cfg, recent_days=14)
-    return _render(request, "telemetry.html", page="telemetry", telemetry=summary)
+    # Phase 6.1 of ops-runner-tier2 — surface in-memory UI interaction
+    # counters alongside the persisted workflow telemetry. These are
+    # per-process tallies (reset on dashboard restart); the template
+    # labels the section accordingly so users don't confuse them with
+    # the disk-backed numbers above.
+    counters = getattr(request.app.state, "interaction_counters", None)
+    interaction_totals = counters.totals() if counters is not None else {}
+    interaction_top = {
+        "pill_clicks": counters.top("pill_click", limit=10) if counters else [],
+        "rec_card_clicks": counters.top("rec_card_click", limit=10) if counters else [],
+        "scope_picker_changes": (counters.top("scope_picker_change", limit=10) if counters else []),
+    }
+    return _render(
+        request,
+        "telemetry.html",
+        page="telemetry",
+        telemetry=summary,
+        interaction_totals=interaction_totals,
+        interaction_top=interaction_top,
+    )
 
 
 @router.get("/health", response_class=HTMLResponse)

--- a/src/attune/ops/routes/interaction_counters.py
+++ b/src/attune/ops/routes/interaction_counters.py
@@ -1,0 +1,105 @@
+"""HTTP API for dashboard UI interaction counters.
+
+Phase 6.1 of ops-runner-tier2. Two endpoints:
+
+- ``POST /api/telemetry/interaction`` — increment a counter
+- ``GET /api/telemetry/interactions`` — read the snapshot
+
+Body validation is intentionally permissive — unknown events are
+ignored with a 204, not 400, so a stale client running against a
+newer server can't trip the dashboard. Same for unknown targets:
+they bucket as ``"(unknown)"`` rather than reject.
+
+Read-only mode (``allow_run=False``) still accepts counter writes
+— these are UI telemetry, not workflow execution, and the
+dashboard is the only thing that POSTs them.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+
+from attune.ops.interaction_counters import EVENTS, InteractionCounters
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class InteractionEvent(BaseModel):
+    """Request body for ``POST /api/telemetry/interaction``.
+
+    ``event`` is the one required field. ``target`` is optional and
+    only meaningful for ``pill_click`` and ``scope_picker_change``
+    (workflow name) and ``rec_card_click`` (kind: ``next-workflow``
+    or ``open-url``). The model accepts anything for ``target`` —
+    sanitization happens in :func:`InteractionCounters.record`.
+    """
+
+    event: str = Field(..., min_length=1, max_length=64)
+    target: str | None = Field(default=None, max_length=256)
+
+
+def _counters(request: Request) -> InteractionCounters:
+    """Return the per-app counters singleton.
+
+    Defensive shim: if the app was constructed before Phase 6.1
+    wiring (e.g. an old test fixture), lazily attach a fresh
+    counters instance so the endpoints never 500.
+    """
+    counters = getattr(request.app.state, "interaction_counters", None)
+    if counters is None:
+        counters = InteractionCounters()
+        request.app.state.interaction_counters = counters
+    return counters
+
+
+@router.post("/api/telemetry/interaction")
+async def record_interaction(payload: InteractionEvent, request: Request) -> Response:
+    """Increment a UI interaction counter.
+
+    Returns 204 No Content on success AND on unknown events (so a
+    stale client doesn't break the dashboard). The body shape is
+    validated by pydantic; anything else (charset, length) is
+    handled inside the counter store.
+    """
+    counters = _counters(request)
+    recorded = counters.record(payload.event, payload.target)
+    if not recorded:
+        # Unknown event — log at debug, ignore the request body, and
+        # return 204 so the client doesn't retry. This keeps the
+        # dashboard resilient to client/server version skew during
+        # active development.
+        logger.debug(
+            "ops.interaction: ignoring unknown event %r (known: %s)",
+            payload.event[:64],
+            EVENTS,
+        )
+    return Response(status_code=204)
+
+
+@router.get("/api/telemetry/interactions")
+async def read_interactions(request: Request) -> JSONResponse:
+    """Return the full counter snapshot + per-event totals.
+
+    Output shape::
+
+        {
+          "totals": {"pill_clicks": int, ...},
+          "pill_clicks": {"<workflow>": int, ...},
+          "rec_card_clicks": {"<kind>": int, ...},
+          "scope_picker_changes": {"<workflow>": int, ...}
+        }
+    """
+    counters = _counters(request)
+    snapshot = counters.snapshot()
+    return JSONResponse(
+        {
+            "totals": counters.totals(),
+            **snapshot,
+        }
+    )

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -13,7 +13,9 @@ from fastapi.templating import Jinja2Templates
 from attune import __version__
 from attune.ops import sweep_results as sweep_results_mod
 from attune.ops.config import Config
+from attune.ops.interaction_counters import InteractionCounters
 from attune.ops.routes import dashboard
+from attune.ops.routes import interaction_counters as interaction_counters_routes
 from attune.ops.routes import runner as runner_routes
 from attune.ops.routes import runs_history as runs_history_routes
 from attune.ops.routes import sessions as sessions_routes
@@ -95,6 +97,11 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.state.config = config
     app.state.templates = templates
     app.state.runner = runner if runner is not None else _build_default_runner(config)
+    # Phase 6.1 of ops-runner-tier2 — process-lifetime UI interaction
+    # counters (pill clicks, recommendation-card clicks, scope-picker
+    # changes). In-memory only; resets on restart. See
+    # ``interaction_counters.py`` for bucket layout.
+    app.state.interaction_counters = InteractionCounters()
 
     app.include_router(dashboard.router)
     app.include_router(runner_routes.router)
@@ -102,6 +109,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.include_router(sessions_routes.router)
     app.include_router(specs_routes.router)
     app.include_router(sweep_results_routes.router)
+    app.include_router(interaction_counters_routes.router)
 
     # Phase 2B of discovery-sweep-ops-integration: when sweep-result
     # persistence is enabled, wrap the runner's start() so each

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -250,12 +250,23 @@
     return null;
   }
 
+  // Phase 6.1 — fire-and-forget UI counter helper. Delegates to
+  // runner.js's recordInteraction if available; no-op otherwise so
+  // counter wiring never blocks the pill/rec-card user flow.
+  function recordInteraction(event, target) {
+    var runner = (typeof window !== "undefined") ? window.__attuneRunner : null;
+    if (runner && typeof runner.recordInteraction === "function") {
+      runner.recordInteraction(event, target);
+    }
+  }
+
   function handlePillClick(ev) {
     var pill = pillTargetFromEvent(ev);
     if (!pill) return;
     ev.preventDefault();
     var target = (pill.textContent || "").trim();
     if (!target) return;
+    recordInteraction("pill_click", target);
     if (!ALLOW_RUN) {
       showInlineError(
         "Read-only mode — restart attune ops without --read-only to chain runs."
@@ -480,6 +491,7 @@
     action.type = "button";
     action.textContent = kind === "next-workflow" ? "Run" : "Open";
     action.addEventListener("click", function () {
+      recordInteraction("rec_card_click", kind);
       action.disabled = true;
       if (kind === "next-workflow") {
         var name = payload.name;

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -159,6 +159,33 @@
     if (pre) while (pre.firstChild) pre.removeChild(pre.firstChild);
   }
 
+  // Phase 6.1 — fire-and-forget UI interaction counter ping. Sends
+  // a small JSON POST to /api/telemetry/interaction. Any failure
+  // (network, 4xx/5xx, missing endpoint) is swallowed silently:
+  // these counters are best-effort dashboard telemetry, never on
+  // the critical path of a user action.
+  function recordInteraction(event, target) {
+    if (typeof fetch !== "function") return;
+    var body = { event: String(event || "") };
+    if (target != null && target !== "") {
+      body.target = String(target);
+    }
+    try {
+      fetch("/api/telemetry/interaction", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        // keepalive lets the request survive a navigation away
+        // from the page (e.g. pill-click → navigate to new run).
+        keepalive: true
+      }).catch(function () {
+        // INTENTIONAL: best-effort telemetry, no surfacing.
+      });
+    } catch (e) {
+      // INTENTIONAL: same as above — never raise from telemetry.
+    }
+  }
+
   // Export internals for the test page (tests/unit/ops/static/test_runner.html).
   // Wrapped in a check so it's a no-op in environments without window.
   if (typeof window !== "undefined") {
@@ -182,7 +209,8 @@
       appendBusyErrorLine: appendBusyErrorLine,
       applyChipCounts: applyChipCounts,
       refreshSweepChips: refreshSweepChips,
-      wireSweepChipRefresh: wireSweepChipRefresh
+      wireSweepChipRefresh: wireSweepChipRefresh,
+      recordInteraction: recordInteraction
     };
   }
 
@@ -462,9 +490,15 @@
     var picker = row.querySelector("[data-scope-picker]");
     var custom = row.querySelector("[data-scope-custom]");
     if (!picker) return;
+    // Phase 6.1 — workflow name is the per-row data attribute set by
+    // the workflows.html template (data-workflow=<name>). Falls back
+    // to "" so recordInteraction buckets unidentified rows under
+    // "(unknown)" rather than mislabeling them.
+    var workflowName = row.getAttribute("data-workflow") || "";
     picker.addEventListener("change", function () {
       if (picker.value === "__custom__") return;
       saveScope(picker.value);
+      recordInteraction("scope_picker_change", workflowName);
     });
     if (custom) {
       custom.addEventListener("change", function () {
@@ -475,6 +509,7 @@
         var trimmed = (custom.value || "").trim();
         if (trimmed === "") return; // Blank custom is Project-wide; skip.
         saveScope(trimmed);
+        recordInteraction("scope_picker_change", workflowName);
       });
     }
   }

--- a/src/attune/ops/templates/telemetry.html
+++ b/src/attune/ops/templates/telemetry.html
@@ -56,4 +56,59 @@
 {% if telemetry.last_event_at %}
   <p class="meta">Last event recorded: <code>{{ telemetry.last_event_at }}</code></p>
 {% endif %}
+
+<section class="panel">
+  <h2>Dashboard interactions (this session)</h2>
+  <p class="page-sub">In-memory counters since the dashboard process started. Resets on restart; no PII, no disk write.</p>
+  <div class="kpi-grid">
+    <div class="kpi">
+      <div class="kpi-label">Pill clicks</div>
+      <div class="kpi-value">{{ '{:,}'.format(interaction_totals.get('pill_clicks', 0)) }}</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-label">Recommendation card clicks</div>
+      <div class="kpi-value">{{ '{:,}'.format(interaction_totals.get('rec_card_clicks', 0)) }}</div>
+    </div>
+    <div class="kpi">
+      <div class="kpi-label">Scope picker changes</div>
+      <div class="kpi-value">{{ '{:,}'.format(interaction_totals.get('scope_picker_changes', 0)) }}</div>
+    </div>
+  </div>
+  {% if interaction_top.pill_clicks %}
+    <h3>Top pills clicked</h3>
+    <table class="data-table">
+      <thead><tr><th>Workflow</th><th class="num">Clicks</th></tr></thead>
+      <tbody>
+        {% for name, count in interaction_top.pill_clicks %}
+          <tr><td><code>{{ name }}</code></td><td class="num">{{ count }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+  {% if interaction_top.rec_card_clicks %}
+    <h3>Recommendation cards by kind</h3>
+    <table class="data-table">
+      <thead><tr><th>Kind</th><th class="num">Clicks</th></tr></thead>
+      <tbody>
+        {% for kind, count in interaction_top.rec_card_clicks %}
+          <tr><td><code>{{ kind }}</code></td><td class="num">{{ count }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+  {% if interaction_top.scope_picker_changes %}
+    <h3>Scope picker changes by workflow</h3>
+    <table class="data-table">
+      <thead><tr><th>Workflow</th><th class="num">Changes</th></tr></thead>
+      <tbody>
+        {% for name, count in interaction_top.scope_picker_changes %}
+          <tr><td><code>{{ name }}</code></td><td class="num">{{ count }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+  {% if not interaction_top.pill_clicks and not interaction_top.rec_card_clicks and not interaction_top.scope_picker_changes %}
+    <p class="empty">No dashboard interactions recorded yet this session.</p>
+  {% endif %}
+</section>
 {% endblock %}

--- a/tests/unit/ops/test_interaction_counters.py
+++ b/tests/unit/ops/test_interaction_counters.py
@@ -1,0 +1,278 @@
+"""Tests for the in-memory UI interaction counters (Phase 6.1)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.interaction_counters import (  # noqa: E402
+    EVENTS,
+    InteractionCounters,
+    _normalize_target,
+)
+from attune.ops.server import create_app  # noqa: E402
+
+# ---------------------------------------------------------------
+# Pure-Python counter store tests
+# ---------------------------------------------------------------
+
+
+def test_normalize_target_accepts_workflow_name_shape():
+    assert _normalize_target("security-audit") == "security-audit"
+    assert _normalize_target("code-review") == "code-review"
+    assert _normalize_target("next-workflow") == "next-workflow"
+    assert _normalize_target("a/b/c.py") == "a/b/c.py"
+
+
+def test_normalize_target_rejects_html_collapses_to_unknown():
+    assert _normalize_target("<script>x</script>") == "(unknown)"
+    assert _normalize_target("name with space") == "(unknown)"
+    assert _normalize_target("name;rm -rf") == "(unknown)"
+    assert _normalize_target("") == "(unknown)"
+    assert _normalize_target(None) == "(unknown)"
+
+
+def test_normalize_target_caps_length_at_64_chars():
+    # 64 char ok; 65 char rejected
+    long_ok = "a" * 64
+    long_no = "a" * 65
+    assert _normalize_target(long_ok) == long_ok
+    assert _normalize_target(long_no) == "(unknown)"
+
+
+def test_record_known_event_returns_true_and_increments():
+    counters = InteractionCounters()
+    assert counters.record("pill_click", "security-audit") is True
+    assert counters.record("pill_click", "security-audit") is True
+    assert counters.record("pill_click", "code-review") is True
+    snap = counters.snapshot()
+    assert snap["pill_clicks"] == {"security-audit": 2, "code-review": 1}
+
+
+def test_record_unknown_event_returns_false_and_is_a_noop():
+    counters = InteractionCounters()
+    assert counters.record("bogus_event", "anything") is False
+    assert counters.totals() == {
+        "pill_clicks": 0,
+        "rec_card_clicks": 0,
+        "scope_picker_changes": 0,
+    }
+
+
+def test_record_each_event_kind_lands_in_its_bucket():
+    counters = InteractionCounters()
+    counters.record("pill_click", "a")
+    counters.record("rec_card_click", "next-workflow")
+    counters.record("scope_picker_change", "b")
+    snap = counters.snapshot()
+    assert snap["pill_clicks"] == {"a": 1}
+    assert snap["rec_card_clicks"] == {"next-workflow": 1}
+    assert snap["scope_picker_changes"] == {"b": 1}
+
+
+def test_totals_sums_across_targets_per_bucket():
+    counters = InteractionCounters()
+    for name in ("a", "a", "b"):
+        counters.record("pill_click", name)
+    counters.record("rec_card_click", "next-workflow")
+    assert counters.totals() == {
+        "pill_clicks": 3,
+        "rec_card_clicks": 1,
+        "scope_picker_changes": 0,
+    }
+
+
+def test_top_returns_most_common_targets_descending():
+    counters = InteractionCounters()
+    for name in ("a", "a", "a", "b", "b", "c"):
+        counters.record("pill_click", name)
+    top = counters.top("pill_click", limit=2)
+    assert top == [("a", 3), ("b", 2)]
+
+
+def test_top_returns_empty_for_unknown_event():
+    counters = InteractionCounters()
+    assert counters.top("bogus", limit=5) == []
+
+
+def test_record_does_not_raise_on_garbage_target_types():
+    """Non-string targets bucket as ``(unknown)`` rather than raising."""
+    counters = InteractionCounters()
+    # mypy would catch this in real callers; the API takes str | None
+    # but defends against runtime garbage anyway.
+    assert counters.record("pill_click", 123) is True  # type: ignore[arg-type]
+    assert counters.record("pill_click", ["a", "b"]) is True  # type: ignore[arg-type]
+    snap = counters.snapshot()
+    # Both calls bucketed under "(unknown)" — count is 2.
+    assert snap["pill_clicks"] == {"(unknown)": 2}
+
+
+def test_events_constant_lists_supported_events():
+    assert "pill_click" in EVENTS
+    assert "rec_card_click" in EVENTS
+    assert "scope_picker_change" in EVENTS
+
+
+# ---------------------------------------------------------------
+# HTTP API tests
+# ---------------------------------------------------------------
+
+
+def _client(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        trusted_hosts=("testserver", "test"),
+    )
+    app = create_app(config)
+    return TestClient(app)
+
+
+def test_get_interactions_empty_snapshot(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    resp = client.get("/api/telemetry/interactions")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["totals"] == {
+        "pill_clicks": 0,
+        "rec_card_clicks": 0,
+        "scope_picker_changes": 0,
+    }
+    assert body["pill_clicks"] == {}
+    assert body["rec_card_clicks"] == {}
+    assert body["scope_picker_changes"] == {}
+
+
+def test_post_interaction_returns_204_and_increments(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+    resp = client.post(
+        "/api/telemetry/interaction",
+        json={"event": "pill_click", "target": "security-audit"},
+    )
+    assert resp.status_code == 204
+    assert resp.content == b""
+
+    body = client.get("/api/telemetry/interactions").json()
+    assert body["pill_clicks"] == {"security-audit": 1}
+    assert body["totals"]["pill_clicks"] == 1
+
+
+def test_post_interaction_unknown_event_still_returns_204(tmp_path, monkeypatch):
+    """Resilience: stale clients must not see a 4xx for new events."""
+    client = _client(tmp_path, monkeypatch)
+    resp = client.post(
+        "/api/telemetry/interaction",
+        json={"event": "future_event_kind", "target": "x"},
+    )
+    assert resp.status_code == 204
+    # No bucket was incremented.
+    body = client.get("/api/telemetry/interactions").json()
+    assert body["totals"] == {
+        "pill_clicks": 0,
+        "rec_card_clicks": 0,
+        "scope_picker_changes": 0,
+    }
+
+
+def test_post_interaction_html_target_buckets_as_unknown(tmp_path, monkeypatch):
+    """XSS-like targets are normalized; never lands in HTML un-escaped."""
+    client = _client(tmp_path, monkeypatch)
+    resp = client.post(
+        "/api/telemetry/interaction",
+        json={"event": "pill_click", "target": "<script>alert(1)</script>"},
+    )
+    assert resp.status_code == 204
+    body = client.get("/api/telemetry/interactions").json()
+    assert body["pill_clicks"] == {"(unknown)": 1}
+
+
+def test_post_interaction_missing_target_buckets_as_unknown(tmp_path, monkeypatch):
+    """``target`` is optional; missing it buckets as ``(unknown)``."""
+    client = _client(tmp_path, monkeypatch)
+    resp = client.post("/api/telemetry/interaction", json={"event": "rec_card_click"})
+    assert resp.status_code == 204
+    body = client.get("/api/telemetry/interactions").json()
+    assert body["rec_card_clicks"] == {"(unknown)": 1}
+
+
+def test_post_interaction_missing_event_returns_422(tmp_path, monkeypatch):
+    """Missing required field: pydantic catches it (422)."""
+    client = _client(tmp_path, monkeypatch)
+    resp = client.post("/api/telemetry/interaction", json={"target": "x"})
+    assert resp.status_code == 422
+
+
+def test_telemetry_page_renders_interaction_section_when_empty(tmp_path, monkeypatch):
+    """Telemetry page always renders the section header, even when
+    no events have been recorded — empty-state message appears."""
+    client = _client(tmp_path, monkeypatch)
+    resp = client.get("/telemetry")
+    assert resp.status_code == 200
+    assert "Dashboard interactions" in resp.text
+    assert "No dashboard interactions recorded yet" in resp.text
+
+
+def test_telemetry_page_renders_top_tables_after_events(tmp_path, monkeypatch):
+    """After events land, the top-N tables surface in the rendered HTML."""
+    client = _client(tmp_path, monkeypatch)
+    for target in ("security-audit", "security-audit", "code-review"):
+        client.post(
+            "/api/telemetry/interaction",
+            json={"event": "pill_click", "target": target},
+        )
+    client.post(
+        "/api/telemetry/interaction",
+        json={"event": "scope_picker_change", "target": "code-review"},
+    )
+
+    html = client.get("/telemetry").text
+    assert "Top pills clicked" in html
+    assert "Scope picker changes by workflow" in html
+    # The KPI tile should show the totals (3 pill clicks, 1 scope change).
+    # ``{:,}`` formatting renders 3 as "3" so a simple substring check
+    # is enough.
+    assert "security-audit" in html
+    assert "code-review" in html
+
+
+def test_telemetry_page_escapes_unknown_targets(tmp_path, monkeypatch):
+    """The ``(unknown)`` sentinel renders literally — no script tag
+    bleed-through even if a malicious target was posted."""
+    client = _client(tmp_path, monkeypatch)
+    client.post(
+        "/api/telemetry/interaction",
+        json={"event": "pill_click", "target": "<script>alert(1)</script>"},
+    )
+    html = client.get("/telemetry").text
+    assert "(unknown)" in html
+    # The escaped form must NOT appear as a live tag.
+    assert "<script>alert(1)</script>" not in html
+
+
+def test_counters_persist_across_requests_on_same_app(tmp_path, monkeypatch):
+    """Counters are process-lifetime — multiple requests against the
+    same app instance accumulate, not reset."""
+    client = _client(tmp_path, monkeypatch)
+    for _ in range(5):
+        client.post(
+            "/api/telemetry/interaction",
+            json={"event": "pill_click", "target": "security-audit"},
+        )
+    body = client.get("/api/telemetry/interactions").json()
+    assert body["totals"]["pill_clicks"] == 5
+
+
+def test_record_interaction_helper_exported_from_runner_js():
+    """Drift guard: the JS helper must remain on the
+    ``window.__attuneRunner`` export so run_view.js can find it."""
+    from pathlib import Path
+
+    js = Path(__file__).parents[3] / "src/attune/ops/static/js/runner.js"
+    text = js.read_text(encoding="utf-8")
+    assert "recordInteraction: recordInteraction" in text
+    assert "function recordInteraction(" in text


### PR DESCRIPTION
## Summary

Phase 6.1 of the [ops-runner-tier2](docs/specs/ops-runner-tier2/tasks.md) spec. Adds process-lifetime in-memory counters for three dashboard UI events — pill clicks, recommendation-card clicks, and scope-picker changes — and surfaces them on the `/telemetry` tab. No persistence, no network egress, no PII; counters reset on dashboard restart.

## What's new

**Backend**

- `src/attune/ops/interaction_counters.py` — thread-safe `Counter` buckets with conservative target normalization (workflow-name charset + 64-char length cap). Anything off-pattern (HTML, spaces, semicolons) buckets as `(unknown)`.
- `src/attune/ops/routes/interaction_counters.py` — two endpoints:
  - `POST /api/telemetry/interaction` — returns 204 on success **and** on unknown events (so a stale client running against a newer server can't trip the dashboard).
  - `GET /api/telemetry/interactions` — JSON snapshot with per-event totals + per-target counts.
- Wired onto `app.state.interaction_counters` in `server.py`; `/telemetry` route reads the snapshot and passes top-10 lists into the template.

**Frontend**

- `runner.js` — new `recordInteraction(event, target)` helper on `window.__attuneRunner`. Uses `fetch` with `keepalive: true` so a pill click that navigates immediately to the new run still gets recorded. Fire-and-forget; never raises.
- `run_view.js` — `handlePillClick` and the recommendation-card action handler each call `recordInteraction(...)` via the runner helper. Missing-helper case degrades silently.
- `runner.js::wireScopeSave` — records `scope_picker_change` on both picker dropdown changes and custom-path saves.

**Telemetry page**

- New "Dashboard interactions (this session)" section with three KPI tiles + top-N tables per bucket. Empty-state message renders when no events have been recorded.

## Tests

22 new tests in `tests/unit/ops/test_interaction_counters.py` covering:

- Counter store: normalization edges (HTML/length cap/`None`/garbage types), bucket isolation, totals, top-N descending order, unknown-event no-op behavior.
- HTTP API: empty-snapshot shape, increment round-trip, unknown event → 204, HTML target → `(unknown)`, missing target → `(unknown)`, missing event → 422.
- Rendered HTML: section always present, empty-state copy, post-event top-N tables surface, `(unknown)` sentinel escapes properly.
- Drift guard: `recordInteraction` helper stays on `window.__attuneRunner`.

Full ops suite (759 tests) green.

## Spec update

Marks 6.1 done in [docs/specs/ops-runner-tier2/tasks.md](docs/specs/ops-runner-tier2/tasks.md). Phases 6.2 (sweep COVERAGE_BUG_LOG for Phase 1–5 findings), 6.3 (Patrick smoke-tests on a real feature), and 6.4 (close spec) remain.

## Test plan

- [ ] Boot dashboard locally → `/telemetry` shows new section in empty state
- [ ] Trigger a workflow run, click a pill in the streaming log → POST lands, counter increments
- [ ] Click a recommendation card (visible after a code-review run with a security finding) → counter increments
- [ ] Change a scope picker (dropdown or custom path) → counter increments
- [ ] Refresh `/telemetry` → top-N tables render
- [ ] Restart dashboard → counters reset to zero (confirms in-memory only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)