### PR TITLE
test(ops): cover lazy-attach branch in interaction_counters route

### DIFF
--- a/tests/unit/ops/test_interaction_counters.py
+++ b/tests/unit/ops/test_interaction_counters.py
@@ -267,6 +267,50 @@ def test_counters_persist_across_requests_on_same_app(tmp_path, monkeypatch):
     assert body["totals"]["pill_clicks"] == 5
 
 
+def test_counters_lazy_attach_when_app_state_missing():
+    """Defensive shim: if an app was constructed without the counter
+    pre-attached (e.g. a custom test fixture or pre-Phase-6.1 app
+    instance), the route's ``_counters()`` helper lazily attaches a
+    fresh ``InteractionCounters`` so the endpoint never 500s.
+
+    Exercises lines 55-57 of ``routes/interaction_counters.py`` —
+    the ``app.state.interaction_counters is None`` branch — which
+    ``create_app()`` skips because it wires the counter upfront.
+    """
+    from fastapi import FastAPI
+
+    from attune.ops.routes import interaction_counters as routes_mod
+
+    # Bare app — NO ``create_app``, NO ``app.state.interaction_counters``
+    # set. This is the exact pre-condition the defensive shim guards
+    # against.
+    app = FastAPI()
+    app.include_router(routes_mod.router)
+
+    assert not hasattr(app.state, "interaction_counters")
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/telemetry/interaction",
+        json={"event": "pill_click", "target": "security-audit"},
+    )
+    assert resp.status_code == 204
+
+    # The shim should have populated ``app.state.interaction_counters``
+    # AND the record should have landed.
+    assert isinstance(app.state.interaction_counters, InteractionCounters)
+    snapshot = app.state.interaction_counters.snapshot()
+    assert snapshot["pill_clicks"] == {"security-audit": 1}
+
+    # Second request reuses the lazily-attached counters; not a fresh one.
+    client.post(
+        "/api/telemetry/interaction",
+        json={"event": "pill_click", "target": "security-audit"},
+    )
+    snapshot = app.state.interaction_counters.snapshot()
+    assert snapshot["pill_clicks"] == {"security-audit": 2}
+
+
 def test_record_interaction_helper_exported_from_runner_js():
     """Drift guard: the JS helper must remain on the
     ``window.__attuneRunner`` export so run_view.js can find it."""


### PR DESCRIPTION
## Summary

Closes the codecov complaint from PR #430 — `routes/interaction_counters.py` patch coverage was 89.65% with 3 lines missing (the defensive `_counters()` lazy-attach shim).

Adds one test that builds a bare FastAPI app without pre-attaching the counter to `app.state`, then verifies the route handler:

1. Returns 204 (doesn't 500 from missing state)
2. Lazily populates `app.state.interaction_counters` on first request
3. Reuses the same counter instance on subsequent requests (not re-instantiated)

**No production code change.** Coverage of the route module goes from 89.65% → **100%**.

## Why this branch existed

`create_app()` wires the counter onto `app.state` upfront, so production flows never trigger the shim. The shim guards against tests / migrations / future refactors where an app is constructed without that wiring — the new test exercises exactly that scenario.

## Test plan

- [x] New test passes locally
- [x] Coverage of `attune.ops.routes.interaction_counters` = 100%
- [x] All 23 tests in the file still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)