### PR TITLE
chore: weekly report 2026-05-18

### DIFF
--- a/weekly-reports/2026-05-18.md
+++ b/weekly-reports/2026-05-18.md
@@ -1,0 +1,169 @@
+# Anthropic Ecosystem Weekly — 2026-05-18
+
+## Summary
+
+Agent SDK v0.2.82 (May 15) ships two breaking changes that land inside
+attune-ai's current `>=0.1.60,<1.0.0` version range: MCP servers now
+connect in the background by default, and `TodoWrite` is replaced by
+Task tools in headless/SDK sessions. Claude Code shipped five releases
+(v2.1.139–143) with notable additions: `CLAUDE_PROJECT_DIR` in MCP
+stdio servers, hook `args` semantics tightened, fast mode defaulting to
+Opus 4.7, and a `claude agents` Research Preview. The SDK also pulls in
+a security fix for `mcp>=1.23.0` (GHSA-9h52-p55h-vw2f).
+
+---
+
+## Recommendations
+
+**1. Cap the Agent SDK below v0.2.82 until the two breaking changes are
+verified**
+
+`pyproject.toml` has `claude-agent-sdk>=0.1.60,<1.0.0`, so v0.2.82
+will be auto-resolved on the next `uv lock --upgrade-package
+claude-agent-sdk`. Two breaking changes fire together:
+
+- **MCP background connection** — sessions start immediately; the
+  attune-ai MCP server (in `.claude/mcp.json` and `.mcp.json`) may not
+  be connected when turn-1 tool calls arrive, returning `status:
+  "pending"` with no useful error.
+- **TodoWrite → Task tools** — headless/SDK sessions now emit
+  `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` instead of
+  `TodoWrite`. `plugin/hooks/_resume_prompt.py` references TodoWrite
+  in a docstring only (no functional impact), but any future code
+  parsing tool-call names from SDK sessions needs updating.
+
+Two-step upgrade path:
+1. Add `"alwaysLoad": true` to the `attune-ai` entry in both
+   `.claude/mcp.json` and `.mcp.json` to restore blocking connection
+   for this server while leaving others non-blocking.
+2. Test in a worktree against v0.2.82 before relaxing the cap.
+
+- **Applies to:** `pyproject.toml`, `.claude/mcp.json`, `.mcp.json`,
+  all SDK-native workflows in `src/attune/workflows/`
+- **Urgency:** High — the version range admits the breaking release
+  today.
+- **Alternative:** Set `MCP_CONNECTION_NONBLOCKING=0` env var as a
+  temporary override if you want the upgrade now without the `alwaysLoad`
+  change.
+
+**2. Pick up the MCP security fix (GHSA-9h52-p55h-vw2f) deliberately**
+
+SDK v0.2.82 bumps its MCP dependency to `>=1.23.0` for a CVE fix. The
+attune-ai MCP server (`attune.mcp.server`) depends on `mcp` as a
+transitive dep through `claude-agent-sdk`. Once you cap-and-test per
+Rec #1, verify `uv pip show mcp` shows `>=1.23.0`.
+
+- **Applies to:** `src/attune/mcp/`, `uv.lock`
+- **Urgency:** Medium — upgrade when Rec #1 is resolved, not before.
+
+**3. Use `CLAUDE_PROJECT_DIR` in the MCP server to fix worktree-cwd
+drift**
+
+Claude Code v2.1.139 now passes `CLAUDE_PROJECT_DIR` to all MCP stdio
+servers as an environment variable. The attune-ai MCP server currently
+defaults `workspace_root` to `os.getcwd()`, which resolves to a
+worktree slug when sessions are launched from worktrees (documented
+nightmare in CLAUDE.md lessons). `CLAUDE_PROJECT_DIR` gives the
+canonical repo root directly.
+
+- **Fix:** In `EmpathyMCPServer.__init__` (or wherever
+  `_workspace_root` is set), replace `os.getcwd()` with
+  `os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()`.
+- **Applies to:** `src/attune/mcp/server.py`
+- **Urgency:** Low — no active breakage, but closes one of the
+  longest-standing worktree friction points.
+
+**4. Fast mode now defaults to Opus 4.7 in Claude Code v2.1.142 —
+compounds last week's tokenizer warning**
+
+Claude Code v2.1.142 changed fast mode's default model from Opus 4.6
+to Opus 4.7. Any attune-ops workflow or SDK session that spawns a
+Claude Code CLI subprocess in fast mode now uses the Opus 4.7
+tokenizer, which produces up to 35% more tokens on identical input.
+Last week's Rec #1 (audit Opus 4.7 token budgets) is now more urgent.
+
+- **Applies to:** PREMIUM tier routing in `src/attune/models/`,
+  any attune-ops workflow launching subagents via CLI
+- **Action:** If the Rec #1 audit is still pending, prioritize it.
+
+**5. Hook `"args"` field change (v2.1.139) — attune-ai not affected,
+but note for future hook authoring**
+
+Claude Code v2.1.139 changed the `"args"` array field on hooks to
+spawn commands directly without a shell (no `&&`, no `$(...)`, no env
+var expansion). Attune-ai's hooks in `.claude/settings.json` use the
+`"command"` string field exclusively (e.g. `"command": "cd
+\"$(git rev-parse ...)\" && ..."`), which still runs via shell and is
+not affected. **But:** any new hook added using the `["cmd", "arg"]
+array` pattern will break if it relies on shell features.
+
+- **Applies to:** Future hook authoring only. No current code change
+  needed.
+
+---
+
+## Carry-overs
+
+| # | Recommendation | Status |
+|---|---|---|
+| 1 | Audit Opus 4.7 token budgets before routing live traffic | **More urgent** — fast mode now defaults to 4.7 (see Rec #4 above) |
+| 2 | Replace `"Skill"` in `allowed_tools` with `skills=` kwarg | Still open; `grep -r '"Skill"' src/attune/workflows/` to check exposure |
+| 3 | Add `ENABLE_PROMPT_CACHING_1H` to attune-author polish step | Still open if PR #12 hasn't merged |
+| 4 | Surface `api_error_status` from `ResultMessage` in adapter | Still open; one-line addition to `agent_sdk_adapter.py` |
+| 5 | Audit docs for "Max plan" / subscription language | Treat as done unless new docs were added this cycle |
+
+---
+
+## Watch list
+
+- **`claude agents` command (Research Preview, v2.1.139)** — New
+  `claude agents` CLI lists all sessions with IDs. Directly relevant
+  to attune-ops session dashboard (the `~/.claude/projects/` scanning
+  work from PRs #379/#384). Track for GA — may become the canonical
+  API for session discovery rather than filesystem scraping.
+- **`/goal` command (Research Preview, v2.1.139)** — Completion
+  condition with live metrics overlay. No SDK exposure yet, but if it
+  surfaces as an API primitive it could augment attune-ops run
+  tracking.
+- **Claude Managed Agents Multiagent Sessions + Outcomes (public beta,
+  May 6)** — Multi-agent sessions with defined Outcomes. Structural
+  overlap with `ReleasePrepTeam`. Gap is narrowing; worth a comparison
+  pass before adding more orchestration to the SDK-native workflow
+  layer.
+- **Claude Managed Agents Memory (public beta, April 23)** —
+  Structural overlap with attune-ai's `MemoryBackend` protocol and
+  Redis short-term memory. Not urgent, but if Anthropic's memory
+  becomes feature-complete and cheaper, it's the displacement path.
+- **Claude Platform on AWS (May 11)** — Same Messages API, IAM auth,
+  AWS billing. No action now; relevant if enterprise customers require
+  AWS billing constraints.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Claude Platform on AWS GA (May 11) | Stack uses direct API; no AWS billing requirement |
+| Rate Limits API (April 24) | Useful for enterprise dashboards; not needed at current scale |
+| `worktree.bgIsolation: 'none'` (v2.1.143) | No active friction from current isolation; optional setting |
+| Hook `terminalSequence` field (v2.1.141) | Desktop notification primitive; no current need in the hook set |
+| `ANTHROPIC_WORKSPACE_ID` (v2.1.141) | Workload identity federation; direct API key auth is fine |
+| Plugin marketplace cost estimates (v2.1.143) | UX for marketplace users, not builders |
+| Plugin dependency enforcement (v2.1.143) | attune-ai plugin is self-contained; no cross-plugin deps |
+| `EffortLevel` type export (SDK v0.2.82) | Already used as string literals; no type annotation change needed |
+| Fast mode for Opus 4.7 (API, May 12) | Premium-priced research preview; not on the API key budget yet |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` (through May 12, 2026)
+- Claude Code: releasebot.io/updates/anthropic/claude-code
+  (v2.1.139–v2.1.143, May 11–15, 2026)
+- Agent SDK: github.com/anthropics/claude-agent-sdk-python/releases
+  (v0.2.82, May 15, 2026)
+- Prior week report: `weekly-reports/2026-05-11.md`
+- Repo audit: `pyproject.toml` (SDK version constraint),
+  `.claude/mcp.json`, `.mcp.json`, `.claude/settings.json`,
+  `plugin/hooks/_resume_prompt.py`


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-05-18

## Summary

Agent SDK v0.2.82 (May 15) ships two breaking changes that land inside
attune-ai's current `>=0.1.60,<1.0.0` version range: MCP servers now
connect in the background by default, and `TodoWrite` is replaced by
Task tools in headless/SDK sessions. Claude Code shipped five releases
(v2.1.139–143) with notable additions: `CLAUDE_PROJECT_DIR` in MCP
stdio servers, hook `args` semantics tightened, fast mode defaulting to
Opus 4.7, and a `claude agents` Research Preview. The SDK also pulls in
a security fix for `mcp>=1.23.0` (GHSA-9h52-p55h-vw2f).

---

## Recommendations

**1. Cap the Agent SDK below v0.2.82 until the two breaking changes are
verified**

`pyproject.toml` has `claude-agent-sdk>=0.1.60,<1.0.0`, so v0.2.82
will be auto-resolved on the next `uv lock --upgrade-package
claude-agent-sdk`. Two breaking changes fire together:

- **MCP background connection** — sessions start immediately; the
  attune-ai MCP server (in `.claude/mcp.json` and `.mcp.json`) may not
  be connected when turn-1 tool calls arrive, returning `status:
  "pending"` with no useful error.
- **TodoWrite → Task tools** — headless/SDK sessions now emit
  `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` instead of
  `TodoWrite`. `plugin/hooks/_resume_prompt.py` references TodoWrite
  in a docstring only (no functional impact), but any future code
  parsing tool-call names from SDK sessions needs updating.

Two-step upgrade path:
1. Add `"alwaysLoad": true` to the `attune-ai` entry in both
   `.claude/mcp.json` and `.mcp.json` to restore blocking connection
   for this server while leaving others non-blocking.
2. Test in a worktree against v0.2.82 before relaxing the cap.

- **Applies to:** `pyproject.toml`, `.claude/mcp.json`, `.mcp.json`,
  all SDK-native workflows in `src/attune/workflows/`
- **Urgency:** High — the version range admits the breaking release
  today.
- **Alternative:** Set `MCP_CONNECTION_NONBLOCKING=0` env var as a
  temporary override if you want the upgrade now without the `alwaysLoad`
  change.

**2. Pick up the MCP security fix (GHSA-9h52-p55h-vw2f) deliberately**

SDK v0.2.82 bumps its MCP dependency to `>=1.23.0` for a CVE fix. The
attune-ai MCP server (`attune.mcp.server`) depends on `mcp` as a
transitive dep through `claude-agent-sdk`. Once you cap-and-test per
Rec #1, verify `uv pip show mcp` shows `>=1.23.0`.

- **Applies to:** `src/attune/mcp/`, `uv.lock`
- **Urgency:** Medium — upgrade when Rec #1 is resolved, not before.

**3. Use `CLAUDE_PROJECT_DIR` in the MCP server to fix worktree-cwd
drift**

Claude Code v2.1.139 now passes `CLAUDE_PROJECT_DIR` to all MCP stdio
servers as an environment variable. The attune-ai MCP server currently
defaults `workspace_root` to `os.getcwd()`, which resolves to a
worktree slug when sessions are launched from worktrees (documented
nightmare in CLAUDE.md lessons). `CLAUDE_PROJECT_DIR` gives the
canonical repo root directly.

- **Fix:** In `EmpathyMCPServer.__init__` (or wherever
  `_workspace_root` is set), replace `os.getcwd()` with
  `os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()`.
- **Applies to:** `src/attune/mcp/server.py`
- **Urgency:** Low — no active breakage, but closes one of the
  longest-standing worktree friction points.

**4. Fast mode now defaults to Opus 4.7 in Claude Code v2.1.142 —
compounds last week's tokenizer warning**

Claude Code v2.1.142 changed fast mode's default model from Opus 4.6
to Opus 4.7. Any attune-ops workflow or SDK session that spawns a
Claude Code CLI subprocess in fast mode now uses the Opus 4.7
tokenizer, which produces up to 35% more tokens on identical input.
Last week's Rec #1 (audit Opus 4.7 token budgets) is now more urgent.

- **Applies to:** PREMIUM tier routing in `src/attune/models/`,
  any attune-ops workflow launching subagents via CLI
- **Action:** If the Rec #1 audit is still pending, prioritize it.

**5. Hook `"args"` field change (v2.1.139) — attune-ai not affected,
but note for future hook authoring**

Claude Code v2.1.139 changed the `"args"` array field on hooks to
spawn commands directly without a shell (no `&&`, no `$(...)`, no env
var expansion). Attune-ai's hooks in `.claude/settings.json` use the
`"command"` string field exclusively, which still runs via shell and is
not affected. **But:** any new hook added using the `["cmd", "arg"]
array` pattern will break if it relies on shell features.

- **Applies to:** Future hook authoring only. No current code change
  needed.

---

## Carry-overs

| # | Recommendation | Status |
|---|---|---|
| 1 | Audit Opus 4.7 token budgets before routing live traffic | **More urgent** — fast mode now defaults to 4.7 (see Rec #4 above) |
| 2 | Replace `"Skill"` in `allowed_tools` with `skills=` kwarg | Still open; `grep -r '"Skill"' src/attune/workflows/` to check exposure |
| 3 | Add `ENABLE_PROMPT_CACHING_1H` to attune-author polish step | Still open if PR #12 hasn't merged |
| 4 | Surface `api_error_status` from `ResultMessage` in adapter | Still open; one-line addition to `agent_sdk_adapter.py` |
| 5 | Audit docs for "Max plan" / subscription language | Treat as done unless new docs were added this cycle |

---

## Watch list

- **`claude agents` command (Research Preview, v2.1.139)** — New
  `claude agents` CLI lists all sessions with IDs. Directly relevant
  to attune-ops session dashboard (the `~/.claude/projects/` scanning
  work from PRs #379/#384). Track for GA — may become the canonical
  API for session discovery rather than filesystem scraping.
- **`/goal` command (Research Preview, v2.1.139)** — Completion
  condition with live metrics overlay. No SDK exposure yet, but if it
  surfaces as an API primitive it could augment attune-ops run
  tracking.
- **Claude Managed Agents Multiagent Sessions + Outcomes (public beta,
  May 6)** — Multi-agent sessions with defined Outcomes. Structural
  overlap with `ReleasePrepTeam`. Gap is narrowing; worth a comparison
  pass before adding more orchestration to the SDK-native workflow
  layer.
- **Claude Managed Agents Memory (public beta, April 23)** —
  Structural overlap with attune-ai's `MemoryBackend` protocol and
  Redis short-term memory. Not urgent, but if Anthropic's memory
  becomes feature-complete and cheaper, it's the displacement path.
- **Claude Platform on AWS (May 11)** — Same Messages API, IAM auth,
  AWS billing. No action now; relevant if enterprise customers require
  AWS billing constraints.

---

## No-ops

| Item | Why skipped |
|---|---|
| Claude Platform on AWS GA (May 11) | Stack uses direct API; no AWS billing requirement |
| Rate Limits API (April 24) | Useful for enterprise dashboards; not needed at current scale |
| `worktree.bgIsolation: 'none'` (v2.1.143) | No active friction from current isolation; optional setting |
| Hook `terminalSequence` field (v2.1.141) | Desktop notification primitive; no current need in the hook set |
| `ANTHROPIC_WORKSPACE_ID` (v2.1.141) | Workload identity federation; direct API key auth is fine |
| Plugin marketplace cost estimates (v2.1.143) | UX for marketplace users, not builders |
| Plugin dependency enforcement (v2.1.143) | attune-ai plugin is self-contained; no cross-plugin deps |
| `EffortLevel` type export (SDK v0.2.82) | Already used as string literals; no type annotation change needed |
| Fast mode for Opus 4.7 (API, May 12) | Premium-priced research preview; not on the API key budget yet |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/api` (through May 12, 2026)
- Claude Code: releasebot.io/updates/anthropic/claude-code
  (v2.1.139–v2.1.143, May 11–15, 2026)
- Agent SDK: github.com/anthropics/claude-agent-sdk-python/releases
  (v0.2.82, May 15, 2026)
- Prior week report: `weekly-reports/2026-05-11.md`
- Repo audit: `pyproject.toml` (SDK version constraint),
  `.claude/mcp.json`, `.mcp.json`, `.claude/settings.json`,
  `plugin/hooks/_resume_prompt.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_01838JHqBju4Le2GZYFkzcQF)_