### PR TITLE
feat(workflows): expose ATTUNE_AGENT_MODEL_{DETECTOR,REVIEWER} overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Two new role-keyword hooks (`detector`, `reviewer`) in the
+  subagent-model registry, exposing `ATTUNE_AGENT_MODEL_DETECTOR`
+  and `ATTUNE_AGENT_MODEL_REVIEWER` as opt-in overrides for agents
+  that previously had no env-var hook (secret-detector,
+  auth-reviewer, perf-reviewer, safety-reviewer). Both default to
+  `inherit` so they preserve current "inherit parent" behavior
+  for users who don't set the override — zero behavior change for
+  default users. Subscription users hitting rate limits on
+  subagent-heavy workflows (security-audit, deep-review,
+  code-review with 4-5 parallel Opus subagents) can now rebalance
+  via `ATTUNE_AGENT_MODEL_VULN=sonnet ATTUNE_AGENT_MODEL_DETECTOR
+  =sonnet ATTUNE_AGENT_MODEL_REVIEWER=sonnet attune workflow run
+  security-audit` without code changes. Docs at
+  [docs/PROJECT_OVERVIEW.md](docs/PROJECT_OVERVIEW.md#per-agent-model-override)
+  enumerate every keyword + default + which subagents it matches.
 - Ops dashboard now tracks in-memory UI interaction counters (pill
   clicks, recommendation-card clicks, scope-picker changes) and
   surfaces them under a new "Dashboard interactions (this session)"

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -151,10 +151,56 @@ Set via `ATTUNE_MAX_BUDGET_USD` environment variable.
 
 ### Per-Agent Model Override
 
+Each subagent is matched against a set of role-keyword env vars to
+determine which model it runs on. Setting any of the keywords to
+a tier name overrides the built-in default for subagents whose
+name contains that keyword.
+
 ```bash
-export ATTUNE_AGENT_MODEL_SECURITY=sonnet
-export ATTUNE_AGENT_MODEL_DEFAULT=opus
+# Examples
+export ATTUNE_AGENT_MODEL_SECURITY=sonnet   # security-reviewer → sonnet
+export ATTUNE_AGENT_MODEL_DEFAULT=opus      # any unmatched agent → opus
 ```
+
+**Available keywords and built-in defaults:**
+
+| Keyword | Default | Matches subagents like |
+| --- | --- | --- |
+| `security` | opus | security-reviewer |
+| `vuln` | opus | vuln-scanner |
+| `architect` | opus | architect-reviewer |
+| `quality` | sonnet | quality-reviewer |
+| `plan` | sonnet | remediation-planner |
+| `research` | sonnet | research-* |
+| `complexity` | haiku | complexity-analyzer |
+| `lint` | haiku | lint-checker |
+| `coverage` | haiku | coverage-analyzer |
+| `dep` | haiku | dep-checker |
+| `detector` | inherit | secret-detector |
+| `reviewer` | inherit | auth-reviewer, perf-reviewer, safety-reviewer |
+
+The `inherit`-default keywords (`detector`, `reviewer`) exist
+primarily as override hooks — without an env var they fall
+through to the orchestrator's model or `ATTUNE_AGENT_MODEL_DEFAULT`.
+
+**Subscription users hitting rate limits** on subagent-heavy
+workflows (security-audit fans out to 4 subagents, deep-review
+to 4-5, all Opus by default) can rebalance with:
+
+```bash
+# Lighten security-audit by routing 3 of 4 subagents to Sonnet.
+# The orchestrator stays on Opus for cross-finding synthesis.
+export ATTUNE_AGENT_MODEL_VULN=sonnet
+export ATTUNE_AGENT_MODEL_DETECTOR=sonnet
+export ATTUNE_AGENT_MODEL_REVIEWER=sonnet
+attune workflow run security-audit
+```
+
+Trade-off: small accuracy reduction on pattern-finding work
+(Sonnet 4.6 closes most of the gap with Opus 4.7 for vuln /
+secret / auth pattern matching) in exchange for substantially
+lower rate-limit pressure and (for API-billed users) ~70% lower
+per-run cost.
 
 ---
 

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -583,7 +583,25 @@ def resolve_cwd_for_path(path: str | Path) -> Path:
     return p.parent if p.is_file() else p
 
 
-# Role-keyword to model mapping for subagents
+# Role-keyword to model mapping for subagents.
+#
+# Each entry registers a keyword that hooks two things:
+#
+# 1. The default model for subagents whose name contains the keyword.
+# 2. An env-var override path: ``ATTUNE_AGENT_MODEL_<KEYWORD>=sonnet``
+#    lets users opt subagents matching that keyword to a different
+#    tier without code changes.
+#
+# Map value ``"inherit"`` means "preserve current behavior — fall
+# through to the orchestrator's model unless overridden by env var."
+# Useful for agent roles where we want the override knob exposed
+# but don't want to commit to a specific tier as the default.
+#
+# Subscription-tier (Pro/Max) users hitting rate limits on
+# subagent-heavy workflows (security-audit, deep-review,
+# code-review) can lighten the load with e.g.
+# ``ATTUNE_AGENT_MODEL_VULN=sonnet ATTUNE_AGENT_MODEL_DETECTOR=sonnet
+# ATTUNE_AGENT_MODEL_REVIEWER=sonnet attune workflow run security-audit``.
 _SUBAGENT_MODEL_MAP: dict[str, str] = {
     # Deep reasoning agents → opus
     "security": "opus",
@@ -598,6 +616,14 @@ _SUBAGENT_MODEL_MAP: dict[str, str] = {
     "lint": "haiku",
     "coverage": "haiku",
     "dep": "haiku",
+    # Role-shape keywords with no committed default; exposed
+    # primarily as override hooks. ``inherit`` preserves the
+    # parent's model unless the corresponding env var is set.
+    # Covers: secret-detector (security-audit), auth-reviewer
+    # (security-audit), perf-reviewer (code-review),
+    # safety-reviewer (simplify-code).
+    "detector": "inherit",
+    "reviewer": "inherit",
 }
 
 
@@ -612,7 +638,9 @@ def get_subagent_model(agent_name: str) -> str | None:
     4. ``None`` (inherit parent model)
 
     Valid model values: ``"opus"``, ``"sonnet"``, ``"haiku"``,
-    ``"inherit"``.
+    ``"inherit"``. The literal ``"inherit"`` is normalized to
+    ``None`` so callers can pass the return value directly to the
+    SDK ``AgentDefinition.model`` field.
 
     Args:
         agent_name: Name of the subagent (e.g. ``"security-reviewer"``).
@@ -629,7 +657,14 @@ def get_subagent_model(agent_name: str) -> str | None:
             env_val = os.environ.get(env_key)
             if env_val:
                 return env_val if env_val != "inherit" else None
-            return _SUBAGENT_MODEL_MAP[keyword]
+            configured = _SUBAGENT_MODEL_MAP[keyword]
+            if configured != "inherit":
+                return configured
+            # Map value is ``inherit`` — this keyword exists solely
+            # to expose an override hook. Without that override, fall
+            # through to the global DEFAULT or ultimately None
+            # (parent-inherit) below. Match the FIRST keyword only.
+            break
 
     # Check global default override
     default = os.environ.get("ATTUNE_AGENT_MODEL_DEFAULT")

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -846,6 +846,87 @@ class TestGetSubagentModel:
         """Given mixed-case name, keyword matching is case-insensitive."""
         assert get_subagent_model("Security-Reviewer") == "opus"
 
+    # -- "inherit"-default keywords (reviewer, detector) -----------
+    #
+    # These keywords are registered in the map with value ``"inherit"``
+    # so that subagents matching them get an env-var override hook
+    # without committing to a specific tier as the default. Behavior
+    # for users who don't set the keyword-specific env var must be
+    # identical to the pre-existing inherit-parent semantics: fall
+    # through to the global DEFAULT env var, then return None.
+
+    def test_detector_keyword_inherits_by_default(self) -> None:
+        """secret-detector returns None (inherit) when no env vars set."""
+        assert get_subagent_model("secret-detector") is None
+
+    def test_reviewer_keyword_inherits_by_default(self) -> None:
+        """auth-reviewer / perf-reviewer / safety-reviewer return None
+        (inherit) when no env vars set.
+
+        Regression: ``perf-reviewer`` previously had no keyword match
+        and returned None via the unmatched path. Now it matches the
+        new ``reviewer`` keyword whose default is ``inherit``, which
+        must still return None.
+        """
+        assert get_subagent_model("auth-reviewer") is None
+        assert get_subagent_model("perf-reviewer") is None
+        assert get_subagent_model("safety-reviewer") is None
+
+    def test_detector_env_var_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ATTUNE_AGENT_MODEL_DETECTOR=sonnet routes secret-detector."""
+        monkeypatch.setenv("ATTUNE_AGENT_MODEL_DETECTOR", "sonnet")
+        assert get_subagent_model("secret-detector") == "sonnet"
+
+    def test_reviewer_env_var_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ATTUNE_AGENT_MODEL_REVIEWER=sonnet routes auth-reviewer."""
+        monkeypatch.setenv("ATTUNE_AGENT_MODEL_REVIEWER", "sonnet")
+        assert get_subagent_model("auth-reviewer") == "sonnet"
+        # perf-reviewer and safety-reviewer also match the keyword.
+        assert get_subagent_model("perf-reviewer") == "sonnet"
+        assert get_subagent_model("safety-reviewer") == "sonnet"
+
+    def test_inherit_default_falls_through_to_global_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the matched keyword's map value is ``inherit``, the
+        global ATTUNE_AGENT_MODEL_DEFAULT must still apply.
+
+        Without this fallthrough, adding ``reviewer`` to the map
+        would silently override the existing global-default contract
+        for perf-reviewer / auth-reviewer / safety-reviewer.
+        """
+        monkeypatch.setenv("ATTUNE_AGENT_MODEL_DEFAULT", "opus")
+        assert get_subagent_model("perf-reviewer") == "opus"
+        assert get_subagent_model("auth-reviewer") == "opus"
+        assert get_subagent_model("safety-reviewer") == "opus"
+
+    def test_keyword_override_beats_global_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Keyword-specific env var has priority over DEFAULT."""
+        monkeypatch.setenv("ATTUNE_AGENT_MODEL_DEFAULT", "opus")
+        monkeypatch.setenv("ATTUNE_AGENT_MODEL_REVIEWER", "sonnet")
+        assert get_subagent_model("auth-reviewer") == "sonnet"
+
+    def test_specific_keyword_wins_over_inherit_keyword(self) -> None:
+        """When an agent name matches BOTH a specific-default keyword
+        (e.g. ``security``) AND the ``reviewer`` inherit keyword, the
+        first dict-iteration match wins. The map orders specific
+        keywords before inherit ones so ``security-reviewer`` stays
+        on opus.
+        """
+        assert get_subagent_model("security-reviewer") == "opus"
+        assert get_subagent_model("quality-reviewer") == "sonnet"
+        assert get_subagent_model("architect-reviewer") == "opus"
+
 
 @pytest.mark.unit
 class TestAgentSDKResultAdapterStructuredOutput:


### PR DESCRIPTION
## Summary

Adds two new role-keyword hooks (`detector`, `reviewer`) to the subagent-model registry so subscription-tier users can rebalance subagent-heavy workflows away from Opus without code changes. Both default to `inherit` — **zero behavior change** for users who don't set the new env vars.

## Motivation

Tonight's `deep-review` failure after 213.7s on a fresh subscription seat showed the practical edge of the current "fan out 5 Opus subagents in parallel" default. Patrick asked: should security-audit's subagents all be Opus?

**Current security-audit subagent assignment:**

| Subagent | Currently | Reason |
|---|---|---|
| `vuln-scanner` | Opus | matches `vuln` keyword |
| `secret-detector` | inherit parent (Opus) | no keyword match — no env-var hook |
| `auth-reviewer` | inherit parent (Opus) | no keyword match — no env-var hook |
| `remediation-planner` | Sonnet | matches `plan` keyword |

So 3 of 4 subagents run on Opus, and only 1 of them (`vuln-scanner`) had an env-var override available. This PR exposes the missing hooks.

## Change shape

Single new sentinel value `"inherit"` in `_SUBAGENT_MODEL_MAP`. Two new entries:

```python
"detector": "inherit",   # matches secret-detector
"reviewer": "inherit",   # matches auth-reviewer, perf-reviewer, safety-reviewer
```

Resolver function updated so `"inherit"` map values no longer short-circuit — they fall through to `ATTUNE_AGENT_MODEL_DEFAULT` or ultimately `None` (parent-inherit). This is the load-bearing detail that preserves existing semantics: setting `ATTUNE_AGENT_MODEL_DEFAULT=opus` still applies to `perf-reviewer` after this change, as it does today.

## Usage

After this PR, subscription users can lighten security-audit's load:

```bash
ATTUNE_AGENT_MODEL_VULN=sonnet \
ATTUNE_AGENT_MODEL_DETECTOR=sonnet \
ATTUNE_AGENT_MODEL_REVIEWER=sonnet \
  attune workflow run security-audit
```

This routes 3 of 4 subagents to Sonnet, keeps the orchestrator on Opus (where cross-finding synthesis benefits most), and substantially reduces parallel-Opus rate-limit pressure on subscription quotas. For API-billed users, ~70% per-run cost reduction.

## Tests

7 new tests in `TestGetSubagentModel`:

- `test_detector_keyword_inherits_by_default`
- `test_reviewer_keyword_inherits_by_default` — regression guard for the pre-existing `perf-reviewer is None` contract
- `test_detector_env_var_override`
- `test_reviewer_env_var_override` — confirms `auth-reviewer`, `perf-reviewer`, `safety-reviewer` all route via the new keyword
- `test_inherit_default_falls_through_to_global_default` — regression guard: `ATTUNE_AGENT_MODEL_DEFAULT=opus` still applies after keyword match (load-bearing)
- `test_keyword_override_beats_global_default`
- `test_specific_keyword_wins_over_inherit_keyword` — `security-reviewer` / `quality-reviewer` / `architect-reviewer` still match their specific keywords first

20/20 `TestGetSubagentModel` tests pass.

## Docs

[docs/PROJECT_OVERVIEW.md](docs/PROJECT_OVERVIEW.md#per-agent-model-override) now has a full keyword / default / matched-subagents table plus the rebalance recipe.

## Test plan

- [ ] No behavior change without explicit env vars set
- [ ] `ATTUNE_AGENT_MODEL_DEFAULT=opus attune workflow run <whatever>` continues to apply globally (regression test guards this)
- [ ] New env vars route the targeted subagents to the requested tier
- [ ] `security-reviewer` (matches `security` keyword first) is unaffected by `ATTUNE_AGENT_MODEL_REVIEWER`

🤖 Generated with [Claude Code](https://claude.com/claude-code)