### PR TITLE
chore: gitignore personal .claude/launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,6 @@ dashboard/dist/
 # create stray MagicMock/mock.attune_dir/<id>/ trees. Ignore them as a
 # safety net; ideally the underlying tests should be fixed to use tmp_path.
 MagicMock/
+
+# Personal IDE launch configs (per-dev-machine; not portable)
+.claude/launch.json


### PR DESCRIPTION
## Summary
- Add `.claude/launch.json` to `.gitignore`
- Per-dev-machine VSCode launch config for `attune-ops` debugging; not portable across collaborators

## Why
After the worktree audit + main checkout cleanup this morning, `.claude/launch.json` was the only untracked file left in `git status`. Gitignoring it stops it showing up while preserving the file on disk for convenience.

## Test plan
- [x] `git check-ignore -v .claude/launch.json` resolves to `.gitignore:261`
- [x] Pre-commit hooks pass (detect-secrets, end-of-files, trailing-whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)