### PR TITLE
docs(spec/parallelism): refined baseline + resolved decisions

### DIFF
--- a/docs/specs/agent-surface-parallelism-evaluation/decisions.md
+++ b/docs/specs/agent-surface-parallelism-evaluation/decisions.md
@@ -1,6 +1,6 @@
 # Decisions — Agent Surface Parallelism Evaluation
 
-**Status:** draft (2026-05-16) — no decisions resolved yet
+**Status:** in progress (2026-05-19) — Phase 0.1 complete (telemetry), refined baseline + D2 resolved; D1 provisional; D3+D4 still gated on Phase 0 outcome
 
 ---
 
@@ -34,14 +34,7 @@ This matrix is recorded BEFORE Phase 0 runs, per the existing CLAUDE.md lesson "
 
 ### D2 — Concurrency in the parallel fan-out
 
-**Status:** open
-
-**Options:**
-- 3 workflows (`security`, `code-quality`, `deep-review`) — smallest interesting number.
-- 4 workflows (add `bug-predict`).
-- 5+ — approaches Anthropic concurrency limits and cost-cap edges.
-
-**Recommendation pending Phase 0 design**: 3 for the first pass.
+**Status:** RESOLVED 2026-05-19 — see "Resolved decisions" below. Chosen: 3 workflows = `bug-predict + code-review + security-audit` (the modal triplet from Phase 0.1).
 
 ### D3 — Surface for PROCEED case
 
@@ -69,4 +62,51 @@ The orchestrator subagent that synthesizes the parallel results either (a) runs 
 
 ## Resolved decisions
 
-(None yet — this is a draft.)
+### Refined baseline for Phase 0.3–0.5 (2026-05-19)
+
+**Decision:** Phase 0.3 (sequential) and 0.4 (parallel) compare against `/deep-review` as the baseline, NOT three workflows run serially via shell as the original spec proposed.
+
+**Rationale:** Phase 0.1 findings (2026-05-16) showed that 27 of 48 multi-analytical sessions hit exactly the `bug-predict + code-review + security-audit` triplet — which is what `/deep-review` already spawns as Claude Agent SDK subagents (`src/attune/workflows/deep_review.py:268-291`). The proposed orchestrator substantially duplicates `/deep-review`'s pipeline. Measuring against three-workflows-serial would inflate the wall-clock-savings number relative to reality, and the qualitative-synthesis gate has to clear "better than `/deep-review`" — not "better than no synthesis at all" — to justify a new surface.
+
+**Concrete change to tasks:**
+- **0.3 (Sequential baseline)**: run `/security`, `/code-review`, `/bug-predict` sequentially against the target region. Capture wall-clock, cost, tokens. This is the worst-case latency upper bound.
+- **0.3b (New)**: run `/deep-review` once against the same target. Capture the same metrics plus a trace of whether the orchestrator dispatched subagents in one assistant turn (parallel) or three (serial). This is the *real* baseline.
+- **0.4 (Parallel arm)**: build a throwaway orchestrator that fans out the same three analyses in parallel. Capture same metrics.
+- **0.5 (Qualitative)**: hand-eval the parallel arm's synthesis vs both (a) the three sequential reports and (b) `/deep-review`'s synthesized output.
+
+**Gates (refined per Phase 0.1 recommendation):**
+
+| Original gate | Refined gate |
+|---|---|
+| Wall-clock savings vs 3-workflows-serial | Wall-clock savings vs `/deep-review` pipeline |
+| Synthesis adds qualitative signal | Synthesis adds signal *beyond what /deep-review already produces* |
+
+The pre-committed matrix in this file still routes the decision; only the comparison baseline changed.
+
+### Probe before measurement (2026-05-19)
+
+**Decision:** Phase 0.3 instruments the `/deep-review` run to determine whether its subagents currently dispatch in parallel or serially.
+
+**Rationale:** The orchestrator system prompt (`deep_review.py:121-126`) and task template (`deep_review.py:128-148`) say "each subagent focuses on a specific domain and will report findings independently" — a parallel hint, but not a guarantee. The Claude Agent SDK's dispatch behavior depends on whether the orchestrator issues multiple Task tool calls in one assistant turn. If it does (parallel), the spec retires because the proposed work is already shipping. If it doesn't (serial), the right fix is a one-line orchestrator-prompt tweak to deep-review, not a new orchestrator skill. Either way, this probe costs nothing extra — same `/deep-review` run that's already in 0.3b.
+
+**Probe output:** record in `phase0-data/deep-review-trace.md`: the sequence of assistant turns and which Task tool calls fire in each. One-line conclusion: "parallel" or "serial" or "mixed."
+
+### D1 — Target codebase region: (a) `src/attune/ops/` (provisional)
+
+**Status:** provisional — confirm at Phase 0.3 kickoff that `ops/` is still ~29 files / ~5k LOC. Has grown substantially since 2026-05-16; may now be ~40 files. Verify with `find src/attune/ops -name "*.py" | wc -l` before running measurement.
+
+**Rationale:** Mid-size representative codebase. Pattern matches what users actually invoke `/deep-review` on. Cheaper than `src/attune/workflows/` (15k LOC) but more realistic than a single file.
+
+### D2 — Concurrency in parallel fan-out: 3 workflows
+
+**Status:** RESOLVED.
+
+**Choice:** `bug-predict + code-review + security-audit` — the modal triplet from Phase 0.1 telemetry (27 of 48 multi-analytical sessions). Matches what users actually run. Avoids spec-original `code-quality + deep-review` which was partially redundant with `/deep-review` itself.
+
+**Rationale:** Three is the smallest interesting number per the original spec. Using the telemetry-derived modal triplet means the measurement directly addresses the dominant real-world usage pattern. Four+ workflows are out of scope for Phase 0 — revisit if Phase 0 routes to PROCEED.
+
+### Single-operator skew — acknowledged limitation (2026-05-19)
+
+**Acknowledgment:** Phase 0.1's 45.7% multi-analytical-sessions figure is heavily Patrick-weighted (13,318 of 19,014 events from one user_id). All Phase 0 measurement decisions inherit this skew. Even with rigorous A/B, the outcome reflects "what's right for Patrick's workflow pattern," not external users. This is a known limitation and not a blocker — but any PROCEED/DEFER/RETIRE decision must be honest about the sample size.
+
+**Mitigation:** if Phase 0 routes to PROCEED, Phase 1 dogfood (gated on feature flag) becomes the multi-user telemetry pass. If it routes to RETIRE or DEFER, the single-operator caveat is documented and we trust that real users hitting a different pattern would surface a different spec.


### PR DESCRIPTION
## Summary

Captures the 2026-05-19 chat on Phase 0.3–0.6 scoping for the `agent-surface-parallelism-evaluation` spec, ahead of the budgeted ~$10–15 measurement (queued for a dedicated next session).

## Resolved decisions

**1. Refined baseline.** Phase 0.3 (sequential) and 0.4 (parallel) compare against `/deep-review` as the baseline, NOT three workflows run serially. Phase 0.1 (2026-05-16) showed 27 of 48 multi-analytical sessions hit exactly the `bug-predict + code-review + security-audit` triplet — which is what `/deep-review` already spawns as Claude Agent SDK subagents (`deep_review.py:268-291`). Original baseline would have inflated the wall-clock-savings number vs reality.

**2. Probe-before-measure.** Phase 0.3 instruments `/deep-review` to determine whether its subagents currently dispatch in parallel (one assistant turn) or serially (three turns). The orchestrator prompt is parallel-hinting but not -guaranteeing; the dispatch shape is the SDK's call. Costs nothing extra — same run that's already in 0.3b.

**3. D2 resolved.** 3 workflows = `bug-predict + code-review + security-audit` (modal triplet, not spec-original `code-quality + deep-review` which was partially redundant with `/deep-review` itself).

## Still open

- **D1** (target region): provisionally `src/attune/ops/` but flagged to re-verify at Phase 0.3 kickoff — the `ops/` codebase has grown since 2026-05-16; original ~29 files may now be ~40.
- **D3** (surface for PROCEED case) and **D4** (synthesis hosting): still gated on Phase 0 outcome.

## Single-operator skew acknowledged

13,318 of 19,014 telemetry events come from one user_id. Any PROCEED/DEFER/RETIRE outcome from Phase 0 must be honest about the sample size. Not a blocker; documented as a known limitation in the decisions file.

## Test plan

- [x] Decisions file renders correctly
- [x] Pre-commit hooks pass (trailing-whitespace, end-of-file-fixer, etc.)
- [ ] CI matrix (docs-only PR — should be fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
