### PR TITLE
fix(telemetry): SDK workflows skip usage.jsonl writes since May 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `navigator.clipboard` is unavailable (old browsers, insecure
   contexts) — surfaces the error rather than silently failing.
 
+### Fixed
+
+- SDK-native workflows now write to `~/.attune/telemetry/usage.jsonl`.
+  Prior to this fix, every SDK workflow (bug-predict, code-review,
+  security-audit, test-gen, simplify-code, doc-gen, deep-review,
+  dependency-check, perf-audit, refactor-plan, doc-audit,
+  document-gen, test-audit, release-prep, research-synthesis,
+  rag-code-gen) called `claude_agent_sdk.query()` directly,
+  bypassing the legacy `llm_mixin` path that calls
+  `_track_telemetry()`. As a result, `usage.jsonl` had not been
+  written to since the SDK migration completed in early May 2026,
+  and the dashboard's home / telemetry KPIs (7-day spend, today's
+  events, per-workflow rollups) silently went stale. Two coupled
+  fixes land together: (a) new `_track_sdk_run_telemetry()` helper
+  on `TelemetryMixin` extracts cost / tokens / duration from
+  `AgentRunResult` and forwards to the existing `_track_telemetry`
+  pipeline, wired into all 15 SDK workflows; (b) an `atexit`
+  handler on `UsageTracker.get_instance()` flushes the in-memory
+  write buffer (default size 50) when the process exits, so
+  short-lived CLI runs that produce 1-2 buffered entries no longer
+  lose them at shutdown. A drift-guard test fails CI if any new
+  SDK workflow is added without the wiring. Unblocks the Quality
+  dashboard work in [telemetry-rethink](docs/specs/telemetry-rethink/),
+  which had explicitly deferred storage-layer work assuming
+  `usage.jsonl` was being written correctly.
+
 ## [7.0.0] — 2026-05-16
 
 ### Removed — BREAKING

--- a/docs/specs/telemetry-rethink/decisions.md
+++ b/docs/specs/telemetry-rethink/decisions.md
@@ -67,3 +67,14 @@ To be filled in during implementation:
   Triggered by QA review and Patrick's "moving away from cost-
   saving-first" framing. Memory page dropped, Sessions page
   scoped separately.
+- 2026-05-19 — Storage-layer telemetry write gap fixed (unblocks
+  Phase 1). The spec's `requirements.md` line 103-105 explicitly
+  deferred storage-layer work, assuming `usage.jsonl` was being
+  written correctly. It wasn't — SDK-native workflows had bypassed
+  the telemetry write path since the SDK migration in early May,
+  freezing `usage.jsonl` for ~10 days. Without the fix, this
+  spec's Quality dashboard would have rendered empty panels for
+  every SDK workflow on launch. Fix wires `_track_sdk_run_telemetry`
+  through all 15 SDK workflows and adds an `atexit` flush so
+  buffered entries persist on CLI exit. See `CHANGELOG.md` under
+  `## [Unreleased] ### Fixed` for the full scope.

--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -7,6 +7,7 @@ Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
 
+import atexit
 import hashlib
 import hmac
 import json
@@ -102,7 +103,28 @@ class UsageTracker:
         with cls._lock:
             if cls._instance is None:
                 cls._instance = cls(**kwargs)
+                # Register atexit flush so short-lived CLI runs (which
+                # typically produce 1-2 buffered entries — well below
+                # ``buffer_size``) still persist to disk before the
+                # process exits. Without this, ``usage.jsonl`` silently
+                # stops accumulating data once workflows move off the
+                # multi-call legacy LLM path (e.g. after the SDK
+                # migration).
+                atexit.register(cls._atexit_flush, cls._instance)
         return cls._instance
+
+    @staticmethod
+    def _atexit_flush(instance: "UsageTracker") -> None:
+        """atexit handler: flush any buffered entries on process exit.
+
+        Intentionally swallows all exceptions — telemetry failures must
+        never affect process exit status.
+        """
+        try:
+            instance.flush()
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: best-effort flush at shutdown
+            pass
 
     # =========================================================================
     # Shared helpers

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -166,6 +166,7 @@ class BugPredictionWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_predict(resolved_path, max_turns, depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(

--- a/src/attune/workflows/code_review.py
+++ b/src/attune/workflows/code_review.py
@@ -224,6 +224,7 @@ class CodeReviewWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_review(resolved_path, max_turns, depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
 
             # Recover per-subagent transcripts so reviewer findings

--- a/src/attune/workflows/deep_review.py
+++ b/src/attune/workflows/deep_review.py
@@ -215,6 +215,7 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_deep_review(resolved_path, max_turns, active_agents, depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/dependency_check.py
+++ b/src/attune/workflows/dependency_check.py
@@ -155,6 +155,7 @@ class DependencyCheckWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_check(resolved_path, max_turns, depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -133,6 +133,7 @@ class DocAuditWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_audit(resolved_path, max_turns, depth=depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/document_gen/workflow.py
+++ b/src/attune/workflows/document_gen/workflow.py
@@ -140,6 +140,7 @@ class DocumentGenerationWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_gen(resolved_path, max_turns, depth=depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/perf_audit.py
+++ b/src/attune/workflows/perf_audit.py
@@ -152,6 +152,7 @@ class PerformanceAuditWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_audit(resolved_path, max_turns, depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -262,6 +262,7 @@ class RagCodeGenWorkflow(BaseWorkflow):
                 model=model,
                 cwd=cwd,
             )
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
         except ImportError as exc:
             logger.error("Agent SDK import failed: %s", exc)
             return self._error_result(f"Agent SDK unavailable: {exc}")

--- a/src/attune/workflows/refactor_plan.py
+++ b/src/attune/workflows/refactor_plan.py
@@ -156,6 +156,7 @@ class RefactorPlanWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_plan(resolved_path, max_turns, depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -129,6 +129,7 @@ class ReleasePreparationWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_prep(resolved_path, max_turns, depth=depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/research_synthesis.py
+++ b/src/attune/workflows/research_synthesis.py
@@ -153,6 +153,7 @@ class ResearchSynthesisWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_synthesis(resolved_path, max_turns, depth=depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/security_audit.py
+++ b/src/attune/workflows/security_audit.py
@@ -147,6 +147,7 @@ class SecurityAuditWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_audit(resolved_path, max_turns, depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
 
             # Recover per-subagent findings from the session transcript

--- a/src/attune/workflows/simplify_code.py
+++ b/src/attune/workflows/simplify_code.py
@@ -148,6 +148,7 @@ class SimplifyCodeWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_simplify(resolved_path, max_turns, depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/telemetry_mixin.py
+++ b/src/attune/workflows/telemetry_mixin.py
@@ -14,6 +14,8 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from attune.workflows.agent_sdk_adapter import AgentRunResult
+
 if TYPE_CHECKING:
     from attune.models import (
         TelemetryBackend,
@@ -149,6 +151,51 @@ class TelemetryMixin:
         except (OSError, PermissionError) as e:
             # File system errors - log but never crash workflow
             logger.debug(f"Failed to track telemetry (file system error): {e}")
+
+    def _track_sdk_run_telemetry(
+        self,
+        stage: str,
+        agent_run_result: AgentRunResult,
+    ) -> None:
+        """Record telemetry for an SDK-native workflow run.
+
+        SDK workflows call ``claude_agent_sdk.query()`` directly, bypassing
+        the legacy ``llm_mixin`` path that calls ``_track_telemetry()``. As
+        a result, ``usage.jsonl`` was never written for SDK runs and the
+        dashboard's home / telemetry KPIs went stale after the SDK migration.
+
+        Call this once per run, after the message-collection loop completes
+        and the ``AgentRunResult`` has been populated from the final
+        ``ResultMessage``. Failed runs (``is_error=True``) and zero-cost
+        runs (typically startup failures) are skipped.
+
+        Args:
+            stage: Stage name to record (e.g. ``"agent"``, ``"predict"``).
+            agent_run_result: Aggregated result from ``collect_agent_output``.
+        """
+        if not self._enable_telemetry or self._telemetry_tracker is None:
+            return
+        if agent_run_result.is_error:
+            return
+        cost = agent_run_result.total_cost_usd or 0.0
+        if cost <= 0:
+            return
+        usage = agent_run_result.usage or {}
+        self._track_telemetry(
+            stage=stage,
+            tier="SDK",
+            model="agent-sdk",
+            cost=cost,
+            tokens={
+                "input": int(usage.get("input_tokens", 0) or 0),
+                "output": int(usage.get("output_tokens", 0) or 0),
+            },
+            cache_hit=False,
+            cache_type=None,
+            duration_ms=agent_run_result.duration_ms or 0,
+            prompt_cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0) or 0),
+            prompt_cache_read_tokens=int(usage.get("cache_read_input_tokens", 0) or 0),
+        )
 
     def _emit_call_telemetry(
         self,

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -164,6 +164,7 @@ class TestAuditWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_audit(resolved_path, max_turns, depth=depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
 

--- a/src/attune/workflows/test_gen/workflow.py
+++ b/src/attune/workflows/test_gen/workflow.py
@@ -139,6 +139,7 @@ class TestGenerationWorkflow(BaseWorkflow):
 
         try:
             run_result = await self._run_agent_gen(resolved_path, max_turns, depth=depth)
+            self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(

--- a/tests/unit/workflows/test_sdk_telemetry_recording.py
+++ b/tests/unit/workflows/test_sdk_telemetry_recording.py
@@ -1,0 +1,178 @@
+"""Regression tests for SDK-workflow telemetry recording.
+
+Pre-2026-05-19: SDK-native workflows (bug_predict, code_review, etc.) bypassed
+the legacy ``llm_mixin`` path that calls ``_track_telemetry()``. As a result,
+``usage.jsonl`` was never written for SDK runs and the dashboard's home /
+telemetry KPIs went stale.
+
+The fix added ``_track_sdk_run_telemetry()`` on ``TelemetryMixin`` and wired
+each SDK workflow to call it after the message-collection loop. These tests
+pin that contract.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from attune.workflows.agent_sdk_adapter import AgentRunResult
+from attune.workflows.telemetry_mixin import TelemetryMixin
+
+
+@pytest.fixture
+def wired_mixin() -> TelemetryMixin:
+    """A TelemetryMixin with a mocked tracker, ready to record."""
+    mixin = TelemetryMixin()
+    mixin._telemetry_tracker = MagicMock()
+    mixin._enable_telemetry = True
+    mixin.name = "bug-predict"
+    mixin._provider_str = "anthropic"
+    return mixin
+
+
+@pytest.mark.unit
+class TestSdkRunTelemetryRecording:
+    """Pin the SDK telemetry wiring contract."""
+
+    def test_records_successful_run(self, wired_mixin):
+        """Successful runs with non-zero cost write to the tracker."""
+        result = AgentRunResult(
+            result_text="ok",
+            total_cost_usd=3.62,
+            usage={"input_tokens": 12345, "output_tokens": 678},
+            duration_ms=77800,
+        )
+
+        wired_mixin._track_sdk_run_telemetry(stage="agent", agent_run_result=result)
+
+        wired_mixin._telemetry_tracker.track_llm_call.assert_called_once()
+        kwargs = wired_mixin._telemetry_tracker.track_llm_call.call_args.kwargs
+        assert kwargs["workflow"] == "bug-predict"
+        assert kwargs["stage"] == "agent"
+        assert kwargs["cost"] == 3.62
+        assert kwargs["tokens"] == {"input": 12345, "output": 678}
+        assert kwargs["duration_ms"] == 77800
+        assert kwargs["tier"] == "SDK"
+        assert kwargs["model"] == "agent-sdk"
+
+    def test_skips_errored_run(self, wired_mixin):
+        """is_error=True runs are skipped (cost is unreliable)."""
+        result = AgentRunResult(
+            result_text="",
+            total_cost_usd=2.50,
+            is_error=True,
+        )
+
+        wired_mixin._track_sdk_run_telemetry(stage="agent", agent_run_result=result)
+
+        wired_mixin._telemetry_tracker.track_llm_call.assert_not_called()
+
+    def test_skips_zero_cost_run(self, wired_mixin):
+        """Zero-cost runs (startup failures) are skipped."""
+        result = AgentRunResult(
+            result_text="",
+            total_cost_usd=0.0,
+        )
+
+        wired_mixin._track_sdk_run_telemetry(stage="agent", agent_run_result=result)
+
+        wired_mixin._telemetry_tracker.track_llm_call.assert_not_called()
+
+    def test_skips_none_cost_run(self, wired_mixin):
+        """None cost (no ResultMessage received) is skipped."""
+        result = AgentRunResult(result_text="")  # total_cost_usd defaults to None
+
+        wired_mixin._track_sdk_run_telemetry(stage="agent", agent_run_result=result)
+
+        wired_mixin._telemetry_tracker.track_llm_call.assert_not_called()
+
+    def test_skips_when_tracker_unavailable(self, wired_mixin):
+        """No-op when telemetry tracker hasn't been initialized."""
+        wired_mixin._telemetry_tracker = None
+        result = AgentRunResult(result_text="ok", total_cost_usd=1.0)
+
+        # Should not raise
+        wired_mixin._track_sdk_run_telemetry(stage="agent", agent_run_result=result)
+
+    def test_skips_when_telemetry_disabled(self, wired_mixin):
+        """No-op when telemetry is explicitly disabled."""
+        wired_mixin._enable_telemetry = False
+        result = AgentRunResult(result_text="ok", total_cost_usd=1.0)
+
+        wired_mixin._track_sdk_run_telemetry(stage="agent", agent_run_result=result)
+
+        wired_mixin._telemetry_tracker.track_llm_call.assert_not_called()
+
+    def test_records_prompt_cache_tokens(self, wired_mixin):
+        """Cache-creation and cache-read tokens flow through when present."""
+        result = AgentRunResult(
+            result_text="ok",
+            total_cost_usd=1.0,
+            usage={
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 200,
+                "cache_read_input_tokens": 300,
+            },
+        )
+
+        wired_mixin._track_sdk_run_telemetry(stage="agent", agent_run_result=result)
+
+        kwargs = wired_mixin._telemetry_tracker.track_llm_call.call_args.kwargs
+        assert kwargs["prompt_cache_creation_tokens"] == 200
+        assert kwargs["prompt_cache_read_tokens"] == 300
+
+    def test_handles_missing_usage_dict(self, wired_mixin):
+        """Missing usage dict yields zero token counts, not a crash."""
+        result = AgentRunResult(result_text="ok", total_cost_usd=1.0, usage=None)
+
+        wired_mixin._track_sdk_run_telemetry(stage="agent", agent_run_result=result)
+
+        kwargs = wired_mixin._telemetry_tracker.track_llm_call.call_args.kwargs
+        assert kwargs["tokens"] == {"input": 0, "output": 0}
+
+
+@pytest.mark.unit
+class TestSdkWorkflowsCallTelemetry:
+    """Drift guard: every SDK workflow must invoke ``_track_sdk_run_telemetry``."""
+
+    SDK_WORKFLOW_FILES = [
+        "src/attune/workflows/bug_predict.py",
+        "src/attune/workflows/code_review.py",
+        "src/attune/workflows/dependency_check.py",
+        "src/attune/workflows/deep_review.py",
+        "src/attune/workflows/perf_audit.py",
+        "src/attune/workflows/release_prep.py",
+        "src/attune/workflows/rag_code_gen.py",
+        "src/attune/workflows/security_audit.py",
+        "src/attune/workflows/research_synthesis.py",
+        "src/attune/workflows/refactor_plan.py",
+        "src/attune/workflows/simplify_code.py",
+        "src/attune/workflows/doc_audit/workflow.py",
+        "src/attune/workflows/document_gen/workflow.py",
+        "src/attune/workflows/test_gen/workflow.py",
+        "src/attune/workflows/test_audit/workflow.py",
+    ]
+
+    @pytest.mark.parametrize("workflow_path", SDK_WORKFLOW_FILES)
+    def test_workflow_wires_sdk_telemetry(self, workflow_path):
+        """Each SDK workflow must call ``_track_sdk_run_telemetry``.
+
+        If a future workflow is added that uses ``claude_agent_sdk.query()``
+        without this call, ``usage.jsonl`` silently goes stale for that
+        workflow. Update this list AND wire the call when adding new SDK
+        workflows.
+        """
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[3]
+        text = (repo_root / workflow_path).read_text(encoding="utf-8")
+        assert "_track_sdk_run_telemetry" in text, (
+            f"{workflow_path} uses the SDK but never calls "
+            "_track_sdk_run_telemetry() — usage.jsonl won't reflect "
+            "this workflow's runs."
+        )


### PR DESCRIPTION
## Summary

- SDK-native workflows (15 of them) skipped `usage.jsonl` writes since the early-May SDK migration, silently freezing the dashboard's spend / events KPIs and blocking [telemetry-rethink](docs/specs/telemetry-rethink/)'s Quality dashboard (which had explicitly deferred storage-layer work, assuming the file was healthy).
- Two coupled fixes ship together because each is useless alone: (1) wire `_track_sdk_run_telemetry()` into every SDK workflow after the SDK message loop, (2) add an `atexit` flush so short-lived CLI runs no longer lose their 1–2 buffered entries at process exit.
- Drift-guard test fails CI if a new SDK workflow is added without the wiring.

## Diagnosis trail

Discovered while testing the dashboard in a real workflow run. `usage.jsonl` showed `mtime = May 9` despite a bug-predict run completing successfully today. Traced through `TelemetryMixin._track_telemetry` → `UsageTracker.track_llm_call` and found:

1. **Wiring gap (primary)**: `bug_predict.py`, `code_review.py`, and 13 other SDK workflows call `claude_agent_sdk.query()` directly. `_track_telemetry()` is only invoked from `llm_mixin.py` (legacy non-SDK path). SDK workflows had zero entries written ever.
2. **Buffer gap (secondary, discovered during E2E verification)**: `track_llm_call` buffers entries (`buffer_size=50`) with no `atexit` flush. Even after wiring fix, single-call CLI runs lost their entries at process exit.

Both root causes confirmed by:

```bash
# Before fix:
BEFORE=$(wc -l < ~/.attune/telemetry/usage.jsonl)  # 19014
attune workflow run simplify-code --path ...
AFTER=$(wc -l < ~/.attune/telemetry/usage.jsonl)   # 19014 (unchanged)

# After fix:
BEFORE=$(wc -l < ~/.attune/telemetry/usage.jsonl)  # 19014
attune workflow run simplify-code --path ...
AFTER=$(wc -l < ~/.attune/telemetry/usage.jsonl)   # 19015 ✓
tail -1 ~/.attune/telemetry/usage.jsonl
# {"workflow":"simplify-code","tier":"SDK","cost":4.72,
#  "duration_ms":101537,"prompt_cache":{...}}
```

## What's wired

| File | Change |
|---|---|
| `src/attune/workflows/telemetry_mixin.py` | New `_track_sdk_run_telemetry()` method — extracts cost / tokens / duration from `AgentRunResult`, forwards to `_track_telemetry()`. Skips errored runs and zero-cost runs. |
| `src/attune/telemetry/usage_tracker.py` | `atexit.register(_atexit_flush, ...)` in `get_instance()`. Best-effort flush, swallows all exceptions. |
| `src/attune/workflows/{bug_predict,code_review,...}.py` (15 files) | One-line call to `_track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)` after the SDK message loop. |
| `tests/unit/workflows/test_sdk_telemetry_recording.py` | 8 unit tests for the helper + 15 parametrized drift-guard tests pinning the wiring contract. |
| `CHANGELOG.md` | Entry under `[Unreleased] ### Fixed`. |
| `docs/specs/telemetry-rethink/decisions.md` | Decision-change log entry noting Phase 1 is now unblocked. |

## Trade-offs / non-obvious choices

- **Wire per-workflow, not in `AgentSDKResultAdapter.from_agent_output()`.** The adapter is a stateless classmethod and adding a workflow-instance parameter felt heavier than a one-line call site. Per-workflow wiring is also easier to grep / discover / disable case-by-case.
- **`tier="SDK"`, `model="agent-sdk"`** as a single composite tier rather than decomposing per-subagent. Real SDK runs spawn multiple subagents at different models; the final cost is aggregate. A future enhancement could record per-subagent telemetry from `model_usage`, but the current single-record-per-run approach is enough to unblock telemetry-rethink and is consistent with how the cost is reported by `ResultMessage.total_cost_usd`.
- **Skip errored / zero-cost runs.** SDK reports unreliable cost data on startup failures (the `Command failed with exit code 1` shape covered by [sdk-error-message-fidelity](docs/specs/sdk-error-message-fidelity/)). Better to write nothing than write `cost=$0` rows that pollute aggregates.

## Test plan

- [x] Unit: 23/23 new tests pass (`tests/unit/workflows/test_sdk_telemetry_recording.py`)
- [x] Regression: 405 existing telemetry tests still pass (`tests/unit/workflows/test_telemetry_*` + `tests/unit/telemetry/`)
- [x] Lint: ruff clean on all touched files
- [x] E2E: live `simplify-code` run writes new entry to `usage.jsonl` with all fields populated
- [ ] CI: green on all platforms
- [ ] Dashboard verification (post-merge): home page `7-day spend` KPI populates after a few SDK workflow runs

## Related

- Unblocks: [telemetry-rethink](docs/specs/telemetry-rethink/) Phase 1 (was silently broken on its premise)
- Adjacent: [sdk-error-message-fidelity](docs/specs/sdk-error-message-fidelity/) (errored-run skip relates to opaque exit-1 shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
