### PR TITLE
docs(rules): add decision routine + 5 session lessons

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5519,3 +5519,118 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   and accept that any survivors you didn't enumerate
   upfront are likely additional live sessions, not
   leaks.
+
+- **Buffered telemetry/event trackers in short-lived CLI processes
+  silently lose data without an atexit flush**: discovered 2026-05-19
+  while fixing the SDK-workflow telemetry gap (PR #439).
+  `UsageTracker.track_llm_call` buffers entries in memory (default
+  `buffer_size=50`) and only flushes when the buffer fills. The
+  buffer naturally filled in the era of multi-call legacy LLM
+  workflows (one workflow run = many `track_llm_call` invocations,
+  buffer hit quickly). After the SDK migration consolidated each
+  workflow run into ONE `track_llm_call`, a typical CLI invocation
+  produced 1-2 buffered entries that never flushed before the
+  process exited — `usage.jsonl` silently stopped growing and the
+  dashboard's home / telemetry KPIs went stale for ~10 days before
+  anyone noticed. Two-part lesson: (1) any singleton tracker that
+  buffers writes and lives in CLI/script processes needs an
+  `atexit.register(instance.flush)` at construction time, OR will
+  silently drop data when typical run volume falls below the buffer
+  threshold; (2) when investigating "why are my JSONL events not
+  appearing," check the writer's buffering semantics BEFORE
+  inspecting upstream wiring — the wiring might be correct but the
+  exit path may be lossy. Pairs with the existing
+  "Home's 7-day spend always shows 0" lesson (which is a different
+  bug in the READ path) — same surface symptom, three distinct root
+  causes (read field name, write path missing, write path buffered).
+
+- **Multi-subagent workflows hitting `ATTUNE_MAX_BUDGET_USD` during
+  startup planning surface as opaque `Command failed with exit
+  code 1`, NOT the structured "Reached maximum budget" message**:
+  discovered 2026-05-19. The existing CLAUDE.md lesson covers the
+  case where the cap fires mid-stream — that path produces a clean
+  `Exception: Claude Code returned an error result: Reached
+  maximum budget ($X)` from the SDK. A DIFFERENT path fires when
+  the cap is checked at subprocess-startup-time (before the first
+  turn completes), and that path raises the generic
+  `Command failed with exit code 1` from the SDK transport layer
+  with `$0.0000 | 0.0s` and no budget-message subtype. Diagnostic
+  shortcut: when a multi-subagent workflow (`bug-predict`,
+  `test-gen`, `code-review`, `security-audit`, `deep-review`)
+  fails with exit-1 and `$0.0000` on a small target, raise the
+  cap (`ATTUNE_MAX_BUDGET_USD=10`) and retry. If it succeeds at
+  real cost > old cap, the cap was the culprit. The hint that
+  this is a cap-hit rather than auth/PATH/quota: `claude -p`
+  works directly, AND the minimal SDK probe (`max_turns=2`,
+  one subagent) succeeds with the same cap value. The error
+  surface needs improvement — flagged in
+  [sdk-error-message-fidelity](docs/specs/sdk-error-message-fidelity/).
+  Practical rule for users: single-agent SDK workflows
+  (`simplify-code`, `doc-gen`, `dependency-check`) fit under
+  `$1.50`. Multi-subagent workflows need `≥$5` even on tiny
+  inputs because each subagent's planning phase emits costly
+  setup tokens before producing useful output.
+
+- **Specs and XML-enhanced prompts are LAYERED in
+  attune-ai, not alternatives — a spec contains XML
+  prompts at the task level**: easy mistake to frame
+  them as competing artifacts when presenting work-
+  shape decisions to the user. The existing rule file
+  at `.claude/rules/attune/xml-enhanced-prompts.md`
+  documents the format as "any task given to another
+  agent or future session to execute" — including
+  tasks inside specs. `docs/implementation/TASK_PROMPTS.md`
+  has 10 executed examples of this nesting (tasks
+  decompose into 2-3 XML prompts each by concern:
+  backend wiring + test scaffold + docs update). The
+  correct decision tree is sequential, not branching:
+  (1) does this work need a spec (design ambiguity /
+  multi-session / premise validation)? (2) if yes,
+  its tasks use XML prompts per the existing file's
+  criteria; (3) if no, the standalone work either
+  IS an XML prompt (3+ files, dependencies, subagent
+  handoff) or is too small for either. Pattern: when
+  helping the user choose between artifact types in
+  this codebase, never present "spec vs XML prompt"
+  as a choice — they nest like outline-and-paragraphs.
+
+- **Decision-criteria duplication across rule files
+  silently goes stale — reference, don't duplicate**:
+  when authoring a new project rule / playbook /
+  memory file that overlaps with an existing rule
+  file's criteria (e.g. "when to use X"), don't copy
+  the criteria into the new file. Reference the
+  existing file as canonical: "see
+  `.claude/rules/attune/<file>.md` — When to Use."
+  Otherwise both files become sources of truth and
+  drift independently. Discovered 2026-05-19 when
+  drafting a decision-routine framework with my own
+  "when XML prompts apply" list — the existing
+  `xml-enhanced-prompts.md` already had that list
+  with slightly different wording. The user
+  immediately flagged "wouldn't this make the other
+  code stale at the least." Generalizes to any
+  authoring task that touches decision criteria
+  documented elsewhere — find the canonical source
+  via grep BEFORE writing, then reference it. The
+  cost of grep is ~30 seconds; the cost of drift
+  surfaces months later when one of the two diverges.
+
+- **Pushback without a concretely-rendered alternative
+  is noise, not signal**: extends the
+  `feedback-pushback-welcomed` memory with the
+  operational test. Patrick clarified the signal for
+  when his stated preference deserves pushback: it's
+  not "do I have a theoretical objection" but "can I
+  show a solid right-sized alternative." Concrete
+  shapes: the actual XML prompt body, the
+  inline-implementation sketch, the specific file
+  list, the measurable acceptance criterion. If I
+  can't render the alternative in the message, the
+  pushback is hedging and creates friction without
+  carrying value. Heuristic for me: before pressing
+  back on a user-stated approach, can I produce ≥1
+  concrete artifact (code block, file list,
+  measurement plan) demonstrating the alternative
+  works at smaller scale? If no, just execute the
+  user's plan and learn the boundary later.

--- a/.claude/rules/attune/decision-routine.md
+++ b/.claude/rules/attune/decision-routine.md
@@ -1,0 +1,135 @@
+# Decision Routine — Choosing the Right Shape of Work
+
+**Created:** 2026-05-19
+**Source:** Session conversation; codifies the lead-with-
+recommendation + concerns-palette discipline.
+
+---
+
+## Purpose
+
+This routine enhances focus, accuracy, and proactive surfacing of
+options the user can redirect. It is not a compliance flowchart — it
+is a discipline that produces sharper proposals.
+
+The default failure mode it counteracts: presenting balanced options
+without a preference, jumping into execution without proposing the
+right artifact shape, or proposing artifacts whose composition
+(impl-only, no regression guard, etc.) silently encourages padding
+or omission.
+
+---
+
+## When this routine fires
+
+Any request that meets at least one of:
+
+- Touches 3+ files
+- Involves a design decision with more than one defensible answer
+- Could be executed multiple ways with materially different cost
+  or scope
+- References a premise that should be measured before
+  implementation
+
+For trivial work (single-file edits, bug fixes, config tweaks per
+`xml-enhanced-prompts.md`'s "Do NOT use" list), this routine does
+NOT fire. Just do the work.
+
+---
+
+## Decision tree
+
+```text
+Is this trivial per xml-enhanced-prompts.md?
+├─ YES → Just do it. No artifact.
+└─ NO  → continue
+
+Does this need decision recording, premise validation,
+or multi-session coordination?
+├─ YES → Spec via /spec
+│        Within the spec, individual tasks use XML-enhanced
+│        prompts per xml-enhanced-prompts.md criteria.
+└─ NO  → continue
+
+Does this meet xml-enhanced-prompts.md's "When to Use" criteria?
+├─ YES → Single (or several) XML-enhanced prompts
+└─ NO  → Just do it inline
+```
+
+XML-enhanced prompt criteria are canonical in
+`xml-enhanced-prompts.md`. This file does not duplicate them. If
+you find yourself listing them here, stop and reference the
+canonical file instead.
+
+---
+
+## Concerns palette
+
+When recommending one or more XML-enhanced prompts, also propose
+which **concerns** the work needs. Each concern maps to one prompt
+block. Don't pad with concerns that don't apply.
+
+| Concern | When to include |
+|---|---|
+| `impl` | The production change itself. Always present. |
+| `test` | New tests covering new behavior. Skip when impl includes test changes inline. |
+| `regression-guard` | Drift-protection test that fails CI if the bug returns. Use on bug fixes; skip on feature adds. |
+| `docs` | User-facing docs that aren't release artifacts: mkdocs pages, in-code docstrings, README structural content (not badges/version). Skip when the change is invisible to users. |
+| `migration` | Backward-compat shims, deprecation timers. Use on breaking changes; skip on additive ones. |
+| `release-notes` | CHANGELOG entry, README badges/version refs, decisions.md log when unblocking a spec, plus version-bump files per CLAUDE.md's "Version bumps touch 7+ files" lesson when shipping a release. Use when the change ships externally or unblocks a spec. |
+| `preflight` | Lint / format / typecheck pass before staging. Use when the change touches files known to trip pre-commit (mixed formats, generated files, sibling-package boundaries). |
+
+Don't extend this palette ad-hoc. If a new concern emerges, propose
+it in a session and add it deliberately — additions here drift into
+"checklist of every possible thing" if uncurated.
+
+---
+
+## Visible output pattern
+
+When the routine fires, produce output in this shape:
+
+> **Recommended: X.** *(one sentence — what and why)*
+>
+> *Rationale: 2-3 lines.*
+>
+> **Concerns:** `impl` + `regression-guard` + `release-notes`
+> *(only when XML prompts are recommended)*
+>
+> *Inline XML prompt(s) here if XML is the recommendation.*
+>
+> **Alternatives:**
+>
+> - Option B — one-line tradeoff
+> - Option C — one-line tradeoff
+>
+> **Open questions** *(only if real ambiguity exists)*
+
+Lead with the recommendation. Render the XML prompt inline when XML
+is the answer — don't make the user approve-then-see. List
+alternatives ranked, briefly. Surface open questions only when they
+genuinely matter; don't manufacture ambiguity.
+
+---
+
+## Pushback discipline
+
+When a user-stated preference looks weaker than an alternative I
+see, push back — but only if I can render the alternative
+concretely (XML prompt body, file list, measurement plan). Pushback
+without a concrete artifact is hedging, creates friction, and
+carries no value. If I can't render the alternative, execute the
+user's plan and learn the boundary later.
+
+---
+
+## Cross-references
+
+- `.claude/rules/attune/xml-enhanced-prompts.md` — canonical for
+  XML prompt criteria and schema
+- `.claude/CLAUDE.md` — Critical Rules section names when to use
+  XML format; Lessons Learned section has the "Version bumps touch
+  7+ files" checklist that `release-notes` references
+- `docs/implementation/TASK_PROMPTS.md` — 10 executed XML prompt
+  examples showing the spec → tasks → XML-prompts nesting
+- `/spec` command — spec-driven workflow with approval loop


### PR DESCRIPTION
## Summary

Adds a project rule that codifies how to choose artifact shape (no artifact / XML-enhanced prompt / spec) and proposes a 7-concern palette for XML-prompt compositions. References `xml-enhanced-prompts.md` as canonical rather than duplicating its criteria.

Also appends 5 lessons learned this session to `CLAUDE.md`.

## What's in the decision routine

- **Decision tree** with three sequential stages: trivial → spec? → XML prompt? → just do it inline
- **Concerns palette**: 7 named concerns (`impl`, `test`, `regression-guard`, `docs`, `migration`, `release-notes`, `preflight`) with "skip when" guidance per concern, so XML-prompt recommendations name what the work actually needs instead of padding with defaults
- **Visible output pattern** — lead with recommendation, render XML inline when XML is the answer, ranked alternatives
- **Pushback discipline** — only push back on a user-stated preference if I can render the alternative concretely; otherwise execute and learn the boundary

The `release-notes` concern explicitly bundles CHANGELOG + README badges/version refs + the 7+ release-bump files from CLAUDE.md's existing "Version bumps" lesson — preventing the "forgot to update README after CHANGELOG" trip that surfaced this PR.

## Lessons added to CLAUDE.md

1. Buffered telemetry/event trackers in short-lived CLI processes silently lose data without an atexit flush (root cause behind [#439](https://github.com/Smart-AI-Memory/attune-ai/pull/439))
2. Multi-subagent workflows hitting `ATTUNE_MAX_BUDGET_USD` at startup planning surface as opaque exit-1, not the structured "Reached maximum budget" message
3. Specs and XML-enhanced prompts are layered (not competing) — specs contain XML prompts at the task level
4. Decision-criteria duplication across rule files silently goes stale — reference, don't duplicate
5. Pushback without a concretely-rendered alternative is noise, not signal

## Trade-offs / non-obvious choices

- **Palette as vocabulary, not pipeline runtime** — the palette is a dictionary the routine consults, not an executor. No orchestration layer. Influences my suggestions and your reviews; doesn't add a new system to maintain.
- **References canonical XML criteria rather than duplicating** — drift between this file and `xml-enhanced-prompts.md` is the failure mode being prevented; the file actively reminds future authors to stop and cross-link instead of copy.
- **`docs` and `release-notes` have explicit boundary** — README structural content lives in `docs`; README badges/version refs live in `release-notes`. Each concern's "skip when" guidance names this boundary so they don't both fire on the same change.

## Test plan

- [x] File created at `.claude/rules/attune/decision-routine.md`
- [x] References `xml-enhanced-prompts.md` as canonical (3 mentions)
- [x] Does NOT duplicate the "Do NOT use" list from the canonical file
- [x] Concerns palette has 7 entries with explicit "skip when" guidance
- [x] `release-notes` concern names README badges/version refs
- [x] Pre-commit hooks pass (black, ruff, bandit, detect-secrets, markdown checks)
- [ ] CI green

## Related

- [#439](https://github.com/Smart-AI-Memory/attune-ai/pull/439) — SDK telemetry write gap (lessons 1+2 originate from that work)
- `.claude/rules/attune/xml-enhanced-prompts.md` — canonical XML prompt schema this rule references

🤖 Generated with [Claude Code](https://claude.com/claude-code)
