### PR TITLE
fix(ops/runner): anchor relative scope to project_root (unblocks workflows when cwd ≠ project_root)

### DIFF
--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import AsyncIterator
+from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -12,6 +13,31 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from attune.ops import data
 from attune.ops.runner import RunnerBusyError, RunnerService
 from attune.security.path_validation import _validate_file_path
+
+
+def _absolutize_scope(scope: str, project_root: Path) -> str:
+    """Resolve a user-supplied scope path against ``project_root``.
+
+    The dashboard sends scopes as repo-relative strings (e.g.
+    ``"src/attune/agents"``) derived from ``features.yaml`` via
+    ``data.workflow_default_scope``. The downstream validator does
+    ``Path(scope).resolve()``, which resolves a relative path against
+    ``Path.cwd()`` — NOT against ``project_root``. When the dashboard
+    is launched from a directory other than its ``--project-root``
+    (common in worktree setups), cwd and project_root diverge and
+    every scope-bearing workflow run is rejected as "outside allowed
+    directory".
+
+    Anchoring relative scopes here, before validation, decouples scope
+    resolution from process cwd. Absolute scopes are passed through
+    unchanged so the validator can still reject anything that escapes
+    ``project_root``.
+    """
+    p = Path(scope)
+    if p.is_absolute():
+        return scope
+    return str(project_root / p)
+
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +98,11 @@ async def start_run(name: str, request: Request) -> JSONResponse:
                 detail=f"workflow '{name}' does not accept a path argument",
             )
         cfg = request.app.state.config
+        # Anchor relative scopes to project_root BEFORE validation. The
+        # validator's Path.resolve() uses cwd for relative paths, which
+        # breaks when the dashboard's cwd != --project-root (common in
+        # worktree launches). See _absolutize_scope docstring.
+        scope = _absolutize_scope(scope, cfg.project_root)
         try:
             validated = _validate_file_path(scope, allowed_dir=str(cfg.project_root))
         except ValueError as exc:

--- a/tests/unit/ops/test_runner.py
+++ b/tests/unit/ops/test_runner.py
@@ -132,6 +132,83 @@ def test_run_busy_returns_409(tmp_path, monkeypatch):
     assert detail["current_run_id"] == first.json()["run_id"]
 
 
+def test_run_relative_scope_resolves_against_project_root_not_cwd(tmp_path, monkeypatch):
+    """Regression — relative scopes must anchor to ``--project-root``.
+
+    Bug: ``_validate_file_path`` calls ``Path(scope).resolve()``, which
+    resolves a relative scope against ``Path.cwd()``. When the
+    dashboard process is launched from a directory other than its
+    ``--project-root`` (common in worktree setups), every relative
+    scope is rejected as "outside allowed directory" — manifests as
+    "all workflows producing errors" in the UI.
+
+    Fix: anchor relative scopes to ``cfg.project_root`` before the
+    validator sees them. Absolute paths still flow through unchanged.
+
+    Repro:
+      - project_root = tmp_path/proj  (with a file inside it)
+      - cwd          = tmp_path/elsewhere  (no such file)
+      - POST {"path": "src/foo.txt"} to /workflows/code-review/run
+      - Pre-fix: 400 "outside allowed directory"
+      - Post-fix: 201 (run starts)
+    """
+    proj_root = tmp_path / "proj"
+    (proj_root / "src").mkdir(parents=True)
+    (proj_root / "src" / "foo.txt").write_text("body")
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=proj_root,
+        allow_run=True,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(command_builder=_echo_cmd)
+    app = create_app(config, runner=runner)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/code-review/run",
+            json={"path": "src/foo.txt"},
+        )
+    assert resp.status_code == 201, resp.text
+    assert "run_id" in resp.json()
+
+
+def test_run_absolute_scope_outside_project_root_still_rejected(tmp_path, monkeypatch):
+    """Defense check — the cwd fix must not weaken the security guard.
+
+    Absolute paths outside ``project_root`` were rejected pre-fix and
+    must stay rejected post-fix. Lock in the contract so a future
+    refactor of ``_absolutize_scope`` can't silently widen the
+    allowlist."""
+    proj_root = tmp_path / "proj"
+    proj_root.mkdir()
+    outside = tmp_path / "outside" / "leak.txt"
+    outside.parent.mkdir()
+    outside.write_text("nope")
+
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=proj_root,
+        allow_run=True,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(command_builder=_echo_cmd)
+    app = create_app(config, runner=runner)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/code-review/run",
+            json={"path": str(outside)},
+        )
+    assert resp.status_code == 400
+    assert "outside allowed" in resp.json()["detail"]
+
+
 # --- async tests: real subprocess lifecycle in a single loop
 
 


### PR DESCRIPTION
## Summary

**Unblocks**: "all workflows producing errors" when the dashboard is launched from a directory other than its `--project-root` (e.g. from a sibling worktree).

## Root cause

`_validate_file_path` in `attune.security.path_validation` does:

```python
resolved = Path(path).resolve()
```

For a *relative* input, `Path.resolve()` resolves against `Path.cwd()` — **not** the validator's `allowed_dir` argument. So a scope like `"src/attune/agents"` (the canonical form from `data.workflow_default_scope` reading `features.yaml`) resolves to `<process-cwd>/src/attune/agents` regardless of what `allowed_dir` says.

When the dashboard process's cwd diverges from its `--project-root`, every relative scope gets rejected as **"outside allowed directory"** — manifests as every workflow row in the UI throwing the same error.

Sample error from the wild:

```
"detail":"invalid path: Path '/Users/patrickroebuck/attune-gui/.claude/worktrees/relaxed-dewdney-088daf/src/attune/agents' is outside allowed directory '/Users/patrickroebuck/attune-ai'. Operations are restricted to the workspace."
```

## Fix

Caller-side. New helper `_absolutize_scope(scope, project_root)` in `src/attune/ops/routes/runner.py`:

- Relative scope → prefix with `project_root`.
- Absolute scope → pass through unchanged.

Then the validator runs as before. Security contract is preserved: the validator still rejects anything that escapes `project_root` (verified by the second test).

### Why caller-side, not validator-side

`_validate_file_path` is in `attune.security` and is shared across multiple call sites with different semantics around `allowed_dir`. The ops route is the only known caller that combines `cfg.project_root` with a user-supplied relative scope, so the fix is naturally scoped here.

A follow-up could change the validator to resolve relative paths against `allowed_dir` when one is given — cleaner semantics, broader blast radius. Worth its own spec.

## Tests

Two new tests in `tests/unit/ops/test_runner.py`:

| Test | Locks in |
|---|---|
| `test_run_relative_scope_resolves_against_project_root_not_cwd` | The regression — `project_root ≠ cwd`, relative scope, file exists in `project_root`, run starts (201). Without the fix this returns 400. |
| `test_run_absolute_scope_outside_project_root_still_rejected` | Defense check — absolute path outside `project_root` still returns 400. Guards against a future refactor silently widening the allowlist. |

## Test plan

- [x] `pytest tests/unit/ops/test_runner.py` — 25/25 pass (was 23 before; +2 new)
- [x] `pytest tests/unit/ops/test_runner.py -k scope` — both new tests pass
- [x] Pre-commit checks pass (ruff, black, bandit, etc.)

## Provenance

Surfaced during the Phase 4 ops-dashboard review session (see [docs/specs/ops-specs-features/phase4-findings.md](https://github.com/Smart-AI-Memory/attune-ai/pull/443) in PR #443) when launching attune ops from a sibling worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)