### PR TITLE
fix(ops): make read_telemetry_summary rolling-window testable (unblocks all PRs)

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -813,8 +813,21 @@ def sparkline_points(values: list[float], *, width: int = 240, height: int = 40)
     return " ".join(points)
 
 
-def read_telemetry_summary(config: Config, *, recent_days: int = 7) -> TelemetrySummary:
-    """Aggregate ``usage.jsonl`` into a UI-friendly summary."""
+def read_telemetry_summary(
+    config: Config,
+    *,
+    recent_days: int = 7,
+    today: date | None = None,
+) -> TelemetrySummary:
+    """Aggregate ``usage.jsonl`` into a UI-friendly summary.
+
+    ``today`` is a test injection point — production callers leave it
+    ``None`` so the rolling-window cutoff uses ``date.today()``. Tests
+    pass an explicit date so fixed-date fixtures (e.g. events dated
+    ``2026-05-14``) stay inside the recent-days window regardless of
+    when the test actually runs. Mirrors the existing ``now=None``
+    injection pattern elsewhere in this module.
+    """
     path = config.telemetry_path
     if not path.exists():
         return TelemetrySummary(0, 0.0, 0.0, [], [], None)
@@ -892,7 +905,8 @@ def read_telemetry_summary(config: Config, *, recent_days: int = 7) -> Telemetry
     ]
     by_workflow = sorted(filtered, key=lambda row: row[2], reverse=True)[:20]
 
-    today = date.today()
+    if today is None:
+        today = date.today()
     cutoff = today.toordinal() - recent_days
     recent_days_data = sorted(
         (

--- a/tests/unit/ops/test_telemetry_summary.py
+++ b/tests/unit/ops/test_telemetry_summary.py
@@ -11,11 +11,19 @@ coordinating, this test fails.
 from __future__ import annotations
 
 import json
+from datetime import date
 
 import pytest
 
 from attune.ops import data
 from attune.ops.config import Config
+
+# Frozen "today" for the by-day-window assertions below. Events in the
+# fixtures are dated 2026-05-14; this anchors the rolling window to the
+# same day so the assertions don't age out as wall-clock time advances.
+# The production code path keeps using date.today() — the parameter
+# only affects tests that pass it.
+_FIXED_TODAY = date(2026, 5, 14)
 
 
 def _write_jsonl(path, events):
@@ -60,7 +68,7 @@ def test_read_telemetry_summary_recognizes_ts_field(tmp_path):
         ],
     )
 
-    summary = data.read_telemetry_summary(cfg)
+    summary = data.read_telemetry_summary(cfg, today=_FIXED_TODAY)
 
     assert summary.total_requests == 1
     assert summary.total_cost == pytest.approx(0.05)
@@ -88,7 +96,7 @@ def test_read_telemetry_summary_falls_back_to_legacy_timestamp(tmp_path):
         ],
     )
 
-    summary = data.read_telemetry_summary(cfg)
+    summary = data.read_telemetry_summary(cfg, today=_FIXED_TODAY)
 
     assert summary.total_requests == 1
     assert summary.by_day == [("2026-05-14", 1, 0.05)]
@@ -114,7 +122,7 @@ def test_read_telemetry_summary_handles_both_fields_in_same_file(tmp_path):
         ],
     )
 
-    summary = data.read_telemetry_summary(cfg)
+    summary = data.read_telemetry_summary(cfg, today=_FIXED_TODAY)
 
     assert summary.total_requests == 3
     assert summary.total_cost == pytest.approx(0.06)
@@ -132,7 +140,7 @@ def test_read_telemetry_summary_skips_event_with_no_timestamp(tmp_path):
         [{"workflow": "a", "total_cost": 0.01}],
     )
 
-    summary = data.read_telemetry_summary(cfg)
+    summary = data.read_telemetry_summary(cfg, today=_FIXED_TODAY)
 
     assert summary.total_requests == 1
     assert summary.total_cost == pytest.approx(0.01)


### PR DESCRIPTION
## Summary

**Unblocks every open PR against attune-ai/main today, including [#443](https://github.com/Smart-AI-Memory/attune-ai/pull/443) and [#444](https://github.com/Smart-AI-Memory/attune-ai/pull/444).**

The 3 failing tests in `tests/unit/ops/test_telemetry_summary.py` aren't caused by any PR's diff — they hard-code `2026-05-14` in their fixtures, the production `read_telemetry_summary` filters `by_day` to the last 7 days using `date.today()`, and 9 days have passed since the tests were written. So today (2026-05-23), every test run sees `by_day == []` and the assertions fail.

Sample failure from PR #443's run:

```
FAILED test_read_telemetry_summary_falls_back_to_legacy_timestamp
  AssertionError: assert [] == [('2026-05-14', 1, 0.05)]
FAILED test_read_telemetry_summary_handles_both_fields_in_same_file
  KeyError: '2026-05-14'
```

## Fix

`src/attune/ops/data.py` — add an optional `today: date | None = None` injection parameter to `read_telemetry_summary`:

```python
def read_telemetry_summary(
    config: Config,
    *,
    recent_days: int = 7,
    today: date | None = None,
) -> TelemetrySummary:
    ...
    if today is None:
        today = date.today()
    ...
```

Mirrors the existing `now=None` injection pattern used elsewhere in `data.py` (line 589 for cost queries). Production callers (`routes/dashboard.py`, 2 callsites) leave `today=None` so behavior is unchanged.

`tests/unit/ops/test_telemetry_summary.py` — module-level constant `_FIXED_TODAY = date(2026, 5, 14)` anchors the window to the same day the fixtures use. The 4 `read_telemetry_summary` callsites now pass `today=_FIXED_TODAY`. Assertions hold indefinitely.

## Test plan

- [x] `pytest tests/unit/ops/test_telemetry_summary.py` — 4/4 pass (was 3 fail / 1 pass)
- [x] `pytest tests/unit/ops/test_smoke.py tests/unit/ops/test_telemetry_summary.py` — 28/28 pass
- [x] Pre-commit hooks pass (ruff, black, bandit)

## Provenance

Surfaced when PR #443's docs-only diff triggered the same test failure pattern as #444's code diff. Confirmed against the most-recent merged PR (#442) which was green at that time, demonstrating the failures are calendar-driven, not content-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)