### PR TITLE
fix(ops/specs): cancel-on-blur instead of commit-on-blur (closes Finding 0 trigger)

### DIFF
--- a/src/attune/ops/static/js/specs.js
+++ b/src/attune/ops/static/js/specs.js
@@ -185,8 +185,19 @@
     select.addEventListener("change", function () {
       finish(true);
     });
+    // Blur CANCELS — does not commit. Previously this committed on any
+    // blur (commit=true), which fired PUT /api/specs/.../status whenever
+    // focus left the select for any reason: alt-tab, screen-reader
+    // navigation, an a11y-tree traversal by an automated tool. Browsing
+    // the Specs page with a snapshotting/accessibility tool was enough
+    // to flip status across multiple specs without any user click. See
+    // docs/specs/ops-specs-features/phase4-findings.md Finding 0.
+    //
+    // Cancel-on-blur is the standard form pattern: only an explicit
+    // `change` event saves; clicking anywhere else closes the dropdown
+    // without writing.
     select.addEventListener("blur", function () {
-      finish(true);
+      finish(false);
     });
     select.addEventListener("keydown", function (e) {
       if (e.key === "Escape") {


### PR DESCRIPTION
## Summary

**Closes [Finding 0](https://github.com/Smart-AI-Memory/attune-ai/pull/443) — the unintended PUT mutations during dashboard browsing.**

Single-line behavior change in `src/attune/ops/static/js/specs.js`: the status-pill `<select>` element's `blur` handler called `finish(true)` (commit). Now calls `finish(false)` (cancel).

## Root cause

The Specs page click-to-edit flow had a **commit-on-blur** anti-pattern:

```js
select.addEventListener("change", function () { finish(true); });
select.addEventListener("blur",   function () { finish(true); });   // ← the trap
```

`enterEditMode()` hides the pill and immediately inserts/focuses a `<select>`. The `blur` handler then committed `select.value` on any focus change. Blur fires for any reason — alt-tab, a screen reader navigating away, an a11y-tree traversal by an automated tool. Combined with `status-pill-editable` being `<span role="button" tabindex="0">`, the chain became:

1. Tool snapshots a11y tree → activates Space/Enter on a `role=button` pill → keydown handler fires → `enterEditMode`
2. `<select>` appears, focused
3. Tool moves to next element → blur fires → `finish(true)` → PUT
4. Repeat across multiple pills

Observed pattern from the Phase 4 review (see [`docs/specs/ops-specs-features/phase4-findings.md`](https://github.com/Smart-AI-Memory/attune-ai/pull/443)): 6+ PUTs fired across all phases of one or more specs during a single browsing session, without any deliberate user click.

## Confirmation under `--read-only`

Read-only mode does not render status pills as `role=button` (the `status-pill-editable` class is gated on `allow_run` in `templates/specs.html:113`). Repro under `--read-only` with the same browsing pattern: **zero PUTs**. This isolated the JS handler as the trigger.

## Fix

```js
select.addEventListener("blur", function () {
  finish(false);  // ← was finish(true)
});
```

Standard form pattern: only an explicit `change` event saves. Blur-elsewhere closes the dropdown without writing.

**User-visible behavior:**

| Action | Before | After |
|---|---|---|
| Click pill → pick new option → dropdown closes via change | ✓ saves | ✓ saves (unchanged) |
| Click pill → click elsewhere without picking | ✓ saves whatever the dropdown defaulted to | ✗ cancels, no save |
| Press Escape with dropdown open | ✗ cancels (unchanged) | ✗ cancels (unchanged) |
| A11y tool / screen-reader navigation | ✓ saves phantom value | ✗ cancels, no save |

The middle row is the only behavioral change visible to deliberate users — and it matches standard form UX (e.g. native `<select>` doesn't commit on blur either).

## Follow-up (separate spec, not this PR)

Defense-in-depth: port attune-gui's `X-Attune-Client` per-process token gate (`require_client_token` Depends() on mutating endpoints + `/api/session/token` endpoint + page JS sends header). Filing this as a new spec — see ops-mutating-endpoint-auth (forthcoming).

## Test plan

- [x] Pre-commit checks pass (the diff is JS-only; nothing to lint at the Python level).
- [ ] Manual verification post-merge: launch ops with `--allow-run`, click a status pill, click elsewhere → no PUT. Click pill, pick new option → PUT fires and persists.
- [ ] Re-run the Phase 4 browsing pattern via preview MCP tool against the patched dashboard; confirm zero unintended PUTs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)