### PR TITLE
docs(specs): ops-mutating-endpoint-auth — port X-Attune-Client gate (Phase 4 follow-up)

### DIFF
--- a/docs/specs/ops-mutating-endpoint-auth/decisions.md
+++ b/docs/specs/ops-mutating-endpoint-auth/decisions.md
@@ -1,0 +1,74 @@
+# Decisions — Ops mutating-endpoint auth (per-process token gate)
+
+**Status:** Draft (2026-05-23)
+**Owner:** Patrick
+**Context:** [`docs/specs/ops-specs-features/phase4-findings.md`](../ops-specs-features/phase4-findings.md) (Finding 0)
+
+---
+
+## Problem
+
+`attune ops`' mutating endpoints (`PUT /api/specs/{slug}/{phase}/status`, `POST /api/specs/{slug}/completion-candidates/dismiss`, `POST /workflows/{name}/run`, and any future ones) are gated only by `config.allow_run` (the `--read-only` flag). Once `--allow-run` is on (the default), **any client that can reach the loopback bind can issue mutations**. Browsing the dashboard with an a11y-traversing tool flipped status on multiple specs without explicit user action — see Finding 0.
+
+[PR #446](https://github.com/Smart-AI-Memory/attune-ai/pull/446) addressed the specific JS trigger (commit-on-blur → cancel-on-blur). That eliminates the observed trigger but doesn't reduce the **blast radius** of any future trigger: a misconfigured client, a Chrome extension, a stray `curl`, a different a11y interaction.
+
+`attune-gui` solves this with a **per-process session token**: a `secrets.token_urlsafe(32)` minted at startup, exposed via `GET /api/session/token`, required as the `X-Attune-Client` header on every mutating route. The page JS reads it once at load and echoes it. The contract: any client that didn't first see the page (e.g., raw `curl`, automation that didn't bootstrap from `/api/session/token`) cannot mutate.
+
+Port that pattern to `attune ops`. Defense in depth: the page's UX flow is unchanged; the bug class of "accidental mutation from non-page client" is eliminated.
+
+## Decision
+
+Mirror attune-gui's `security.py` module verbatim:
+
+- `_SESSION_TOKEN = secrets.token_urlsafe(32)` generated once at process start
+- `current_session_token()` returns the in-process token
+- `require_client_token` is a FastAPI `Depends(...)` that 403s on missing/mismatched `X-Attune-Client`
+- New route `GET /api/session/token` returns `{"token": "..."}` — read-only, no auth (it's the way pages bootstrap)
+
+Apply `Depends(require_client_token)` to **every existing mutating endpoint**:
+
+| Endpoint | File | Method |
+|---|---|---|
+| `PUT  /api/specs/{slug}/{phase}/status` | `routes/specs.py` | rewrite phase-file status |
+| `POST /api/specs/{slug}/completion-candidates/dismiss` | `routes/specs.py` | dismiss-store write |
+| `POST /workflows/{name}/run` | `routes/runner.py` | start workflow run |
+| `POST /runs/{run_id}/cancel` (if exists) | `routes/runs_history_routes.py` | cancel run |
+
+(Inventory to be finalized in Phase 1 task 1.1 by `grep -rn '@router\.(put\|post\|delete\|patch)' src/attune/ops/routes/`.)
+
+## What's NOT in scope (firm)
+
+- Multi-user auth / OAuth / OIDC — the dashboard is single-user localhost.
+- Encryption at rest of the token — in-memory only, dies with the process.
+- Long-lived tokens / refresh tokens — new server = new token; pages reload.
+- Server-side CSRF state — the token IS the CSRF defense.
+- Cookie-based auth — explicit header keeps the surface minimal and curl-debuggable.
+- Tightening `--read-only` defaults to read-only — separate UX/CLI decision.
+
+## Alternatives considered
+
+1. **Origin-header check only**: cheap, but the preview MCP tool's requests ARE from a browser context with a same-origin Origin header. Doesn't block the observed trigger class.
+2. **`X-Requested-With: XMLHttpRequest` header**: even cheaper, blocks naive `curl`/scripts. Doesn't block tools that mimic a browser's header set. Lower barrier than tokens.
+3. **CSRF cookie + double-submit token**: standard web pattern but introduces cookie storage. Not worth the surface area for a localhost-only dashboard.
+4. **Drop the gate; rely on PR #446's JS fix**: cheapest, but leaves the blast radius open to the next trigger.
+
+Token gate wins on defense-in-depth + already-validated-by-attune-gui + minimal new infrastructure.
+
+## Acceptance criteria
+
+- `GET /api/session/token` exists and returns `{"token": "<32-char-url-safe>"}`.
+- Every mutating endpoint listed above 403s on missing or wrong `X-Attune-Client`.
+- Every mutating client-side fetch (in `specs.js`, `completion_candidates.js`, `runner.js`, and any others) reads the token at page load and includes it.
+- The token is delivered to the page via a `<meta name="attune-client-token" content="...">` tag in `base.html` (avoids an extra fetch on every page load).
+- Tests cover: missing header → 403, wrong token → 403, correct token → 2xx, GET `/api/session/token` is reachable without auth.
+- `--read-only` still 403s mutating endpoints (existing behavior preserved).
+
+## Execution gate
+
+Not urgent. Don't start until:
+
+1. PR #446 merged (Finding 0's JS trigger fixed first, so this isn't gated on the bug it defends against).
+2. No active CI debt in attune-ai.
+3. A reviewable inventory of mutating endpoints has been produced (see tasks.md task 1.1).
+
+PR #446 alone closes the immediate observable bug. This spec is the structural follow-up.

--- a/docs/specs/ops-mutating-endpoint-auth/tasks.md
+++ b/docs/specs/ops-mutating-endpoint-auth/tasks.md
@@ -1,0 +1,43 @@
+# Tasks — Ops mutating-endpoint auth
+
+## Phase 1 — Inventory + scaffold
+
+- [ ] **1.1** Inventory every `@router.(put|post|delete|patch)` route under `src/attune/ops/routes/`. Produce a table in this file: route, method, file:line, "needs token?" (default yes; document any "no" with reason).
+- [ ] **1.2** Add `src/attune/ops/security.py` (mirror `attune-gui/sidecar/attune_gui/security.py`):
+  - `_SESSION_TOKEN = secrets.token_urlsafe(32)`
+  - `current_session_token()` getter
+  - `require_client_token` Depends function (reads `x_attune_client: str | None = Header(default=None)`)
+  - Unit tests in `tests/unit/ops/test_security.py`
+
+## Phase 2 — Session-token endpoint
+
+- [ ] **2.1** New route `GET /api/session/token` returning `{"token": "..."}`. No auth. Place in a new file `src/attune/ops/routes/session.py` or inline in `server.py` near the app factory.
+- [ ] **2.2** Inject the token into the rendered page via a `<meta name="attune-client-token" content="...">` tag in `templates/base.html`. Reading via meta avoids a second fetch on every page load.
+- [ ] **2.3** Tests: the endpoint returns 200 with a non-empty token; the meta tag appears on every server-rendered page.
+
+## Phase 3 — Apply the gate
+
+For each mutating route surfaced in 1.1:
+
+- [ ] **3.1** Add `Depends(require_client_token)` to the route signature.
+- [ ] **3.2** Add tests: PUT/POST without header → 403; with wrong token → 403; with correct token → expected 2xx.
+
+Workflows already covered if 1.1 surfaces them.
+
+## Phase 4 — Wire the client side
+
+- [ ] **4.1** Add a tiny helper at the top of every JS file that does mutating fetches: read the meta tag once at module load, store in a module-scoped const. Inject `X-Attune-Client` on every mutating `fetch()`.
+  - Files known so far: `static/js/specs.js`, `static/js/completion_candidates.js`, `static/js/runner.js`. Confirm via grep for `method: "PUT"`, `method: "POST"`, `method: "DELETE"`.
+- [ ] **4.2** Manual smoke: launch ops, do each mutating action via the dashboard (status flip, completion-confirm, completion-dismiss, workflow run, run cancel). All should still work.
+
+## Phase 5 — Docs + close
+
+- [ ] **5.1** README section: "Localhost security model" — explain the layered approach (loopback bind, trusted Host, read-only flag, X-Attune-Client token).
+- [ ] **5.2** Close `docs/specs/ops-specs-features/phase4-findings.md` Finding 0 with a forward reference to this spec.
+
+## Out of scope (firm — do not creep)
+
+- Multi-user / network-exposed auth.
+- Token rotation / refresh.
+- Cookie-based auth.
+- A token-aware curl wrapper / CLI helper (could be a follow-up if it turns out to be friction).


### PR DESCRIPTION
## Summary

Two-file draft spec for the structural follow-up to [Finding 0](https://github.com/Smart-AI-Memory/attune-ai/pull/443):

- `docs/specs/ops-mutating-endpoint-auth/decisions.md`
- `docs/specs/ops-mutating-endpoint-auth/tasks.md`

[PR #446](https://github.com/Smart-AI-Memory/attune-ai/pull/446) closes the immediate JS trigger for Finding 0 (`commit-on-blur → cancel-on-blur`). This spec captures the defense-in-depth layer: a per-process session token, modeled on attune-gui's `X-Attune-Client` pattern, required on every mutating endpoint.

## Why a separate spec, not bundled into #446

Phase A (#446) is a 1-line behavior change with a 12-line diff. Phase B (this spec) requires:

- A new `src/attune/ops/security.py` module
- A new `GET /api/session/token` route
- `Depends(require_client_token)` applied to ~4 mutating endpoints (inventory in tasks.md task 1.1)
- A `<meta name="attune-client-token">` tag in `base.html`
- Client-side header injection across `specs.js`, `completion_candidates.js`, `runner.js`, possibly others
- ~8-12 tests covering each guarded endpoint + the session-token endpoint

That's 8-10 files modified. Worth its own spec, review, and PR.

## What's NOT in scope

Documented firmly in `decisions.md`:

- Multi-user / network-exposed auth
- Token rotation / refresh
- Cookie-based auth
- CSRF cookies
- Tightening `--read-only` defaults

## Execution gate

1. PR #446 merged (closes the immediate observable bug first)
2. No active CI debt in attune-ai

Not urgent — the bug is closed by #446. This spec ships at someone's leisure.

## Test plan

- [x] Spec files render correctly (decisions.md + tasks.md)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)