### PR TITLE
chore(help): regen ops-dashboard/plugin/rag-grounding templates with type+name frontmatter

### DIFF
--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,43 +1,58 @@
 ---
+type: concept
+name: ops-dashboard-concept
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-05-18T08:28:31.395014+00:00
-source_hash: 8cd4d31ba199aa38922ceab758f1620f6d922f2902f55ff70c107ecd4b00686e
+generated_at: 2026-05-21T03:19:56.072840+00:00
+source_hash: 70c9679ee8d985ef96c30f885e28ddd1a4c9216d86c485efecac67f77809fb67
 status: generated
 ---
 
 # Ops Dashboard
 
-## How it works
+The ops dashboard is a web interface that runs workflows, tracks their progress, and provides operational insights into your project's AI activity.
 
-Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
+## Core capabilities
 
-The main building blocks are:
+**Workflow execution**: Run any workflow from the dashboard with a scope picker that filters available options by project features. Each run streams logs in real-time and persists its history for later review.
 
-- **`CostFetchError`** — Categorized failure for cost-report fetch.
-- **`CostSummary`** — Account-level cost data from the Anthropic admin cost-report.
-- **`Candidate`** — One completion-candidate spec returned by the detector.
-- **`Config`** — Where attune ops reads project + attune state from.
-- **`TelemetrySummary`** — core component
+**Cost monitoring**: Display usage costs from the Anthropic admin API, broken down by day, model, and cost type. The dashboard caches this data locally and refreshes on demand.
 
-Under the hood, this feature spans 41 source
-files covering:
+**Session tracking**: Show active Claude Code sessions with duration, message counts, and starter prompts. This gives you visibility into how AI tools are being used across your project.
 
-- Run via ``python -m attune.ops``.
-- Anthropic admin cost-report client.
-- CLI entrypoint for ``attune ops``.
+**Spec completion detection**: Identify workflow specifications that appear ready for the next phase based on their current status and file contents.
 
-## What connects to it
+## Architecture overview
 
-This feature relates to: ops, dashboard, runner, workflows, scope-picker, persistence, sse.
+The dashboard runs as a FastAPI application on `127.0.0.1:8765` by default. You start it with `python -m attune.ops` or `attune ops`.
 
-Other parts of the codebase interact with
-ops dashboard through these interfaces:
+**Configuration**: The `Config` class determines where the dashboard reads project state from, which directories to scan for specs, and operational settings like run retention and trusted hosts.
 
-| Interface | Purpose | File |
-|-----------|---------|------|
-| `CostFetchError` | Categorized failure for cost-report fetch. | `src/attune/ops/anthropic_cost.py` |
-| `CostSummary` | Account-level cost data from the Anthropic admin cost-report. | `src/attune/ops/anthropic_cost.py` |
-| `Candidate` | One completion-candidate spec returned by the detector. | `src/attune/ops/completion_candidates.py` |
-| `Config` | Where attune ops reads project + attune state from. | `src/attune/ops/config.py` |
-| `TelemetrySummary` | — | `src/attune/ops/data.py` |
+**Cost data**: `CostSummary` structures hold account-level spending data fetched from Anthropic's admin API. The `CostFetchError` class categorizes fetch failures when the API is unavailable or credentials are missing.
+
+**Workflow intelligence**: The dashboard scans your spec directories to detect completion candidates - workflows that have reached a natural stopping point and might benefit from moving to the next phase.
+
+**Telemetry**: `TelemetrySummary` aggregates request counts, costs, and savings across workflows, providing insight into which parts of your project generate the most AI activity.
+
+## Data persistence
+
+The dashboard stores operational data in your attune home directory:
+
+- Run history persists for 30 days by default (configurable via `runs_retention_days`)
+- Cost data caches to reduce API calls to Anthropic
+- Session information tracks Claude Code usage patterns
+- Spec completion dismissals remember which candidates you've already reviewed
+
+## Integration points
+
+The ops dashboard connects to several parts of the attune ecosystem:
+
+| Component | Connection | Purpose |
+|-----------|------------|---------|
+| Workflow runner | Direct execution | Run workflows from the web interface |
+| Scope picker | Feature detection | Filter workflows by project areas |
+| Anthropic API | Cost reporting | Monitor usage and spending |
+| Claude Code | Session tracking | Visibility into AI tool usage |
+| Spec detector | Completion analysis | Identify workflows ready for next phase |
+
+The dashboard serves as the operational control center, giving you a unified view of workflow execution, cost management, and project AI activity.

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,133 +1,198 @@
 ---
+type: reference
+name: ops-dashboard-reference
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-05-18T08:28:31.405678+00:00
-source_hash: 8cd4d31ba199aa38922ceab758f1620f6d922f2902f55ff70c107ecd4b00686e
+generated_at: 2026-05-21T03:19:56.089222+00:00
+source_hash: 70c9679ee8d985ef96c30f885e28ddd1a4c9216d86c485efecac67f77809fb67
 status: generated
 ---
 
-# Ops Dashboard reference
+# Operations dashboard reference
 
-## Classes
+The operations dashboard provides a web interface for monitoring workflows, costs, sessions, and project specs. Access it via `python -m attune.ops` or the `attune ops` command.
 
-| Class | Description | File |
-|-------|-------------|------|
-| `CostFetchError` | Categorized failure for cost-report fetch. | `src/attune/ops/anthropic_cost.py` |
-| `CostSummary` | Account-level cost data from the Anthropic admin cost-report. | `src/attune/ops/anthropic_cost.py` |
-| `Candidate` | One completion-candidate spec returned by the detector. | `src/attune/ops/completion_candidates.py` |
-| `Config` | Where attune ops reads project + attune state from. | `src/attune/ops/config.py` |
-| `TelemetrySummary` | — | `src/attune/ops/data.py` |
-| `WorkflowEntry` | — | `src/attune/ops/data.py` |
-| `PathArgSpec` | How a workflow accepts a scope path on the CLI. | `src/attune/ops/data.py` |
-| `Feature` | One feature from ``.help/features.yaml`` for the scope picker. | `src/attune/ops/data.py` |
-| `Session` | One Claude Code session — what surfaces on the dashboard's /sessions page. | `src/attune/ops/data.py` |
-| `FamilyVersion` | — | `src/attune/ops/data.py` |
-| `DailyCost` | One day's cost for the home-page sparkline. | `src/attune/ops/data.py` |
-| `HomeKpis` | Summary numbers shown above the fold on the home page. | `src/attune/ops/data.py` |
-| `SweepChipCounts` | Per-bucket counts loaded from a persisted discovery-sweep result. | `src/attune/ops/data.py` |
-| `DismissEntry` | One dismissed candidate's persisted state. | `src/attune/ops/dismiss_store.py` |
-| `TrustedHostMiddleware` | Reject requests whose ``Host`` header isn't on the allowlist. | `src/attune/ops/middleware.py` |
-| `SpecPhase` | One phase file's status snapshot. | `src/attune/ops/routes/specs.py` |
-| `SpecRecord` | One spec's summary — directory + status of each phase file present. | `src/attune/ops/routes/specs.py` |
-| `RunnerBusyError` | Raised when a run is already pending/running. | `src/attune/ops/runner.py` |
-| `Run` | Single workflow execution + its broadcast state. | `src/attune/ops/runner.py` |
-| `RunnerService` | Owns the run history + concurrency lock. | `src/attune/ops/runner.py` |
-| `RedactionResult` | Outcome of a redaction pass. | `src/attune/ops/session_redaction.py` |
-| `SummaryResult` | One Haiku-or-cache result, ready to slot into a :class:`Session`. | `src/attune/ops/session_summarizer.py` |
-| `Budget` | Mutable spend ledger for one page-load summarization loop. | `src/attune/ops/session_summarizer.py` |
-| `CacheKey` | Stable key that invalidates a cached summary when the source moves. | `src/attune/ops/session_summary_cache.py` |
-| `CachedSummary` | One persisted session summary plus the metadata to validate it. | `src/attune/ops/session_summary_cache.py` |
+## Core classes
+
+### Configuration
+
+| Class | Description |
+|-------|-------------|
+| `Config` | Configuration for the dashboard server and project state |
+| `TrustedHostMiddleware` | Middleware that rejects requests from untrusted hosts |
+
+#### Config fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `project_root` | `Path` | | Project root directory |
+| `attune_home` | `Path` | | Attune state directory |
+| `host` | `str` | `'127.0.0.1'` | Server bind address |
+| `port` | `int` | `8765` | Server port |
+| `allow_run` | `bool` | `False` | Whether to enable workflow execution |
+| `specs_roots` | `tuple[Path, ...]` | `()` | Spec directory roots |
+| `trusted_hosts` | `tuple[str, ...]` | `()` | Allowed Host headers |
+| `runs_retention_days` | `int` | `30` | Days to retain run records |
+| `specs_candidates_enabled` | `bool` | `False` | Enable spec completion detection |
+
+#### Config properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `telemetry_path` | `Path` | Path to telemetry data file |
+| `runs_dir` | `Path` | Directory for persisted workflow runs |
+| `memory_dir` | `Path` | Memory persistence directory |
+| `sessions_dir` | `Path` | Claude sessions directory |
+
+### Cost reporting
+
+| Class | Description |
+|-------|-------------|
+| `CostSummary` | Account-level cost data from Anthropic admin API |
+| `CostFetchError` | Categorized cost fetch failure |
+
+#### CostSummary fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `today_usd` | `float` | Today's cost in USD |
+| `seven_day_usd` | `float` | Last 7 days cost |
+| `month_to_date_usd` | `float` | Month-to-date cost |
+| `thirty_day_usd` | `float` | Last 30 days cost |
+| `by_day` | `list[tuple[date, float]]` | Daily cost breakdown |
+| `by_model` | `list[tuple[str, float]]` | Cost by model |
+| `by_cost_type` | `list[tuple[str, float]]` | Cost by type |
+| `fetched_at` | `datetime` | Fetch timestamp |
+| `source` | `Literal['live', 'cached']` | Data source |
+
+#### CostFetchError fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `kind` | `CostFetchErrorKind` | Error category |
+| `message` | `str` | Error message |
+
+### Workflow execution
+
+| Class | Description |
+|-------|-------------|
+| `Run` | Single workflow execution and its broadcast state |
+| `RunnerService` | Workflow execution service with concurrency control |
+| `RunnerBusyError` | Exception raised when runner is already busy |
+
+### Sessions
+
+| Class | Description |
+|-------|-------------|
+| `Session` | Claude Code session for dashboard display |
+| `SummaryResult` | Session summary result from AI or cache |
+| `CachedSummary` | Persisted session summary with validation metadata |
+| `RedactionResult` | Outcome of content redaction |
+
+#### Session fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `str` | Session identifier |
+| `started_at` | `str` | Start timestamp |
+| `last_activity` | `str` | Last activity timestamp |
+| `duration_seconds` | `float` | Session duration |
+| `message_count` | `int` | Number of messages |
+| `starter_prompt` | `str` | Initial prompt |
+| `source` | `str` | How session was detected |
+
+### Spec management
+
+| Class | Description |
+|-------|-------------|
+| `Candidate` | Spec completion candidate |
+| `SpecRecord` | Spec summary with phase file status |
+| `SpecPhase` | Individual phase file status |
+
+#### Candidate fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slug` | `str` | Candidate identifier |
+| `path` | `str` | File path |
+| `current_status` | `str` | Current status |
+| `evidence` | `list[str]` | Evidence for completion |
+| `snapshot_hash` | `str` | Content hash |
+
+### Data structures
+
+| Class | Description |
+|-------|-------------|
+| `TelemetrySummary` | Aggregated usage telemetry |
+| `WorkflowEntry` | Workflow catalog entry |
+| `PathArgSpec` | CLI path argument specification |
+| `Feature` | Feature from `.help/features.yaml` |
+| `FamilyVersion` | Package version information |
 
 ## Functions
 
-| Function | Description | File |
-|----------|-------------|------|
-| `create_app()` | Lazy-import the FastAPI factory so importing attune doesn't pull FastAPI. | `src/attune/ops/__init__.py` |
-| `build_config()` | Lazy import of the config builder. | `src/attune/ops/__init__.py` |
-| `clear_cache()` | Empty the in-memory cache. Test-only convenience. | `src/attune/ops/anthropic_cost.py` |
-| `load_admin_key()` | Return the admin API key, or ``None`` if unavailable. | `src/attune/ops/anthropic_cost.py` |
-| `fetch_summary()` | Return the current cost summary or a categorized error. | `src/attune/ops/anthropic_cost.py` |
-| `add_subparser()` | Register the `ops` subparser on the main attune CLI parser. | `src/attune/ops/cli.py` |
-| `cmd_ops()` | Run the dashboard server (blocking). | `src/attune/ops/cli.py` |
-| `main()` | Standalone entry: ``python -m attune.ops``. | `src/attune/ops/cli.py` |
-| `clear_cache()` | Reset the in-memory caches. Test helper. | `src/attune/ops/completion_candidates.py` |
-| `detect_candidates()` | Return all completion candidates across the configured spec roots. | `src/attune/ops/completion_candidates.py` |
-| `attune_home()` | Resolve the user's attune home dir (env override -> ~/.attune). | `src/attune/ops/config.py` |
-| `build_config()` | Build a Config from inputs and environment defaults. | `src/attune/ops/config.py` |
-| `list_features()` | Return features parsed from ``<project_root>/.help/features.yaml``. | `src/attune/ops/data.py` |
-| `first_feature()` | Return the alphabetically-first feature with a renderable scope. | `src/attune/ops/data.py` |
-| `workflow_default_scope()` | Return the default scope for one workflow on first paint. | `src/attune/ops/data.py` |
-| `derive_project_name()` | Return a human-readable project name for the dashboard header. | `src/attune/ops/data.py` |
-| `claude_sessions_dir()` | Return the canonical directory Claude Code stores sessions for this project in. | `src/attune/ops/data.py` |
-| `enumerate_project_encoded_keys()` | Return all ``~/.claude/projects/`` dirs belonging to this logical project. | `src/attune/ops/data.py` |
-| `list_recent_sessions_with_paths()` | Same as :func:`list_recent_sessions` but also returns each | `src/attune/ops/data.py` |
-| `list_recent_sessions()` | Return Session records for this project's last ``days`` of activity. | `src/attune/ops/data.py` |
-| `home_kpis()` | Derive home-page KPIs from a telemetry summary. | `src/attune/ops/data.py` |
-| `sparkline_points()` | Render values as an SVG ``polyline`` ``points`` string. | `src/attune/ops/data.py` |
-| `read_telemetry_summary()` | Aggregate ``usage.jsonl`` into a UI-friendly summary. | `src/attune/ops/data.py` |
-| `read_sweep_chip_counts()` | Read the latest persisted sweep result for ``scope_path`` and tally chips. | `src/attune/ops/data.py` |
-| `list_workflows()` | Return the registered workflow catalog. Empty if the registry is unavailable. | `src/attune/ops/data.py` |
-| `family_versions()` | Resolve installed versions for every related attune package. | `src/attune/ops/data.py` |
-| `env_health()` | Lightweight environment snapshot for the Health page. | `src/attune/ops/data.py` |
-| `store_path()` | Return the absolute path to the dismiss-store JSON file. | `src/attune/ops/dismiss_store.py` |
-| `load()` | Read the dismiss store. Missing or corrupt file → ``{}``. | `src/attune/ops/dismiss_store.py` |
-| `save()` | Persist a dismiss entry for ``slug`` (overwrites prior entry). | `src/attune/ops/dismiss_store.py` |
-| `clear()` | Remove the entry for ``slug``. No-op if absent. | `src/attune/ops/dismiss_store.py` |
-| `is_active()` | True iff a dismiss for ``slug`` is currently suppressing it. | `src/attune/ops/dismiss_store.py` |
-| `compute_allowlist()` | Compute the default + user-supplied Host allowlist. | `src/attune/ops/middleware.py` |
-| `settings_path()` | Return the absolute path to the ops settings file. | `src/attune/ops/ops_config_store.py` |
-| `load_settings()` | Read persisted ops settings. Missing or corrupt file → ``{}``. | `src/attune/ops/ops_config_store.py` |
-| `save_setting()` | Persist a single setting; returns True on success, False on failure. | `src/attune/ops/ops_config_store.py` |
-| `resolve_specs_candidates_enabled()` | Resolve the ``specs_candidates_enabled`` setting. | `src/attune/ops/ops_config_store.py` |
-| `home()` | — | `src/attune/ops/routes/dashboard.py` |
-| `workflows_page()` | — | `src/attune/ops/routes/dashboard.py` |
-| `telemetry_page()` | — | `src/attune/ops/routes/dashboard.py` |
-| `health_page()` | — | `src/attune/ops/routes/dashboard.py` |
-| `sessions_page()` | Sessions page — recent Claude Code sessions for this project. | `src/attune/ops/routes/dashboard.py` |
-| `run_view_page()` | Full-page view for one workflow run. | `src/attune/ops/routes/dashboard.py` |
-| `specs_page()` | Specs tab — federated listing of all specs across configured roots. | `src/attune/ops/routes/dashboard.py` |
-| `spec_detail_page()` | Drill-in for a single spec: show every phase file's content (read-only). | `src/attune/ops/routes/dashboard.py` |
-| `start_run()` | — | `src/attune/ops/routes/runner.py` |
-| `get_run()` | — | `src/attune/ops/routes/runner.py` |
-| `stream_run()` | — | `src/attune/ops/routes/runner.py` |
-| `list_runs()` | Return up to 20 newest runs for ``workflow``, newest first. | `src/attune/ops/routes/runs_history.py` |
-| `get_run_record()` | Return one persisted run record (metadata + log). | `src/attune/ops/routes/runs_history.py` |
-| `enrich_with_summaries()` | Public helper used by both the JSON route and the HTML page. | `src/attune/ops/routes/sessions.py` |
-| `list_sessions()` | ``GET /api/sessions`` — JSON listing of recent sessions. | `src/attune/ops/routes/sessions.py` |
-| `list_specs()` | Federated listing across all configured spec roots. | `src/attune/ops/routes/specs.py` |
-| `list_completion_candidates()` | Return "Ready to close?" candidates for the Specs page. | `src/attune/ops/routes/specs.py` |
-| `get_spec()` | Return phase-file contents for one spec. | `src/attune/ops/routes/specs.py` |
-| `update_phase_status()` | Rewrite the ``**Status**`` line in the named phase file. | `src/attune/ops/routes/specs.py` |
-| `dismiss_completion_candidate()` | Suppress a completion candidate for the default TTL (14 days). | `src/attune/ops/routes/specs.py` |
-| `get_sweep_result()` | Return the latest sweep result for a scope-hash, or 404. | `src/attune/ops/routes/sweep_results.py` |
-| `get_sweep_chips()` | Return chip counts for an arbitrary scope path. | `src/attune/ops/routes/sweep_results.py` |
-| `sweep_detail_page()` | Scope-keyed detail page for the latest discovery-sweep result. | `src/attune/ops/routes/sweep_results.py` |
-| `echo_command_builder()` | Test helper: produce a portable subprocess that prints two lines + exits 0. | `src/attune/ops/runner.py` |
-| `prune_old_runs()` | Delete persisted run files older than ``days``. Returns the deletion count. | `src/attune/ops/runner.py` |
-| `create_app()` | Build the FastAPI app, wiring config + templates into request state. | `src/attune/ops/server.py` |
-| `redact()` | Run all redaction passes over ``text`` and return the result. | `src/attune/ops/session_redaction.py` |
-| `redact_json_line()` | Redact one JSON-serialized line in-place, preserving structure. | `src/attune/ops/session_redaction.py` |
-| `new_budget()` | Build a :class:`Budget` from the env override or default. | `src/attune/ops/session_summarizer.py` |
-| `llm_enabled()` | Return True iff the Haiku path is enabled this run. | `src/attune/ops/session_summarizer.py` |
-| `summarize_session()` | Return a Haiku-or-cached summary for one session JSONL. | `src/attune/ops/session_summarizer.py` |
-| `compute_cache_key()` | Build a :class:`CacheKey` for one JSONL file. ``None`` on I/O failure. | `src/attune/ops/session_summary_cache.py` |
-| `cache_path_for()` | Return the on-disk cache path for one session id. | `src/attune/ops/session_summary_cache.py` |
-| `load()` | Return the cached summary iff the on-disk record matches ``expected``. | `src/attune/ops/session_summary_cache.py` |
-| `save()` | Write a summary to the on-disk cache, atomically. | `src/attune/ops/session_summary_cache.py` |
-| `is_persistence_enabled()` | True when ``ATTUNE_OPS_SWEEP_RESULTS`` is set to a non-empty value. | `src/attune/ops/sweep_results.py` |
-| `results_dir()` | Return ``<attune_home>/ops/sweep-results/`` (created if missing). | `src/attune/ops/sweep_results.py` |
-| `scope_hash()` | Hash a scope path to a fixed-length hex identifier. | `src/attune/ops/sweep_results.py` |
-| `parse_lines()` | Parse a captured stdout buffer into the final SweepResult JSON. | `src/attune/ops/sweep_results.py` |
-| `persist_result()` | Atomically write ``sweep_result`` to ``<results_dir>/<hash>.json``. | `src/attune/ops/sweep_results.py` |
-| `read_result()` | Read a previously-persisted result by its scope-hash digest. | `src/attune/ops/sweep_results.py` |
-| `persist_from_lines()` | Parse captured stdout lines and persist the result for ``scope_path``. | `src/attune/ops/sweep_results.py` |
-| `watch_and_persist()` | Subscribe to a discovery-sweep run; persist its result on success. | `src/attune/ops/sweep_results_watcher.py` |
+### Application lifecycle
 
+| Function | Parameters | Returns | Description |
+|----------|------------|---------|-------------|
+| `create_app` | `*args, **kwargs` | | Lazy FastAPI application factory |
+| `build_config` | `*args, **kwargs` | | Configuration builder |
+| `main` | | `int` | Standalone entry point |
+| `cmd_ops` | `args: argparse.Namespace` | `int` | CLI command handler |
 
-## Source files
+### Cost reporting
 
-- `src/attune/ops/**`
+| Function | Parameters | Returns | Description |
+|----------|------------|---------|-------------|
+| `load_admin_key` | | `str \| None` | Load Anthropic admin API key |
+| `fetch_summary` | `*, refresh: bool = False` | `tuple[CostSummary \| None, CostFetchError \| None]` | Fetch current cost summary |
+| `clear_cache` | | `None` | Clear cost cache |
 
-## Tags
+### Spec detection
 
-`ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`
+| Function | Parameters | Returns | Description |
+|----------|------------|---------|-------------|
+| `detect_candidates` | `config: Config, *, now: float \| None = None` | `list[Candidate]` | Find spec completion candidates |
+| `clear_cache` | | `None` | Reset candidate cache |
+
+### Data access
+
+| Function | Parameters | Returns | Description |
+|----------|------------|---------|-------------|
+| `list_features` | | | Parse features from `.help/features.yaml` |
+| `list_recent_sessions` | | | Recent Claude Code sessions |
+| `read_telemetry_summary` | | | Aggregate usage telemetry |
+| `list_workflows` | | | Available workflow catalog |
+| `family_versions` | | | Installed package versions |
+
+## Constants
+
+### API configuration
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `_COST_REPORT_URL` | `'https://api.anthropic.com/v1/organizations/cost_report'` | Anthropic cost API endpoint |
+| `_API_VERSION` | `'2023-06-01'` | API version header |
+
+### File patterns
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `_PR_REF_FILES` | `('decisions.md', 'tasks.md')` | Pull request reference files |
+| `_PHASE_FILES` | `('decisions.md', 'requirements.md', 'design.md', 'tasks.md')` | Spec phase files |
+| `STORE_FILENAME` | `'spec_completion_dismissed.json'` | Dismissal store file |
+| `SETTINGS_FILENAME` | `'config.json'` | Settings file |
+
+### Status values
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `_VALID_STATUSES` | `('draft', 'in-review', 'approved', 'complete', 'completed', 'done')` | Valid spec statuses |
+| `_COMPLETE_LIKE_STATUSES` | `{'complete', 'completed', 'done'}` | Completion status variants |
+| `_VALID_BUCKETS` | `('queue', 'questions', 'rejected')` | Valid spec buckets |
+
+### UI events
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `EVENTS` | `('pill_click', 'rec_card_click', 'scope_picker_change')` | Tracked UI interactions |

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,57 +1,102 @@
 ---
+type: task
+name: ops-dashboard-task
 feature: ops-dashboard
 depth: task
-generated_at: 2026-05-18T08:28:31.401288+00:00
-source_hash: 8cd4d31ba199aa38922ceab758f1620f6d922f2902f55ff70c107ecd4b00686e
+generated_at: 2026-05-21T03:19:56.082581+00:00
+source_hash: 70c9679ee8d985ef96c30f885e28ddd1a4c9216d86c485efecac67f77809fb67
 status: generated
 ---
 
 # Work with ops dashboard
 
-Use ops dashboard when you need to local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live sse log streaming.
+Use the ops dashboard when you need to monitor workflow operations, track costs, or manage running processes through a local web interface with real-time updates.
 
 ## Prerequisites
 
-- Access to the project source code
-- Familiarity with the files under src/attune/ops/**
+- Python environment with attune installed
+- Access to the project source code in `src/attune/ops/`
+- Admin API key for Anthropic cost reporting (optional, for cost features)
 
-## Steps
+## Start the dashboard
 
-1. **Understand the current behavior.**
-   Read the entry points to see what ops dashboard
-   does today before making changes.
-   The primary functions are:
-   - `create_app()` in `src/attune/ops/__init__.py` — Lazy-import the FastAPI factory so importing attune doesn't pull FastAPI.
-   - `build_config()` in `src/attune/ops/__init__.py` — Lazy import of the config builder.
-   - `clear_cache()` in `src/attune/ops/anthropic_cost.py` — Empty the in-memory cache. Test-only convenience.
-   - `load_admin_key()` in `src/attune/ops/anthropic_cost.py` — Return the admin API key, or ``None`` if unavailable.
-   - `fetch_summary()` in `src/attune/ops/anthropic_cost.py` — Return the current cost summary or a categorized error.
-2. **Locate the right function to change.**
-   Each function has a single responsibility. Read its
-   docstring, parameters, and return type to confirm it
-   owns the behavior you need to modify.
+1. **Launch the dashboard server.**
+   Run the ops dashboard from your project root:
+   ```bash
+   python -m attune.ops
+   ```
+   Or use the CLI subcommand:
+   ```bash
+   attune ops
+   ```
 
-3. **Make your change.**
-   Follow existing patterns in the file — naming
-   conventions, error handling style, and logging.
+2. **Access the web interface.**
+   Open `http://127.0.0.1:8765` in your browser. The dashboard loads with:
+   - Workflow runner with scope picker
+   - Cost tracking from Anthropic admin API
+   - Session history and telemetry
+   - Real-time SSE log streaming
 
-4. **Run the related tests.**
-   This catches regressions before they reach other
-   developers. Target with `pytest -k "ops-dashboard"`.
+3. **Configure dashboard settings.**
+   Modify the dashboard configuration by editing the config parameters:
+   - Host and port: Default `127.0.0.1:8765`
+   - Project root: Auto-detected from current directory
+   - Spec roots: Configured via `Config.specs_roots`
+   - Retention policy: `runs_retention_days` (default 30)
 
-## Key files
+## Monitor costs and usage
 
-- `src/attune/ops/**`
+1. **View cost summaries.**
+   Check the cost panel for:
+   - Today's usage in USD
+   - 7-day and 30-day trends
+   - Month-to-date totals
+   - Breakdown by model and cost type
 
-## Common modifications
+2. **Handle cost fetch errors.**
+   If cost data fails to load, check:
+   - Admin API key availability via `load_admin_key()`
+   - Network connectivity to `api.anthropic.com`
+   - API rate limits and authentication
 
-Functions you are most likely to modify:
+3. **Clear cached data.**
+   Reset cost cache when testing or troubleshooting:
+   ```python
+   from attune.ops.anthropic_cost import clear_cache
+   clear_cache()
+   ```
 
-- `create_app()` in `src/attune/ops/__init__.py`
-- `build_config()` in `src/attune/ops/__init__.py`
-- `clear_cache()` in `src/attune/ops/anthropic_cost.py`
-- `load_admin_key()` in `src/attune/ops/anthropic_cost.py`
-- `fetch_summary()` in `src/attune/ops/anthropic_cost.py`
-- `add_subparser()` in `src/attune/ops/cli.py`
-- `cmd_ops()` in `src/attune/ops/cli.py`
-- `main()` in `src/attune/ops/cli.py`
+## Track workflow sessions
+
+1. **Review session history.**
+   The sessions page shows:
+   - Claude Code session IDs and timestamps
+   - Message counts and duration
+   - Starting prompts and activity patterns
+
+2. **Analyze telemetry data.**
+   Check telemetry summaries for:
+   - Total requests and costs
+   - Cost savings from workflow optimization
+   - Usage patterns by workflow type
+   - Daily activity trends
+
+## Detect completion candidates
+
+1. **Enable candidate detection.**
+   Set `specs_candidates_enabled: true` in your config to scan for specs ready for completion.
+
+2. **Review detected candidates.**
+   The dashboard identifies specs with:
+   - Status progression indicators
+   - Evidence of completion readiness
+   - Current phase and next steps
+
+## Verification
+
+The ops dashboard is working correctly when:
+- Web interface loads at the configured host/port
+- Cost data appears (if admin key is configured)
+- Workflow scope picker shows your project features
+- Session history displays recent Claude Code activity
+- Real-time logs stream during workflow execution

--- a/.help/templates/plugin/concept.md
+++ b/.help/templates/plugin/concept.md
@@ -1,37 +1,56 @@
 ---
+type: concept
+name: plugin-concept
 feature: plugin
 depth: concept
-generated_at: 2026-05-17T18:27:08.904228+00:00
-source_hash: 7c317f125965385a2a8e8ed6605ef6bd454625bc8fded43149d47d64438b73b0
+generated_at: 2026-05-21T03:20:39.390756+00:00
+source_hash: 5586c41f1c99c9715bfc73d5dc9622c7133d156e10d5ec551da7c26153748cf1
 status: generated
 ---
 
 # Plugin
 
-## How it works
+The Claude Code plugin provides a bundled runtime environment that enables standalone plugin operation with session continuity, state tracking, and context management.
 
-Claude Code plugin — skills, hooks, commands, and MCP config.
+## Core architecture
 
-The main building blocks are:
+The plugin consists of four interconnected systems:
 
-- **`SpecInfo`** — One in-flight spec discovered under a workspace root.
-- **`GitState`** — Snapshot of the worktree's git state at hook fire time.
+- **Command interface** — CLI wrapper that handles `/handoff` slash commands and routes them through the plugin runtime
+- **Session continuity** — State discovery helpers that track workspace changes and maintain context across sessions
+- **Resume prompt system** — Single source of truth for generating structured prompts that preserve session state
+- **Context monitoring** — Transcript size estimation to prevent context overflow during long sessions
 
-Under the hood, this feature spans 964 source
-files covering:
+## State tracking model
 
-- CLI wrapper for the ``/handoff`` slash command.
-- Resume-prompt builder — single source of truth for the format.
-- Shared state-discovery helpers for session-continuity hooks.
+The plugin maintains awareness of your development environment through two key data structures:
 
-## What connects to it
+**`SpecInfo`** captures in-flight specifications discovered in your workspace:
+- Spec location and metadata (path, layer, phase)
+- Current status and last modification time
+- Hierarchical organization under workspace roots
 
-This feature relates to: plugin, claude-code.
+**`GitState`** provides a snapshot of version control state:
+- Current branch and last commit details
+- Uncommitted file inventory for session restoration
+- Change tracking for intelligent prompt building
 
-Other parts of the codebase interact with
-plugin through these interfaces:
+## Session continuity workflow
 
-| Interface | Purpose | File |
-|-----------|---------|------|
-| `SpecInfo` | One in-flight spec discovered under a workspace root. | `plugin/hooks/_state.py` |
-| `GitState` | Snapshot of the worktree's git state at hook fire time. | `plugin/hooks/_state.py` |
+When you start a new session, the plugin:
+
+1. Scans workspace roots to discover active specifications
+2. Captures current git state including uncommitted changes
+3. Estimates context utilization from previous transcripts
+4. Builds a resume prompt with relevant state information
+5. Warns if context usage approaches limits
+
+This workflow ensures each session begins with full awareness of your project state, eliminating the need to re-explain context or lose track of in-progress work.
+
+## Integration points
+
+The plugin integrates with your development workflow through:
+- **MCP configuration** for Claude Desktop integration
+- **Workspace detection** that identifies project boundaries
+- **Sentinel file management** for once-per-session warnings
+- **Context utilization tracking** across transcript boundaries

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -1,51 +1,76 @@
 ---
+type: reference
+name: plugin-reference
 feature: plugin
 depth: reference
-generated_at: 2026-05-17T18:27:08.915959+00:00
-source_hash: 7c317f125965385a2a8e8ed6605ef6bd454625bc8fded43149d47d64438b73b0
+generated_at: 2026-05-21T03:20:39.401647+00:00
+source_hash: 5586c41f1c99c9715bfc73d5dc9622c7133d156e10d5ec551da7c26153748cf1
 status: generated
 ---
 
 # Plugin reference
 
+Core API for the attune-ai plugin runtime. Provides session continuity, workspace discovery, and Claude Code integration hooks.
+
 ## Classes
 
-| Class | Description | File |
-|-------|-------------|------|
-| `SpecInfo` | One in-flight spec discovered under a workspace root. | `plugin/hooks/_state.py` |
-| `GitState` | Snapshot of the worktree's git state at hook fire time. | `plugin/hooks/_state.py` |
+| Class | Description |
+|-------|-------------|
+| `SpecInfo` | One in-flight spec discovered under a workspace root |
+| `GitState` | Snapshot of the worktree's git state at hook fire time |
+
+### Fields
+
+#### SpecInfo fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slug` | `str` | Unique identifier for the spec |
+| `path` | `Path` | File system location of the spec |
+| `layer` | `str` | Spec layer classification |
+| `phase` | `str` | Current development phase |
+| `status` | `str` | Processing status |
+| `mtime` | `float` | Last modification timestamp |
+
+#### GitState fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `branch` | `str` | Current git branch name |
+| `last_sha` | `str` | SHA of the most recent commit |
+| `last_subject` | `str` | Subject line of the most recent commit |
+| `uncommitted` | `tuple[str, ...]` | List of files with uncommitted changes |
 
 ## Functions
 
-| Function | Description | File |
-|----------|-------------|------|
-| `main()` | — | `plugin/hooks/_handoff_cli.py` |
-| `build_resume_prompt()` | Render the user-facing resume prompt body. | `plugin/hooks/_resume_prompt.py` |
-| `discover_specs()` | Walk ``specs/`` directories under each root for in-flight specs. | `plugin/hooks/_state.py` |
-| `git_state()` | Return branch, last commit, and uncommitted files for ``cwd``. | `plugin/hooks/_state.py` |
-| `session_sentinel_path()` | Path to the once-per-session compact-warning sentinel. | `plugin/hooks/_state.py` |
-| `prune_stale_sentinels()` | Delete sentinel files older than the TTL. | `plugin/hooks/_state.py` |
-| `workspace_roots()` | Best-effort guess at workspace roots to scan for specs. | `plugin/hooks/_state.py` |
-| `estimate_utilization()` | Return estimated context utilization in ``[0.0, 1.0]``. | `plugin/hooks/_transcript_size.py` |
-| `format_warning()` | Compose the user-facing warning + resume prompt. | `plugin/hooks/compact_warning.py` |
-| `main()` | Entry point — never raises. | `plugin/hooks/compact_warning.py` |
-| `main()` | Read tool result from stdin, format Python files. | `plugin/hooks/format_on_save.py` |
-| `main()` | Check help template freshness on session start. | `plugin/hooks/help_freshness_check.py` |
-| `main()` | Read PostToolUse payload and suggest help if applicable. | `plugin/hooks/help_on_error.py` |
-| `main()` | Check for stale help after git commit. | `plugin/hooks/help_post_commit.py` |
-| `validate_bash_command()` | Validate a Bash command against security policies. | `plugin/hooks/security_guard.py` |
-| `validate_file_path()` | Validate a file path against security policies. | `plugin/hooks/security_guard.py` |
-| `main()` | Validate a tool call against security policies. | `plugin/hooks/security_guard.py` |
-| `format_orientation()` | Short markdown list of in-flight specs for non-compact starts. | `plugin/hooks/spec_orient.py` |
-| `render_spec_pin()` | Render a spec body for post-compact context restoration. | `plugin/hooks/spec_orient.py` |
-| `main()` | Entry point — branches on ``source``, never raises. | `plugin/hooks/spec_orient.py` |
-| `main()` | Print welcome message to stderr (Claude Code surfaces stderr). | `plugin/hooks/welcome.py` |
+| Function | Parameters | Returns | Description |
+|----------|------------|---------|-------------|
+| `main` | — | `int` | CLI entry point for `/handoff` command |
+| `build_resume_prompt` | `spec_info: SpecInfo \| None, git_state: GitState, *, workspace_path: str = '~/attune', todo_summary: str \| None = None` | `str` | Render the user-facing resume prompt body |
+| `discover_specs` | `roots: list[Path]` | `list[SpecInfo]` | Walk `specs/` directories under each root for in-flight specs |
+| `git_state` | `cwd: Path` | `GitState` | Return branch, last commit, and uncommitted files for `cwd` |
+| `session_sentinel_path` | `session_id: str \| None` | `Path` | Path to the once-per-session compact-warning sentinel |
+| `prune_stale_sentinels` | `now: float \| None = None` | `int` | Delete sentinel files older than the TTL |
+| `workspace_roots` | `cwd: Path \| None = None` | `list[Path]` | Best-effort guess at workspace roots to scan for specs |
+| `estimate_utilization` | `transcript_path: str \| Path` | `float` | Return estimated context utilization in `[0.0, 1.0]` |
+| `format_warning` | `util: float, threshold: float, resume_body: str` | `str` | Compose the user-facing warning + resume prompt |
+| `validate_bash_command` | Command validation parameters | Validation result | Validate a Bash command against security policies |
+| `validate_file_path` | Path validation parameters | Validation result | Validate a file path against security policies |
+| `format_orientation` | Spec formatting parameters | `str` | Short markdown list of in-flight specs for non-compact starts |
+| `render_spec_pin` | Spec rendering parameters | `str` | Render a spec body for post-compact context restoration |
 
+### Return values
 
-## Source files
+#### main function returns
 
-- `plugin/**`
+```
+0
+```
 
-## Tags
+## Constants
 
-`plugin`, `claude-code`
+| Constant | Type | Values | Description |
+|----------|------|--------|-------------|
+| `__version__` | `str` | `'7.0.0'` | Plugin version identifier |
+| `SYSTEM_DIRECTORIES` | `frozenset` | `'/etc', '/sys', '/proc', '/dev', '/boot', '/sbin', '/usr/sbin', '/private/etc', '/private/var'` | Protected system directories |
+| `SEARCH_COMMAND_PREFIXES` | `frozenset` | `'grep', 'rg', 'ack', 'ag', 'git grep', 'git log', 'git diff'` | Recognized search command prefixes |

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -1,57 +1,59 @@
 ---
+type: task
+name: plugin-task
 feature: plugin
 depth: task
-generated_at: 2026-05-17T18:27:08.911339+00:00
-source_hash: 7c317f125965385a2a8e8ed6605ef6bd454625bc8fded43149d47d64438b73b0
+generated_at: 2026-05-21T03:20:39.396433+00:00
+source_hash: 5586c41f1c99c9715bfc73d5dc9622c7133d156e10d5ec551da7c26153748cf1
 status: generated
 ---
 
 # Work with plugin
 
-Use plugin when you need to claude code plugin — skills, hooks, commands, and mcp config.
+Use the plugin module when you need to modify session-continuity hooks, resume prompts, or state discovery for Claude's workspace integration.
 
 ## Prerequisites
 
 - Access to the project source code
-- Familiarity with the files under plugin/**
+- Familiarity with the plugin module structure
+- Understanding of git workflows and spec discovery patterns
 
-## Steps
+## Identify the component you need to modify
 
-1. **Understand the current behavior.**
-   Read the entry points to see what plugin
-   does today before making changes.
-   The primary functions are:
-   - `main()` in `plugin/hooks/_handoff_cli.py`
-   - `build_resume_prompt()` in `plugin/hooks/_resume_prompt.py` — Render the user-facing resume prompt body.
-   - `discover_specs()` in `plugin/hooks/_state.py` — Walk ``specs/`` directories under each root for in-flight specs.
-   - `git_state()` in `plugin/hooks/_state.py` — Return branch, last commit, and uncommitted files for ``cwd``.
-   - `session_sentinel_path()` in `plugin/hooks/_state.py` — Path to the once-per-session compact-warning sentinel.
-2. **Locate the right function to change.**
-   Each function has a single responsibility. Read its
-   docstring, parameters, and return type to confirm it
-   owns the behavior you need to modify.
+The plugin module contains four core components:
 
-3. **Make your change.**
-   Follow existing patterns in the file — naming
-   conventions, error handling style, and logging.
+1. **Handoff CLI** (`plugin/hooks/_handoff_cli.py`) — Entry point for the `/handoff` slash command
+2. **Resume prompt builder** (`plugin/hooks/_resume_prompt.py`) — Generates user-facing prompts with workspace context
+3. **State discovery** (`plugin/hooks/_state.py`) — Finds in-flight specs and captures git state
+4. **Transcript sizing** (`plugin/hooks/_transcript_size.py`) — Estimates context utilization for warnings
 
-4. **Run the related tests.**
-   This catches regressions before they reach other
-   developers. Target with `pytest -k "plugin"`.
+## Locate the specific function
 
-## Key files
+Each component contains focused functions with single responsibilities:
 
-- `plugin/**`
+- For CLI integration: `main()` in `_handoff_cli.py`
+- For prompt generation: `build_resume_prompt()` in `_resume_prompt.py`
+- For workspace discovery: `discover_specs()`, `git_state()`, or `workspace_roots()` in `_state.py`
+- For context management: `estimate_utilization()` or `format_warning()` in `_transcript_size.py`
 
-## Common modifications
+Read the function's docstring and parameters to confirm it handles your use case.
 
-Functions you are most likely to modify:
+## Modify the function
 
-- `main()` in `plugin/hooks/_handoff_cli.py`
-- `build_resume_prompt()` in `plugin/hooks/_resume_prompt.py`
-- `discover_specs()` in `plugin/hooks/_state.py`
-- `git_state()` in `plugin/hooks/_state.py`
-- `session_sentinel_path()` in `plugin/hooks/_state.py`
-- `prune_stale_sentinels()` in `plugin/hooks/_state.py`
-- `workspace_roots()` in `plugin/hooks/_state.py`
-- `estimate_utilization()` in `plugin/hooks/_transcript_size.py`
+1. Open the file containing your target function
+2. Preserve the existing error handling and logging patterns
+3. Match the naming conventions used in surrounding code
+4. Test your changes incrementally as you work
+
+## Verify your changes
+
+Run the plugin-specific tests to catch regressions:
+
+```bash
+pytest -k "plugin"
+```
+
+Your modification works correctly when:
+- All existing tests pass
+- The function returns the expected type as documented
+- Error conditions are handled consistently with the existing codebase

--- a/.help/templates/rag-grounding/concept.md
+++ b/.help/templates/rag-grounding/concept.md
@@ -1,28 +1,41 @@
 ---
+type: concept
+name: rag-grounding-concept
 feature: rag-grounding
 depth: concept
-generated_at: 2026-05-16T07:57:53.299579+00:00
-source_hash: b292cc405776df72a1b9d1d8305fef86784d97ef15f9c68d9509bccecf1f865a
+generated_at: 2026-05-21T03:20:54.610898+00:00
+source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
 status: generated
 ---
 
-# Rag Grounding
+# RAG Grounding
 
-## How it works
+RAG grounding is a code generation approach that retrieves relevant documentation from attune-help before generating code, ensuring all outputs are backed by real attune ecosystem APIs and patterns.
 
-RAG-grounded code generation — retrieves attune-help context via attune-rag, feeds citation-forced prompts to Claude, emits answers with provenance.
+## How RAG grounding works
 
-The main building blocks are:
+When you ask for code or explanations, the system first searches attune-help documentation for relevant context. This retrieved content is then passed to Claude along with your request, but with strict instructions to only reference what's actually documented. The result is generated code that cites real APIs, workflow names, and CLI commands rather than inventing features.
 
-- **`RagCodeGenWorkflow`** — SDK-native RAG-grounded code generation workflow.
+The grounding process prevents hallucination by:
 
-## What connects to it
+1. **Retrieval first** — attune-rag searches the help system for content matching your request
+2. **Context injection** — retrieved passages are embedded in the prompt as `<passage>...</passage>` blocks
+3. **Citation forcing** — Claude receives explicit instructions to ground all responses in the provided context
+4. **Provenance tracking** — generated answers include references to the source files where patterns originated
 
-This feature relates to: rag, retrieval, grounding, faithfulness, citation.
+## Core components
 
-Other parts of the codebase interact with
-rag grounding through these interfaces:
+**`RagCodeGenWorkflow`** orchestrates the entire process. This SDK-native workflow takes your request, retrieves relevant documentation through attune-rag, constructs a grounded prompt, and returns generated code with citations.
 
-| Interface | Purpose | File |
-|-----------|---------|------|
-| `RagCodeGenWorkflow` | SDK-native RAG-grounded code generation workflow. | `src/attune/workflows/rag_code_gen.py` |
+The workflow uses a system prompt (`_SYSTEM_PROMPT`) that specifically instructs Claude to treat passage content as documentation rather than commands, preventing prompt injection attacks where malicious content might try to override the grounding instructions.
+
+## When to use RAG grounding
+
+RAG grounding is essential when you need generated code that integrates with the attune ecosystem. Unlike general-purpose code generation, it ensures that:
+
+- API calls use real method signatures from attune
+- Workflow references point to actual workflow classes
+- CLI commands match the current attune interface
+- Code patterns follow documented attune conventions
+
+This makes RAG grounding particularly valuable for onboarding new developers, generating integration examples, and creating documentation that stays synchronized with the codebase.

--- a/.help/templates/rag-grounding/reference.md
+++ b/.help/templates/rag-grounding/reference.md
@@ -1,20 +1,35 @@
 ---
+type: reference
+name: rag-grounding-reference
 feature: rag-grounding
 depth: reference
-generated_at: 2026-05-16T07:57:53.311988+00:00
-source_hash: b292cc405776df72a1b9d1d8305fef86784d97ef15f9c68d9509bccecf1f865a
+generated_at: 2026-05-21T03:20:54.627075+00:00
+source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
 status: generated
 ---
 
-# Rag Grounding reference
+# RAG grounding reference
+
+Generate code with citations to real attune APIs and documentation.
 
 ## Classes
 
-| Class | Description | File |
-|-------|-------------|------|
-| `RagCodeGenWorkflow` | SDK-native RAG-grounded code generation workflow. | `src/attune/workflows/rag_code_gen.py` |
+| Class | Description |
+|-------|-------------|
+| `RagCodeGenWorkflow` | SDK-native RAG-grounded code generation workflow |
 
+### RagCodeGenWorkflow
 
+| Method | Parameters | Returns | Description |
+|--------|------------|---------|-------------|
+| `__init__` | `**kwargs: Any` | `None` | Initialize the workflow |
+| `execute` | `**kwargs: Any` | `WorkflowResult` | Execute the RAG-grounded code generation |
+
+## Constants
+
+| Constant | Description |
+|----------|-------------|
+| `_SYSTEM_PROMPT` | System prompt that enforces grounding in attune documentation and prevents hallucination of non-existent features |
 
 ## Source files
 

--- a/.help/templates/rag-grounding/task.md
+++ b/.help/templates/rag-grounding/task.md
@@ -1,45 +1,58 @@
 ---
+type: task
+name: rag-grounding-task
 feature: rag-grounding
 depth: task
-generated_at: 2026-05-16T07:57:53.307294+00:00
-source_hash: b292cc405776df72a1b9d1d8305fef86784d97ef15f9c68d9509bccecf1f865a
+generated_at: 2026-05-21T03:20:54.619948+00:00
+source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
 status: generated
 ---
 
 # Work with rag grounding
 
-Use rag grounding when you need to rag-grounded code generation — retrieves attune-help context via attune-rag, feeds citation-forced prompts to claude, emits answers with provenance.
+Use rag grounding when you need to generate code backed by verified documentation — it retrieves attune-help context and forces Claude to cite real APIs and patterns rather than hallucinating features.
 
 ## Prerequisites
 
 - Access to the project source code
-- Familiarity with the files under src/attune/workflows/rag_code_gen.py
+- Familiarity with `src/attune/workflows/rag_code_gen.py`
 
-## Steps
+## Configure the workflow
 
-1. **Understand the class hierarchy.**
-   Read the interfaces to see how rag grounding
-   is structured before extending or modifying.
-   The key classes are:
-   - `RagCodeGenWorkflow` in `src/attune/workflows/rag_code_gen.py` — SDK-native RAG-grounded code generation workflow.
-2. **Decide whether to extend or modify.**
-   If the class has subclasses, extend with a new one
-   rather than changing the base. If it stands alone,
-   modify directly.
+1. **Import the RagCodeGenWorkflow class:**
+   ```python
+   from attune.workflows.rag_code_gen import RagCodeGenWorkflow
+   ```
 
-3. **Make your change.**
-   Follow existing patterns — naming, error handling,
-   and logging style.
+2. **Initialize the workflow:**
+   ```python
+   workflow = RagCodeGenWorkflow(**kwargs)
+   ```
 
-4. **Run the related tests.**
-   Target with `pytest -k "rag-grounding"`.
+3. **Execute with your requirements:**
+   ```python
+   result = workflow.execute(**kwargs)
+   ```
 
-## Key files
+## Extend the workflow behavior
 
-- `src/attune/workflows/rag_code_gen.py`
+1. **Review the base RagCodeGenWorkflow class** in `src/attune/workflows/rag_code_gen.py` to understand the existing citation and grounding mechanisms.
 
-## Common modifications
+2. **Create a subclass for custom behavior:**
+   ```python
+   class CustomRagCodeGenWorkflow(RagCodeGenWorkflow):
+       def execute(self, **kwargs):
+           # Your custom logic here
+           return super().execute(**kwargs)
+   ```
 
-Classes you are most likely to extend:
+3. **Preserve the citation system** — the workflow includes a `_SYSTEM_PROMPT` that enforces grounding in real attune documentation and prevents feature hallucination.
 
-- `RagCodeGenWorkflow` in `src/attune/workflows/rag_code_gen.py`
+## Verify the grounding works
+
+Run your workflow and confirm that:
+- Generated code references actual attune APIs from the retrieved context
+- Citations include source file references
+- No invented features appear in the output
+
+The workflow should return a `WorkflowResult` containing grounded code with proper provenance tracking.


### PR DESCRIPTION
## Summary

- Refreshes nine `.help/templates/*` files (ops-dashboard, plugin, rag-grounding — × concept/task/reference) from a 2026-05-21 `attune-author` run
- Adds the new `type:` and `name:` frontmatter fields the attune-help reader now expects
- Polished prose bodies replace the older bullet-list scaffolds; integration-points tables get explicit columns

## Test plan

- [x] Source hashes in frontmatter match current source — no staleness regressions
- [x] All nine files pass pre-commit (black, ruff, trailing whitespace, EOF)
- [ ] Spot-load any one of the three features in attune-help and confirm the new frontmatter renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)