### PR TITLE
docs(specs): build out sdk-error-message-fidelity — decisions/design/tasks

### DIFF
--- a/docs/specs/sdk-error-message-fidelity/decisions.md
+++ b/docs/specs/sdk-error-message-fidelity/decisions.md
@@ -1,0 +1,41 @@
+# Spec: SDK Error Message Fidelity — Decisions
+
+> Pre-committed decisions per the existing lesson "Pre-committed
+> decision matrices survive contact with data." Edits to this file
+> after Phase 1 ships require a follow-up PR with rationale.
+
+**Status:** draft (2026-05-24)
+
+---
+
+## Decision matrix
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Implementation path | **Path A — wrap the SDK call site** | No SDK fork, no monkey-patch fragility. Path B (monkey-patch `subprocess_cli`) is rejected: brittle across SDK upgrades, hard to test, smell. The double-spend on Path A only fires on failure paths and the second `subprocess.run` exits in sub-second for quota/auth failures (which dominate the failure modes). |
+| Classifier shape | **Hard-coded `(regex, kind, message)` tuples in `agent_sdk_adapter.py`** | Five-ish known shapes is well below the table-driven threshold. Hard-coded reads fine, tests fine, ships fine. Revisit only if the list grows past ~8 shapes or a project-specific override becomes a real ask. |
+| Stderr redaction | **Yes — route through `session_redaction.redact()` before persistence + render** | Captured stderr from a `claude` failure could carry API keys (esp. on auth failures where the SDK logs the literal env value). Reusing the existing redactor matches the lesson on "all-paths-touched-by-secrets get redacted" without adding a new code path. Cost: one O(stderr-length) pass per failed run. Acceptable. |
+| Chip-classifier defense-in-depth (PR #366) | **Keep for now, simplify in Phase 4** | The log-scan chip classifier solved the same surface from a different angle. Once Phase 1–3 ship, Phase 4 reads the typed `kind` from the persisted run record and stops scanning the log text. Defense-in-depth stays until the new typed channel proves itself in production. |
+| Exception type | **`SdkSubprocessError(message, stderr, kind, original_exc)`** | Single dataclass-style exception in `agent_sdk_adapter.py`. `kind` is an enum (`Literal["api_quota","auth","rate_limit","not_found","schema_rejected","unknown"]`). `original_exc` retains the SDK's wrapped Exception so callers / tests can chain. |
+| Persistence surface | **Add `sdk_stderr: str \| None` + `sdk_error_kind: str \| None` to `Run.to_record()`** | Two new fields, both nullable. No schema migration needed — older run records read them as missing → None → render falls back to the legacy "What Went Wrong" block. |
+| Render placement | **Collapsible `<details>` on `/runs/<id>/view`, below "What Went Wrong"** | Default-collapsed so the page stays scannable; one click to expand the raw stderr. Matches the existing run-view info hierarchy. |
+| Scope of v1 rollout | **Six workflows: `code-review`, `security-audit`, `bug-predict`, `perf-audit`, `refactor-plan`, `dependency-check`** | The high-traffic SDK workflows Patrick exercised during the 2026-05-24 dashboard run. Hits the most common surfaces fast. Other SDK workflows (`test-audit`, `doc-audit`, `doc-gen`, `discovery-sweep`, `secure-release` pipeline, `deep-review`) get the same treatment in Phase 5 once the API stabilizes. |
+
+---
+
+## Open questions (resolved)
+
+1. **Should the classifier be table-driven (config file) or hard-coded?**
+   **Hard-coded** for v1; table-driven if the list grows past ~8 shapes. See matrix.
+
+2. **Should the captured stderr be redacted before persisting?**
+   **Yes**, reuse the existing `session_redaction.redact()`. See matrix.
+
+3. **Does PR #366's chip-classifier get simplified once this lands?**
+   **Yes, in Phase 4**, not earlier. Defense-in-depth holds until typed channel proves out. See matrix.
+
+---
+
+## Carryover
+
+- 2026-05-24 — Initial decisions captured during spec build-out, triggered by the morning's firefight on the same surface (PR #452 was a separate symptom of the same root cause). Patrick.

--- a/docs/specs/sdk-error-message-fidelity/design.md
+++ b/docs/specs/sdk-error-message-fidelity/design.md
@@ -1,0 +1,250 @@
+# Spec: SDK Error Message Fidelity — Design
+
+**Status:** draft (2026-05-24)
+
+---
+
+## Module layout
+
+All new code lands in two existing modules + one new test surface:
+
+| File | Change |
+|---|---|
+| `src/attune/workflows/agent_sdk_adapter.py` | New `SdkSubprocessError`, new `classify_subprocess_failure(stderr)`, new `capture_subprocess_failure(args, env)` helper, modified `collect_agent_output()` / call-site decorators |
+| `src/attune/workflows/dependency_check.py` (+ 5 siblings) | Replace `sdk_error_message(exc, ...)` calls in the broad-except branch with `SdkSubprocessError.format_user_message()` |
+| `src/attune/ops/data.py` (runs JSON read path) + `src/attune/ops/templates/run_view.html` | New `sdk_stderr` / `sdk_error_kind` fields on the run record; collapsible `<details>` block in the run-view template |
+| `tests/unit/workflows/test_sdk_error_fidelity.py` | New file — unit tests for the exception, classifier, and capture helper |
+| `tests/unit/workflows/test_*` (each affected workflow) | New test per workflow: `test_<wf>_surfaces_real_cause_on_subprocess_failure` |
+
+---
+
+## `SdkSubprocessError` shape
+
+```python
+# agent_sdk_adapter.py
+from dataclasses import dataclass
+from typing import Literal
+
+SdkErrorKind = Literal[
+    "api_quota",
+    "auth",
+    "rate_limit",
+    "not_found",
+    "schema_rejected",
+    "unknown",
+]
+
+@dataclass
+class SdkSubprocessError(Exception):
+    """Typed wrapper around the SDK's bare 'Command failed' Exception.
+
+    Captures the underlying ``claude`` CLI's stderr (via a second
+    direct-subprocess call) and classifies it into one of the known
+    failure-kind labels for user-facing messaging.
+
+    Attributes:
+        message: User-facing one-line summary (e.g. "API quota
+            reached (regains 2026-06-01)").
+        stderr: Raw captured stderr from the second ``subprocess.run``
+            call, redacted through ``session_redaction.redact()``.
+        kind: Classified failure category (see ``SdkErrorKind``).
+        original_exc: The SDK's wrapped exception, preserved so
+            callers / tests can ``raise X from err.original_exc``.
+    """
+
+    message: str
+    stderr: str
+    kind: SdkErrorKind
+    original_exc: BaseException | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+    def format_user_message(self) -> str:
+        """Voice-layer-ready user-facing block."""
+        if self.kind == "unknown":
+            return (
+                f"{self.message}\n\n"
+                "Underlying error (raw stderr from the claude CLI):\n"
+                f"{self.stderr.strip()}"
+            )
+        return f"{self.message}\n\nFull stderr is available on /runs/<id>/view."
+```
+
+---
+
+## Classifier
+
+```python
+# agent_sdk_adapter.py
+import re
+
+# (compiled_re, kind, message_template) tuples. Ordered: most-specific
+# first so a more-precise label wins over a generic one.
+_CLASSIFIERS: list[tuple[re.Pattern[str], SdkErrorKind, str]] = [
+    (re.compile(r"specified API usage limits", re.I),
+     "api_quota",
+     "Anthropic API quota reached for this account."),
+    (re.compile(r"\b(401|invalid[_\s-]?api[_\s-]?key|unauthorized)\b", re.I),
+     "auth",
+     "Anthropic auth invalid or missing."),
+    (re.compile(r"\b(429|rate[_\s-]?limit|too many requests)\b", re.I),
+     "rate_limit",
+     "Rate-limited by Anthropic; retry shortly."),
+    (re.compile(r"FileNotFoundError|claude.*not.*(found|on.*PATH)", re.I),
+     "not_found",
+     "The bundled claude CLI was not found at the expected path."),
+    (re.compile(r"json[_\s-]?schema|--?json-?schema", re.I),
+     "schema_rejected",
+     "The output schema was rejected by the claude CLI."),
+]
+
+def classify_subprocess_failure(stderr: str) -> tuple[SdkErrorKind, str]:
+    """Classify a captured stderr blob into (kind, user-message)."""
+    for pattern, kind, message in _CLASSIFIERS:
+        if pattern.search(stderr):
+            return kind, message
+    return "unknown", "The claude CLI subprocess failed; see raw stderr below."
+```
+
+---
+
+## Capture helper
+
+```python
+# agent_sdk_adapter.py
+import subprocess
+from attune.security.session_redaction import redact
+
+def capture_subprocess_failure(
+    args: list[str],
+    env: dict[str, str] | None = None,
+    timeout_s: float = 10.0,
+) -> str:
+    """Re-run the failed ``claude`` invocation with stderr capture.
+
+    Called from the broad-except branch around a
+    ``claude_agent_sdk.query()`` call when the bare 'Command failed'
+    exception fires. Returns redacted stderr ready to attach to a
+    ``SdkSubprocessError``.
+
+    Args:
+        args: Exact argv used by the SDK's first invocation. Pulled
+            from the SDK's ``subprocess_cli`` log-prefix line (the
+            "$ claude --output-format stream-json …" we already see
+            in the run log).
+        env: Optional env override. Defaults to ``os.environ``.
+        timeout_s: Subprocess timeout. The failure mode we care about
+            (quota / auth / not-found) all exit in sub-second; 10s
+            is a generous ceiling.
+
+    Returns:
+        Redacted stderr text, or a synthetic
+        "(capture-call also failed: <reason>)" string if the second
+        subprocess itself raises.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603
+            args,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,  # we want to inspect failure output
+        )
+        # Some failures put real errors on stdout (e.g. JSON envelope).
+        # Concatenate; the classifier scans both anyway.
+        combined = (result.stderr or "") + ("\n" + result.stdout if result.stdout else "")
+        return redact(combined)
+    except subprocess.TimeoutExpired:
+        return f"(capture-call timed out after {timeout_s}s)"
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"(capture-call also failed: {type(exc).__name__}: {exc})"
+```
+
+---
+
+## Call-site integration
+
+Each affected workflow's `_run_agent_<stage>()` already has a broad-except wrapper. We change the body of that except branch.
+
+**Before:**
+
+```python
+# workflows/dependency_check.py
+except Exception as exc:  # noqa: BLE001
+    logger.exception("Agent SDK dependency check failed: %s", type(exc).__name__)
+    duration = (datetime.now() - started_at).total_seconds()
+    return self._error_result(
+        sdk_error_message(exc, duration_seconds=duration, depth=depth)
+    )
+```
+
+**After:**
+
+```python
+except Exception as exc:  # noqa: BLE001
+    logger.exception("Agent SDK dependency check failed: %s", type(exc).__name__)
+    duration = (datetime.now() - started_at).total_seconds()
+    stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+    kind, summary = classify_subprocess_failure(stderr)
+    sdk_err = SdkSubprocessError(
+        message=summary, stderr=stderr, kind=kind, original_exc=exc
+    )
+    return self._error_result(
+        sdk_err.format_user_message(),
+        sdk_stderr=stderr,
+        sdk_error_kind=kind,
+    )
+```
+
+`_last_subprocess_argv(exc)` extracts the argv from the SDK exception's repr (we already log it; the SDK stores it on the inner attr `exc.__cause__.args` in current versions — needs verification in Phase 1).
+
+---
+
+## Persistence + render
+
+**`Run.to_record()`** gains:
+
+```python
+sdk_stderr: str | None = None
+sdk_error_kind: str | None = None
+```
+
+Both default-None so existing run records on disk read back correctly (missing keys → None).
+
+**`run_view.html`** gains, immediately under the existing "What Went Wrong" block:
+
+```html
+{% if run.sdk_stderr %}
+<details class="sdk-error-detail">
+  <summary>Raw stderr from claude CLI
+    {% if run.sdk_error_kind %} ({{ run.sdk_error_kind }}){% endif %}
+  </summary>
+  <pre class="sdk-error-stderr">{{ run.sdk_stderr }}</pre>
+</details>
+{% endif %}
+```
+
+CSS: `.sdk-error-stderr` matches the existing log-pre style — monospace, muted background, scroll-on-overflow.
+
+---
+
+## Failure modes (what could go wrong)
+
+| Mode | Mitigation |
+|---|---|
+| Second subprocess call hangs | 10s timeout in `capture_subprocess_failure()`; synthetic "timed out" message. |
+| SDK argv format changes across versions | Pinned `claude-agent-sdk` minor version; drift-guard test in Phase 1 asserts the argv-extraction path still works against installed SDK. |
+| Captured stderr contains secrets | All paths route through `redact()` before persistence + render. |
+| Classifier false-positive | "unknown" fallback always shows the raw stderr, so a misclassification still leaves the user with the truth. |
+| Capture call itself rate-limited (the "rate_limit" kind ironically can't capture) | Synthetic "(capture-call also failed: …)" string preserves the first-class failure indication; user sees "rate-limited" from the first call's exception text. |
+
+---
+
+## Out of scope
+
+- Retry / backoff on transient errors — surface, don't recover.
+- Predicting every error class — five-shape menu + unknown fallback is the v1 surface.
+- SDK fork or upstream PR — explicit non-goal per decisions.md.
+- Exit-code propagation — sibling spec `workflow-failure-exit-propagation` owns it.

--- a/docs/specs/sdk-error-message-fidelity/requirements.md
+++ b/docs/specs/sdk-error-message-fidelity/requirements.md
@@ -5,10 +5,10 @@
 > "Command failed with exit code 1" wrapped in a list of plausible-
 > but-wrong remediation suggestions.
 
-**Status:** draft
+**Status:** approved (2026-05-24)
 **Created:** 2026-05-17
 **Owner:** TBD
-**Related:** [`workflow-failure-exit-propagation`](../workflow-failure-exit-propagation/) (sibling — same surface, exit-code side)
+**Related:** [`workflow-failure-exit-propagation`](../workflow-failure-exit-propagation/) (sibling — same surface, exit-code side); [`decisions.md`](decisions.md) and [`design.md`](design.md) and [`tasks.md`](tasks.md) (built out 2026-05-24 after firefight reproduction confirmed the requirements as written)
 
 ---
 

--- a/docs/specs/sdk-error-message-fidelity/tasks.md
+++ b/docs/specs/sdk-error-message-fidelity/tasks.md
@@ -1,0 +1,113 @@
+# Spec: SDK Error Message Fidelity — Tasks
+
+**Status:** draft (2026-05-24)
+
+> Five phases, each shipping as its own PR. Phase 1 is the recommended
+> first commitment; Phases 2–5 build on it. Phase 1 can be approved
+> and shipped independently — it adds the primitives without touching
+> any workflow.
+
+---
+
+## Phase 1 — Primitives (no workflow changes yet)
+
+Goal: ship `SdkSubprocessError`, the classifier, and the capture helper as standalone, well-tested building blocks in `agent_sdk_adapter.py`. No call sites change yet.
+
+- [ ] **1.1** Add `SdkErrorKind` `Literal[...]` and `SdkSubprocessError` dataclass-exception to `src/attune/workflows/agent_sdk_adapter.py` per [design.md](design.md) § "SdkSubprocessError shape".
+- [ ] **1.2** Add `_CLASSIFIERS` tuple table and `classify_subprocess_failure(stderr)` function. Order tuples most-specific-first so `api_quota` wins over `auth` when both patterns match.
+- [ ] **1.3** Add `capture_subprocess_failure(args, env, timeout_s)` helper. Route output through `attune.security.session_redaction.redact()` before returning.
+- [ ] **1.4** Add `_last_subprocess_argv(exc)` extractor that pulls the failing argv from the SDK exception. **Test against installed `claude-agent-sdk` version** — if the attribute path drifts, the test fails loud and Phase 2 stays blocked until fixed.
+- [ ] **1.5** Tests in `tests/unit/workflows/test_sdk_error_fidelity.py`:
+  - Classifier branches: one test per `SdkErrorKind` value (6 total — including `unknown` fallback)
+  - Most-specific-wins ordering (e.g. an "API quota" message containing "401" still classifies as `api_quota`)
+  - `capture_subprocess_failure` against a synthetic failing command (`["false"]` or similar) — should return non-empty redacted output
+  - `capture_subprocess_failure` timeout path — synthetic sleep command, timeout=1s, asserts the "(capture-call timed out)" string
+  - `capture_subprocess_failure` OSError path — invalid argv, asserts the "(capture-call also failed)" string
+  - `redact()` integration — synthetic stderr containing an `sk-`-prefixed token comes out scrubbed
+  - `_last_subprocess_argv` happy-path + drift guard
+
+**Acceptance:** ≥15 unit tests, all green. Coverage on `agent_sdk_adapter.py` ≥ existing baseline + the new lines. No production behavior change (call sites still use `sdk_error_message`).
+
+---
+
+## Phase 2 — Two-workflow pilot (`code-review` + `dependency-check`)
+
+Goal: replace the `sdk_error_message(exc, ...)` call in two high-traffic workflows with the new `SdkSubprocessError` flow. Validate the API + UX on a small surface before fanning out.
+
+- [ ] **2.1** Modify `src/attune/workflows/code_review.py`'s broad-except branch per [design.md](design.md) § "Call-site integration". Pass `sdk_stderr=...` and `sdk_error_kind=...` to `_error_result()`.
+- [ ] **2.2** Modify `src/attune/workflows/dependency_check.py` the same way.
+- [ ] **2.3** Extend `_error_result()` on `BaseWorkflow` (or wherever it lives) to accept + thread the two new kwargs into the returned `WorkflowResult`'s metadata.
+- [ ] **2.4** Tests:
+  - `test_code_review_surfaces_real_cause_on_subprocess_failure` — mock `claude_agent_sdk.query` to raise the generic `Exception("Command failed ...")`, mock `capture_subprocess_failure` to return a stub stderr with "specified API usage limits", assert the returned `WorkflowResult.error` contains "Anthropic API quota reached" and NOT the legacy three-cause menu
+  - Same for `test_dependency_check_surfaces_real_cause_on_subprocess_failure`
+  - Happy-path regression: existing `code_review` / `dependency_check` success tests still pass unmodified
+
+**Acceptance:** both workflows surface real causes on induced failures. CI green. No happy-path regressions.
+
+---
+
+## Phase 3 — Persistence + render
+
+Goal: thread `sdk_stderr` + `sdk_error_kind` through the runner so they land in `<runs_dir>/<workflow>/<run-id>.json` and render in the dashboard.
+
+- [ ] **3.1** Add `sdk_stderr: str | None = None` and `sdk_error_kind: str | None = None` to `Run.to_record()` / `from_record()` in `src/attune/ops/runner.py`. Existing records without the keys read back as None.
+- [ ] **3.2** `RunnerService._execute()` pulls the fields off the `WorkflowResult.metadata` (set in Phase 2.3) and stores on the `Run` before persistence.
+- [ ] **3.3** `src/attune/ops/templates/run_view.html` — add the collapsible `<details>` block per [design.md](design.md) § "Persistence + render".
+- [ ] **3.4** `src/attune/ops/static/css/main.css` — `.sdk-error-detail` + `.sdk-error-stderr` styles. Monospace, muted background, scroll-on-overflow.
+- [ ] **3.5** Tests:
+  - `test_run_record_round_trips_sdk_stderr_fields` — write Run with `sdk_stderr` + `sdk_error_kind`, read back, assert equal
+  - `test_run_record_back_compat_missing_sdk_fields` — old-format record without keys, read back, assert both fields are None
+  - `test_run_view_renders_collapsible_stderr_when_present` — Jinja render with mock Run carrying `sdk_stderr`, assert `<details>` block in output
+  - `test_run_view_omits_stderr_block_when_absent` — same with None, assert no `<details>` block
+
+**Acceptance:** persisted runs carry the fields, dashboard renders them, back-compat holds.
+
+---
+
+## Phase 4 — Four-workflow fan-out (`bug-predict`, `perf-audit`, `refactor-plan`, `security-audit`)
+
+Goal: roll the Phase 2 pattern to the remaining four high-traffic SDK workflows. Should be mechanical copy of the Phase 2 changes per workflow.
+
+- [ ] **4.1** Apply the Phase 2.1 / 2.2 pattern to each of: `src/attune/workflows/bug_predict.py`, `src/attune/workflows/perf_audit.py`, `src/attune/workflows/refactor_plan.py`, `src/attune/workflows/security_audit.py`.
+- [ ] **4.2** One `test_<wf>_surfaces_real_cause_on_subprocess_failure` test per workflow (4 tests total). Tight, mirror the Phase 2.4 shape.
+- [ ] **4.3** Simplify the PR #366 chip-classifier defense-in-depth per [decisions.md](decisions.md): the log-scan heuristic stops firing when `sdk_error_kind` is set on the persisted record. Read the typed `kind` from the record and render the chip directly. Keep the log-scan as a fallback for unmigrated workflows.
+
+**Acceptance:** all six target workflows (Phase 2 two + Phase 4 four) surface real causes. Chip classifier reads typed field when present. CI green.
+
+---
+
+## Phase 5 — Long-tail workflows + retrospective
+
+Goal: cover the remaining SDK-backed workflows, then close the spec.
+
+- [ ] **5.1** Apply the pattern to: `test-audit`, `doc-audit`, `doc-gen`, `discovery-sweep`, the `secure-release` pipeline, and `deep-review`. Same test shape per workflow.
+- [ ] **5.2** Manual verification across three induced failure modes:
+  - `ANTHROPIC_API_KEY=invalid` → expect "auth" classification
+  - Force a 429 (or mock at the SDK boundary) → expect "rate_limit"
+  - `PATH=""` → expect "not_found"
+- [ ] **5.3** Update `docs/COVERAGE_BUG_LOG.md` if any bugs surfaced during Phase 1–4 implementation.
+- [ ] **5.4** Close this spec. Open follow-up specs for `NextAction.kind` schema cleanup (the `learn-*` chip fix in PR #452 deferred this) and any other surface that emerges.
+
+**Acceptance:** all 12+ SDK-backed workflows migrated. Spec marked complete. Follow-up specs noted.
+
+---
+
+## Out of scope (parking lot)
+
+- Forking or upstream-patching `claude-agent-sdk` — explicit non-goal per [decisions.md](decisions.md)
+- Retry/backoff on transient errors — surface, don't recover
+- Table-driven classifier with per-project overrides — defer until classifier exceeds ~8 entries
+- Exit-code propagation — sibling spec [`workflow-failure-exit-propagation`](../workflow-failure-exit-propagation/) owns it
+- Predicting every possible error class — five-shape menu + unknown fallback is the v1 surface
+
+---
+
+## Rollback plan
+
+Each phase is a single squash-merge commit. Rollback = `git revert <commit>`. Phase ordering is designed so reverting later phases leaves earlier phases working:
+
+- Revert Phase 5 → six workflows still on the new pattern, long-tail workflows on the old `sdk_error_message`
+- Revert Phase 4 → two workflows on new pattern, chip classifier reverts to log-scan-only
+- Revert Phase 3 → workflows still classify errors, but persistence + render fall back to the legacy "error" string
+- Revert Phase 2 → no call sites use the new primitives; classifier + capture helper are dead code in `agent_sdk_adapter.py` (test coverage flags but doesn't fail)
+- Revert Phase 1 → back to current behavior; no schema changes to migrate back


### PR DESCRIPTION
## Summary

Promotes [`sdk-error-message-fidelity`](docs/specs/sdk-error-message-fidelity/) from requirements-only-draft to a four-file approved draft. Triggered by today's firefight reproduction that confirmed the requirements doc's hypothesis: a workflow's "What Went Wrong" block lists three plausible-but-often-wrong causes (auth / PATH / SDK version) instead of the actual one (quota / 429 / not-found / schema-rejected / etc).

| File | Status | Change |
|---|---|---|
| [requirements.md](docs/specs/sdk-error-message-fidelity/requirements.md) | draft → **approved (2026-05-24)** | Existing content untouched — already thorough. |
| [decisions.md](docs/specs/sdk-error-message-fidelity/decisions.md) | **new** | 8 pre-committed decisions (Path A, hard-coded classifier, redaction yes, kind enum, persistence shape, render placement, v1 scope of 6 workflows). |
| [design.md](docs/specs/sdk-error-message-fidelity/design.md) | **new** | `SdkSubprocessError` dataclass-exception, `_CLASSIFIERS` table (5 kinds + unknown fallback), `capture_subprocess_failure()` with timeout + synthetic-fallback paths, call-site before/after, persistence + render fragment, failure-mode mitigations. |
| [tasks.md](docs/specs/sdk-error-message-fidelity/tasks.md) | **new** | 5 phases — Primitives → 2-workflow pilot → Persistence/render → 4-workflow fan-out + chip-classifier simplification → long-tail + close. Each independently shippable + reversible. |

## Why now

Two converging signals today:
- The morning's firefight pattern (`learn-test-gen` 404 was *one* symptom, the SDK-error-fidelity surface is the broader class)
- [refactor-plan](https://github.com/Smart-AI-Memory/attune-ai/pull/454)'s directive: *"completing in-flight specs is higher-ROI than opening new specs"* — this draft existed, just needed the rest of the canonical files

## Test plan

- [x] Docs-only — 4 files, +406/-2
- [x] Pre-commit hooks all pass
- [ ] First implementation PR (Phase 1 — primitives in `agent_sdk_adapter.py`) is the next concrete commit; tracked in [tasks.md](docs/specs/sdk-error-message-fidelity/tasks.md) § Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)