### PR TITLE
fix(deps): declare tomli for Python 3.10 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `release-prep` and `orchestrated-health-check` workflows now load on
+  Python 3.10. `attune.utils.coverage` falls back to `tomli` when stdlib
+  `tomllib` is unavailable (3.10), but `tomli` was not declared as a
+  dependency — the fallback crashed at import time, surfacing as
+  `Failed to load workflow ... No module named 'tomli'` warnings on
+  fresh installs. Declared `tomli>=2.0.0; python_version < '3.11'` in
+  the runtime deps. No effect on 3.11+ users (stdlib `tomllib` already
+  resolves first).
+
 ## [7.1.0] — 2026-05-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "python-frontmatter>=1.0.0,<2.0.0",  # YAML frontmatter parsing for help templates — required by attune.help.engine which backs the help_lookup MCP tool (progressive/workflow_help/precursor/search_tag modes all parse template files). Vanilla pip install attune-ai without this breaks every help_lookup mode except `preamble`.
     "attune-rag>=0.1.5,<0.2",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy.
+    "tomli>=2.0.0; python_version < '3.11'",  # tomllib fallback for Python 3.10. Used by attune.utils.coverage (loaded transitively from release-prep + orchestrated-health-check workflows). Without this, those workflows fail to load on 3.10.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
     # NOTE: redis is opt-in via the [redis] extra (bundled attune_redis

--- a/uv.lock
+++ b/uv.lock
@@ -253,6 +253,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "structlog" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typer" },
     { name = "typing-extensions" },
 ]
@@ -563,6 +564,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'enterprise'", specifier = ">=0.40.0,<2.0.0" },
     { name = "structlog", specifier = ">=24.0.0,<26.0.0" },
     { name = "tiktoken", marker = "extra == 'dev'", specifier = ">=0.7.0,<1.0.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "typer", specifier = ">=0.9.0,<1.0.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0,<7.0" },
     { name = "typing-extensions", specifier = ">=4.0.0,<5.0.0" },


### PR DESCRIPTION
## Summary

Bug surfaced during v7.1.0 release smoke test on Python 3.10.

`attune.utils.coverage` uses the canonical `try: tomllib / except ImportError: tomli as tomllib` fallback for 3.10 (no stdlib tomllib). The pattern is correct — but `tomli` was never declared as a dependency. On a fresh 3.10 install the fallback fires and crashes:

```
WARNING:attune.workflows:Failed to load workflow 'orchestrated-health-check' (OrchestratedHealthCheckWorkflow): No module named 'tomli'
WARNING:attune.workflows:Failed to load workflow 'release-prep' (ReleasePrepTeamWorkflow): No module named 'tomli'
```

Both workflows become unavailable on 3.10.

## Fix

Declared `tomli>=2.0.0; python_version < '3.11'` in runtime deps. `uv.lock` regenerated to track the new constraint. No effect on 3.11+ users — stdlib `tomllib` already resolves first in the try/except.

## Import chain (verified)

`OrchestratedHealthCheckWorkflow` / `ReleasePrepTeamWorkflow` → `attune.agents.release.release_prep_team` → `release_agents` → `coverage_agent` → `attune.utils.coverage:24` (`import tomli as tomllib`)

## Test plan

- [ ] CI green
- [ ] After merge: fresh venv on Python 3.10, `pip install attune-ai`, confirm no `Failed to load workflow` warnings
- [ ] On Python 3.11+, confirm no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)