### PR TITLE
fix(ci): trigger publish-pypi on tag push, not release-published

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,9 +1,16 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:  # Allow manual trigger
+  # Trigger on tag push rather than release-published. Releases created by
+  # GITHUB_TOKEN (i.e. by another workflow, like release.yml) do NOT fire
+  # the `release:[published]` event — a documented GitHub Actions
+  # limitation that bit us on the v7.1.0 ship (PyPI publish had to be
+  # dispatched manually). Tag-push fires unconditionally regardless of
+  # the actor, so the chain release.yml → tag → publish-pypi works.
+  push:
+    tags:
+      - 'v*.*.*'  # match release.yml; runs in parallel with it
+  workflow_dispatch:  # Manual fallback / re-run on demand
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `publish-pypi.yml` now triggers on `push: tags: 'v*.*.*'` instead of
+  `release: [published]`. The release-published event does NOT fire when
+  the GitHub release is created by `GITHUB_TOKEN` (i.e. by another
+  workflow, like `release.yml`) — a documented GitHub Actions
+  limitation that surfaced on the v7.1.0 ship, where the PyPI publish
+  had to be dispatched manually. Tag-push fires regardless of actor,
+  closing the gap. publish-pypi now runs in parallel with release.yml
+  (both build dist independently); manual `workflow_dispatch` retained
+  as fallback.
+
 ### Fixed
 
 - `release-prep` and `orchestrated-health-check` workflows now load on


### PR DESCRIPTION
## Summary

The v7.1.0 ship surfaced a documented GitHub Actions limitation: **releases created by `GITHUB_TOKEN` (i.e. by another workflow, like our `release.yml`) do NOT fire the `release: [published]` event.** That broke the intended chain `release.yml` → GitHub release → `publish-pypi.yml` → PyPI. PyPI publish had to be manually dispatched (`gh workflow run publish-pypi.yml`) + env-approved.

## Fix

Switch publish-pypi's trigger from:
```yaml
on:
  release:
    types: [published]
```
to:
```yaml
on:
  push:
    tags:
      - 'v*.*.*'   # match release.yml; runs in parallel with it
```

Tag-push fires regardless of actor, so the chain works end-to-end. `workflow_dispatch` retained as a manual fallback.

## Trade-off (documented in the commit body)

publish-pypi now runs in **parallel** with release.yml, not after. Both build dist from source independently. If release.yml fails mid-flight, publish-pypi may still succeed — PyPI gets the new version even if the GitHub release is incomplete. **PyPI is the canonical artifact source so this is acceptable**; if tighter coupling is needed later, switch to `workflow_run` (which isn't subject to the GITHUB_TOKEN limitation).

## Test plan

- [ ] CI green on this PR
- [ ] After merge: next tag push (any release) auto-triggers publish-pypi without manual dispatch
- [ ] env approval still gates the actual PyPI upload (unchanged)

## Reference

- GitHub docs on the GITHUB_TOKEN trigger limitation: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
- v7.1.0 ship session (manual dispatch was run id 26377350897)

🤖 Generated with [Claude Code](https://claude.com/claude-code)