### PR TITLE
release: v7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.1] — 2026-05-25
+
 ### Added
 
 - `docs/MULTI_PACKAGE_RELEASE_PATTERNS.md` — pattern catalogue for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "7.1.0"
+version = "7.1.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "7.1.0"
+version = "7.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release v7.1.1

Bundles three follow-ups from the v7.1.0 ship session (2026-05-24/25). All are small, mechanical, and surfaced by smoke-testing 7.1.0 + reflecting on the release-engineering session.

**Bundle:**

- **Added** — `docs/MULTI_PACKAGE_RELEASE_PATTERNS.md` pattern catalogue (#460)
- **Changed** — `publish-pypi.yml` now triggers on `push: tags: 'v*.*.*'` rather than `release: [published]`, closing the GITHUB_TOKEN auto-trigger gap that forced manual workflow_dispatch on the v7.1.0 ship (#459)
- **Fixed** — declared `tomli>=2.0.0; python_version < '3.11'` so `release-prep` and `orchestrated-health-check` workflows load on Python 3.10. Without this, both workflows silently fail to load on 3.10 with `No module named 'tomli'` (#458)

**Diffstat (this PR only):**
```
CHANGELOG.md   | 2 ++
pyproject.toml | 2 +-
uv.lock        | 2 +-
```

(Underlying changes already landed via #458, #459, #460 — this PR is pure release-prep.)

## What gets validated by this release

- **#458 validation:** fresh-venv smoke test on Python 3.10 after PyPI publish should show no `Failed to load workflow ... No module named 'tomli'` warnings
- **#459 validation:** `git push origin v7.1.1` should auto-trigger **both** the `Release` AND `Publish to PyPI` workflows, without any manual `workflow_dispatch`. **This is the moment of truth for the trigger fix.**

## Test plan

- [ ] CI green on this PR (new branch protection: 8 Tier 1 required checks)
- [ ] After merge: `/attune-release-check` passes
- [ ] After tag: both `Release` and `Publish to PyPI` workflows fire on tag-push (no manual dispatch needed)
- [ ] env approval gates the actual PyPI upload (unchanged behavior)
- [ ] Smoke test on Python 3.10: `pip install attune-ai==7.1.1` then `python -m attune.cli_minimal workflow list` shows NO `tomli` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)