### PR TITLE
release: v7.1.2 — widen attune-rag pin to <0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.2] — 2026-05-25
+
+### Changed
+
+- **Widen `attune-rag` core pin: `>=0.1.5,<0.2` → `>=0.1.5,<0.3`
+  (and matching widen in the `[dev]` extra's test-coverage pin).**
+  Unblocks fresh `pip install attune-ai` alongside
+  [attune-rag 0.2.0](https://pypi.org/project/attune-rag/0.2.0/),
+  released 2026-05-25 as the first SemVer-binding cut. The 0.2.0
+  bump is purely additive (new `attune_rag.measure_corpus` public
+  module, new `load_aliases_from_file` helper, new
+  `DirectoryCorpus(extra_aliases_file=...)` kwarg); the
+  `RagPipeline` / `DirectoryCorpus` / `format_citations_markdown`
+  surfaces consumed by `attune.workflows.rag_code_gen`,
+  `attune.memory.personal`, and `attune.mcp.workflow_handlers`
+  are unchanged across 0.1.x → 0.2.0, so this is a pin widen only
+  with no code changes. Cap raised one minor rather than
+  open-ended so the next breaking attune-rag bump still requires
+  explicit re-validation. Companion comment block at the bottom
+  of `pyproject.toml` updated to match.
+
 ## [7.1.1] — 2026-05-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "7.1.1"
+version = "7.1.2"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
@@ -73,7 +73,7 @@ dependencies = [
     "langsmith>=0.7.31,<2.0.0",  # GHSA-rr7j-v2q5-chgv (transitive via langchain-core)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "python-frontmatter>=1.0.0,<2.0.0",  # YAML frontmatter parsing for help templates — required by attune.help.engine which backs the help_lookup MCP tool (progressive/workflow_help/precursor/search_tag modes all parse template files). Vanilla pip install attune-ai without this breaks every help_lookup mode except `preamble`.
-    "attune-rag>=0.1.5,<0.2",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy.
+    "attune-rag>=0.1.5,<0.3",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap raised to <0.3 in 7.1.2 to admit attune-rag 0.2.0 (purely additive SemVer-binding cut, no breaking API changes); next breaking minor still requires explicit re-validation.
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib fallback for Python 3.10. Used by attune.utils.coverage (loaded transitively from release-prep + orchestrated-health-check workflows). Without this, those workflows fail to load on 3.10.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
@@ -233,7 +233,7 @@ dev = [
     # branches (rag tests use pytest.importorskip). Floor
     # matches the [rag] extra so dev + runtime deps stay in
     # lock-step.
-    "attune-rag>=0.1.5,<0.2",
+    "attune-rag>=0.1.5,<0.3",
     # Test deps for paths that import optional runtime libs
     # unconditionally. Without these, the unit suite fails at
     # collection on a fresh `pip install -e .[dev]`. See
@@ -758,9 +758,9 @@ exclude_lines = [
 ]
 
 # Sibling repos — all published to PyPI:
-#   attune-rag     — core dep (>=0.1.5,<0.2) — promoted from optional; required for accuracy
+#   attune-rag     — core dep (>=0.1.5,<0.3) — promoted from optional; required for accuracy
 #   attune-author  — [author] optional extra (>=0.4.1,<0.5)
-#   attune-rag     — [rag] optional extra (>=0.1.5,<0.2)
+#   attune-rag     — [rag] optional extra (>=0.1.5,<0.3) — no-op alias since rag is core
 #
 # No [tool.uv.sources] overrides needed: CI resolves all three
 # from PyPI (https://pypi.org/simple). For local iteration against

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "7.1.1"
+version = "7.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -436,8 +436,8 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
     { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.6.2,<0.14" },
-    { name = "attune-rag", specifier = ">=0.1.5,<0.2" },
-    { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.2" },
+    { name = "attune-rag", specifier = ">=0.1.5,<0.3" },
+    { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.3" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "bcrypt", marker = "extra == 'all'", specifier = ">=4.0.0,<6.0.0" },
@@ -605,16 +605,18 @@ wheels = [
 
 [[package]]
 name = "attune-rag"
-version = "0.1.5"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
+    { name = "jsonschema" },
     { name = "pyyaml" },
+    { name = "rich" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/c9/b3ea4348209273e980c38a7e43f9c43cf4c9bd5eb15b9dce4092f95e1972/attune_rag-0.1.5.tar.gz", hash = "sha256:b35e116658fca88dc70660fc53fffb59e69e7b58877e2009ed28eff12585429f", size = 29731, upload-time = "2026-04-19T17:00:22.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/da/5de2d3a5e6f9f1830c19998b504f4fbd8e24d77e2a32709403389166bb30/attune_rag-0.2.0.tar.gz", hash = "sha256:d8d5f26bfa4b2379845492d2c36d29359e09ef8c7d03f47435cd06baacba4711", size = 102841, upload-time = "2026-05-25T03:53:32.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/5d/d5971db69551fa0a15ec863ca230671368f48a9ed73e265ab1ad9ef9d013/attune_rag-0.1.5-py3-none-any.whl", hash = "sha256:f02e2ce1b660c71cd4850c456c3006d6ffb97cb0888d332262ee94e52aec9164", size = 36335, upload-time = "2026-04-19T17:00:21.143Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/005cf1581d99227c15bf4afddfa115cada1d666d9836296fd28f3619de29/attune_rag-0.2.0-py3-none-any.whl", hash = "sha256:a8c1b46e18c3336a654cf3609d628fcf2087d4e00459a22ad6ede3c4d88e33ae", size = 114144, upload-time = "2026-05-25T03:53:31.013Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Widen `attune-rag` core pin from `<0.2` to `<0.3` (and matching widen in the `[dev]` extra's test-coverage pin) so fresh `pip install attune-ai` picks up the freshly-released [attune-rag 0.2.0](https://pypi.org/project/attune-rag/0.2.0/) (first SemVer-binding cut, purely additive).
- Bumped 7.1.1 → 7.1.2 (patch) and regenerated `uv.lock`.
- Pyproject companion comment block at the bottom of the file updated for accuracy.
- No code changes — `RagPipeline` / `DirectoryCorpus` / `format_citations_markdown` surfaces consumed by `attune.workflows.rag_code_gen`, `attune.memory.personal`, and `attune.mcp.workflow_handlers` are unchanged across attune-rag 0.1.x → 0.2.0.

## Test plan

- [x] Fresh `uv sync --extra dev` resolves `attune-rag 0.2.0` (was capped at 0.1.5)
- [x] All four attune_rag import paths used by attune-ai work cleanly
- [x] 137/137 attune_rag-importing tests pass (3 xfails are pre-existing structural ceilings)
- [ ] CI green
- [ ] After merge: tag `v7.1.2` (push triggers `publish-pypi.yml`)

## Companion releases

This is the third in a coordinated set widening the attune-rag pin across the downstream family. Companions:
- [attune-author#43](https://github.com/Smart-AI-Memory/attune-author/pull/43) — merged, 0.14.1 published
- [attune-gui#64](https://github.com/Smart-AI-Memory/attune-gui/pull/64) — open
