### PR TITLE
chore: widen attune-author cap to <0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Widen `attune-author` cap in the `[author]` optional extra:
+  `>=0.6.2,<0.14` → `>=0.6.2,<0.15`.** Admits
+  [attune-author 0.14.x](https://pypi.org/project/attune-author/)
+  which has been released for weeks but was silently locked out
+  by the stale cap. The `[author]` extra is workspace-only dev
+  tooling (used by local attune-ai contributors who run
+  `attune-author` inside this venv); no runtime path. Cap raised
+  one minor so the next breaking attune-author bump still
+  requires explicit re-validation.
+
 ## [7.1.2] — 2026-05-25
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ rag = []
 # to the sibling path for workspace dev; PyPI is the
 # fallback.
 author = [
-    "attune-author>=0.6.2,<0.14",
+    "attune-author>=0.6.2,<0.15",
 ]
 
 # `[memory]` extra removed in v6.8.0 (P2 of redis-decoupling spec).

--- a/uv.lock
+++ b/uv.lock
@@ -435,7 +435,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'enterprise'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
-    { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.6.2,<0.14" },
+    { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.6.2,<0.15" },
     { name = "attune-rag", specifier = ">=0.1.5,<0.3" },
     { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.3" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },


### PR DESCRIPTION
## Summary

Widen the `attune-author` cap in the `[author]` extra from `<0.14` to `<0.15` so [attune-author 0.14.x](https://pypi.org/project/attune-author/) (released weeks ago) is admitted by installs of `attune-ai[author]`.

Replaces [dependabot #464](https://github.com/Smart-AI-Memory/attune-ai/pull/464) which had the lockfile out of sync with the pyproject change (the pre-commit `check-uv-lock` hook flagged it). This PR bundles the pyproject widen with a fresh lockfile regen in a single coherent commit.

## Scope

- `pyproject.toml`: cap `<0.14` → `<0.15` (1 line)
- `uv.lock`: matching cap spec update (1 line; no transitive churn)
- `CHANGELOG.md`: `[Unreleased]` entry

## Safety

- The `[author]` extra is **workspace-only dev tooling** (local attune-ai contributors who run `attune-author` inside this venv). No runtime path in the published wheel is affected.
- Cap raised one minor (`<0.15`) rather than open-ended so the next breaking attune-author bump still requires explicit re-validation.

## Test plan

- [x] Local: `uv lock` produces a clean 1-line diff
- [x] All pre-commit hooks pass (including `check-uv-lock`)
- [ ] CI green
