### PR TITLE
docs(specs): persist dashboard-driven spec status advances

### DIFF
--- a/docs/specs/agent-surface-parallelism-evaluation/requirements.md
+++ b/docs/specs/agent-surface-parallelism-evaluation/requirements.md
@@ -1,6 +1,5 @@
 # Requirements — Agent Surface Parallelism Evaluation
-
-**Status:** draft (2026-05-16)
+**Status:** approved (2026-05-16)
 **Pairs with:** [`agent-surface-rebalance`](../agent-surface-rebalance/) (retired 2026-05-12)
 
 ---

--- a/docs/specs/agent-surface-parallelism-evaluation/tasks.md
+++ b/docs/specs/agent-surface-parallelism-evaluation/tasks.md
@@ -1,7 +1,5 @@
 # Tasks — Agent Surface Parallelism Evaluation
-
-**Status:** draft (2026-05-16)
-
+**Status:** approved (2026-05-16)
 | Phase | Status | Owner | Notes |
 |---|---|---|---|
 | Phase 0 — Telemetry + A/B measurement | in progress | | 0.1 done 2026-05-16, see `phase0-findings.md` |

--- a/docs/specs/anthropic-cost-integration/design.md
+++ b/docs/specs/anthropic-cost-integration/design.md
@@ -1,7 +1,5 @@
 # Design — Anthropic Cost Integration
-
-**Status:** Draft 2026-05-18
-
+**Status:** approved
 ---
 
 ## Component layout

--- a/docs/specs/anthropic-cost-integration/requirements.md
+++ b/docs/specs/anthropic-cost-integration/requirements.md
@@ -1,6 +1,5 @@
 # Requirements — Anthropic Cost Integration
-
-**Status:** Draft 2026-05-18
+**Status:** approved
 **Owner:** Patrick
 
 ---

--- a/docs/specs/anthropic-cost-integration/tasks.md
+++ b/docs/specs/anthropic-cost-integration/tasks.md
@@ -1,7 +1,5 @@
 # Tasks — Anthropic Cost Integration
-
-**Status:** Draft 2026-05-18; awaiting Phase 0 result before Phase 1 begins.
-
+**Status:** approved
 Each phase is independently shippable and reversible.
 
 ---

--- a/docs/specs/coverage-exclusion-policy/decisions.md
+++ b/docs/specs/coverage-exclusion-policy/decisions.md
@@ -1,8 +1,5 @@
 # Per-decision log — Coverage exclusion policy
-
-**Status:** approved
-
-
+**Status:** complete
 Append-only log. Phase 3A audit findings + per-entry resolution as
 Phase 3B commits land.
 

--- a/docs/specs/discovery-sweep-ops-integration/decisions.md
+++ b/docs/specs/discovery-sweep-ops-integration/decisions.md
@@ -1,7 +1,5 @@
 # Decisions — Discovery-Sweep Ops Dashboard Integration
-
-**Status:** draft (2026-05-13)
-
+**Status:** approved (2026-05-13)
 Records the **why** behind shape choices. New decisions append at
 the bottom with date + context.
 

--- a/docs/specs/discovery-sweep-ops-integration/requirements.md
+++ b/docs/specs/discovery-sweep-ops-integration/requirements.md
@@ -1,6 +1,5 @@
 # Requirements — Discovery-Sweep Ops Dashboard Integration
-
-**Status:** draft (2026-05-13)
+**Status:** approved (2026-05-13)
 **Parent spec:** `docs/specs/discovery-sweep/` (feature-complete on
 `main` as of #321)
 **Blocks on:** `docs/specs/ops-runner-tier2/` Phase 2 (must ship

--- a/docs/specs/multi-actor-bulletin/decisions.md
+++ b/docs/specs/multi-actor-bulletin/decisions.md
@@ -1,8 +1,5 @@
 # Decisions: Multi-Actor Bulletin Board
-
-**Status:** approved
-
-
+**Status:** complete
 Resolutions on open questions, captured as Patrick reviewed the
 [`requirements.md`](requirements.md) draft.
 

--- a/docs/specs/ops-specs-completion-candidates/decisions.md
+++ b/docs/specs/ops-specs-completion-candidates/decisions.md
@@ -1,5 +1,5 @@
 # Spec: Ops Specs Completion Candidates — Decisions
-
+**Status:** complete
 > Pre-committed decisions captured 2026-05-15/16. Triggered by
 > Patrick's observation that approved specs accumulate stale
 > status because manual completion-marking has no nudge surface.


### PR DESCRIPTION
## Summary

Persist 10 spec status advances that were sitting unstaged in the main checkout's working tree. The ops dashboard's spec status setter writes to disk live but doesn't auto-commit — these were dashboard-initiated edits from a parallel session today and were at risk of being lost on next `git reset` / `git pull --rebase`.

## Status flips

**draft → approved** (specs that have progressed past initial drafting):
- `agent-surface-parallelism-evaluation/{requirements,tasks}.md`
- `anthropic-cost-integration/{requirements,tasks,design}.md`
- `discovery-sweep-ops-integration/{requirements,decisions}.md`

**approved → complete** (specs the dashboard's completion-candidate detector flagged as done):
- `coverage-exclusion-policy/decisions.md` — 4 PRs merged (#6, #7, #9, #212), 11 task rows done
- `multi-actor-bulletin/decisions.md` — decisions-only spec, no open work
- `ops-specs-completion-candidates/decisions.md` — decisions-only spec, no open work

## Note

Minor context loss for completeness: `anthropic-cost-integration` status was `Draft 2026-05-18; awaiting Phase 0 result before Phase 1 begins` and got collapsed to `approved` by the dashboard setter (it doesn't preserve free-form context). Original wording is in git history.

## Test plan

- Docs-only; no source / test / runtime impact
- No version bump
- [ ] CI green (markdown lint + pre-commit hooks)
