### PR TITLE
chore: weekly report 2026-05-25

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5672,3 +5672,29 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   files" lesson (same failure mode, different file class) and the
   "Never paste PyPI tokens into chat" lesson (transcripts are
   permanent).
+
+- **In remote cloud sessions, `mcp__github__push_files` + `mcp__github__create_pull_request`
+  replace `gh` CLI — but the local `Write` leaves an untracked file that blocks `git checkout`
+  of the new branch**: in remote/cloud Claude Code sessions (web, mobile, GitHub Actions), the
+  `gh` CLI is not available. Correct pattern for creating a PR with a new file: (1) `Write`
+  the file locally, (2) `mcp__github__push_files` to push it to a new remote branch in one
+  commit (the tool auto-creates the branch), (3) `mcp__github__create_pull_request`. Gotcha:
+  the local `Write` leaves an untracked copy; a subsequent `git checkout <new-branch>` fails
+  with "untracked working tree files would be overwritten." Fix: `rm <file>` first, then
+  `git checkout`. Better pattern for the next time: skip the local `Write` entirely and rely
+  solely on `mcp__github__push_files` — the file only needs to exist on the remote branch.
+  Only write locally when the file also needs to be present in the current session's working
+  tree (e.g. for further edits or commands that read it). Companion: `mcp__github__get_label`
+  errors (not returns null) when a label doesn't exist — run label checks in parallel and
+  proceed without labels on error.
+
+- **Dated-snapshot model aliases retire; stable aliases don't — always prefer stable aliases
+  in code**: Anthropic ships models under two alias forms: dated snapshots like
+  `claude-sonnet-4-20250514` (pinned to the exact checkpoint, retired on a published date)
+  and stable aliases like `claude-sonnet-4-6` (always point at the latest minor of that
+  series, never retired). Snapshot aliases retire with ~6 weeks notice. In-code references
+  using snapshot aliases will 404 after retirement. Search for dated patterns
+  (`YYYYMMDD` at the end of a model ID) across all source files before each model generation
+  EOL date. Safe replacement: the stable alias for the same series routes to the same
+  checkpoint until a new minor is released. Relevant files to grep: any that call the
+  Anthropic API directly (`polish.py`, `cost_tracker.py`, workflow configs, MCP server).

--- a/weekly-reports/2026-05-25.md
+++ b/weekly-reports/2026-05-25.md
@@ -1,0 +1,156 @@
+# Anthropic Ecosystem Weekly — 2026-05-25
+
+## Summary
+
+The headline this week is a **June 15 model retirement deadline**: `claude-sonnet-4-20250514`
+and `claude-opus-4-20250514` are EOL in three weeks, and attune-ai has both hardcoded. Claude
+Code shipped six releases (v2.1.144–v2.1.150) with one directly actionable item: `claude agents
+--json` in v2.1.145 replaces the fragile filesystem scraping that attune-ops currently uses for
+session discovery. Cache diagnostics (API, May 13 — missed last week) add observable
+`cache_miss_reason` fields that would cut the debug cycle on attune-author's polish pipeline.
+Agent SDK v0.2.83–v0.2.87 are all pure CLI bundler bumps with no user-facing changes.
+
+---
+
+## Recommendations
+
+**1. Fix two deprecated model IDs before June 15 — three weeks out**
+
+Both `claude-sonnet-4-20250514` and `claude-opus-4-20250514` retire June 15, 2026. These are
+the dated-snapshot aliases from the April launch, not stable aliases like `claude-sonnet-4-6`.
+
+Two live callsites in the stack:
+
+- **`src/attune/help/polish.py:113`** — `model="claude-sonnet-4-20250514"` in the attune-author
+  polish pass. Replace with `claude-sonnet-4-6` (same model, stable alias, already used
+  elsewhere in the stack).
+- **`src/attune/cost_tracker.py:52`** — pricing entry keyed on `claude-opus-4-20250514`. The
+  key itself isn't called directly if no workflow routes to it by that name, but it points at a
+  retiring ID. Replace key with `claude-opus-4-6` and verify no SDK session is requesting the
+  dated alias.
+
+Neither is a breaking change — the stable alias routes to the same checkpoint. Do it this week,
+not next.
+
+- **Applies to:** `src/attune/help/polish.py`, `src/attune/cost_tracker.py`
+- **Urgency:** High — hard deadline June 15, three weeks away.
+
+**2. Switch attune-ops session discovery to `claude agents --json`**
+
+Claude Code v2.1.145 (May 19) added `--json` output to the `claude agents` command. This
+returns structured data for all active sessions including IDs, project paths, and status.
+CLAUDE.md documents the current `~/.claude/projects/` filesystem-scraping approach as having
+47+ worktree-slug key proliferation, encoded-path drift, and needing prefix-glob heuristics.
+The `claude agents --json` output is canonical and Anthropic-maintained.
+
+Swap the session discovery code to:
+
+```python
+import subprocess, json
+result = subprocess.run(
+    ["claude", "agents", "--json"],
+    capture_output=True, text=True, timeout=5
+)
+sessions = json.loads(result.stdout)
+```
+
+The command is still labeled Research Preview in some contexts — validate the JSON schema is
+stable before removing the filesystem fallback entirely. Keep the glob-based scraper as a
+fallback for one release.
+
+- **Applies to:** `src/attune/ops/` (session discovery code), attune-ops dashboard
+- **Urgency:** Medium — addresses documented friction but the command is still Research Preview.
+
+**3. Add cache diagnostics to attune-author polish pipeline**
+
+The Anthropic API shipped cache diagnostics in public beta on May 13 (missed last week's
+report). Pass `diagnostics.previous_message_id` in the request body plus the
+`anthropic-beta: cache-diagnosis-2026-04-07` header to get a `cache_miss_reason` field in
+the response. Values include `SIMILAR_REQUEST`, `DIFFERENT_TOKENS`, `TOO_SHORT`,
+`CACHE_NOT_SPECIFIED`.
+
+The polish pipeline makes N Anthropic API calls with the same large system prompt across a
+batch of templates — the same pattern identified in May-11 Rec #3 (1-hour TTL). Adding
+diagnostics under a `ATTUNE_CACHE_DIAGNOSTICS=1` env var would tell you exactly why cache
+misses fire without adding prod overhead.
+
+This pairs naturally with the 1-hour TTL carry-over (May-11 #3) — enable both together and
+you'll have the long TTL AND observability into whether it's actually hitting.
+
+- **Applies to:** `attune-author` (polish pipeline, Anthropic client wrapper)
+- **Urgency:** Medium — additive debug capability, no breaking changes.
+
+**4. `/simplify` built-in renamed to `/code-review` in v2.1.147**
+
+The Claude Code built-in `/simplify` command was renamed to `/code-review` (with optional
+`effort:` parameter). Impact for attune-ai:
+
+- `SimplifyCodeWorkflow` (accessed via MCP tool `simplify_code`) is unaffected — different
+  invocation path.
+- No attune-ai plugin skill named `simplify` exists in `plugin/skills/`.
+- Net user impact: typing `/simplify` now produces command-not-found. Any attune-hub docs
+  that mentioned the built-in `/simplify` as a peer should reference `/code-review` instead.
+
+The new `/code-review` built-in overlaps functionally with attune-ai's deep-review workflow.
+Worth adding a note to the attune-hub skill's "When to use this vs..." section distinguishing
+effort-level quick reviews (built-in `/code-review`) from multi-subagent deep analysis
+(attune-ai `/deep-review`).
+
+- **Applies to:** Plugin docs only — no production code change needed.
+- **Urgency:** Low.
+
+---
+
+## Carry-overs
+
+| # | Week | Recommendation | Status |
+|---|------|---|---|
+| 1 | May-18 | Cap Agent SDK below v0.2.82 + `alwaysLoad: true` | Still open. Lock at 0.1.63. v0.2.83–v0.2.87 are all bundler-only — once v0.2.82 breaking changes are resolved, jump straight to 0.2.87. |
+| 2 | May-18 | Pick up MCP security fix (mcp>=1.23.0) | Still open — tied to #1. |
+| 3 | May-18 | `CLAUDE_PROJECT_DIR` in MCP server `workspace_root` | Still open. One-line fix in `EmpathyMCPServer.__init__`. |
+| 4 | May-18 | Audit Opus 4.7 token budgets | Still open. More urgent now — model-retirement work this week is a good moment to audit which tiers route where. |
+| 5 | May-11 | Replace `"Skill"` in `allowed_tools` with `skills=` kwarg | **Done ✅** — confirmed zero occurrences in `src/attune/workflows/`. |
+| 6 | May-11 | `ENABLE_PROMPT_CACHING_1H` for attune-author polish | Still open if PR #12 hasn't merged. Pair with new Rec #3 (cache diagnostics). |
+| 7 | May-11 | Surface `api_error_status` from `ResultMessage` in adapter | Still open. |
+
+---
+
+## Watch list
+
+- **`claude agents` command maturity**: Now has `--json` output (Rec #2) but still Research
+  Preview in parts of the changelog. Track for GA before removing the filesystem fallback.
+- **MCP tunnels (May 19, Research Preview)**: Connect to private-network MCP servers without
+  opening inbound ports. Not needed for local dev, but relevant if customers need the MCP
+  server inside a private subnet.
+- **Stainless acquisition (May 18)**: Anthropic acquired the SDK-generation company Stainless.
+  No immediate changes, but expect the Claude Agent SDK and Anthropic Python SDK to gain
+  better generated types and docs over the next several releases. Nothing to act on now.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Agent SDK v0.2.83–v0.2.87 | Pure CLI bundler updates; zero user-facing API changes |
+| Claude Managed Agents (self-hosted sandboxes, live config, large output) | Stack uses Agent SDK, not Managed Agents |
+| Claude Compliance API (May 21) | Enterprise IT governance, not applicable |
+| `allowAllClaudeAiMcps` enterprise setting (v2.1.149) | Managed Claude Code deployment only |
+| v2.1.150 internal infrastructure | No user-facing changes |
+| Markdown GFM checkboxes, diff keyboard nav (v2.1.149) | Claude Code developer UX; no stack impact |
+| Web search SEC filing data (May 18) | Stack doesn't route web search against financial data |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` (through May 25, 2026)
+- Claude Code: releasebot.io/updates/anthropic/claude-code
+  (v2.1.144–v2.1.150, May 19–25, 2026)
+- Agent SDK: github.com/anthropics/claude-agent-sdk-python/releases
+  (v0.2.83–v0.2.87, May 19–25, 2026)
+- Prior week report: `weekly-reports/2026-05-18.md`
+- Repo audit: `src/attune/help/polish.py` (deprecated model ID),
+  `src/attune/cost_tracker.py` (deprecated model pricing key),
+  `src/attune/models/registry.py`, `src/attune/workflows/` (allowed_tools scan),
+  `plugin/skills/` (simplify skill check)


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-05-25

## Summary

The headline this week is a **June 15 model retirement deadline**: `claude-sonnet-4-20250514`
and `claude-opus-4-20250514` are EOL in three weeks, and attune-ai has both hardcoded. Claude
Code shipped six releases (v2.1.144–v2.1.150) with one directly actionable item: `claude agents
--json` in v2.1.145 replaces the fragile filesystem scraping that attune-ops currently uses for
session discovery. Cache diagnostics (API, May 13 — missed last week) add observable
`cache_miss_reason` fields that would cut the debug cycle on attune-author's polish pipeline.
Agent SDK v0.2.83–v0.2.87 are all pure CLI bundler bumps with no user-facing changes.

---

## Recommendations

**1. Fix two deprecated model IDs before June 15 — three weeks out**

Both `claude-sonnet-4-20250514` and `claude-opus-4-20250514` retire June 15, 2026. These are
the dated-snapshot aliases from the April launch, not stable aliases like `claude-sonnet-4-6`.

Two live callsites in the stack:

- **`src/attune/help/polish.py:113`** — `model="claude-sonnet-4-20250514"` in the attune-author
  polish pass. Replace with `claude-sonnet-4-6` (same model, stable alias, already used
  elsewhere in the stack).
- **`src/attune/cost_tracker.py:52`** — pricing entry keyed on `claude-opus-4-20250514`. The
  key itself isn't called directly if no workflow routes to it by that name, but it points at a
  retiring ID. Replace key with `claude-opus-4-6` and verify no SDK session is requesting the
  dated alias.

Neither is a breaking change — the stable alias routes to the same checkpoint. Do it this week,
not next.

- **Applies to:** `src/attune/help/polish.py`, `src/attune/cost_tracker.py`
- **Urgency:** High — hard deadline June 15, three weeks away.

**2. Switch attune-ops session discovery to `claude agents --json`**

Claude Code v2.1.145 (May 19) added `--json` output to the `claude agents` command. This
returns structured data for all active sessions including IDs, project paths, and status.
CLAUDE.md documents the current `~/.claude/projects/` filesystem-scraping approach as having
47+ worktree-slug key proliferation, encoded-path drift, and needing prefix-glob heuristics.
The `claude agents --json` output is canonical and Anthropic-maintained.

Swap the session discovery code to:

```python
import subprocess, json
result = subprocess.run(
    ["claude", "agents", "--json"],
    capture_output=True, text=True, timeout=5
)
sessions = json.loads(result.stdout)
```

The command is still labeled Research Preview in some contexts — validate the JSON schema is
stable before removing the filesystem fallback entirely. Keep the glob-based scraper as a
fallback for one release.

- **Applies to:** `src/attune/ops/` (session discovery code), attune-ops dashboard
- **Urgency:** Medium — addresses documented friction but the command is still Research Preview.

**3. Add cache diagnostics to attune-author polish pipeline**

The Anthropic API shipped cache diagnostics in public beta on May 13 (missed last week's
report). Pass `diagnostics.previous_message_id` in the request body plus the
`anthropic-beta: cache-diagnosis-2026-04-07` header to get a `cache_miss_reason` field in
the response. Values include `SIMILAR_REQUEST`, `DIFFERENT_TOKENS`, `TOO_SHORT`,
`CACHE_NOT_SPECIFIED`.

The polish pipeline makes N Anthropic API calls with the same large system prompt across a
batch of templates — the same pattern identified in May-11 Rec #3 (1-hour TTL). Adding
diagnostics under a `ATTUNE_CACHE_DIAGNOSTICS=1` env var would tell you exactly why cache
misses fire without adding prod overhead.

This pairs naturally with the 1-hour TTL carry-over (May-11 #3) — enable both together and
you'll have the long TTL AND observability into whether it's actually hitting.

- **Applies to:** `attune-author` (polish pipeline, Anthropic client wrapper)
- **Urgency:** Medium — additive debug capability, no breaking changes.

**4. `/simplify` built-in renamed to `/code-review` in v2.1.147**

The Claude Code built-in `/simplify` command was renamed to `/code-review` (with optional
`effort:` parameter). Impact for attune-ai:

- `SimplifyCodeWorkflow` (accessed via MCP tool `simplify_code`) is unaffected — different
  invocation path.
- No attune-ai plugin skill named `simplify` exists in `plugin/skills/`.
- Net user impact: typing `/simplify` now produces command-not-found. Any attune-hub docs
  that mentioned the built-in `/simplify` as a peer should reference `/code-review` instead.

The new `/code-review` built-in overlaps functionally with attune-ai's deep-review workflow.
Worth adding a note to the attune-hub skill's "When to use this vs..." section distinguishing
effort-level quick reviews (built-in `/code-review`) from multi-subagent deep analysis
(attune-ai `/deep-review`).

- **Applies to:** Plugin docs only — no production code change needed.
- **Urgency:** Low.

---

## Carry-overs

| # | Week | Recommendation | Status |
|---|------|---|---|
| 1 | May-18 | Cap Agent SDK below v0.2.82 + `alwaysLoad: true` | Still open. Lock at 0.1.63. v0.2.83–v0.2.87 are all bundler-only — once v0.2.82 breaking changes are resolved, jump straight to 0.2.87. |
| 2 | May-18 | Pick up MCP security fix (mcp>=1.23.0) | Still open — tied to #1. |
| 3 | May-18 | `CLAUDE_PROJECT_DIR` in MCP server `workspace_root` | Still open. One-line fix in `EmpathyMCPServer.__init__`. |
| 4 | May-18 | Audit Opus 4.7 token budgets | Still open. More urgent now — model-retirement work this week is a good moment to audit which tiers route where. |
| 5 | May-11 | Replace `"Skill"` in `allowed_tools` with `skills=` kwarg | **Done ✅** — confirmed zero occurrences in `src/attune/workflows/`. |
| 6 | May-11 | `ENABLE_PROMPT_CACHING_1H` for attune-author polish | Still open if PR #12 hasn't merged. Pair with new Rec #3 (cache diagnostics). |
| 7 | May-11 | Surface `api_error_status` from `ResultMessage` in adapter | Still open. |

---

## Watch list

- **`claude agents` command maturity**: Now has `--json` output (Rec #2) but still Research
  Preview in parts of the changelog. Track for GA before removing the filesystem fallback.
- **MCP tunnels (May 19, Research Preview)**: Connect to private-network MCP servers without
  opening inbound ports. Not needed for local dev, but relevant if customers need the MCP
  server inside a private subnet.
- **Stainless acquisition (May 18)**: Anthropic acquired the SDK-generation company Stainless.
  No immediate changes, but expect the Claude Agent SDK and Anthropic Python SDK to gain
  better generated types and docs over the next several releases. Nothing to act on now.

---

## No-ops

| Item | Why skipped |
|---|---|
| Agent SDK v0.2.83–v0.2.87 | Pure CLI bundler updates; zero user-facing API changes |
| Claude Managed Agents (self-hosted sandboxes, live config, large output) | Stack uses Agent SDK, not Managed Agents |
| Claude Compliance API (May 21) | Enterprise IT governance, not applicable |
| `allowAllClaudeAiMcps` enterprise setting (v2.1.149) | Managed Claude Code deployment only |
| v2.1.150 internal infrastructure | No user-facing changes |
| Markdown GFM checkboxes, diff keyboard nav (v2.1.149) | Claude Code developer UX; no stack impact |
| Web search SEC filing data (May 18) | Stack doesn't route web search against financial data |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/api` (through May 25, 2026)
- Claude Code: releasebot.io/updates/anthropic/claude-code (v2.1.144–v2.1.150, May 19–25, 2026)
- Agent SDK: github.com/anthropics/claude-agent-sdk-python/releases (v0.2.83–v0.2.87, May 19–25, 2026)
- Prior week report: `weekly-reports/2026-05-18.md`
- Repo audit: `src/attune/help/polish.py` (deprecated model ID), `src/attune/cost_tracker.py` (deprecated model pricing key), `src/attune/models/registry.py`, `src/attune/workflows/` (allowed_tools scan), `plugin/skills/` (simplify skill check)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3p4zQXNqdyJeeB3ARuiqo)_