### PR TITLE
feat(ops): pending-writes journal Phase 1 — durable record + API

### DIFF
--- a/docs/specs/dashboard-pending-writes-journal/decisions.md
+++ b/docs/specs/dashboard-pending-writes-journal/decisions.md
@@ -1,0 +1,188 @@
+# Decisions: Dashboard Pending-Writes Journal
+
+**Status:** approved (2026-05-25)
+
+Append-only log. New decisions go at the bottom with date +
+context. Earlier decisions are not edited (they're history,
+not live config).
+
+---
+
+## D1 — 2026-05-25 — Journal as source of truth, not auto-commit
+
+**Context:** Six solution approaches considered in scoping
+discussion (full enumeration in design.md). Auto-commit on
+heartbeat was attractive but introduces too many failure
+modes.
+
+**Decision:** Journal (append-only JSONL) is the source of
+truth. Humans remain in the commit loop. The journal makes
+the loop frictionless; it doesn't replace the loop.
+
+**Rationale:**
+
+- Auto-commit needs git permissions on the dashboard process
+  (GPG keys, SSH agent forwarding, branch policy) — operational
+  burden
+- Auto-commit creates a discoverability problem: small commits
+  on side branches that humans never see
+- Race conditions: dashboard PID 35492 commits while session
+  PID 12345 is doing manual git work
+- Branch cleanup burden grows linearly with usage
+- Cleaner contract: dashboard records, human decides, agent
+  facilitates
+
+**Counter-arguments considered:**
+
+- "But humans forget to commit" — yes; the surfacing layer
+  (UI chip + session-start hook) makes forgetting hard. That's
+  the right place to address forgetting, not auto-commit.
+
+---
+
+## D2 — 2026-05-25 — Layered, not monolithic
+
+**Context:** Each damage mode (loss, confusion, drift,
+time-cost) maps to a different consumer (current-session
+user, fresh-session agent, downstream tooling).
+
+**Decision:** Three layers — journal (source of truth) → API
+(contract) → consumers (UI chip, session-start hook, anyone
+else who wants the signal).
+
+**Rationale:** Each layer addresses a distinct concern with
+a distinct surface. Coupling them loses flexibility. The
+journal serves any consumer; the API formalizes the contract;
+each consumer slices the API output per its needs.
+
+---
+
+## D3 — 2026-05-25 — API returns enriched-not-filtered
+
+**Context:** Multiple consumers will want to filter the
+journal differently (UI chip wants `uncommitted_count`;
+session-start hook wants entries where `is_committed=false`;
+an auditor wants `matches_journal=false`).
+
+**Decision:** API returns ALL journal entries enriched with
+computed fields (`is_committed`, `matches_journal`,
+`dashboard_still_running`, `current_disk_sha256`). Consumers
+filter as needed.
+
+**Rationale:** Better to enrich once at the API layer and let
+consumers slice than to re-implement git-status checks in
+every consumer. Reduces duplication and makes the contract
+inspectable.
+
+**Tradeoff:** Larger response payload. Mitigation: the
+journal is small (<10KB even after months of typical usage);
+not a concern.
+
+---
+
+## D4 — 2026-05-25 — Phase split: journal+API today, UI+hook later
+
+**Context:** Original plan was "spec + implementation today."
+Patrick approved phase split during scoping
+([feedback exchange](../../../docs/COVERAGE_BUG_LOG.md) —
+recommendation lead with Phase 1 only).
+
+**Decision:** Phase 1 (this spec, this session) ships journal
++ API + tests + spec status setter wire-in. Phase 2 (UI chip
++ review page) and Phase 3 (session-start hook + CLI
+subcommand) are scoped here but ship in future sessions.
+
+**Rationale:** Phase 1 is independently shippable: the
+journal becomes durable infrastructure; the API becomes a
+queryable contract. Phase 2 and Phase 3 are independently
+useful additions, not blocked on each other. The Phase 1
+slice gives us the worked example for the article without
+exhausting today's energy budget.
+
+**Acceptance for Phase 1:** journal writes happen on the
+spec-status setter; API returns enriched entries; tests
+cover both; manual smoke test passes (edit a spec status in
+the dashboard, see the entry appear via curl on the API,
+commit the file, see `is_committed=true` on next API call).
+
+---
+
+## D5 — 2026-05-25 — Journal failures must not block writes
+
+**Context:** If the journal append fails (disk full, no
+permission to `~/.attune/ops/`, etc.), should the actual
+dashboard write fail or proceed?
+
+**Decision:** Proceed. The journal append is wrapped in
+try/except; failures log WARNING; the actual write
+endpoint returns success per its normal contract.
+
+**Rationale:** The journal is observability infrastructure,
+not a precondition for correctness. Blocking real user work
+on infrastructure failure is the wrong tradeoff. The
+WARNING log surfaces the journal failure for separate
+investigation.
+
+**Counter-argument considered:** "But then we lose
+provenance." Yes — for that one write. The git history
+(once committed) is still the authoritative record. The
+journal is a convenience layer.
+
+---
+
+## D6 — 2026-05-25 — In-scope endpoints: spec status setter only (Phase 1)
+
+**Context:** Multiple dashboard endpoints potentially mutate
+the working tree. Should Phase 1 instrument all of them?
+
+**Decision:** Phase 1 instruments the spec-status setter
+endpoint only (`PUT /api/cowork/specs/{feature}/{phase}/status`).
+Other mutating endpoints (manifest edits, feature toggles,
+future surfaces) are NOT instrumented in Phase 1.
+
+**Rationale:**
+
+- The spec-status setter is the highest-traffic mutating
+  endpoint; today's evidence (10 unstaged edits) is entirely
+  from this surface
+- Instrumenting all endpoints at once requires auditing the
+  whole dashboard route surface — scope creep
+- Adding instrumentation to a new endpoint is a single
+  `pending_writes.append_entry(...)` call — easy to extend
+  per-endpoint as the need surfaces
+
+**Future:** A follow-up task to audit all mutating endpoints
+and instrument them. Best done as a sweep after Phase 1
+ships.
+
+---
+
+## Notes on the spec itself as worked example
+
+This spec was produced during a session where Patrick said
+"we should try to find a proactive solution to this problem...
+it would make a good example" — meaning the spec design and
+implementation work would itself become article material for
+§6 (Multi-agent Coordination) of the
+[Discipline of Agent Collaboration article](../../process/COLLABORATION_DISCIPLINE_outline.md).
+
+The discipline-in-action visible in this spec:
+
+- **Problem named**: dashboard live-writes becoming silent
+  debt — observed today, named as a class of bug
+- **Solution space enumerated**: 6 candidates with
+  pros/cons before picking
+- **Recommendation made with reasoning**: layered approach,
+  with each layer addressing a distinct damage mode
+- **Phase split proposed**: don't try to ship the whole thing
+  in one session
+- **Decisions captured here as durable**: future sessions
+  see the choices and their rationales, not just the
+  outcomes
+- **Article cross-reference**: this spec is intentionally a
+  worked example, not just utility infrastructure
+
+That's the article's central thesis demonstrated by the work
+of designing the article: discipline producing both the
+artifact AND the example of the discipline producing the
+artifact.

--- a/docs/specs/dashboard-pending-writes-journal/design.md
+++ b/docs/specs/dashboard-pending-writes-journal/design.md
@@ -1,0 +1,246 @@
+# Design: Dashboard Pending-Writes Journal
+
+**Status:** draft (2026-05-25)
+
+**Phase 1 scope:** journal writer + API endpoint. UI chip
+(Phase 2) and session-start hook (Phase 3) are sketched at
+the bottom for design coherence, not for this session's
+implementation.
+
+---
+
+## Architecture
+
+Three layers, each addressing a distinct damage mode:
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│  ┌──────────────┐        ┌──────────────────────────┐  │
+│  │  Dashboard   │ writes │ ~/.attune/ops/           │  │
+│  │  endpoints   ├───────►│   pending_writes.jsonl   │  │
+│  │  (mutating)  │        │   (append-only JOURNAL)  │  │
+│  └──────────────┘        └────────────┬─────────────┘  │
+│                                       │ reads           │
+│                                       ▼                 │
+│                          ┌──────────────────────────┐  │
+│                          │ GET /api/pending-writes  │  │
+│                          │   (cross-refs git status │  │
+│                          │    to filter committed)  │  │
+│                          └────────────┬─────────────┘  │
+│                                       │ consumed by    │
+│              ┌───────────────────────┼─────────────┐  │
+│              ▼                       ▼             ▼  │
+│      ┌───────────────┐     ┌──────────────┐  ┌──────┐│
+│      │ Dashboard UI  │     │ Session-     │  │ Other ││
+│      │ chip + review │     │ start hook   │  │ tools ││
+│      │ (Phase 2)     │     │ (Phase 3)    │  │       ││
+│      └───────────────┘     └──────────────┘  └──────┘│
+└─────────────────────────────────────────────────────────┘
+```
+
+**Why three layers, not one shot:**
+
+- The **journal** is the source of truth — durable, append-only,
+  easy to inspect, no in-memory state to lose
+- The **API** is the contract — multiple consumers can read
+  without each re-implementing the git-status cross-reference
+- The **consumers** address distinct surfaces (in-session
+  user vs fresh-session agent vs anyone else who wants the
+  signal) without coupling
+
+---
+
+## Data model
+
+### Journal entry shape
+
+```jsonc
+{
+  "ts": "2026-05-25T15:00:00.000Z",      // ISO 8601 UTC, microsecond precision OK
+  "session_id": "...",                    // CLAUDE_CODE_SESSION_ID or "dashboard-<pid>" if no session
+  "dashboard_pid": 35492,                 // OS PID of the dashboard process that made the write
+  "endpoint": "PUT /api/cowork/specs/{feature}/{phase}/status",  // canonical endpoint name
+  "action": "set_spec_status",            // human-readable action
+  "file_path": "docs/specs/coverage-exclusion-policy/decisions.md",  // POSIX path, project-relative
+  "project_root": "/Users/patrickroebuck/attune-ai",   // absolute, for disambiguation
+  "before_sha256": "457e21fa...",         // sha256 of file content BEFORE the write (or null if file was new)
+  "after_sha256": "36985342..."           // sha256 of file content AFTER the write
+}
+```
+
+**Why these fields:**
+
+- `ts` — for ordering, age display, age-based pruning (future)
+- `session_id` + `dashboard_pid` — provenance for triage ("which session made this? still running?")
+- `endpoint` + `action` — for human readability ("this is a spec status edit, not a random write")
+- `file_path` + `project_root` — for git-status cross-reference, and for disambiguating worktree-local edits
+- `before_sha256` / `after_sha256` — verifies the journal entry matches actual disk state at filter time; lets the API detect "user reverted manually" without losing audit
+
+### Storage
+
+`~/.attune/ops/pending_writes.jsonl` (one JSON object per line, append-only).
+
+Rationale: matches existing telemetry pattern
+(`~/.attune/telemetry/usage.jsonl`). Atomic appends are
+trivial with POSIX semantics (`open(path, 'a')` + `write` +
+`fsync`). Journal grows linearly with dashboard activity; a
+future maintenance task can prune entries whose file is
+committed AND whose `after_sha256` matches `git show
+HEAD:<file>` (i.e. fully reconciled).
+
+---
+
+## API: `GET /api/pending-writes`
+
+### Request
+
+`GET /api/pending-writes` — no params.
+
+Future Phase 2 may add `?project_root=<path>` filtering for
+multi-project dashboards; out of scope here.
+
+### Response
+
+```jsonc
+{
+  "pending": [
+    {
+      "ts": "2026-05-25T15:00:00.000Z",
+      "session_id": "abc-123",
+      "dashboard_pid": 35492,
+      "dashboard_still_running": false,    // computed: kill(pid, 0) succeeds
+      "endpoint": "PUT /api/cowork/specs/{feature}/{phase}/status",
+      "action": "set_spec_status",
+      "file_path": "docs/specs/coverage-exclusion-policy/decisions.md",
+      "project_root": "/Users/patrickroebuck/attune-ai",
+      "before_sha256": "457e21fa...",
+      "after_sha256": "36985342...",
+      "current_disk_sha256": "36985342...",  // computed at API time
+      "matches_journal": true,               // current_disk == after_sha
+      "is_committed": false,                 // git status check
+      "age_seconds": 1234
+    }
+    // ... more pending entries
+  ],
+  "summary": {
+    "total_entries": 12,
+    "uncommitted_count": 5,
+    "stale_dashboard_count": 3,          // entries whose dashboard PID is dead
+    "drifted_count": 1                   // entries where matches_journal=false
+  }
+}
+```
+
+### Filter semantics
+
+The API returns ALL journal entries (not filtered to
+uncommitted), but ENRICHES each with computed fields:
+
+- `dashboard_still_running` — `kill(pid, 0)` check
+- `current_disk_sha256` — sha256 of file at API call time
+- `matches_journal` — does current_disk_sha == after_sha
+- `is_committed` — does `git status --porcelain <file>`
+  return empty for this file? (file is clean in git)
+
+Consumers filter as needed. The dashboard UI chip would
+show `uncommitted_count`. A session-start hook would show
+entries where `is_committed=false`. An auditor might want
+entries where `matches_journal=false` to investigate manual
+reverts.
+
+**Why enriched-not-filtered:** the journal is the source of
+truth; filtering varies per consumer. Better to enrich once
+and let consumers slice than re-implement git-status checks
+in every consumer.
+
+---
+
+## Implementation: Phase 1
+
+### Module placement
+
+- **Journal writer:** new module
+  `src/attune/ops/pending_writes.py` with:
+  - `JournalEntry` dataclass matching the schema above
+  - `append_entry(entry: JournalEntry) -> None` — appends to
+    JSONL, atomic, swallows errors with WARNING log (don't
+    let journal failures block the actual write)
+  - `JOURNAL_PATH` constant pointing at
+    `~/.attune/ops/pending_writes.jsonl`
+  - Helper: `compute_file_sha256(path: Path) -> str | None`
+- **API endpoint:** new route in
+  `src/attune/ops/routes/pending_writes.py`:
+  - `GET /api/pending-writes` — reads journal, enriches,
+    returns JSON per the schema above
+  - Helper: `_load_journal_entries() -> Iterator[dict]`
+  - Helper: `_enrich(entry: dict, project_root: Path) -> dict`
+- **Wire-in to existing write endpoint:**
+  in the spec-status setter route (currently in
+  `src/attune/ops/routes/cowork_specs.py` for attune-ai),
+  call `pending_writes.append_entry(...)` after the
+  successful write, BEFORE returning the response.
+
+### Tests
+
+- `tests/unit/ops/test_pending_writes.py`:
+  - `append_entry` writes one line per call (parametric on
+    entry shapes)
+  - `append_entry` survives `IOError` (logs WARNING, does
+    not raise) — journal failure must not block actual write
+  - `compute_file_sha256` handles: existing file, missing
+    file, unreadable file
+- `tests/unit/ops/test_pending_writes_api.py`:
+  - Empty journal returns `{pending: [], summary: {...}}`
+  - Single entry: returns enriched with all computed fields
+  - Entry whose file is now committed: `is_committed=true`
+  - Entry whose file was manually reverted: `matches_journal=false`
+  - Entry whose dashboard PID is dead: `dashboard_still_running=false`
+  - Use `tmp_path` for project_root + journal path
+- `tests/unit/ops/test_cowork_specs_journal.py` (or extend
+  existing test file):
+  - PUT /api/cowork/specs/.../.../status appends to journal
+  - Failed write (e.g. invalid status) does NOT append
+
+### Wire to startup config
+
+The dashboard's `app.state` likely already exposes
+`attune_home` (the `~/.attune` directory). The journal
+path derives from that. No new config needed.
+
+---
+
+## Phase 2 (sketched — not this session)
+
+- **Topbar chip** in `base.html`: yellow indicator with
+  count when `uncommitted_count > 0`
+- **Review page** at `/pending-writes/view`: list of pending
+  entries with per-file `git diff` rendered, "Commit
+  selected" and "Revert selected" buttons
+- **Commit action** opens a small modal: review the commit
+  message (auto-generated from the action types), confirm,
+  commit + push to a `chore(dashboard)` branch OR to
+  current branch per a config flag
+
+## Phase 3 (sketched — not this session)
+
+- **Session-start hook**: CLAUDE.md preamble that runs at
+  session start, queries `GET /api/pending-writes` (if the
+  dashboard is running on a known port), surfaces any
+  uncommitted entries to the agent for triage
+- **CLI subcommand**: `attune ops pending` shows pending
+  writes from terminal; `attune ops pending --commit-all`
+  one-shots the commit path
+
+---
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Journal writes block the actual write endpoint | `append_entry` is wrapped in try/except; failures log WARNING; actual write proceeds regardless |
+| Journal grows unbounded over months | Future maintenance task prunes fully-reconciled entries; out of scope for Phase 1 |
+| sha256 computation is slow on large files | Spec status files are tiny (<100KB); not a concern. Pre-emptively cap journal entries to files under 10MB if it ever matters. |
+| Concurrent appends from multiple dashboard processes | POSIX `O_APPEND` is atomic per write under the page size; entries fit in <1KB; no race. |
+| API endpoint returns stale data if cache layer added | No cache layer in Phase 1; if added later, invalidate on every `append_entry`. |
+| Worktree-local edits get mixed with main-checkout edits | `project_root` field in each entry disambiguates; API filters by current project_root by default (future enhancement) |

--- a/docs/specs/dashboard-pending-writes-journal/requirements.md
+++ b/docs/specs/dashboard-pending-writes-journal/requirements.md
@@ -1,0 +1,126 @@
+# Spec: Dashboard Pending-Writes Journal
+
+> Make ops-dashboard live-state writes (spec status setters,
+> any future endpoint that mutates the working tree) durable
+> across sessions. Journal each write; expose via API; surface
+> in the UI; allow fresh sessions to discover inherited state.
+
+---
+
+## Phase 1: Requirements
+
+**Status:** draft (2026-05-25)
+
+### Problem statement
+
+The ops dashboard mutates the working tree live — primarily
+through the `PUT /api/cowork/specs/{feature}/{phase}/status`
+endpoint (and equivalents in attune-gui's
+`/api/cowork/specs/{feature}/{phase}/status`). These writes
+are real, intentional edits made by the user via the UI, but:
+
+- They are **never committed** by the dashboard
+- When the user closes the browser tab, ends the session,
+  or moves to a different worktree, those edits become
+  **silent debt** sitting in `git status`
+- A fresh session opening to a dirty working tree has **no
+  provenance trail** — no way to know whether the edits were
+  intentional, who made them, or when
+- `git pull --rebase` / `git reset --hard` / `git stash drop`
+  can silently destroy the edits
+- Worktree-aware workflows (per existing CLAUDE.md lessons)
+  compound the problem: a sibling session may overwrite the
+  edits or get confused by them
+
+**Today's evidence (2026-05-25 session, 11:00 AM):** 10 spec
+status edits sitting unstaged in `attune-ai` main checkout's
+working tree. The "other session" Patrick had closed earlier
+had made dashboard-driven status advances on 6 specs (covering
+`agent-surface-parallelism-evaluation`, `anthropic-cost-integration`,
+`coverage-exclusion-policy`, `discovery-sweep-ops-integration`,
+`multi-actor-bulletin`, `ops-specs-completion-candidates`).
+They were invisible until the fresh session ran `git status`,
+and required ad-hoc triage to decide whether to commit, stash,
+or discard. Eventually committed as PR #467 — but only after
+a question to Patrick, manual review, and a confirmation cycle
+that wouldn't have been needed if the writes had been surfaced
+proactively.
+
+This is **a class of bug**, not a one-off: any long-running
+service that holds a session-scoped concept of work but
+mutates a shared filesystem outside that scope has the same
+shape.
+
+### Goals
+
+1. **Durability** — no dashboard-driven edit is ever lost to
+   `git pull` / `git reset --hard` / `git stash drop`
+2. **Provenance** — every dashboard-driven edit can be
+   traced to: when, what file, what action, what session id,
+   what dashboard PID
+3. **Surfacing** — fresh sessions, currently-running
+   dashboard UI, and downstream consumers (session-start
+   hooks, shell prompt, etc.) can all discover pending
+   edits via a single canonical contract
+4. **Frictionless commit path** — once surfaced, committing
+   pending edits should be a one-click (UI) or one-command
+   (CLI) action
+
+### Non-goals (this spec)
+
+- Auto-commit on heartbeat (rejected during design discussion —
+  too many race conditions, git permission complexity, branch
+  cleanup burden; humans-in-loop is correct)
+- Generalizing to non-dashboard live-state writers (e.g.
+  attune-gui sidecar, future MCP write tools) — this spec
+  starts with the ops dashboard; a future spec can promote
+  the pattern if it generalizes well
+- Auditing or replaying historical pre-spec writes — the
+  journal is forward-looking from spec-ship date
+- Conflict resolution when a user edits the same file the
+  dashboard wrote (treat as standard merge conflict; out of
+  scope here)
+
+### Acceptance criteria
+
+**Phase 1 (this spec, this session):**
+
+1. Every dashboard write endpoint (`PUT
+   /api/cowork/specs/{feature}/{phase}/status` at minimum)
+   appends an entry to `~/.attune/ops/pending_writes.jsonl`
+   describing the write
+2. `GET /api/pending-writes` returns the list of journal
+   entries that are still uncommitted (cross-references
+   against `git status`)
+3. Tests cover: journal write succeeds; API returns
+   correctly-filtered list; entries with committed-to-git
+   state are filtered out
+4. Manual smoke test passes: make a dashboard edit, query the
+   API, see the entry; commit the file, query again, entry
+   gone
+
+**Phase 2 (future session):**
+
+- UI chip in dashboard topbar: "N unsaved changes" → review
+  page with per-file diff + commit/revert actions
+
+**Phase 3 (future session):**
+
+- Session-start hook (CLAUDE.md preamble or attune CLI
+  subcommand) that queries the API on fresh-session start and
+  surfaces pending writes to the agent for proactive
+  human-in-loop triage
+
+### Out of scope (deferred)
+
+- attune-gui sidecar integration (same pattern, different
+  endpoint set) — could be a follow-up spec
+- Shell-prompt integration (`PS1` hook showing pending count)
+  — nice-to-have, not load-bearing
+
+### Audience
+
+attune-ai contributors and downstream consumers of the ops
+dashboard. Users of the dashboard who edit spec statuses
+benefit directly; agents starting fresh sessions in worktrees
+benefit indirectly.

--- a/src/attune/ops/pending_writes.py
+++ b/src/attune/ops/pending_writes.py
@@ -1,0 +1,161 @@
+"""Pending-writes journal — durable log of dashboard-driven disk writes.
+
+See `docs/specs/dashboard-pending-writes-journal/` for the full
+design. Phase 1: journal writer + module-level helpers.
+
+The journal lives at ``~/.attune/ops/pending_writes.jsonl`` (one JSON
+object per line, append-only). Each entry records a single mutating
+endpoint call: when, by which dashboard process, to which file, with
+before/after sha256s.
+
+Failures here are best-effort: the actual write endpoint must NOT
+be blocked by a journal-append failure. All write paths in this
+module log a WARNING and swallow the exception.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Default journal path. Tests should patch via the
+# ``journal_path`` kwarg on append_entry, not by mutating this.
+JOURNAL_PATH: Path = Path.home() / ".attune" / "ops" / "pending_writes.jsonl"
+
+
+@dataclass(frozen=True)
+class JournalEntry:
+    """One pending-writes journal entry.
+
+    See `docs/specs/dashboard-pending-writes-journal/design.md` for
+    the schema rationale.
+
+    Fields:
+        ts: ISO-8601 UTC timestamp (microsecond precision).
+        session_id: CLAUDE_CODE_SESSION_ID env var, or ``dashboard-<pid>``
+            fallback when no Claude Code session env is present (e.g.,
+            the dashboard was started outside a session).
+        dashboard_pid: OS pid of the dashboard process that made the
+            write. Lets consumers check whether the originator is
+            still alive.
+        endpoint: Canonical FastAPI route path (e.g.,
+            ``PUT /api/specs/{slug}/{phase}/status``).
+        action: Human-readable action name (e.g., ``set_spec_status``).
+        file_path: POSIX path of the written file, RELATIVE to
+            ``project_root`` (forward slashes regardless of platform).
+        project_root: Absolute path of the project root the file lives
+            under. Disambiguates worktree-local vs main-checkout edits.
+        before_sha256: sha256 of file content BEFORE the write
+            (``None`` if the file was newly created).
+        after_sha256: sha256 of file content AFTER the write
+            (must be present).
+    """
+
+    ts: str
+    session_id: str
+    dashboard_pid: int
+    endpoint: str
+    action: str
+    file_path: str
+    project_root: str
+    before_sha256: str | None
+    after_sha256: str
+
+
+def compute_file_sha256(path: Path) -> str | None:
+    """Compute sha256 of a file's contents.
+
+    Returns ``None`` if the file doesn't exist or can't be read.
+    Failures are intentional: a missing or unreadable file at journal
+    time is signal, not an error.
+    """
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError as exc:
+        logger.warning("compute_file_sha256: failed for %s: %s", path, exc)
+        return None
+
+
+def _resolve_session_id(dashboard_pid: int) -> str:
+    """Best-effort session id for the journal entry.
+
+    Returns ``CLAUDE_CODE_SESSION_ID`` if set, otherwise the
+    ``dashboard-<pid>`` fallback.
+    """
+    env_session = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
+    if env_session:
+        return env_session
+    return f"dashboard-{dashboard_pid}"
+
+
+def make_entry(
+    *,
+    endpoint: str,
+    action: str,
+    file_path: str,
+    project_root: str,
+    before_sha256: str | None,
+    after_sha256: str,
+    session_id: str | None = None,
+    dashboard_pid: int | None = None,
+    ts: str | None = None,
+) -> JournalEntry:
+    """Construct a JournalEntry, filling in defaults from runtime context.
+
+    Kwargs-only by design — callers should be explicit about what
+    they're recording. Defaults handle the boilerplate (pid, session
+    id, timestamp).
+    """
+    if dashboard_pid is None:
+        dashboard_pid = os.getpid()
+    if session_id is None:
+        session_id = _resolve_session_id(dashboard_pid)
+    if ts is None:
+        ts = datetime.now(timezone.utc).isoformat()
+    return JournalEntry(
+        ts=ts,
+        session_id=session_id,
+        dashboard_pid=dashboard_pid,
+        endpoint=endpoint,
+        action=action,
+        file_path=file_path,
+        project_root=project_root,
+        before_sha256=before_sha256,
+        after_sha256=after_sha256,
+    )
+
+
+def append_entry(entry: JournalEntry, journal_path: Path | None = None) -> None:
+    """Append a journal entry to the JSONL journal.
+
+    Best-effort: failures log a WARNING and do not raise. The actual
+    write endpoint that called this MUST NOT be blocked by a journal
+    failure (see D5 in decisions.md).
+
+    Atomic per write: POSIX ``O_APPEND`` semantics guarantee
+    concurrent appends from multiple dashboard processes do not
+    interleave for writes under the page size (entries are well under
+    1KB).
+    """
+    path = journal_path if journal_path is not None else JOURNAL_PATH
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(asdict(entry), sort_keys=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except (OSError, TypeError, ValueError) as exc:
+        # OSError/IOError: disk full, permission denied, etc.
+        # TypeError/ValueError: dataclass serialization issue (shouldn't
+        # happen with the frozen dataclass shape, but defense in depth).
+        logger.warning(
+            "pending_writes.append_entry: failed (%s); journal at %s",
+            exc,
+            path,
+        )

--- a/src/attune/ops/routes/pending_writes.py
+++ b/src/attune/ops/routes/pending_writes.py
@@ -1,0 +1,202 @@
+"""Pending-writes API — GET /api/pending-writes.
+
+See `docs/specs/dashboard-pending-writes-journal/` for the full
+design. Phase 1: read the journal, enrich each entry with computed
+fields (current disk sha, is_committed via git status, dashboard
+liveness, age), return JSON.
+
+Consumers filter per their needs (UI chip uses uncommitted_count;
+session-start hook uses is_committed=false; auditors use
+matches_journal=false). The API returns everything enriched, not
+pre-filtered — see D3 in decisions.md.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from attune.ops import pending_writes as journal
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["pending-writes"])
+
+
+def _load_journal_entries(journal_path: Path) -> list[dict[str, Any]]:
+    """Read JSONL journal; return list of entry dicts.
+
+    Best-effort: corrupt lines are skipped with a WARNING log. Missing
+    journal file returns empty list (no error — a fresh install has
+    no journal).
+    """
+    if not journal_path.is_file():
+        return []
+    entries: list[dict[str, Any]] = []
+    try:
+        text = journal_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("pending_writes: cannot read journal at %s: %s", journal_path, exc)
+        return []
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "pending_writes: corrupt journal line %d in %s: %s",
+                lineno,
+                journal_path,
+                exc,
+            )
+    return entries
+
+
+def _is_dashboard_running(pid: int) -> bool:
+    """Best-effort: does this PID belong to a running process?
+
+    Uses ``os.kill(pid, 0)`` which doesn't send a real signal but
+    raises ``ProcessLookupError`` if the pid is dead and
+    ``PermissionError`` if the pid is alive but owned by another
+    user (we can't signal it).
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we can't signal it — still counts as alive.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _is_file_committed(file_path: Path, project_root: Path) -> bool | None:
+    """Does ``git status --porcelain`` show this file as clean?
+
+    Returns:
+        True  — file exists, git treats it as committed (no dirty status)
+        False — file appears as modified / untracked / staged in git status
+        None  — couldn't determine (no git repo, git command failed, etc.)
+    """
+    if not project_root.is_dir():
+        return None
+    try:
+        rel = file_path.relative_to(project_root)
+    except ValueError:
+        # file is not under project_root — out of scope for this check
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603 — args are derived from validated paths
+            ["git", "-C", str(project_root), "status", "--porcelain", "--", str(rel)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("pending_writes: git status check failed for %s: %s", file_path, exc)
+        return None
+    if result.returncode != 0:
+        # Not a git repo, or git couldn't read the file. Treat as unknown.
+        return None
+    # Empty output from `git status --porcelain -- <file>` means clean
+    # (no dirty status). Non-empty means modified/untracked/staged/etc.
+    return result.stdout.strip() == ""
+
+
+def _enrich(entry: dict[str, Any], now: datetime) -> dict[str, Any]:
+    """Add computed fields to a journal entry.
+
+    Adds:
+        dashboard_still_running: bool
+        current_disk_sha256: str | None
+        matches_journal: bool
+        is_committed: bool | None
+        age_seconds: int | None
+    """
+    enriched = dict(entry)
+
+    pid = entry.get("dashboard_pid")
+    enriched["dashboard_still_running"] = (
+        _is_dashboard_running(int(pid)) if isinstance(pid, int) else False
+    )
+
+    project_root_str = entry.get("project_root", "")
+    file_path_rel = entry.get("file_path", "")
+    project_root = Path(project_root_str) if project_root_str else None
+    abs_file_path: Path | None = None
+    if project_root is not None and file_path_rel:
+        abs_file_path = project_root / file_path_rel
+
+    enriched["current_disk_sha256"] = (
+        journal.compute_file_sha256(abs_file_path) if abs_file_path else None
+    )
+    enriched["matches_journal"] = (
+        enriched["current_disk_sha256"] == entry.get("after_sha256")
+        if enriched["current_disk_sha256"] is not None
+        else False
+    )
+    enriched["is_committed"] = (
+        _is_file_committed(abs_file_path, project_root) if abs_file_path and project_root else None
+    )
+
+    ts_raw = entry.get("ts", "")
+    try:
+        entry_ts = datetime.fromisoformat(ts_raw)
+        enriched["age_seconds"] = int((now - entry_ts).total_seconds())
+    except (ValueError, TypeError):
+        enriched["age_seconds"] = None
+
+    return enriched
+
+
+def _summarize(enriched_entries: list[dict[str, Any]]) -> dict[str, int]:
+    """Compute summary counts across the enriched entries."""
+    total = len(enriched_entries)
+    uncommitted = sum(1 for e in enriched_entries if e.get("is_committed") is False)
+    stale = sum(1 for e in enriched_entries if not e.get("dashboard_still_running"))
+    drifted = sum(1 for e in enriched_entries if not e.get("matches_journal"))
+    return {
+        "total_entries": total,
+        "uncommitted_count": uncommitted,
+        "stale_dashboard_count": stale,
+        "drifted_count": drifted,
+    }
+
+
+@router.get("/pending-writes")
+async def list_pending_writes(request: Request) -> dict[str, Any]:
+    """Return all journal entries enriched with computed status fields.
+
+    See `docs/specs/dashboard-pending-writes-journal/design.md` for
+    the response shape.
+
+    Consumers should filter per their needs (e.g. dashboard UI chip
+    uses ``uncommitted_count``; a session-start hook filters
+    entries where ``is_committed`` is False).
+    """
+    # Allow tests + dev to override the journal path via app.state.
+    journal_path: Path = getattr(
+        request.app.state, "pending_writes_journal_path", journal.JOURNAL_PATH
+    )
+    now = datetime.now(timezone.utc)
+    raw_entries = _load_journal_entries(journal_path)
+    enriched = [_enrich(entry, now) for entry in raw_entries]
+    return {
+        "pending": enriched,
+        "summary": _summarize(enriched),
+    }

--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -20,6 +20,7 @@ server runs with ``--read-only``, mutations are rejected with 403.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import tempfile
@@ -29,7 +30,9 @@ from typing import Any
 
 from fastapi import APIRouter, Body, HTTPException, Request
 
-from attune.ops import dismiss_store
+from attune.ops import dismiss_store, pending_writes
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/specs", tags=["specs"])
 
@@ -421,6 +424,53 @@ def _extract_status_annotation(old_value: str) -> str:
     return annotation if annotation.strip() else ""
 
 
+def _record_pending_write(
+    *,
+    target: Path,
+    before_text: str,
+    after_text: str,
+    project_root: Path | str,
+    request: Request,
+) -> None:
+    """Best-effort journal append for a successful spec-status write.
+
+    Honors D5 in docs/specs/dashboard-pending-writes-journal/decisions.md:
+    journal failures MUST NOT block the calling write endpoint. Wraps the
+    entire body so any defect in the journal layer — including ones that
+    bypass ``append_entry``'s internal try/except — surfaces as a WARNING
+    log, not a 500 response.
+    """
+    import hashlib
+
+    try:
+        project_root_path = Path(project_root)
+        try:
+            rel_file_path = target.relative_to(project_root_path).as_posix()
+        except ValueError:
+            # target lives outside project_root (e.g. spec lives in a
+            # sibling repo via --specs-root). Fall back to absolute.
+            rel_file_path = target.as_posix()
+        before_sha = hashlib.sha256(before_text.encode("utf-8")).hexdigest()
+        after_sha = hashlib.sha256(after_text.encode("utf-8")).hexdigest()
+        entry = pending_writes.make_entry(
+            endpoint="PUT /api/specs/{slug}/{phase}/status",
+            action="set_spec_status",
+            file_path=rel_file_path,
+            project_root=str(project_root_path),
+            before_sha256=before_sha,
+            after_sha256=after_sha,
+        )
+        # Allow tests / dev to override the journal path via app.state.
+        journal_path = getattr(request.app.state, "pending_writes_journal_path", None)
+        pending_writes.append_entry(entry, journal_path=journal_path)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: D5 contract — journal failure must never block the
+        # actual write. Log + swallow at the route boundary as defense in
+        # depth, even though append_entry catches internally.
+        logger = logging.getLogger(__name__)
+        logger.warning("pending_writes: journal append failed for %s: %s", target, exc)
+
+
 @router.put("/{slug}/{phase}/status")
 async def update_phase_status(
     slug: str,
@@ -479,6 +529,18 @@ async def update_phase_status(
         _atomic_write(target, new_text)
     except OSError as exc:
         raise HTTPException(status_code=500, detail=f"write failed: {exc}") from exc
+
+    # Append a pending-writes journal entry so the edit is durable
+    # across sessions even before it's committed to git. Best-effort:
+    # journal failures log a WARNING and do not block this endpoint.
+    # See docs/specs/dashboard-pending-writes-journal/ for the design.
+    _record_pending_write(
+        target=target,
+        before_text=original,
+        after_text=new_text,
+        project_root=getattr(config, "project_root", matched_root),
+        request=request,
+    )
 
     # On successful flip AWAY from a complete-like status, clear any
     # dismiss entry for this slug. Re-completion can then re-surface

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -16,6 +16,7 @@ from attune.ops.config import Config
 from attune.ops.interaction_counters import InteractionCounters
 from attune.ops.routes import dashboard
 from attune.ops.routes import interaction_counters as interaction_counters_routes
+from attune.ops.routes import pending_writes as pending_writes_routes
 from attune.ops.routes import runner as runner_routes
 from attune.ops.routes import runs_history as runs_history_routes
 from attune.ops.routes import sessions as sessions_routes
@@ -110,6 +111,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.include_router(specs_routes.router)
     app.include_router(sweep_results_routes.router)
     app.include_router(interaction_counters_routes.router)
+    app.include_router(pending_writes_routes.router)
 
     # Phase 2B of discovery-sweep-ops-integration: when sweep-result
     # persistence is enabled, wrap the runner's start() so each

--- a/tests/unit/ops/test_pending_writes.py
+++ b/tests/unit/ops/test_pending_writes.py
@@ -1,0 +1,271 @@
+"""Unit tests for the pending-writes journal module.
+
+Phase 1 of docs/specs/dashboard-pending-writes-journal/.
+
+Covers:
+
+- ``compute_file_sha256`` — happy path, missing file, unreadable file.
+- ``make_entry`` — explicit kwargs, default fill-ins (pid, session, ts).
+- ``append_entry`` — single + multiple appends, parent-dir creation,
+  best-effort failure swallowing (IOError on write, dataclass
+  serialization errors).
+- ``_resolve_session_id`` — env-var precedence, fallback shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from attune.ops import pending_writes
+from attune.ops.pending_writes import (
+    JournalEntry,
+    _resolve_session_id,
+    append_entry,
+    compute_file_sha256,
+    make_entry,
+)
+
+# --- compute_file_sha256 -----------------------------------------
+
+
+def test_compute_file_sha256_happy_path(tmp_path: Path) -> None:
+    target = tmp_path / "f.txt"
+    target.write_text("hello world", encoding="utf-8")
+    # sha256 of "hello world" is a well-known constant
+    expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    assert compute_file_sha256(target) == expected
+
+
+def test_compute_file_sha256_missing_file_returns_none(tmp_path: Path) -> None:
+    assert compute_file_sha256(tmp_path / "does-not-exist") is None
+
+
+def test_compute_file_sha256_unreadable_returns_none(tmp_path: Path) -> None:
+    # Simulate unreadable file via mock — making files unreadable on
+    # disk is OS-conditional (root bypasses, Windows permissions
+    # differ). Mock is the portable verification.
+    target = tmp_path / "f.txt"
+    target.write_text("x", encoding="utf-8")
+    with patch.object(Path, "read_bytes", side_effect=PermissionError("no read")):
+        assert compute_file_sha256(target) is None
+
+
+# --- _resolve_session_id -----------------------------------------
+
+
+def test_resolve_session_id_uses_env_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "abc-123")
+    assert _resolve_session_id(dashboard_pid=9999) == "abc-123"
+
+
+def test_resolve_session_id_falls_back_to_dashboard_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    assert _resolve_session_id(dashboard_pid=42) == "dashboard-42"
+
+
+def test_resolve_session_id_treats_empty_env_as_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Whitespace-only env value should fall back, not be passed through.
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "   ")
+    assert _resolve_session_id(dashboard_pid=7) == "dashboard-7"
+
+
+# --- make_entry --------------------------------------------------
+
+
+def test_make_entry_with_explicit_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = make_entry(
+        endpoint="PUT /api/specs/{slug}/{phase}/status",
+        action="set_spec_status",
+        file_path="docs/specs/foo/decisions.md",
+        project_root="/repo",
+        before_sha256="aaa",
+        after_sha256="bbb",
+        session_id="sess-1",
+        dashboard_pid=12345,
+        ts="2026-05-25T15:00:00+00:00",
+    )
+    assert entry.session_id == "sess-1"
+    assert entry.dashboard_pid == 12345
+    assert entry.ts == "2026-05-25T15:00:00+00:00"
+    assert entry.endpoint == "PUT /api/specs/{slug}/{phase}/status"
+    assert entry.action == "set_spec_status"
+    assert entry.file_path == "docs/specs/foo/decisions.md"
+    assert entry.project_root == "/repo"
+    assert entry.before_sha256 == "aaa"
+    assert entry.after_sha256 == "bbb"
+
+
+def test_make_entry_fills_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "live-session")
+    entry = make_entry(
+        endpoint="PUT /api/x",
+        action="x",
+        file_path="x",
+        project_root="/r",
+        before_sha256=None,
+        after_sha256="bbb",
+    )
+    # ts defaults to "now" — just check format & approximate freshness
+    assert "T" in entry.ts and entry.ts.endswith("+00:00")
+    assert entry.session_id == "live-session"
+    assert entry.dashboard_pid == os.getpid()
+
+
+def test_make_entry_allows_before_sha_none() -> None:
+    """File-was-newly-created case: before_sha256 is None, after is required."""
+    entry = make_entry(
+        endpoint="x",
+        action="x",
+        file_path="x",
+        project_root="/r",
+        before_sha256=None,
+        after_sha256="bbb",
+    )
+    assert entry.before_sha256 is None
+    assert entry.after_sha256 == "bbb"
+
+
+# --- append_entry ------------------------------------------------
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_append_entry_writes_one_line(tmp_path: Path) -> None:
+    journal_path = tmp_path / "journal.jsonl"
+    entry = make_entry(
+        endpoint="x",
+        action="x",
+        file_path="x",
+        project_root="/r",
+        before_sha256="a",
+        after_sha256="b",
+        ts="2026-05-25T15:00:00+00:00",
+    )
+    append_entry(entry, journal_path=journal_path)
+    rows = _read_jsonl(journal_path)
+    assert len(rows) == 1
+    assert rows[0]["endpoint"] == "x"
+    assert rows[0]["before_sha256"] == "a"
+    assert rows[0]["after_sha256"] == "b"
+
+
+def test_append_entry_appends_multiple(tmp_path: Path) -> None:
+    journal_path = tmp_path / "journal.jsonl"
+    for i in range(3):
+        entry = make_entry(
+            endpoint=f"e-{i}",
+            action="x",
+            file_path=f"f-{i}",
+            project_root="/r",
+            before_sha256=None,
+            after_sha256=f"s-{i}",
+            ts=f"2026-05-25T15:00:0{i}+00:00",
+        )
+        append_entry(entry, journal_path=journal_path)
+    rows = _read_jsonl(journal_path)
+    assert len(rows) == 3
+    assert [r["endpoint"] for r in rows] == ["e-0", "e-1", "e-2"]
+
+
+def test_append_entry_creates_parent_dir(tmp_path: Path) -> None:
+    journal_path = tmp_path / "deep" / "nested" / "journal.jsonl"
+    entry = make_entry(
+        endpoint="x",
+        action="x",
+        file_path="x",
+        project_root="/r",
+        before_sha256=None,
+        after_sha256="b",
+    )
+    append_entry(entry, journal_path=journal_path)
+    assert journal_path.is_file()
+
+
+def test_append_entry_swallows_io_error(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Journal failures MUST NOT block the calling write endpoint."""
+    journal_path = tmp_path / "journal.jsonl"
+    entry = make_entry(
+        endpoint="x",
+        action="x",
+        file_path="x",
+        project_root="/r",
+        before_sha256=None,
+        after_sha256="b",
+    )
+    with patch.object(Path, "open", side_effect=OSError("disk full")):
+        # Should not raise.
+        append_entry(entry, journal_path=journal_path)
+    # WARNING log must surface the failure for separate investigation.
+    assert any("append_entry: failed" in record.message for record in caplog.records)
+
+
+def test_append_entry_uses_default_journal_path_when_none(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When journal_path=None, the module-level JOURNAL_PATH constant is used."""
+    custom_path = tmp_path / "custom.jsonl"
+    monkeypatch.setattr(pending_writes, "JOURNAL_PATH", custom_path)
+    entry = make_entry(
+        endpoint="x",
+        action="x",
+        file_path="x",
+        project_root="/r",
+        before_sha256=None,
+        after_sha256="b",
+    )
+    append_entry(entry)  # journal_path=None → falls back to module constant
+    assert custom_path.is_file()
+
+
+def test_append_entry_serializes_dataclass_correctly(tmp_path: Path) -> None:
+    """The on-disk representation matches the dataclass field names."""
+    journal_path = tmp_path / "journal.jsonl"
+    entry = JournalEntry(
+        ts="2026-05-25T15:00:00+00:00",
+        session_id="sess-1",
+        dashboard_pid=1234,
+        endpoint="PUT /x",
+        action="act",
+        file_path="docs/x.md",
+        project_root="/repo",
+        before_sha256=None,
+        after_sha256="bbb",
+    )
+    append_entry(entry, journal_path=journal_path)
+    rows = _read_jsonl(journal_path)
+    assert len(rows) == 1
+    # Every dataclass field must be present in the JSON (with sort_keys
+    # so the output is stable for debugging).
+    assert set(rows[0].keys()) == {
+        "ts",
+        "session_id",
+        "dashboard_pid",
+        "endpoint",
+        "action",
+        "file_path",
+        "project_root",
+        "before_sha256",
+        "after_sha256",
+    }
+    assert rows[0]["before_sha256"] is None

--- a/tests/unit/ops/test_pending_writes_api.py
+++ b/tests/unit/ops/test_pending_writes_api.py
@@ -1,0 +1,457 @@
+"""HTTP-level tests for GET /api/pending-writes.
+
+Phase 1 of docs/specs/dashboard-pending-writes-journal/.
+
+Covers:
+
+- Empty journal returns ``{pending: [], summary: {...}}``
+- Single entry: returns enriched with all computed fields
+- Entry whose file is now committed: ``is_committed=true``
+- Entry whose file was manually reverted: ``matches_journal=false``
+- Entry whose dashboard PID is dead: ``dashboard_still_running=false``
+- Summary counts (total, uncommitted, stale-dashboard, drifted)
+- Integration: PUT /api/specs/{slug}/{phase}/status appends to journal
+
+Tests run against a real FastAPI TestClient + real create_app.
+Journal path is overridden via ``app.state.pending_writes_journal_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops import pending_writes  # noqa: E402
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+# --- fixtures ----------------------------------------------------
+
+
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    """A tmp project root, initialized as a git repo so is_committed checks work."""
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main"],
+        cwd=project,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=project,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=project,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"],
+        cwd=project,
+        check=True,
+    )
+    return project
+
+
+@pytest.fixture
+def client_factory(tmp_project: Path, tmp_path: Path):
+    """Factory: build a TestClient with a custom journal path on app.state."""
+
+    def _make(journal_path: Path | None = None) -> TestClient:
+        config = build_config(
+            project_root=tmp_project,
+            allow_run=True,
+            trusted_hosts=("testserver", "test"),
+        )
+        app = create_app(config)
+        if journal_path is None:
+            journal_path = tmp_path / "journal.jsonl"
+        app.state.pending_writes_journal_path = journal_path
+        return TestClient(app)
+
+    return _make
+
+
+def _write_journal(journal_path: Path, entries: list[dict]) -> None:
+    """Write a sequence of journal entry dicts to a JSONL file."""
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    with journal_path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _make_journal_dict(
+    *,
+    project_root: Path,
+    file_path: str,
+    after_sha256: str,
+    before_sha256: str | None = None,
+    dashboard_pid: int | None = None,
+    ts: str = "2026-05-25T15:00:00+00:00",
+) -> dict:
+    """Build a journal entry dict matching the on-disk schema."""
+    if dashboard_pid is None:
+        dashboard_pid = os.getpid()
+    return {
+        "ts": ts,
+        "session_id": "test-session",
+        "dashboard_pid": dashboard_pid,
+        "endpoint": "PUT /api/specs/{slug}/{phase}/status",
+        "action": "set_spec_status",
+        "file_path": file_path,
+        "project_root": str(project_root),
+        "before_sha256": before_sha256,
+        "after_sha256": after_sha256,
+    }
+
+
+# --- GET /api/pending-writes -------------------------------------
+
+
+def test_empty_journal_returns_empty_pending_and_zero_summary(
+    client_factory,
+) -> None:
+    client = client_factory()
+    response = client.get("/api/pending-writes")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pending"] == []
+    assert body["summary"] == {
+        "total_entries": 0,
+        "uncommitted_count": 0,
+        "stale_dashboard_count": 0,
+        "drifted_count": 0,
+    }
+
+
+def test_single_entry_enriches_all_computed_fields(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+) -> None:
+    # Create a real file with known content, then journal it.
+    target = tmp_project / "spec.md"
+    target.write_text("hello\n", encoding="utf-8")
+    after_sha = pending_writes.compute_file_sha256(target)
+
+    journal_path = tmp_path / "journal.jsonl"
+    _write_journal(
+        journal_path,
+        [
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path="spec.md",
+                after_sha256=after_sha,
+            )
+        ],
+    )
+
+    client = client_factory(journal_path=journal_path)
+    response = client.get("/api/pending-writes")
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["pending"]) == 1
+    entry = body["pending"][0]
+    # All enriched fields present
+    assert "dashboard_still_running" in entry
+    assert "current_disk_sha256" in entry
+    assert "matches_journal" in entry
+    assert "is_committed" in entry
+    assert "age_seconds" in entry
+    # current disk matches journal (no manual revert)
+    assert entry["matches_journal"] is True
+    # file is uncommitted (untracked in git)
+    assert entry["is_committed"] is False
+    # dashboard pid is THIS process so dashboard_still_running=True
+    assert entry["dashboard_still_running"] is True
+
+
+def test_entry_whose_file_was_committed_shows_is_committed_true(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+) -> None:
+    target = tmp_project / "spec.md"
+    target.write_text("hello\n", encoding="utf-8")
+    after_sha = pending_writes.compute_file_sha256(target)
+    # Commit the file.
+    subprocess.run(["git", "add", "spec.md"], cwd=tmp_project, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "add spec"],
+        cwd=tmp_project,
+        check=True,
+    )
+
+    journal_path = tmp_path / "journal.jsonl"
+    _write_journal(
+        journal_path,
+        [
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path="spec.md",
+                after_sha256=after_sha,
+            )
+        ],
+    )
+
+    client = client_factory(journal_path=journal_path)
+    body = client.get("/api/pending-writes").json()
+    entry = body["pending"][0]
+    assert entry["is_committed"] is True
+    assert body["summary"]["uncommitted_count"] == 0
+
+
+def test_entry_whose_file_was_manually_reverted_shows_matches_journal_false(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+) -> None:
+    target = tmp_project / "spec.md"
+    target.write_text("original\n", encoding="utf-8")
+    journaled_sha = pending_writes.compute_file_sha256(target)
+    # User manually edits the file AFTER the journal entry was made.
+    target.write_text("user-changed-it\n", encoding="utf-8")
+
+    journal_path = tmp_path / "journal.jsonl"
+    _write_journal(
+        journal_path,
+        [
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path="spec.md",
+                after_sha256=journaled_sha,
+            )
+        ],
+    )
+
+    client = client_factory(journal_path=journal_path)
+    body = client.get("/api/pending-writes").json()
+    entry = body["pending"][0]
+    assert entry["matches_journal"] is False
+    assert body["summary"]["drifted_count"] == 1
+
+
+def test_entry_whose_dashboard_pid_is_dead_marked_stale(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+) -> None:
+    target = tmp_project / "spec.md"
+    target.write_text("hello\n", encoding="utf-8")
+    after_sha = pending_writes.compute_file_sha256(target)
+
+    journal_path = tmp_path / "journal.jsonl"
+    # PID 1 (init) won't accept kill(0) from a normal user → "dead" for our purposes.
+    # Use a guaranteed-dead PID instead: a high number unlikely to be allocated.
+    dead_pid = 2_147_483_646  # max int-32, will not exist
+    _write_journal(
+        journal_path,
+        [
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path="spec.md",
+                after_sha256=after_sha,
+                dashboard_pid=dead_pid,
+            )
+        ],
+    )
+
+    client = client_factory(journal_path=journal_path)
+    body = client.get("/api/pending-writes").json()
+    entry = body["pending"][0]
+    assert entry["dashboard_still_running"] is False
+    assert body["summary"]["stale_dashboard_count"] == 1
+
+
+def test_summary_counts_aggregate_correctly(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+) -> None:
+    # Three entries: one fresh, one stale-dashboard, one drifted-from-disk.
+    fresh = tmp_project / "fresh.md"
+    fresh.write_text("a\n", encoding="utf-8")
+    stale = tmp_project / "stale.md"
+    stale.write_text("b\n", encoding="utf-8")
+    drifted = tmp_project / "drifted.md"
+    drifted.write_text("c\n", encoding="utf-8")
+    journaled_drift_sha = pending_writes.compute_file_sha256(drifted)
+    drifted.write_text("changed\n", encoding="utf-8")  # user edited after journal
+
+    journal_path = tmp_path / "journal.jsonl"
+    _write_journal(
+        journal_path,
+        [
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path="fresh.md",
+                after_sha256=pending_writes.compute_file_sha256(fresh),
+            ),
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path="stale.md",
+                after_sha256=pending_writes.compute_file_sha256(stale),
+                dashboard_pid=2_147_483_646,
+            ),
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path="drifted.md",
+                after_sha256=journaled_drift_sha,
+            ),
+        ],
+    )
+
+    client = client_factory(journal_path=journal_path)
+    summary = client.get("/api/pending-writes").json()["summary"]
+    assert summary["total_entries"] == 3
+    # All three uncommitted (none added to git)
+    assert summary["uncommitted_count"] == 3
+    # One has a dead PID
+    assert summary["stale_dashboard_count"] == 1
+    # One drifted from disk
+    assert summary["drifted_count"] == 1
+
+
+def test_corrupt_journal_line_is_skipped_not_fatal(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    target = tmp_project / "spec.md"
+    target.write_text("hello\n", encoding="utf-8")
+    valid_entry = _make_journal_dict(
+        project_root=tmp_project,
+        file_path="spec.md",
+        after_sha256=pending_writes.compute_file_sha256(target),
+    )
+    journal_path = tmp_path / "journal.jsonl"
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+    with journal_path.open("w", encoding="utf-8") as fh:
+        fh.write("this is not json\n")
+        fh.write(json.dumps(valid_entry) + "\n")
+        fh.write("{also-broken\n")
+
+    client = client_factory(journal_path=journal_path)
+    body = client.get("/api/pending-writes").json()
+    # Only the valid line surfaces.
+    assert len(body["pending"]) == 1
+    assert any("corrupt journal line" in record.message for record in caplog.records)
+
+
+# --- integration: PUT spec status appends to journal -------------
+
+
+def test_put_spec_status_appends_journal_entry(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+) -> None:
+    # Set up a spec the route can find.
+    specs_root = tmp_project / "docs" / "specs" / "demo"
+    specs_root.mkdir(parents=True)
+    spec_file = specs_root / "decisions.md"
+    spec_file.write_text("# demo\n\n**Status:** draft\n\nbody\n", encoding="utf-8")
+
+    journal_path = tmp_path / "journal.jsonl"
+    client = client_factory(journal_path=journal_path)
+
+    response = client.put(
+        "/api/specs/demo/decisions/status",
+        json={"status": "approved"},
+    )
+    assert response.status_code == 200, response.text
+
+    # Journal entry should exist.
+    assert journal_path.is_file()
+    lines = journal_path.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["action"] == "set_spec_status"
+    assert entry["endpoint"] == "PUT /api/specs/{slug}/{phase}/status"
+    assert entry["file_path"] == "docs/specs/demo/decisions.md"
+    assert entry["project_root"] == str(tmp_project)
+    assert entry["before_sha256"] is not None
+    assert entry["after_sha256"] is not None
+    assert entry["before_sha256"] != entry["after_sha256"]
+
+
+def test_failed_put_status_does_not_append_journal(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+) -> None:
+    """Validation failures must NOT leak a journal entry."""
+    journal_path = tmp_path / "journal.jsonl"
+    client = client_factory(journal_path=journal_path)
+
+    # Invalid status value → 422 from validator before any write.
+    response = client.put(
+        "/api/specs/demo/decisions/status",
+        json={"status": "not-a-real-status"},
+    )
+    assert response.status_code != 200
+    # Journal file should never have been touched.
+    assert not journal_path.is_file()
+
+
+def test_journal_failure_does_not_block_put_status(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """D5 contract: journal failures must NOT propagate as 500s.
+
+    Even if ``pending_writes.append_entry`` itself raises (bypassing
+    its own internal try/except, e.g. via a future regression or
+    direct subclass surprise), the spec-status write endpoint must
+    still succeed. The route layer is exception-safe by design.
+    """
+    specs_root = tmp_project / "docs" / "specs" / "demo"
+    specs_root.mkdir(parents=True)
+    spec_file = specs_root / "decisions.md"
+    spec_file.write_text("# demo\n\n**Status:** draft\n\nbody\n", encoding="utf-8")
+
+    journal_path = tmp_path / "journal.jsonl"
+    client = client_factory(journal_path=journal_path)
+
+    # Patch append_entry to raise an arbitrary Exception (simulating
+    # a regression where the internal swallow contract is violated).
+    # The route's _record_pending_write wrapper MUST catch this so the
+    # write endpoint returns 200 and the spec file actually gets
+    # updated. Patch path: where the route IMPORTS it from, not where
+    # it's defined — see CLAUDE.md "patch the import site" lesson.
+    with patch(
+        "attune.ops.routes.specs.pending_writes.append_entry",
+        side_effect=Exception("simulated journal regression"),
+    ):
+        response = client.put(
+            "/api/specs/demo/decisions/status",
+            json={"status": "approved"},
+        )
+
+    # Contract: 200 OK even though journal raised.
+    assert response.status_code == 200, response.text
+
+    # Spec file actually got updated (write happened despite journal
+    # explosion).
+    body = spec_file.read_text(encoding="utf-8")
+    assert "**Status:** approved" in body
+    assert "**Status:** draft" not in body
+
+    # Journal failure was logged for separate investigation.
+    assert any("journal append failed" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary

Ships Phase 1 of [`dashboard-pending-writes-journal`](docs/specs/dashboard-pending-writes-journal/) — the durable record + API for ops-dashboard live-state writes that otherwise become silent debt in the working tree.

**What's in:**
- Journal writer module (`src/attune/ops/pending_writes.py`) — appends one JSONL entry per dashboard write to `~/.attune/ops/pending_writes.jsonl` with `ts`, `session_id`, `dashboard_pid`, `endpoint`, `action`, `file_path`, `project_root`, `before_sha256`, `after_sha256`.
- API endpoint module (`src/attune/ops/routes/pending_writes.py`) — `GET /api/pending-writes` reads journal and enriches each entry with `dashboard_still_running`, `current_disk_sha256`, `matches_journal`, `is_committed`, `age_seconds`, plus a summary block.
- Wire-in to the spec-status setter (`PUT /api/specs/{slug}/{phase}/status`) — first instrumented endpoint; others can adopt with a one-line `append_entry` call.
- Best-effort discipline (D5): journal failures NEVER block the actual write — `append_entry` catches internally, route wrapper has defense-in-depth outer catch.

**What's deferred:** Phase 2 (UI chip + review/commit page) and Phase 3 (session-start hook + CLI subcommand) sketched in `design.md`, each independently shippable atop Phase 1.

## Motivation

On 2026-05-25 morning, a parallel session clicked through ~10 spec status edits in the dashboard. They sat unstaged in main checkout's working tree for hours, discovered only when this session ran `git status` — and could have been lost to `git pull --rebase`, `git reset --hard`, or `git stash drop` at any point. This spec turns that "silent debt" pattern into "surfaced state with a frictionless commit path."

Designed and shipped in the same session as the worked example for the article on [agent-collaboration discipline](docs/process/COLLABORATION_DISCIPLINE_outline.md) (the discipline running on itself).

## Test plan

- [x] 25 tests (15 module + 10 API) — all green locally
- [x] End-to-end smoke against live dashboard:
  - empty journal returns `{pending: [], summary: {total_entries: 0, ...}}`
  - PUT spec status flip → journal entry appears with correct enriched fields
  - revert spec file → API still shows entry but with `is_committed: false` and correct sha
  - cleared journal returns to empty state
- [ ] CI green
