### PR TITLE
chore(specs): approve bulletin-curator + doc-stack-reference-subtypes

### DIFF
--- a/docs/specs/bulletin-curator/requirements.md
+++ b/docs/specs/bulletin-curator/requirements.md
@@ -5,8 +5,7 @@
 > summary, and dispatches focused follow-ups via
 > `AskUserQuestion`. Fires on-demand when Patrick opens the
 > bulletin — not continuously.
-
-**Status:** draft
+**Status:** approved
 **Created:** 2026-05-17
 **Owner:** TBD
 **Related:**

--- a/docs/specs/doc-stack-reference-subtypes/decisions.md
+++ b/docs/specs/doc-stack-reference-subtypes/decisions.md
@@ -1,7 +1,5 @@
 # Decisions — Doc-Stack Reference Subtypes
-
-**Status:** draft (2026-05-16) — no decisions resolved yet
-
+**Status:** approved (2026-05-16) — no decisions resolved yet
 ---
 
 ## Pre-committed decision matrix (Phase 0 → action)

--- a/docs/specs/doc-stack-reference-subtypes/requirements.md
+++ b/docs/specs/doc-stack-reference-subtypes/requirements.md
@@ -1,6 +1,5 @@
 # Requirements — Doc-Stack Reference Subtypes
-
-**Status:** draft (2026-05-16)
+**Status:** approved (2026-05-16)
 **Owner package:** `attune-author` (sibling repo — this spec lives in attune-ai because cross-package specs live here per the spec-viewer-ia precedent)
 
 ---

--- a/docs/specs/doc-stack-reference-subtypes/tasks.md
+++ b/docs/specs/doc-stack-reference-subtypes/tasks.md
@@ -1,7 +1,5 @@
 # Tasks — Doc-Stack Reference Subtypes
-
-**Status:** draft (2026-05-16)
-
+**Status:** approved (2026-05-16)
 | Phase | Status | Owner | Notes |
 |---|---|---|---|
 | Phase 0 — Inventory + hand-crafted samples | not started | | Gate: decisions matrix committed BEFORE Phase 0 |


### PR DESCRIPTION
## Summary

Land the status-flip writes the ops dashboard's spec-status setter made this morning. Per §6 of the agent-collaboration discipline, dashboard live-state writes need to land in a commit before session boundary or they're stranded in the working tree.

## What flipped

- **bulletin-curator** (Opus-tier synthesis agent for the dashboard) — draft → approved.
- **doc-stack-reference-subtypes** (three reference subtypes for the meta-template — procedural, tabular, free-form) — draft → approved across requirements.md, tasks.md, decisions.md.

No content changes — status fields only.

## Sequencing context

- **bulletin-curator** is hard-blocked on **multi-actor-bulletin** (also approved, also not yet implemented). The curator reads from \`attune.bulletin.read_active()\` which doesn't exist yet (no \`src/attune/bulletin/\` module). Curator work needs the bulletin board built first.
- **doc-stack-reference-subtypes** is independent. Pre-committed decision matrix already in place. Phase 0 (inventory + hand-crafted samples) can start immediately and is the cheapest action.

Both specs are documented in detail in their respective directories. Sequencing rationale will land in the next \`_sequencing.md\` refresh.

## Test plan

- [x] Diff is status-only (verified locally — only Status: field changes plus dashboard's blank-line removal)
- [x] Pre-commit hooks pass (mixed line ending, merge conflicts, etc.)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)