### PR TITLE
feat(ops/runner): wire RunnerService into the multi-actor bulletin

### DIFF
--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,58 +1,43 @@
 ---
-type: concept
-name: ops-dashboard-concept
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-05-21T03:19:56.072840+00:00
-source_hash: 70c9679ee8d985ef96c30f885e28ddd1a4c9216d86c485efecac67f77809fb67
+generated_at: 2026-05-26T21:06:44.507101+00:00
+source_hash: 358cabd372029010a81638242e718fe7c18cf5e3884933957d5eb43dcf498eed
 status: generated
 ---
 
 # Ops Dashboard
 
-The ops dashboard is a web interface that runs workflows, tracks their progress, and provides operational insights into your project's AI activity.
+## How it works
 
-## Core capabilities
+Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
 
-**Workflow execution**: Run any workflow from the dashboard with a scope picker that filters available options by project features. Each run streams logs in real-time and persists its history for later review.
+The main building blocks are:
 
-**Cost monitoring**: Display usage costs from the Anthropic admin API, broken down by day, model, and cost type. The dashboard caches this data locally and refreshes on demand.
+- **`CostFetchError`** — Categorized failure for cost-report fetch.
+- **`CostSummary`** — Account-level cost data from the Anthropic admin cost-report.
+- **`Candidate`** — One completion-candidate spec returned by the detector.
+- **`Config`** — Where attune ops reads project + attune state from.
+- **`TelemetrySummary`** — core component
 
-**Session tracking**: Show active Claude Code sessions with duration, message counts, and starter prompts. This gives you visibility into how AI tools are being used across your project.
+Under the hood, this feature spans 45 source
+files covering:
 
-**Spec completion detection**: Identify workflow specifications that appear ready for the next phase based on their current status and file contents.
+- Run via ``python -m attune.ops``.
+- Anthropic admin cost-report client.
+- CLI entrypoint for ``attune ops``.
 
-## Architecture overview
+## What connects to it
 
-The dashboard runs as a FastAPI application on `127.0.0.1:8765` by default. You start it with `python -m attune.ops` or `attune ops`.
+This feature relates to: ops, dashboard, runner, workflows, scope-picker, persistence, sse.
 
-**Configuration**: The `Config` class determines where the dashboard reads project state from, which directories to scan for specs, and operational settings like run retention and trusted hosts.
+Other parts of the codebase interact with
+ops dashboard through these interfaces:
 
-**Cost data**: `CostSummary` structures hold account-level spending data fetched from Anthropic's admin API. The `CostFetchError` class categorizes fetch failures when the API is unavailable or credentials are missing.
-
-**Workflow intelligence**: The dashboard scans your spec directories to detect completion candidates - workflows that have reached a natural stopping point and might benefit from moving to the next phase.
-
-**Telemetry**: `TelemetrySummary` aggregates request counts, costs, and savings across workflows, providing insight into which parts of your project generate the most AI activity.
-
-## Data persistence
-
-The dashboard stores operational data in your attune home directory:
-
-- Run history persists for 30 days by default (configurable via `runs_retention_days`)
-- Cost data caches to reduce API calls to Anthropic
-- Session information tracks Claude Code usage patterns
-- Spec completion dismissals remember which candidates you've already reviewed
-
-## Integration points
-
-The ops dashboard connects to several parts of the attune ecosystem:
-
-| Component | Connection | Purpose |
-|-----------|------------|---------|
-| Workflow runner | Direct execution | Run workflows from the web interface |
-| Scope picker | Feature detection | Filter workflows by project areas |
-| Anthropic API | Cost reporting | Monitor usage and spending |
-| Claude Code | Session tracking | Visibility into AI tool usage |
-| Spec detector | Completion analysis | Identify workflows ready for next phase |
-
-The dashboard serves as the operational control center, giving you a unified view of workflow execution, cost management, and project AI activity.
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `CostFetchError` | Categorized failure for cost-report fetch. | `src/attune/ops/anthropic_cost.py` |
+| `CostSummary` | Account-level cost data from the Anthropic admin cost-report. | `src/attune/ops/anthropic_cost.py` |
+| `Candidate` | One completion-candidate spec returned by the detector. | `src/attune/ops/completion_candidates.py` |
+| `Config` | Where attune ops reads project + attune state from. | `src/attune/ops/config.py` |
+| `TelemetrySummary` | — | `src/attune/ops/data.py` |

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,198 +1,142 @@
 ---
-type: reference
-name: ops-dashboard-reference
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-05-21T03:19:56.089222+00:00
-source_hash: 70c9679ee8d985ef96c30f885e28ddd1a4c9216d86c485efecac67f77809fb67
+generated_at: 2026-05-26T21:06:44.519030+00:00
+source_hash: 358cabd372029010a81638242e718fe7c18cf5e3884933957d5eb43dcf498eed
 status: generated
 ---
 
-# Operations dashboard reference
+# Ops Dashboard reference
 
-The operations dashboard provides a web interface for monitoring workflows, costs, sessions, and project specs. Access it via `python -m attune.ops` or the `attune ops` command.
+## Classes
 
-## Core classes
-
-### Configuration
-
-| Class | Description |
-|-------|-------------|
-| `Config` | Configuration for the dashboard server and project state |
-| `TrustedHostMiddleware` | Middleware that rejects requests from untrusted hosts |
-
-#### Config fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `project_root` | `Path` | | Project root directory |
-| `attune_home` | `Path` | | Attune state directory |
-| `host` | `str` | `'127.0.0.1'` | Server bind address |
-| `port` | `int` | `8765` | Server port |
-| `allow_run` | `bool` | `False` | Whether to enable workflow execution |
-| `specs_roots` | `tuple[Path, ...]` | `()` | Spec directory roots |
-| `trusted_hosts` | `tuple[str, ...]` | `()` | Allowed Host headers |
-| `runs_retention_days` | `int` | `30` | Days to retain run records |
-| `specs_candidates_enabled` | `bool` | `False` | Enable spec completion detection |
-
-#### Config properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `telemetry_path` | `Path` | Path to telemetry data file |
-| `runs_dir` | `Path` | Directory for persisted workflow runs |
-| `memory_dir` | `Path` | Memory persistence directory |
-| `sessions_dir` | `Path` | Claude sessions directory |
-
-### Cost reporting
-
-| Class | Description |
-|-------|-------------|
-| `CostSummary` | Account-level cost data from Anthropic admin API |
-| `CostFetchError` | Categorized cost fetch failure |
-
-#### CostSummary fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `today_usd` | `float` | Today's cost in USD |
-| `seven_day_usd` | `float` | Last 7 days cost |
-| `month_to_date_usd` | `float` | Month-to-date cost |
-| `thirty_day_usd` | `float` | Last 30 days cost |
-| `by_day` | `list[tuple[date, float]]` | Daily cost breakdown |
-| `by_model` | `list[tuple[str, float]]` | Cost by model |
-| `by_cost_type` | `list[tuple[str, float]]` | Cost by type |
-| `fetched_at` | `datetime` | Fetch timestamp |
-| `source` | `Literal['live', 'cached']` | Data source |
-
-#### CostFetchError fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `kind` | `CostFetchErrorKind` | Error category |
-| `message` | `str` | Error message |
-
-### Workflow execution
-
-| Class | Description |
-|-------|-------------|
-| `Run` | Single workflow execution and its broadcast state |
-| `RunnerService` | Workflow execution service with concurrency control |
-| `RunnerBusyError` | Exception raised when runner is already busy |
-
-### Sessions
-
-| Class | Description |
-|-------|-------------|
-| `Session` | Claude Code session for dashboard display |
-| `SummaryResult` | Session summary result from AI or cache |
-| `CachedSummary` | Persisted session summary with validation metadata |
-| `RedactionResult` | Outcome of content redaction |
-
-#### Session fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | `str` | Session identifier |
-| `started_at` | `str` | Start timestamp |
-| `last_activity` | `str` | Last activity timestamp |
-| `duration_seconds` | `float` | Session duration |
-| `message_count` | `int` | Number of messages |
-| `starter_prompt` | `str` | Initial prompt |
-| `source` | `str` | How session was detected |
-
-### Spec management
-
-| Class | Description |
-|-------|-------------|
-| `Candidate` | Spec completion candidate |
-| `SpecRecord` | Spec summary with phase file status |
-| `SpecPhase` | Individual phase file status |
-
-#### Candidate fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `slug` | `str` | Candidate identifier |
-| `path` | `str` | File path |
-| `current_status` | `str` | Current status |
-| `evidence` | `list[str]` | Evidence for completion |
-| `snapshot_hash` | `str` | Content hash |
-
-### Data structures
-
-| Class | Description |
-|-------|-------------|
-| `TelemetrySummary` | Aggregated usage telemetry |
-| `WorkflowEntry` | Workflow catalog entry |
-| `PathArgSpec` | CLI path argument specification |
-| `Feature` | Feature from `.help/features.yaml` |
-| `FamilyVersion` | Package version information |
+| Class | Description | File |
+|-------|-------------|------|
+| `CostFetchError` | Categorized failure for cost-report fetch. | `src/attune/ops/anthropic_cost.py` |
+| `CostSummary` | Account-level cost data from the Anthropic admin cost-report. | `src/attune/ops/anthropic_cost.py` |
+| `Candidate` | One completion-candidate spec returned by the detector. | `src/attune/ops/completion_candidates.py` |
+| `Config` | Where attune ops reads project + attune state from. | `src/attune/ops/config.py` |
+| `TelemetrySummary` | — | `src/attune/ops/data.py` |
+| `WorkflowEntry` | — | `src/attune/ops/data.py` |
+| `PathArgSpec` | How a workflow accepts a scope path on the CLI. | `src/attune/ops/data.py` |
+| `Feature` | One feature from ``.help/features.yaml`` for the scope picker. | `src/attune/ops/data.py` |
+| `Session` | One Claude Code session — what surfaces on the dashboard's /sessions page. | `src/attune/ops/data.py` |
+| `FamilyVersion` | — | `src/attune/ops/data.py` |
+| `DailyCost` | One day's cost for the home-page sparkline. | `src/attune/ops/data.py` |
+| `HomeKpis` | Summary numbers shown above the fold on the home page. | `src/attune/ops/data.py` |
+| `SweepChipCounts` | Per-bucket counts loaded from a persisted discovery-sweep result. | `src/attune/ops/data.py` |
+| `DismissEntry` | One dismissed candidate's persisted state. | `src/attune/ops/dismiss_store.py` |
+| `InteractionCounters` | Process-lifetime counters for dashboard UI interactions. | `src/attune/ops/interaction_counters.py` |
+| `TrustedHostMiddleware` | Reject requests whose ``Host`` header isn't on the allowlist. | `src/attune/ops/middleware.py` |
+| `JournalEntry` | One pending-writes journal entry. | `src/attune/ops/pending_writes.py` |
+| `InteractionEvent` | Request body for ``POST /api/telemetry/interaction``. | `src/attune/ops/routes/interaction_counters.py` |
+| `SpecPhase` | One phase file's status snapshot. | `src/attune/ops/routes/specs.py` |
+| `SpecRecord` | One spec's summary — directory + status of each phase file present. | `src/attune/ops/routes/specs.py` |
+| `RunnerBusyError` | Raised when a run is already pending/running. | `src/attune/ops/runner.py` |
+| `Run` | Single workflow execution + its broadcast state. | `src/attune/ops/runner.py` |
+| `RunnerService` | Owns the run history + concurrency lock. | `src/attune/ops/runner.py` |
+| `RedactionResult` | Outcome of a redaction pass. | `src/attune/ops/session_redaction.py` |
+| `SummaryResult` | One Haiku-or-cache result, ready to slot into a :class:`Session`. | `src/attune/ops/session_summarizer.py` |
+| `Budget` | Mutable spend ledger for one page-load summarization loop. | `src/attune/ops/session_summarizer.py` |
+| `CacheKey` | Stable key that invalidates a cached summary when the source moves. | `src/attune/ops/session_summary_cache.py` |
+| `CachedSummary` | One persisted session summary plus the metadata to validate it. | `src/attune/ops/session_summary_cache.py` |
 
 ## Functions
 
-### Application lifecycle
+| Function | Description | File |
+|----------|-------------|------|
+| `create_app()` | Lazy-import the FastAPI factory so importing attune doesn't pull FastAPI. | `src/attune/ops/__init__.py` |
+| `build_config()` | Lazy import of the config builder. | `src/attune/ops/__init__.py` |
+| `clear_cache()` | Empty the in-memory cache. Test-only convenience. | `src/attune/ops/anthropic_cost.py` |
+| `load_admin_key()` | Return the admin API key, or ``None`` if unavailable. | `src/attune/ops/anthropic_cost.py` |
+| `fetch_summary()` | Return the current cost summary or a categorized error. | `src/attune/ops/anthropic_cost.py` |
+| `add_subparser()` | Register the `ops` subparser on the main attune CLI parser. | `src/attune/ops/cli.py` |
+| `cmd_ops()` | Run the dashboard server (blocking). | `src/attune/ops/cli.py` |
+| `main()` | Standalone entry: ``python -m attune.ops``. | `src/attune/ops/cli.py` |
+| `clear_cache()` | Reset the in-memory caches. Test helper. | `src/attune/ops/completion_candidates.py` |
+| `detect_candidates()` | Return all completion candidates across the configured spec roots. | `src/attune/ops/completion_candidates.py` |
+| `attune_home()` | Resolve the user's attune home dir (env override -> ~/.attune). | `src/attune/ops/config.py` |
+| `build_config()` | Build a Config from inputs and environment defaults. | `src/attune/ops/config.py` |
+| `list_features()` | Return features parsed from ``<project_root>/.help/features.yaml``. | `src/attune/ops/data.py` |
+| `first_feature()` | Return the alphabetically-first feature with a renderable scope. | `src/attune/ops/data.py` |
+| `workflow_default_scope()` | Return the default scope for one workflow on first paint. | `src/attune/ops/data.py` |
+| `derive_project_name()` | Return a human-readable project name for the dashboard header. | `src/attune/ops/data.py` |
+| `claude_sessions_dir()` | Return the canonical directory Claude Code stores sessions for this project in. | `src/attune/ops/data.py` |
+| `enumerate_project_encoded_keys()` | Return all ``~/.claude/projects/`` dirs belonging to this logical project. | `src/attune/ops/data.py` |
+| `list_recent_sessions_with_paths()` | Same as :func:`list_recent_sessions` but also returns each | `src/attune/ops/data.py` |
+| `list_recent_sessions()` | Return Session records for this project's last ``days`` of activity. | `src/attune/ops/data.py` |
+| `home_kpis()` | Derive home-page KPIs from a telemetry summary. | `src/attune/ops/data.py` |
+| `sparkline_points()` | Render values as an SVG ``polyline`` ``points`` string. | `src/attune/ops/data.py` |
+| `read_telemetry_summary()` | Aggregate ``usage.jsonl`` into a UI-friendly summary. | `src/attune/ops/data.py` |
+| `read_sweep_chip_counts()` | Read the latest persisted sweep result for ``scope_path`` and tally chips. | `src/attune/ops/data.py` |
+| `list_workflows()` | Return the registered workflow catalog. Empty if the registry is unavailable. | `src/attune/ops/data.py` |
+| `family_versions()` | Resolve installed versions for every related attune package. | `src/attune/ops/data.py` |
+| `env_health()` | Lightweight environment snapshot for the Health page. | `src/attune/ops/data.py` |
+| `store_path()` | Return the absolute path to the dismiss-store JSON file. | `src/attune/ops/dismiss_store.py` |
+| `load()` | Read the dismiss store. Missing or corrupt file → ``{}``. | `src/attune/ops/dismiss_store.py` |
+| `save()` | Persist a dismiss entry for ``slug`` (overwrites prior entry). | `src/attune/ops/dismiss_store.py` |
+| `clear()` | Remove the entry for ``slug``. No-op if absent. | `src/attune/ops/dismiss_store.py` |
+| `is_active()` | True iff a dismiss for ``slug`` is currently suppressing it. | `src/attune/ops/dismiss_store.py` |
+| `compute_allowlist()` | Compute the default + user-supplied Host allowlist. | `src/attune/ops/middleware.py` |
+| `settings_path()` | Return the absolute path to the ops settings file. | `src/attune/ops/ops_config_store.py` |
+| `load_settings()` | Read persisted ops settings. Missing or corrupt file → ``{}``. | `src/attune/ops/ops_config_store.py` |
+| `save_setting()` | Persist a single setting; returns True on success, False on failure. | `src/attune/ops/ops_config_store.py` |
+| `resolve_specs_candidates_enabled()` | Resolve the ``specs_candidates_enabled`` setting. | `src/attune/ops/ops_config_store.py` |
+| `compute_file_sha256()` | Compute sha256 of a file's contents. | `src/attune/ops/pending_writes.py` |
+| `make_entry()` | Construct a JournalEntry, filling in defaults from runtime context. | `src/attune/ops/pending_writes.py` |
+| `append_entry()` | Append a journal entry to the JSONL journal. | `src/attune/ops/pending_writes.py` |
+| `home()` | — | `src/attune/ops/routes/dashboard.py` |
+| `workflows_page()` | — | `src/attune/ops/routes/dashboard.py` |
+| `telemetry_page()` | — | `src/attune/ops/routes/dashboard.py` |
+| `health_page()` | — | `src/attune/ops/routes/dashboard.py` |
+| `sessions_page()` | Sessions page — recent Claude Code sessions for this project. | `src/attune/ops/routes/dashboard.py` |
+| `run_view_page()` | Full-page view for one workflow run. | `src/attune/ops/routes/dashboard.py` |
+| `specs_page()` | Specs tab — federated listing of all specs across configured roots. | `src/attune/ops/routes/dashboard.py` |
+| `spec_detail_page()` | Drill-in for a single spec: show every phase file's content (read-only). | `src/attune/ops/routes/dashboard.py` |
+| `record_interaction()` | Increment a UI interaction counter. | `src/attune/ops/routes/interaction_counters.py` |
+| `read_interactions()` | Return the full counter snapshot + per-event totals. | `src/attune/ops/routes/interaction_counters.py` |
+| `list_pending_writes()` | Return all journal entries enriched with computed status fields. | `src/attune/ops/routes/pending_writes.py` |
+| `start_run()` | — | `src/attune/ops/routes/runner.py` |
+| `get_run()` | — | `src/attune/ops/routes/runner.py` |
+| `stream_run()` | — | `src/attune/ops/routes/runner.py` |
+| `list_runs()` | Return up to 20 newest runs for ``workflow``, newest first. | `src/attune/ops/routes/runs_history.py` |
+| `get_run_record()` | Return one persisted run record (metadata + log). | `src/attune/ops/routes/runs_history.py` |
+| `enrich_with_summaries()` | Public helper used by both the JSON route and the HTML page. | `src/attune/ops/routes/sessions.py` |
+| `list_sessions()` | ``GET /api/sessions`` — JSON listing of recent sessions. | `src/attune/ops/routes/sessions.py` |
+| `list_specs()` | Federated listing across all configured spec roots. | `src/attune/ops/routes/specs.py` |
+| `list_completion_candidates()` | Return "Ready to close?" candidates for the Specs page. | `src/attune/ops/routes/specs.py` |
+| `get_spec()` | Return phase-file contents for one spec. | `src/attune/ops/routes/specs.py` |
+| `update_phase_status()` | Rewrite the ``**Status**`` line in the named phase file. | `src/attune/ops/routes/specs.py` |
+| `dismiss_completion_candidate()` | Suppress a completion candidate for the default TTL (14 days). | `src/attune/ops/routes/specs.py` |
+| `get_sweep_result()` | Return the latest sweep result for a scope-hash, or 404. | `src/attune/ops/routes/sweep_results.py` |
+| `get_sweep_chips()` | Return chip counts for an arbitrary scope path. | `src/attune/ops/routes/sweep_results.py` |
+| `sweep_detail_page()` | Scope-keyed detail page for the latest discovery-sweep result. | `src/attune/ops/routes/sweep_results.py` |
+| `echo_command_builder()` | Test helper: produce a portable subprocess that prints two lines + exits 0. | `src/attune/ops/runner.py` |
+| `prune_old_runs()` | Delete persisted run files older than ``days``. Returns the deletion count. | `src/attune/ops/runner.py` |
+| `create_app()` | Build the FastAPI app, wiring config + templates into request state. | `src/attune/ops/server.py` |
+| `redact()` | Run all redaction passes over ``text`` and return the result. | `src/attune/ops/session_redaction.py` |
+| `redact_json_line()` | Redact one JSON-serialized line in-place, preserving structure. | `src/attune/ops/session_redaction.py` |
+| `new_budget()` | Build a :class:`Budget` from the env override or default. | `src/attune/ops/session_summarizer.py` |
+| `llm_enabled()` | Return True iff the Haiku path is enabled this run. | `src/attune/ops/session_summarizer.py` |
+| `summarize_session()` | Return a Haiku-or-cached summary for one session JSONL. | `src/attune/ops/session_summarizer.py` |
+| `compute_cache_key()` | Build a :class:`CacheKey` for one JSONL file. ``None`` on I/O failure. | `src/attune/ops/session_summary_cache.py` |
+| `cache_path_for()` | Return the on-disk cache path for one session id. | `src/attune/ops/session_summary_cache.py` |
+| `load()` | Return the cached summary iff the on-disk record matches ``expected``. | `src/attune/ops/session_summary_cache.py` |
+| `save()` | Write a summary to the on-disk cache, atomically. | `src/attune/ops/session_summary_cache.py` |
+| `is_persistence_enabled()` | True when ``ATTUNE_OPS_SWEEP_RESULTS`` is set to a non-empty value. | `src/attune/ops/sweep_results.py` |
+| `results_dir()` | Return ``<attune_home>/ops/sweep-results/`` (created if missing). | `src/attune/ops/sweep_results.py` |
+| `scope_hash()` | Hash a scope path to a fixed-length hex identifier. | `src/attune/ops/sweep_results.py` |
+| `parse_lines()` | Parse a captured stdout buffer into the final SweepResult JSON. | `src/attune/ops/sweep_results.py` |
+| `persist_result()` | Atomically write ``sweep_result`` to ``<results_dir>/<hash>.json``. | `src/attune/ops/sweep_results.py` |
+| `read_result()` | Read a previously-persisted result by its scope-hash digest. | `src/attune/ops/sweep_results.py` |
+| `persist_from_lines()` | Parse captured stdout lines and persist the result for ``scope_path``. | `src/attune/ops/sweep_results.py` |
+| `watch_and_persist()` | Subscribe to a discovery-sweep run; persist its result on success. | `src/attune/ops/sweep_results_watcher.py` |
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `create_app` | `*args, **kwargs` | | Lazy FastAPI application factory |
-| `build_config` | `*args, **kwargs` | | Configuration builder |
-| `main` | | `int` | Standalone entry point |
-| `cmd_ops` | `args: argparse.Namespace` | `int` | CLI command handler |
 
-### Cost reporting
+## Source files
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `load_admin_key` | | `str \| None` | Load Anthropic admin API key |
-| `fetch_summary` | `*, refresh: bool = False` | `tuple[CostSummary \| None, CostFetchError \| None]` | Fetch current cost summary |
-| `clear_cache` | | `None` | Clear cost cache |
+- `src/attune/ops/**`
 
-### Spec detection
+## Tags
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `detect_candidates` | `config: Config, *, now: float \| None = None` | `list[Candidate]` | Find spec completion candidates |
-| `clear_cache` | | `None` | Reset candidate cache |
-
-### Data access
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `list_features` | | | Parse features from `.help/features.yaml` |
-| `list_recent_sessions` | | | Recent Claude Code sessions |
-| `read_telemetry_summary` | | | Aggregate usage telemetry |
-| `list_workflows` | | | Available workflow catalog |
-| `family_versions` | | | Installed package versions |
-
-## Constants
-
-### API configuration
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `_COST_REPORT_URL` | `'https://api.anthropic.com/v1/organizations/cost_report'` | Anthropic cost API endpoint |
-| `_API_VERSION` | `'2023-06-01'` | API version header |
-
-### File patterns
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `_PR_REF_FILES` | `('decisions.md', 'tasks.md')` | Pull request reference files |
-| `_PHASE_FILES` | `('decisions.md', 'requirements.md', 'design.md', 'tasks.md')` | Spec phase files |
-| `STORE_FILENAME` | `'spec_completion_dismissed.json'` | Dismissal store file |
-| `SETTINGS_FILENAME` | `'config.json'` | Settings file |
-
-### Status values
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `_VALID_STATUSES` | `('draft', 'in-review', 'approved', 'complete', 'completed', 'done')` | Valid spec statuses |
-| `_COMPLETE_LIKE_STATUSES` | `{'complete', 'completed', 'done'}` | Completion status variants |
-| `_VALID_BUCKETS` | `('queue', 'questions', 'rejected')` | Valid spec buckets |
-
-### UI events
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `EVENTS` | `('pill_click', 'rec_card_click', 'scope_picker_change')` | Tracked UI interactions |
+`ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,102 +1,57 @@
 ---
-type: task
-name: ops-dashboard-task
 feature: ops-dashboard
 depth: task
-generated_at: 2026-05-21T03:19:56.082581+00:00
-source_hash: 70c9679ee8d985ef96c30f885e28ddd1a4c9216d86c485efecac67f77809fb67
+generated_at: 2026-05-26T21:06:44.514298+00:00
+source_hash: 358cabd372029010a81638242e718fe7c18cf5e3884933957d5eb43dcf498eed
 status: generated
 ---
 
 # Work with ops dashboard
 
-Use the ops dashboard when you need to monitor workflow operations, track costs, or manage running processes through a local web interface with real-time updates.
+Use ops dashboard when you need to local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live sse log streaming.
 
 ## Prerequisites
 
-- Python environment with attune installed
-- Access to the project source code in `src/attune/ops/`
-- Admin API key for Anthropic cost reporting (optional, for cost features)
+- Access to the project source code
+- Familiarity with the files under src/attune/ops/**
 
-## Start the dashboard
+## Steps
 
-1. **Launch the dashboard server.**
-   Run the ops dashboard from your project root:
-   ```bash
-   python -m attune.ops
-   ```
-   Or use the CLI subcommand:
-   ```bash
-   attune ops
-   ```
+1. **Understand the current behavior.**
+   Read the entry points to see what ops dashboard
+   does today before making changes.
+   The primary functions are:
+   - `create_app()` in `src/attune/ops/__init__.py` — Lazy-import the FastAPI factory so importing attune doesn't pull FastAPI.
+   - `build_config()` in `src/attune/ops/__init__.py` — Lazy import of the config builder.
+   - `clear_cache()` in `src/attune/ops/anthropic_cost.py` — Empty the in-memory cache. Test-only convenience.
+   - `load_admin_key()` in `src/attune/ops/anthropic_cost.py` — Return the admin API key, or ``None`` if unavailable.
+   - `fetch_summary()` in `src/attune/ops/anthropic_cost.py` — Return the current cost summary or a categorized error.
+2. **Locate the right function to change.**
+   Each function has a single responsibility. Read its
+   docstring, parameters, and return type to confirm it
+   owns the behavior you need to modify.
 
-2. **Access the web interface.**
-   Open `http://127.0.0.1:8765` in your browser. The dashboard loads with:
-   - Workflow runner with scope picker
-   - Cost tracking from Anthropic admin API
-   - Session history and telemetry
-   - Real-time SSE log streaming
+3. **Make your change.**
+   Follow existing patterns in the file — naming
+   conventions, error handling style, and logging.
 
-3. **Configure dashboard settings.**
-   Modify the dashboard configuration by editing the config parameters:
-   - Host and port: Default `127.0.0.1:8765`
-   - Project root: Auto-detected from current directory
-   - Spec roots: Configured via `Config.specs_roots`
-   - Retention policy: `runs_retention_days` (default 30)
+4. **Run the related tests.**
+   This catches regressions before they reach other
+   developers. Target with `pytest -k "ops-dashboard"`.
 
-## Monitor costs and usage
+## Key files
 
-1. **View cost summaries.**
-   Check the cost panel for:
-   - Today's usage in USD
-   - 7-day and 30-day trends
-   - Month-to-date totals
-   - Breakdown by model and cost type
+- `src/attune/ops/**`
 
-2. **Handle cost fetch errors.**
-   If cost data fails to load, check:
-   - Admin API key availability via `load_admin_key()`
-   - Network connectivity to `api.anthropic.com`
-   - API rate limits and authentication
+## Common modifications
 
-3. **Clear cached data.**
-   Reset cost cache when testing or troubleshooting:
-   ```python
-   from attune.ops.anthropic_cost import clear_cache
-   clear_cache()
-   ```
+Functions you are most likely to modify:
 
-## Track workflow sessions
-
-1. **Review session history.**
-   The sessions page shows:
-   - Claude Code session IDs and timestamps
-   - Message counts and duration
-   - Starting prompts and activity patterns
-
-2. **Analyze telemetry data.**
-   Check telemetry summaries for:
-   - Total requests and costs
-   - Cost savings from workflow optimization
-   - Usage patterns by workflow type
-   - Daily activity trends
-
-## Detect completion candidates
-
-1. **Enable candidate detection.**
-   Set `specs_candidates_enabled: true` in your config to scan for specs ready for completion.
-
-2. **Review detected candidates.**
-   The dashboard identifies specs with:
-   - Status progression indicators
-   - Evidence of completion readiness
-   - Current phase and next steps
-
-## Verification
-
-The ops dashboard is working correctly when:
-- Web interface loads at the configured host/port
-- Cost data appears (if admin key is configured)
-- Workflow scope picker shows your project features
-- Session history displays recent Claude Code activity
-- Real-time logs stream during workflow execution
+- `create_app()` in `src/attune/ops/__init__.py`
+- `build_config()` in `src/attune/ops/__init__.py`
+- `clear_cache()` in `src/attune/ops/anthropic_cost.py`
+- `load_admin_key()` in `src/attune/ops/anthropic_cost.py`
+- `fetch_summary()` in `src/attune/ops/anthropic_cost.py`
+- `add_subparser()` in `src/attune/ops/cli.py`
+- `cmd_ops()` in `src/attune/ops/cli.py`
+- `main()` in `src/attune/ops/cli.py`

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -26,7 +26,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
+from attune.bulletin import BulletinBackend, BulletinEntry, resolve_actor
+from attune.bulletin.protocol import ActorKind
+
 logger = logging.getLogger(__name__)
+
+# Heartbeat cadence (seconds) — matches the bulletin's 90s stale GC
+# threshold; missing 3 ticks marks an actor dead. Lives in the wrapper
+# process per multi-actor-bulletin/decisions.md so blocked SDK calls
+# inside a workflow don't look like crashes to other actors.
+_BULLETIN_HEARTBEAT_INTERVAL_SEC = 30.0
 
 # Log-byte cap for persisted records. Records with logs larger than this
 # get truncated and a trailing ``<TRUNCATED — N bytes more>`` marker is
@@ -287,6 +296,9 @@ class RunnerService:
         executor: Callable[[Run], Awaitable[None]] | None = None,
         persistence_dir: Path | None = None,
         project_root: Path | None = None,
+        bulletin: BulletinBackend | None = None,
+        actor_id: str | None = None,
+        actor_kind: ActorKind = "dashboard",
     ) -> None:
         self._runs: OrderedDict[str, Run] = OrderedDict()
         self._history_limit = history_limit
@@ -301,6 +313,17 @@ class RunnerService:
         # the SSE channel; production wiring in ``server.py`` always
         # supplies it.
         self._project_root = project_root
+        # Bulletin wiring. ``bulletin=None`` disables all writes — the
+        # runner behaves exactly as before. Production server.py wires
+        # a FileBulletinBackend; tests inject a fake to assert calls.
+        self._bulletin = bulletin
+        if actor_id is None:
+            actor_id, _ = resolve_actor(actor_kind=actor_kind)
+        self._actor_id = actor_id
+        self._actor_kind: ActorKind = actor_kind
+        # Maps run_id -> heartbeat asyncio task so _finish_run can
+        # cancel cleanly. Pruned when the task is cancelled.
+        self._heartbeat_tasks: dict[str, asyncio.Task[None]] = {}
 
     @property
     def persistence_dir(self) -> Path | None:
@@ -507,6 +530,9 @@ class RunnerService:
             self._runs[run.id] = run
             while len(self._runs) > self._history_limit:
                 self._runs.popitem(last=False)
+        # Bulletin start record. Errors swallowed by the backend — never
+        # blocks workflow start. See multi-actor-bulletin spec.
+        self._bulletin_write(run, "running")
         # Fire and forget — execution streams events via the run's subscribers
         asyncio.create_task(self._executor(run))
         return run
@@ -523,10 +549,69 @@ class RunnerService:
         run.mark_done(exit_code)
         if self._persistence_dir is not None:
             _persist_run(run, self._persistence_dir)
+        # Cancel the wrapper-process heartbeat task (no-op if absent).
+        task = self._heartbeat_tasks.pop(run.id, None)
+        if task is not None:
+            task.cancel()
+        # Write the terminal bulletin record. ``mark_done`` already set
+        # status to ``completed`` or ``failed``.
+        self._bulletin_write(run, run.status)
+
+    def _bulletin_write(self, run: Run, status: str) -> None:
+        """Best-effort bulletin write — never raises to the caller.
+
+        ``status`` is one of ``running``, ``completed``, ``failed``,
+        ``cancelled``. ``mark_done`` only produces ``completed`` or
+        ``failed``; the runner doesn't emit ``cancelled`` today, but
+        the bulletin entry schema accepts it for future use.
+        """
+        if self._bulletin is None:
+            return
+        coerced_status = (
+            status if status in ("running", "completed", "failed", "cancelled") else "running"
+        )
+        try:
+            self._bulletin.append(
+                BulletinEntry(
+                    actor_id=self._actor_id,
+                    actor_kind=self._actor_kind,
+                    workflow=run.workflow,
+                    run_id=run.id,
+                    current_status=coerced_status,  # type: ignore[arg-type]
+                    scope=run.path,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            # INTENTIONAL: bulletin is advisory; backend bugs must not
+            # take down a workflow run. Log and continue.
+            logger.warning("bulletin: write failed for run %s: %s", run.id, exc)
+
+    async def _heartbeat_loop(self, run: Run) -> None:
+        """Tick every ``_BULLETIN_HEARTBEAT_INTERVAL_SEC`` until cancelled.
+
+        Lives in the wrapper process (this method), not inside the
+        workflow loop — so an SDK call blocking >60s inside the
+        subprocess doesn't look like a crash to other actors. See
+        multi-actor-bulletin/decisions.md.
+        """
+        try:
+            while True:
+                await asyncio.sleep(_BULLETIN_HEARTBEAT_INTERVAL_SEC)
+                if run.is_terminal:
+                    return
+                self._bulletin_write(run, "running")
+        except asyncio.CancelledError:
+            # Normal path: _finish_run cancels us at terminal status.
+            raise
 
     async def _execute(self, run: Run) -> None:
         run.status = "running"
         run.started_at = datetime.now(timezone.utc)
+        # Start the wrapper-process heartbeat. ``None`` when the
+        # bulletin isn't wired — keeps test fixtures and read-only
+        # mode behaving exactly as before.
+        if self._bulletin is not None:
+            self._heartbeat_tasks[run.id] = asyncio.create_task(self._heartbeat_loop(run))
         cmd = list(self._command_builder(run.workflow))
         # Append ``--path <scope>`` after the builder's output so test
         # fixtures (with simple ``workflow -> command`` signatures) don't

--- a/tests/unit/ops/test_runner_bulletin.py
+++ b/tests/unit/ops/test_runner_bulletin.py
@@ -1,0 +1,291 @@
+"""Bulletin wiring tests for RunnerService.
+
+Verifies the integration with the multi-actor-bulletin module:
+
+- ``bulletin=None`` (default) preserves existing behavior exactly
+- start() writes a ``running`` entry when bulletin is wired
+- _finish_run() writes a terminal entry (``completed`` / ``failed``)
+- A heartbeat asyncio task lives in the wrapper process while running
+- The heartbeat task is cancelled when the run terminates
+- Bulletin backend exceptions never propagate out of the runner
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from attune.bulletin import BulletinEntry
+from attune.ops.runner import RunnerService, echo_command_builder
+
+
+class _FakeBulletin:
+    """Records every ``append`` call so tests can assert on the stream."""
+
+    def __init__(self) -> None:
+        self.entries: list[BulletinEntry] = []
+        self.raise_on_next: Exception | None = None
+
+    def append(self, entry: BulletinEntry) -> None:
+        if self.raise_on_next is not None:
+            exc = self.raise_on_next
+            self.raise_on_next = None
+            raise exc
+        self.entries.append(entry)
+
+    def read_active(self, *, stale_after_seconds: float = 90.0) -> list[BulletinEntry]:
+        return list(self.entries)
+
+    @property
+    def statuses(self) -> list[str]:
+        return [e.current_status for e in self.entries]
+
+    @property
+    def run_ids(self) -> list[str]:
+        return [e.run_id for e in self.entries]
+
+
+# ---------------------------------------------------------------------------
+# bulletin=None preserves existing behavior
+# ---------------------------------------------------------------------------
+
+
+class TestBulletinDisabled:
+    @pytest.mark.asyncio
+    async def test_no_bulletin_runs_complete_normally(self) -> None:
+        runner = RunnerService(command_builder=echo_command_builder)
+        run = await runner.start("noop")
+        # Wait for the executor task to finish.
+        await _wait_for_terminal(runner, run.id)
+        assert run.status == "completed"
+        assert run.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_no_bulletin_no_heartbeat_task(self) -> None:
+        runner = RunnerService(command_builder=echo_command_builder)
+        run = await runner.start("noop")
+        # No heartbeat task should have been registered.
+        assert run.id not in runner._heartbeat_tasks
+        await _wait_for_terminal(runner, run.id)
+
+
+# ---------------------------------------------------------------------------
+# start() and _finish_run() bulletin writes
+# ---------------------------------------------------------------------------
+
+
+class TestStartAndFinishWrites:
+    @pytest.mark.asyncio
+    async def test_start_writes_running_entry(self) -> None:
+        bulletin = _FakeBulletin()
+        runner = RunnerService(
+            command_builder=echo_command_builder,
+            bulletin=bulletin,
+            actor_id="test-actor",
+        )
+        run = await runner.start("noop")
+        # The "running" record is the first entry.
+        assert bulletin.statuses[0] == "running"
+        assert bulletin.entries[0].run_id == run.id
+        assert bulletin.entries[0].actor_id == "test-actor"
+        assert bulletin.entries[0].workflow == "noop"
+        await _wait_for_terminal(runner, run.id)
+
+    @pytest.mark.asyncio
+    async def test_finish_writes_completed_entry(self) -> None:
+        bulletin = _FakeBulletin()
+        runner = RunnerService(
+            command_builder=echo_command_builder,
+            bulletin=bulletin,
+            actor_id="test-actor",
+        )
+        run = await runner.start("noop")
+        await _wait_for_terminal(runner, run.id)
+        # Last entry for this run_id should be terminal.
+        terminal = [e for e in bulletin.entries if e.run_id == run.id][-1]
+        assert terminal.current_status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_failed_run_writes_failed_entry(self) -> None:
+        bulletin = _FakeBulletin()
+
+        def _failing_command(_workflow: str) -> tuple[str, ...]:
+            import sys
+
+            return (sys.executable, "-c", "import sys; sys.exit(1)")
+
+        runner = RunnerService(
+            command_builder=_failing_command,
+            bulletin=bulletin,
+            actor_id="test-actor",
+        )
+        run = await runner.start("noop")
+        await _wait_for_terminal(runner, run.id)
+        terminal = [e for e in bulletin.entries if e.run_id == run.id][-1]
+        assert terminal.current_status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_scope_propagated_to_bulletin(self) -> None:
+        bulletin = _FakeBulletin()
+        runner = RunnerService(
+            command_builder=echo_command_builder,
+            bulletin=bulletin,
+            actor_id="test-actor",
+        )
+        run = await runner.start("noop", path="src/attune/ops/")
+        await _wait_for_terminal(runner, run.id)
+        # Every entry for the run should carry the scope.
+        for entry in bulletin.entries:
+            if entry.run_id == run.id:
+                assert entry.scope == "src/attune/ops/"
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat task lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeat:
+    @pytest.mark.asyncio
+    async def test_heartbeat_task_created_on_execute(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The heartbeat task is registered before the subprocess starts."""
+        bulletin = _FakeBulletin()
+        # Build a runner with a fake executor that pauses long enough
+        # for us to observe the heartbeat task being registered.
+        observed: dict[str, Any] = {}
+
+        async def _slow_executor(run: Any) -> None:
+            run.status = "running"
+            # Register a heartbeat manually inline so we mirror what
+            # _execute does. But we want to test that _execute itself
+            # registers — so just call the real _execute on a script
+            # that's slow enough to observe.
+            ...
+
+        # Use the real _execute with a slow command instead.
+        import sys
+
+        def _slow_command(_workflow: str) -> tuple[str, ...]:
+            return (sys.executable, "-c", "import time; time.sleep(0.5); print('done')")
+
+        runner = RunnerService(
+            command_builder=_slow_command,
+            bulletin=bulletin,
+            actor_id="test-actor",
+        )
+        run = await runner.start("noop")
+        # Give the executor a moment to register the heartbeat task.
+        await asyncio.sleep(0.05)
+        observed["registered"] = run.id in runner._heartbeat_tasks
+        await _wait_for_terminal(runner, run.id)
+        assert observed["registered"] is True
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_task_cancelled_on_finish(self) -> None:
+        """After terminal status, the heartbeat task is gone."""
+        bulletin = _FakeBulletin()
+        runner = RunnerService(
+            command_builder=echo_command_builder,
+            bulletin=bulletin,
+            actor_id="test-actor",
+        )
+        run = await runner.start("noop")
+        await _wait_for_terminal(runner, run.id)
+        assert run.id not in runner._heartbeat_tasks
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop_writes_when_ticking(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct-drive the heartbeat loop with patched sleep."""
+        bulletin = _FakeBulletin()
+        runner = RunnerService(bulletin=bulletin, actor_id="test-actor")
+
+        # Manually construct a Run we can drive (don't start a subprocess).
+        from attune.ops.runner import Run
+
+        run = Run(id="abc123", workflow="noop")
+        run.status = "running"
+
+        # Patch asyncio.sleep so the loop ticks instantly. After three
+        # ticks, mark the run terminal so the loop returns cleanly.
+        tick_count = {"n": 0}
+        original_sleep = asyncio.sleep
+
+        async def _fast_sleep(_seconds: float) -> None:
+            tick_count["n"] += 1
+            if tick_count["n"] >= 3:
+                run.mark_done(0)
+            # Yield once to let the loop iterate.
+            await original_sleep(0)
+
+        monkeypatch.setattr("attune.ops.runner.asyncio.sleep", _fast_sleep)
+
+        await runner._heartbeat_loop(run)
+        # The heartbeat should have written at least two "running" entries
+        # (the third tick saw a terminal run and returned without writing).
+        running_writes = [e for e in bulletin.entries if e.current_status == "running"]
+        assert len(running_writes) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Bulletin failure is non-fatal
+# ---------------------------------------------------------------------------
+
+
+class TestFailureToleration:
+    @pytest.mark.asyncio
+    async def test_bulletin_exception_doesnt_kill_run(self) -> None:
+        """Backend bug must not propagate — bulletin is advisory."""
+        bulletin = _FakeBulletin()
+        bulletin.raise_on_next = RuntimeError("backend exploded")
+        runner = RunnerService(
+            command_builder=echo_command_builder,
+            bulletin=bulletin,
+            actor_id="test-actor",
+        )
+        # start() invokes _bulletin_write which would raise without
+        # the try/except guard. Must not raise.
+        run = await runner.start("noop")
+        await _wait_for_terminal(runner, run.id)
+        assert run.status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Actor identity
+# ---------------------------------------------------------------------------
+
+
+class TestActorIdentity:
+    def test_explicit_actor_id_used(self) -> None:
+        bulletin = _FakeBulletin()
+        runner = RunnerService(bulletin=bulletin, actor_id="explicit-id", actor_kind="cli")
+        assert runner._actor_id == "explicit-id"
+        assert runner._actor_kind == "cli"
+
+    def test_default_resolves_to_dashboard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No CLAUDE_CODE_SESSION_ID env — the dashboard fallback fires.
+        monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+        bulletin = _FakeBulletin()
+        runner = RunnerService(bulletin=bulletin)
+        assert runner._actor_kind == "dashboard"
+        assert runner._actor_id.startswith("dashboard-")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for_terminal(runner: RunnerService, run_id: str, timeout: float = 5.0) -> None:
+    """Spin until the named run reaches a terminal status."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        run = runner.get(run_id)
+        if run is not None and run.is_terminal:
+            return
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError(f"run {run_id} did not terminate within {timeout}s")
+        await asyncio.sleep(0.02)


### PR DESCRIPTION
## Summary

Phase 1 Task 3 of [`multi-actor-bulletin`](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/multi-actor-bulletin). Wires the dashboard's `RunnerService` into the bulletin so every workflow start/heartbeat/finish is observable to other actors.

- `RunnerService.__init__` gains `bulletin`, `actor_id`, `actor_kind` params (all optional; default `bulletin=None` preserves existing behavior)
- `start()` writes a `"running"` entry on each successful `Run` creation
- `_finish_run()` cancels the heartbeat task + writes a terminal entry
- `_bulletin_write()` helper guards every backend call with try/except — bulletin remains advisory and cannot crash a workflow
- `_heartbeat_loop()` lives in the wrapper process per [`decisions.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/multi-actor-bulletin/decisions.md) — ticks every 30s, cancels cleanly on terminal status, immune to blocked SDK calls inside the workflow subprocess

## Scoped down deliberately

What's NOT in this PR (intentionally separate):
- `server.py` wiring (the dashboard runner doesn't construct a `FileBulletinBackend` yet — keeping this PR purely additive at the `RunnerService` layer; server wiring is a 5-line follow-up)
- CLI dispatcher integration (separate spec task)
- Dashboard "Now running across actors" strip (Phase 1 Task 4)

Keeping each layer in its own PR so any rollback is surgical.

## Test plan

- [x] `pytest tests/unit/ops/test_runner_bulletin.py` → 12 new tests pass
- [x] `pytest tests/unit/ops/test_runner.py` → 25 existing tests pass (zero regressions)
- [x] `ruff check src/attune/ops/runner.py tests/unit/ops/test_runner_bulletin.py` → clean
- [x] Pre-commit hooks pass
- [ ] CI green across all OS/Python lanes

## Heartbeat behavior verified

- Registered on `_execute()` entry when bulletin is wired
- Cancelled by `_finish_run()` at terminal status (no orphan tasks)
- Loop returns cleanly on `asyncio.CancelledError`
- Run's `is_terminal` checked each tick to avoid post-finish writes
- Backend exceptions logged + swallowed by `_bulletin_write()` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
