### PR TITLE
feat(ops/server): construct FileBulletinBackend in writeable runners

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5768,3 +5768,37 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   red on the same commit, cross-reference PyPI release
   timestamps for deps in the failing test's stack. Companion to
   the existing "matrix-wide red from one root cause" lesson.
+
+- **Cross-platform concurrent file appends — pick the
+  mechanism by platform reach, encode the trade-off in
+  tests**: the spec for `multi-actor-bulletin` called for
+  `fcntl` advisory locks on each append. `fcntl` is
+  POSIX-only — wiring it would make the bulletin a no-op
+  on Windows. The cross-platform alternative is POSIX
+  `O_APPEND` atomicity: writes ≤ `PIPE_BUF` (typically
+  4096B) on the same append-mode fd are guaranteed atomic
+  on POSIX, and "best-effort" on Windows (occasional
+  malformed lines, not corruption — readers tolerate the
+  skip). When the entries are well under the cap (~250-
+  400B for bulletin records), `O_APPEND` is the right
+  choice for any advisory-not-strict logger. **Encode the
+  platform difference in the test**: a single
+  "concurrent-writers don't lose entries" assertion that
+  passes 100% delivery on POSIX but allows <10% loss on
+  Windows. Splitting via `sys.platform == "win32"` is the
+  honest way to document the contract. PR #474's Windows
+  lane caught the trade-off exactly as the PR body
+  predicted (4/100 entries lost); the fix was a 30-line
+  test split that landed in the same PR. Reaching for a
+  real file-lock dep (`portalocker`, `filelock`) is the
+  fallback only when the operation's correctness depends
+  on strict delivery; for advisory logs (heartbeats,
+  metrics, debug events), `O_APPEND` + platform-split test
+  is cleaner. Pairs with the existing "Path.rename fails
+  on Windows when target exists" lesson — same shape
+  (POSIX-vs-Windows semantic divergence in stdlib file
+  ops), different mechanism. Bonus consequence: when
+  diverging from a spec for cross-platform reasons,
+  document the divergence in the PR body BEFORE pushing,
+  then let CI surface the predicted trade-off — the
+  divergence becomes self-validating.

--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-05-26T21:06:44.507101+00:00
-source_hash: 358cabd372029010a81638242e718fe7c18cf5e3884933957d5eb43dcf498eed
+generated_at: 2026-05-26T21:24:05.329875+00:00
+source_hash: 1e99b94aaa6cb25d1a8177ca5ac28496f3fbd5498c6aea2873c19d7fdab748f0
 status: generated
 ---
 

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-05-26T21:06:44.519030+00:00
-source_hash: 358cabd372029010a81638242e718fe7c18cf5e3884933957d5eb43dcf498eed
+generated_at: 2026-05-26T21:24:05.340959+00:00
+source_hash: 1e99b94aaa6cb25d1a8177ca5ac28496f3fbd5498c6aea2873c19d7fdab748f0
 status: generated
 ---
 

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: task
-generated_at: 2026-05-26T21:06:44.514298+00:00
-source_hash: 358cabd372029010a81638242e718fe7c18cf5e3884933957d5eb43dcf498eed
+generated_at: 2026-05-26T21:24:05.336270+00:00
+source_hash: 1e99b94aaa6cb25d1a8177ca5ac28496f3fbd5498c6aea2873c19d7fdab748f0
 status: generated
 ---
 

--- a/src/attune/ops/config.py
+++ b/src/attune/ops/config.py
@@ -54,6 +54,11 @@ class Config:
     def sessions_dir(self) -> Path:
         return self.attune_home / "sessions"
 
+    @property
+    def bulletin_dir(self) -> Path:
+        """Directory for the multi-actor bulletin's active log + archive."""
+        return self.attune_home / "bulletin"
+
 
 def attune_home() -> Path:
     """Resolve the user's attune home dir (env override -> ~/.attune)."""

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -11,6 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from attune import __version__
+from attune.bulletin import FileBulletinBackend
 from attune.ops import sweep_results as sweep_results_mod
 from attune.ops.config import Config
 from attune.ops.interaction_counters import InteractionCounters
@@ -36,12 +37,16 @@ def _build_default_runner(config: Config) -> RunnerService:
 
     Read-only mode (``allow_run=False``) disables disk writes entirely —
     a read-only dashboard should not modify the user's ``~/.attune``.
+    The bulletin is only wired in writeable mode for the same reason.
     """
     if not config.allow_run:
         return RunnerService(project_root=config.project_root)
+    bulletin = FileBulletinBackend(config.bulletin_dir)
     return RunnerService(
         persistence_dir=config.runs_dir,
         project_root=config.project_root,
+        bulletin=bulletin,
+        actor_kind="dashboard",
     )
 
 

--- a/tests/unit/ops/test_server_bulletin_wiring.py
+++ b/tests/unit/ops/test_server_bulletin_wiring.py
@@ -1,0 +1,53 @@
+"""Server-layer bulletin wiring tests.
+
+Covers ``_build_default_runner`` and ``Config.bulletin_dir`` —
+the production glue that lets the dashboard write multi-actor
+bulletin entries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.bulletin import FileBulletinBackend
+from attune.ops.config import Config
+from attune.ops.server import _build_default_runner
+
+
+def _make_config(*, allow_run: bool, attune_home: Path, project_root: Path) -> Config:
+    return Config(
+        project_root=project_root,
+        attune_home=attune_home,
+        allow_run=allow_run,
+    )
+
+
+class TestBulletinDir:
+    def test_bulletin_dir_under_attune_home(self, tmp_path: Path) -> None:
+        cfg = _make_config(allow_run=True, attune_home=tmp_path / "ah", project_root=tmp_path)
+        assert cfg.bulletin_dir == tmp_path / "ah" / "bulletin"
+
+
+class TestBuildDefaultRunner:
+    def test_writeable_mode_constructs_bulletin(self, tmp_path: Path) -> None:
+        """The dashboard runner gets a FileBulletinBackend in writeable mode."""
+        cfg = _make_config(allow_run=True, attune_home=tmp_path / "ah", project_root=tmp_path)
+        runner = _build_default_runner(cfg)
+        # The bulletin was wired and points at the right directory.
+        assert isinstance(runner._bulletin, FileBulletinBackend)
+        assert runner._bulletin._root == cfg.bulletin_dir
+        # Actor identity defaults to the dashboard shape.
+        assert runner._actor_kind == "dashboard"
+        assert runner._actor_id.startswith("dashboard-")
+
+    def test_read_only_mode_skips_bulletin(self, tmp_path: Path) -> None:
+        """Read-only mode must not touch the user's ~/.attune directory."""
+        cfg = _make_config(allow_run=False, attune_home=tmp_path / "ah", project_root=tmp_path)
+        runner = _build_default_runner(cfg)
+        assert runner._bulletin is None
+
+    def test_writeable_runner_keeps_persistence_dir(self, tmp_path: Path) -> None:
+        """Existing persistence wiring is preserved alongside the bulletin."""
+        cfg = _make_config(allow_run=True, attune_home=tmp_path / "ah", project_root=tmp_path)
+        runner = _build_default_runner(cfg)
+        assert runner.persistence_dir == cfg.runs_dir


### PR DESCRIPTION
## Summary

Activates the dormant bulletin wiring from [#476](https://github.com/Smart-AI-Memory/attune-ai/pull/476). The dashboard runner now writes its in-flight workflows to the multi-actor bulletin so other actors (CLI, other Claude Code sessions, scheduled tasks) can see what's running across the host.

- `Config.bulletin_dir` → `<attune_home>/bulletin/`
- `_build_default_runner` constructs a `FileBulletinBackend` and passes it to `RunnerService` with `actor_kind="dashboard"`
- Read-only mode (`allow_run=False`) keeps `bulletin=None` — a read-only dashboard must not touch `~/.attune`

## Phase 1 status

| # | Task | State |
|---|---|---|
| 1 | Protocol + file backend | ✅ #474 |
| 2 | Actor-ID resolver | ✅ #474 |
| 3 | RunnerService wiring | ✅ #476 |
| 5 | Server.py construction | 🟡 this PR |
| 4 | Dashboard "Now running" strip | ⏸ next |

## What's in the commits

1. `feat(ops/server)` — the 10 lines of production wiring + 4 tests
2. `docs(claude)` — captures the cross-platform append-atomicity lesson validated through #474 (the trade-off discussed in that PR's body became its own CLAUDE.md entry)
3. `chore(.help)` — auto-regenerated `ops-dashboard` templates for the `server.py` source_hash bump (per the existing pre-commit-regen pattern)

## Test plan

- [x] `pytest tests/unit/ops/test_server_bulletin_wiring.py` → 4 pass
- [x] `pytest tests/unit/ops/test_runner.py tests/unit/ops/test_runner_bulletin.py` → 37 pass (no regressions)
- [x] `ruff check` → clean
- [x] Pre-commit hooks pass
- [ ] CI green across all OS/Python lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
