### PR TITLE
feat(ops/bulletin): "Now running across actors" strip on the Workflows page

### DIFF
--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-05-26T21:24:05.329875+00:00
-source_hash: 1e99b94aaa6cb25d1a8177ca5ac28496f3fbd5498c6aea2873c19d7fdab748f0
+generated_at: 2026-05-26T21:52:50.465761+00:00
+source_hash: 2fa0737b9485076376be660db12bde8986aea4140b365e93a95ac041c50aaf0f
 status: generated
 ---
 
@@ -20,7 +20,7 @@ The main building blocks are:
 - **`Config`** — Where attune ops reads project + attune state from.
 - **`TelemetrySummary`** — core component
 
-Under the hood, this feature spans 45 source
+Under the hood, this feature spans 47 source
 files covering:
 
 - Run via ``python -m attune.ops``.

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-05-26T21:24:05.340959+00:00
-source_hash: 1e99b94aaa6cb25d1a8177ca5ac28496f3fbd5498c6aea2873c19d7fdab748f0
+generated_at: 2026-05-26T21:52:50.476961+00:00
+source_hash: 2fa0737b9485076376be660db12bde8986aea4140b365e93a95ac041c50aaf0f
 status: generated
 ---
 
@@ -85,6 +85,7 @@ status: generated
 | `compute_file_sha256()` | Compute sha256 of a file's contents. | `src/attune/ops/pending_writes.py` |
 | `make_entry()` | Construct a JournalEntry, filling in defaults from runtime context. | `src/attune/ops/pending_writes.py` |
 | `append_entry()` | Append a journal entry to the JSONL journal. | `src/attune/ops/pending_writes.py` |
+| `list_active()` | Return active bulletin entries across all actors. | `src/attune/ops/routes/bulletin.py` |
 | `home()` | — | `src/attune/ops/routes/dashboard.py` |
 | `workflows_page()` | — | `src/attune/ops/routes/dashboard.py` |
 | `telemetry_page()` | — | `src/attune/ops/routes/dashboard.py` |

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: task
-generated_at: 2026-05-26T21:24:05.336270+00:00
-source_hash: 1e99b94aaa6cb25d1a8177ca5ac28496f3fbd5498c6aea2873c19d7fdab748f0
+generated_at: 2026-05-26T21:52:50.472204+00:00
+source_hash: 2fa0737b9485076376be660db12bde8986aea4140b365e93a95ac041c50aaf0f
 status: generated
 ---
 

--- a/src/attune/ops/routes/bulletin.py
+++ b/src/attune/ops/routes/bulletin.py
@@ -1,0 +1,76 @@
+"""Read-only API for the multi-actor bulletin.
+
+One endpoint: ``GET /api/bulletin/active`` returns the current
+non-stale, non-terminal entries across all actors as JSON. The
+dashboard's "Now running across actors" strip polls it.
+
+The route is always mounted; in read-only mode (where the
+dashboard runner doesn't write entries itself) it still surfaces
+entries written by other actors (CLI runs, scheduled tasks,
+other Claude Code sessions).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from attune.bulletin import FileBulletinBackend
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _bulletin_dir_for(request: Request):
+    """Resolve the bulletin directory from app config.
+
+    ``Config.bulletin_dir`` is the canonical accessor — points at
+    ``<attune_home>/bulletin/`` per the multi-actor-bulletin spec.
+    """
+    cfg = request.app.state.config
+    return cfg.bulletin_dir
+
+
+@router.get("/api/bulletin/active")
+async def list_active(request: Request) -> JSONResponse:
+    """Return active bulletin entries across all actors.
+
+    Response shape::
+
+        {
+          "entries": [
+            {
+              "actor_id": "...",
+              "actor_kind": "...",
+              "workflow": "...",
+              "run_id": "...",
+              "started_at": "...",
+              "last_heartbeat": "...",
+              "current_status": "running",
+              "scope": "...",
+              "hostname": null
+            },
+            ...
+          ]
+        }
+
+    Stale entries (no heartbeat for > 90s) and terminal entries
+    are filtered server-side. Order: most recent heartbeat first.
+    Empty list when nothing is in flight or the bulletin directory
+    doesn't exist yet.
+    """
+    backend = FileBulletinBackend(_bulletin_dir_for(request))
+    try:
+        entries = backend.read_active()
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: route must not 500 if the bulletin is malformed.
+        # The bulletin's own read path tolerates malformed lines, so
+        # this catches only catastrophic backend errors.
+        logger.warning("bulletin route: read failed: %s", exc)
+        entries = []
+
+    return JSONResponse({"entries": [asdict(e) for e in entries]})

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -15,6 +15,7 @@ from attune.bulletin import FileBulletinBackend
 from attune.ops import sweep_results as sweep_results_mod
 from attune.ops.config import Config
 from attune.ops.interaction_counters import InteractionCounters
+from attune.ops.routes import bulletin as bulletin_routes
 from attune.ops.routes import dashboard
 from attune.ops.routes import interaction_counters as interaction_counters_routes
 from attune.ops.routes import pending_writes as pending_writes_routes
@@ -117,6 +118,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.include_router(sweep_results_routes.router)
     app.include_router(interaction_counters_routes.router)
     app.include_router(pending_writes_routes.router)
+    app.include_router(bulletin_routes.router)
 
     # Phase 2B of discovery-sweep-ops-integration: when sweep-result
     # persistence is enabled, wrap the runner's start() so each

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1588,3 +1588,69 @@ a.kpi:hover {
   border-color: var(--danger, #b91c1c);
   border-style: solid;
 }
+
+/* ------------------------------------------------------------------
+ * Multi-actor bulletin strip — Workflows page, "Now running across
+ * actors". See docs/specs/multi-actor-bulletin/.
+ * ------------------------------------------------------------------ */
+.bulletin-strip {
+  margin: 12px 0 16px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-soft);
+}
+.bulletin-strip[hidden] {
+  display: none;
+}
+.bulletin-strip-title {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.bulletin-strip-count {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 8px;
+  margin-left: 6px;
+  border-radius: 99px;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  letter-spacing: 0;
+}
+.bulletin-strip-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+}
+.bulletin-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 99px;
+  background: var(--bg, #fff);
+  border: 1px solid var(--accent, #4f46e5);
+  color: var(--fg, #111);
+}
+.bulletin-chip-actor {
+  font-weight: 600;
+}
+.bulletin-chip-workflow {
+  color: var(--fg-muted);
+}
+.bulletin-chip-scope {
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+}
+.bulletin-chip-stale {
+  border-style: dashed;
+  opacity: 0.6;
+}

--- a/src/attune/ops/static/js/bulletin.js
+++ b/src/attune/ops/static/js/bulletin.js
@@ -1,0 +1,127 @@
+/* Multi-actor bulletin polling — renders the "Now running across
+   actors" strip on the Workflows page.
+
+   Polls /api/bulletin/active every BULLETIN_POLL_MS and rewrites the
+   chips container. Hides the whole section when zero entries are
+   active so single-actor sessions don't see chrome they don't need.
+
+   The strip is intentionally additive — it shows runs from the
+   current actor too, which doubles as a "the bulletin is alive"
+   confirmation. Filtering "self" is a future refinement once we
+   expose the dashboard's own actor_id to the page.
+
+   See docs/specs/multi-actor-bulletin/ for the data model.
+*/
+
+(function () {
+  "use strict";
+
+  var BULLETIN_POLL_MS = 5000;
+  var BULLETIN_ENDPOINT = "/api/bulletin/active";
+
+  var section = document.getElementById("bulletin-strip");
+  var chipsEl = document.getElementById("bulletin-strip-chips");
+  var countEl = document.getElementById("bulletin-strip-count");
+
+  if (!section || !chipsEl || !countEl) {
+    // Page doesn't have the strip — nothing to do.
+    return;
+  }
+
+  function escapeHtml(s) {
+    if (s == null) return "";
+    return String(s)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function ageSeconds(iso) {
+    if (!iso) return null;
+    var parsed = Date.parse(iso);
+    if (isNaN(parsed)) return null;
+    return Math.max(0, Math.round((Date.now() - parsed) / 1000));
+  }
+
+  function ageLabel(iso) {
+    var s = ageSeconds(iso);
+    if (s == null) return "";
+    if (s < 60) return s + "s ago";
+    if (s < 3600) return Math.round(s / 60) + "m ago";
+    return Math.round(s / 3600) + "h ago";
+  }
+
+  function renderChip(entry) {
+    // Stale = heartbeat older than 60s (the server filters >90s; the
+    // 60-90s window shows muted to telegraph "this actor may be gone").
+    var age = ageSeconds(entry.last_heartbeat);
+    var staleClass = age != null && age > 60 ? " bulletin-chip-stale" : "";
+    var scope = entry.scope ? " — " + escapeHtml(entry.scope) : "";
+    var tooltip =
+      "Actor: " +
+      escapeHtml(entry.actor_id) +
+      "\nKind: " +
+      escapeHtml(entry.actor_kind) +
+      "\nStarted: " +
+      escapeHtml(entry.started_at) +
+      "\nLast heartbeat: " +
+      escapeHtml(entry.last_heartbeat) +
+      " (" +
+      escapeHtml(ageLabel(entry.last_heartbeat)) +
+      ")";
+    return (
+      '<span class="bulletin-chip' +
+      staleClass +
+      '" data-tooltip="' +
+      tooltip +
+      '">' +
+      '<span class="bulletin-chip-actor">' +
+      escapeHtml(entry.actor_id) +
+      "</span>" +
+      '<span class="bulletin-chip-workflow"> · ' +
+      escapeHtml(entry.workflow) +
+      "</span>" +
+      '<span class="bulletin-chip-scope">' +
+      scope +
+      "</span>" +
+      "</span>"
+    );
+  }
+
+  function render(entries) {
+    if (!entries || entries.length === 0) {
+      section.hidden = true;
+      chipsEl.innerHTML = "";
+      countEl.textContent = "0";
+      return;
+    }
+    countEl.textContent = String(entries.length);
+    chipsEl.innerHTML = entries.map(renderChip).join("");
+    section.hidden = false;
+  }
+
+  function poll() {
+    fetch(BULLETIN_ENDPOINT, {
+      headers: { Accept: "application/json" },
+      credentials: "same-origin",
+    })
+      .then(function (resp) {
+        if (!resp.ok) throw new Error("bulletin: HTTP " + resp.status);
+        return resp.json();
+      })
+      .then(function (body) {
+        render(body.entries || []);
+      })
+      .catch(function (err) {
+        // Best-effort: log and try again next tick. The bulletin is
+        // advisory; an outage doesn't break the page.
+        if (window.console && console.warn) console.warn(err);
+      });
+  }
+
+  // Initial fetch + recurring poll.
+  poll();
+  setInterval(poll, BULLETIN_POLL_MS);
+})();

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -13,6 +13,21 @@
   </p>
 </section>
 
+{# Multi-actor bulletin strip — shows in-flight runs from OTHER actors
+   (other Claude Code sessions, CLI invocations, scheduled tasks). The
+   container is empty on first paint; bulletin.js polls
+   /api/bulletin/active every 5s and renders chips. The whole section
+   stays hidden via the ``hidden`` attribute when zero entries are
+   active, so it doesn't add visual noise in single-actor workflows.
+   See docs/specs/multi-actor-bulletin/. #}
+<section id="bulletin-strip" class="bulletin-strip" hidden>
+  <h2 class="bulletin-strip-title">
+    Now running across actors
+    <span class="bulletin-strip-count" id="bulletin-strip-count">0</span>
+  </h2>
+  <div class="bulletin-strip-chips" id="bulletin-strip-chips"></div>
+</section>
+
 {% if workflows %}
   <table class="data-table runner-table">
     <thead>
@@ -153,4 +168,9 @@
    elements that only exist when allow_run is True, so the read-only
    page sees a no-op for those features. #}
 <script src="{{ url_for('static', path='js/runner.js') }}?v={{ attune_version }}"></script>
+{# bulletin.js polls /api/bulletin/active every 5s to populate the
+   "Now running across actors" strip rendered above. Loaded
+   unconditionally so the strip appears in both run and read-only
+   modes — read-only dashboards can still surface OTHER actors' work. #}
+<script src="{{ url_for('static', path='js/bulletin.js') }}?v={{ attune_version }}"></script>
 {% endblock %}

--- a/tests/unit/ops/test_bulletin_route.py
+++ b/tests/unit/ops/test_bulletin_route.py
@@ -1,0 +1,134 @@
+"""Tests for the /api/bulletin/active route."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from attune.bulletin import BulletinEntry, FileBulletinBackend
+from attune.ops.config import Config
+from attune.ops.server import create_app
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    """FastAPI test client with attune_home pointed at tmp_path."""
+    cfg = Config(
+        project_root=tmp_path,
+        attune_home=tmp_path / "ah",
+        allow_run=False,
+        trusted_hosts=("testserver", "test"),
+    )
+    return TestClient(create_app(cfg))
+
+
+def _seed(
+    attune_home: Path,
+    *,
+    actor_id: str = "actor-1",
+    workflow: str = "code-review",
+    run_id: str = "run-1",
+    status: str = "running",
+    heartbeat: str | None = None,
+    scope: str | None = None,
+) -> None:
+    """Write a bulletin entry to ``<attune_home>/bulletin/`` directly."""
+    backend = FileBulletinBackend(attune_home / "bulletin")
+    backend.append(
+        BulletinEntry(
+            actor_id=actor_id,
+            actor_kind="cli",
+            workflow=workflow,
+            run_id=run_id,
+            current_status=status,  # type: ignore[arg-type]
+            scope=scope,
+            last_heartbeat=heartbeat or datetime.now(timezone.utc).isoformat(),
+        )
+    )
+
+
+class TestEmptyState:
+    def test_no_bulletin_dir_returns_empty_list(self, client: TestClient) -> None:
+        """The route works even before any actor has written."""
+        resp = client.get("/api/bulletin/active")
+        assert resp.status_code == 200
+        assert resp.json() == {"entries": []}
+
+
+class TestPopulated:
+    def test_single_entry_returned(self, client: TestClient, tmp_path: Path) -> None:
+        _seed(tmp_path / "ah", run_id="run-1")
+        resp = client.get("/api/bulletin/active")
+        data = resp.json()
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["run_id"] == "run-1"
+        assert data["entries"][0]["current_status"] == "running"
+
+    def test_multiple_actors_visible(self, client: TestClient, tmp_path: Path) -> None:
+        _seed(tmp_path / "ah", actor_id="actor-A", run_id="A-1")
+        _seed(tmp_path / "ah", actor_id="actor-B", run_id="B-1")
+        resp = client.get("/api/bulletin/active")
+        actors = {e["actor_id"] for e in resp.json()["entries"]}
+        assert actors == {"actor-A", "actor-B"}
+
+    def test_scope_propagated(self, client: TestClient, tmp_path: Path) -> None:
+        _seed(tmp_path / "ah", scope="src/attune/ops/", run_id="r1")
+        entry = resp_first(client.get("/api/bulletin/active"))
+        assert entry["scope"] == "src/attune/ops/"
+
+
+class TestStaleAndTerminal:
+    def test_stale_entry_filtered(self, client: TestClient, tmp_path: Path) -> None:
+        """Entries with heartbeat > 90s old are dropped (backend filters)."""
+        old = (datetime.now(timezone.utc) - timedelta(seconds=120)).isoformat()
+        _seed(tmp_path / "ah", heartbeat=old, run_id="r-stale")
+        resp = client.get("/api/bulletin/active")
+        assert resp.json()["entries"] == []
+
+    @pytest.mark.parametrize("status", ["completed", "failed", "cancelled"])
+    def test_terminal_entry_filtered(self, client: TestClient, tmp_path: Path, status: str) -> None:
+        """Terminal entries don't appear in the active list."""
+        # Write a running record then a terminal one for the same run.
+        _seed(tmp_path / "ah", run_id="r-done")
+        _seed(
+            tmp_path / "ah",
+            run_id="r-done",
+            status=status,
+            heartbeat=(datetime.now(timezone.utc) + timedelta(seconds=1)).isoformat(),
+        )
+        resp = client.get("/api/bulletin/active")
+        assert resp.json()["entries"] == []
+
+
+class TestPayloadShape:
+    def test_response_has_entries_key(self, client: TestClient, tmp_path: Path) -> None:
+        _seed(tmp_path / "ah", run_id="r1")
+        body = client.get("/api/bulletin/active").json()
+        assert "entries" in body
+        assert isinstance(body["entries"], list)
+
+    def test_entry_fields_match_dataclass(self, client: TestClient, tmp_path: Path) -> None:
+        _seed(tmp_path / "ah", run_id="r1")
+        entry = resp_first(client.get("/api/bulletin/active"))
+        expected_keys = {
+            "actor_id",
+            "actor_kind",
+            "workflow",
+            "run_id",
+            "started_at",
+            "last_heartbeat",
+            "current_status",
+            "scope",
+            "hostname",
+        }
+        assert set(entry.keys()) == expected_keys
+
+
+def resp_first(resp) -> dict:
+    """Return the first entry from a response payload."""
+    body = resp.json()
+    assert body["entries"], "expected at least one entry"
+    return body["entries"][0]


### PR DESCRIPTION
## Summary

Phase 1 Task 4 — the visible payoff of the multi-actor-bulletin spec. The Workflows page now shows a "Now running across actors" strip listing in-flight runs from every actor (Claude Code sessions, CLI invocations, scheduled tasks, the dashboard itself). Polls `/api/bulletin/active` every 5 seconds.

## What lands

- **`GET /api/bulletin/active`** — new route in `attune.ops.routes.bulletin`. Reads via `FileBulletinBackend` pointed at `Config.bulletin_dir`, returns active (non-stale, non-terminal) entries as JSON. Sorted by most-recent heartbeat first.
- **`bulletin.js`** — polls + renders chips; hides the section when zero entries are active so single-actor sessions don't see chrome.
- **Chips** show `actor_id` (bold) · `workflow` (muted) · `scope` (mono). Tooltip exposes actor kind + heartbeat age.
- **Stale visual** — entries with heartbeat 60-90s old render dashed/muted to telegraph "this actor may be gone." Beyond 90s the server filters them out.
- **CSS** uses existing chip/var conventions, matches dashboard style.

## Verified end-to-end in preview

Seeded `/tmp/bulletin-preview-home/bulletin/` with 4 entries (3 fresh + 1 stale-window) and confirmed:
- ✅ Strip renders above the workflows table when entries exist
- ✅ Polls /api/bulletin/active every 5s (network log shows recurring requests)
- ✅ Count badge updates to match chip count
- ✅ Fresh chips get `bulletin-chip`; 60-90s-old chip gets `bulletin-chip bulletin-chip-stale`
- ✅ Section hides automatically when bulletin empties (>90s entries filtered server-side)
- ✅ Zero console warnings

## Phase 1 status: COMPLETE 🎉

| # | Task | PR |
|---|---|---|
| 1 | Protocol + file backend | #474 |
| 2 | Actor-ID resolver | #474 |
| 3 | RunnerService wiring | #476 |
| 5 | Server.py construction | #477 |
| 4 | Dashboard "Now running" | **this PR** |

## What's NOT in this PR (intentional follow-ups)

- **Self-filtering** — chips for the dashboard's own runs also appear. For v1 that's a feature (confirms the local actor is on the bulletin); the curator spec will eventually want to dedupe.
- **SSE push instead of polling** — 5s polling is fine; SSE wiring is overkill until we have higher update pressure.
- **CLI dispatcher wiring** — separate spec task. The dashboard reads the same bulletin file the CLI would write to, so adding CLI wiring later doesn't require changes here.

## Test plan

- [x] `pytest tests/unit/ops/test_bulletin_route.py` → 10 new tests pass
- [x] Full bulletin pass: `pytest tests/unit/bulletin/ tests/unit/ops/test_bulletin_route.py tests/unit/ops/test_runner_bulletin.py tests/unit/ops/test_server_bulletin_wiring.py tests/unit/ops/test_runner.py` → 91 pass, zero regressions
- [x] `ruff check` → clean
- [x] Pre-commit hooks pass
- [x] Manual browser verification with seeded bulletin
- [ ] CI green across all OS/Python lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
