### PR TITLE
test(bulletin/route): close codecov gap from #478

### DIFF
--- a/tests/unit/ops/test_bulletin_route.py
+++ b/tests/unit/ops/test_bulletin_route.py
@@ -127,6 +127,28 @@ class TestPayloadShape:
         assert set(entry.keys()) == expected_keys
 
 
+class TestBackendFailure:
+    """The route must swallow backend errors — bulletin is advisory."""
+
+    def test_backend_exception_returns_empty_list(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A backend that raises must not produce a 500 — return [] instead."""
+
+        def _boom(self, *_a, **_kw):
+            raise RuntimeError("catastrophic backend error")
+
+        # Patch the bulletin's read_active to raise — covers the
+        # except Exception guard in the route handler.
+        monkeypatch.setattr("attune.bulletin.FileBulletinBackend.read_active", _boom)
+
+        resp = client.get("/api/bulletin/active")
+        assert resp.status_code == 200
+        assert resp.json() == {"entries": []}
+
+
 def resp_first(resp) -> dict:
     """Return the first entry from a response payload."""
     body = resp.json()


### PR DESCRIPTION
## Summary

Closes the codecov/patch 85% gap on `src/attune/ops/routes/bulletin.py` that landed with [#478](https://github.com/Smart-AI-Memory/attune-ai/pull/478) (#478 merged before this fix could ride along).

Codecov flagged lines 69-74 — the defensive `except Exception` catch around `FileBulletinBackend.read_active()` that returns an empty entries list rather than 500'ing when the backend explodes.

## Fix

One new test injects a `RuntimeError` via monkeypatch and asserts the route returns 200 + empty entries. Brings the patch to 100%.

## Why this was orphaned

Hit the existing CLAUDE.md lesson "Squash-merge deletes the remote branch; subsequent push silently recreates it with no PR attached." Pushed the coverage fix to the dashboard branch after #478 had already squash-merged; the push went to an orphaned branch with no PR. Cherry-picked onto a fresh branch off main.

## Test plan

- [x] `pytest tests/unit/ops/test_bulletin_route.py` → 11 pass
- [x] Coverage on `src/attune/ops/routes/bulletin.py` → 100%
- [x] `ruff check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)