### PR TITLE
docs(specs/ops-help-page): draft requirements + wireframes

### DIFF
--- a/docs/specs/ops-help-page/mockups/_partials.html
+++ b/docs/specs/ops-help-page/mockups/_partials.html
@@ -1,0 +1,111 @@
+<!-- Shared HTML fragments for the mockups. NOT included server-side
+     — the mockups are static HTML files so they can be opened
+     directly from disk. Copy-paste into each page. -->
+
+<!-- Mockup banner (top of body) -->
+<div class="mockup-banner">
+  📐 Mockup — visual reference for
+  <a href="https://github.com/Smart-AI-Memory/attune-ai/pull/482">PR #482 (ops-help-page spec)</a>.
+  Not connected to the real corpus.
+</div>
+
+<!-- Topbar (after banner) -->
+<header class="topbar">
+  <span class="topbar-brand">attune ops</span>
+  <span class="topbar-version">v7.1.2</span>
+  <nav class="topbar-nav">
+    <a href="#">Home</a>
+    <a href="#">Workflows</a>
+    <a href="#">Specs</a>
+    <a href="#">Sessions</a>
+    <a href="#">Telemetry</a>
+    <a href="index.html" class="active">Help</a>
+  </nav>
+  <span class="topbar-spacer"></span>
+  <span class="topbar-project">PROJECT <code>attune-ai</code></span>
+</header>
+
+<!-- Sidebar (sidebar) — feature tree with all 25 real features -->
+<aside class="sidebar">
+  <input type="search" class="search" placeholder="Search help…">
+
+  <div class="sidebar-section">
+    <h3 class="sidebar-section-title">Features (25)</h3>
+    <ul class="feature-tree">
+      <li><details><summary>agents</summary>
+        <ul>
+          <li><a class="leaf" href="#">concept <span class="kind-tag">md</span></a></li>
+          <li><a class="leaf" href="#">task <span class="kind-tag">md</span></a></li>
+          <li><a class="leaf" href="#">reference <span class="kind-tag">md</span></a></li>
+        </ul>
+      </details></li>
+      <li><details><summary>bug-predict <span class="stale-dot" title="1 stale template"></span></summary>
+        <ul>
+          <li><a class="leaf" href="#">concept</a></li>
+          <li><a class="leaf" href="#">task</a></li>
+          <li><a class="leaf" href="#">reference</a></li>
+        </ul>
+      </details></li>
+      <li><details><summary>cli</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+      <li><details><summary>code-quality</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
+      <li><details><summary>configuration</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+      <li><details><summary>deep-review</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
+      <li><details><summary>doc-gen</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
+      <li><details><summary>fix-test</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
+      <li><details><summary>help-system</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      <li><details><summary>hooks</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+      <li><details><summary>mcp-server</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+      <li><details><summary>memory</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      <li><details><summary>models</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+      <li><details><summary>ops-dashboard</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
+      <li><details><summary>orchestration</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      <li><details><summary>plugin</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      <li><details><summary>rag-grounding</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      <li><details><summary>refactor-plan</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+      <li><details><summary>release-prep</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+      <li><details><summary>resilience</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      <li><details open><summary>security-audit <span class="stale-dot" title="1 stale"></span></summary>
+        <ul>
+          <li><a class="leaf" href="#">comparison</a></li>
+          <li><a class="leaf" href="#">concept</a></li>
+          <li><a class="leaf" href="#">error</a></li>
+          <li><a class="leaf" href="#">faq</a></li>
+          <li><a class="leaf" href="#">note</a></li>
+          <li><a class="leaf" href="#">quickstart</a></li>
+          <li><a class="leaf" href="#">reference</a></li>
+          <li><a class="leaf active" href="template.html">task</a></li>
+          <li><a class="leaf" href="#">tip</a></li>
+          <li><a class="leaf" href="#">troubleshooting</a></li>
+          <li><a class="leaf" href="#">warning</a></li>
+        </ul>
+      </details></li>
+      <li><details><summary>smart-test</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+      <li><details><summary>spec-engine</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      <li><details><summary>telemetry</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+      <li><details><summary>wizards</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+    </ul>
+  </div>
+
+  <div class="sidebar-section">
+    <h3 class="sidebar-section-title">Browse by kind</h3>
+    <ul class="feature-tree">
+      <li><a class="leaf" href="#">concept <span class="kind-tag">25</span></a></li>
+      <li><a class="leaf" href="#">task <span class="kind-tag">19</span></a></li>
+      <li><a class="leaf" href="#">reference <span class="kind-tag">12</span></a></li>
+      <li><a class="leaf" href="#">faq <span class="kind-tag">8</span></a></li>
+      <li><a class="leaf" href="#">troubleshooting <span class="kind-tag">5</span></a></li>
+      <li><a class="leaf" href="#">tip <span class="kind-tag">5</span></a></li>
+      <li><a class="leaf" href="#">… 5 more kinds</a></li>
+    </ul>
+  </div>
+
+  <div class="sidebar-section">
+    <h3 class="sidebar-section-title">Pages</h3>
+    <ul class="feature-tree">
+      <li><a class="leaf" href="index.html">Home</a></li>
+      <li><a class="leaf" href="gaps.html">Coverage gaps</a></li>
+      <li><a class="leaf" href="search.html">Search results (demo)</a></li>
+      <li><a class="leaf" href="template.html">Template view (demo)</a></li>
+    </ul>
+  </div>
+</aside>

--- a/docs/specs/ops-help-page/mockups/gaps.html
+++ b/docs/specs/ops-help-page/mockups/gaps.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Coverage gaps — Help (mockup)</title>
+  <link rel="stylesheet" href="mockup.css">
+</head>
+<body>
+
+<div class="mockup-banner">
+  📐 Mockup — coverage gaps view.
+  <a href="index.html">← Back to home</a>
+</div>
+
+<header class="topbar">
+  <span class="topbar-brand">attune ops</span>
+  <span class="topbar-version">v7.1.2</span>
+  <nav class="topbar-nav">
+    <a href="#">Home</a><a href="#">Workflows</a><a href="#">Specs</a>
+    <a href="#">Sessions</a><a href="#">Telemetry</a>
+    <a href="index.html" class="active">Help</a>
+  </nav>
+  <span class="topbar-spacer"></span>
+  <span class="topbar-project">PROJECT <code>attune-ai</code></span>
+</header>
+
+<div class="shell">
+  <aside class="sidebar">
+    <input type="search" class="search" placeholder="Search help…">
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">Pages</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="index.html">Home</a></li>
+        <li><a class="leaf" href="search.html">Search results</a></li>
+        <li><a class="leaf" href="template.html">Template view</a></li>
+        <li><a class="leaf active" href="gaps.html">Coverage gaps</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">Filter by</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="#">All gaps</a></li>
+        <li><a class="leaf" href="#">Incomplete sets only</a></li>
+        <li><a class="leaf" href="#">Stale only</a></li>
+      </ul>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="page-head">
+      <h1>Coverage gaps</h1>
+      <div class="sub">Features with incomplete template sets or stale source hashes.</div>
+    </div>
+
+    <div class="stat-strip">
+      <div class="stat"><div class="stat-value">96%</div><div class="stat-label">complete</div></div>
+      <div class="stat"><div class="stat-value">286/297</div><div class="stat-label">templates</div></div>
+      <div class="stat"><div class="stat-value">92%</div><div class="stat-label">fresh</div></div>
+      <div class="stat"><div class="stat-value warn">10</div><div class="stat-label">stale</div></div>
+    </div>
+
+    <section class="section">
+      <h2>Incomplete sets <span class="count">2</span></h2>
+      <table class="gaps-table">
+        <thead>
+          <tr><th>Feature</th><th>Kinds</th><th>Completeness</th><th>Missing</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="#">help-system</a></td>
+            <td>9/11</td>
+            <td><span class="completeness-bar" style="--pct: 82%"></span> 82%</td>
+            <td class="missing">comparison, warning</td>
+          </tr>
+          <tr>
+            <td><a href="#">orchestration</a></td>
+            <td>7/11</td>
+            <td><span class="completeness-bar" style="--pct: 64%"></span> 64%</td>
+            <td class="missing">error, faq, tip, troubleshooting</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="section">
+      <h2>Stale templates <span class="count">10</span></h2>
+      <p style="color: var(--fg-muted); font-size: 12px; margin-top: -4px;">
+        Source hash drift older than 7 days · regenerate via
+        <code>attune-author generate &lt;feature&gt; --all-kinds</code>
+      </p>
+      <table class="gaps-table">
+        <thead>
+          <tr><th>Feature</th><th>Kind</th><th>Last regen</th><th>Source drift</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><a href="#">bug-predict</a></td><td><span class="item-kind">task</span></td><td>14 days ago</td><td class="missing">3 commits</td></tr>
+          <tr><td><a href="#">security-audit</a></td><td><span class="item-kind">faq</span></td><td>11 days ago</td><td class="missing">2 commits</td></tr>
+          <tr><td><a href="#">code-quality</a></td><td><span class="item-kind">reference</span></td><td>9 days ago</td><td class="missing">1 commit</td></tr>
+          <tr><td><a href="#">cli</a></td><td><span class="item-kind">concept</span></td><td>9 days ago</td><td class="missing">1 commit</td></tr>
+          <tr><td><a href="#">configuration</a></td><td><span class="item-kind">reference</span></td><td>8 days ago</td><td class="missing">1 commit</td></tr>
+          <tr><td colspan="4" style="text-align:center; color: var(--fg-muted);">… 5 more</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="section">
+      <h2>How to fix</h2>
+      <ol>
+        <li>For <strong>incomplete sets</strong>, run
+            <code>attune-author generate &lt;feature&gt; --all-kinds</code>
+            from the project root.</li>
+        <li>For <strong>stale templates</strong>, the same command
+            regenerates only the kinds whose source hash drifted.</li>
+        <li>Review the regenerated content before committing — the
+            polish pass is LLM-assisted; spot-check for facts you
+            care about per the existing hallucination-shapes lesson.</li>
+      </ol>
+    </section>
+  </main>
+</div>
+
+</body>
+</html>

--- a/docs/specs/ops-help-page/mockups/gaps.html
+++ b/docs/specs/ops-help-page/mockups/gaps.html
@@ -26,7 +26,15 @@
 
 <div class="shell">
   <aside class="sidebar">
-    <input type="search" class="search" placeholder="Search help…">
+    <form class="search-form" action="search.html" method="get" role="search">
+      <input type="search" name="q" class="search" placeholder="Search help…">
+      <button type="submit" class="search-btn" aria-label="Search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="7"></circle>
+          <line x1="21" y1="21" x2="16.5" y2="16.5"></line>
+        </svg>
+      </button>
+    </form>
     <div class="sidebar-section">
       <h3 class="sidebar-section-title">Pages</h3>
       <ul class="feature-tree">

--- a/docs/specs/ops-help-page/mockups/index.html
+++ b/docs/specs/ops-help-page/mockups/index.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Help — attune ops (mockup)</title>
+  <link rel="stylesheet" href="mockup.css">
+</head>
+<body>
+
+<div class="mockup-banner">
+  📐 Mockup — visual reference for
+  <a href="https://github.com/Smart-AI-Memory/attune-ai/pull/482">PR #482 (ops-help-page spec)</a>.
+  Not connected to the real corpus.
+</div>
+
+<header class="topbar">
+  <span class="topbar-brand">attune ops</span>
+  <span class="topbar-version">v7.1.2</span>
+  <nav class="topbar-nav">
+    <a href="#">Home</a><a href="#">Workflows</a><a href="#">Specs</a>
+    <a href="#">Sessions</a><a href="#">Telemetry</a>
+    <a href="index.html" class="active">Help</a>
+  </nav>
+  <span class="topbar-spacer"></span>
+  <span class="topbar-project">PROJECT <code>attune-ai</code></span>
+</header>
+
+<div class="shell">
+  <aside class="sidebar">
+    <input type="search" class="search" placeholder="Search help…">
+
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">Features (25)</h3>
+      <ul class="feature-tree">
+        <li><details><summary>agents</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>bug-predict <span class="stale-dot" title="1 stale"></span></summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>cli</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>code-quality</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>configuration</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+        <li><details><summary>deep-review</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>doc-gen</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>fix-test</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>help-system</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>hooks</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+        <li><details><summary>mcp-server</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+        <li><details><summary>memory</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>models</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+        <li><details><summary>ops-dashboard</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>orchestration</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>plugin</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>rag-grounding</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>refactor-plan</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>release-prep</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>resilience</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>security-audit <span class="stale-dot" title="1 stale"></span></summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="template.html">task</a></li><li><a class="leaf" href="#">reference</a></li><li><a class="leaf" href="#">faq</a></li></ul></details></li>
+        <li><details><summary>smart-test</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>spec-engine</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>telemetry</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+        <li><details><summary>wizards</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      </ul>
+    </div>
+
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">Browse by kind</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="#">concept <span class="kind-tag">25</span></a></li>
+        <li><a class="leaf" href="#">task <span class="kind-tag">19</span></a></li>
+        <li><a class="leaf" href="#">reference <span class="kind-tag">12</span></a></li>
+        <li><a class="leaf" href="#">faq <span class="kind-tag">8</span></a></li>
+        <li><a class="leaf" href="#">troubleshooting <span class="kind-tag">5</span></a></li>
+        <li><a class="leaf" href="#">… 5 more kinds</a></li>
+      </ul>
+    </div>
+
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">Pages</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="index.html">Home</a></li>
+        <li><a class="leaf" href="search.html">Search results</a></li>
+        <li><a class="leaf" href="template.html">Template view</a></li>
+        <li><a class="leaf" href="gaps.html">Coverage gaps</a></li>
+      </ul>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="page-head">
+      <h1>Help</h1>
+      <div class="sub">Browse + search the <code>.help/templates/</code> corpus.</div>
+    </div>
+
+    <div class="stat-strip">
+      <div class="stat"><div class="stat-value">25</div><div class="stat-label">features</div></div>
+      <div class="stat"><div class="stat-value">286</div><div class="stat-label">templates</div></div>
+      <div class="stat"><div class="stat-value warn">10</div><div class="stat-label">stale</div></div>
+      <div class="stat"><div class="stat-value warn">2</div><div class="stat-label">incomplete</div></div>
+      <div class="stat-strip-spacer"></div>
+      <button class="btn">Refresh</button>
+    </div>
+
+    <section class="section">
+      <h2>Recent</h2>
+      <ul class="item-list">
+        <li>
+          <span class="item-feature">security-audit</span>
+          <span class="item-kind">task</span>
+          <span class="item-spacer"></span>
+          <span class="item-meta">read 4 min ago</span>
+        </li>
+        <li>
+          <span class="item-feature">bulletin</span>
+          <span class="item-kind">concept</span>
+          <span class="item-spacer"></span>
+          <span class="item-meta">read 12 min ago</span>
+        </li>
+        <li>
+          <span class="item-feature">discovery-sweep</span>
+          <span class="item-kind">reference</span>
+          <span class="item-spacer"></span>
+          <span class="item-meta">read 1 h ago</span>
+        </li>
+      </ul>
+    </section>
+
+    <section class="section">
+      <h2>Pinned <span class="count">0</span></h2>
+      <div class="empty">No pinned templates yet — pin from any template view.</div>
+    </section>
+
+    <section class="section">
+      <h2>Coverage gaps <span class="count">2</span></h2>
+      <ul class="item-list">
+        <li>
+          <span class="item-feature">help-system</span>
+          <span class="item-kind">9 of 11 kinds</span>
+          <span class="item-spacer"></span>
+          <span class="item-meta">missing: comparison, warning</span>
+        </li>
+        <li>
+          <span class="item-feature">orchestration</span>
+          <span class="item-kind">7 of 11 kinds</span>
+          <span class="item-spacer"></span>
+          <span class="item-meta">missing: error, faq, tip, troubleshooting</span>
+        </li>
+      </ul>
+      <p style="margin-top: 8px; font-size: 12px;">
+        <a href="gaps.html">View all coverage gaps →</a>
+      </p>
+    </section>
+
+    <section class="section">
+      <h2>Recently regenerated</h2>
+      <ul class="item-list">
+        <li>
+          <span class="item-feature">ops-dashboard</span>
+          <span class="item-kind">concept</span>
+          <span class="item-spacer"></span>
+          <span class="item-meta">today</span>
+        </li>
+        <li>
+          <span class="item-feature">plugin</span>
+          <span class="item-kind">reference</span>
+          <span class="item-spacer"></span>
+          <span class="item-meta">today</span>
+        </li>
+        <li>
+          <span class="item-feature">code-quality</span>
+          <span class="item-kind">task</span>
+          <span class="item-spacer"></span>
+          <span class="item-meta">2 days ago</span>
+        </li>
+      </ul>
+    </section>
+  </main>
+</div>
+
+</body>
+</html>

--- a/docs/specs/ops-help-page/mockups/index.html
+++ b/docs/specs/ops-help-page/mockups/index.html
@@ -2,15 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Help — attune ops (mockup)</title>
+  <title>Help — attune ops (mockup, user-first)</title>
   <link rel="stylesheet" href="mockup.css">
 </head>
 <body>
 
 <div class="mockup-banner">
-  📐 Mockup — visual reference for
-  <a href="https://github.com/Smart-AI-Memory/attune-ai/pull/482">PR #482 (ops-help-page spec)</a>.
-  Not connected to the real corpus.
+  📐 Mockup v2 — user-first home for
+  <a href="https://github.com/Smart-AI-Memory/attune-ai/pull/482">PR #482</a>.
+  Maintainer view moved to <a href="gaps.html">Maintain corpus</a> at the bottom.
 </div>
 
 <header class="topbar">
@@ -25,96 +25,106 @@
   <span class="topbar-project">PROJECT <code>attune-ai</code></span>
 </header>
 
-<div class="shell">
-  <aside class="sidebar">
-    <input type="search" class="search" placeholder="Search help…">
-
-    <div class="sidebar-section">
-      <h3 class="sidebar-section-title">Features (25)</h3>
-      <ul class="feature-tree">
-        <li><details><summary>agents</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
-        <li><details><summary>bug-predict <span class="stale-dot" title="1 stale"></span></summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
-        <li><details><summary>cli</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>code-quality</summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="#">task</a></li></ul></details></li>
-        <li><details><summary>configuration</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
-        <li><details><summary>deep-review</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>doc-gen</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
-        <li><details><summary>fix-test</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
-        <li><details><summary>help-system</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>hooks</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
-        <li><details><summary>mcp-server</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
-        <li><details><summary>memory</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>models</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
-        <li><details><summary>ops-dashboard</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>orchestration</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>plugin</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>rag-grounding</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>refactor-plan</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
-        <li><details><summary>release-prep</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
-        <li><details><summary>resilience</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>security-audit <span class="stale-dot" title="1 stale"></span></summary><ul><li><a class="leaf" href="#">concept</a></li><li><a class="leaf" href="template.html">task</a></li><li><a class="leaf" href="#">reference</a></li><li><a class="leaf" href="#">faq</a></li></ul></details></li>
-        <li><details><summary>smart-test</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
-        <li><details><summary>spec-engine</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-        <li><details><summary>telemetry</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
-        <li><details><summary>wizards</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
-      </ul>
-    </div>
-
-    <div class="sidebar-section">
-      <h3 class="sidebar-section-title">Browse by kind</h3>
-      <ul class="feature-tree">
-        <li><a class="leaf" href="#">concept <span class="kind-tag">25</span></a></li>
-        <li><a class="leaf" href="#">task <span class="kind-tag">19</span></a></li>
-        <li><a class="leaf" href="#">reference <span class="kind-tag">12</span></a></li>
-        <li><a class="leaf" href="#">faq <span class="kind-tag">8</span></a></li>
-        <li><a class="leaf" href="#">troubleshooting <span class="kind-tag">5</span></a></li>
-        <li><a class="leaf" href="#">… 5 more kinds</a></li>
-      </ul>
-    </div>
-
-    <div class="sidebar-section">
-      <h3 class="sidebar-section-title">Pages</h3>
-      <ul class="feature-tree">
-        <li><a class="leaf" href="index.html">Home</a></li>
-        <li><a class="leaf" href="search.html">Search results</a></li>
-        <li><a class="leaf" href="template.html">Template view</a></li>
-        <li><a class="leaf" href="gaps.html">Coverage gaps</a></li>
-      </ul>
-    </div>
-  </aside>
-
+<div class="shell shell-full">
   <main class="main">
-    <div class="page-head">
-      <h1>Help</h1>
-      <div class="sub">Browse + search the <code>.help/templates/</code> corpus.</div>
-    </div>
 
-    <div class="stat-strip">
-      <div class="stat"><div class="stat-value">25</div><div class="stat-label">features</div></div>
-      <div class="stat"><div class="stat-value">286</div><div class="stat-label">templates</div></div>
-      <div class="stat"><div class="stat-value warn">10</div><div class="stat-label">stale</div></div>
-      <div class="stat"><div class="stat-value warn">2</div><div class="stat-label">incomplete</div></div>
-      <div class="stat-strip-spacer"></div>
-      <button class="btn">Refresh</button>
-    </div>
+    <section class="hero">
+      <h1>How can attune help?</h1>
+      <input type="search" class="hero-search"
+             placeholder="Search anything — security audit, fix tests, commit message…"
+             autofocus>
+      <div class="hero-suggestions">
+        Try:
+        <a href="search.html">security audit</a>
+        <a href="#">how do I commit</a>
+        <a href="#">fix failing tests</a>
+        <a href="#">multi-agent coordination</a>
+      </div>
+    </section>
 
     <section class="section">
-      <h2>Recent</h2>
+      <h2>Browse by what you need</h2>
+      <div class="intent-grid">
+        <a href="#" class="intent-card">
+          <div class="intent-icon">⚡</div>
+          <div class="intent-title">Do something</div>
+          <div class="intent-sub">task · quickstart</div>
+          <div class="intent-count">27 articles</div>
+        </a>
+        <a href="#" class="intent-card">
+          <div class="intent-icon">🔧</div>
+          <div class="intent-title">Solve a problem</div>
+          <div class="intent-sub">troubleshooting · error · faq</div>
+          <div class="intent-count">21 articles</div>
+        </a>
+        <a href="#" class="intent-card">
+          <div class="intent-icon">💡</div>
+          <div class="intent-title">Understand</div>
+          <div class="intent-sub">concept</div>
+          <div class="intent-count">25 articles</div>
+        </a>
+        <a href="#" class="intent-card">
+          <div class="intent-icon">📖</div>
+          <div class="intent-title">Look it up</div>
+          <div class="intent-sub">reference</div>
+          <div class="intent-count">12 articles</div>
+        </a>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2>Featured topics</h2>
+      <ul class="featured-list">
+        <li>
+          <a href="template.html">
+            <span class="name">security-audit</span>
+            <span class="desc">Scan a codebase for vulnerabilities — eval/exec, path traversal, hardcoded secrets, injection.</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span class="name">smart-test</span>
+            <span class="desc">Find test gaps and generate tests for uncovered code paths.</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span class="name">bulletin</span>
+            <span class="desc">Coordinate work across multiple Claude Code sessions and CLI invocations.</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span class="name">deep-review</span>
+            <span class="desc">Multi-pass review covering security, quality, and test gaps.</span>
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            <span class="name">release-prep</span>
+            <span class="desc">Pre-release checklist — health checks, security audit, changelog validation.</span>
+          </a>
+        </li>
+      </ul>
+    </section>
+
+    <section class="section">
+      <h2>Continue where you left off</h2>
       <ul class="item-list">
         <li>
-          <span class="item-feature">security-audit</span>
+          <a class="item-feature" href="template.html">security-audit</a>
           <span class="item-kind">task</span>
           <span class="item-spacer"></span>
           <span class="item-meta">read 4 min ago</span>
         </li>
         <li>
-          <span class="item-feature">bulletin</span>
+          <a class="item-feature" href="#">bulletin</a>
           <span class="item-kind">concept</span>
           <span class="item-spacer"></span>
           <span class="item-meta">read 12 min ago</span>
         </li>
         <li>
-          <span class="item-feature">discovery-sweep</span>
+          <a class="item-feature" href="#">discovery-sweep</a>
           <span class="item-kind">reference</span>
           <span class="item-spacer"></span>
           <span class="item-meta">read 1 h ago</span>
@@ -122,55 +132,44 @@
       </ul>
     </section>
 
-    <section class="section">
-      <h2>Pinned <span class="count">0</span></h2>
-      <div class="empty">No pinned templates yet — pin from any template view.</div>
-    </section>
-
-    <section class="section">
-      <h2>Coverage gaps <span class="count">2</span></h2>
-      <ul class="item-list">
-        <li>
-          <span class="item-feature">help-system</span>
-          <span class="item-kind">9 of 11 kinds</span>
-          <span class="item-spacer"></span>
-          <span class="item-meta">missing: comparison, warning</span>
-        </li>
-        <li>
-          <span class="item-feature">orchestration</span>
-          <span class="item-kind">7 of 11 kinds</span>
-          <span class="item-spacer"></span>
-          <span class="item-meta">missing: error, faq, tip, troubleshooting</span>
-        </li>
+    <details class="all-features">
+      <summary>Browse all 25 features</summary>
+      <ul>
+        <li><a href="#">agents</a></li>
+        <li><a href="#">bug-predict</a></li>
+        <li><a href="#">cli</a></li>
+        <li><a href="#">code-quality</a></li>
+        <li><a href="#">configuration</a></li>
+        <li><a href="#">deep-review</a></li>
+        <li><a href="#">doc-gen</a></li>
+        <li><a href="#">fix-test</a></li>
+        <li><a href="#">help-system</a></li>
+        <li><a href="#">hooks</a></li>
+        <li><a href="#">mcp-server</a></li>
+        <li><a href="#">memory</a></li>
+        <li><a href="#">models</a></li>
+        <li><a href="#">ops-dashboard</a></li>
+        <li><a href="#">orchestration</a></li>
+        <li><a href="#">plugin</a></li>
+        <li><a href="#">rag-grounding</a></li>
+        <li><a href="#">refactor-plan</a></li>
+        <li><a href="#">release-prep</a></li>
+        <li><a href="#">resilience</a></li>
+        <li><a href="template.html">security-audit</a></li>
+        <li><a href="#">smart-test</a></li>
+        <li><a href="#">spec-engine</a></li>
+        <li><a href="#">telemetry</a></li>
+        <li><a href="#">wizards</a></li>
       </ul>
-      <p style="margin-top: 8px; font-size: 12px;">
-        <a href="gaps.html">View all coverage gaps →</a>
-      </p>
-    </section>
+    </details>
 
-    <section class="section">
-      <h2>Recently regenerated</h2>
-      <ul class="item-list">
-        <li>
-          <span class="item-feature">ops-dashboard</span>
-          <span class="item-kind">concept</span>
-          <span class="item-spacer"></span>
-          <span class="item-meta">today</span>
-        </li>
-        <li>
-          <span class="item-feature">plugin</span>
-          <span class="item-kind">reference</span>
-          <span class="item-spacer"></span>
-          <span class="item-meta">today</span>
-        </li>
-        <li>
-          <span class="item-feature">code-quality</span>
-          <span class="item-kind">task</span>
-          <span class="item-spacer"></span>
-          <span class="item-meta">2 days ago</span>
-        </li>
-      </ul>
-    </section>
+    <footer class="maintain-footer">
+      <span>286 templates across 25 features</span>
+      <span>
+        <a href="gaps.html">Maintain corpus →</a>
+        <span class="health-chip">10 stale · 2 incomplete</span>
+      </span>
+    </footer>
   </main>
 </div>
 

--- a/docs/specs/ops-help-page/mockups/index.html
+++ b/docs/specs/ops-help-page/mockups/index.html
@@ -30,9 +30,19 @@
 
     <section class="hero">
       <h1>How can attune help?</h1>
-      <input type="search" class="hero-search"
-             placeholder="Search anything — security audit, fix tests, commit message…"
-             autofocus>
+      <form class="hero-search-form" action="search.html" method="get" role="search">
+        <input type="search" name="q" class="hero-search"
+               placeholder="Search anything — security audit, fix tests, commit message…"
+               autofocus>
+        <button type="submit" class="hero-search-btn" aria-label="Search">
+          <!-- magnifier glyph -->
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+               stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="11" cy="11" r="7"></circle>
+            <line x1="21" y1="21" x2="16.5" y2="16.5"></line>
+          </svg>
+        </button>
+      </form>
       <div class="hero-suggestions">
         Try:
         <a href="search.html">security audit</a>

--- a/docs/specs/ops-help-page/mockups/mockup.css
+++ b/docs/specs/ops-help-page/mockups/mockup.css
@@ -744,3 +744,62 @@ a:hover { text-decoration: underline; }
   margin: 0 auto;
   padding: 0 32px 40px;
 }
+
+/* Search button overlay — sits inside the hero search input */
+.hero-search-form {
+  position: relative;
+  width: 100%;
+}
+.hero-search { padding-right: 56px; }
+.hero-search-btn {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--accent);
+  color: white;
+  border: 0;
+  border-radius: 8px;
+  width: 44px;
+  height: 36px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  transition: background 80ms;
+}
+.hero-search-btn:hover { background: #4338ca; }
+.hero-search-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.hero-search-btn svg { width: 18px; height: 18px; }
+
+/* Smaller search-go button inside the sidebar search */
+.search-form {
+  position: relative;
+  width: 100%;
+}
+.search { padding-right: 36px; }
+.search-form .search-btn {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: 0;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  color: var(--fg-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+}
+.search-form .search-btn:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+.search-form .search-btn svg { width: 14px; height: 14px; }

--- a/docs/specs/ops-help-page/mockups/mockup.css
+++ b/docs/specs/ops-help-page/mockups/mockup.css
@@ -562,3 +562,185 @@ a:hover { text-decoration: underline; }
   font-weight: 500;
 }
 .mockup-banner a { color: var(--warn); }
+
+/* ------------------------------------------------------------------
+ * User-first home additions (v2 mockup)
+ * ------------------------------------------------------------------ */
+
+.hero {
+  text-align: center;
+  padding: 48px 0 24px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+.hero h1 {
+  margin: 0 0 24px;
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+}
+.hero-search {
+  display: block;
+  width: 100%;
+  padding: 14px 20px;
+  font-size: 16px;
+  font-family: inherit;
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  background: var(--bg);
+  outline: none;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+}
+.hero-search:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.hero-suggestions {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.hero-suggestions a {
+  margin: 0 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  font-size: 11px;
+  background: var(--bg-soft);
+}
+
+.intent-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin: 32px 0 16px;
+}
+.intent-card {
+  display: block;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+  text-decoration: none;
+  color: var(--fg);
+  transition: border-color 80ms, transform 80ms;
+}
+.intent-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+.intent-icon {
+  font-size: 22px;
+  margin-bottom: 8px;
+}
+.intent-title {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.intent-sub {
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  margin-bottom: 8px;
+}
+.intent-count {
+  font-size: 11px;
+  color: var(--fg-subtle);
+}
+
+/* Featured + Continue sections — lighter than item-list */
+.featured-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.featured-list li {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+.featured-list li:last-child { border: 0; }
+.featured-list a {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  color: var(--fg);
+}
+.featured-list .name {
+  font-weight: 500;
+  color: var(--accent);
+  min-width: 160px;
+}
+.featured-list .desc {
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+
+/* All features (collapsed by default) */
+.all-features {
+  margin-top: 24px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-soft);
+}
+.all-features summary {
+  padding: 12px 16px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 13px;
+  list-style: none;
+}
+.all-features summary::before {
+  content: "▶";
+  display: inline-block;
+  margin-right: 8px;
+  font-size: 10px;
+  color: var(--fg-muted);
+  transition: transform 100ms;
+}
+.all-features[open] summary::before { transform: rotate(90deg); }
+.all-features ul {
+  list-style: none;
+  margin: 0;
+  padding: 8px 16px 16px;
+  columns: 3;
+  column-gap: 16px;
+}
+.all-features li {
+  padding: 2px 0;
+  break-inside: avoid;
+}
+
+/* Maintainer footer */
+.maintain-footer {
+  margin-top: 60px;
+  padding: 16px 0;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--fg-muted);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.maintain-footer a { color: var(--fg-muted); }
+.maintain-footer a:hover { color: var(--accent); }
+.maintain-footer .health-chip {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 99px;
+  background: var(--warn-soft);
+  color: var(--warn);
+  margin-left: 6px;
+  font-size: 11px;
+}
+
+/* Full-width main for user-home (no sidebar) */
+.shell-full {
+  display: block;
+}
+.shell-full .main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 32px 40px;
+}

--- a/docs/specs/ops-help-page/mockups/mockup.css
+++ b/docs/specs/ops-help-page/mockups/mockup.css
@@ -1,0 +1,564 @@
+/* attune ops help page — visual mockup
+   Approximates the dashboard's main.css conventions for layout
+   review. Not pixel-perfect; serves to communicate IA + chrome
+   placement. */
+
+:root {
+  --bg: #ffffff;
+  --bg-soft: #f6f7f9;
+  --bg-hover: #eef0f3;
+  --fg: #111827;
+  --fg-muted: #6b7280;
+  --fg-subtle: #9ca3af;
+  --border: #e5e7eb;
+  --border-strong: #d1d5db;
+  --accent: #4f46e5;
+  --accent-soft: #eef2ff;
+  --warn: #b45309;
+  --warn-soft: #fef3c7;
+  --danger: #b91c1c;
+  --ok: #047857;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--bg);
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Top nav */
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.topbar-brand {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.topbar-version {
+  font-size: 11px;
+  color: var(--fg-muted);
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 99px;
+}
+.topbar-nav {
+  display: flex;
+  gap: 4px;
+  margin-left: 20px;
+}
+.topbar-nav a {
+  padding: 4px 10px;
+  border-radius: 6px;
+  color: var(--fg);
+}
+.topbar-nav a.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 500;
+}
+.topbar-spacer { flex: 1; }
+.topbar-project {
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.topbar-project code {
+  font-family: var(--font-mono);
+  background: var(--bg-soft);
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: var(--fg);
+}
+
+/* Page shell — sidebar + main */
+.shell {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: calc(100vh - 49px);
+}
+
+.sidebar {
+  border-right: 1px solid var(--border);
+  background: var(--bg-soft);
+  padding: 16px 12px;
+  overflow-y: auto;
+  max-height: calc(100vh - 49px);
+  position: sticky;
+  top: 49px;
+  align-self: start;
+}
+
+.search {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+}
+.search:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.sidebar-section {
+  margin-top: 18px;
+}
+.sidebar-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  margin: 0 0 6px;
+  padding: 0 6px;
+}
+.feature-tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.feature-tree li { margin: 1px 0; }
+.feature-tree summary,
+.feature-tree .leaf {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--fg);
+  font-size: 13px;
+}
+.feature-tree summary:hover,
+.feature-tree .leaf:hover { background: var(--bg-hover); }
+.feature-tree .leaf.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: 500;
+}
+.feature-tree details > ul {
+  list-style: none;
+  margin: 2px 0 4px 16px;
+  padding: 0;
+  border-left: 1px solid var(--border);
+}
+.feature-tree details > ul .leaf {
+  padding-left: 12px;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.feature-tree details > ul .leaf:hover { color: var(--fg); }
+.kind-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-subtle);
+  margin-left: auto;
+}
+.stale-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--warn);
+  display: inline-block;
+}
+
+/* Main panel */
+.main {
+  padding: 24px 32px;
+  max-width: 900px;
+}
+.page-head { margin-bottom: 24px; }
+.page-head h1 {
+  margin: 0 0 4px;
+  font-size: 24px;
+  font-weight: 600;
+}
+.page-head .sub {
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+
+/* Stat strip */
+.stat-strip {
+  display: flex;
+  gap: 16px;
+  padding: 12px 16px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 20px;
+  align-items: center;
+}
+.stat {
+  display: flex;
+  flex-direction: column;
+  min-width: 80px;
+}
+.stat-value {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.stat-value.warn { color: var(--warn); }
+.stat-value.danger { color: var(--danger); }
+.stat-label {
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.stat-strip-spacer { flex: 1; }
+.btn {
+  padding: 4px 10px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--fg);
+}
+.btn:hover { background: var(--bg-hover); }
+.btn-accent {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+/* Section blocks */
+.section {
+  margin-bottom: 28px;
+}
+.section h2 {
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+}
+.section h2 .count {
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  padding: 1px 8px;
+  border-radius: 99px;
+  margin-left: 6px;
+  letter-spacing: 0;
+}
+
+/* List items */
+.item-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.item-list li {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.item-list li:last-child { border-bottom: none; }
+.item-list li:hover { background: var(--bg-soft); }
+.item-feature {
+  font-weight: 500;
+  color: var(--fg);
+}
+.item-kind {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  padding: 1px 6px;
+  background: var(--bg-soft);
+  border-radius: 4px;
+}
+.item-spacer { flex: 1; }
+.item-meta {
+  font-size: 11px;
+  color: var(--fg-subtle);
+}
+.empty {
+  padding: 14px;
+  color: var(--fg-muted);
+  font-style: italic;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  text-align: center;
+}
+
+/* Result cards */
+.result {
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 10px;
+  background: var(--bg);
+}
+.result:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.result-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.result-feature {
+  font-weight: 600;
+  color: var(--accent);
+}
+.result-kind {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+.result-spacer { flex: 1; }
+.result-score {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+.result-snippet {
+  color: var(--fg-muted);
+  font-size: 13px;
+  line-height: 1.55;
+}
+.result-snippet mark {
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
+/* Template view */
+.template-head {
+  margin-bottom: 20px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.breadcrumb {
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-bottom: 4px;
+}
+.template-title {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 600;
+}
+.template-meta {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  font-size: 11px;
+  background: var(--bg-soft);
+}
+.chip-stale {
+  border-color: var(--warn);
+  background: var(--warn-soft);
+  color: var(--warn);
+}
+.chip-fresh {
+  border-color: var(--ok);
+  color: var(--ok);
+}
+
+.on-this-page {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 20px;
+  background: var(--bg-soft);
+}
+.on-this-page h3 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+}
+.on-this-page ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.on-this-page li {
+  margin: 2px 0;
+  font-size: 13px;
+}
+
+/* Prose content */
+.prose h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 28px 0 8px;
+  padding-top: 8px;
+  scroll-margin-top: 60px;
+}
+.prose h3 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 20px 0 6px;
+  scroll-margin-top: 60px;
+}
+.prose p {
+  margin: 0 0 12px;
+  color: var(--fg);
+}
+.prose ul, .prose ol {
+  padding-left: 22px;
+  margin: 0 0 14px;
+}
+.prose li { margin: 2px 0; }
+.prose code {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  background: var(--bg-soft);
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+.prose pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  padding: 14px 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 0 0 14px;
+}
+.prose pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: inherit;
+}
+.prose a { color: var(--accent); }
+
+/* See-also block */
+.see-also {
+  margin-top: 32px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-soft);
+}
+.see-also h3 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+}
+.see-also ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.see-also a {
+  padding: 4px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+/* Gaps page */
+.gaps-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 24px;
+}
+.gaps-table th,
+.gaps-table td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.gaps-table th {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+  font-weight: 600;
+}
+.gaps-table td.missing {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--warn);
+}
+.completeness-bar {
+  display: inline-block;
+  width: 120px;
+  height: 6px;
+  background: var(--border);
+  border-radius: 99px;
+  position: relative;
+  vertical-align: middle;
+}
+.completeness-bar::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--accent);
+  border-radius: 99px;
+  width: var(--pct, 0%);
+}
+
+/* Mockup banner */
+.mockup-banner {
+  background: var(--warn-soft);
+  border-bottom: 1px solid var(--warn);
+  color: var(--warn);
+  text-align: center;
+  font-size: 12px;
+  padding: 6px;
+  font-weight: 500;
+}
+.mockup-banner a { color: var(--warn); }

--- a/docs/specs/ops-help-page/mockups/search.html
+++ b/docs/specs/ops-help-page/mockups/search.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Search — Help (mockup)</title>
+  <link rel="stylesheet" href="mockup.css">
+</head>
+<body>
+
+<div class="mockup-banner">
+  📐 Mockup — search results view.
+  <a href="index.html">← Back to home</a>
+</div>
+
+<header class="topbar">
+  <span class="topbar-brand">attune ops</span>
+  <span class="topbar-version">v7.1.2</span>
+  <nav class="topbar-nav">
+    <a href="#">Home</a><a href="#">Workflows</a><a href="#">Specs</a>
+    <a href="#">Sessions</a><a href="#">Telemetry</a>
+    <a href="index.html" class="active">Help</a>
+  </nav>
+  <span class="topbar-spacer"></span>
+  <span class="topbar-project">PROJECT <code>attune-ai</code></span>
+</header>
+
+<div class="shell">
+  <aside class="sidebar">
+    <input type="search" class="search" value="injection" placeholder="Search help…">
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">Browse features</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="index.html">← All features</a></li>
+        <li><details><summary>security-audit</summary><ul><li><a class="leaf" href="template.html">task</a></li><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+        <li><details><summary>bug-predict</summary><ul><li><a class="leaf" href="#">reference</a></li></ul></details></li>
+        <li><details><summary>code-quality</summary><ul><li><a class="leaf" href="#">task</a></li></ul></details></li>
+        <li><details><summary>deep-review</summary><ul><li><a class="leaf" href="#">concept</a></li></ul></details></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">Pages</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="index.html">Home</a></li>
+        <li><a class="leaf" href="search.html">Search results</a></li>
+        <li><a class="leaf" href="template.html">Template view</a></li>
+        <li><a class="leaf" href="gaps.html">Coverage gaps</a></li>
+      </ul>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="page-head">
+      <h1>Search</h1>
+      <div class="sub">7 results for <code>injection</code> · 142ms · semantic (attune-rag) + lexical fallback</div>
+    </div>
+
+    <div class="result">
+      <div class="result-head">
+        <a class="result-feature" href="template.html">security-audit</a>
+        <span class="result-kind">task</span>
+        <span class="result-spacer"></span>
+        <span class="result-score">★★★★★  0.92</span>
+      </div>
+      <div class="result-snippet">
+        …detects SQL <mark>injection</mark> patterns, command
+        <mark>injection</mark>, path traversal, hardcoded secrets,
+        and other CWE-aligned vulnerabilities. The scanner emits
+        severity-grouped findings with remediation steps…
+      </div>
+    </div>
+
+    <div class="result">
+      <div class="result-head">
+        <a class="result-feature" href="#">security-audit</a>
+        <span class="result-kind">concept</span>
+        <span class="result-spacer"></span>
+        <span class="result-score">★★★★☆  0.88</span>
+      </div>
+      <div class="result-snippet">
+        …OWASP top-10 coverage including <mark>injection</mark>,
+        broken authentication, sensitive data exposure, and XSS.
+        The scanner uses pattern-based detection with smart
+        false-positive filtering…
+      </div>
+    </div>
+
+    <div class="result">
+      <div class="result-head">
+        <a class="result-feature" href="#">bug-predict</a>
+        <span class="result-kind">reference</span>
+        <span class="result-spacer"></span>
+        <span class="result-score">★★★☆☆  0.61</span>
+      </div>
+      <div class="result-snippet">
+        …the <code>dangerous_eval</code> scanner flags potential
+        <mark>injection</mark> via <code>eval()</code> and
+        <code>exec()</code> usage. False positives are filtered
+        by context analysis (test fixtures, detection code)…
+      </div>
+    </div>
+
+    <div class="result">
+      <div class="result-head">
+        <a class="result-feature" href="#">code-quality</a>
+        <span class="result-kind">task</span>
+        <span class="result-spacer"></span>
+        <span class="result-score">★★★☆☆  0.54</span>
+      </div>
+      <div class="result-snippet">
+        …reviews code for quality issues that adjacent to but
+        distinct from security findings — style, structure, and
+        complexity that don't rise to <mark>injection</mark>-level
+        severity but still warrant attention…
+      </div>
+    </div>
+
+    <div class="result">
+      <div class="result-head">
+        <a class="result-feature" href="#">deep-review</a>
+        <span class="result-kind">concept</span>
+        <span class="result-spacer"></span>
+        <span class="result-score">★★☆☆☆  0.42</span>
+      </div>
+      <div class="result-snippet">
+        …multi-pass review escalates to a deeper security-focused
+        pass when surface scanning surfaces high-severity
+        candidates like <mark>injection</mark> or auth bypass…
+      </div>
+    </div>
+
+    <p style="margin-top: 16px; color: var(--fg-muted); font-size: 12px;">
+      2 more results below 0.40 score · <a href="#">show all</a>
+    </p>
+  </main>
+</div>
+
+</body>
+</html>

--- a/docs/specs/ops-help-page/mockups/search.html
+++ b/docs/specs/ops-help-page/mockups/search.html
@@ -26,7 +26,15 @@
 
 <div class="shell">
   <aside class="sidebar">
-    <input type="search" class="search" value="injection" placeholder="Search help…">
+    <form class="search-form" action="search.html" method="get" role="search">
+      <input type="search" name="q" class="search" value="injection" placeholder="Search help…">
+      <button type="submit" class="search-btn" aria-label="Search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="7"></circle>
+          <line x1="21" y1="21" x2="16.5" y2="16.5"></line>
+        </svg>
+      </button>
+    </form>
     <div class="sidebar-section">
       <h3 class="sidebar-section-title">Browse features</h3>
       <ul class="feature-tree">

--- a/docs/specs/ops-help-page/mockups/template.html
+++ b/docs/specs/ops-help-page/mockups/template.html
@@ -26,7 +26,15 @@
 
 <div class="shell">
   <aside class="sidebar">
-    <input type="search" class="search" placeholder="Search help…">
+    <form class="search-form" action="search.html" method="get" role="search">
+      <input type="search" name="q" class="search" placeholder="Search help…">
+      <button type="submit" class="search-btn" aria-label="Search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="7"></circle>
+          <line x1="21" y1="21" x2="16.5" y2="16.5"></line>
+        </svg>
+      </button>
+    </form>
     <div class="sidebar-section">
       <h3 class="sidebar-section-title">security-audit</h3>
       <ul class="feature-tree">

--- a/docs/specs/ops-help-page/mockups/template.html
+++ b/docs/specs/ops-help-page/mockups/template.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>security-audit / task — Help (mockup)</title>
+  <link rel="stylesheet" href="mockup.css">
+</head>
+<body>
+
+<div class="mockup-banner">
+  📐 Mockup — template detail view.
+  <a href="index.html">← Back to home</a>
+</div>
+
+<header class="topbar">
+  <span class="topbar-brand">attune ops</span>
+  <span class="topbar-version">v7.1.2</span>
+  <nav class="topbar-nav">
+    <a href="#">Home</a><a href="#">Workflows</a><a href="#">Specs</a>
+    <a href="#">Sessions</a><a href="#">Telemetry</a>
+    <a href="index.html" class="active">Help</a>
+  </nav>
+  <span class="topbar-spacer"></span>
+  <span class="topbar-project">PROJECT <code>attune-ai</code></span>
+</header>
+
+<div class="shell">
+  <aside class="sidebar">
+    <input type="search" class="search" placeholder="Search help…">
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">security-audit</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="#">comparison</a></li>
+        <li><a class="leaf" href="#">concept</a></li>
+        <li><a class="leaf" href="#">error</a></li>
+        <li><a class="leaf" href="#">faq</a></li>
+        <li><a class="leaf" href="#">note</a></li>
+        <li><a class="leaf" href="#">quickstart</a></li>
+        <li><a class="leaf" href="#">reference</a></li>
+        <li><a class="leaf active" href="template.html">task</a></li>
+        <li><a class="leaf" href="#">tip</a></li>
+        <li><a class="leaf" href="#">troubleshooting</a></li>
+        <li><a class="leaf" href="#">warning</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">See also</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="#">bug-predict</a></li>
+        <li><a class="leaf" href="#">code-quality</a></li>
+        <li><a class="leaf" href="#">deep-review</a></li>
+      </ul>
+    </div>
+    <div class="sidebar-section">
+      <h3 class="sidebar-section-title">Pages</h3>
+      <ul class="feature-tree">
+        <li><a class="leaf" href="index.html">Home</a></li>
+        <li><a class="leaf" href="search.html">Search results</a></li>
+        <li><a class="leaf" href="template.html">Template view</a></li>
+        <li><a class="leaf" href="gaps.html">Coverage gaps</a></li>
+      </ul>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="template-head">
+      <div class="breadcrumb">
+        <a href="index.html">Help</a> ›
+        <a href="#">security-audit</a> ›
+        <span>task</span>
+      </div>
+      <h1 class="template-title">Run a security audit</h1>
+      <div class="template-meta">
+        <span class="chip">task</span>
+        <span class="chip chip-fresh">fresh · 4 days ago</span>
+        <button class="btn">⊕ Pin</button>
+        <button class="btn">Copy link</button>
+      </div>
+    </div>
+
+    <div class="on-this-page">
+      <h3>On this page</h3>
+      <ul>
+        <li><a href="#prerequisites">Prerequisites</a></li>
+        <li><a href="#run-the-audit">Run the audit</a></li>
+        <li><a href="#interpret-results">Interpret results</a></li>
+        <li><a href="#act-on-findings">Act on findings</a></li>
+      </ul>
+    </div>
+
+    <article class="prose">
+      <p>
+        Use <code>attune workflow run security-audit</code> when you
+        want to scan a codebase for vulnerabilities — eval/exec usage,
+        path traversal, hardcoded secrets, and injection risks — and
+        receive a severity-grouped report with actionable remediation
+        steps.
+      </p>
+
+      <h2 id="prerequisites">Prerequisites</h2>
+      <ul>
+        <li>Access to the project source code you want to scan</li>
+        <li>The <code>attune</code> CLI installed and accessible on your <code>PATH</code></li>
+      </ul>
+
+      <h2 id="run-the-audit">Run the audit</h2>
+
+      <h3>1. Choose the path to scan</h3>
+      <p>
+        Identify the directory or file you want to audit. For most
+        projects, <code>src/</code> is a good starting point. Smaller
+        scopes (e.g. <code>src/myapp/auth/</code>) finish faster and
+        produce more focused reports.
+      </p>
+
+      <h3>2. Run the workflow</h3>
+<pre><code>$ attune workflow run security-audit --path src/
+[security-audit] starting on src/
+[security-audit] scanning 234 files…
+[security-audit] 3 findings (1 HIGH, 2 MEDIUM)
+</code></pre>
+
+      <h3>3. Read the report</h3>
+      <p>
+        The workflow writes a severity-grouped report. HIGH findings
+        warrant immediate attention; MEDIUM and LOW can be triaged.
+      </p>
+
+      <h2 id="interpret-results">Interpret results</h2>
+      <p>
+        Each finding includes:
+      </p>
+      <ul>
+        <li><strong>Severity</strong> — HIGH, MEDIUM, or LOW based on CWE classification</li>
+        <li><strong>Location</strong> — <code>file:line</code> reference, clickable in most editors</li>
+        <li><strong>Pattern</strong> — what was detected (e.g. <code>dangerous_eval</code>, <code>broad_exception</code>)</li>
+        <li><strong>Remediation</strong> — a concrete fix suggestion</li>
+      </ul>
+
+      <p>
+        See <a href="#">security-audit / reference</a> for the full
+        pattern catalog, and <a href="#">bug-predict / concept</a> for
+        the broader detection philosophy.
+      </p>
+
+      <h2 id="act-on-findings">Act on findings</h2>
+      <p>
+        Fix HIGH findings first. If the scanner flags a false positive,
+        add the file to the audit-exclusion list (see
+        <a href="#">security-audit / faq</a>).
+      </p>
+
+      <div class="see-also">
+        <h3>See also</h3>
+        <ul>
+          <li><a href="#">security-audit / reference — pattern catalog</a></li>
+          <li><a href="#">security-audit / troubleshooting — common false positives</a></li>
+          <li><a href="#">bug-predict / concept — detection philosophy</a></li>
+          <li><a href="#">code-quality / task — style-vs-security review</a></li>
+        </ul>
+      </div>
+    </article>
+  </main>
+</div>
+
+</body>
+</html>

--- a/docs/specs/ops-help-page/requirements.md
+++ b/docs/specs/ops-help-page/requirements.md
@@ -1,0 +1,300 @@
+# Spec: Ops Help Page
+
+> A first-class help-browsing surface in the attune ops
+> dashboard. Lets users search, browse, and read the
+> `.help/templates/` corpus directly from the browser —
+> independent of any chat / CLI flow.
+
+**Status:** draft
+**Created:** 2026-05-26
+**Owner:** TBD
+**Related:**
+- [`bulletin-curator`](../bulletin-curator/requirements.md) — sibling consumer of the help corpus; same retrieval primitives
+- `attune-help` package — provides the corpus + reader primitives
+- `attune-rag` package — provides the search/retrieval relevance
+- Future spec: `attune-help-client` — extracts the live Q&A surface (current MCP `help_lookup`) into a reusable library; the dashboard help page deliberately does NOT bundle this in v1
+
+---
+
+## Problem statement
+
+The `.help/` system is a substantial body of work — 11 template
+kinds per feature, polished prose, freshness-tracked, queryable
+via `attune-rag`. Today there are only three ways to consume it:
+
+1. The MCP `help_lookup` tool — agent-facing, invoked through
+   Claude Code only
+2. The CLI `/coach` skill — terminal-bound, transient
+3. Reading the raw `.help/templates/<feature>/*.md` files —
+   no search, no cross-references, no rendering
+
+A human user who wants to **browse** the help — see what's there,
+search across it, follow cross-references, surface gaps — has no
+good surface. The dashboard is the natural home for that.
+
+Patrick's framing on the help system: *"a point of pride for me"*.
+The page should reflect that — not a minimum-viable search box,
+but a well-built reading and browsing surface that does justice
+to the corpus.
+
+---
+
+## Goals
+
+1. **Browse the corpus** — sidebar tree of features; expand to
+   see all 11 template kinds per feature; click any to open.
+2. **Search the corpus** — top-bar search backed by attune-rag's
+   semantic retrieval; results ranked by relevance with snippets
+   and click-through.
+3. **Read templates beautifully** — markdown rendered with
+   headings (auto-anchored), code highlighting, working
+   cross-references, math/diagrams if present.
+4. **Surface freshness signals** — the existing
+   "10 stale, 2 incomplete" signal visible in the UI; stale
+   templates get a marker, missing kinds get a gap indicator.
+5. **Surface coverage gaps** — a dedicated tab listing features
+   with incomplete template sets (fewer than the 11 kinds, or
+   stale beyond N days), to support pride-of-craftsmanship in
+   the corpus itself.
+6. **Deep-link friendly** — URLs like
+   `/help/security-audit/task#section-name` work; users can
+   bookmark and share them.
+7. **Power-user affordances** — recent views + pinned templates
+   (local-storage only; no server state needed).
+
+## Non-goals (v1)
+
+- **Live Q&A from the page.** A "type a question, get a synthesized
+  answer" surface — that's the future `attune-help-client` library
+  + a separate dashboard widget. v1 is browse + search only.
+- **Editing.** Templates are read-only in v1. Patrick edits via
+  `attune-author` from the CLI.
+- **Authentication / multi-user.** Same as the rest of the
+  dashboard — single-user, localhost-bound.
+- **Generation / regeneration triggers.** v1 only displays. Buttons
+  to regenerate stale templates can land in v2 if the friction
+  warrants it.
+- **Telemetry on browse patterns.** Don't track what users read
+  in v1. If recommendation-quality tuning needs that signal later,
+  add it deliberately.
+
+---
+
+## Acceptance criteria
+
+1. **Browse the full corpus** — `/help` renders a sidebar with
+   every feature in the corpus and every kind under each feature.
+   No feature missing; no template silently dropped.
+2. **Search returns ranked semantic results** — a query like
+   "how do I detect injection" returns the `security-audit/task`
+   and `security-audit/concept` templates in the top 3 results,
+   not just lexical keyword matches.
+3. **Read renders correctly** — opening a template shows the
+   markdown with proper headings, code highlighting, lists, and
+   tables. Cross-references to other templates are live links.
+4. **Freshness signals visible** — at least one stale template
+   in the corpus renders with a "stale" chip; at least one
+   feature with incomplete kinds shows a gap indicator.
+5. **Coverage gaps surface** — a `/help/gaps` view (or tab)
+   lists features with incomplete sets, sorted by completeness.
+6. **Deep-link works** — opening
+   `/help/security-audit/task#run-the-scan` (or whichever
+   section anchor exists) scrolls to the right section, not
+   the top of the page.
+7. **Performance** — the home page loads in <500ms cold (corpus
+   browse is server-rendered, no JS round-trip). Search responds
+   in <1s for any single query.
+8. **Read-only safety** — no API endpoint exposed under `/api/help/`
+   accepts writes. GET-only.
+
+---
+
+## Wireframes (low-fi, ASCII)
+
+### Home — `/help`
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  attune ops    Home  Workflows  Specs  Sessions  Help …    │
+├──────────────────┬──────────────────────────────────────────┤
+│                  │                                          │
+│  Search help…    │   Help                                   │
+│  [_____________] │                                          │
+│                  │   26 features · 286 templates ·          │
+│  ─ Browse ─      │   10 stale · 2 incomplete   [refresh]   │
+│                  │                                          │
+│  ▾ Features      │   ─ Recent ─                             │
+│    ▸ bug-predict │     • security-audit / task              │
+│    ▾ code-review │     • bulletin / concept                 │
+│      • concept   │     • discovery-sweep / reference        │
+│      • task      │                                          │
+│      • reference │   ─ Pinned ─                             │
+│      • error     │     (none yet — pin from any template)   │
+│      • faq       │                                          │
+│      ⋮ (11 kinds)│   ─ Coverage gaps ─                      │
+│    ▸ discovery-… │     ⚠ 2 features with incomplete sets   │
+│    ⋮ (26 feats)  │     [view all →]                         │
+│                  │                                          │
+│  ─ Browse by kind│   ─ Recently regenerated ─              │
+│    • concept (26)│     • ops-dashboard / concept (today)   │
+│    • task (24)   │     • plugin / reference (today)        │
+│    • reference … │     ⋮                                    │
+│                  │                                          │
+└──────────────────┴──────────────────────────────────────────┘
+```
+
+### Search results — `/help?q=injection`
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  Search help…  [injection_____]                             │
+├──────────────────┬──────────────────────────────────────────┤
+│                  │   Results for "injection" — 7 matches    │
+│  Browse sidebar  │                                          │
+│  (collapsed)     │   ★ security-audit / task                │
+│                  │     "…detects SQL injection patterns,    │
+│                  │     command injection, path traversal…"  │
+│                  │     score 0.92 · 200 chars               │
+│                  │                                          │
+│                  │   ★ security-audit / concept             │
+│                  │     "…OWASP top-10 coverage including    │
+│                  │     injection, XSS, broken auth…"        │
+│                  │     score 0.88                           │
+│                  │                                          │
+│                  │   bug-predict / reference                │
+│                  │     "…the `dangerous_eval` scanner flags │
+│                  │     potential injection via eval()…"     │
+│                  │     score 0.61                           │
+│                  │                                          │
+│                  │   …4 more                                │
+│                  │                                          │
+└──────────────────┴──────────────────────────────────────────┘
+```
+
+### Template view — `/help/security-audit/task`
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  Search help…    │                                          │
+├──────────────────┤   security-audit                         │
+│                  │   ──────────────                         │
+│  ▾ security-audit│   task · ⊕ pin · last updated 4d ago    │
+│    • concept     │                                          │
+│   ★ task ◀       │   On this page                           │
+│    • reference   │   • Run the scan                         │
+│    • error       │   • Interpreting results                 │
+│    • faq         │   • Acting on findings                   │
+│    • troublesh…  │   • Related features                     │
+│    ⋮             │                                          │
+│                  │   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━     │
+│  See also        │                                          │
+│  • bug-predict   │   ## Run the scan                        │
+│  • code-quality  │                                          │
+│  • deep-review   │   ```bash                                │
+│                  │   attune workflow run security-audit \   │
+│                  │     --path src/                          │
+│                  │   ```                                    │
+│                  │                                          │
+│                  │   ## Interpreting results                │
+│                  │   …                                      │
+└──────────────────┴──────────────────────────────────────────┘
+```
+
+### Coverage gaps — `/help/gaps`
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│   Coverage gaps                                              │
+│                                                              │
+│   Features with incomplete template sets (target: 11 kinds): │
+│                                                              │
+│   ⚠ foo-feature           7/11   missing: error,            │
+│                                  troubleshooting, faq, tip   │
+│                                                              │
+│   ⚠ bar-feature           9/11   missing: comparison,       │
+│                                  warning                     │
+│                                                              │
+│   Stale templates (source_hash drift > 7d):                 │
+│                                                              │
+│   ⏰ workflow-x / task     14 days  [regenerate via         │
+│                                     attune-author cli]      │
+│                                                              │
+│   ⏰ feature-y / concept   9 days   …                       │
+│                                                              │
+│   ─ Coverage metrics ─                                       │
+│   Overall: 96% complete (286/297 templates)                 │
+│   Fresh: 92% (264/286 within 7d)                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Tasks (phased)
+
+### Phase 1 — Read primitives + read-only API (~3h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 1 | `attune.ops.help_data` module — wrap attune-help + attune-rag for the corpus / template / search reads | 1h |
+| 2 | Freshness + gap computation (reuse existing attune-author `check_staleness` + a small completeness helper) | 30m |
+| 3 | API routes: `GET /api/help/`, `/api/help/feature/<slug>`, `/api/help/template/<feature>/<kind>`, `/api/help/search?q=`, `/api/help/gaps` | 1h |
+| 4 | Route tests + API contract tests | 30m |
+
+### Phase 2 — Browse + search UI (~4h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 5 | `/help` route + `help.html` template (home + sidebar) | 1.5h |
+| 6 | Search results rendering (snippet highlighting, relevance score) | 1h |
+| 7 | Template view route + render (markdown w/ anchors + code highlighting) | 1h |
+| 8 | Cross-reference link resolution (`concepts/tool-X.md` → `/help/X/concept`) | 30m |
+
+### Phase 3 — Polish + power-user (~2h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 9 | Freshness chips + coverage gaps tab | 45m |
+| 10 | Recent + pinned (localStorage only) | 30m |
+| 11 | Deep-link / anchor handling | 30m |
+| 12 | CSS pass — match dashboard conventions, prose typography | 30m |
+
+### Phase 4 — Verification (~1h)
+
+| # | Task | Effort |
+|---|------|--------|
+| 13 | Live verification against the real attune-ai `.help/` corpus; eyeball search relevance + browse UX with Patrick | 1h |
+
+**Total estimated:** 10h. Phases 1+2 are the MVP (browse + search work);
+Phases 3+4 are the polish that earns "point of pride."
+
+---
+
+## Open questions
+
+1. **Search backend choice.** attune-rag's existing retrieval is the
+   semantic option; a simple lexical fallback is the no-cost option.
+   Lean: use attune-rag (you've already invested in benchmarks +
+   faithfulness scoring; this surface inherits that quality). If
+   attune-rag isn't installed, degrade to lexical (filename + first
+   500 chars match).
+
+2. **Markdown renderer choice.** `markdown-it-py` (used elsewhere in
+   attune-ops for the spec viewer) is the obvious pick — same
+   sanitization story, consistent code-block styling. Confirmed
+   default: yes.
+
+3. **Pinned scope.** localStorage-only (per-browser) vs persisted to
+   `<attune_home>/help/pins.json` (per-machine). Lean: localStorage
+   for v1 — simpler, no server state to migrate; users who want
+   persistence can wait for v2.
+
+4. **Coverage-gap thresholds.** Currently the corpus targets 11 kinds
+   per feature; staleness is "> 7d source_hash drift" per
+   attune-author. Confirm both as the v1 defaults, or surface as
+   config.
+
+5. **Help-page indexing for the curator.** Should the curator have
+   a separate `help.py` source reader that surfaces "feature X
+   has documentation drift Patrick might want to fix"? Probably
+   yes, but separate task — falls under the curator spec's source
+   list, not this one.


### PR DESCRIPTION
## Summary

New spec for a first-class help-browsing surface in the attune-ops dashboard. Browse, search, and read the \`.help/templates/\` corpus directly from the browser — independent of MCP \`help_lookup\` / CLI \`/coach\`.

## What's in this PR

Just \`requirements.md\` (300 lines). Includes:

- **Problem + goals + non-goals** — captures the v1 scope we agreed on: A (static browse + search) as the dashboard-native surface; B (live Q&A) deferred to a future \`attune-help-client\` library that any consumer can call
- **Acceptance criteria** (8 items) — including the freshness + coverage-gap requirements
- **Low-fi ASCII wireframes** for the four key views:
  - Home (\`/help\`) — sidebar tree + corpus stats + recent + pinned + gaps preview
  - Search results (\`/help?q=...\`) — ranked snippets with relevance score
  - Template detail (\`/help/<feature>/<kind>\`) — markdown rendering with on-page nav + cross-references
  - Coverage gaps (\`/help/gaps\`) — features with incomplete sets + stale templates
- **Phased plan**: ~10h across 4 phases. Phases 1+2 ship the browse+search MVP; phases 3+4 are polish
- **5 open questions** at the end — search backend choice, markdown renderer, pinned scope, gap thresholds, curator integration

## Design choices baked in (open for pushback)

- **Search backend:** attune-rag (semantic) by default; lexical fallback when attune-rag isn't installed
- **Markdown:** \`markdown-it-py\` (consistent with the spec viewer)
- **Pinned:** localStorage only in v1 (no server state to migrate)
- **Read-only:** GET-only API surface; no edit / regenerate buttons in v1
- **No telemetry** on browse patterns in v1

## What's NOT in this PR

- \`design.md\` and \`tasks.md\` — drafted next, after you react to requirements + wireframes
- Implementation — \`design.md\` translates to executable tasks; implementation is a separate set of PRs

## Test plan

- [x] Wireframes render legibly in markdown
- [x] All 5 open questions are real questions, not pseudo-decisions
- [x] Cross-references to bulletin-curator + future attune-help-client land correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)