### PR TITLE
docs(specs/ops-help-page): promote 'Maintain corpus' to 'Admin tools' button

### DIFF
--- a/docs/specs/ops-help-page/mockups/_partials.html
+++ b/docs/specs/ops-help-page/mockups/_partials.html
@@ -103,7 +103,7 @@
     <h3 class="sidebar-section-title">Pages</h3>
     <ul class="feature-tree">
       <li><a class="leaf" href="index.html">Home</a></li>
-      <li><a class="leaf" href="gaps.html">Coverage gaps</a></li>
+      <li><a class="leaf" href="admin.html">Admin tools</a></li>
       <li><a class="leaf" href="search.html">Search results (demo)</a></li>
       <li><a class="leaf" href="template.html">Template view (demo)</a></li>
     </ul>

--- a/docs/specs/ops-help-page/mockups/admin.html
+++ b/docs/specs/ops-help-page/mockups/admin.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Coverage gaps — Help (mockup)</title>
+  <title>Admin tools — Help (mockup)</title>
   <link rel="stylesheet" href="mockup.css">
 </head>
 <body>
 
 <div class="mockup-banner">
-  📐 Mockup — coverage gaps view.
+  📐 Mockup — Admin tools (coverage gaps + corpus health).
   <a href="index.html">← Back to home</a>
 </div>
 
@@ -41,7 +41,7 @@
         <li><a class="leaf" href="index.html">Home</a></li>
         <li><a class="leaf" href="search.html">Search results</a></li>
         <li><a class="leaf" href="template.html">Template view</a></li>
-        <li><a class="leaf active" href="gaps.html">Coverage gaps</a></li>
+        <li><a class="leaf active" href="admin.html">Admin tools</a></li>
       </ul>
     </div>
     <div class="sidebar-section">
@@ -56,8 +56,8 @@
 
   <main class="main">
     <div class="page-head">
-      <h1>Coverage gaps</h1>
-      <div class="sub">Features with incomplete template sets or stale source hashes.</div>
+      <h1>Admin tools</h1>
+      <div class="sub">Maintenance surface for the <code>.help/templates/</code> corpus — coverage gaps, stale templates, regeneration shortcuts.</div>
     </div>
 
     <div class="stat-strip">

--- a/docs/specs/ops-help-page/mockups/index.html
+++ b/docs/specs/ops-help-page/mockups/index.html
@@ -8,9 +8,8 @@
 <body>
 
 <div class="mockup-banner">
-  📐 Mockup v2 — user-first home for
-  <a href="https://github.com/Smart-AI-Memory/attune-ai/pull/482">PR #482</a>.
-  Maintainer view moved to <a href="gaps.html">Maintain corpus</a> at the bottom.
+  📐 Mockup v3 — user-first home with prominent
+  <a href="admin.html">Admin tools</a> button (top right).
 </div>
 
 <header class="topbar">
@@ -27,6 +26,20 @@
 
 <div class="shell shell-full">
   <main class="main">
+
+    <div class="page-toolbar">
+      <a href="admin.html" class="btn-admin">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M14.7 6.3a1 1 0 0 0 .256 1.085l2.66 2.66a1 1 0 0 0 1.085.256 6 6 0 1 1-4.001 4Z"></path>
+          <path d="m14 7-3 3"></path>
+          <path d="M19.7 9.3l1.3 1.3"></path>
+          <path d="M9.4 9.4a3 3 0 0 0-4.2 4.2L3 16v3h3l2.4-2.4a3 3 0 0 0 4.2-4.2L9.4 9.4Z"></path>
+        </svg>
+        Admin tools
+        <span class="health-chip">10 stale · 2 incomplete</span>
+      </a>
+    </div>
 
     <section class="hero">
       <h1>How can attune help?</h1>
@@ -175,10 +188,6 @@
 
     <footer class="maintain-footer">
       <span>286 templates across 25 features</span>
-      <span>
-        <a href="gaps.html">Maintain corpus →</a>
-        <span class="health-chip">10 stale · 2 incomplete</span>
-      </span>
     </footer>
   </main>
 </div>

--- a/docs/specs/ops-help-page/mockups/mockup.css
+++ b/docs/specs/ops-help-page/mockups/mockup.css
@@ -803,3 +803,38 @@ a:hover { text-decoration: underline; }
   color: var(--fg);
 }
 .search-form .search-btn svg { width: 14px; height: 14px; }
+
+/* Admin tools button — top-right of the home page */
+.page-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 16px 0 0;
+}
+.btn-admin {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--fg);
+  font-weight: 500;
+  font-size: 13px;
+  text-decoration: none;
+  transition: border-color 80ms, background 80ms;
+}
+.btn-admin:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  text-decoration: none;
+}
+.btn-admin svg {
+  width: 16px;
+  height: 16px;
+  color: var(--fg-muted);
+}
+.btn-admin:hover svg { color: var(--accent); }
+.btn-admin .health-chip {
+  margin-left: 4px;
+}

--- a/docs/specs/ops-help-page/mockups/search.html
+++ b/docs/specs/ops-help-page/mockups/search.html
@@ -51,7 +51,7 @@
         <li><a class="leaf" href="index.html">Home</a></li>
         <li><a class="leaf" href="search.html">Search results</a></li>
         <li><a class="leaf" href="template.html">Template view</a></li>
-        <li><a class="leaf" href="gaps.html">Coverage gaps</a></li>
+        <li><a class="leaf" href="admin.html">Admin tools</a></li>
       </ul>
     </div>
   </aside>

--- a/docs/specs/ops-help-page/mockups/template.html
+++ b/docs/specs/ops-help-page/mockups/template.html
@@ -65,7 +65,7 @@
         <li><a class="leaf" href="index.html">Home</a></li>
         <li><a class="leaf" href="search.html">Search results</a></li>
         <li><a class="leaf" href="template.html">Template view</a></li>
-        <li><a class="leaf" href="gaps.html">Coverage gaps</a></li>
+        <li><a class="leaf" href="admin.html">Admin tools</a></li>
       </ul>
     </div>
   </aside>


### PR DESCRIPTION
## Summary

Per feedback on #482 — the maintainer surface was buried in the page footer. Promoted to a top-right button with prominence + clearer naming.

### Before
- Tiny "Maintain corpus →" link in the page footer (easy to miss)
- "Coverage gaps" page H1

### After
- Top-right \`Admin tools\` button with wrench icon + health chip inline
- \`admin.html\` (renamed from \`gaps.html\`) with H1 "Admin tools"
- Same content underneath; just reframed as the maintenance surface

## Why "Admin tools"

- Clearer role-shift signal than "Maintain corpus" (action-language → role-language)
- Matches the convention readers expect when leaving a user surface
- Future admin surfaces (audit log, regen, etc.) land on the same page as sections, not new routes

## Test plan

- [x] Mockup preview confirms button + chip render correctly top-right
- [x] All cross-references (sidebar nav, search/template links) updated to \`admin.html\`
- [x] Banner text updated to v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)