### PR TITLE
feat(ops/help): live /help page — browse + search + admin tools

### DIFF
--- a/src/attune/ops/help_data.py
+++ b/src/attune/ops/help_data.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
+import subprocess
+import time
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -23,6 +26,17 @@ from pathlib import Path
 from attune.ops.config import Config
 
 logger = logging.getLogger(__name__)
+
+# Authority cache TTL for attune-author status. Short enough that
+# regen jobs that change staleness state surface promptly; long
+# enough that a page-refresh burst doesn't re-spawn the subprocess
+# per request.
+_STALENESS_CACHE_TTL_SECONDS = 5.0
+
+# Process-lifetime cache for attune-author status. Keyed on the
+# (project_root, help_dir) pair so multiple dashboards in one
+# process don't cross-contaminate.
+_staleness_cache: dict[tuple[str, str], tuple[float, frozenset[str]]] = {}
 
 # The 11 template kinds attune-author produces per feature. A
 # feature with all 11 is "complete"; fewer = an incomplete set.
@@ -177,18 +191,28 @@ def corpus_root(config: Config) -> Path:
 
 
 def list_features(config: Config) -> list[FeatureSummary]:
-    """All features in the corpus, alphabetical."""
+    """All features in the corpus, alphabetical.
+
+    Staleness comes from ``attune-author status`` when available
+    (the authoritative source-hash drift signal). Falls back to
+    per-template age-based check when attune-author isn't on PATH.
+    """
     root = corpus_root(config)
     if not root.exists():
         return []
+    stale = _attune_author_stale_features(config.project_root, config.project_root / ".help")
     out: list[FeatureSummary] = []
     for feat_dir in sorted(p for p in root.iterdir() if p.is_dir()):
-        out.append(_summarize_feature(feat_dir))
+        out.append(_summarize_feature(feat_dir, stale_features=stale))
     return out
 
 
 def get_template(config: Config, feature: str, kind: str) -> TemplateRecord | None:
-    """Load one template by feature + kind. None if missing."""
+    """Load one template by feature + kind. None if missing.
+
+    Staleness uses the attune-author authority when available;
+    falls back to age-based when the CLI isn't on PATH.
+    """
     if not _safe_slug(feature) or not _safe_slug(kind):
         return None
     path = corpus_root(config) / feature / f"{kind}.md"
@@ -199,7 +223,8 @@ def get_template(config: Config, feature: str, kind: str) -> TemplateRecord | No
     except OSError as exc:
         logger.warning("help_data: cannot read %s: %s", path, exc)
         return None
-    return _parse_template(feature, kind, path, raw)
+    stale = _attune_author_stale_features(config.project_root, config.project_root / ".help")
+    return _parse_template(feature, kind, path, raw, stale_features=stale)
 
 
 def search(config: Config, query: str, *, limit: int = 20) -> list[SearchHit]:
@@ -389,18 +414,38 @@ def _safe_slug(s: str) -> bool:
     return bool(s) and bool(_SLUG_RE.match(s)) and ".." not in s
 
 
-def _summarize_feature(feat_dir: Path) -> FeatureSummary:
-    """Scan a feature directory for its kinds + freshness."""
+def _summarize_feature(
+    feat_dir: Path, *, stale_features: frozenset[str] | None = None
+) -> FeatureSummary:
+    """Scan a feature directory for its kinds + freshness.
+
+    ``stale_features`` is the authoritative set from
+    :func:`_attune_author_stale_features` (drift-based). When
+    ``None`` the function falls back to per-template age-based
+    staleness — used in tests and when attune-author isn't on PATH.
+    """
     name = feat_dir.name
     kinds: list[str] = []
-    stale_count = 0
-    for kind in EXPECTED_KINDS:
-        path = feat_dir / f"{kind}.md"
-        if not path.is_file():
-            continue
-        kinds.append(kind)
-        if _is_template_stale(path):
-            stale_count += 1
+    if stale_features is None:
+        # Fallback: age-based per-template check.
+        stale_count = 0
+        for kind in EXPECTED_KINDS:
+            path = feat_dir / f"{kind}.md"
+            if not path.is_file():
+                continue
+            kinds.append(kind)
+            if _is_template_stale(path):
+                stale_count += 1
+    else:
+        # Authority path: if the feature is in attune-author's
+        # stale set, every kind it has is treated as stale (the
+        # source files drifted; all derived templates need
+        # regen). If not in the set, nothing is stale.
+        for kind in EXPECTED_KINDS:
+            path = feat_dir / f"{kind}.md"
+            if path.is_file():
+                kinds.append(kind)
+        stale_count = len(kinds) if name in stale_features else 0
     missing = tuple(k for k in EXPECTED_KINDS if k not in kinds)
     return FeatureSummary(
         name=name,
@@ -411,11 +456,20 @@ def _summarize_feature(feat_dir: Path) -> FeatureSummary:
     )
 
 
-def _is_template_stale(path: Path) -> bool:
-    """Quick freshness check — frontmatter generated_at > STALE_THRESHOLD_DAYS old.
+def _is_template_stale(path: Path, *, stale_features: frozenset[str] | None = None) -> bool:
+    """Per-template freshness check.
 
-    We read only the frontmatter, not the full body — cheap.
+    Two modes:
+    - Authority (``stale_features`` provided): a template is stale
+      if its parent feature is in attune-author's drift set.
+    - Fallback (``stale_features`` is ``None``): age-based —
+      ``generated_at`` older than :data:`STALE_THRESHOLD_DAYS`.
     """
+    if stale_features is not None:
+        # path is .../<feature>/<kind>.md
+        feature = path.parent.name
+        return feature in stale_features
+
     try:
         with path.open("r", encoding="utf-8", errors="replace") as fh:
             chunk = fh.read(1024)
@@ -436,8 +490,114 @@ def _is_template_stale(path: Path) -> bool:
     return age_days > STALE_THRESHOLD_DAYS
 
 
-def _parse_template(feature: str, kind: str, path: Path, raw: str) -> TemplateRecord:
-    """Split frontmatter + body, build a TemplateRecord."""
+# ---------------------------------------------------------------------------
+# attune-author authority — source-hash drift, the real staleness signal
+# ---------------------------------------------------------------------------
+
+
+# Markdown table-row pattern from attune-author's ``status``
+# output. Format:
+#   | <feature> | <description> | <files-changed> |
+# The header + divider rows are filtered by the surrounding
+# parser context (only rows AFTER "### Stale" + the divider row).
+_TABLE_ROW_RE = re.compile(r"^\s*\|\s*([a-z][a-z0-9-]*)\s*\|")
+
+
+def _attune_author_stale_features(project_root: Path, help_dir: Path) -> frozenset[str] | None:
+    """Return the set of features attune-author reports as stale.
+
+    Shells out to ``attune-author status`` and parses the markdown
+    output. Result cached for :data:`_STALENESS_CACHE_TTL_SECONDS`
+    per ``(project_root, help_dir)`` key.
+
+    Returns:
+        - ``frozenset[str]``: feature names with source-hash drift,
+          including the empty set when everything is in sync.
+        - ``None`` when attune-author isn't on PATH or its
+          subprocess fails — callers fall back to age-based
+          staleness in that case.
+    """
+    key = (str(project_root), str(help_dir))
+    now = time.monotonic()
+    cached = _staleness_cache.get(key)
+    if cached is not None and (now - cached[0]) < _STALENESS_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    binary = shutil.which("attune-author")
+    if binary is None:
+        logger.info("help_data: attune-author not on PATH; using age fallback")
+        return None
+    cmd = [
+        binary,
+        "status",
+        "--project-root",
+        str(project_root),
+        "--help-dir",
+        str(help_dir),
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.warning("help_data: attune-author status failed: %s", exc)
+        return None
+    stale = _parse_status_output(result.stdout)
+    _staleness_cache[key] = (now, stale)
+    return stale
+
+
+def _parse_status_output(text: str) -> frozenset[str]:
+    """Extract stale feature names from ``attune-author status`` output.
+
+    Strategy: walk lines, track whether we're inside the
+    ``### Stale`` section, treat each markdown table row whose
+    first column is a slug-shaped string as a stale feature.
+    Skips the header and divider rows automatically because they
+    don't match :data:`_TABLE_ROW_RE` (they begin with ``Feature``
+    or ``-----``).
+    """
+    out: set[str] = set()
+    in_stale = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("###"):
+            in_stale = stripped == "### Stale"
+            continue
+        if not in_stale:
+            continue
+        m = _TABLE_ROW_RE.match(line)
+        if m:
+            out.add(m.group(1))
+    return frozenset(out)
+
+
+def _clear_staleness_cache() -> None:
+    """Test hook — flushes the per-process staleness cache."""
+    _staleness_cache.clear()
+
+
+def _parse_template(
+    feature: str,
+    kind: str,
+    path: Path,
+    raw: str,
+    *,
+    stale_features: frozenset[str] | None = None,
+) -> TemplateRecord:
+    """Split frontmatter + body, build a TemplateRecord.
+
+    When ``stale_features`` is provided (the attune-author
+    authority set), staleness comes from feature-in-set lookup.
+    Otherwise falls back to age-based staleness from the
+    frontmatter ``generated_at``.
+    """
     m = _FRONTMATTER_RE.match(raw)
     if m:
         fm = m.group("fm")
@@ -448,16 +608,21 @@ def _parse_template(feature: str, kind: str, path: Path, raw: str) -> TemplateRe
     generated_at = _extract_frontmatter_field(fm, "generated_at")
     source_hash = _extract_frontmatter_field(fm, "source_hash")
     title = _title_from_content(body) or f"{feature} / {kind}"
-    is_stale = False
-    if generated_at:
-        try:
-            when = datetime.fromisoformat(generated_at)
-            if when.tzinfo is None:
-                when = when.replace(tzinfo=timezone.utc)
-            age_days = (datetime.now(timezone.utc) - when).total_seconds() / 86_400
-            is_stale = age_days > STALE_THRESHOLD_DAYS
-        except (ValueError, TypeError):
-            pass
+
+    if stale_features is not None:
+        is_stale = feature in stale_features
+    else:
+        is_stale = False
+        if generated_at:
+            try:
+                when = datetime.fromisoformat(generated_at)
+                if when.tzinfo is None:
+                    when = when.replace(tzinfo=timezone.utc)
+                age_days = (datetime.now(timezone.utc) - when).total_seconds() / 86_400
+                is_stale = age_days > STALE_THRESHOLD_DAYS
+            except (ValueError, TypeError):
+                pass
+
     return TemplateRecord(
         feature=feature,
         kind=kind,

--- a/src/attune/ops/help_data.py
+++ b/src/attune/ops/help_data.py
@@ -620,8 +620,14 @@ def _parse_template(
                     when = when.replace(tzinfo=timezone.utc)
                 age_days = (datetime.now(timezone.utc) - when).total_seconds() / 86_400
                 is_stale = age_days > STALE_THRESHOLD_DAYS
-            except (ValueError, TypeError):
-                pass
+            except (ValueError, TypeError) as exc:
+                logger.debug(
+                    "could not parse generated_at=%r for %s/%s (%s); " "leaving is_stale=False",
+                    generated_at,
+                    feature,
+                    kind,
+                    exc,
+                )
 
     return TemplateRecord(
         feature=feature,

--- a/src/attune/ops/help_data.py
+++ b/src/attune/ops/help_data.py
@@ -1,0 +1,536 @@
+"""Help-corpus reads for the ops dashboard's /help page.
+
+Wraps :mod:`attune_rag` (corpus walker + keyword retrieval) and
+the on-disk ``.help/templates/`` layout into a small set of
+read-only functions the dashboard route + JSON API consume.
+
+See ``docs/specs/ops-help-page/`` for the spec. The data shape
+mirrors the mockup HTML the spec ships with.
+
+Zero new deps. Falls back gracefully when ``attune_rag`` isn't
+installed (returns empty results rather than 500).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from attune.ops.config import Config
+
+logger = logging.getLogger(__name__)
+
+# The 11 template kinds attune-author produces per feature. A
+# feature with all 11 is "complete"; fewer = an incomplete set.
+EXPECTED_KINDS: tuple[str, ...] = (
+    "comparison",
+    "concept",
+    "error",
+    "faq",
+    "note",
+    "quickstart",
+    "reference",
+    "task",
+    "tip",
+    "troubleshooting",
+    "warning",
+)
+
+# Kinds grouped by user intent — drives the "Browse by what you
+# need" cards on the home page.
+INTENT_GROUPS: dict[str, tuple[str, ...]] = {
+    "do": ("task", "quickstart"),
+    "solve": ("troubleshooting", "error", "faq"),
+    "understand": ("concept",),
+    "lookup": ("reference",),
+}
+
+# Staleness threshold — a template whose ``generated_at`` is more
+# than this many days old gets a "stale" chip. Matches the
+# attune-author docs convention.
+STALE_THRESHOLD_DAYS = 7
+
+# Frontmatter regex — quick parse without pulling in PyYAML.
+_FRONTMATTER_RE = re.compile(
+    r"\A---\s*\n(?P<fm>.*?)\n---\s*\n(?P<body>.*)\Z",
+    re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TemplateRecord:
+    """One template file."""
+
+    feature: str
+    kind: str
+    path: str
+    title: str
+    body: str
+    generated_at: str | None
+    source_hash: str | None
+    is_stale: bool
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class FeatureSummary:
+    """One feature — name + which kinds exist."""
+
+    name: str
+    kinds: tuple[str, ...]
+    missing_kinds: tuple[str, ...]
+    stale_count: int
+    has_any_stale: bool
+
+    @property
+    def is_complete(self) -> bool:
+        return len(self.missing_kinds) == 0
+
+    @property
+    def completeness_pct(self) -> int:
+        if not EXPECTED_KINDS:
+            return 100
+        return round(100 * len(self.kinds) / len(EXPECTED_KINDS))
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["kinds"] = list(self.kinds)
+        d["missing_kinds"] = list(self.missing_kinds)
+        d["is_complete"] = self.is_complete
+        d["completeness_pct"] = self.completeness_pct
+        return d
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    """One ranked hit from a search query."""
+
+    feature: str
+    kind: str
+    title: str
+    snippet: str
+    score: float
+    match_reason: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class GapsReport:
+    """Coverage-gap signals — incomplete sets + stale templates."""
+
+    incomplete: tuple[FeatureSummary, ...] = field(default_factory=tuple)
+    stale: tuple[TemplateRecord, ...] = field(default_factory=tuple)
+    total_features: int = 0
+    total_templates: int = 0
+    complete_features: int = 0
+
+    @property
+    def completeness_pct(self) -> int:
+        if self.total_features == 0:
+            return 0
+        return round(100 * self.complete_features / self.total_features)
+
+    @property
+    def fresh_pct(self) -> int:
+        if self.total_templates == 0:
+            return 0
+        stale_n = len(self.stale)
+        return round(100 * (self.total_templates - stale_n) / self.total_templates)
+
+    def to_dict(self) -> dict:
+        return {
+            "incomplete": [f.to_dict() for f in self.incomplete],
+            "stale": [t.to_dict() for t in self.stale],
+            "total_features": self.total_features,
+            "total_templates": self.total_templates,
+            "complete_features": self.complete_features,
+            "completeness_pct": self.completeness_pct,
+            "fresh_pct": self.fresh_pct,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Public functions
+# ---------------------------------------------------------------------------
+
+
+def corpus_root(config: Config) -> Path:
+    """Return the ``.help/templates/`` directory for this project.
+
+    The dashboard reads templates from the project root's ``.help``
+    directory — same source attune-author writes to.
+    """
+    return config.project_root / ".help" / "templates"
+
+
+def list_features(config: Config) -> list[FeatureSummary]:
+    """All features in the corpus, alphabetical."""
+    root = corpus_root(config)
+    if not root.exists():
+        return []
+    out: list[FeatureSummary] = []
+    for feat_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        out.append(_summarize_feature(feat_dir))
+    return out
+
+
+def get_template(config: Config, feature: str, kind: str) -> TemplateRecord | None:
+    """Load one template by feature + kind. None if missing."""
+    if not _safe_slug(feature) or not _safe_slug(kind):
+        return None
+    path = corpus_root(config) / feature / f"{kind}.md"
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("help_data: cannot read %s: %s", path, exc)
+        return None
+    return _parse_template(feature, kind, path, raw)
+
+
+def search(config: Config, query: str, *, limit: int = 20) -> list[SearchHit]:
+    """Run a keyword search against the corpus.
+
+    Returns ranked hits. Empty list when attune-rag isn't installed
+    or the corpus is empty — both are graceful degradations.
+
+    Builds inline summaries (first non-empty paragraph after the
+    frontmatter) for each template and passes them to the retriever
+    via ``extra_summaries``. attune-rag's KeywordRetriever weights
+    summary hits ~1.5x content hits, so without a summary it
+    returns zero results regardless of content matches — see the
+    existing CLAUDE.md lesson "Metadata can reach a retriever with
+    zero signal if the sidecar schema doesn't match the loader's
+    expected shape."
+    """
+    if not query or not query.strip():
+        return []
+    root = corpus_root(config)
+    if not root.exists():
+        return []
+    try:
+        from attune_rag import DirectoryCorpus, KeywordRetriever
+    except ImportError:
+        logger.info("help_data: attune-rag not installed, search disabled")
+        return []
+
+    try:
+        summaries = _build_inline_summaries(root)
+        corpus = DirectoryCorpus(root, extra_summaries=summaries)
+        retriever = KeywordRetriever()
+        hits = list(retriever.retrieve(query, corpus, k=limit))
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: search must not 500 the dashboard. Log and
+        # return empty.
+        logger.warning("help_data: search failed: %s", exc)
+        return []
+
+    out: list[SearchHit] = []
+    for hit in hits:
+        path = Path(hit.entry.path)
+        feature, kind = _feature_kind_from_path(path)
+        if feature is None or kind is None:
+            continue
+        title = _title_from_content(hit.entry.content) or f"{feature} / {kind}"
+        snippet = _snippet(hit.entry.content, query, max_len=240)
+        out.append(
+            SearchHit(
+                feature=feature,
+                kind=kind,
+                title=title,
+                snippet=snippet,
+                score=float(hit.score),
+                match_reason=str(hit.match_reason or ""),
+            )
+        )
+    return out
+
+
+def _build_inline_summaries(root: Path) -> dict[str, str]:
+    """Walk the corpus and extract a one-paragraph summary per template.
+
+    Used by :func:`search` to give attune-rag's retriever something
+    to score against. The summary is the first non-empty paragraph
+    after the frontmatter, truncated to ~400 chars.
+
+    Returns a dict keyed by path-relative-to-root (the shape
+    DirectoryCorpus expects from ``extra_summaries``).
+    """
+    out: dict[str, str] = {}
+    for md_file in root.rglob("*.md"):
+        try:
+            rel = str(md_file.relative_to(root))
+        except ValueError:
+            continue
+        try:
+            raw = md_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        m = _FRONTMATTER_RE.match(raw)
+        body = m.group("body") if m else raw
+        summary = _first_paragraph(body, max_chars=400)
+        if summary:
+            out[rel] = summary
+    return out
+
+
+def _first_paragraph(body: str, *, max_chars: int = 400) -> str:
+    """First non-empty, non-heading paragraph of a markdown body."""
+    paragraph_lines: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if paragraph_lines:
+                break
+            continue
+        if stripped.startswith("#") or stripped.startswith("```"):
+            if paragraph_lines:
+                break
+            continue
+        paragraph_lines.append(stripped)
+    text = " ".join(paragraph_lines)
+    if len(text) > max_chars:
+        text = text[: max_chars - 1].rsplit(" ", 1)[0] + "…"
+    return text
+
+
+def coverage_gaps(config: Config) -> GapsReport:
+    """Compute incomplete sets + stale templates across the corpus."""
+    features = list_features(config)
+    if not features:
+        return GapsReport()
+
+    incomplete = tuple(f for f in features if not f.is_complete)
+    complete_features = sum(1 for f in features if f.is_complete)
+    total_features = len(features)
+    total_templates = sum(len(f.kinds) for f in features)
+
+    stale: list[TemplateRecord] = []
+    for feat in features:
+        for kind in feat.kinds:
+            rec = get_template(config, feat.name, kind)
+            if rec is None or not rec.is_stale:
+                continue
+            stale.append(rec)
+    # Sort stale by oldest first (most-stale at top).
+    stale.sort(key=lambda r: r.generated_at or "")
+
+    return GapsReport(
+        incomplete=incomplete,
+        stale=tuple(stale),
+        total_features=total_features,
+        total_templates=total_templates,
+        complete_features=complete_features,
+    )
+
+
+def recently_regenerated(config: Config, *, limit: int = 5) -> list[TemplateRecord]:
+    """N most-recently-generated templates across the corpus."""
+    records: list[TemplateRecord] = []
+    for feat in list_features(config):
+        for kind in feat.kinds:
+            rec = get_template(config, feat.name, kind)
+            if rec is None or rec.generated_at is None:
+                continue
+            records.append(rec)
+    records.sort(key=lambda r: r.generated_at or "", reverse=True)
+    return records[:limit]
+
+
+def featured_topics(config: Config) -> list[FeatureSummary]:
+    """Curated list of high-leverage features for the home page.
+
+    v1: hard-coded shortlist of features the dashboard wants to
+    nudge users toward. Falls back to "first N features" if any of
+    the curated picks aren't in the corpus.
+    """
+    curated = (
+        "security-audit",
+        "smart-test",
+        "bug-predict",
+        "deep-review",
+        "release-prep",
+    )
+    features = {f.name: f for f in list_features(config)}
+    out = [features[name] for name in curated if name in features]
+    if len(out) < 3:
+        # Fallback — first few features alphabetically.
+        out = list(features.values())[:5]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+_SLUG_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def _safe_slug(s: str) -> bool:
+    """True if ``s`` matches the feature/kind slug shape.
+
+    Defense in depth against path-traversal in /api/help/template/...
+    """
+    return bool(s) and bool(_SLUG_RE.match(s)) and ".." not in s
+
+
+def _summarize_feature(feat_dir: Path) -> FeatureSummary:
+    """Scan a feature directory for its kinds + freshness."""
+    name = feat_dir.name
+    kinds: list[str] = []
+    stale_count = 0
+    for kind in EXPECTED_KINDS:
+        path = feat_dir / f"{kind}.md"
+        if not path.is_file():
+            continue
+        kinds.append(kind)
+        if _is_template_stale(path):
+            stale_count += 1
+    missing = tuple(k for k in EXPECTED_KINDS if k not in kinds)
+    return FeatureSummary(
+        name=name,
+        kinds=tuple(kinds),
+        missing_kinds=missing,
+        stale_count=stale_count,
+        has_any_stale=stale_count > 0,
+    )
+
+
+def _is_template_stale(path: Path) -> bool:
+    """Quick freshness check — frontmatter generated_at > STALE_THRESHOLD_DAYS old.
+
+    We read only the frontmatter, not the full body — cheap.
+    """
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            chunk = fh.read(1024)
+    except OSError:
+        return False
+    m = _FRONTMATTER_RE.match(chunk + "\n---\n" if "---" not in chunk[3:] else chunk)
+    fm = m.group("fm") if m else chunk
+    gen_at = _extract_frontmatter_field(fm, "generated_at")
+    if not gen_at:
+        return False
+    try:
+        when = datetime.fromisoformat(gen_at)
+    except (ValueError, TypeError):
+        return False
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    age_days = (datetime.now(timezone.utc) - when).total_seconds() / 86_400
+    return age_days > STALE_THRESHOLD_DAYS
+
+
+def _parse_template(feature: str, kind: str, path: Path, raw: str) -> TemplateRecord:
+    """Split frontmatter + body, build a TemplateRecord."""
+    m = _FRONTMATTER_RE.match(raw)
+    if m:
+        fm = m.group("fm")
+        body = m.group("body")
+    else:
+        fm = ""
+        body = raw
+    generated_at = _extract_frontmatter_field(fm, "generated_at")
+    source_hash = _extract_frontmatter_field(fm, "source_hash")
+    title = _title_from_content(body) or f"{feature} / {kind}"
+    is_stale = False
+    if generated_at:
+        try:
+            when = datetime.fromisoformat(generated_at)
+            if when.tzinfo is None:
+                when = when.replace(tzinfo=timezone.utc)
+            age_days = (datetime.now(timezone.utc) - when).total_seconds() / 86_400
+            is_stale = age_days > STALE_THRESHOLD_DAYS
+        except (ValueError, TypeError):
+            pass
+    return TemplateRecord(
+        feature=feature,
+        kind=kind,
+        path=str(path.relative_to(path.parents[2])) if len(path.parents) >= 3 else str(path),
+        title=title,
+        body=body,
+        generated_at=generated_at,
+        source_hash=source_hash,
+        is_stale=is_stale,
+    )
+
+
+def _extract_frontmatter_field(fm: str, key: str) -> str | None:
+    """Pull a top-level key from YAML-shaped frontmatter without PyYAML."""
+    pattern = rf"^{re.escape(key)}\s*:\s*(.+?)\s*$"
+    for line in fm.splitlines():
+        m = re.match(pattern, line)
+        if m:
+            value = m.group(1).strip()
+            # Strip surrounding quotes if present.
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                value = value[1:-1]
+            return value
+    return None
+
+
+def _title_from_content(content: str) -> str | None:
+    """First ``# H1`` line, stripped of the leading hash."""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+    return None
+
+
+def _feature_kind_from_path(path: Path) -> tuple[str | None, str | None]:
+    """Split ``security-audit/task.md`` into ``("security-audit", "task")``."""
+    parts = path.parts
+    if len(parts) < 2:
+        return (None, None)
+    feature = parts[-2]
+    kind = path.stem
+    if not _safe_slug(feature) or not _safe_slug(kind):
+        return (None, None)
+    return (feature, kind)
+
+
+def _snippet(content: str, query: str, *, max_len: int = 240) -> str:
+    """Build a snippet around the first query-term hit in content."""
+    if not content:
+        return ""
+    terms = [t for t in query.lower().split() if len(t) >= 3]
+    lower = content.lower()
+    hit_pos = -1
+    for term in terms:
+        pos = lower.find(term)
+        if pos >= 0:
+            hit_pos = pos
+            break
+    if hit_pos < 0:
+        return content[:max_len].strip().replace("\n", " ")
+    start = max(0, hit_pos - 60)
+    end = min(len(content), hit_pos + max_len - 60)
+    fragment = content[start:end].replace("\n", " ").strip()
+    if start > 0:
+        fragment = "…" + fragment
+    if end < len(content):
+        fragment = fragment + "…"
+    return fragment
+
+
+def _format_kinds(kinds: Iterable[str]) -> str:
+    """Comma-joined kinds — used in API responses."""
+    return ", ".join(kinds)

--- a/src/attune/ops/help_regen.py
+++ b/src/attune/ops/help_regen.py
@@ -1,0 +1,232 @@
+"""Async subprocess runner for ``attune-author`` regen jobs.
+
+Used by the ``/help/admin`` page to trigger help-template
+regeneration without leaving the dashboard. Each job runs
+``attune-author <action> ...`` in a subprocess, captures stdout
+line-by-line, and exposes status via the in-memory ``HelpRegenRunner``.
+
+Lives separate from :class:`attune.ops.runner.RunnerService` —
+that runner builds ``attune workflow run <name>`` commands and
+its workflow-registry lookups don't fit help-regen jobs cleanly.
+Mirroring the simpler shape here keeps the surface focused.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import shutil
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+JobStatus = Literal["pending", "running", "completed", "failed"]
+
+# Strip ANSI escape sequences before storing log lines. attune-author
+# (and the structlog renderer it uses) emit ``\x1b[36m...\x1b[0m``
+# color codes which render as garbage in the dashboard's <pre>.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+# Feature slug shape — same as attune.ops.help_data._safe_slug
+_SLUG_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+# Max captured output bytes per job. attune-author regens are
+# usually <50 KB of console output; 500 KB is generous and
+# protects against runaway loops filling memory.
+_OUTPUT_CAP_BYTES = 500_000
+
+
+@dataclass
+class HelpRegenJob:
+    """One regen invocation — status, captured stdout, exit code."""
+
+    id: str
+    action: Literal["generate", "regenerate", "status"]
+    feature: str | None
+    command: list[str]
+    status: JobStatus = "pending"
+    exit_code: int | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    lines: list[str] = field(default_factory=list)
+    bytes_captured: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "action": self.action,
+            "feature": self.feature,
+            "command": list(self.command),
+            "status": self.status,
+            "exit_code": self.exit_code,
+            "started_at": (self.started_at.isoformat() if self.started_at else None),
+            "completed_at": (self.completed_at.isoformat() if self.completed_at else None),
+            "lines": list(self.lines),
+            "line_count": len(self.lines),
+        }
+
+
+class HelpRegenRunner:
+    """Owns the regen-job history + active subprocess.
+
+    Single concurrent job by design — attune-author regens touch
+    ``.help/templates/`` and parallel writes could collide. Trying
+    to start a second job while one is running raises
+    :class:`HelpRegenBusyError` with the active job id.
+    """
+
+    def __init__(
+        self,
+        *,
+        history_limit: int = 20,
+        attune_author_path: str | None = None,
+    ) -> None:
+        self._jobs: OrderedDict[str, HelpRegenJob] = OrderedDict()
+        self._history_limit = history_limit
+        self._lock = asyncio.Lock()
+        # Allow injection for tests; production resolves at start time.
+        self._attune_author_path = attune_author_path
+
+    def _resolve_command(self) -> str | None:
+        """Find the ``attune-author`` executable on PATH."""
+        if self._attune_author_path:
+            return self._attune_author_path
+        return shutil.which("attune-author")
+
+    @property
+    def current(self) -> HelpRegenJob | None:
+        for job in reversed(self._jobs.values()):
+            if job.status in ("pending", "running"):
+                return job
+        return None
+
+    def get(self, job_id: str) -> HelpRegenJob | None:
+        return self._jobs.get(job_id)
+
+    def recent(self, limit: int = 5) -> list[HelpRegenJob]:
+        return list(reversed(list(self._jobs.values())))[:limit]
+
+    async def start(
+        self,
+        action: Literal["generate", "regenerate", "status"],
+        *,
+        feature: str | None = None,
+        project_root: str | None = None,
+        help_dir: str | None = None,
+        all_kinds: bool = True,
+        dry_run: bool = False,
+    ) -> HelpRegenJob:
+        """Start a regen job. Returns the created HelpRegenJob.
+
+        Raises:
+            HelpRegenBusyError: if a job is already in flight.
+            ValueError: invalid feature slug.
+            FileNotFoundError: attune-author not on PATH.
+        """
+        if action == "generate" and not feature:
+            raise ValueError("feature required for generate action")
+        if feature is not None and not _SLUG_RE.match(feature):
+            raise ValueError(f"invalid feature slug: {feature!r}")
+
+        binary = self._resolve_command()
+        if binary is None:
+            raise FileNotFoundError("attune-author not found on PATH — install it to use regen")
+
+        # Build argv.
+        cmd: list[str] = [binary, action]
+        if action == "generate":
+            cmd.append(feature)  # type: ignore[arg-type]
+            if all_kinds:
+                cmd.append("--all-kinds")
+        elif action == "regenerate":
+            if dry_run:
+                cmd.append("--dry-run")
+        if project_root:
+            cmd.extend(["--project-root", project_root])
+        if help_dir:
+            cmd.extend(["--help-dir", help_dir])
+
+        async with self._lock:
+            if self.current is not None:
+                raise HelpRegenBusyError(self.current.id)
+            job = HelpRegenJob(
+                id=uuid.uuid4().hex[:12],
+                action=action,
+                feature=feature,
+                command=cmd,
+            )
+            self._jobs[job.id] = job
+            while len(self._jobs) > self._history_limit:
+                self._jobs.popitem(last=False)
+        # Fire and forget. The executor captures output and marks
+        # the job done; the caller polls /api/help/regen/<id> for
+        # status.
+        asyncio.create_task(self._execute(job))
+        return job
+
+    async def _execute(self, job: HelpRegenJob) -> None:
+        job.status = "running"
+        job.started_at = datetime.now(timezone.utc)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *job.command,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+        except FileNotFoundError as exc:
+            self._append(job, f"[regen error] command not found: {exc}")
+            self._finish(job, -1)
+            return
+        except Exception as exc:  # noqa: BLE001
+            # INTENTIONAL: any subprocess startup failure is reflected
+            # as exit code -1 and a captured error line. The runner
+            # itself never raises to the route handler.
+            self._append(job, f"[regen error] {exc}")
+            self._finish(job, -1)
+            return
+
+        assert proc.stdout is not None
+        try:
+            while True:
+                raw = await proc.stdout.readline()
+                if not raw:
+                    break
+                line = raw.decode("utf-8", errors="replace").rstrip("\n")
+                self._append(job, line)
+            await proc.wait()
+            self._finish(job, proc.returncode if proc.returncode is not None else -1)
+        except Exception as exc:  # noqa: BLE001
+            self._append(job, f"[regen error] {exc}")
+            self._finish(job, -1)
+
+    def _append(self, job: HelpRegenJob, line: str) -> None:
+        # Strip ANSI color codes before storing — the dashboard renders
+        # the log in a plain <pre>, not a terminal emulator.
+        clean = _ANSI_RE.sub("", line)
+        encoded = clean.encode("utf-8", errors="replace")
+        if job.bytes_captured + len(encoded) > _OUTPUT_CAP_BYTES:
+            if not job.lines or not job.lines[-1].startswith("[output truncated"):
+                job.lines.append(
+                    f"[output truncated — {len(encoded)} bytes more would have followed]"
+                )
+            return
+        job.lines.append(clean)
+        job.bytes_captured += len(encoded) + 1  # +1 for newline
+
+    def _finish(self, job: HelpRegenJob, exit_code: int) -> None:
+        job.exit_code = exit_code
+        job.completed_at = datetime.now(timezone.utc)
+        job.status = "completed" if exit_code == 0 else "failed"
+
+
+class HelpRegenBusyError(RuntimeError):
+    """Raised when a regen job is requested while one is already running."""
+
+    def __init__(self, current_id: str) -> None:
+        super().__init__(f"regen job already in flight: {current_id}")
+        self.current_id = current_id

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -177,6 +177,148 @@ async def health_page(request: Request) -> HTMLResponse:
     return _render(request, "health.html", page="health", snapshot=snapshot)
 
 
+# ---------------------------------------------------------------------------
+# Help — see docs/specs/ops-help-page/
+# ---------------------------------------------------------------------------
+
+
+# Kinds grouped by intent — used by the home page's "Browse by
+# what you need" cards. Same shape as help_data.INTENT_GROUPS but
+# duplicated here for template-side rendering convenience.
+_HELP_INTENTS = (
+    {
+        "id": "do",
+        "icon": "⚡",
+        "title": "Do something",
+        "kinds": ("task", "quickstart"),
+    },
+    {
+        "id": "solve",
+        "icon": "🔧",
+        "title": "Solve a problem",
+        "kinds": ("troubleshooting", "error", "faq"),
+    },
+    {
+        "id": "understand",
+        "icon": "💡",
+        "title": "Understand",
+        "kinds": ("concept",),
+    },
+    {
+        "id": "lookup",
+        "icon": "📖",
+        "title": "Look it up",
+        "kinds": ("reference",),
+    },
+)
+
+
+def _count_articles_for_kinds(features, kinds: tuple[str, ...]) -> int:
+    """Total templates across features that match the intent's kinds."""
+    out = 0
+    for f in features:
+        for k in kinds:
+            if k in f.kinds:
+                out += 1
+    return out
+
+
+@router.get("/help", response_class=HTMLResponse)
+async def help_home_page(request: Request) -> HTMLResponse:
+    """Help home — user-first browse + search entry point."""
+    from attune.ops import help_data
+
+    cfg = request.app.state.config
+    features = help_data.list_features(cfg)
+    featured = help_data.featured_topics(cfg)
+    recent = help_data.recently_regenerated(cfg, limit=5)
+    intents = [
+        dict(intent, count=_count_articles_for_kinds(features, intent["kinds"]))
+        for intent in _HELP_INTENTS
+    ]
+    total_templates = sum(len(f.kinds) for f in features)
+    stale_count = sum(f.stale_count for f in features)
+    incomplete_count = sum(1 for f in features if not f.is_complete)
+    return _render(
+        request,
+        "help.html",
+        page="help",
+        features=features,
+        featured=featured,
+        recent=recent,
+        intents=intents,
+        total_features=len(features),
+        total_templates=total_templates,
+        stale_count=stale_count,
+        incomplete_count=incomplete_count,
+    )
+
+
+@router.get("/help/search", response_class=HTMLResponse)
+async def help_search_page(request: Request, q: str = "") -> HTMLResponse:
+    """Help search results page."""
+    from attune.ops import help_data
+
+    cfg = request.app.state.config
+    hits = help_data.search(cfg, q, limit=20)
+    return _render(request, "help_search.html", page="help", q=q, hits=hits)
+
+
+@router.get("/help/admin", response_class=HTMLResponse)
+async def help_admin_page(request: Request) -> HTMLResponse:
+    """Admin tools — coverage gaps + stale templates."""
+    from attune.ops import help_data
+
+    cfg = request.app.state.config
+    report = help_data.coverage_gaps(cfg)
+    return _render(request, "help_admin.html", page="help", report=report)
+
+
+@router.get("/help/{feature}/{kind}", response_class=HTMLResponse)
+async def help_template_page(request: Request, feature: str, kind: str) -> HTMLResponse:
+    """One template — markdown-rendered."""
+    from fastapi import HTTPException
+
+    from attune.ops import help_data
+
+    if not help_data._safe_slug(feature) or not help_data._safe_slug(kind):
+        raise HTTPException(status_code=400, detail="invalid slug")
+    cfg = request.app.state.config
+    rec = help_data.get_template(cfg, feature, kind)
+    if rec is None:
+        raise HTTPException(status_code=404, detail=f"template not found: {feature}/{kind}")
+    # Sibling kinds for the in-page nav
+    features = {f.name: f for f in help_data.list_features(cfg)}
+    feat = features.get(feature)
+    sibling_kinds = list(feat.kinds) if feat else []
+    rendered_body = _render_markdown_safe(rec.body)
+    return _render(
+        request,
+        "help_template.html",
+        page="help",
+        record=rec,
+        sibling_kinds=sibling_kinds,
+        rendered_body=rendered_body,
+    )
+
+
+@router.get("/help/{feature}", response_class=HTMLResponse)
+async def help_feature_page(request: Request, feature: str) -> HTMLResponse:
+    """Feature index — list of available kinds, click to read."""
+    from fastapi import HTTPException
+
+    from attune.ops import help_data
+
+    if not help_data._safe_slug(feature):
+        raise HTTPException(status_code=400, detail="invalid feature slug")
+    cfg = request.app.state.config
+    features = {f.name: f for f in help_data.list_features(cfg)}
+    feat = features.get(feature)
+    if feat is None:
+        raise HTTPException(status_code=404, detail=f"feature not found: {feature}")
+    return _render(request, "help_feature.html", page="help", feature_obj=feat)
+
+
 @router.get("/sessions", response_class=HTMLResponse)
 async def sessions_page(request: Request) -> HTMLResponse:
     """Sessions page — recent Claude Code sessions for this project.

--- a/src/attune/ops/routes/help.py
+++ b/src/attune/ops/routes/help.py
@@ -114,3 +114,94 @@ async def help_recent(request: Request, limit: int = 5) -> JSONResponse:
     cfg = request.app.state.config
     recs = help_data.recently_regenerated(cfg, limit=limit)
     return JSONResponse({"recent": [r.to_dict() for r in recs]})
+
+
+# ---------------------------------------------------------------------------
+# Regen jobs — Admin tools actions
+# ---------------------------------------------------------------------------
+
+
+@router.post("/api/help/regen")
+async def help_regen_start(request: Request) -> JSONResponse:
+    """Start an attune-author regen job.
+
+    Body shape (JSON)::
+
+        {
+          "action": "generate" | "regenerate",
+          "feature": "<slug>",    // required when action == "generate"
+          "dry_run": false        // only meaningful for regenerate
+        }
+
+    Returns the created job's metadata with HTTP 202. Poll
+    ``GET /api/help/regen/<id>`` for live status + output.
+    """
+    from attune.ops.help_regen import HelpRegenBusyError
+
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        body = {}
+    action = (body or {}).get("action")
+    if action not in ("generate", "regenerate"):
+        raise HTTPException(
+            status_code=400,
+            detail="action must be 'generate' or 'regenerate'",
+        )
+    feature = (body or {}).get("feature")
+    dry_run = bool((body or {}).get("dry_run", False))
+
+    cfg = request.app.state.config
+    runner = request.app.state.help_regen
+    try:
+        job = await runner.start(
+            action,
+            feature=feature,
+            project_root=str(cfg.project_root),
+            help_dir=str(cfg.project_root / ".help"),
+            all_kinds=True,
+            dry_run=dry_run,
+        )
+    except HelpRegenBusyError as exc:
+        # Existing job in flight — surface its id so the client
+        # can poll it directly instead of opening a second.
+        return JSONResponse(
+            {
+                "error": "busy",
+                "detail": str(exc),
+                "current_job_id": exc.current_id,
+            },
+            status_code=409,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return JSONResponse(job.to_dict(), status_code=202)
+
+
+@router.get("/api/help/regen/{job_id}")
+async def help_regen_status(request: Request, job_id: str) -> JSONResponse:
+    """Poll a regen job's status + captured output.
+
+    Returns the full ``lines`` array each call — clients can
+    diff to display incremental output. The job stays in
+    history (oldest evicted at history_limit) so this is safe
+    to poll after completion.
+    """
+    if not job_id or len(job_id) > 64 or not job_id.isalnum():
+        raise HTTPException(status_code=400, detail="invalid job id")
+    runner = request.app.state.help_regen
+    job = runner.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail=f"job not found: {job_id}")
+    return JSONResponse(job.to_dict())
+
+
+@router.get("/api/help/regen")
+async def help_regen_recent(request: Request, limit: int = 5) -> JSONResponse:
+    """Recent regen jobs — used by the Admin tools UI to surface
+    in-flight + just-finished work without polling each id."""
+    limit = max(1, min(20, int(limit)))
+    runner = request.app.state.help_regen
+    return JSONResponse({"jobs": [j.to_dict() for j in runner.recent(limit=limit)]})

--- a/src/attune/ops/routes/help.py
+++ b/src/attune/ops/routes/help.py
@@ -1,0 +1,116 @@
+"""Read-only API for the dashboard's /help page.
+
+Routes:
+
+  - GET /api/help/              → corpus summary (features, stats)
+  - GET /api/help/search?q=…    → ranked search hits
+  - GET /api/help/feature/<slug> → one feature's kinds + summary
+  - GET /api/help/template/<feature>/<kind> → one template (metadata + body)
+  - GET /api/help/gaps          → coverage gaps + stale templates
+
+All GET-only. Slugs are validated against ``[a-z][a-z0-9-]*`` to
+prevent path-traversal in the template route. The data module
+swallows internal errors and returns empty results, so the routes
+themselves only convert dataclasses → JSON.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from attune.ops import help_data
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/api/help/")
+async def help_index(request: Request) -> JSONResponse:
+    """Top-level summary — features list + corpus stats."""
+    cfg = request.app.state.config
+    features = help_data.list_features(cfg)
+    return JSONResponse(
+        {
+            "features": [f.to_dict() for f in features],
+            "total_features": len(features),
+            "total_templates": sum(len(f.kinds) for f in features),
+            "stale_count": sum(f.stale_count for f in features),
+            "incomplete_count": sum(1 for f in features if not f.is_complete),
+        }
+    )
+
+
+@router.get("/api/help/search")
+async def help_search(request: Request, q: str = "", limit: int = 20) -> JSONResponse:
+    """Ranked search hits.
+
+    Empty query → empty list (not an error). limit is clamped to 50.
+    """
+    limit = max(1, min(50, int(limit)))
+    cfg = request.app.state.config
+    hits = help_data.search(cfg, q, limit=limit)
+    return JSONResponse(
+        {
+            "query": q,
+            "limit": limit,
+            "hits": [h.to_dict() for h in hits],
+        }
+    )
+
+
+@router.get("/api/help/feature/{slug}")
+async def help_feature(request: Request, slug: str) -> JSONResponse:
+    """All kinds available for a single feature."""
+    if not help_data._safe_slug(slug):
+        raise HTTPException(status_code=400, detail="invalid feature slug")
+    cfg = request.app.state.config
+    features = {f.name: f for f in help_data.list_features(cfg)}
+    feature = features.get(slug)
+    if feature is None:
+        raise HTTPException(status_code=404, detail=f"feature not found: {slug}")
+    return JSONResponse(feature.to_dict())
+
+
+@router.get("/api/help/template/{feature}/{kind}")
+async def help_template(request: Request, feature: str, kind: str) -> JSONResponse:
+    """One template — metadata + full markdown body."""
+    if not help_data._safe_slug(feature):
+        raise HTTPException(status_code=400, detail="invalid feature slug")
+    if not help_data._safe_slug(kind):
+        raise HTTPException(status_code=400, detail="invalid kind slug")
+    cfg = request.app.state.config
+    rec = help_data.get_template(cfg, feature, kind)
+    if rec is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"template not found: {feature}/{kind}",
+        )
+    return JSONResponse(rec.to_dict())
+
+
+@router.get("/api/help/gaps")
+async def help_gaps(request: Request) -> JSONResponse:
+    """Coverage gaps + stale templates — admin-tools surface."""
+    cfg = request.app.state.config
+    return JSONResponse(help_data.coverage_gaps(cfg).to_dict())
+
+
+@router.get("/api/help/featured")
+async def help_featured(request: Request) -> JSONResponse:
+    """Curated featured-topics list for the home page."""
+    cfg = request.app.state.config
+    feats = help_data.featured_topics(cfg)
+    return JSONResponse({"featured": [f.to_dict() for f in feats]})
+
+
+@router.get("/api/help/recent")
+async def help_recent(request: Request, limit: int = 5) -> JSONResponse:
+    """Recently-regenerated templates."""
+    limit = max(1, min(20, int(limit)))
+    cfg = request.app.state.config
+    recs = help_data.recently_regenerated(cfg, limit=limit)
+    return JSONResponse({"recent": [r.to_dict() for r in recs]})

--- a/src/attune/ops/routes/help.py
+++ b/src/attune/ops/routes/help.py
@@ -165,18 +165,26 @@ async def help_regen_start(request: Request) -> JSONResponse:
     except HelpRegenBusyError as exc:
         # Existing job in flight — surface its id so the client
         # can poll it directly instead of opening a second.
+        # Scrub the exception message from the response; the
+        # current_job_id field carries the only data the client needs.
+        logger.info("help_regen busy: %s", exc)
         return JSONResponse(
             {
                 "error": "busy",
-                "detail": str(exc),
+                "detail": "another regen job is already in flight",
                 "current_job_id": exc.current_id,
             },
             status_code=409,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        logger.warning("help_regen bad request: %s", exc)
+        raise HTTPException(status_code=400, detail="invalid help_regen request") from exc
     except FileNotFoundError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        logger.warning("help_regen missing dependency: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="help_regen unavailable (missing dependency)",
+        ) from exc
     return JSONResponse(job.to_dict(), status_code=202)
 
 

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -111,6 +111,12 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     # changes). In-memory only; resets on restart. See
     # ``interaction_counters.py`` for bucket layout.
     app.state.interaction_counters = InteractionCounters()
+    # Help-corpus regen runner — wraps attune-author subprocess
+    # invocations. Single concurrent job, one history per server
+    # instance. See docs/specs/ops-help-page/.
+    from attune.ops.help_regen import HelpRegenRunner
+
+    app.state.help_regen = HelpRegenRunner()
 
     app.include_router(dashboard.router)
     app.include_router(runner_routes.router)

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -17,6 +17,7 @@ from attune.ops.config import Config
 from attune.ops.interaction_counters import InteractionCounters
 from attune.ops.routes import bulletin as bulletin_routes
 from attune.ops.routes import dashboard
+from attune.ops.routes import help as help_routes
 from attune.ops.routes import interaction_counters as interaction_counters_routes
 from attune.ops.routes import pending_writes as pending_writes_routes
 from attune.ops.routes import runner as runner_routes
@@ -98,6 +99,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
         ("/sessions", "Sessions"),
         ("/telemetry", "Telemetry"),
         ("/health", "Health"),
+        ("/help", "Help"),
     ]
 
     app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
@@ -119,6 +121,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.include_router(interaction_counters_routes.router)
     app.include_router(pending_writes_routes.router)
     app.include_router(bulletin_routes.router)
+    app.include_router(help_routes.router)
 
     # Phase 2B of discovery-sweep-ops-integration: when sweep-result
     # persistence is enabled, wrap the runner's start() so each

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1654,3 +1654,541 @@ a.kpi:hover {
   border-style: dashed;
   opacity: 0.6;
 }
+
+/* ============================================================
+ * Help page — see docs/specs/ops-help-page/
+ * ============================================================ */
+
+.help-page-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+.btn-help-admin {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 8px;
+  background: var(--bg, #fff);
+  color: var(--fg, #111);
+  font-weight: 500;
+  font-size: 13px;
+  text-decoration: none;
+}
+.btn-help-admin:hover {
+  border-color: var(--accent, #4f46e5);
+  background: var(--accent-soft, #eef2ff);
+}
+.btn-help-admin svg { width: 16px; height: 16px; color: var(--fg-muted, #6b7280); }
+.btn-help-admin:hover svg { color: var(--accent, #4f46e5); }
+.btn-help-admin .health-chip {
+  display: inline-block;
+  padding: 1px 8px;
+  margin-left: 4px;
+  border-radius: 99px;
+  background: var(--warn-soft, #fef3c7);
+  color: var(--warn, #b45309);
+  font-size: 11px;
+}
+
+.help-hero {
+  text-align: center;
+  padding: 48px 0 24px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+.help-hero-small { padding: 16px 0; }
+.help-hero h1 {
+  margin: 0 0 24px;
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.help-hero-search-form {
+  position: relative;
+}
+.help-hero-search {
+  width: 100%;
+  padding: 14px 56px 14px 20px;
+  font-size: 16px;
+  font-family: inherit;
+  border: 1px solid var(--border-strong, #d1d5db);
+  border-radius: 12px;
+  background: var(--bg, #fff);
+  outline: none;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+}
+.help-hero-search:focus {
+  border-color: var(--accent, #4f46e5);
+  box-shadow: 0 0 0 4px var(--accent-soft, #eef2ff);
+}
+.help-hero-search-btn {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--accent, #4f46e5);
+  color: white;
+  border: 0;
+  border-radius: 8px;
+  width: 44px;
+  height: 36px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.help-hero-search-btn:hover { background: #4338ca; }
+.help-hero-search-btn svg { width: 18px; height: 18px; }
+
+.help-section { margin: 28px 0; }
+.help-section-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted, #6b7280);
+  margin: 0 0 10px;
+}
+.help-section-sub {
+  color: var(--fg-muted, #6b7280);
+  font-size: 12px;
+  margin: -6px 0 10px;
+}
+.help-count {
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--bg-soft, #f6f7f9);
+  color: var(--fg-muted, #6b7280);
+  padding: 1px 8px;
+  border-radius: 99px;
+  margin-left: 6px;
+}
+
+.help-intent-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+@media (max-width: 800px) { .help-intent-grid { grid-template-columns: repeat(2, 1fr); } }
+.help-intent-card {
+  display: block;
+  padding: 18px;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 10px;
+  background: var(--bg, #fff);
+  text-decoration: none;
+  color: var(--fg, #111);
+}
+.help-intent-card:hover {
+  border-color: var(--accent, #4f46e5);
+  text-decoration: none;
+}
+.help-intent-icon { font-size: 22px; margin-bottom: 8px; }
+.help-intent-title { font-weight: 600; margin-bottom: 4px; }
+.help-intent-sub {
+  font-size: 11px;
+  color: var(--fg-muted, #6b7280);
+  font-family: var(--font-mono, monospace);
+  margin-bottom: 8px;
+}
+.help-intent-count { font-size: 11px; color: var(--fg-subtle, #9ca3af); }
+
+.help-featured-list { list-style: none; margin: 0; padding: 0; }
+.help-featured-list li {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+}
+.help-featured-list li:last-child { border: 0; }
+.help-featured-list a {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  color: var(--fg, #111);
+}
+.help-feat-name {
+  font-weight: 500;
+  color: var(--accent, #4f46e5);
+  min-width: 160px;
+}
+.help-feat-kinds { color: var(--fg-muted, #6b7280); font-size: 13px; }
+
+.help-item-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.help-item-list li {
+  display: flex;
+  gap: 12px;
+  align-items: baseline;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+}
+.help-item-list li:last-child { border-bottom: 0; }
+.help-item-feature { font-weight: 500; color: var(--accent, #4f46e5); }
+.help-item-kind {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--fg-muted, #6b7280);
+  padding: 1px 6px;
+  background: var(--bg-soft, #f6f7f9);
+  border-radius: 4px;
+}
+.help-item-spacer { flex: 1; }
+.help-item-meta { font-size: 11px; color: var(--fg-subtle, #9ca3af); }
+
+.help-all-features {
+  margin: 24px 0;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  background: var(--bg-soft, #f6f7f9);
+}
+.help-all-features summary {
+  padding: 12px 16px;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 13px;
+  list-style: none;
+}
+.help-all-features ul {
+  list-style: none;
+  margin: 0;
+  padding: 8px 16px 16px;
+  columns: 3;
+  column-gap: 16px;
+}
+@media (max-width: 800px) { .help-all-features ul { columns: 2; } }
+.help-all-features li {
+  padding: 2px 0;
+  break-inside: avoid;
+}
+.help-stale-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--warn, #b45309);
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.help-corpus-footer {
+  margin-top: 48px;
+  padding: 16px 0;
+  border-top: 1px solid var(--border, #e5e7eb);
+  font-size: 12px;
+  color: var(--fg-muted, #6b7280);
+}
+
+/* Template detail with sidebar */
+.help-template-wrap {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 24px;
+}
+@media (max-width: 800px) {
+  .help-template-wrap { grid-template-columns: 1fr; }
+}
+.help-sidebar {
+  padding: 0 12px;
+}
+.help-sidebar-search {
+  position: relative;
+  margin-bottom: 16px;
+}
+.help-sidebar-search input {
+  width: 100%;
+  padding: 6px 30px 6px 10px;
+  border: 1px solid var(--border-strong, #d1d5db);
+  border-radius: 6px;
+  font-size: 12px;
+  font-family: inherit;
+}
+.help-sidebar-search button {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: 0;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  color: var(--fg-muted, #6b7280);
+}
+.help-sidebar-search button svg { width: 14px; height: 14px; }
+.help-sidebar-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted, #6b7280);
+  margin: 14px 0 6px;
+}
+.help-sidebar-tree { list-style: none; margin: 0; padding: 0; }
+.help-sidebar-tree li { margin: 1px 0; }
+.help-sidebar-tree a {
+  display: block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--fg, #111);
+  text-decoration: none;
+}
+.help-sidebar-tree a:hover { background: var(--bg-hover, #eef0f3); }
+.help-sidebar-tree a.is-active {
+  background: var(--accent-soft, #eef2ff);
+  color: var(--accent, #4f46e5);
+  font-weight: 500;
+}
+
+.help-template-main { min-width: 0; }
+.help-breadcrumb {
+  font-size: 12px;
+  color: var(--fg-muted, #6b7280);
+  margin-bottom: 6px;
+}
+.help-template-title {
+  margin: 0 0 8px;
+  font-size: 26px;
+  font-weight: 600;
+}
+.help-template-meta {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  margin-bottom: 20px;
+  font-size: 12px;
+}
+.help-template-meta .chip {
+  display: inline-flex;
+  padding: 2px 8px;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 99px;
+  font-size: 11px;
+  background: var(--bg-soft, #f6f7f9);
+}
+.chip-stale {
+  border-color: var(--warn, #b45309);
+  background: var(--warn-soft, #fef3c7);
+  color: var(--warn, #b45309);
+}
+.chip-fresh { color: var(--ok, #047857); border-color: var(--ok, #047857); }
+.help-template-genat { color: var(--fg-subtle, #9ca3af); }
+.help-page-sub {
+  color: var(--fg-muted, #6b7280);
+  font-size: 13px;
+  margin: -4px 0 16px;
+}
+
+/* Search results */
+.help-search-meta {
+  margin: 16px 0;
+  color: var(--fg-muted, #6b7280);
+  font-size: 13px;
+}
+.help-results { margin-top: 12px; }
+.help-result {
+  display: block;
+  padding: 14px 16px;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  margin-bottom: 10px;
+  text-decoration: none;
+  color: var(--fg, #111);
+}
+.help-result:hover {
+  border-color: var(--accent, #4f46e5);
+  background: var(--accent-soft, #eef2ff);
+  text-decoration: none;
+}
+.help-result-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.help-result-feature { font-weight: 600; color: var(--accent, #4f46e5); }
+.help-result-kind {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--fg-muted, #6b7280);
+}
+.help-result-spacer { flex: 1; }
+.help-result-score {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--fg-muted, #6b7280);
+}
+.help-result-title { font-weight: 500; margin: 2px 0 4px; }
+.help-result-snippet {
+  color: var(--fg-muted, #6b7280);
+  font-size: 13px;
+  line-height: 1.55;
+}
+.help-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--fg-muted, #6b7280);
+  border: 1px dashed var(--border, #e5e7eb);
+  border-radius: 8px;
+}
+
+/* Admin / gaps tables */
+.help-stat-strip {
+  display: flex;
+  gap: 16px;
+  padding: 12px 16px;
+  background: var(--bg-soft, #f6f7f9);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  margin: 16px 0 20px;
+}
+.help-stat { display: flex; flex-direction: column; min-width: 80px; }
+.help-stat-value { font-size: 18px; font-weight: 600; }
+.help-stat-value.warn { color: var(--warn, #b45309); }
+.help-stat-label {
+  font-size: 11px;
+  color: var(--fg-muted, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.help-gaps-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 8px 0 24px;
+  font-size: 13px;
+}
+.help-gaps-table th, .help-gaps-table td {
+  text-align: left;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+}
+.help-gaps-table th {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted, #6b7280);
+  font-weight: 600;
+}
+.help-missing {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--warn, #b45309);
+}
+.help-completeness-bar {
+  display: inline-block;
+  width: 100px;
+  height: 6px;
+  background: var(--border, #e5e7eb);
+  border-radius: 99px;
+  position: relative;
+  vertical-align: middle;
+}
+.help-completeness-bar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--accent, #4f46e5);
+  border-radius: 99px;
+  width: var(--pct, 0%);
+}
+.help-table-more {
+  text-align: center;
+  color: var(--fg-muted, #6b7280);
+  font-style: italic;
+}
+
+/* Feature page */
+.help-kind-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+}
+.help-kind-card {
+  display: block;
+  padding: 14px;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--fg, #111);
+  text-align: center;
+}
+.help-kind-card:hover {
+  border-color: var(--accent, #4f46e5);
+  background: var(--accent-soft, #eef2ff);
+  text-decoration: none;
+}
+.help-kind-name {
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+}
+.help-missing-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.help-missing-list li {
+  padding: 3px 10px;
+  background: var(--warn-soft, #fef3c7);
+  color: var(--warn, #b45309);
+  border-radius: 99px;
+  font-size: 12px;
+  font-family: var(--font-mono, monospace);
+}
+
+/* Markdown rendering inside template body */
+.help-prose h2 { font-size: 18px; font-weight: 600; margin: 28px 0 8px; }
+.help-prose h3 { font-size: 15px; font-weight: 600; margin: 20px 0 6px; }
+.help-prose p { margin: 0 0 12px; }
+.help-prose ul, .help-prose ol { padding-left: 22px; margin: 0 0 14px; }
+.help-prose li { margin: 2px 0; }
+.help-prose code {
+  font-family: var(--font-mono, monospace);
+  font-size: 12.5px;
+  background: var(--bg-soft, #f6f7f9);
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border, #e5e7eb);
+}
+.help-prose pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: var(--font-mono, monospace);
+  font-size: 12.5px;
+  padding: 14px 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+.help-prose pre code {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: inherit;
+}
+.help-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 12px 0;
+}
+.help-prose th, .help-prose td {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+  font-size: 13px;
+}
+.help-stale-text {
+  color: var(--warn, #b45309);
+  font-weight: 500;
+}

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -2192,3 +2192,141 @@ a.kpi:hover {
   color: var(--warn, #b45309);
   font-weight: 500;
 }
+
+/* Admin tools — action buttons + regen status panel */
+.help-bulk-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 16px 0 20px;
+}
+.btn-help-action {
+  padding: 8px 14px;
+  border: 1px solid var(--border-strong, #d1d5db);
+  background: var(--bg, #fff);
+  color: var(--fg, #111);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.btn-help-action:hover {
+  border-color: var(--accent, #4f46e5);
+  background: var(--accent-soft, #eef2ff);
+}
+.btn-help-action-primary {
+  background: var(--accent, #4f46e5);
+  color: white;
+  border-color: var(--accent, #4f46e5);
+}
+.btn-help-action-primary:hover {
+  background: #4338ca;
+  color: white;
+}
+.btn-help-action-ghost { background: transparent; }
+
+.btn-help-row-action {
+  padding: 4px 10px;
+  border: 1px solid var(--border-strong, #d1d5db);
+  background: var(--bg, #fff);
+  color: var(--fg, #111);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn-help-row-action:hover {
+  border-color: var(--accent, #4f46e5);
+  background: var(--accent-soft, #eef2ff);
+  color: var(--accent, #4f46e5);
+}
+.help-col-action { width: 1%; white-space: nowrap; }
+
+.help-regen-status {
+  position: sticky;
+  top: 56px;
+  z-index: 5;
+  margin: 16px 0;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  background: var(--bg, #fff);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.06);
+  overflow: hidden;
+}
+.help-regen-status-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-soft, #f6f7f9);
+  border-bottom: 1px solid var(--border, #e5e7eb);
+  font-size: 12px;
+}
+.help-regen-status-label {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted, #6b7280);
+  font-weight: 600;
+  font-size: 11px;
+}
+.help-regen-status-id {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  padding: 1px 6px;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 4px;
+}
+.help-regen-status-state {
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border, #e5e7eb);
+}
+.help-regen-status-state.state-pending,
+.help-regen-status-state.state-running {
+  background: var(--accent-soft, #eef2ff);
+  color: var(--accent, #4f46e5);
+  border-color: var(--accent, #4f46e5);
+}
+.help-regen-status-state.state-completed {
+  color: var(--ok, #047857);
+  border-color: var(--ok, #047857);
+}
+.help-regen-status-state.state-failed {
+  color: var(--danger, #b91c1c);
+  border-color: var(--danger, #b91c1c);
+  background: #fef2f2;
+}
+.help-regen-status-spacer { flex: 1; }
+.btn-help-action-close {
+  background: transparent;
+  border: 0;
+  color: var(--fg-muted, #6b7280);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.btn-help-action-close:hover { color: var(--fg, #111); }
+.help-regen-status-log {
+  margin: 0;
+  padding: 14px 16px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  line-height: 1.6;
+  max-height: 320px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}

--- a/src/attune/ops/templates/help.html
+++ b/src/attune/ops/templates/help.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+{% block title %}Help{% endblock %}
+{% block content %}
+
+<div class="help-page-toolbar">
+  <a href="/help/admin" class="btn-help-admin">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M14.7 6.3a1 1 0 0 0 .256 1.085l2.66 2.66a1 1 0 0 0 1.085.256 6 6 0 1 1-4.001 4Z"></path>
+      <path d="m14 7-3 3"></path>
+      <path d="M19.7 9.3l1.3 1.3"></path>
+      <path d="M9.4 9.4a3 3 0 0 0-4.2 4.2L3 16v3h3l2.4-2.4a3 3 0 0 0 4.2-4.2L9.4 9.4Z"></path>
+    </svg>
+    Admin tools
+    {% if stale_count or incomplete_count %}
+      <span class="health-chip">{{ stale_count }} stale · {{ incomplete_count }} incomplete</span>
+    {% endif %}
+  </a>
+</div>
+
+<section class="help-hero">
+  <h1>How can attune help?</h1>
+  <form class="help-hero-search-form" action="/help/search" method="get" role="search">
+    <input type="search" name="q" class="help-hero-search"
+           placeholder="Search anything — security audit, fix tests, commit message…"
+           value="" autofocus>
+    <button type="submit" class="help-hero-search-btn" aria-label="Search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+           stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="11" cy="11" r="7"></circle>
+        <line x1="21" y1="21" x2="16.5" y2="16.5"></line>
+      </svg>
+    </button>
+  </form>
+</section>
+
+<section class="help-section">
+  <h2 class="help-section-title">Browse by what you need</h2>
+  <div class="help-intent-grid">
+    {% for intent in intents %}
+      <a href="/help/search?q={{ intent.kinds | join(' OR ') }}" class="help-intent-card">
+        <div class="help-intent-icon">{{ intent.icon }}</div>
+        <div class="help-intent-title">{{ intent.title }}</div>
+        <div class="help-intent-sub">{{ intent.kinds | join(' · ') }}</div>
+        <div class="help-intent-count">{{ intent.count }} articles</div>
+      </a>
+    {% endfor %}
+  </div>
+</section>
+
+{% if featured %}
+<section class="help-section">
+  <h2 class="help-section-title">Featured topics</h2>
+  <ul class="help-featured-list">
+    {% for feat in featured %}
+      <li>
+        <a href="/help/{{ feat.name }}">
+          <span class="help-feat-name">{{ feat.name }}</span>
+          {% if feat.is_complete %}
+            <span class="help-feat-kinds">{{ feat.kinds | length }} of {{ feat.kinds | length }} kinds</span>
+          {% else %}
+            <span class="help-feat-kinds">{{ feat.kinds | length }} of 11 kinds</span>
+          {% endif %}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+
+{% if recent %}
+<section class="help-section">
+  <h2 class="help-section-title">Recently regenerated</h2>
+  <ul class="help-item-list">
+    {% for r in recent %}
+      <li>
+        <a class="help-item-feature" href="/help/{{ r.feature }}/{{ r.kind }}">{{ r.feature }}</a>
+        <span class="help-item-kind">{{ r.kind }}</span>
+        <span class="help-item-spacer"></span>
+        <span class="help-item-meta">{{ r.generated_at | replace("T", " ") | replace("+00:00", " UTC") }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+
+<details class="help-all-features">
+  <summary>Browse all {{ total_features }} features</summary>
+  <ul>
+    {% for f in features %}
+      <li><a href="/help/{{ f.name }}">{{ f.name }}</a>{% if f.has_any_stale %} <span class="help-stale-dot" title="{{ f.stale_count }} stale"></span>{% endif %}</li>
+    {% endfor %}
+  </ul>
+</details>
+
+<footer class="help-corpus-footer">
+  {{ total_templates }} templates across {{ total_features }} features
+</footer>
+
+{% endblock %}

--- a/src/attune/ops/templates/help_admin.html
+++ b/src/attune/ops/templates/help_admin.html
@@ -112,7 +112,7 @@
         </tr>
       {% endfor %}
       {% if report.stale | length > 25 %}
-        <tr><td colspan="4" class="help-table-more">… {{ report.stale | length - 25 }} more</td></tr>
+        <tr><td colspan="4" class="help-table-more">… {{ (report.stale | length) - 25 }} more</td></tr>
       {% endif %}
     </tbody>
   </table>

--- a/src/attune/ops/templates/help_admin.html
+++ b/src/attune/ops/templates/help_admin.html
@@ -9,7 +9,7 @@
 <h1 class="help-template-title">Admin tools</h1>
 <p class="help-page-sub">
   Maintenance surface for the <code>.help/templates/</code> corpus — coverage gaps,
-  stale templates, and regeneration shortcuts.
+  stale templates, and one-click regeneration.
 </p>
 
 <div class="help-stat-strip">
@@ -31,12 +31,39 @@
   </div>
 </div>
 
+<div class="help-bulk-actions">
+  <button class="btn-help-action btn-help-action-primary"
+          data-regen-action="regenerate"
+          data-confirm="Regenerate ALL stale templates? This can take several minutes.">
+    Regenerate all stale
+  </button>
+  <button class="btn-help-action"
+          data-regen-action="regenerate"
+          data-dry-run="1">
+    Dry run (preview)
+  </button>
+  <a href="/help/admin" class="btn-help-action btn-help-action-ghost">
+    Refresh page
+  </a>
+</div>
+
+<div id="help-regen-status" class="help-regen-status" hidden>
+  <div class="help-regen-status-head">
+    <span class="help-regen-status-label">Regen job</span>
+    <code class="help-regen-status-id"></code>
+    <span class="help-regen-status-state">pending</span>
+    <span class="help-regen-status-spacer"></span>
+    <button class="btn-help-action-close" aria-label="Close">×</button>
+  </div>
+  <pre class="help-regen-status-log"></pre>
+</div>
+
 {% if report.incomplete %}
 <section class="help-section">
   <h2 class="help-section-title">Incomplete sets <span class="help-count">{{ report.incomplete | length }}</span></h2>
   <table class="help-gaps-table">
     <thead>
-      <tr><th>Feature</th><th>Kinds</th><th>Completeness</th><th>Missing</th></tr>
+      <tr><th>Feature</th><th>Kinds</th><th>Completeness</th><th>Missing</th><th class="help-col-action">Action</th></tr>
     </thead>
     <tbody>
       {% for f in report.incomplete %}
@@ -48,6 +75,11 @@
             {{ f.completeness_pct }}%
           </td>
           <td class="help-missing">{{ f.missing_kinds | join(", ") }}</td>
+          <td>
+            <button class="btn-help-row-action"
+                    data-regen-action="generate"
+                    data-feature="{{ f.name }}">Generate missing</button>
+          </td>
         </tr>
       {% endfor %}
     </tbody>
@@ -59,12 +91,12 @@
 <section class="help-section">
   <h2 class="help-section-title">Stale templates <span class="help-count">{{ report.stale | length }}</span></h2>
   <p class="help-section-sub">
-    Source hash drift older than 7 days · regenerate via
-    <code>attune-author generate &lt;feature&gt; --all-kinds</code>
+    Source hash drift older than 7 days. Use the per-row button or the bulk
+    "Regenerate all stale" above.
   </p>
   <table class="help-gaps-table">
     <thead>
-      <tr><th>Feature</th><th>Kind</th><th>Generated</th></tr>
+      <tr><th>Feature</th><th>Kind</th><th>Generated</th><th class="help-col-action">Action</th></tr>
     </thead>
     <tbody>
       {% for t in report.stale[:25] %}
@@ -72,10 +104,15 @@
           <td><a href="/help/{{ t.feature }}/{{ t.kind }}">{{ t.feature }}</a></td>
           <td><span class="help-item-kind">{{ t.kind }}</span></td>
           <td>{{ t.generated_at | replace("T", " ") | replace("+00:00", " UTC") }}</td>
+          <td>
+            <button class="btn-help-row-action"
+                    data-regen-action="generate"
+                    data-feature="{{ t.feature }}">Regen feature</button>
+          </td>
         </tr>
       {% endfor %}
       {% if report.stale | length > 25 %}
-        <tr><td colspan="3" class="help-table-more">… {{ report.stale | length - 25 }} more</td></tr>
+        <tr><td colspan="4" class="help-table-more">… {{ report.stale | length - 25 }} more</td></tr>
       {% endif %}
     </tbody>
   </table>
@@ -83,16 +120,132 @@
 {% endif %}
 
 <section class="help-section">
-  <h2 class="help-section-title">How to fix</h2>
+  <h2 class="help-section-title">How regen works</h2>
   <ol>
-    <li>For <strong>incomplete sets</strong>, run
-        <code>attune-author generate &lt;feature&gt; --all-kinds</code>
-        from the project root.</li>
-    <li>For <strong>stale templates</strong>, the same command regenerates
-        only the kinds whose source hash drifted.</li>
-    <li>Review the regenerated content before committing — the polish pass
-        is LLM-assisted; spot-check facts you care about.</li>
+    <li><strong>Per-feature regen</strong> shells out to
+        <code>attune-author generate &lt;feature&gt; --all-kinds</code> — regenerates
+        all 11 kinds, including missing ones.</li>
+    <li><strong>Regenerate all stale</strong> runs
+        <code>attune-author regenerate</code> which detects every stale feature
+        and regenerates each in turn.</li>
+    <li>Each job runs in the dashboard's process; output streams below as it
+        appears. Only one job can run at a time — touching the corpus from
+        multiple processes would race.</li>
+    <li>Review regenerated content before committing — the polish pass is
+        LLM-assisted; spot-check the facts you care about per the existing
+        hallucination-shapes lesson.</li>
   </ol>
 </section>
 
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+  "use strict";
+  var status = document.getElementById("help-regen-status");
+  var statusId = status.querySelector(".help-regen-status-id");
+  var statusState = status.querySelector(".help-regen-status-state");
+  var statusLog = status.querySelector(".help-regen-status-log");
+  var closeBtn = status.querySelector(".btn-help-action-close");
+  var pollTimer = null;
+
+  function setState(state) {
+    statusState.textContent = state;
+    statusState.className = "help-regen-status-state state-" + state;
+  }
+
+  function appendLines(lines) {
+    statusLog.textContent = (lines || []).join("\n");
+    statusLog.scrollTop = statusLog.scrollHeight;
+  }
+
+  function stopPolling() {
+    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+  }
+
+  function showStatus(jobId) {
+    statusId.textContent = jobId;
+    setState("pending");
+    statusLog.textContent = "";
+    status.hidden = false;
+  }
+
+  function pollOnce(jobId) {
+    fetch("/api/help/regen/" + encodeURIComponent(jobId), {
+      headers: { Accept: "application/json" }
+    })
+      .then(function (r) { return r.json(); })
+      .then(function (job) {
+        setState(job.status);
+        appendLines(job.lines);
+        if (job.status === "completed" || job.status === "failed") {
+          stopPolling();
+        }
+      })
+      .catch(function (err) {
+        if (window.console) console.warn("regen poll:", err);
+      });
+  }
+
+  function startRegen(action, opts) {
+    var body = { action: action };
+    if (opts && opts.feature) body.feature = opts.feature;
+    if (opts && opts.dry_run) body.dry_run = true;
+    fetch("/api/help/regen", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(body),
+    })
+      .then(function (r) {
+        if (r.status === 409) {
+          return r.json().then(function (data) {
+            var existing = data.current_job_id;
+            if (existing) {
+              showStatus(existing);
+              pollOnce(existing);
+              pollTimer = setInterval(function () { pollOnce(existing); }, 2000);
+            } else {
+              alert("Regen already in flight.");
+            }
+            return null;
+          });
+        }
+        if (!r.ok) { alert("Regen failed to start: HTTP " + r.status); return null; }
+        return r.json();
+      })
+      .then(function (job) {
+        if (!job) return;
+        showStatus(job.id);
+        pollOnce(job.id);
+        pollTimer = setInterval(function () { pollOnce(job.id); }, 2000);
+      })
+      .catch(function (err) {
+        alert("Regen failed: " + err);
+      });
+  }
+
+  // Wire all .btn-help-action / .btn-help-row-action buttons that
+  // have a data-regen-action attribute.
+  Array.prototype.forEach.call(
+    document.querySelectorAll("[data-regen-action]"),
+    function (btn) {
+      btn.addEventListener("click", function () {
+        var action = btn.getAttribute("data-regen-action");
+        var feature = btn.getAttribute("data-feature");
+        var dryRun = btn.getAttribute("data-dry-run") === "1";
+        var confirmMsg = btn.getAttribute("data-confirm");
+        if (confirmMsg && !window.confirm(confirmMsg)) return;
+        stopPolling();
+        startRegen(action, { feature: feature, dry_run: dryRun });
+      });
+    }
+  );
+
+  closeBtn.addEventListener("click", function () {
+    stopPolling();
+    status.hidden = true;
+  });
+})();
+</script>
 {% endblock %}

--- a/src/attune/ops/templates/help_admin.html
+++ b/src/attune/ops/templates/help_admin.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+{% block title %}Admin tools{% endblock %}
+{% block content %}
+
+<div class="help-breadcrumb">
+  <a href="/help">Help</a> &rsaquo; <span>Admin tools</span>
+</div>
+
+<h1 class="help-template-title">Admin tools</h1>
+<p class="help-page-sub">
+  Maintenance surface for the <code>.help/templates/</code> corpus — coverage gaps,
+  stale templates, and regeneration shortcuts.
+</p>
+
+<div class="help-stat-strip">
+  <div class="help-stat">
+    <div class="help-stat-value">{{ report.completeness_pct }}%</div>
+    <div class="help-stat-label">complete</div>
+  </div>
+  <div class="help-stat">
+    <div class="help-stat-value">{{ report.total_templates }}</div>
+    <div class="help-stat-label">templates</div>
+  </div>
+  <div class="help-stat">
+    <div class="help-stat-value">{{ report.fresh_pct }}%</div>
+    <div class="help-stat-label">fresh</div>
+  </div>
+  <div class="help-stat">
+    <div class="help-stat-value {% if report.stale | length %}warn{% endif %}">{{ report.stale | length }}</div>
+    <div class="help-stat-label">stale</div>
+  </div>
+</div>
+
+{% if report.incomplete %}
+<section class="help-section">
+  <h2 class="help-section-title">Incomplete sets <span class="help-count">{{ report.incomplete | length }}</span></h2>
+  <table class="help-gaps-table">
+    <thead>
+      <tr><th>Feature</th><th>Kinds</th><th>Completeness</th><th>Missing</th></tr>
+    </thead>
+    <tbody>
+      {% for f in report.incomplete %}
+        <tr>
+          <td><a href="/help/{{ f.name }}">{{ f.name }}</a></td>
+          <td>{{ f.kinds | length }}/11</td>
+          <td>
+            <span class="help-completeness-bar" style="--pct: {{ f.completeness_pct }}%"></span>
+            {{ f.completeness_pct }}%
+          </td>
+          <td class="help-missing">{{ f.missing_kinds | join(", ") }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
+
+{% if report.stale %}
+<section class="help-section">
+  <h2 class="help-section-title">Stale templates <span class="help-count">{{ report.stale | length }}</span></h2>
+  <p class="help-section-sub">
+    Source hash drift older than 7 days · regenerate via
+    <code>attune-author generate &lt;feature&gt; --all-kinds</code>
+  </p>
+  <table class="help-gaps-table">
+    <thead>
+      <tr><th>Feature</th><th>Kind</th><th>Generated</th></tr>
+    </thead>
+    <tbody>
+      {% for t in report.stale[:25] %}
+        <tr>
+          <td><a href="/help/{{ t.feature }}/{{ t.kind }}">{{ t.feature }}</a></td>
+          <td><span class="help-item-kind">{{ t.kind }}</span></td>
+          <td>{{ t.generated_at | replace("T", " ") | replace("+00:00", " UTC") }}</td>
+        </tr>
+      {% endfor %}
+      {% if report.stale | length > 25 %}
+        <tr><td colspan="3" class="help-table-more">… {{ report.stale | length - 25 }} more</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
+
+<section class="help-section">
+  <h2 class="help-section-title">How to fix</h2>
+  <ol>
+    <li>For <strong>incomplete sets</strong>, run
+        <code>attune-author generate &lt;feature&gt; --all-kinds</code>
+        from the project root.</li>
+    <li>For <strong>stale templates</strong>, the same command regenerates
+        only the kinds whose source hash drifted.</li>
+    <li>Review the regenerated content before committing — the polish pass
+        is LLM-assisted; spot-check facts you care about.</li>
+  </ol>
+</section>
+
+{% endblock %}

--- a/src/attune/ops/templates/help_feature.html
+++ b/src/attune/ops/templates/help_feature.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% block title %}{{ feature_obj.name }}{% endblock %}
+{% block content %}
+
+<div class="help-breadcrumb">
+  <a href="/help">Help</a> &rsaquo; <span>{{ feature_obj.name }}</span>
+</div>
+
+<h1 class="help-template-title">{{ feature_obj.name }}</h1>
+<p class="help-page-sub">
+  {{ feature_obj.kinds | length }} of 11 template kinds
+  {% if feature_obj.has_any_stale %}
+    · <span class="help-stale-text">{{ feature_obj.stale_count }} stale</span>
+  {% endif %}
+</p>
+
+<section class="help-section">
+  <h2 class="help-section-title">Available kinds</h2>
+  <ul class="help-kind-grid">
+    {% for k in feature_obj.kinds %}
+      <li><a href="/help/{{ feature_obj.name }}/{{ k }}" class="help-kind-card">
+        <span class="help-kind-name">{{ k }}</span>
+      </a></li>
+    {% endfor %}
+  </ul>
+</section>
+
+{% if feature_obj.missing_kinds %}
+<section class="help-section">
+  <h2 class="help-section-title">Missing kinds <span class="help-count">{{ feature_obj.missing_kinds | length }}</span></h2>
+  <p class="help-section-sub">Run <code>attune-author generate {{ feature_obj.name }} --all-kinds</code> to fill in.</p>
+  <ul class="help-missing-list">
+    {% for k in feature_obj.missing_kinds %}
+      <li>{{ k }}</li>
+    {% endfor %}
+  </ul>
+</section>
+{% endif %}
+
+{% endblock %}

--- a/src/attune/ops/templates/help_search.html
+++ b/src/attune/ops/templates/help_search.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block title %}Search: {{ q }}{% endblock %}
+{% block content %}
+
+<section class="help-hero help-hero-small">
+  <form class="help-hero-search-form" action="/help/search" method="get" role="search">
+    <input type="search" name="q" class="help-hero-search"
+           value="{{ q }}" placeholder="Search help…" autofocus>
+    <button type="submit" class="help-hero-search-btn" aria-label="Search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+           stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="11" cy="11" r="7"></circle>
+        <line x1="21" y1="21" x2="16.5" y2="16.5"></line>
+      </svg>
+    </button>
+  </form>
+</section>
+
+<div class="help-search-meta">
+  {% if q %}
+    {{ hits | length }} result{% if hits | length != 1 %}s{% endif %} for <code>{{ q }}</code>
+  {% else %}
+    Enter a query above to search the help corpus.
+  {% endif %}
+  · <a href="/help">← back to help home</a>
+</div>
+
+{% if hits %}
+<div class="help-results">
+  {% for hit in hits %}
+    <a href="/help/{{ hit.feature }}/{{ hit.kind }}" class="help-result">
+      <div class="help-result-head">
+        <span class="help-result-feature">{{ hit.feature }}</span>
+        <span class="help-result-kind">{{ hit.kind }}</span>
+        <span class="help-result-spacer"></span>
+        <span class="help-result-score">{{ '%.2f' % hit.score }}</span>
+      </div>
+      <div class="help-result-title">{{ hit.title }}</div>
+      <div class="help-result-snippet">{{ hit.snippet }}</div>
+    </a>
+  {% endfor %}
+</div>
+{% elif q %}
+<div class="help-empty">
+  No results for <code>{{ q }}</code>.
+  Try a different phrase, or
+  <a href="/help">browse the corpus</a>.
+</div>
+{% endif %}
+
+{% endblock %}

--- a/src/attune/ops/templates/help_search.html
+++ b/src/attune/ops/templates/help_search.html
@@ -33,7 +33,7 @@
         <span class="help-result-feature">{{ hit.feature }}</span>
         <span class="help-result-kind">{{ hit.kind }}</span>
         <span class="help-result-spacer"></span>
-        <span class="help-result-score">{{ '%.2f' % hit.score }}</span>
+        <span class="help-result-score">{{ '%.2f' % (hit.score | float) }}</span>
       </div>
       <div class="help-result-title">{{ hit.title }}</div>
       <div class="help-result-snippet">{{ hit.snippet }}</div>

--- a/src/attune/ops/templates/help_template.html
+++ b/src/attune/ops/templates/help_template.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% block title %}{{ record.feature }} / {{ record.kind }}{% endblock %}
+{% block content %}
+
+<div class="help-template-wrap">
+  <aside class="help-sidebar">
+    <form class="help-sidebar-search" action="/help/search" method="get" role="search">
+      <input type="search" name="q" placeholder="Search help…">
+      <button type="submit" aria-label="Search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+             stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="11" cy="11" r="7"></circle>
+          <line x1="21" y1="21" x2="16.5" y2="16.5"></line>
+        </svg>
+      </button>
+    </form>
+
+    <h3 class="help-sidebar-title">{{ record.feature }}</h3>
+    <ul class="help-sidebar-tree">
+      {% for k in sibling_kinds %}
+        <li>
+          <a href="/help/{{ record.feature }}/{{ k }}"
+             class="{% if k == record.kind %}is-active{% endif %}">{{ k }}</a>
+        </li>
+      {% endfor %}
+    </ul>
+
+    <h3 class="help-sidebar-title">Pages</h3>
+    <ul class="help-sidebar-tree">
+      <li><a href="/help">Help home</a></li>
+      <li><a href="/help/admin">Admin tools</a></li>
+    </ul>
+  </aside>
+
+  <main class="help-template-main">
+    <div class="help-breadcrumb">
+      <a href="/help">Help</a> &rsaquo;
+      <a href="/help/{{ record.feature }}">{{ record.feature }}</a> &rsaquo;
+      <span>{{ record.kind }}</span>
+    </div>
+    <h1 class="help-template-title">{{ record.title }}</h1>
+    <div class="help-template-meta">
+      <span class="chip">{{ record.kind }}</span>
+      {% if record.is_stale %}
+        <span class="chip chip-stale">stale · regen recommended</span>
+      {% else %}
+        <span class="chip chip-fresh">fresh</span>
+      {% endif %}
+      {% if record.generated_at %}
+        <span class="help-template-genat">generated {{ record.generated_at | replace("T", " ") | replace("+00:00", " UTC") }}</span>
+      {% endif %}
+    </div>
+
+    <article class="help-prose markdown-body">
+      {{ rendered_body | safe }}
+    </article>
+  </main>
+</div>
+
+{% endblock %}

--- a/tests/unit/ops/test_help_data.py
+++ b/tests/unit/ops/test_help_data.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from attune.ops import help_data as help_data_mod
 from attune.ops.config import Config
 from attune.ops.help_data import (
     EXPECTED_KINDS,
@@ -125,10 +126,8 @@ def _force_age_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     the age-based path. Tests that exercise the authority path
     re-monkeypatch shutil.which themselves.
     """
-    import attune.ops.help_data as mod
-
-    monkeypatch.setattr(mod.shutil, "which", lambda _: None)
-    mod._clear_staleness_cache()
+    monkeypatch.setattr(help_data_mod.shutil, "which", lambda _: None)
+    help_data_mod._clear_staleness_cache()
 
 
 @pytest.fixture

--- a/tests/unit/ops/test_help_data.py
+++ b/tests/unit/ops/test_help_data.py
@@ -116,6 +116,21 @@ def corpus(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture(autouse=True)
+def _force_age_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the age-based staleness fallback in tests.
+
+    Implemented by stubbing ``shutil.which`` so the authority
+    function naturally returns None and callers fall through to
+    the age-based path. Tests that exercise the authority path
+    re-monkeypatch shutil.which themselves.
+    """
+    import attune.ops.help_data as mod
+
+    monkeypatch.setattr(mod.shutil, "which", lambda _: None)
+    mod._clear_staleness_cache()
+
+
 @pytest.fixture
 def cfg(corpus: Path) -> Config:
     return Config(
@@ -583,3 +598,188 @@ class TestIsTemplateStale:
     def test_unreadable_file_returns_false(self, tmp_path: Path) -> None:
         # Pass a path that doesn't exist — open() raises OSError
         assert _is_template_stale(tmp_path / "missing.md") is False
+
+
+# ---------------------------------------------------------------------------
+# attune-author authority path
+# ---------------------------------------------------------------------------
+
+
+_REAL_STATUS_OUTPUT = """## Help Templates
+
+**24** current, **2** stale
+
+### Stale
+
+| Feature | Description | Files Changed |
+|---------|-------------|---------------|
+| spec-engine | The spec engine | 8 source files |
+| smart-test | Find test gaps | 3 source files |
+
+
+### Current
+
+- **security-audit** — desc
+- **code-quality** — desc
+"""
+
+
+class TestParseStatusOutput:
+    def test_extracts_stale_features(self) -> None:
+        from attune.ops.help_data import _parse_status_output
+
+        stale = _parse_status_output(_REAL_STATUS_OUTPUT)
+        assert stale == frozenset({"spec-engine", "smart-test"})
+
+    def test_no_stale_section_returns_empty(self) -> None:
+        from attune.ops.help_data import _parse_status_output
+
+        text = "## Help Templates\n\n**25** current, **0** stale\n"
+        assert _parse_status_output(text) == frozenset()
+
+    def test_empty_string(self) -> None:
+        from attune.ops.help_data import _parse_status_output
+
+        assert _parse_status_output("") == frozenset()
+
+    def test_ignores_table_header_and_divider(self) -> None:
+        """Header row (Feature/Description/Files) and the |---|---| divider
+        don't match the slug regex, so they're correctly skipped."""
+        from attune.ops.help_data import _parse_status_output
+
+        text = (
+            "### Stale\n\n"
+            "| Feature | Description | Files Changed |\n"
+            "|---------|-------------|---------------|\n"
+            "| valid-slug | desc | 1 file |\n"
+        )
+        assert _parse_status_output(text) == frozenset({"valid-slug"})
+
+    def test_current_section_ignored(self) -> None:
+        """Bullets in the ### Current section don't pollute the stale set."""
+        from attune.ops.help_data import _parse_status_output
+
+        text = (
+            "### Stale\n\n"
+            "| a-feature | x | 1 |\n\n"
+            "### Current\n\n"
+            "- **other-feature** — desc\n"
+        )
+        assert _parse_status_output(text) == frozenset({"a-feature"})
+
+
+class TestAttuneAuthorStaleFeatures:
+    """Tests for the subprocess wrapper. We mock subprocess.run to
+    keep tests fast and deterministic — no dependency on the real
+    attune-author CLI being installed in the venv."""
+
+    def test_returns_none_when_binary_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from attune.ops import help_data
+
+        # Autouse fixture already stubs shutil.which to return None.
+        help_data._clear_staleness_cache()
+        result = help_data._attune_author_stale_features(tmp_path, tmp_path / ".help")
+        assert result is None
+
+    def test_parses_subprocess_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from attune.ops import help_data
+
+        monkeypatch.setattr(help_data.shutil, "which", lambda _: "/fake/attune-author")
+
+        class _FakeResult:
+            stdout = _REAL_STATUS_OUTPUT
+            stderr = ""
+            returncode = 0
+
+        monkeypatch.setattr(help_data.subprocess, "run", lambda *a, **kw: _FakeResult())
+        help_data._clear_staleness_cache()
+        result = help_data._attune_author_stale_features(tmp_path, tmp_path / ".help")
+        assert result == frozenset({"spec-engine", "smart-test"})
+
+    def test_subprocess_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        import subprocess as _sp
+
+        from attune.ops import help_data
+
+        monkeypatch.setattr(help_data.shutil, "which", lambda _: "/fake/attune-author")
+
+        def _raise(*_a, **_kw):
+            raise _sp.SubprocessError("boom")
+
+        monkeypatch.setattr(help_data.subprocess, "run", _raise)
+        help_data._clear_staleness_cache()
+        result = help_data._attune_author_stale_features(tmp_path, tmp_path / ".help")
+        assert result is None
+
+    def test_cache_hits_skip_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from attune.ops import help_data
+
+        monkeypatch.setattr(help_data.shutil, "which", lambda _: "/fake/attune-author")
+
+        call_count = {"n": 0}
+
+        class _FakeResult:
+            stdout = _REAL_STATUS_OUTPUT
+            returncode = 0
+            stderr = ""
+
+        def _counting_run(*a, **kw):
+            call_count["n"] += 1
+            return _FakeResult()
+
+        monkeypatch.setattr(help_data.subprocess, "run", _counting_run)
+        help_data._clear_staleness_cache()
+        # First call: subprocess fires
+        help_data._attune_author_stale_features(tmp_path, tmp_path / ".help")
+        # Second call within TTL: cache hit, no subprocess
+        help_data._attune_author_stale_features(tmp_path, tmp_path / ".help")
+        assert call_count["n"] == 1
+
+    def test_drift_set_used_for_feature_staleness(
+        self, monkeypatch: pytest.MonkeyPatch, cfg: Config, corpus: Path
+    ) -> None:
+        """End-to-end: with attune-author saying 'complete-feature' is
+        stale, list_features() should mark it stale (and no other)."""
+        from attune.ops import help_data
+
+        # Override the autouse fallback to return a known stale set.
+        monkeypatch.setattr(
+            help_data,
+            "_attune_author_stale_features",
+            lambda *_a, **_kw: frozenset({"complete-feature"}),
+        )
+        feats = {f.name: f for f in help_data.list_features(cfg)}
+        # Authority says complete-feature is stale → every kind it has
+        # is treated as stale. stale-feature (which has only old
+        # generated_at timestamps) is NOT in the authority set →
+        # zero stale.
+        assert feats["complete-feature"].has_any_stale is True
+        assert feats["complete-feature"].stale_count == 11
+        assert feats["stale-feature"].has_any_stale is False
+        assert feats["stale-feature"].stale_count == 0
+
+
+class TestIsTemplateStaleAuthorityMode:
+    def test_in_authority_set_returns_true(self, tmp_path: Path) -> None:
+        from attune.ops.help_data import _is_template_stale
+
+        p = tmp_path / "my-feat" / "concept.md"
+        p.parent.mkdir()
+        p.write_text("# x\n", encoding="utf-8")
+        assert _is_template_stale(p, stale_features=frozenset({"my-feat"})) is True
+
+    def test_not_in_authority_set_returns_false(self, tmp_path: Path) -> None:
+        from attune.ops.help_data import _is_template_stale
+
+        p = tmp_path / "my-feat" / "concept.md"
+        p.parent.mkdir()
+        p.write_text("# x\n", encoding="utf-8")
+        assert _is_template_stale(p, stale_features=frozenset({"other-feat"})) is False

--- a/tests/unit/ops/test_help_data.py
+++ b/tests/unit/ops/test_help_data.py
@@ -1,0 +1,585 @@
+"""Unit tests for attune.ops.help_data — read primitives over the
+.help/templates/ corpus.
+
+Builds a synthetic corpus under tmp_path so every test is
+deterministic and independent of the real attune-ai .help/
+state.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.ops.config import Config
+from attune.ops.help_data import (
+    EXPECTED_KINDS,
+    FeatureSummary,
+    GapsReport,
+    SearchHit,
+    _extract_frontmatter_field,
+    _feature_kind_from_path,
+    _first_paragraph,
+    _format_kinds,
+    _is_template_stale,
+    _safe_slug,
+    _snippet,
+    _title_from_content,
+    corpus_root,
+    coverage_gaps,
+    featured_topics,
+    get_template,
+    list_features,
+    recently_regenerated,
+    search,
+)
+
+
+def _fresh_ts() -> str:
+    """A generated_at timestamp younger than the staleness threshold."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _stale_ts() -> str:
+    """A generated_at timestamp older than the 7-day threshold."""
+    return (datetime.now(timezone.utc) - timedelta(days=14)).isoformat()
+
+
+def _write_template(
+    root: Path,
+    feature: str,
+    kind: str,
+    *,
+    title: str | None = None,
+    body: str = "",
+    generated_at: str | None = None,
+    source_hash: str = "abc123",
+) -> Path:
+    """Create a single template file with valid frontmatter."""
+    if title is None:
+        title = f"{feature} {kind}"
+    if generated_at is None:
+        generated_at = _fresh_ts()
+    feat_dir = root / feature
+    feat_dir.mkdir(parents=True, exist_ok=True)
+    path = feat_dir / f"{kind}.md"
+    fm = (
+        f"---\n"
+        f"type: {kind}\n"
+        f"name: {feature}-{kind}\n"
+        f"feature: {feature}\n"
+        f"depth: {kind}\n"
+        f"generated_at: {generated_at}\n"
+        f"source_hash: {source_hash}\n"
+        f"status: generated\n"
+        f"---\n\n"
+        f"# {title}\n\n"
+        f"{body or 'A standard introduction paragraph for this template.'}\n\n"
+        f"## How it works\n\nDetails go here.\n"
+    )
+    path.write_text(fm, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def corpus(tmp_path: Path) -> Path:
+    """Build a small but realistic .help/templates corpus under tmp_path.
+
+    Layout:
+      .help/templates/
+        complete-feature/         # all 11 kinds, all fresh
+        incomplete-feature/       # 3 kinds, fresh
+        stale-feature/            # 5 kinds, all stale
+        mixed-feature/            # 11 kinds, mix of fresh + stale
+    """
+    root = tmp_path / ".help" / "templates"
+
+    # complete-feature — all 11 kinds, fresh
+    for kind in EXPECTED_KINDS:
+        _write_template(root, "complete-feature", kind)
+
+    # incomplete-feature — only 3 kinds
+    for kind in ("concept", "task", "reference"):
+        _write_template(root, "incomplete-feature", kind)
+
+    # stale-feature — 5 kinds, all >7 days old
+    for kind in ("concept", "task", "reference", "faq", "tip"):
+        _write_template(root, "stale-feature", kind, generated_at=_stale_ts())
+
+    # mixed-feature — 11 kinds, half stale
+    for i, kind in enumerate(EXPECTED_KINDS):
+        ts = _stale_ts() if i % 2 == 0 else _fresh_ts()
+        _write_template(root, "mixed-feature", kind, generated_at=ts)
+
+    return tmp_path
+
+
+@pytest.fixture
+def cfg(corpus: Path) -> Config:
+    return Config(
+        project_root=corpus,
+        attune_home=corpus / "ah",
+        allow_run=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# corpus_root
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusRoot:
+    def test_points_at_help_templates(self, cfg: Config) -> None:
+        assert corpus_root(cfg) == cfg.project_root / ".help" / "templates"
+
+    def test_missing_corpus_dir_handled_by_callers(self, tmp_path: Path) -> None:
+        c = Config(project_root=tmp_path / "nowhere", attune_home=tmp_path / "ah")
+        assert list_features(c) == []
+
+
+# ---------------------------------------------------------------------------
+# _safe_slug
+# ---------------------------------------------------------------------------
+
+
+class TestSafeSlug:
+    @pytest.mark.parametrize(
+        "slug,ok",
+        [
+            ("security-audit", True),
+            ("bug-predict", True),
+            ("a", True),  # single lowercase char is valid per regex
+            ("ab", True),
+            ("123-bad-start", False),  # must start with a-z
+            ("Security-Audit", False),  # uppercase
+            ("foo_bar", False),  # underscore
+            ("../etc", False),  # traversal
+            ("foo/bar", False),  # slash
+            ("", False),
+            (".hidden", False),
+        ],
+    )
+    def test_validation(self, slug: str, ok: bool) -> None:
+        assert _safe_slug(slug) is ok
+
+
+# ---------------------------------------------------------------------------
+# list_features
+# ---------------------------------------------------------------------------
+
+
+class TestListFeatures:
+    def test_returns_all_features(self, cfg: Config) -> None:
+        names = {f.name for f in list_features(cfg)}
+        assert names == {
+            "complete-feature",
+            "incomplete-feature",
+            "stale-feature",
+            "mixed-feature",
+        }
+
+    def test_complete_feature_marked_complete(self, cfg: Config) -> None:
+        feats = {f.name: f for f in list_features(cfg)}
+        complete = feats["complete-feature"]
+        assert complete.is_complete is True
+        assert len(complete.kinds) == 11
+        assert complete.missing_kinds == ()
+
+    def test_incomplete_feature_lists_missing(self, cfg: Config) -> None:
+        feats = {f.name: f for f in list_features(cfg)}
+        inc = feats["incomplete-feature"]
+        assert inc.is_complete is False
+        assert set(inc.kinds) == {"concept", "task", "reference"}
+        # Missing kinds preserve EXPECTED_KINDS order
+        assert "comparison" in inc.missing_kinds
+        assert "warning" in inc.missing_kinds
+
+    def test_stale_feature_has_stale_count(self, cfg: Config) -> None:
+        feats = {f.name: f for f in list_features(cfg)}
+        stale = feats["stale-feature"]
+        assert stale.has_any_stale is True
+        assert stale.stale_count == 5  # all 5 kinds are stale
+
+    def test_mixed_feature_partial_stale(self, cfg: Config) -> None:
+        feats = {f.name: f for f in list_features(cfg)}
+        mixed = feats["mixed-feature"]
+        # Half stale, half fresh — exact count depends on parity
+        assert mixed.has_any_stale is True
+        assert 0 < mixed.stale_count < 11
+
+    def test_alphabetical_order(self, cfg: Config) -> None:
+        names = [f.name for f in list_features(cfg)]
+        assert names == sorted(names)
+
+
+class TestFeatureSummary:
+    def test_completeness_pct(self) -> None:
+        f = FeatureSummary(
+            name="x",
+            kinds=("concept", "task"),
+            missing_kinds=tuple(k for k in EXPECTED_KINDS if k not in ("concept", "task")),
+            stale_count=0,
+            has_any_stale=False,
+        )
+        # 2 of 11 kinds
+        assert f.completeness_pct == round(100 * 2 / 11)
+
+    def test_to_dict_shape(self) -> None:
+        f = FeatureSummary(
+            name="x",
+            kinds=("concept",),
+            missing_kinds=("task",),
+            stale_count=0,
+            has_any_stale=False,
+        )
+        d = f.to_dict()
+        assert d["name"] == "x"
+        assert d["kinds"] == ["concept"]
+        assert d["missing_kinds"] == ["task"]
+        assert "is_complete" in d
+        assert "completeness_pct" in d
+
+
+# ---------------------------------------------------------------------------
+# get_template
+# ---------------------------------------------------------------------------
+
+
+class TestGetTemplate:
+    def test_loads_existing_template(self, cfg: Config) -> None:
+        rec = get_template(cfg, "complete-feature", "task")
+        assert rec is not None
+        assert rec.feature == "complete-feature"
+        assert rec.kind == "task"
+        assert rec.title == "complete-feature task"
+        assert rec.source_hash == "abc123"
+        assert rec.generated_at is not None
+        assert rec.is_stale is False
+
+    def test_stale_template_marked(self, cfg: Config) -> None:
+        rec = get_template(cfg, "stale-feature", "concept")
+        assert rec is not None
+        assert rec.is_stale is True
+
+    def test_missing_feature_returns_none(self, cfg: Config) -> None:
+        assert get_template(cfg, "nonexistent", "task") is None
+
+    def test_missing_kind_returns_none(self, cfg: Config) -> None:
+        assert get_template(cfg, "incomplete-feature", "warning") is None
+
+    def test_invalid_feature_slug_returns_none(self, cfg: Config) -> None:
+        assert get_template(cfg, "../etc", "task") is None
+        assert get_template(cfg, "Bad-Slug", "task") is None
+
+    def test_invalid_kind_slug_returns_none(self, cfg: Config) -> None:
+        assert get_template(cfg, "complete-feature", "../etc") is None
+
+    def test_to_dict_shape(self, cfg: Config) -> None:
+        rec = get_template(cfg, "complete-feature", "concept")
+        assert rec is not None
+        d = rec.to_dict()
+        assert d["feature"] == "complete-feature"
+        assert d["kind"] == "concept"
+        assert "body" in d
+        assert "is_stale" in d
+
+
+class TestTemplateParsing:
+    def test_missing_frontmatter_treated_as_body(self, tmp_path: Path) -> None:
+        root = tmp_path / ".help" / "templates" / "no-fm"
+        root.mkdir(parents=True)
+        (root / "concept.md").write_text("# Just a body\n\nNo frontmatter here.", encoding="utf-8")
+        cfg = Config(project_root=tmp_path, attune_home=tmp_path / "ah", allow_run=False)
+        rec = get_template(cfg, "no-fm", "concept")
+        assert rec is not None
+        assert rec.title == "Just a body"
+        assert rec.generated_at is None
+        assert rec.source_hash is None
+        # Without generated_at we can't compute staleness; defaults to False
+        assert rec.is_stale is False
+
+    def test_malformed_generated_at_doesnt_crash(self, tmp_path: Path) -> None:
+        root = tmp_path / ".help" / "templates" / "bad-ts"
+        root.mkdir(parents=True)
+        (root / "concept.md").write_text(
+            "---\ntype: concept\ngenerated_at: not-an-iso-string\nsource_hash: x\n---\n\n# Test\n",
+            encoding="utf-8",
+        )
+        cfg = Config(project_root=tmp_path, attune_home=tmp_path / "ah", allow_run=False)
+        rec = get_template(cfg, "bad-ts", "concept")
+        assert rec is not None
+        # Bad timestamp → not stale (can't compute)
+        assert rec.is_stale is False
+
+
+# ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+
+
+class TestSearch:
+    def test_empty_query_returns_empty(self, cfg: Config) -> None:
+        assert search(cfg, "") == []
+        assert search(cfg, "   ") == []
+
+    def test_missing_corpus_returns_empty(self, tmp_path: Path) -> None:
+        cfg = Config(
+            project_root=tmp_path / "no-corpus",
+            attune_home=tmp_path / "ah",
+        )
+        assert search(cfg, "anything") == []
+
+    def test_returns_search_hits(self, cfg: Config) -> None:
+        # Write a template with a distinctive token
+        _write_template(
+            cfg.project_root / ".help" / "templates",
+            "matchable",
+            "concept",
+            body="This template mentions xyz_unique_marker prominently.",
+        )
+        hits = search(cfg, "xyz_unique_marker")
+        # Search may return 0 if attune-rag not installed or token is too rare;
+        # at minimum the function shouldn't crash.
+        assert isinstance(hits, list)
+        for h in hits:
+            assert isinstance(h, SearchHit)
+            assert h.feature
+            assert h.kind
+            assert 0 <= h.score
+
+
+# ---------------------------------------------------------------------------
+# coverage_gaps
+# ---------------------------------------------------------------------------
+
+
+class TestCoverageGaps:
+    def test_empty_corpus(self, tmp_path: Path) -> None:
+        cfg = Config(
+            project_root=tmp_path / "empty",
+            attune_home=tmp_path / "ah",
+        )
+        report = coverage_gaps(cfg)
+        assert isinstance(report, GapsReport)
+        assert report.total_features == 0
+        assert report.total_templates == 0
+        assert report.completeness_pct == 0
+        assert report.fresh_pct == 0
+
+    def test_incomplete_features_surfaced(self, cfg: Config) -> None:
+        report = coverage_gaps(cfg)
+        incomplete_names = {f.name for f in report.incomplete}
+        assert "incomplete-feature" in incomplete_names
+        assert "stale-feature" in incomplete_names
+        # complete-feature and mixed-feature both have all 11 kinds
+        assert "complete-feature" not in incomplete_names
+        assert "mixed-feature" not in incomplete_names
+
+    def test_stale_templates_surfaced(self, cfg: Config) -> None:
+        report = coverage_gaps(cfg)
+        stale_pairs = {(t.feature, t.kind) for t in report.stale}
+        # stale-feature has 5 stale templates
+        assert ("stale-feature", "concept") in stale_pairs
+        assert ("stale-feature", "task") in stale_pairs
+
+    def test_aggregate_stats(self, cfg: Config) -> None:
+        report = coverage_gaps(cfg)
+        # 4 features total
+        assert report.total_features == 4
+        # 2 complete (complete-feature + mixed-feature have 11 kinds each)
+        assert report.complete_features == 2
+        # completeness pct rounded
+        assert report.completeness_pct == round(100 * 2 / 4)
+
+    def test_to_dict_shape(self, cfg: Config) -> None:
+        d = coverage_gaps(cfg).to_dict()
+        assert "incomplete" in d
+        assert "stale" in d
+        assert "total_features" in d
+        assert "completeness_pct" in d
+        assert "fresh_pct" in d
+
+
+# ---------------------------------------------------------------------------
+# featured_topics
+# ---------------------------------------------------------------------------
+
+
+class TestFeaturedTopics:
+    def test_fallback_when_no_curated_match(self, cfg: Config) -> None:
+        """None of our test features match the curated list, so it falls
+        back to first-N alphabetical."""
+        feats = featured_topics(cfg)
+        # Fallback returns up to 5 features alphabetically.
+        assert 1 <= len(feats) <= 5
+        names = [f.name for f in feats]
+        assert names == sorted(names)
+
+    def test_returns_curated_when_present(self, tmp_path: Path) -> None:
+        """If we synthesize a 'security-audit' feature, the curated path
+        picks it up."""
+        root = tmp_path / ".help" / "templates"
+        _write_template(root, "security-audit", "concept")
+        _write_template(root, "smart-test", "task")
+        cfg = Config(project_root=tmp_path, attune_home=tmp_path / "ah", allow_run=False)
+        feats = featured_topics(cfg)
+        names = [f.name for f in feats]
+        assert "security-audit" in names
+        assert "smart-test" in names
+
+
+# ---------------------------------------------------------------------------
+# recently_regenerated
+# ---------------------------------------------------------------------------
+
+
+class TestRecentlyRegenerated:
+    def test_default_limit(self, cfg: Config) -> None:
+        recs = recently_regenerated(cfg)
+        assert len(recs) <= 5
+
+    def test_sorted_newest_first(self, cfg: Config) -> None:
+        recs = recently_regenerated(cfg, limit=20)
+        timestamps = [r.generated_at for r in recs if r.generated_at]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+    def test_custom_limit(self, cfg: Config) -> None:
+        recs = recently_regenerated(cfg, limit=2)
+        assert len(recs) <= 2
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFrontmatterField:
+    def test_extracts_value(self) -> None:
+        fm = "key: value\nother: thing\n"
+        assert _extract_frontmatter_field(fm, "key") == "value"
+        assert _extract_frontmatter_field(fm, "other") == "thing"
+
+    def test_strips_quotes(self) -> None:
+        assert _extract_frontmatter_field('key: "quoted"\n', "key") == "quoted"
+        assert _extract_frontmatter_field("key: 'quoted'\n", "key") == "quoted"
+
+    def test_missing_returns_none(self) -> None:
+        assert _extract_frontmatter_field("x: y\n", "missing") is None
+
+    def test_empty_fm(self) -> None:
+        assert _extract_frontmatter_field("", "anything") is None
+
+
+class TestTitleFromContent:
+    def test_first_h1(self) -> None:
+        body = "Some intro\n\n# The Title\n\nbody"
+        assert _title_from_content(body) == "The Title"
+
+    def test_no_h1_returns_none(self) -> None:
+        assert _title_from_content("just text") is None
+
+    def test_h2_not_matched(self) -> None:
+        assert _title_from_content("## H2 only") is None
+
+
+class TestFeatureKindFromPath:
+    def test_valid_path(self) -> None:
+        from pathlib import Path
+
+        assert _feature_kind_from_path(Path("security-audit/task.md")) == (
+            "security-audit",
+            "task",
+        )
+
+    def test_too_few_parts(self) -> None:
+        from pathlib import Path
+
+        assert _feature_kind_from_path(Path("loose-file.md")) == (None, None)
+
+    def test_invalid_slug_rejected(self) -> None:
+        from pathlib import Path
+
+        assert _feature_kind_from_path(Path("Bad-Feature/concept.md")) == (None, None)
+
+
+class TestSnippet:
+    def test_returns_around_hit(self) -> None:
+        body = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * 5
+        body += "Then INJECTION appears here. " + "Tail text. " * 5
+        s = _snippet(body, "injection", max_len=200)
+        assert "INJECTION" in s
+        assert "…" in s or len(s) <= 200
+
+    def test_no_match_returns_prefix(self) -> None:
+        body = "No match for the term anywhere in this body."
+        s = _snippet(body, "nonexistent", max_len=100)
+        assert s.startswith("No match")
+
+    def test_empty_content(self) -> None:
+        assert _snippet("", "anything", max_len=50) == ""
+
+    def test_short_terms_filtered(self) -> None:
+        # Terms < 3 chars get filtered; no match → prefix
+        body = "I am a body"
+        s = _snippet(body, "I", max_len=100)
+        assert s == "I am a body"
+
+
+class TestFirstParagraph:
+    def test_skips_headings(self) -> None:
+        body = "# Heading\n\nFirst paragraph text.\n\nSecond."
+        assert _first_paragraph(body) == "First paragraph text."
+
+    def test_truncates(self) -> None:
+        body = "Lorem ipsum " * 100
+        out = _first_paragraph(body, max_chars=50)
+        assert len(out) <= 50
+        assert out.endswith("…")
+
+    def test_empty_body(self) -> None:
+        assert _first_paragraph("") == ""
+
+    def test_skips_leading_fence_line(self) -> None:
+        """A code fence on the first line is skipped (the ``` opener).
+
+        The implementation skips any line starting with `` ``` `` until
+        a paragraph accumulates — sufficient for typical template bodies
+        that start with prose. Full fenced-block awareness is a v2.
+        """
+        body = "```python\nx = 1\n```\n\nReal paragraph here."
+        # Without full fence tracking the first content line wins.
+        out = _first_paragraph(body)
+        # Either the fence content OR the real paragraph is acceptable —
+        # what matters is that we get *something*, not the empty string.
+        assert out != ""
+
+
+class TestFormatKinds:
+    def test_joins(self) -> None:
+        assert _format_kinds(["a", "b", "c"]) == "a, b, c"
+
+    def test_empty(self) -> None:
+        assert _format_kinds([]) == ""
+
+
+class TestIsTemplateStale:
+    def test_fresh_returns_false(self, tmp_path: Path) -> None:
+        p = tmp_path / "fresh.md"
+        p.write_text(f"---\ngenerated_at: {_fresh_ts()}\n---\n\n# x\n", encoding="utf-8")
+        assert _is_template_stale(p) is False
+
+    def test_stale_returns_true(self, tmp_path: Path) -> None:
+        p = tmp_path / "stale.md"
+        p.write_text(f"---\ngenerated_at: {_stale_ts()}\n---\n\n# x\n", encoding="utf-8")
+        assert _is_template_stale(p) is True
+
+    def test_no_generated_at_returns_false(self, tmp_path: Path) -> None:
+        p = tmp_path / "nogen.md"
+        p.write_text("---\ntype: concept\n---\n\n# x\n", encoding="utf-8")
+        assert _is_template_stale(p) is False
+
+    def test_unreadable_file_returns_false(self, tmp_path: Path) -> None:
+        # Pass a path that doesn't exist — open() raises OSError
+        assert _is_template_stale(tmp_path / "missing.md") is False

--- a/tests/unit/ops/test_help_regen.py
+++ b/tests/unit/ops/test_help_regen.py
@@ -139,7 +139,16 @@ class TestRegenerate:
         runner = HelpRegenRunner(attune_author_path=str(fake_binary))
 
         async def run() -> HelpRegenJob:
-            return await runner.start("regenerate", dry_run=True)
+            job = await runner.start("regenerate", dry_run=True)
+            # Wait for the subprocess to complete so its transport
+            # cleanup doesn't race with the event-loop close — same
+            # pattern as the other tests in this file. Without it,
+            # xdist workers crash on Ubuntu CI (Python 3.11/3.12).
+            for _ in range(50):
+                if job.status in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.05)
+            return job
 
         job = _await(run())
         assert "--dry-run" in job.command

--- a/tests/unit/ops/test_help_regen.py
+++ b/tests/unit/ops/test_help_regen.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,17 @@ from attune.ops.help_regen import (
     HelpRegenRunner,
 )
 from attune.ops.server import create_app
+
+# The fake-binary fixtures below write POSIX shell scripts with
+# `#!/bin/sh` shebangs and chmod 0o755 — neither resolves on Windows.
+# Tests that actually invoke the binary fail there (subprocess startup
+# errors); tests that only exercise validation logic before invocation
+# still pass. Apply this mark to the affected tests only.
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fake-binary fixture is a POSIX shell script; production "
+    "runner itself is OS-agnostic",
+)
 
 
 @pytest.fixture
@@ -86,6 +98,7 @@ def _await(coro):
 
 
 class TestGenerate:
+    @_skip_on_windows
     def test_generate_runs_subprocess(self, fake_binary: Path) -> None:
         runner = HelpRegenRunner(attune_author_path=str(fake_binary))
 
@@ -120,6 +133,7 @@ class TestGenerate:
 
 
 class TestRegenerate:
+    @_skip_on_windows
     def test_regenerate_runs(self, fake_binary: Path) -> None:
         runner = HelpRegenRunner(attune_author_path=str(fake_binary))
 
@@ -155,6 +169,7 @@ class TestRegenerate:
 
 
 class TestFailingSubprocess:
+    @_skip_on_windows
     def test_nonzero_exit_marks_failed(self, fake_binary: Path) -> None:
         runner = HelpRegenRunner(attune_author_path=str(fake_binary))
 
@@ -208,6 +223,7 @@ class TestMissingBinary:
 
 
 class TestAnsiStripping:
+    @_skip_on_windows
     def test_ansi_codes_stripped_from_log(self, ansi_binary: Path) -> None:
         runner = HelpRegenRunner(attune_author_path=str(ansi_binary))
 
@@ -245,6 +261,7 @@ class TestAnsiRegex:
 
 
 class TestOutputCap:
+    @_skip_on_windows
     def test_oversized_output_truncated(self, tmp_path: Path) -> None:
         # Build a script that floods stdout
         flooder = tmp_path / "flood"
@@ -403,6 +420,7 @@ class TestRegenRoute:
         resp = regen_client.get("/api/help/regen/has-dashes")
         assert resp.status_code == 400
 
+    @_skip_on_windows
     def test_get_status_returns_job(self, regen_client: TestClient) -> None:
         """POST creates a job, GET returns its current state.
 

--- a/tests/unit/ops/test_help_regen.py
+++ b/tests/unit/ops/test_help_regen.py
@@ -1,0 +1,419 @@
+"""Tests for HelpRegenRunner — async subprocess manager for
+attune-author regen jobs.
+
+Uses a fake binary (a tiny shell script) so tests don't depend
+on attune-author being installed in the venv. The script echoes
+its arguments and exits with whatever code we want — enough to
+exercise every code path in the runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from attune.ops.config import Config
+from attune.ops.help_regen import (
+    _ANSI_RE,
+    HelpRegenBusyError,
+    HelpRegenJob,
+    HelpRegenRunner,
+)
+from attune.ops.server import create_app
+
+
+@pytest.fixture
+def fake_binary(tmp_path: Path) -> Path:
+    """Tiny shell script that mimics attune-author CLI shape.
+
+    Echoes "started action=<action>", a numbered line, and exits 0
+    unless ATTUNE_FAKE_EXIT_CODE is set.
+    """
+    script = tmp_path / "fake-attune-author"
+    script.write_text(
+        "#!/bin/sh\n"
+        'echo "started action=$1"\n'
+        'for i in 1 2 3; do echo "line $i"; done\n'
+        'exit "${ATTUNE_FAKE_EXIT_CODE:-0}"\n',
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script
+
+
+@pytest.fixture
+def slow_binary(tmp_path: Path) -> Path:
+    """Fake binary that sleeps briefly — used for concurrency tests."""
+    script = tmp_path / "slow-attune-author"
+    script.write_text("#!/bin/sh\nsleep 0.3\necho 'done'\n", encoding="utf-8")
+    script.chmod(0o755)
+    return script
+
+
+@pytest.fixture
+def ansi_binary(tmp_path: Path) -> Path:
+    """Fake binary that emits ANSI color codes."""
+    script = tmp_path / "ansi-attune-author"
+    # Real ANSI bytes — match what attune-author + structlog emit
+    script.write_text(
+        "#!/bin/sh\nprintf '\\033[36mcolor line\\033[0m\\n'\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script
+
+
+def _await(coro):
+    """Run a coroutine to completion with full asyncio cleanup.
+
+    Uses ``asyncio.run()`` rather than a hand-managed loop because
+    subprocess transports queue close-time cleanup callbacks; with a
+    raw ``new_event_loop().run_until_complete()`` those callbacks fire
+    after the loop is closed and raise ``RuntimeError("Event loop is
+    closed")``. ``asyncio.run()`` shuts down async gens before closing
+    so the cleanup lands cleanly.
+    """
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Basic execution paths
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_generate_runs_subprocess(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+
+        async def run() -> HelpRegenJob:
+            job = await runner.start("generate", feature="example-feat")
+            # Wait for it to finish.
+            for _ in range(50):
+                if job.status in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.05)
+            return job
+
+        job = _await(run())
+        assert job.status == "completed"
+        assert job.exit_code == 0
+        assert any("started action=generate" in line for line in job.lines)
+
+    def test_generate_requires_feature(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+        with pytest.raises(ValueError, match="feature required"):
+            _await(runner.start("generate"))
+
+    def test_invalid_feature_slug_rejected(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+        with pytest.raises(ValueError, match="invalid feature slug"):
+            _await(runner.start("generate", feature="../etc"))
+
+    def test_uppercase_feature_rejected(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+        with pytest.raises(ValueError, match="invalid feature slug"):
+            _await(runner.start("generate", feature="Bad-Slug"))
+
+
+class TestRegenerate:
+    def test_regenerate_runs(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+
+        async def run() -> HelpRegenJob:
+            job = await runner.start("regenerate")
+            for _ in range(50):
+                if job.status in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.05)
+            return job
+
+        job = _await(run())
+        assert job.status == "completed"
+        assert any("started action=regenerate" in line for line in job.lines)
+
+    def test_dry_run_flag_added(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+
+        async def run() -> HelpRegenJob:
+            return await runner.start("regenerate", dry_run=True)
+
+        job = _await(run())
+        assert "--dry-run" in job.command
+
+
+class TestFailingSubprocess:
+    def test_nonzero_exit_marks_failed(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+
+        async def run() -> HelpRegenJob:
+            os.environ["ATTUNE_FAKE_EXIT_CODE"] = "1"
+            try:
+                job = await runner.start("regenerate")
+                for _ in range(50):
+                    if job.status in ("completed", "failed"):
+                        break
+                    await asyncio.sleep(0.05)
+                return job
+            finally:
+                os.environ.pop("ATTUNE_FAKE_EXIT_CODE", None)
+
+        job = _await(run())
+        assert job.status == "failed"
+        assert job.exit_code == 1
+
+
+class TestBusy:
+    def test_second_start_while_running_raises(self, slow_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(slow_binary))
+
+        async def run() -> None:
+            await runner.start("regenerate")
+            # Second call while first is running — should raise.
+            with pytest.raises(HelpRegenBusyError):
+                await runner.start("regenerate")
+            # Wait for first to finish so we don't leak the subprocess.
+            for _ in range(100):
+                cur = runner.current
+                if cur is None:
+                    break
+                await asyncio.sleep(0.05)
+
+        _await(run())
+
+
+class TestMissingBinary:
+    def test_no_binary_raises_filenotfound(self, tmp_path: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(tmp_path / "nonexistent-binary"))
+        # The runner accepts the path at construction; the binary
+        # absence is detected when subprocess startup fails. We use
+        # the resolve-check to pre-empt this.
+        # Path that doesn't resolve via shutil.which → fall through
+        runner._attune_author_path = ""
+        runner._resolve_command = lambda: None  # type: ignore[method-assign]
+        with pytest.raises(FileNotFoundError, match="attune-author not found"):
+            _await(runner.start("regenerate"))
+
+
+class TestAnsiStripping:
+    def test_ansi_codes_stripped_from_log(self, ansi_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(ansi_binary))
+
+        async def run() -> HelpRegenJob:
+            job = await runner.start("regenerate")
+            for _ in range(50):
+                if job.status in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.05)
+            return job
+
+        job = _await(run())
+        assert job.status == "completed"
+        for line in job.lines:
+            assert "\x1b[" not in line, f"unstripped ANSI in {line!r}"
+        # Color word still present even with codes removed
+        assert any("color line" in line for line in job.lines)
+
+
+class TestAnsiRegex:
+    def test_strips_color(self) -> None:
+        assert _ANSI_RE.sub("", "\x1b[36mhello\x1b[0m") == "hello"
+
+    def test_strips_complex(self) -> None:
+        text = "\x1b[2m2026-05-26\x1b[0m \x1b[32m\x1b[1minfo\x1b[0m rag.run"
+        assert _ANSI_RE.sub("", text) == "2026-05-26 info rag.run"
+
+    def test_passes_through_plain_text(self) -> None:
+        assert _ANSI_RE.sub("", "no color here") == "no color here"
+
+
+# ---------------------------------------------------------------------------
+# Output cap + history
+# ---------------------------------------------------------------------------
+
+
+class TestOutputCap:
+    def test_oversized_output_truncated(self, tmp_path: Path) -> None:
+        # Build a script that floods stdout
+        flooder = tmp_path / "flood"
+        flooder.write_text(
+            "#!/bin/sh\nfor i in $(seq 1 50000); do echo "
+            "'flood line with some bulk text for size estimate'; done\n",
+            encoding="utf-8",
+        )
+        flooder.chmod(0o755)
+        runner = HelpRegenRunner(attune_author_path=str(flooder))
+
+        async def run() -> HelpRegenJob:
+            job = await runner.start("regenerate")
+            for _ in range(200):
+                if job.status in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.05)
+            return job
+
+        job = _await(run())
+        # The cap kicks in and adds a truncation marker; total bytes
+        # captured should stay under the cap.
+        assert any("[output truncated" in line for line in job.lines)
+
+
+class TestHistory:
+    def test_recent_returns_jobs(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary), history_limit=3)
+
+        async def run() -> None:
+            for _ in range(2):
+                job = await runner.start("regenerate")
+                # Wait for completion before starting next (single-concurrent).
+                for _ in range(50):
+                    if job.status in ("completed", "failed"):
+                        break
+                    await asyncio.sleep(0.05)
+
+        _await(run())
+        recent = runner.recent(limit=5)
+        assert len(recent) == 2
+        # Newest first.
+        assert recent[0].started_at >= recent[1].started_at
+
+    def test_history_limit_evicts_oldest(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary), history_limit=2)
+
+        async def run() -> None:
+            for _ in range(4):
+                job = await runner.start("regenerate")
+                for _ in range(50):
+                    if job.status in ("completed", "failed"):
+                        break
+                    await asyncio.sleep(0.05)
+
+        _await(run())
+        # Only the 2 most recent jobs retained.
+        assert len(runner.recent(limit=10)) == 2
+
+
+class TestJobToDict:
+    def test_to_dict_has_required_fields(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+
+        async def run() -> HelpRegenJob:
+            job = await runner.start("regenerate")
+            for _ in range(50):
+                if job.status in ("completed", "failed"):
+                    break
+                await asyncio.sleep(0.05)
+            return job
+
+        job = _await(run())
+        d = job.to_dict()
+        for field in (
+            "id",
+            "action",
+            "feature",
+            "command",
+            "status",
+            "exit_code",
+            "started_at",
+            "completed_at",
+            "lines",
+            "line_count",
+        ):
+            assert field in d
+        assert d["line_count"] == len(d["lines"])
+
+
+# ---------------------------------------------------------------------------
+# Resolve command path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCommand:
+    def test_explicit_path_used(self, fake_binary: Path) -> None:
+        runner = HelpRegenRunner(attune_author_path=str(fake_binary))
+        assert runner._resolve_command() == str(fake_binary)
+
+    def test_no_explicit_path_uses_which(self) -> None:
+        runner = HelpRegenRunner()
+        # Whatever shutil.which returns is OK — the test just confirms
+        # the function returns either a string or None without raising.
+        result = runner._resolve_command()
+        assert result is None or isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Regen route integration — uses TestClient
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def regen_client(tmp_path: Path, fake_binary: Path) -> TestClient:
+    cfg = Config(
+        project_root=tmp_path,
+        attune_home=tmp_path / "ah",
+        allow_run=False,
+        trusted_hosts=("testserver", "test"),
+    )
+    app = create_app(cfg)
+    # Replace the default regen runner with one pointed at the fake binary.
+    app.state.help_regen = HelpRegenRunner(attune_author_path=str(fake_binary))
+    return TestClient(app)
+
+
+class TestRegenRoute:
+    def test_post_starts_job(self, regen_client: TestClient) -> None:
+        resp = regen_client.post("/api/help/regen", json={"action": "regenerate"})
+        assert resp.status_code == 202
+        data = resp.json()
+        assert data["status"] in ("pending", "running")
+        assert data["action"] == "regenerate"
+
+    def test_post_invalid_action_400(self, regen_client: TestClient) -> None:
+        resp = regen_client.post("/api/help/regen", json={"action": "nope"})
+        assert resp.status_code == 400
+
+    def test_post_generate_without_feature_400(self, regen_client: TestClient) -> None:
+        resp = regen_client.post("/api/help/regen", json={"action": "generate"})
+        assert resp.status_code == 400
+
+    def test_post_generate_invalid_slug_400(self, regen_client: TestClient) -> None:
+        resp = regen_client.post(
+            "/api/help/regen",
+            json={"action": "generate", "feature": "../etc"},
+        )
+        assert resp.status_code == 400
+
+    def test_get_status_404_for_unknown(self, regen_client: TestClient) -> None:
+        resp = regen_client.get("/api/help/regen/0123456789ab")
+        assert resp.status_code == 404
+
+    def test_get_invalid_job_id_400(self, regen_client: TestClient) -> None:
+        resp = regen_client.get("/api/help/regen/has-dashes")
+        assert resp.status_code == 400
+
+    def test_get_status_returns_job(self, regen_client: TestClient) -> None:
+        """POST creates a job, GET returns its current state.
+
+        Note: TestClient is sync, so the runner's asyncio.create_task
+        doesn't get to drive the subprocess to completion between
+        request cycles. We assert on wiring (200 + JSON shape),
+        not on terminal completion. Subprocess execution is
+        exercised by the non-route tests with asyncio.run().
+        """
+        post = regen_client.post("/api/help/regen", json={"action": "regenerate"})
+        job_id = post.json()["id"]
+        resp = regen_client.get(f"/api/help/regen/{job_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == job_id
+        assert body["status"] in ("pending", "running", "completed")
+        assert body["action"] == "regenerate"
+
+    def test_recent_list(self, regen_client: TestClient) -> None:
+        regen_client.post("/api/help/regen", json={"action": "regenerate"})
+        resp = regen_client.get("/api/help/regen")
+        assert resp.status_code == 200
+        assert "jobs" in resp.json()

--- a/tests/unit/ops/test_help_regen.py
+++ b/tests/unit/ops/test_help_regen.py
@@ -290,14 +290,15 @@ class TestAnsiRegex:
 
 class TestOutputCap:
     def test_oversized_output_truncated(self, tmp_path: Path) -> None:
-        # Build a script that floods stdout
-        flooder = tmp_path / "flood"
-        flooder.write_text(
-            "#!/bin/sh\nfor i in $(seq 1 50000); do echo "
-            "'flood line with some bulk text for size estimate'; done\n",
-            encoding="utf-8",
+        # Build a fake binary that floods stdout — cross-platform via
+        # the same .py + wrapper pattern as the module-level fixtures.
+        flooder = _make_fake_binary(
+            tmp_path,
+            "flood",
+            "for _ in range(50000):\n"
+            "    print('flood line with some bulk text for size estimate', "
+            "flush=True)\n",
         )
-        flooder.chmod(0o755)
         runner = HelpRegenRunner(attune_author_path=str(flooder))
 
         async def run() -> HelpRegenJob:

--- a/tests/unit/ops/test_help_regen.py
+++ b/tests/unit/ops/test_help_regen.py
@@ -26,57 +26,89 @@ from attune.ops.help_regen import (
 )
 from attune.ops.server import create_app
 
-# The fake-binary fixtures below write POSIX shell scripts with
-# `#!/bin/sh` shebangs and chmod 0o755 — neither resolves on Windows.
-# Tests that actually invoke the binary fail there (subprocess startup
-# errors); tests that only exercise validation logic before invocation
-# still pass. Apply this mark to the affected tests only.
-_skip_on_windows = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="fake-binary fixture is a POSIX shell script; production "
-    "runner itself is OS-agnostic",
-)
+
+# The fake-binary fixtures below are cross-platform: the actual
+# script logic lives in a .py file (deterministic, runs anywhere
+# Python runs), and a tiny per-OS wrapper (.bat on Windows, shell
+# script on POSIX) invokes it via ``sys.executable``. This keeps the
+# fixture path executable from asyncio.create_subprocess_exec on
+# either platform.
+def _make_fake_binary(tmp_path: Path, name: str, py_body: str) -> Path:
+    """Write a .py script + a cross-platform wrapper that invokes it.
+
+    The wrapper is what gets passed to HelpRegenRunner as
+    ``attune_author_path``; the runner's
+    ``asyncio.create_subprocess_exec`` then launches the wrapper,
+    which in turn invokes ``python <name>.py %*`` (Windows) or
+    ``python <name>.py "$@"`` (POSIX). Returns the wrapper path.
+    """
+    py_script = tmp_path / f"_{name.replace('-', '_')}.py"
+    py_script.write_text(py_body, encoding="utf-8")
+
+    if sys.platform == "win32":
+        wrapper = tmp_path / f"{name}.bat"
+        wrapper.write_text(
+            f'@echo off\r\n"{sys.executable}" "{py_script}" %*\r\n',
+            encoding="utf-8",
+        )
+    else:
+        wrapper = tmp_path / name
+        wrapper.write_text(
+            f'#!/bin/sh\nexec "{sys.executable}" "{py_script}" "$@"\n',
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+    return wrapper
 
 
 @pytest.fixture
 def fake_binary(tmp_path: Path) -> Path:
-    """Tiny shell script that mimics attune-author CLI shape.
+    """Cross-platform fake binary that mimics attune-author CLI shape.
 
-    Echoes "started action=<action>", a numbered line, and exits 0
-    unless ATTUNE_FAKE_EXIT_CODE is set.
+    Echoes "started action=<action>" plus 3 numbered lines, and exits
+    with ATTUNE_FAKE_EXIT_CODE (default 0). Equivalent to the prior
+    POSIX shell script but works on Windows via a .bat wrapper.
     """
-    script = tmp_path / "fake-attune-author"
-    script.write_text(
-        "#!/bin/sh\n"
-        'echo "started action=$1"\n'
-        'for i in 1 2 3; do echo "line $i"; done\n'
-        'exit "${ATTUNE_FAKE_EXIT_CODE:-0}"\n',
-        encoding="utf-8",
+    return _make_fake_binary(
+        tmp_path,
+        "fake-attune-author",
+        "import os, sys\n"
+        'action = sys.argv[1] if len(sys.argv) > 1 else "unknown"\n'
+        'print(f"started action={action}", flush=True)\n'
+        "for i in (1, 2, 3):\n"
+        '    print(f"line {i}", flush=True)\n'
+        'sys.exit(int(os.environ.get("ATTUNE_FAKE_EXIT_CODE", "0")))\n',
     )
-    script.chmod(0o755)
-    return script
 
 
 @pytest.fixture
 def slow_binary(tmp_path: Path) -> Path:
-    """Fake binary that sleeps briefly — used for concurrency tests."""
-    script = tmp_path / "slow-attune-author"
-    script.write_text("#!/bin/sh\nsleep 0.3\necho 'done'\n", encoding="utf-8")
-    script.chmod(0o755)
-    return script
+    """Cross-platform fake binary that sleeps briefly.
+
+    Used for concurrency tests where the subprocess needs to remain
+    "in flight" long enough for the test to interact with it.
+    """
+    return _make_fake_binary(
+        tmp_path,
+        "slow-attune-author",
+        "import time\ntime.sleep(0.3)\nprint('done', flush=True)\n",
+    )
 
 
 @pytest.fixture
 def ansi_binary(tmp_path: Path) -> Path:
-    """Fake binary that emits ANSI color codes."""
-    script = tmp_path / "ansi-attune-author"
-    # Real ANSI bytes — match what attune-author + structlog emit
-    script.write_text(
-        "#!/bin/sh\nprintf '\\033[36mcolor line\\033[0m\\n'\n",
-        encoding="utf-8",
+    """Cross-platform fake binary that emits ANSI color codes.
+
+    Matches what attune-author + structlog produce in real runs:
+    raw ANSI escapes that the runner is responsible for stripping.
+    """
+    return _make_fake_binary(
+        tmp_path,
+        "ansi-attune-author",
+        "import sys\n"
+        'sys.stdout.write("\\x1b[36mcolor line\\x1b[0m\\n")\n'
+        "sys.stdout.flush()\n",
     )
-    script.chmod(0o755)
-    return script
 
 
 def _await(coro):
@@ -98,7 +130,6 @@ def _await(coro):
 
 
 class TestGenerate:
-    @_skip_on_windows
     def test_generate_runs_subprocess(self, fake_binary: Path) -> None:
         runner = HelpRegenRunner(attune_author_path=str(fake_binary))
 
@@ -133,7 +164,6 @@ class TestGenerate:
 
 
 class TestRegenerate:
-    @_skip_on_windows
     def test_regenerate_runs(self, fake_binary: Path) -> None:
         runner = HelpRegenRunner(attune_author_path=str(fake_binary))
 
@@ -169,7 +199,6 @@ class TestRegenerate:
 
 
 class TestFailingSubprocess:
-    @_skip_on_windows
     def test_nonzero_exit_marks_failed(self, fake_binary: Path) -> None:
         runner = HelpRegenRunner(attune_author_path=str(fake_binary))
 
@@ -223,7 +252,6 @@ class TestMissingBinary:
 
 
 class TestAnsiStripping:
-    @_skip_on_windows
     def test_ansi_codes_stripped_from_log(self, ansi_binary: Path) -> None:
         runner = HelpRegenRunner(attune_author_path=str(ansi_binary))
 
@@ -261,7 +289,6 @@ class TestAnsiRegex:
 
 
 class TestOutputCap:
-    @_skip_on_windows
     def test_oversized_output_truncated(self, tmp_path: Path) -> None:
         # Build a script that floods stdout
         flooder = tmp_path / "flood"
@@ -420,7 +447,6 @@ class TestRegenRoute:
         resp = regen_client.get("/api/help/regen/has-dashes")
         assert resp.status_code == 400
 
-    @_skip_on_windows
     def test_get_status_returns_job(self, regen_client: TestClient) -> None:
         """POST creates a job, GET returns its current state.
 

--- a/tests/unit/ops/test_help_routes.py
+++ b/tests/unit/ops/test_help_routes.py
@@ -1,0 +1,262 @@
+"""End-to-end tests for the help-page routes (HTML + JSON API).
+
+Builds a synthetic .help/templates corpus, spins up the full
+FastAPI app via TestClient, and exercises every help-related
+route — both the dashboard HTML pages and the JSON API.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from attune.ops.config import Config
+from attune.ops.help_data import EXPECTED_KINDS
+from attune.ops.server import create_app
+
+
+def _write_template(
+    root: Path,
+    feature: str,
+    kind: str,
+    *,
+    title: str | None = None,
+    body: str = "",
+) -> None:
+    feat_dir = root / feature
+    feat_dir.mkdir(parents=True, exist_ok=True)
+    path = feat_dir / f"{kind}.md"
+    title = title or f"{feature} {kind}"
+    ts = datetime.now(timezone.utc).isoformat()
+    path.write_text(
+        f"---\n"
+        f"type: {kind}\n"
+        f"generated_at: {ts}\n"
+        f"source_hash: x\n"
+        f"---\n\n"
+        f"# {title}\n\n"
+        f"{body or 'Standard intro paragraph for this template.'}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    root = tmp_path / ".help" / "templates"
+    # security-audit — all 11 kinds, will be featured
+    for k in EXPECTED_KINDS:
+        _write_template(root, "security-audit", k)
+    # incomplete-feature — 2 kinds
+    _write_template(root, "incomplete-feature", "concept")
+    _write_template(root, "incomplete-feature", "task")
+    # smart-test — picked up by featured fallback / curated
+    for k in EXPECTED_KINDS:
+        _write_template(root, "smart-test", k)
+    cfg = Config(
+        project_root=tmp_path,
+        attune_home=tmp_path / "ah",
+        allow_run=False,
+        trusted_hosts=("testserver", "test"),
+    )
+    return TestClient(create_app(cfg))
+
+
+# ---------------------------------------------------------------------------
+# JSON API
+# ---------------------------------------------------------------------------
+
+
+class TestHelpIndexApi:
+    def test_returns_corpus_summary(self, client: TestClient) -> None:
+        resp = client.get("/api/help/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_features"] == 3
+        assert data["total_templates"] == 11 + 2 + 11
+        assert data["incomplete_count"] == 1
+        feature_names = {f["name"] for f in data["features"]}
+        assert "security-audit" in feature_names
+        assert "incomplete-feature" in feature_names
+
+
+class TestHelpSearchApi:
+    def test_empty_query_returns_empty_hits(self, client: TestClient) -> None:
+        resp = client.get("/api/help/search?q=")
+        assert resp.status_code == 200
+        assert resp.json()["hits"] == []
+
+    def test_query_returns_results_or_empty_gracefully(self, client: TestClient) -> None:
+        # Tiny fixture, attune-rag might still return zero — test the shape
+        resp = client.get("/api/help/search?q=security&limit=5")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "query" in data
+        assert "limit" in data
+        assert "hits" in data
+        assert data["query"] == "security"
+        assert data["limit"] == 5
+
+    def test_limit_clamped(self, client: TestClient) -> None:
+        resp = client.get("/api/help/search?q=x&limit=9999")
+        assert resp.status_code == 200
+        assert resp.json()["limit"] == 50
+
+
+class TestHelpFeatureApi:
+    def test_existing_feature(self, client: TestClient) -> None:
+        resp = client.get("/api/help/feature/security-audit")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "security-audit"
+        assert len(data["kinds"]) == 11
+
+    def test_missing_feature_returns_404(self, client: TestClient) -> None:
+        resp = client.get("/api/help/feature/nonexistent")
+        assert resp.status_code == 404
+
+    def test_invalid_slug_returns_400(self, client: TestClient) -> None:
+        resp = client.get("/api/help/feature/Bad-Slug")
+        assert resp.status_code == 400
+
+
+class TestHelpTemplateApi:
+    def test_existing_template(self, client: TestClient) -> None:
+        resp = client.get("/api/help/template/security-audit/task")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["feature"] == "security-audit"
+        assert data["kind"] == "task"
+        assert "body" in data
+
+    def test_missing_template_returns_404(self, client: TestClient) -> None:
+        resp = client.get("/api/help/template/security-audit/nonexistent-kind")
+        # Slug "nonexistent-kind" is shape-valid but file missing → 404
+        assert resp.status_code == 404
+
+    def test_invalid_feature_slug(self, client: TestClient) -> None:
+        resp = client.get("/api/help/template/Bad/task")
+        assert resp.status_code == 400
+
+    def test_invalid_kind_slug(self, client: TestClient) -> None:
+        resp = client.get("/api/help/template/security-audit/Bad-Kind")
+        assert resp.status_code == 400
+
+
+class TestHelpGapsApi:
+    def test_returns_gap_report(self, client: TestClient) -> None:
+        resp = client.get("/api/help/gaps")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "incomplete" in data
+        assert "stale" in data
+        incomplete_names = {f["name"] for f in data["incomplete"]}
+        assert "incomplete-feature" in incomplete_names
+
+
+class TestHelpFeaturedApi:
+    def test_returns_featured_list(self, client: TestClient) -> None:
+        resp = client.get("/api/help/featured")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "featured" in data
+        names = [f["name"] for f in data["featured"]]
+        # Curated picks include security-audit and smart-test
+        assert "security-audit" in names
+
+
+class TestHelpRecentApi:
+    def test_returns_recent_list(self, client: TestClient) -> None:
+        resp = client.get("/api/help/recent?limit=3")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "recent" in data
+        assert len(data["recent"]) <= 3
+
+    def test_limit_clamped(self, client: TestClient) -> None:
+        resp = client.get("/api/help/recent?limit=9999")
+        assert resp.status_code == 200
+        assert len(resp.json()["recent"]) <= 20
+
+
+# ---------------------------------------------------------------------------
+# HTML pages
+# ---------------------------------------------------------------------------
+
+
+class TestHelpHomePage:
+    def test_renders_home(self, client: TestClient) -> None:
+        resp = client.get("/help")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "How can attune help?" in body
+        assert "Admin tools" in body
+        # Featured topic present
+        assert "security-audit" in body
+
+
+class TestHelpSearchPage:
+    def test_empty_query_renders(self, client: TestClient) -> None:
+        resp = client.get("/help/search?q=")
+        assert resp.status_code == 200
+        assert "Enter a query" in resp.text
+
+    def test_with_query(self, client: TestClient) -> None:
+        resp = client.get("/help/search?q=security")
+        assert resp.status_code == 200
+        assert "security" in resp.text
+
+
+class TestHelpAdminPage:
+    def test_renders_admin(self, client: TestClient) -> None:
+        resp = client.get("/help/admin")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Admin tools" in body
+        # incomplete-feature shows up in the incomplete table
+        assert "incomplete-feature" in body
+        # Action buttons present
+        assert "Regenerate all stale" in body
+
+
+class TestHelpFeaturePage:
+    def test_renders_feature(self, client: TestClient) -> None:
+        resp = client.get("/help/security-audit")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "security-audit" in body
+        assert "task" in body
+
+    def test_missing_feature_404(self, client: TestClient) -> None:
+        resp = client.get("/help/nonexistent")
+        assert resp.status_code == 404
+
+    def test_invalid_slug_400(self, client: TestClient) -> None:
+        resp = client.get("/help/Bad-Slug")
+        assert resp.status_code == 400
+
+
+class TestHelpTemplatePage:
+    def test_renders_template(self, client: TestClient) -> None:
+        resp = client.get("/help/security-audit/task")
+        assert resp.status_code == 200
+        body = resp.text
+        # H1 rendered from markdown
+        assert "security-audit task" in body
+        # Sidebar shows sibling kinds
+        assert "concept" in body
+        assert "reference" in body
+
+    def test_missing_template_404(self, client: TestClient) -> None:
+        resp = client.get("/help/security-audit/nonexistent-kind")
+        assert resp.status_code == 404
+
+    def test_invalid_feature_400(self, client: TestClient) -> None:
+        resp = client.get("/help/Bad-Slug/task")
+        assert resp.status_code == 400
+
+    def test_invalid_kind_400(self, client: TestClient) -> None:
+        resp = client.get("/help/security-audit/Bad-Kind")
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Phase 1+2 of the [`ops-help-page` spec](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/ops-help-page). The mockups from #482 are now a live dashboard surface backed by the real \`.help/templates/\` corpus.

## What's wired

**Data module** \`src/attune/ops/help_data.py\` — frozen dataclasses + read functions over the corpus (\`list_features\`, \`get_template\`, \`search\`, \`coverage_gaps\`, \`featured_topics\`, \`recently_regenerated\`).

**JSON API** \`src/attune/ops/routes/help.py\` — six GET endpoints (\`/api/help/*\`) for programmatic consumers.

**HTML pages** \`src/attune/ops/routes/dashboard.py\`:
- \`GET /help\` — user-first home (hero search, 4 intent cards, featured topics, recent, all features)
- \`GET /help/search?q=\` — ranked results with snippets
- \`GET /help/<feature>\` — feature index
- \`GET /help/<feature>/<kind>\` — template detail with sidebar + rendered markdown
- \`GET /help/admin\` — coverage gaps + stale templates

**5 templates + ~540 lines of CSS** appended to \`main.css\`.

## Spec divergences worth flagging

- **Search:** attune-rag's \`KeywordRetriever\` returned 0 hits because corpus entries had no summaries (the lesson "Metadata can reach a retriever with zero signal" exact fingerprint). Built inline summary extraction from each template's first paragraph and passed via \`extra_summaries\` — search now works without depending on attune-help being installed.
- **Admin tools naming:** matches the rename from #483 ("Admin tools" not "Coverage gaps"). Route is \`/help/admin\`.
- **No sidebar on home:** intentional — full-width centered hero per the user-first IA. Sidebar appears on template detail pages where it's contextually useful.

## Verified end-to-end against the real corpus

- 25 features, 259 templates, 250 stale, 2 incomplete (\`hooks\`, \`resilience\`)
- Search for "injection" → 8 ranked results, security-audit/* in top hits
- Search for "fix failing tests" → fix-test/* templates ranked correctly
- Admin page shows the actual stale list + completeness bars

Screenshots in the conversation thread.

## What's NOT in this PR

- Phase 3 polish — localStorage recent reads / pinned templates (next PR)
- Tests — Phase 1's data module + API routes have no tests yet. Adding them next; the implementation is fresh enough that I wanted you to see it work first.

## Test plan

- [x] All four HTML routes render against the real corpus
- [x] All six JSON API endpoints return valid payloads
- [x] Slug validation rejects \`../\` and other path-traversal shapes
- [x] Markdown rendering uses CommonMark (no raw HTML; XSS-safe)
- [x] Cross-references navigate correctly between pages
- [ ] Unit tests — coming in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)