### PR TITLE
feat(curator): Phase 1 — source readers + cache scaffolding

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5880,3 +5880,88 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   that flips it, you've found a CI-vs-dev environment
   drift bug. Don't bundle the fix into an unrelated PR;
   flag in the PR body and file separately.
+
+- **Local `coverage run -m pytest` defaults to LINE
+  coverage; codecov runs BRANCH coverage — always use
+  `coverage run --branch` locally to match what CI
+  enforces**: hit 2026-05-27 on PR #485 (bulletin-
+  curator Phase 1). After lifting line coverage to 100%
+  and pushing, codecov flagged 2 partial branches in
+  `sources/sweep.py` at 99.74% patch coverage. Local
+  re-run with `--branch` immediately reproduced the gap
+  (`Branch=28, BrPart=2`). The two partials were
+  `elif isinstance(row, dict)` False (non-dict bucket
+  rows) and `if reason:` False (empty reason in
+  questions-bucket finding) — both reachable by adding
+  one fixture each. Three corollaries: (1) when fixing
+  coverage gaps on any PR with codecov, run
+  `coverage run --branch -m pytest` from the start;
+  line-only reports lie by omission about partial
+  branches. (2) When writing the local-fast-feedback
+  pre-push hook, it MUST run with `--branch` (see
+  `docs/specs/test-discipline-controls/decisions.md` D5).
+  (3) When the report shows `Branch=N, BrPart=0,
+  Cover=100%`, you actually have full coverage; when
+  the same numbers say `Cover=100% line` only without
+  branch columns, treat as suspicious until verified.
+  Diagnostic: `coverage report -m` with `--branch`
+  prints a "BrPart" column and "Missing" lines with
+  `103->96` notation for branch arrows; line-only
+  prints integer line numbers only.
+
+- **Rapid pushes to a PR with `cancel-in-progress`
+  concurrency cancel the prior workflow run — and
+  cancelled-but-required = blocking, indistinguishable
+  from real failure to the PR gate**: extends the
+  existing "`gh pr checks --watch --fail-fast` mistakes
+  cancellations for failures" lesson with the
+  inbound-cause variant. Hit 2026-05-27 on PR #485
+  during the coverage-fix cycle: 4 commits pushed
+  within 17 minutes triggered 4 security-workflow runs
+  via `pull_request` events. The workflow's
+  `concurrency.group: $workflow-$head_ref` plus
+  `cancel-in-progress: true` meant each new push
+  cancelled the prior run mid-execution. The LATEST
+  commit's security run was also cancelled (likely a
+  webhook race or stale dispatch), leaving the
+  required `security` check in `cancel` bucket and the
+  PR `BLOCKED`. Recovery: `gh run rerun <run-id>` on
+  the cancelled run for the latest SHA. Prevention:
+  before pushing a fix, check whether a security /
+  long workflow is still in-flight via
+  `gh run list --workflow=security.yml --branch=<name>
+  --limit=1 --json status`. If `in_progress`, either
+  wait for it to settle (~5-7 min) or accept the
+  re-run cost. The `cancel-in-progress` design assumes
+  the new push superseded the old one, but for
+  required checks the cancellation is treated as a
+  fail-state by branch protection.
+
+- **Mark tasks complete on outcome verification, not
+  on tool-call success — especially "open PR" tasks**:
+  Hit 2026-05-27 across multiple PR-opening tasks in
+  the same session. Pattern: `gh pr create` returns a
+  URL → mark task "completed" → discover hours later
+  that CI is blocking the PR for codecov / security /
+  windows-test reasons → task should have stayed
+  in-progress the whole time. The misalignment: a tool
+  call returning success ≠ the deliverable being done.
+  The deliverable for "open PR" is "PR opened and
+  green on required checks." For "run tests" it's
+  "tests pass on the CI matrix, not just locally." For
+  "commit fix" it's "fix is on main, not just in a
+  local commit." Operational rule: when a task has an
+  outcome that lives outside the agent's machine (PR
+  state on GitHub, CI results, deploy state, package
+  on PyPI), mark the task complete ONLY when the
+  external state matches the desired outcome — not
+  when the local tool call succeeded. Practical
+  application: task "open PR" stays in_progress until
+  `gh pr checks <pr>` shows zero pending and zero
+  failing; task "push fix" stays in_progress until
+  codecov posts a green check; task "merge PR" stays
+  in_progress until `gh pr view` shows
+  `state=MERGED`. The task list as a planning artifact
+  is only useful if "completed" means "the work I
+  said I'd do is done in reality" — not "I called the
+  tool and it didn't error."

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5802,3 +5802,81 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   document the divergence in the PR body BEFORE pushing,
   then let CI surface the predicted trade-off — the
   divergence becomes self-validating.
+
+- **The `rag-code-gen` workflow's agent is read-only —
+  `allowed_tools=["Read", "Glob", "Grep"]` — so it cannot
+  write files**: hit 2026-05-26 trying to use rag-code-gen
+  to draft a Phase 1 implementation skeleton from a spec.
+  The workflow retrieves RAG-grounded context, calls the
+  agent with the augmented prompt, and returns the agent's
+  output as a single text blob in
+  ``WorkflowResult.final_output``. The agent CAN read the
+  spec + existing patterns to ground its output, but the
+  returned text then has to be manually split across the
+  spec's target paths. For multi-file scaffolding
+  (12 files for the bulletin-curator Phase 1), this is
+  strictly worse than just executing the spec's XML
+  prompts directly with Edit/Write — same grounding,
+  no transcription step. Pattern: when a workflow's name
+  suggests "code generation," check its `allowed_tools`
+  list before relying on it for file creation. Read-only
+  tool surfaces produce text, not commits.
+  ([rag_code_gen.py:359](src/attune/workflows/rag_code_gen.py:359))
+
+- **z-score anomaly detection silently never fires when
+  the historical sample has zero variance — decide
+  explicitly how to handle stddev=0 before shipping**:
+  classic implementation:
+  ```python
+  mean = sum(prior) / len(prior)
+  variance = sum((c - mean) ** 2 for c in prior) / len(prior)
+  stddev = math.sqrt(variance) if variance > 0 else 0.0
+  if stddev == 0:
+      continue  # ← skips workflows with identical prior values
+  z = (today_cost - mean) / stddev
+  if z > 2.0:
+      emit_spike(...)
+  ```
+  Real-world hit: telemetry test fixture with 6 identical
+  $0.01 days and a $5.00 spike today produces stddev=0 →
+  no spike fired. Test failed for the wrong reason (looked
+  like a logic bug; was a fixture problem). Two valid
+  resolutions: (a) require fixture variance (real
+  workflow telemetry has natural variation across model
+  tiers + run sizes — uniform synthetic data is the
+  problem); (b) production code adds a multiplier
+  fallback for the stddev=0 case (e.g. "today >5× the
+  mean AND mean > 0"). Pick one before writing tests so
+  fixtures and code agree. The "no anomaly when prior is
+  flat" interpretation is actually defensible — a
+  workflow that ran at $0.01 every day for a week
+  arguably SHOULD trigger an alert when it suddenly hits
+  $5, because that's a 500× jump, but the heuristic the
+  spec named was "z-score" which structurally can't
+  catch it. Surface the trade-off in the spec / decisions.md
+  rather than papering over it in a test.
+
+- **Pre-existing TZ-sensitive test failures pass under
+  `TZ=UTC` and fail under local TZ — diagnose before
+  treating as a regression**: hit 2026-05-26 on the
+  bulletin Phase 1's `_maybe_rotate` test. After adding
+  an unrelated method to `file_backend.py`,
+  `test_yesterdays_log_moved_to_archive` fired red.
+  Stashing the change and running on pristine origin/main
+  reproduced the failure → not caused by my change.
+  Re-running under `TZ=UTC` made it pass. Root cause:
+  `_maybe_rotate` compares `mtime.date()` (computed with
+  `tz=timezone.utc`) against `date.today()` (which uses
+  local TZ). In Eastern, an mtime backdated to "yesterday
+  +60s ago" maps to a UTC date that's still "today" in
+  local TZ → rotation no-ops. CI is UTC so the failure
+  never surfaces on origin/main; only local non-UTC dev
+  environments hit it. Diagnostic recipe when an
+  unrelated-looking test fails after your change:
+  (1) `git stash` your changes, (2) re-run the test on
+  pristine origin/main — if it still fails, the cause
+  is pre-existing; (3) try `TZ=UTC` (or other env
+  overrides like `LC_ALL=C`, `LANG=en_US.UTC-8`) — if
+  that flips it, you've found a CI-vs-dev environment
+  drift bug. Don't bundle the fix into an unrelated PR;
+  flag in the PR body and file separately.

--- a/src/attune/bulletin/file_backend.py
+++ b/src/attune/bulletin/file_backend.py
@@ -135,6 +135,38 @@ class FileBulletinBackend:
         out.sort(key=lambda e: e.last_heartbeat, reverse=True)
         return out
 
+    def read_archive(self, *, since: datetime) -> list[BulletinEntry]:
+        """Return archived entries whose snapshot date is >= ``since``.
+
+        Walks ``archive/YYYY-MM-DD.jsonl`` files. Files whose name
+        cannot be parsed as ISO date are skipped silently. A
+        missing ``archive/`` directory returns ``[]`` (rotation
+        may not have fired yet).
+        """
+        if not self.archive_dir.exists():
+            return []
+
+        cutoff = since.date()
+        out: list[BulletinEntry] = []
+        try:
+            children = sorted(self.archive_dir.iterdir())
+        except OSError as e:
+            logger.warning("bulletin: cannot list %s: %s", self.archive_dir, e)
+            return []
+
+        for path in children:
+            if not path.is_file() or path.suffix != ".jsonl":
+                continue
+            try:
+                snapshot_date = date.fromisoformat(path.stem)
+            except ValueError:
+                logger.debug("bulletin: skipping non-date archive %s", path.name)
+                continue
+            if snapshot_date < cutoff:
+                continue
+            out.extend(self._iter_entries(path))
+        return out
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------

--- a/src/attune/curator/__init__.py
+++ b/src/attune/curator/__init__.py
@@ -1,0 +1,28 @@
+"""Bulletin Curator — on-demand briefing across project surfaces.
+
+See ``docs/specs/bulletin-curator/`` for the spec.
+"""
+
+from __future__ import annotations
+
+from .result import (
+    ActionKind,
+    CuratorItem,
+    CuratorResult,
+    Severity,
+    SourceItem,
+    SourceSummary,
+    SuggestedAction,
+)
+from .sources import SourceReader
+
+__all__ = [
+    "ActionKind",
+    "CuratorItem",
+    "CuratorResult",
+    "Severity",
+    "SourceItem",
+    "SourceReader",
+    "SourceSummary",
+    "SuggestedAction",
+]

--- a/src/attune/curator/cache.py
+++ b/src/attune/curator/cache.py
@@ -1,0 +1,221 @@
+"""TTL cache for :class:`CuratorResult` objects.
+
+One file per cache key under ``<attune_home>/curator-cache/``. The
+key is derived from the source-state hash by the caller; this module
+just persists / loads / evicts. Read path: validates the entry's
+``cached_at`` against the configured TTL and returns ``None`` if
+stale. Write path: serialises the :class:`CuratorResult` as JSON.
+
+Lazy eviction (stale entries are skipped on read but not actively
+deleted) plus an explicit ``sweep(older_than_days=...)`` for the
+daily housekeeping the spec calls for.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from attune.ops.config import attune_home
+
+from .result import (
+    CuratorItem,
+    CuratorResult,
+    Severity,
+    SourceSummary,
+    SuggestedAction,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TTL_SECONDS = 300
+_DEFAULT_SUBDIR = "curator-cache"
+
+
+class CuratorCache:
+    """5-minute TTL cache for :class:`CuratorResult`.
+
+    The cache key is computed via :meth:`key` from the source-state
+    hashes; callers can also pass a pre-computed key string directly
+    to :meth:`get` / :meth:`put`.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+        root: Path | None = None,
+    ) -> None:
+        self._ttl = max(0, int(ttl_seconds))
+        self._root = root if root is not None else attune_home() / _DEFAULT_SUBDIR
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    @property
+    def ttl_seconds(self) -> int:
+        return self._ttl
+
+    def key(self, summaries: list[SourceSummary]) -> str:
+        """Derive a cache key from concatenated source hashes."""
+        joined = "|".join(s.state_hash for s in summaries)
+        return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+    def get(self, key: str) -> CuratorResult | None:
+        """Return the cached result for ``key`` if fresh; else ``None``.
+
+        A missing file, malformed JSON, version-mismatched schema,
+        or expired ``cached_at`` all surface as ``None`` (cache
+        miss). Never raises.
+        """
+        path = self._path_for(key)
+        if not path.is_file():
+            return None
+        try:
+            raw = path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("curator-cache: read %s failed: %s", path, exc)
+            return None
+        if not isinstance(data, dict):
+            return None
+
+        cached_at = _parse_iso(str(data.get("cached_at") or ""))
+        if cached_at is None:
+            return None
+        if self._is_stale(cached_at):
+            return None
+
+        try:
+            return _deserialise(data)
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.debug("curator-cache: bad schema in %s: %s", path, exc)
+            return None
+
+    def put(self, key: str, result: CuratorResult) -> None:
+        """Persist ``result`` under ``key``. Best-effort.
+
+        The cached entry stamps ``cached_at`` to ``now`` if the
+        caller passed ``None`` so the TTL is always meaningful.
+        """
+        try:
+            self._root.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.warning("curator-cache: cannot create %s: %s", self._root, exc)
+            return
+
+        stamp = result.cached_at or datetime.now(timezone.utc)
+        snapshot = _serialise(result, cached_at=stamp)
+        path = self._path_for(key)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        try:
+            tmp_path.write_text(
+                json.dumps(snapshot, sort_keys=True),
+                encoding="utf-8",
+            )
+            tmp_path.replace(path)
+        except OSError as exc:
+            logger.warning("curator-cache: write %s failed: %s", path, exc)
+
+    def sweep(self, *, older_than_days: int = 7) -> int:
+        """Delete cache files whose mtime is older than ``older_than_days``.
+
+        Returns the deletion count. Safe to call when the cache dir
+        doesn't exist (returns 0).
+        """
+        if older_than_days <= 0 or not self._root.is_dir():
+            return 0
+        cutoff = time.time() - older_than_days * 86_400
+        deleted = 0
+        try:
+            entries = list(self._root.glob("*.json"))
+        except OSError:
+            return 0
+        for entry in entries:
+            try:
+                if entry.stat().st_mtime < cutoff:
+                    entry.unlink()
+                    deleted += 1
+            except OSError as exc:
+                logger.debug("curator-cache: sweep %s failed: %s", entry, exc)
+        return deleted
+
+    def _path_for(self, key: str) -> Path:
+        safe = "".join(ch for ch in key if ch.isalnum() or ch in ("-", "_"))
+        if not safe:
+            safe = "default"
+        return self._root / f"{safe}.json"
+
+    def _is_stale(self, cached_at: datetime) -> bool:
+        if self._ttl == 0:
+            return True
+        age = datetime.now(timezone.utc) - cached_at
+        return age > timedelta(seconds=self._ttl)
+
+
+def _serialise(result: CuratorResult, *, cached_at: datetime) -> dict:
+    payload = asdict(result)
+    payload["cached_at"] = cached_at.isoformat()
+    return payload
+
+
+def _deserialise(data: dict) -> CuratorResult:
+    items_raw = data.get("items") or []
+    items: list[CuratorItem] = []
+    for entry in items_raw:
+        if not isinstance(entry, dict):
+            continue
+        action_raw = entry.get("suggested_action")
+        action: SuggestedAction | None = None
+        if isinstance(action_raw, dict) and action_raw.get("kind"):
+            action = SuggestedAction(
+                kind=action_raw["kind"],  # type: ignore[arg-type]
+                label=action_raw.get("label"),
+                question=action_raw.get("question"),
+                choices=list(action_raw.get("choices") or []),
+                url=action_raw.get("url"),
+                workflow=action_raw.get("workflow"),
+                scope=action_raw.get("scope"),
+            )
+        items.append(
+            CuratorItem(
+                id=str(entry["id"]),
+                title=str(entry["title"]),
+                severity=_coerce_severity(entry.get("severity")),
+                rationale=str(entry.get("rationale") or ""),
+                sources=list(entry.get("sources") or []),
+                suggested_action=action,
+            )
+        )
+    return CuratorResult(
+        summary=str(data.get("summary") or ""),
+        items=items,
+        sources_consulted=list(data.get("sources_consulted") or []),
+        cost_usd=float(data.get("cost_usd") or 0.0),
+        cached_at=_parse_iso(str(data.get("cached_at") or "")),
+        model=str(data.get("model") or ""),
+    )
+
+
+def _coerce_severity(value) -> Severity:
+    if value in ("info", "nudge", "warn", "block"):
+        return value  # type: ignore[return-value]
+    return "info"
+
+
+def _parse_iso(s: str) -> datetime | None:
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt

--- a/src/attune/curator/result.py
+++ b/src/attune/curator/result.py
@@ -1,0 +1,98 @@
+"""Curator data model — frozen dataclasses for sources and results.
+
+See docs/specs/bulletin-curator/design.md for the contract.
+
+Source readers return :class:`SourceSummary`. The orchestrator
+synthesises across them and returns a :class:`CuratorResult`. All
+dataclasses are frozen so the cache layer can rely on them as
+value objects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+Severity = Literal["info", "nudge", "warn", "block"]
+ActionKind = Literal["ask", "open", "run", "dismiss"]
+
+
+@dataclass(frozen=True)
+class SourceItem:
+    """One row from a source — a unit the curator can cite.
+
+    ``item_id`` is the stable handle the LLM uses in its
+    ``sources`` array. The orchestrator validates that every cited
+    id resolves back to a known item before returning the result.
+    """
+
+    item_id: str
+    title: str
+    detail: str
+    link: str
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SourceSummary:
+    """The output of one source reader.
+
+    ``state_hash`` MUST be deterministic for the same logical
+    state — the cache layer keys on it. ``items=[]`` is a valid
+    empty result; readers must not raise.
+    """
+
+    source_id: str
+    state_hash: str
+    items: list[SourceItem] = field(default_factory=list)
+    fetch_ms: int = 0
+
+
+@dataclass(frozen=True)
+class SuggestedAction:
+    """The actionable footer of a CuratorItem.
+
+    ``kind`` selects which of the optional fields are meaningful.
+    The dashboard / CLI render the kind-appropriate UI.
+    """
+
+    kind: ActionKind
+    label: str | None = None
+    question: str | None = None
+    choices: list[str] = field(default_factory=list)
+    url: str | None = None
+    workflow: str | None = None
+    scope: str | None = None
+
+
+@dataclass(frozen=True)
+class CuratorItem:
+    """One ranked attention item.
+
+    ``sources`` is a list of ``SourceItem.item_id`` values — the
+    orchestrator drops any item that cites an unknown id.
+    """
+
+    id: str
+    title: str
+    severity: Severity
+    rationale: str
+    sources: list[str] = field(default_factory=list)
+    suggested_action: SuggestedAction | None = None
+
+
+@dataclass(frozen=True)
+class CuratorResult:
+    """The synthesised briefing returned by ``run_curator``.
+
+    Cached as JSON under ``<attune_home>/curator-cache/<key>.json``
+    by :class:`attune.curator.cache.CuratorCache`.
+    """
+
+    summary: str
+    items: list[CuratorItem] = field(default_factory=list)
+    sources_consulted: list[str] = field(default_factory=list)
+    cost_usd: float = 0.0
+    cached_at: datetime | None = None
+    model: str = ""

--- a/src/attune/curator/sources/__init__.py
+++ b/src/attune/curator/sources/__init__.py
@@ -1,0 +1,39 @@
+"""Source readers for the bulletin curator.
+
+Each reader is a pure-Python module exporting a top-level
+``read(*, project_root, since=None) -> SourceSummary`` function
+that matches the :class:`SourceReader` Protocol. Readers must NOT
+raise — empty / unreadable sources return an empty
+``SourceSummary``. The curator orchestrator can tolerate any
+individual source being silent; it cannot tolerate one source
+crashing the run.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol
+
+from ..result import SourceSummary
+
+
+class SourceReader(Protocol):
+    """Shape every source reader implements at module level."""
+
+    def read(
+        self,
+        *,
+        project_root: Path,
+        since: datetime | None = None,
+    ) -> SourceSummary:
+        """Return a compact summary of this source's current state.
+
+        Must not raise. Empty / unreadable sources return an
+        empty ``SourceSummary`` whose ``state_hash`` is stable
+        across calls.
+        """
+        ...
+
+
+__all__ = ["SourceReader"]

--- a/src/attune/curator/sources/__init__.py
+++ b/src/attune/curator/sources/__init__.py
@@ -33,7 +33,6 @@ class SourceReader(Protocol):
         empty ``SourceSummary`` whose ``state_hash`` is stable
         across calls.
         """
-        ...
 
 
 __all__ = ["SourceReader"]

--- a/src/attune/curator/sources/bulletin.py
+++ b/src/attune/curator/sources/bulletin.py
@@ -1,0 +1,161 @@
+"""Bulletin source reader — active runs + archived terminal entries.
+
+Reads the multi-actor bulletin under ``<attune_home>/bulletin/``.
+Active entries become SourceItems with ``metadata.kind="active"``;
+archived entries become items with ``metadata.kind="archived"`` and
+their terminal status.
+
+The reader must never raise — a missing bulletin dir, malformed
+lines, or unreadable archive files all collapse to an empty
+``SourceSummary`` with a stable hash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from attune.bulletin.file_backend import FileBulletinBackend
+from attune.bulletin.protocol import BulletinEntry
+from attune.ops.config import attune_home
+
+from ..result import SourceItem, SourceSummary
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_ID = "bulletin"
+
+
+def read(
+    *,
+    project_root: Path,
+    since: datetime | None = None,
+) -> SourceSummary:
+    """Read active + archived bulletin entries.
+
+    Args:
+        project_root: Project root (unused — bulletin is per-user,
+            not per-project). Kept for Protocol conformance.
+        since: Optional cutoff for archive scan. Defaults to 24h
+            ago when omitted. Active entries are always included
+            regardless of ``since``.
+    """
+    started = time.perf_counter()
+
+    cutoff = since if since is not None else _default_since()
+    backend = FileBulletinBackend(attune_home() / "bulletin")
+
+    try:
+        active_entries = backend.read_active()
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: A reader that raises is a worse outcome than
+        # one that returns empty — the curator orchestrator treats
+        # both as "no signal" but only the latter doesn't crash the
+        # parallel gather().
+        logger.warning("bulletin: read_active failed: %s", exc)
+        active_entries = []
+
+    try:
+        archived_entries = backend.read_archive(since=cutoff)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: same rationale as above.
+        logger.warning("bulletin: read_archive failed: %s", exc)
+        archived_entries = []
+
+    items: list[SourceItem] = []
+    now = datetime.now(timezone.utc)
+    for entry in active_entries:
+        items.append(_active_to_item(entry, now=now))
+    for entry in archived_entries:
+        items.append(_archived_to_item(entry))
+
+    state_hash = _hash_entries(active_entries + archived_entries)
+    fetch_ms = int((time.perf_counter() - started) * 1000)
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=state_hash,
+        items=items,
+        fetch_ms=fetch_ms,
+    )
+
+
+def _default_since() -> datetime:
+    """24 hours before now, UTC."""
+    from datetime import timedelta
+
+    return datetime.now(timezone.utc) - timedelta(hours=24)
+
+
+def _active_to_item(entry: BulletinEntry, *, now: datetime) -> SourceItem:
+    heartbeat_dt = _parse_iso(entry.last_heartbeat)
+    if heartbeat_dt is None:
+        age_s = "unknown"
+    else:
+        age_s = str(int((now - heartbeat_dt).total_seconds()))
+    title = f"{entry.workflow} ({entry.actor_kind}, {entry.actor_id})"
+    detail = (
+        f"Run {entry.run_id} started {entry.started_at}. Last heartbeat: {entry.last_heartbeat}."
+    )
+    if entry.scope:
+        detail += f" Scope: {entry.scope}."
+    return SourceItem(
+        item_id=f"bulletin:active:{entry.run_id}",
+        title=title,
+        detail=_truncate(detail, 500),
+        link=f"/runs/{entry.run_id}/view",
+        metadata={
+            "kind": "active",
+            "actor_kind": entry.actor_kind,
+            "actor_id": entry.actor_id,
+            "workflow": entry.workflow,
+            "heartbeat_age_s": age_s,
+        },
+    )
+
+
+def _archived_to_item(entry: BulletinEntry) -> SourceItem:
+    title = f"{entry.workflow} — {entry.current_status} ({entry.actor_kind})"
+    detail = (
+        f"Run {entry.run_id} terminal status: {entry.current_status}. "
+        f"Started {entry.started_at}, last heartbeat {entry.last_heartbeat}."
+    )
+    if entry.scope:
+        detail += f" Scope: {entry.scope}."
+    return SourceItem(
+        item_id=f"bulletin:archived:{entry.run_id}",
+        title=title,
+        detail=_truncate(detail, 500),
+        link=f"/runs/{entry.run_id}/view",
+        metadata={
+            "kind": "archived",
+            "actor_kind": entry.actor_kind,
+            "actor_id": entry.actor_id,
+            "workflow": entry.workflow,
+            "terminal_status": entry.current_status,
+        },
+    )
+
+
+def _hash_entries(entries: list[BulletinEntry]) -> str:
+    """Deterministic hash over (run_id, last_heartbeat) pairs.
+
+    Order-independent — sort before hashing so two reads with the
+    same logical state always produce the same digest.
+    """
+    pairs = sorted((e.run_id, e.last_heartbeat) for e in entries)
+    joined = "|".join(f"{rid}@{hb}" for rid, hb in pairs)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_iso(s: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _truncate(s: str, limit: int) -> str:
+    return s if len(s) <= limit else s[: limit - 1] + "…"

--- a/src/attune/curator/sources/git_state.py
+++ b/src/attune/curator/sources/git_state.py
@@ -1,0 +1,236 @@
+"""Git state source reader — three discrete repo-health signals.
+
+* diverged-from-main: HEAD's commit-date is >3 days behind
+  ``origin/main`` (signals stale branch);
+* uncommitted-files: ``git status --porcelain`` reports >10 entries;
+* secrets-shaped untracked: untracked files whose names match common
+  credential file patterns (per the CLAUDE.md "filename smell test"
+  lesson).
+
+Subprocess calls use argv-list form with ``timeout=5s``. A locked or
+hung git repo collapses to a no-signal empty summary rather than a
+traceback.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import shutil
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..result import SourceItem, SourceSummary
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_ID = "git-state"
+_DETAIL_CHAR_LIMIT = 500
+_GIT_TIMEOUT_S = 5.0
+_STALE_DAYS_THRESHOLD = 3
+_UNCOMMITTED_THRESHOLD = 10
+
+# Filename patterns that suggest credential content. Conservative —
+# false positives are cheap (one curator item the user dismisses),
+# false negatives leave real keys exposed.
+_SECRETS_FILENAME_PATTERNS = (
+    re.compile(r"^\.env(\..+)?$", re.IGNORECASE),
+    re.compile(r".*\.pem$", re.IGNORECASE),
+    re.compile(r".*\.key$", re.IGNORECASE),
+    re.compile(r".*credential.*", re.IGNORECASE),
+    re.compile(r".*secret.*", re.IGNORECASE),
+    re.compile(r".*token.*\.txt$", re.IGNORECASE),
+    re.compile(r".*api[_-]?key.*", re.IGNORECASE),
+)
+
+
+def read(
+    *,
+    project_root: Path,
+    since: datetime | None = None,
+) -> SourceSummary:
+    """Probe the project_root git repo for stale / dirty / leaky state."""
+    del since  # noqa: F841 — git signals are instantaneous, no since-window
+
+    started = time.perf_counter()
+
+    if shutil.which("git") is None:
+        return _empty_summary(started)
+    if not (project_root / ".git").exists():
+        return _empty_summary(started)
+
+    items: list[SourceItem] = []
+    items.extend(_diverged_signal(project_root))
+    items.extend(_uncommitted_signal(project_root))
+    items.extend(_secrets_signal(project_root))
+
+    state_hash = _hash_items(items)
+    fetch_ms = int((time.perf_counter() - started) * 1000)
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=state_hash,
+        items=items,
+        fetch_ms=fetch_ms,
+    )
+
+
+def _diverged_signal(project_root: Path) -> list[SourceItem]:
+    """Emit an item if HEAD's date is >3 days behind origin/main."""
+    head_dt = _commit_date(project_root, "HEAD")
+    main_dt = _commit_date(project_root, "origin/main")
+    if head_dt is None or main_dt is None:
+        return []
+    delta = main_dt - head_dt
+    if delta.days < _STALE_DAYS_THRESHOLD:
+        return []
+    detail = (
+        f"HEAD is {delta.days} days behind origin/main "
+        f"(HEAD: {head_dt.date().isoformat()}, "
+        f"main: {main_dt.date().isoformat()})."
+    )
+    return [
+        SourceItem(
+            item_id=f"git:diverged:{delta.days}d",
+            title=f"Branch is {delta.days} days behind origin/main",
+            detail=_truncate(detail, _DETAIL_CHAR_LIMIT),
+            link="",
+            metadata={
+                "signal": "diverged",
+                "days_behind": str(delta.days),
+            },
+        )
+    ]
+
+
+def _uncommitted_signal(project_root: Path) -> list[SourceItem]:
+    """Emit an item if `git status --porcelain` has >10 entries."""
+    result = _run_git(project_root, ["status", "--porcelain"])
+    if result is None:
+        return []
+    lines = [line for line in result.splitlines() if line.strip()]
+    if len(lines) <= _UNCOMMITTED_THRESHOLD:
+        return []
+    sample = lines[:5]
+    detail = f"{len(lines)} uncommitted entries in working tree. Sample: {'; '.join(sample)}"
+    return [
+        SourceItem(
+            item_id=f"git:uncommitted:{len(lines)}",
+            title=f"{len(lines)} uncommitted files in working tree",
+            detail=_truncate(detail, _DETAIL_CHAR_LIMIT),
+            link="",
+            metadata={
+                "signal": "uncommitted",
+                "count": str(len(lines)),
+            },
+        )
+    ]
+
+
+def _secrets_signal(project_root: Path) -> list[SourceItem]:
+    """Emit one item per untracked file whose name looks credential-shaped."""
+    result = _run_git(
+        project_root,
+        ["ls-files", "--others", "--exclude-standard"],
+    )
+    if result is None:
+        return []
+    suspicious: list[str] = []
+    for line in result.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        name = Path(line).name
+        if any(p.match(name) for p in _SECRETS_FILENAME_PATTERNS):
+            suspicious.append(line)
+        if len(suspicious) >= 10:
+            break
+    if not suspicious:
+        return []
+    out: list[SourceItem] = []
+    for path in suspicious:
+        digest = hashlib.sha256(path.encode("utf-8")).hexdigest()[:12]
+        out.append(
+            SourceItem(
+                item_id=f"git:secret-shape:{digest}",
+                title=f"Untracked credential-shaped file: {path}",
+                detail=_truncate(
+                    f"Untracked file '{path}' matches a credential-shape "
+                    "filename pattern. Move out of the working tree or "
+                    "add to .gitignore + verify no real secrets inside.",
+                    _DETAIL_CHAR_LIMIT,
+                ),
+                link="",
+                metadata={
+                    "signal": "secret_shape",
+                    "path": path,
+                },
+            )
+        )
+    return out
+
+
+def _commit_date(project_root: Path, ref: str) -> datetime | None:
+    out = _run_git(
+        project_root,
+        ["log", "-1", "--format=%cI", ref],
+    )
+    if out is None:
+        return None
+    line = out.strip().splitlines()[0] if out.strip() else ""
+    if not line:
+        return None
+    try:
+        dt = datetime.fromisoformat(line)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _run_git(project_root: Path, argv: list[str]) -> str | None:
+    """Argv-list git invocation with timeout. Returns stdout or None on failure."""
+    try:
+        proc = subprocess.run(
+            ["git", *argv],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_GIT_TIMEOUT_S,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("git_state: %s timed out / failed: %s", argv, exc)
+        return None
+    if proc.returncode != 0:
+        logger.debug(
+            "git_state: %s exited %d: %s",
+            argv,
+            proc.returncode,
+            proc.stderr.strip()[:200],
+        )
+        return None
+    return proc.stdout
+
+
+def _hash_items(items: list[SourceItem]) -> str:
+    rows = sorted(item.item_id for item in items)
+    return hashlib.sha256("|".join(rows).encode("utf-8")).hexdigest()[:16]
+
+
+def _empty_summary(started: float) -> SourceSummary:
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=hashlib.sha256(b"").hexdigest()[:16],
+        items=[],
+        fetch_ms=int((time.perf_counter() - started) * 1000),
+    )
+
+
+def _truncate(s: str, limit: int) -> str:
+    return s if len(s) <= limit else s[: limit - 1] + "…"

--- a/src/attune/curator/sources/recommendations.py
+++ b/src/attune/curator/sources/recommendations.py
@@ -82,8 +82,8 @@ def _recent_records(workflow_dir: Path, cutoff: datetime) -> list[Path]:
         return []
     fresh: list[Path] = []
     for path in files:
-        if path.name.endswith(".tmp"):
-            continue
+        # `*.json` glob already excludes `*.json.tmp` atomic-write
+        # leftovers, so no extra .tmp filter needed here.
         try:
             mtime = path.stat().st_mtime
         except OSError:

--- a/src/attune/curator/sources/recommendations.py
+++ b/src/attune/curator/sources/recommendations.py
@@ -1,0 +1,163 @@
+"""Recommendations source reader — pending ATTUNE_REC cards.
+
+Walks persisted run records under ``<attune_home>/ops/runs/<workflow>/``
+and extracts each run's ``recommendations: [...]`` array. Each
+recommendation becomes one ``SourceItem`` so the curator can rank
+unresolved cards alongside other signals.
+
+Filters to runs whose newest mtime is within the configured window
+(default 24h) — older recommendations have presumably been
+seen-and-ignored or actioned.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from attune.ops.config import attune_home
+
+from ..result import SourceItem, SourceSummary
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_ID = "recommendations"
+_DETAIL_CHAR_LIMIT = 500
+_MAX_ITEMS = 50
+_RUNS_SUBDIR = ("ops", "runs")
+
+
+def read(
+    *,
+    project_root: Path,
+    since: datetime | None = None,
+) -> SourceSummary:
+    """Surface pending recommendation cards from recent run records."""
+    del project_root  # noqa: F841 — runs live under attune_home, not per-project
+
+    started = time.perf_counter()
+    runs_dir = attune_home().joinpath(*_RUNS_SUBDIR)
+    cutoff = since if since is not None else _default_since()
+
+    if not runs_dir.is_dir():
+        return _empty_summary(started)
+
+    try:
+        workflow_dirs = sorted(p for p in runs_dir.iterdir() if p.is_dir())
+    except OSError as exc:
+        logger.warning("recommendations: cannot list %s: %s", runs_dir, exc)
+        return _empty_summary(started)
+
+    items: list[SourceItem] = []
+    for workflow_dir in workflow_dirs:
+        for record_path in _recent_records(workflow_dir, cutoff):
+            items.extend(_items_from_record(workflow=workflow_dir.name, record_path=record_path))
+            if len(items) >= _MAX_ITEMS:
+                items = items[:_MAX_ITEMS]
+                break
+        if len(items) >= _MAX_ITEMS:
+            break
+
+    state_hash = _hash_items(items)
+    fetch_ms = int((time.perf_counter() - started) * 1000)
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=state_hash,
+        items=items,
+        fetch_ms=fetch_ms,
+    )
+
+
+def _recent_records(workflow_dir: Path, cutoff: datetime) -> list[Path]:
+    cutoff_ts = cutoff.timestamp()
+    try:
+        files = list(workflow_dir.glob("*.json"))
+    except OSError as exc:
+        logger.debug("recommendations: glob %s failed: %s", workflow_dir, exc)
+        return []
+    fresh: list[Path] = []
+    for path in files:
+        if path.name.endswith(".tmp"):
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime >= cutoff_ts:
+            fresh.append(path)
+    fresh.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return fresh
+
+
+def _items_from_record(*, workflow: str, record_path: Path) -> list[SourceItem]:
+    try:
+        raw = record_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("recommendations: skipping %s: %s", record_path, exc)
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    recommendations = data.get("recommendations")
+    if not isinstance(recommendations, list) or not recommendations:
+        return []
+
+    run_id = record_path.stem
+    out: list[SourceItem] = []
+    for idx, rec in enumerate(recommendations):
+        if not isinstance(rec, dict):
+            continue
+        kind = str(rec.get("kind") or "open")
+        label = str(rec.get("label") or rec.get("title") or "Recommendation")
+        detail = _format_detail(rec)
+        out.append(
+            SourceItem(
+                item_id=f"rec:{workflow}:{run_id}:{idx}",
+                title=_truncate(f"{workflow}: {label}", 150),
+                detail=_truncate(detail, _DETAIL_CHAR_LIMIT),
+                link=f"/runs/{run_id}/view",
+                metadata={
+                    "workflow": workflow,
+                    "run_id": run_id,
+                    "kind": kind,
+                },
+            )
+        )
+    return out
+
+
+def _format_detail(rec: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key in ("kind", "label", "title", "description", "url", "workflow", "scope"):
+        v = rec.get(key)
+        if v:
+            parts.append(f"{key}={v}")
+    return "; ".join(parts) if parts else json.dumps(rec, sort_keys=True)[:_DETAIL_CHAR_LIMIT]
+
+
+def _default_since() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(hours=24)
+
+
+def _hash_items(items: list[SourceItem]) -> str:
+    rows = sorted(item.item_id for item in items)
+    return hashlib.sha256("|".join(rows).encode("utf-8")).hexdigest()[:16]
+
+
+def _empty_summary(started: float) -> SourceSummary:
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=hashlib.sha256(b"").hexdigest()[:16],
+        items=[],
+        fetch_ms=int((time.perf_counter() - started) * 1000),
+    )
+
+
+def _truncate(s: str, limit: int) -> str:
+    return s if len(s) <= limit else s[: limit - 1] + "…"

--- a/src/attune/curator/sources/specs.py
+++ b/src/attune/curator/sources/specs.py
@@ -1,0 +1,184 @@
+"""Specs source reader — spec status + completion-candidate signals.
+
+Walks ``<project_root>/docs/specs/`` (the default spec root) and
+emits one ``SourceItem`` per spec directory. Items carry the spec's
+status (parsed from ``**Status:**`` lines in the canonical phase
+files), an age signal from the newest ``.md`` mtime, and a flag
+indicating whether the completion-candidates detector classified
+the spec as ready-to-close.
+
+The completion-candidates side is best-effort: if the detector
+raises (network, missing config, etc.), the reader still returns
+status + age and just sets ``is_completion_candidate="false"`` for
+every item.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from attune.ops.config import build_config
+from attune.ops.routes.specs import SpecRecord, _list_specs_in_root
+
+from ..result import SourceItem, SourceSummary
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_ID = "specs"
+_DEFAULT_SPECS_ROOT = Path("docs/specs")
+_DETAIL_CHAR_LIMIT = 500
+
+
+def read(
+    *,
+    project_root: Path,
+    since: datetime | None = None,
+) -> SourceSummary:
+    """List specs with status, age, and completion-candidate flag.
+
+    Args:
+        project_root: Repository root. Specs are discovered at
+            ``<project_root>/docs/specs/``.
+        since: Unused — kept for Protocol conformance. (Spec status
+            doesn't have a since-window in v1.)
+    """
+    del since  # noqa: F841 — protocol-required arg
+
+    started = time.perf_counter()
+    root = (project_root / _DEFAULT_SPECS_ROOT).resolve()
+
+    try:
+        specs = _list_specs_in_root(root)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a reader that raises crashes the parallel
+        # gather() in the orchestrator. Log + return empty.
+        logger.warning("specs: listing failed: %s", exc)
+        return _empty_summary(started)
+
+    candidate_slugs = _safe_completion_candidates(project_root, root)
+
+    items: list[SourceItem] = []
+    for spec in specs:
+        items.append(
+            _spec_to_item(
+                spec,
+                is_candidate=spec.slug in candidate_slugs,
+            )
+        )
+
+    state_hash = _hash_specs(specs, candidate_slugs)
+    fetch_ms = int((time.perf_counter() - started) * 1000)
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=state_hash,
+        items=items,
+        fetch_ms=fetch_ms,
+    )
+
+
+def _safe_completion_candidates(project_root: Path, specs_root: Path) -> set[str]:
+    """Detect completion candidates without crashing the reader.
+
+    The detector hits the GitHub API for PR / issue verification.
+    Network failures, missing ``gh`` CLI, and missing remote all
+    surface as empty rather than tracebacks.
+    """
+    try:
+        from attune.ops.completion_candidates import detect_candidates
+
+        cfg = build_config(
+            project_root=project_root,
+            specs_roots=(specs_root,),
+            specs_candidates_enabled=True,
+        )
+        return {c.slug for c in detect_candidates(cfg)}
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: candidate detection is auxiliary. If it
+        # fails the reader still produces useful status + age data.
+        logger.debug("specs: completion-candidates skipped: %s", exc)
+        return set()
+
+
+def _spec_to_item(spec: SpecRecord, *, is_candidate: bool) -> SourceItem:
+    status = _preferred_status(spec) or "unknown"
+    age_days = _age_days(spec.last_modified)
+    detail_lines: list[str] = []
+    for phase in spec.phases:
+        if not phase.exists:
+            continue
+        phase_status = phase.status or "(no status line)"
+        detail_lines.append(f"{phase.name}: {phase_status}")
+    detail = f"{spec.slug} — status: {status}, age_days: {age_days}. " + "; ".join(detail_lines)
+    metadata = {
+        "status": status,
+        "age_days": str(age_days) if age_days is not None else "unknown",
+        "is_completion_candidate": "true" if is_candidate else "false",
+    }
+    return SourceItem(
+        item_id=f"spec:{spec.slug}",
+        title=spec.slug,
+        detail=_truncate(detail, _DETAIL_CHAR_LIMIT),
+        link=f"/specs/{spec.slug}",
+        metadata=metadata,
+    )
+
+
+def _preferred_status(spec: SpecRecord) -> str | None:
+    """Pick the most authoritative status across the spec's phases.
+
+    Prefers tasks → design → requirements → decisions, matching the
+    completion-candidates heuristic. Returns the first non-empty
+    status found in that order.
+    """
+    order = ("tasks", "design", "requirements", "decisions")
+    by_name = {p.name: p for p in spec.phases}
+    for name in order:
+        phase = by_name.get(name)
+        if phase and phase.status:
+            return phase.status
+    return None
+
+
+def _age_days(last_modified: str | None) -> int | None:
+    if not last_modified:
+        return None
+    try:
+        dt = datetime.fromisoformat(last_modified)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - dt
+    return max(0, delta.days)
+
+
+def _hash_specs(specs: list[SpecRecord], candidate_slugs: set[str]) -> str:
+    """Deterministic hash over (slug, status, last_modified, candidate)."""
+    rows = sorted(
+        (
+            spec.slug,
+            _preferred_status(spec) or "",
+            spec.last_modified or "",
+            spec.slug in candidate_slugs,
+        )
+        for spec in specs
+    )
+    joined = "|".join(f"{s}@{st}@{lm}@{c}" for s, st, lm, c in rows)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+def _empty_summary(started: float) -> SourceSummary:
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=hashlib.sha256(b"").hexdigest()[:16],
+        items=[],
+        fetch_ms=int((time.perf_counter() - started) * 1000),
+    )
+
+
+def _truncate(s: str, limit: int) -> str:
+    return s if len(s) <= limit else s[: limit - 1] + "…"

--- a/src/attune/curator/sources/sweep.py
+++ b/src/attune/curator/sources/sweep.py
@@ -1,0 +1,179 @@
+"""Discovery-sweep source reader — queue + questions buckets.
+
+Walks persisted sweep results at ``<attune_home>/ops/sweep-results/``
+and emits one ``SourceItem`` per finding in the ``queue`` and
+``questions`` buckets. The ``rejected`` bucket is excluded — it's
+already-filtered noise.
+
+Each scope hashes to its own ``<digest>.json`` file (latest-only
+semantics). Reader is read-only and tolerant of missing dir,
+malformed JSON, and unknown schema versions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from attune.ops.config import attune_home
+
+from ..result import SourceItem, SourceSummary
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_ID = "sweep"
+_DETAIL_CHAR_LIMIT = 500
+_RESULTS_SUBDIR = ("ops", "sweep-results")
+_MAX_ITEMS = 50  # mirror tasks.md "max 50 rows per source" guidance
+
+
+def read(
+    *,
+    project_root: Path,
+    since: datetime | None = None,
+) -> SourceSummary:
+    """Read sweep results across all scopes."""
+    del since  # noqa: F841 — sweep results are latest-only, no since-window
+    del project_root  # noqa: F841 — attune_home is per-user, not per-project
+
+    started = time.perf_counter()
+    results_dir = attune_home().joinpath(*_RESULTS_SUBDIR)
+
+    if not results_dir.is_dir():
+        return _empty_summary(started)
+
+    try:
+        files = sorted(results_dir.glob("*.json"))
+    except OSError as exc:
+        logger.warning("sweep: cannot list %s: %s", results_dir, exc)
+        return _empty_summary(started)
+
+    items: list[SourceItem] = []
+    for path in files:
+        items.extend(_items_from_file(path))
+        if len(items) >= _MAX_ITEMS:
+            items = items[:_MAX_ITEMS]
+            break
+
+    state_hash = _hash_items(items)
+    fetch_ms = int((time.perf_counter() - started) * 1000)
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=state_hash,
+        items=items,
+        fetch_ms=fetch_ms,
+    )
+
+
+def _items_from_file(path: Path) -> list[SourceItem]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("sweep: skipping malformed %s: %s", path, exc)
+        return []
+    if not isinstance(data, dict):
+        return []
+
+    scope_digest = path.stem
+    out: list[SourceItem] = []
+    for finding in _iter_findings(data, bucket="queue"):
+        out.append(_finding_to_item(finding, bucket="queue", scope=scope_digest))
+    for finding in _iter_findings(data, bucket="questions"):
+        out.append(_finding_to_item(finding, bucket="questions", scope=scope_digest))
+    return out
+
+
+def _iter_findings(data: dict[str, Any], *, bucket: str):
+    rows = data.get(bucket)
+    if not isinstance(rows, list):
+        return
+    for row in rows:
+        # Question entries wrap the finding; queue entries are findings directly.
+        if isinstance(row, dict) and "finding" in row and isinstance(row["finding"], dict):
+            payload = dict(row["finding"])
+            payload["_question_reason"] = str(row.get("reason", ""))
+            payload["_question_next_step"] = str(row.get("next_step", ""))
+            yield payload
+        elif isinstance(row, dict):
+            yield row
+
+
+def _finding_to_item(finding: dict[str, Any], *, bucket: str, scope: str) -> SourceItem:
+    title = str(finding.get("title") or "(untitled finding)")
+    source = str(finding.get("source") or "unknown")
+    severity = str(finding.get("severity") or "info")
+    description = str(finding.get("description") or "")
+    file_ref = finding.get("file")
+    line_ref = finding.get("line")
+
+    detail_parts = [f"[{source}/{severity}] {description}"]
+    if file_ref:
+        location = f"{file_ref}:{line_ref}" if line_ref else str(file_ref)
+        detail_parts.append(f"at {location}")
+    if bucket == "questions":
+        reason = finding.get("_question_reason")
+        if reason:
+            detail_parts.append(f"question: {reason}")
+    detail = " ".join(detail_parts)
+
+    metadata = {
+        "bucket": bucket,
+        "source": source,
+        "severity": severity,
+        "scope": scope,
+    }
+    if file_ref:
+        metadata["file"] = str(file_ref)
+
+    item_id = _stable_finding_id(scope, bucket, finding)
+    return SourceItem(
+        item_id=item_id,
+        title=_truncate(title, 150),
+        detail=_truncate(detail, _DETAIL_CHAR_LIMIT),
+        link=f"/sweep-results/{scope}#{bucket}",
+        metadata=metadata,
+    )
+
+
+def _stable_finding_id(scope: str, bucket: str, finding: dict[str, Any]) -> str:
+    """Build a stable id from scope + bucket + finding signature.
+
+    Findings don't carry a server-side id, so we hash the salient
+    fields. Same finding across reads → same id.
+    """
+    sig = "|".join(
+        [
+            scope,
+            bucket,
+            str(finding.get("source") or ""),
+            str(finding.get("title") or ""),
+            str(finding.get("file") or ""),
+            str(finding.get("line") or ""),
+        ]
+    )
+    digest = hashlib.sha256(sig.encode("utf-8")).hexdigest()[:12]
+    return f"sweep:{bucket}:{digest}"
+
+
+def _hash_items(items: list[SourceItem]) -> str:
+    rows = sorted(item.item_id for item in items)
+    return hashlib.sha256("|".join(rows).encode("utf-8")).hexdigest()[:16]
+
+
+def _empty_summary(started: float) -> SourceSummary:
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=hashlib.sha256(b"").hexdigest()[:16],
+        items=[],
+        fetch_ms=int((time.perf_counter() - started) * 1000),
+    )
+
+
+def _truncate(s: str, limit: int) -> str:
+    return s if len(s) <= limit else s[: limit - 1] + "…"

--- a/src/attune/curator/sources/telemetry.py
+++ b/src/attune/curator/sources/telemetry.py
@@ -1,0 +1,232 @@
+"""Telemetry source reader — cost spikes + recent errors.
+
+Two cheap heuristics over ``<attune_home>/telemetry/usage.jsonl``:
+
+* per-workflow cost spike: today's total spend on a workflow is >2σ
+  above its 7-day mean (skip workflows with <3 events in the window —
+  too few samples to reason about variance);
+* recent error: any event in the last hour with ``error`` truthy or
+  ``status`` matching an HTTP 4xx/5xx code.
+
+Both signals cap at 10 items per :class:`SourceSummary` to keep the
+prompt budget bounded.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from attune.ops.config import attune_home
+
+from ..result import SourceItem, SourceSummary
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_ID = "telemetry"
+_DETAIL_CHAR_LIMIT = 500
+_MAX_ITEMS = 10
+_WINDOW_DAYS = 7
+
+
+def read(
+    *,
+    project_root: Path,
+    since: datetime | None = None,
+) -> SourceSummary:
+    """Surface cost + error anomalies from usage.jsonl."""
+    del project_root  # noqa: F841 — telemetry is per-user, not per-project
+
+    started = time.perf_counter()
+    path = attune_home() / "telemetry" / "usage.jsonl"
+    cutoff = since if since is not None else _default_since()
+
+    if not path.is_file():
+        return _empty_summary(started)
+
+    events = _read_events(path, cutoff)
+    if not events:
+        return _empty_summary(started)
+
+    items: list[SourceItem] = []
+    items.extend(_cost_spike_items(events))
+    items.extend(_recent_error_items(events))
+    items = items[:_MAX_ITEMS]
+
+    state_hash = _hash_items(items)
+    fetch_ms = int((time.perf_counter() - started) * 1000)
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=state_hash,
+        items=items,
+        fetch_ms=fetch_ms,
+    )
+
+
+def _read_events(path: Path, cutoff: datetime) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                ts_str = event.get("ts") or event.get("timestamp")
+                dt = _parse_iso(str(ts_str)) if ts_str else None
+                if dt is None or dt < cutoff:
+                    continue
+                event["_dt"] = dt
+                out.append(event)
+    except OSError as exc:
+        logger.warning("telemetry: read %s failed: %s", path, exc)
+    return out
+
+
+def _cost_spike_items(events: list[dict[str, Any]]) -> list[SourceItem]:
+    """Emit one item per workflow whose today's spend is >2σ above the
+    7-day mean. Skips workflows with <3 events (insufficient samples)."""
+    now = datetime.now(timezone.utc)
+    today = now.date()
+    daily_by_workflow: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+
+    for event in events:
+        workflow = str(event.get("workflow") or event.get("event_type") or "unknown")
+        cost = _safe_float(event.get("total_cost") or event.get("cost") or 0.0)
+        dt: datetime = event["_dt"]
+        day_iso = dt.date().isoformat()
+        daily_by_workflow[workflow][day_iso] += cost
+
+    out: list[SourceItem] = []
+    today_iso = today.isoformat()
+    for workflow, by_day in daily_by_workflow.items():
+        today_cost = by_day.get(today_iso, 0.0)
+        prior = [c for day, c in by_day.items() if day != today_iso]
+        if len(prior) < 3:
+            continue
+        mean = sum(prior) / len(prior)
+        variance = sum((c - mean) ** 2 for c in prior) / len(prior)
+        stddev = math.sqrt(variance) if variance > 0 else 0.0
+        if stddev == 0:
+            continue
+        z = (today_cost - mean) / stddev
+        if z <= 2.0:
+            continue
+        detail = (
+            f"Today's {workflow} spend ${today_cost:.2f} is {z:.1f}σ above "
+            f"the 7-day mean ${mean:.2f} (stddev ${stddev:.2f})."
+        )
+        out.append(
+            SourceItem(
+                item_id=f"telemetry:cost-spike:{workflow}:{today_iso}",
+                title=f"{workflow}: cost spike (+{z:.1f}σ)",
+                detail=_truncate(detail, _DETAIL_CHAR_LIMIT),
+                link="/telemetry",
+                metadata={
+                    "kind": "cost_spike",
+                    "workflow": workflow,
+                    "today_cost_usd": f"{today_cost:.4f}",
+                    "mean_cost_usd": f"{mean:.4f}",
+                    "z_score": f"{z:.2f}",
+                },
+            )
+        )
+    return out
+
+
+def _recent_error_items(events: list[dict[str, Any]]) -> list[SourceItem]:
+    """Emit items for 4xx/5xx or ``error`` events in the last hour."""
+    now = datetime.now(timezone.utc)
+    one_hour_ago = now - timedelta(hours=1)
+    out: list[SourceItem] = []
+    for event in events:
+        dt: datetime = event["_dt"]
+        if dt < one_hour_ago:
+            continue
+        if not _is_error(event):
+            continue
+        workflow = str(event.get("workflow") or event.get("event_type") or "unknown")
+        status = event.get("status")
+        error_msg = event.get("error") or event.get("error_message") or ""
+        ts_iso = dt.isoformat()
+        detail = f"{workflow} error at {ts_iso} (status={status}): {str(error_msg)[:300]}"
+        digest = hashlib.sha256(f"{workflow}|{ts_iso}|{status}".encode()).hexdigest()[:12]
+        out.append(
+            SourceItem(
+                item_id=f"telemetry:error:{digest}",
+                title=f"{workflow}: error (status={status})",
+                detail=_truncate(detail, _DETAIL_CHAR_LIMIT),
+                link="/telemetry",
+                metadata={
+                    "kind": "error",
+                    "workflow": workflow,
+                    "status": str(status) if status is not None else "",
+                    "timestamp": ts_iso,
+                },
+            )
+        )
+    return out
+
+
+def _is_error(event: dict[str, Any]) -> bool:
+    if event.get("error"):
+        return True
+    status = event.get("status")
+    if isinstance(status, int) and 400 <= status < 600:
+        return True
+    if isinstance(status, str) and status.isdigit():
+        n = int(status)
+        if 400 <= n < 600:
+            return True
+    return False
+
+
+def _safe_float(v: Any) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _parse_iso(s: str) -> datetime | None:
+    try:
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _default_since() -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=_WINDOW_DAYS)
+
+
+def _hash_items(items: list[SourceItem]) -> str:
+    rows = sorted(item.item_id for item in items)
+    return hashlib.sha256("|".join(rows).encode("utf-8")).hexdigest()[:16]
+
+
+def _empty_summary(started: float) -> SourceSummary:
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=hashlib.sha256(b"").hexdigest()[:16],
+        items=[],
+        fetch_ms=int((time.perf_counter() - started) * 1000),
+    )
+
+
+def _truncate(s: str, limit: int) -> str:
+    return s if len(s) <= limit else s[: limit - 1] + "…"

--- a/tests/commands/test_loader.py
+++ b/tests/commands/test_loader.py
@@ -182,10 +182,20 @@ Body.
         # Valid file should not be in results (no errors)
         assert str(tmp_path / "valid.md") not in results
 
-    def test_validate_directory_nonexistent(self, loader):
-        """Test validating non-existent directory."""
-        results = loader.validate_directory("/nonexistent")
-        assert "nonexistent" in str(list(results.keys())[0])
+    def test_validate_directory_nonexistent(self, loader, tmp_path):
+        """Test validating non-existent directory.
+
+        Uses a path under tmp_path so the test is robust on every OS.
+        Earlier versions hardcoded ``"/nonexistent"`` which resolved
+        to ``<current-drive>:\\nonexistent`` on Windows and silently
+        passed/failed depending on whether the runner image had a
+        directory there. Windows-3.11/12/13 hit the false-pass path
+        in CI; the tmp_path form is deterministic.
+        """
+        target = tmp_path / "definitely-does-not-exist-xyz123"
+        assert not target.exists()  # pre-condition the old test assumed
+        results = loader.validate_directory(str(target))
+        assert "definitely-does-not-exist-xyz123" in str(list(results.keys())[0])
 
     def test_get_command_names(self, loader, commands_dir):
         """Test getting command names without full loading."""

--- a/tests/unit/bulletin/test_file_backend.py
+++ b/tests/unit/bulletin/test_file_backend.py
@@ -480,3 +480,55 @@ class TestMalformedReadPaths:
             fh.write(json.dumps(payload) + "\n")
         # Heartbeat parse failure -> entry dropped as if stale.
         assert backend.read_active() == []
+
+
+# ---------------------------------------------------------------------------
+# read_archive coverage — error paths + skip conditions
+# ---------------------------------------------------------------------------
+
+
+class TestReadArchive:
+    """Cover read_archive's edge paths: missing dir, OSError on iter,
+    non-jsonl files, and non-ISO-date filenames."""
+
+    def test_missing_archive_dir_returns_empty(self, tmp_path: Path) -> None:
+        backend = FileBulletinBackend(tmp_path / "bulletin")
+        # archive/ never created
+        result = backend.read_archive(since=datetime.now(timezone.utc))
+        assert result == []
+
+    def test_iterdir_oserror_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        backend = FileBulletinBackend(tmp_path / "bulletin")
+        backend.archive_dir.mkdir(parents=True, exist_ok=True)
+
+        def boom(self):  # noqa: ANN001
+            raise OSError("simulated")
+
+        monkeypatch.setattr(Path, "iterdir", boom)
+        result = backend.read_archive(since=datetime.now(timezone.utc))
+        assert result == []
+
+    def test_non_jsonl_files_are_skipped(self, tmp_path: Path) -> None:
+        backend = FileBulletinBackend(tmp_path / "bulletin")
+        backend.archive_dir.mkdir(parents=True, exist_ok=True)
+        # A regular file with non-jsonl suffix and a subdirectory
+        (backend.archive_dir / "README.md").write_text("ignore me", encoding="utf-8")
+        (backend.archive_dir / "subdir").mkdir()
+        # A valid jsonl-with-date file alongside the noise
+        today_iso = datetime.now(timezone.utc).date().isoformat()
+        valid_path = backend.archive_dir / f"{today_iso}.jsonl"
+        entry = _entry(run_id="r1")
+        valid_path.write_text(json.dumps(entry.to_dict()) + "\n", encoding="utf-8")
+        result = backend.read_archive(since=datetime.now(timezone.utc) - timedelta(days=2))
+        assert [e.run_id for e in result] == ["r1"]
+
+    def test_non_date_filename_skipped(self, tmp_path: Path) -> None:
+        backend = FileBulletinBackend(tmp_path / "bulletin")
+        backend.archive_dir.mkdir(parents=True, exist_ok=True)
+        # File matching *.jsonl but stem isn't an ISO date
+        bad = backend.archive_dir / "not-a-date.jsonl"
+        bad.write_text("{}\n", encoding="utf-8")
+        result = backend.read_archive(since=datetime.now(timezone.utc) - timedelta(days=1))
+        assert result == []

--- a/tests/unit/curator/test_cache.py
+++ b/tests/unit/curator/test_cache.py
@@ -142,3 +142,180 @@ def test_key_sanitisation(cache_root):
     # Sanitised name contains no path separators.
     assert "/" not in files[0].name
     assert ".." not in files[0].name
+
+
+def test_properties_expose_root_and_ttl(cache_root):
+    """The root and ttl_seconds properties return the configured values."""
+    cache = CuratorCache(root=cache_root, ttl_seconds=600)
+    assert cache.root == cache_root
+    assert cache.ttl_seconds == 600
+
+
+def test_empty_key_sanitises_to_default(cache_root):
+    """A key with no alphanumerics falls through to 'default.json'."""
+    cache = CuratorCache(root=cache_root)
+    cache.put("@@@", _make_result())
+    assert (cache_root / "default.json").is_file()
+
+
+def test_get_returns_none_when_payload_not_dict(cache_root):
+    """A JSON file whose top-level is not a dict is treated as cache miss."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    (cache_root / "abc.json").write_text("[1, 2, 3]", encoding="utf-8")
+    cache = CuratorCache(root=cache_root)
+    assert cache.get("abc") is None
+
+
+def test_get_returns_none_when_cached_at_missing(cache_root):
+    """A dict payload missing cached_at is a cache miss."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    (cache_root / "abc.json").write_text('{"summary": "x", "items": []}', encoding="utf-8")
+    cache = CuratorCache(root=cache_root)
+    assert cache.get("abc") is None
+
+
+def test_get_returns_none_on_bad_item_schema(cache_root):
+    """A cache entry whose item is missing required fields raises during
+    deserialisation; the cache swallows the error and returns None."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "summary": "x",
+        "items": [{"id": "i1"}],  # missing 'title' — KeyError in _deserialise
+        "cached_at": "2030-01-01T00:00:00+00:00",
+        "cost_usd": 0.0,
+        "model": "claude-opus-4-7",
+        "sources_consulted": [],
+    }
+    import json as _json
+
+    (cache_root / "abc.json").write_text(_json.dumps(payload), encoding="utf-8")
+    cache = CuratorCache(root=cache_root, ttl_seconds=10_000_000)
+    assert cache.get("abc") is None
+
+
+def test_put_swallows_mkdir_failure(cache_root, monkeypatch):
+    """If mkdir raises OSError, put logs and returns without writing."""
+    cache = CuratorCache(root=cache_root)
+
+    from pathlib import Path as _Path
+
+    def boom(self, *a, **kw):  # noqa: ANN001
+        raise OSError("simulated")
+
+    monkeypatch.setattr(_Path, "mkdir", boom)
+    cache.put("abc", _make_result())  # must not raise
+    # No file should have been written.
+    assert not any(cache_root.glob("*.json"))
+
+
+def test_put_swallows_write_failure(cache_root, monkeypatch):
+    """If the atomic write fails partway, put logs and returns cleanly."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    cache = CuratorCache(root=cache_root)
+
+    from pathlib import Path as _Path
+
+    def boom(self, *a, **kw):  # noqa: ANN001
+        raise OSError("disk full")
+
+    monkeypatch.setattr(_Path, "write_text", boom)
+    cache.put("abc", _make_result())  # must not raise
+    assert not (cache_root / "abc.json").is_file()
+
+
+def test_sweep_glob_oserror_returns_zero(cache_root, monkeypatch):
+    """If glob raises OSError during sweep, return 0 deletions."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    cache = CuratorCache(root=cache_root)
+
+    from pathlib import Path as _Path
+
+    def boom(self, pattern):  # noqa: ANN001
+        raise OSError("simulated")
+
+    monkeypatch.setattr(_Path, "glob", boom)
+    assert cache.sweep(older_than_days=7) == 0
+
+
+def test_sweep_unlink_oserror_continues(cache_root, monkeypatch):
+    """If one unlink fails, sweep keeps going and counts only successes."""
+    cache = CuratorCache(root=cache_root)
+    cache.put("alpha", _make_result())
+    cache.put("beta", _make_result())
+    # Backdate both files past the sweep cutoff.
+    target = time.time() - 30 * 86_400
+    for path in cache_root.glob("*.json"):
+        os.utime(path, (target, target))
+
+    from pathlib import Path as _Path
+
+    real_unlink = _Path.unlink
+
+    def selective_boom(self, *a, **kw):  # noqa: ANN001
+        if self.name == "alpha.json":
+            raise OSError("simulated")
+        return real_unlink(self, *a, **kw)
+
+    monkeypatch.setattr(_Path, "unlink", selective_boom)
+    deleted = cache.sweep(older_than_days=7)
+    assert deleted == 1  # beta got removed; alpha's failure was swallowed
+    assert (cache_root / "alpha.json").is_file()
+
+
+def test_deserialise_skips_non_dict_items(cache_root):
+    """Cache entries whose items[i] is not a dict get silently dropped."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "summary": "x",
+        "items": ["not-a-dict", {"id": "i1", "title": "t", "severity": "info"}],
+        "cached_at": "2099-01-01T00:00:00+00:00",
+        "cost_usd": 0.0,
+        "model": "claude-opus-4-7",
+        "sources_consulted": [],
+    }
+    import json as _json
+
+    (cache_root / "abc.json").write_text(_json.dumps(payload), encoding="utf-8")
+    cache = CuratorCache(root=cache_root, ttl_seconds=10_000_000)
+    result = cache.get("abc")
+    assert result is not None
+    assert len(result.items) == 1  # the dict item; string was dropped
+
+
+def test_deserialise_coerces_unknown_severity_to_info(cache_root):
+    """An item with an unrecognised severity falls back to 'info'."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "summary": "x",
+        "items": [
+            {
+                "id": "i1",
+                "title": "t",
+                "severity": "totally-bogus",
+                "rationale": "r",
+                "sources": ["src"],
+            }
+        ],
+        "cached_at": "2099-01-01T00:00:00+00:00",
+        "cost_usd": 0.0,
+        "model": "claude-opus-4-7",
+        "sources_consulted": [],
+    }
+    import json as _json
+
+    (cache_root / "abc.json").write_text(_json.dumps(payload), encoding="utf-8")
+    cache = CuratorCache(root=cache_root, ttl_seconds=10_000_000)
+    result = cache.get("abc")
+    assert result is not None
+    assert result.items[0].severity == "info"
+
+
+def test_parse_iso_helpers():
+    """The cache module's internal _parse_iso handles bad inputs."""
+    from attune.curator.cache import _parse_iso
+
+    assert _parse_iso("") is None
+    assert _parse_iso("not-iso") is None
+    # Naive ISO string -> UTC-aware datetime.
+    dt = _parse_iso("2026-05-26T12:00:00")
+    assert dt is not None and dt.tzinfo is not None

--- a/tests/unit/curator/test_cache.py
+++ b/tests/unit/curator/test_cache.py
@@ -1,0 +1,144 @@
+"""Tests for the CuratorCache."""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.curator.cache import CuratorCache
+from attune.curator.result import (
+    CuratorItem,
+    CuratorResult,
+    SourceSummary,
+    SuggestedAction,
+)
+
+
+def _make_result(
+    *,
+    summary: str = "two specs ready to close",
+    cached_at: datetime | None = None,
+) -> CuratorResult:
+    item = CuratorItem(
+        id="spec:deprecated-module-retirement",
+        title="Ready to mark complete?",
+        severity="nudge",
+        rationale="all 3 tasks done; PR merged [spec:foo]",
+        sources=["spec:foo"],
+        suggested_action=SuggestedAction(
+            kind="ask",
+            label="Mark complete?",
+            question="Mark this spec complete?",
+            choices=["Yes", "Not yet", "Dismiss for 14 days"],
+        ),
+    )
+    return CuratorResult(
+        summary=summary,
+        items=[item],
+        sources_consulted=["specs", "bulletin"],
+        cost_usd=0.08,
+        cached_at=cached_at,
+        model="claude-opus-4-7",
+    )
+
+
+@pytest.fixture
+def cache_root(tmp_path) -> Path:
+    return tmp_path / "curator-cache"
+
+
+def test_put_then_get_returns_identical_payload(cache_root):
+    cache = CuratorCache(root=cache_root)
+    result = _make_result()
+    cache.put("abc123", result)
+    loaded = cache.get("abc123")
+    assert loaded is not None
+    assert loaded.summary == result.summary
+    assert loaded.cost_usd == result.cost_usd
+    assert loaded.model == result.model
+    assert [item.id for item in loaded.items] == ["spec:deprecated-module-retirement"]
+    assert loaded.items[0].suggested_action is not None
+    assert loaded.items[0].suggested_action.kind == "ask"
+    assert loaded.items[0].suggested_action.choices == [
+        "Yes",
+        "Not yet",
+        "Dismiss for 14 days",
+    ]
+
+
+def test_get_returns_none_on_missing_key(cache_root):
+    cache = CuratorCache(root=cache_root)
+    assert cache.get("does-not-exist") is None
+
+
+def test_ttl_expiry(cache_root):
+    cache = CuratorCache(ttl_seconds=300, root=cache_root)
+    # Stamp the cached_at 10 minutes in the past — well beyond TTL.
+    past = datetime.now(timezone.utc) - timedelta(minutes=10)
+    cache.put("abc", _make_result(cached_at=past))
+    assert cache.get("abc") is None
+
+
+def test_ttl_zero_is_always_stale(cache_root):
+    cache = CuratorCache(ttl_seconds=0, root=cache_root)
+    cache.put("abc", _make_result(cached_at=datetime.now(timezone.utc)))
+    assert cache.get("abc") is None
+
+
+def test_key_derives_from_source_hashes(cache_root):
+    cache = CuratorCache(root=cache_root)
+    s_a = [
+        SourceSummary(source_id="bulletin", state_hash="aaa"),
+        SourceSummary(source_id="specs", state_hash="bbb"),
+    ]
+    s_b = [
+        SourceSummary(source_id="bulletin", state_hash="aaa"),
+        SourceSummary(source_id="specs", state_hash="bbb"),
+    ]
+    s_c = [
+        SourceSummary(source_id="bulletin", state_hash="zzz"),
+        SourceSummary(source_id="specs", state_hash="bbb"),
+    ]
+    assert cache.key(s_a) == cache.key(s_b)
+    assert cache.key(s_a) != cache.key(s_c)
+
+
+def test_malformed_cache_file_returns_none(cache_root):
+    cache = CuratorCache(root=cache_root)
+    cache_root.mkdir(parents=True, exist_ok=True)
+    (cache_root / "bad.json").write_text("not-json", encoding="utf-8")
+    assert cache.get("bad") is None
+
+
+def test_sweep_removes_old_files(cache_root):
+    cache = CuratorCache(root=cache_root)
+    cache.put("fresh", _make_result())
+    cache.put("ancient", _make_result())
+    # Backdate "ancient" 30 days.
+    ancient_path = cache_root / "ancient.json"
+    target = time.time() - 30 * 86_400
+    os.utime(ancient_path, (target, target))
+    deleted = cache.sweep(older_than_days=7)
+    assert deleted == 1
+    assert (cache_root / "fresh.json").is_file()
+    assert not ancient_path.exists()
+
+
+def test_sweep_missing_dir_returns_zero(tmp_path):
+    cache = CuratorCache(root=tmp_path / "never-created")
+    assert cache.sweep(older_than_days=7) == 0
+
+
+def test_key_sanitisation(cache_root):
+    """Keys with shell-special chars get sanitised into safe filenames."""
+    cache = CuratorCache(root=cache_root)
+    cache.put("../escape/attempt", _make_result())
+    files = list(cache_root.glob("*.json"))
+    assert len(files) == 1
+    # Sanitised name contains no path separators.
+    assert "/" not in files[0].name
+    assert ".." not in files[0].name

--- a/tests/unit/curator/test_source_bulletin.py
+++ b/tests/unit/curator/test_source_bulletin.py
@@ -1,0 +1,160 @@
+"""Tests for the bulletin source reader."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.bulletin.file_backend import FileBulletinBackend
+from attune.bulletin.protocol import BulletinEntry
+from attune.curator.sources import bulletin as bulletin_source
+
+
+def _seed_active(root: Path, entries: list[BulletinEntry]) -> None:
+    backend = FileBulletinBackend(root)
+    for entry in entries:
+        backend.append(entry)
+
+
+def _seed_archive(root: Path, date_iso: str, entries: list[BulletinEntry]) -> None:
+    archive = root / "archive"
+    archive.mkdir(parents=True, exist_ok=True)
+    path = archive / f"{date_iso}.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry.to_dict()) + "\n")
+
+
+@pytest.fixture
+def bulletin_home(tmp_path, monkeypatch):
+    """Point attune_home() at a temp dir so tests don't touch ~/.attune."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+    return tmp_path / "bulletin"
+
+
+def _make_entry(
+    *,
+    run_id: str = "r1",
+    workflow: str = "code-review",
+    actor_kind: str = "cli",
+    heartbeat: datetime | None = None,
+    status: str = "running",
+    scope: str | None = None,
+) -> BulletinEntry:
+    now = datetime.now(timezone.utc)
+    hb = heartbeat or now
+    return BulletinEntry(
+        actor_id="actor-1",
+        actor_kind=actor_kind,  # type: ignore[arg-type]
+        workflow=workflow,
+        run_id=run_id,
+        started_at=(hb - timedelta(seconds=10)).isoformat(),
+        last_heartbeat=hb.isoformat(),
+        current_status=status,  # type: ignore[arg-type]
+        scope=scope,
+    )
+
+
+def test_empty_bulletin_returns_empty_summary(tmp_path, bulletin_home):
+    summary = bulletin_source.read(project_root=tmp_path)
+    assert summary.source_id == "bulletin"
+    assert summary.items == []
+    # Stable hash on empty input.
+    assert isinstance(summary.state_hash, str) and len(summary.state_hash) == 16
+
+
+def test_active_entries_become_source_items(tmp_path, bulletin_home):
+    _seed_active(
+        bulletin_home,
+        [
+            _make_entry(run_id="r1", workflow="code-review"),
+            _make_entry(run_id="r2", workflow="security-audit", actor_kind="dashboard"),
+        ],
+    )
+    summary = bulletin_source.read(project_root=tmp_path)
+    assert len(summary.items) == 2
+    ids = {item.item_id for item in summary.items}
+    assert ids == {"bulletin:active:r1", "bulletin:active:r2"}
+    for item in summary.items:
+        assert item.metadata["kind"] == "active"
+        assert item.metadata["heartbeat_age_s"].isdigit()
+        assert (
+            item.link
+            == f"/runs/{item.metadata.get('workflow') and item.item_id.split(':')[-1]}/view"
+        )
+
+
+def test_state_hash_stable_across_calls(tmp_path, bulletin_home):
+    _seed_active(bulletin_home, [_make_entry(run_id="r1")])
+    a = bulletin_source.read(project_root=tmp_path).state_hash
+    b = bulletin_source.read(project_root=tmp_path).state_hash
+    assert a == b
+
+
+def test_state_hash_changes_on_new_heartbeat(tmp_path, bulletin_home):
+    _seed_active(bulletin_home, [_make_entry(run_id="r1")])
+    first = bulletin_source.read(project_root=tmp_path).state_hash
+    # Append another heartbeat for the same run with a later timestamp.
+    later = datetime.now(timezone.utc) + timedelta(seconds=5)
+    _seed_active(
+        bulletin_home,
+        [_make_entry(run_id="r1", heartbeat=later)],
+    )
+    second = bulletin_source.read(project_root=tmp_path).state_hash
+    assert first != second
+
+
+def test_archive_filter_respects_since(tmp_path, bulletin_home):
+    today = datetime.now(timezone.utc).date()
+    older = (today - timedelta(days=5)).isoformat()
+    recent = (today - timedelta(days=1)).isoformat()
+    _seed_archive(
+        bulletin_home,
+        older,
+        [_make_entry(run_id="old", status="completed")],
+    )
+    _seed_archive(
+        bulletin_home,
+        recent,
+        [_make_entry(run_id="new", status="completed")],
+    )
+    cutoff = datetime.now(timezone.utc) - timedelta(days=2)
+    summary = bulletin_source.read(project_root=tmp_path, since=cutoff)
+    ids = {item.item_id for item in summary.items}
+    assert "bulletin:archived:new" in ids
+    assert "bulletin:archived:old" not in ids
+
+
+def test_missing_archive_dir_does_not_raise(tmp_path, bulletin_home):
+    # No archive/ created — only an active log.
+    _seed_active(bulletin_home, [_make_entry(run_id="r1")])
+    summary = bulletin_source.read(project_root=tmp_path)
+    # Should include only the active entry, no errors from missing archive.
+    assert any(item.item_id == "bulletin:active:r1" for item in summary.items)
+
+
+def test_archived_items_carry_terminal_status(tmp_path, bulletin_home):
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    _seed_archive(
+        bulletin_home,
+        today_iso,
+        [_make_entry(run_id="r1", status="failed")],
+    )
+    summary = bulletin_source.read(project_root=tmp_path)
+    archived = [i for i in summary.items if i.metadata["kind"] == "archived"]
+    assert len(archived) == 1
+    assert archived[0].metadata["terminal_status"] == "failed"
+
+
+def test_reader_never_raises_on_unreadable_dir(tmp_path, bulletin_home, monkeypatch):
+    # Force read_active to raise; reader must swallow and return empty active items.
+    def boom(*args, **kwargs):
+        raise OSError("simulated")
+
+    monkeypatch.setattr(FileBulletinBackend, "read_active", boom)
+    summary = bulletin_source.read(project_root=tmp_path)
+    assert summary.source_id == "bulletin"
+    assert summary.items == []  # Nothing to show; no crash.

--- a/tests/unit/curator/test_source_bulletin.py
+++ b/tests/unit/curator/test_source_bulletin.py
@@ -158,3 +158,80 @@ def test_reader_never_raises_on_unreadable_dir(tmp_path, bulletin_home, monkeypa
     summary = bulletin_source.read(project_root=tmp_path)
     assert summary.source_id == "bulletin"
     assert summary.items == []  # Nothing to show; no crash.
+
+
+def test_read_archive_failure_does_not_raise(tmp_path, bulletin_home, monkeypatch):
+    """read_archive raising should be swallowed; active entries still flow."""
+    _seed_active(bulletin_home, [_make_entry(run_id="r-active")])
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("archive corrupted")
+
+    monkeypatch.setattr(FileBulletinBackend, "read_archive", boom)
+    summary = bulletin_source.read(project_root=tmp_path)
+    ids = {item.item_id for item in summary.items}
+    assert "bulletin:active:r-active" in ids
+
+
+def test_active_entry_with_unparseable_heartbeat_marked_unknown(tmp_path, bulletin_home):
+    """An active entry whose last_heartbeat fails ISO parse keeps the
+    'unknown' marker rather than crashing."""
+    backend = FileBulletinBackend(bulletin_home)
+    backend.active_path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    payload = {
+        "actor_id": "actor-1",
+        "actor_kind": "cli",
+        "workflow": "code-review",
+        "run_id": "weird",
+        "started_at": now.isoformat(),
+        "last_heartbeat": now.isoformat(),  # valid on the active path
+        "current_status": "running",
+    }
+    with backend.active_path.open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload) + "\n")
+
+    # Patch the source-internal _parse_iso to return None, simulating
+    # an entry whose heartbeat falls past the ISO parser. (We can't
+    # easily put a bad ISO into BulletinEntry since read_active
+    # already filters those out as stale.)
+    import attune.curator.sources.bulletin as bmod
+
+    orig = bmod._parse_iso
+    bmod._parse_iso = lambda s: None
+    try:
+        summary = bulletin_source.read(project_root=tmp_path)
+    finally:
+        bmod._parse_iso = orig
+    active = [i for i in summary.items if i.metadata["kind"] == "active"]
+    assert active and active[0].metadata["heartbeat_age_s"] == "unknown"
+
+
+def test_active_item_includes_scope_when_set(tmp_path, bulletin_home):
+    _seed_active(
+        bulletin_home,
+        [_make_entry(run_id="r-scoped", scope="src/attune/security/")],
+    )
+    summary = bulletin_source.read(project_root=tmp_path)
+    active = [i for i in summary.items if i.item_id == "bulletin:active:r-scoped"]
+    assert active and "Scope: src/attune/security/" in active[0].detail
+
+
+def test_archived_item_includes_scope_when_set(tmp_path, bulletin_home):
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    _seed_archive(
+        bulletin_home,
+        today_iso,
+        [_make_entry(run_id="r-arch", status="completed", scope="docs/")],
+    )
+    summary = bulletin_source.read(project_root=tmp_path)
+    archived = [i for i in summary.items if i.item_id == "bulletin:archived:r-arch"]
+    assert archived and "Scope: docs/" in archived[0].detail
+
+
+def test_parse_iso_returns_none_on_bad_input():
+    """Direct unit test of the _parse_iso helper's failure path."""
+    import attune.curator.sources.bulletin as bmod
+
+    assert bmod._parse_iso("totally-not-iso") is None
+    assert bmod._parse_iso(None) is None  # type: ignore[arg-type]

--- a/tests/unit/curator/test_source_git_state.py
+++ b/tests/unit/curator/test_source_git_state.py
@@ -108,3 +108,89 @@ def test_git_timeout_does_not_raise(empty_repo, monkeypatch):
     assert summary.source_id == "git-state"
     # No signals emitted — but no traceback either.
     assert summary.items == []
+
+
+def test_diverged_signal_fires_when_head_is_stale(empty_repo, monkeypatch):
+    """If origin/main is >3 days ahead of HEAD, emit a diverged item."""
+    from datetime import datetime, timedelta, timezone
+
+    head = datetime.now(timezone.utc) - timedelta(days=10)
+    main = datetime.now(timezone.utc)
+
+    def fake_commit_date(project_root, ref):  # noqa: ANN001
+        if ref == "HEAD":
+            return head
+        if ref == "origin/main":
+            return main
+        return None
+
+    monkeypatch.setattr(git_source, "_commit_date", fake_commit_date)
+    summary = git_source.read(project_root=empty_repo)
+    diverged = [i for i in summary.items if i.metadata["signal"] == "diverged"]
+    assert len(diverged) == 1
+    assert int(diverged[0].metadata["days_behind"]) >= 3
+
+
+def test_diverged_signal_silent_when_head_caught_up(empty_repo, monkeypatch):
+    """Within 3 days of origin/main, no diverged item fires."""
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime.now(timezone.utc)
+
+    def fake_commit_date(project_root, ref):  # noqa: ANN001
+        if ref == "HEAD":
+            return now - timedelta(hours=12)
+        if ref == "origin/main":
+            return now
+        return None
+
+    monkeypatch.setattr(git_source, "_commit_date", fake_commit_date)
+    summary = git_source.read(project_root=empty_repo)
+    assert not any(i.metadata.get("signal") == "diverged" for i in summary.items)
+
+
+def test_secrets_signal_caps_at_10(empty_repo):
+    """Even with 20 matching files only 10 secret-shape items surface."""
+    for i in range(20):
+        (empty_repo / f"secret{i}.key").write_text("x\n", encoding="utf-8")
+    summary = git_source.read(project_root=empty_repo)
+    secret_items = [item for item in summary.items if item.metadata["signal"] == "secret_shape"]
+    assert len(secret_items) == 10
+
+
+def test_secrets_signal_ignores_blank_ls_files_lines(empty_repo, monkeypatch):
+    """Blank lines in ls-files output don't crash or false-fire."""
+    real_run_git = git_source._run_git
+
+    def stub(project_root, argv):  # noqa: ANN001
+        if argv[0] == "ls-files":
+            return "\n\n.env\n\n"
+        return real_run_git(project_root, argv)
+
+    monkeypatch.setattr(git_source, "_run_git", stub)
+    summary = git_source.read(project_root=empty_repo)
+    secret_items = [i for i in summary.items if i.metadata["signal"] == "secret_shape"]
+    assert any(item.metadata["path"] == ".env" for item in secret_items)
+
+
+def test_commit_date_returns_none_on_empty_output(empty_repo, monkeypatch):
+    """When git log returns whitespace-only stdout, _commit_date is None."""
+    monkeypatch.setattr(git_source, "_run_git", lambda root, argv: "   \n")
+    assert git_source._commit_date(empty_repo, "HEAD") is None
+
+
+def test_commit_date_returns_none_on_bad_iso(empty_repo, monkeypatch):
+    """If git log emits unparseable ISO, _commit_date returns None."""
+    monkeypatch.setattr(git_source, "_run_git", lambda root, argv: "not-an-iso\n")
+    assert git_source._commit_date(empty_repo, "HEAD") is None
+
+
+def test_commit_date_coerces_naive_to_utc(empty_repo, monkeypatch):
+    """A naive ISO string (no tz) gets stamped UTC."""
+    monkeypatch.setattr(
+        git_source,
+        "_run_git",
+        lambda root, argv: "2026-05-26T12:00:00\n",
+    )
+    dt = git_source._commit_date(empty_repo, "HEAD")
+    assert dt is not None and dt.tzinfo is not None

--- a/tests/unit/curator/test_source_git_state.py
+++ b/tests/unit/curator/test_source_git_state.py
@@ -1,0 +1,110 @@
+"""Tests for the git_state source reader.
+
+These tests build a real git repo in tmp_path so subprocess calls
+exercise the same code path production uses — no mocks needed for
+the happy paths.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from attune.curator.sources import git_state as git_source
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not on PATH")
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def empty_repo(tmp_path):
+    """A real git repo with one initial commit on `main`."""
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "test")
+    _git(tmp_path, "config", "commit.gpgsign", "false")
+    (tmp_path / "README.md").write_text("init\n", encoding="utf-8")
+    _git(tmp_path, "add", "README.md")
+    _git(tmp_path, "commit", "-q", "-m", "init")
+    return tmp_path
+
+
+def test_non_repo_returns_empty(tmp_path):
+    summary = git_source.read(project_root=tmp_path)
+    assert summary.source_id == "git-state"
+    assert summary.items == []
+
+
+def test_clean_repo_has_no_signals(empty_repo):
+    summary = git_source.read(project_root=empty_repo)
+    # No origin/main → diverged signal silent. Clean working tree → no
+    # uncommitted signal. No untracked files → no secrets signal.
+    assert summary.items == []
+
+
+def test_uncommitted_signal_fires_above_threshold(empty_repo):
+    for i in range(15):
+        (empty_repo / f"file_{i}.txt").write_text(f"x{i}\n", encoding="utf-8")
+    summary = git_source.read(project_root=empty_repo)
+    uncommitted = [i for i in summary.items if i.metadata["signal"] == "uncommitted"]
+    assert len(uncommitted) == 1
+    assert int(uncommitted[0].metadata["count"]) >= 15
+
+
+def test_uncommitted_signal_silent_below_threshold(empty_repo):
+    for i in range(5):
+        (empty_repo / f"file_{i}.txt").write_text("x\n", encoding="utf-8")
+    summary = git_source.read(project_root=empty_repo)
+    assert not any(i.metadata["signal"] == "uncommitted" for i in summary.items)
+
+
+def test_secrets_shape_files_surface(empty_repo):
+    (empty_repo / ".env.production").write_text("API_KEY=xxx\n", encoding="utf-8")
+    (empty_repo / "credentials.json").write_text("{}\n", encoding="utf-8")
+    (empty_repo / "README.txt").write_text("safe\n", encoding="utf-8")
+    summary = git_source.read(project_root=empty_repo)
+    secret_items = [item for item in summary.items if item.metadata["signal"] == "secret_shape"]
+    paths = {item.metadata["path"] for item in secret_items}
+    assert ".env.production" in paths
+    assert "credentials.json" in paths
+    # README.txt does NOT match a credential pattern.
+    assert "README.txt" not in paths
+
+
+def test_state_hash_deterministic(empty_repo):
+    (empty_repo / ".env").write_text("X=1\n", encoding="utf-8")
+    a = git_source.read(project_root=empty_repo).state_hash
+    b = git_source.read(project_root=empty_repo).state_hash
+    assert a == b
+
+
+def test_subprocess_failure_returns_empty(empty_repo, monkeypatch):
+    """If git binary is reported missing mid-call, return empty."""
+    monkeypatch.setattr(git_source.shutil, "which", lambda _: None)
+    summary = git_source.read(project_root=empty_repo)
+    assert summary.items == []
+
+
+def test_git_timeout_does_not_raise(empty_repo, monkeypatch):
+    """A hung git invocation collapses to no-signal, never an exception."""
+
+    def boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=5)
+
+    monkeypatch.setattr(git_source.subprocess, "run", boom)
+    summary = git_source.read(project_root=empty_repo)
+    assert summary.source_id == "git-state"
+    # No signals emitted — but no traceback either.
+    assert summary.items == []

--- a/tests/unit/curator/test_source_recommendations.py
+++ b/tests/unit/curator/test_source_recommendations.py
@@ -1,0 +1,132 @@
+"""Tests for the recommendations source reader."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.curator.sources import recommendations as rec_source
+
+
+def _write_run(
+    attune_home_dir: Path,
+    workflow: str,
+    run_id: str,
+    *,
+    recommendations: list[dict] | None = None,
+    mtime_offset_hours: float = 0.0,
+) -> Path:
+    runs_dir = attune_home_dir / "ops" / "runs" / workflow
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "run_id": run_id,
+        "workflow": workflow,
+        "recommendations": recommendations or [],
+    }
+    path = runs_dir / f"{run_id}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    if mtime_offset_hours:
+        target = time.time() + mtime_offset_hours * 3600
+        os.utime(path, (target, target))
+    return path
+
+
+@pytest.fixture
+def attune_home_tmp(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_missing_runs_dir_returns_empty(tmp_path, attune_home_tmp):
+    summary = rec_source.read(project_root=tmp_path)
+    assert summary.source_id == "recommendations"
+    assert summary.items == []
+    assert len(summary.state_hash) == 16
+
+
+def test_emits_one_item_per_recommendation(tmp_path, attune_home_tmp):
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "r1",
+        recommendations=[
+            {"kind": "open", "label": "Review fix", "url": "/runs/r1/view"},
+            {"kind": "run", "label": "Re-run", "workflow": "code-review"},
+        ],
+    )
+    summary = rec_source.read(project_root=tmp_path)
+    assert len(summary.items) == 2
+    ids = {item.item_id for item in summary.items}
+    assert ids == {"rec:code-review:r1:0", "rec:code-review:r1:1"}
+
+
+def test_old_runs_excluded(tmp_path, attune_home_tmp):
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "old",
+        recommendations=[{"kind": "open", "label": "stale"}],
+        mtime_offset_hours=-48,  # 2 days old
+    )
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "fresh",
+        recommendations=[{"kind": "open", "label": "fresh"}],
+    )
+    summary = rec_source.read(project_root=tmp_path)
+    ids = {item.item_id for item in summary.items}
+    assert "rec:code-review:fresh:0" in ids
+    assert "rec:code-review:old:0" not in ids
+
+
+def test_runs_without_recommendations_skipped(tmp_path, attune_home_tmp):
+    _write_run(attune_home_tmp, "code-review", "r1", recommendations=[])
+    summary = rec_source.read(project_root=tmp_path)
+    assert summary.items == []
+
+
+def test_state_hash_deterministic(tmp_path, attune_home_tmp):
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "r1",
+        recommendations=[{"kind": "open", "label": "x"}],
+    )
+    a = rec_source.read(project_root=tmp_path).state_hash
+    b = rec_source.read(project_root=tmp_path).state_hash
+    assert a == b
+
+
+def test_malformed_record_skipped(tmp_path, attune_home_tmp):
+    runs_dir = attune_home_tmp / "ops" / "runs" / "code-review"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "bad.json").write_text("not-json", encoding="utf-8")
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "good",
+        recommendations=[{"kind": "open", "label": "g"}],
+    )
+    summary = rec_source.read(project_root=tmp_path)
+    assert len(summary.items) == 1
+    assert summary.items[0].item_id == "rec:code-review:good:0"
+
+
+def test_since_param_overrides_default(tmp_path, attune_home_tmp):
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "old",
+        recommendations=[{"kind": "open", "label": "x"}],
+        mtime_offset_hours=-48,
+    )
+    # since=72h ago — pulls in the 48h-old record.
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=72)
+    summary = rec_source.read(project_root=tmp_path, since=cutoff)
+    assert len(summary.items) == 1

--- a/tests/unit/curator/test_source_recommendations.py
+++ b/tests/unit/curator/test_source_recommendations.py
@@ -130,3 +130,133 @@ def test_since_param_overrides_default(tmp_path, attune_home_tmp):
     cutoff = datetime.now(timezone.utc) - timedelta(hours=72)
     summary = rec_source.read(project_root=tmp_path, since=cutoff)
     assert len(summary.items) == 1
+
+
+def test_runs_dir_iterdir_oserror_returns_empty(tmp_path, attune_home_tmp, monkeypatch):
+    """If iterdir on runs_dir raises, reader returns empty (caps the
+    error before any workflow-dir traversal)."""
+    from pathlib import Path
+
+    (attune_home_tmp / "ops" / "runs").mkdir(parents=True, exist_ok=True)
+
+    def boom(self):  # noqa: ANN001
+        raise OSError("simulated")
+
+    monkeypatch.setattr(Path, "iterdir", boom)
+    summary = rec_source.read(project_root=tmp_path)
+    assert summary.items == []
+
+
+def test_workflow_glob_oserror_skips_dir(tmp_path, attune_home_tmp, monkeypatch):
+    """If a workflow_dir.glob raises, that dir is skipped but others proceed."""
+    from pathlib import Path
+
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "good",
+        recommendations=[{"kind": "open", "label": "x"}],
+    )
+    # Make a second workflow dir whose glob will raise.
+    _write_run(
+        attune_home_tmp,
+        "bad-workflow",
+        "x",
+        recommendations=[{"kind": "open", "label": "y"}],
+    )
+
+    original_glob = Path.glob
+
+    def selective_boom(self, pattern):  # noqa: ANN001
+        if self.name == "bad-workflow":
+            raise OSError("simulated")
+        return original_glob(self, pattern)
+
+    monkeypatch.setattr(Path, "glob", selective_boom)
+    summary = rec_source.read(project_root=tmp_path)
+    ids = {item.item_id for item in summary.items}
+    # Good workflow's recs still surface; bad-workflow's are skipped.
+    assert any("code-review:good" in i for i in ids)
+    assert not any("bad-workflow" in i for i in ids)
+
+
+def test_stat_oserror_on_record_skips_silently(tmp_path, attune_home_tmp, monkeypatch):
+    """A stat() failure on a record path should skip that file, not crash."""
+    from pathlib import Path
+
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "r1",
+        recommendations=[{"kind": "open", "label": "x"}],
+    )
+
+    original_stat = Path.stat
+
+    def selective_boom(self, *a, **kw):  # noqa: ANN001
+        if self.name == "r1.json":
+            raise OSError("simulated stat fail")
+        return original_stat(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "stat", selective_boom)
+    summary = rec_source.read(project_root=tmp_path)
+    assert summary.source_id == "recommendations"
+    assert summary.items == []
+
+
+def test_tmp_record_files_skipped(tmp_path, attune_home_tmp):
+    """Atomic-replace temp suffixes (.tmp) are skipped on read."""
+    runs_dir = attune_home_tmp / "ops" / "runs" / "code-review"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "abc.json.tmp").write_text(
+        json.dumps({"run_id": "abc", "recommendations": [{"kind": "open", "label": "x"}]}),
+        encoding="utf-8",
+    )
+    summary = rec_source.read(project_root=tmp_path)
+    assert summary.items == []
+
+
+def test_non_dict_payload_skipped(tmp_path, attune_home_tmp):
+    """A JSON record whose top-level isn't a dict produces zero items."""
+    runs_dir = attune_home_tmp / "ops" / "runs" / "code-review"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "r1.json").write_text('["not", "dict"]', encoding="utf-8")
+    summary = rec_source.read(project_root=tmp_path)
+    assert summary.items == []
+
+
+def test_non_dict_recommendation_entries_skipped(tmp_path, attune_home_tmp):
+    """recommendations: [<string>, ...] entries get skipped (non-dict)."""
+    _write_run(
+        attune_home_tmp,
+        "code-review",
+        "r1",
+        recommendations=[
+            "not-a-dict",  # type: ignore[list-item]
+            {"kind": "open", "label": "valid"},
+        ],
+    )
+    summary = rec_source.read(project_root=tmp_path)
+    # Only the valid one surfaces.
+    assert len(summary.items) == 1
+
+
+def test_max_items_cap_truncates(tmp_path, attune_home_tmp):
+    """When a single run carries >50 recommendations, the per-file
+    extension still respects the global cap on the next iteration."""
+    # Spread 60 recs across two runs to force the post-extend truncation
+    # plus the outer break.
+    _write_run(
+        attune_home_tmp,
+        "wf-a",
+        "r1",
+        recommendations=[{"kind": "open", "label": f"a{i}"} for i in range(30)],
+    )
+    _write_run(
+        attune_home_tmp,
+        "wf-b",
+        "r2",
+        recommendations=[{"kind": "open", "label": f"b{i}"} for i in range(30)],
+    )
+    summary = rec_source.read(project_root=tmp_path)
+    assert len(summary.items) == 50

--- a/tests/unit/curator/test_source_specs.py
+++ b/tests/unit/curator/test_source_specs.py
@@ -101,3 +101,72 @@ def test_reader_does_not_raise_when_detect_candidates_blows_up(project_with_spec
     assert len(summary.items) == 3
     for item in summary.items:
         assert item.metadata["is_completion_candidate"] == "false"
+
+
+def test_list_specs_raise_returns_empty(project_with_specs, monkeypatch):
+    """If _list_specs_in_root raises, reader returns empty summary."""
+    monkeypatch.setenv("ATTUNE_HOME", str(project_with_specs / ".attune"))
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated listing failure")
+
+    monkeypatch.setattr(
+        "attune.curator.sources.specs._list_specs_in_root",
+        boom,
+    )
+    summary = specs_source.read(project_root=project_with_specs)
+    assert summary.source_id == "specs"
+    assert summary.items == []
+    assert len(summary.state_hash) == 16
+
+
+def test_spec_without_any_status_falls_through(project_with_specs, monkeypatch):
+    """A spec dir whose phase files all lack '**Status:**' lines yields
+    metadata.status='unknown'."""
+    monkeypatch.setenv("ATTUNE_HOME", str(project_with_specs / ".attune"))
+    silent = project_with_specs / "docs" / "specs" / "silent"
+    silent.mkdir(parents=True, exist_ok=True)
+    (silent / "tasks.md").write_text(
+        "# Tasks\n\nNo status line here.\n\n- [ ] todo\n",
+        encoding="utf-8",
+    )
+    summary = specs_source.read(project_root=project_with_specs)
+    silent_items = [i for i in summary.items if i.item_id == "spec:silent"]
+    assert silent_items
+    assert silent_items[0].metadata["status"] == "unknown"
+
+
+def test_age_days_none_when_no_last_modified():
+    """Direct unit test of the _age_days helper: empty input -> None."""
+    import attune.curator.sources.specs as spec_mod
+
+    assert spec_mod._age_days(None) is None
+    assert spec_mod._age_days("") is None
+
+
+def test_age_days_returns_none_on_bad_iso():
+    """_age_days swallows fromisoformat ValueError and returns None."""
+    import attune.curator.sources.specs as spec_mod
+
+    assert spec_mod._age_days("not-an-iso-string") is None
+
+
+def test_age_days_handles_naive_datetime():
+    """A naive datetime (no tz) gets UTC-coerced before delta math."""
+    from datetime import datetime, timedelta, timezone
+
+    import attune.curator.sources.specs as spec_mod
+
+    naive_yesterday = (datetime.now(timezone.utc) - timedelta(days=2)).replace(tzinfo=None)
+    days = spec_mod._age_days(naive_yesterday.isoformat())
+    assert days is not None and days >= 1
+
+
+def test_empty_summary_helper():
+    """_empty_summary returns the canonical empty SourceSummary."""
+    import attune.curator.sources.specs as spec_mod
+
+    summary = spec_mod._empty_summary(started=0.0)
+    assert summary.source_id == "specs"
+    assert summary.items == []
+    assert len(summary.state_hash) == 16

--- a/tests/unit/curator/test_source_specs.py
+++ b/tests/unit/curator/test_source_specs.py
@@ -1,0 +1,103 @@
+"""Tests for the specs source reader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.curator.sources import specs as specs_source
+
+
+def _make_spec(specs_root: Path, slug: str, *, status: str = "approved") -> None:
+    spec_dir = specs_root / slug
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / "requirements.md").write_text(
+        f"# {slug}\n\n**Status:** {status}\n\nBody.\n",
+        encoding="utf-8",
+    )
+    (spec_dir / "tasks.md").write_text(
+        f"# Tasks\n\n**Status:** {status}\n\n- [ ] something\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def project_with_specs(tmp_path):
+    """Create a tmp project with docs/specs/<3 specs>."""
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(specs_root, "alpha", status="approved")
+    _make_spec(specs_root, "beta", status="draft")
+    _make_spec(specs_root, "gamma", status="complete")
+    return tmp_path
+
+
+def test_lists_specs_with_status(project_with_specs, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(project_with_specs / ".attune"))
+    summary = specs_source.read(project_root=project_with_specs)
+    assert summary.source_id == "specs"
+    ids = {item.item_id for item in summary.items}
+    assert ids == {"spec:alpha", "spec:beta", "spec:gamma"}
+    statuses = {item.item_id: item.metadata["status"] for item in summary.items}
+    assert statuses == {
+        "spec:alpha": "approved",
+        "spec:beta": "draft",
+        "spec:gamma": "complete",
+    }
+
+
+def test_links_use_spec_slug(project_with_specs, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(project_with_specs / ".attune"))
+    summary = specs_source.read(project_root=project_with_specs)
+    for item in summary.items:
+        slug = item.item_id.split(":", 1)[1]
+        assert item.link == f"/specs/{slug}"
+
+
+def test_age_days_present_for_existing_specs(project_with_specs, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(project_with_specs / ".attune"))
+    summary = specs_source.read(project_root=project_with_specs)
+    for item in summary.items:
+        # Newly-created files: age_days should be 0.
+        assert item.metadata["age_days"] in ("0", "1")  # tolerate tz edge
+
+
+def test_completion_candidate_flag_defaults_false(project_with_specs, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(project_with_specs / ".attune"))
+    summary = specs_source.read(project_root=project_with_specs)
+    flags = {item.metadata["is_completion_candidate"] for item in summary.items}
+    # Without GitHub access / PR refs, every spec is "false" — that's
+    # the safe default the reader guarantees when detection skips.
+    assert flags == {"false"}
+
+
+def test_state_hash_stable_across_calls(project_with_specs, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(project_with_specs / ".attune"))
+    a = specs_source.read(project_root=project_with_specs).state_hash
+    b = specs_source.read(project_root=project_with_specs).state_hash
+    assert a == b
+
+
+def test_missing_specs_dir_returns_empty_summary(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    summary = specs_source.read(project_root=tmp_path)
+    assert summary.source_id == "specs"
+    assert summary.items == []
+
+
+def test_reader_does_not_raise_when_detect_candidates_blows_up(project_with_specs, monkeypatch):
+    """If completion-candidate detection raises, the reader still
+    returns spec status + age — just with is_completion_candidate=false."""
+    monkeypatch.setenv("ATTUNE_HOME", str(project_with_specs / ".attune"))
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated detector failure")
+
+    monkeypatch.setattr(
+        "attune.ops.completion_candidates.detect_candidates",
+        boom,
+    )
+    summary = specs_source.read(project_root=project_with_specs)
+    assert len(summary.items) == 3
+    for item in summary.items:
+        assert item.metadata["is_completion_candidate"] == "false"

--- a/tests/unit/curator/test_source_sweep.py
+++ b/tests/unit/curator/test_source_sweep.py
@@ -1,0 +1,117 @@
+"""Tests for the discovery-sweep source reader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from attune.curator.sources import sweep as sweep_source
+
+
+def _write_sweep(attune_home_dir: Path, scope_digest: str, payload: dict) -> None:
+    results = attune_home_dir / "ops" / "sweep-results"
+    results.mkdir(parents=True, exist_ok=True)
+    (results / f"{scope_digest}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+@pytest.fixture
+def attune_home_tmp(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_empty_results_dir_returns_empty(tmp_path, attune_home_tmp):
+    summary = sweep_source.read(project_root=tmp_path)
+    assert summary.source_id == "sweep"
+    assert summary.items == []
+    assert len(summary.state_hash) == 16
+
+
+def test_emits_queue_and_questions_skips_rejected(tmp_path, attune_home_tmp):
+    _write_sweep(
+        attune_home_tmp,
+        "abc123",
+        {
+            "queue": [
+                {
+                    "source": "bug-predict",
+                    "severity": "high",
+                    "title": "race condition in foo",
+                    "description": "...",
+                    "file": "src/a.py",
+                    "line": 12,
+                    "confidence": 0.8,
+                },
+            ],
+            "questions": [
+                {
+                    "finding": {
+                        "source": "security-audit",
+                        "severity": "medium",
+                        "title": "weak token check",
+                        "description": "...",
+                        "file": "src/b.py",
+                        "line": 30,
+                        "confidence": 0.5,
+                    },
+                    "reason": "LOW_CONFIDENCE",
+                    "next_step": "review",
+                },
+            ],
+            "rejected": [
+                {
+                    "finding": {
+                        "source": "bug-predict",
+                        "severity": "low",
+                        "title": "noise",
+                        "description": "...",
+                        "file": "src/c.py",
+                    },
+                    "rule": "SEVERITY_BELOW_THRESHOLD",
+                },
+            ],
+        },
+    )
+    summary = sweep_source.read(project_root=tmp_path)
+    buckets = {item.metadata["bucket"] for item in summary.items}
+    assert buckets == {"queue", "questions"}
+    assert len(summary.items) == 2
+
+
+def test_malformed_file_skipped(tmp_path, attune_home_tmp):
+    results = attune_home_tmp / "ops" / "sweep-results"
+    results.mkdir(parents=True, exist_ok=True)
+    (results / "bad.json").write_text("not-json", encoding="utf-8")
+    _write_sweep(
+        attune_home_tmp,
+        "good",
+        {
+            "queue": [
+                {"source": "bug-predict", "severity": "high", "title": "x"},
+            ]
+        },
+    )
+    summary = sweep_source.read(project_root=tmp_path)
+    assert len(summary.items) == 1
+
+
+def test_state_hash_deterministic(tmp_path, attune_home_tmp):
+    _write_sweep(
+        attune_home_tmp,
+        "abc",
+        {"queue": [{"source": "x", "severity": "high", "title": "t"}]},
+    )
+    a = sweep_source.read(project_root=tmp_path).state_hash
+    b = sweep_source.read(project_root=tmp_path).state_hash
+    assert a == b
+
+
+def test_caps_at_50_items(tmp_path, attune_home_tmp):
+    findings = [
+        {"source": "bug-predict", "severity": "info", "title": f"f-{i}"} for i in range(100)
+    ]
+    _write_sweep(attune_home_tmp, "big", {"queue": findings})
+    summary = sweep_source.read(project_root=tmp_path)
+    assert len(summary.items) == 50

--- a/tests/unit/curator/test_source_sweep.py
+++ b/tests/unit/curator/test_source_sweep.py
@@ -115,3 +115,28 @@ def test_caps_at_50_items(tmp_path, attune_home_tmp):
     _write_sweep(attune_home_tmp, "big", {"queue": findings})
     summary = sweep_source.read(project_root=tmp_path)
     assert len(summary.items) == 50
+
+
+def test_results_dir_glob_oserror_returns_empty(tmp_path, attune_home_tmp, monkeypatch):
+    """If glob('*.json') raises OSError, reader returns empty."""
+    from pathlib import Path
+
+    # Make the dir exist so we reach the glob call.
+    (attune_home_tmp / "ops" / "sweep-results").mkdir(parents=True, exist_ok=True)
+
+    def boom(self, pattern):  # noqa: ANN001
+        raise OSError("simulated")
+
+    monkeypatch.setattr(Path, "glob", boom)
+    summary = sweep_source.read(project_root=tmp_path)
+    assert summary.source_id == "sweep"
+    assert summary.items == []
+
+
+def test_non_dict_payload_skipped(tmp_path, attune_home_tmp):
+    """A JSON file whose top-level isn't a dict produces zero items."""
+    sweep_dir = attune_home_tmp / "ops" / "sweep-results"
+    sweep_dir.mkdir(parents=True, exist_ok=True)
+    (sweep_dir / "abc.json").write_text('["not", "a", "dict"]', encoding="utf-8")
+    summary = sweep_source.read(project_root=tmp_path)
+    assert summary.items == []

--- a/tests/unit/curator/test_source_sweep.py
+++ b/tests/unit/curator/test_source_sweep.py
@@ -140,3 +140,52 @@ def test_non_dict_payload_skipped(tmp_path, attune_home_tmp):
     (sweep_dir / "abc.json").write_text('["not", "a", "dict"]', encoding="utf-8")
     summary = sweep_source.read(project_root=tmp_path)
     assert summary.items == []
+
+
+def test_non_dict_row_in_bucket_is_skipped(tmp_path, attune_home_tmp):
+    """Bucket entries that aren't dicts (e.g. nulls, strings)
+    get skipped silently — exercises the elif-False loop-continue
+    branch in _iter_findings.
+    """
+    _write_sweep(
+        attune_home_tmp,
+        "abc",
+        {
+            "queue": [
+                None,
+                "stray-string",
+                42,
+                {"source": "bug-predict", "severity": "high", "title": "real"},
+            ]
+        },
+    )
+    summary = sweep_source.read(project_root=tmp_path)
+    titles = {item.title for item in summary.items}
+    assert titles == {"real"}
+
+
+def test_questions_row_with_empty_reason_omits_question_marker(tmp_path, attune_home_tmp):
+    """A questions-bucket finding whose reason is empty/missing
+    should produce an item with no 'question: ...' suffix —
+    exercises the False branch of `if reason:` in _finding_to_item.
+    """
+    _write_sweep(
+        attune_home_tmp,
+        "abc",
+        {
+            "questions": [
+                {
+                    "finding": {
+                        "source": "bug-predict",
+                        "severity": "warn",
+                        "title": "ambiguous",
+                    },
+                    # 'reason' deliberately omitted -> empty string
+                    # default; falsy in the formatter.
+                }
+            ]
+        },
+    )
+    summary = sweep_source.read(project_root=tmp_path)
+    assert len(summary.items) == 1
+    assert "question:" not in summary.items[0].detail

--- a/tests/unit/curator/test_source_telemetry.py
+++ b/tests/unit/curator/test_source_telemetry.py
@@ -1,0 +1,118 @@
+"""Tests for the telemetry source reader."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.curator.sources import telemetry as telemetry_source
+
+
+def _write_events(attune_home_dir: Path, events: list[dict]) -> None:
+    tel_dir = attune_home_dir / "telemetry"
+    tel_dir.mkdir(parents=True, exist_ok=True)
+    path = tel_dir / "usage.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for event in events:
+            fh.write(json.dumps(event) + "\n")
+
+
+@pytest.fixture
+def attune_home_tmp(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_missing_usage_file_returns_empty(tmp_path, attune_home_tmp):
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert summary.source_id == "telemetry"
+    assert summary.items == []
+
+
+def test_cost_spike_fires_above_two_sigma(tmp_path, attune_home_tmp):
+    now = datetime.now(timezone.utc)
+    today_iso = now.isoformat()
+    # Realistic varied prior days (~$0.05-0.15 range), today at $5.00.
+    prior_costs = [0.05, 0.08, 0.12, 0.06, 0.10, 0.15]
+    prior_events = [
+        {
+            "ts": (now - timedelta(days=d + 1)).isoformat(),
+            "workflow": "code-review",
+            "total_cost": cost,
+        }
+        for d, cost in enumerate(prior_costs)
+    ]
+    today_event = {"ts": today_iso, "workflow": "code-review", "total_cost": 5.00}
+    _write_events(attune_home_tmp, prior_events + [today_event])
+
+    summary = telemetry_source.read(project_root=tmp_path)
+    spike_items = [i for i in summary.items if i.metadata["kind"] == "cost_spike"]
+    assert len(spike_items) == 1
+    assert spike_items[0].metadata["workflow"] == "code-review"
+
+
+def test_no_spike_when_sample_too_small(tmp_path, attune_home_tmp):
+    now = datetime.now(timezone.utc)
+    # Only one prior day → samples < 3, skip the workflow.
+    events = [
+        {
+            "ts": (now - timedelta(days=1)).isoformat(),
+            "workflow": "code-review",
+            "total_cost": 0.01,
+        },
+        {"ts": now.isoformat(), "workflow": "code-review", "total_cost": 5.0},
+    ]
+    _write_events(attune_home_tmp, events)
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert not any(i.metadata["kind"] == "cost_spike" for i in summary.items)
+
+
+def test_error_event_in_last_hour_surfaces(tmp_path, attune_home_tmp):
+    now = datetime.now(timezone.utc)
+    events = [
+        {
+            "ts": (now - timedelta(minutes=10)).isoformat(),
+            "workflow": "code-review",
+            "status": 500,
+            "error": "boom",
+        },
+    ]
+    _write_events(attune_home_tmp, events)
+    summary = telemetry_source.read(project_root=tmp_path)
+    err_items = [i for i in summary.items if i.metadata["kind"] == "error"]
+    assert len(err_items) == 1
+    assert err_items[0].metadata["status"] == "500"
+
+
+def test_old_error_excluded(tmp_path, attune_home_tmp):
+    now = datetime.now(timezone.utc)
+    events = [
+        {
+            "ts": (now - timedelta(hours=3)).isoformat(),
+            "workflow": "code-review",
+            "status": 500,
+            "error": "ancient",
+        },
+    ]
+    _write_events(attune_home_tmp, events)
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert not any(i.metadata["kind"] == "error" for i in summary.items)
+
+
+def test_caps_items_at_ten(tmp_path, attune_home_tmp):
+    now = datetime.now(timezone.utc)
+    events = [
+        {
+            "ts": (now - timedelta(minutes=i)).isoformat(),
+            "workflow": f"wf-{i}",
+            "status": 500,
+            "error": "err",
+        }
+        for i in range(20)
+    ]
+    _write_events(attune_home_tmp, events)
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert len(summary.items) <= 10

--- a/tests/unit/curator/test_source_telemetry.py
+++ b/tests/unit/curator/test_source_telemetry.py
@@ -116,3 +116,182 @@ def test_caps_items_at_ten(tmp_path, attune_home_tmp):
     _write_events(attune_home_tmp, events)
     summary = telemetry_source.read(project_root=tmp_path)
     assert len(summary.items) <= 10
+
+
+def test_no_recent_events_returns_empty(tmp_path, attune_home_tmp):
+    """If usage.jsonl exists but every event is older than the cutoff,
+    return the canonical empty summary."""
+    long_ago = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    _write_events(
+        attune_home_tmp,
+        [{"ts": long_ago, "workflow": "code-review", "total_cost": 0.05}],
+    )
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert summary.items == []
+
+
+def test_malformed_and_empty_lines_skipped(tmp_path, attune_home_tmp):
+    """Empty lines and lines that fail json.loads are silently skipped."""
+    telemetry_dir = attune_home_tmp / "telemetry"
+    telemetry_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    valid = {"ts": now.isoformat(), "workflow": "code-review", "total_cost": 0.05}
+    with (telemetry_dir / "usage.jsonl").open("w", encoding="utf-8") as fh:
+        fh.write("\n")
+        fh.write("not-json\n")
+        fh.write("[1, 2, 3]\n")  # not a dict
+        fh.write(json.dumps(valid) + "\n")
+    summary = telemetry_source.read(project_root=tmp_path)
+    # The lone valid event has no error / no spike — no items but no crash.
+    assert summary.source_id == "telemetry"
+
+
+def test_event_without_ts_skipped(tmp_path, attune_home_tmp):
+    """An event missing both 'ts' and 'timestamp' falls through the
+    cutoff filter."""
+    _write_events(
+        attune_home_tmp,
+        [{"workflow": "code-review", "total_cost": 1.0}],
+    )
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert summary.items == []
+
+
+def test_usage_jsonl_oserror_returns_empty(tmp_path, attune_home_tmp, monkeypatch):
+    """An OSError while reading usage.jsonl collapses to empty summary."""
+    telemetry_dir = attune_home_tmp / "telemetry"
+    telemetry_dir.mkdir(parents=True, exist_ok=True)
+    (telemetry_dir / "usage.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "workflow": "code-review",
+                "total_cost": 0.05,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    real_open = Path.open
+
+    def boom(self, *args, **kwargs):  # noqa: ANN001
+        if self.name == "usage.jsonl":
+            raise OSError("simulated read failure")
+        return real_open(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", boom)
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert summary.items == []
+
+
+def test_cost_spike_zero_variance_skipped(tmp_path, attune_home_tmp):
+    """Six identical prior days (variance=0) + spike today produces no
+    cost-spike item. Documents the z-score-on-zero-variance behaviour
+    (see CLAUDE.md lesson)."""
+    now = datetime.now(timezone.utc)
+    prior_events = [
+        {
+            "ts": (now - timedelta(days=d + 1)).isoformat(),
+            "workflow": "flat-workflow",
+            "total_cost": 0.01,
+        }
+        for d in range(6)
+    ]
+    today = {"ts": now.isoformat(), "workflow": "flat-workflow", "total_cost": 5.00}
+    _write_events(attune_home_tmp, prior_events + [today])
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert not any(i.metadata.get("kind") == "cost_spike" for i in summary.items)
+
+
+def test_cost_below_two_sigma_skipped(tmp_path, attune_home_tmp):
+    """A spike that's < 2σ above the prior mean is filtered out."""
+    now = datetime.now(timezone.utc)
+    prior_costs = [0.05, 0.08, 0.12, 0.06, 0.10, 0.15]
+    prior_events = [
+        {
+            "ts": (now - timedelta(days=d + 1)).isoformat(),
+            "workflow": "code-review",
+            "total_cost": cost,
+        }
+        for d, cost in enumerate(prior_costs)
+    ]
+    # Today's cost is only slightly above mean — well under 2σ.
+    today = {"ts": now.isoformat(), "workflow": "code-review", "total_cost": 0.12}
+    _write_events(attune_home_tmp, prior_events + [today])
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert not any(i.metadata.get("kind") == "cost_spike" for i in summary.items)
+
+
+def test_integer_status_in_5xx_range_fires_error_without_error_field(tmp_path, attune_home_tmp):
+    """An integer 500-599 status (no 'error' key) hits the int-status
+    branch of _is_error."""
+    now = datetime.now(timezone.utc)
+    _write_events(
+        attune_home_tmp,
+        [
+            {
+                "ts": (now - timedelta(seconds=30)).isoformat(),
+                "workflow": "code-review",
+                "status": 502,  # int, no 'error' field
+            }
+        ],
+    )
+    summary = telemetry_source.read(project_root=tmp_path)
+    errors = [i for i in summary.items if i.metadata["kind"] == "error"]
+    assert len(errors) == 1
+    assert errors[0].metadata["status"] == "502"
+
+
+def test_string_status_in_4xx_range_fires_error(tmp_path, attune_home_tmp):
+    """Status field present as a digit-string (e.g. '503') fires the
+    error path."""
+    now = datetime.now(timezone.utc)
+    _write_events(
+        attune_home_tmp,
+        [
+            {
+                "ts": (now - timedelta(seconds=30)).isoformat(),
+                "workflow": "code-review",
+                "status": "503",
+            }
+        ],
+    )
+    summary = telemetry_source.read(project_root=tmp_path)
+    errors = [i for i in summary.items if i.metadata["kind"] == "error"]
+    assert len(errors) == 1
+
+
+def test_string_status_non_error_ignored(tmp_path, attune_home_tmp):
+    """A '200' status string doesn't fire the error path."""
+    now = datetime.now(timezone.utc)
+    _write_events(
+        attune_home_tmp,
+        [
+            {
+                "ts": (now - timedelta(seconds=30)).isoformat(),
+                "workflow": "code-review",
+                "status": "200",
+            }
+        ],
+    )
+    summary = telemetry_source.read(project_root=tmp_path)
+    assert summary.items == []
+
+
+def test_safe_float_coerces_bad_values():
+    """Direct unit test of _safe_float — bad inputs collapse to 0.0."""
+    import attune.curator.sources.telemetry as tmod
+
+    assert tmod._safe_float("not-a-number") == 0.0
+    assert tmod._safe_float(None) == 0.0
+    assert tmod._safe_float(3.14) == 3.14
+
+
+def test_parse_iso_helpers():
+    """_parse_iso returns None on bad input; coerces naive to UTC."""
+    import attune.curator.sources.telemetry as tmod
+
+    assert tmod._parse_iso("bad") is None
+    naive_dt = tmod._parse_iso("2026-05-26T12:00:00")
+    assert naive_dt is not None and naive_dt.tzinfo is not None


### PR DESCRIPTION
## Summary

- Phase 1 of [`bulletin-curator`](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/bulletin-curator): source readers + cache scaffolding (Tasks 1.1–1.5).
- 6 source readers (bulletin, specs, sweep, telemetry, recommendations, git_state) each conforming to the `SourceReader` Protocol; every reader is contract-bound to NOT raise.
- `CuratorCache` with 5-min TTL, source-state-hash keying, JSON-per-file persistence under `<attune_home>/curator-cache/`.
- Purely additive `FileBulletinBackend.read_archive(since=)` for the bulletin reader.
- 50 unit tests, all passing locally; no production callers wired yet (Phase 2 lights up the agent invocation, Phase 3 the dashboard/CLI surface).

## Test plan

- [ ] `pytest tests/unit/curator/` — 50 passing
- [ ] `pytest tests/unit/bulletin/` — green except the pre-existing TZ-sensitive `test_yesterdays_log_moved_to_archive` (passes under `TZ=UTC`; CI is UTC so origin/main is green)
- [ ] `ruff check src/attune/curator/ tests/unit/curator/` — clean
- [ ] `ruff format --check src/attune/curator/ tests/unit/curator/` — clean
- [ ] Smoke imports: `python -c "from attune.curator import CuratorResult, SourceSummary; from attune.curator.sources import bulletin, specs, sweep, telemetry, recommendations, git_state; from attune.curator.cache import CuratorCache"` — OK

## Notes for review

- Pattern grounding: bulletin/protocol.py's frozen-dataclass + Protocol layout, file_backend.py's never-raises error model, sweep_results.py's atomic-replace persistence shape.
- All-readers-cap policy: each reader truncates to keep the eventual Phase 2 prompt budget bounded (50 items for sweep/recs, 10 for telemetry anomalies, 500-char per-item detail).
- This PR ships headless API only — no `attune curator` CLI yet, no `/curator` route, no LLM calls. Phase 2 and Phase 3 are separate PRs by design (per the spec's "each phase ships independently").
- Out-of-scope finding worth tracking: `tests/unit/bulletin/test_file_backend.py::TestRotation::test_yesterdays_log_moved_to_archive` has a UTC-vs-local-date mismatch in `_maybe_rotate`. CI is UTC so it never fires there, but it makes the rotation test fail under any non-UTC dev TZ. Not blocking this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
