### PR TITLE
docs(specs/test-discipline-controls): draft 4-control proposal

### DIFF
--- a/docs/specs/test-discipline-controls/decisions.md
+++ b/docs/specs/test-discipline-controls/decisions.md
@@ -101,3 +101,35 @@ trivially. No special-casing needed in the hook.
 **Caveat:** a `feat:` commit that adds 200 lines of code without
 tests *and* claims "refactor only" should be reviewed for accuracy
 of the claim. Reviewer responsibility, not hook responsibility.
+
+---
+
+## D5 — Hook MUST run with `--branch` coverage (2026-05-27)
+
+**Question:** does the pre-push hook run `coverage` in
+line-coverage-only or line+branch mode?
+
+**Decision:** **Branch coverage required.** The hook invokes
+`coverage run --branch -m pytest <tests>`.
+
+**Rationale:** PR #485's codecov failure was 2 partial branches
+flagged at 99.74% patch coverage while local line coverage
+reported 100%. The gap: codecov runs branch coverage
+(`[coverage:run] branch = true`), and the local
+`coverage run -m pytest` (without `--branch`) doesn't. So an
+agent running the local-coverage-default workflow sees 100%
+and pushes; codecov sees 99.74% and rejects.
+
+If the pre-push hook is going to close this loop, it MUST
+match codecov's mode. Line-only would re-introduce the same
+discipline gap this spec is built to fix.
+
+Implementation: `scripts/coverage_gate/check_patch.py` passes
+`--branch` to `coverage run` and parses the branch-coverage
+columns (`Branch`, `BrPart`, `BrMissing`) from the report.
+Threshold check intersects touched lines AND touched branches
+with the executed set.
+
+**Reference:** PR #485's second codecov-failure cycle
+(2026-05-27); see commit c4099ac2 which closed the partials
+that line coverage missed.

--- a/docs/specs/test-discipline-controls/decisions.md
+++ b/docs/specs/test-discipline-controls/decisions.md
@@ -1,0 +1,103 @@
+# Decisions: Test Discipline Controls
+
+> Decision log. Append-only — each entry stamped with date and
+> the question it resolves.
+
+**Status:** living document
+**Created:** 2026-05-27
+
+---
+
+## D1 — TDD as policy: REJECTED (2026-05-27)
+
+**Question:** should we adopt strict TDD (red-green-refactor) as
+the development discipline for this codebase?
+
+**Decision:** No. Adopt the four mechanical controls in
+[`requirements.md`](requirements.md) instead.
+
+**Rationale:**
+
+1. **AI agents fake the red phase.** With a human in the loop,
+   TDD's value comes from imagining the system, writing a test
+   that *requires* it, then building. With an AI agent in the
+   driver's seat, the "see red, then build" discipline depends
+   on the agent reading the test failure and reasoning about it
+   — but agents (notably this one) tend to write the test then
+   write the code that exactly satisfies it in the same edit
+   window, losing the design pressure. The discipline's value
+   evaporates and the cost stays.
+2. **Spec-driven development is already this codebase's design
+   layer.** `/spec` produces requirements + design + tasks + XML
+   prompts with `<validation>`. That IS the up-front thinking
+   layer TDD claims. TDD on top of /spec is two parallel design
+   structures competing for the same cognitive slot, not
+   additive.
+3. **Cost: 2-3× more LLM turns per task.** Strict TDD =
+   test-red → code → test-green → refactor → test-green. For a
+   Phase-1-size task, ~200 tool calls instead of ~50.
+   Cost-per-value-added is worst at the moment of highest churn
+   (early in a spec, when the API moves).
+4. **The four-control proposal addresses the same failure mode
+   at lower cost.** The actual gap on PR #485 was (a) happy-
+   path-only tests and (b) no measurement gate before push. A
+   pre-push coverage hook + branch-enumeration habit + selective
+   test-first for new-API modules + regression-first for `fix:`
+   commits closes both without imposing red-green on every task.
+
+**What we'd reconsider TDD for:** if patch coverage on agent-
+driven PRs stays below 90% three months after this spec lands,
+re-open the question. The remaining gap would suggest the
+controls are insufficient.
+
+**Reference:** session conversation 2026-05-27 leading to this
+spec; PR #485 review where the gap surfaced.
+
+---
+
+## D2 — Coverage bar single source of truth (2026-05-27, pending)
+
+**Question:** where does the patch-coverage threshold live so
+the hook + docs + CI can't drift?
+
+**Decision:** **PENDING** — defer to Phase 1 inspection of
+current codecov config. Candidates:
+
+- (a) `codecov.yml` — already load-bearing for CI
+- (b) `pyproject.toml [tool.coverage.report] fail_under` — already
+  on the box, tools respect natively
+- (c) `.claude/coverage-bar.json` — new file, both hook + docs
+  read it
+
+Lean: (b). Decided in Phase 1 when we read the current
+configuration and pick the simplest write path.
+
+---
+
+## D3 — Pre-push hook: opt-in or default-on (2026-05-27)
+
+**Decision:** opt-in via the project's existing settings.json
+hook-installer mechanism.
+
+**Rationale:** forcing a `pre-push` onto every contributor's
+machine is heavy-handed and breaks non-developer worktrees (CI
+runners, ephemeral build agents, fresh clones used for read-only
+work). The hook ships in the repo; contributors enable it once
+via `attune setup hooks` (or equivalent). Documented in CLAUDE.md
+as part of the Phase 1 work.
+
+---
+
+## D4 — `feat:` commits without new test coverage (2026-05-27)
+
+**Question:** does a `feat:` commit that's pure refactor (no new
+lines) need to satisfy the coverage gate?
+
+**Decision:** the gate is patch-coverage-based, so refactors that
+don't add new lines pass by definition (denominator is 0 →
+coverage trivially passes). Dead-code removal also passes
+trivially. No special-casing needed in the hook.
+
+**Caveat:** a `feat:` commit that adds 200 lines of code without
+tests *and* claims "refactor only" should be reviewed for accuracy
+of the claim. Reviewer responsibility, not hook responsibility.

--- a/docs/specs/test-discipline-controls/design.md
+++ b/docs/specs/test-discipline-controls/design.md
@@ -1,0 +1,294 @@
+# Design: Test Discipline Controls
+
+> Concrete shapes for the four mechanical controls in
+> [`requirements.md`](requirements.md). Pairs with
+> [`tasks.md`](tasks.md) for the execution prompts.
+
+**Status:** draft
+**Last updated:** 2026-05-27
+
+---
+
+## Threshold: single source of truth
+
+Per [`decisions.md`](decisions.md) D2 (pending), the leading
+candidate is `pyproject.toml`:
+
+```toml
+[tool.coverage.report]
+fail_under = 90  # patch-coverage gate enforced by pre-push hook
+                 # and by codecov.yml's status.patch.target
+```
+
+Phase 1 verifies that codecov.yml can be configured to read this
+value (or that we accept a tiny static-config duplication with a
+drift-guard test).
+
+The number itself is determined by inspecting codecov's current
+config. If codecov enforces 90% patch coverage today, we encode
+90%. If it's looser, we tighten. If it's tighter, we loosen.
+The goal is alignment, not raising the bar arbitrarily.
+
+---
+
+## Pre-push coverage gate
+
+### Hook file
+
+`hooks/pre-push/coverage-gate.sh` — bash script invoked by the
+git pre-push hook chain.
+
+```bash
+#!/usr/bin/env bash
+# Pre-push: refuse if patch coverage on touched src/ files
+# falls below the configured threshold.
+#
+# Override: PUSH_BYPASS_COVERAGE_GATE=1 git push ...
+
+set -euo pipefail
+
+# Honour the explicit-bypass env var.
+if [[ "${PUSH_BYPASS_COVERAGE_GATE:-}" == "1" ]]; then
+    echo "coverage-gate: bypass requested via PUSH_BYPASS_COVERAGE_GATE=1"
+    exit 0
+fi
+
+# Identify changed Python files in the push range.
+# `@{push}` is the upstream tip; HEAD is what we're about to push.
+TOUCHED=$(git diff --name-only "@{push}..HEAD" -- 'src/**/*.py' 2>/dev/null || true)
+if [[ -z "$TOUCHED" ]]; then
+    # No production code changes — gate is a no-op.
+    exit 0
+fi
+
+# Map src/foo/bar.py -> tests/unit/foo/test_bar.py (with fallback to
+# tests/unit/foo/ if the exact test file doesn't exist).
+TEST_PATHS=$(python scripts/coverage_gate/test_paths_for.py $TOUCHED)
+
+THRESHOLD=$(python scripts/coverage_gate/read_threshold.py)
+# Runs coverage + computes patch coverage on the diff.
+python scripts/coverage_gate/check_patch.py \
+    --files "$TOUCHED" \
+    --tests "$TEST_PATHS" \
+    --threshold "$THRESHOLD"
+# Exit code: 0 if patch coverage >= threshold; non-zero otherwise.
+```
+
+### Companion Python helpers
+
+Three small scripts under `scripts/coverage_gate/`:
+
+| File | Purpose |
+|---|---|
+| `read_threshold.py` | Reads the threshold from the SOTH (pyproject.toml). Single line of Python; exits with the integer printed. |
+| `test_paths_for.py` | Maps `src/foo/bar.py` → `tests/unit/foo/test_bar.py`. Falls back to `tests/unit/foo/` if the exact file is absent. Idempotent on already-test paths. |
+| `check_patch.py` | Runs `coverage run -m pytest <tests>`, parses `coverage report -m` output, computes patch-coverage (lines touched ∩ lines covered / lines touched), exits non-zero if below threshold. Prints which lines are uncovered. |
+
+### Installation
+
+The hook is **opt-in** per D3. Wire-up via the existing
+`attune setup hooks` machinery (or the equivalent). The setup
+command copies `hooks/pre-push/coverage-gate.sh` into
+`.git/hooks/pre-push` (or chains it if one already exists).
+Contributors who never run setup don't get the hook; CI is
+unaffected (CI doesn't push, it merges).
+
+### Error message UX
+
+When the gate fires:
+
+```text
+coverage-gate: patch coverage 84.5% below threshold 90%
+ missing lines:
+   src/attune/curator/cache.py:109-111  (mkdir failure path)
+   src/attune/curator/cache.py:123-124  (write failure path)
+   src/attune/curator/sources/telemetry.py:188  (5xx int status)
+
+ actions:
+   - add tests covering the lines above, OR
+   - PUSH_BYPASS_COVERAGE_GATE=1 git push  (emergencies only)
+```
+
+Concrete and actionable. The agent reading this should be able to
+write the missing tests without re-running coverage to find them.
+
+---
+
+## Documentation alignment
+
+Three files quote the coverage bar:
+
+1. `.claude/rules/attune/coding-standards-index.md`
+2. `CLAUDE.md` (project root)
+3. `python-standards.md` (loaded via `@./python-standards.md` from
+   `.claude/CLAUDE.md`)
+
+All three get updated to quote the same number as the SOTH. A
+drift-guard test under `tests/unit/docs/` parses each file, grep
+the codecov/pyproject SOTH, and fails if any disagree.
+
+---
+
+## XML prompt template extensions
+
+### Test-first guidance (Item 3)
+
+New section appended to
+`.claude/rules/attune/xml-enhanced-prompts.md`:
+
+````markdown
+## Test-first for new-API modules
+
+When a task creates a **new module with a public API** (e.g., a
+fresh package's first source file, a dataclass + Protocol layer,
+a public-facing service class), list the test file BEFORE the
+implementation file in `<files-to-create>` and add this note:
+
+```xml
+<files-to-create>
+  <file path="tests/unit/foo/test_bar.py" order="first">
+    Write the test file as a contract assertion BEFORE the
+    implementation. The tests document the public API; the
+    implementation makes them pass.
+  </file>
+  <file path="src/attune/foo/bar.py" order="second">
+    Implement to satisfy the tests above.
+  </file>
+</files-to-create>
+```
+
+Apply selectively:
+- ✅ new public API of a new module / package
+- ❌ modifications to existing modules — write tests after, check
+  coverage diff
+- ❌ internal helpers, refactors, formatting changes
+- ❌ single-file edits, bug fixes (use `regression-guard` instead)
+
+The reason this isn't universal: TDD's value comes from design
+pressure on the API. When there's no new API, there's no design
+pressure to capture. Forcing test-first on every task is the
+strict-TDD model rejected in `decisions.md` D1.
+````
+
+### Branch-enumeration in `<validation>` (Item 5)
+
+The existing `<validation>` block schema grows a `<branches>`
+sub-element:
+
+```xml
+<validation>
+  <check>functional happy-path assertion</check>
+  <check>another functional check</check>
+  <branches>
+    <branch test="test_X">except OSError on iterdir</branch>
+    <branch test="test_Y">data not a dict</branch>
+    <branch test="test_Z">empty input → empty return</branch>
+  </branches>
+</validation>
+```
+
+Rules for the agent:
+
+- Every `except` clause added by the task gets a `<branch>` line.
+- Every `if not X: return` / `if X is None: return` early-out
+  added by the task gets a `<branch>` line.
+- Every meaningful malformed-input path (json decode failure,
+  unicode error, type coercion failure) gets a `<branch>` line.
+- Each branch names the test function that exercises it.
+
+If a branch in the production code doesn't have a corresponding
+`<branch>` entry, the task isn't done — write the test and add
+the line. This is the structural pressure that closes the
+happy-path-only failure mode at authoring time.
+
+---
+
+## Regression-first for `fix:` commits
+
+Update `.claude/rules/attune/decision-routine.md` — the existing
+concerns palette table — to promote `regression-guard` from
+"optional" to "required when subject starts with `fix:`":
+
+```markdown
+| `regression-guard` | **Required** for any commit whose subject
+starts with `fix:`. Optional for other concerns. A regression test
+that fails on the pre-fix code and passes on the post-fix code is
+the only proof the fix is real. |
+```
+
+No code change for v1 — this is documentation. The
+`commit-msg` git hook (stretch goal) could parse the message and
+warn if no test file is in the same commit, but the wording is
+strong enough that human review catches violations.
+
+---
+
+## Drift-guard tests
+
+Three new tests under `tests/unit/docs/` and `tests/unit/ci/`:
+
+1. **`tests/unit/docs/test_coverage_bar_alignment.py`** — parses
+   the SOTH (pyproject.toml `fail_under`) and asserts the value
+   appears verbatim in the three doc files. Detects future drift.
+2. **`tests/unit/ci/test_codecov_alignment.py`** — parses
+   `codecov.yml` and asserts its patch-coverage target matches
+   the SOTH. (Skips with a clear `pytest.skip()` if codecov.yml
+   isn't present in the working tree, which is the case for
+   sibling-repo checkouts.)
+3. **`tests/unit/docs/test_xml_validation_branches.py`** — finds
+   every XML prompt in `docs/implementation/TASK_PROMPTS.md` and
+   `docs/specs/**/tasks.md` (only for spec status: in-flight /
+   approved) and asserts each has a `<branches>` section if it
+   touches `<files-to-modify>` or `<files-to-create>` for `.py`
+   files. Allows opt-out via a `<branches none-applicable="true"
+   />` marker for refactor-only tasks.
+
+These tests are part of the regular suite — they'd fail in CI if
+someone bumps codecov's threshold without updating docs, or vice
+versa. Drift becomes a CI failure, not a slow-drift surprise.
+
+---
+
+## Self-application
+
+The PR that lands this spec uses every control on itself:
+
+- The pre-push hook installs and runs against the PR's own diff.
+- The drift-guard tests are in the same commit set as the
+  doc-alignment changes — proving they catch drift if either side
+  moves without the other.
+- The XML prompts in [`tasks.md`](tasks.md) include the new
+  `<branches>` sections.
+- The PR's commit messages demonstrate the `regression-guard`
+  pattern (the drift-guard tests ARE the regression guards
+  against future drift).
+
+---
+
+## What this spec doesn't do
+
+- **No automated `<branches>` linter for retroactive specs.** The
+  existing 30+ in-flight specs don't get retrofitted automatically;
+  they're updated lazily as their tasks ship.
+- **No required `commit-msg` hook.** The hook chain stays
+  minimal — pre-push is the structural one; commit-msg is too
+  invasive for v1.
+- **No CI rejection of low-coverage PRs.** Codecov already does
+  this. Adding a redundant gate would be friction without
+  benefit.
+- **No "type coverage" gate.** mypy / pyright coverage is a
+  separate concern (and already broken — see CLAUDE.md "mypy
+  removed from pre-commit"). This spec touches only test
+  coverage.
+
+---
+
+## Cross-references
+
+- [`requirements.md`](requirements.md) — problem statement,
+  goals, acceptance criteria
+- [`decisions.md`](decisions.md) — TDD-rejection rationale +
+  pending threshold-SOTH decision
+- [`tasks.md`](tasks.md) — XML-prompt execution plan
+- [`.claude/rules/attune/xml-enhanced-prompts.md`](../../../.claude/rules/attune/xml-enhanced-prompts.md) — template this spec extends
+- [`.claude/rules/attune/decision-routine.md`](../../../.claude/rules/attune/decision-routine.md) — concerns palette this spec extends

--- a/docs/specs/test-discipline-controls/requirements.md
+++ b/docs/specs/test-discipline-controls/requirements.md
@@ -1,0 +1,240 @@
+# Spec: Test Discipline Controls
+
+> Four mechanical controls that close the test-coverage discipline
+> gap surfaced by PR #485 — without adopting strict TDD.
+
+**Status:** draft
+**Created:** 2026-05-27
+**Owner:** TBD
+**Related:**
+
+- [PR #485](https://github.com/Smart-AI-Memory/attune-ai/pull/485) — surfaced the gap (89% local coverage, codecov flagged 6 modules below patch-coverage gate)
+- [`.claude/rules/attune/coding-standards-index.md`](../../../.claude/rules/attune/coding-standards-index.md) — current "Minimum 80%" rule
+- [`.claude/rules/attune/xml-enhanced-prompts.md`](../../../.claude/rules/attune/xml-enhanced-prompts.md) — XML prompt schema this spec extends
+- [`.claude/rules/attune/decision-routine.md`](../../../.claude/rules/attune/decision-routine.md) — concerns palette this spec extends
+
+---
+
+## Problem statement
+
+PR #485 shipped with 89% line coverage on Phase 1 of bulletin-curator.
+The coding standards say 80% is the floor, so on paper the work was
+compliant. Codecov's patch-coverage gate disagreed and flagged six
+modules below threshold. Two distinct issues collided:
+
+1. **The agent's working pattern produced happy-path-only tests.** Tests
+   came AFTER production code, exercised success paths, and stopped
+   at "green." Error branches (`except` clauses, `if not X: return`
+   early-outs, malformed-input handlers) were systematically
+   under-tested. The pattern hit ~89% reliably and felt "done."
+2. **The repo's stated bar is below the enforced bar.** CLAUDE.md
+   says "Minimum 80%" but codecov flags <90% on patches. Agents
+   reading the docs target 80%; CI rejects them. The doc and the
+   gate disagree, and the gate is the load-bearing one. The agent
+   only learns this AFTER pushing and reading codecov.
+
+The cost wasn't catastrophic (we caught it in PR review, added
+tests, lifted coverage to 100%). But the failure mode is recurring
+and structural — *every* agent-written PR on a fresh module set
+will hit the same shape unless the controls change.
+
+Strict TDD adoption was considered and rejected (see [Decision: not
+TDD](decisions.md)). The cost-per-value of red-green-refactor with
+an AI agent in the loop is high (2-3× more tool calls per task,
+plus AI-faithfulness verification overhead on the "did the red
+phase actually run" step). Cheaper, more mechanical controls
+address the same failure mode at lower cost.
+
+---
+
+## Goals
+
+1. **Pre-push coverage gate.** Make it impossible to push code with
+   patch coverage below threshold without explicitly overriding —
+   the check fires on the developer's machine, not 7 minutes later
+   in CI.
+2. **Documentation/enforcement alignment.** The stated coverage bar
+   in CLAUDE.md and the codecov enforcement gate must agree.
+   Whichever way the alignment lands, agents reading the rules
+   should be targeting the same number CI enforces.
+3. **Selective test-first for new-API modules.** When a task creates
+   a brand-new module with a clear public surface, write the test
+   file *first* — the test file IS the API contract. This
+   captures TDD's design-pressure benefit at exactly the moment it
+   pays off, without imposing it on internal/refactor work where
+   it doesn't.
+4. **Regression-first required for `fix:` commits.** The existing
+   `regression-guard` concern (in the decision-routine concerns
+   palette) becomes required, not optional, for any commit whose
+   subject starts with `fix:`. The fix doesn't go in without a
+   test that fails on the pre-fix code and passes on the post-fix
+   code.
+5. **Branch-enumeration in XML `<validation>` blocks.** Strengthen
+   the XML-prompt template so `<validation>` lists every error
+   branch added and which test exercises it. Surfaces gaps at
+   authoring time, not at codecov time.
+
+## Non-goals
+
+- **Adopting strict TDD as policy.** See `decisions.md`. The four
+  controls in this spec address the same failure mode at lower
+  cost without the AI-verification problem TDD introduces.
+- **Raising the bar to 100%.** 100% coverage is a poor target —
+  it rewards testing trivial branches and dead defensive code. A
+  realistic target is 90-95% patch coverage with the branch-
+  enumeration habit catching meaningful gaps.
+- **Replacing CI's coverage gate.** The pre-push hook is a *local*
+  fast-feedback control; CI stays the authoritative gate. The
+  push hook just moves the signal forward in time.
+- **Blocking workflow / agent-development specs.** This spec ships
+  alongside ongoing work; no in-flight spec gets blocked by it.
+
+---
+
+## Design
+
+### Item 1 — Pre-push coverage gate
+
+A git `pre-push` hook (opt-in via project settings) that:
+
+- Detects which `src/attune/**/*.py` files are in the push range
+  (commits between `@{push}` and `HEAD`).
+- Runs `coverage run -m pytest <targeted-tests>` over the matching
+  `tests/unit/` paths.
+- Computes patch coverage (lines in the diff that were exercised
+  during the run vs total touched lines).
+- Refuses the push with a clear message if patch coverage falls
+  below the configured threshold (default 90%).
+- Provides a one-time override (`PUSH_BYPASS_COVERAGE_GATE=1`) for
+  emergencies and infrastructure-only commits.
+
+The hook lives at `.claude/hooks/pre-push/coverage-gate.sh` (or
+equivalent) and is wired into `.git/hooks/pre-push` via the
+project's existing hook-installer machinery.
+
+### Item 2 — Documentation alignment
+
+Two files change to match codecov's actual enforcement:
+
+- `.claude/rules/attune/coding-standards-index.md` — replace
+  "Minimum 80% test coverage" with the explicit codecov-aligned
+  number (likely "Minimum 90% patch coverage on new/modified
+  modules; 80% line coverage as the long-running floor").
+- `CLAUDE.md` (project root) — same alignment, plus a one-line
+  pointer to the pre-push hook setup.
+
+The exact number is set by inspecting codecov's current config
+during Phase 1; whatever it is, the docs match.
+
+### Item 3 — Selective test-first for new-API modules
+
+Add a new section to `xml-enhanced-prompts.md`:
+
+> **Test-first when the task creates a new module with a public
+> API.** For these tasks, the XML prompt's `<files-to-create>`
+> block lists the test file BEFORE the implementation file, with
+> a note that the test file should be written and committed first
+> as a contract assertion. Subsequent commits implement the
+> contract.
+
+This is guidance, not enforcement. Apply selectively per the
+decision routine — single-file edits, internal helpers, and bug
+fixes don't qualify.
+
+### Item 4 — Regression-first for `fix:` commits
+
+Promote `regression-guard` from "use on bug fixes" (current
+status: optional concern in the palette) to "required for any
+commit whose subject line starts with `fix:`."
+
+Mechanism: extend the existing decision-routine concerns palette
+in `.claude/rules/attune/decision-routine.md` with the
+required-when condition. Optionally add a `commit-msg` git hook
+that warns (not blocks) when a `fix:` commit lands without a test
+file change in the same commit — but this is a stretch goal, not
+required for the spec.
+
+### Item 5 — Branch-enumeration in `<validation>` blocks
+
+Extend the XML-prompt template's `<validation>` block schema:
+
+```xml
+<validation>
+  <check>existing functional check</check>
+  <branches>
+    <branch>except OSError on iterdir — covered by test_X</branch>
+    <branch>data not a dict — covered by test_Y</branch>
+    <branch>empty input → empty return — covered by test_Z</branch>
+  </branches>
+</validation>
+```
+
+Force the agent to enumerate the new error branches per task with
+the test that exercises each. The cost is ~30 seconds per task;
+the benefit is the gap becomes visible at authoring time.
+
+---
+
+## Acceptance criteria
+
+1. **Coverage gate fires locally.** A staged commit with patch
+   coverage <90% blocks `git push`; the message names the modules
+   and line numbers that are missing. Override env var bypasses
+   cleanly.
+2. **Docs match enforcement.** `.claude/rules/attune/coding-
+   standards-index.md` and `CLAUDE.md` both quote the same number
+   codecov enforces. Demonstrate by adding a drift-guard test:
+   `tests/unit/docs/test_coverage_bar_alignment.py` parses the
+   codecov config + greps the docs and fails if they disagree.
+3. **Test-first guidance lands in `xml-enhanced-prompts.md`.** The
+   new section is present, references the decision routine, and
+   includes an example XML prompt where the test file precedes the
+   implementation file.
+4. **Regression-guard required for `fix:` commits.** Updated
+   concerns palette in decision-routine.md. The change is
+   documentation — no enforcement code required for v1 — but the
+   wording is clear enough that a reviewer can call out missing
+   regression tests in `fix:` PRs.
+5. **`<validation>` blocks gain a `<branches>` section.** Schema
+   updated, example XML prompts in `TASK_PROMPTS.md` retrofitted
+   to demonstrate. Drift-guard test asserts every task in the
+   existing spec library that's marked "in-flight" has a
+   `<branches>` section.
+6. **Self-application.** PR that lands this spec uses the new
+   controls on itself: branch-enumerated `<validation>` blocks for
+   each task, pre-push hook validates the push, regression test
+   verifies the alignment-drift-guard.
+
+---
+
+## Tasks (overview)
+
+Detail in [`tasks.md`](tasks.md). Phased:
+
+- **Phase 1** — Coverage gate hook + docs alignment (3h)
+- **Phase 2** — XML-prompt template extensions (1.5h)
+- **Phase 3** — Drift-guard tests + self-application (1h)
+
+Total: ~5.5h. Each phase ships independently.
+
+---
+
+## Open questions
+
+1. **Where does the threshold live as a single source of truth?**
+   Three candidates: (a) codecov.yml — already the load-bearing
+   gate; (b) `pyproject.toml [tool.coverage.report] fail_under` —
+   already in our tooling; (c) a new `.claude/coverage-bar.json`
+   that both the hook and docs read. Lean: (b), because it's
+   already on the box and tools respect it natively.
+2. **Hook installation: opt-in or default-on?** Lean opt-in via
+   the project's existing settings.json mechanism — forcing a hook
+   onto every contributor's machine is heavy-handed and breaks
+   non-developer worktrees (CI runners, ephemeral build agents).
+3. **What about `feat:` commits that ship without tests because
+   the feature is a refactor / dead-code-removal?** Lean: the
+   coverage gate's role is to ensure *new* code is covered.
+   Removing code can't fail the gate by definition. Refactors of
+   existing code that don't add new lines also can't fail (no
+   new patch to cover). The hook should be self-resolving for
+   these cases.

--- a/docs/specs/test-discipline-controls/tasks.md
+++ b/docs/specs/test-discipline-controls/tasks.md
@@ -1,0 +1,457 @@
+# Tasks: Test Discipline Controls
+
+> XML-enhanced execution prompts per
+> [`.claude/rules/attune/xml-enhanced-prompts.md`](../../../.claude/rules/attune/xml-enhanced-prompts.md).
+> Companion to [`requirements.md`](requirements.md) and
+> [`design.md`](design.md).
+
+**Status:** draft
+**Last updated:** 2026-05-27
+**Total estimate:** ~5.5h across 3 phases.
+
+---
+
+## Phase 1 — Coverage gate hook + docs alignment
+
+### Task 1.1 — Resolve threshold SOTH + read current codecov target
+
+```xml
+<task id="1.1" name="threshold-soth">
+  <objective>
+    Inspect the current codecov configuration and pick the
+    single-source-of-truth (SOTH) for the patch-coverage
+    threshold. Write the chosen value into pyproject.toml's
+    [tool.coverage.report] fail_under (per design.md leaning),
+    or document why a different location is better.
+  </objective>
+
+  <context>
+    <design-ref>design.md "Threshold: single source of truth"</design-ref>
+    <decision-ref>decisions.md D2 (pending — this task resolves it)</decision-ref>
+  </context>
+
+  <files-to-read>
+    <file path="codecov.yml">
+      Source of truth for what CI enforces today.
+    </file>
+    <file path="pyproject.toml">
+      Existing [tool.coverage.report] section if any.
+    </file>
+  </files-to-read>
+
+  <files-to-modify>
+    <file path="pyproject.toml">
+      <change location="[tool.coverage.report]">
+        Add or update fail_under to match codecov's patch-coverage
+        target. Add a one-line comment naming this as the SOTH.
+      </change>
+    </file>
+    <file path="docs/specs/test-discipline-controls/decisions.md">
+      <change location="D2 entry">
+        Resolve D2 with the chosen location + number + brief
+        rationale. Stamp the date.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>pyproject.toml's fail_under value matches codecov.yml's
+    patch-coverage target.</check>
+    <check>decisions.md D2 is no longer "PENDING".</check>
+    <branches>
+      <branches none-applicable="true" />
+      <!-- Pure configuration update; no production code branches. -->
+    </branches>
+  </validation>
+</task>
+```
+
+### Task 1.2 — Pre-push hook + helper scripts
+
+```xml
+<task id="1.2" name="pre-push-hook">
+  <objective>
+    Implement the pre-push coverage gate as a shell hook plus
+    three Python helpers. Hook refuses pushes whose patch
+    coverage falls below the SOTH threshold; PUSH_BYPASS_COVERAGE
+    _GATE=1 bypasses.
+  </objective>
+
+  <context>
+    <design-ref>design.md "Pre-push coverage gate"</design-ref>
+    <existing-pattern path="src/attune/hooks/scripts/">
+      Existing hook scripts (lessons_reminder, security_guard).
+      Match this directory's conventions: stdlib-only when
+      possible, shebang line, explicit `set -euo pipefail`.
+    </existing-pattern>
+  </context>
+
+  <files-to-create>
+    <file path="hooks/pre-push/coverage-gate.sh">
+      Bash hook per design.md. Identifies touched src/ files in
+      the push range, maps to test paths, invokes check_patch.py,
+      exits non-zero on failure. Honours PUSH_BYPASS_COVERAGE_GATE.
+    </file>
+    <file path="scripts/coverage_gate/__init__.py">
+      Empty marker so the gate scripts are an importable package
+      for unit testing.
+    </file>
+    <file path="scripts/coverage_gate/read_threshold.py">
+      Reads fail_under from pyproject.toml; prints integer; exits
+      non-zero if missing.
+    </file>
+    <file path="scripts/coverage_gate/test_paths_for.py">
+      Maps src/foo/bar.py to tests/unit/foo/test_bar.py with
+      fallback to tests/unit/foo/. Idempotent on already-test
+      paths. Handles deleted source files cleanly (drops them).
+    </file>
+    <file path="scripts/coverage_gate/check_patch.py">
+      Runs `coverage run -m pytest <tests>`, parses coverage's
+      JSON output, intersects with the touched-line set from
+      `git diff @{push}..HEAD --unified=0`, computes patch
+      coverage, exits non-zero if below threshold with the
+      actionable error message from design.md UX section.
+    </file>
+    <file path="tests/unit/coverage_gate/test_read_threshold.py">
+      Asserts read_threshold parses pyproject correctly; missing
+      [tool.coverage.report] returns non-zero with clear stderr.
+    </file>
+    <file path="tests/unit/coverage_gate/test_test_paths_for.py">
+      Round-trips: src/x/y.py → tests/unit/x/test_y.py; fallback
+      to dir when exact file missing; already-test paths pass
+      through; deleted-src files dropped.
+    </file>
+    <file path="tests/unit/coverage_gate/test_check_patch.py">
+      End-to-end against a fixture mini-repo: tmp_path with a
+      synthetic src + tests + git history; assert hook exits
+      0 when coverage ≥ threshold; non-zero when below; bypass
+      env var short-circuits.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>Hook refuses a push whose patch coverage is below
+    threshold (verified with fixture).</check>
+    <check>Hook passes when patch coverage meets threshold.</check>
+    <check>PUSH_BYPASS_COVERAGE_GATE=1 bypasses the check.</check>
+    <check>Hook is a no-op when no src/**/*.py files changed.</check>
+    <check>Error message names the missing line ranges with the
+    "actions:" footer from design.md UX section.</check>
+    <branches>
+      <branch test="test_check_patch_below_threshold_exits_non_zero">below-threshold path</branch>
+      <branch test="test_check_patch_above_threshold_exits_zero">happy path</branch>
+      <branch test="test_check_patch_bypass_env_short_circuits">bypass env var</branch>
+      <branch test="test_check_patch_no_src_changes_is_noop">no-touched-files path</branch>
+      <branch test="test_check_patch_missing_threshold_errors_clearly">missing SOTH config</branch>
+      <branch test="test_test_paths_for_falls_back_to_dir">missing test file fallback</branch>
+      <branch test="test_test_paths_for_drops_deleted_sources">deleted-src filter</branch>
+      <branch test="test_read_threshold_missing_section_exits_non_zero">missing pyproject section</branch>
+    </branches>
+  </validation>
+
+  <risks>
+    <risk severity="medium">
+      `git diff @{push}..HEAD` requires an upstream to exist; on
+      first push to a fresh branch, @{push} doesn't resolve.
+      Mitigation: fall back to `git diff origin/main..HEAD` when
+      @{push} is undefined; document in the hook header.
+    </risk>
+    <risk severity="low">
+      coverage's JSON output format may shift between minor
+      versions. Mitigation: pin coverage to >=7.x,&lt;8 in the
+      [dev] extra (or wherever its already pinned) and assert
+      the JSON shape in test_check_patch's fixtures.
+    </risk>
+  </risks>
+</task>
+```
+
+### Task 1.3 — Hook installation via setup machinery + docs alignment
+
+```xml
+<task id="1.3" name="hook-install-and-docs">
+  <objective>
+    Wire the hook into the project's setup-hooks mechanism
+    (opt-in per D3) and update the three doc files to quote the
+    SOTH threshold. Add the drift-guard tests.
+  </objective>
+
+  <context>
+    <decision-ref>decisions.md D3 (opt-in installation)</decision-ref>
+    <existing-code path="src/attune/hooks/">
+      Hook installer machinery — find the entry point that
+      copies hooks into .git/hooks/ and add coverage-gate to its
+      pre-push chain.
+    </existing-code>
+    <design-ref>design.md "Documentation alignment" + "Drift-guard tests"</design-ref>
+  </context>
+
+  <files-to-modify>
+    <file path="src/attune/hooks/installer.py">
+      <change location="pre-push hook chain (or equivalent)">
+        Register hooks/pre-push/coverage-gate.sh as part of the
+        pre-push chain. Idempotent install (don't double-add if
+        already wired).
+      </change>
+    </file>
+    <file path=".claude/rules/attune/coding-standards-index.md">
+      <change location="'Minimum 80% test coverage' line">
+        Replace with the SOTH-aligned wording. Reference the
+        pre-push hook and the bypass env var.
+      </change>
+    </file>
+    <file path="CLAUDE.md">
+      <change location="Critical Rules section">
+        Update coverage line to match SOTH; add one-line pointer
+        to `attune setup hooks` (or equivalent) for the gate.
+      </change>
+    </file>
+    <file path=".claude/python-standards.md">
+      <change location="Target 90%+ test coverage line">
+        Align to the SOTH; remove or update the "90%+" wording.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <files-to-create>
+    <file path="tests/unit/docs/test_coverage_bar_alignment.py">
+      Reads pyproject.toml fail_under; greps the three doc files;
+      asserts they all quote the same number. Fails CI on drift.
+    </file>
+    <file path="tests/unit/ci/test_codecov_alignment.py">
+      Reads codecov.yml + pyproject.toml; asserts the patch-
+      coverage target matches the SOTH. Skips cleanly if
+      codecov.yml is absent in the working tree.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>`attune setup hooks` (or equivalent) installs the hook
+    into .git/hooks/pre-push.</check>
+    <check>The three doc files quote the same threshold number
+    that pyproject.toml's fail_under specifies.</check>
+    <check>The drift-guard tests fail loudly if the doc strings
+    diverge from the SOTH.</check>
+    <branches>
+      <branch test="test_coverage_bar_alignment_passes_when_synced">in-sync passes</branch>
+      <branch test="test_coverage_bar_alignment_fails_on_doc_drift">doc drift detected</branch>
+      <branch test="test_codecov_alignment_skipped_without_yml">codecov.yml-absent skip</branch>
+      <branch test="test_codecov_alignment_fails_on_target_mismatch">codecov drift detected</branch>
+    </branches>
+  </validation>
+</task>
+```
+
+---
+
+## Phase 2 — XML-prompt template extensions
+
+### Task 2.1 — `<branches>` schema + test-first section
+
+```xml
+<task id="2.1" name="xml-prompt-extensions">
+  <objective>
+    Extend the XML-prompt rule file with the new test-first
+    guidance (Item 3) and the <branches> sub-element of
+    <validation> (Item 5). Provide a worked example.
+  </objective>
+
+  <context>
+    <design-ref>design.md "Test-first guidance" + "Branch-enumeration in <validation>"</design-ref>
+    <existing-code path=".claude/rules/attune/xml-enhanced-prompts.md">
+      Current template — extend, don't rewrite.
+    </existing-code>
+  </context>
+
+  <files-to-modify>
+    <file path=".claude/rules/attune/xml-enhanced-prompts.md">
+      <change location="end of file or new ## section">
+        Add the Test-first section per design.md. Add the
+        <branches> schema description. Update the "Quick Example"
+        block to demonstrate both (the security-guard-hook example
+        gains a <branches> section).
+      </change>
+    </file>
+    <file path="docs/guides/xml-enhanced-prompts.md">
+      <change location="schema reference">
+        Mirror the rule-file changes — the docs guide stays in
+        lockstep with the rule file.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>The rule file has a "Test-first" section with the
+    selective-application bullets from design.md.</check>
+    <check>The rule file's <validation> schema includes
+    <branches>.</check>
+    <check>The quick example XML in both files now includes a
+    <branches> sub-element.</check>
+    <branches>
+      <branches none-applicable="true" />
+      <!-- Documentation update — no production-code branches. -->
+    </branches>
+  </validation>
+</task>
+```
+
+### Task 2.2 — Decision-routine concerns palette: regression-guard required for `fix:`
+
+```xml
+<task id="2.2" name="regression-guard-required">
+  <objective>
+    Promote regression-guard from "use on bug fixes" to "required
+    for any commit whose subject starts with fix:" in the
+    concerns palette.
+  </objective>
+
+  <context>
+    <design-ref>design.md "Regression-first for `fix:` commits"</design-ref>
+    <existing-code path=".claude/rules/attune/decision-routine.md">
+      Current concerns palette table. Update the regression-guard
+      row's "When to include" cell.
+    </existing-code>
+  </context>
+
+  <files-to-modify>
+    <file path=".claude/rules/attune/decision-routine.md">
+      <change location="concerns palette table, regression-guard row">
+        Change the "When to include" cell to the wording in
+        design.md "Regression-first for fix: commits". Keep the
+        other rows untouched.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <validation>
+    <check>The regression-guard row's text reads "Required for
+    any commit whose subject starts with `fix:`..."</check>
+    <check>No other palette rows changed (verified by diff).</check>
+    <branches>
+      <branches none-applicable="true" />
+    </branches>
+  </validation>
+</task>
+```
+
+---
+
+## Phase 3 — Drift-guard + self-application
+
+### Task 3.1 — XML branches drift-guard test
+
+```xml
+<task id="3.1" name="xml-branches-drift-guard">
+  <objective>
+    Add the third drift-guard test that asserts every in-flight
+    spec's tasks.md XML prompts include a <branches> section
+    when they touch .py files.
+  </objective>
+
+  <context>
+    <design-ref>design.md "Drift-guard tests" item 3</design-ref>
+  </context>
+
+  <files-to-create>
+    <file path="tests/unit/docs/test_xml_validation_branches.py">
+      Walks docs/specs/**/tasks.md AND docs/implementation/
+      TASK_PROMPTS.md. For each <task> block: parse via stdlib
+      ElementTree (XML-fragment-extraction from markdown);
+      check if any <files-to-modify> or <files-to-create> path
+      ends in .py; if so, assert <validation> contains either
+      <branches> with at least one <branch>, or
+      <branches none-applicable="true"/>.
+      Skip task blocks in specs whose status is "retired",
+      "paused", "done", or "complete".
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>Test passes against the current repo (all in-flight
+    tasks already comply OR are exempt).</check>
+    <check>Test fails if a new XML prompt touches a .py file
+    without a <branches> section.</check>
+    <check>Test skips correctly when a spec is marked
+    retired/paused/done/complete.</check>
+    <branches>
+      <branch test="test_in_flight_spec_with_py_files_must_have_branches">required-section enforcement</branch>
+      <branch test="test_branches_none_applicable_marker_is_accepted">explicit-opt-out path</branch>
+      <branch test="test_retired_spec_is_skipped">status-skip path</branch>
+      <branch test="test_doc_only_task_doesnt_require_branches">no-py-files path</branch>
+    </branches>
+  </validation>
+</task>
+```
+
+### Task 3.2 — Self-application: backfill `<branches>` on this spec's own tasks
+
+```xml
+<task id="3.2" name="self-apply-branches">
+  <objective>
+    Verify this spec's own tasks (above) include <branches>
+    sections that satisfy the drift-guard from Task 3.1.
+    Verify the pre-push hook can run against this PR's diff.
+  </objective>
+
+  <context>
+    <note>
+      This is a verification pass, not new code. The XML prompts
+      in this tasks.md should already include the <branches>
+      sections — Task 3.1's test ensures they do.
+    </note>
+  </context>
+
+  <validation>
+    <check>tests/unit/docs/test_xml_validation_branches.py passes
+    against this spec.</check>
+    <check>The full pytest suite passes locally.</check>
+    <check>The pre-push hook runs against this PR's diff without
+    firing (because this PR doesn't touch src/**/*.py beyond
+    scripts/coverage_gate/, which is covered by Phase 1's own
+    test suite).</check>
+    <branches>
+      <branches none-applicable="true" />
+      <!-- Self-verification only; no new code. -->
+    </branches>
+  </validation>
+</task>
+```
+
+---
+
+## Dependencies
+
+```text
+Task 1.1 (threshold SOTH) ─┐
+                            ├── Task 1.2 (hook + helpers)
+                            │
+                            └── Task 1.3 (install + docs align + drift-guards)
+                                  │
+Task 2.1 (XML schema) ──────┐    │
+                            │    │
+Task 2.2 (regression-guard) ┤    │
+                            │    │
+                            ├──── Task 3.1 (xml branches drift-guard)
+                            │            │
+                            │            └── Task 3.2 (self-apply)
+```
+
+Phase 1 must complete before Phase 3 (the drift-guard needs the
+SOTH wired). Phase 2 is independent of Phase 1 and can run in
+parallel. Phase 3 depends on both 1 and 2.
+
+---
+
+## Out of scope (deferred)
+
+- **Automated retrofit** of existing in-flight specs' tasks.md
+  files to add `<branches>` sections. The drift-guard in Task 3.1
+  fails on new specs only — existing specs are grandfathered via
+  the `none-applicable` marker as they ship.
+- **`commit-msg` git hook** that warns on `fix:` commits without
+  a test file change. Stretch goal; not in this spec.
+- **mypy / type-coverage gates.** Separate concern; mypy was
+  removed from pre-commit per CLAUDE.md. Out of scope here.
+- **Per-module coverage targets** (e.g. higher for security code).
+  The single threshold simplifies the SOTH story; per-module
+  tuning is a follow-up if the data shows it's needed.


### PR DESCRIPTION
## Summary

- Draft of [`docs/specs/test-discipline-controls`](https://github.com/Smart-AI-Memory/attune-ai/tree/spec/test-discipline-controls/docs/specs/test-discipline-controls) — four mechanical controls that close the test-coverage discipline gap surfaced by PR #485.
- Built in response to: PR #485 shipping at 89% coverage when codecov's actual gate is ~90% patch coverage; CLAUDE.md says "Minimum 80%" but enforcement is tighter, so agents reading the docs target a number CI rejects.
- TDD was considered and rejected — see [`decisions.md` D1](https://github.com/Smart-AI-Memory/attune-ai/blob/spec/test-discipline-controls/docs/specs/test-discipline-controls/decisions.md). AI agents tend to fake the red phase, spec-driven dev already covers the design layer, and the cost is 2-3× more LLM turns per task. The four mechanical controls address the same failure mode at lower cost.

## Status

**Draft — awaiting approval before implementation.** This PR ships only the spec docs (1094 lines of requirements/design/decisions/tasks). No production code changes.

## The four controls

1. **Pre-push coverage gate hook** — opt-in `pre-push` hook that runs `coverage run -m pytest <touched-tests>` against the push range and refuses if patch coverage <90%. `PUSH_BYPASS_COVERAGE_GATE=1` for emergencies.
2. **Documentation/enforcement alignment** — single source of truth for the threshold (likely `pyproject.toml [tool.coverage.report] fail_under`). CLAUDE.md, coding-standards-index, python-standards all quote the same number. Drift-guard tests fail CI if any diverge.
3. **Selective test-first for new-API modules** — when a task creates a new module with a public API, list the test file before the implementation in `<files-to-create>`. Captures TDD's design pressure at the right scope without imposing red-green on every task.
4. **Regression-first required for `fix:` commits** — promote `regression-guard` from optional to required for any commit whose subject starts with `fix:`. Plus a `<branches>` sub-element on XML `<validation>` blocks: every error branch added by a task names the test that exercises it.

## Phases

- **Phase 1** — Coverage gate hook + docs alignment + drift-guards (3h)
- **Phase 2** — XML prompt template extensions (1.5h)
- **Phase 3** — Drift-guard for XML `<branches>` sections + self-application (1h)

Total ~5.5h. Each phase ships independently.

## Open questions for review

- **D2 (threshold SOTH location)** — currently pending; resolved during Phase 1 inspection of codecov's config. Leading candidate: `pyproject.toml [tool.coverage.report] fail_under`.
- **Should the `commit-msg` git hook that warns on `fix:`-without-test be in v1?** Currently a stretch goal; the documentation in `decision-routine.md` is the primary mechanism. Easy to add later.
- **Are there cases where strict TDD is the right call?** Captured in D1 — re-open the question if patch coverage stays <90% three months after this spec lands.

## Test plan

- [ ] Read `requirements.md`, `design.md`, `decisions.md`, `tasks.md` end-to-end
- [ ] Confirm D1 rationale lands the right way (TDD-rejection)
- [ ] Confirm the four controls map cleanly onto the PR-#485 failure mode
- [ ] Approve / request changes — once approved, execute Phase 1 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
