### PR TITLE
docs: recover uncommitted snapshot from 2026-05-26 evening session

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6076,3 +6076,119 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   CheckRun + StatusContext + RequiredStatusCheck records,
   not all of which carry the same fields. Same fix shape
   for `.workflowName`, `.detailsUrl`, etc.
+
+- **Required `security` check fires CANCELLED on every non-
+  dependabot PR — the guard-skip pattern collides with
+  branch protection**: the `Security Scan` workflow's
+  `security` job uses a job-level conditional that
+  cancels-on-skip when not running against a dependabot
+  PR. The cancelled status surfaces as a failed required
+  check in branch protection, blocking merge on EVERY
+  regular PR until manually rerun. Hit on three separate
+  PRs in one session (#477, #478, #480) — same fingerprint
+  each time. **Workaround that works:**
+  ```
+  URL=$(gh pr view <N> --json statusCheckRollup --jq \
+    '.statusCheckRollup[] | select(.name == "security") | .detailsUrl')
+  RUN=$(echo "$URL" | grep -oE 'runs/[0-9]+' | grep -oE '[0-9]+')
+  JOB=$(echo "$URL" | grep -oE 'job/[0-9]+' | grep -oE '[0-9]+')
+  gh run rerun "$RUN" --job "$JOB"
+  ```
+  Rerun typically lands SUCCESS — the second invocation
+  enters the dependabot-or-rerun branch and runs the real
+  scan. The proper fix is workflow- or branch-protection-
+  level: either remove `security` from
+  `required_status_checks` (it's also in the merged
+  rollup of `Run Security Scanner` which already runs),
+  or rewrite the workflow to emit SUCCESS instead of
+  CANCELLED for non-dependabot PRs. Until that's done,
+  budget ~30s per PR to rerun the security job. Pairs
+  with the existing "GitHub branch protection and
+  admin-merge — four interlocking constraints" lesson —
+  same root cause family (required-check semantics) but
+  a different specific failure (cancellation vs missing).
+
+- **xdist worker pollution from a stale module-level
+  patch recurs in the SAME test file when new test files
+  shift worker distribution — and the fix is to mirror the
+  existing xfail, NOT re-investigate**: PR #421
+  (2026-05-16) xfail'd `test_redis_fallback.py::Test
+  MetricsTracking::test_tracks_retries_in_metrics` for
+  xdist-induced retry-loop bypass. The session that
+  shipped multi-actor-bulletin Phase 1 (2026-05-26)
+  added new bulletin test files which shifted xdist
+  worker distribution, surfacing a SECOND test in the
+  same file
+  (`TestErrorHandlingEdgeCases::test_handles_max_clients
+  _exceeded`) with the identical "DID NOT RAISE
+  ConnectionError" symptom on 6 lanes (3 Ubuntu + 3
+  Windows). Resolution shipped in #481 was to mirror the
+  PR #421 xfail with identical rationale, NOT to dive
+  into the polluter — that would be hours of bisection
+  against a non-locally-reproducing failure. Generalized
+  recognition pattern: if a previously-green test file
+  has an existing xfail comment naming xdist pollution
+  AND a sibling test starts failing across multiple
+  lanes with the same symptom, the fix is to apply the
+  same xfail. Three tests sharing the xfail is the
+  signal to actually invest in root-causing the polluter.
+  Pairs with the existing "Matrix-wide red on a feature
+  PR is usually one root-cause test" lesson — that one
+  is about diagnosis discipline (verify all lanes fail
+  on the SAME test before treating as N bugs); this one
+  is about the resolution pattern once that diagnosis
+  points at a specific known-flaky file.
+
+- **When a single page serves both users and maintainers, lead
+  user-first and tuck maintainer affordances behind a clearly
+  labeled access point**: hit on the ops dashboard's `/help`
+  page design (2026-05-26). My first mockup led with the
+  maintainer surface — stat strip with "X stale · Y incomplete,"
+  coverage gaps preview, "Recently regenerated" — because those
+  signals were what I'd built first and felt obvious to display.
+  Patrick called it: *"this is good for developing a help system
+  but not for learning from it as an end user. It's an audience
+  thing."* The two audiences want different first impressions:
+  - **User:** "How do I do X?" / "I'm stuck" / "What does Y
+    mean?" — wants search prominent, intent-based browsing,
+    featured topics, clear entry points.
+  - **Maintainer:** "Is the corpus healthy?" — wants stale chips,
+    completeness bars, gap inventory, regen instructions.
+  Concrete v1 rule that emerged: default to user-first; the
+  maintainer view stays on the same page but moves behind a
+  prominent-but-not-primary button ("Admin tools" with health
+  chip showing the live N stale · M incomplete inline). Same
+  surface, different audiences flow naturally between modes.
+  Generalizes beyond /help — any dashboard page that does
+  double duty (user-facing + admin/maintenance) hits this
+  framing question. The maintainer's needs ARE legitimate,
+  just not primary.
+
+- **`attune-rag.DirectoryCorpus` accepts `extra_summaries={path:
+  text}` to inject per-template summaries inline — the workaround
+  to the empty-summary issue from CLAUDE.md**: extends the
+  existing "Metadata can reach a retriever with zero signal if
+  the sidecar schema doesn't match the loader's expected shape"
+  lesson with the concrete fix. When you control the corpus on
+  disk but can't install `attune-help` (and thus can't use
+  `AttuneHelpCorpus.from_attune_help()`), build a summaries
+  dict inline:
+  ```python
+  summaries = {}
+  for md in root.rglob("*.md"):
+      rel = str(md.relative_to(root))
+      body = strip_frontmatter(md.read_text())
+      first_para = first_non_heading_paragraph(body, max_chars=400)
+      if first_para:
+          summaries[rel] = first_para
+  corpus = DirectoryCorpus(root, extra_summaries=summaries)
+  ```
+  Without this, `KeywordRetriever.retrieve()` returns zero hits
+  against the .help/templates/ corpus (every entry has
+  `summary=None` so the 1.5× SUMMARY_WEIGHT applies to zero
+  data — the same fingerprint the original lesson named). The
+  inline-summary approach takes ~10 ms per template and works
+  cross-package without depending on `attune-help` being
+  installed in the venv. Practical for any dashboard /
+  consumer that wants attune-rag search over an on-disk corpus
+  without the full attune-help package dependency.

--- a/docs/architecture/hooks.md
+++ b/docs/architecture/hooks.md
@@ -1,0 +1,78 @@
+---
+type: architecture
+name: hooks
+tags: [hooks, events, automation, webhooks]
+source: hooks
+---
+
+# Hooks architecture
+
+## Purpose
+
+The hooks subsystem intercepts Claude Code lifecycle events and dispatches configured actions — shell commands, webhooks, or Python callables — in response. It owns event matching, prioritized rule evaluation, execution (async and sync), and the execution log. It does **not** own the lifecycle events themselves (those come from the Claude Code host), nor does it own the business logic inside hook scripts; that lives in `scripts/`.
+
+## Key classes
+
+| Class | Responsibility | File |
+|---|---|---|
+| `HookEvent` | Enum of lifecycle event types that map to Claude Code hook points. | `hooks/config.py` |
+| `HookType` | Enum of the action kinds a hook can perform (shell, webhook, Python callable, etc.). | `hooks/config.py` |
+| `HookDefinition` | Declares a single hook action: its type, target, and parameters. | `hooks/config.py` |
+| `HookMatcher` | Evaluates a context dict against a predicate to decide whether a rule applies. | `hooks/config.py` |
+| `HookRule` | Pairs a `HookMatcher` with one or more `HookDefinition`s and a priority. | `hooks/config.py` |
+| `HookConfig` | Holds the full set of `HookRule`s for a session; loads from and serializes to YAML. | `hooks/config.py` |
+| `HookExecutor` | Runs a `HookDefinition` against a context dict and returns a result dict; async-native. | `hooks/executor.py` |
+| `HookExecutorSync` | Synchronous wrapper around `HookExecutor` for call sites that cannot use `await`. | `hooks/executor.py` |
+| `HookRegistry` | Owns registration, matching, dispatch, and the execution log; the single entry point for callers. | `hooks/registry.py` |
+
+> **Design note:** `HookConfig` does three distinct things — acts as a data container, handles YAML serialization via `from_yaml`/`to_yaml`, and implements event-indexed lookup via `get_hooks_for_event`. If this class grows, splitting serialization into its own layer is the natural seam.
+
+## Data flow
+
+Hook firing follows this path through the subsystem:
+
+```
+Caller
+  │
+  ▼
+HookRegistry.fire(event, context)
+  │
+  ├─► HookConfig.get_hooks_for_event(event)
+  │       └─► returns list[HookRule] ordered by priority
+  │
+  ├─► HookMatcher.matches(context)   ← per rule; non-matching rules are dropped
+  │
+  ├─► HookExecutor.execute(hook, context)   ← per matched HookDefinition
+  │       └─► returns dict[str, Any] result
+  │
+  ├─► execution log (internal)
+  │
+  └─► returns list[dict[str, Any]]   ← one entry per executed hook
+
+Synchronous callers use HookRegistry.fire_sync(), which
+delegates to HookExecutorSync rather than HookExecutor.
+```
+
+YAML configuration enters through `HookConfig.from_yaml()` and reaches `HookRegistry` via `HookRegistry.load_config()`. Programmatic registration bypasses YAML entirely through `HookRegistry.register()`.
+
+## Design decisions
+
+**Async executor with a synchronous wrapper, not two separate implementations.**
+`HookExecutorSync` wraps `HookExecutor` rather than reimplementing execution. This keeps execution logic in one place while letting synchronous call sites (scripts that cannot use `async/await`) still dispatch hooks. The trade-off is a thin extra layer; the benefit is that bug fixes in `HookExecutor` apply to both paths automatically.
+
+**Priority and matching are resolved in `HookRegistry`, not in `HookConfig`.**
+`HookConfig.get_hooks_for_event` returns all rules for an event without filtering by context. `HookRegistry.get_matching_hooks` then applies `HookMatcher.matches` and priority ordering. This keeps `HookConfig` a pure data holder and concentrates dispatch policy in `HookRegistry`, where it can be tested independently of YAML loading.
+
+**`HookRegistry.register()` returns a `handler_id` string.**
+Programmatically registered handlers get an opaque ID that callers pass back to `unregister()`. This avoids requiring callers to hold a reference to the original callable just to remove it, which matters when lambdas or partials are registered.
+
+## Extension points
+
+- **Add a new event type:** Add a member to `HookEvent` in `hooks/config.py`. `HookConfig.get_hooks_for_event` and `HookRegistry.fire` both key off `HookEvent` values, so the new event is immediately dispatchable.
+- **Add a new action type:** Add a member to `HookType` and handle it in `HookExecutor.execute`. No changes to `HookRegistry` or `HookConfig` are required.
+- **Register a Python callable at runtime:** Call `HookRegistry.register(event, handler, description, matcher, priority)`. It returns a `handler_id` you can pass to `HookRegistry.unregister()` to remove it later.
+- **Load hook rules from YAML:** Call `HookConfig.from_yaml(yaml_path)` to build a config object, then pass it to `HookRegistry.load_config(config)` or the `HookRegistry.__init__` constructor.
+- **Add a custom matching predicate:** Subclass `HookMatcher` and override `matches(self, context: dict[str, Any]) -> bool`. Pass an instance to `HookConfig.add_hook` or `HookRegistry.register` via the `matcher` parameter.
+- **Inspect execution history:** Call `HookRegistry.get_execution_log(limit, event_filter)` to retrieve past results, or `HookRegistry.get_stats()` for aggregate counts. Use `HookRegistry.clear_execution_log()` to reset between test runs.
+
+For usage details, see the hooks reference documentation.

--- a/docs/architecture/resilience.md
+++ b/docs/architecture/resilience.md
@@ -1,0 +1,92 @@
+---
+type: architecture
+name: resilience
+tags: [resilience, fault-tolerance, circuit-breaker, retry, timeout, fallback, health-check]
+source: resilience
+---
+
+# Resilience architecture
+
+Fault-tolerance primitives — circuit breakers, retries, timeouts, fallbacks, and health checks.
+
+## Purpose
+
+The `resilience` module provides decorators and runtime classes that protect call sites from cascading failures: it handles transient errors through retry with exponential backoff, stops calling a dependency that is already failing through circuit breaking, bounds execution time via timeouts, and degrades gracefully through ordered fallback chains. It also exposes a health-check registry so external monitors can observe the state of registered components.
+
+The module is **not** responsible for service discovery, connection pooling, load balancing, or any network transport. It wraps callables that already exist; it does not produce them.
+
+## Key classes
+
+| Class | Responsibility | File |
+|---|---|---|
+| `CircuitBreaker` | Tracks per-dependency failure counts and open/half-open/closed state transitions; raises `CircuitOpenError` when calls should be blocked | `resilience/circuit_breaker.py` |
+| `CircuitState` | Enum of the three states a `CircuitBreaker` can occupy | `resilience/circuit_breaker.py` |
+| `CircuitOpenError` | Raised on blocked calls; carries `name` and `reset_time` so callers can log or surface a useful message | `resilience/circuit_breaker.py` |
+| `RetryConfig` | Holds backoff parameters (`backoff_factor`, `initial_delay`, `max_delay`, `jitter`) and computes per-attempt delay via `get_delay(attempt)` | `resilience/retry.py` |
+| `Fallback` | Ordered list of callables tried in sequence; `execute()` walks `functions` and returns the first success, then `default_value` | `resilience/fallback.py` |
+| `HealthCheck` | Registry of named check functions; `run_all()` / `run_all_sync()` execute every registered check and aggregate results into a `SystemHealth` | `resilience/health.py` |
+| `HealthCheckResult` | Captures the outcome of one check: `status`, `latency_ms`, `message`, and freeform `details` | `resilience/health.py` |
+| `SystemHealth` | Aggregated snapshot of all checks; `to_dict()` serialises it for HTTP health endpoints | `resilience/health.py` |
+| `HealthStatus` | Enum of health severity levels used by both `HealthCheckResult` and `SystemHealth` | `resilience/health.py` |
+| `TimeoutError` | Raised by `timeout` / `with_timeout` when the deadline is exceeded; carries `operation` and `timeout` for structured error messages | `resilience/timeout.py` |
+
+## Data flow
+
+An inbound call passes through whichever guards are applied as decorators. The typical composition from outermost to innermost is:
+
+```
+Caller
+  │
+  ▼
+[timeout decorator]  ──── deadline exceeded ──► TimeoutError
+  │                                              (or fallback value)
+  ▼
+[circuit_breaker decorator]
+  │  CircuitBreaker.is_open?
+  ├── YES ──────────────────────────────────────► CircuitOpenError
+  │                                              (or decorator fallback)
+  │  NO (CLOSED or HALF_OPEN)
+  ▼
+[retry decorator]
+  │  attempt loop (up to RetryConfig.max_attempts)
+  │    RetryConfig.get_delay(attempt) ──► sleep
+  ├── all attempts failed ────────────────────► re-raise last exception
+  │
+  ▼
+[fallback decorator / Fallback.execute()]
+  │  walk Fallback.functions in order
+  ├── first success ────────────────────────────► return result
+  ├── all fail + default_value set ─────────────► return default_value
+  └── all fail, no default ────────────────────► RuntimeError
+                                                 'All fallbacks failed for {…}'
+
+Side channel (independent of call path):
+  HealthCheck.register(name) ──► registers a check function
+  HealthCheck.run_all() ───────► [HealthCheckResult, …] ──► SystemHealth
+                                  (aggregated status + to_dict() for
+                                   HTTP /health endpoints)
+```
+
+`CircuitBreaker.record_success()` and `record_failure()` are called by the `circuit_breaker` decorator after each attempt to drive state transitions. `get_circuit_breaker(name)` retrieves any named breaker from the global registry, which is how the health-check layer can report circuit state without a direct import dependency on the protected function.
+
+## Design decisions
+
+**Four independent modules, one public surface.** Retry, circuit breaking, timeout, and fallback are each implemented in their own module and composed at the decorator level rather than baked into a single `Resilience` class. This means you can apply `@retry` without `@circuit_breaker`, or combine them in any order. The trade-off is that interaction effects between decorators (for example, whether a retry attempt resets the circuit-breaker's half-open call budget) are the caller's responsibility to reason about.
+
+**`RetryConfig` as a first-class dataclass.** Retry parameters are extracted into `RetryConfig` rather than kept as closed-over locals in the decorator. This was a deliberate choice to support `retry_with_backoff(func, *args, config=my_config)`, which lets non-decorator call sites (tests, scripts) reuse the same backoff logic without applying a decorator.
+
+**Global registries for `CircuitBreaker` and `HealthCheck`.** `get_circuit_breaker(name)` and `get_health_check()` return shared instances. This lets observability code (dashboards, `/health` handlers) inspect live breaker state without holding a reference to the original decorated function. The cost is that tests must reset global state explicitly between runs.
+
+**`excluded_exceptions` on `CircuitBreaker`.** Failures that match `excluded_exceptions` do not increment the failure counter. This reflects the design intent that some exceptions (e.g., `ValueError` from bad input) should not count against a dependency's health — only infrastructure-level errors should trip the breaker.
+
+## Extension points
+
+- **Add a new health check**: call `HealthCheck.register(name, timeout, critical)` as a decorator on any async or sync function. The registered function must return a value that `HealthCheckResult` can wrap. Use `get_health_check()` to obtain the singleton instance, or pass a `HealthCheck` instance to `register_default_checks(health)` to populate standard Attune checks.
+
+- **Customise retry behaviour**: construct a `RetryConfig` with your own `backoff_factor`, `initial_delay`, `max_delay`, and `retryable_exceptions`, then pass it to `retry_with_backoff(func, *args, config=my_config)`. The `get_delay(attempt)` method on `RetryConfig` is the single calculation point — override it in a subclass to implement a non-exponential schedule.
+
+- **Add a fallback chain programmatically**: instantiate `Fallback(name="…")`, call `.add(func)` for each candidate in priority order, then call `.execute(*args, **kwargs)`. This is equivalent to the `@fallback` decorator but lets you build the chain at runtime rather than at import time.
+
+- **Inspect or reset a circuit breaker by name**: use `get_circuit_breaker(name)` to retrieve a live `CircuitBreaker`, then call `get_stats()` to read counters or `reset()` to force it back to CLOSED — useful in integration tests or admin endpoints.
+
+For usage examples, see the `resilience` reference documentation.

--- a/docs/specs/bulletin-curator/design.md
+++ b/docs/specs/bulletin-curator/design.md
@@ -4,8 +4,7 @@
 > module layout, source-reader signatures, agent system prompt,
 > output schema, cache mechanics, dashboard surface, and error
 > model.
-
-**Status:** draft
+**Status:** approved
 **Last updated:** 2026-05-26
 
 ---

--- a/docs/specs/bulletin-curator/tasks.md
+++ b/docs/specs/bulletin-curator/tasks.md
@@ -4,8 +4,7 @@
 > [`.claude/rules/attune/xml-enhanced-prompts.md`](../../../.claude/rules/attune/xml-enhanced-prompts.md).
 > Companion to [`requirements.md`](requirements.md) and
 > [`design.md`](design.md).
-
-**Status:** draft
+**Status:** approved
 **Last updated:** 2026-05-26
 **Total estimate:** ~10h across 4 phases. Each phase ships
 independently; CLI/dashboard surfaces (Phase 3) can ship after

--- a/docs/specs/dashboard-pending-writes-journal/design.md
+++ b/docs/specs/dashboard-pending-writes-journal/design.md
@@ -1,7 +1,5 @@
 # Design: Dashboard Pending-Writes Journal
-
-**Status:** draft (2026-05-25)
-
+**Status:** approved (2026-05-25)
 **Phase 1 scope:** journal writer + API endpoint. UI chip
 (Phase 2) and session-start hook (Phase 3) are sketched at
 the bottom for design coherence, not for this session's

--- a/docs/specs/dashboard-pending-writes-journal/requirements.md
+++ b/docs/specs/dashboard-pending-writes-journal/requirements.md
@@ -8,9 +8,7 @@
 ---
 
 ## Phase 1: Requirements
-
-**Status:** draft (2026-05-25)
-
+**Status:** approved (2026-05-25)
 ### Problem statement
 
 The ops dashboard mutates the working tree live — primarily


### PR DESCRIPTION
## Summary

Recovers work that was left uncommitted in the `vigorous-pike-a1325f` worktree at 22:25 on 2026-05-26 — the exact "silent pending writes" pattern that the `dashboard-pending-writes-journal` spec exists to address (and which this PR also marks approved).

The dirty state spanned 43 files; cruft (`coverage_output.txt`, `memdocs_storage/test_key.json`) was dropped, the auto-regenerated `.help/templates/` content was dropped (pre-commit's regen hook will refresh them from current source on the next sweep), and the new `.help/templates/{hooks,resilience}/` template sets were deferred pending a `features.yaml` registration step.

What's left here is the human-authored content, split into three commits for clean review.

## Commits

1. `docs(architecture): add hooks + resilience reference docs` — 2 new architectural reference docs (`docs/architecture/hooks.md`, `docs/architecture/resilience.md`).
2. `docs(specs): mark bulletin-curator + dashboard-pending-writes-journal approved` — 4 spec files flipped from `draft` to `approved`. These were dashboard UI status writes that never committed.
3. `docs(claude): 4 new lessons from 2026-05-26 sessions` — 116 lines appended to `.claude/CLAUDE.md`. All four lessons are net-new (verified via grep against current `origin/main`). Merge against main was clean once treated as a pure tail-append.

## Recovery method

The dirty state was captured to a tar archive before switching branches, then unpacked on a new branch off `origin/main`. The `CLAUDE.md` divergence (origin/main had grown 160 lines since the PR base) was handled by extracting yesterday's 116-line append and concatenating it to main's tail. The other 23 modified-tracked files were byte-identical between the PR base and `origin/main`, so no merge needed.

## What was deferred

- The auto-regenerated `.help/templates/` content for existing features (help-system, ops-dashboard, plugin, spec-engine) — pre-commit will re-regenerate from current source.
- The new `.help/templates/{hooks,resilience}/` template sets — these need `features.yaml` entries first; better re-generated fresh via `attune-author` once registered.

## Test plan

- [ ] CI passes (docs-only; no functional changes)
- [ ] `mkdocs build --strict` works against the two new architecture docs (they'll need a nav entry in `mkdocs.yml` to be discoverable on the site; CI build is just structural)
- [ ] No regression on existing CLAUDE.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)