### PR TITLE
docs: persist 2026-05-26 dashboard state + Pandoc print lesson

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6076,7 +6076,6 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   CheckRun + StatusContext + RequiredStatusCheck records,
   not all of which carry the same fields. Same fix shape
   for `.workflowName`, `.detailsUrl`, etc.
-
 - **Required `security` check fires CANCELLED on every non-
   dependabot PR — the guard-skip pattern collides with
   branch protection**: the `Security Scan` workflow's
@@ -6192,3 +6191,63 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   installed in the venv. Practical for any dashboard /
   consumer that wants attune-rag search over an on-disk corpus
   without the full attune-help package dependency.
+
+- **Pandoc + weasyprint print artifacts need BOTH `@page` rules
+  AND `@media screen` rules — print-only CSS makes the HTML look
+  broken on a monitor**: `@page` rules (margins, headers,
+  footers, named-string section markers) ONLY fire during print
+  preview / PDF generation. They do NOT apply when the same HTML
+  is viewed in a browser. If the CSS only sets `@page` margins
+  and assumes body fills the printable area, the browser view
+  will sprawl full-width across whatever monitor it lands on
+  with zero centering or padding — looks unfinished even when
+  the PDF output is fine. Fix shape:
+  ```css
+  @media screen {
+    html { background: #ececec; font-size: 13pt; }
+    body {
+      max-width: 44em;
+      margin: 0 auto;
+      padding: 4em 3.5em 5em 3.5em;
+      background: #fdfcf8;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+    }
+    h2 { page-break-before: auto; }   /* suppress for screen */
+    #TOC { margin: 2em 0 3em 0; padding: 1.5em 0;
+           border-top: 1px solid #ddd;
+           border-bottom: 1px solid #ddd; }
+  }
+  @media (max-width: 600px) {
+    body { padding: 2em 1.2em 3em 1.2em; box-shadow: none; }
+  }
+  ```
+  Discovered building the `COLLABORATION_DISCIPLINE` article PDF
+  on 2026-05-25 — the v1 PDF looked fine, but the HTML opened in
+  Safari sprawled full-width with no margins. Pattern generalizes
+  to any print-styled HTML/PDF artifact: always test both
+  print-preview AND on-screen rendering before declaring done,
+  and budget for both `@page` and `@media screen` blocks from
+  the start.
+
+- **Pandoc `--from gfm` does NOT enable fenced divs (`:::`); use
+  `--from markdown+fenced_divs+autolink_bare_uris`**: building a
+  print artifact from a markdown source that uses pandoc's
+  fenced-div extension (`::: callout ... :::` →
+  `<div class="callout">`) silently fails under `--from gfm`. The
+  `:::` markers pass through as literal text and the HTML/PDF
+  renders them as visible characters at the top of each block.
+  The `gfm` input format is GitHub-Flavored Markdown which
+  doesn't recognize fenced divs. Two fixes: (1) use
+  `--from markdown+fenced_divs+autolink_bare_uris` (pandoc's
+  extended markdown enables fenced_divs by default; the
+  `autolink_bare_uris` extension preserves bare URL clickability),
+  or (2) maintain two parallel source files — a clean canonical
+  `.md` for GitHub rendering, and a `_print.md` companion with
+  the fenced divs for the pandoc → PDF pipeline. The fenced div
+  syntax doesn't render at all in GitHub's viewer (the `:::`
+  text appears literally), which is a worse failure mode than
+  the source files being slightly out of sync — so for any
+  document that lives both on GitHub and as a styled PDF, option
+  (2) is cleaner: canonical .md stays GitHub-friendly with plain
+  blockquotes instead of fenced divs, print .md adds the
+  div-wrapped markup for the pandoc step.

--- a/docs/specs/discovery-sweep-ops-integration/design.md
+++ b/docs/specs/discovery-sweep-ops-integration/design.md
@@ -1,6 +1,5 @@
 # Design — Discovery-Sweep Ops Dashboard Integration
-
-**Status:** revised 2026-05-13 to Option A (see
+**Status:** approved (see
 [`audit-2026-05-13.md`](audit-2026-05-13.md))
 **Requirements:** `requirements.md`
 **Parent code:** `docs/specs/discovery-sweep/` (feature-complete on

--- a/docs/specs/discovery-sweep/tasks.md
+++ b/docs/specs/discovery-sweep/tasks.md
@@ -1,7 +1,5 @@
 # Tasks — Discovery Sweep
-
-**Status:** feature-complete (2026-05-13) — Phase 1, 2A, 2B, 3 shipped; Phase 4 closed empty per P2.7 surface evaluation.
-
+**Status:** approved (2026-05-13) — Phase 1, 2A, 2B, 3 shipped; Phase 4 closed empty per P2.7 surface evaluation.
 | Phase | Status | Shipped via |
 |---|---|---|
 | Phase 1 — Engine + PatternScanSource | done | [#303](https://github.com/Smart-AI-Memory/attune-ai/pull/303), [#306](https://github.com/Smart-AI-Memory/attune-ai/pull/306) FP filter, [#309](https://github.com/Smart-AI-Memory/attune-ai/pull/309) AST filter |

--- a/docs/specs/files-api-adoption/decisions.md
+++ b/docs/specs/files-api-adoption/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Anthropic Files API adoption in attune-ai
-
-**Status:** Draft (2026-05-11) — gated on briefing-followup batch
+**Status:** approved (2026-05-11) — gated on briefing-followup batch
 **Owner:** Patrick
 
 ---

--- a/docs/specs/integration-coverage/decisions.md
+++ b/docs/specs/integration-coverage/decisions.md
@@ -1,5 +1,8 @@
 # Per-phase decisions — Integration Coverage Program
 
+**Status:** approved
+
+
 Append-only log. One section per phase as it lands. See
 `requirements.md` and `tasks.md` for the framework.
 

--- a/docs/specs/integration-coverage/requirements.md
+++ b/docs/specs/integration-coverage/requirements.md
@@ -1,6 +1,5 @@
 # Spec: Integration Coverage Program
-
-**Status**: draft
+**Status:** approved
 **Created**: 2026-05-13
 **Origin**: Complement to the `test-quality-program` umbrella
 ([requirements.md](../test-quality-program/requirements.md)).

--- a/docs/specs/integration-coverage/tasks.md
+++ b/docs/specs/integration-coverage/tasks.md
@@ -1,7 +1,5 @@
 # Tasks: Integration Coverage Program
-
-**Status**: draft
-
+**Status:** approved
 ---
 
 ## Phase 0 — Audit before design

--- a/docs/specs/larger-runners/decisions.md
+++ b/docs/specs/larger-runners/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Larger CI Runners
-
-**Status:** Draft (2026-05-11, revised post-Probe-C)
+**Status:** approved (2026-05-11, revised post-Probe-C)
 **Owner:** Patrick
 
 ---

--- a/docs/specs/ops-dashboard-polish/decisions.md
+++ b/docs/specs/ops-dashboard-polish/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Ops Dashboard Polish
-
-**Status:** draft
+**Status:** approved
 **Owner:** Patrick
 **Opened:** 2026-05-14
 **Predecessors:**

--- a/docs/specs/ops-mutating-endpoint-auth/decisions.md
+++ b/docs/specs/ops-mutating-endpoint-auth/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Ops mutating-endpoint auth (per-process token gate)
-
-**Status:** Draft (2026-05-23)
+**Status:** approved (2026-05-23)
 **Owner:** Patrick
 **Context:** [`docs/specs/ops-specs-features/phase4-findings.md`](../ops-specs-features/phase4-findings.md) (Finding 0)
 

--- a/docs/specs/ops-mutating-endpoint-auth/tasks.md
+++ b/docs/specs/ops-mutating-endpoint-auth/tasks.md
@@ -1,5 +1,8 @@
 # Tasks — Ops mutating-endpoint auth
 
+**Status:** approved
+
+
 ## Phase 1 — Inventory + scaffold
 
 - [ ] **1.1** Inventory every `@router.(put|post|delete|patch)` route under `src/attune/ops/routes/`. Produce a table in this file: route, method, file:line, "needs token?" (default yes; document any "no" with reason).

--- a/docs/specs/ops-path-picker/decisions.md
+++ b/docs/specs/ops-path-picker/decisions.md
@@ -1,5 +1,8 @@
 # Spec: Ops Path Picker — Decisions
 
+**Status:** approved
+
+
 > Pre-committed decisions captured 2026-05-14. Triggered by QA
 > punch-list item P2-7 reframed by Patrick from "fix the overflow"
 > to "give users a real path-selection affordance."

--- a/docs/specs/ops-path-picker/requirements.md
+++ b/docs/specs/ops-path-picker/requirements.md
@@ -8,9 +8,7 @@
 ---
 
 ## Phase 1: Requirements
-
-**Status**: draft
-
+**Status:** approved
 ### Problem statement
 
 The 2026-05-14 QA punch list flagged P2-7 (run-view scope path

--- a/docs/specs/ops-sessions-page/decisions.md
+++ b/docs/specs/ops-sessions-page/decisions.md
@@ -1,5 +1,8 @@
 # Spec: Ops Sessions Page — Decisions
 
+**Status:** approved
+
+
 > Pre-committed decisions captured 2026-05-14.
 
 ---

--- a/docs/specs/ops-sessions-page/requirements.md
+++ b/docs/specs/ops-sessions-page/requirements.md
@@ -7,9 +7,7 @@
 ---
 
 ## Phase 1: Requirements
-
-**Status**: draft
-
+**Status:** approved
 ### Problem statement
 
 The 2026-05-14 QA punch list flagged that `/sessions` returns 404 —

--- a/docs/specs/rag-async-integration/decisions.md
+++ b/docs/specs/rag-async-integration/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Wire attune-rag's `expand_async` into attune-ai workflows
-
-**Status:** Draft (2026-05-11) — gated on briefing-followup batch
+**Status:** approved (2026-05-11) — gated on briefing-followup batch
 **Owner:** Patrick
 
 ---

--- a/docs/specs/sdk-error-message-fidelity/decisions.md
+++ b/docs/specs/sdk-error-message-fidelity/decisions.md
@@ -3,9 +3,7 @@
 > Pre-committed decisions per the existing lesson "Pre-committed
 > decision matrices survive contact with data." Edits to this file
 > after Phase 1 ships require a follow-up PR with rationale.
-
-**Status:** draft (2026-05-24)
-
+**Status:** approved (2026-05-24)
 ---
 
 ## Decision matrix

--- a/docs/specs/sdk-error-message-fidelity/design.md
+++ b/docs/specs/sdk-error-message-fidelity/design.md
@@ -1,7 +1,5 @@
 # Spec: SDK Error Message Fidelity — Design
-
-**Status:** draft (2026-05-24)
-
+**Status:** approved (2026-05-24)
 ---
 
 ## Module layout

--- a/docs/specs/sdk-error-message-fidelity/tasks.md
+++ b/docs/specs/sdk-error-message-fidelity/tasks.md
@@ -1,7 +1,5 @@
 # Spec: SDK Error Message Fidelity — Tasks
-
-**Status:** draft (2026-05-24)
-
+**Status:** approved (2026-05-24)
 > Five phases, each shipping as its own PR. Phase 1 is the recommended
 > first commitment; Phases 2–5 build on it. Phase 1 can be approved
 > and shipped independently — it adds the primitives without touching

--- a/docs/specs/vercel-noise-cleanup/decisions.md
+++ b/docs/specs/vercel-noise-cleanup/decisions.md
@@ -1,6 +1,5 @@
 # Decisions — Vercel Noise Cleanup
-
-**Status:** draft — DECIDE callouts need Patrick's input before
+**Status:** approved — DECIDE callouts need Patrick's input before
 design.md can be written
 
 Context, investigation findings, and the resolution option set. See

--- a/docs/specs/vercel-noise-cleanup/requirements.md
+++ b/docs/specs/vercel-noise-cleanup/requirements.md
@@ -1,7 +1,5 @@
 # Requirements — Vercel Noise Cleanup
-
-**Status:** draft — awaiting approval before design.md and tasks.md
-
+**Status:** approved — awaiting approval before design.md and tasks.md
 User-facing stories and the contracts they imply. See `decisions.md`
 for context and the chosen resolution path. `design.md` and `tasks.md`
 are intentionally omitted — they will be written after Patrick reviews


### PR DESCRIPTION
## Summary

Two bundled docs-only changes that were sitting unstaged in main checkout from yesterday's session:

**(a) 22 spec status flips** — same pattern as [PR #467](https://github.com/Smart-AI-Memory/attune-ai/pull/467) (the 2026-05-25 batch). All dashboard-driven advances (mostly draft→approved). Most went UNJOURNALED because the OLD dashboard process (PID 35492 from 2026-05-24) predated the journal feature shipped in [PR #469](https://github.com/Smart-AI-Memory/attune-ai/pull/469). The dashboard has since been restarted on 2026-05-27 against current code; future writes are journaled.

**(b) New CLAUDE.md lesson** (~60 lines) on Pandoc + weasyprint print artifacts needing both `@page` rules AND `@media screen` rules. Bundled here because it was in the same working tree as (a). Resolves the CLAUDE.md merge conflict against [PR #489](https://github.com/Smart-AI-Memory/attune-ai/pull/489)'s 3 lessons — resolution is union (both halves kept, chronological order).

## Affected specs (22)

`dashboard-pending-writes-journal` (design, requirements), `discovery-sweep` (tasks), `discovery-sweep-ops-integration` (design), `files-api-adoption` (decisions), `integration-coverage` (3), `larger-runners` (decisions), `ops-dashboard-polish` (decisions), `ops-mutating-endpoint-auth` (2), `ops-path-picker` (2), `ops-sessions-page` (2), `rag-async-integration` (decisions), `sdk-error-message-fidelity` (3), `vercel-noise-cleanup` (2)

## Test plan

- [x] Pre-commit hooks pass (formatters, trailing whitespace, etc.)
- [x] CLAUDE.md merge conflict resolved as union (no markers left, both content blocks intact)
- [ ] CI green
