### PR TITLE
feat(ops): pending-writes API filters test-fixture + stale entries

### DIFF
--- a/src/attune/ops/routes/pending_writes.py
+++ b/src/attune/ops/routes/pending_writes.py
@@ -118,6 +118,53 @@ def _is_file_committed(file_path: Path, project_root: Path) -> bool | None:
     return result.stdout.strip() == ""
 
 
+_TMP_PATH_PREFIXES: tuple[str, ...] = (  # nosec B108 — filter prefixes, not file I/O
+    "/tmp/",  # nosec B108
+    "/private/tmp/",  # nosec B108
+    "/var/folders/",
+    "/private/var/folders/",
+    "/var/tmp/",  # nosec B108
+    "/private/var/tmp/",  # nosec B108
+)
+"""Known transient-directory prefixes — pytest tmp_path, OS scratch
+dirs. Entries whose project_root lives under any of these are
+test-fixture pollution, even when the dir still exists at read
+time (macOS pytest keeps the last few tmp dirs alive)."""
+
+
+def _is_real_entry(entry: dict[str, Any]) -> bool:
+    """Drop test-fixture / stale entries at read time.
+
+    Two-part heuristic. A journal entry is "real" if its
+    ``project_root``:
+      - is present
+      - is NOT under a known transient-directory prefix
+        (``/tmp``, ``/var/folders/...pytest``, etc.)
+      - points at an existing directory on disk
+
+    Tmp-path prefixes catch pytest fixtures even while they're
+    still alive (macOS pytest holds the last few runs). Existence
+    check catches stale entries from projects the user has since
+    deleted or moved.
+
+    This is a READ-side filter only — the journal itself stays as
+    the append-only source of truth (see D1 in decisions.md).
+    Auditors who need the raw stream can read
+    ``~/.attune/ops/pending_writes.jsonl`` directly.
+    """
+    pr = entry.get("project_root", "")
+    if not isinstance(pr, str) or not pr:
+        return False
+    # Tmp-path prefix exclusion runs BEFORE the existence check
+    # because macOS keeps pytest tmp_path dirs alive across runs.
+    if any(pr.startswith(prefix) for prefix in _TMP_PATH_PREFIXES):
+        return False
+    try:
+        return Path(pr).is_dir()
+    except (OSError, ValueError):
+        return False
+
+
 def _enrich(entry: dict[str, Any], now: datetime) -> dict[str, Any]:
     """Add computed fields to a journal entry.
 
@@ -195,7 +242,11 @@ async def list_pending_writes(request: Request) -> dict[str, Any]:
     )
     now = datetime.now(timezone.utc)
     raw_entries = _load_journal_entries(journal_path)
-    enriched = [_enrich(entry, now) for entry in raw_entries]
+    # Filter test-fixture / stale entries before enrichment — see
+    # ``_is_real_entry`` for the heuristic. Skips expensive sha256 +
+    # git-status computation for entries we'd just drop anyway.
+    real_entries = [e for e in raw_entries if _is_real_entry(e)]
+    enriched = [_enrich(entry, now) for entry in real_entries]
     return {
         "pending": enriched,
         "summary": _summarize(enriched),

--- a/src/attune/ops/routes/pending_writes.py
+++ b/src/attune/ops/routes/pending_writes.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import subprocess
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -118,7 +119,20 @@ def _is_file_committed(file_path: Path, project_root: Path) -> bool | None:
     return result.stdout.strip() == ""
 
 
+def _system_tmp_prefix() -> str:
+    """Platform-native system tempdir as a path prefix.
+
+    Covers Windows ``%TEMP%`` / ``%TMP%`` (typically
+    ``C:\\Users\\<user>\\AppData\\Local\\Temp``), Linux ``$TMPDIR``,
+    and macOS default. ``startswith()`` matches against the same
+    separator form the journal writer recorded
+    (``os.sep`` from ``str(Path(...))``).
+    """
+    return tempfile.gettempdir().rstrip(os.sep) + os.sep
+
+
 _TMP_PATH_PREFIXES: tuple[str, ...] = (  # nosec B108 — filter prefixes, not file I/O
+    _system_tmp_prefix(),
     "/tmp/",  # nosec B108
     "/private/tmp/",  # nosec B108
     "/var/folders/",
@@ -129,7 +143,12 @@ _TMP_PATH_PREFIXES: tuple[str, ...] = (  # nosec B108 — filter prefixes, not f
 """Known transient-directory prefixes — pytest tmp_path, OS scratch
 dirs. Entries whose project_root lives under any of these are
 test-fixture pollution, even when the dir still exists at read
-time (macOS pytest keeps the last few tmp dirs alive)."""
+time (macOS pytest keeps the last few tmp dirs alive).
+
+First entry is the platform tempdir (covers Windows
+``AppData\\Local\\Temp``). The static POSIX entries cover macOS's
+``/private/var/folders/...pytest-of-...`` cases that survive even
+when ``TMPDIR`` is overridden by tests or CI."""
 
 
 def _is_real_entry(entry: dict[str, Any]) -> bool:

--- a/tests/unit/ops/test_pending_writes_api.py
+++ b/tests/unit/ops/test_pending_writes_api.py
@@ -433,12 +433,24 @@ def test_entries_under_tmp_path_prefixes_are_filtered_out(
 
     See ``_TMP_PATH_PREFIXES`` in routes/pending_writes.py.
     """
+    import tempfile
+
     from attune.ops.routes import pending_writes as pw_routes
 
+    # Use the actual platform tempdir as the prefix so the test
+    # works on macOS, Linux, and Windows. Include both the raw
+    # ``gettempdir()`` form (``/var/folders/...``) AND the resolved
+    # form (``/private/var/folders/...``) because macOS's
+    # ``/var`` ↔ ``/private/var`` symlink means tmp_path may show
+    # up under either depending on whether it was resolved (see
+    # CLAUDE.md "macOS /var → /private/var symlink" lesson). Keep
+    # ``/tmp/`` for the second (non-existent) entry below.
+    raw_tmp = tempfile.gettempdir().rstrip(os.sep) + os.sep
+    resolved_tmp = str(Path(tempfile.gettempdir()).resolve()).rstrip(os.sep) + os.sep
     monkeypatch.setattr(
         pw_routes,
         "_TMP_PATH_PREFIXES",
-        ("/tmp/", "/private/tmp/", "/var/folders/", "/private/var/folders/"),
+        (raw_tmp, resolved_tmp, "/tmp/"),
     )
     # tmp_path exists on disk and is under one of the tmp prefixes.
     # The entry's other fields don't matter for this assertion — the

--- a/tests/unit/ops/test_pending_writes_api.py
+++ b/tests/unit/ops/test_pending_writes_api.py
@@ -85,6 +85,23 @@ def client_factory(tmp_project: Path, tmp_path: Path):
     return _make
 
 
+@pytest.fixture(autouse=True)
+def _disable_tmp_path_prefix_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tests in this module use pytest ``tmp_path`` as the project_root,
+    which is itself under one of the production tmp-path prefixes
+    (``/private/var/folders/.../pytest-of-...`` on macOS,
+    ``/tmp/pytest-of-...`` on Linux). The prod prefix filter would
+    reject those entries and break every test in the module.
+
+    Disable the prefix filter at the source-list level. Tests that
+    specifically verify prefix-filter behavior re-enable it via
+    their own monkeypatch or by setting specific prefix values.
+    """
+    from attune.ops.routes import pending_writes as pw_routes
+
+    monkeypatch.setattr(pw_routes, "_TMP_PATH_PREFIXES", ())
+
+
 def _write_journal(journal_path: Path, entries: list[dict]) -> None:
     """Write a sequence of journal entry dicts to a JSONL file."""
     journal_path.parent.mkdir(parents=True, exist_ok=True)
@@ -350,6 +367,106 @@ def test_corrupt_journal_line_is_skipped_not_fatal(
     # Only the valid line surfaces.
     assert len(body["pending"]) == 1
     assert any("corrupt journal line" in record.message for record in caplog.records)
+
+
+def test_entries_with_nonexistent_project_root_are_filtered_out(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+) -> None:
+    """Stale entries (project_root no longer on disk) drop out at read.
+
+    Most common cause: pytest tmp_path is garbage-collected after a
+    test, leaving journal entries pointing at non-existent dirs. Same
+    for projects the user has since deleted or moved.
+
+    Module's autouse fixture disables the prefix filter, so this test
+    isolates the existence-check behavior. Prefix-filter behavior is
+    verified separately in the next test.
+
+    See ``_is_real_entry`` in routes/pending_writes.py.
+    """
+    real = tmp_project / "real.md"
+    real.write_text("real\n", encoding="utf-8")
+
+    journal_path = tmp_path / "journal.jsonl"
+    _write_journal(
+        journal_path,
+        [
+            # Real: tmp_project exists
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path="real.md",
+                after_sha256=pending_writes.compute_file_sha256(real),
+            ),
+            # Stale: dir was never created
+            _make_journal_dict(
+                project_root=tmp_path / "deleted-dir-never-created",
+                file_path="some.md",
+                after_sha256="aaa",
+            ),
+        ],
+    )
+
+    client = client_factory(journal_path=journal_path)
+    body = client.get("/api/pending-writes").json()
+    assert len(body["pending"]) == 1
+    assert body["pending"][0]["file_path"] == "real.md"
+    assert body["summary"]["total_entries"] == 1
+
+
+def test_entries_under_tmp_path_prefixes_are_filtered_out(
+    tmp_path: Path,
+    client_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entries whose project_root is under a known transient-dir prefix
+    drop out at read, even when the dir still exists on disk.
+
+    pytest tmp_path is itself under one of those prefixes
+    (``/private/var/folders/.../pytest-of-...`` on macOS), so we can
+    use tmp_path directly as a project_root that DOES exist but should
+    still be filtered as test-fixture pollution.
+
+    Re-enables the prefix list that the module's autouse fixture
+    cleared.
+
+    See ``_TMP_PATH_PREFIXES`` in routes/pending_writes.py.
+    """
+    from attune.ops.routes import pending_writes as pw_routes
+
+    monkeypatch.setattr(
+        pw_routes,
+        "_TMP_PATH_PREFIXES",
+        ("/tmp/", "/private/tmp/", "/var/folders/", "/private/var/folders/"),
+    )
+    # tmp_path exists on disk and is under one of the tmp prefixes.
+    # The entry's other fields don't matter for this assertion — the
+    # filter rejects it on prefix alone, before existence check.
+    journal_path = tmp_path / "journal.jsonl"
+    _write_journal(
+        journal_path,
+        [
+            _make_journal_dict(
+                project_root=tmp_path,  # under /private/var/folders/.../pytest-of-...
+                file_path="anything.md",
+                after_sha256="aaa",
+            ),
+            # Also include a /tmp/ entry for the second prefix
+            _make_journal_dict(
+                project_root=Path("/tmp/test-fixture-never-created"),
+                file_path="other.md",
+                after_sha256="bbb",
+            ),
+        ],
+    )
+
+    client = client_factory(journal_path=journal_path)
+    body = client.get("/api/pending-writes").json()
+    # Both should be filtered — first by prefix match (tmp_path under
+    # pytest-of-), second by both prefix (/tmp/) AND nonexistence.
+    assert len(body["pending"]) == 0
+    assert body["summary"]["total_entries"] == 0
 
 
 # --- integration: PUT spec status appends to journal -------------

--- a/tests/unit/ops/test_pending_writes_api.py
+++ b/tests/unit/ops/test_pending_writes_api.py
@@ -481,6 +481,25 @@ def test_entries_under_tmp_path_prefixes_are_filtered_out(
     assert body["summary"]["total_entries"] == 0
 
 
+def test_system_tmp_prefix_returns_path_with_trailing_separator() -> None:
+    """``_system_tmp_prefix()`` returns the platform tempdir with a
+    trailing ``os.sep``. The trailing separator matters: without it,
+    ``"/tmp/foo".startswith("/tmp")`` would match ``"/tmp"`` AND
+    ``"/tmpfoo"`` — only the separator-terminated form is safe.
+
+    The function is invoked at module-import time to populate the
+    first entry of ``_TMP_PATH_PREFIXES``. This test exercises it
+    directly so codecov sees the call.
+    """
+    import tempfile
+
+    from attune.ops.routes import pending_writes as pw_routes
+
+    result = pw_routes._system_tmp_prefix()
+    assert result.endswith(os.sep)
+    assert result.rstrip(os.sep) == tempfile.gettempdir().rstrip(os.sep)
+
+
 # --- integration: PUT spec status appends to journal -------------
 
 


### PR DESCRIPTION
## Summary

Adds read-side filter to `GET /api/pending-writes` that drops journal entries from test fixtures and stale projects, surfacing only actionable real-world entries.

**Two-part heuristic** — an entry is "real" if its `project_root`:
1. Is NOT under a known transient-directory prefix (`/tmp/`, `/private/var/folders/`, etc.)
2. Points at an existing directory on disk

Prefix exclusion runs BEFORE the existence check because macOS pytest holds the last few `tmp_path` runs alive — entries under `/private/var/folders/.../pytest-of-X` pass existence but are still test pollution.

**Read-side, not write-side:** the journal stays as the append-only source of truth (see D1 in decisions.md). Auditors needing the raw stream can read `~/.attune/ops/pending_writes.jsonl` directly.

## Real-world impact

Verified against the live dashboard immediately before opening this PR: **96 raw journal entries → 0 surfaced after filter.** The 96 entries were entirely test pollution from Phase 1 test runs against the prod journal path (separate followup: scope tests to per-test `journal_path` so prod path isn't touched).

## Tests

27/27 pass (was 25; added 2):
- `test_entries_with_nonexistent_project_root_are_filtered_out` — existence check
- `test_entries_under_tmp_path_prefixes_are_filtered_out` — prefix check
- Plus autouse module fixture `_disable_tmp_path_prefix_filter` for existing tests (otherwise the prod prefix list would reject every test's pytest-`tmp_path` `project_root`)

## Followup work flagged but NOT in this PR

- Scope Phase 1 tests to per-test `journal_path` so prod path stops getting polluted (the 96 raw entries already on disk are the evidence we don't have that scoping yet)
- Consider periodic compaction of the journal file (drop entries that match `is_real_entry`=False) — not urgent, journal stays small
