### PR TITLE
feat(ops/help): hash-only staleness; drop 7-day age fallback

### DIFF
--- a/src/attune/ops/help_data.py
+++ b/src/attune/ops/help_data.py
@@ -20,7 +20,6 @@ import subprocess
 import time
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 
 from attune.ops.config import Config
@@ -62,11 +61,6 @@ INTENT_GROUPS: dict[str, tuple[str, ...]] = {
     "understand": ("concept",),
     "lookup": ("reference",),
 }
-
-# Staleness threshold — a template whose ``generated_at`` is more
-# than this many days old gets a "stale" chip. Matches the
-# attune-author docs convention.
-STALE_THRESHOLD_DAYS = 7
 
 # Frontmatter regex — quick parse without pulling in PyYAML.
 _FRONTMATTER_RE = re.compile(
@@ -457,37 +451,21 @@ def _summarize_feature(
 
 
 def _is_template_stale(path: Path, *, stale_features: frozenset[str] | None = None) -> bool:
-    """Per-template freshness check.
+    """Per-template freshness check (hash-based only).
 
-    Two modes:
-    - Authority (``stale_features`` provided): a template is stale
-      if its parent feature is in attune-author's drift set.
-    - Fallback (``stale_features`` is ``None``): age-based —
-      ``generated_at`` older than :data:`STALE_THRESHOLD_DAYS`.
+    A template is stale iff its parent feature is in
+    ``stale_features`` — attune-author's source-hash drift set.
+    When ``stale_features`` is ``None`` (attune-author unavailable),
+    the dashboard cannot determine drift, so it reports
+    ``False`` (assume fresh). The previous age-based fallback was
+    dropped: a template's age in days is not a proxy for whether
+    its content matches the current source.
     """
-    if stale_features is not None:
-        # path is .../<feature>/<kind>.md
-        feature = path.parent.name
-        return feature in stale_features
-
-    try:
-        with path.open("r", encoding="utf-8", errors="replace") as fh:
-            chunk = fh.read(1024)
-    except OSError:
+    if stale_features is None:
         return False
-    m = _FRONTMATTER_RE.match(chunk + "\n---\n" if "---" not in chunk[3:] else chunk)
-    fm = m.group("fm") if m else chunk
-    gen_at = _extract_frontmatter_field(fm, "generated_at")
-    if not gen_at:
-        return False
-    try:
-        when = datetime.fromisoformat(gen_at)
-    except (ValueError, TypeError):
-        return False
-    if when.tzinfo is None:
-        when = when.replace(tzinfo=timezone.utc)
-    age_days = (datetime.now(timezone.utc) - when).total_seconds() / 86_400
-    return age_days > STALE_THRESHOLD_DAYS
+    # path is .../<feature>/<kind>.md
+    feature = path.parent.name
+    return feature in stale_features
 
 
 # ---------------------------------------------------------------------------
@@ -593,10 +571,11 @@ def _parse_template(
 ) -> TemplateRecord:
     """Split frontmatter + body, build a TemplateRecord.
 
-    When ``stale_features`` is provided (the attune-author
-    authority set), staleness comes from feature-in-set lookup.
-    Otherwise falls back to age-based staleness from the
-    frontmatter ``generated_at``.
+    Staleness is hash-based only: a template is stale iff its
+    parent feature is in ``stale_features`` (attune-author's
+    source-hash drift set). When ``stale_features`` is ``None``
+    (attune-author unavailable), the dashboard cannot determine
+    drift and reports ``is_stale=False`` — see ``_is_template_stale``.
     """
     m = _FRONTMATTER_RE.match(raw)
     if m:
@@ -609,25 +588,7 @@ def _parse_template(
     source_hash = _extract_frontmatter_field(fm, "source_hash")
     title = _title_from_content(body) or f"{feature} / {kind}"
 
-    if stale_features is not None:
-        is_stale = feature in stale_features
-    else:
-        is_stale = False
-        if generated_at:
-            try:
-                when = datetime.fromisoformat(generated_at)
-                if when.tzinfo is None:
-                    when = when.replace(tzinfo=timezone.utc)
-                age_days = (datetime.now(timezone.utc) - when).total_seconds() / 86_400
-                is_stale = age_days > STALE_THRESHOLD_DAYS
-            except (ValueError, TypeError) as exc:
-                logger.debug(
-                    "could not parse generated_at=%r for %s/%s (%s); " "leaving is_stale=False",
-                    generated_at,
-                    feature,
-                    kind,
-                    exc,
-                )
+    is_stale = stale_features is not None and feature in stale_features
 
     return TemplateRecord(
         feature=feature,

--- a/src/attune/ops/templates/help_admin.html
+++ b/src/attune/ops/templates/help_admin.html
@@ -91,8 +91,8 @@
 <section class="help-section">
   <h2 class="help-section-title">Stale templates <span class="help-count">{{ report.stale | length }}</span></h2>
   <p class="help-section-sub">
-    Source hash drift older than 7 days. Use the per-row button or the bulk
-    "Regenerate all stale" above.
+    Source has changed since the template was generated (source-hash drift).
+    Use the per-row button or the bulk "Regenerate all stale" above.
   </p>
   <table class="help-gaps-table">
     <thead>

--- a/tests/unit/ops/test_help_data.py
+++ b/tests/unit/ops/test_help_data.py
@@ -39,12 +39,23 @@ from attune.ops.help_data import (
 
 
 def _fresh_ts() -> str:
-    """A generated_at timestamp younger than the staleness threshold."""
+    """A recent ``generated_at`` timestamp (now, UTC).
+
+    Staleness is hash-based; the timestamp itself does not affect
+    ``is_stale``. Kept so corpus templates have realistic frontmatter.
+    """
     return datetime.now(timezone.utc).isoformat()
 
 
 def _stale_ts() -> str:
-    """A generated_at timestamp older than the 7-day threshold."""
+    """An old ``generated_at`` timestamp (14 days ago, UTC).
+
+    Pre-rewrite this name drove date-based staleness; under the new
+    hash-only logic it just makes a template's frontmatter LOOK old.
+    Kept for tests that document the no-authority behavior
+    (an old timestamp alone is no longer enough to mark a template
+    stale — see :class:`TestIsTemplateStale`).
+    """
     return (datetime.now(timezone.utc) - timedelta(days=14)).isoformat()
 
 
@@ -118,15 +129,29 @@ def corpus(tmp_path: Path) -> Path:
 
 
 @pytest.fixture(autouse=True)
-def _force_age_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Force the age-based staleness fallback in tests.
+def _inject_stale_features(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inject the attune-author authority set used by the corpus.
 
-    Implemented by stubbing ``shutil.which`` so the authority
-    function naturally returns None and callers fall through to
-    the age-based path. Tests that exercise the authority path
-    re-monkeypatch shutil.which themselves.
+    Staleness is hash-based only (no date fallback). The synthetic
+    corpus marks ``stale-feature`` and ``mixed-feature`` as the
+    features whose source has drifted; this fixture stubs
+    ``_attune_author_stale_features`` to return that exact set so
+    tests run deterministically without needing the real
+    attune-author CLI on PATH.
+
+    Skipped for ``TestAttuneAuthorStaleFeatures`` — those tests
+    exercise the real ``_attune_author_stale_features`` body, so
+    they need to see the un-stubbed function. Tests in other
+    classes that need a different authority set re-monkeypatch
+    ``_attune_author_stale_features`` themselves.
     """
-    monkeypatch.setattr(help_data_mod.shutil, "which", lambda _: None)
+    if request.cls is not None and request.cls.__name__ == "TestAttuneAuthorStaleFeatures":
+        return
+    monkeypatch.setattr(
+        help_data_mod,
+        "_attune_author_stale_features",
+        lambda *_args, **_kwargs: frozenset({"stale-feature", "mixed-feature"}),
+    )
     help_data_mod._clear_staleness_cache()
 
 
@@ -216,12 +241,16 @@ class TestListFeatures:
         assert stale.has_any_stale is True
         assert stale.stale_count == 5  # all 5 kinds are stale
 
-    def test_mixed_feature_partial_stale(self, cfg: Config) -> None:
+    def test_mixed_feature_marked_fully_stale(self, cfg: Config) -> None:
+        """Staleness is hash-based at the feature level (no per-kind
+        granularity). If a feature is in the authority set, ALL its
+        kinds are stale together. The pre-rename ``partial_stale``
+        semantics came from the dropped per-template date check.
+        """
         feats = {f.name: f for f in list_features(cfg)}
         mixed = feats["mixed-feature"]
-        # Half stale, half fresh — exact count depends on parity
         assert mixed.has_any_stale is True
-        assert 0 < mixed.stale_count < 11
+        assert mixed.stale_count == 11
 
     def test_alphabetical_order(self, cfg: Config) -> None:
         names = [f.name for f in list_features(cfg)]
@@ -579,15 +608,30 @@ class TestFormatKinds:
 
 
 class TestIsTemplateStale:
-    def test_fresh_returns_false(self, tmp_path: Path) -> None:
+    """Tests for the no-authority path (``stale_features=None``).
+
+    Staleness is hash-based only: without the attune-author authority
+    set, ``_is_template_stale`` cannot determine drift and returns
+    ``False`` for every input. The authority-mode path is covered by
+    :class:`TestIsTemplateStaleAuthorityMode` below.
+    """
+
+    def test_no_authority_returns_false(self, tmp_path: Path) -> None:
+        """A template with a fresh ``generated_at`` returns False —
+        unsurprising. The point is that ``stale_features=None`` means
+        we cannot judge, so we report not-stale rather than guessing.
+        """
         p = tmp_path / "fresh.md"
         p.write_text(f"---\ngenerated_at: {_fresh_ts()}\n---\n\n# x\n", encoding="utf-8")
         assert _is_template_stale(p) is False
 
-    def test_stale_returns_true(self, tmp_path: Path) -> None:
-        p = tmp_path / "stale.md"
+    def test_no_authority_returns_false_even_for_old_template(self, tmp_path: Path) -> None:
+        """Pre-rewrite this returned True via the age-based fallback.
+        Hash-only semantics: without an authority set, age is irrelevant.
+        """
+        p = tmp_path / "ancient.md"
         p.write_text(f"---\ngenerated_at: {_stale_ts()}\n---\n\n# x\n", encoding="utf-8")
-        assert _is_template_stale(p) is True
+        assert _is_template_stale(p) is False
 
     def test_no_generated_at_returns_false(self, tmp_path: Path) -> None:
         p = tmp_path / "nogen.md"
@@ -675,9 +719,12 @@ class TestAttuneAuthorStaleFeatures:
     def test_returns_none_when_binary_missing(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        """When ``shutil.which`` reports the binary missing,
+        ``_attune_author_stale_features`` returns ``None`` (the
+        signal callers use to mean 'cannot determine drift')."""
         from attune.ops import help_data
 
-        # Autouse fixture already stubs shutil.which to return None.
+        monkeypatch.setattr(help_data.shutil, "which", lambda _: None)
         help_data._clear_staleness_cache()
         result = help_data._attune_author_stale_features(tmp_path, tmp_path / ".help")
         assert result is None


### PR DESCRIPTION
## Summary

- Drop the date-based staleness fallback (`generated_at > 7 days`) from the ops dashboard's `/help` admin tab.
- Staleness is now hash-based only: a template is stale iff attune-author reports its parent feature has source-hash drift.
- When attune-author is unavailable, the dashboard reports `is_stale=False` (honest "cannot determine") rather than falling back to age.

## Why

The previous logic confounded two orthogonal signals:

- **Hash drift** — the template content may not match its current source (the real "stale" signal).
- **Age in days** — how long ago the template was last polished.

Conflating them produced:

- **False positives.** A template older than 7 days whose source was unchanged still got flagged.
- **False negatives.** A recently-regenerated template against heavily-drifted source was reported fresh.

A template's age in days isn't a proxy for whether its content matches the current source.

## Behavioral changes worth noting

1. **Per-template staleness collapses to per-feature.** attune-author's hash drift is feature-level (one source-hash per feature, not per kind), so all 11 kinds of a stale feature are now reported stale together. The pre-rewrite per-kind staleness came purely from per-template `generated_at` timestamps under the date fallback.
2. **No-authority case reports fresh.** When attune-author is missing or its subprocess fails, the dashboard reports zero stale templates rather than guessing. Accurate ("we cannot determine drift") rather than misleading.
3. **UI text updated.** "Source hash drift older than 7 days" → "Source has changed since the template was generated (source-hash drift)".

## Diff

- `src/attune/ops/help_data.py`: remove `STALE_THRESHOLD_DAYS`, simplify `_is_template_stale` to authority-only, remove the age-fallback branch in `_parse_template`.
- `src/attune/ops/templates/help_admin.html`: clarify the section subtitle.
- `tests/unit/ops/test_help_data.py`: replace `_force_age_fallback` autouse fixture with `_inject_stale_features` injecting the authority set directly; rewrite `TestIsTemplateStale` around the no-authority returns-False contract; rename `test_mixed_feature_partial_stale` → `..._marked_fully_stale`; fix `test_returns_none_when_binary_missing` to stub `shutil.which` explicitly.

Net: +86 / -78.

## Test plan

- [x] Local: `pytest tests/unit/ops/` — 995/995 pass
- [ ] CI: full matrix (12 lanes) green
- [ ] Manual: open dashboard `/help` admin tab, confirm stale chips render correctly (or report zero when attune-author is unavailable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)