### PR TITLE
fix(ops/help): scope status parser to Help Templates section only

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6251,3 +6251,38 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   (2) is cleaner: canonical .md stays GitHub-friendly with plain
   blockquotes instead of fenced divs, print .md adds the
   div-wrapped markup for the pandoc step.
+
+- **Status-output parsers that walk every section break the moment
+  the upstream tool grows a second corpus — track h2 boundaries,
+  not just h3 markers**: hit 2026-05-27 on PR #494. The dashboard's
+  ``_parse_status_output`` walked every ``### Stale`` markdown
+  section in ``attune-author status`` output without tracking which
+  ``## `` h2 it lived under. attune-author emits TWO sections:
+  ``## Help Templates`` (drift in ``.help/templates/``, which
+  ``attune-author regenerate`` can fix) and ``## Project Docs``
+  (drift in ``docs/how-to/``, ``docs/reference/``, etc. — separate
+  corpus, NOT touched by regenerate). The parser rolled both into
+  one ``stale_features`` set, so the dashboard reported ~31
+  features stale (1 from help-templates + 30 from project-docs).
+  That expanded to 154 templates marked stale across the
+  ``.help/templates/`` corpus. Clicking "Regenerate all stale"
+  could only fix the help-templates side (~2 features actually
+  drifted); the other 29 features' drift lived in ``docs/`` and
+  was untouched — so the counter never went down regardless of
+  how many times the user clicked. **Diagnostic shape:** when a
+  dashboard surfaces a count that NEVER decreases after the
+  remediation action runs, suspect a scope mismatch between what
+  the count includes and what the action fixes. Fix: track h2
+  section boundaries in the parser; only collect inside the
+  section the consumer's actions can address. Generalizes beyond
+  attune-author to any tool whose output groups multiple
+  sub-corpora under separate h2 headers (CI tools with per-runner
+  sections, lint tools with per-language sections, etc.). Default
+  to the desired-corpus context when no h2 appears — preserves
+  backward compat with older versions of the upstream tool that
+  emit single-section output. Companion observation: this kind of
+  bug hides behind the more visible "two parallel generators
+  drift silently" lesson because the symptom (stale count never
+  drops) feels like a regen tool bug, but the actual root cause
+  is the staleness *reporter* including items the regen tool was
+  never designed to handle.

--- a/src/attune/ops/help_data.py
+++ b/src/attune/ops/help_data.py
@@ -534,21 +534,41 @@ def _attune_author_stale_features(project_root: Path, help_dir: Path) -> frozens
 def _parse_status_output(text: str) -> frozenset[str]:
     """Extract stale feature names from ``attune-author status`` output.
 
-    Strategy: walk lines, track whether we're inside the
-    ``### Stale`` section, treat each markdown table row whose
-    first column is a slug-shaped string as a stale feature.
-    Skips the header and divider rows automatically because they
-    don't match :data:`_TABLE_ROW_RE` (they begin with ``Feature``
-    or ``-----``).
+    The status command emits two top-level sections:
+
+    - ``## Help Templates`` — drift in ``.help/templates/`` files,
+      which ``attune-author regenerate`` can fix.
+    - ``## Project Docs`` — drift in ``docs/`` files (``docs/how-to/``,
+      ``docs/reference/``, etc.) which is a SEPARATE corpus that
+      ``regenerate`` does NOT touch.
+
+    The dashboard only manages ``.help/templates/``, so this parser
+    collects feature names ONLY from the Stale section under
+    ``## Help Templates``. Including Project Docs stale features
+    here caused the dashboard to flag all templates of those
+    features as stale, but "Regenerate all stale" couldn't fix
+    them (the regenerate command leaves ``docs/`` alone) — so the
+    count never went down. Default behavior when no ``## `` headers
+    appear: assume Help Templates context (backward compat with
+    older attune-author versions that omitted the header).
+
+    Skips the table header and divider rows automatically because
+    they don't match :data:`_TABLE_ROW_RE` (they begin with
+    ``Feature`` or ``-----``).
     """
     out: set[str] = set()
+    in_project_docs = False
     in_stale = False
     for line in text.splitlines():
         stripped = line.strip()
+        if stripped.startswith("## "):
+            in_project_docs = "Project Docs" in stripped
+            in_stale = False  # h2 boundary resets h3 state
+            continue
         if stripped.startswith("###"):
             in_stale = stripped == "### Stale"
             continue
-        if not in_stale:
+        if not in_stale or in_project_docs:
             continue
         m = _TABLE_ROW_RE.match(line)
         if m:

--- a/tests/unit/ops/test_help_data.py
+++ b/tests/unit/ops/test_help_data.py
@@ -710,6 +710,45 @@ class TestParseStatusOutput:
         )
         assert _parse_status_output(text) == frozenset({"a-feature"})
 
+    def test_project_docs_stale_section_ignored(self) -> None:
+        """``## Project Docs`` is a SEPARATE corpus from
+        ``.help/templates/``. Its stale section must NOT contribute
+        to the dashboard's help-templates stale set — otherwise
+        clicking "Regenerate all stale" can never bring the count
+        down (regenerate only touches .help/, not docs/).
+
+        This is the bug PR #494 fixed: pre-fix the parser walked
+        every "### Stale" section regardless of its parent h2,
+        rolling project-docs drift into help-templates staleness.
+        """
+        from attune.ops.help_data import _parse_status_output
+
+        text = (
+            "## Help Templates\n\n"
+            "**1** current, **1** stale\n\n"
+            "### Stale\n\n"
+            "| help-only-feat | foo | 1 |\n\n"
+            "## Project Docs\n\n"
+            "**0** current, **2** stale\n\n"
+            "### Stale\n\n"
+            "| docs-only-feat | bar | 2 |\n"
+            "| another-docs-feat | baz | 1 |\n"
+        )
+        # Only the help-templates feature appears; the project-docs
+        # features are silently dropped.
+        assert _parse_status_output(text) == frozenset({"help-only-feat"})
+
+    def test_help_templates_implicit_when_no_h2(self) -> None:
+        """If no ``## `` h2 appears, default to Help Templates context.
+
+        Backward compat with older attune-author versions whose
+        status output didn't include section headers.
+        """
+        from attune.ops.help_data import _parse_status_output
+
+        text = "### Stale\n\n| legacy-feat | foo | 1 |\n"
+        assert _parse_status_output(text) == frozenset({"legacy-feat"})
+
 
 class TestAttuneAuthorStaleFeatures:
     """Tests for the subprocess wrapper. We mock subprocess.run to


### PR DESCRIPTION
## Summary

The dashboard's stale count was unfixable by the **Regenerate all stale** button. Clicking it never brought the count down.

## Root cause

`_parse_status_output` walked every `### Stale` markdown section in `attune-author status` output, ignoring the parent `## ` h2. `attune-author status` emits TWO sections:

```
## Help Templates       ← drift in .help/templates/ (regenerate fixes these)
## Project Docs         ← drift in docs/how-to/, docs/reference/ etc. (regenerate does NOT touch these)
```

The dashboard rolled ~31 features (1 from Help Templates + 30 from Project Docs) into one stale set. Feature-level staleness then expanded across `.help/templates/` kinds to ~154 templates. Clicking Regenerate only fixed the Help Templates side (~2 features), so the other 29 features (and their ~150 templates) stayed marked stale forever.

## Fix

Track `## ` h2 section boundaries in the parser. Only collect features inside `## Help Templates → ### Stale`. Default to Help Templates context when no h2 appears (backward compat with older attune-author versions).

## Tests

- `test_project_docs_stale_section_ignored` — explicit regression test for this bug
- `test_help_templates_implicit_when_no_h2` — backward compat with header-less output
- All existing parser tests still pass

## Test plan

- [x] Local: 81/81 ops/test_help_data tests pass
- [ ] CI: full matrix green
- [ ] Manual: restart dashboard with this fix; stale count should drop substantially (from 154 to whatever genuinely exists in `.help/templates/` alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)