### PR TITLE
chore(release): 7.2.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v7.0.0
+# Attune AI Framework v7.2.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 7.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 7.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.2.0] — 2026-05-27
+
+### Added
+
+- **Live `/help` page in ops dashboard** — browse and search across
+  the `.help/templates/` corpus, with a separate "Admin tools" tab
+  for coverage gaps, staleness inventory, and one-click regeneration.
+  Drives the maintenance surface for the help corpus that previously
+  required shelling out to `attune-author status` (#482, #483, #484).
+- **Pending-writes API filters test-fixture and stale entries** —
+  `GET /api/pending-writes` now drops entries whose `project_root`
+  is under a known transient directory prefix (`/tmp`,
+  `/var/folders/`, the platform `tempfile.gettempdir()`) or doesn't
+  exist on disk. Filter runs on the read side; the journal itself
+  remains append-only and auditors can still read raw entries from
+  `~/.attune/ops/pending_writes.jsonl`. Cross-platform: includes
+  Windows `AppData\Local\Temp` paths (#492).
+- **Curator Phase 1** — source readers and cache scaffolding for the
+  bulletin-curator pipeline (#485).
+- **Multi-actor bulletin Phase 1** — protocol, file backend, and
+  actor-id foundation. A "Now running across actors" strip on the
+  Workflows page surfaces concurrent runs from sibling sessions so
+  parallel work is visible rather than guessed at (#474, #476, #477,
+  #478, #480).
+
 ### Changed
 
+- **Staleness detection on `/help/admin` is hash-only.** The 7-day
+  age fallback that conflated "source-hash drift" with "polished a
+  while ago" is removed. When attune-author is unavailable, the
+  dashboard reports zero stale rather than guessing via
+  `generated_at` age. Behavioral shift: per-template staleness now
+  collapses to per-feature because attune-author's source-hash
+  drift is feature-level (one hash per feature, not per kind), so
+  all kinds of a stale feature are reported stale together (#493).
 - **Widen `attune-author` cap in the `[author]` optional extra:
   `>=0.6.2,<0.14` → `>=0.6.2,<0.15`.** Admits
   [attune-author 0.14.x](https://pypi.org/project/attune-author/)
@@ -18,6 +51,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `attune-author` inside this venv); no runtime path. Cap raised
   one minor so the next breaking attune-author bump still
   requires explicit re-validation.
+
+### Fixed
+
+- **Dashboard stale count never decreased after "Regenerate all
+  stale".** `_parse_status_output` walked every `### Stale` section
+  in `attune-author status` output regardless of its parent `## `
+  h2, so it included features from BOTH `## Help Templates` (which
+  regenerate can fix) and `## Project Docs` (which it cannot —
+  separate corpus). That made ~30 docs-side features look stale to
+  the dashboard, expanded to ~150 templates flagged. The parser now
+  tracks h2 boundaries and only collects features inside
+  `## Help Templates → ### Stale`. Backward compat with older
+  attune-author output that omits the h2 (#494).
+- **Bulletin Windows loss-rate threshold** — widened to absorb
+  boundary runs from intermittent `O_APPEND` atomicity gaps on
+  Windows. POSIX is unaffected (#490).
+- **Closed codecov gap on `bulletin/route`** from #478 (#480).
+- **xdist worker pollution xfail (second test)** — sibling test in
+  `test_redis_fallback` failing on 6 lanes with the identical
+  symptom as PR #421's existing xfail; mirrored the xfail rather
+  than re-investigating the polluter (#481).
+- **typer 0.26 vendored its own click** — test imports asserting on
+  `click.exceptions.Exit` broke the moment typer auto-upgraded past
+  0.25.x. Swapped to `typer.Exit` (works across all typer versions)
+  (#473).
+- **`help/polish` model alias** — swapped the deprecated Anthropic
+  model snapshot for the stable alias to avoid the retirement
+  cutover (#470).
+
+### Docs
+
+- New `Lessons Learned` entries from 2026-05-27 session investigation,
+  plus h2-scoped status-parsing lesson (#489, #494).
+- Dashboard QA + Pandoc/weasyprint print-CSS lesson persisted (#491).
+- ops-help-page spec: requirements + wireframes drafted, "Admin tools"
+  button promoted, open questions resolved (#482, #483, #487).
+- test-discipline-controls 4-control proposal drafted (#486).
+- bulletin-curator design + tasks drafted, spec approved (#472, #479).
+- doc-stack reference subtypes spec Phase 0 inventory complete; spec
+  approved (#472, #475).
+- `_sequencing.md` refreshed for 2026-05-26 (#471).
+- Recovery snapshot from 2026-05-26 evening session (#488).
 
 ## [7.1.2] — 2026-05-25
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 7.0.0
+**Version:** 7.2.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 7.0.0 | **License:** Apache 2.0
+**Version:** 7.2.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "7.1.2"
+version = "7.2.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "7.1.2"
+version = "7.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Bundles ~14 PRs landed since v7.1.2 (2026-05-25) into a coordinated 7.2.0 release.

## Highlights

**Added**

- Live `/help` page in the ops dashboard with browse + search + an "Admin tools" tab for staleness inventory and one-click regen (#482, #483, #484)
- Pending-writes API filters test-fixture + stale entries — drops journal entries whose `project_root` is under a tmp prefix or no longer exists. Cross-platform: includes Windows `AppData\Local\Temp` (#492)
- Curator Phase 1 — source readers + cache scaffolding (#485)
- Multi-actor bulletin Phase 1 — protocol, file backend, actor-id; "Now running across actors" strip surfaces sibling-session concurrency on the Workflows page (#474, #476, #477, #478)

**Changed**

- `/help/admin` staleness is hash-only. The 7-day age fallback that conflated drift with polish-age is gone. Per-template staleness collapses to per-feature (drift is feature-level in attune-author) (#493)
- `attune-author` cap widened from `<0.14` to `<0.15`

**Fixed**

- Dashboard stale count never decreased after "Regenerate all stale" — parser was including features from `## Project Docs` section that regenerate can't touch. Scoped to `## Help Templates → ### Stale` (#494)
- Bulletin Windows loss-rate threshold (#490)
- typer 0.26 vendored its own click — swap to `typer.Exit` (#473)
- `help/polish` retiring model alias (#470)
- Closed codecov gap on `bulletin/route` (#480), xdist xfail mirror (#481)

Full CHANGELOG entry in this PR's diff.

## Version-bump files

- `pyproject.toml`: 7.1.2 → 7.2.0
- `.claude/CLAUDE.md`: header + footer
- `docs/reference/API_REFERENCE.md`: header + footer
- `uv.lock`: refreshed for new local version

Plugin manifests stay at 7.0.0 — `git log v7.0.0..HEAD -- plugin/` returns zero commits, so the plugin distribution genuinely hasn't changed. Plugin version-consistency test (29/29) still passes.

## Test plan

- [x] Local: `uv run --with build python -m build` produces `attune_ai-7.2.0-py3-none-any.whl` + `.tar.gz`
- [x] Local: plugin version-consistency test 29/29 pass
- [ ] CI: full matrix green
- [ ] After merge: tag `v7.2.0` (signed) → trigger `publish-pypi.yml` via `gh workflow run --ref main` → self-approve `pypi` env deployment → verify on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
