### PR TITLE
chore: sync plugin manifest version to 7.2.0 + drift-guard test

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "7.0.0"
+    "version": "7.2.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "7.0.0",
+      "version": "7.2.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6286,3 +6286,61 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   drops) feels like a regen tool bug, but the actual root cause
   is the staleness *reporter* including items the regen tool was
   never designed to handle.
+
+- **Policy: PyPI package version and plugin manifest version
+  MUST be the same value, always — they are one release, not
+  two streams**: project policy is that ``pyproject.toml``'s
+  ``version`` and ALL plugin manifest version fields
+  (``plugin/.claude-plugin/plugin.json``,
+  ``plugin/.claude-plugin/marketplace.json`` — both
+  ``metadata.version`` AND ``plugins[0].version``, the
+  root-level ``.claude-plugin/marketplace.json`` — same two
+  fields, ``plugin/core/__init__.py``'s ``__version__``)
+  carry the SAME version string on every release. Even when
+  ``plugin/`` content hasn't changed since the last release,
+  the plugin manifests still get bumped to match the new PyPI
+  version. **Why:** the PyPI install and the Claude Code
+  plugin install are two surfaces for ONE release. A user
+  running ``pip show attune-ai`` (e.g. 7.2.0) and
+  ``claude plugin list`` (showing 7.0.0) should NEVER see a
+  mismatch — they installed the same release, even if some
+  files in it didn't change. **What broke and why this lesson
+  exists:** the v7.2.0 release shipped with plugin manifests
+  still at 7.0.0 — they had stayed at 7.0.0 since the actual
+  v7.0.0 release, four PyPI minor versions earlier (7.0.x →
+  7.1.0 → 7.1.1 → 7.1.2 → 7.2.0). The
+  ``test_all_versions_match`` test only checks
+  internal-to-plugin consistency (the four plugin files agree
+  with each other), not cross-stream consistency against
+  ``pyproject.toml``, so the drift went unnoticed through four
+  publishes. **Required:** bump ALL plugin-file occurrences
+  to match the target ``pyproject.toml`` version every
+  release, no exceptions. The drift-guard test should be
+  extended to also assert ``pyproject.toml`` == plugin
+  manifests — that one new assertion would have caught every
+  miss since v7.0.0. Forward correction lives in a bump-only
+  follow-up PR; don't try to re-tag historical releases.
+
+- **Tag push + workflow_dispatch both fire ``publish-pypi.yml`` —
+  approve ONE, cancel the other**: extends the existing
+  "``release: published`` + ``workflow_dispatch`` both
+  approved for ``pypi`` env = duplicate publish" lesson with
+  the second auto-trigger shape. Repo's ``publish-pypi.yml``
+  is triggered by ``push: tags: 'v*.*.*'`` (changed to this
+  in v7.1.1 per its CHANGELOG entry). Pushing ``v7.2.0``
+  auto-fires a publish run. Additionally calling
+  ``gh workflow run publish-pypi.yml --ref main`` fires a
+  SECOND run via ``workflow_dispatch``. Both then sit waiting
+  for ``pypi`` environment approval. If both get approved,
+  the second 422s on "File already exists" — but the alarming
+  "failed" appearance hides that the first uploaded
+  successfully. **Operational rule** for any release whose
+  workflow has BOTH an auto-trigger AND
+  ``workflow_dispatch:``: choose ONE path, not both. For
+  ``push: tags``-triggered publishes, the cleaner default is
+  to let the tag push do it and skip the explicit
+  ``gh workflow run``. If you've already triggered both,
+  approve the tag-run via
+  ``gh api .../pending_deployments -X POST`` and
+  ``gh run cancel <dispatch-run-id>`` the duplicate before it
+  reaches the upload step.

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "7.0.0"
+    "version": "7.2.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "7.0.0",
+      "version": "7.2.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "7.0.0",
+  "version": "7.2.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "7.0.0"
+__version__ = "7.2.0"

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -16,6 +16,7 @@ import pytest
 import yaml
 
 PLUGIN_ROOT = Path(__file__).parents[3] / "plugin"
+REPO_ROOT = Path(__file__).parents[3]
 
 
 @pytest.mark.unit
@@ -350,34 +351,75 @@ class TestVersionConsistency:
     """Test that version numbers are consistent across plugin files."""
 
     def _get_versions(self) -> dict[str, str]:
-        """Collect version strings from all plugin files."""
+        """Collect version strings from all release-artifact files.
+
+        Project policy: PyPI package version (``pyproject.toml``) and
+        every plugin manifest version MUST be identical on every
+        release. See CLAUDE.md "Policy: PyPI package version and
+        plugin manifest version MUST be the same value, always".
+        Each release-relevant file's version goes here so a single
+        ``test_all_versions_match`` assertion catches any drift
+        across PyPI, plugin, and marketplace surfaces.
+        """
         versions: dict[str, str] = {}
 
-        # plugin.json
+        # pyproject.toml — PyPI package version (authoritative
+        # source for what gets uploaded to PyPI)
+        py = REPO_ROOT / "pyproject.toml"
+        for line in py.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("version = "):
+                versions["pyproject.toml"] = stripped.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+
+        # plugin/.claude-plugin/plugin.json — Claude Code plugin manifest
         pj = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
         data = json.loads(pj.read_text(encoding="utf-8"))
-        versions["plugin.json"] = data["version"]
+        versions["plugin/.claude-plugin/plugin.json"] = data["version"]
 
-        # marketplace.json (metadata + plugins[0])
+        # plugin/.claude-plugin/marketplace.json — bundled marketplace
+        # (metadata.version + plugins[0].version)
         mj = PLUGIN_ROOT / ".claude-plugin" / "marketplace.json"
         data = json.loads(mj.read_text(encoding="utf-8"))
-        versions["marketplace.json:metadata"] = data["metadata"]["version"]
-        versions["marketplace.json:plugin"] = data["plugins"][0]["version"]
+        versions["plugin/.claude-plugin/marketplace.json:metadata"] = data["metadata"]["version"]
+        versions["plugin/.claude-plugin/marketplace.json:plugin"] = data["plugins"][0]["version"]
 
-        # core/__init__.py
+        # .claude-plugin/marketplace.json — root-level marketplace
+        # (the one users `claude plugin marketplace add` against)
+        root_mj = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+        data = json.loads(root_mj.read_text(encoding="utf-8"))
+        versions["root .claude-plugin/marketplace.json:metadata"] = data["metadata"]["version"]
+        versions["root .claude-plugin/marketplace.json:plugin"] = data["plugins"][0]["version"]
+
+        # plugin/core/__init__.py — bundled runtime version
         init = PLUGIN_ROOT / "core" / "__init__.py"
         content = init.read_text(encoding="utf-8")
         for line in content.splitlines():
             if line.startswith("__version__"):
-                versions["core/__init__.py"] = line.split("=")[1].strip().strip('"').strip("'")
+                versions["plugin/core/__init__.py"] = (
+                    line.split("=")[1].strip().strip('"').strip("'")
+                )
 
         return versions
 
     def test_all_versions_match(self) -> None:
-        """Test that all version strings are identical."""
+        """Every release-artifact file carries the SAME version.
+
+        Project policy (see CLAUDE.md "Policy: PyPI package version
+        and plugin manifest version MUST be the same value"): the
+        PyPI package and the Claude Code plugin distribution are
+        ONE release, even when only one surface's content changed.
+        A user running ``pip show attune-ai`` and ``claude plugin
+        list`` should never see a mismatch.
+        """
         versions = self._get_versions()
         unique = set(versions.values())
-        assert len(unique) == 1, f"Version mismatch across files: {versions}"
+        assert len(unique) == 1, (
+            f"Version mismatch across release-artifact files: {versions}. "
+            "Project policy requires pyproject.toml and every plugin "
+            "manifest to carry the same version. Bump all entries to "
+            "match the new release."
+        )
 
     def test_version_is_semver(self) -> None:
         """Test that the version follows semver format."""


### PR DESCRIPTION
## Summary

Realigns the plugin distribution version with the PyPI package version per the new project policy ("PyPI and plugin manifest must always carry the same version"). Captures the policy as a CLAUDE.md lesson and extends the drift-guard test so future regressions get caught at CI time, not at release time.

## Why

The plugin manifests had been at **7.0.0** since the actual v7.0.0 release while PyPI moved through 7.0.1 → 7.1.0 → 7.1.1 → 7.1.2 → 7.2.0. The drift went unnoticed for four publishes because `test_all_versions_match` only checked plugin-internal consistency (`plugin/.claude-plugin/*.json` agreed with each other), not cross-stream against `pyproject.toml`.

## Changes

**Plugin version bumps (6 fields, 7.0.0 → 7.2.0):**
- `plugin/.claude-plugin/plugin.json`
- `plugin/.claude-plugin/marketplace.json` (metadata.version + plugins[0].version)
- `.claude-plugin/marketplace.json` (metadata.version + plugins[0].version)
- `plugin/core/__init__.py`

**Drift-guard test extended:**
- `test_all_versions_match` now ALSO reads `pyproject.toml`'s `version` and asserts it equals all plugin manifest versions. Single assertion catches any future cross-stream drift. Pre-fix this assertion would have failed at every PyPI publish since v7.0.1.

**Policy lesson captured:**
- New CLAUDE.md lesson: *"Policy: PyPI package version and plugin manifest version MUST be the same value, always — they are one release, not two streams."*
- New CLAUDE.md lesson: *"Tag push + workflow_dispatch both fire publish-pypi.yml — approve ONE, cancel the other"* (operational follow-up from the v7.2.0 ceremony hitting both triggers).

## No PyPI republish needed

This PR only changes plugin distribution metadata. The wheel already on PyPI as `attune-ai==7.2.0` is unaffected. Users who already installed 7.2.0 from PyPI don't need to do anything; users who install the plugin via `claude plugin marketplace add Smart-AI-Memory/attune-ai` after this PR merges will see 7.2.0 reported (instead of 7.0.0).

## Test plan

- [x] Local: `pytest tests/unit/plugins/test_plugin_config_validation.py` — 29/29 pass
- [ ] CI: full matrix green
- [ ] After merge: dashboard shows plugin version 7.2.0 (the version-consistency test would have failed pre-fix; passes now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
