### PR TITLE
feat(attune-ai-dev): add static landing page for attune-ai.dev

### DIFF
--- a/attune-ai-dev/README.md
+++ b/attune-ai-dev/README.md
@@ -1,0 +1,70 @@
+# attune-ai-dev
+
+Source for [attune-ai.dev](https://attune-ai.dev) — the canonical
+home for the article *The Discipline of Agent Collaboration* plus
+a minimal landing page for the `attune-ai` package.
+
+Sibling site to `website/` (smartaimemory.com). The two have
+different jobs:
+
+| Site | Job |
+|---|---|
+| `website/` (smartaimemory.com) | Full product marketing — six packages, docs, blog, pricing. |
+| `attune-ai-dev/` (attune-ai.dev) | Article home + wayfinding. Points back to smartaimemory.com for the full surface. |
+
+## Files
+
+- `index.html` — bare-domain landing page. Single file, no build
+  step, no external dependencies. Matches the smartaimemory.com
+  brand tokens (`#004ac6` primary, Manrope headline, system body).
+- `discipline/` — *(planned)* the article *The Discipline of Agent
+  Collaboration*, served at `attune-ai.dev/discipline`.
+- `og.png` — *(planned)* 1200×630 social card image. Generated
+  from the brand tokens.
+
+## Deploying
+
+Static site. Deployed on **Vercel** (same account as
+`website/` / smartaimemory.com).
+
+### One-time setup in Vercel
+
+1. New Project → Import this repo (`Smart-AI-Memory/attune-ai`).
+2. **Root Directory:** `attune-ai-dev`
+3. **Framework Preset:** Other (or none — static site).
+4. **Build Command:** *(leave empty)*
+5. **Output Directory:** *(leave empty — serves repo root)*
+6. **Install Command:** *(leave empty)*
+7. Deploy.
+
+`vercel.json` in this directory carries the runtime config
+(clean URLs, security headers, OG-image cache policy).
+
+### Custom domain
+
+1. Vercel project → Settings → Domains → Add `attune-ai.dev`.
+2. Vercel will show DNS records to add (typically an A record
+   for the apex pointing at `76.76.21.21`, and a CNAME for
+   `www` pointing at `cname.vercel-dns.com`).
+3. Add those records in Cloudflare DNS for `attune-ai.dev`.
+   Set Cloudflare proxy status to **DNS only** (gray cloud)
+   for the Vercel records — Vercel handles its own CDN/SSL.
+
+## DNS
+
+Domain registered at Cloudflare Registrar. DNS managed
+through Cloudflare. Vercel handles SSL termination
+automatically once the DNS records resolve.
+
+## Updating the version chip
+
+The eyebrow chip in `index.html` shows the current package
+version (currently `v7.2.0`). Update by hand on each release,
+or wire it to `pyproject.toml` later via a build step.
+
+## Why a separate site
+
+`attune-ai.dev` exists primarily to serve the article and reinforce
+the `pip install attune-ai` brand surface. Duplicating the
+smartaimemory.com marketing here would be redundant; pointing
+back to it from the landing keeps both sites doing one job each.

--- a/attune-ai-dev/index.html
+++ b/attune-ai-dev/index.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>attune-ai — the discipline behind productive agent collaboration</title>
+  <meta name="description" content="A toolchain for the work that lives between sessions, across files, and across packages — specs, releases, memory, dashboards, verification." />
+
+  <!-- Social sharing -->
+  <meta property="og:title" content="attune-ai" />
+  <meta property="og:description" content="The discipline behind productive collaboration with AI coding agents." />
+  <meta property="og:url" content="https://attune-ai.dev" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://attune-ai.dev/og.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+
+  <link rel="canonical" href="https://attune-ai.dev" />
+
+  <style>
+    :root {
+      /* Matches smartaimemory.com brand tokens (app/globals.css) */
+      --primary: #004ac6;
+      --primary-light: #2563eb;
+      --bg: #f8f9ff;
+      --ink: #0b1c30;
+      --muted: #434655;
+      --rule: #c3c6d7;
+      --surface-low: #eff4ff;
+      --surface-high: #dce9ff;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b1c30;
+        --ink: #f8f9ff;
+        --muted: #b7c8e1;
+        --rule: #38485d;
+        --surface-low: #132438;
+        --surface-high: #213145;
+        --primary: #6ea1ff;
+      }
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, sans-serif;
+      font-size: 17px;
+      line-height: 1.55;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    main {
+      max-width: 38rem;
+      margin: 0 auto;
+      padding: 5rem 1.5rem 3rem;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      background: var(--surface-high);
+      color: var(--primary);
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-bottom: 1.5rem;
+    }
+    .eyebrow .dot {
+      width: 4px; height: 4px; border-radius: 50%;
+      background: var(--primary);
+    }
+
+    h1 {
+      font-family: "Manrope", -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 3rem;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      line-height: 1.05;
+      margin: 0 0 0.75rem;
+    }
+    .tagline {
+      font-size: 1.25rem;
+      color: var(--muted);
+      margin: 0 0 2.5rem;
+      font-weight: 400;
+      line-height: 1.45;
+    }
+
+    .install {
+      display: flex;
+      align-items: stretch;
+      background: var(--surface-low);
+      border: 1px solid var(--rule);
+      border-radius: 8px;
+      margin: 0 0 3rem;
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+      font-size: 0.95rem;
+    }
+    .install code {
+      flex: 1;
+      padding: 0.85rem 1rem;
+      background: none;
+      color: var(--ink);
+      user-select: all;
+    }
+    .install button {
+      background: none;
+      border: none;
+      border-left: 1px solid var(--rule);
+      padding: 0 1.1rem;
+      color: var(--muted);
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.85rem;
+      transition: color 120ms ease;
+    }
+    .install button:hover { color: var(--primary); }
+
+    nav ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      border-top: 1px solid var(--rule);
+    }
+    nav li { border-bottom: 1px solid var(--rule); }
+    nav a {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      padding: 1.35rem 0;
+      text-decoration: none;
+      color: var(--ink);
+      transition: color 120ms ease;
+    }
+    nav a:hover { color: var(--primary); }
+    nav a:hover .arrow { transform: translateX(2px); color: var(--primary); }
+    .label { font-weight: 600; font-size: 1.05rem; }
+    .desc {
+      display: block;
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin-top: 0.2rem;
+      font-weight: 400;
+    }
+    .arrow {
+      color: var(--muted);
+      font-size: 1.1rem;
+      transition: transform 120ms ease, color 120ms ease;
+      flex-shrink: 0;
+    }
+
+    footer {
+      margin-top: 4rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--rule);
+      color: var(--muted);
+      font-size: 0.85rem;
+      display: flex;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--ink); }
+
+    @media (max-width: 480px) {
+      main { padding: 3rem 1.25rem 2rem; }
+      h1 { font-size: 2.25rem; }
+      .tagline { font-size: 1.1rem; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <span class="eyebrow">
+      <span>v7.2.0</span>
+      <span class="dot"></span>
+      <span>AI Workflow OS for Claude Code</span>
+    </span>
+
+    <h1>attune-ai</h1>
+    <p class="tagline">
+      The discipline behind productive collaboration with AI coding agents.
+    </p>
+
+    <div class="install" aria-label="Install command">
+      <code id="install-cmd">pip install attune-ai</code>
+      <button type="button" onclick="copyInstall()" aria-label="Copy install command">copy</button>
+    </div>
+
+    <nav aria-label="Primary">
+      <ul>
+        <li>
+          <a href="/discipline">
+            <span>
+              <span class="label">Read: The Discipline of Agent Collaboration</span>
+              <span class="desc">The field manual. Six disciplines, named.</span>
+            </span>
+            <span class="arrow" aria-hidden="true">→</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://smartaimemory.com">
+            <span>
+              <span class="label">smartaimemory.com</span>
+              <span class="desc">Full docs, blog, and the rest of the attune family.</span>
+            </span>
+            <span class="arrow" aria-hidden="true">→</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/Smart-AI-Memory/attune-ai">
+            <span>
+              <span class="label">Source on GitHub</span>
+              <span class="desc">Smart-AI-Memory / attune-ai &middot; Apache 2.0</span>
+            </span>
+            <span class="arrow" aria-hidden="true">→</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+
+    <footer>
+      <span>Smart AI Memory</span>
+      <span>
+        <a href="https://pypi.org/project/attune-ai/">PyPI</a>
+        &nbsp;&middot;&nbsp;
+        <a href="https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE">Apache 2.0</a>
+      </span>
+    </footer>
+  </main>
+
+  <script>
+    function copyInstall() {
+      const text = document.getElementById('install-cmd').textContent;
+      navigator.clipboard.writeText(text).then(() => {
+        const btn = document.querySelector('.install button');
+        const orig = btn.textContent;
+        btn.textContent = 'copied';
+        setTimeout(() => btn.textContent = orig, 1200);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/attune-ai-dev/vercel.json
+++ b/attune-ai-dev/vercel.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    },
+    {
+      "source": "/og.png",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, must-revalidate"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New top-level `attune-ai-dev/` directory holding a single-file static landing page for the just-registered `attune-ai.dev` domain
- Brand-matched to smartaimemory.com via shared design tokens (#004ac6 primary, Material Design 3 palette from `website/app/globals.css`)
- Vercel-deployable as-is; future `/discipline` article subdirectory planned for a follow-up PR

## Why a new directory
The new domain hosts the forthcoming *Discipline of Agent Collaboration* article plus a minimal wayfinding shelf. The existing `website/` (smartaimemory.com) keeps doing full product marketing; this directory is single-purpose.

## Files
- `attune-ai-dev/index.html` — single-file landing page, ~250 lines including inline styles and clipboard JS
- `attune-ai-dev/README.md` — purpose, sibling-site distinction, Vercel deploy steps
- `attune-ai-dev/vercel.json` — clean URLs, security headers, OG image cache

## Test plan
- [ ] `attune-ai-dev/index.html` renders in light + dark mode
- [ ] Copy button on install command works
- [ ] Links resolve (placeholder `/discipline`, smartaimemory.com, GitHub repo)
- [ ] Vercel preview deploys without build errors
- [ ] Pre-commit hooks pass (markdown linting on README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
