### PR TITLE
feat(hooks): discover specs under docs/specs (sibling-hooks P0)

### DIFF
--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -137,16 +137,28 @@ def _is_in_flight(phase: str, status: str) -> bool:
     return True
 
 
-def _layer_for(roots: list[Path], spec_dir: Path) -> str:
-    """Resolve the layer slug for a spec directory.
+def _layer_for(roots: list[Path], base: Path) -> str:
+    """Resolve the layer slug for a spec's base directory.
 
-    Workspace-root specs (``<workspace>/specs/foo``) → ``workspace``.
-    Layer specs (``<workspace>/attune-rag/specs/foo``) → ``attune-rag``.
+    ``base`` is the directory that *contains* the spec subdir
+    (``specs`` or ``docs/specs``) — either the workspace root or a
+    layer dir.
+
+    Workspace-root specs → ``workspace``.
+    Layer specs (``<workspace>/attune-rag/...``) → ``attune-rag``.
     """
-    parent = spec_dir.parent.parent
-    if parent in roots:
+    if base in roots:
         return "workspace"
-    return parent.name or "workspace"
+    return base.name or "workspace"
+
+
+# Spec-subdir conventions probed under each root and layer dir.
+# attune-gui and workspace-root specs live in ``specs/``;
+# attune-rag/author/help keep theirs in ``docs/specs/``. Probing both
+# lets one identical hook serve every repo (supersedes a per-repo
+# config). Root-level matches are processed before layer matches so a
+# root ``docs/specs`` is attributed to ``workspace`` (see dedup below).
+_SPEC_SUBDIRS: tuple[str, ...] = ("specs", "docs/specs")
 
 
 def discover_specs(roots: list[Path]) -> list[SpecInfo]:
@@ -164,14 +176,18 @@ def discover_specs(roots: list[Path]) -> list[SpecInfo]:
     found: list[SpecInfo] = []
     seen: set[Path] = set()
     for root in roots:
-        candidate_specs_dirs: list[Path] = [root / "specs"]
+        # (base, specs_dir) pairs. ``base`` is the dir that contains the
+        # spec subdir and decides the layer label. Root-level bases are
+        # listed first so a ``docs/specs`` at the root is attributed to
+        # ``workspace`` before the layer walk reaches the same path.
+        candidate_bases: list[tuple[Path, Path]] = [(root, root / sub) for sub in _SPEC_SUBDIRS]
         try:
-            for entry in root.iterdir():
+            for entry in sorted(root.iterdir()):
                 if entry.is_dir():
-                    candidate_specs_dirs.append(entry / "specs")
+                    candidate_bases.extend((entry, entry / sub) for sub in _SPEC_SUBDIRS)
         except OSError:
             continue
-        for specs_dir in candidate_specs_dirs:
+        for base, specs_dir in candidate_bases:
             if not specs_dir.is_dir():
                 continue
             try:
@@ -193,7 +209,7 @@ def discover_specs(roots: list[Path]) -> list[SpecInfo]:
                     SpecInfo(
                         slug=spec_dir.name,
                         path=spec_dir,
-                        layer=_layer_for(roots, spec_dir),
+                        layer=_layer_for(roots, base),
                         phase=phase,
                         status=status,
                         mtime=mtime,

--- a/tests/unit/hooks/test_session_continuity_state.py
+++ b/tests/unit/hooks/test_session_continuity_state.py
@@ -145,6 +145,35 @@ class TestDiscoverSpecs:
         (specs_dir / "README.md").write_text("not a spec dir")
         assert state_mod.discover_specs([tmp_path]) == []
 
+    def test_docs_specs_at_root_is_workspace(self, tmp_path: Path, state_mod) -> None:
+        # attune-rag/author/help keep specs under docs/specs/, not specs/.
+        spec = tmp_path / "docs" / "specs" / "rag-feat"
+        _write_spec(spec, requirements_status="approved")
+        result = state_mod.discover_specs([tmp_path])
+        assert len(result) == 1
+        assert result[0].slug == "rag-feat"
+        assert result[0].layer == "workspace"
+
+    def test_docs_specs_under_layer(self, tmp_path: Path, state_mod) -> None:
+        spec = tmp_path / "attune-author" / "docs" / "specs" / "author-feat"
+        _write_spec(spec, requirements_status="approved")
+        result = state_mod.discover_specs([tmp_path])
+        assert len(result) == 1
+        assert result[0].slug == "author-feat"
+        assert result[0].layer == "attune-author"
+
+    def test_both_conventions_coexist_without_dup(self, tmp_path: Path, state_mod) -> None:
+        # A repo using specs/ and one using docs/specs/ side by side; no
+        # double-counting, each attributed to the right layer.
+        _write_spec(tmp_path / "specs" / "ws-feat", requirements_status="approved")
+        _write_spec(
+            tmp_path / "attune-rag" / "docs" / "specs" / "rag-feat",
+            requirements_status="approved",
+        )
+        result = state_mod.discover_specs([tmp_path])
+        layers = {s.slug: s.layer for s in result}
+        assert layers == {"ws-feat": "workspace", "rag-feat": "attune-rag"}
+
 
 # ── git_state ────────────────────────────────────────────────
 


### PR DESCRIPTION
**P0** of the `sibling-claude-hooks` port (spec: `attune/specs/sibling-claude-hooks/`).

## Problem
The spec-orientation SessionStart hook delegates discovery to `_state.discover_specs`, which only scanned `specs/` directories. attune-rag/author/help keep their specs in `docs/specs/` — so when these hooks are ported to those repos (P1+), the orientation hook would find nothing.

## Change
`discover_specs` now probes **both** `specs/` and `docs/specs/` under each root and each layer dir. One identical hook serves every repo — this **supersedes the per-repo `SPECS_DIR` config** (DECIDE-2) from the original design, and we keep the 3-line UTF-8 guard inline rather than extracting `_encoding.py` (fewer shared files = simpler copy-based distribution + drift-guard).

- `_SPEC_SUBDIRS = ('specs', 'docs/specs')`; root-level matches win over layer matches for the same resolved dir.
- `_layer_for` now takes the spec's **base dir** so `docs/specs` is attributed to the right layer.

## Tests
3 new (`docs/specs` at root → workspace; under a layer → layer; both conventions coexist, no dup). Existing `discover_specs` tests unchanged. **206 hook unit tests pass; ruff clean.**

## Unblocks
P1 (attune-rag pilot) and P2–P4. After merge, siblings copy the 4 hooks as-is and orientation Just Works regardless of `specs/` vs `docs/specs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)