### PR TITLE
docs(fiction-cleanup): Phase 2 MECHANICAL batch (8 docs renamed)

### DIFF
--- a/docs/BLOG_CLAUDE_OPTIMIZATION.md
+++ b/docs/BLOG_CLAUDE_OPTIMIZATION.md
@@ -114,11 +114,6 @@ I didn't break anything. Attune AI supports:
 
 All providers use async clients. All providers work with workflows. The difference: Claude-specific features (slash commands, conversation persistence) unlock capabilities the others don't have.
 
-```python
-# Still works fine
-from attune_llm.providers import OpenAIProvider, GeminiProvider, LocalProvider
-```
-
 ## The Skills System
 
 I put all the workflow logic in markdown files:

--- a/docs/EXCEPTION_HANDLING_GUIDE.md
+++ b/docs/EXCEPTION_HANDLING_GUIDE.md
@@ -516,42 +516,7 @@ for py_file in self.project_root.rglob("*.py"):
         })
 ```
 
-### Example 4: Health Check with Specific Handlers
-**File:** `attune_llm/code_health.py:393`
-
-```python
-try:
-    if tool == "ruff":
-        result = subprocess.run(
-            ["ruff", "check", "--output-format=json", str(self.project_root)],
-            check=False, capture_output=True, text=True
-        )
-        ruff_issues = json.loads(result.stdout)
-        # Process issues...
-except json.JSONDecodeError as e:
-    # Tool output not in expected JSON format
-    logger.warning(f"Lint check JSON parse error ({tool}): {e}")
-    return CheckResult(
-        category=CheckCategory.LINT, status=HealthStatus.ERROR,
-        score=0, details={"error": f"Failed to parse {tool} output: {e}"}
-    )
-except subprocess.SubprocessError as e:
-    # Tool execution failed
-    logger.error(f"Lint check subprocess error ({tool}): {e}")
-    return CheckResult(
-        category=CheckCategory.LINT, status=HealthStatus.ERROR,
-        score=0, details={"error": f"Failed to run {tool}: {e}"}
-    )
-except Exception as e:
-    # INTENTIONAL: Broad handler for graceful degradation of optional check
-    logger.exception(f"Unexpected error in lint check ({tool}): {e}")
-    return CheckResult(
-        category=CheckCategory.LINT, status=HealthStatus.ERROR,
-        score=0, details={"error": str(e)}
-    )
-```
-
-### Example 5: Acceptable Broad Exception with noqa
+### Example 4: Acceptable Broad Exception with noqa
 **File:** `src/attune/cli.py:2041`
 
 ```python
@@ -627,7 +592,6 @@ Is this an optional feature (wizard, plugin, tip)?
   - `backend/services/database/auth_db.py` - Database patterns
   - `backend/api/wizard_api.py` - Graceful degradation
   - `agents/code_inspection/adapters/security_adapter.py` - Fail-secure
-  - `attune_llm/code_health.py` - Health checks
   - `src/attune/cli.py` - CLI error handling
 
 ---

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -18,7 +18,7 @@ The context management system handles:
 ## Quick Start
 
 ```python
-from attune_llm.context import ContextManager
+from attune.context import ContextManager
 
 # Initialize
 manager = ContextManager(storage_dir=".attune/compact_states")
@@ -93,7 +93,7 @@ handoff = manager.set_handoff(
 path = manager.save_for_compaction(collaboration_state)
 
 # Or create manually
-from attune_llm.context import CompactState, CompactionStateManager
+from attune.context import CompactState, CompactionStateManager
 
 state = CompactState(
     user_id="user123",
@@ -178,7 +178,7 @@ implementation
 ### Pre-Compact Hook
 
 ```python
-from attune_llm.hooks import HookRegistry, HookEvent
+from attune.hooks import HookRegistry, HookEvent
 
 registry = HookRegistry()
 

--- a/docs/continuous-learning.md
+++ b/docs/continuous-learning.md
@@ -18,7 +18,7 @@ The continuous learning system:
 ## Quick Start
 
 ```python
-from attune_llm.learning import (
+from attune.learning import (
     SessionEvaluator,
     PatternExtractor,
     LearnedSkillsStorage,
@@ -235,7 +235,7 @@ relevant = ctx.search_patterns("authentication")
 Aggregate patterns into higher-level skills:
 
 ```python
-from attune_llm.learning import LearnedSkill
+from attune.learning import LearnedSkill
 
 skill = LearnedSkill(
     skill_id="skill_001",
@@ -283,7 +283,7 @@ summary = storage.get_summary("user123")
 ### Session End Evaluation
 
 ```python
-from attune_llm.hooks import HookRegistry, HookEvent
+from attune.hooks import HookRegistry, HookEvent
 
 def evaluate_session_handler(context):
     evaluator = SessionEvaluator()

--- a/docs/guides/DISTRIBUTION_POLICY.md
+++ b/docs/guides/DISTRIBUTION_POLICY.md
@@ -26,7 +26,7 @@ Users receive the **core framework** needed to use Empathy:
 
 | Category | Included |
 |----------|----------|
-| **Source Code** | All Python packages (attune, attune_llm, etc.) |
+| **Source Code** | All Python packages (attune, etc.) |
 | **Documentation** | README.md, CHANGELOG.md, QUICKSTART.md, CONTRIBUTING.md |
 | **Configuration** | pyproject.toml, requirements.txt, example configs |
 | **User Docs** | API reference, guides, getting-started, examples |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,7 +18,7 @@ Hooks allow you to execute custom code at specific points in the session lifecyc
 ## Quick Start
 
 ```python
-from attune_llm.hooks import HookRegistry, HookEvent
+from attune.hooks import HookRegistry, HookEvent
 
 # Create registry
 registry = HookRegistry()
@@ -67,7 +67,7 @@ hooks:
         match_all: true
       hooks:
         - type: python
-          command: attune_llm.hooks.scripts.session_start:main
+          command: attune.hooks.scripts.first_time_init:main
           description: Restore previous context
 
   PostToolUse:
@@ -86,7 +86,7 @@ log_executions: true
 ### Loading Configuration
 
 ```python
-from attune_llm.hooks import HookConfig
+from attune.hooks import HookConfig
 
 config = HookConfig.from_yaml("hooks.yaml")
 registry = HookRegistry(config=config)
@@ -97,7 +97,7 @@ registry = HookRegistry(config=config)
 Matchers determine when hooks fire:
 
 ```python
-from attune_llm.hooks import HookMatcher
+from attune.hooks import HookMatcher
 
 # Match specific tool
 tool_matcher = HookMatcher(tool="Edit")

--- a/docs/how-to/unified-memory-system.md
+++ b/docs/how-to/unified-memory-system.md
@@ -431,11 +431,11 @@ empathy.stash(...)  # Convenience method
 empathy.memory.stash(...)  # Or via unified interface
 ```
 
-### From `attune_llm.security`
+### From `attune.security`
 
 ```python
 # OLD (still works via re-exports)
-from attune_llm.security import PIIScrubber, SecretsDetector
+from attune.security import PIIScrubber, SecretsDetector
 
 # NEW (recommended)
 from attune.memory import PIIScrubber, SecretsDetector
@@ -447,7 +447,7 @@ from attune.memory.security import AuditLogger
 ## Next Steps
 
 - **[Short-Term Memory Implementation](./short-term-memory-implementation.md)**: Detailed Redis setup
-- **[Security Architecture](./security-architecture.md)**: PII scrubbing, encryption, audit logging
+- **[Security Architecture](./security-architecture.md)**: PII scrubbing, audit logging
 - **[API Reference: Memory](../reference/multi-agent.md)**: Complete class documentation
 
 ---

--- a/docs/markdown-agents.md
+++ b/docs/markdown-agents.md
@@ -50,7 +50,7 @@ You are an expert code reviewer focused on:
 ### 2. Load the Agent
 
 ```python
-from attune_llm.agents_md import AgentRegistry
+from attune.agents_md import AgentRegistry
 
 registry = AgentRegistry.get_instance()
 registry.load_from_directory("agents/")
@@ -149,7 +149,7 @@ The framework includes these agents in `agents_md/`:
 ### From Directory
 
 ```python
-from attune_llm.agents_md import AgentRegistry
+from attune.agents_md import AgentRegistry
 
 registry = AgentRegistry.get_instance()
 count = registry.load_from_directory("agents/", recursive=True)
@@ -197,7 +197,7 @@ for name in registry.list_agents():
 Validate agent files before loading:
 
 ```python
-from attune_llm.agents_md import AgentLoader
+from attune.agents_md import AgentLoader
 
 loader = AgentLoader()
 errors = loader.validate_directory("agents/")

--- a/docs/specs/doc-fiction-cleanup/decisions.md
+++ b/docs/specs/doc-fiction-cleanup/decisions.md
@@ -167,6 +167,65 @@ retire decision — to be triaged in Phase 2. See `tasks.md`.
   `docs/archive/` tree, and (c) the historical
   `deprecated-module-retirement/tasks.md:35` note (intentional).
 
+## Phase 2 outcomes (2026-05-30, PR-B — MECHANICAL batch)
+
+### Renamed (5 docs, pure `attune_llm` → `attune` rename)
+
+- **`docs/context-management.md`** — 3 imports renamed; all
+  symbols (`ContextManager`, `CompactState`, `CompactionStateManager`,
+  `HookRegistry`, `HookEvent`) resolve at the new paths.
+- **`docs/continuous-learning.md`** — 3 imports renamed; all
+  symbols (`SessionEvaluator`, `PatternExtractor`,
+  `LearnedSkillsStorage`, `SessionQuality`, `PatternCategory`,
+  `LearnedSkill`, `HookRegistry`, `HookEvent`) verified present.
+  This closes the previously-open "may be fiction" question on
+  this doc — scout was correct, every symbol resolves.
+- **`docs/hooks.md`** — 4 imports renamed (`HookRegistry`,
+  `HookEvent`, `HookConfig`, `HookMatcher`). One example
+  pointer broken even after rename: replaced
+  `attune_llm.hooks.scripts.session_start:main` with
+  `attune.hooks.scripts.first_time_init:main` (real script in
+  the same dir; semantically aligned for SessionStart events;
+  `session_start.py` does not exist in current source).
+- **`docs/markdown-agents.md`** — 3 imports renamed
+  (`AgentRegistry`, `AgentLoader`). Closes the second
+  previously-open "may be fiction" question — scout was correct.
+- **`docs/how-to/unified-memory-system.md`** — 2 imports renamed
+  (`PIIScrubber`, `SecretsDetector` from `attune.security`).
+  Also: dropped "encryption" from the inline description of
+  `security-architecture.md` at line ~450 (no encryption module
+  exists; was overpromising) per Phase 2 preflight note.
+
+### Pruned fiction (3 docs, partial cleanup)
+
+- **`docs/EXCEPTION_HANDLING_GUIDE.md`** — deleted the entire
+  35-line "Example 4: Health Check with Specific Handlers"
+  section (referenced `attune_llm/code_health.py:393`;
+  `code_health.py` does not exist in source). Also removed the
+  bullet pointing to `attune_llm/code_health.py` in the
+  "Codebase Examples" section. Examples 1, 2, 3, and 5 retained
+  (Example 5 auto-renumbered to 4 by markdown convention; no
+  inbound deep-links to anchors).
+- **`docs/BLOG_CLAUDE_OPTIMIZATION.md`** — deleted a 3-line
+  fenced code block `from attune_llm.providers import
+  OpenAIProvider, GeminiProvider, LocalProvider`. The multi-
+  provider story is broader fiction than the rename (real
+  surface is Anthropic-only today), but the surrounding prose
+  + table are left intact for the BLOG owner to revisit
+  separately. Scope-bounded to the import-line fiction.
+- **`docs/guides/DISTRIBUTION_POLICY.md`** — single trivial
+  change: `(attune, attune_llm, etc.)` → `(attune, etc.)` in
+  a table cell.
+
+### Verification
+
+- Net diff: -41 lines (18 insertions, 59 deletions).
+- `mkdocs build --strict` passes.
+- Grep sanity: remaining `attune_llm` references confined to
+  (a) `docs/archive/` (intentional fossils), (b) the cleanup
+  spec itself, (c) the pending REWRITE targets `agent-factory.md`
+  and `TROUBLESHOOTING.md` (Phase 2 PR-C and Phase 3 respectively).
+
 ---
 
 ## Phase 2 preflight notes (2026-05-30)

--- a/docs/specs/doc-fiction-cleanup/tasks.md
+++ b/docs/specs/doc-fiction-cleanup/tasks.md
@@ -63,15 +63,22 @@ concrete claim, surface for review before finalizing.
   (3 entries), `how-to/index.md`, both `sbar-clinical-handoff.md`,
   `how-to/telemetry-and-signals.md`, `reference/index.md`. `mkdocs build --strict`
   passes.
-- [ ] **MECHANICAL batch (PR-B):** 8 docs grep+replace
-  `attune_llm` → `attune` with per-import verification:
-  `BLOG_CLAUDE_OPTIMIZATION.md` (or just delete the snippet),
-  `EXCEPTION_HANDLING_GUIDE.md`, `context-management.md`,
-  `continuous-learning.md`, `guides/DISTRIBUTION_POLICY.md`,
-  `hooks.md`, `markdown-agents.md`, `unified-memory-system.md`
-  (also drop "encryption" from line 450 per `decisions.md`
-  Phase 2 preflight). All symbols verified present at the
-  renamed path per triage file.
+- [x] **MECHANICAL batch (PR-B, 2026-05-30):** 8 docs renamed
+  `attune_llm` → `attune` with per-import verification.
+  Net -41 lines. Renamed: `context-management.md` (3 imports),
+  `continuous-learning.md` (3 imports), `hooks.md` (4 imports
+  + replaced broken `session_start:main` with real
+  `first_time_init:main`), `markdown-agents.md` (3 imports),
+  `unified-memory-system.md` (2 imports + dropped "encryption"
+  from line 450 per Phase 2 preflight). Pruned: a 35-line
+  fictional `Example 4: Health Check` block in
+  `EXCEPTION_HANDLING_GUIDE.md` (`attune_llm/code_health.py`
+  doesn't exist); a 3-line broken multi-provider import snippet
+  in `BLOG_CLAUDE_OPTIMIZATION.md`; one `attune_llm` mention
+  in `guides/DISTRIBUTION_POLICY.md`. `mkdocs build --strict`
+  passes. Zero remaining `attune_llm` references outside
+  `docs/archive/`, the cleanup spec, and the pending REWRITE
+  targets (agent-factory.md, TROUBLESHOOTING.md).
 - [ ] **REWRITE batch (PR-C, ≤1 doc this session):**
   `agent-factory.md` recommended. Deferred to Phase 3:
   `TROUBLESHOOTING.md` (mixed real troubleshooting + fiction;


### PR DESCRIPTION
## Summary

Second of three Phase 2 PRs for [`doc-fiction-cleanup`](docs/specs/doc-fiction-cleanup/). MECHANICAL batch — `attune_llm` → `attune` renames plus minor fiction prunes where the renamed path itself wouldn't resolve.

Follows #507 (RETIRE + ARCHIVE batch). PR-C (REWRITE batch for `agent-factory.md`) follows.

**Net: -41 lines.**

## Renamed (5 docs, pure imports)

| Doc | Imports renamed | Notes |
|---|---|---|
| `context-management.md` | 3 (`ContextManager`, `CompactState`/`CompactionStateManager`, `HookRegistry`/`HookEvent`) | symbols verified at `attune.context` and `attune.hooks` |
| `continuous-learning.md` | 3 (`SessionEvaluator` et al, `LearnedSkill`, `HookRegistry`/`HookEvent`) | **closes "may be fiction" open question** — scout was correct, all symbols resolve |
| `hooks.md` | 4 (`HookRegistry`/`HookEvent`, `HookConfig`, `HookMatcher`) | + 1 example pointer fix: `session_start:main` → `first_time_init:main` (the original referenced a script that doesn't exist; `first_time_init` is the SessionStart-aligned equivalent in the same dir) |
| `markdown-agents.md` | 3 (`AgentRegistry` ×2, `AgentLoader`) | **closes second "may be fiction" open question** |
| `how-to/unified-memory-system.md` | 2 (`PIIScrubber`, `SecretsDetector`) | + dropped "encryption" from line 450 per Phase 2 preflight note (Q5 decision) |

## Pruned fiction (3 docs, partial cleanup)

| Doc | What was pruned |
|---|---|
| `EXCEPTION_HANDLING_GUIDE.md` | 35-line `Example 4: Health Check` section (referenced `attune_llm/code_health.py` which doesn't exist); 1 bullet in Codebase Examples |
| `BLOG_CLAUDE_OPTIMIZATION.md` | 3-line snippet importing nonexistent OpenAI/Gemini/Local providers (multi-provider claim in surrounding prose/table left intact — out of scope) |
| `guides/DISTRIBUTION_POLICY.md` | trivial: `(attune, attune_llm, etc.)` → `(attune, etc.)` |

## Verification

- `mkdocs build --strict` passes. Pre-existing anchor warnings in `API_REFERENCE.md` are unrelated to this PR.
- Grep sanity: remaining `attune_llm` references confined to `docs/archive/` (intentional fossils), the cleanup spec itself, and the pending REWRITE targets `agent-factory.md` (PR-C) and `TROUBLESHOOTING.md` (Phase 3).
- All renamed symbols verified at their new paths against `src/` before edit (scout-verified in `phase-2-triage.md`, spot-checked again in session).

## Spec updates

- `tasks.md` — MECHANICAL row checked off.
- `decisions.md` — Phase 2 PR-B outcomes section added; the two `decisions.md` "Open questions" entries on `continuous-learning.md` and `markdown-agents.md` formally resolved (both renamed cleanly with all symbols resolving).

## Follow-ups

- **PR-C (REWRITE):** `agent-factory.md` only — ≤1 REWRITE this session per session contract.
- **Phase 3 (deferred):** `TROUBLESHOOTING.md` REWRITE (mixed real troubleshooting + fiction); remaining MEDIUM/LOW fact-drift docs from `decisions.md`; two `webhook-event-integration.md` example docs.

## Test plan

- [ ] `mkdocs build --strict` passes in CI.
- [ ] `grep -rln attune_llm docs/` returns only `docs/archive/`, `docs/specs/doc-fiction-cleanup/`, `docs/how-to/agent-factory.md`, and `docs/reference/TROUBLESHOOTING.md`.
- [ ] Each renamed import resolves in a fresh `python -c "from attune.X import Y"` smoke check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)