### PR TITLE
docs(fiction-cleanup): Phase 2 REWRITE batch (agent-factory.md)

### DIFF
--- a/docs/how-to/agent-factory.md
+++ b/docs/how-to/agent-factory.md
@@ -1,25 +1,41 @@
 ---
-description: Agent Factory: The Universal Agent Factory allows you to create AI agents and workflows using your preferred framework while retaining Empathy's core features:
+description: How to create agents and workflows across multiple frameworks (LangChain, LangGraph, AutoGen, Haystack, or native) through a single unified factory.
 ---
 
 # Agent Factory
 
-The Universal Agent Factory allows you to create AI agents and workflows using your preferred framework while retaining Empathy's core features: cost optimization, pattern learning, and memory.
+`attune.agent_factory` provides a **universal factory** for creating agents
+and workflows across multiple frameworks through one common interface.
+Pick your framework once, and the same `create_agent` / `create_workflow`
+calls work whether the underlying agents are LangChain chains, LangGraph
+state machines, AutoGen conversational agents, Haystack pipelines, or
+Attune's native adapter.
 
-## Supported Frameworks
+The factory layers Attune-side features — model-tier routing,
+cost-tracking flags, optional Memory Graph integration, optional
+resilience wrapping — on top of the chosen framework.
 
-| Framework | Best For | Install Command |
-|-----------|----------|-----------------|
-| **Native** | Simple agents, cost optimization | Included |
-| **LangChain** | Chains, tools, RAG | `pip install langchain langchain-anthropic` |
-| **LangGraph** | Stateful workflows, multi-step | `pip install langgraph` |
-| **AutoGen** | Multi-agent conversations | `pip install pyautogen` |
-| **Haystack** | Document QA, RAG pipelines | `pip install haystack-ai` |
+## Supported frameworks
 
-## Quick Start
+| Framework value          | Adapter                                                   | Install                                  |
+|--------------------------|-----------------------------------------------------------|------------------------------------------|
+| `Framework.NATIVE`       | `NativeAdapter` (built-in)                                | included                                 |
+| `Framework.LANGCHAIN`    | `LangChainAdapter` (lazy)                                 | `pip install langchain langchain-anthropic` |
+| `Framework.LANGGRAPH`    | `LangGraphAdapter` (lazy)                                 | `pip install langgraph langchain-anthropic` |
+| `Framework.AUTOGEN`      | `AutoGenAdapter` (lazy)                                   | `pip install pyautogen`                  |
+| `Framework.HAYSTACK`     | `HaystackAdapter` (lazy)                                  | `pip install haystack-ai`                |
+
+Framework adapters are imported lazily — you only pay the import cost for
+the one you use. `Framework.NATIVE` is always available.
+
+If a framework isn't selected explicitly, `AgentFactory` picks one based
+on what's installed and the `use_case` argument, falling back to
+`Framework.NATIVE`.
+
+## Quick start
 
 ```python
-from attune_llm.agent_factory import AgentFactory, Framework
+from attune.agent_factory import AgentFactory, Framework
 
 # Create factory with your preferred framework
 factory = AgentFactory(framework=Framework.LANGGRAPH)
@@ -28,328 +44,290 @@ factory = AgentFactory(framework=Framework.LANGGRAPH)
 researcher = factory.create_agent(
     name="researcher",
     role="researcher",
-    model_tier="capable"  # Uses Sonnet
+    model_tier="capable",
 )
 
 writer = factory.create_agent(
     name="writer",
     role="writer",
-    model_tier="premium"  # Uses Opus
+    model_tier="premium",
 )
 
 # Create workflow
 pipeline = factory.create_workflow(
     name="research_pipeline",
     agents=[researcher, writer],
-    mode="sequential"
+    mode="sequential",
 )
 
-# Run
+# Run (workflows are async)
 result = await pipeline.run("Research AI trends in 2025")
 print(result["output"])
 ```
 
-## Framework Selection
+`framework=` can be a `Framework` enum value or a string like
+`"langgraph"` / `"langchain"` / `"autogen"` / `"haystack"` / `"native"`.
 
-### CLI
+## The `AgentFactory` class
 
-```bash
-# List installed frameworks
-Attune AIs
-
-# Show all frameworks (including uninstalled)
-Attune AIs --all
-
-# Get recommendation for a use case
-Attune AIs --recommend rag
-Attune AIs --recommend multi_agent
-```
-
-### Programmatic
+### Constructor
 
 ```python
-from attune_llm.agent_factory import AgentFactory
-
-# Auto-select based on use case
-factory = AgentFactory(use_case="rag")  # Will use Haystack if installed
-
-# Or specify explicitly
-factory = AgentFactory(framework="langgraph")
-```
-
-## Creating Agents
-
-### Basic Agent
-
-```python
-agent = factory.create_agent(
-    name="helper",
-    role="researcher",
-    model_tier="capable"
-)
-
-result = await agent.invoke("What is quantum computing?")
-print(result["output"])
-```
-
-### Agent with Tools
-
-```python
-def search_web(query: str) -> str:
-    """Search the web for information."""
-    return f"Results for: {query}"
-
-search_tool = factory.create_tool(
-    name="search",
-    description="Search the web",
-    func=search_web
-)
-
-agent = factory.create_agent(
-    name="researcher",
-    role="researcher",
-    tools=[search_tool],
-    capabilities=[AgentCapability.TOOL_USE]
+AgentFactory(
+    framework: Framework | str | None = None,
+    provider: str = "anthropic",
+    api_key: str | None = None,
+    use_case: str = "general",
 )
 ```
 
-### Model Tiers
+- `framework` — explicit framework choice. If `None`, auto-selected from
+  installed packages and `use_case` (falls back to `Framework.NATIVE`).
+- `provider` — LLM provider name. Defaults to `"anthropic"`.
+- `api_key` — API key string. If not provided, falls back to the
+  `ANTHROPIC_API_KEY` env var (or `OPENAI_API_KEY` when `provider="openai"`).
+- `use_case` — recommendation hint when `framework` is `None`. Valid values:
+  `"general"`, `"rag"`, `"multi_agent"`, `"code_analysis"`, `"workflow"`,
+  `"conversational"`.
 
-| Tier | Model (Anthropic) | Cost | Best For |
-|------|-------------------|------|----------|
-| `cheap` | Haiku | $0.25/M | Summarization, classification |
-| `capable` | Sonnet | $3/M | Code generation, analysis |
-| `premium` | Opus | $15/M | Architecture, synthesis |
+### `create_agent(...) -> BaseAgent`
+
+Creates an agent through the active adapter. Frequently used arguments:
+
+| Argument           | Type                            | Default              | Notes                                                  |
+|--------------------|---------------------------------|----------------------|--------------------------------------------------------|
+| `name`             | `str`                           | required             | Unique agent name (tracked for `get_agent` / `list_agents`) |
+| `role`             | `AgentRole` or `str`            | `AgentRole.CUSTOM`   | One of the values in `AgentRole` (see below)           |
+| `description`      | `str`                           | `""`                 |                                                        |
+| `model_tier`       | `str`                           | `"capable"`          | `"cheap"`, `"capable"`, `"premium"`                    |
+| `model_override`   | `str | None`                    | `None`               | Specific model ID, bypassing tier routing              |
+| `capabilities`     | `list[AgentCapability] | None`  | `None`               | See `AgentCapability` below                            |
+| `tools`            | `list[Any] | None`              | `None`               | Framework-native tool objects (or what `create_tool` returns) |
+| `system_prompt`    | `str | None`                    | `None`               | Custom system prompt                                   |
+| `temperature`      | `float`                         | `0.7`                |                                                        |
+| `max_tokens`       | `int`                           | `4096`               |                                                        |
+| `empathy_level`    | `int`                           | `4`                  | 1–5; used by Attune-side features                      |
+| `use_patterns`     | `bool`                          | `True`               | Load learned patterns (config flag)                    |
+| `track_costs`      | `bool`                          | `True`               | Track API costs (config flag)                          |
+| `memory_enabled`   | `bool`                          | `True`               | Conversation memory                                    |
+| `memory_type`      | `str`                           | `"conversation"`     | `"conversation"`, `"summary"`, `"vector"`              |
+| `resilience_enabled` | `bool`                        | `False`              | Wraps result in a `ResilientAgent` (see below)         |
+| `memory_graph_enabled` | `bool`                      | `False`              | Wraps result in a `MemoryAwareAgent` (see below)       |
+
+Returns an object that implements `BaseAgent` — i.e. has
+`async def invoke(input_data, context=None) -> dict` and
+`async def stream(input_data, context=None)`.
+
+### `create_workflow(name, agents, mode="sequential", ...) -> BaseWorkflow`
+
+Creates a workflow from a list of agents.
+
+- `mode` — `"sequential"`, `"parallel"`, `"graph"`, or `"conversation"`.
+  Which modes are actually supported depends on the active adapter
+  (e.g. `"conversation"` is most natural in AutoGen, `"graph"` in
+  LangGraph).
+- Other arguments: `max_iterations=10`, `timeout_seconds=300`,
+  `state_schema=None`, `checkpointing=True`, `retry_on_error=True`,
+  `max_retries=3`, `framework_options=None`.
+
+Returns an object implementing `BaseWorkflow` —
+`async def run(input_data, initial_state=None) -> dict` and
+`async def stream(input_data, initial_state=None)`.
+
+### `create_tool(name, description, func, args_schema=None) -> Any`
+
+Creates a tool in the active adapter's native format. The exact return
+type is adapter-specific; the default `BaseAdapter` implementation
+returns a `dict` and individual adapters may override.
+
+### `get_agent(name) -> BaseAgent | None` / `list_agents() -> list[str]`
+
+Look up an agent (or list names of agents) previously created on this
+factory instance. Agents are tracked by name inside the factory.
+
+### `switch_framework(framework)`
+
+Switches the factory to a new framework. **Clears the agent registry** —
+existing agents created under the previous framework are not migrated.
+
+### `list_frameworks(installed_only=True)` (classmethod)
+
+Returns a list of dicts describing frameworks. Each dict has
+`framework`, `installed`, plus the fields from
+`framework.get_framework_info` (`name`, `description`, `best_for`,
+`install_command`, `docs_url`). When `installed_only=False`, all five
+supported frameworks are returned regardless of installation status.
+
+### `recommend_framework(use_case="general")` (classmethod)
+
+Returns a `Framework` enum value: the best-installed framework for the
+given use case, or `Framework.NATIVE` if no preferred option is
+installed.
+
+### Convenience constructors
+
+Thin wrappers around `create_agent` with role + sensible tier defaults:
+
+- `create_researcher(name="researcher", model_tier="capable", **kwargs)`
+- `create_writer(name="writer", model_tier="premium", **kwargs)`
+- `create_reviewer(name="reviewer", model_tier="capable", **kwargs)`
+- `create_debugger(name="debugger", model_tier="capable", **kwargs)` —
+  also enables `AgentCapability.CODE_EXECUTION`
+- `create_coordinator(name="coordinator", model_tier="premium", **kwargs)`
+
+### Pipeline helpers
+
+- `create_research_pipeline(topic="", include_reviewer=True)` —
+  research → write → (review) sequential pipeline.
+- `create_code_review_pipeline()` — security → debug → review sequential
+  pipeline.
+
+## Enums
+
+### `AgentRole`
+
+Built-in roles (string values shown):
+
+```
+COORDINATOR    "coordinator"
+RESEARCHER     "researcher"
+WRITER         "writer"
+REVIEWER       "reviewer"
+EDITOR         "editor"
+EXECUTOR       "executor"
+DEBUGGER       "debugger"
+SECURITY       "security"
+ARCHITECT      "architect"
+TESTER         "tester"
+DOCUMENTER     "documenter"
+RETRIEVER      "retriever"
+SUMMARIZER     "summarizer"
+ANSWERER       "answerer"
+CUSTOM         "custom"
+```
+
+You can pass either the enum value (`role=AgentRole.RESEARCHER`) or the
+lowercase string (`role="researcher"`).
+
+### `AgentCapability`
+
+```
+CODE_EXECUTION     "code_execution"
+TOOL_USE           "tool_use"
+WEB_SEARCH         "web_search"
+FILE_ACCESS        "file_access"
+MEMORY             "memory"
+RETRIEVAL          "retrieval"
+VISION             "vision"
+FUNCTION_CALLING   "function_calling"
+```
+
+## Model tiers
+
+`model_tier` is resolved by the adapter's `get_model_for_tier`, which
+delegates to `attune.routing.ModelRouter` when available. The hard-coded
+fallback for `provider="anthropic"` (used when the router is not
+importable) maps:
+
+| Tier      | Fallback model (Anthropic) |
+|-----------|----------------------------|
+| `cheap`   | `claude-haiku-4-5-20251001` |
+| `capable` | `claude-sonnet-4-6`         |
+| `premium` | `claude-opus-4-6`           |
+
+These IDs are fallback constants — the live mapping is whatever
+`ModelRouter` resolves at runtime.
+
+## Optional wrappers
+
+When you set the right flags on `create_agent`, the returned agent is
+wrapped with one or both of:
+
+### `MemoryAwareAgent` — Memory Graph integration
+
+Enabled by `memory_graph_enabled=True`. Queries similar past findings
+before invocation and stores new findings after. Imported lazily from
+`attune.agent_factory.memory_integration`; if the import fails, the flag
+is logged and ignored (the underlying agent is returned unwrapped).
+
+Tuning args on `create_agent`: `memory_graph_path` (default
+`"patterns/memory_graph.json"`), `store_findings` (default `True`),
+`query_similar` (default `True`).
+
+### `ResilientAgent` — Circuit breaker / retry / timeout
+
+Enabled by `resilience_enabled=True`. Imported lazily from
+`attune.agent_factory.resilient`; same fail-soft behavior on import
+error. Tuning args: `circuit_breaker_threshold` (default `3`),
+`retry_max_attempts` (default `2`), `timeout_seconds` (default `30.0`).
+
+When both flags are set, `ResilientAgent` is applied as the *outer*
+wrapper around `MemoryAwareAgent`.
+
+## Public exports
 
 ```python
-# Cost-optimized agent
-summarizer = factory.create_agent(
-    name="summarizer",
-    role="summarizer",
-    model_tier="cheap"  # Uses Haiku - 60x cheaper
-)
-
-# High-quality agent
-architect = factory.create_agent(
-    name="architect",
-    role="architect",
-    model_tier="premium"  # Uses Opus
+from attune.agent_factory import (
+    AgentCapability,
+    AgentConfig,
+    AgentFactory,
+    AgentRole,
+    BaseAdapter,
+    BaseAgent,
+    Framework,
+    WorkflowConfig,
 )
 ```
 
-## Creating Workflows
+That list is the `__all__` of `attune.agent_factory`. `MemoryAwareAgent`,
+`ResilientAgent`, `ResilienceConfig`, and the framework-specific
+adapters are importable from their submodules but not re-exported at the
+top level.
 
-### Sequential Pipeline
-
-```python
-workflow = factory.create_workflow(
-    name="review_pipeline",
-    agents=[analyzer, reviewer, editor],
-    mode="sequential"
-)
-
-result = await workflow.run("Review this code...")
-```
-
-### Parallel Execution
+## Example: code review pipeline
 
 ```python
-workflow = factory.create_workflow(
-    name="parallel_analysis",
-    agents=[security_agent, quality_agent, perf_agent],
-    mode="parallel"
-)
-```
-
-### Convenience Methods
-
-```python
-# Pre-built research pipeline
-pipeline = factory.create_research_pipeline(
-    topic="AI in healthcare",
-    include_reviewer=True
-)
-
-# Pre-built code review pipeline
-review = factory.create_code_review_pipeline()
-```
-
-## Agent Roles
-
-Built-in roles with optimized prompts:
-
-```python
-from attune_llm.agent_factory import AgentRole
-
-# Standard roles
-AgentRole.RESEARCHER    # Gathers information
-AgentRole.WRITER        # Produces content
-AgentRole.REVIEWER      # Reviews/critiques
-AgentRole.EDITOR        # Refines content
-AgentRole.DEBUGGER      # Finds bugs
-AgentRole.SECURITY      # Security analysis
-AgentRole.COORDINATOR   # Orchestrates agents
-
-# RAG roles
-AgentRole.RETRIEVER     # Document retrieval
-AgentRole.SUMMARIZER    # Summarization
-AgentRole.ANSWERER      # Question answering
-```
-
-## Framework-Specific Features
-
-### LangChain
-
-```python
-factory = AgentFactory(framework=Framework.LANGCHAIN)
-
-# Full LangChain tool support
-from langchain_core.tools import StructuredTool
-
-lc_tool = StructuredTool.from_function(my_func)
-agent = factory.create_agent(
-    name="agent",
-    tools=[lc_tool]
-)
-```
-
-### LangGraph
-
-```python
-factory = AgentFactory(framework=Framework.LANGGRAPH)
-
-# Stateful workflows with cycles
-workflow = factory.create_workflow(
-    name="iterative",
-    agents=[planner, executor, reviewer],
-    mode="graph",
-    max_iterations=5
-)
-```
-
-### AutoGen
-
-```python
-factory = AgentFactory(framework=Framework.AUTOGEN)
-
-# Multi-agent conversation
-workflow = factory.create_workflow(
-    name="team_chat",
-    agents=[coder, reviewer, tester],
-    mode="conversation"
-)
-```
-
-### Haystack
-
-```python
-factory = AgentFactory(framework=Framework.HAYSTACK)
-
-# RAG pipeline
-retriever = factory.create_agent(
-    name="retriever",
-    role=AgentRole.RETRIEVER,
-    capabilities=[AgentCapability.RETRIEVAL]
-)
-```
-
-## Empathy Integration
-
-### Cost Tracking
-
-```python
-agent = factory.create_agent(
-    name="agent",
-    track_costs=True  # Default
-)
-
-# Costs are tracked in .attune/costs.json
-# View with: attune costs
-```
-
-### Pattern Learning
-
-```python
-agent = factory.create_agent(
-    name="debugger",
-    use_patterns=True  # Load learned patterns
-)
-
-# Patterns from patterns/debugging.json are available
-```
-
-### Empathy Levels
-
-```python
-agent = factory.create_agent(
-    name="advisor",
-    empathy_level=4  # Anticipatory (predicts problems)
-)
-```
-
-## Example: Code Review Pipeline
-
-```python
-from attune_llm.agent_factory import AgentFactory, AgentRole
+from attune.agent_factory import AgentFactory, AgentRole
 
 factory = AgentFactory(framework="langgraph")
 
-# Create specialized agents
 security = factory.create_agent(
     name="security",
     role=AgentRole.SECURITY,
     model_tier="capable",
-    system_prompt="Analyze code for security vulnerabilities."
+    system_prompt="Analyze code for security vulnerabilities.",
 )
 
 quality = factory.create_agent(
     name="quality",
     role=AgentRole.REVIEWER,
     model_tier="capable",
-    system_prompt="Review code quality and suggest improvements."
+    system_prompt="Review code quality and suggest improvements.",
 )
 
 coordinator = factory.create_agent(
     name="coordinator",
     role=AgentRole.COORDINATOR,
     model_tier="premium",
-    system_prompt="Synthesize reviews into actionable feedback."
+    system_prompt="Synthesize reviews into actionable feedback.",
 )
 
-# Create workflow
 pipeline = factory.create_workflow(
     name="code_review",
     agents=[security, quality, coordinator],
-    mode="sequential"
+    mode="sequential",
 )
 
-# Run review
-code = """
-def login(username, password):
-    query = f"SELECT * FROM users WHERE name='{username}'"
-    ...
-"""
-
-result = await pipeline.run(f"Review this code:\n{code}")
+result = await pipeline.run("Review this code:\n<paste code here>")
 print(result["output"])
 ```
 
-## CLI Reference
+The same code works with `framework="langchain"`, `"autogen"`,
+`"haystack"`, or `"native"` — the adapter handles the framework-specific
+mechanics, and the call sites are identical.
 
-```bash
-# List frameworks
-Attune AIs
-Attune AIs --all
-Attune AIs --json
+## Next steps
 
-# Get recommendation
-Attune AIs --recommend general
-Attune AIs --recommend rag
-Attune AIs --recommend multi_agent
-Attune AIs --recommend code_analysis
-```
-
-## Next Steps
-
-- [CLI Reference](../reference/cli-reference.md) - Quick reference
-- [Reference](../reference/index.md) - Full API documentation
+- [Resilience patterns](./resilience-patterns.md) — deeper detail on
+  `ResilientAgent` configuration.
+- [Reference index](../reference/index.md)

--- a/docs/specs/doc-fiction-cleanup/decisions.md
+++ b/docs/specs/doc-fiction-cleanup/decisions.md
@@ -226,6 +226,78 @@ retire decision — to be triaged in Phase 2. See `tasks.md`.
   spec itself, (c) the pending REWRITE targets `agent-factory.md`
   and `TROUBLESHOOTING.md` (Phase 2 PR-C and Phase 3 respectively).
 
+## Phase 2 outcomes (2026-05-30, PR-C — REWRITE batch)
+
+### Rewritten
+
+- **`docs/how-to/agent-factory.md`** — Phase-1-style rewrite
+  against `src/attune/agent_factory/`. Real surface documented:
+  - `AgentFactory` class (`factory.py:60`) with verified
+    constructor + `create_agent` / `create_workflow` /
+    `create_*` method signatures.
+  - 5 framework adapters: Native, LangChain, LangGraph, AutoGen,
+    Haystack (verified from `adapters/__init__.py`).
+  - Enums: `Framework` (5 members + `from_string`), `AgentRole`
+    (15 members), `AgentCapability` (8 members).
+  - Optional wrappers: `MemoryAwareAgent`, `ResilientAgent`
+    (applied conditionally; `Resilient` outer of `MemoryAware`).
+  - Model-tier fallback table from `base.py:288–317`.
+  - Framework install commands from
+    `framework.py:get_framework_info`.
+- 30+ concrete claims verified against source in the draft's
+  Verification log section (stripped before swap, per Phase 1
+  pattern).
+
+### Decisions on per-doc open questions
+
+- **CLI section omitted (Q1 → option A).** No `attune frameworks`
+  CLI exists in current source. `[project.scripts]` only exposes
+  `attune = attune.cli_minimal:main`; grep of CLI modules for
+  `framework`/`agent_factory` returns nothing. Original doc's
+  "Attune AIs frameworks" command was a corrupted/mangled
+  reference. Future CLI feature spec spawned as a separate chip
+  (not a Phase 2 obligation).
+- **Decorators omitted from public reference.** `decorators.py`
+  exports 6 decorators but none are in `agent_factory.__init__`
+  `__all__`. Treated as internal — same discipline as
+  `_validate_file_path` in Phase 1 security-architecture rewrite
+  (only document internal primitives when load-bearing single
+  source of truth; decorators are utility helpers).
+- **`__init__.py:26-27` docstring drift** — references a
+  `create_wizard` example method that doesn't exist on
+  `AgentFactory`. Out of scope for this doc PR (code fix, not
+  doc fix). Spawned as a separate 1-line-fix chip.
+
+### Real ideas preserved from original
+
+- "Pick framework → same call sites" framing
+- Model-tier mental model (cheap/capable/premium)
+- Framework-selection-by-use-case (`use_case="rag"` → Haystack)
+- Code-review-pipeline example (rewritten against verified APIs)
+
+### Discarded fiction
+
+- `attune_llm.*` imports throughout
+- "Attune AIs frameworks" CLI block
+- Model price-per-million table ($0.25/$3/$15) — billing data
+  not in source
+- Framework-specific examples using invented APIs (e.g.
+  `StructuredTool.from_function`)
+
+### Phase 2 status
+
+- PR-A (RETIRE + ARCHIVE) ✅ merged as #507
+- PR-B (MECHANICAL) ✅ merged as #508
+- PR-C (REWRITE) shipping now
+
+Phase 2 substantially complete. Out-of-cohort items still open:
+- TROUBLESHOOTING.md REWRITE (deferred to Phase 3)
+- Two `webhook-event-integration.md` example docs (decisions.md
+  open question, unchanged)
+- MEDIUM/LOW fact-drift docs from the original 30-doc triage
+  (`auto-chaining`, `multi-agent`, `llm-toolkit`,
+  `telemetry-and-signals`, `configuration`, `help-system-maintenance`).
+
 ---
 
 ## Phase 2 preflight notes (2026-05-30)

--- a/docs/specs/doc-fiction-cleanup/tasks.md
+++ b/docs/specs/doc-fiction-cleanup/tasks.md
@@ -79,8 +79,18 @@ concrete claim, surface for review before finalizing.
   passes. Zero remaining `attune_llm` references outside
   `docs/archive/`, the cleanup spec, and the pending REWRITE
   targets (agent-factory.md, TROUBLESHOOTING.md).
-- [ ] **REWRITE batch (PR-C, ≤1 doc this session):**
-  `agent-factory.md` recommended. Deferred to Phase 3:
+- [x] **REWRITE batch (PR-C, 2026-05-30):**
+  `agent-factory.md` rewritten against
+  `src/attune/agent_factory/`. 30+ claims verified in draft
+  Verification log (stripped before swap, per Phase 1 pattern).
+  CLI section omitted — no `attune frameworks` CLI exists;
+  mangled "Attune AIs frameworks" command from original was
+  fiction. Decorators omitted from public reference (none in
+  `__all__`). Real surface documented: `AgentFactory` class +
+  5 framework adapters (Native, LangChain, LangGraph, AutoGen,
+  Haystack) + `AgentRole` / `AgentCapability` / `Framework`
+  enums + `MemoryAwareAgent` / `ResilientAgent` optional
+  wrappers + model-tier table. Deferred to Phase 3:
   `TROUBLESHOOTING.md` (mixed real troubleshooting + fiction;
   needs careful surgery).
 - [ ] Decide on the two `webhook-event-integration.md` example


### PR DESCRIPTION
## Summary

Third and final Phase 2 PR for [`doc-fiction-cleanup`](docs/specs/doc-fiction-cleanup/). REWRITE batch — rewrites `docs/how-to/agent-factory.md` against current source in `src/attune/agent_factory/`.

Follows #507 (RETIRE + ARCHIVE) and #508 (MECHANICAL). Same Phase-1 discipline: every concrete claim verified against `src/` before writing; Verification log included in the draft and stripped before swap.

## Real surface documented

| Surface | Source verification |
|---|---|
| `AgentFactory` class | `src/attune/agent_factory/factory.py:60` |
| 5 framework adapters (Native, LangChain, LangGraph, AutoGen, Haystack) | `src/attune/agent_factory/adapters/__init__.py` |
| `Framework` enum (5 members + `from_string`) | `framework.py` |
| `AgentRole` enum (15 members), `AgentCapability` enum (8 members) | `base.py` |
| `MemoryAwareAgent` / `ResilientAgent` optional wrappers | `memory_integration.py`, `resilient.py` |
| Model-tier fallback table | `base.py:288-317` |
| Framework install commands | `framework.py:get_framework_info` |

**30+ concrete claims** verified in the draft's Verification log section before strip.

## Per-doc decisions

| Question | Decision | Rationale |
|---|---|---|
| CLI section? | **Omitted** | No `attune frameworks` CLI exists in current source. Original's "Attune AIs frameworks" was a corrupted/mangled reference. A future spec for `attune frameworks list/info` has been spawned as a separate chip. |
| Decorators surface? | **Omitted from public reference** | `decorators.py` exports 6 but none in `__all__`. Same discipline as `_validate_file_path` in Phase 1 — only document internal primitives when load-bearing single source of truth. |
| `__init__.py:26-27` docstring drift | **Out of scope (separate chip spawned)** | References nonexistent `create_wizard` example method; code fix, not doc fix. |

## Discarded fiction

- `attune_llm.*` imports throughout
- "Attune AIs frameworks" CLI block (mangled)
- Model price-per-million table ($0.25/$3/$15) — billing data not in source
- Framework-specific examples using invented APIs (e.g. `StructuredTool.from_function`)

## Real ideas preserved from the original

- "Pick framework → same call sites" framing
- Model-tier mental model (cheap/capable/premium)
- Framework-selection-by-use-case (`use_case="rag"` → Haystack)
- Code-review-pipeline example (rewritten against verified APIs)

## Verification

- `mkdocs build --strict` passes. Pre-existing anchor warnings in `API_REFERENCE.md` are unrelated to this PR.
- Sanity grep: zero `attune_llm` / `Attune AIs` / `coach_wizards` / `HealthcareWizard` in the rewritten doc.
- All renamed symbols verified at their source paths.

## Spec updates

- `tasks.md` — REWRITE row checked off.
- `decisions.md` — Phase 2 PR-C outcomes section added; Phase 2 status table.

## Phase 2 substantially complete

| PR | Batch | Status |
|---|---|---|
| #507 | RETIRE + ARCHIVE (8 docs, -4620 lines) | ✅ merged |
| #508 | MECHANICAL (8 docs, -41 lines) | ✅ merged |
| #509 (this) | REWRITE (1 doc, agent-factory.md) | open |

## Phase 3 picks up

- `TROUBLESHOOTING.md` REWRITE (mixed real + fiction; careful surgery)
- Two `webhook-event-integration.md` example docs (still in `decisions.md` open questions)
- MEDIUM/LOW fact-drift docs from the original 30-doc triage

## Test plan

- [ ] `mkdocs build --strict` passes in CI.
- [ ] `grep -n attune_llm docs/how-to/agent-factory.md` returns nothing.
- [ ] Spot-check a few imports from the rewrite resolve at the renamed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)