### PR TITLE
fix(wizards): read entry points from attune.wizards group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Wizard entry-point group renamed to ``attune.wizards``.** The
+  registry now reads the canonical ``attune.wizards`` group (which
+  ``pyproject.toml`` has declared since the package rename). Third-party
+  wizards still declared under the legacy ``empathy.wizards`` group
+  continue to load with a ``DeprecationWarning`` for one release; the
+  legacy fallback will be removed in the next major. Builtin wizards
+  are unaffected — they load by hardcoded module path, not entry-point
+  discovery.
+
 ## [7.2.0] — 2026-05-27
 
 ### Added

--- a/docs/guides/wizard-architecture.md
+++ b/docs/guides/wizard-architecture.md
@@ -312,10 +312,15 @@ The wizard registry (`registry.py`) finds wizards through a 3-tier search:
 
 ```text
 1. In-memory registry     ← Programmatic registration
-2. Entry points           ← pip-installed packages (empathy.wizards group)
+2. Entry points           ← pip-installed packages (attune.wizards group)
 3. Built-in loading       ← src/attune/wizards/builtin/
 4. Custom YAML loading    ← .attune/wizards/*.yaml
 ```
+
+The legacy entry-point group ``empathy.wizards`` is still loaded for
+backward compatibility but emits a ``DeprecationWarning`` and will be
+removed in the next major release. Third-party packages should declare
+wizards under ``[project.entry-points."attune.wizards"]``.
 
 Each tier only runs once per process (guarded by flags). The registry supports:
 

--- a/src/attune/wizards/registry.py
+++ b/src/attune/wizards/registry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import logging
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -188,9 +189,24 @@ def delete_custom_wizard(wizard_id: str, base_dir: str | None = None) -> bool:
 
 _discovered = False
 
+_ENTRY_POINT_GROUP = "attune.wizards"
+_LEGACY_ENTRY_POINT_GROUP = "empathy.wizards"
+
+
+def _select_entry_points(eps: Any, group: str) -> list[Any]:
+    """Return entry points for ``group`` across Python versions."""
+    if hasattr(eps, "select"):
+        return list(eps.select(group=group))
+    return list(eps.get(group, []))
+
 
 def _discover_wizards() -> None:
-    """Discover wizards from entry points (``empathy.wizards`` group).
+    """Discover wizards from entry points.
+
+    Reads the canonical ``attune.wizards`` group, then falls back to the
+    deprecated ``empathy.wizards`` group (with a ``DeprecationWarning``)
+    so third-party packages that still declare the old group continue to
+    load for one release.
 
     Only runs once per process.
     """
@@ -201,25 +217,42 @@ def _discover_wizards() -> None:
 
     try:
         eps = importlib.metadata.entry_points()
-        # Python 3.12+ returns a SelectableGroups; older returns dict
-        if hasattr(eps, "select"):
-            wizard_eps = eps.select(group="empathy.wizards")
-        else:
-            wizard_eps = eps.get("empathy.wizards", [])
+        loaded_names: set[str] = set()
 
-        for ep in wizard_eps:
-            try:
-                wizard_class = ep.load()
-                if hasattr(wizard_class, "config"):
-                    _WIZARD_REGISTRY[wizard_class.config.wizard_id] = wizard_class
-                    logger.debug("Discovered wizard via entry point: %s", ep.name)
-            except Exception as e:  # noqa: BLE001
-                # INTENTIONAL: Entry point loading is best-effort
-                logger.warning("Failed to load wizard entry point %s: %s", ep.name, e)
+        for ep in _select_entry_points(eps, _ENTRY_POINT_GROUP):
+            if _try_load_wizard(ep):
+                loaded_names.add(ep.name)
+
+        for ep in _select_entry_points(eps, _LEGACY_ENTRY_POINT_GROUP):
+            if ep.name in loaded_names:
+                continue
+            warnings.warn(
+                f"Wizard entry-point group '{_LEGACY_ENTRY_POINT_GROUP}' is "
+                f"deprecated; declare '{ep.name}' under '{_ENTRY_POINT_GROUP}' "
+                "instead. The legacy group will be removed in the next major "
+                "release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            _try_load_wizard(ep)
 
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Entry point discovery is optional
         logger.debug("Entry point discovery failed: %s", e)
+
+
+def _try_load_wizard(ep: Any) -> bool:
+    """Load a single wizard entry point. Returns True on success."""
+    try:
+        wizard_class = ep.load()
+        if hasattr(wizard_class, "config"):
+            _WIZARD_REGISTRY[wizard_class.config.wizard_id] = wizard_class
+            logger.debug("Discovered wizard via entry point: %s", ep.name)
+            return True
+    except Exception as e:  # noqa: BLE001
+        # INTENTIONAL: Entry point loading is best-effort
+        logger.warning("Failed to load wizard entry point %s: %s", ep.name, e)
+    return False
 
 
 def _load_builtins() -> None:

--- a/tests/unit/wizards/test_wizard_registry.py
+++ b/tests/unit/wizards/test_wizard_registry.py
@@ -449,6 +449,28 @@ class TestDiscovery:
         ]
         assert not any("dual-wizard" in msg for msg in deprecation_msgs)
 
+    def test_discover_skips_entry_point_without_config_attr(self):
+        """Wizard classes missing a ``config`` attribute are silently
+        skipped — not registered, no exception raised."""
+        registry._discovered = False
+        registry._WIZARD_REGISTRY.clear()
+
+        mock_ep = MagicMock()
+        mock_ep.name = "no-config"
+        # Object without a ``config`` attribute.
+        mock_ep.load.return_value = object()
+
+        mock_eps = MagicMock()
+        mock_eps.select = MagicMock(return_value=[mock_ep])
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            registry._discover_wizards()
+
+        assert "no-config" not in registry._WIZARD_REGISTRY
+        assert not any(
+            getattr(v, "__class__", None) is object for v in registry._WIZARD_REGISTRY.values()
+        )
+
     def test_discover_skips_broken_entry_point(self):
         """Test _discover_wizards gracefully handles broken entry points."""
         registry._discovered = False

--- a/tests/unit/wizards/test_wizard_registry.py
+++ b/tests/unit/wizards/test_wizard_registry.py
@@ -366,12 +366,88 @@ class TestDiscovery:
         mock_ep.load.return_value = mock_wizard_class
 
         # No .select attribute — simulates older Python
-        mock_eps = {"empathy.wizards": [mock_ep]}
+        mock_eps = {"attune.wizards": [mock_ep]}
 
         with patch("importlib.metadata.entry_points", return_value=mock_eps):
             registry._discover_wizards()
 
         assert "dict-wizard" in registry._WIZARD_REGISTRY
+
+    def test_discover_loads_from_legacy_empathy_wizards_group(self):
+        """Wizards declared under the deprecated ``empathy.wizards`` group
+        still load (with a DeprecationWarning) for one release window."""
+        registry._discovered = False
+        registry._WIZARD_REGISTRY.clear()
+
+        mock_ep = MagicMock()
+        mock_ep.name = "legacy-wizard"
+        mock_wizard_class = MagicMock()
+        mock_wizard_class.config = WizardConfig(
+            wizard_id="legacy-wizard",
+            name="Legacy",
+            description="From legacy group",
+        )
+        mock_ep.load.return_value = mock_wizard_class
+
+        # Dict-style: only the legacy group is populated.
+        mock_eps = {"empathy.wizards": [mock_ep]}
+
+        import warnings as _warnings
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with _warnings.catch_warnings(record=True) as caught:
+                _warnings.simplefilter("always")
+                registry._discover_wizards()
+
+        assert "legacy-wizard" in registry._WIZARD_REGISTRY
+        deprecation_msgs = [
+            str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert any("empathy.wizards" in msg for msg in deprecation_msgs)
+        assert any("attune.wizards" in msg for msg in deprecation_msgs)
+
+    def test_discover_prefers_new_group_over_legacy_on_name_collision(self):
+        """When the same entry-point name appears in both groups, the new
+        group wins and no deprecation warning fires for that name."""
+        registry._discovered = False
+        registry._WIZARD_REGISTRY.clear()
+
+        new_ep = MagicMock()
+        new_ep.name = "dual-wizard"
+        new_class = MagicMock()
+        new_class.config = WizardConfig(
+            wizard_id="dual-wizard", name="New", description="From new group"
+        )
+        new_ep.load.return_value = new_class
+
+        legacy_ep = MagicMock()
+        legacy_ep.name = "dual-wizard"
+        legacy_class = MagicMock()
+        legacy_class.config = WizardConfig(
+            wizard_id="dual-wizard",
+            name="Legacy",
+            description="From legacy group",
+        )
+        legacy_ep.load.return_value = legacy_class
+
+        mock_eps = {
+            "attune.wizards": [new_ep],
+            "empathy.wizards": [legacy_ep],
+        }
+
+        import warnings as _warnings
+
+        with patch("importlib.metadata.entry_points", return_value=mock_eps):
+            with _warnings.catch_warnings(record=True) as caught:
+                _warnings.simplefilter("always")
+                registry._discover_wizards()
+
+        assert registry._WIZARD_REGISTRY["dual-wizard"] is new_class
+        legacy_ep.load.assert_not_called()
+        deprecation_msgs = [
+            str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert not any("dual-wizard" in msg for msg in deprecation_msgs)
 
     def test_discover_skips_broken_entry_point(self):
         """Test _discover_wizards gracefully handles broken entry points."""


### PR DESCRIPTION
## Summary

The wizard registry was reading the legacy `empathy.wizards` entry-point group, but `pyproject.toml` has declared the builtins under `attune.wizards` since the package rename. Result: any third-party wizard declared under `attune.wizards` (per the public docs) never loaded. Builtins were unaffected because they load via hardcoded module path, not entry-point discovery.

This PR migrates the registry to read `attune.wizards` first, with a one-release backward-compat fallback to `empathy.wizards` that emits a `DeprecationWarning`. Mirrors the rename direction already in pyproject.toml; matches the public docs.

Discovered 2026-05-30 during the `doc-fiction-cleanup` Phase 1 rewrite of `docs/reference/wizards.md`, which faithfully documented what `registry.py` did — exposing the mismatch with what pyproject.toml ships.

## Changes

- `src/attune/wizards/registry.py` — extracted `_select_entry_points()` and `_try_load_wizard()` helpers; reads `attune.wizards` first then falls back to `empathy.wizards` with `DeprecationWarning`; deduplicated by entry-point name (new group wins, no warning on collision).
- `tests/unit/wizards/test_wizard_registry.py` — updated the existing dict-fallback test to use the new group, added `test_discover_loads_from_legacy_empathy_wizards_group` (verifies the fallback + warning) and `test_discover_prefers_new_group_over_legacy_on_name_collision` (verifies precedence + no spurious warning).
- `docs/guides/wizard-architecture.md` — group name updated, deprecation note added.
- `CHANGELOG.md` — entry under `## [Unreleased]` → `### Changed`.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `pre-commit run black` (pinned) — passed
- [x] `pytest tests/unit/wizards/test_wizard_registry.py` — 32 passed (2 new)
- [x] Direct import probe: all 5 builtin wizards load via the new code path
- [x] `grep empathy.wizards` shows only the intentional references (legacy-fallback constant, docstrings, CHANGELOG note, new deprecation test)
- [ ] CI green on all platforms

## Out of scope

- Renaming the wizards package (the public name is already `attune.wizards`)
- Migrating other entry-point groups
- The broader `doc-fiction-cleanup` Phase 2/3 sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)
