### PR TITLE
docs(specs): approve 3 doc-release-path specs + author wiring-audit design + tasks

### DIFF
--- a/docs/specs/docs-completeness-audit/decisions.md
+++ b/docs/specs/docs-completeness-audit/decisions.md
@@ -1,0 +1,116 @@
+# Per-decision log — Docs completeness audit
+
+Append-only log. Resolutions for the open questions enumerated in
+[requirements.md](./requirements.md#open-questions). Each decision
+moves the spec one step closer to Phase 1 execution.
+
+---
+
+## Phase 1 approval (2026-05-31)
+
+Three open questions resolved in one session. Spec status flips
+from `draft` to `approved`. Phase 1 (subagent triage of in-scope
+docs) can spawn after this lands on `main`.
+
+---
+
+### Q1 — Blog-shaped docs (`docs/blog/*.md`, `docs/BLOG_*.md`): in or out?
+
+**Decision:** **Date-cutoff IN.** Posts dated within 6 months of
+release are in-scope for the completeness audit; older posts move
+to `docs/archive/blog/<year>/` and are exempt.
+
+**Rationale:** Recent blog posts ARE discoverable from the site
+and behave as quasi-docs — a 4-month-old post claiming a feature
+works one way contradicts current behaviour and counts as fiction.
+Historical posts describing v3.x behaviour aren't fiction; they're
+record-keeping. The date cutoff distinguishes the two without
+forcing every historical post through audit (wrong) or letting
+every recent post stay unaudited (also wrong).
+
+**Alternatives considered:**
+
+- **All blog OUT** — Smallest scope. Risk: recent posts stay
+  unaudited and become drift sources.
+- **All blog IN** — Largest scope. Risk: forces rewriting
+  historical posts that intentionally describe old behaviour.
+
+**Implementation note for Phase 1:**
+
+- Stage A's subagent prompt classifies each blog post by date
+  before triage.
+- Posts older than 6 months from `pyproject.toml` version's
+  release date → flag for archive move, skip content audit.
+- Posts within 6 months → full triage like any other doc.
+- The 6-month threshold is a starting value; revisit if it
+  produces obviously-wrong categorizations.
+
+---
+
+### Q2 — `docs/PROJECT_OVERVIEW.md`: MECHANICAL, REWRITE, or evergreen?
+
+**Decision:** **Evergreen rewrite, strip versions.** Rewrite to be
+version-agnostic so the doc stops drifting at every release.
+
+**Rationale:** This is the canonical "stale version in long-lived
+doc" pattern. Mechanical sweeps fix today's drift but the same
+doc will drift again at the next release. A top-level project
+narrative shouldn't need to claim a specific version anyway — the
+README badge and PyPI page handle that. One focused rewrite now
+beats forever-recurring sweeps.
+
+**Alternatives considered:**
+
+- **MECHANICAL** — Cheapest fix; pure debt-paydown without
+  addressing the root cause. The doc drifts again at 7.4.0.
+- **REWRITE** — Full rework assuming framing is stale. Larger
+  scope. If framing turns out fine in execution, evergreen
+  collapses into MECHANICAL anyway, so picking evergreen
+  pre-emptively gives optional headroom.
+
+**Implementation note for Phase 1:**
+
+- Treat `docs/PROJECT_OVERVIEW.md` as a single-subagent task
+  (not part of a bucket).
+- Removes version numbers, specific workflow counts, "as of
+  vX.Y.Z" timestamps. Keeps narrative framing where current.
+- Adds a footer note: "For current version, see [PyPI](
+  https://pypi.org/project/attune-ai/) or the README badge."
+
+---
+
+### Q3 — Counting / sizing: verify the math before subagent spawning
+
+**Decision:** **Verified now.** The spec's preliminary 203 number
+holds (same methodology — `find docs/ -name '*.md'` excluding
+`docs/archive/` and `docs/specs/`). My earlier session-time
+verification using `git ls-files docs/` returned 400 because it
+counts non-`.md` files (`.json`, `.txt`, sitemap, robots, etc.);
+that was a methodology mismatch, not a sizing error in the spec.
+
+**Verified baseline (2026-05-31):**
+
+| Bucket | Count |
+|--------|-------|
+| Total in scope (find docs/ -name '*.md' \\| not archive/specs) | 203 |
+| Tracked in `features.yaml` (already audited via help system) | 24 |
+| PR-touched (PRs #506-510 doc-fiction-cleanup) | ~30 |
+| Blog cohort (docs/blog/ + top-level BLOG_*.md) | 55 |
+| Untracked .md (none — clean) | 0 |
+
+**Implication for Phase 1 triage budget:**
+
+After applying decisions Q1 (most blog → archive at 6mo cutoff)
+and excluding already-audited / already-cleaned docs, in-scope
+estimate is **~135 files** (203 baseline − ~24 features.yaml − ~30
+PR-touched − ~15 blog moved to archive). At 15 files per
+subagent, budget is **~9 subagents** — close to the spec's
+original 10-subagent estimate.
+
+**Implementation note for Phase 1:**
+
+- Stage A's first task is to re-run the inventory immediately
+  before spawning, using the same `find` invocation, and produce
+  the final bucket list as a committed artefact under
+  `.audit/completeness-inventory.md`. The 135 number is a
+  planning estimate; the execution-time count is the budget.

--- a/docs/specs/docs-completeness-audit/requirements.md
+++ b/docs/specs/docs-completeness-audit/requirements.md
@@ -11,7 +11,7 @@
 > as the tracked cohort — or the next reader still hits fiction,
 > just in a different aisle of the store.
 
-**Status:** draft
+**Status:** approved (2026-05-31; see [decisions.md](./decisions.md))
 **Created:** 2026-05-30
 **Owner:** TBD
 **Related:** [`doc-fiction-cleanup`](../doc-fiction-cleanup/) (sibling — tracked-cohort triage);

--- a/docs/specs/docs-release-prep/decisions.md
+++ b/docs/specs/docs-release-prep/decisions.md
@@ -1,0 +1,146 @@
+# Per-decision log — Docs release prep
+
+Append-only log. Resolutions for the open questions enumerated in
+[requirements.md](./requirements.md#open-questions). The release
+ceremony itself remains unscheduled — it executes only after the
+two prerequisite specs (`docs-completeness-audit` Phase 1 and
+`docs-wiring-audit` Phase 1) land on `main`.
+
+---
+
+## Phase 1 approval (2026-05-31)
+
+Three open questions resolved in one session. Spec status flips
+from `draft` to `approved`. Phase 2 (the release ceremony itself)
+runs only after dependencies in
+[requirements.md → Dependencies](./requirements.md#dependencies--block-release-until-each-is-met)
+are met.
+
+---
+
+### Q1 — Version bump policy: 7.3.0 minor vs 7.2.1 patch?
+
+**Decision:** **7.3.0 minor.** Signals "user-visible improvement"
+and matches the scale of the corpus change.
+
+**Rationale:** Strict semver requires a minor bump when a `feat`
+commit ships, and main already has PR #500 (`feat(hooks): discover
+specs under docs/specs`) since 7.2.0. Patch undersells what's
+shipping. Additionally, the doc-cleanup arc is substantial
+(~120-135 files audited and corrected per
+[docs-completeness-audit/decisions.md Q3](
+../docs-completeness-audit/decisions.md#q3--counting--sizing-verify-the-math-before-subagent-spawning))
+— calling that "patch" reads as understated to users glancing at
+release notes.
+
+**Alternatives considered:**
+
+- **7.2.1 patch** — Technically correct for a docs-only change
+  IF docs were the only thing landing. But PR #500's `feat` makes
+  patch semantically wrong.
+- **7.3.0 minor framed as 'docs release'** — Same version,
+  different release-notes framing. Release notes will lead with
+  the doc cleanup (primary value) but version stays minor for
+  semver correctness.
+
+**Implementation note for Phase 2:**
+
+- Release notes lead-in: "v7.3.0 — Docs cleanup release.
+  Fictional and out-of-date documentation removed or rewritten
+  across ~135 files; new feature: hooks now discover specs under
+  `docs/specs/`."
+- CHANGELOG entry under `## [7.3.0]` aggregates the
+  doc-fiction-cleanup arc PRs (#499, #506-510), the
+  docs-completeness-audit execution PRs, the docs-wiring-audit
+  execution PRs, PR #500, PR #512 (wizard entry-point fix), and
+  any chips that happen to land in time.
+- See [CLAUDE.md "Version bumps touch 7+ files"](../../../.claude/CLAUDE.md)
+  lesson for the version-bump checklist.
+
+---
+
+### Q2 — Do the 4 spawned chips block this release?
+
+**Decision:** **Don't block. Ship as docs-cleanup release; chips
+ride the wave if they happen to land in time.**
+
+**Chip inventory:**
+
+| # | Chip | Status |
+|---|------|--------|
+| 1 | Wizard entry-point group fix | **DONE** — PR #512 merged 2026-05-30 |
+| 2 | `create_wizard` docstring fix | Pending; small fix |
+| 3 | `attune-frameworks` CLI spec | Pending; weeks of new-spec work |
+| 4 | Team-coordination-on-shared-redis spec | Pending; weeks of new-spec work |
+
+**Rationale:** Chips 3 and 4 are net-new specs that haven't even
+been scoped yet — blocking on them pushes the release out
+indefinitely while the doc fixes sit unshipped, which is exactly
+the inconsistent-intermediate-state the spec was authored to
+prevent. Chip 2 is a small docstring fix; if its session lands
+before tag, great; if not, it goes in 7.3.1 or 7.4.0. The
+doc-cleanup arc shipping is higher value than waiting for any
+individual chip.
+
+**Alternatives considered:**
+
+- **Block only on chip 2 (small docstring fix), defer 3+4** —
+  Marginally better discipline; requires chip 2 to actually land
+  before tag (if its session stalls, the release stalls too).
+- **Block on all 3 remaining chips** — Strongest discipline
+  signal but impractical given 3+4 are unscoped spec work.
+
+**Implementation note for Phase 2:**
+
+- Phase 2's first task checks chip status. Chip 2 status will be
+  recorded in release notes either way: "fixed in this release"
+  or "deferred to next release."
+- Chips 3+4 are explicitly NOT release prerequisites; they're
+  release-notes mentions only ("spawned during cleanup arc;
+  shipping separately").
+
+---
+
+### Q3 — `attune-redis` coordinated bump?
+
+**Decision:** **No coordinated bump.** attune-ai 7.3.0 ships
+independently of any attune-redis activity.
+
+**Finding (verified 2026-05-31):**
+
+- attune-redis is **not on PyPI** — confirmed via
+  `https://pypi.org/pypi/attune-redis/json` returning no `info`
+  field. Pairs with the existing
+  [redis-decoupling spec finding](../redis-decoupling/decisions.md)
+  that attune-redis as an external package never shipped.
+- attune-ai docs reference "attune-redis" in only three shapes:
+  (1) a Docker container name (`docker run --name attune-redis`)
+  — cosmetic, not a package reference;
+  (2) `pip install 'attune-ai[redis]'` — that's attune-ai's own
+  optional extra, not the separate plugin;
+  (3) sibling-list mentions in
+  `docs/MULTI_PACKAGE_RELEASE_PATTERNS.md` — informational.
+- **Zero version-pinned cross-repo references.**
+  `grep -rEn "attune.redis[\>\<=]" docs/` returns empty.
+
+**Implication:** The premise of the question (cross-repo doc
+coherence depends on coordinated bumps) doesn't hold for the
+current state. Independent-versioning discipline can carry this
+release without any attune-redis activity.
+
+**Rationale:** No coupling exists to coordinate around. If
+attune-redis is ever revived as a separate plugin, this question
+re-opens — but that's a future-spec concern, not a 7.3.0
+blocker.
+
+**Alternatives considered:**
+
+- **Paired bump required** — Adds attune-redis to release
+  checklist. Currently impossible (no package to bump) and
+  unjustified by the doc surface.
+
+**Implementation note for Phase 2:**
+
+- No attune-redis step in the release checklist.
+- If during release prep someone proposes "shouldn't we also bump
+  attune-redis," reference this decision.

--- a/docs/specs/docs-release-prep/requirements.md
+++ b/docs/specs/docs-release-prep/requirements.md
@@ -9,7 +9,7 @@
 > docs in one cut rather than across a string of inconsistent
 > intermediate states.
 
-**Status:** draft
+**Status:** approved (2026-05-31; see [decisions.md](./decisions.md))
 **Created:** 2026-05-30
 **Owner:** TBD
 **Related:** [`doc-fiction-cleanup`](../doc-fiction-cleanup/),

--- a/docs/specs/docs-wiring-audit/decisions.md
+++ b/docs/specs/docs-wiring-audit/decisions.md
@@ -1,0 +1,126 @@
+# Per-decision log — Docs wiring audit
+
+Append-only log. Resolutions for the open questions enumerated in
+[requirements.md](./requirements.md#open-questions). Each decision
+moves the spec one step closer to Phase 1 execution.
+
+---
+
+## Phase 1 approval (2026-05-31)
+
+Three open questions resolved in one session. Spec status flips
+from `draft` to `approved`. Phase 1 (design + implement the
+wiring-check tooling) can proceed after this lands on `main`.
+
+---
+
+### Q1 — Anchor rename policy: redirect/alias or update all inbound links?
+
+**Decision:** **Update all inbound links, no redirect.** When a
+heading is renamed (e.g. `#industry-wizards` →
+`#configdrivenwizard`), grep + update every internal link in the
+same PR as the rename. No `redirects.yml` shim.
+
+**Rationale:** Single source of truth. A redirects file bloats
+over time, becomes a separate corpus of fiction, and undermines
+the wiring audit itself — the audit is about link integrity, and
+a shim that makes broken links appear unbroken defeats that.
+External links (blog posts, conference talks, Stack Overflow)
+break with either policy; they're out of scope for an internal
+wiring audit anyway. Anchor renames are rare — this isn't a
+high-frequency operation that needs ergonomic shims.
+
+**Alternatives considered:**
+
+- **Keep a redirect/alias file** — More forgiving for external
+  links, but introduces a second source of truth and adds
+  long-term maintenance debt.
+- **Hybrid (short-lived alias)** — Both: update inbound links
+  AND keep a temporary redirect with a documented removal date.
+  Cleanest for users mid-bookmark but adds a tracking obligation
+  (someone has to remove the redirect when the date hits, or it
+  sticks forever and becomes the unmaintained case anyway).
+
+**Implementation note for Phase 1:**
+
+- The wiring-check tool flags any internal `[…](…#anchor)` whose
+  anchor doesn't exist at the target.
+- Rename workflow: when renaming a heading, the same commit
+  greps `docs/` for the old anchor and updates every inbound
+  link. CI enforces zero broken-anchor count.
+
+---
+
+### Q2 — Orphan strictness: subtree, per-file, or nav-hidden?
+
+**Decision:** **Entire subtree allowlisted.** A small allowlist
+file (`.audit/orphans.yml`-style) lists subtree paths exempt from
+the orphan check. Subtrees on the initial allowlist:
+
+- `docs/examples/`
+- `docs/blog/`
+- `docs/BLOG_*.md` (top-level blog files)
+- `docs/archive/`
+- `docs/specs/`
+- `docs/pitch/`
+
+**Rationale:** Per-file allowlisting is high-friction — every new
+example file requires touching the allowlist, which means in
+practice the allowlist grows stale and people stop updating it.
+Nav-hidden status would reuse `mkdocs.yml` config but couples the
+audit to nav-structure decisions (changing nav can silently break
+orphan-check semantics). Subtree allowlist is the right balance:
+low maintenance, explicit, decoupled from nav.
+
+**Alternatives considered:**
+
+- **Per-file allowlisting** — Tightest control; in practice
+  unmaintained.
+- **Nav-hidden subtrees** → exempt from orphan check — Elegant
+  reuse of mkdocs config; tightly couples audit semantics to UX
+  decisions.
+
+**Implementation note for Phase 1:**
+
+- Allowlist format: YAML list of subtree paths (trailing slash
+  for directories, exact match for top-level files).
+- The wiring-check tool walks `docs/` for `.md` files, computes
+  inbound-link graph, then filters out any file under an
+  allowlisted subtree before flagging orphans.
+- Real orphans hidden inside an allowlisted subtree are
+  acknowledged risk — these subtrees are by-design orphan-friendly,
+  so the cost is acceptable.
+
+---
+
+### Q3 — mkdocstrings scope: 5 known files or whole-tree sweep?
+
+**Decision:** **Sweep the whole `docs/` tree.** v1 audits every
+`:::` directive across `docs/`, not just the 5 session-confirmed
+files (`core.md`, `empathy-os.md`, `llm-toolkit.md`,
+`multi-agent.md`, `persistence.md`).
+
+**Rationale:** `grep '^:::'` across `docs/` takes seconds — no cost
+to broadening. The 5 known files came from session-time
+confirmation, not a comprehensive scan; limiting scope to them
+means new mkdocstrings usage in other files goes uncaught, which
+is exactly the drift the audit is meant to catch. v1 should
+establish a strong pattern from day one.
+
+**Alternatives considered:**
+
+- **Audit only the 5 known files for v1** — Faster Phase 1,
+  easier to validate. Defers the whole-tree sweep to v2. Risk:
+  unknown mkdocstrings files in other paths continue to drift
+  between v1 and v2.
+
+**Implementation note for Phase 1:**
+
+- Wiring-check tool's first pass: `grep -rn '^:::' docs/` to
+  build the full `:::` directive inventory.
+- Each directive is verified: the referenced symbol (e.g.
+  `::: attune.coordination.ConflictResolver`) must resolve in
+  current `src/`. Unresolved references fail the audit.
+- This subsumes both `mkdocs build --strict` (which would
+  surface the same failures at build time) and adds the
+  precondition check at lint/CI time.

--- a/docs/specs/docs-wiring-audit/design.md
+++ b/docs/specs/docs-wiring-audit/design.md
@@ -1,0 +1,449 @@
+# Design: Documentation Wiring Audit
+
+**Status:** draft (2026-05-31)
+**Phase:** 2 — Design
+**Predecessor:** [requirements.md](./requirements.md) (Phase 1
+approved 2026-05-31, see [decisions.md](./decisions.md))
+**Successor:** tasks.md (Phase 3, not started)
+
+---
+
+## Phase 2: Design
+
+### Approach
+
+Five artifacts, each with a clear ship/no-ship gate, designed so
+v1 ships incrementally rather than as a big-bang. The first three
+artifacts (audit script, two cheap checks, allowlist) land
+together as the minimum-viable wiring gate. The remaining two
+(mkdocstrings, advisory See-Also) land in follow-up PRs since
+they have more design surface area and aren't blockers for the
+release-prep release.
+
+1. **`scripts/audit_docs_wiring.py`** — single CLI entry point;
+   subcommands per check; structured output (JSON for CI, markdown
+   for humans).
+2. **`.audit/orphans.yml`** — subtree-level allowlist file; the
+   single source of "this is intentionally orphan."
+3. **Three cheap checks** — anchor integrity, nav ↔ filesystem,
+   `features.yaml` ↔ filesystem. Each ~50-100 LOC. Ship together
+   in v1.
+4. **mkdocstrings symbol resolution check** — needs Python import
+   logic; ships in v1.1 to keep v1's scope tight.
+5. **Reciprocal See-Also advisory check** — opinionated, low
+   urgency; ships in v1.2 or deferred.
+
+CI integration lands with v1 as a separate commit so the cheap
+checks gate PRs from day one.
+
+---
+
+### Artifact 1 — `scripts/audit_docs_wiring.py`
+
+**CLI shape:**
+
+```bash
+# Run all checks, exit non-zero on any failure
+python scripts/audit_docs_wiring.py
+
+# Run a specific check
+python scripts/audit_docs_wiring.py --check anchor
+python scripts/audit_docs_wiring.py --check nav
+python scripts/audit_docs_wiring.py --check features-yaml
+python scripts/audit_docs_wiring.py --check mkdocstrings  # v1.1
+python scripts/audit_docs_wiring.py --check see-also      # v1.2; advisory only
+
+# Output format
+python scripts/audit_docs_wiring.py --format json    # default in CI
+python scripts/audit_docs_wiring.py --format markdown  # default for humans
+
+# Suppress findings covered by allowlist (default: on)
+python scripts/audit_docs_wiring.py --no-allowlist  # surface everything for review
+```
+
+**Module layout:**
+
+```text
+scripts/audit_docs_wiring.py     # CLI entry; argument parsing; dispatch
+scripts/audit_docs_wiring/
+  __init__.py                    # __version__, public API
+  cli.py                         # argparse wiring, output routing
+  allowlist.py                   # load .audit/orphans.yml + match logic
+  checks/
+    __init__.py
+    anchor.py                    # Artifact 3a — anchor integrity
+    nav.py                       # Artifact 3b — nav ↔ filesystem
+    features_yaml.py             # Artifact 3c — features.yaml ↔ fs
+    mkdocstrings.py              # Artifact 4 — symbol resolution (v1.1)
+    see_also.py                  # Artifact 5 — reciprocal links (v1.2)
+  report.py                      # markdown + json formatters
+```
+
+**Why a `scripts/audit_docs_wiring/` package, not a single file?**
+Each check has its own data structures, helpers, and tests. Keeping
+them in one 800-line `.py` makes the file painful to maintain.
+Package layout also means each check can be developed/tested
+independently — important for the v1 / v1.1 / v1.2 staging.
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| 0 | All requested checks passed (zero findings after allowlist) |
+| 1 | One or more findings remain after allowlist (CI fails) |
+| 2 | Bad invocation (unknown check name, malformed allowlist, etc.) |
+
+**Output contract:**
+
+```python
+# Each check returns a list of Finding dataclasses
+@dataclass(frozen=True)
+class Finding:
+    check: str           # "anchor" | "nav" | "features-yaml" | ...
+    severity: str        # "error" | "warning" | "info" | "advisory"
+    file: str            # Path relative to repo root
+    line: int | None     # 1-indexed, or None if file-level
+    message: str         # Human-readable description
+    fix: str | None      # One-line suggested fix
+```
+
+JSON output is `{"findings": [Finding.asdict(), ...]}`; markdown
+output groups findings by check and renders each as a table row.
+
+---
+
+### Artifact 2 — `.audit/orphans.yml`
+
+**Schema:**
+
+```yaml
+# Subtree-level allowlist for orphan / wiring checks.
+# Per docs-wiring-audit/decisions.md Q2: subtree-level entries
+# only (no per-file allowlisting).
+#
+# Format: list of paths relative to repo root. Trailing slash =
+# directory (recursive). Exact match for top-level files.
+#
+# Each entry MUST have a "# reason:" comment on the line above.
+
+orphan_subtrees:
+  # reason: blog posts are dated artefacts; covered by
+  # docs-completeness-audit's date-cutoff policy
+  - docs/blog/
+
+  # reason: top-level BLOG_*.md files have the same disposition
+  # as docs/blog/; pattern match by glob
+  - docs/BLOG_*.md
+
+  # reason: archived docs are historical; not in nav by design
+  - docs/archive/
+
+  # reason: examples are reference snippets, intentionally not in nav
+  - docs/examples/
+
+  # reason: pitch deck assets, separate from product docs
+  - docs/pitch/
+
+  # reason: every spec dir has its own internal structure;
+  # nav lists specs at the level above (index pages)
+  - docs/specs/
+
+  # reason: implementation notes for spec executors, not user docs
+  - docs/implementation/
+
+  # reason: cost-analysis is for maintainers, not end users
+  - docs/cost-analysis/
+
+  # reason: conversation captures; archival
+  - docs/conversations/
+```
+
+**Why YAML, not JSON or TOML?**
+YAML supports the per-entry comment convention without ceremony.
+The audit script only needs to read the file, not write it.
+Comments are the documentation; rejecting an entry without a
+reason comment is a hard policy enforced by the loader.
+
+**Loader contract:**
+
+```python
+# scripts/audit_docs_wiring/allowlist.py
+@dataclass(frozen=True)
+class Allowlist:
+    orphan_subtrees: tuple[str, ...]  # normalised paths
+
+    def is_orphan_exempt(self, path: str) -> bool:
+        """True if `path` is under any allowlisted subtree."""
+        ...
+
+def load_allowlist(path: Path = Path(".audit/orphans.yml")) -> Allowlist:
+    """Load + validate the orphan allowlist. Raises if any entry
+    lacks a `# reason:` comment on the preceding line."""
+    ...
+```
+
+**The reason-comment enforcement** matters: without it, the file
+becomes a junk drawer of "we'll figure it out later" exemptions.
+
+---
+
+### Artifact 3 — Three cheap checks
+
+#### 3a. Anchor integrity (`checks/anchor.py`)
+
+**What it does:** for every internal markdown link of the form
+`[text](file.md#anchor)`:
+
+1. Resolve `file.md` to an absolute repo path.
+2. Parse the target file's markdown headings.
+3. Slugify each heading using the same algorithm mkdocs uses (PyMdown
+   extensions' `toc.slugify`).
+4. Assert the link's `#anchor` matches a slugified heading.
+
+**Why slugify?** Markdown headings get auto-slugified for HTML
+anchors. `## My Section` becomes `#my-section`. Authors write
+links against the slug, not the original heading text. The audit
+must use the same slugifier mkdocs does, else false negatives.
+
+**Edge cases handled:**
+
+- Intra-page anchors (`[text](#anchor)` with no file part) — check
+  against the *current* file's headings.
+- External links (`http://`, `https://`, `mailto:`) — skipped.
+- Cross-repo anchors (e.g. `https://github.com/.../file.md#anchor`)
+  — skipped in v1; flagged as v2 work in the design doc.
+- Reference-style links (`[text][ref]` ... `[ref]: file.md#anchor`)
+  — resolve the reference, then check normally.
+
+**v1 scope:** intra-`docs/` links only. Links from `README.md`,
+`CHANGELOG.md`, `CLAUDE.md`, etc. checked in v1.1.
+
+**Output:**
+
+```text
+Finding(
+  check="anchor",
+  severity="error",
+  file="docs/reference/API_REFERENCE.md",
+  line=42,
+  message="Link target '#chainexecutor' not found in docs/reference/API_REFERENCE.md (headings: 'overview', 'getting-started', 'workflows')",
+  fix="Update link to match an existing heading, or rename the heading and update inbound links per decisions.md Q1",
+)
+```
+
+#### 3b. Nav ↔ filesystem (`checks/nav.py`)
+
+**What it does:**
+
+1. Parse `mkdocs.yml`'s `nav:` section.
+2. Walk every nav entry, collecting referenced file paths.
+3. For each referenced path: assert the file exists on disk.
+4. Walk `docs/**/*.md`; for each file: assert it is either in nav
+   OR under an allowlisted orphan subtree.
+
+**Two failure shapes:**
+
+- **Dangling nav entry:** `mkdocs.yml` references `docs/old.md` but
+  the file was deleted. Severity: `error`.
+- **Unlisted doc:** `docs/new.md` exists but isn't in nav and
+  isn't allowlisted. Severity: `error`.
+
+**The orphan-subtree allowlist** (Artifact 2) exempts subtrees
+listed in `.audit/orphans.yml` from the "unlisted doc" check. A
+file under `docs/blog/` doesn't need to be in nav to pass.
+
+**Output:**
+
+```text
+# Dangling nav entry
+Finding(check="nav", severity="error", file="mkdocs.yml", line=147,
+  message="nav references docs/old.md but file does not exist",
+  fix="Remove the nav entry or restore the file")
+
+# Unlisted doc (not allowlisted)
+Finding(check="nav", severity="error", file="docs/new.md", line=None,
+  message="File exists in docs/ but is not in nav and not in .audit/orphans.yml",
+  fix="Add to nav in mkdocs.yml, or add the containing subtree to .audit/orphans.yml with a reason comment")
+```
+
+#### 3c. `features.yaml` ↔ filesystem (`checks/features_yaml.py`)
+
+**What it does:**
+
+1. Load `.help/features.yaml`.
+2. For every `doc_paths` entry across every feature: assert the
+   file exists on disk.
+3. **Advisory check (warning, not error):** for every `docs/` file
+   matching a known feature-doc pattern (`docs/reference/<name>.md`,
+   `docs/how-to/<name>.md`), check if that feature has any
+   `doc_paths` entry pointing at it. Surface mismatches as
+   `severity="warning"` — surface but don't fail the build.
+
+**Why advisory on the inverse direction?** features.yaml is
+maintained by hand; "this doc should be tracked" is a judgement
+call. The check is informational so authors notice the gap, not a
+gate that blocks PRs.
+
+**Output:**
+
+```text
+# Dangling doc_paths
+Finding(check="features-yaml", severity="error",
+  file=".help/features.yaml", line=88,
+  message="Feature 'bug-predict' doc_paths references docs/reference/bug-predict.md but file does not exist",
+  fix="Update doc_paths or restore/rename the file")
+
+# Advisory: unlinked doc that looks like a feature doc
+Finding(check="features-yaml", severity="warning",
+  file="docs/reference/new-feature.md", line=None,
+  message="Looks like a feature reference doc but no features.yaml entry points at it",
+  fix="Add to .help/features.yaml's doc_paths if this is a tracked feature; ignore if it's something else")
+```
+
+---
+
+### Artifact 4 — mkdocstrings symbol resolution (v1.1)
+
+**Why ship in v1.1, not v1?** Requires importing Python at audit
+time (slow, can fail due to dependency-injection issues, requires
+careful PYTHONPATH setup in CI). The three cheap checks ship first
+to get the gate established; mkdocstrings adds in follow-up.
+
+**What it does:**
+
+1. `grep -rn '^:::' docs/` — find every mkdocstrings directive
+   anywhere in `docs/` (per decisions.md Q3 — whole-tree sweep).
+2. Parse each `:::` line for the symbol path (e.g.
+   `::: attune.coordination.ConflictResolver`).
+3. Try to resolve each symbol via `importlib.import_module` +
+   `getattr` chain.
+4. Unresolved symbols → `severity="error"`.
+
+**Subprocess isolation:** run the symbol resolution in a fresh
+subprocess so import failures don't crash the audit. Use
+`subprocess.run([sys.executable, "-c", "import attune.X; getattr(attune.X, 'Y')"])`
+and check exit code.
+
+**Why subprocess?** Some modules have import-time side effects
+(env vars, network calls). Running each resolution in isolation
+matches what mkdocstrings does at build time.
+
+**Output:**
+
+```text
+Finding(check="mkdocstrings", severity="error",
+  file="docs/reference/multi-agent.md", line=14,
+  message="Directive '::: attune.coordination.ConflictResolver' fails to resolve (ModuleNotFoundError: No module named 'attune.coordination')",
+  fix="The symbol was renamed/moved. Either restore at the expected path, or update the directive to the new path")
+```
+
+---
+
+### Artifact 5 — Reciprocal See-Also advisory (v1.2 or deferred)
+
+**What it does:** parse "See also" / "Related" sections. If A
+links to B, check whether B's See-Also section links back to A.
+Asymmetric pairs are flagged as `severity="advisory"`.
+
+**Why advisory and likely deferred:** opinionated heuristic that
+not every author wants enforced. Implementation depends on
+detecting "See Also" sections reliably across varied markdown
+styles. Worth designing now so the audit script's report format
+supports it, but probably not shipping in this spec's
+implementation window — punt to a future spec if it doesn't fit.
+
+**Decision deferred to Phase 3 task review.**
+
+---
+
+### Artifact 6 — CI integration
+
+Add a `wiring-audit` job to `.github/workflows/docs.yml`:
+
+```yaml
+jobs:
+  wiring-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Run wiring audit
+        run: uv run python scripts/audit_docs_wiring.py --format json
+```
+
+**Gating:** add `wiring-audit` to `required_status_checks` in
+branch protection only after v1 is green on `main`. Avoid
+launching with the check failing — that creates immediate red CI
+on every PR and erodes the signal.
+
+**Sequencing:**
+
+1. Land v1 audit script + allowlist in a single PR. CI runs but
+   advisory-only.
+2. Iterate: each subsequent PR fixes one finding category until
+   audit reports zero on `main`.
+3. Promote to required status check.
+
+---
+
+### Implementation order (Phase 4)
+
+| Step | Deliverable | Estimated effort |
+|------|-------------|------------------|
+| 1 | Skeleton: `scripts/audit_docs_wiring.py` CLI, allowlist loader, Finding dataclass, JSON + markdown formatters | 1-2 hr |
+| 2 | Anchor check (Artifact 3a) + tests | 2-3 hr |
+| 3 | Nav check (Artifact 3b) + tests | 1-2 hr |
+| 4 | features.yaml check (Artifact 3c) + tests | 1 hr |
+| 5 | Allowlist file (Artifact 2) with initial entries from spec | 30 min |
+| 6 | First end-to-end run against current `docs/`; iterate on findings (fix or allowlist each) | 2-4 hr (depends on count) |
+| 7 | CI integration (Artifact 6), advisory mode | 30 min |
+| 8 | Land v1; iterate until `main` is green | (passive — open PRs over time) |
+| 9 | Promote to required check | 5 min |
+| 10 | v1.1: mkdocstrings symbol resolution (Artifact 4) | 2-3 hr |
+| 11 | v1.2 or defer: reciprocal See-Also (Artifact 5) | 2-4 hr (if pursued) |
+
+**Total v1 effort:** ~8-12 hours focused. Splittable across 2-3
+sessions; minimum viable is steps 1-7 in one session.
+
+---
+
+## Phase 3: Tasks
+
+**Status:** not started
+
+_To be authored after Phase 2 approval. Will decompose the
+Implementation order above into per-step task entries with
+acceptance criteria, file paths, and any necessary XML-enhanced
+prompts._
+
+---
+
+## Phase 4: Implementation
+
+**Status:** not started
+
+_To be executed after Phase 3 approval._
+
+---
+
+## Open questions for Phase 3 review
+
+These aren't blockers for Phase 2 approval but should be resolved
+before Phase 3 task authoring:
+
+1. **`scripts/audit_docs_wiring/` package layout — pure stdlib or
+   reuse existing utilities?** Some of the parsing (markdown
+   headings, YAML loading) overlaps with `attune-author` and
+   `attune-help`. Decision: pure stdlib + `pyyaml` for v1; revisit
+   if we want to factor a shared `attune-docs` package later.
+2. **Test framework — pytest in `tests/scripts/` or unittest?**
+   The existing `scripts/` directory has minimal test coverage;
+   adding tests requires picking a location. Recommended:
+   `tests/unit/scripts/test_audit_docs_wiring/` under the existing
+   pytest setup.
+3. **Reciprocal See-Also advisory check — ship v1.2 or defer to
+   a sibling spec?** Implementation complexity is real but the
+   value is moderate. Could be a good "good first issue" for a
+   contributor.

--- a/docs/specs/docs-wiring-audit/requirements.md
+++ b/docs/specs/docs-wiring-audit/requirements.md
@@ -9,7 +9,7 @@
 > **Orthogonal to content correctness.** This spec does not touch what
 > docs *say* — only how they connect.
 
-**Status:** draft
+**Status:** approved (2026-05-31; see [decisions.md](./decisions.md))
 **Created:** 2026-05-30
 **Owner:** TBD
 **Related:**

--- a/docs/specs/docs-wiring-audit/tasks.md
+++ b/docs/specs/docs-wiring-audit/tasks.md
@@ -1,0 +1,358 @@
+# Tasks: Documentation Wiring Audit
+
+**Status:** draft (2026-05-31)
+**Phase:** 3 — Tasks
+**Predecessor:** [design.md](./design.md) (Phase 2 authored
+2026-05-31)
+**Successor:** Phase 4 implementation (not started)
+
+---
+
+## Phase 3: Tasks
+
+This phase decomposes [design.md's implementation order](./design.md#implementation-order-phase-4)
+into reviewable task entries with explicit acceptance criteria,
+file paths, and dependencies. Tasks 1-7 ship in v1; tasks 8-9 ship
+in v1.1 and v1.2 respectively.
+
+**Task numbering matches the design's implementation order
+table** so a reviewer can cross-reference one-to-one.
+
+---
+
+### Task 1 — Audit script skeleton
+
+**Goal:** establish the CLI, allowlist loader, `Finding`
+dataclass, and output formatters with zero checks wired in.
+Running `python scripts/audit_docs_wiring.py` prints "no checks
+registered" and exits 0.
+
+**Files to create:**
+
+- `scripts/audit_docs_wiring.py` (CLI entry, ~30 LOC)
+- `scripts/audit_docs_wiring/__init__.py` (`__version__`)
+- `scripts/audit_docs_wiring/cli.py` (argparse + dispatch)
+- `scripts/audit_docs_wiring/allowlist.py` (`Allowlist` dataclass,
+  `load_allowlist()`, reason-comment enforcement)
+- `scripts/audit_docs_wiring/report.py` (markdown + JSON
+  formatters)
+- `scripts/audit_docs_wiring/checks/__init__.py` (empty)
+- `tests/unit/scripts/test_audit_docs_wiring/__init__.py`
+- `tests/unit/scripts/test_audit_docs_wiring/test_allowlist.py`
+- `tests/unit/scripts/test_audit_docs_wiring/test_report.py`
+
+**Acceptance criteria:**
+
+- [ ] `python scripts/audit_docs_wiring.py --help` prints CLI
+  usage with all subcommands listed (even though they're empty
+  stubs).
+- [ ] `python scripts/audit_docs_wiring.py --check anchor` exits
+  0 with `"No findings."` markdown output.
+- [ ] `python scripts/audit_docs_wiring.py --format json` outputs
+  valid JSON `{"findings": []}`.
+- [ ] `Allowlist.load_allowlist()` raises `ValueError` if any
+  entry in `.audit/orphans.yml` lacks a `# reason:` comment on
+  the preceding line.
+- [ ] `Finding` dataclass is frozen (immutable).
+- [ ] Tests cover: empty allowlist, well-formed allowlist,
+  missing-reason allowlist, all three formatter outputs.
+
+**Effort:** 1-2 hours.
+
+**Out of scope for this task:** any actual check logic. The
+goal is the scaffolding only.
+
+---
+
+### Task 2 — Anchor integrity check
+
+**Goal:** `scripts/audit_docs_wiring/checks/anchor.py`
+implements the anchor check per [design.md §3a](./design.md#3a-anchor-integrity-checksanchorpy).
+
+**Files to create:**
+
+- `scripts/audit_docs_wiring/checks/anchor.py` (~150 LOC)
+- `tests/unit/scripts/test_audit_docs_wiring/test_anchor.py`
+  (~100 LOC)
+
+**Acceptance criteria:**
+
+- [ ] Walks every `[text](file.md#anchor)` and `[text](#anchor)`
+  link in `docs/**/*.md`.
+- [ ] Uses the same slugifier mkdocs uses (PyMdown extensions'
+  `toc.slugify`); confirms via test against a known
+  heading→anchor pair (e.g. `## My Section ✨` → `#my-section`).
+- [ ] Skips external links (`http://`, `https://`, `mailto:`).
+- [ ] Skips cross-repo anchors (links with `github.com` host) —
+  flagged as v2 work in comment.
+- [ ] Resolves reference-style links before checking.
+- [ ] Returns a `Finding` per broken anchor with `severity="error"`,
+  `file`, `line`, descriptive `message`, and `fix` suggestion.
+- [ ] Test covers: valid anchor, invalid anchor, intra-page
+  anchor, reference-style link, external link skipped, slugifier
+  matches mkdocs.
+
+**Effort:** 2-3 hours.
+
+**Dependencies:** Task 1 (skeleton must exist).
+
+---
+
+### Task 3 — Nav ↔ filesystem check
+
+**Goal:**
+`scripts/audit_docs_wiring/checks/nav.py` implements the
+nav-vs-filesystem check per [design.md §3b](./design.md#3b-nav--filesystem-checksnavpy).
+
+**Files to create:**
+
+- `scripts/audit_docs_wiring/checks/nav.py` (~100 LOC)
+- `tests/unit/scripts/test_audit_docs_wiring/test_nav.py`
+  (~80 LOC)
+
+**Acceptance criteria:**
+
+- [ ] Parses `mkdocs.yml`'s `nav:` section recursively (nav can
+  be deeply nested).
+- [ ] For every nav entry pointing at a file: assert the file
+  exists. Surface dangling entries as
+  `severity="error"`.
+- [ ] For every `docs/**/*.md` not in nav: check the allowlist.
+  If not allowlisted, surface as `severity="error"`.
+- [ ] Allowlist matching handles trailing-slash directory
+  prefixes AND glob patterns (`docs/BLOG_*.md`).
+- [ ] Test covers: well-formed nav, dangling nav entry, unlisted
+  doc not allowlisted, unlisted doc that IS allowlisted, nested
+  nav structure, glob pattern matching.
+
+**Effort:** 1-2 hours.
+
+**Dependencies:** Task 1 (skeleton + allowlist loader).
+
+---
+
+### Task 4 — `features.yaml` ↔ filesystem check
+
+**Goal:**
+`scripts/audit_docs_wiring/checks/features_yaml.py` implements
+the features.yaml check per [design.md §3c](./design.md#3c-featuresyaml--filesystem-checksfeatures_yamlpy).
+
+**Files to create:**
+
+- `scripts/audit_docs_wiring/checks/features_yaml.py` (~80 LOC)
+- `tests/unit/scripts/test_audit_docs_wiring/test_features_yaml.py`
+  (~60 LOC)
+
+**Acceptance criteria:**
+
+- [ ] Loads `.help/features.yaml`.
+- [ ] For every `doc_paths` entry across every feature: assert
+  file exists. Dangling → `severity="error"`.
+- [ ] Walks `docs/reference/*.md` and `docs/how-to/*.md`; for
+  each: check whether any feature lists it in `doc_paths`.
+  Unlinked files matching the pattern surface as
+  `severity="warning"` (advisory).
+- [ ] Test covers: valid features.yaml, dangling doc_paths,
+  unlinked feature-shaped doc, doc that's correctly listed.
+
+**Effort:** ~1 hour.
+
+**Dependencies:** Task 1.
+
+---
+
+### Task 5 — Initial `.audit/orphans.yml`
+
+**Goal:** create the allowlist file with the initial subtree
+entries enumerated in [design.md §2](./design.md#artifact-2--auditorphansyml).
+
+**Files to create:**
+
+- `.audit/orphans.yml` (~30 LOC with reason comments)
+- `.audit/README.md` (brief explanation: what `.audit/` is for,
+  how to add entries, who reviews changes)
+
+**Acceptance criteria:**
+
+- [ ] Every entry has a `# reason:` comment on the preceding
+  line.
+- [ ] Loads cleanly via `Allowlist.load_allowlist()` (verifies
+  Task 1's enforcement works).
+- [ ] Initial entries: `docs/blog/`, `docs/BLOG_*.md`,
+  `docs/archive/`, `docs/examples/`, `docs/pitch/`,
+  `docs/specs/`, `docs/implementation/`, `docs/cost-analysis/`,
+  `docs/conversations/`.
+
+**Effort:** 30 min.
+
+**Dependencies:** Task 1 (for the loader's reason-comment
+enforcement; Task 5 stress-tests it).
+
+---
+
+### Task 6 — First end-to-end run + iterate fixes
+
+**Goal:** run the v1 audit (Tasks 2-4) against current `docs/`
+and bring the finding count to zero by either fixing the issue
+or adding to the allowlist with reason.
+
+**Process:**
+
+1. Run `python scripts/audit_docs_wiring.py --format markdown >
+   /tmp/audit-baseline.md`.
+2. Triage every finding: real-bug → fix it; intentional → add
+   to allowlist with reason.
+3. Re-run audit; iterate until count is zero.
+4. Commit the fixes + allowlist updates as separate commits per
+   logical group (e.g. "fix(docs): repair 9 broken anchors in
+   API_REFERENCE.md", "chore(audit): allowlist docs/archive/").
+
+**Acceptance criteria:**
+
+- [ ] `python scripts/audit_docs_wiring.py` exits 0 against
+  current `main`.
+- [ ] No allowlist entries lack a reason comment.
+- [ ] Each fix commit is scoped (one finding category per
+  commit) for clean review.
+
+**Effort:** 2-4 hours depending on actual finding count. The
+spec estimates ~9 anchor warnings + ~10 excluded-link warnings +
+~35 orphan-page warnings as the baseline; allowlisting handles
+most orphans, fixes handle the anchor breakage.
+
+**Dependencies:** Tasks 1-5 must all be merged or co-located on
+the same branch.
+
+---
+
+### Task 7 — CI integration (advisory mode)
+
+**Goal:** add the `wiring-audit` job to
+`.github/workflows/docs.yml` per [design.md §6](./design.md#artifact-6--ci-integration).
+Job runs on every PR but is NOT yet a required status check.
+
+**Files to modify:**
+
+- `.github/workflows/docs.yml` (~10 LOC added)
+
+**Acceptance criteria:**
+
+- [ ] `wiring-audit` job appears on PRs.
+- [ ] Job runs `uv run python scripts/audit_docs_wiring.py
+  --format json` and exits with the script's exit code.
+- [ ] Job is NOT added to branch protection's
+  `required_status_checks` yet (advisory only).
+- [ ] README or CONTRIBUTING note added explaining the audit
+  job exists and how to interpret findings.
+
+**Effort:** 30 min.
+
+**Dependencies:** Task 6 (audit must be exit-0 on main before
+CI integration, else every PR is red from day one).
+
+---
+
+### Task 8 — Promote to required check
+
+**Goal:** once `main` has held green on wiring-audit for ≥3
+consecutive PRs, add it to branch protection as a required
+status check.
+
+**Process:**
+
+1. Verify last 3 merges to main have green `wiring-audit` job.
+2. Update branch protection via `gh api`:
+   `gh api repos/Smart-AI-Memory/attune-ai/branches/main/protection/required_status_checks/contexts -X POST -F 'contexts[]=wiring-audit'`
+3. Verify the check now appears as required on a new PR.
+
+**Acceptance criteria:**
+
+- [ ] New PRs cannot merge without `wiring-audit` passing.
+- [ ] Decision recorded in [`decisions.md`](./decisions.md) with
+  the date promoted.
+
+**Effort:** 5 min (3-PR baking window is passive).
+
+**Dependencies:** Task 7 merged; 3 successful green runs on main.
+
+---
+
+### Task 9 — mkdocstrings symbol resolution (v1.1)
+
+**Goal:**
+`scripts/audit_docs_wiring/checks/mkdocstrings.py` implements
+the symbol-resolution check per [design.md §4](./design.md#artifact-4--mkdocstrings-symbol-resolution-v11).
+
+**Files to create:**
+
+- `scripts/audit_docs_wiring/checks/mkdocstrings.py` (~120 LOC)
+- `tests/unit/scripts/test_audit_docs_wiring/test_mkdocstrings.py`
+  (~80 LOC)
+
+**Acceptance criteria:**
+
+- [ ] `grep -rn '^:::' docs/` finds every directive across the
+  whole tree (not just the 5 known files).
+- [ ] Each directive's symbol is resolved via subprocess
+  isolation (`subprocess.run([sys.executable, "-c", "import X;
+  getattr(X, 'Y')"])`).
+- [ ] Subprocess failures surface as `severity="error"` with
+  the underlying error message.
+- [ ] Test covers: valid resolution, missing module, missing
+  attribute, malformed directive.
+
+**Effort:** 2-3 hours.
+
+**Dependencies:** Tasks 1-7 complete; new release ships v1
+before v1.1 starts.
+
+---
+
+### Task 10 — Reciprocal See-Also advisory (v1.2 or defer)
+
+**Decision deferred to post-v1 review.** If the v1 audit script
+proves valuable and the See-Also gap surfaces concrete pain, this
+task gets scheduled. Otherwise, the design is on file and the
+task can sit indefinitely.
+
+**Acceptance criteria (if pursued):**
+
+- [ ] `scripts/audit_docs_wiring/checks/see_also.py` implemented
+  per [design.md §5](./design.md#artifact-5--reciprocal-see-also-advisory-v12-or-deferred).
+- [ ] `severity="advisory"` — surfaces in reports but does NOT
+  fail CI.
+
+**Effort:** 2-4 hours (if pursued).
+
+---
+
+## Task ordering summary
+
+| Task | Effort | Phase | Blocks |
+|------|--------|-------|--------|
+| 1 — Skeleton | 1-2 hr | v1 | All others |
+| 2 — Anchor check | 2-3 hr | v1 | Task 6 |
+| 3 — Nav check | 1-2 hr | v1 | Task 6 |
+| 4 — features.yaml check | 1 hr | v1 | Task 6 |
+| 5 — Allowlist file | 30 min | v1 | Task 6 |
+| 6 — End-to-end run + fixes | 2-4 hr | v1 | Task 7 |
+| 7 — CI advisory mode | 30 min | v1 | Task 8 |
+| 8 — Promote to required | 5 min | v1 | (release-prep dep) |
+| 9 — mkdocstrings | 2-3 hr | v1.1 | (independent) |
+| 10 — See-Also | 2-4 hr | v1.2 | (independent, deferred) |
+
+**v1 total:** ~8-12 hours focused, splittable across 2-3 sessions.
+**Minimum-viable session:** Tasks 1-7 in one focused session
+(7-10 hours).
+**Faster split:** Tasks 1+2 in session 1 (3-5 hr); Tasks 3-5
+in session 2 (2-3 hr); Tasks 6-7 in session 3 (2-4 hr).
+
+---
+
+## Phase 4: Implementation
+
+**Status:** not started
+
+_To be executed after Phase 3 approval. Tasks above are the
+playbook; each task corresponds to a PR or a single commit
+within a PR, with the acceptance criteria as the test gate._


### PR DESCRIPTION
## Summary

Three-part PR completing the wiring-audit spec's Phases 1-3 and approving its two sibling specs:

**Part 1: Approve all 3 prerequisite specs (decisions.md + status flips).** Resolves the 9 open questions across `docs-completeness-audit`, `docs-wiring-audit`, and `docs-release-prep` (all authored in PR #511) and flips their status from `draft` to `approved`. Each spec gets a `decisions.md` following the established append-only-log pattern.

**Part 2: Author `docs-wiring-audit` Phase 2 (`design.md`).** Designs the wiring-audit tool, allowlist file, and CI integration. Five-artifact decomposition staged across v1 / v1.1 / v1.2.

**Part 3: Author `docs-wiring-audit` Phase 3 (`tasks.md`).** Decomposes the design's implementation order into 10 reviewable task entries with acceptance criteria, file paths, effort estimates, and dependencies. After this PR lands, Phase 4 (implementation) can start.

## Key decisions (Part 1)

**`docs-completeness-audit`:**
- **Q1 Blog scope:** date-cutoff IN (6 months); older posts → `docs/archive/`
- **Q2 `PROJECT_OVERVIEW.md`:** evergreen rewrite, strip versions
- **Q3 Sizing:** spec's 203 baseline verified; ~135 in-scope; ~9 subagents

**`docs-wiring-audit`:**
- **Q1 Anchor renames:** update inbound links in same PR, no redirect
- **Q2 Orphan allowlist:** subtree-level in `.audit/orphans.yml`
- **Q3 mkdocstrings:** sweep whole `docs/` tree, not just 5 known files

**`docs-release-prep`:**
- **Q1 Version:** 7.3.0 minor (PR #500's `feat` makes patch dishonest)
- **Q2 Chips:** don't block (chip 1 done; chips 3+4 are weeks of new spec work)
- **Q3 attune-redis:** no coordinated bump (not on PyPI; no version-pinned doc coupling)

## Design overview (Part 2)

`scripts/audit_docs_wiring.py` as a single CLI entry point with per-check subcommands. Five artifacts:

1. **Audit script** (Python package, not single file) — CLI, dispatch, output formatters
2. **`.audit/orphans.yml`** — subtree allowlist with reason-comment enforcement
3. **Three cheap checks** (v1): anchor integrity, nav ↔ filesystem, `features.yaml` ↔ filesystem
4. **mkdocstrings symbol resolution** (v1.1) — requires Python import; subprocess-isolated
5. **Reciprocal See-Also advisory** (v1.2 or deferred) — opinionated, lower urgency

CI integration: `wiring-audit` job in `docs.yml`, advisory mode first, promote to required check after `main` is green.

## Task decomposition (Part 3)

10 tasks total: 1-7 ship in v1 (~8-12 hours focused, splittable across 2-3 sessions), task 9 in v1.1, task 10 in v1.2 or defer. Each task has explicit acceptance criteria, file paths, and dependency chain. Task numbering matches design.md's implementation order one-to-one.

## What this PR is NOT

- Not the release ceremony. Gated on the two prerequisite specs being executed.
- Not the implementation of wiring-audit. That's Phase 4, after this PR's Phase 3 approval lands.
- Not a version bump. Stays at 7.2.0.

## Test plan

- [x] 8 files modified/created across three logical commits
- [x] decisions.md follow the `redis-decoupling/decisions.md` format
- [x] design.md follows the `coverage-exclusion-policy/design.md` format
- [x] tasks.md follows established task-decomposition format with acceptance criteria
- [x] No code changes; pure docs/specs
- [x] Pre-commit clean
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
