### PR TITLE
chore(rescue): preserve test flake fix + create_wizard docstring fix from at-risk worktrees

### DIFF
--- a/src/attune/agent_factory/__init__.py
+++ b/src/attune/agent_factory/__init__.py
@@ -23,8 +23,8 @@ Usage:
     # Create workflows
     pipeline = factory.create_workflow([researcher, writer])
 
-    # Create wizards with framework backing
-    debug_wizard = factory.create_wizard("debugging")
+    # Create role-specialized agents with sensible defaults
+    debugger = factory.create_debugger()
 
 Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0

--- a/tests/unit/orchestration/test_composition_patterns.py
+++ b/tests/unit/orchestration/test_composition_patterns.py
@@ -100,16 +100,28 @@ class TestParallelComposition:
         test_context,
         mock_execute_agent,
     ):
-        """Test that agents execute independently in parallel."""
+        """Test that agents execute independently in parallel.
+
+        Verifies parallelism structurally via asyncio scheduling order rather
+        than wall-clock duration ratios. When ParallelStrategy uses
+        ``asyncio.gather``, every agent enters its coroutine and reaches its
+        first ``await`` before any of them returns — so the count of started
+        agents at each finish is ``[n, n, n]``. Sequential execution would
+        produce ``[1, 2, 3]``. The previous duration-ratio assertion was
+        flaky on Windows 3.12 where timer granularity and asyncio scheduling
+        overhead exceeded the measured individual durations of instant mock
+        agents.
+        """
         strategy = ParallelStrategy()
 
-        # Track execution order to verify parallelism
-        execution_times = []
+        started = 0
+        finished_when_started: list[int] = []
 
         async def tracked_execute(agent, context):
-            start = time.perf_counter()
+            nonlocal started
+            started += 1
             result = await mock_execute_agent(agent, context)
-            execution_times.append((agent.id, time.perf_counter() - start))
+            finished_when_started.append(started)
             return result
 
         strategy._execute_agent = tracked_execute
@@ -118,14 +130,13 @@ class TestParallelComposition:
 
         assert result.success
         assert len(result.outputs) == 3
+        assert len(finished_when_started) == 3
 
-        # All agents should have executed
-        assert len(execution_times) == 3
-
-        # Verify parallel execution: total duration should be max, not sum
-        # (allowing some overhead for async coordination)
-        max_individual = max(t[1] for t in execution_times)
-        assert result.total_duration <= max_individual * 1.5
+        assert finished_when_started == [3, 3, 3], (
+            "Agents did not execute in parallel: "
+            f"finished_when_started={finished_when_started} "
+            "(parallel expected [3, 3, 3], sequential would be [1, 2, 3])"
+        )
 
     @pytest.mark.asyncio
     async def test_parallel_result_aggregation(self, mock_agents, test_context, mock_execute_agent):


### PR DESCRIPTION
## Summary

Two fixes rescued from at-risk worktrees during 2026-05-31 morning briefing triage. Both are real, independent improvements that were sitting unmerged in dirty worktrees.

**1. Test flake fix** (`fix(tests): replace flaky timing-based parallel-execution assertion`) — rescued from `compassionate-hypatia-7c8a97`. Replaces `test_parallel_strategy_executes_independently`'s wall-clock duration ratios with a structural assertion (count of started agents when each finishes). Fixes a documented Windows 3.12 timer-granularity flake without changing the test's intent.

**2. Docstring fix** (`docs(agent-factory): fix fabricated create_wizard example`) — rescued from `optimistic-northcutt-538016` (original commit `e5a74c33`). The package docstring at `src/attune/agent_factory/__init__.py` advertised `factory.create_wizard("debugging")` as an example — that method doesn't exist on `AgentFactory`. Copy-pasters got `AttributeError`. Replaced with the real `factory.create_debugger()`. **This closes chip 2** from the wiring-fix carryover list named in PR #513's docs-release-prep decisions.md.

## What this PR is NOT

- Not a worktree-removal action — the worktrees stay until this PR merges, then they get removed in a separate cleanup pass.
- Not a code change beyond the two fixes — both are surgical.

## Test plan

- [x] `pytest tests/unit/orchestration/test_composition_patterns.py` — 35 passed
- [x] Two separate clean commits (one file each) — verified scope
- [x] Pre-commit hooks all pass; `regenerate-help-templates` skipped on commit 2 to preserve polished prose per the existing "two parallel `.help/templates/` regen pipelines" lesson
- [ ] CI green on all platforms

## Worktree cleanup follow-up

After this PR merges, the following can be removed safely:

- `.claude/worktrees/lessons-incorp` (already safe per audit; not touched here)
- `.claude/worktrees/compassionate-hypatia-7c8a97` (work preserved by commit 1)
- `.claude/worktrees/optimistic-northcutt-538016` (work preserved by commit 2; `.help/templates/agents/*.md` regen discarded as stub overwrites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
