### PR TITLE
feat(sdk-error-fidelity): Phase 1 primitives in agent_sdk_adapter.py

### DIFF
--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -17,9 +17,11 @@ import subprocess
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import claude_agent_sdk
+
+from attune.ops.session_redaction import redact
 
 from .base import ModelTier
 from .data_classes import CostReport, NextAction, WorkflowResult, WorkflowStage
@@ -532,6 +534,222 @@ def sdk_error_message(
         "If this recurs, check the stderr output for the underlying "
         f"error and consider opening an issue.\n{raw_tail}"
     )
+
+
+# ----------------------------------------------------------------------
+# SDK error fidelity (spec: docs/specs/sdk-error-message-fidelity/)
+#
+# Phase 1 primitives: typed exception, classifier, capture helper,
+# argv extractor. No call sites use these yet — wiring happens in
+# Phase 2 onward.
+# ----------------------------------------------------------------------
+
+SdkErrorKind = Literal[
+    "api_quota",
+    "auth",
+    "rate_limit",
+    "not_found",
+    "schema_rejected",
+    "unknown",
+]
+
+
+@dataclass
+class SdkSubprocessError(Exception):
+    """Typed wrapper around the SDK's bare 'Command failed' Exception.
+
+    Captures the underlying ``claude`` CLI's stderr (via a second
+    direct-subprocess call) and classifies it into one of the known
+    failure-kind labels for user-facing messaging.
+
+    Attributes:
+        message: User-facing one-line summary (e.g. "Anthropic API
+            quota reached for this account.").
+        stderr: Redacted stderr captured from the second
+            ``subprocess.run`` call.
+        kind: Classified failure category (see ``SdkErrorKind``).
+        original_exc: The SDK's wrapped exception, preserved so
+            callers / tests can ``raise X from err.original_exc``.
+    """
+
+    message: str
+    stderr: str
+    kind: SdkErrorKind
+    original_exc: BaseException | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+    def format_user_message(self) -> str:
+        """Voice-layer-ready user-facing block.
+
+        When ``kind == "unknown"`` the raw stderr is included inline
+        so the user has the truth even when the classifier didn't
+        match a known pattern. For classified kinds, the message is
+        the summary and the full stderr is available via the run
+        view (persisted by Phase 3).
+        """
+        if self.kind == "unknown":
+            return (
+                f"{self.message}\n\n"
+                "Underlying error (raw stderr from the claude CLI):\n"
+                f"{self.stderr.strip()}"
+            )
+        return f"{self.message}\n\nFull stderr is available on /runs/<id>/view."
+
+
+# (compiled_re, kind, message) tuples. Ordered most-specific first so
+# a more-precise label wins over a generic one (e.g. an "API usage
+# limits" message that also mentions "401" still classifies as
+# api_quota).
+_CLASSIFIERS: list[tuple[re.Pattern[str], SdkErrorKind, str]] = [
+    (
+        re.compile(r"specified API usage limits", re.I),
+        "api_quota",
+        "Anthropic API quota reached for this account.",
+    ),
+    (
+        re.compile(r"\b(401|invalid[_\s-]?api[_\s-]?key|unauthorized)\b", re.I),
+        "auth",
+        "Anthropic auth invalid or missing.",
+    ),
+    (
+        re.compile(r"\b(429|rate[_\s-]?limit|too many requests)\b", re.I),
+        "rate_limit",
+        "Rate-limited by Anthropic; retry shortly.",
+    ),
+    (
+        re.compile(r"FileNotFoundError|claude.*not.*(found|on.*PATH)", re.I),
+        "not_found",
+        "The bundled claude CLI was not found at the expected path.",
+    ),
+    (
+        re.compile(r"json[_\s-]?schema|--?json-?schema", re.I),
+        "schema_rejected",
+        "The output schema was rejected by the claude CLI.",
+    ),
+]
+
+
+def classify_subprocess_failure(stderr: str) -> tuple[SdkErrorKind, str]:
+    """Classify a captured stderr blob into ``(kind, user-message)``.
+
+    Args:
+        stderr: Captured stderr text from the ``claude`` CLI
+            subprocess. Typically the redacted output of
+            ``capture_subprocess_failure()``.
+
+    Returns:
+        A 2-tuple of ``(SdkErrorKind, str)``. Falls back to
+        ``("unknown", "The claude CLI subprocess failed; see raw
+        stderr below.")`` when no classifier pattern matches.
+    """
+    for pattern, kind, message in _CLASSIFIERS:
+        if pattern.search(stderr):
+            return kind, message
+    return "unknown", "The claude CLI subprocess failed; see raw stderr below."
+
+
+def capture_subprocess_failure(
+    args: list[str],
+    env: dict[str, str] | None = None,
+    timeout_s: float = 10.0,
+) -> str:
+    """Re-run the failed ``claude`` invocation with stderr capture.
+
+    Called from the broad-except branch around a
+    ``claude_agent_sdk.query()`` call when the bare 'Command failed'
+    exception fires. The SDK swallows stderr; this helper re-runs
+    the same argv directly via ``subprocess.run()`` so the real
+    cause becomes visible.
+
+    Args:
+        args: Exact argv used by the SDK's first invocation. Pulled
+            from the SDK's exception via ``_last_subprocess_argv()``.
+        env: Optional env override. Defaults to the inherited
+            process environment.
+        timeout_s: Subprocess timeout. The failure modes we care
+            about (quota / auth / not-found) all exit in sub-second;
+            10s is a generous ceiling.
+
+    Returns:
+        Redacted stderr text, or a synthetic
+        ``"(capture-call also failed: <reason>)"`` / ``"(capture-call
+        timed out after <Ns>)"`` string if the second subprocess
+        itself raises. The synthetic strings are intentionally
+        formatted so the classifier's "unknown" fallback still
+        renders them to the user.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603
+            args,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,  # we want to inspect failure output
+        )
+        # Some failures put real errors on stdout (e.g. JSON envelope).
+        # Concatenate; the classifier scans both anyway.
+        combined = (result.stderr or "") + ("\n" + result.stdout if result.stdout else "")
+        return redact(combined).text
+    except subprocess.TimeoutExpired:
+        return f"(capture-call timed out after {timeout_s}s)"
+    except (OSError, subprocess.SubprocessError, IndexError, ValueError) as exc:
+        # IndexError / ValueError: empty or malformed argv from
+        # _last_subprocess_argv() — subprocess.run([]) raises IndexError
+        # on Python's stdlib path; ValueError covers None / non-str entries.
+        return f"(capture-call also failed: {type(exc).__name__}: {exc})"
+
+
+def _last_subprocess_argv(exc: BaseException) -> list[str]:
+    """Extract the failing argv from an SDK ``Exception('Command failed ...')``.
+
+    The SDK's ``claude_agent_sdk._internal.query`` raises a bare
+    ``Exception`` with a string message but stores the subprocess
+    args on the exception's ``__cause__`` or in an attribute the
+    classifier walks. This helper centralises that extraction so
+    a drift-guard test can fail loudly when the SDK changes shape.
+
+    Walks these candidate attribute paths in order:
+
+    1. ``exc.args[0]`` if it's already a ``list[str]`` (some SDK
+       versions stash the argv there).
+    2. ``exc.__cause__.cmd`` — ``subprocess.CalledProcessError``-shaped
+       wrap.
+    3. ``exc.cmd`` — direct attribute on the exception.
+    4. Fallback: empty list — caller's downstream
+       ``capture_subprocess_failure([])`` will hit the OSError path
+       and surface a synthetic "(capture-call also failed)" string.
+
+    Returns:
+        The captured argv as ``list[str]``, or ``[]`` if no
+        recognized shape was found.
+    """
+    # Shape 1: argv stashed in exc.args[0]
+    args_attr = getattr(exc, "args", None)
+    if args_attr and isinstance(args_attr, tuple) and len(args_attr) > 0:
+        first = args_attr[0]
+        if isinstance(first, list) and all(isinstance(x, str) for x in first):
+            return first
+
+    # Shape 2: subprocess.CalledProcessError on __cause__
+    cause = getattr(exc, "__cause__", None)
+    if cause is not None:
+        cmd = getattr(cause, "cmd", None)
+        if isinstance(cmd, list) and all(isinstance(x, str) for x in cmd):
+            return cmd
+        if isinstance(cmd, str):
+            return [cmd]
+
+    # Shape 3: direct .cmd on the exception
+    cmd = getattr(exc, "cmd", None)
+    if isinstance(cmd, list) and all(isinstance(x, str) for x in cmd):
+        return cmd
+    if isinstance(cmd, str):
+        return [cmd]
+
+    return []
 
 
 def get_max_budget_usd(depth: str = "standard") -> float | None:

--- a/tests/unit/workflows/test_sdk_error_fidelity.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity.py
@@ -1,0 +1,241 @@
+"""Unit tests for SDK error fidelity primitives.
+
+Covers Phase 1 of docs/specs/sdk-error-message-fidelity/:
+
+- ``SdkSubprocessError`` dataclass-exception (str, format_user_message)
+- ``classify_subprocess_failure`` (all 6 kinds, most-specific-wins)
+- ``capture_subprocess_failure`` (happy path, timeout, OSError, redaction)
+- ``_last_subprocess_argv`` extractor (3 shapes + fallback + drift guard)
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from attune.workflows.agent_sdk_adapter import (
+    SdkSubprocessError,
+    _last_subprocess_argv,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
+)
+
+# ---------------------------------------------------------------------
+# SdkSubprocessError
+# ---------------------------------------------------------------------
+
+
+class TestSdkSubprocessError:
+    """The typed wrapper around the SDK's bare 'Command failed' exception."""
+
+    def test_str_returns_message(self):
+        err = SdkSubprocessError(
+            message="Anthropic API quota reached for this account.",
+            stderr="raw stderr",
+            kind="api_quota",
+        )
+        assert str(err) == "Anthropic API quota reached for this account."
+
+    def test_format_user_message_unknown_kind_includes_raw_stderr(self):
+        """Unknown classifications include the raw stderr inline so the
+        user has the truth even when no pattern matched."""
+        err = SdkSubprocessError(
+            message="The claude CLI subprocess failed; see raw stderr below.",
+            stderr="weird error nobody recognized",
+            kind="unknown",
+        )
+        rendered = err.format_user_message()
+        assert "weird error nobody recognized" in rendered
+        assert "raw stderr" in rendered.lower()
+
+    def test_format_user_message_classified_kind_points_to_run_view(self):
+        """Classified kinds give the summary + a pointer to the dashboard
+        view (where Phase 3 will surface the full stderr)."""
+        err = SdkSubprocessError(
+            message="Anthropic API quota reached for this account.",
+            stderr="full stderr blob",
+            kind="api_quota",
+        )
+        rendered = err.format_user_message()
+        assert "API quota" in rendered
+        assert "/runs/<id>/view" in rendered
+        # Full stderr is NOT inlined for classified kinds
+        assert "full stderr blob" not in rendered
+
+    def test_original_exc_round_trips(self):
+        """The original SDK exception is preserved on the wrapper so
+        callers / tests can `raise X from err.original_exc`."""
+        underlying = ValueError("inner")
+        err = SdkSubprocessError(
+            message="msg",
+            stderr="",
+            kind="unknown",
+            original_exc=underlying,
+        )
+        assert err.original_exc is underlying
+
+
+# ---------------------------------------------------------------------
+# classify_subprocess_failure
+# ---------------------------------------------------------------------
+
+
+class TestClassifySubprocessFailure:
+    """One test per ``SdkErrorKind`` + most-specific-wins ordering."""
+
+    def test_classifies_api_quota(self):
+        kind, msg = classify_subprocess_failure(
+            "Error: You have reached your specified API usage limits. "
+            "You will regain access on 2026-06-01."
+        )
+        assert kind == "api_quota"
+        assert "quota" in msg.lower()
+
+    def test_classifies_auth(self):
+        kind, msg = classify_subprocess_failure("401 Unauthorized: invalid api key provided")
+        assert kind == "auth"
+        assert "auth" in msg.lower()
+
+    def test_classifies_auth_via_invalid_api_key(self):
+        kind, _ = classify_subprocess_failure("Error: invalid_api_key")
+        assert kind == "auth"
+
+    def test_classifies_rate_limit(self):
+        kind, msg = classify_subprocess_failure("429 Too Many Requests: rate limit exceeded")
+        assert kind == "rate_limit"
+        assert "rate" in msg.lower()
+
+    def test_classifies_not_found(self):
+        kind, _ = classify_subprocess_failure(
+            "FileNotFoundError: [Errno 2] No such file or directory: 'claude'"
+        )
+        assert kind == "not_found"
+
+    def test_classifies_not_found_via_path_message(self):
+        kind, _ = classify_subprocess_failure("Error: claude not found on PATH")
+        assert kind == "not_found"
+
+    def test_classifies_schema_rejected(self):
+        kind, _ = classify_subprocess_failure("Error: --json-schema parameter rejected")
+        assert kind == "schema_rejected"
+
+    def test_falls_back_to_unknown(self):
+        """No pattern match → unknown + a generic message."""
+        kind, msg = classify_subprocess_failure("Some completely novel error nobody anticipated")
+        assert kind == "unknown"
+        assert "see raw stderr" in msg
+
+    def test_most_specific_wins_quota_over_auth(self):
+        """An error message containing both 'API usage limits' AND '401'
+        classifies as api_quota (more specific) not auth."""
+        kind, _ = classify_subprocess_failure(
+            "401 Unauthorized — also: specified API usage limits reached"
+        )
+        assert kind == "api_quota"
+
+    def test_empty_stderr_classifies_as_unknown(self):
+        kind, _ = classify_subprocess_failure("")
+        assert kind == "unknown"
+
+
+# ---------------------------------------------------------------------
+# capture_subprocess_failure
+# ---------------------------------------------------------------------
+
+
+class TestCaptureSubprocessFailure:
+    """The second-subprocess helper that captures real stderr."""
+
+    def test_captures_failing_command_stderr(self):
+        """A failing command's stderr should come back non-empty."""
+        # `false` exits 1 with no output; use `sh -c` to produce stderr.
+        out = capture_subprocess_failure(["sh", "-c", "echo 'real failure' 1>&2; exit 1"])
+        assert "real failure" in out
+
+    def test_returns_synthetic_string_on_timeout(self):
+        out = capture_subprocess_failure(
+            ["sh", "-c", "sleep 5"],
+            timeout_s=0.2,
+        )
+        assert "timed out" in out
+        assert "0.2s" in out
+
+    def test_returns_synthetic_string_on_os_error(self):
+        """Invalid argv → OSError (FileNotFoundError) → synthetic
+        '(capture-call also failed)' string."""
+        out = capture_subprocess_failure(["/no/such/binary/anywhere"])
+        assert "capture-call also failed" in out
+        # The error class name should be in the synthetic string
+        assert "Error" in out or "OSError" in out
+
+    def test_routes_output_through_redact(self):
+        """Any sensitive token in captured output must be redacted before
+        return. Uses a synthetic Anthropic-shaped API key via runtime
+        concat so the source file itself doesn't trigger push protection
+        (per CLAUDE.md GitHub push-protection lesson)."""
+        fake_key = "sk-" + "ant-api03-" + "TESTFAKETOKEN" + "ABCDEFGHIJ"
+        out = capture_subprocess_failure(["sh", "-c", f"echo 'key=\"{fake_key}\"' 1>&2; exit 1"])
+        # The exact token should NOT appear in output (redacted away)
+        assert fake_key not in out
+
+    def test_empty_argv_returns_synthetic_failure(self):
+        """An empty argv hits the OSError path inside subprocess.run."""
+        out = capture_subprocess_failure([])
+        assert "capture-call also failed" in out
+
+
+# ---------------------------------------------------------------------
+# _last_subprocess_argv
+# ---------------------------------------------------------------------
+
+
+class TestLastSubprocessArgv:
+    """Drift guard + the three recognized exception shapes."""
+
+    def test_extracts_from_args_zero_list(self):
+        """Shape 1: SDK stashes argv in exc.args[0] as a list[str]."""
+        exc = Exception(["claude", "--output-format", "stream-json"])
+        assert _last_subprocess_argv(exc) == [
+            "claude",
+            "--output-format",
+            "stream-json",
+        ]
+
+    def test_extracts_from_cause_cmd_list(self):
+        """Shape 2: subprocess.CalledProcessError-shaped __cause__ with
+        .cmd as list[str]."""
+        called = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["claude", "-p", "test"],
+        )
+        wrapper = Exception("Command failed with exit code 1")
+        wrapper.__cause__ = called
+        assert _last_subprocess_argv(wrapper) == ["claude", "-p", "test"]
+
+    def test_extracts_from_direct_cmd_attribute(self):
+        """Shape 3: direct .cmd attribute on the exception itself."""
+        exc = Exception("Command failed")
+        exc.cmd = ["claude", "--version"]
+        assert _last_subprocess_argv(exc) == ["claude", "--version"]
+
+    def test_returns_empty_list_when_no_shape_matches(self):
+        """Drift guard: when none of the recognized shapes apply,
+        return []. Downstream capture_subprocess_failure([]) hits the
+        OSError path and surfaces a synthetic message."""
+        exc = Exception("plain string message, no argv anywhere")
+        assert _last_subprocess_argv(exc) == []
+
+    def test_handles_cause_cmd_as_string(self):
+        """Some subprocess errors store .cmd as a single string instead
+        of a list — wrap in a single-element list."""
+        called = subprocess.CalledProcessError(
+            returncode=1,
+            cmd="claude -p test",
+        )
+        wrapper = Exception("Command failed")
+        wrapper.__cause__ = called
+        assert _last_subprocess_argv(wrapper) == ["claude -p test"]
+
+    def test_ignores_args_zero_when_not_list_of_str(self):
+        """Don't false-positive on non-string args[0]."""
+        exc = Exception({"not": "a list"})
+        assert _last_subprocess_argv(exc) == []


### PR DESCRIPTION
## Summary

Phase 1 of [`docs/specs/sdk-error-message-fidelity/`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/sdk-error-message-fidelity/). Adds the typed exception, classifier, capture helper, and argv extractor as standalone primitives in `src/attune/workflows/agent_sdk_adapter.py`. **No call sites change yet** — Phase 2 wires the primitives into individual workflows.

The user-visible bug this whole spec is meant to fix: when an SDK workflow fails with `Exception("Command failed with exit code 1")`, the current `sdk_error_message()` helper surfaces a fixed menu of three plausible-but-often-wrong causes, none of which may be the actual reason. The Phase 1 primitives capture the real `claude` CLI stderr (via a second `subprocess.run` call) and classify it into one of five known kinds (`api_quota`, `auth`, `rate_limit`, `not_found`, `schema_rejected`) plus an `unknown` fallback that inlines raw stderr.

## What's in this PR

**New primitives** (additive only, no existing code changed):

- `SdkErrorKind` `Literal[...]` — six categories.
- `SdkSubprocessError` dataclass-exception — typed wrapper with `format_user_message()`.
- `_CLASSIFIERS` table + `classify_subprocess_failure(stderr)` — most-specific-first ordering.
- `capture_subprocess_failure(args, env, timeout_s)` — re-runs the failed claude invocation directly, redacts output through `attune.ops.session_redaction`.
- `_last_subprocess_argv(exc)` — walks three exception shapes with drift-guard test.

**Tests** (25 total, spec required ≥15):

- All 6 `SdkErrorKind` classifier branches.
- Most-specific-wins ordering (quota over auth).
- All 3 argv-extraction shapes + fallback + non-list-of-str guard.
- Capture-helper happy path, timeout, OSError, IndexError-on-empty-argv.
- Redaction integration with synthetic Anthropic-shaped token (constructed via runtime concat per the existing CLAUDE.md "GitHub push protection" lesson).

## Defensive choice worth noting

The capture helper's except clause includes `IndexError` and `ValueError` beyond the spec's `(OSError, subprocess.SubprocessError)` — `subprocess.run([])` raises `IndexError` (not OSError) on Python's stdlib path. Since `_last_subprocess_argv()` can return `[]` when no shape matches, the capture helper must surface a synthetic message there rather than letting IndexError bubble. Caught by the new `test_empty_argv_returns_synthetic_failure` test.

## What this PR is NOT

- Not a workflow change. The `sdk_error_message` legacy function is untouched.
- Not the persistence layer. Phase 3 adds `sdk_stderr` / `sdk_error_kind` to run records.
- Not the dashboard render. Phase 3 adds the collapsible `<details>` block.

## Test plan

- [x] 25 unit tests, all green
- [x] All 81 existing `agent_sdk_adapter.py` tests still pass — additive change confirmed
- [x] `ruff check` clean
- [x] Pre-commit hooks all pass
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
