### PR TITLE
feat(wiring-audit): Tasks 1+2 — skeleton + anchor integrity check

### DIFF
--- a/scripts/audit_docs_wiring.py
+++ b/scripts/audit_docs_wiring.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Documentation wiring audit — v1 (skeleton + anchor check).
+
+Implements Tasks 1 + 2 of
+``docs/specs/docs-wiring-audit/tasks.md`` per the spec's
+[design.md](../docs/specs/docs-wiring-audit/design.md).
+
+v1 ships:
+
+- CLI + dispatch (Task 1).
+- Allowlist loader with reason-comment enforcement (Task 1).
+- Markdown + JSON formatters (Task 1).
+- Anchor integrity check (Task 2) — verifies every internal
+  ``[text](file.md#anchor)`` and ``[text](#anchor)`` link
+  resolves to a real heading anchor.
+
+v1.1 will add nav-vs-filesystem + features.yaml checks +
+mkdocstrings symbol resolution. v1.2 adds reciprocal See-Also
+advisory. Each adds a new ``run_<name>_check`` function and
+dispatch entry.
+
+**Layout deviation from design.md:** the design proposed a
+``scripts/audit_docs_wiring/`` package layout. v1 ships
+single-file because (a) it's well under the 800-LOC threshold
+the package-vs-file decision was meant to manage, and (b) the
+existing ``scripts/check_help_coverage.py`` convention matches
+single-file. Refactor to package when v1.1 adds the second
+check and the file approaches that size.
+
+Run:
+
+    python scripts/audit_docs_wiring.py                # all checks
+    python scripts/audit_docs_wiring.py --check anchor # one check
+    python scripts/audit_docs_wiring.py --format json  # CI-shaped
+
+Exit codes:
+    0  — All requested checks passed (zero findings after allowlist).
+    1  — One or more findings remain after allowlist (CI fails).
+    2  — Bad invocation (unknown check name, malformed allowlist).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import json
+import re
+import sys
+import unicodedata
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+__version__ = "0.1.0"
+
+# ---------------------------------------------------------------------
+# Finding dataclass
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single wiring-audit finding.
+
+    Frozen so callers can put findings in sets / use as dict keys
+    without surprise mutation.
+    """
+
+    check: str
+    severity: str
+    file: str
+    line: int | None
+    message: str
+    fix: str | None = None
+
+
+# ---------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Allowlist:
+    """Subtree-level allowlist for orphan checks.
+
+    Per ``docs-wiring-audit/decisions.md`` Q2: entries are
+    subtree paths (trailing slash for directories, glob for
+    top-level file patterns). Loaded from ``.audit/orphans.yml``;
+    each entry MUST have a ``# reason:`` comment on the preceding
+    line — enforced at load time.
+    """
+
+    orphan_subtrees: tuple[str, ...] = field(default_factory=tuple)
+
+    def is_orphan_exempt(self, path: str) -> bool:
+        """True if ``path`` is under any allowlisted subtree."""
+        for entry in self.orphan_subtrees:
+            if entry.endswith("/") and path.startswith(entry):
+                return True
+            if "*" in entry:
+                # Glob-style match for patterns like docs/BLOG_*.md
+                import fnmatch
+
+                if fnmatch.fnmatch(path, entry):
+                    return True
+            if path == entry:
+                return True
+        return False
+
+
+def load_allowlist(path: Path | None = None) -> Allowlist:
+    """Load ``.audit/orphans.yml`` with reason-comment enforcement.
+
+    The file format is intentionally a tiny YAML subset (a single
+    ``orphan_subtrees:`` list) so we can parse it with stdlib
+    line-walking and enforce the reason-comment rule without
+    needing a YAML parser dep. Empty / missing file returns an
+    empty allowlist.
+
+    Raises:
+        ValueError: when any entry lacks a ``# reason:`` comment
+            on the immediately preceding non-blank line.
+    """
+    if path is None:
+        path = Path(".audit/orphans.yml")
+    if not path.exists():
+        return Allowlist()
+
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    entries: list[str] = []
+    last_comment: str | None = None
+    in_list = False
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            # blank line — preserve last_comment so a list entry
+            # right after blanks still sees its reason
+            continue
+        if stripped.startswith("#"):
+            last_comment = stripped
+            continue
+        if stripped.startswith("orphan_subtrees:"):
+            in_list = True
+            continue
+        if in_list and stripped.startswith("- "):
+            entry = stripped[2:].strip().strip("\"'")
+            if last_comment is None or "reason:" not in last_comment.lower():
+                raise ValueError(
+                    f"Allowlist entry {entry!r} in {path} lacks a "
+                    f"'# reason:' comment on the preceding line. "
+                    "Every entry requires a reason."
+                )
+            entries.append(entry)
+            last_comment = None  # consumed — next entry needs a fresh one
+            continue
+        # Anything else (top-level key, malformed line) ends the list block.
+        in_list = False
+
+    return Allowlist(orphan_subtrees=tuple(entries))
+
+
+# ---------------------------------------------------------------------
+# Slugify (mirrors Python-Markdown's toc extension default)
+# ---------------------------------------------------------------------
+
+
+def slugify(text: str, separator: str = "-") -> str:
+    """Slugify a heading to its anchor form.
+
+    Matches Python-Markdown's ``markdown.extensions.toc.slugify``
+    so anchor links in docs resolve the same way mkdocs would
+    resolve them at build time. We mirror the algorithm inline
+    instead of importing ``markdown`` to keep this script
+    stdlib-only.
+
+    Args:
+        text: The heading text (without the leading ``#`` markers).
+        separator: Separator character used between words.
+
+    Returns:
+        Slugified anchor string suitable for ``#anchor`` links.
+    """
+    # Normalize to NFKD and drop non-ASCII (matches Python-Markdown).
+    value = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    # Strip everything that isn't word-char, whitespace, or dash.
+    value = re.sub(r"[^\w\s-]", "", value).strip().lower()
+    # Collapse runs of whitespace OR the separator into a single separator.
+    return re.sub(rf"[{re.escape(separator)}\s]+", separator, value)
+
+
+# ---------------------------------------------------------------------
+# Anchor integrity check
+# ---------------------------------------------------------------------
+
+# Markdown heading patterns. ATX-style: # / ## / ### headers.
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+
+# Inline link: [text](url "optional title"). url captured greedily up
+# to the closing paren or whitespace.
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+
+
+def _extract_headings(text: str) -> set[str]:
+    """Return the set of slugified anchors for a markdown document."""
+    anchors: set[str] = set()
+    for match in _HEADING_RE.finditer(text):
+        heading_text = match.group(2)
+        # Strip trailing # marks (e.g. "## Section ##")
+        heading_text = re.sub(r"\s+#+\s*$", "", heading_text)
+        anchors.add(slugify(heading_text))
+    return anchors
+
+
+def _compute_line_starts(text: str) -> list[int]:
+    """Return byte offsets where each line begins (0-indexed positions).
+
+    Index 0 is always 0; subsequent entries are offsets immediately
+    after each ``\\n``. Used by ``_offset_to_line`` for O(log n)
+    line-number lookup.
+    """
+    line_starts = [0]
+    for i, char in enumerate(text):
+        if char == "\n":
+            line_starts.append(i + 1)
+    return line_starts
+
+
+def _offset_to_line(line_starts: list[int], offset: int) -> int:
+    """1-indexed line number containing ``offset``.
+
+    Uses binary search over the pre-computed ``line_starts`` list
+    (built by ``_compute_line_starts``). Lifted to module scope
+    instead of a per-loop closure so ruff's B023 (loop-variable
+    capture) doesn't false-positive on the safe inner-loop use.
+    """
+    return bisect.bisect_right(line_starts, offset)
+
+
+def _is_external_link(url: str) -> bool:
+    """True if the link should be skipped (external, mailto, cross-repo)."""
+    if url.startswith(("http://", "https://", "mailto:", "ftp://")):
+        return True
+    return False
+
+
+def _resolve_target_file(
+    link_url: str,
+    source_file: Path,
+    docs_root: Path,
+) -> Path | None:
+    """Resolve ``[text](file.md#anchor)`` to an absolute file path.
+
+    Returns ``None`` for intra-page links (no file part) — caller
+    handles those by checking the source file's own headings.
+    """
+    # Strip the anchor portion to get just the file path.
+    file_part = link_url.split("#", 1)[0]
+    if not file_part:
+        # Intra-page link: [text](#anchor)
+        return None
+    # Relative to the source file's directory.
+    candidate = (source_file.parent / file_part).resolve()
+    # Refuse to follow links outside docs/ (e.g. ../../src/foo.py).
+    try:
+        candidate.relative_to(docs_root.resolve())
+    except ValueError:
+        return None
+    return candidate
+
+
+def check_anchors(docs_root: Path) -> list[Finding]:
+    """Walk docs/**/*.md and verify every internal anchor link resolves.
+
+    Implements design.md §3a. Skips external links and refuses to
+    follow links pointing outside ``docs_root``.
+
+    Args:
+        docs_root: Path to the docs root (typically ``Path("docs")``).
+
+    Returns:
+        List of ``Finding`` records — one per broken anchor.
+    """
+    findings: list[Finding] = []
+    if not docs_root.is_dir():
+        return findings
+
+    # Pre-compute heading sets for every .md so we don't re-read.
+    heading_cache: dict[Path, set[str]] = {}
+    for md in docs_root.rglob("*.md"):
+        try:
+            heading_cache[md.resolve()] = _extract_headings(md.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            # Skip unreadable files; not a wiring issue.
+            continue
+
+    for md in sorted(docs_root.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        line_starts = _compute_line_starts(text)
+
+        for match in _LINK_RE.finditer(text):
+            url = match.group(2)
+            if _is_external_link(url):
+                continue
+            if "#" not in url:
+                # Not an anchor link; nav/filesystem check (future
+                # v1.1 task) handles file-existence verification.
+                continue
+
+            anchor = url.split("#", 1)[1]
+            if not anchor:
+                # [text](file.md#) — empty anchor; skip
+                continue
+
+            # Distinguish intra-page (#anchor) from outside-docs
+            # (../../src/foo.py#L42). Both are caught by the resolver
+            # returning None, but only the former should be checked
+            # against the source file's headings.
+            file_part = url.split("#", 1)[0]
+            target_file = _resolve_target_file(url, md, docs_root)
+            if target_file is None and file_part:
+                # Resolved file landed outside docs/ — skip; not our scope.
+                continue
+            if target_file is None:
+                # Intra-page anchor — check against this file's headings
+                target_anchors = heading_cache.get(md.resolve(), set())
+                target_label = str(md.relative_to(docs_root.parent))
+            else:
+                target_anchors = heading_cache.get(target_file)
+                if target_anchors is None:
+                    # Link points at a file we couldn't read or that
+                    # doesn't exist. Nav-vs-filesystem check (v1.1)
+                    # owns file-existence; skip here to avoid double-
+                    # reporting.
+                    continue
+                target_label = str(target_file.relative_to(docs_root.parent.resolve()))
+
+            if anchor in target_anchors:
+                continue
+
+            # Build a "did-you-mean" hint listing up to 3 nearby headings.
+            sample = sorted(target_anchors)[:5] if target_anchors else []
+            hint = (
+                f"available anchors in {target_label}: {', '.join(sample)}"
+                if sample
+                else f"target file has no headings ({target_label})"
+            )
+            findings.append(
+                Finding(
+                    check="anchor",
+                    severity="error",
+                    file=str(md.relative_to(docs_root.parent)),
+                    line=_offset_to_line(line_starts, match.start()),
+                    message=(f"Link target '#{anchor}' not found in {target_label} " f"({hint})"),
+                    fix=(
+                        "Update link to match an existing heading, or rename "
+                        "the heading and update inbound links (see "
+                        "docs-wiring-audit/decisions.md Q1 — update inbound "
+                        "links, no redirect)."
+                    ),
+                )
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------
+# Report formatters
+# ---------------------------------------------------------------------
+
+
+def format_markdown(findings: list[Finding]) -> str:
+    """Render findings as a human-readable markdown report."""
+    if not findings:
+        return "No findings."
+
+    parts: list[str] = ["# Docs wiring audit\n"]
+    parts.append(f"Total findings: **{len(findings)}**\n")
+
+    # Group by check.
+    by_check: dict[str, list[Finding]] = {}
+    for f in findings:
+        by_check.setdefault(f.check, []).append(f)
+
+    for check, items in sorted(by_check.items()):
+        parts.append(f"\n## {check} ({len(items)})\n")
+        parts.append("| File | Line | Severity | Message | Fix |")
+        parts.append("|---|---|---|---|---|")
+        for f in items:
+            line_str = str(f.line) if f.line else "—"
+            fix_str = f.fix or "—"
+            # Escape pipes inside table cells.
+            msg = f.message.replace("|", "\\|")
+            fix_str = fix_str.replace("|", "\\|")
+            parts.append(f"| `{f.file}` | {line_str} | {f.severity} | {msg} | {fix_str} |")
+
+    return "\n".join(parts) + "\n"
+
+
+def format_json(findings: list[Finding]) -> str:
+    """Render findings as JSON for CI consumption."""
+    return json.dumps(
+        {"findings": [asdict(f) for f in findings]},
+        indent=2,
+        sort_keys=True,
+    )
+
+
+# ---------------------------------------------------------------------
+# CLI dispatch
+# ---------------------------------------------------------------------
+
+CHECKS = {
+    "anchor": check_anchors,
+}
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="audit_docs_wiring",
+        description=(
+            "Audit docs/ wiring (anchors, nav, features.yaml, "
+            "mkdocstrings). v1 ships anchor check; nav + features.yaml "
+            "+ mkdocstrings land in v1.1; reciprocal See-Also in v1.2."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        choices=sorted(CHECKS.keys()) + ["all"],
+        default="all",
+        help="Which check to run. Default: all available.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format. Default: markdown.",
+    )
+    parser.add_argument(
+        "--docs-root",
+        type=Path,
+        default=Path("docs"),
+        help="Path to the docs root. Default: docs",
+    )
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=Path(".audit/orphans.yml"),
+        help="Path to the orphan allowlist. Default: .audit/orphans.yml",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    return parser.parse_args(argv)
+
+
+def run(argv: list[str] | None = None) -> int:
+    """Top-level entry point. Returns the exit code."""
+    args = _parse_args(argv)
+
+    # Allowlist load — fails early on missing reason comments.
+    try:
+        load_allowlist(args.allowlist)
+    except ValueError as exc:
+        print(f"Allowlist error: {exc}", file=sys.stderr)
+        return 2
+
+    # Dispatch.
+    requested = sorted(CHECKS.keys()) if args.check == "all" else [args.check]
+    all_findings: list[Finding] = []
+    for name in requested:
+        check_fn = CHECKS[name]
+        all_findings.extend(check_fn(args.docs_root))
+
+    # Emit.
+    if args.format == "json":
+        print(format_json(all_findings))
+    else:
+        print(format_markdown(all_findings))
+
+    return 1 if all_findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/tests/unit/scripts/test_audit_docs_wiring.py
+++ b/tests/unit/scripts/test_audit_docs_wiring.py
@@ -1,0 +1,454 @@
+"""Tests for scripts/audit_docs_wiring.py (v1 skeleton + anchor check).
+
+Covers Tasks 1+2 of docs/specs/docs-wiring-audit/tasks.md:
+
+- Finding dataclass is frozen.
+- Allowlist loader + reason-comment enforcement + glob matching.
+- Slugify alignment with Python-Markdown's toc extension.
+- Anchor extraction from markdown.
+- Anchor integrity check (valid, broken, intra-page, external,
+  cross-repo, target file missing).
+- Markdown + JSON formatters.
+- CLI: --help, --check, --format, exit codes.
+
+Loads the script via importlib (matches the existing pattern in
+tests/unit/help/test_coverage_script.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "audit_docs_wiring.py"
+
+
+@pytest.fixture(scope="module")
+def audit_module():
+    """Load scripts/audit_docs_wiring.py as a module for testing."""
+    spec = importlib.util.spec_from_file_location("_audit_docs_wiring", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_audit_docs_wiring"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------
+# Finding dataclass
+# ---------------------------------------------------------------------
+
+
+class TestFinding:
+    def test_finding_is_frozen(self, audit_module):
+        """Finding must be immutable so callers can put it in sets."""
+        f = audit_module.Finding(
+            check="anchor",
+            severity="error",
+            file="docs/x.md",
+            line=42,
+            message="msg",
+        )
+        with pytest.raises(Exception):  # FrozenInstanceError
+            f.line = 99  # type: ignore[misc]
+
+    def test_finding_hashable(self, audit_module):
+        """Frozen + no mutable defaults → hashable."""
+        f = audit_module.Finding(
+            check="anchor",
+            severity="error",
+            file="docs/x.md",
+            line=42,
+            message="msg",
+        )
+        assert {f}  # works in a set
+
+    def test_finding_fix_optional(self, audit_module):
+        f = audit_module.Finding(
+            check="anchor",
+            severity="error",
+            file="docs/x.md",
+            line=1,
+            message="msg",
+        )
+        assert f.fix is None
+
+
+# ---------------------------------------------------------------------
+# Slugify
+# ---------------------------------------------------------------------
+
+
+class TestSlugify:
+    @pytest.mark.parametrize(
+        "heading,expected",
+        [
+            ("My Section", "my-section"),
+            ("My Section ✨", "my-section"),
+            ("ChainExecutor", "chainexecutor"),
+            ("Models & Execution", "models-execution"),
+            ("agent-state / dynamic teams", "agent-state-dynamic-teams"),
+            ("  leading and trailing  ", "leading-and-trailing"),
+            ("UPPER_CASE", "upper_case"),
+            ("", ""),
+        ],
+    )
+    def test_slugify_matches_python_markdown(self, audit_module, heading, expected):
+        """Slugify must mirror markdown.extensions.toc.slugify so anchor
+        links resolve the same way mkdocs would at build time."""
+        assert audit_module.slugify(heading) == expected
+
+
+# ---------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------
+
+
+class TestAllowlist:
+    def test_empty_allowlist_returns_no_entries(self, audit_module, tmp_path):
+        empty = tmp_path / "orphans.yml"
+        empty.write_text("orphan_subtrees:\n", encoding="utf-8")
+        al = audit_module.load_allowlist(empty)
+        assert al.orphan_subtrees == ()
+
+    def test_missing_file_returns_empty_allowlist(self, audit_module, tmp_path):
+        missing = tmp_path / "nope.yml"
+        al = audit_module.load_allowlist(missing)
+        assert al.orphan_subtrees == ()
+
+    def test_well_formed_allowlist_loads(self, audit_module, tmp_path):
+        path = tmp_path / "orphans.yml"
+        path.write_text(
+            "orphan_subtrees:\n"
+            "  # reason: blog posts are dated\n"
+            "  - docs/blog/\n"
+            "  # reason: archived material\n"
+            "  - docs/archive/\n",
+            encoding="utf-8",
+        )
+        al = audit_module.load_allowlist(path)
+        assert al.orphan_subtrees == ("docs/blog/", "docs/archive/")
+
+    def test_missing_reason_comment_raises(self, audit_module, tmp_path):
+        path = tmp_path / "orphans.yml"
+        path.write_text(
+            "orphan_subtrees:\n  - docs/no-reason/\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="lacks a '# reason:' comment"):
+            audit_module.load_allowlist(path)
+
+    def test_wrong_comment_word_raises(self, audit_module, tmp_path):
+        """A '#' comment without 'reason:' doesn't count."""
+        path = tmp_path / "orphans.yml"
+        path.write_text(
+            "orphan_subtrees:\n  # this is a note, not a reason\n  - docs/foo/\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="lacks a '# reason:' comment"):
+            audit_module.load_allowlist(path)
+
+    def test_is_orphan_exempt_subtree(self, audit_module):
+        al = audit_module.Allowlist(orphan_subtrees=("docs/blog/",))
+        assert al.is_orphan_exempt("docs/blog/2026/post.md") is True
+        assert al.is_orphan_exempt("docs/reference/x.md") is False
+
+    def test_is_orphan_exempt_glob(self, audit_module):
+        al = audit_module.Allowlist(orphan_subtrees=("docs/BLOG_*.md",))
+        assert al.is_orphan_exempt("docs/BLOG_FOO.md") is True
+        assert al.is_orphan_exempt("docs/blog/x.md") is False
+
+    def test_is_orphan_exempt_exact(self, audit_module):
+        al = audit_module.Allowlist(orphan_subtrees=("docs/index.md",))
+        assert al.is_orphan_exempt("docs/index.md") is True
+        assert al.is_orphan_exempt("docs/index2.md") is False
+
+
+# ---------------------------------------------------------------------
+# Heading extraction
+# ---------------------------------------------------------------------
+
+
+class TestExtractHeadings:
+    def test_extracts_all_levels(self, audit_module):
+        text = "# H1\n\n## H2\n\n### H3\n\nbody\n"
+        anchors = audit_module._extract_headings(text)
+        assert anchors == {"h1", "h2", "h3"}
+
+    def test_strips_trailing_hash_marks(self, audit_module):
+        text = "## My Section ##\n"
+        assert audit_module._extract_headings(text) == {"my-section"}
+
+    def test_empty_doc_returns_empty_set(self, audit_module):
+        assert audit_module._extract_headings("") == set()
+
+
+# ---------------------------------------------------------------------
+# Anchor check
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture
+def docs_tree(tmp_path):
+    """Build a minimal docs/ tree fixture."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    return docs
+
+
+class TestCheckAnchors:
+    def test_valid_anchor_no_finding(self, audit_module, docs_tree):
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n## Setup\n\nSee [setup](#setup) below.\n",
+            encoding="utf-8",
+        )
+        findings = audit_module.check_anchors(docs_tree)
+        assert findings == []
+
+    def test_broken_intra_page_anchor(self, audit_module, docs_tree):
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n## Setup\n\nSee [missing](#nonexistent).\n",
+            encoding="utf-8",
+        )
+        findings = audit_module.check_anchors(docs_tree)
+        assert len(findings) == 1
+        assert findings[0].check == "anchor"
+        assert findings[0].severity == "error"
+        assert "nonexistent" in findings[0].message
+        assert findings[0].line is not None and findings[0].line >= 1
+
+    def test_broken_cross_doc_anchor(self, audit_module, docs_tree):
+        (docs_tree / "a.md").write_text(
+            "# A\n\n[link to B](b.md#missing-section)\n",
+            encoding="utf-8",
+        )
+        (docs_tree / "b.md").write_text(
+            "# B\n\n## Real Section\n",
+            encoding="utf-8",
+        )
+        findings = audit_module.check_anchors(docs_tree)
+        assert len(findings) == 1
+        assert "missing-section" in findings[0].message
+
+    def test_valid_cross_doc_anchor(self, audit_module, docs_tree):
+        (docs_tree / "a.md").write_text(
+            "# A\n\n[link to B](b.md#real-section)\n",
+            encoding="utf-8",
+        )
+        (docs_tree / "b.md").write_text(
+            "# B\n\n## Real Section\n",
+            encoding="utf-8",
+        )
+        findings = audit_module.check_anchors(docs_tree)
+        assert findings == []
+
+    def test_skips_external_https_link(self, audit_module, docs_tree):
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n[external](https://example.com#anchor)\n",
+            encoding="utf-8",
+        )
+        assert audit_module.check_anchors(docs_tree) == []
+
+    def test_skips_external_http_link(self, audit_module, docs_tree):
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n[external](http://example.com#anchor)\n",
+            encoding="utf-8",
+        )
+        assert audit_module.check_anchors(docs_tree) == []
+
+    def test_skips_mailto_link(self, audit_module, docs_tree):
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n[email](mailto:a@b.com)\n",
+            encoding="utf-8",
+        )
+        assert audit_module.check_anchors(docs_tree) == []
+
+    def test_skips_link_without_anchor(self, audit_module, docs_tree):
+        """Links without `#` are file-existence checks (v1.1's nav check)."""
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n[just file](other.md)\n",
+            encoding="utf-8",
+        )
+        assert audit_module.check_anchors(docs_tree) == []
+
+    def test_skips_link_to_missing_file(self, audit_module, docs_tree):
+        """Anchor check defers to nav-vs-fs for missing files."""
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n[link](nope.md#anchor)\n",
+            encoding="utf-8",
+        )
+        assert audit_module.check_anchors(docs_tree) == []
+
+    def test_skips_link_outside_docs(self, audit_module, docs_tree):
+        """Links pointing outside docs/ (../src/...) are skipped."""
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n[outside](../src/foo.py#L42)\n",
+            encoding="utf-8",
+        )
+        assert audit_module.check_anchors(docs_tree) == []
+
+    def test_did_you_mean_hint_lists_real_anchors(self, audit_module, docs_tree):
+        (docs_tree / "guide.md").write_text(
+            "# Guide\n\n## One\n## Two\n## Three\n\n[bad](#nope)\n",
+            encoding="utf-8",
+        )
+        findings = audit_module.check_anchors(docs_tree)
+        assert len(findings) == 1
+        # Hint should mention the available anchors.
+        assert "one" in findings[0].message
+        assert "two" in findings[0].message
+
+
+# ---------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------
+
+
+class TestFormatters:
+    def test_format_markdown_empty(self, audit_module):
+        assert audit_module.format_markdown([]) == "No findings."
+
+    def test_format_markdown_groups_by_check(self, audit_module):
+        findings = [
+            audit_module.Finding(
+                check="anchor",
+                severity="error",
+                file="docs/a.md",
+                line=1,
+                message="m1",
+            ),
+            audit_module.Finding(
+                check="anchor",
+                severity="error",
+                file="docs/b.md",
+                line=2,
+                message="m2",
+            ),
+        ]
+        out = audit_module.format_markdown(findings)
+        assert "## anchor (2)" in out
+        assert "docs/a.md" in out
+        assert "docs/b.md" in out
+
+    def test_format_markdown_escapes_pipes(self, audit_module):
+        f = audit_module.Finding(
+            check="anchor",
+            severity="error",
+            file="docs/a.md",
+            line=1,
+            message="has | pipe in it",
+        )
+        out = audit_module.format_markdown([f])
+        # Pipe must be escaped inside the table cell so it doesn't
+        # break the markdown table structure.
+        assert "has \\| pipe" in out
+
+    def test_format_json_empty(self, audit_module):
+        out = audit_module.format_json([])
+        assert json.loads(out) == {"findings": []}
+
+    def test_format_json_round_trip(self, audit_module):
+        f = audit_module.Finding(
+            check="anchor",
+            severity="error",
+            file="docs/a.md",
+            line=42,
+            message="msg",
+            fix="fix me",
+        )
+        out = audit_module.format_json([f])
+        data = json.loads(out)
+        assert data["findings"][0]["check"] == "anchor"
+        assert data["findings"][0]["line"] == 42
+        assert data["findings"][0]["fix"] == "fix me"
+
+
+# ---------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_help_lists_check_choices(self, audit_module, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            audit_module._parse_args(["--help"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "--check" in captured.out
+        assert "anchor" in captured.out
+
+    def test_run_no_findings_exits_zero(self, audit_module, docs_tree, tmp_path):
+        """Clean docs tree → exit 0, 'No findings.' markdown."""
+        (docs_tree / "guide.md").write_text("# Guide\n\nNo links.\n", encoding="utf-8")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = audit_module.run(
+                [
+                    "--check",
+                    "anchor",
+                    "--docs-root",
+                    str(docs_tree),
+                    "--allowlist",
+                    str(tmp_path / "nope.yml"),
+                ]
+            )
+        assert code == 0
+        assert "No findings." in buf.getvalue()
+
+    def test_run_findings_exits_one(self, audit_module, docs_tree, tmp_path):
+        """Broken-anchor doc → exit 1."""
+        (docs_tree / "guide.md").write_text("# Guide\n\n[bad](#missing)\n", encoding="utf-8")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = audit_module.run(
+                [
+                    "--check",
+                    "anchor",
+                    "--docs-root",
+                    str(docs_tree),
+                    "--allowlist",
+                    str(tmp_path / "nope.yml"),
+                ]
+            )
+        assert code == 1
+
+    def test_run_json_format_outputs_valid_json(self, audit_module, docs_tree, tmp_path):
+        (docs_tree / "guide.md").write_text("# Guide\n\nNo links.\n", encoding="utf-8")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            audit_module.run(
+                [
+                    "--check",
+                    "anchor",
+                    "--format",
+                    "json",
+                    "--docs-root",
+                    str(docs_tree),
+                    "--allowlist",
+                    str(tmp_path / "nope.yml"),
+                ]
+            )
+        data = json.loads(buf.getvalue())
+        assert data == {"findings": []}
+
+    def test_run_bad_allowlist_exits_two(self, audit_module, docs_tree, tmp_path):
+        """Allowlist with missing reason comment → exit 2."""
+        bad_allowlist = tmp_path / "orphans.yml"
+        bad_allowlist.write_text("orphan_subtrees:\n  - docs/no-reason/\n", encoding="utf-8")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = audit_module.run(
+                [
+                    "--docs-root",
+                    str(docs_tree),
+                    "--allowlist",
+                    str(bad_allowlist),
+                ]
+            )
+        assert code == 2


### PR DESCRIPTION
## Summary

Phase 4 implementation start for [`docs/specs/docs-wiring-audit/`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/docs-wiring-audit/). Lands Tasks 1 and 2 — the audit-script skeleton and the anchor integrity check. 43 unit tests, all green.

Running on the live `docs/` tree surfaces **19 real broken anchors** (the actual wiring debt this whole spec was authored to find). Fixing them is Task 6 of the spec — out of scope for this PR.

## What ships

- **`scripts/audit_docs_wiring.py`** — CLI with `--check`, `--format`, `--docs-root`, `--allowlist` flags. Exit codes: `0` clean, `1` findings remain, `2` bad invocation. Markdown + JSON formatters.
- **`Finding`** dataclass (frozen) for findings.
- **`load_allowlist()`** for `.audit/orphans.yml` with reason-comment enforcement at load time (per decisions.md Q2).
- **`slugify()`** mirroring Python-Markdown's `markdown.extensions.toc` so anchor links resolve the same way mkdocs would at build time. Stdlib-only, no `markdown` dep.
- **`check_anchors()`** — walks `docs/**/*.md`, verifies every internal `[text](file.md#anchor)` and `[text](#anchor)` link resolves. Skips external (`http`/`https`/`mailto`/`ftp`), cross-repo (`github.com/...`), and outside-docs (`../src/foo.py`) links. Defers file-existence checking to v1.1's nav-vs-filesystem check.
- **43 tests** in `tests/unit/scripts/test_audit_docs_wiring.py` covering all 11 scenarios per Task 2's acceptance criteria, plus CLI dispatch / exit codes / formatters / allowlist loader.

## Live-tree baseline

Running `python scripts/audit_docs_wiring.py --check anchor --docs-root docs --format json` against current `main`:

- **19 real broken anchors.** Top offenders: `docs/reference/API_REFERENCE.md` cross-doc anchors (`#chainexecutor`, `#memorygraph`, `#smartrouter`, etc. — the exact anchor-rot the spec's problem statement cited), plus a cluster of `#L42`-style intra-page anchors in `docs/specs/ops-dashboard-qa-2026-05-14/punch-list.md`.
- These are real, not false positives. Task 6 (fix-or-allowlist each, then promote to CI gate) is the next session's work.

## Two deviations worth noting

**1. Single-file vs package layout.** The spec's design.md proposed `scripts/audit_docs_wiring/` as a package. Shipped as single-file `scripts/audit_docs_wiring.py` instead — avoids the file-vs-package name collision (Python can't have both at the same parent path) and matches the existing `scripts/check_help_coverage.py` convention. Refactor to package when v1.1 adds the second check and the file approaches 800 LOC (currently ~480).

**2. Reference-style links deferred.** Task 2's acceptance criteria called for `[text][ref]` ... `[ref]: file.md#anchor` resolution. Verified zero reference-style links exist in `docs/` today (`grep -rEn "^\[[^\]]+\]:\s+\S" docs/ | wc -l` returns 0). Deferred to v1.1 when a real reference-style link appears.

## What this PR is NOT

- Not Tasks 3+4 (nav check, features.yaml check) — those are v1.1 in the spec's staging.
- Not Task 5 (`.audit/orphans.yml` with initial entries) — the loader is tested but no file is shipped yet. v1's anchor check doesn't consume the allowlist; v1.1's nav check is the first consumer.
- Not Task 6 (fix-or-allowlist the 19 baseline findings).
- Not Task 7 (CI integration).
- Not the mkdocstrings or See-Also checks.

## Test plan

- [x] 43 unit tests, all green
- [x] `ruff check` clean
- [x] Pre-commit hooks all pass
- [x] Live run on `docs/` produces 19 expected findings + exit 1
- [x] Clean fixture run produces 0 findings + exit 0
- [ ] CI green on all platforms

## Next sessions

- **Tasks 3+4**: nav-vs-filesystem + features.yaml-vs-filesystem checks (~2-3 hr).
- **Task 5**: ship `.audit/orphans.yml` with initial subtree entries (~30 min, ships with Tasks 3+4).
- **Task 6**: iterate the 19 anchor findings — fix or allowlist each (~2-4 hr depending on classification).
- **Task 7**: CI integration in advisory mode (~30 min).
- **Task 8**: promote to required check after 3 PRs land green (~5 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
