### PR TITLE
docs(specs): enforcement-vs-documentation framework

### DIFF
--- a/docs/specs/enforcement-vs-documentation/decisions.md
+++ b/docs/specs/enforcement-vs-documentation/decisions.md
@@ -1,0 +1,165 @@
+# Per-decision log — Enforcement vs Documentation
+
+Append-only log. Decisions recorded 2026-05-31 during the
+morning session that surfaced the framing.
+
+---
+
+## D1 — Promotion criteria (2026-05-31)
+
+**Decision:** A lesson is promoted from documentation to
+enforcement candidate only when ALL three criteria hold:
+
+1. Recurrence ≥2 times in **distinct** sessions.
+2. Cost ≥10 min recovery OR irrecoverable state per occurrence.
+3. Mechanical check available (not "be careful").
+
+**Rationale:** prevents the enforcement list from absorbing
+every lesson ever written. The three criteria align cost-of-
+enforcement with cost-of-recurrence. The "distinct sessions"
+qualifier specifically guards against same-session double-hits
+masking as "this happens all the time" — they reflect in-flight
+forgetting, which is a different problem.
+
+**Alternatives considered:**
+
+- **Recurrence ≥3 across any sessions** — more conservative;
+  delays valuable enforcements. Rejected as too slow.
+- **Recurrence ≥1 if cost is severe** — handles "shouldn't
+  happen even once" cases (security incidents, data loss).
+  Implicitly covered by "irrecoverable state" in criterion 2:
+  if the first occurrence loses state, the enforcement can be
+  built defensively without waiting for a second hit.
+
+---
+
+## D2 — List-size discipline (2026-05-31)
+
+**Decision:** **Soft cap of 10 active enforcements.** When a
+new candidate would push past 10, Patrick is notified
+explicitly and presented with current retirement candidates
+ranked by retirement metrics. He may approve growth OR retire
+one.
+
+Patrick's exact framing during the session:
+
+> "I'm not sure about capping the list at 10. We should be
+> informed if there are more than 10, which needs approval."
+
+This is the implemented shape: the cap is **attention-
+triggering**, not blocking. 10 is the default discomfort
+threshold — picked because it's small enough that each member
+gets remembered, large enough to cover the genuinely
+high-cost recurring patterns.
+
+**Rationale:** unbounded enforcement lists become their own
+maintenance burden; each enforcement is code, costs
+attention to tune, and risks false alarms that erode trust
+in the whole system. Bounding the list forces explicit
+trade-offs.
+
+**Alternatives considered:**
+
+- **Hard cap of 10** — would block legitimate additions.
+  Rejected per Patrick's direction.
+- **No cap, periodic review only** — defers the decision to
+  whenever review happens. Rejected because growth without
+  attention is the failure mode this discipline addresses.
+
+---
+
+## D3 — Retirement metrics (2026-05-31)
+
+**Decision:** Each active enforcement carries four metrics:
+
+| Metric | Retirement signal |
+|---|---|
+| **Hit rate** (real saves) | Drops toward zero over rolling window (suggest: 0 hits in 30 days) |
+| **False-alarm rate** | Rises above 20% of fires |
+| **Override count** | Rising trend (suggest: ≥3 overrides in 30 days) |
+| **Days since last hit** | >60 days |
+
+Retirement candidates are surfaced in a periodic review
+(weekly or monthly — exact cadence TBD with first review).
+Patrick decides retire vs keep. Retired enforcements: code
+removed, lesson stays in `CLAUDE.md` as documentation.
+
+**Rationale:** Patrick explicitly asked for "appropriate
+metrics that will guide me regarding possible retirement
+candidates." These four cover the failure modes an enforcement
+can have: (a) no longer needed (low hit rate, high days-since-
+last), (b) wrong (high false-alarm), (c) annoying (high
+override). Any one trending bad is a retirement signal.
+
+**Implementation note for the first enforcement:**
+
+The pre-Write worktree-path hook will need a metrics
+collector. Lightweight: append-only JSONL log at
+`~/.attune/enforcement-metrics.jsonl` with `{timestamp,
+enforcement, action, outcome}` records. The periodic review
+aggregates from this log. Build the metrics scaffolding ALONG
+WITH the first enforcement so it's not bolted on later.
+
+---
+
+## D4 — Mechanical-enforcement shape catalog (2026-05-31)
+
+**Decision:** Five appropriate shapes for attune-ai:
+
+1. **PreToolUse hook** — agent-action source.
+2. **Pre-commit hook** — commit-source.
+3. **Shell wrapper / alias** — CLI-invocation source.
+4. **Test as drift-guard** — static drift (file lists,
+   counts, configuration).
+5. **Env-var gate** — runtime misconfiguration.
+
+**Rationale:** these five cover every action source attune-ai
+has surfaces for. Any enforcement should pick the shape that
+matches where the dangerous action originates. The wrong
+shape means the enforcement misses cases (e.g. a pre-commit
+hook can't catch agent actions during a session — they don't
+go through commits).
+
+**Implementation note:** when proposing a new enforcement,
+the spec should name which shape and why. If the shape
+doesn't fit any of the five, that's a signal the enforcement
+isn't ready (or the catalog needs a sixth entry — escalate).
+
+---
+
+## D5 — Where this spec leaves us (2026-05-31)
+
+**Decision:** **Ship the framework now, validate with one
+concrete enforcement, expand later.** This spec lands as
+documentation of the criteria; the first concrete enforcement
+(pre-Write worktree-path hook) ships in its own follow-up PR
+and proves the framework end-to-end.
+
+If the first enforcement works (hits real cases, false-alarm
+rate stays low), the framework is validated. The next two
+candidates (`.help` template regen skip, `git pull` wrapper)
+can be queued. If the first enforcement fails to add value or
+fires too often, the framework needs revision before more
+enforcements ship.
+
+**Initial enforced set (after first PR lands):** 1.
+
+**Cap to be respected:** 10. Next addition past 10 triggers
+the notification + retirement-candidates surfacing per D2.
+
+---
+
+## Cross-cutting note
+
+This spec is itself a meta-improvement. It doesn't change any
+user-facing behavior; it changes how the project decides which
+lessons to encode mechanically. Pairs with
+[`spec-status-self-truthing`](../spec-status-self-truthing/) —
+both make the project's operational discipline more reliable
+without shipping new product surface.
+
+The pattern of pairing a documentation-only meta-spec with one
+concrete validating implementation (a "framework + first
+case") is itself worth noting. It's how this spec ships
+honestly: the framework is testable because we ship one real
+case alongside it.

--- a/docs/specs/enforcement-vs-documentation/requirements.md
+++ b/docs/specs/enforcement-vs-documentation/requirements.md
@@ -1,0 +1,217 @@
+# Spec: Enforcement vs Documentation for CLAUDE.md Lessons
+
+> `CLAUDE.md` is currently 6500+ lines of append-only lessons.
+> Most are reference documentation — interesting once, rarely
+> recurring. A small subset are recurring high-cost failure
+> patterns that documentation alone hasn't prevented (proven
+> by the 2026-05-31 session where I wrote a lesson and
+> immediately violated it). This spec separates the two,
+> proposes criteria for promotion to mechanical enforcement,
+> and establishes the size discipline + retirement metrics
+> that keep the enforced set tractable.
+
+**Status:** approved (2026-05-31; see [decisions.md](./decisions.md))
+**Created:** 2026-05-31
+**Owner:** —
+**Related:**
+- The 2026-05-31 morning session that surfaced the framing
+  (see PRs #514-#519, lessons appended in #519)
+- [`spec-status-self-truthing`](../spec-status-self-truthing/) —
+  similar shape: a meta-spec that improves how we operate
+  rather than shipping user-facing code
+
+---
+
+## Phase 1: Requirements
+
+**Status:** approved (2026-05-31; see [decisions.md](./decisions.md))
+
+### Problem statement
+
+`CLAUDE.md` lessons are written under the implicit assumption
+that "I read this lesson at session start, so I won't repeat
+the mistake." That assumption is wrong:
+
+1. **Volume defeats recall.** With 6500+ lines of lessons, no
+   specific lesson is salient at the moment of action. I scan
+   the file at SessionStart but can't actively hold every lesson
+   in working memory while doing the task.
+2. **Documentation and action are different cognitive moves.**
+   Writing a lesson is a reflective, summarizing act. Catching
+   yourself about to repeat the lesson while in flow requires a
+   different mental gear — one that documentation alone doesn't
+   develop.
+3. **Empirical evidence:** on 2026-05-31, I wrote a lesson about
+   "Write to bare repo absolute path from worktree pollutes main
+   checkout" — and within the same session, while editing the
+   very file containing that lesson, I made the exact mistake
+   the lesson warns against. The lesson did not prevent the bug
+   it documented.
+
+Today, the project treats every lesson identically: append-only,
+re-read each session, equally weighted. This conflates two
+different artifacts:
+
+- **Documentation** — captures a one-time insight or a quirk for
+  future reference. Most lessons. Cost of not enforcing: minor
+  re-discovery if pattern recurs.
+- **Enforcement candidates** — recurring high-cost failure
+  patterns where a mechanical check would prevent the repeat.
+  A small subset of lessons. Cost of not enforcing: real time
+  loss, state loss, or user-trust loss every time the pattern
+  re-fires.
+
+### Scope
+
+**In scope:**
+
+- Define **promotion criteria** that distinguish documentation
+  from enforcement candidates.
+- Define **mechanical-enforcement shapes** appropriate for the
+  attune-ai codebase (pre-tool hooks, pre-commit hooks, shell
+  wrappers).
+- Define **retirement criteria** so the enforcement set doesn't
+  grow indefinitely.
+- Define **list-size discipline** — what happens when the
+  enforced set exceeds a soft cap.
+- Define **metrics** that inform retirement decisions.
+
+**Out of scope:**
+
+- Restructuring `CLAUDE.md` itself. Documentation stays where
+  it lives.
+- Building any specific enforcement (each is its own follow-up
+  PR; the first one — pre-Write worktree-path hook — is queued
+  separately).
+- Cross-project enforcement (other attune-* repos). This spec
+  applies to attune-ai. Other repos can adopt the framework
+  later if useful.
+
+### Promotion criteria
+
+A lesson is a candidate for promotion from documentation to
+mechanical enforcement when ALL three of:
+
+1. **Recurrence** — Hit ≥2 times in distinct sessions (not just
+   twice in one session). The "distinct sessions" qualifier
+   matters: a same-session double-hit reflects in-flight
+   forgetting, while cross-session recurrence reflects a
+   genuinely sticky pattern.
+2. **Cost** — Each occurrence costs ≥10 min recovery time OR
+   causes irrecoverable state (lost work, leaked secret,
+   broke main, misled the user). "Annoying" doesn't qualify;
+   "destructive or costly" does.
+3. **Mechanical check available** — A pre-flight command,
+   hook, env-var validation, or alias exists that catches
+   the bad action before it lands. "Be more careful" is NOT
+   a mechanical check. If the only available remediation is
+   "remember harder," it stays documentation.
+
+A lesson failing any one criterion stays documentation. A
+lesson meeting all three becomes an enforcement candidate
+requiring Patrick's approval before promotion.
+
+### Mechanical-enforcement shapes
+
+Appropriate shapes for attune-ai's environment:
+
+| Shape | Use when | Example |
+|---|---|---|
+| **PreToolUse hook** | Catching a bad agent action before it executes | Pre-Write hook validating target path matches session worktree |
+| **Pre-commit hook** | Catching a bad commit before it lands | `regenerate-help-templates` skip when the regenerated content is stub-style |
+| **Shell wrapper / alias** | Catching a bad CLI invocation | `git pull` wrapper that handles `pull.rebase=true` on dirty trees |
+| **Test as drift-guard** | Catching a drift class in CI | `test_all_skill_dirs_referenced_by_attune_hub` |
+| **Env-var gate** | Catching a misconfiguration at runtime | `ATTUNE_OPS_SESSIONS_LLM=0` for the budget-cap off-switch |
+
+The shape choice depends on where the dangerous action
+originates. Hooks are best when the agent is the source. Shell
+wrappers are best when CLI invocations are the source. Tests
+are best for static drift.
+
+### List-size discipline
+
+**Soft cap: 10 active enforcements.**
+
+When a new candidate would push the active list past 10:
+
+1. Patrick is notified explicitly: "Adding `<new>` would put
+   active enforcements at 11. Approve, or pick a retirement
+   candidate from the current list?"
+2. He may approve the growth (active count rises) OR retire one
+   to make room.
+3. The system surfaces current retirement candidates (ranked by
+   retirement metrics — see below) to inform the choice.
+4. The cap is **advisory**, not enforced. If 12 enforcements all
+   pay for themselves, that's the right number. The trigger is
+   *attention*, not blocking.
+
+### Retirement metrics
+
+Each active enforcement carries metadata tracked over time:
+
+| Metric | What it measures | Retirement signal |
+|---|---|---|
+| **Hit rate** | Number of times the enforcement fired and prevented a real bad action | Dropping toward zero over rolling window (e.g. 0 hits in 30 days) |
+| **False-alarm rate** | Number of times the enforcement fired on actions that were actually OK | Rising above some threshold (e.g. >20% of fires are false) signals tuning needed or retirement |
+| **Override count** | Number of times Patrick explicitly bypassed the enforcement | Rising signals the enforcement isn't well-tuned |
+| **Days since last hit** | Time since the enforcement last prevented a real bad action | >30-60 days is a retirement candidate |
+
+Retirement candidates are surfaced in a periodic review
+(weekly or monthly cadence, exact shape TBD). Patrick decides
+to retire or keep. Retired enforcements become passive
+documentation — the lesson stays in `CLAUDE.md` but the
+mechanical check is removed.
+
+### Acceptance criteria
+
+This spec is "done" when:
+
+- [x] Promotion criteria documented.
+- [x] List-size discipline documented (soft cap 10 + notification
+  on growth).
+- [x] Retirement metrics enumerated.
+- [x] At least one concrete enforcement is in design or
+  implementation (the pre-Write worktree-path hook is the
+  validating first case — see Phase 4).
+
+### Out of band
+
+The pre-Write worktree-path hook (the first enforcement)
+ships in its own PR after this spec lands. Its existence
+validates the framework: if we can't ship one mechanical
+enforcement using these criteria, the framework is wrong.
+
+---
+
+## Phase 2: Design
+
+**Status:** N/A — see decisions.md.
+
+This is a meta-spec; the framework itself is the design. The
+concrete shape for any individual enforcement is in that
+enforcement's own spec/PR. The first one — pre-Write
+worktree-path hook — is in its own follow-up.
+
+---
+
+## Phase 3: Tasks
+
+**Status:** see decisions.md follow-up plan.
+
+The initial enforcement set:
+
+1. **Pre-Write worktree-path hook** (this session's follow-up
+   PR) — closes the bare-repo-absolute-path bug.
+2. **Pre-commit `.help` template regen skip** (future) — closes
+   the stub-overwrite class.
+3. **`git pull` wrapper** for `pull.rebase=true` on dirty trees
+   (future) — closes the recurring stash-required pattern.
+
+Each ships as its own PR with its own metrics tracked.
+
+---
+
+## Phase 4: Implementation
+
+**Status:** in flight via follow-up PR (pre-Write worktree-path
+hook).


### PR DESCRIPTION
## Summary

Meta-spec separating `CLAUDE.md` lessons into two artifacts: **documentation** (most lessons; passive reference) and **enforcement** (small set of recurring high-cost patterns where a mechanical check prevents the repeat).

Motivated by the 2026-05-31 morning session where I wrote a lesson about a bug and immediately violated it within the same session. Documentation alone didn't prevent the repeat; the leverage is mechanical enforcement co-located with the dangerous action.

## Promotion criteria

A lesson becomes an enforcement candidate when ALL three hold:

1. **Recurrence** ≥2 times in *distinct* sessions (not same-session double-hits)
2. **Cost** ≥10 min recovery OR irrecoverable state per occurrence
3. **Mechanical check available** (not "be careful")

## List-size discipline

**Soft cap of 10 active enforcements.** New additions past 10 trigger explicit notification + retirement-candidate surfacing for your approval. Cap is attention-triggering, not blocking.

## Retirement metrics

Each active enforcement carries four metrics tracked over time:

| Metric | Retirement signal |
|---|---|
| Hit rate | 0 hits in 30 days |
| False-alarm rate | >20% of fires |
| Override count | ≥3 overrides in 30 days |
| Days since last hit | >60 days |

Periodic review (weekly or monthly, cadence TBD) surfaces candidates. You decide retire vs keep.

## Five mechanical-enforcement shapes catalogued

- PreToolUse hook (agent-action source)
- Pre-commit hook (commit source)
- Shell wrapper / alias (CLI source)
- Drift-guard test (static drift)
- Env-var gate (runtime misconfig)

## What this PR is NOT

- Not the first enforcement. The pre-Write worktree-path hook ships in a follow-up PR and validates the framework end-to-end.
- Not a `CLAUDE.md` restructure. Documentation stays where it lives.
- Not cross-project. attune-ai only for now.

## Test plan

- [x] Two files: `requirements.md` + `decisions.md`
- [x] Pre-commit clean
- [x] No code changes
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
