### PR TITLE
feat(sdk-error-fidelity): Phase 2 — wire code-review + dependency-check

### DIFF
--- a/src/attune/workflows/base.py
+++ b/src/attune/workflows/base.py
@@ -368,7 +368,13 @@ class BaseWorkflow(
 
         self.provider = provider
 
-    def _error_result(self, message: str) -> WorkflowResult:
+    def _error_result(
+        self,
+        message: str,
+        *,
+        sdk_stderr: str | None = None,
+        sdk_error_kind: str | None = None,
+    ) -> WorkflowResult:
         """Build a failed WorkflowResult with the given error message.
 
         Provides a standard error result so subclasses don't need
@@ -377,13 +383,33 @@ class BaseWorkflow(
 
         Args:
             message: Human-readable error description.
+            sdk_stderr: Optional raw stderr captured from the
+                ``claude`` CLI subprocess (already redacted). When
+                provided, threaded into ``metadata["sdk_stderr"]``
+                so Phase 3's persistence + render layer surfaces it
+                on the run-view page. Part of the
+                ``docs/specs/sdk-error-message-fidelity/`` flow.
+            sdk_error_kind: Optional classifier kind (see
+                ``SdkErrorKind`` Literal in ``agent_sdk_adapter``).
+                Threaded into ``metadata["sdk_error_kind"]`` so
+                downstream consumers (run-view chip classifier,
+                periodic reporting) can branch on a typed value
+                instead of regex-scanning the error string.
 
         Returns:
-            WorkflowResult with success=False.
+            WorkflowResult with success=False. When either SDK kwarg
+            is set, the corresponding ``metadata[...]`` key is
+            populated; absent kwargs leave ``metadata`` empty.
         """
         from datetime import datetime
 
         now = datetime.now()
+        metadata: dict[str, Any] = {}
+        if sdk_stderr is not None:
+            metadata["sdk_stderr"] = sdk_stderr
+        if sdk_error_kind is not None:
+            metadata["sdk_error_kind"] = sdk_error_kind
+
         return WorkflowResult(
             success=False,
             stages=[
@@ -405,6 +431,7 @@ class BaseWorkflow(
             total_duration_ms=0,
             provider="anthropic",
             error=message,
+            metadata=metadata,
         )
 
     def get_tier_for_stage(self, stage_name: str) -> ModelTier:

--- a/src/attune/workflows/code_review.py
+++ b/src/attune/workflows/code_review.py
@@ -27,7 +27,11 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     collect_subagent_transcripts,
     format_subagent_transcripts_markdown,
@@ -36,7 +40,6 @@ from .agent_sdk_adapter import (
     get_task_budget,
     get_thinking_config,
     resolve_cwd_for_path,
-    sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -270,18 +273,28 @@ class CodeReviewWorkflow(BaseWorkflow):
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors to
             # return a structured WorkflowResult rather than
-            # crashing the CLI. The helper classifies the failure
-            # by exception type and elapsed time so the message
-            # names the most-likely cause (auth, budget, network,
-            # …) instead of leaking the SDK's opaque
-            # "Command failed with exit code 1" string.
+            # crashing the CLI. Phase 2 of
+            # docs/specs/sdk-error-message-fidelity/ — capture the
+            # real claude CLI stderr via a second subprocess call,
+            # classify it into a known kind, and thread the typed
+            # fields onto WorkflowResult.metadata so the dashboard
+            # can render the truth instead of regex-guessing.
             logger.exception(
                 "Agent SDK code review failed: %s",
                 type(exc).__name__,
             )
-            duration = (datetime.now() - started_at).total_seconds()
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary,
+                stderr=stderr,
+                kind=kind,
+                original_exc=exc,
+            )
             return self._error_result(
-                sdk_error_message(exc, duration_seconds=duration, depth=depth)
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
             )
 
     async def _run_agent_review(

--- a/src/attune/workflows/dependency_check.py
+++ b/src/attune/workflows/dependency_check.py
@@ -20,12 +20,15 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
-    sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -179,12 +182,25 @@ class DependencyCheckWorkflow(BaseWorkflow):
             logger.error("Agent SDK network error: %s", exc)
             return self._error_result(f"Agent SDK connection failed: {exc}")
         except Exception as exc:  # noqa: BLE001
-            # INTENTIONAL: Catch-all for unknown SDK errors to return
-            # a structured WorkflowResult rather than crashing.
+            # INTENTIONAL: Catch-all for unknown SDK errors. Phase 2 of
+            # docs/specs/sdk-error-message-fidelity/ — capture the real
+            # claude CLI stderr via a second subprocess call, classify
+            # it, and thread the typed fields onto
+            # WorkflowResult.metadata for the dashboard to render the
+            # truth instead of regex-guessing.
             logger.exception("Agent SDK dependency check failed: %s", type(exc).__name__)
-            duration = (datetime.now() - started_at).total_seconds()
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary,
+                stderr=stderr,
+                kind=kind,
+                original_exc=exc,
+            )
             return self._error_result(
-                sdk_error_message(exc, duration_seconds=duration, depth=depth)
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
             )
 
     async def _run_agent_check(

--- a/tests/unit/workflows/test_code_review_agent_sdk.py
+++ b/tests/unit/workflows/test_code_review_agent_sdk.py
@@ -100,7 +100,8 @@ class TestCodeReviewWorkflowExecution:
 
     @pytest.mark.asyncio
     async def test_execute_handles_sdk_exception_gracefully(self) -> None:
-        """Given SDK raises an exception, execute returns error result."""
+        """Given SDK raises an exception, execute returns the Phase 2
+        typed error result (sdk-error-message-fidelity spec)."""
         mock_sdk = MagicMock()
         mock_sdk.query = MagicMock(side_effect=RuntimeError("SDK crashed"))
         mock_sdk.ClaudeAgentOptions = MagicMock()
@@ -117,7 +118,11 @@ class TestCodeReviewWorkflowExecution:
 
         assert isinstance(result, WorkflowResult)
         assert result.success is False
-        assert "RuntimeError" in (result.error or "")
+        # Phase 2 surfaces the classifier's user-facing message; the
+        # mock exception has no recognizable argv shape so the
+        # classifier falls back to "unknown".
+        assert "claude CLI subprocess failed" in (result.error or "")
+        assert result.metadata.get("sdk_error_kind") == "unknown"
 
     @pytest.mark.asyncio
     async def test_execute_without_path_returns_error(self) -> None:

--- a/tests/unit/workflows/test_code_review_workflow.py
+++ b/tests/unit/workflows/test_code_review_workflow.py
@@ -94,7 +94,8 @@ class TestWorkflowExecution:
 
     @pytest.mark.asyncio
     async def test_execute_handles_runtime_error(self):
-        """Test execute catches RuntimeError from SDK."""
+        """Test execute catches RuntimeError from SDK and returns the
+        Phase 2 typed error result (sdk-error-message-fidelity spec)."""
         mock_sdk = MagicMock()
         mock_sdk.query = MagicMock(side_effect=RuntimeError("boom"))
         mock_sdk.ClaudeAgentOptions = MagicMock()
@@ -106,7 +107,13 @@ class TestWorkflowExecution:
 
         assert isinstance(result, WorkflowResult)
         assert result.success is False
-        assert "RuntimeError" in (result.error or "")
+        # Phase 2 surfaces the classifier's user-facing message instead
+        # of the raw exception type. The mock exception has no argv
+        # shape, so the classifier falls back to "unknown" with a
+        # synthetic capture-failure stderr inlined.
+        assert "claude CLI subprocess failed" in (result.error or "")
+        assert result.metadata.get("sdk_error_kind") == "unknown"
+        assert "sdk_stderr" in result.metadata
 
     @pytest.mark.asyncio
     async def test_execute_handles_connection_error(self):

--- a/tests/unit/workflows/test_dependency_check_execute.py
+++ b/tests/unit/workflows/test_dependency_check_execute.py
@@ -248,11 +248,16 @@ class TestExecuteExceptionHandling:
         assert "connection failed" in result.error.lower()
 
     def test_generic_exception(self, workflow, monkeypatch):
+        """Generic SDK exception surfaces the Phase 2 typed error
+        result (sdk-error-message-fidelity spec). Mock exception has
+        no recognizable argv shape, so classifier falls back to
+        'unknown' with synthetic capture-failure stderr."""
         self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
         result = asyncio.run(workflow.execute(path="/tmp/proj"))
         assert result.success is False
-        assert "RuntimeError" in result.error
-        assert "kaboom" in result.error
+        assert "claude CLI subprocess failed" in result.error
+        assert result.metadata.get("sdk_error_kind") == "unknown"
+        assert "sdk_stderr" in result.metadata
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/test_sdk_error_fidelity_phase2.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity_phase2.py
@@ -1,0 +1,149 @@
+"""Tests for sdk-error-fidelity Phase 2 workflow wiring.
+
+Covers Task 2.4 of docs/specs/sdk-error-message-fidelity/tasks.md:
+
+- code-review surfaces the real cause on subprocess failure
+  (not the legacy three-cause menu)
+- dependency-check surfaces the real cause on subprocess failure
+- _error_result on BaseWorkflow threads sdk_stderr + sdk_error_kind
+  into WorkflowResult.metadata
+
+The Phase 2 contract:
+
+1. Workflow's broad-except branch calls capture_subprocess_failure +
+   classify_subprocess_failure.
+2. Returns a typed SdkSubprocessError message via format_user_message.
+3. Threads sdk_stderr + sdk_error_kind onto _error_result via
+   metadata, so Phase 3's persistence + render layer can surface
+   them on the run-view page.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_failing_sdk():
+    """Build a mock claude_agent_sdk module whose query raises."""
+    mock_sdk = MagicMock()
+    mock_sdk.query = MagicMock(side_effect=RuntimeError("Command failed"))
+    mock_sdk.ClaudeAgentOptions = MagicMock()
+    mock_sdk.AgentDefinition = MagicMock()
+    return mock_sdk
+
+
+class TestCodeReviewPhase2:
+    """code_review.py surfaces real cause on subprocess failure."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        """When capture_subprocess_failure returns api_quota stderr, the
+        workflow returns 'API quota reached' (not the legacy menu)."""
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch("attune.workflows.code_review.claude_agent_sdk", mock_sdk),
+            patch(
+                "attune.workflows.code_review.capture_subprocess_failure",
+                return_value=(
+                    "Error: You have reached your specified API usage limits. "
+                    "Regain access on 2026-06-01."
+                ),
+            ),
+        ):
+            from attune.workflows.code_review import CodeReviewWorkflow
+
+            wf = CodeReviewWorkflow()
+            result = await wf.execute(path="src/")
+
+        assert result.success is False
+        assert "API quota reached" in (result.error or "")
+        assert result.metadata.get("sdk_error_kind") == "api_quota"
+        assert "specified API usage limits" in (result.metadata.get("sdk_stderr") or "")
+        # Legacy three-cause menu must NOT appear.
+        assert "ANTHROPIC_API_KEY" not in (result.error or "")
+        assert "isn't installed" not in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_surfaces_auth_classification(self):
+        """401 stderr → 'auth invalid' classification."""
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch("attune.workflows.code_review.claude_agent_sdk", mock_sdk),
+            patch(
+                "attune.workflows.code_review.capture_subprocess_failure",
+                return_value="401 Unauthorized: invalid api key",
+            ),
+        ):
+            from attune.workflows.code_review import CodeReviewWorkflow
+
+            wf = CodeReviewWorkflow()
+            result = await wf.execute(path="src/")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "auth"
+        assert "auth invalid" in (result.error or "").lower()
+
+
+class TestDependencyCheckPhase2:
+    """dependency_check.py surfaces real cause on subprocess failure."""
+
+    def test_surfaces_real_cause_on_subprocess_failure(self):
+        """Same Phase 2 contract for dependency-check workflow."""
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch(
+                "attune.workflows.dependency_check.claude_agent_sdk",
+                mock_sdk,
+            ),
+            patch(
+                "attune.workflows.dependency_check.capture_subprocess_failure",
+                return_value="429 Too Many Requests: rate limit exceeded",
+            ),
+        ):
+            from attune.workflows.dependency_check import (
+                DependencyCheckWorkflow,
+            )
+
+            wf = DependencyCheckWorkflow()
+            result = asyncio.run(wf.execute(path="/tmp/proj"))
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "rate_limit"
+        assert "rate" in (result.error or "").lower()
+
+
+class TestErrorResultThreading:
+    """_error_result on BaseWorkflow threads the two new kwargs into
+    WorkflowResult.metadata."""
+
+    def test_threads_sdk_stderr_into_metadata(self):
+        from attune.workflows.code_review import CodeReviewWorkflow
+
+        wf = CodeReviewWorkflow()
+        result = wf._error_result(
+            "test error",
+            sdk_stderr="captured stderr",
+            sdk_error_kind="api_quota",
+        )
+        assert result.metadata["sdk_stderr"] == "captured stderr"
+        assert result.metadata["sdk_error_kind"] == "api_quota"
+
+    def test_omits_metadata_when_kwargs_unset(self):
+        """Back-compat: callers not passing the SDK kwargs get empty
+        metadata, matching pre-Phase-2 behavior."""
+        from attune.workflows.code_review import CodeReviewWorkflow
+
+        wf = CodeReviewWorkflow()
+        result = wf._error_result("test error")
+        assert result.metadata == {}
+
+    def test_threads_only_one_kwarg(self):
+        """Passing only one of the two kwargs surfaces just that key."""
+        from attune.workflows.code_review import CodeReviewWorkflow
+
+        wf = CodeReviewWorkflow()
+        result = wf._error_result("test error", sdk_error_kind="auth")
+        assert result.metadata == {"sdk_error_kind": "auth"}


### PR DESCRIPTION
feat(sdk-error-fidelity): Phase 2 — wire code-review + dependency-check

Phase 2 of docs/specs/sdk-error-message-fidelity/. Replaces the
legacy sdk_error_message broad-except handler in two high-traffic
workflows with the Phase 1 SdkSubprocessError flow.

What changes:

- src/attune/workflows/base.py: _error_result on BaseWorkflow now
  accepts sdk_stderr and sdk_error_kind kwargs (keyword-only) and
  threads them into WorkflowResult.metadata. Defaults preserve
  pre-Phase-2 behavior — absent kwargs leave metadata empty.
- src/attune/workflows/code_review.py: broad-except branch calls
  capture_subprocess_failure + classify_subprocess_failure +
  SdkSubprocessError.format_user_message instead of the legacy
  sdk_error_message helper. Threads typed fields onto _error_result.
- src/attune/workflows/dependency_check.py: same Phase 2 pattern.

Both workflows now surface the real claude CLI stderr cause
("Anthropic API quota reached", "auth invalid", "rate-limited",
etc.) instead of the legacy three-cause menu (ANTHROPIC_API_KEY
unset / claude not on PATH / SDK version mismatch) that often
named the wrong cause.

What persists for Phase 3:
- metadata["sdk_stderr"] is the raw redacted stderr from the
  capture-call
- metadata["sdk_error_kind"] is the typed classifier output

Phase 3 adds these fields to the Run record (runner.py) and
renders them in run_view.html as a collapsible <details> block.

Tests:

- New: 7 tests in test_sdk_error_fidelity_phase2.py covering the
  Phase 2 contract — code-review surfaces api_quota + auth,
  dependency-check surfaces rate_limit, _error_result threads
  both kwargs into metadata (plus back-compat empty-metadata).
- Updated: 3 existing tests (test_code_review_workflow.py,
  test_code_review_agent_sdk.py, test_dependency_check_execute.py)
  asserted on the legacy exception-type-leak behavior. Phase 2
  intentionally replaces that. Updated assertions to check the
  new shape: "claude CLI subprocess failed" message + metadata
  sdk_error_kind == "unknown" for mock exceptions with no argv
  shape.
- All 2530 workflow tests pass — no regressions outside the 3
  updated assertions.

Spec progression: Phase 1 (PR #516, merged) shipped primitives;
Phase 2 (this PR) wires two workflows; Phase 3 (next) persists +
renders; Phase 4 fans out to bug-predict, perf-audit,
refactor-plan, security-audit; Phase 5 covers the tail + spec
retrospective.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
