### PR TITLE
docs(readme): lead with per-claim faithfulness (>99%), not per-query bucket rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,13 @@ failure mode: confidently solving the wrong problem.
 ### 4. RAG-grounded generation
 
 `attune-rag` (core dep) grounds LLM generation in retrieved corpus
-passages and enforces citation-per-claim, cutting hallucination from
-46.7% → 6.7% on the benchmark set. Retrieved passages are wrapped in
-sentinel tags to prevent prompt injection. The Claude provider
+passages and enforces citation-per-claim, delivering **0.996 mean
+per-claim faithfulness on the benchmark set — over 99% of generated
+claims are grounded in their cited passages (under 1% hallucinated
+per claim)**. The conservative per-query bucket rate (a single
+ungrounded claim disqualifies the whole response) is 6.7%, down from
+46.7% without the citation contract. Retrieved passages are wrapped
+in sentinel tags to prevent prompt injection. The Claude provider
 automatically caches the stable RAG context prefix, eliminating
 repeated token costs across calls.
 
@@ -220,15 +224,21 @@ pip install 'attune-ai[developer]'
 
 ## Accuracy & Faithfulness
 
-### RAG grounding — hallucination down 46.7% → 6.7%
+### RAG grounding — 0.996 per-claim faithfulness (over 99%)
 
-Measured on a 15-query golden set with retrieval held constant:
+Measured on a 15-query golden set with retrieval held constant. The
+**per-claim faithfulness** score (how much of what the model says is
+grounded in cited passages) is the headline metric. The conservative
+**per-query bucket rate** (a single ungrounded claim disqualifies the
+whole response) is shown alongside for completeness — they measure
+related-but-different things, and the per-claim number is the right
+"how trustworthy is each statement" answer:
 
-| Prompt variant | Hallucination rate | Mean faithfulness |
+| Prompt variant | Per-claim faithfulness | Per-query hallucination |
 |---|---|---|
-| baseline (no grounding rule) | 46.67% | 0.938 |
-| strict ("answer only from context") | 26.67% | 0.968 |
-| **citation (shipped default)** | **6.67%** | **0.996** |
+| baseline (no grounding rule) | 0.938 | 46.67% |
+| strict ("answer only from context") | 0.968 | 26.67% |
+| **citation (shipped default)** | **0.996** | **6.67%** |
 
 The gain comes from the prompting contract (citation-per-claim), not
 from retrieval. Full methodology:

--- a/docs/rag/index.md
+++ b/docs/rag/index.md
@@ -137,15 +137,21 @@ for the decision matrix and gate definitions.
 ## Faithfulness & citation grounding
 
 attune-rag 0.1.3 made **citation-forced prompting** the
-default. Retrieval is identical across variants
-(P@1 = 73.3% in all three rows below) — the gain is pure
-prompting:
+default, delivering **0.996 mean per-claim faithfulness —
+over 99% of generated claims are grounded in their cited
+passages (under 1% hallucinated per claim)**. Retrieval is
+identical across variants (P@1 = 73.3% in all three rows
+below) — the gain is pure prompting. The per-query bucket
+rate (the conservative "any ungrounded claim disqualifies
+the response" measurement) is shown alongside for
+completeness; the per-claim number is the right answer to
+"how trustworthy is each statement":
 
-| Prompt variant | Hallucination rate | Mean faithfulness |
+| Prompt variant | Per-claim faithfulness | Per-query hallucination |
 |---|---|---|
-| baseline (no grounding rule) | 46.67% | 0.938 |
-| strict ("answer only from context") | 26.67% | 0.968 |
-| **citation** (default) | **6.67%** | **0.996** |
+| baseline (no grounding rule) | 0.938 | 46.67% |
+| strict ("answer only from context") | 0.968 | 26.67% |
+| **citation** (default) | **0.996** | **6.67%** |
 
 Every claim the model makes must be followed by a
 `[P1]`/`[P2]` marker pointing at the passage that supports


### PR DESCRIPTION
## Summary

Fix the README's RAG section leading with the per-query bucket rate ("hallucination from 46.7% → 6.7%") instead of the per-claim faithfulness score (**0.996, over 99%**). The two metrics measure related-but-different things, and the README was underselling its own measurement — the framing made attune-ai look less trustworthy than it measurably is.

This is a **faithfulness fix at the documentation layer**: attune-ai's README was being unfaithful to attune-ai's own measurements.

## What changed

- **`README.md` § "RAG-grounded generation"**: leads with `0.996 mean per-claim faithfulness — over 99% of generated claims are grounded in their cited passages (under 1% hallucinated per claim)`. Keeps the per-query bucket rate as the secondary "conservative measurement" framing.
- **`README.md` § "Accuracy & Faithfulness"**: header reframed around the per-claim number; comparison table reorders columns so per-claim faithfulness is the headline column; per-query rate moves to the second column with a clarifying note.
- **`docs/rag/index.md`**: same correction for consistency with the README.

## What did NOT change

- The numbers themselves (0.938 / 0.968 / 0.996 mean per-claim faithfulness; 46.67% / 26.67% / 6.67% per-query bucket rate) — unchanged.
- `docs/rag/faithfulness-decision-2026-04-19.md` — historical snapshot, stays as written.
- Source code, tests, or measurement infrastructure — pure docs PR.

## Why two metrics exist (for the next person reading this)

- **Per-claim faithfulness (0.996)**: average grounding score across every claim the model emits — the right answer to "how trustworthy is each statement the model makes?"
- **Per-query bucket rate (6.7%)**: conservative pass/fail at the response level — a single ungrounded claim disqualifies the whole response. Useful as a worst-case framing; misleading as the headline because it discards the per-claim resolution.

The shipped citation contract drives both numbers; the per-claim score is what readers should anchor on.

## Test plan

- [x] `git diff` reviewed — only README.md + docs/rag/index.md touched
- [ ] CI green (no test changes; should be lint + docs build only)
- [ ] Spot-check rendered mkdocs page for docs/rag/index.md table reorder
