### PR TITLE
feat(ops): wire derive_lifecycle into SpecRecord + route serializers (A2)

### DIFF
--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -491,6 +491,7 @@ async def specs_page(request: Request) -> HTMLResponse:
                     "path": record.path,
                     "phases": [asdict(p) for p in record.phases],
                     "last_modified": record.last_modified,
+                    "lifecycle": record.lifecycle,
                 }
             )
     return _render(

--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -24,7 +24,7 @@ import logging
 import os
 import re
 import tempfile
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -113,6 +113,24 @@ class SpecRecord:
     # (which shouldn't happen since _list_specs_in_root requires at
     # least one canonical phase file, but handled defensively).
     last_modified: str | None = None
+    # Lifecycle bucket derived from `phases` + `last_modified` via
+    # `attune.ops.spec_lifecycle.derive_lifecycle`. Computed in
+    # `__post_init__` so callers don't need to coordinate. `init=False`
+    # keeps the constructor signature backward-compatible with the many
+    # `SpecRecord(slug=..., phases=..., last_modified=...)` test fixtures.
+    # One of: "paused", "complete", "stale", "draft",
+    # "approved-not-shipped", "active". See
+    # [docs/specs/ops-specs-page-refinement/decisions.md](../../../docs/specs/ops-specs-page-refinement/decisions.md).
+    lifecycle: str = field(init=False, default="")
+
+    def __post_init__(self) -> None:
+        # Lazy import to avoid any chance of an import cycle between
+        # routes/specs.py and spec_lifecycle.py (defensive; no cycle
+        # exists today since spec_lifecycle uses a structural Protocol).
+        from attune.ops.spec_lifecycle import derive_lifecycle
+
+        # Frozen dataclass — use object.__setattr__ to set the field.
+        object.__setattr__(self, "lifecycle", derive_lifecycle(self))
 
 
 def _extract_status(text: str) -> str | None:
@@ -222,6 +240,7 @@ async def list_specs(request: Request) -> dict:
                 "root": s.root,
                 "path": s.path,
                 "phases": [asdict(p) for p in s.phases],
+                "lifecycle": s.lifecycle,
             }
             for s in specs
         ],

--- a/tests/unit/ops/test_specs_routes.py
+++ b/tests/unit/ops/test_specs_routes.py
@@ -170,6 +170,142 @@ def test_list_specs_multi_root_collision_preserved(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# A2 — lifecycle field wired into SpecRecord and JSON serializer
+#
+# Pure data layer: every spec in the /api/specs response carries a
+# `lifecycle` string from the 6-bucket cascade in
+# `attune.ops.spec_lifecycle`. Template + JS consumers land in A3.
+# See [docs/specs/ops-specs-page-refinement/decisions.md](
+# ../../../docs/specs/ops-specs-page-refinement/decisions.md).
+# ---------------------------------------------------------------------------
+
+
+def test_specrecord_post_init_computes_lifecycle():
+    """Constructing a SpecRecord auto-populates the lifecycle field.
+
+    Backstop for the __post_init__ wiring — if anyone removes the hook,
+    this fires before the route-level tests even run.
+    """
+    from attune.ops.routes.specs import SpecPhase, SpecRecord
+
+    phases = [
+        SpecPhase(name="requirements", file="requirements.md", exists=True, status="approved"),
+        SpecPhase(name="design", file="design.md", exists=False, status=None),
+        SpecPhase(name="tasks", file="tasks.md", exists=False, status=None),
+        SpecPhase(name="decisions", file="decisions.md", exists=False, status=None),
+    ]
+    record = SpecRecord(
+        slug="example",
+        root="/r",
+        path="/r/example",
+        phases=phases,
+        last_modified="2026-05-31T00:00:00+00:00",
+    )
+    # requirements approved, no tasks file → falls to Rule 6 (Active)
+    assert record.lifecycle == "active"
+
+
+def test_list_specs_response_includes_lifecycle_field(tmp_path, monkeypatch):
+    """Every spec in /api/specs response carries a `lifecycle` string."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "alpha",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+    _make_spec(
+        specs_root,
+        "beta",
+        files={
+            "requirements.md": "**Status:** approved\n",
+            "decisions.md": "**Status:** approved\n",
+        },
+    )
+
+    client = _client(tmp_path)
+    body = client.get("/api/specs").json()
+    for spec in body["specs"]:
+        assert "lifecycle" in spec, f"missing lifecycle on {spec['slug']}"
+        assert isinstance(spec["lifecycle"], str)
+        assert spec["lifecycle"] in {
+            "paused",
+            "complete",
+            "stale",
+            "draft",
+            "approved-not-shipped",
+            "active",
+        }
+
+
+def test_list_specs_lifecycle_matches_bucket_cascade(tmp_path, monkeypatch):
+    """Lifecycle values reflect the bucket cascade for known fixtures.
+
+    Smoke-tests the wiring end-to-end: a paused spec surfaces as
+    "paused", a fully-complete spec surfaces as "complete", a
+    requirements-missing spec surfaces as "draft". The cascade itself
+    is exhaustively tested in test_spec_lifecycle.py — this asserts
+    the route hands the right shape to derive_lifecycle.
+    """
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "paused-spec",
+        files={"decisions.md": "**Status:** paused 2026-05-12 — premise invalidated\n"},
+    )
+    _make_spec(
+        specs_root,
+        "complete-spec",
+        files={
+            "requirements.md": "**Status:** complete\n",
+            "design.md": "**Status:** complete\n",
+            "tasks.md": "**Status:** complete\n",
+        },
+    )
+    _make_spec(
+        specs_root,
+        "draft-spec",
+        files={"decisions.md": "**Status:** draft\n"},  # no requirements.md
+    )
+
+    client = _client(tmp_path)
+    body = client.get("/api/specs").json()
+    lifecycles = {s["slug"]: s["lifecycle"] for s in body["specs"]}
+    assert lifecycles["paused-spec"] == "paused"
+    assert lifecycles["complete-spec"] == "complete"
+    assert lifecycles["draft-spec"] == "draft"
+
+
+def test_specs_html_page_renders_with_lifecycle_in_context(tmp_path, monkeypatch):
+    """`/specs` HTML page renders 200 and each spec's dict carries a lifecycle.
+
+    A2 doesn't add UI surface for the field — template still shows
+    the 4 phase pills. This test just guards that the route
+    serializer didn't drop the field on the way to the template.
+    Verified by inspecting the rendered HTML for the slug + lifecycle
+    bucket appearing in a data-lifecycle attribute would be cleaner
+    once A3 ships; for now, just smoke-test the page renders.
+    """
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "smoke",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+
+    client = _client(tmp_path)
+    response = client.get("/specs")
+    assert response.status_code == 200
+    # Template intentionally doesn't render lifecycle in A2.
+    # The field IS in the template context per `routes/dashboard.py`'s
+    # `specs_page` serializer; this is a smoke check that the page
+    # still renders cleanly with the new field present.
+    assert "smoke" in response.text
+
+
+# ---------------------------------------------------------------------------
 # GET /api/specs/{slug} — drill-in
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

A2 of [ops-specs-page-refinement](docs/specs/ops-specs-page-refinement/) — pure data layer per the ratified scope ([decisions.md D5](docs/specs/ops-specs-page-refinement/decisions.md), confirmed in session). No UI change.

**What lands:**

- `SpecRecord.lifecycle: str` — frozen-dataclass field with `init=False`; `__post_init__` computes it via `derive_lifecycle` (the module shipped in #533)
- `/api/specs` JSON serializer adds `lifecycle` to each spec entry
- `/specs` HTML route's per-spec dict gets the same field in template context (template still renders the 4 phase pills — A3 lands the new UI)

**Invariant:** every `SpecRecord` carries its derived bucket automatically. Existing construction sites (route serializer, `completion_candidates.py`, 9 fixtures in `test_completion_candidates.py`) keep working unchanged because `init=False` removes the field from the constructor signature.

## Wireframe scope tracker

| Phase | Scope | Status |
|---|---|---|
| A1 ([#533](https://github.com/Smart-AI-Memory/attune-ai/pull/533)) | Lifecycle module + 43 unit tests | ✅ merged |
| **A2 (this PR)** | **Route serializer + SpecRecord wiring** | **🟡 open** |
| A3 (next) | Template rewrite — chip filter row, bucket pill replaces 4 phase pills, kebab menu, URL param parsing | 🔲 |

## Tests

4 new tests in `test_specs_routes.py`:

- `test_specrecord_post_init_computes_lifecycle` — wiring guard for the dataclass hook
- `test_list_specs_response_includes_lifecycle_field` — every spec in the JSON response has `lifecycle`
- `test_list_specs_lifecycle_matches_bucket_cascade` — paused/complete/draft fixtures route through `derive_lifecycle` correctly
- `test_specs_html_page_renders_with_lifecycle_in_context` — `/specs` HTML still renders 200 with the new field present

All 141 tests in `test_specs_routes.py` + `test_completion_candidates.py` + `test_specs_dashboard.py` pass locally. Lint clean.

## Test plan

- [x] Local tests pass (`pytest tests/unit/ops/test_specs_routes.py`)
- [x] Ruff clean on changed files
- [x] Existing `SpecRecord(slug=..., phases=...)` construction unchanged (init=False)
- [ ] CI green across the matrix
- [ ] Codecov patch coverage ≥ 95%
