### PR TITLE
feat(ops): A3a — chip filter toolbar + lifecycle badge column

### DIFF
--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -494,6 +494,14 @@ async def specs_page(request: Request) -> HTMLResponse:
                     "lifecycle": record.lifecycle,
                 }
             )
+    # Bucket counts for the chip filter row. All 6 keys are always present
+    # so the template can render chips with `0` counts for empty buckets
+    # (better UX than missing chips that pop in/out as data shifts).
+    bucket_counts = dict.fromkeys(
+        ("active", "approved-not-shipped", "complete", "paused", "stale", "draft"), 0
+    )
+    for s in specs:
+        bucket_counts[s["lifecycle"]] = bucket_counts.get(s["lifecycle"], 0) + 1
     return _render(
         request,
         "specs.html",
@@ -502,6 +510,7 @@ async def specs_page(request: Request) -> HTMLResponse:
         roots=[str(r) for r in roots],
         allow_run=cfg.allow_run,
         specs_candidates_enabled=cfg.specs_candidates_enabled,
+        bucket_counts=bucket_counts,
     )
 
 

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -2365,3 +2365,241 @@ a.kpi:hover {
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* ============================================================
+   A3a — Specs page refinement: toolbar, lifecycle badges,
+   empty state. Scoped via `.specs-toolbar` and `.lifecycle-badge`
+   to avoid collision with the global `.chip` class which is used
+   by tier chips, workflow status chips, and others.
+   ============================================================ */
+
+.specs-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  align-items: center;
+  margin: 16px 0;
+  padding: 12px;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 6px;
+}
+.specs-toolbar .chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.specs-toolbar .chip-label,
+.specs-toolbar .search-label,
+.specs-toolbar .sort-label {
+  font-size: 12px;
+  color: var(--fg-muted, #6b7280);
+  margin-right: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+}
+.specs-toolbar .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 99px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  user-select: none;
+  margin: 0;
+  background: var(--bg-soft, #f9fafb);
+  color: var(--fg, #374151);
+  font-family: inherit;
+  line-height: 1.2;
+}
+.specs-toolbar .chip:focus-visible {
+  outline: 2px solid var(--accent, #2563eb);
+  outline-offset: 1px;
+}
+.specs-toolbar .chip-active {
+  background: #dbeafe;
+  color: #1e40af;
+  border-color: #bfdbfe;
+}
+.specs-toolbar .chip-active.bucket-paused {
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #fde68a;
+}
+.specs-toolbar .chip-active.bucket-complete {
+  background: #d1fae5;
+  color: #065f46;
+  border-color: #a7f3d0;
+}
+.specs-toolbar .chip-active.bucket-draft {
+  background: #f3f4f6;
+  color: #374151;
+  border-color: #e5e7eb;
+}
+.specs-toolbar .chip-active.bucket-approved-not-shipped {
+  background: #ede9fe;
+  color: #5b21b6;
+  border-color: #ddd6fe;
+}
+/* Stale: distinct amber-orange shade, separate from Paused's softer
+   amber. Per decisions.md D1: "amber distinct from Paused signaling
+   needs decision." */
+.specs-toolbar .chip-active.bucket-stale {
+  background: #ffedd5;
+  color: #9a3412;
+  border-color: #fdba74;
+}
+.specs-toolbar .chip-inactive {
+  background: var(--bg-soft, #f9fafb);
+  color: var(--fg-subtle, #9ca3af);
+  border-color: var(--border, #e5e7eb);
+}
+.specs-toolbar .chip-inactive .chip-hidden-mark {
+  color: var(--danger, #ef4444);
+  margin-left: 2px;
+}
+.specs-toolbar .chip:hover {
+  filter: brightness(0.97);
+}
+.specs-toolbar .chip-count {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.specs-toolbar .search-wrap,
+.specs-toolbar .sort-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.specs-toolbar .search-input {
+  padding: 4px 8px;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 4px;
+  font-size: 13px;
+  width: 180px;
+  font-family: inherit;
+  background: var(--bg, #fff);
+  color: var(--fg, #111827);
+}
+.specs-toolbar .search-input:focus {
+  outline: 2px solid var(--accent, #2563eb);
+  outline-offset: 1px;
+}
+.specs-toolbar .sort-select {
+  padding: 4px 8px;
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 4px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--bg, #fff);
+  color: var(--fg, #111827);
+}
+
+/* Phase pills compaction — 4 pills in a single cell with consistent
+   spacing. Replaces the old 4-column per-phase layout. */
+.specs-table .col-phases {
+  text-align: center;
+  white-space: nowrap;
+}
+.specs-table .phase-axis {
+  font-size: 10px;
+  color: var(--fg-subtle, #9ca3af);
+  margin-left: 4px;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+}
+.specs-table .phase-pills {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+
+/* Lifecycle badge — per-row derived bucket. Shares the chip palette
+   in the toolbar (active variants) for visual consistency. */
+.lifecycle-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  border: 1px solid transparent;
+  text-transform: capitalize;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+.lifecycle-active {
+  background: #dbeafe;
+  color: #1e40af;
+  border-color: #bfdbfe;
+}
+.lifecycle-approved-not-shipped {
+  background: #ede9fe;
+  color: #5b21b6;
+  border-color: #ddd6fe;
+}
+.lifecycle-complete {
+  background: #d1fae5;
+  color: #065f46;
+  border-color: #a7f3d0;
+}
+.lifecycle-paused {
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #fde68a;
+}
+.lifecycle-stale {
+  background: #ffedd5;
+  color: #9a3412;
+  border-color: #fdba74;
+}
+.lifecycle-draft {
+  background: #f3f4f6;
+  color: #374151;
+  border-color: #e5e7eb;
+}
+
+/* Empty state inside the specs table area — shown when filters
+   eliminate all rows, or search produces no matches. Hidden by
+   default; JS toggles via `hidden` attribute. */
+.specs-empty-state {
+  margin: 32px auto;
+  padding: 24px;
+  text-align: center;
+  background: var(--bg-soft, #f9fafb);
+  border: 1px dashed var(--border, #e5e7eb);
+  border-radius: 6px;
+  max-width: 480px;
+}
+.specs-empty-state .empty-state-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg, #374151);
+  margin-bottom: 6px;
+}
+.specs-empty-state .empty-state-hint {
+  font-size: 13px;
+  color: var(--fg-muted, #6b7280);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+.specs-empty-state .empty-state-action {
+  padding: 6px 14px;
+  border: 1px solid var(--accent, #2563eb);
+  background: var(--bg, #fff);
+  color: var(--accent, #2563eb);
+  border-radius: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.specs-empty-state .empty-state-action:hover {
+  background: var(--accent-soft, #dbeafe);
+}

--- a/src/attune/ops/static/js/specs_refined.js
+++ b/src/attune/ops/static/js/specs_refined.js
@@ -1,0 +1,237 @@
+// Specs page — chip filter / search / sort behavior (A3a).
+//
+// Reads the server-rendered table at /specs and applies client-side
+// filtering by lifecycle bucket, slug substring, and a 3-way sort.
+// State lives entirely in memory; URL persistence + chip-state-from-URL
+// ships in A3c.
+//
+// Default state (per docs/specs/ops-specs-page-refinement/decisions.md):
+//   - All lifecycle buckets active EXCEPT Complete
+//   - Search empty
+//   - Sort: "recent" (newest last-modified first)
+//
+// Exports a `window.__attuneSpecs` namespace so future PRs (A3c URL
+// params, A3b kebab integration) can hook the same state object
+// without re-implementing the chip/search/sort wiring.
+
+(function () {
+  "use strict";
+
+  // Default buckets active per R1.3 — all on except Complete.
+  // Stale is default-on: stale specs need attention, not concealment.
+  var DEFAULT_BUCKETS = [
+    "active",
+    "approved-not-shipped",
+    "paused",
+    "stale",
+    "draft",
+  ];
+
+  var state = {
+    buckets: new Set(DEFAULT_BUCKETS),
+    search: "",
+    sort: "recent",
+  };
+
+  // -------------------------------------------------------------------
+  // Element lookups (idempotent on missing — script may load on
+  // an empty-state page where most elements don't exist).
+  // -------------------------------------------------------------------
+
+  function $(sel) { return document.querySelector(sel); }
+  function $$(sel) { return Array.prototype.slice.call(document.querySelectorAll(sel)); }
+
+  // -------------------------------------------------------------------
+  // Filter / sort application
+  // -------------------------------------------------------------------
+
+  function rowBucket(tr) {
+    return tr.getAttribute("data-bucket") || "";
+  }
+
+  function rowSlug(tr) {
+    return (tr.getAttribute("data-slug") || "").toLowerCase();
+  }
+
+  function rowMtime(tr) {
+    var v = tr.getAttribute("data-mtime");
+    if (!v) return 0;
+    var t = Date.parse(v);
+    return isNaN(t) ? 0 : t;
+  }
+
+  function applyFilters() {
+    var tbody = $(".specs-table tbody");
+    if (!tbody) return;
+    var rows = $$(".specs-table tbody tr");
+    var query = state.search.trim().toLowerCase();
+    var anyVisible = false;
+
+    rows.forEach(function (tr) {
+      var inBucket = state.buckets.has(rowBucket(tr));
+      var matchesQuery = !query || rowSlug(tr).indexOf(query) !== -1;
+      var visible = inBucket && matchesQuery;
+      if (visible) anyVisible = true;
+      tr.hidden = !visible;
+    });
+
+    updateEmptyState(anyVisible, query);
+  }
+
+  function applySort() {
+    var tbody = $(".specs-table tbody");
+    if (!tbody) return;
+    var rows = $$(".specs-table tbody tr");
+    var sort = state.sort;
+
+    rows.sort(function (a, b) {
+      if (sort === "alpha") {
+        return rowSlug(a).localeCompare(rowSlug(b));
+      } else if (sort === "oldest") {
+        return rowMtime(a) - rowMtime(b);
+      }
+      // "recent" — newest first; rows without mtime sink to bottom.
+      return rowMtime(b) - rowMtime(a);
+    });
+
+    var frag = document.createDocumentFragment();
+    rows.forEach(function (tr) { frag.appendChild(tr); });
+    tbody.appendChild(frag);
+  }
+
+  // -------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------
+
+  function updateEmptyState(anyVisible, query) {
+    var box = $("#specs-empty-state");
+    var titleEl = $("#specs-empty-title");
+    var hintEl = $("#specs-empty-hint");
+    if (!box || !titleEl || !hintEl) return;
+
+    if (anyVisible) {
+      box.hidden = true;
+      return;
+    }
+
+    box.hidden = false;
+    if (state.buckets.size === 0) {
+      titleEl.textContent = "All buckets filtered out";
+      hintEl.textContent =
+        "Re-enable at least one lifecycle chip above to see specs.";
+    } else if (query) {
+      titleEl.textContent = "No matches";
+      hintEl.textContent =
+        "No specs in active buckets match “" + query +
+        "”. Try clearing the search or enabling more chips above.";
+    } else {
+      titleEl.textContent = "No specs in active buckets";
+      hintEl.textContent =
+        "Toggle more chips above to surface specs.";
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // Wiring
+  // -------------------------------------------------------------------
+
+  function setChipState(chip, active) {
+    chip.classList.toggle("chip-active", active);
+    chip.classList.toggle("chip-inactive", !active);
+    chip.setAttribute("aria-pressed", active ? "true" : "false");
+
+    // Add/remove the "✗" hidden-count marker on inactive chips.
+    var mark = chip.querySelector(".chip-hidden-mark");
+    if (!active && !mark) {
+      var span = document.createElement("span");
+      span.className = "chip-hidden-mark";
+      span.setAttribute("aria-hidden", "true");
+      span.textContent = " ✗";
+      chip.appendChild(span);
+    } else if (active && mark) {
+      mark.parentNode.removeChild(mark);
+    }
+  }
+
+  function wireChips() {
+    $$(".specs-toolbar .chip[data-bucket]").forEach(function (chip) {
+      chip.addEventListener("click", function () {
+        var bucket = chip.getAttribute("data-bucket");
+        if (state.buckets.has(bucket)) {
+          state.buckets.delete(bucket);
+          setChipState(chip, false);
+        } else {
+          state.buckets.add(bucket);
+          setChipState(chip, true);
+        }
+        applyFilters();
+      });
+    });
+  }
+
+  function wireSearch() {
+    var input = $("#specs-search");
+    if (!input) return;
+    input.addEventListener("input", function () {
+      state.search = input.value;
+      applyFilters();
+    });
+  }
+
+  function wireSort() {
+    var sel = $("#specs-sort");
+    if (!sel) return;
+    sel.addEventListener("change", function () {
+      state.sort = sel.value;
+      applySort();
+    });
+  }
+
+  function wireResetButton() {
+    var btn = $("#specs-reset-filters");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      // Reset chips to default and clear search.
+      state.buckets = new Set(DEFAULT_BUCKETS);
+      state.search = "";
+      var input = $("#specs-search");
+      if (input) input.value = "";
+      $$(".specs-toolbar .chip[data-bucket]").forEach(function (chip) {
+        var bucket = chip.getAttribute("data-bucket");
+        setChipState(chip, state.buckets.has(bucket));
+      });
+      applyFilters();
+    });
+  }
+
+  function init() {
+    wireChips();
+    wireSearch();
+    wireSort();
+    wireResetButton();
+    // Apply the default sort on load — server renders rows in
+    // directory order (sorted by slug), but the default UI sort is
+    // "recent." Re-order on first paint so users see what the sort
+    // control claims to be doing.
+    applySort();
+    applyFilters();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  // Exports — namespace mirrors `window.__attuneRunner` from
+  // runner.js so source-grep tests (per the test_runner_js_parsing
+  // convention) can verify the surface.
+  window.__attuneSpecs = {
+    DEFAULT_BUCKETS: DEFAULT_BUCKETS,
+    state: state,
+    applyFilters: applyFilters,
+    applySort: applySort,
+    setChipState: setChipState,
+    init: init,
+  };
+})();

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -3,7 +3,7 @@
 {% block content %}
 <section class="page-head">
   <h1>Specs</h1>
-  <p class="page-sub">
+  <p class="page-sub" id="page-sub">
     {{ specs|length }} spec{{ '' if specs|length == 1 else 's' }}
     across {{ roots|length }} root{{ '' if roots|length == 1 else 's' }}.
     {% if allow_run %}
@@ -43,6 +43,50 @@
 {% endif %}
 
 {% if specs %}
+  {# A3a toolbar — chip filter row, search, sort. JS in specs_refined.js
+     handles state; default chip state is all-on EXCEPT Complete per
+     decisions.md D1 + R1.3. URL param persistence ships in A3c. #}
+  <div class="specs-toolbar" role="region" aria-label="Spec filter and sort controls">
+    <div class="chip-row" role="group" aria-label="Lifecycle bucket filters">
+      <span class="chip-label">Filter:</span>
+      {% set bucket_styles = [
+        ('active', 'Active', ''),
+        ('approved-not-shipped', 'Approved-not-shipped', 'bucket-approved-not-shipped'),
+        ('complete', 'Complete', 'bucket-complete'),
+        ('paused', 'Paused', 'bucket-paused'),
+        ('stale', 'Stale', 'bucket-stale'),
+        ('draft', 'Draft', 'bucket-draft'),
+      ] %}
+      {% for bucket, label, color_cls in bucket_styles %}
+        {% set active = bucket != 'complete' %}
+        {# bucket-* class always present so chips colorize correctly
+           after JS toggles chip-active on/off. CSS gates the color
+           on `.chip-active.bucket-*` — inactive chips show neutral. #}
+        <button
+          type="button"
+          class="chip {% if color_cls %}{{ color_cls }} {% endif %}{% if active %}chip-active{% else %}chip-inactive{% endif %}"
+          data-bucket="{{ bucket }}"
+          aria-pressed="{{ 'true' if active else 'false' }}"
+          aria-label="{{ label }} bucket — {{ bucket_counts[bucket] }} specs"
+        >{{ label }} <span class="chip-count" data-count="{{ bucket }}">{{ bucket_counts[bucket] }}</span>{% if not active %} <span class="chip-hidden-mark" aria-hidden="true">✗</span>{% endif %}</button>
+      {% endfor %}
+    </div>
+    <div class="search-wrap">
+      <label class="search-label" for="specs-search">Search:</label>
+      <input id="specs-search" class="search-input" type="search"
+        placeholder="slug substring…" autocomplete="off"
+        aria-label="Filter specs by slug substring" />
+    </div>
+    <div class="sort-wrap">
+      <label class="sort-label" for="specs-sort">Sort:</label>
+      <select id="specs-sort" class="sort-select" aria-label="Sort specs">
+        <option value="recent">Recently updated</option>
+        <option value="alpha">Alphabetical</option>
+        <option value="oldest">Oldest untouched</option>
+      </select>
+    </div>
+  </div>
+
   {# Compact status display: dot + 3-letter code for known statuses,
      truncated text + dotted underline for custom strings. Full status
      in title attribute (native tooltip). Click on editable pills swaps
@@ -76,14 +120,13 @@
       <tr>
         <th class="col-slug">Spec</th>
         <th class="col-mtime">Updated</th>
-        {% for phase_name in ("decisions", "requirements", "design", "tasks") %}
-          <th class="col-phase">{{ phase_name|capitalize }}</th>
-        {% endfor %}
+        <th class="col-phases" data-tooltip="Decisions / Requirements / Design / Tasks">Phases <span class="phase-axis">D&middot;R&middot;D&middot;T</span></th>
+        <th class="col-lifecycle">Lifecycle</th>
       </tr>
     </thead>
     <tbody>
       {% for s in specs %}
-        <tr data-slug="{{ s.slug }}">
+        <tr data-slug="{{ s.slug }}" data-bucket="{{ s.lifecycle }}" data-mtime="{{ s.last_modified or '' }}">
           <td class="col-slug">
             <a href="/specs/{{ s.slug }}" class="link spec-slug" data-tooltip="{{ s.slug }}" aria-label="{{ s.slug }}"><code>{{ s.slug }}</code></a>
           </td>
@@ -101,35 +144,47 @@
               <span class="spec-mtime spec-mtime-empty" aria-label="No update time recorded">—</span>
             {% endif %}
           </td>
-          {% for phase in s.phases %}
-            <td class="col-phase" data-phase="{{ phase.name }}">
-              {% if not phase.exists %}
-                <span class="status-pill chip-muted" data-tooltip="No {{ phase.name }}.md file" aria-label="No {{ phase.name }}.md file">—</span>
-              {% else %}
-                {% set cls = chip_cls(phase.status)|trim %}
-                {% set code = status_code(phase.status)|trim %}
-                {% set custom = is_custom(phase.status)|trim == '1' %}
-                <span
-                  class="status-pill {{ cls }}{% if custom %} status-pill-custom{% endif %}{% if allow_run %} status-pill-editable{% endif %}"
-                  data-tooltip="{{ phase.status or '(no status)' }}"
-                  {% if allow_run %}
-                  data-slug="{{ s.slug }}"
-                  data-phase="{{ phase.name }}"
-                  data-original="{{ phase.status or '' }}"
-                  role="button"
-                  tabindex="0"
-                  aria-label="Status for {{ phase.name }} of {{ s.slug }}: {{ phase.status or 'no status' }}. Click to edit."
-                  {% else %}
-                  aria-label="Status for {{ phase.name }} of {{ s.slug }}: {{ phase.status or 'no status' }}"
-                  {% endif %}
-                ><span class="status-dot" aria-hidden="true"></span><span class="status-code">{{ code or '(none)' }}</span></span>
-              {% endif %}
-            </td>
-          {% endfor %}
+          <td class="col-phases">
+            <span class="phase-pills" role="group" aria-label="Phase statuses for {{ s.slug }}">
+              {% for phase in s.phases %}
+                {% if not phase.exists %}
+                  <span class="status-pill chip-muted" data-phase="{{ phase.name }}" data-tooltip="No {{ phase.name }}.md file" aria-label="No {{ phase.name }}.md file">—</span>
+                {% else %}
+                  {% set cls = chip_cls(phase.status)|trim %}
+                  {% set code = status_code(phase.status)|trim %}
+                  {% set custom = is_custom(phase.status)|trim == '1' %}
+                  <span
+                    class="status-pill {{ cls }}{% if custom %} status-pill-custom{% endif %}{% if allow_run %} status-pill-editable{% endif %}"
+                    data-phase="{{ phase.name }}"
+                    data-tooltip="{{ phase.name|capitalize }}: {{ phase.status or '(no status)' }}"
+                    {% if allow_run %}
+                    data-slug="{{ s.slug }}"
+                    data-original="{{ phase.status or '' }}"
+                    role="button"
+                    tabindex="0"
+                    aria-label="Status for {{ phase.name }} of {{ s.slug }}: {{ phase.status or 'no status' }}. Click to edit."
+                    {% else %}
+                    aria-label="Status for {{ phase.name }} of {{ s.slug }}: {{ phase.status or 'no status' }}"
+                    {% endif %}
+                  ><span class="status-dot" aria-hidden="true"></span><span class="status-code">{{ code or '(none)' }}</span></span>
+                {% endif %}
+              {% endfor %}
+            </span>
+          </td>
+          <td class="col-lifecycle">
+            <span class="lifecycle-badge lifecycle-{{ s.lifecycle }}" data-tooltip="Derived from phase statuses + last-modified date">
+              {{ s.lifecycle.replace('-', ' ') }}
+            </span>
+          </td>
         </tr>
       {% endfor %}
     </tbody>
   </table>
+  <div id="specs-empty-state" class="specs-empty-state" hidden role="status" aria-live="polite">
+    <div class="empty-state-title" id="specs-empty-title">No matches</div>
+    <div class="empty-state-hint" id="specs-empty-hint"></div>
+    <button type="button" class="empty-state-action" id="specs-reset-filters">Reset to default filters</button>
+  </div>
 {% else %}
   <p class="empty">
     No specs found. Configure a roots directory with
@@ -140,10 +195,19 @@
 {% endblock %}
 
 {% block scripts %}
-{% if allow_run %}
-  <script src="{{ url_for('static', path='js/specs.js') }}?v={{ attune_version }}"></script>
-  {% if specs_candidates_enabled %}
-    <script src="{{ url_for('static', path='js/completion_candidates.js') }}?v={{ attune_version }}"></script>
+  {# A3a: chip filter / search / sort behavior. Loaded for all users
+     (read-only and editable) since filtering is a navigation aid, not
+     a mutation. URL persistence + chip-state-from-URL ships in A3c. #}
+  {% if specs %}
+    <script src="{{ url_for('static', path='js/specs_refined.js') }}?v={{ attune_version }}"></script>
   {% endif %}
-{% endif %}
+  {% if allow_run %}
+    {# Pre-A3 status-flip behavior — still loaded so per-phase pill
+       clicks open the inline editor. A future PR can fold its logic
+       into specs_refined.js if the surfaces converge. #}
+    <script src="{{ url_for('static', path='js/specs.js') }}?v={{ attune_version }}"></script>
+    {% if specs_candidates_enabled %}
+      <script src="{{ url_for('static', path='js/completion_candidates.js') }}?v={{ attune_version }}"></script>
+    {% endif %}
+  {% endif %}
 {% endblock %}

--- a/tests/unit/ops/test_specs_dashboard.py
+++ b/tests/unit/ops/test_specs_dashboard.py
@@ -87,8 +87,12 @@ def test_specs_page_writeable_mode_shows_editable_pills(tmp_path):
     client = _client(tmp_path, specs_roots=(root,), allow_run=True)
     r = client.get("/specs")
     assert r.status_code == 200
-    # No inline <select> — that's now created client-side on click.
-    assert "<select" not in r.text
+    # No inline status-edit <select> inside the table body — those are
+    # created client-side on pill click. The toolbar's sort <select>
+    # (added in A3a) is a navigation control, not a status mutation,
+    # so it sits outside <tbody> by construction.
+    tbody = r.text.split("<tbody>", 1)[1].split("</tbody>", 1)[0]
+    assert "<select" not in tbody
     # Pills carry the writeable markers so specs.js can wire click-to-edit.
     assert "status-pill-editable" in r.text
     assert 'role="button"' in r.text
@@ -99,14 +103,21 @@ def test_specs_page_writeable_mode_shows_editable_pills(tmp_path):
     assert 'data-original="draft"' in r.text
 
 
-def test_specs_page_readonly_mode_no_dropdowns(tmp_path):
-    """allow_run=False → no <select> elements, plain chips only."""
+def test_specs_page_readonly_mode_no_status_dropdowns(tmp_path):
+    """allow_run=False → no status-edit dropdowns inside the table body.
+
+    The toolbar's sort <select> (A3a) is always present regardless of
+    allow_run — it's a navigation control. What read-only mode forbids
+    is per-pill status mutation, which would render as a <select>
+    inside the spec table's <tbody>.
+    """
     root = tmp_path / "specs"
     _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
     client = _client(tmp_path, specs_roots=(root,), allow_run=False)
     r = client.get("/specs")
     assert r.status_code == 200
-    assert "<select" not in r.text
+    tbody = r.text.split("<tbody>", 1)[1].split("</tbody>", 1)[0]
+    assert "<select" not in tbody
     assert "Read-only mode" in r.text
 
 

--- a/tests/unit/ops/test_specs_routes.py
+++ b/tests/unit/ops/test_specs_routes.py
@@ -277,6 +277,130 @@ def test_list_specs_lifecycle_matches_bucket_cascade(tmp_path, monkeypatch):
     assert lifecycles["draft-spec"] == "draft"
 
 
+def test_specs_html_page_includes_bucket_chip_row(tmp_path, monkeypatch):
+    """A3a — chip filter row with all 6 buckets renders on /specs.
+
+    The toolbar is server-rendered (data-bucket + count attributes),
+    JS attaches behavior on load. All 6 chips are always present even
+    when the bucket count is zero — that's a UX choice so chips don't
+    pop in/out as data shifts.
+    """
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "smoke",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+
+    client = _client(tmp_path)
+    response = client.get("/specs")
+    assert response.status_code == 200
+    body = response.text
+    # All 6 bucket chips render — even buckets with 0 count.
+    for bucket in (
+        "active",
+        "approved-not-shipped",
+        "complete",
+        "paused",
+        "stale",
+        "draft",
+    ):
+        assert f'data-bucket="{bucket}"' in body, f"missing chip for {bucket}"
+        assert f'data-count="{bucket}"' in body, f"missing count slot for {bucket}"
+    # Default chip state per decisions.md: all-active except Complete.
+    # Complete chip has `chip-inactive` class; others have `chip-active`.
+    # Just smoke-check the Complete chip is inactive — full default-state
+    # behavior is in the JS, which is source-grep tested below.
+    assert "chip-inactive" in body
+
+
+def test_specs_html_page_includes_lifecycle_column(tmp_path, monkeypatch):
+    """A3a — each spec row gets a lifecycle badge with the derived bucket."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "draft-only",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+
+    client = _client(tmp_path)
+    body = client.get("/specs").text
+    # Row carries data-bucket so the JS can filter without re-fetching.
+    assert 'data-bucket="draft"' in body  # both the chip and the row
+    # The lifecycle badge renders with the derived bucket class.
+    assert "lifecycle-badge" in body
+    assert "lifecycle-draft" in body
+
+
+def test_specs_html_page_includes_search_and_sort(tmp_path, monkeypatch):
+    """A3a — toolbar carries search input and sort select.
+
+    URL persistence ships in A3c — these controls work client-side
+    only for now.
+    """
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "smoke",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+
+    client = _client(tmp_path)
+    body = client.get("/specs").text
+    assert 'id="specs-search"' in body
+    assert 'id="specs-sort"' in body
+    # All 3 sort options present.
+    for opt in ("recent", "alpha", "oldest"):
+        assert f'value="{opt}"' in body
+
+
+def test_specs_refined_js_exposes_expected_api():
+    """A3a — specs_refined.js exposes the documented surface.
+
+    Source-grep test mirroring the test_runner_js_parsing convention.
+    Future PRs (A3b kebab integration, A3c URL params) hook the same
+    state/surface — this guards against accidental removal.
+    """
+    js_path = (
+        Path(__file__).parent.parent.parent.parent
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "specs_refined.js"
+    )
+    js_text = js_path.read_text(encoding="utf-8")
+    # Exports namespace.
+    assert "window.__attuneSpecs" in js_text
+    # Documented surface — A3c will hook state.buckets; A3b may hook init.
+    for name in (
+        "DEFAULT_BUCKETS",
+        "state",
+        "applyFilters",
+        "applySort",
+        "setChipState",
+        "init",
+    ):
+        assert name in js_text, f"missing export: {name}"
+    # Default bucket set must match decisions.md (all-on except Complete).
+    for bucket in (
+        "active",
+        "approved-not-shipped",
+        "paused",
+        "stale",
+        "draft",
+    ):
+        assert f'"{bucket}"' in js_text, f"missing default bucket: {bucket}"
+    # Complete must NOT be in DEFAULT_BUCKETS — it's the only chip
+    # that's default-off per R1.3.
+    default_block = js_text.split("DEFAULT_BUCKETS", 1)[1].split("]", 1)[0]
+    assert "complete" not in default_block.lower()
+
+
 def test_specs_html_page_renders_with_lifecycle_in_context(tmp_path, monkeypatch):
     """`/specs` HTML page renders 200 and each spec's dict carries a lifecycle.
 


### PR DESCRIPTION
## Summary

A3a of [ops-specs-page-refinement](docs/specs/ops-specs-page-refinement/) — first visible UI change. The Specs page now ships the toolbar (chip filter row + search + sort) and the lifecycle badge column. URL persistence still defers to A3c; kebab action menu to A3b.

**What you can do on the page now:**

- Filter by lifecycle bucket via the chip row (default: all on except Complete per [decisions.md R1.3](docs/specs/ops-specs-page-refinement/decisions.md))
- Substring-search slugs within active buckets
- Sort by Recently updated / Alphabetical / Oldest untouched
- See each spec's derived lifecycle bucket as a colored badge
- Empty-state guidance when filters/search return zero rows

**What's deferred (per the split):**

- **A3b** — kebab `⋯` action column (Open in editor / Copy slug / View linked PRs)
- **A3c** — URL param parsing (`?bucket=active,paused&sort=alpha&q=rag`) + chip-state-from-URL on first paint

## Wireframe scope tracker

| Phase | Scope | Status |
|---|---|---|
| A1 ([#533](https://github.com/Smart-AI-Memory/attune-ai/pull/533)) | Lifecycle module + 43 unit tests | ✅ merged |
| A2 ([#534](https://github.com/Smart-AI-Memory/attune-ai/pull/534)) | Route serializer + SpecRecord wiring | ✅ merged |
| **A3a (this PR)** | **Toolbar + lifecycle badge + JS filter/search/sort** | **🟡 open** |
| A3b | Kebab `⋯` actions | 🔲 |
| A3c | URL param parsing | 🔲 |

## Implementation notes

**CSS scoping.** The existing `.chip` class is used by tier chips (CHEAP/CAPABLE/PREMIUM), runner status chips (completed/failed), and others. All new chip styles are scoped via `.specs-toolbar .chip` to avoid collision. New `.lifecycle-badge` class for per-row bucket display.

**Server-side bucket counts.** `routes/dashboard.py` computes `bucket_counts` per page render. All 6 keys are always present (count 0 for empty buckets) so chips don't pop in/out as data shifts.

**JS surface.** `specs_refined.js` exposes `window.__attuneSpecs` with `{DEFAULT_BUCKETS, state, applyFilters, applySort, setChipState, init}`. This is the hook surface A3c uses for URL params and A3b for kebab integration. Same shape as the existing `window.__attuneRunner` (per the runner.js pattern).

**Phase pill survival.** The 4 phase pills survive — compacted from 4 columns to 1 cell with a `D·R·D·T` axis label. Click-to-flip behavior preserved via the existing `specs.js`. The new bucket badge is in its own Lifecycle column.

## What to eyeball when reviewing

1. **Chip colors per bucket** — Active blue, Approved-not-shipped purple, Complete green, Paused yellow, Stale amber-orange (distinct from Paused), Draft grey.
2. **Default chip state** — Complete chip should render greyed with a small `✗` marker; all others active.
3. **Compact phase pills** — Look at any row's Phases column. The 4 pills should fit comfortably side-by-side, not wrap.
4. **Lifecycle badge** — Should be a small colored pill matching the chip palette of its bucket.
5. **Empty states** — Click all chips off (you'll see "All buckets filtered out"). Or type `zzzzzz` in search (you'll see "No matches").
6. **Reset button** — Should restore the default chip set and clear search.

## Test plan

- [x] Local pytest (`tests/unit/ops/test_specs_routes.py`) — 50 pass, 0 fail
- [x] Ruff clean
- [x] Smoke-tested in preview: chips, search, sort, empty states, reset all work
- [ ] CI green across the matrix
- [ ] Codecov patch coverage ≥ 95%
- [ ] **Patrick's eyeball** on the rendered page (the B option I'm running on — assembled UI review at the end of A3a/b/c, not between each)

## Smoke verification snapshot

From the preview server during development:

- 54 specs total
- Active 14 / Approved-not-shipped 11 / Complete 5 / Paused 1 / Stale 0 / Draft 23 = 54 ✓
- Search "rag" → 4 matches
- All chips off → 0 visible + "All buckets filtered out" empty state
- Reset button → 49 visible (Complete still off by default)
