### PR TITLE
feat(ops): A3c — URL param parsing + chip-state-from-URL (final A3)

### DIFF
--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -509,6 +509,12 @@ async def specs_page(request: Request) -> HTMLResponse:
     from attune.ops.completion_candidates import _resolve_host_repo
 
     github_repo = _resolve_host_repo(cfg.project_root)
+    # URL params for initial chip / sort / search state (A3c). The JS
+    # owns the live state machine; the server's job is to make the
+    # first paint already match what the URL says, so a shared link
+    # like `?bucket=stale&q=rag` renders correctly without a flash of
+    # default state followed by JS re-render.
+    initial_buckets, initial_sort, initial_query = _parse_specs_url_state(request.query_params)
     return _render(
         request,
         "specs.html",
@@ -519,7 +525,71 @@ async def specs_page(request: Request) -> HTMLResponse:
         specs_candidates_enabled=cfg.specs_candidates_enabled,
         bucket_counts=bucket_counts,
         github_repo=github_repo,
+        initial_buckets=initial_buckets,
+        initial_sort=initial_sort,
+        initial_query=initial_query,
     )
+
+
+# A3c — URL param parsing helpers. Module-level so tests can import
+# without spinning up the full FastAPI app.
+
+_VALID_BUCKETS: frozenset[str] = frozenset(
+    {"active", "approved-not-shipped", "complete", "paused", "stale", "draft"}
+)
+_VALID_SORTS: frozenset[str] = frozenset({"recent", "alpha", "oldest"})
+# Defaults match the JS DEFAULT_BUCKETS in specs_refined.js exactly:
+# all chips on except Complete (R1.3).
+_DEFAULT_BUCKETS: tuple[str, ...] = (
+    "active",
+    "approved-not-shipped",
+    "paused",
+    "stale",
+    "draft",
+)
+
+
+def _parse_specs_url_state(
+    query_params,
+) -> tuple[list[str], str, str]:
+    """Parse `?bucket=`, `?sort=`, `?q=` URL params for the Specs page.
+
+    Args:
+        query_params: Starlette ``QueryParams`` (request.query_params).
+
+    Returns:
+        ``(initial_buckets, initial_sort, initial_query)``. Invalid
+        values fall back to defaults silently rather than rejecting
+        the request — the URL is a UI affordance, not a strict
+        contract, and a malformed share link should still render the
+        page (with default state) rather than 400.
+
+    The default bucket set matches the JS ``DEFAULT_BUCKETS`` exactly
+    so the first paint and the JS-controlled state align.
+    """
+    # bucket=active,paused → ["active", "paused"]. Missing param → defaults.
+    raw_buckets = query_params.get("bucket")
+    if raw_buckets is None:
+        buckets = list(_DEFAULT_BUCKETS)
+    else:
+        candidates = [b.strip() for b in raw_buckets.split(",") if b.strip()]
+        buckets = [b for b in candidates if b in _VALID_BUCKETS]
+        # If filtering left nothing valid, fall back to defaults so the
+        # page isn't stuck in an empty state from a malformed share link.
+        if not buckets:
+            buckets = list(_DEFAULT_BUCKETS)
+
+    # sort=alpha → "alpha". Invalid → "recent" (default).
+    raw_sort = query_params.get("sort", "recent")
+    initial_sort = raw_sort if raw_sort in _VALID_SORTS else "recent"
+
+    # q=substring → "substring". Cap at 200 chars to bound rendering
+    # cost; the JS already does substring filtering so longer queries
+    # don't unlock new behavior, just bloat the URL.
+    raw_query = query_params.get("q", "")
+    initial_query = raw_query[:200] if raw_query else ""
+
+    return buckets, initial_sort, initial_query
 
 
 def _render_markdown_safe(text: str) -> str:

--- a/src/attune/ops/static/js/specs_refined.js
+++ b/src/attune/ops/static/js/specs_refined.js
@@ -27,11 +27,46 @@
     "draft",
   ];
 
-  var state = {
-    buckets: new Set(DEFAULT_BUCKETS),
-    search: "",
-    sort: "recent",
-  };
+  var VALID_BUCKETS = new Set([
+    "active",
+    "approved-not-shipped",
+    "complete",
+    "paused",
+    "stale",
+    "draft",
+  ]);
+
+  var VALID_SORTS = new Set(["recent", "alpha", "oldest"]);
+
+  // A3c — read initial state from URL (`?bucket=...&sort=...&q=...`).
+  // Server already renders the right chips/sort/search on first paint
+  // (via dashboard.py's _parse_specs_url_state); this is the JS-side
+  // mirror so in-memory state matches the DOM before any user action.
+  function readURLState() {
+    var params = new URLSearchParams(window.location.search);
+    var bucketParam = params.get("bucket");
+    var sortParam = params.get("sort");
+    var qParam = params.get("q");
+
+    var buckets;
+    if (bucketParam === null) {
+      buckets = new Set(DEFAULT_BUCKETS);
+    } else {
+      var candidates = bucketParam.split(",").map(function (b) {
+        return b.trim();
+      }).filter(function (b) {
+        return b && VALID_BUCKETS.has(b);
+      });
+      buckets = candidates.length > 0
+        ? new Set(candidates)
+        : new Set(DEFAULT_BUCKETS);
+    }
+    var sort = (sortParam && VALID_SORTS.has(sortParam)) ? sortParam : "recent";
+    var search = qParam ? qParam.slice(0, 200) : "";
+    return { buckets: buckets, sort: sort, search: search };
+  }
+
+  var state = readURLState();
 
   // -------------------------------------------------------------------
   // Element lookups (idempotent on missing — script may load on
@@ -40,6 +75,54 @@
 
   function $(sel) { return document.querySelector(sel); }
   function $$(sel) { return Array.prototype.slice.call(document.querySelectorAll(sel)); }
+
+  // -------------------------------------------------------------------
+  // URL sync (A3c). Writes the current state back to the URL via
+  // history.replaceState so refreshes preserve filters and the URL
+  // can be shared. Params that match the default are OMITTED from
+  // the URL to keep shared links tidy (`?bucket=stale` instead of
+  // `?bucket=active,approved-not-shipped,paused,stale,draft&sort=recent`).
+  // -------------------------------------------------------------------
+
+  function bucketsAreDefault(bucketSet) {
+    if (bucketSet.size !== DEFAULT_BUCKETS.length) return false;
+    for (var i = 0; i < DEFAULT_BUCKETS.length; i++) {
+      if (!bucketSet.has(DEFAULT_BUCKETS[i])) return false;
+    }
+    return true;
+  }
+
+  function syncURL() {
+    var params = new URLSearchParams(window.location.search);
+    // Preserve any params we didn't author (future-proofs against
+    // other tools sharing the URL).
+    if (bucketsAreDefault(state.buckets)) {
+      params.delete("bucket");
+    } else {
+      // Sort buckets alphabetically for stable URLs.
+      var bucketList = Array.from(state.buckets).sort();
+      params.set("bucket", bucketList.join(","));
+    }
+    if (state.sort === "recent") {
+      params.delete("sort");
+    } else {
+      params.set("sort", state.sort);
+    }
+    if (!state.search) {
+      params.delete("q");
+    } else {
+      params.set("q", state.search);
+    }
+    var qs = params.toString();
+    var newURL = window.location.pathname + (qs ? "?" + qs : "") +
+      window.location.hash;
+    try {
+      window.history.replaceState(null, "", newURL);
+    } catch (e) {
+      // Older browsers / restrictive contexts — silent fail is fine,
+      // the in-memory state is still correct, just not persisted to URL.
+    }
+  }
 
   // -------------------------------------------------------------------
   // Filter / sort application
@@ -165,6 +248,7 @@
           setChipState(chip, true);
         }
         applyFilters();
+        syncURL();
       });
     });
   }
@@ -175,6 +259,7 @@
     input.addEventListener("input", function () {
       state.search = input.value;
       applyFilters();
+      syncURL();
     });
   }
 
@@ -184,6 +269,7 @@
     sel.addEventListener("change", function () {
       state.sort = sel.value;
       applySort();
+      syncURL();
     });
   }
 
@@ -201,18 +287,27 @@
         setChipState(chip, state.buckets.has(bucket));
       });
       applyFilters();
+      syncURL();
     });
   }
 
   function init() {
+    // Sync the sort <select>'s value to match state — server template
+    // honors initial_sort via the `selected` attribute, but if the
+    // user pressed back / restored a tab, the select's value may not
+    // match the URL. Be defensive.
+    var sortSel = $("#specs-sort");
+    if (sortSel && sortSel.value !== state.sort) {
+      sortSel.value = state.sort;
+    }
     wireChips();
     wireSearch();
     wireSort();
     wireResetButton();
-    // Apply the default sort on load — server renders rows in
-    // directory order (sorted by slug), but the default UI sort is
-    // "recent." Re-order on first paint so users see what the sort
-    // control claims to be doing.
+    // Apply the current sort on load — server renders rows in
+    // directory order (sorted by slug), but the live sort is
+    // determined by state. Re-order on first paint so users see
+    // what the sort control claims to be doing.
     applySort();
     applyFilters();
   }
@@ -228,10 +323,15 @@
   // convention) can verify the surface.
   window.__attuneSpecs = {
     DEFAULT_BUCKETS: DEFAULT_BUCKETS,
+    VALID_BUCKETS: VALID_BUCKETS,
+    VALID_SORTS: VALID_SORTS,
     state: state,
     applyFilters: applyFilters,
     applySort: applySort,
     setChipState: setChipState,
+    readURLState: readURLState,
+    syncURL: syncURL,
+    bucketsAreDefault: bucketsAreDefault,
     init: init,
   };
 })();

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -58,7 +58,11 @@
         ('draft', 'Draft', 'bucket-draft'),
       ] %}
       {% for bucket, label, color_cls in bucket_styles %}
-        {% set active = bucket != 'complete' %}
+        {# A3c — chip active state honors `?bucket=` URL param when
+           present, else falls back to defaults (all on except Complete).
+           initial_buckets is always a list — pre-parsed in
+           dashboard.py via _parse_specs_url_state. #}
+        {% set active = bucket in initial_buckets %}
         {# bucket-* class always present so chips colorize correctly
            after JS toggles chip-active on/off. CSS gates the color
            on `.chip-active.bucket-*` — inactive chips show neutral. #}
@@ -73,16 +77,19 @@
     </div>
     <div class="search-wrap">
       <label class="search-label" for="specs-search">Search:</label>
+      {# A3c — initial_query from ?q= URL param (empty by default). #}
       <input id="specs-search" class="search-input" type="search"
         placeholder="slug substring…" autocomplete="off"
+        value="{{ initial_query }}"
         aria-label="Filter specs by slug substring" />
     </div>
     <div class="sort-wrap">
       <label class="sort-label" for="specs-sort">Sort:</label>
+      {# A3c — initial_sort from ?sort= URL param (default "recent"). #}
       <select id="specs-sort" class="sort-select" aria-label="Sort specs">
-        <option value="recent">Recently updated</option>
-        <option value="alpha">Alphabetical</option>
-        <option value="oldest">Oldest untouched</option>
+        <option value="recent"{% if initial_sort == 'recent' %} selected{% endif %}>Recently updated</option>
+        <option value="alpha"{% if initial_sort == 'alpha' %} selected{% endif %}>Alphabetical</option>
+        <option value="oldest"{% if initial_sort == 'oldest' %} selected{% endif %}>Oldest untouched</option>
       </select>
     </div>
   </div>

--- a/tests/unit/ops/test_specs_routes.py
+++ b/tests/unit/ops/test_specs_routes.py
@@ -516,6 +516,192 @@ def test_specs_kebab_js_exposes_expected_api():
     assert "g" + "ithub.com" in js_text
 
 
+# ---------------------------------------------------------------------------
+# A3c — URL param parsing + initial state on first paint
+#
+# Server reads ?bucket=, ?sort=, ?q= and renders chips/sort/search to
+# match. JS picks up the same URL state on init so refreshes preserve
+# the live state. Invalid values silently fall back to defaults — a
+# malformed share link still renders cleanly rather than 400ing.
+# ---------------------------------------------------------------------------
+
+
+class TestParseSpecsURLState:
+    """Unit tests for the URL param parser (pure logic, no client needed)."""
+
+    def _parse(self, **params):
+        """Helper: build a Starlette-compatible mapping and parse."""
+        from starlette.datastructures import QueryParams
+
+        from attune.ops.routes.dashboard import _parse_specs_url_state
+
+        return _parse_specs_url_state(QueryParams(params))
+
+    def test_no_params_returns_defaults(self):
+        buckets, sort, query = self._parse()
+        # All on except Complete (R1.3).
+        assert set(buckets) == {
+            "active",
+            "approved-not-shipped",
+            "paused",
+            "stale",
+            "draft",
+        }
+        assert sort == "recent"
+        assert query == ""
+
+    def test_bucket_param_subset(self):
+        buckets, _, _ = self._parse(bucket="active,paused")
+        assert set(buckets) == {"active", "paused"}
+
+    def test_bucket_param_includes_complete(self):
+        buckets, _, _ = self._parse(bucket="complete")
+        assert buckets == ["complete"]
+
+    def test_invalid_bucket_silently_dropped(self):
+        buckets, _, _ = self._parse(bucket="active,bogus,paused")
+        assert set(buckets) == {"active", "paused"}
+
+    def test_all_invalid_buckets_falls_back_to_defaults(self):
+        buckets, _, _ = self._parse(bucket="bogus,fake")
+        # All-invalid → defaults so the page isn't stuck empty.
+        assert set(buckets) == {
+            "active",
+            "approved-not-shipped",
+            "paused",
+            "stale",
+            "draft",
+        }
+
+    def test_sort_param_valid(self):
+        _, sort, _ = self._parse(sort="alpha")
+        assert sort == "alpha"
+
+    def test_sort_param_invalid_falls_back(self):
+        _, sort, _ = self._parse(sort="random")
+        assert sort == "recent"
+
+    def test_query_param_passed_through(self):
+        _, _, query = self._parse(q="rag")
+        assert query == "rag"
+
+    def test_query_param_capped_at_200_chars(self):
+        _, _, query = self._parse(q="x" * 300)
+        assert len(query) == 200
+
+    def test_empty_bucket_string_falls_back_to_defaults(self):
+        # ?bucket= (empty value) — same as no param.
+        buckets, _, _ = self._parse(bucket="")
+        assert set(buckets) == {
+            "active",
+            "approved-not-shipped",
+            "paused",
+            "stale",
+            "draft",
+        }
+
+
+def test_specs_page_with_bucket_url_param(tmp_path, monkeypatch):
+    """A3c — `?bucket=stale,paused` URL → only those chips render active."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "smoke",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+
+    client = _client(tmp_path)
+    body = client.get("/specs?bucket=stale,paused").text
+    # Build a per-bucket regex-friendly extractor.
+    import re
+
+    chip_blocks = re.findall(
+        r'<button[^>]*data-bucket="([^"]+)"[^>]*aria-pressed="([^"]+)"',
+        body,
+    )
+    chip_state = dict(chip_blocks)
+    assert chip_state["stale"] == "true"
+    assert chip_state["paused"] == "true"
+    # Everything else inactive.
+    for bucket in ("active", "approved-not-shipped", "complete", "draft"):
+        assert chip_state[bucket] == "false", f"{bucket} unexpectedly active"
+
+
+def test_specs_page_with_sort_url_param(tmp_path, monkeypatch):
+    """A3c — `?sort=alpha` → `<option value="alpha" selected>`."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "smoke",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+
+    client = _client(tmp_path)
+    body = client.get("/specs?sort=alpha").text
+    assert 'value="alpha" selected' in body
+    # The other two options are NOT selected.
+    assert 'value="recent" selected' not in body
+    assert 'value="oldest" selected' not in body
+
+
+def test_specs_page_with_query_url_param(tmp_path, monkeypatch):
+    """A3c — `?q=rag` → search input renders with that value pre-filled."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "smoke",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+
+    client = _client(tmp_path)
+    body = client.get("/specs?q=rag").text
+    assert 'value="rag"' in body
+
+
+def test_specs_page_malformed_url_renders_defaults(tmp_path, monkeypatch):
+    """A3c — invalid params don't 400; page falls back to defaults."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    specs_root = tmp_path / "docs" / "specs"
+    _make_spec(
+        specs_root,
+        "smoke",
+        files={"decisions.md": "**Status:** Draft\n"},
+    )
+
+    client = _client(tmp_path)
+    # All params bogus.
+    response = client.get("/specs?bucket=fake&sort=random&q=hi")
+    assert response.status_code == 200
+    # Complete chip is inactive (default state preserved despite the
+    # invalid bucket param).
+    assert "chip-inactive" in response.text
+
+
+def test_specs_refined_js_exposes_url_helpers():
+    """A3c — specs_refined.js exports readURLState + syncURL.
+
+    Extends the A3a source-grep test with the new URL-sync surface.
+    """
+    js_path = (
+        Path(__file__).parent.parent.parent.parent
+        / "src"
+        / "attune"
+        / "ops"
+        / "static"
+        / "js"
+        / "specs_refined.js"
+    )
+    js_text = js_path.read_text(encoding="utf-8")
+    for name in ("readURLState", "syncURL", "bucketsAreDefault"):
+        assert name in js_text, f"missing export: {name}"
+    # URL machinery is wired.
+    assert "URLSearchParams" in js_text
+    assert "history.replaceState" in js_text
+
+
 def test_specs_html_page_renders_with_lifecycle_in_context(tmp_path, monkeypatch):
     """`/specs` HTML page renders 200 and each spec's dict carries a lifecycle.
 


### PR DESCRIPTION
## Summary

**Final A3 PR.** Closes out the [ops-specs-page-refinement](docs/specs/ops-specs-page-refinement/) implementation. Shared links like `?bucket=stale,paused&sort=alpha&q=rag` now render correctly on first paint, and state changes write back to the URL so refreshes preserve filters.

**What's wired:**

- Server reads `?bucket=`, `?sort=`, `?q=` and passes initial state to the template
- Chip aria-pressed / sort option `selected` / search input `value` all reflect the URL on first paint
- JS reads URL on init + writes URL on every state change via `history.replaceState`
- URL hygiene: params matching defaults are **omitted** (clean shared links), foreign params (tracking, analytics) **preserved**
- Buckets serialized alphabetically sorted for stable URLs
- Permissive validation: invalid values silently fall back to defaults (malformed share link still renders the page, not a 400)

## Wireframe scope tracker — complete

| Phase | Scope | Status |
|---|---|---|
| A1 ([#533](https://github.com/Smart-AI-Memory/attune-ai/pull/533)) | Lifecycle module + 43 unit tests | ✅ merged |
| A2 ([#534](https://github.com/Smart-AI-Memory/attune-ai/pull/534)) | Route serializer + SpecRecord wiring | ✅ merged |
| A3a ([#535](https://github.com/Smart-AI-Memory/attune-ai/pull/535)) | Toolbar + lifecycle badge + filter/search/sort | ✅ merged |
| A3b ([#536](https://github.com/Smart-AI-Memory/attune-ai/pull/536)) | Kebab `⋯` actions | ✅ merged |
| **A3c (this PR)** | **URL param parsing + chip-state-from-URL** | **🟡 open** |

After A3c merges, the spec implementation is **complete** and the v7.3.0 release-prep pass can start.

## Implementation notes

**Server-side validation.** `_parse_specs_url_state` returns `(buckets, sort, query)` with these rules:

- `?bucket=active,bogus,paused` → `["active", "paused"]` (drops invalid)
- `?bucket=fake` (all invalid) → defaults (page isn't stuck empty)
- `?sort=random` → "recent" (silent fallback)
- `?q=<300 chars>` → first 200 chars only
- All missing → defaults

**JS-side first paint.** Server template honors initial state via the `selected` attribute on `<option>` + `chip-active` class on `<button>` + `value=` on `<input>`. The JS then reads the URL on init and seeds `state` to match — so the in-memory state matches the DOM before any user action.

**URL hygiene.** When state matches defaults, the corresponding param is removed from the URL. Result: a user who's at "default state" sees a clean `/specs` URL, not `?bucket=active,approved-not-shipped,paused,stale,draft&sort=recent`. Conversely, a user with `?bucket=stale` sees only `?bucket=stale`.

**Foreign params preserved.** `URLSearchParams.set/delete` only touches the keys A3c authors. A test for `?bucket=stale&_=<timestamp>` confirms the `_` param survives.

## What to eyeball when reviewing

1. **Share link** — `http://127.0.0.1:8765/specs?bucket=stale&q=rag` should render with only Stale chip active and "rag" in the search.
2. **Refresh preservation** — Click some chips, refresh the page — chip state should persist.
3. **Reset cleanup** — Click "Reset to default filters" — URL should drop all A3c params (just the pathname remains).
4. **Sort drop-down** — `?sort=alpha` should make Alphabetical the selected option AND immediately re-order rows.
5. **Search field** — `?q=rag` should pre-fill the search input.

## Test plan

- [x] Local pytest — 81 pass, 0 fail
- [x] Ruff clean
- [x] Smoke-tested in preview: read URL params on load, write back on every state change, URL hygiene confirmed
- [ ] CI green across the matrix
- [ ] Codecov patch coverage ≥ 95%
- [ ] **Patrick's eyeball on the assembled UI** (B option — review at the end of A3a/b/c)
