### PR TITLE
ci(docs): wiring-audit job in advisory mode (Task 7)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,11 +7,17 @@ on:
       - 'docs/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
+      # wiring-audit job — also fire on source / script changes that
+      # could break docs references (anchor links, mkdocstrings symbols).
+      - 'src/**'
+      - 'scripts/audit_docs_wiring.py'
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'src/**'
+      - 'scripts/audit_docs_wiring.py'
   workflow_dispatch:
 
 permissions:
@@ -22,6 +28,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Wiring-audit job — advisory mode per docs/specs/docs-wiring-audit/
+  # tasks.md Task 7. NOT yet in required_status_checks; Task 8 will
+  # promote once main has held 3 consecutive green runs. Script is
+  # stdlib-only so this job needs no dependency install — just
+  # checkout + a Python interpreter (any 3.10+).
+  wiring-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Run wiring audit
+        run: python scripts/audit_docs_wiring.py --format json
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,11 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
+          # No actual install needed (script is stdlib-only) but the
+          # `cache: pip` field is required by the repo-wide CI guard
+          # in tests/unit/ci/test_workflow_yaml.py::TestPipCaching.
+          # Cache is a no-op here — there's nothing to cache.
+          cache: 'pip'
 
       - name: Run wiring audit
         run: python scripts/audit_docs_wiring.py --format json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,6 +375,37 @@ Update documentation when:
 - **Docstrings**: In-code documentation
 - **CONTRIBUTING.md**: This file
 
+### Documentation wiring audit (advisory CI)
+
+A `wiring-audit` job in `.github/workflows/docs.yml` runs
+[`scripts/audit_docs_wiring.py`](scripts/audit_docs_wiring.py)
+on every PR that touches `docs/`, `mkdocs.yml`, `src/`, or the
+audit script itself. The check is **advisory** for now — failures
+do NOT block merge. After the audit holds green on `main` for 3
+consecutive PRs, it will be promoted to a required status check
+(per `docs/specs/docs-wiring-audit/tasks.md` Task 8).
+
+**Run locally** (stdlib-only, no deps required):
+
+```bash
+python scripts/audit_docs_wiring.py            # human-readable
+python scripts/audit_docs_wiring.py --format json  # CI shape
+python scripts/audit_docs_wiring.py --check anchor # specific check
+```
+
+**Findings to expect:**
+
+- **anchor** — broken `[link](file.md#anchor)` references where
+  the anchor doesn't exist in the target file.
+- **nav** — pages on disk that aren't reachable from any nav
+  entry in `mkdocs.yml`.
+- **features-yaml** — entries in `.help/features.yaml` whose
+  referenced doc paths don't exist.
+
+If a PR's audit fails, the job log lists each finding with the
+source location. Fix at the source, or open a follow-up issue
+if the finding is intentional (legacy redirect, etc.).
+
 ### Writing Examples
 
 Good examples are:

--- a/docs/specs/docs-wiring-audit/tasks.md
+++ b/docs/specs/docs-wiring-audit/tasks.md
@@ -225,7 +225,7 @@ the same branch.
 
 ---
 
-### Task 7 — CI integration (advisory mode)
+### Task 7 — CI integration (advisory mode) — **done 2026-06-01**
 
 **Goal:** add the `wiring-audit` job to
 `.github/workflows/docs.yml` per [design.md §6](./design.md#artifact-6-ci-integration).


### PR DESCRIPTION
## Summary

Task 7 of [docs-wiring-audit](docs/specs/docs-wiring-audit/) — wires the existing `scripts/audit_docs_wiring.py` into CI as an advisory check. Findings will show up on PRs but do NOT block merge yet. Task 8 promotes to a required status check after main holds green for 3 consecutive PRs.

## Changes

- **`.github/workflows/docs.yml`** — new `wiring-audit` job (stdlib-only, no install step, ~5min timeout). Path triggers expanded to include `src/**` + the script itself so code changes that break doc anchors fire the audit too.
- **`CONTRIBUTING.md`** — new "Documentation wiring audit" subsection under Documentation explaining the job, local run commands, and what the 3 check types find.
- **`docs/specs/docs-wiring-audit/tasks.md`** — marks Task 7 done.

## Why advisory-only for now

Per the spec design.md: "Add `wiring-audit` to `required_status_checks` in branch protection ONLY after v1 is green on `main`. Avoid launching with the check failing — that creates immediate red CI on every PR and erodes the signal."

Verified locally — `python scripts/audit_docs_wiring.py --format json` exits 0 with zero findings on main, so the job will be green from day one.

## Test plan

- [x] YAML syntax valid (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] Script runs clean on main with exit 0
- [ ] CI green on this PR (the new job runs on itself)
- [ ] Pre-existing path filter still triggers `build` + `deploy` correctly
