### PR TITLE
chore(release): v7.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "7.2.0"
+    "version": "7.3.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "7.2.0",
+      "version": "7.3.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v7.2.0
+# Attune AI Framework v7.3.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 7.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 7.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/.help/templates/plugin/concept.md
+++ b/.help/templates/plugin/concept.md
@@ -1,64 +1,37 @@
 ---
-type: concept
-name: plugin-concept
 feature: plugin
 depth: concept
-generated_at: 2026-05-27T13:42:27.323011+00:00
-source_hash: ff7ee791016c71dc1aca7ef059da6fba3d0f06aa842c544cc71910c9900d0b2f
+generated_at: 2026-06-01T11:22:16.304320+00:00
+source_hash: dabe4c5a604a6dee1873da9c2239b8ea78416f31b4bdf292d61a93fe213be717
 status: generated
 ---
 
 # Plugin
 
-The attune plugin is a collection of hooks, slash commands, and MCP configuration that runs inside Claude Code to maintain session continuity, enforce security boundaries, and surface workspace context at the right moment.
+## How it works
 
-## Core responsibilities
+Claude Code plugin — skills, hooks, commands, and MCP config.
 
-The plugin operates through a set of focused entry points, each fired at a specific moment in the Claude Code lifecycle:
+The main building blocks are:
 
-| Hook module | When it runs | What it does |
-|---|---|---|
-| `hooks.welcome` | Session start | Orients you to the current workspace |
-| `hooks.spec_orient` | Session start | Summarizes in-flight specs from `~/attune` |
-| `hooks.format_on_save` | File save | Runs the formatter on changed files |
-| `hooks.compact_warning` | Context growth | Warns when transcript utilization approaches the limit |
-| `hooks.help_on_error` | Tool error | Surfaces relevant help for the failing operation |
-| `hooks.help_post_commit` | Git commit | Suggests next steps after a commit |
-| `hooks.help_freshness_check` | Session start | Checks whether cached help content is stale |
-| `hooks.security_guard` | Before tool use | Validates bash commands and file paths before execution |
-| `hooks._handoff_cli` | `/handoff` command | Builds a handoff summary for session transitions |
+- **`SpecInfo`** — One in-flight spec discovered under a workspace root.
+- **`GitState`** — Snapshot of the worktree's git state at hook fire time.
 
-## Mental model
+Under the hood, this feature spans 964 source
+files covering:
 
-Think of the plugin as a thin event bus between Claude Code and your workspace. Each hook reads shared state — git history, open specs, transcript size — and either blocks an action, emits a prompt insertion, or exits silently. No hook carries persistent state of its own; they all read from the same sources at fire time.
+- CLI wrapper for the ``/handoff`` slash command.
+- Resume-prompt builder — single source of truth for the format.
+- Shared state-discovery helpers for session-continuity hooks.
 
-Two dataclasses carry that shared state:
+## What connects to it
 
-- **`SpecInfo`** (`slug`, `path`, `layer`, `phase`, `status`, `mtime`) — represents one in-flight spec discovered under a workspace root. `discover_specs(roots)` walks `specs/` directories and returns a list of these.
-- **`GitState`** (`branch`, `last_sha`, `last_subject`, `uncommitted`) — a snapshot of the worktree at the moment a hook fires. `git_state(cwd)` populates it.
+This feature relates to: plugin, claude-code.
 
-A typical hook call looks like this:
+Other parts of the codebase interact with
+plugin through these interfaces:
 
-1. `workspace_roots(cwd)` finds the workspace directories to scan.
-2. `discover_specs(roots)` returns the current `SpecInfo` list.
-3. `git_state(cwd)` returns the current `GitState`.
-4. The hook formats output — for example, `build_resume_prompt(spec_info, git_state)` assembles the resume prompt body — and writes it to stdout or returns a allow/deny verdict.
-
-## Context utilization and compact warnings
-
-`estimate_utilization(transcript_path)` returns a float in `[0.0, 1.0]` representing how full the active transcript is. When that value crosses a threshold, `format_warning(util, threshold, resume_body)` composes a visible warning that includes the resume prompt so you can continue work in a fresh session without losing context.
-
-The plugin uses sentinel files (see `session_sentinel_path`, `prune_stale_sentinels`) to ensure the warning appears at most once per session, not on every message after the threshold is crossed.
-
-## Security boundary
-
-`hooks.security_guard` runs before any bash or file-write tool call. `validate_bash_command(command)` rejects commands that target system directories listed in `SYSTEM_DIRECTORIES` (such as `/etc`, `/proc`, and `/sys`), while allowing read-only search prefixes in `SEARCH_COMMAND_PREFIXES` (such as `rg`, `git log`, and `git diff`). `validate_file_path(file_path)` applies the same directory list to write operations. Both return a `(allowed: bool, reason: str)` tuple that `main(context)` uses to either pass the tool call through or return a denial with an explanation.
-
-## When this matters
-
-The plugin is relevant when you are:
-
-- **Resuming a session** — `spec_orient` and `welcome` fire at startup to rebuild context from `SpecInfo` and `GitState` rather than relying on transcript history.
-- **Approaching the context limit** — `compact_warning` fires before Claude Code compacts automatically, giving you a structured resume prompt to carry forward.
-- **Running potentially destructive commands** — `security_guard` intercepts tool calls and stops writes to system directories before they execute.
-- **Handing off to another session** — the `/handoff` command via `_handoff_cli` produces a summary built from the same `SpecInfo` and `GitState` that the other hooks use.
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `SpecInfo` | One in-flight spec discovered under a workspace root. | `plugin/hooks/_state.py` |
+| `GitState` | Snapshot of the worktree's git state at hook fire time. | `plugin/hooks/_state.py` |

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -1,16 +1,12 @@
 ---
-type: reference
-name: plugin-reference
 feature: plugin
 depth: reference
-generated_at: 2026-05-27T13:42:27.332532+00:00
-source_hash: ff7ee791016c71dc1aca7ef059da6fba3d0f06aa842c544cc71910c9900d0b2f
+generated_at: 2026-06-01T11:22:16.315225+00:00
+source_hash: dabe4c5a604a6dee1873da9c2239b8ea78416f31b4bdf292d61a93fe213be717
 status: generated
 ---
 
 # Plugin reference
-
-Bundled runtime for standalone plugin operation — skills, hooks, commands, and MCP config.
 
 ## Classes
 
@@ -19,59 +15,32 @@ Bundled runtime for standalone plugin operation — skills, hooks, commands, and
 | `SpecInfo` | One in-flight spec discovered under a workspace root. | `plugin/hooks/_state.py` |
 | `GitState` | Snapshot of the worktree's git state at hook fire time. | `plugin/hooks/_state.py` |
 
-### `SpecInfo` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `slug` | `str` | — |
-| `path` | `Path` | — |
-| `layer` | `str` | — |
-| `phase` | `str` | — |
-| `status` | `str` | — |
-| `mtime` | `float` | — |
-
-### `GitState` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `branch` | `str` | — |
-| `last_sha` | `str` | — |
-| `last_subject` | `str` | — |
-| `uncommitted` | `tuple[str, ...]` | — |
-
 ## Functions
 
-| Function | Parameters | Returns | Description | File |
-|----------|------------|---------|-------------|------|
-| `main` | — | `int` | CLI entry point for the `/handoff` slash command. | `plugin/hooks/_handoff_cli.py` |
-| `build_resume_prompt` | `spec_info: SpecInfo \| None, git_state: GitState, *, workspace_path: str = '~/attune', todo_summary: str \| None = None` | `str` | Render the user-facing resume prompt body. | `plugin/hooks/_resume_prompt.py` |
-| `discover_specs` | `roots: list[Path]` | `list[SpecInfo]` | Walk `specs/` directories under each root for in-flight specs. | `plugin/hooks/_state.py` |
-| `git_state` | `cwd: Path` | `GitState` | Return branch, last commit, and uncommitted files for `cwd`. | `plugin/hooks/_state.py` |
-| `session_sentinel_path` | `session_id: str \| None` | `Path` | Path to the once-per-session compact-warning sentinel. | `plugin/hooks/_state.py` |
-| `prune_stale_sentinels` | `now: float \| None = None` | `int` | Delete sentinel files older than the TTL. | `plugin/hooks/_state.py` |
-| `workspace_roots` | `cwd: Path \| None = None` | `list[Path]` | Best-effort guess at workspace roots to scan for specs. | `plugin/hooks/_state.py` |
-| `estimate_utilization` | `transcript_path: str \| Path` | `float` | Return estimated context utilization in `[0.0, 1.0]`. | `plugin/hooks/_transcript_size.py` |
-| `format_warning` | `util: float, threshold: float, resume_body: str` | `str` | Compose the user-facing warning + resume prompt. | `plugin/hooks/compact_warning.py` |
-| `main` | — | `int` | Entry point — never raises. | `plugin/hooks/compact_warning.py` |
-| `main` | — | `None` | Read tool result from stdin and format Python files. | `plugin/hooks/format_on_save.py` |
-| `main` | — | `None` | Check help template freshness on session start. | `plugin/hooks/help_freshness_check.py` |
-| `main` | — | `None` | Read PostToolUse payload and suggest help if applicable. | `plugin/hooks/help_on_error.py` |
-| `main` | — | `None` | Check for stale help after a git commit. | `plugin/hooks/help_post_commit.py` |
-| `validate_bash_command` | `command: str` | `tuple[bool, str]` | Validate a Bash command against security policies. | `plugin/hooks/security_guard.py` |
-| `validate_file_path` | `file_path: str` | `tuple[bool, str]` | Validate a file path against security policies. | `plugin/hooks/security_guard.py` |
-| `main` | `context: dict[str, Any]` | `dict[str, Any]` | Validate a tool call against security policies. | `plugin/hooks/security_guard.py` |
-| `format_orientation` | `specs: list[SpecInfo]` | `str` | Short markdown list of in-flight specs for non-compact starts. | `plugin/hooks/spec_orient.py` |
-| `render_spec_pin` | `spec: SpecInfo, char_budget: int = _POST_COMPACT_CHAR_BUDGET` | `str` | Render a spec body for post-compact context restoration. | `plugin/hooks/spec_orient.py` |
-| `main` | — | `int` | Entry point — branches on `source`, never raises. | `plugin/hooks/spec_orient.py` |
-| `main` | — | `None` | Print welcome message to stderr (Claude Code surfaces stderr). | `plugin/hooks/welcome.py` |
+| Function | Description | File |
+|----------|-------------|------|
+| `main()` | — | `plugin/hooks/_handoff_cli.py` |
+| `build_resume_prompt()` | Render the user-facing resume prompt body. | `plugin/hooks/_resume_prompt.py` |
+| `discover_specs()` | Walk ``specs/`` directories under each root for in-flight specs. | `plugin/hooks/_state.py` |
+| `git_state()` | Return branch, last commit, and uncommitted files for ``cwd``. | `plugin/hooks/_state.py` |
+| `session_sentinel_path()` | Path to the once-per-session compact-warning sentinel. | `plugin/hooks/_state.py` |
+| `prune_stale_sentinels()` | Delete sentinel files older than the TTL. | `plugin/hooks/_state.py` |
+| `workspace_roots()` | Best-effort guess at workspace roots to scan for specs. | `plugin/hooks/_state.py` |
+| `estimate_utilization()` | Return estimated context utilization in ``[0.0, 1.0]``. | `plugin/hooks/_transcript_size.py` |
+| `format_warning()` | Compose the user-facing warning + resume prompt. | `plugin/hooks/compact_warning.py` |
+| `main()` | Entry point — never raises. | `plugin/hooks/compact_warning.py` |
+| `main()` | Read tool result from stdin, format Python files. | `plugin/hooks/format_on_save.py` |
+| `main()` | Check help template freshness on session start. | `plugin/hooks/help_freshness_check.py` |
+| `main()` | Read PostToolUse payload and suggest help if applicable. | `plugin/hooks/help_on_error.py` |
+| `main()` | Check for stale help after git commit. | `plugin/hooks/help_post_commit.py` |
+| `validate_bash_command()` | Validate a Bash command against security policies. | `plugin/hooks/security_guard.py` |
+| `validate_file_path()` | Validate a file path against security policies. | `plugin/hooks/security_guard.py` |
+| `main()` | Validate a tool call against security policies. | `plugin/hooks/security_guard.py` |
+| `format_orientation()` | Short markdown list of in-flight specs for non-compact starts. | `plugin/hooks/spec_orient.py` |
+| `render_spec_pin()` | Render a spec body for post-compact context restoration. | `plugin/hooks/spec_orient.py` |
+| `main()` | Entry point — branches on ``source``, never raises. | `plugin/hooks/spec_orient.py` |
+| `main()` | Print welcome message to stderr (Claude Code surfaces stderr). | `plugin/hooks/welcome.py` |
 
-## Constants
-
-| Constant | Type | Value |
-|----------|------|-------|
-| `__version__` | `str` | `'7.2.0'` |
-| `SYSTEM_DIRECTORIES` | `frozenset` | `{'/etc', '/sys', '/proc', '/dev', '/boot', '/sbin', '/usr/sbin', '/private/etc', '/private/var'}` |
-| `SEARCH_COMMAND_PREFIXES` | `frozenset` | `{'grep', 'rg', 'ack', 'ag', 'git grep', 'git log', 'git diff'}` |
 
 ## Source files
 

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -1,73 +1,57 @@
 ---
-type: task
-name: plugin-task
 feature: plugin
 depth: task
-generated_at: 2026-05-27T13:42:27.328414+00:00
-source_hash: ff7ee791016c71dc1aca7ef059da6fba3d0f06aa842c544cc71910c9900d0b2f
+generated_at: 2026-06-01T11:22:16.310741+00:00
+source_hash: dabe4c5a604a6dee1873da9c2239b8ea78416f31b4bdf292d61a93fe213be717
 status: generated
 ---
 
-# Work with the plugin
+# Work with plugin
 
-Use the plugin when you need to extend or modify Claude Code's hooks, slash commands, or MCP configuration — such as changing how session state is discovered, adjusting the compact warning threshold, or customizing the resume prompt.
+Use plugin when you need to claude code plugin — skills, hooks, commands, and mcp config.
 
 ## Prerequisites
 
-- Access to the project source code under `hooks/`
-- Basic familiarity with Python dataclasses and entry-point functions
+- Access to the project source code
+- Familiarity with the files under plugin/**
 
-## Identify the right entry point
+## Steps
 
-The plugin is organized into focused modules. Match your goal to the function that owns it:
+1. **Understand the current behavior.**
+   Read the entry points to see what plugin
+   does today before making changes.
+   The primary functions are:
+   - `main()` in `plugin/hooks/_handoff_cli.py`
+   - `build_resume_prompt()` in `plugin/hooks/_resume_prompt.py` — Render the user-facing resume prompt body.
+   - `discover_specs()` in `plugin/hooks/_state.py` — Walk ``specs/`` directories under each root for in-flight specs.
+   - `git_state()` in `plugin/hooks/_state.py` — Return branch, last commit, and uncommitted files for ``cwd``.
+   - `session_sentinel_path()` in `plugin/hooks/_state.py` — Path to the once-per-session compact-warning sentinel.
+2. **Locate the right function to change.**
+   Each function has a single responsibility. Read its
+   docstring, parameters, and return type to confirm it
+   owns the behavior you need to modify.
 
-| Goal | Function | Module |
-|---|---|---|
-| Modify the `/handoff` slash command | `main()` | `hooks/_handoff_cli.py` |
-| Change the resume prompt format | `build_resume_prompt()` | `hooks/_resume_prompt.py` |
-| Change how in-flight specs are discovered | `discover_specs()` | `hooks/_state.py` |
-| Change how git state is captured | `git_state()` | `hooks/_state.py` |
-| Adjust sentinel file behavior | `session_sentinel_path()` or `prune_stale_sentinels()` | `hooks/_state.py` |
-| Change workspace root resolution | `workspace_roots()` | `hooks/_state.py` |
-| Adjust context utilization estimation | `estimate_utilization()` | `hooks/_transcript_size.py` |
-| Modify the compact warning message | `format_warning()` | `hooks/compact_warning.py` |
-| Change security validation logic | `validate_bash_command()` or `validate_file_path()` | `hooks/security_guard.py` |
+3. **Make your change.**
+   Follow existing patterns in the file — naming
+   conventions, error handling style, and logging.
 
-## Understand the data shapes
+4. **Run the related tests.**
+   This catches regressions before they reach other
+   developers. Target with `pytest -k "plugin"`.
 
-Before editing, review the two core dataclasses that flow through most of the plugin:
+## Key files
 
-**`SpecInfo`** — represents one in-flight spec found under a workspace root:
-- `slug: str` — identifier for the spec
-- `path: Path` — location on disk
-- `layer: str`, `phase: str`, `status: str` — workflow position
-- `mtime: float` — last modification time
+- `plugin/**`
 
-**`GitState`** — snapshot of the worktree at hook-fire time:
-- `branch: str` — current branch name
-- `last_sha: str`, `last_subject: str` — most recent commit
-- `uncommitted: tuple[str, ...]` — list of changed files
+## Common modifications
 
-## Modify the function
+Functions you are most likely to modify:
 
-1. Open the module identified in the table above.
-2. Read the function's signature, docstring, and return type to confirm it owns the behavior you want to change.
-3. Edit the function body. Keep return types consistent — for example, `estimate_utilization()` returns a `float` in `[0.0, 1.0]`, and `validate_bash_command()` returns a `tuple[bool, str]`.
-4. If your change affects `build_resume_prompt()`, note that `spec_info` is optional (`SpecInfo | None`) and `workspace_path` defaults to `'~/attune'`.
-
-## Run the tests
-
-Run the plugin-scoped tests to catch regressions before they reach other developers:
-
-```bash
-pytest -k "plugin"
-```
-
-## Verify success
-
-You know your change works when:
-
-1. `pytest -k "plugin"` passes with no failures.
-2. For hook entry points (`main()` functions), manually trigger the hook and confirm the output reflects your change.
-3. For `build_resume_prompt()`, inspect the rendered string to confirm the resume body contains the fields from `SpecInfo` and `GitState` that you expect.
-4. For `estimate_utilization()`, confirm the returned value stays within `[0.0, 1.0]` for representative transcript inputs.
+- `main()` in `plugin/hooks/_handoff_cli.py`
+- `build_resume_prompt()` in `plugin/hooks/_resume_prompt.py`
+- `discover_specs()` in `plugin/hooks/_state.py`
+- `git_state()` in `plugin/hooks/_state.py`
+- `session_sentinel_path()` in `plugin/hooks/_state.py`
+- `prune_stale_sentinels()` in `plugin/hooks/_state.py`
+- `workspace_roots()` in `plugin/hooks/_state.py`
+- `estimate_utilization()` in `plugin/hooks/_transcript_size.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,102 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.0] — 2026-06-01
+
+### Added
+
+- **Ops dashboard Specs page refinement** — the `/specs` route gains
+  a 6-bucket lifecycle (Active / Approved-not-shipped / Complete /
+  Paused / Stale / Draft), a chip filter toolbar, a per-row kebab
+  action menu (Open in editor, Copy slug, View linked PRs), and URL
+  parameter support for shareable filter state
+  (`?bucket=active,paused&sort=alpha`). Stale auto-surfaces specs
+  not touched in 30 days. The derivation is pure-Python and testable
+  in isolation; the dashboard reads from it on every render
+  (#533, #534, #535, #536, #539).
+- **SDK error message fidelity (Phase 1-3)** — when a workflow's
+  `claude_agent_sdk.query()` fails, the dashboard's Recent Runs
+  page now surfaces the real `claude` CLI stderr in a collapsible
+  block instead of the legacy "Command failed with exit code 1"
+  message. A typed `sdk_error_kind` classifier identifies
+  `api_quota`, `auth`, `rate_limit`, `not_found`, `budget_cap`,
+  and `unknown` cases. Phase 2 wires `code-review` and
+  `dependency-check`; Phase 3 adds persistence + render + CLI
+  side-channel for the runner consumer. Remaining workflows
+  (`bug-predict`, `perf-audit`, `refactor-plan`, `security-audit`,
+  long-tail) ship in a follow-up
+  (#516, #522, #526, #531).
+- **Pre-Write worktree-path-guard hook** — first enforced pattern
+  from the enforcement-vs-documentation framework. The hook blocks
+  Write/Edit operations targeting a path outside the current git
+  worktree's root, exiting with code 2 and a remediation message.
+  Catches the wrong-tree-write class of bugs at the moment of the
+  attempted write (#521).
+- **SessionStart starter-prompt nudge** — a hook surfaces the
+  contents of `~/.attune/next_session_starter.md` at session start
+  so cross-session handoff context is visible without manual paste.
+  Pairs with the existing cross-account-handoff feedback memory
+  (#524).
+- **Docs wiring-audit CI job (advisory mode)** — Tasks 1+2+6+7 of
+  the `docs-wiring-audit` spec ship a stdlib-only audit script
+  that checks anchor integrity across `docs/`. Wired as a GitHub
+  Actions job that runs on every PR but is NOT yet in
+  `required_status_checks` — explicit advisory-mode runway before
+  branch-protection enforcement (#518, #523, #540).
+- **Spec discovery extension to `docs/specs/`** — the SessionStart
+  hook now lists in-flight specs by walking `docs/specs/`,
+  surfacing each spec's `requirements.md` `status:` field. Replaces
+  the previous Workflows-only inventory at session start (#500).
+- **`attune-ai.dev` static landing page** — first commit of the
+  domain's marketing surface. Lives at `attune-ai-dev/` in the
+  repo as a sibling to `website/` (the smartaimemory.com Next.js
+  site) so each deployable surface is one top-level directory
+  (#498).
+
 ### Changed
 
-- **Wizard entry-point group renamed to ``attune.wizards``.** The
-  registry now reads the canonical ``attune.wizards`` group (which
-  ``pyproject.toml`` has declared since the package rename). Third-party
-  wizards still declared under the legacy ``empathy.wizards`` group
-  continue to load with a ``DeprecationWarning`` for one release; the
-  legacy fallback will be removed in the next major. Builtin wizards
-  are unaffected — they load by hardcoded module path, not entry-point
-  discovery.
+- **Wizard entry-point group renamed to `attune.wizards`.** The
+  registry reads the canonical `attune.wizards` group (which
+  `pyproject.toml` has declared since the package rename).
+  Third-party wizards still declared under the legacy
+  `empathy.wizards` group continue to load with a
+  `DeprecationWarning` for one release; the legacy fallback will
+  be removed in the next major. Builtin wizards are unaffected —
+  they load by hardcoded module path, not entry-point discovery
+  (#512).
+- **README leads with per-claim faithfulness (>99%), not per-query
+  bucket rate (6.7% hallucination).** The two metrics measure the
+  same RAG-grounding property at different granularities;
+  per-claim is the stronger honest framing. Burying the better
+  number was unfaithful to attune-rag's own measurements (#527).
+
+### Fixed
+
+- **Stale test flake + `create_wizard` docstring** — rescued from
+  at-risk worktrees during 2026-05-30 repo-hygiene work. Two
+  small fixes that had landed in WIP branches but not main (#514).
+
+### Chore
+
+- **Plugin manifest version sync + drift-guard test** — bumps the
+  plugin/.claude-plugin/ version fields to match `pyproject.toml`
+  (the v7.2.0 release shipped with them at 7.0.0 through four
+  releases). A new `test_pyproject_matches_plugin_manifests` test
+  asserts cross-stream version match going forward (#496).
+- **Docs fiction cleanup (Phases 1-3)** — 8 docs renamed
+  mechanically, 1 doc rewritten, 4 docs archived. Eliminates
+  references to features that never shipped or were retired
+  (#506, #507, #508, #509, #510). Pairs with the
+  `doc-fiction-cleanup` spec authored in (#499).
+- **`.help/templates/` plugin feature regenerated** with
+  attune-author 0.14.2 — picks up the latest polish-pass output
+  for the plugin feature surface (#497).
+- **18 CLAUDE.md lessons added** across the session — Windows
+  test-fragility, documentation-framing faithfulness, wireframes
+  surface design gaps, 3-stage gap discovery, CodeQL URL
+  substring rule, etc. (#519, #525, #527, #528, #530, #532, plus
+  PR #541 in this release window).
+- **Dependency cap bumps** — `streamlit>=1.58.0,<2.0.0` (#537).
 
 ## [7.2.0] — 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,18 +20,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not touched in 30 days. The derivation is pure-Python and testable
   in isolation; the dashboard reads from it on every render
   (#533, #534, #535, #536, #539).
-- **SDK error message fidelity (Phase 1-3)** — when a workflow's
-  `claude_agent_sdk.query()` fails, the dashboard's Recent Runs
-  page now surfaces the real `claude` CLI stderr in a collapsible
-  block instead of the legacy "Command failed with exit code 1"
-  message. A typed `sdk_error_kind` classifier identifies
-  `api_quota`, `auth`, `rate_limit`, `not_found`, `budget_cap`,
-  and `unknown` cases. Phase 2 wires `code-review` and
-  `dependency-check`; Phase 3 adds persistence + render + CLI
-  side-channel for the runner consumer. Remaining workflows
-  (`bug-predict`, `perf-audit`, `refactor-plan`, `security-audit`,
-  long-tail) ship in a follow-up
-  (#516, #522, #526, #531).
+- **SDK error message fidelity (Phases 1-5 complete)** — when a
+  workflow's `claude_agent_sdk.query()` fails, the dashboard's
+  Recent Runs page now surfaces the real `claude` CLI stderr in
+  a collapsible block instead of the legacy "Command failed with
+  exit code 1" message. A typed `sdk_error_kind` classifier
+  identifies `api_quota`, `auth`, `rate_limit`, `not_found`,
+  `budget_cap`, and `unknown` cases. Eleven SDK-backed workflows
+  now surface real causes — `code-review`, `dependency-check`
+  (Phase 2), `bug-predict`, `perf-audit`, `refactor-plan`,
+  `security-audit` (Phase 4), plus `simplify-code`, `deep-review`,
+  `research-synthesis`, `rag-code-gen`, `release-prep` (Phase 5).
+  Phase 3 added persistence + render + CLI side-channel for the
+  runner consumer; Phase 4.3 wired the dashboard chip classifier
+  to read the typed `sdk_error_kind` directly. The remaining 5
+  workflows (`test-audit`, `doc-audit`, `doc-gen`,
+  `discovery-sweep`, `secure-release`) have hand-rolled error
+  messages without the misleading three-cause menu and ship in
+  a v7.4.0 follow-up
+  (#516, #522, #526, #531, #543, #544).
 - **Pre-Write worktree-path-guard hook** — first enforced pattern
   from the enforcement-vs-documentation framework. The hook blocks
   Write/Edit operations targeting a path outside the current git

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 7.2.0
+**Version:** 7.3.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 7.2.0 | **License:** Apache 2.0
+**Version:** 7.3.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "7.2.0"
+    "version": "7.3.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "7.2.0",
+      "version": "7.3.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "7.2.0"
+__version__ = "7.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "7.2.0"
+version = "7.3.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "7.2.0"
+version = "7.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Release prep for **v7.3.0** — 44 PRs since v7.2.0 (2026-05-27 → 2026-06-01).

## Headline features

- **Ops dashboard Specs page refinement** — 6-bucket lifecycle
  derivation (Active / Approved / Complete / Paused / Stale /
  Draft), chip filter toolbar, kebab action menu, URL params for
  shareable filter state ([#533](https://github.com/Smart-AI-Memory/attune-ai/pull/533), [#534](https://github.com/Smart-AI-Memory/attune-ai/pull/534),
  [#535](https://github.com/Smart-AI-Memory/attune-ai/pull/535), [#536](https://github.com/Smart-AI-Memory/attune-ai/pull/536), [#539](https://github.com/Smart-AI-Memory/attune-ai/pull/539))
- **SDK error message fidelity Phase 1-3** — workflows surface
  real `claude` CLI stderr in dashboard instead of legacy
  three-cause menu. Phase 4+5 (remaining 10 workflows) ship
  in a follow-up ([#516](https://github.com/Smart-AI-Memory/attune-ai/pull/516), [#522](https://github.com/Smart-AI-Memory/attune-ai/pull/522), [#526](https://github.com/Smart-AI-Memory/attune-ai/pull/526), [#531](https://github.com/Smart-AI-Memory/attune-ai/pull/531))
- **Pre-Write worktree-path-guard hook** — first enforced pattern
  from the enforcement-vs-documentation framework ([#521](https://github.com/Smart-AI-Memory/attune-ai/pull/521))
- **SessionStart starter-prompt nudge** — auto-surface
  `~/.attune/next_session_starter.md` at session start ([#524](https://github.com/Smart-AI-Memory/attune-ai/pull/524))
- **Docs wiring-audit CI gate** (advisory mode) — Tasks 1+2+6+7
  ([#518](https://github.com/Smart-AI-Memory/attune-ai/pull/518), [#523](https://github.com/Smart-AI-Memory/attune-ai/pull/523), [#540](https://github.com/Smart-AI-Memory/attune-ai/pull/540))

## Version bumps (per CLAUDE.md release checklist)

9 sites across 7 files:

- `pyproject.toml`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.claude-plugin/marketplace.json` (2 fields)
- `.claude-plugin/marketplace.json` (2 fields)
- `plugin/core/__init__.py`
- `docs/reference/API_REFERENCE.md` (header + footer)
- `.claude/CLAUDE.md` (header + footer; lessons-text references preserved)

`uv lock` regenerated. `test_all_versions_match` drift-guard green.

## Test plan

- [x] Pre-commit hooks pass
- [x] `test_all_versions_match` passes
- [ ] CI green across full matrix
- [ ] Post-merge: tag `v7.3.0`, trigger `publish-pypi.yml` via `workflow_dispatch --ref main` (per CLAUDE.md lesson on `pypi` env tag-policy issue)
- [ ] Approve PyPI environment deployment via `gh api .../pending_deployments`
- [ ] Verify wheel + sdist on https://pypi.org/project/attune-ai/7.3.0/
- [ ] Edit GitHub release notes via `gh release edit v7.3.0 --notes-file <changelog-extract>` to replace auto-body
