### PR TITLE
feat(sdk-fidelity): Phase 5 — 5 long-tail workflows

### DIFF
--- a/.help/templates/deep-review/concept.md
+++ b/.help/templates/deep-review/concept.md
@@ -1,45 +1,28 @@
 ---
-type: concept
 feature: deep-review
 depth: concept
-generated_at: 2026-05-04T02:28:14.874596+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-01T11:59:09.442052+00:00
+source_hash: c88c39a4d669dd53e0c79a38f05bf3f121d25317b59202f71eed73be8dc817a0
 status: generated
 ---
 
 # Deep Review
 
-Deep review is a multi-pass code analysis workflow that examines your codebase through three specialized lenses: security vulnerabilities, code quality issues, and test coverage gaps.
-
 ## How it works
 
-The workflow coordinates three subagents that run in parallel, each focusing on a specific domain:
+Multi-pass deep code review — security, quality, and test gap analysis.
 
-- **Security reviewer** — Scans for vulnerabilities, insecure patterns, and authentication flaws
-- **Quality reviewer** — Evaluates maintainability, performance, and architectural concerns
-- **Test gap reviewer** — Identifies missing test coverage and edge cases
+The main building blocks are:
 
-After all three subagents complete their analysis, the workflow synthesizes their findings into a single consolidated report with an overall health score (0-100) and prioritized recommendations.
+- **`DeepReviewAgentSDKWorkflow`** — Multi-pass deep code review using Claude Agent SDK subagents.
 
-## Review orchestration
+## What connects to it
 
-The `DeepReviewAgentSDKWorkflow` class manages the entire process:
+This feature relates to: review, security, quality, tests, comprehensive-review.
 
-1. Spawns three specialized Claude Agent SDK subagents
-2. Each subagent analyzes the codebase independently
-3. Collects and correlates findings across all domains
-4. Produces a structured report with sections for security, quality, test gaps, and actionable suggestions
+Other parts of the codebase interact with
+deep review through these interfaces:
 
-The orchestrator ensures thoroughness while maintaining focus — each subagent operates within its expertise domain, then findings are consolidated to avoid duplication and provide clear next steps.
-
-## Report structure
-
-Every deep review generates a standardized report containing:
-
-- **Summary** — Health score and executive overview with finding counts by severity
-- **Security** — Vulnerabilities and security concerns, ordered by risk level
-- **Quality** — Maintainability and performance issues, ordered by impact
-- **Test gaps** — Missing coverage areas, ordered by priority
-- **Suggestions** — Top 5-10 actionable improvements with specific file references
-
-This structure gives you both the high-level assessment you need for planning and the detailed findings required for implementation.
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `DeepReviewAgentSDKWorkflow` | Multi-pass deep code review using Claude Agent SDK subagents. | `src/attune/workflows/deep_review.py` |

--- a/.help/templates/deep-review/reference.md
+++ b/.help/templates/deep-review/reference.md
@@ -1,35 +1,24 @@
 ---
-type: reference
 feature: deep-review
 depth: reference
-generated_at: 2026-05-04T02:28:33.091892+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-01T11:59:09.451028+00:00
+source_hash: c88c39a4d669dd53e0c79a38f05bf3f121d25317b59202f71eed73be8dc817a0
 status: generated
 ---
 
 # Deep Review reference
 
-Orchestrate comprehensive code reviews through specialized security, quality, and test analysis workflows.
-
 ## Classes
 
-| Class | Description |
-|-------|-------------|
-| `DeepReviewAgentSDKWorkflow` | Multi-pass deep code review using Claude Agent SDK subagents |
+| Class | Description | File |
+|-------|-------------|------|
+| `DeepReviewAgentSDKWorkflow` | Multi-pass deep code review using Claude Agent SDK subagents. | `src/attune/workflows/deep_review.py` |
 
-### Methods
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `execute` | `self, **kwargs: Any` | `WorkflowResult` | Execute the multi-pass review workflow |
 
-## Constants
+## Source files
 
-| Constant | Values | Description |
-|----------|--------|-------------|
-| `_SUBAGENT_NAMES` | `{'security-reviewer', 'quality-reviewer', 'test-gap-reviewer'}` | Specialized reviewers for each analysis domain |
-| `_SYSTEM_PROMPT` | `'You are a senior code review orchestrator performing a multi-pass deep review. You coordinate three specialized subagents to produce a consolidated code review report. Be thorough but concise. Cite file paths and line numbers.'` | System prompt for the orchestrator agent |
-| `_TASK_PROMPT_TEMPLATE` | `'Review the codebase at {path} using the three specialized subagents below. Each subagent focuses on a specific domain and will report findings independently.\n\nAfter all subagents finish, synthesize their findings into a single consolidated report with these sections:\n\n## Summary\nOverall code health score (0-100) and a 2-3 sentence executive summary. Include counts of findings by severity.\n\n## Security\nFindings from the security reviewer, ordered by severity.\n\n## Quality\nFindings from the quality reviewer, ordered by severity.\n\n## Test Gaps\nFindings from the test gap reviewer, ordered by priority.\n\n## Suggestions\nTop 5-10 actionable next steps ordered by impact. Each suggestion should reference the specific finding it addresses.'` | Template for coordinating subagent reviews |
+- `src/attune/workflows/deep_review.py`
 
 ## Tags
 

--- a/.help/templates/deep-review/task.md
+++ b/.help/templates/deep-review/task.md
@@ -1,51 +1,45 @@
 ---
-type: task
 feature: deep-review
 depth: task
-generated_at: 2026-05-04T02:28:25.316934+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-01T11:59:09.446905+00:00
+source_hash: c88c39a4d669dd53e0c79a38f05bf3f121d25317b59202f71eed73be8dc817a0
 status: generated
 ---
 
-# Run deep review
+# Work with deep review
 
-Run deep review when you need comprehensive code analysis across security, quality, and test coverage dimensions.
+Use deep review when you need to multi-pass deep code review — security, quality, and test gap analysis.
 
 ## Prerequisites
 
-- Access to the target codebase
-- Claude Agent SDK configured in your environment
-- Permission to read the files you want to review
+- Access to the project source code
+- Familiarity with the files under src/attune/workflows/deep_review.py
 
-## Execute a deep review
+## Steps
 
-1. **Import the workflow class.**
-   ```python
-   from attune.workflows.deep_review import DeepReviewAgentSDKWorkflow
-   ```
+1. **Understand the class hierarchy.**
+   Read the interfaces to see how deep review
+   is structured before extending or modifying.
+   The key classes are:
+   - `DeepReviewAgentSDKWorkflow` in `src/attune/workflows/deep_review.py` — Multi-pass deep code review using Claude Agent SDK subagents.
+2. **Decide whether to extend or modify.**
+   If the class has subclasses, extend with a new one
+   rather than changing the base. If it stands alone,
+   modify directly.
 
-2. **Initialize the workflow.**
-   ```python
-   workflow = DeepReviewAgentSDKWorkflow()
-   ```
+3. **Make your change.**
+   Follow existing patterns — naming, error handling,
+   and logging style.
 
-3. **Run the review on your target path.**
-   ```python
-   result = workflow.execute(path="/path/to/your/code")
-   ```
+4. **Run the related tests.**
+   Target with `pytest -k "deep-review"`.
 
-4. **Access the consolidated report.**
-   The result contains findings from three specialized reviewers:
-   - Security vulnerabilities and risks
-   - Code quality issues and maintainability concerns
-   - Test coverage gaps and missing test scenarios
+## Key files
 
-## Verify the review completed
+- `src/attune/workflows/deep_review.py`
 
-Check that your `WorkflowResult` contains:
-- Overall health score (0-100)
-- Findings categorized by severity
-- Actionable recommendations ranked by impact
-- Specific file paths and line numbers for each finding
+## Common modifications
 
-The review runs three passes automatically — you don't need to coordinate the security-reviewer, quality-reviewer, and test-gap-reviewer subagents manually.
+Classes you are most likely to extend:
+
+- `DeepReviewAgentSDKWorkflow` in `src/attune/workflows/deep_review.py`

--- a/.help/templates/rag-grounding/concept.md
+++ b/.help/templates/rag-grounding/concept.md
@@ -1,41 +1,28 @@
 ---
-type: concept
-name: rag-grounding-concept
 feature: rag-grounding
 depth: concept
-generated_at: 2026-05-21T03:20:54.610898+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-01T11:59:09.454643+00:00
+source_hash: 93cb0ee5d2aca6e29f80507cc0c23c2ba8b904fe0e64bf16403a5a0dd115ccef
 status: generated
 ---
 
-# RAG Grounding
+# Rag Grounding
 
-RAG grounding is a code generation approach that retrieves relevant documentation from attune-help before generating code, ensuring all outputs are backed by real attune ecosystem APIs and patterns.
+## How it works
 
-## How RAG grounding works
+RAG-grounded code generation — retrieves attune-help context via attune-rag, feeds citation-forced prompts to Claude, emits answers with provenance.
 
-When you ask for code or explanations, the system first searches attune-help documentation for relevant context. This retrieved content is then passed to Claude along with your request, but with strict instructions to only reference what's actually documented. The result is generated code that cites real APIs, workflow names, and CLI commands rather than inventing features.
+The main building blocks are:
 
-The grounding process prevents hallucination by:
+- **`RagCodeGenWorkflow`** — SDK-native RAG-grounded code generation workflow.
 
-1. **Retrieval first** — attune-rag searches the help system for content matching your request
-2. **Context injection** — retrieved passages are embedded in the prompt as `<passage>...</passage>` blocks
-3. **Citation forcing** — Claude receives explicit instructions to ground all responses in the provided context
-4. **Provenance tracking** — generated answers include references to the source files where patterns originated
+## What connects to it
 
-## Core components
+This feature relates to: rag, retrieval, grounding, faithfulness, citation.
 
-**`RagCodeGenWorkflow`** orchestrates the entire process. This SDK-native workflow takes your request, retrieves relevant documentation through attune-rag, constructs a grounded prompt, and returns generated code with citations.
+Other parts of the codebase interact with
+rag grounding through these interfaces:
 
-The workflow uses a system prompt (`_SYSTEM_PROMPT`) that specifically instructs Claude to treat passage content as documentation rather than commands, preventing prompt injection attacks where malicious content might try to override the grounding instructions.
-
-## When to use RAG grounding
-
-RAG grounding is essential when you need generated code that integrates with the attune ecosystem. Unlike general-purpose code generation, it ensures that:
-
-- API calls use real method signatures from attune
-- Workflow references point to actual workflow classes
-- CLI commands match the current attune interface
-- Code patterns follow documented attune conventions
-
-This makes RAG grounding particularly valuable for onboarding new developers, generating integration examples, and creating documentation that stays synchronized with the codebase.
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `RagCodeGenWorkflow` | SDK-native RAG-grounded code generation workflow. | `src/attune/workflows/rag_code_gen.py` |

--- a/.help/templates/rag-grounding/reference.md
+++ b/.help/templates/rag-grounding/reference.md
@@ -1,35 +1,20 @@
 ---
-type: reference
-name: rag-grounding-reference
 feature: rag-grounding
 depth: reference
-generated_at: 2026-05-21T03:20:54.627075+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-01T11:59:09.463771+00:00
+source_hash: 93cb0ee5d2aca6e29f80507cc0c23c2ba8b904fe0e64bf16403a5a0dd115ccef
 status: generated
 ---
 
-# RAG grounding reference
-
-Generate code with citations to real attune APIs and documentation.
+# Rag Grounding reference
 
 ## Classes
 
-| Class | Description |
-|-------|-------------|
-| `RagCodeGenWorkflow` | SDK-native RAG-grounded code generation workflow |
+| Class | Description | File |
+|-------|-------------|------|
+| `RagCodeGenWorkflow` | SDK-native RAG-grounded code generation workflow. | `src/attune/workflows/rag_code_gen.py` |
 
-### RagCodeGenWorkflow
 
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__` | `**kwargs: Any` | `None` | Initialize the workflow |
-| `execute` | `**kwargs: Any` | `WorkflowResult` | Execute the RAG-grounded code generation |
-
-## Constants
-
-| Constant | Description |
-|----------|-------------|
-| `_SYSTEM_PROMPT` | System prompt that enforces grounding in attune documentation and prevents hallucination of non-existent features |
 
 ## Source files
 

--- a/.help/templates/rag-grounding/task.md
+++ b/.help/templates/rag-grounding/task.md
@@ -1,58 +1,45 @@
 ---
-type: task
-name: rag-grounding-task
 feature: rag-grounding
 depth: task
-generated_at: 2026-05-21T03:20:54.619948+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-01T11:59:09.459247+00:00
+source_hash: 93cb0ee5d2aca6e29f80507cc0c23c2ba8b904fe0e64bf16403a5a0dd115ccef
 status: generated
 ---
 
 # Work with rag grounding
 
-Use rag grounding when you need to generate code backed by verified documentation — it retrieves attune-help context and forces Claude to cite real APIs and patterns rather than hallucinating features.
+Use rag grounding when you need to rag-grounded code generation — retrieves attune-help context via attune-rag, feeds citation-forced prompts to claude, emits answers with provenance.
 
 ## Prerequisites
 
 - Access to the project source code
-- Familiarity with `src/attune/workflows/rag_code_gen.py`
+- Familiarity with the files under src/attune/workflows/rag_code_gen.py
 
-## Configure the workflow
+## Steps
 
-1. **Import the RagCodeGenWorkflow class:**
-   ```python
-   from attune.workflows.rag_code_gen import RagCodeGenWorkflow
-   ```
+1. **Understand the class hierarchy.**
+   Read the interfaces to see how rag grounding
+   is structured before extending or modifying.
+   The key classes are:
+   - `RagCodeGenWorkflow` in `src/attune/workflows/rag_code_gen.py` — SDK-native RAG-grounded code generation workflow.
+2. **Decide whether to extend or modify.**
+   If the class has subclasses, extend with a new one
+   rather than changing the base. If it stands alone,
+   modify directly.
 
-2. **Initialize the workflow:**
-   ```python
-   workflow = RagCodeGenWorkflow(**kwargs)
-   ```
+3. **Make your change.**
+   Follow existing patterns — naming, error handling,
+   and logging style.
 
-3. **Execute with your requirements:**
-   ```python
-   result = workflow.execute(**kwargs)
-   ```
+4. **Run the related tests.**
+   Target with `pytest -k "rag-grounding"`.
 
-## Extend the workflow behavior
+## Key files
 
-1. **Review the base RagCodeGenWorkflow class** in `src/attune/workflows/rag_code_gen.py` to understand the existing citation and grounding mechanisms.
+- `src/attune/workflows/rag_code_gen.py`
 
-2. **Create a subclass for custom behavior:**
-   ```python
-   class CustomRagCodeGenWorkflow(RagCodeGenWorkflow):
-       def execute(self, **kwargs):
-           # Your custom logic here
-           return super().execute(**kwargs)
-   ```
+## Common modifications
 
-3. **Preserve the citation system** — the workflow includes a `_SYSTEM_PROMPT` that enforces grounding in real attune documentation and prevents feature hallucination.
+Classes you are most likely to extend:
 
-## Verify the grounding works
-
-Run your workflow and confirm that:
-- Generated code references actual attune APIs from the retrieved context
-- Citations include source file references
-- No invented features appear in the output
-
-The workflow should return a `WorkflowResult` containing grounded code with proper provenance tracking.
+- `RagCodeGenWorkflow` in `src/attune/workflows/rag_code_gen.py`

--- a/.help/templates/release-prep/concept.md
+++ b/.help/templates/release-prep/concept.md
@@ -1,61 +1,43 @@
 ---
-type: concept
 feature: release-prep
 depth: concept
-generated_at: 2026-05-04T02:26:51.738297+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-01T11:59:09.426641+00:00
+source_hash: 4c7a32841bb910c6bfc8e67572024ffed2759925aeba9ce59b7fbfb6fda20b18
 status: generated
 ---
 
 # Release Prep
 
-Release prep is an automated quality gate that runs a comprehensive pre-release assessment across your codebase to determine whether it's safe to publish.
+## How it works
 
-## Core assessment areas
+Pre-release quality gate — health checks, security audit, changelog, version bumps.
 
-The system coordinates four specialized agents to evaluate different aspects of release readiness:
+The main building blocks are:
 
-- **Test coverage** — Runs `pytest --cov` and parses coverage reports to verify test completeness
-- **Code quality** — Uses ruff to check linting, type hints, and complexity metrics
-- **Documentation health** — Verifies docstring coverage, README currency, and CHANGELOG presence
-- **Security posture** — Scans for vulnerabilities, outdated dependencies, and potential secret leaks
+- **`ReleasePreparationWorkflow`** — Pre-release quality gate workflow powered by Agent SDK subagents.
+- **`ReleaseAgent`** — Base agent with CHEAP -> CAPABLE -> PREMIUM escalation.
+- **`TestCoverageAgent`** — Runs pytest --cov and parses coverage report.
+- **`DocumentationAgent`** — Checks docstring coverage, README currency, and CHANGELOG presence.
+- **`CodeQualityAgent`** — Runs ruff, checks type hints and complexity.
 
-Each agent operates independently and reports structured findings that get synthesized into a single go/no-go recommendation.
+Under the hood, this feature spans 11 source
+files covering:
 
-## Progressive cost management
+- Release Preparation Agent Team.
+- Base release agent with progressive tier escalation.
+- Test coverage agent for Release Preparation Agent Team.
 
-The `ReleaseAgent` base class implements a three-tier escalation strategy to balance thoroughness with cost:
+## What connects to it
 
-1. **CHEAP** tier — Fast heuristics and cached results
-2. **CAPABLE** tier — Standard analysis with moderate compute
-3. **PREMIUM** tier — Deep inspection for complex edge cases
+This feature relates to: release, publishing, quality.
 
-Agents automatically escalate to higher tiers when confidence is low or when critical issues need deeper investigation.
+Other parts of the codebase interact with
+release prep through these interfaces:
 
-## Quality gate mechanics
-
-The `ReleasePrepTeam` orchestrates parallel agent execution and applies configurable quality gates:
-
-```python
-quality_gates = {
-    "test_coverage": 80.0,      # Minimum coverage percentage
-    "code_quality": 8.0,        # Ruff score threshold
-    "security_score": 90.0      # Security assessment minimum
-}
-```
-
-The `ReleaseReadinessReport` aggregates all findings into:
-- Overall approval status (approved/blocked)
-- Confidence level with supporting evidence
-- Specific blockers that must be addressed
-- Prioritized suggestions for improvement
-
-## When release prep matters
-
-Use release prep as the final checkpoint before:
-- Bumping version numbers in `pyproject.toml`
-- Creating git tags for releases
-- Publishing packages to PyPI
-- Merging release branches to main
-
-The assessment is intentionally conservative — a single failing test or stale changelog entry will block the release until fixed.
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `ReleasePreparationWorkflow` | Pre-release quality gate workflow powered by Agent SDK subagents. | `src/attune/workflows/release_prep.py` |
+| `ReleaseAgent` | Base agent with CHEAP -> CAPABLE -> PREMIUM escalation. | `src/attune/agents/release/base_agent.py` |
+| `TestCoverageAgent` | Runs pytest --cov and parses coverage report. | `src/attune/agents/release/coverage_agent.py` |
+| `DocumentationAgent` | Checks docstring coverage, README currency, and CHANGELOG presence. | `src/attune/agents/release/documentation_agent.py` |
+| `CodeQualityAgent` | Runs ruff, checks type hints and complexity. | `src/attune/agents/release/quality_agent.py` |

--- a/.help/templates/release-prep/reference.md
+++ b/.help/templates/release-prep/reference.md
@@ -1,171 +1,37 @@
 ---
-type: reference
 feature: release-prep
 depth: reference
-generated_at: 2026-05-04T02:27:19.978842+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-01T11:59:09.437954+00:00
+source_hash: 4c7a32841bb910c6bfc8e67572024ffed2759925aeba9ce59b7fbfb6fda20b18
 status: generated
 ---
 
-# Release prep reference
-
-Run preflight checks across your project before publishing. Assesses health, security, changelog, dependencies, and version consistency, then provides a go/no-go recommendation.
+# Release Prep reference
 
 ## Classes
 
-| Class | Description |
-|-------|-------------|
-| `ReleaseAgent` | Base agent with progressive tier escalation from cheap to premium models |
-| `TestCoverageAgent` | Runs pytest with coverage analysis and parses results |
-| `DocumentationAgent` | Validates docstring coverage, README currency, and changelog presence |
-| `CodeQualityAgent` | Runs linting, checks type hints, and measures code complexity |
-| `SecurityAuditorAgent` | Analyzes security vulnerabilities and classifies findings by severity |
-| `Tier` | Model tier enumeration for progressive escalation |
-| `ReleaseAgentResult` | Individual agent execution result with findings and metrics |
-| `QualityGate` | Release readiness threshold with pass/fail status |
-| `ReleaseReadinessReport` | Consolidated assessment with go/no-go recommendation |
-| `ReleasePrepTeam` | Orchestrates parallel execution of specialized release agents |
-| `ReleasePrepTeamWorkflow` | CLI-integrated workflow wrapper for release preparation |
-| `ReleasePreparationWorkflow` | Quality gate workflow powered by agent subteams |
+| Class | Description | File |
+|-------|-------------|------|
+| `ReleasePreparationWorkflow` | Pre-release quality gate workflow powered by Agent SDK subagents. | `src/attune/workflows/release_prep.py` |
+| `ReleaseAgent` | Base agent with CHEAP -> CAPABLE -> PREMIUM escalation. | `src/attune/agents/release/base_agent.py` |
+| `TestCoverageAgent` | Runs pytest --cov and parses coverage report. | `src/attune/agents/release/coverage_agent.py` |
+| `DocumentationAgent` | Checks docstring coverage, README currency, and CHANGELOG presence. | `src/attune/agents/release/documentation_agent.py` |
+| `CodeQualityAgent` | Runs ruff, checks type hints and complexity. | `src/attune/agents/release/quality_agent.py` |
+| `Tier` | Model tier for progressive escalation. | `src/attune/agents/release/release_models.py` |
+| `ReleaseAgentResult` | Result from an individual release agent. | `src/attune/agents/release/release_models.py` |
+| `QualityGate` | Quality gate threshold for release readiness. | `src/attune/agents/release/release_models.py` |
+| `ReleaseReadinessReport` | Aggregated release readiness assessment. | `src/attune/agents/release/release_models.py` |
+| `ReleasePrepTeam` | Coordinates parallel execution of release preparation agents. | `src/attune/agents/release/release_prep_team.py` |
+| `ReleasePrepTeamWorkflow` | Workflow wrapper that integrates ReleasePrepTeam with the CLI registry. | `src/attune/agents/release/release_prep_team.py` |
+| `SecurityAuditorAgent` | Analyzes bandit output and classifies vulnerabilities by severity. | `src/attune/agents/release/security_agent.py` |
 
-## ReleaseAgent
 
-Base agent with progressive tier escalation.
 
-### Methods
+## Source files
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `__init__` | `agent_id: str, role: str, redis_client: Any \| None = None, state_store: AgentStateStore \| None = None` | `None` | Initializes release agent with role and optional state management |
-| `process` | `codebase_path: str = '.'` | `ReleaseAgentResult` | Processes codebase and returns analysis results |
+- `src/attune/workflows/release_prep.py`
+- `src/attune/agents/release/**`
 
-## TestCoverageAgent
+## Tags
 
-Runs pytest --cov and parses coverage report.
-
-### Methods
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `__init__` | `redis_client: Any \| None = None, state_store: AgentStateStore \| None = None` | `None` | Initializes coverage agent with optional state management |
-
-## DocumentationAgent
-
-Checks docstring coverage, README currency, and CHANGELOG presence.
-
-### Methods
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `__init__` | `redis_client: Any \| None = None, state_store: AgentStateStore \| None = None` | `None` | Initializes documentation agent with optional state management |
-
-## CodeQualityAgent
-
-Runs ruff, checks type hints and complexity.
-
-### Methods
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `__init__` | `redis_client: Any \| None = None, state_store: AgentStateStore \| None = None` | `None` | Initializes code quality agent with optional state management |
-
-## ReleaseAgentResult
-
-Result from an individual release agent.
-
-### Fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `agent_id` | `str` | | Agent identifier |
-| `agent_role` | `str` | | Agent's specialized role |
-| `success` | `bool` | | Whether agent execution succeeded |
-| `tier_used` | `Tier` | | Model tier used for analysis |
-| `findings` | `dict[str, Any]` | `{}` | Structured findings from agent analysis |
-| `score` | `float` | `0.0` | Quality score from 0-100 |
-| `confidence` | `float` | `0.0` | Confidence level in results |
-| `cost` | `float` | `0.0` | Execution cost in credits |
-| `execution_time_ms` | `float` | `0.0` | Processing time in milliseconds |
-| `escalated` | `bool` | `False` | Whether agent escalated to higher tier |
-
-## QualityGate
-
-Quality gate threshold for release readiness.
-
-### Fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `name` | `str` | | Gate name identifier |
-| `threshold` | `float` | | Required minimum score |
-| `actual` | `float` | `0.0` | Measured score |
-| `passed` | `bool` | `False` | Whether gate passed |
-| `critical` | `bool` | `True` | Whether failure blocks release |
-| `message` | `str` | `''` | Status message |
-
-## ReleaseReadinessReport
-
-Aggregated release readiness assessment.
-
-### Methods
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `to_dict` | | `dict[str, Any]` | Converts report to dictionary format |
-| `format_console_output` | | `str` | Formats report for terminal display |
-
-### Fields
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `approved` | `bool` | | Whether release is approved |
-| `confidence` | `str` | | Confidence level in assessment |
-| `quality_gates` | `list[QualityGate]` | `[]` | Individual gate results |
-| `agent_results` | `list[ReleaseAgentResult]` | `[]` | Results from each agent |
-| `blockers` | `list[str]` | `[]` | Critical issues blocking release |
-| `warnings` | `list[str]` | `[]` | Non-blocking concerns |
-| `summary` | `str` | `''` | Executive summary |
-| `timestamp` | `str` | current ISO time | Assessment timestamp |
-| `total_duration` | `float` | `0.0` | Total execution time |
-| `total_cost` | `float` | `0.0` | Total execution cost |
-
-## ReleasePrepTeam
-
-Coordinates parallel execution of release preparation agents.
-
-### Methods
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `__init__` | `quality_gates: dict[str, Any] \| None = None, redis_url: str \| None = None` | `None` | Initializes team with quality gates and Redis connection |
-| `get_total_cost` | | `float` | Calculates total execution cost across agents |
-| `assess_readiness` | `codebase_path: str = '.'` | `ReleaseReadinessReport` | Runs full release assessment |
-
-## ReleasePrepTeamWorkflow
-
-Workflow wrapper that integrates ReleasePrepTeam with the CLI registry.
-
-### Methods
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `__init__` | `quality_gates: dict[str, float] \| None = None, **kwargs: Any` | `None` | Initializes workflow with quality gates |
-| `run_stage` | `stage_name: str, tier: ModelTier, input_data: Any` | `Any` | Executes specific workflow stage |
-| `execute` | `path: str = '.', context: dict[str, Any] \| None = None, **kwargs: Any` | `ReleaseReadinessReport` | Runs complete release preparation workflow |
-
-## ReleasePreparationWorkflow
-
-Pre-release quality gate workflow powered by Agent SDK subagents.
-
-### Methods
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `run_stage` | `stage_name: str, tier: ModelTier, input_data: Any` | `Any` | Executes workflow stage with specified model tier |
-| `execute` | `path: str = '.', context: dict[str, Any] \| None = None, **kwargs: Any` | `ReleaseReadinessReport` | Runs full preparation workflow |
-
-## Constants
-
-| Constant | Values | Description |
-|----------|--------|-------------|
-| `_SUBAGENT_NAMES` | `['health-checker', 'security-scanner', 'changelog-generator', 'release-assessor']` | Specialized agent roles for release preparation |
+`release`, `publishing`, `quality`

--- a/.help/templates/release-prep/task.md
+++ b/.help/templates/release-prep/task.md
@@ -1,80 +1,57 @@
 ---
-type: task
 feature: release-prep
 depth: task
-generated_at: 2026-05-04T02:27:06.561642+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-01T11:59:09.433154+00:00
+source_hash: 4c7a32841bb910c6bfc8e67572024ffed2759925aeba9ce59b7fbfb6fda20b18
 status: generated
 ---
 
 # Work with release prep
 
-Use release prep when you need to customize the pre-release quality gates, add new check types, or modify the agent escalation behavior.
+Use release prep when you need to pre-release quality gate — health checks, security audit, changelog, version bumps.
 
 ## Prerequisites
 
 - Access to the project source code
-- Familiarity with the agent system architecture
+- Familiarity with the files under src/attune/workflows/release_prep.py
 
-## Examine the existing agent structure
+## Steps
 
-Review the release prep components to understand the current implementation:
+1. **Understand the class hierarchy.**
+   Read the interfaces to see how release prep
+   is structured before extending or modifying.
+   The key classes are:
+   - `ReleasePreparationWorkflow` in `src/attune/workflows/release_prep.py` — Pre-release quality gate workflow powered by Agent SDK subagents.
+   - `ReleaseAgent` in `src/attune/agents/release/base_agent.py` — Base agent with CHEAP -> CAPABLE -> PREMIUM escalation.
+   - `TestCoverageAgent` in `src/attune/agents/release/coverage_agent.py` — Runs pytest --cov and parses coverage report.
+   - `DocumentationAgent` in `src/attune/agents/release/documentation_agent.py` — Checks docstring coverage, README currency, and CHANGELOG presence.
+   - `CodeQualityAgent` in `src/attune/agents/release/quality_agent.py` — Runs ruff, checks type hints and complexity.
+2. **Decide whether to extend or modify.**
+   If the class has subclasses, extend with a new one
+   rather than changing the base. If it stands alone,
+   modify directly.
 
-- `ReleaseAgent` — Base agent with tiered escalation (CHEAP → CAPABLE → PREMIUM)
-- `TestCoverageAgent` — Runs pytest with coverage analysis
-- `DocumentationAgent` — Validates docstrings, README, and changelog
-- `CodeQualityAgent` — Executes ruff linting and complexity checks
-- `ReleasePrepTeam` — Orchestrates parallel agent execution
+3. **Make your change.**
+   Follow existing patterns — naming, error handling,
+   and logging style.
 
-## Choose your modification approach
+4. **Run the related tests.**
+   Target with `pytest -k "release-prep"`.
 
-Determine whether to extend or modify the existing components:
+## Key files
 
-1. **Extend with a new agent** if you need additional check types (security scanning, performance benchmarks)
-2. **Modify existing agents** if you need to change thresholds, add new quality gates, or alter escalation logic
-3. **Customize the team orchestration** if you need different parallel execution patterns
+- `src/attune/workflows/release_prep.py`
+- `src/attune/agents/release/**`
 
-## Implement your changes
+## Common modifications
 
-### Add a new specialized agent
+Classes you are most likely to extend:
 
-Create a subclass of `ReleaseAgent` in the appropriate module:
-
-```python
-class SecurityAgent(ReleaseAgent):
-    def __init__(self, redis_client=None, state_store=None):
-        super().__init__("security-scanner", "security", redis_client, state_store)
-```
-
-### Modify quality gates
-
-Update the `QualityGate` thresholds in `ReleasePrepTeam`:
-
-```python
-quality_gates = {
-    "test_coverage": 85.0,  # Raise from default
-    "complexity_score": 10.0,  # Lower threshold
-}
-```
-
-### Customize escalation behavior
-
-Override the `process` method in `ReleaseAgent` to change when tier escalation occurs.
-
-## Validate your implementation
-
-Run the release prep test suite to verify your changes:
-
-```bash
-pytest -k "release-prep" -v
-```
-
-Check that your modifications produce valid `ReleaseReadinessReport` outputs and maintain the go/no-go decision logic.
-
-## Success criteria
-
-Your release prep modifications work correctly when:
-- All existing tests pass
-- New agents integrate with `ReleasePrepTeam` orchestration
-- The assessment report includes your custom quality gates
-- Escalation behavior follows your specified tier progression
+- `ReleasePreparationWorkflow` in `src/attune/workflows/release_prep.py`
+- `ReleaseAgent` in `src/attune/agents/release/base_agent.py`
+- `TestCoverageAgent` in `src/attune/agents/release/coverage_agent.py`
+- `DocumentationAgent` in `src/attune/agents/release/documentation_agent.py`
+- `CodeQualityAgent` in `src/attune/agents/release/quality_agent.py`
+- `Tier` in `src/attune/agents/release/release_models.py`
+- `ReleaseAgentResult` in `src/attune/agents/release/release_models.py`
+- `QualityGate` in `src/attune/agents/release/release_models.py`

--- a/src/attune/workflows/deep_review.py
+++ b/src/attune/workflows/deep_review.py
@@ -30,12 +30,15 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
-    sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -242,11 +245,20 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
             return self._error_result(f"Agent SDK connection failed: {exc}")
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors to return
-            # a structured WorkflowResult rather than crashing.
+            # a structured WorkflowResult rather than crashing. Phase 5
+            # of docs/specs/sdk-error-message-fidelity/ — the exact
+            # workflow Patrick hit 2026-06-01 with a 401 auth failure
+            # that the legacy three-cause menu mis-attributed.
             logger.exception("Deep review failed: %s", type(exc).__name__)
-            duration = (datetime.now() - started_at).total_seconds()
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary, stderr=stderr, kind=kind, original_exc=exc
+            )
             return self._error_result(
-                sdk_error_message(exc, duration_seconds=duration, depth=depth)
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
             )
 
     async def _run_deep_review(

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -27,13 +27,16 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_task_budget,
     get_thinking_config,
     resolve_cwd_for_path,
-    sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -272,14 +275,21 @@ class RagCodeGenWorkflow(BaseWorkflow):
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors so we
             # return a structured WorkflowResult rather than
-            # crashing the CLI.
+            # crashing the CLI. Phase 5 of
+            # docs/specs/sdk-error-message-fidelity/.
             logger.exception(
                 "RAG generation failed: %s",
                 type(exc).__name__,
             )
-            duration = (datetime.now() - started_at).total_seconds()
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary, stderr=stderr, kind=kind, original_exc=exc
+            )
             return self._error_result(
-                sdk_error_message(exc, duration_seconds=duration, depth=depth)
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
             )
 
         completed_at = datetime.now()

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -19,12 +19,15 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
-    sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -154,11 +157,18 @@ class ReleasePreparationWorkflow(BaseWorkflow):
             return self._error_result(f"Agent SDK connection failed: {exc}")
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors to return
-            # a structured WorkflowResult rather than crashing.
+            # a structured WorkflowResult rather than crashing. Phase 5
+            # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK release prep failed: %s", type(exc).__name__)
-            duration = (datetime.now() - started_at).total_seconds()
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary, stderr=stderr, kind=kind, original_exc=exc
+            )
             return self._error_result(
-                sdk_error_message(exc, duration_seconds=duration, depth=depth)
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
             )
 
     async def _run_agent_prep(

--- a/src/attune/workflows/research_synthesis.py
+++ b/src/attune/workflows/research_synthesis.py
@@ -25,12 +25,15 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
-    sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -178,11 +181,18 @@ class ResearchSynthesisWorkflow(BaseWorkflow):
             return self._error_result(f"Agent SDK connection failed: {exc}")
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors to return
-            # a structured WorkflowResult rather than crashing.
+            # a structured WorkflowResult rather than crashing. Phase 5
+            # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK research synthesis failed: %s", type(exc).__name__)
-            duration = (datetime.now() - started_at).total_seconds()
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary, stderr=stderr, kind=kind, original_exc=exc
+            )
             return self._error_result(
-                sdk_error_message(exc, duration_seconds=duration, depth=depth)
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
             )
 
     async def _run_agent_synthesis(

--- a/src/attune/workflows/simplify_code.py
+++ b/src/attune/workflows/simplify_code.py
@@ -25,12 +25,15 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
-    sdk_error_message,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -173,11 +176,18 @@ class SimplifyCodeWorkflow(BaseWorkflow):
             return self._error_result(f"Agent SDK connection failed: {exc}")
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors to return
-            # a structured WorkflowResult rather than crashing.
+            # a structured WorkflowResult rather than crashing. Phase 5
+            # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK code simplification failed: %s", type(exc).__name__)
-            duration = (datetime.now() - started_at).total_seconds()
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary, stderr=stderr, kind=kind, original_exc=exc
+            )
             return self._error_result(
-                sdk_error_message(exc, duration_seconds=duration, depth=depth)
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
             )
 
     async def _run_agent_simplify(

--- a/tests/unit/workflows/test_deep_review.py
+++ b/tests/unit/workflows/test_deep_review.py
@@ -142,7 +142,9 @@ class TestDeepReviewExecution:
 
         assert isinstance(result, WorkflowResult)
         assert result.success is False
-        assert "RuntimeError" in (result.error or "")
+        # Phase 5 — see test_sdk_error_fidelity_phase5.py.
+        assert "claude CLI subprocess failed" in (result.error or "")
+        assert result.metadata.get("sdk_error_kind") == "unknown"
 
     @pytest.mark.asyncio
     async def test_handles_connection_error(self) -> None:

--- a/tests/unit/workflows/test_release_prep_execute.py
+++ b/tests/unit/workflows/test_release_prep_execute.py
@@ -251,9 +251,10 @@ class TestExecuteExceptionHandling:
         self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
         result = asyncio.run(workflow.execute(path="/tmp/proj"))
         assert result.success is False
-        # sdk_error_message wraps the exception; verify the class name
-        # surfaces somewhere in the error string for diagnosability.
-        assert "RuntimeError" in result.error or "kaboom" in result.error
+        # Phase 5 of docs/specs/sdk-error-message-fidelity/ — see
+        # test_sdk_error_fidelity_phase5.py for the new shape.
+        assert "claude CLI subprocess failed" in result.error
+        assert result.metadata.get("sdk_error_kind") == "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/test_sdk_error_fidelity_phase5.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity_phase5.py
@@ -1,0 +1,178 @@
+"""Tests for sdk-error-fidelity Phase 5 workflow wiring.
+
+Covers Task 5.1 of docs/specs/sdk-error-message-fidelity/tasks.md
+for the 5 workflows still using the legacy ``sdk_error_message``
+helper at Phase 5 entry:
+
+- simplify-code
+- deep-review (the morning-2026-06-01 failure case)
+- research-synthesis
+- rag-code-gen
+- release-prep
+
+Same Phase 2/4 contract — workflow's broad-except branch calls
+capture_subprocess_failure + classify_subprocess_failure, returns
+a typed SdkSubprocessError message, and threads sdk_stderr +
+sdk_error_kind onto _error_result.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_failing_sdk():
+    """Build a mock claude_agent_sdk module whose query raises."""
+    mock_sdk = MagicMock()
+    mock_sdk.query = MagicMock(side_effect=RuntimeError("Command failed"))
+    mock_sdk.ClaudeAgentOptions = MagicMock()
+    mock_sdk.AgentDefinition = MagicMock()
+    return mock_sdk
+
+
+class TestSimplifyCodePhase5:
+    """simplify_code.py surfaces real cause on subprocess failure."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch("attune.workflows.simplify_code.claude_agent_sdk", mock_sdk),
+            patch(
+                "attune.workflows.simplify_code.capture_subprocess_failure",
+                return_value="401 Unauthorized: invalid api key",
+            ),
+        ):
+            from attune.workflows.simplify_code import SimplifyCodeWorkflow
+
+            wf = SimplifyCodeWorkflow()
+            result = await wf.execute(path="src/")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "auth"
+        assert "auth invalid" in (result.error or "").lower()
+        assert "ANTHROPIC_API_KEY" not in (result.error or "")
+
+
+class TestDeepReviewPhase5:
+    """deep_review.py surfaces real cause — THE morning-2026-06-01 case.
+
+    Patrick ran `attune workflow run deep-review` against an expired
+    `claude` CLI auth token. The legacy menu blamed
+    `ANTHROPIC_API_KEY unset`, `claude not on PATH`, and `SDK version
+    mismatch` — all wrong. The real cause (401 auth) was discoverable
+    only by running `claude -p` directly. This test pins the new
+    behavior.
+    """
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch("attune.workflows.deep_review.claude_agent_sdk", mock_sdk),
+            patch(
+                "attune.workflows.deep_review.capture_subprocess_failure",
+                return_value=(
+                    "Failed to authenticate. API Error: 401 Invalid " "authentication credentials"
+                ),
+            ),
+        ):
+            from attune.workflows.deep_review import DeepReviewAgentSDKWorkflow
+
+            wf = DeepReviewAgentSDKWorkflow()
+            result = await wf.execute(path="src/")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "auth"
+        assert "auth invalid" in (result.error or "").lower()
+        # The legacy three-cause menu must NOT appear.
+        assert "ANTHROPIC_API_KEY" not in (result.error or "")
+        assert "isn't installed" not in (result.error or "")
+        assert "SDK version" not in (result.error or "")
+
+
+class TestResearchSynthesisPhase5:
+    """research_synthesis.py surfaces real cause on subprocess failure."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch("attune.workflows.research_synthesis.claude_agent_sdk", mock_sdk),
+            patch(
+                "attune.workflows.research_synthesis.capture_subprocess_failure",
+                return_value="429 Too Many Requests: rate limit exceeded",
+            ),
+        ):
+            from attune.workflows.research_synthesis import ResearchSynthesisWorkflow
+
+            wf = ResearchSynthesisWorkflow()
+            result = await wf.execute(path="src/")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "rate_limit"
+        assert "rate" in (result.error or "").lower()
+
+
+class TestRagCodeGenPhase5:
+    """rag_code_gen.py surfaces real cause on subprocess failure."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        mock_sdk = _make_failing_sdk()
+        # RAG pipeline runs BEFORE the SDK query — mock it so execution
+        # reaches the SDK error path instead of failing on RAG init
+        # (which raises if attune-rag's [attune-help] extra isn't
+        # installed in the test env).
+        mock_pipeline = MagicMock()
+        mock_pipeline.run.return_value = MagicMock(
+            citations=[],
+            grounded_prompt="prompt",
+            context="",
+            metadata={},
+        )
+        with (
+            patch("attune.workflows.rag_code_gen.claude_agent_sdk", mock_sdk),
+            patch(
+                "attune.workflows.rag_code_gen.capture_subprocess_failure",
+                return_value=("Error: You have reached your specified API usage limits."),
+            ),
+            patch(
+                "attune.workflows.rag_code_gen.RagCodeGenWorkflow._get_pipeline",
+                return_value=mock_pipeline,
+            ),
+        ):
+            from attune.workflows.rag_code_gen import RagCodeGenWorkflow
+
+            wf = RagCodeGenWorkflow()
+            result = await wf.execute(query="how do I use the test framework?")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "api_quota"
+        assert "API quota reached" in (result.error or "")
+        assert "ANTHROPIC_API_KEY" not in (result.error or "")
+
+
+class TestReleasePrepPhase5:
+    """release_prep.py surfaces real cause on subprocess failure."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch("attune.workflows.release_prep.claude_agent_sdk", mock_sdk),
+            patch(
+                "attune.workflows.release_prep.capture_subprocess_failure",
+                return_value="401 Unauthorized",
+            ),
+        ):
+            from attune.workflows.release_prep import ReleasePreparationWorkflow
+
+            wf = ReleasePreparationWorkflow()
+            result = await wf.execute(path="src/")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "auth"
+        assert "auth invalid" in (result.error or "").lower()

--- a/tests/unit/workflows/test_simplify_code_execute.py
+++ b/tests/unit/workflows/test_simplify_code_execute.py
@@ -155,7 +155,11 @@ class TestSimplifyCodeExecute:
 
         result = asyncio.run(workflow.execute(path="/tmp/test"))
         assert result.success is False
-        assert "RuntimeError" in result.error
+        # Phase 5 of docs/specs/sdk-error-message-fidelity/ replaced the
+        # legacy exception-text leak with the structured
+        # SdkSubprocessError message.
+        assert "claude CLI subprocess failed" in result.error
+        assert result.metadata.get("sdk_error_kind") == "unknown"
 
     def test_execute_default_depth(self, workflow):
         """execute() defaults to 'standard' depth."""


### PR DESCRIPTION
## Summary

Phase 5 of [`docs/specs/sdk-error-message-fidelity/`](docs/specs/sdk-error-message-fidelity/tasks.md). Migrates the remaining workflows that still use the legacy `sdk_error_message` helper, eliminating the last bastion of the misleading three-cause menu (ANTHROPIC_API_KEY unset / claude not on PATH / SDK version mismatch) that motivated the spec.

**Why now**: bumped into v7.3.0 release-prep window with Phase 4 ([#543](https://github.com/Smart-AI-Memory/attune-ai/pull/543)). Stacks on Phase 4; merges before [#542 (v7.3.0)](https://github.com/Smart-AI-Memory/attune-ai/pull/542) can be marked ready.

## Workflow migrations (5)

| Workflow | Before | After |
|---|---|---|
| `simplify-code` | Legacy 3-cause menu | Typed `SdkSubprocessError` flow |
| `deep-review` | Legacy 3-cause menu (the morning-2026-06-01 case) | Typed flow |
| `research-synthesis` | Legacy 3-cause menu | Typed flow |
| `rag-code-gen` | Legacy 3-cause menu | Typed flow |
| `release-prep` | Legacy 3-cause menu | Typed flow |

## Scope difference from spec named list

The spec named **test-audit, doc-audit, doc-gen, discovery-sweep, secure-release, deep-review** as Phase 5 targets — but only `deep-review` actually used the legacy helper. The other 5 named workflows have hand-rolled error messages (`"Agent SDK error: <type>: <exc>"`) that don't surface the misleading three-cause menu — they have a different (less bad) error UX.

**Migrating those 5 is a v7.4.0 follow-up**, not v7.3.0 release-blocking. This PR migrates the 5 workflows that *actually* used the legacy helper.

## Tests

**5 new** — `tests/unit/workflows/test_sdk_error_fidelity_phase5.py`. One test per migrated workflow, mirrors Phase 2/4 shape. The `deep-review` test specifically pins the morning-2026-06-01 401 case.

**3 updated existing** — same pattern as Phase 4 fix:
- `test_simplify_code_execute.py::test_generic_exception`
- `test_deep_review.py::test_handles_sdk_exception_gracefully`
- `test_release_prep_execute.py::test_generic_exception`

All asserted on the legacy "RuntimeError" / "kaboom" leak strings. Updated to check `"claude CLI subprocess failed"` + `sdk_error_kind == "unknown"` (matches Phase 2's update pattern from [#522](https://github.com/Smart-AI-Memory/attune-ai/pull/522)).

## Test plan

- [x] Local: 5 new Phase 5 tests pass
- [x] Local: 3 updated existing tests pass
- [x] Local: 57 tests in adjacent test files pass with no regressions
- [ ] CI green across full matrix
- [ ] Stacks: merge Phase 4 ([#543](https://github.com/Smart-AI-Memory/attune-ai/pull/543)) before this PR

## Spec coverage after Phase 5

| Phase | Status | Workflows |
|---|---|---|
| Phase 2 (#522) | ✅ Shipped | `code-review`, `dependency-check` |
| Phase 4 (#543) | ⏳ Awaiting CI | `bug-predict`, `perf-audit`, `refactor-plan`, `security-audit` |
| **Phase 5 (this)** | **This PR** | `simplify-code`, `deep-review`, `research-synthesis`, `rag-code-gen`, `release-prep` |
| Phase 6 (v7.4.0) | Future | `test-audit`, `doc-audit`, `doc-gen`, `discovery-sweep`, `secure-release` |

11 of 16 SDK-backed workflows now surface real causes. The remaining 5 don't have the misleading-menu problem (hand-rolled error messages); migrating them is consistency cleanup, not bug fix.
