### PR TITLE
chore: weekly report 2026-06-01

### DIFF
--- a/weekly-reports/2026-06-01.md
+++ b/weekly-reports/2026-06-01.md
@@ -1,0 +1,178 @@
+# Anthropic Ecosystem Weekly — 2026-06-01
+
+## Summary
+
+Big week. **Claude Opus 4.8 launched May 28** with the same price as 4.7 but meaningfully
+better code analysis — directly relevant to the security-audit, code-review, and bug-predict
+workflows. Claude Code shipped eight releases (v2.1.152–v2.1.159) including `.claude/skills`
+auto-loading (simplifies attune-ai's install path) and Dynamic Workflows (watch list). No new
+Agent SDK releases. **June 15 deprecation deadline is now 14 days out** — upgrade from
+carry-over to active.
+
+---
+
+## Recommendations
+
+**1. Upgrade PREMIUM tier to Opus 4.8 — same price, better code analysis**
+
+`adaptive_routing.py` routes the PREMIUM tier to `claude-opus-4-6`. Opus 4.8 (`claude-opus-4-8`
+stable alias) launched May 28 with:
+
+- **4× less likely to miss code flaws** (Anthropic's own benchmark)
+- **SWE-Bench Pro 69.2%** — meaningful jump on coding tasks
+- **Adaptive thinking** — selective reasoning reduces wasted thinking tokens (cost
+  impact: PREMIUM-tier multi-subagent runs should be cheaper per token used)
+- **1M token context** by default (no beta header)
+- **Effort defaults to `high`** — consistent with how the SDK adapter already routes
+
+Pricing: unchanged from 4.7 ($5/$25 per MTok input/output). The stable alias `claude-opus-4-8`
+follows CLAUDE.md policy (not a dated snapshot).
+
+Files to update:
+- `src/attune/models/adaptive_routing.py:31` — `"premium": "claude-opus-4-6"` → `"claude-opus-4-8"`
+- `src/attune/agents/release/release_models.py:6` — same key, same change
+- `src/attune/models/registry.py` — add Opus 4.8 entry with pricing
+- `src/attune/models/telemetry/analytics.py:5` — model ID used in analytics filter
+
+Alternative: wait for the model to season (a week or two) in case early-ship quirks emerge.
+Given the code-analysis focus of attune-ai's workflows, the benefit-to-risk is favorable now.
+
+- **Applies to:** `src/attune/models/`, `src/attune/agents/release/`
+- **Urgency:** Medium — no deadline, but the gains are real and the cost is zero.
+
+---
+
+**2. June 15 deprecation is 14 days out — clean up `cost_tracker.py` and audit siblings**
+
+This was Rec #1 from May-25. `polish.py` is already fixed (uses stable `claude-sonnet-4-6` ✅).
+`cost_tracker.py:52` still has a stale pricing entry:
+
+```python
+# src/attune/cost_tracker.py:49-53 — legacy_models dict
+"claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
+```
+
+The pricing dict alone won't cause API failures — it's a lookup table, not a call path. But if
+any process passes the deprecated ID to the Anthropic API after June 15, it will 404. Steps:
+
+1. `grep -r "4-20250514" src/ attune-author/ attune-rag/ attune-help/` across all sibling repos.
+2. Remove or rename the `cost_tracker.py` pricing entry to `claude-opus-4-6`.
+3. Confirm nothing in `attune-author`'s polish pipeline passes a snapshot ID (currently looks
+   clean but verify after #1 above).
+
+Two weeks is enough time but not slack. Do this in the next few days.
+
+- **Applies to:** `src/attune/cost_tracker.py`, and all sibling repos
+- **Urgency:** High — hard deadline June 15.
+
+---
+
+**3. Evaluate `.claude/skills` auto-loading for plugin install UX**
+
+Claude Code v2.1.157 (May 29) added: "Plugins in `.claude/skills`: Automatically loaded without
+marketplace requirement." Currently installing attune-ai as a Claude Code plugin requires two
+commands (marketplace add + plugin install). If `attune setup` copies skills to the user's
+`.claude/skills/` directory, the plugin is available immediately on the next Claude Code session
+without marketplace ceremony.
+
+Caveats before committing: the exact semantics (project-scoped `.claude/skills/` vs. user-global
+`~/.claude/skills/`) need verification against the release notes. The namespacing behavior (skills
+currently load as `attune-ai:<skill-name>`) may differ for auto-loaded skills. Prototype with one
+skill before migrating the full set.
+
+Also new in v2.1.157: `claude plugin init <name>` scaffolds a skill structure — useful for
+attune-ai contributors adding new skills without handcrafting the frontmatter.
+
+- **Applies to:** `plugin/skills/`, `src/attune/` (`attune setup` command if it exists)
+- **Urgency:** Low — investigate + prototype, not a production change yet.
+
+---
+
+**4. Add upper bound to claude-agent-sdk in pyproject.toml**
+
+The lockfile is safely pinned at `0.1.63` (pre-breaking-changes). But `pyproject.toml` declares
+`>=0.1.60,<1.0.0` with no tighter cap. Running `uv lock --upgrade-package claude-agent-sdk`
+would pull in `0.2.87` and land the two breaking changes from May-18 (MCP background
+connection, TodoWrite → Task tools) without any warning. Add an explicit ceiling:
+
+```toml
+"claude-agent-sdk>=0.1.60,<0.2.82"
+```
+
+This documents intent and prevents an accidental bump during routine lock refreshes. When
+you're ready to take on the 0.2.x breaking changes, remove the cap deliberately.
+
+- **Applies to:** `pyproject.toml`
+- **Urgency:** Medium — the lockfile is safe today, but a future `uv lock --upgrade` could
+  break workflows silently.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| May-25 #1 | 2026-05-25 | Fix deprecated model IDs before June 15 | **Partial** — `polish.py` ✅, `cost_tracker.py` still has stale key. Now Rec #2 above. |
+| May-25 #2 | 2026-05-25 | Switch attune-ops session discovery to `claude agents --json` | Open. Still Research Preview; filesystem fallback still defensible. |
+| May-25 #3 | 2026-05-25 | Add cache diagnostics to attune-author polish pipeline | Open. Pairs with Opus 4.8 upgrade — good moment to add observability before changing the model. |
+| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open — minor doc edit, no urgency. |
+| May-18 #1 | 2026-05-18 | Cap Agent SDK below v0.2.82 | Now Rec #4 above — lockfile is safe at 0.1.63 but pyproject.toml is open. |
+| May-18 #2 | 2026-05-18 | Pick up MCP security fix (mcp>=1.23.0) | Still open — tied to SDK cap resolution. |
+| May-18 #3 | 2026-05-18 | `CLAUDE_PROJECT_DIR` in MCP server `workspace_root` | Still open. One-line fix in `EmpathyMCPServer.__init__`. |
+| May-11 #6 | 2026-05-11 | `ENABLE_PROMPT_CACHING_1H` for attune-author polish | Still open if attune-author PR #12 hasn't merged. |
+| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` in adapter | Still open. |
+
+---
+
+## Watch list
+
+- **Opus 4.8 Fast Mode** (Research Preview): 2.5x speed, cheaper than previous models. If it
+  reaches GA, the multi-subagent PREMIUM-tier workflows (security-audit, code-review, deep-review)
+  could cut latency in half. The `max_budget_usd` cap in the SDK adapter would need to account
+  for the new pricing rate.
+
+- **Dynamic Workflows in Claude Code (v2.1.154)**: Claude Code can now orchestrate "tens to
+  hundreds of agents" for large-scale tasks. This is a CLI feature, not an API feature — not
+  directly usable from attune-ai's Python SDK workflows today. But if Anthropic exposes this
+  via the Agent SDK, it maps directly to attune-ai's parallel-subagent pattern. Watch for
+  an SDK-side counterpart.
+
+- **Mid-conversation system messages (Opus 4.8)**: The API now allows `role: "system"` messages
+  at non-first positions in the message array while preserving prompt cache hits. This could
+  let the SDK adapter inject per-run dynamic context (project path, file lists) as stable
+  system messages rather than user message prefixes, keeping cache hits on the large base
+  system prompt. Needs Agent SDK exposure before attune-ai can use it directly.
+
+- **MCP tunnels (Research Preview, May 19)**: Private-network MCP server connections without
+  inbound ports. Not needed for current local dev pattern, but relevant if attune-ai's MCP
+  server is ever deployed inside a customer VPC.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Agent SDK v0.2.83–v0.2.87 | No new releases this week (last was May 23); all were pure CLI bundler updates per prior research |
+| Claude Managed Agents (self-hosted sandboxes, MCP tunnels, AWS expansion) | Stack uses Agent SDK, not Managed Agents |
+| Opus 4.8 Computer Use | Stack doesn't use computer use |
+| Opus 4.8 Advisor Tool | Not used in the stack |
+| Auto mode on Bedrock/Vertex/Azure (v2.1.158) | Stack uses direct Anthropic API, not cloud providers |
+| Opus 4.6 Fast Mode deprecation | Stack doesn't use fast mode on 4.6; no callsites |
+| `claude plugin init` scaffolding | Useful for contributors, not production stack |
+| `/reload-skills` (v2.1.152) | Developer QoL, no stack code impact |
+| Dynamic Workflows in Claude Code (v2.1.154) | CLI feature only; no Python API exposure yet |
+| Claude Design (Anthropic Labs) | Visual collaboration tool, not applicable |
+| Anthropic IPO / funding news | Not actionable |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes` (through June 1, 2026)
+- `www.anthropic.com/news` (Claude Opus 4.8 launch post, May 28, 2026)
+- Claude Code releases: v2.1.152–v2.1.159 (May 27–31, 2026)
+- PyPI: `claude-agent-sdk` — no new releases this week (last: 0.2.87, May 23)
+- Repo audit: `src/attune/models/adaptive_routing.py`, `src/attune/agents/release/release_models.py`,
+  `src/attune/cost_tracker.py`, `src/attune/help/polish.py`, `uv.lock`, `pyproject.toml`
+- Prior week report: `weekly-reports/2026-05-25.md`


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-06-01

## Summary

Big week. **Claude Opus 4.8 launched May 28** with the same price as 4.7 but meaningfully
better code analysis — directly relevant to the security-audit, code-review, and bug-predict
workflows. Claude Code shipped eight releases (v2.1.152–v2.1.159) including `.claude/skills`
auto-loading (simplifies attune-ai's install path) and Dynamic Workflows (watch list). No new
Agent SDK releases. **June 15 deprecation deadline is now 14 days out** — upgrade from
carry-over to active.

---

## Recommendations

**1. Upgrade PREMIUM tier to Opus 4.8 — same price, better code analysis**

`adaptive_routing.py` routes the PREMIUM tier to `claude-opus-4-6`. Opus 4.8 (`claude-opus-4-8`
stable alias) launched May 28 with:

- **4× less likely to miss code flaws** (Anthropic's own benchmark)
- **SWE-Bench Pro 69.2%** — meaningful jump on coding tasks
- **Adaptive thinking** — selective reasoning reduces wasted thinking tokens (cost
  impact: PREMIUM-tier multi-subagent runs should be cheaper per token used)
- **1M token context** by default (no beta header)
- **Effort defaults to `high`** — consistent with how the SDK adapter already routes

Pricing: unchanged from 4.7 ($5/$25 per MTok input/output). The stable alias `claude-opus-4-8`
follows CLAUDE.md policy (not a dated snapshot).

Files to update:
- `src/attune/models/adaptive_routing.py:31` — `"premium": "claude-opus-4-6"` → `"claude-opus-4-8"`
- `src/attune/agents/release/release_models.py:6` — same key, same change
- `src/attune/models/registry.py` — add Opus 4.8 entry with pricing
- `src/attune/models/telemetry/analytics.py:5` — model ID used in analytics filter

Alternative: wait for the model to season (a week or two) in case early-ship quirks emerge.
Given the code-analysis focus of attune-ai's workflows, the benefit-to-risk is favorable now.

- **Applies to:** `src/attune/models/`, `src/attune/agents/release/`
- **Urgency:** Medium — no deadline, but the gains are real and the cost is zero.

---

**2. June 15 deprecation is 14 days out — clean up `cost_tracker.py` and audit siblings**

This was Rec #1 from May-25. `polish.py` is already fixed (uses stable `claude-sonnet-4-6` ✅).
`cost_tracker.py:52` still has a stale pricing entry:

```python
# src/attune/cost_tracker.py:49-53 — legacy_models dict
"claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
```

The pricing dict alone won't cause API failures — it's a lookup table, not a call path. But if
any process passes the deprecated ID to the Anthropic API after June 15, it will 404. Steps:

1. `grep -r "4-20250514" src/ attune-author/ attune-rag/ attune-help/` across all sibling repos.
2. Remove or rename the `cost_tracker.py` pricing entry to `claude-opus-4-6`.
3. Confirm nothing in `attune-author`'s polish pipeline passes a snapshot ID (currently looks
   clean but verify after #1 above).

Two weeks is enough time but not slack. Do this in the next few days.

- **Applies to:** `src/attune/cost_tracker.py`, and all sibling repos
- **Urgency:** High — hard deadline June 15.

---

**3. Evaluate `.claude/skills` auto-loading for plugin install UX**

Claude Code v2.1.157 (May 29) added: "Plugins in `.claude/skills`: Automatically loaded without
marketplace requirement." Currently installing attune-ai as a Claude Code plugin requires two
commands (marketplace add + plugin install). If `attune setup` copies skills to the user's
`.claude/skills/` directory, the plugin is available immediately on the next Claude Code session
without marketplace ceremony.

Caveats before committing: the exact semantics (project-scoped `.claude/skills/` vs. user-global
`~/.claude/skills/`) need verification against the release notes. The namespacing behavior (skills
currently load as `attune-ai:<skill-name>`) may differ for auto-loaded skills. Prototype with one
skill before migrating the full set.

Also new in v2.1.157: `claude plugin init <name>` scaffolds a skill structure — useful for
attune-ai contributors adding new skills without handcrafting the frontmatter.

- **Applies to:** `plugin/skills/`, `src/attune/` (`attune setup` command if it exists)
- **Urgency:** Low — investigate + prototype, not a production change yet.

---

**4. Add upper bound to claude-agent-sdk in pyproject.toml**

The lockfile is safely pinned at `0.1.63` (pre-breaking-changes). But `pyproject.toml` declares
`>=0.1.60,<1.0.0` with no tighter cap. Running `uv lock --upgrade-package claude-agent-sdk`
would pull in `0.2.87` and land the two breaking changes from May-18 (MCP background
connection, TodoWrite → Task tools) without any warning. Add an explicit ceiling:

```toml
"claude-agent-sdk>=0.1.60,<0.2.82"
```

This documents intent and prevents an accidental bump during routine lock refreshes. When
you're ready to take on the 0.2.x breaking changes, remove the cap deliberately.

- **Applies to:** `pyproject.toml`
- **Urgency:** Medium — the lockfile is safe today, but a future `uv lock --upgrade` could
  break workflows silently.

---

## Carry-overs

| # | First raised | Recommendation | Status |
|---|---|---|---|
| May-25 #1 | 2026-05-25 | Fix deprecated model IDs before June 15 | **Partial** — `polish.py` ✅, `cost_tracker.py` still has stale key. Now Rec #2 above. |
| May-25 #2 | 2026-05-25 | Switch attune-ops session discovery to `claude agents --json` | Open. Still Research Preview; filesystem fallback still defensible. |
| May-25 #3 | 2026-05-25 | Add cache diagnostics to attune-author polish pipeline | Open. Pairs with Opus 4.8 upgrade — good moment to add observability before changing the model. |
| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open — minor doc edit, no urgency. |
| May-18 #1 | 2026-05-18 | Cap Agent SDK below v0.2.82 | Now Rec #4 above — lockfile is safe at 0.1.63 but pyproject.toml is open. |
| May-18 #2 | 2026-05-18 | Pick up MCP security fix (mcp>=1.23.0) | Still open — tied to SDK cap resolution. |
| May-18 #3 | 2026-05-18 | `CLAUDE_PROJECT_DIR` in MCP server `workspace_root` | Still open. One-line fix in `EmpathyMCPServer.__init__`. |
| May-11 #6 | 2026-05-11 | `ENABLE_PROMPT_CACHING_1H` for attune-author polish | Still open if attune-author PR #12 hasn't merged. |
| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` in adapter | Still open. |

---

## Watch list

- **Opus 4.8 Fast Mode** (Research Preview): 2.5x speed, cheaper than previous models. If it
  reaches GA, the multi-subagent PREMIUM-tier workflows (security-audit, code-review, deep-review)
  could cut latency in half. The `max_budget_usd` cap in the SDK adapter would need to account
  for the new pricing rate.

- **Dynamic Workflows in Claude Code (v2.1.154)**: Claude Code can now orchestrate "tens to
  hundreds of agents" for large-scale tasks. This is a CLI feature, not an API feature — not
  directly usable from attune-ai's Python SDK workflows today. But if Anthropic exposes this
  via the Agent SDK, it maps directly to attune-ai's parallel-subagent pattern. Watch for
  an SDK-side counterpart.

- **Mid-conversation system messages (Opus 4.8)**: The API now allows `role: "system"` messages
  at non-first positions in the message array while preserving prompt cache hits. This could
  let the SDK adapter inject per-run dynamic context (project path, file lists) as stable
  system messages rather than user message prefixes, keeping cache hits on the large base
  system prompt. Needs Agent SDK exposure before attune-ai can use it directly.

- **MCP tunnels (Research Preview, May 19)**: Private-network MCP server connections without
  inbound ports. Not needed for current local dev pattern, but relevant if attune-ai's MCP
  server is ever deployed inside a customer VPC.

---

## No-ops

| Item | Why skipped |
|---|---|
| Agent SDK v0.2.83–v0.2.87 | No new releases this week (last was May 23); all were pure CLI bundler updates per prior research |
| Claude Managed Agents (self-hosted sandboxes, MCP tunnels, AWS expansion) | Stack uses Agent SDK, not Managed Agents |
| Opus 4.8 Computer Use | Stack doesn't use computer use |
| Opus 4.8 Advisor Tool | Not used in the stack |
| Auto mode on Bedrock/Vertex/Azure (v2.1.158) | Stack uses direct Anthropic API, not cloud providers |
| Opus 4.6 Fast Mode deprecation | Stack doesn't use fast mode on 4.6; no callsites |
| `claude plugin init` scaffolding | Useful for contributors, not production stack |
| `/reload-skills` (v2.1.152) | Developer QoL, no stack code impact |
| Dynamic Workflows in Claude Code (v2.1.154) | CLI feature only; no Python API exposure yet |
| Claude Design (Anthropic Labs) | Visual collaboration tool, not applicable |
| Anthropic IPO / funding news | Not actionable |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes` (through June 1, 2026)
- `www.anthropic.com/news` (Claude Opus 4.8 launch post, May 28, 2026)
- Claude Code releases: v2.1.152–v2.1.159 (May 27–31, 2026)
- PyPI: `claude-agent-sdk` — no new releases this week (last: 0.2.87, May 23)
- Repo audit: `src/attune/models/adaptive_routing.py`, `src/attune/agents/release/release_models.py`,
  `src/attune/cost_tracker.py`, `src/attune/help/polish.py`, `uv.lock`, `pyproject.toml`
- Prior week report: `weekly-reports/2026-05-25.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPupo3FqxFH74k9MNAou64)_