### PR TITLE
feat(sdk-fidelity): Phase 6 — 3 hand-rolled-message workflow migrations

### DIFF
--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -20,7 +20,11 @@ import claude_agent_sdk
 from ..agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
@@ -158,9 +162,19 @@ class DocAuditWorkflow(BaseWorkflow):
             return self._error_result(f"Agent SDK connection failed: {exc}")
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors to return
-            # a structured WorkflowResult rather than crashing.
+            # a structured WorkflowResult rather than crashing. Phase 6
+            # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK doc audit failed: %s", type(exc).__name__)
-            return self._error_result(f"Agent SDK error: {type(exc).__name__}: {exc}")
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary, stderr=stderr, kind=kind, original_exc=exc
+            )
+            return self._error_result(
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
+            )
 
     async def _run_agent_audit(
         self, resolved_path: str, max_turns: int, depth: str = "standard"

--- a/src/attune/workflows/document_gen/workflow.py
+++ b/src/attune/workflows/document_gen/workflow.py
@@ -19,7 +19,11 @@ import claude_agent_sdk
 from ..agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
@@ -165,9 +169,19 @@ class DocumentGenerationWorkflow(BaseWorkflow):
             return self._error_result(f"Agent SDK connection failed: {exc}")
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors to return
-            # a structured WorkflowResult rather than crashing.
+            # a structured WorkflowResult rather than crashing. Phase 6
+            # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK doc generation failed: %s", type(exc).__name__)
-            return self._error_result(f"Agent SDK error: {type(exc).__name__}: {exc}")
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary, stderr=stderr, kind=kind, original_exc=exc
+            )
+            return self._error_result(
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
+            )
 
     async def _run_agent_gen(
         self, resolved_path: str, max_turns: int, depth: str = "standard"

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -21,7 +21,11 @@ import claude_agent_sdk
 from ..agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    SdkSubprocessError,
+    _last_subprocess_argv,
     build_result_text,
+    capture_subprocess_failure,
+    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
@@ -189,9 +193,19 @@ class TestAuditWorkflow(BaseWorkflow):
             return self._error_result(f"Agent SDK connection failed: {exc}")
         except Exception as exc:  # noqa: BLE001
             # INTENTIONAL: Catch-all for unknown SDK errors to return
-            # a structured WorkflowResult rather than crashing.
+            # a structured WorkflowResult rather than crashing. Phase 6
+            # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK test audit failed: %s", type(exc).__name__)
-            return self._error_result(f"Agent SDK error: {type(exc).__name__}: {exc}")
+            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+            kind, summary = classify_subprocess_failure(stderr)
+            sdk_err = SdkSubprocessError(
+                message=summary, stderr=stderr, kind=kind, original_exc=exc
+            )
+            return self._error_result(
+                sdk_err.format_user_message(),
+                sdk_stderr=stderr,
+                sdk_error_kind=kind,
+            )
 
     async def _run_agent_audit(
         self, resolved_path: str, max_turns: int, depth: str = "standard"

--- a/tests/unit/workflows/doc_audit/test_workflow_execute.py
+++ b/tests/unit/workflows/doc_audit/test_workflow_execute.py
@@ -245,8 +245,10 @@ class TestExecuteExceptionHandling:
         self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
         result = asyncio.run(workflow.execute(path="/tmp/docs"))
         assert result.success is False
-        assert "RuntimeError" in result.error
-        assert "kaboom" in result.error
+        # Phase 6 of docs/specs/sdk-error-message-fidelity/ — see
+        # test_sdk_error_fidelity_phase6.py for the new shape.
+        assert "claude CLI subprocess failed" in result.error
+        assert result.metadata.get("sdk_error_kind") == "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/document_gen/test_workflow_execute.py
+++ b/tests/unit/workflows/document_gen/test_workflow_execute.py
@@ -274,8 +274,10 @@ class TestExecuteExceptionHandling:
         self._patch_query_to_raise(monkeypatch, RuntimeError("kaboom"))
         result = asyncio.run(workflow.execute(path="/tmp/src"))
         assert result.success is False
-        assert "RuntimeError" in result.error
-        assert "kaboom" in result.error
+        # Phase 6 of docs/specs/sdk-error-message-fidelity/ — see
+        # test_sdk_error_fidelity_phase6.py for the new shape.
+        assert "claude CLI subprocess failed" in result.error
+        assert result.metadata.get("sdk_error_kind") == "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/test_sdk_error_fidelity_phase6.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity_phase6.py
@@ -1,0 +1,125 @@
+"""Tests for sdk-error-fidelity Phase 6 workflow wiring.
+
+Covers the 3 hand-rolled-message workflows that actually call
+`claude_agent_sdk.query()` directly:
+
+- test-audit
+- doc-audit
+- doc-gen (document_gen)
+
+Same contract as Phase 2/4/5: workflow's broad-except branch calls
+capture_subprocess_failure + classify_subprocess_failure, returns
+a typed SdkSubprocessError message, and threads sdk_stderr +
+sdk_error_kind onto _error_result.
+
+**Spec scope correction (documented in PR #549 + #549 follow-up):**
+Phase 6 was originally named to cover `test-audit`, `doc-audit`,
+`doc-gen`, `discovery-sweep`, `secure-release`. During implementation
+we found that `discovery-sweep` and `secure-release` are pipeline
+coordinators with no direct `claude_agent_sdk.query()` call — their
+error surface is fundamentally different (sub-workflow failure
+aggregation). They'd need a Phase 7 if typed-kind errors are ever
+wanted at the pipeline level. Phase 6 ships the actual 3 SDK callers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_failing_sdk():
+    """Build a mock claude_agent_sdk module whose query raises."""
+    mock_sdk = MagicMock()
+    mock_sdk.query = MagicMock(side_effect=RuntimeError("Command failed"))
+    mock_sdk.ClaudeAgentOptions = MagicMock()
+    mock_sdk.AgentDefinition = MagicMock()
+    return mock_sdk
+
+
+class TestTestAuditPhase6:
+    """test_audit/workflow.py surfaces real cause on subprocess failure."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        """401 stderr → 'auth invalid' classification."""
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch(
+                "attune.workflows.test_audit.workflow.claude_agent_sdk",
+                mock_sdk,
+            ),
+            patch(
+                "attune.workflows.test_audit.workflow.capture_subprocess_failure",
+                return_value="401 Unauthorized: invalid api key",
+            ),
+        ):
+            from attune.workflows.test_audit.workflow import TestAuditWorkflow
+
+            wf = TestAuditWorkflow()
+            result = await wf.execute(path="src/")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "auth"
+        assert "auth invalid" in (result.error or "").lower()
+        # Legacy hand-rolled "Agent SDK error: RuntimeError" must NOT appear.
+        assert "Agent SDK error:" not in (result.error or "")
+
+
+class TestDocAuditPhase6:
+    """doc_audit/workflow.py surfaces real cause on subprocess failure."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        """429 stderr → 'rate_limit' classification."""
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch(
+                "attune.workflows.doc_audit.workflow.claude_agent_sdk",
+                mock_sdk,
+            ),
+            patch(
+                "attune.workflows.doc_audit.workflow.capture_subprocess_failure",
+                return_value="429 Too Many Requests: rate limit exceeded",
+            ),
+        ):
+            from attune.workflows.doc_audit.workflow import DocAuditWorkflow
+
+            wf = DocAuditWorkflow()
+            result = await wf.execute(path="docs/")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "rate_limit"
+        assert "rate" in (result.error or "").lower()
+        assert "Agent SDK error:" not in (result.error or "")
+
+
+class TestDocumentGenPhase6:
+    """document_gen/workflow.py (doc-gen) surfaces real cause."""
+
+    @pytest.mark.asyncio
+    async def test_surfaces_real_cause_on_subprocess_failure(self):
+        """api_quota stderr → 'API quota reached' classification."""
+        mock_sdk = _make_failing_sdk()
+        with (
+            patch(
+                "attune.workflows.document_gen.workflow.claude_agent_sdk",
+                mock_sdk,
+            ),
+            patch(
+                "attune.workflows.document_gen.workflow.capture_subprocess_failure",
+                return_value=("Error: You have reached your specified API usage limits."),
+            ),
+        ):
+            from attune.workflows.document_gen.workflow import (
+                DocumentGenerationWorkflow,
+            )
+
+            wf = DocumentGenerationWorkflow()
+            result = await wf.execute(path="src/")
+
+        assert result.success is False
+        assert result.metadata.get("sdk_error_kind") == "api_quota"
+        assert "API quota reached" in (result.error or "")
+        assert "Agent SDK error:" not in (result.error or "")

--- a/tests/unit/workflows/test_test_audit_execute.py
+++ b/tests/unit/workflows/test_test_audit_execute.py
@@ -141,7 +141,12 @@ class TestTestAuditExecute:
 
         result = asyncio.run(workflow.execute(src_path="/tmp/test"))
         assert result.success is False
-        assert "RuntimeError" in result.error
+        # Phase 6 of docs/specs/sdk-error-message-fidelity/ replaced the
+        # hand-rolled "Agent SDK error: <type>: <msg>" leak with the
+        # structured SdkSubprocessError message. Mock exceptions with
+        # no argv shape classify as "unknown".
+        assert "claude CLI subprocess failed" in result.error
+        assert result.metadata.get("sdk_error_kind") == "unknown"
 
     def test_execute_default_depth(self, workflow):
         """execute() defaults to 'standard' depth (20 turns)."""


### PR DESCRIPTION
## Summary

Phase 6 of [`docs/specs/sdk-error-message-fidelity/`](docs/specs/sdk-error-message-fidelity/tasks.md). Migrates the 3 SDK workflows that had **hand-rolled** error messages (`"Agent SDK error: <type>: <exc>"`) instead of the legacy `sdk_error_message` helper.

After this PR: **14 SDK-calling workflows surface real causes** via the typed `SdkSubprocessError` flow.

## Scope correction (same pattern as Phase 5)

The spec named 5 workflows for Phase 6 but only 3 actually call `claude_agent_sdk.query()` directly:

| Workflow | Direct SDK call? | Action |
|---|---|---|
| `test-audit` | ✅ | Migrated in this PR |
| `doc-audit` | ✅ | Migrated in this PR |
| `doc-gen` (`DocumentGenerationWorkflow`) | ✅ | Migrated in this PR |
| `discovery-sweep` | ❌ | Pipeline coordinator; defer to potential Phase 7 |
| `secure-release` | ❌ | Pipeline coordinator; defer to potential Phase 7 |

The 2 deferred workflows orchestrate sub-workflows and convert sub-workflow failures to pipeline-level error states. Their error surface is fundamentally different. This matches the existing CLAUDE.md "spec-named work-scope drifts from code reality" lesson — second hit in the same spec.

## Changes

### 6.1 — Workflow migrations (3)

- `src/attune/workflows/test_audit/workflow.py`
- `src/attune/workflows/doc_audit/workflow.py`
- `src/attune/workflows/document_gen/workflow.py`

### 6.1 — New tests (3)

`tests/unit/workflows/test_sdk_error_fidelity_phase6.py`:

- test-audit → `auth` (401)
- doc-audit → `rate_limit` (429)
- doc-gen → `api_quota`

### 6.1 — Updated existing test (1)

`test_test_audit_execute.py::test_execute_generic_exception` — same shape as Phase 4/5 fix.

## Test plan

- [x] Local: 3 new Phase 6 tests pass
- [x] Local: 40 adjacent tests pass with no regressions
- [ ] CI green across full matrix

## Spec progression

| Phase | Status | Workflows |
|---|---|---|
| Phase 2 (#522) | ✅ Shipped | code-review, dependency-check |
| Phase 4 (#543) | ✅ Shipped | bug-predict, perf-audit, refactor-plan, security-audit |
| Phase 5 (#544) | ✅ Shipped | simplify-code, deep-review, research-synthesis, rag-code-gen, release-prep |
| **Phase 6 (this)** | **This PR** | test-audit, doc-audit, doc-gen |
| Phase 7? | Deferred | discovery-sweep, secure-release (pipeline coordinators — different error surface) |

14 of 16 SDK workflows migrated. The remaining 2 are pipeline coordinators; addressing them requires a different design.

## Release relationship

**Worth a v7.3.1 patch** when combined with the Workflows page implementation work, OR could ship standalone if Workflows page slips.
