### PR TITLE
feat(ops): workflow_concern module — derive 7-bucket concern from workflow name (A1)

### DIFF
--- a/src/attune/ops/workflow_concern.py
+++ b/src/attune/ops/workflow_concern.py
@@ -1,0 +1,151 @@
+"""Concern bucket derivation for workflow names.
+
+Pure logic — takes a workflow name (string slug like ``"code-review"``)
+and returns one of seven concern bucket labels:
+
+- ``review``  — code-review, deep-review, security-audit, bug-predict
+- ``test``    — test-gen, test-audit
+- ``docs``    — doc-gen, doc-audit, doc-orchestrator
+- ``refactor``— simplify-code, refactor-plan
+- ``audit``   — discovery-sweep, perf-audit, dependency-check
+- ``meta``    — release-prep, secure-release, orchestrated-health-check, health-check
+- ``other``   — rag-code-gen, research-synthesis
+
+The authoritative assignment table lives at
+[docs/specs/ops-workflows-page-refinement/decisions.md](../../../docs/specs/ops-workflows-page-refinement/decisions.md)
+§ "Concern bucket assignment". Pre-committed there before this module
+landed, per the existing "Pre-committed decision matrices survive
+contact with data" lesson.
+
+Unlike ``spec_lifecycle.py`` (which derives a bucket from runtime
+state), concern is a **canonical static property** of the workflow
+itself. Each workflow lives in exactly one bucket.
+
+Module is pure — no I/O, no project-root awareness. Mirrors the
+``spec_lifecycle.derive_lifecycle()`` shape so the ``/workflows``
+route can call it the same way.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+# Type alias for the 7-bucket concern enum. Mirrors how
+# ``spec_lifecycle`` types the lifecycle bucket — string literals for
+# easy JSON serialization without needing dataclasses.
+Concern = Literal[
+    "review",
+    "test",
+    "docs",
+    "refactor",
+    "audit",
+    "meta",
+    "other",
+]
+
+# All valid bucket names, ordered for stable UI rendering. Don't reorder
+# without updating the wireframe + template chip order.
+ALL_CONCERNS: tuple[Concern, ...] = (
+    "review",
+    "test",
+    "docs",
+    "refactor",
+    "audit",
+    "meta",
+    "other",
+)
+
+# Authoritative assignment. Pre-committed in decisions.md.
+#
+# Trade-offs ratified there:
+# - bug-predict + security-audit live in `review` (not `audit`) because
+#   their UX intent matches review-class workflows: "tell me what's
+#   wrong with this code." `audit` is for codebase-wide health surveys.
+# - doc-orchestrator lives in `docs` even though it's a meta-workflow.
+#   `meta` is reserved for release/health ops; doc-orchestrator is a
+#   domain-specific composer.
+# - Naming consistency: `audit` is BOTH a bucket name AND a workflow-
+#   name suffix (`test-audit`, `doc-audit`, `perf-audit`). These are
+#   routed by *purpose*, not name pattern.
+_WORKFLOW_CONCERNS: dict[str, Concern] = {
+    # review
+    "code-review": "review",
+    "deep-review": "review",
+    "security-audit": "review",
+    "bug-predict": "review",
+    # test
+    "test-gen": "test",
+    "test-audit": "test",
+    # docs
+    "doc-gen": "docs",
+    "doc-audit": "docs",
+    "doc-orchestrator": "docs",
+    # refactor
+    "simplify-code": "refactor",
+    "refactor-plan": "refactor",
+    # audit
+    "discovery-sweep": "audit",
+    "perf-audit": "audit",
+    "dependency-check": "audit",
+    # meta
+    "release-prep": "meta",
+    "secure-release": "meta",
+    "orchestrated-health-check": "meta",
+    "health-check": "meta",
+    # other
+    "rag-code-gen": "other",
+    "research-synthesis": "other",
+}
+
+
+def derive_concern(workflow_name: str) -> Concern:
+    """Return the concern bucket for one workflow.
+
+    Args:
+        workflow_name: The workflow's canonical slug (e.g. ``"code-review"``).
+
+    Returns:
+        One of the 7 ``Concern`` values. Unknown workflow names fall
+        through to ``"other"`` — the catch-all bucket also used for
+        rag-code-gen and research-synthesis. This is intentional: new
+        workflows added without an explicit mapping show up in `other`
+        rather than crashing the route. The drift-guard test
+        (``test_all_registered_workflows_have_concern``) catches the
+        missing assignment in CI.
+
+    Never raises.
+    """
+    return _WORKFLOW_CONCERNS.get(workflow_name, "other")
+
+
+def group_by_concern(workflow_names: list[str]) -> dict[Concern, list[str]]:
+    """Group a list of workflow names by their concern bucket.
+
+    Returns a dict keyed by concern with workflow-name lists as values.
+    Buckets are populated in ``ALL_CONCERNS`` order; empty buckets are
+    omitted (callers that want stable ordering should iterate
+    ``ALL_CONCERNS`` and use ``.get(concern, [])``).
+
+    Within each bucket the names are sorted alphabetically — matches
+    D7's sort decision and keeps output deterministic for testing.
+    """
+    by_concern: dict[Concern, list[str]] = {}
+    for name in workflow_names:
+        c = derive_concern(name)
+        by_concern.setdefault(c, []).append(name)
+    for c in by_concern:
+        by_concern[c].sort()
+    return by_concern
+
+
+def concern_counts(workflow_names: list[str]) -> dict[Concern, int]:
+    """Return per-concern counts for a list of workflow names.
+
+    All 7 buckets are populated (zero for empty buckets) so the chip
+    toolbar can render counts without conditional logic. Mirrors the
+    ``/specs`` route's ``bucket_counts`` shape.
+    """
+    counts: dict[Concern, int] = dict.fromkeys(ALL_CONCERNS, 0)
+    for name in workflow_names:
+        counts[derive_concern(name)] += 1
+    return counts

--- a/tests/unit/ops/test_workflow_concern.py
+++ b/tests/unit/ops/test_workflow_concern.py
@@ -1,0 +1,331 @@
+"""Unit tests for workflow_concern.derive_concern + helpers.
+
+Pure-logic tests — no I/O, no fixtures beyond the module's own data.
+Mirrors the shape of ``tests/unit/ops/test_spec_lifecycle.py``.
+
+Coverage targets:
+- All 7 concern buckets populated correctly per decisions.md
+- derive_concern() handles unknown names without raising
+- group_by_concern() returns alphabetically-sorted lists
+- concern_counts() populates all 7 buckets (zero for empty)
+- Drift-guard: every registered workflow has an explicit concern
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.ops.workflow_concern import (
+    ALL_CONCERNS,
+    concern_counts,
+    derive_concern,
+    group_by_concern,
+)
+
+# ---------------------------------------------------------------------------
+# derive_concern() — per-workflow assignments
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveConcernReview:
+    """4 workflows in the review bucket."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["code-review", "deep-review", "security-audit", "bug-predict"],
+    )
+    def test_assigned_to_review(self, name):
+        assert derive_concern(name) == "review"
+
+
+class TestDeriveConcernTest:
+    """2 workflows in the test bucket."""
+
+    @pytest.mark.parametrize("name", ["test-gen", "test-audit"])
+    def test_assigned_to_test(self, name):
+        assert derive_concern(name) == "test"
+
+
+class TestDeriveConcernDocs:
+    """3 workflows in the docs bucket."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["doc-gen", "doc-audit", "doc-orchestrator"],
+    )
+    def test_assigned_to_docs(self, name):
+        assert derive_concern(name) == "docs"
+
+
+class TestDeriveConcernRefactor:
+    """2 workflows in the refactor bucket."""
+
+    @pytest.mark.parametrize("name", ["simplify-code", "refactor-plan"])
+    def test_assigned_to_refactor(self, name):
+        assert derive_concern(name) == "refactor"
+
+
+class TestDeriveConcernAudit:
+    """3 workflows in the audit bucket."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["discovery-sweep", "perf-audit", "dependency-check"],
+    )
+    def test_assigned_to_audit(self, name):
+        assert derive_concern(name) == "audit"
+
+
+class TestDeriveConcernMeta:
+    """4 workflows in the meta bucket."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "release-prep",
+            "secure-release",
+            "orchestrated-health-check",
+            "health-check",
+        ],
+    )
+    def test_assigned_to_meta(self, name):
+        assert derive_concern(name) == "meta"
+
+
+class TestDeriveConcernOther:
+    """2 workflows in the other bucket."""
+
+    @pytest.mark.parametrize("name", ["rag-code-gen", "research-synthesis"])
+    def test_assigned_to_other(self, name):
+        assert derive_concern(name) == "other"
+
+
+# ---------------------------------------------------------------------------
+# derive_concern() — trade-off boundary cases
+# ---------------------------------------------------------------------------
+
+
+class TestConcernBoundaries:
+    """Workflows whose name suggests one bucket but assignment is another.
+
+    These are the explicit trade-offs ratified in decisions.md. Test
+    them as such so future renames or accidental remappings break here
+    loudly.
+    """
+
+    def test_security_audit_is_review_not_audit(self):
+        """`security-audit` is in `review` despite the audit suffix.
+
+        Per decisions.md: review-class workflows are "tell me what's
+        wrong with this code"; audit-class is "codebase-wide health
+        survey." security-audit is focused, not survey.
+        """
+        assert derive_concern("security-audit") == "review"
+
+    def test_bug_predict_is_review_not_audit(self):
+        """`bug-predict` is in `review` for the same reason."""
+        assert derive_concern("bug-predict") == "review"
+
+    def test_doc_orchestrator_is_docs_not_meta(self):
+        """`doc-orchestrator` is a domain-specific composer, not a meta
+        ops workflow. `meta` is reserved for release/health.
+        """
+        assert derive_concern("doc-orchestrator") == "docs"
+
+    def test_test_audit_is_test_not_audit(self):
+        """`test-audit` is `test` concern despite the audit suffix —
+        routed by *purpose* (testing), not name pattern.
+        """
+        assert derive_concern("test-audit") == "test"
+
+    def test_doc_audit_is_docs_not_audit(self):
+        """`doc-audit` is `docs` concern despite the audit suffix —
+        routed by *purpose* (documentation), not name pattern.
+        """
+        assert derive_concern("doc-audit") == "docs"
+
+    def test_perf_audit_is_audit(self):
+        """`perf-audit` IS in `audit` — codebase-wide perf survey,
+        matches the bucket's "health survey" intent.
+        """
+        assert derive_concern("perf-audit") == "audit"
+
+
+# ---------------------------------------------------------------------------
+# derive_concern() — unknown / fallback
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveConcernUnknown:
+    """Unknown workflow names fall through to `other` without raising."""
+
+    def test_unknown_workflow_falls_through_to_other(self):
+        assert derive_concern("totally-made-up-workflow") == "other"
+
+    def test_empty_string_falls_through_to_other(self):
+        assert derive_concern("") == "other"
+
+    def test_uppercase_name_falls_through_to_other(self):
+        """Concern derivation is case-sensitive — canonical slugs are
+        lowercase. Mixed-case names are unknown.
+        """
+        assert derive_concern("Code-Review") == "other"
+
+
+# ---------------------------------------------------------------------------
+# group_by_concern()
+# ---------------------------------------------------------------------------
+
+
+class TestGroupByConcern:
+    """Grouping into per-concern lists."""
+
+    def test_single_workflow_per_bucket(self):
+        result = group_by_concern(["code-review", "test-gen"])
+        assert result == {"review": ["code-review"], "test": ["test-gen"]}
+
+    def test_multiple_workflows_per_bucket_sorted(self):
+        """Names within a bucket sort alphabetically (deterministic)."""
+        result = group_by_concern(["security-audit", "deep-review", "code-review", "bug-predict"])
+        assert result == {"review": ["bug-predict", "code-review", "deep-review", "security-audit"]}
+
+    def test_empty_input_returns_empty_dict(self):
+        assert group_by_concern([]) == {}
+
+    def test_unknown_workflows_grouped_as_other(self):
+        result = group_by_concern(["mystery-workflow", "rag-code-gen"])
+        assert result == {"other": ["mystery-workflow", "rag-code-gen"]}
+
+    def test_input_order_does_not_affect_bucket_order(self):
+        """Buckets appear in the order their first member appears in
+        input; intra-bucket order is alphabetical regardless.
+        """
+        result = group_by_concern(["test-gen", "code-review", "test-audit"])
+        assert result["test"] == ["test-audit", "test-gen"]
+        assert result["review"] == ["code-review"]
+
+
+# ---------------------------------------------------------------------------
+# concern_counts()
+# ---------------------------------------------------------------------------
+
+
+class TestConcernCounts:
+    """Per-bucket counts. All 7 buckets always present."""
+
+    def test_all_seven_buckets_present_in_empty_input(self):
+        counts = concern_counts([])
+        assert set(counts.keys()) == set(ALL_CONCERNS)
+        assert all(v == 0 for v in counts.values())
+
+    def test_counts_match_inputs(self):
+        counts = concern_counts(
+            [
+                "code-review",
+                "deep-review",
+                "test-gen",
+                "doc-gen",
+                "doc-audit",
+                "doc-orchestrator",
+            ]
+        )
+        assert counts["review"] == 2
+        assert counts["test"] == 1
+        assert counts["docs"] == 3
+        # All other buckets should be 0
+        assert counts["refactor"] == 0
+        assert counts["audit"] == 0
+        assert counts["meta"] == 0
+        assert counts["other"] == 0
+
+    def test_unknown_names_count_as_other(self):
+        counts = concern_counts(["unknown-1", "unknown-2"])
+        assert counts["other"] == 2
+
+    def test_total_count_equals_input_length(self):
+        names = [
+            "code-review",
+            "test-gen",
+            "doc-gen",
+            "simplify-code",
+            "perf-audit",
+            "release-prep",
+            "rag-code-gen",
+        ]
+        counts = concern_counts(names)
+        assert sum(counts.values()) == len(names)
+
+
+# ---------------------------------------------------------------------------
+# Drift-guard: every registered workflow has an explicit concern
+# ---------------------------------------------------------------------------
+
+
+class TestDriftGuard:
+    """If list_workflows() ships a new workflow, this test fails until
+    the assignment is added to _WORKFLOW_CONCERNS. Catches the
+    'add-a-workflow-without-mapping' drift.
+    """
+
+    def test_all_registered_workflows_have_explicit_concern(self):
+        """Every workflow returned by attune.workflows.list_workflows()
+        must have an explicit (not fallback-to-other) concern mapping.
+
+        Skipped if attune.workflows can't be imported (e.g., not
+        installed in the test env). Drift caught at CI level where
+        the package is always available.
+        """
+        try:
+            from attune.workflows import list_workflows
+        except ImportError:
+            pytest.skip("attune.workflows not importable in this env")
+
+        from attune.ops.workflow_concern import _WORKFLOW_CONCERNS  # type: ignore[attr-defined]
+
+        registered = {w["name"] for w in list_workflows()}
+        mapped = set(_WORKFLOW_CONCERNS.keys())
+
+        missing = registered - mapped
+        assert not missing, (
+            f"Registered workflows missing concern mapping: {sorted(missing)}. "
+            f"Add them to _WORKFLOW_CONCERNS in src/attune/ops/workflow_concern.py "
+            f"and update the assignment table in decisions.md."
+        )
+
+
+# ---------------------------------------------------------------------------
+# All concerns is exactly 7 + has the expected names
+# ---------------------------------------------------------------------------
+
+
+class TestAllConcerns:
+    """The exported ``ALL_CONCERNS`` tuple is the authoritative list."""
+
+    def test_exactly_seven_concerns(self):
+        assert len(ALL_CONCERNS) == 7
+
+    def test_expected_names(self):
+        assert set(ALL_CONCERNS) == {
+            "review",
+            "test",
+            "docs",
+            "refactor",
+            "audit",
+            "meta",
+            "other",
+        }
+
+    def test_order_is_stable(self):
+        """The tuple's order matters — chip toolbar renders in this
+        order. If the order changes, the wireframe + chip template
+        order must change too.
+        """
+        assert ALL_CONCERNS == (
+            "review",
+            "test",
+            "docs",
+            "refactor",
+            "audit",
+            "meta",
+            "other",
+        )


### PR DESCRIPTION
## Summary

**A1** of the Workflows page refinement. Mirror of the Specs page A1 pattern (PR #533 — `spec_lifecycle.py`).

Pure-logic module that maps a workflow's canonical name to one of 7 concern buckets per [decisions.md](docs/specs/ops-workflows-page-refinement/decisions.md):

| Concern | Workflows |
|---|---|
| `review` | code-review, deep-review, security-audit, bug-predict |
| `test` | test-gen, test-audit |
| `docs` | doc-gen, doc-audit, doc-orchestrator |
| `refactor` | simplify-code, refactor-plan |
| `audit` | discovery-sweep, perf-audit, dependency-check |
| `meta` | release-prep, secure-release, orchestrated-health-check, health-check |
| `other` | rag-code-gen, research-synthesis |

## Module API

Mirrors `spec_lifecycle.py`:

- `derive_concern(name)` → `Concern` (with `"other"` fallback for unknown)
- `group_by_concern(names)` → `dict[Concern, list[str]]` (alphabetically sorted within bucket)
- `concern_counts(names)` → `dict[Concern, int]` (all 7 buckets always populated)
- `ALL_CONCERNS`: ordered tuple for stable UI rendering

## Tests (42)

- Per-bucket assignment tests for all 20 workflows (parameterized per bucket)
- **Boundary tests** for the 6 trade-off cases ratified in decisions.md:
  - `security-audit` in `review` not `audit`
  - `bug-predict` in `review` not `audit`
  - `test-audit` in `test` not `audit`
  - `doc-audit` in `docs` not `audit`
  - `doc-orchestrator` in `docs` not `meta`
  - `perf-audit` confirmed in `audit`
- Unknown/empty/uppercase name → `other` fallback
- `group_by_concern()` alphabetical-within-bucket sort
- `concern_counts()` always-populates-all-7-buckets contract
- `ALL_CONCERNS` order stability (chip toolbar depends on this)
- **Drift-guard**: every workflow returned by `list_workflows()` has an explicit (not-fallback) concern mapping — catches add-a-workflow-without-mapping at CI level

## Test plan

- [x] Local: 42 tests pass
- [x] Drift-guard verified against current `list_workflows()` registry (all 20 workflows mapped)
- [ ] CI green across full matrix

## Spec progression

| Step | Status | What |
|---|---|---|
| **A1 — workflow_concern module** | **This PR** | Pure-logic bucket derivation + drift guard |
| A2 — wire into route serializer | Next | `routes/dashboard.py::workflows_page` populates per-row concern |
| A3a — chip filter toolbar + concern badge column | Next | JS + template |
| A3b — kebab action column + 3-item menu | Next | View recent runs / Copy run command / View docs |
| A3c — URL param parsing + chip state from URL | Next | `?bucket=…&q=…` |

Non-blocking; v7.4.0 candidate. Bundles with Phase 6 (PR #551, just merged) when the next release cuts.
