### PR TITLE
feat(ops): chip filter toolbar + concern badge column + JS (A3a)

### DIFF
--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -2713,3 +2713,176 @@ a.kpi:hover {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
+
+/* ============================================================
+   A3a — Workflows page refinement: chip toolbar + concern pill.
+   Scoped via `.workflows-toolbar` and `.concern-pill` to avoid
+   collision with the global `.chip` class and the Specs page's
+   `.specs-toolbar` selectors. Mirrors the Specs page pattern
+   (PR #535) for visual consistency across the dashboard's two
+   filtered-list surfaces.
+   ============================================================ */
+
+.workflows-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  align-items: center;
+  margin: 16px 0;
+  padding: 12px;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 6px;
+}
+.workflows-toolbar .chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+.workflows-toolbar .chip-label,
+.workflows-toolbar .search-label {
+  font-size: 12px;
+  color: var(--fg-muted, #6b7280);
+  margin-right: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+}
+.workflows-toolbar .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  border-radius: 99px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  user-select: none;
+  margin: 0;
+  background: var(--bg-soft, #f9fafb);
+  color: var(--fg, #374151);
+  font-family: inherit;
+  line-height: 1.2;
+  text-transform: lowercase;
+}
+.workflows-toolbar .chip:focus-visible {
+  outline: 2px solid var(--accent, #2563eb);
+  outline-offset: 1px;
+}
+.workflows-toolbar .chip-inactive {
+  background: var(--bg-soft, #f9fafb);
+  color: var(--fg-muted, #9ca3af);
+  border-color: var(--border, #e5e7eb);
+  opacity: 0.7;
+}
+.workflows-toolbar .chip-hidden-mark {
+  font-size: 11px;
+  font-weight: 700;
+  margin-left: 2px;
+  opacity: 0.6;
+}
+.workflows-toolbar .chip-count {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+  font-weight: 600;
+}
+
+/* Per-concern accent shades. Applied to BOTH the toolbar chip
+   (when active) AND the inline `.concern-pill` per-row badge.
+   Colors chosen to be distinguishable and to roughly cluster by
+   "type of work" — purple-leaning for review/refactor, green for
+   test, orange for docs, amber for audit, cyan for meta.
+   Matches the wireframe.html palette so the implementation
+   visually matches the design reference. */
+.workflows-toolbar .chip-active.bucket-review,
+.concern-pill.bucket-review {
+  background: #ede9fe;
+  color: #5b21b6;
+  border-color: #c4b5fd;
+}
+.workflows-toolbar .chip-active.bucket-test,
+.concern-pill.bucket-test {
+  background: #d1fae5;
+  color: #065f46;
+  border-color: #6ee7b7;
+}
+.workflows-toolbar .chip-active.bucket-docs,
+.concern-pill.bucket-docs {
+  background: #fed7aa;
+  color: #9a3412;
+  border-color: #fdba74;
+}
+.workflows-toolbar .chip-active.bucket-refactor,
+.concern-pill.bucket-refactor {
+  background: #fce7f3;
+  color: #9d174d;
+  border-color: #f9a8d4;
+}
+.workflows-toolbar .chip-active.bucket-audit,
+.concern-pill.bucket-audit {
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #fcd34d;
+}
+.workflows-toolbar .chip-active.bucket-meta,
+.concern-pill.bucket-meta {
+  background: #cffafe;
+  color: #155e75;
+  border-color: #67e8f9;
+}
+.workflows-toolbar .chip-active.bucket-other,
+.concern-pill.bucket-other {
+  background: #e5e7eb;
+  color: #374151;
+  border-color: #d1d5db;
+}
+
+/* Per-row concern pill. Compact pill inside the new Concern column.
+   Renders even when the row is filtered hidden; visibility is
+   controlled by the parent <tr>'s hidden attribute. */
+.concern-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: lowercase;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+/* Empty-state injected by workflows_refined.js when all rows hide. */
+#workflows-empty-state {
+  margin: 16px 0;
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--fg-muted, #6b7280);
+  background: var(--bg-soft, #f9fafb);
+  border: 1px dashed var(--border, #d1d5db);
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+/* Search input mirrors the Specs page's search-wrap layout. */
+.workflows-toolbar .search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.workflows-toolbar .search-input {
+  border: 1px solid var(--border, #d1d5db);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 13px;
+  width: 200px;
+  background: var(--bg, #fff);
+  color: var(--fg, #111);
+}
+.workflows-toolbar .search-input:focus {
+  outline: 2px solid var(--accent, #2563eb);
+  outline-offset: -1px;
+  border-color: var(--accent, #2563eb);
+}

--- a/src/attune/ops/static/js/workflows_refined.js
+++ b/src/attune/ops/static/js/workflows_refined.js
@@ -1,0 +1,185 @@
+// Workflows page — concern-chip filter + search behavior (A3a).
+//
+// Reads the server-rendered table at /workflows and applies client-side
+// filtering by concern bucket + workflow name substring.
+//
+// Default state per docs/specs/ops-workflows-page-refinement/decisions.md D1/D2:
+//   - All 7 concern chips active (no chip is structurally "noise"
+//     unlike Specs page's Complete-off default)
+//   - Search empty
+//
+// No sort dropdown — workflows render alphabetical by name from the
+// server (decisions.md D7: alphabetical-by-name; v2 may add by-last-run).
+//
+// URL params ship in A3c. A3b adds the kebab action menu.
+//
+// Exports a `window.__attuneWorkflows` namespace so future PRs and
+// source-grep tests can verify the surface (matches the
+// `__attuneSpecs` + `__attuneRunner` convention).
+
+(function () {
+  "use strict";
+
+  // All 7 buckets per decisions.md D1. Stable order; chips render in
+  // the template in this order so the JS doesn't need to enforce it.
+  var VALID_BUCKETS = new Set([
+    "review",
+    "test",
+    "docs",
+    "refactor",
+    "audit",
+    "meta",
+    "other",
+  ]);
+
+  // Mutable state. All buckets active by default. Search empty.
+  var state = {
+    buckets: new Set(VALID_BUCKETS),
+    search: "",
+  };
+
+  // ---------- DOM helpers ----------
+
+  function $(sel) {
+    return document.querySelector(sel);
+  }
+  function $$(sel) {
+    return Array.prototype.slice.call(document.querySelectorAll(sel));
+  }
+
+  function rowConcern(tr) {
+    return tr.getAttribute("data-concern") || "";
+  }
+  function rowName(tr) {
+    return (tr.getAttribute("data-workflow") || "").toLowerCase();
+  }
+
+  // ---------- Filter application ----------
+
+  function applyFilters() {
+    var tbody = $(".workflows-table tbody");
+    if (!tbody) return;
+    var rows = $$(".workflows-table tbody tr");
+    var query = state.search.trim().toLowerCase();
+    var anyVisible = false;
+
+    rows.forEach(function (tr) {
+      var inBucket = state.buckets.has(rowConcern(tr));
+      var matchesQuery = !query || rowName(tr).indexOf(query) !== -1;
+      var visible = inBucket && matchesQuery;
+      if (visible) anyVisible = true;
+      tr.hidden = !visible;
+    });
+
+    updateEmptyState(anyVisible, query);
+  }
+
+  function updateEmptyState(anyVisible, query) {
+    // Reuse the existing .empty <p> from the template when present, or
+    // inject an empty-state row inside the table body. Keeping the
+    // affordance close to the table to mirror the Specs page UX.
+    var box = $("#workflows-empty-state");
+    if (!box) {
+      box = document.createElement("div");
+      box.id = "workflows-empty-state";
+      box.className = "empty-state";
+      box.setAttribute("role", "status");
+      box.hidden = true;
+      var table = $(".workflows-table");
+      if (table && table.parentNode) {
+        table.parentNode.insertBefore(box, table.nextSibling);
+      }
+    }
+    if (anyVisible) {
+      box.hidden = true;
+      return;
+    }
+    box.hidden = false;
+    if (state.buckets.size === 0) {
+      box.textContent =
+        "All concerns filtered out — re-enable at least one chip above.";
+    } else if (query) {
+      box.textContent =
+        "No workflows in active concerns match '" + query + "'.";
+    } else {
+      box.textContent = "No workflows match the current filters.";
+    }
+  }
+
+  // ---------- Chip toggle ----------
+
+  function setChipState(chip, active) {
+    chip.classList.toggle("chip-active", active);
+    chip.classList.toggle("chip-inactive", !active);
+    chip.setAttribute("aria-pressed", active ? "true" : "false");
+    // Add or remove the "✗" hidden-count marker on inactive chips so
+    // the visual state matches the Specs page convention.
+    var mark = chip.querySelector(".chip-hidden-mark");
+    if (!active && !mark) {
+      var span = document.createElement("span");
+      span.className = "chip-hidden-mark";
+      span.setAttribute("aria-hidden", "true");
+      span.textContent = "✗";
+      chip.appendChild(span);
+    } else if (active && mark) {
+      mark.remove();
+    }
+  }
+
+  function wireChips() {
+    $$(".workflows-toolbar .chip[data-bucket]").forEach(function (chip) {
+      chip.addEventListener("click", function () {
+        var bucket = chip.getAttribute("data-bucket");
+        if (!VALID_BUCKETS.has(bucket)) return;
+        if (state.buckets.has(bucket)) {
+          state.buckets.delete(bucket);
+          setChipState(chip, false);
+        } else {
+          state.buckets.add(bucket);
+          setChipState(chip, true);
+        }
+        applyFilters();
+      });
+    });
+  }
+
+  function wireSearch() {
+    var input = $("#workflows-search");
+    if (!input) return;
+    input.addEventListener("input", function () {
+      state.search = input.value;
+      applyFilters();
+    });
+  }
+
+  // ---------- Init ----------
+
+  function init() {
+    wireChips();
+    wireSearch();
+    // First-paint render — server already filtered nothing, but the
+    // empty-state logic needs to run in case there's a stored search
+    // (browser back/forward restored the input value).
+    var input = $("#workflows-search");
+    if (input && input.value) {
+      state.search = input.value;
+    }
+    applyFilters();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  // Exports — namespace mirrors `window.__attuneSpecs` from
+  // specs_refined.js so source-grep tests can verify the surface.
+  window.__attuneWorkflows = {
+    VALID_BUCKETS: VALID_BUCKETS,
+    state: state,
+    applyFilters: applyFilters,
+    setChipState: setChipState,
+    init: init,
+  };
+})();

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -29,10 +29,36 @@
 </section>
 
 {% if workflows %}
-  <table class="data-table runner-table">
+  {# A3a toolbar — concern-chip filter row + search. JS in
+     workflows_refined.js handles state; default chip state is all-on
+     (no concern is structurally "noise" — unlike Specs page's
+     Complete default-off). URL param persistence ships in A3c. #}
+  <div class="workflows-toolbar" role="region" aria-label="Workflow filter controls">
+    <div class="chip-row" role="group" aria-label="Concern bucket filters">
+      <span class="chip-label">Concern:</span>
+      {% for bucket in all_concerns %}
+        <button
+          type="button"
+          class="chip bucket-{{ bucket }} chip-active"
+          data-bucket="{{ bucket }}"
+          aria-pressed="true"
+          aria-label="{{ bucket }} bucket — {{ bucket_counts[bucket] }} workflows"
+        >{{ bucket }} <span class="chip-count" data-count="{{ bucket }}">{{ bucket_counts[bucket] }}</span></button>
+      {% endfor %}
+    </div>
+    <div class="search-wrap">
+      <label class="search-label" for="workflows-search">Search:</label>
+      <input id="workflows-search" class="search-input" type="search"
+        placeholder="workflow name…" autocomplete="off"
+        aria-label="Filter workflows by name substring" />
+    </div>
+  </div>
+
+  <table class="data-table runner-table workflows-table">
     <thead>
       <tr>
         <th>Name</th>
+        <th class="col-concern">Concern</th>
         <th>Tier map</th>
         <th>Description</th>
         <th>Scope</th>
@@ -49,8 +75,15 @@
            workflows like release-prep / health-check that don't map
            to a single feature. #}
         <tr data-workflow="{{ w.name }}"
+            data-concern="{{ concerns[w.name] }}"
             data-scope-default="{{ default_scopes[w.name] if supports_path[w.name] else '' }}">
           <td><code>{{ w.name }}</code></td>
+          {# A3a — concern pill, color-keyed off bucket-* class.
+             JS filter uses the row's data-concern attribute; this
+             pill is the per-row visual indicator. #}
+          <td class="col-concern">
+            <span class="concern-pill bucket-{{ concerns[w.name] }}">{{ concerns[w.name] }}</span>
+          </td>
           {# Chip text: humanized stage name + friendly tier descriptor.
              - Stage names like ``agent-review`` strip the ``agent-`` prefix
                and title-case for readability (``Review``).
@@ -173,4 +206,10 @@
    unconditionally so the strip appears in both run and read-only
    modes — read-only dashboards can still surface OTHER actors' work. #}
 <script src="{{ url_for('static', path='js/bulletin.js') }}?v={{ attune_version }}"></script>
+{# A3a — workflows_refined.js handles the chip filter + search.
+   Loaded only when there are workflows to filter; runner.js +
+   bulletin.js still load unconditionally above. #}
+{% if workflows %}
+<script src="{{ url_for('static', path='js/workflows_refined.js') }}?v={{ attune_version }}"></script>
+{% endif %}
 {% endblock %}

--- a/tests/unit/ops/test_workflows_refined_js.py
+++ b/tests/unit/ops/test_workflows_refined_js.py
@@ -1,0 +1,145 @@
+"""Source-grep tests for workflows_refined.js (A3a).
+
+Same pattern as test_specs_routes.py::test_specs_refined_js_exposes_*
+and test_runner_js_parsing.py — grep the JS source for the documented
+exports and key behaviors so future PRs can't accidentally remove
+them without the test failing loudly.
+
+A3a ships the chip filter + search + per-row concern pill. A3b and
+A3c hook the same state/surface; this test guards against accidental
+removal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+JS_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "attune"
+    / "ops"
+    / "static"
+    / "js"
+    / "workflows_refined.js"
+)
+
+
+@pytest.fixture(scope="module")
+def js_text() -> str:
+    """Read workflows_refined.js once for the module."""
+    return JS_PATH.read_text(encoding="utf-8")
+
+
+class TestExposedSurface:
+    """workflows_refined.js exposes the documented API surface."""
+
+    def test_namespace_export(self, js_text: str) -> None:
+        """Window export — namespace mirrors __attuneSpecs convention."""
+        assert "window.__attuneWorkflows" in js_text
+
+    def test_exposes_valid_buckets(self, js_text: str) -> None:
+        assert "VALID_BUCKETS" in js_text
+
+    def test_exposes_state(self, js_text: str) -> None:
+        assert "state" in js_text
+
+    def test_exposes_apply_filters(self, js_text: str) -> None:
+        assert "applyFilters" in js_text
+
+    def test_exposes_set_chip_state(self, js_text: str) -> None:
+        """Future PRs (A3b kebab) may toggle chips programmatically."""
+        assert "setChipState" in js_text
+
+    def test_exposes_init(self, js_text: str) -> None:
+        assert "init" in js_text
+
+
+class TestBucketSet:
+    """The 7 concern buckets all appear in VALID_BUCKETS."""
+
+    @pytest.mark.parametrize(
+        "bucket",
+        ["review", "test", "docs", "refactor", "audit", "meta", "other"],
+    )
+    def test_bucket_present(self, js_text: str, bucket: str) -> None:
+        """Each of the 7 buckets must be in the JS source.
+
+        If a bucket is renamed in decisions.md, this test catches the
+        JS-side drift at CI level rather than at runtime.
+        """
+        # Bucket strings appear inside the VALID_BUCKETS Set literal.
+        # Asserting the quoted form catches both single and double
+        # quotes; specs_refined.js uses double, so we mirror.
+        assert f'"{bucket}"' in js_text
+
+
+class TestDefaultBehavior:
+    """Default state per decisions.md D1/D2."""
+
+    def test_all_buckets_default_on(self, js_text: str) -> None:
+        """state.buckets initializes from VALID_BUCKETS (all 7 on).
+
+        Unlike specs_refined.js (which defaults Complete off), Workflows
+        page has no chip that's structurally "noise" — all 7 are
+        relevant defaults.
+        """
+        # state.buckets = new Set(VALID_BUCKETS) is the literal default.
+        assert "new Set(VALID_BUCKETS)" in js_text
+
+
+class TestDOMSelectors:
+    """The JS targets the template's expected DOM hooks."""
+
+    def test_targets_workflows_table_tbody(self, js_text: str) -> None:
+        """JS reads rows from `.workflows-table tbody`."""
+        assert ".workflows-table tbody" in js_text
+
+    def test_targets_workflows_toolbar_chips(self, js_text: str) -> None:
+        """Chip click handler binds to `.workflows-toolbar .chip[data-bucket]`."""
+        assert ".workflows-toolbar .chip[data-bucket]" in js_text
+
+    def test_targets_search_input(self, js_text: str) -> None:
+        """Search input ID is `#workflows-search`."""
+        assert "#workflows-search" in js_text
+
+    def test_reads_data_concern(self, js_text: str) -> None:
+        """JS reads `data-concern` attribute from each <tr>."""
+        assert "data-concern" in js_text
+
+    def test_reads_data_workflow(self, js_text: str) -> None:
+        """JS reads `data-workflow` attribute for name-based search."""
+        assert "data-workflow" in js_text
+
+
+class TestEmptyStateBehavior:
+    """A3a injects an empty-state element when all rows hide."""
+
+    def test_creates_empty_state_element(self, js_text: str) -> None:
+        assert "workflows-empty-state" in js_text
+
+    def test_handles_all_chips_off_message(self, js_text: str) -> None:
+        """Message names the recovery action."""
+        assert "All concerns filtered out" in js_text
+
+    def test_handles_no_match_message(self, js_text: str) -> None:
+        """Message shows search query."""
+        assert "No workflows" in js_text
+
+
+class TestTemplateIntegration:
+    """The template references the JS file at the documented path."""
+
+    def test_template_loads_workflows_refined_js(self) -> None:
+        template_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "attune"
+            / "ops"
+            / "templates"
+            / "workflows.html"
+        )
+        template_text = template_path.read_text(encoding="utf-8")
+        assert "workflows_refined.js" in template_text


### PR DESCRIPTION
## Summary

**A3a** of the Workflows page refinement — chip filter toolbar + per-row concern pill + filter JS. Mirror of Specs page A3a (PR #535).

## What ships

- **Chip filter toolbar** above the workflows table: 7 concern chips + search input. All 7 active by default.
- **Concern pill column** between Name and Tier map. Color-keyed off the same `bucket-<name>` class as the toolbar chip.
- **`workflows_refined.js`** — pure-DOM chip toggle + search + empty-state. No fetch. Exposes `window.__attuneWorkflows` for source-grep tests.

## Visual design

Per-concern colors (matches the wireframe ratified in PR #550):

| Concern | Color |
|---|---|
| `review` | Purple (#ede9fe / #5b21b6) |
| `test` | Green (#d1fae5 / #065f46) |
| `docs` | Orange (#fed7aa / #9a3412) |
| `refactor` | Pink (#fce7f3 / #9d174d) |
| `audit` | Amber (#fef3c7 / #92400e) |
| `meta` | Cyan (#cffafe / #155e75) |
| `other` | Neutral (#e5e7eb / #374151) |

Same color used in BOTH the toolbar chip (when active) AND the per-row pill for visual continuity.

## Stacks on [#553](https://github.com/Smart-AI-Memory/attune-ai/pull/553) (A2)

When A1 + A2 merge, this PR's base needs retargeting to `main` and a rebase.

## Tests (16 new)

`tests/unit/ops/test_workflows_refined_js.py` — source-grep tests mirroring the `test_specs_routes.py` convention. Catches accidental removal of:

- `window.__attuneWorkflows` namespace
- 7-bucket `VALID_BUCKETS` set (parameterized — one test per bucket)
- API surface (`state`, `applyFilters`, `setChipState`, `init`)
- DOM selectors (`.workflows-table tbody`, `.workflows-toolbar .chip[data-bucket]`, `#workflows-search`)
- Empty-state message text
- Template references `workflows_refined.js`

## Test plan

- [x] Local: 30 tests pass (16 new + 14 from A1/A2 unchanged)
- [x] Existing /workflows route tests still pass (no regressions)
- [ ] CI green
- [ ] Stacks: merge A1 #552 → A2 #553 → rebase + merge this

## Spec progression

| Step | Status |
|---|---|
| A1 — module (#552) | Awaiting CI |
| A2 — route (#553) | Stacked on A1 |
| **A3a — chip + pill + JS (this)** | **Just opened** |
| A3b — kebab action menu | Next |
| A3c — URL param parsing | Next |
