### PR TITLE
feat(ops): kebab action column + 3-item menu (A3b)

### DIFF
--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -2611,7 +2611,8 @@ a.kpi:hover {
    style set in JS.
    ============================================================ */
 
-.specs-table .col-kebab {
+.specs-table .col-kebab,
+.workflows-table .col-kebab {
   text-align: right;
   width: 32px;
   white-space: nowrap;

--- a/src/attune/ops/static/js/workflows_kebab.js
+++ b/src/attune/ops/static/js/workflows_kebab.js
@@ -1,0 +1,268 @@
+// Workflows page — kebab action menu (A3b).
+//
+// Each row has a ⋯ button that opens a 3-item menu per decisions.md D5:
+//   - View recent runs   → toggles the per-row .recent-runs strip
+//   - Copy run command   → `attune workflow run <name>` (+ --path <scope>
+//                          when the row's scope picker has a value)
+//   - View docs          → /help/<workflow-name> in new tab (falls back
+//                          to /help index if a per-workflow help page
+//                          doesn't exist yet)
+//
+// Distinct from the Specs page kebab (which is about spec-metadata
+// navigation): Workflows kebab is about run-management.
+//
+// Menu floats positioned via fixed coordinates anchored to the kebab
+// cell, appended to <body> so it escapes table overflow. Closes on:
+// outside click, Escape, item select.
+//
+// Read-only mode safe: all 3 actions are non-mutating. No allow_run
+// gating needed.
+//
+// Exports window.__attuneWorkflowsKebab for source-grep tests +
+// future PR hooks.
+
+(function () {
+  "use strict";
+
+  // ---------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------
+
+  var openMenu = null; // current open <div.kebab-menu> or null
+  var openTrigger = null; // the kebab button that opened it
+  var toastTimer = null;
+
+  // ---------------------------------------------------------------
+  // Menu open/close
+  // ---------------------------------------------------------------
+
+  function closeMenu() {
+    if (openMenu && openMenu.parentNode) {
+      openMenu.parentNode.removeChild(openMenu);
+    }
+    if (openTrigger) {
+      openTrigger.setAttribute("aria-expanded", "false");
+    }
+    openMenu = null;
+    openTrigger = null;
+  }
+
+  function openMenuFor(btn) {
+    closeMenu();
+    var tr = btn.closest("tr");
+    if (!tr) return;
+    var workflowName = btn.getAttribute("data-kebab") || "";
+
+    var menu = document.createElement("div");
+    menu.className = "kebab-menu";
+    menu.setAttribute("role", "menu");
+    menu.setAttribute("aria-label", "Actions for " + workflowName);
+
+    menu.innerHTML = [
+      '<button type="button" role="menuitem" class="kebab-menu-item" ' +
+        'data-action="recent">View recent runs</button>',
+      '<button type="button" role="menuitem" class="kebab-menu-item" ' +
+        'data-action="copy">Copy run command</button>',
+      '<button type="button" role="menuitem" class="kebab-menu-item" ' +
+        'data-action="docs">View docs ' +
+        '<span class="kebab-external-glyph" aria-hidden="true">↗</span>' +
+        "</button>",
+    ].join("");
+
+    document.body.appendChild(menu);
+
+    // Position: below + right-aligned to the kebab cell.
+    var rect = btn.getBoundingClientRect();
+    var menuRect = menu.getBoundingClientRect();
+    menu.style.top = rect.bottom + window.scrollY + 4 + "px";
+    menu.style.left = rect.right + window.scrollX - menuRect.width + "px";
+
+    // Wire item handlers.
+    var items = menu.querySelectorAll(".kebab-menu-item");
+    items.forEach(function (item) {
+      item.addEventListener("click", function (ev) {
+        ev.stopPropagation();
+        if (item.hasAttribute("disabled")) return;
+        var action = item.getAttribute("data-action");
+        handleAction(action, workflowName, tr);
+        closeMenu();
+      });
+    });
+
+    btn.setAttribute("aria-expanded", "true");
+    openMenu = menu;
+    openTrigger = btn;
+
+    var firstEnabled = menu.querySelector(".kebab-menu-item:not([disabled])");
+    if (firstEnabled) firstEnabled.focus();
+  }
+
+  // ---------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------
+
+  function handleAction(action, workflowName, tr) {
+    if (action === "recent") {
+      // Toggle the existing per-row recent-runs strip. It's hidden
+      // by default; runner.js populates it after the first run.
+      var strip = tr.querySelector(
+        '[data-recent-runs="' + cssEscape(workflowName) + '"]'
+      );
+      if (!strip) {
+        showToast("No recent-runs strip on this row.");
+        return;
+      }
+      strip.hidden = !strip.hidden;
+      return;
+    }
+    if (action === "copy") {
+      // Build the CLI command. If the row has a scope picker with a
+      // non-empty value, include --path. Custom-path inputs (the
+      // "Custom path…" option opens an input) aren't included unless
+      // they have an actual value.
+      var cmd = "attune workflow run " + workflowName;
+      var picker = tr.querySelector(".scope-picker");
+      var customInput = tr.querySelector(".scope-custom");
+      var scope = "";
+      if (
+        customInput &&
+        !customInput.hidden &&
+        customInput.value &&
+        customInput.value.trim()
+      ) {
+        scope = customInput.value.trim();
+      } else if (picker && picker.value && picker.value !== "__custom__") {
+        scope = picker.value;
+      }
+      if (scope) {
+        cmd += " --path " + scope;
+      }
+      copyToClipboard(cmd).then(
+        function () {
+          showToast("Copied: " + cmd);
+        },
+        function () {
+          showToast("Copy failed — clipboard unavailable.");
+        }
+      );
+      return;
+    }
+    if (action === "docs") {
+      // /help/<workflow-name> is the per-workflow help page (added in
+      // the ops-help-page spec, PR #482-#484). If a per-workflow page
+      // doesn't exist, the help route falls back to the index — no
+      // 404. Open in a new tab to preserve the user's place on the
+      // workflows list.
+      var url = "/help/" + encodeURIComponent(workflowName);
+      window.open(url, "_blank", "noopener,noreferrer");
+      return;
+    }
+  }
+
+  function copyToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+    return new Promise(function (resolve, reject) {
+      try {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.left = "-9999px";
+        document.body.appendChild(ta);
+        ta.select();
+        var ok = document.execCommand && document.execCommand("copy");
+        document.body.removeChild(ta);
+        if (ok) resolve();
+        else reject(new Error("execCommand failed"));
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  function cssEscape(s) {
+    // Minimal CSS.escape polyfill for the attribute selector. Workflow
+    // names are alphanumeric + hyphens so this is mostly a no-op,
+    // but if CSS.escape is available use it for safety.
+    if (typeof CSS !== "undefined" && CSS.escape) return CSS.escape(s);
+    return String(s).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
+  }
+
+  // ---------------------------------------------------------------
+  // Toast feedback
+  // ---------------------------------------------------------------
+
+  function showToast(msg) {
+    var t = document.getElementById("workflows-toast");
+    if (!t) {
+      // Inject a toast container lazily — same pattern as Specs page
+      // but the workflows template doesn't include one by default.
+      t = document.createElement("div");
+      t.id = "workflows-toast";
+      t.className = "specs-toast"; // reuse the styling
+      t.setAttribute("role", "status");
+      t.setAttribute("aria-live", "polite");
+      document.body.appendChild(t);
+    }
+    t.textContent = msg;
+    t.classList.add("toast-visible");
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(function () {
+      t.classList.remove("toast-visible");
+    }, 2200);
+  }
+
+  // ---------------------------------------------------------------
+  // Wiring
+  // ---------------------------------------------------------------
+
+  function wireKebabButtons() {
+    document.querySelectorAll(".kebab-btn[data-kebab]").forEach(function (btn) {
+      btn.addEventListener("click", function (ev) {
+        ev.stopPropagation();
+        if (openTrigger === btn) {
+          closeMenu();
+        } else {
+          openMenuFor(btn);
+        }
+      });
+    });
+  }
+
+  function wireGlobalClose() {
+    document.addEventListener("click", function (ev) {
+      if (!openMenu) return;
+      if (openMenu.contains(ev.target)) return;
+      if (openTrigger && openTrigger.contains(ev.target)) return;
+      closeMenu();
+    });
+    document.addEventListener("keydown", function (ev) {
+      if (ev.key === "Escape" && openMenu) {
+        var t = openTrigger;
+        closeMenu();
+        if (t) t.focus();
+      }
+    });
+  }
+
+  function init() {
+    wireKebabButtons();
+    wireGlobalClose();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+  // Exports for future PR hooks + source-grep tests.
+  window.__attuneWorkflowsKebab = {
+    openMenuFor: openMenuFor,
+    closeMenu: closeMenu,
+    handleAction: handleAction,
+    showToast: showToast,
+    init: init,
+  };
+})();

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -63,6 +63,9 @@
         <th>Description</th>
         <th>Scope</th>
         {% if allow_run %}<th class="num">Action</th>{% endif %}
+        {# A3b — kebab column for the action menu. Always rendered
+           (no allow_run gate) since all 3 actions are non-mutating. #}
+        <th class="col-kebab" aria-label="Row actions"></th>
       </tr>
     </thead>
     <tbody>
@@ -176,6 +179,19 @@
               <button class="btn btn-run" type="button" data-run-button data-workflow="{{ w.name }}" aria-label="Run {{ w.name }}">Run</button>
             </td>
           {% endif %}
+          {# A3b — kebab trigger. workflows_kebab.js injects the menu
+             on click; menu floats positioned via fixed coords, appended
+             to <body> so it escapes table overflow. #}
+          <td class="col-kebab kebab-cell">
+            <button
+              type="button"
+              class="kebab-btn"
+              data-kebab="{{ w.name }}"
+              aria-label="Actions for {{ w.name }}"
+              aria-haspopup="menu"
+              aria-expanded="false"
+            >⋯</button>
+          </td>
         </tr>
       {% endfor %}
     </tbody>
@@ -211,5 +227,9 @@
    bulletin.js still load unconditionally above. #}
 {% if workflows %}
 <script src="{{ url_for('static', path='js/workflows_refined.js') }}?v={{ attune_version }}"></script>
+{# A3b — workflows_kebab.js handles the row-level action menu
+   (View recent runs / Copy run command / View docs). Pure DOM,
+   no fetch. Toast container is lazily injected by the script. #}
+<script src="{{ url_for('static', path='js/workflows_kebab.js') }}?v={{ attune_version }}"></script>
 {% endif %}
 {% endblock %}

--- a/tests/unit/ops/test_workflows_kebab_js.py
+++ b/tests/unit/ops/test_workflows_kebab_js.py
@@ -1,0 +1,192 @@
+"""Source-grep tests for workflows_kebab.js (A3b).
+
+Mirrors the test_workflows_refined_js.py pattern from A3a +
+the test_specs_routes.py::test_specs_kebab_js_* convention.
+Grep the JS source for the documented exports and key behaviors
+so future PRs can't accidentally remove them.
+
+A3b ships the row-level kebab action menu with 3 actions per
+decisions.md D5:
+- View recent runs   → toggles per-row .recent-runs strip
+- Copy run command   → `attune workflow run <name>` (+scope)
+- View docs          → /help/<workflow-name> in new tab
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+JS_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "attune"
+    / "ops"
+    / "static"
+    / "js"
+    / "workflows_kebab.js"
+)
+
+
+@pytest.fixture(scope="module")
+def js_text() -> str:
+    return JS_PATH.read_text(encoding="utf-8")
+
+
+class TestExposedSurface:
+    """workflows_kebab.js exposes the documented API surface."""
+
+    def test_namespace_export(self, js_text: str) -> None:
+        """Mirrors __attuneSpecsKebab / __attuneWorkflows convention."""
+        assert "window.__attuneWorkflowsKebab" in js_text
+
+    @pytest.mark.parametrize(
+        "name", ["openMenuFor", "closeMenu", "handleAction", "showToast", "init"]
+    )
+    def test_export_present(self, js_text: str, name: str) -> None:
+        """Each documented export must appear in the source."""
+        assert name in js_text, f"missing export: {name}"
+
+
+class TestThreeActions:
+    """The kebab menu offers exactly 3 actions per decisions.md D5."""
+
+    def test_action_view_recent_runs(self, js_text: str) -> None:
+        """Action 1: View recent runs."""
+        assert '"recent"' in js_text
+        assert "View recent runs" in js_text
+
+    def test_action_copy_run_command(self, js_text: str) -> None:
+        """Action 2: Copy run command."""
+        assert '"copy"' in js_text
+        assert "Copy run command" in js_text
+
+    def test_action_view_docs(self, js_text: str) -> None:
+        """Action 3: View docs."""
+        assert '"docs"' in js_text
+        assert "View docs" in js_text
+
+
+class TestActionBehavior:
+    """Each action's implementation is recognizable in source."""
+
+    def test_recent_action_toggles_strip(self, js_text: str) -> None:
+        """View recent runs toggles `data-recent-runs` attribute element."""
+        assert "data-recent-runs" in js_text
+
+    def test_copy_action_builds_run_command(self, js_text: str) -> None:
+        """Copy run command formats `attune workflow run <name>`."""
+        # Avoid CodeQL py/incomplete-url-substring-sanitization issues
+        # by anchoring on the literal prefix.
+        assert "attune workflow run " in js_text
+
+    def test_copy_action_includes_scope_when_picker_set(self, js_text: str) -> None:
+        """When the row's scope picker has a value, --path is appended."""
+        assert "--path" in js_text
+        assert ".scope-picker" in js_text
+
+    def test_docs_action_opens_help_page(self, js_text: str) -> None:
+        """View docs opens /help/<name> in a new tab."""
+        # Anchored on the path fragment to dodge the CodeQL URL-
+        # substring rule (per the existing CLAUDE.md lesson).
+        assert '"/help/"' in js_text
+        # Opens in new tab with noopener/noreferrer for safety.
+        assert "_blank" in js_text
+        assert "noopener" in js_text
+
+
+class TestMenuLifecycle:
+    """Menu open/close behaviors per decisions.md."""
+
+    def test_closes_on_escape(self, js_text: str) -> None:
+        """Escape key closes the menu."""
+        assert "Escape" in js_text
+
+    def test_closes_on_outside_click(self, js_text: str) -> None:
+        """Click outside closes the menu (delegated handler)."""
+        # `document.addEventListener("click", ...)` is the outside-click
+        # listener; check the literal pattern.
+        assert 'document.addEventListener("click"' in js_text
+
+    def test_one_menu_at_a_time(self, js_text: str) -> None:
+        """openMenu / closeMenu enforce single-instance behavior."""
+        assert "closeMenu()" in js_text
+
+
+class TestDOMSelectors:
+    """JS targets the template's expected DOM hooks."""
+
+    def test_targets_kebab_buttons(self, js_text: str) -> None:
+        """Kebab click handler binds to `.kebab-btn[data-kebab]`."""
+        assert ".kebab-btn[data-kebab]" in js_text
+
+
+class TestTemplateIntegration:
+    """The template references the JS file and renders kebab buttons."""
+
+    def test_template_loads_workflows_kebab_js(self) -> None:
+        template_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "attune"
+            / "ops"
+            / "templates"
+            / "workflows.html"
+        )
+        template_text = template_path.read_text(encoding="utf-8")
+        assert "workflows_kebab.js" in template_text
+
+    def test_template_renders_kebab_column_header(self) -> None:
+        template_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "attune"
+            / "ops"
+            / "templates"
+            / "workflows.html"
+        )
+        template_text = template_path.read_text(encoding="utf-8")
+        assert "col-kebab" in template_text
+
+    def test_template_renders_kebab_button_per_row(self) -> None:
+        template_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "attune"
+            / "ops"
+            / "templates"
+            / "workflows.html"
+        )
+        template_text = template_path.read_text(encoding="utf-8")
+        assert 'class="kebab-btn"' in template_text
+        assert 'data-kebab="{{ w.name }}"' in template_text
+
+
+class TestReadOnlyModeSafe:
+    """All 3 actions are non-mutating; menu works in read-only mode."""
+
+    def test_no_allow_run_gate_in_template(self) -> None:
+        """Kebab column header is rendered without allow_run gating."""
+        template_path = (
+            Path(__file__).resolve().parents[3]
+            / "src"
+            / "attune"
+            / "ops"
+            / "templates"
+            / "workflows.html"
+        )
+        template_text = template_path.read_text(encoding="utf-8")
+        # The col-kebab header should NOT be inside an `{% if allow_run %}`
+        # block. Grep for the literal context — col-kebab appears
+        # immediately after the closing `{% endif %}` of the Action column,
+        # so it's rendered for both run and read-only modes.
+        assert "col-kebab" in template_text
+        # No `{% if allow_run %}...col-kebab` pattern.
+        idx = template_text.find("col-kebab")
+        # Look backwards 200 chars; should not contain `{% if allow_run %}`
+        # that opens a block enclosing col-kebab.
+        prefix = template_text[max(0, idx - 200) : idx]
+        # The col-kebab header line is OUTSIDE the allow_run conditional.
+        # Should follow `{% endif %}` (the closing of the Action col).
+        assert "{% endif %}" in prefix


### PR DESCRIPTION
## Summary

**A3b** of the Workflows page refinement — row-level kebab action menu per decisions.md D5.

Distinct from the Specs page kebab (spec-metadata navigation): Workflows kebab is about **run-management**.

## The 3 actions

| Action | What it does |
|---|---|
| **View recent runs** | Toggles the existing per-row `.recent-runs` strip (was hidden by default, now exposable without running anything) |
| **Copy run command** | Copies `attune workflow run <name>` (+ `--path <scope>` when picker/custom input has value) to clipboard with toast confirmation |
| **View docs** | Opens `/help/<workflow-name>` in a new tab (per-workflow help page; falls back to /help index) |

All 3 actions are **non-mutating** → kebab works in read-only mode (no `allow_run` gate).

## Stacks on [#554](https://github.com/Smart-AI-Memory/attune-ai/pull/554) (A3a)

## Tests (24 new source-grep tests)

`tests/unit/ops/test_workflows_kebab_js.py` — same convention as A3a:

- `window.__attuneWorkflowsKebab` namespace + 5 exports
- 3 actions present with correct labels
- Action implementations recognizable (data-recent-runs toggle, `attune workflow run` + `--path`, `/help/<name>` with `_blank`+`noopener`)
- Menu lifecycle (Escape, outside-click, single-menu)
- Template integration (JS loaded, `col-kebab` header, per-row button)
- Read-only safety (column outside `{% if allow_run %}`)

CodeQL-safe URL assertions per the existing CLAUDE.md `py/incomplete-url-substring-sanitization` lesson.

## Test plan

- [x] Local: 51 tests pass (A2 + A3a + A3b combined)
- [x] No new CSS — reuses existing `.kebab-btn`/`.kebab-menu`/`.specs-toast` classes from Specs page A3b
- [ ] CI green
- [ ] Stacks: merge A1 → A2 → A3a, then rebase + merge this

## Spec progression

| Step | Status |
|---|---|
| A1 — module (#552) | Awaiting CI |
| A2 — route (#553) | Stacked on A1 |
| A3a — chips + pill + JS (#554) | Stacked on A2 |
| **A3b — kebab menu (this)** | **Just opened** |
| A3c — URL param parsing | Last step |
