### PR TITLE
chore(release): v7.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "7.3.0"
+    "version": "7.3.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v7.3.0
+# Attune AI Framework v7.3.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 7.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 7.3.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.3.1] — 2026-06-02
+
+### Added
+
+- **Ops dashboard Workflows page refinement** — the `/workflows` route
+  now mirrors `/specs`: a 7-bucket concern classifier (Security /
+  Quality / Testing / Performance / Docs / Bugs / Discovery / Release)
+  derived from workflow names by a pure-Python module
+  (`workflow_concern.py`), a chip filter toolbar with search, per-row
+  concern badge column, a kebab action menu (View recent runs / Copy
+  run command / View docs), and URL parameter support for shareable
+  filter state (`?bucket=security,testing&q=...`). Backend wiring
+  reads from the derivation on every render (#552, #557, #554, #555,
+  #556).
+- **SDK error message fidelity Phase 6** — three more SDK-backed
+  workflows (`test-audit`, `doc-audit`, `doc-gen`) now surface the
+  real `claude` CLI stderr via the typed `sdk_error_kind` classifier
+  instead of hand-rolled generic messages. Eleven workflows from
+  v7.3.0 + three here = fourteen SDK-backed workflows total surfacing
+  real causes. The two remaining pipeline-coordinator workflows
+  (`discovery-sweep`, `secure-release`) aggregate sub-workflow
+  failures via a different error surface and are queued for Phase 7
+  in a future release (#551).
+
 ## [7.3.0] — 2026-06-01
 
 ### Added

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 7.3.0
+**Version:** 7.3.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 7.3.0 | **License:** Apache 2.0
+**Version:** 7.3.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "7.3.0"
+    "version": "7.3.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "7.3.0"
+__version__ = "7.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "7.3.0"
+version = "7.3.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "7.3.0"
+version = "7.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Patch release bundling 15 user-facing PRs merged since v7.3.0.

### Workflows page refinement (A1-A3c)
- `/workflows` now mirrors `/specs`: 7-bucket concern classifier
  (Security / Quality / Testing / Performance / Docs / Bugs /
  Discovery / Release), chip filter toolbar with search, per-row
  concern badge column, kebab action menu, URL parameter support
  for shareable state.
- Backend uses pure-Python `workflow_concern.py` module derived on
  every render.
- PRs: #552 (A1 module), #557 (A2 wiring), #554 (A3a chips+badge),
  #555 (A3b kebab menu), #556 (A3c URL params).

### SDK error message fidelity Phase 6
- 3 more SDK-backed workflows surface real `claude` CLI stderr:
  `test-audit`, `doc-audit`, `doc-gen`.
- 11 (v7.3.0) + 3 (here) = 14 SDK-backed workflows now surface
  real causes via the typed `sdk_error_kind` classifier.
- Phase 7 (`discovery-sweep`, `secure-release`) queued for future
  release — they aggregate sub-workflow failures and need a
  different error surface.
- PR: #551.

### Version bumps (9 files, per CLAUDE.md checklist)
- `pyproject.toml`
- `plugin/.claude-plugin/plugin.json`
- `plugin/.claude-plugin/marketplace.json` (2 fields)
- `.claude-plugin/marketplace.json` (2 fields)
- `plugin/core/__init__.py`
- `.claude/CLAUDE.md` header + footer
- `docs/reference/API_REFERENCE.md` header + footer
- `uv.lock` (self-reference only, no dep cascade)

## Test plan
- [ ] CI green on all required checks (Ubuntu/macOS/Windows × 3.10-3.13)
- [ ] Drift-guard test passes (`test_all_versions_match`)
- [ ] `uv lock` produced no unexpected dep churn (verified — only the attune-ai self-line changed)

After merge: tag `v7.3.1`, trigger `publish-pypi.yml` workflow,
approve `pypi` env deployment, edit release notes to use the
CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
