### PR TITLE
docs(specs): refresh status headers for 4 shipped/partial specs

### DIFF
--- a/docs/specs/enforcement-vs-documentation/requirements.md
+++ b/docs/specs/enforcement-vs-documentation/requirements.md
@@ -10,7 +10,7 @@
 > and establishes the size discipline + retirement metrics
 > that keep the enforced set tractable.
 
-**Status:** approved (2026-05-31; see [decisions.md](./decisions.md))
+**Status:** partial — framework approved 2026-05-31 (cap=10 enforcements); first enforcement (worktree-path-guard hook, PR #521) shipped; subsequent enforcements queued as candidates surface
 **Created:** 2026-05-31
 **Owner:** —
 **Related:**

--- a/docs/specs/ops-specs-page-refinement/requirements.md
+++ b/docs/specs/ops-specs-page-refinement/requirements.md
@@ -4,7 +4,7 @@
 > right one and see what to do next without scrolling/scanning the
 > whole table.
 
-**Status:** approved (2026-05-31)
+**Status:** complete (2026-05-31; A1-A3 shipped in PRs #533, #534, #535, #536, #539)
 **Created:** 2026-05-31
 **Owner:** Patrick (decisions ratified in-session 2026-05-31)
 **Related:** [`decisions.md`](decisions.md) — 4 design decisions ratified in-conversation before requirements were drafted, so they read as constraints here rather than open questions.

--- a/docs/specs/ops-workflows-page-refinement/requirements.md
+++ b/docs/specs/ops-workflows-page-refinement/requirements.md
@@ -5,7 +5,7 @@
 > the whole table. Mirror of the Specs-page refinement pattern
 > (PRs #533-#536, #539) for the next pain-point area.
 
-**Status:** Phase 1 ratified 2026-06-01 (uncommitted; decisions.md + wireframe.html pending)
+**Status:** complete (2026-06-02; A1-A3c shipped in v7.3.0 + v7.3.1 — PRs #552, #557, #554, #555, #556)
 **Created:** 2026-06-01
 **Owner:** Patrick
 **Related:**

--- a/docs/specs/vercel-noise-cleanup/requirements.md
+++ b/docs/specs/vercel-noise-cleanup/requirements.md
@@ -1,5 +1,5 @@
 # Requirements — Vercel Noise Cleanup
-**Status:** approved — awaiting approval before design.md and tasks.md
+**Status:** complete (2026-05-14; Vercel project deleted upstream, removing the recurring required-check failure that motivated the spec)
 User-facing stories and the contracts they imply. See `decisions.md`
 for context and the chosen resolution path. `design.md` and `tasks.md`
 are intentionally omitted — they will be written after Patrick reviews


### PR DESCRIPTION
## Summary

Manual housekeeping pass — 4 spec status headers had drifted from reality. This refreshes them and names what shipped.

| Spec | Was | Now |
|------|-----|-----|
| `ops-workflows-page-refinement` | "Phase 1 ratified 2026-06-01 (uncommitted; decisions.md + wireframe.html pending)" | `complete (2026-06-02; A1-A3c shipped in v7.3.0 + v7.3.1)` |
| `ops-specs-page-refinement` | "approved (2026-05-31)" | `complete (2026-05-31; A1-A3 shipped in PRs #533-#536, #539)` |
| `vercel-noise-cleanup` | "approved — awaiting approval before design.md and tasks.md" | `complete (2026-05-14; Vercel project deleted upstream)` |
| `enforcement-vs-documentation` | "approved (2026-05-31)" | `partial — framework approved, first enforcement (worktree-path-guard, PR #521) shipped, cap=10 enforcements queued` |

## Why now

A housekeeping triage at end-of-session 2026-06-02 found 21 specs claiming `approved` status. Of those, 4 are actually shipped (or partial) and just had stale header text. Fixing these in one shot reduces the in-flight count surfaced by the SessionStart hook and prevents recommending re-doing work.

## Larger context

The deeper fix is [`spec-status-self-truthing`](docs/specs/spec-status-self-truthing/) (approved 2026-05-31) — it would derive status from completion signals (checklist + terminal lines) rather than the header line, so this kind of drift surfaces automatically with a "header lag" hint. XML prompt for next-session implementation is staged at `~/.attune/next_session_xml_prompts.md`.

This PR is the manual mop-up until that lands.

## Test plan
- [ ] No code changes — pure docs
- [ ] Header strings match what actually shipped (verified against PR numbers + dates)
- [ ] SessionStart hook will pick these up on next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
