### PR TITLE
fix(ci): suppress security-scan PR comment on JSON extraction failure

### DIFF
--- a/.github/scripts/analyze_security_results.py
+++ b/.github/scripts/analyze_security_results.py
@@ -290,6 +290,31 @@ These should be reviewed but won't block the PR:
     return comment
 
 
+# Errors indicating the scan never produced parseable output (e.g. underlying
+# SDK call failed before emitting JSON). These should NOT post an alarming PR
+# comment — the workflow logs and check artifacts carry the real diagnostic,
+# and the GH check stays green so merge is unblocked. See issue #560.
+_EXTRACTION_FAILURE_MARKERS = (
+    "Could not extract JSON from CLI output",
+    "No JSON found in output",
+    "Security scan produced no output",
+    "Security results file is empty",
+    "Could not parse security results from mixed output",
+)
+
+
+def is_extraction_failure(error_text: str) -> bool:
+    """Return True if the error is a JSON-extraction failure, not a real finding.
+
+    Used to decide whether to post a PR comment. Extraction failures are
+    advisory noise (the GH check stays green); real errors should still
+    surface via the comment.
+    """
+    if not error_text:
+        return False
+    return any(marker in error_text for marker in _EXTRACTION_FAILURE_MARKERS)
+
+
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(description="Analyze security scan results")
@@ -303,6 +328,8 @@ def main():
 
     if "error" in results:
         print(f"Error parsing results: {results['error']}", file=sys.stderr)
+        extraction_failure = is_extraction_failure(results["error"])
+
         # Create minimal analysis
         analysis = {
             "total_findings": 0,
@@ -312,15 +339,20 @@ def main():
             "has_critical": False,
             "has_bypass": False,
             "error": results["error"],
+            "scan_skipped": extraction_failure,
         }
 
         with open(args.output, "w") as f:
             json.dump(analysis, f, indent=2)
 
-        # Create error comment
-        with open("pr_comment.md", "w") as f:
-            f.write(
-                f"""## 🔒 Security Scan Results
+        # Suppress PR comment on extraction failure (issue #560): the scan
+        # never produced parseable output, so posting a "⚠️ Error" comment
+        # alarms contributors when the GH check is actually green. Real
+        # errors still get a comment.
+        if not extraction_failure:
+            with open("pr_comment.md", "w") as f:
+                f.write(
+                    f"""## 🔒 Security Scan Results
 
 ⚠️ **Error:** Could not complete security scan
 
@@ -330,7 +362,7 @@ def main():
 
 Please check the workflow logs for details.
 """
-            )
+                )
 
         if args.github_output:
             with open(args.github_output, "a") as f:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -108,7 +108,9 @@ jobs:
             --github-output $GITHUB_OUTPUT
 
       - name: Post results to PR
-        if: github.event_name == 'pull_request'
+        # Skip when extraction failed (no pr_comment.md written) — see issue #560.
+        # The GH check stays green; workflow logs carry the real diagnostic.
+        if: github.event_name == 'pull_request' && hashFiles('pr_comment.md') != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/unit/github_scripts/test_analyze_security_results.py
+++ b/tests/unit/github_scripts/test_analyze_security_results.py
@@ -1,0 +1,201 @@
+"""Tests for .github/scripts/analyze_security_results.py.
+
+Loaded via importlib.util because .github/scripts/ is not a Python
+package — matches the repo convention used in
+tests/unit/help/test_coverage_script.py.
+
+Issue #560 regression guard: when the upstream security-audit
+workflow produces no parseable JSON (typically because the
+underlying SDK call failed before emitting output), the analyzer
+must NOT write pr_comment.md. The workflow's "Post results to PR"
+step is gated on the file existing, so suppressing the write
+suppresses the alarming "⚠️ Error: Could not extract JSON" comment
+that confuses contributors when the GH check is actually green.
+
+Real errors (anything other than the extraction-failure markers)
+still produce a comment so genuine diagnostic info reaches
+reviewers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / ".github" / "scripts" / "analyze_security_results.py"
+
+
+@pytest.fixture
+def analyzer():
+    spec = importlib.util.spec_from_file_location("_analyze_security_results", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_analyze_security_results"] = mod
+    spec.loader.exec_module(mod)
+    yield mod
+    sys.modules.pop("_analyze_security_results", None)
+
+
+def _run_main(analyzer_mod, tmp_path: Path, input_data: dict) -> Path:
+    """Drive the script's main() with the given input JSON.
+
+    Returns the working directory main() ran in (where pr_comment.md
+    and analysis.json land).
+    """
+    cwd = tmp_path / "workdir"
+    cwd.mkdir()
+    input_file = cwd / "security_results.json"
+    output_file = cwd / "analysis.json"
+    gh_output = cwd / "gh_output.txt"
+    gh_output.touch()
+
+    input_file.write_text(json.dumps(input_data))
+
+    original_cwd = Path.cwd()
+    original_argv = sys.argv[:]
+    try:
+        import os
+
+        os.chdir(cwd)
+        sys.argv = [
+            "analyze_security_results.py",
+            "--input",
+            str(input_file),
+            "--output",
+            str(output_file),
+            "--github-output",
+            str(gh_output),
+        ]
+        try:
+            analyzer_mod.main()
+        except SystemExit as exc:
+            # main() calls sys.exit(0) on error paths; treat as normal return
+            assert exc.code == 0, f"main() exited non-zero: {exc.code}"
+    finally:
+        import os
+
+        os.chdir(original_cwd)
+        sys.argv = original_argv
+
+    return cwd
+
+
+class TestIsExtractionFailure:
+    """The classifier that decides whether to suppress the comment."""
+
+    def test_recognizes_could_not_extract_message(self, analyzer):
+        assert analyzer.is_extraction_failure("Could not extract JSON from CLI output")
+
+    def test_recognizes_no_json_found_message(self, analyzer):
+        assert analyzer.is_extraction_failure("No JSON found in output")
+
+    def test_recognizes_no_output_message(self, analyzer):
+        assert analyzer.is_extraction_failure("Security scan produced no output")
+
+    def test_recognizes_empty_file_message(self, analyzer):
+        assert analyzer.is_extraction_failure("Security results file is empty")
+
+    def test_recognizes_mixed_output_message(self, analyzer):
+        assert analyzer.is_extraction_failure("Could not parse security results from mixed output")
+
+    def test_does_not_match_real_diagnostic_errors(self, analyzer):
+        assert not analyzer.is_extraction_failure("Permission denied opening security_results.json")
+        assert not analyzer.is_extraction_failure("Unexpected disk failure")
+        assert not analyzer.is_extraction_failure("KeyError: 'severity'")
+
+    def test_handles_empty_string(self, analyzer):
+        assert not analyzer.is_extraction_failure("")
+
+
+class TestMainSuppressesCommentOnExtractionFailure:
+    """Regression guard for issue #560 — no PR comment on extraction failure."""
+
+    def test_extraction_failure_does_not_write_pr_comment(self, analyzer, tmp_path):
+        cwd = _run_main(
+            analyzer,
+            tmp_path,
+            {"findings": [], "error": "Could not extract JSON from CLI output"},
+        )
+        assert not (cwd / "pr_comment.md").exists(), (
+            "pr_comment.md must not be written on extraction failure — "
+            "would alarm contributors per issue #560"
+        )
+
+    def test_extraction_failure_still_writes_analysis_json(self, analyzer, tmp_path):
+        cwd = _run_main(
+            analyzer,
+            tmp_path,
+            {"findings": [], "error": "No JSON found in output"},
+        )
+        analysis = json.loads((cwd / "analysis.json").read_text())
+        assert analysis["scan_skipped"] is True
+        assert analysis["has_critical"] is False
+        assert analysis["total_findings"] == 0
+
+    def test_real_error_still_writes_pr_comment(self, analyzer, tmp_path):
+        """Non-extraction errors keep their diagnostic comment so reviewers
+        see the real failure."""
+        cwd = _run_main(
+            analyzer,
+            tmp_path,
+            {"findings": [], "error": "KeyError: missing required field 'severity'"},
+        )
+        comment_path = cwd / "pr_comment.md"
+        assert comment_path.exists(), "Real errors must still surface via PR comment"
+        assert "KeyError" in comment_path.read_text()
+
+    def test_real_error_marks_scan_not_skipped(self, analyzer, tmp_path):
+        cwd = _run_main(
+            analyzer,
+            tmp_path,
+            {"findings": [], "error": "Disk write error"},
+        )
+        analysis = json.loads((cwd / "analysis.json").read_text())
+        assert analysis["scan_skipped"] is False
+
+
+class TestMainHandlesNormalFindings:
+    """Sanity check that the normal-findings path still writes a comment."""
+
+    def test_normal_findings_write_pr_comment(self, analyzer, tmp_path):
+        cwd = _run_main(
+            analyzer,
+            tmp_path,
+            {
+                "findings": [
+                    {
+                        "severity": "medium",
+                        "type": "broad_exception",
+                        "file": "src/foo.py",
+                        "line": 42,
+                    },
+                ]
+            },
+        )
+        comment_path = cwd / "pr_comment.md"
+        assert comment_path.exists()
+        comment = comment_path.read_text()
+        assert "Security Scan Results" in comment
+
+    def test_normal_findings_record_counts_in_analysis(self, analyzer, tmp_path):
+        cwd = _run_main(
+            analyzer,
+            tmp_path,
+            {
+                "findings": [
+                    {"severity": "critical", "type": "sql_injection", "file": "a.py"},
+                    {"severity": "medium", "type": "broad_exception", "file": "b.py"},
+                    {"severity": "low", "type": "incomplete_code", "file": "c.py"},
+                ]
+            },
+        )
+        analysis = json.loads((cwd / "analysis.json").read_text())
+        assert analysis["total_findings"] == 3
+        assert analysis["critical_count"] == 1
+        assert analysis["medium_count"] == 1
+        assert analysis["low_count"] == 1
+        assert analysis["has_critical"] is True


### PR DESCRIPTION
## Summary

Closes #560. The `security-scan.yml` advisory job posts a PR comment titled "🔒 Security Scan Results" with an alarming `⚠️ Error: Could not extract JSON from CLI output` body when the underlying `attune workflow run security-audit --json` fails before emitting JSON (typically a budget cap, quota, or rate limit on the SDK call). The GH check stays green and merge is unblocked, but every contributor who hits it asks "is my PR broken?"

Distinguish extraction failures from real diagnostic errors:

- **`analyze_security_results.py`** — new `is_extraction_failure()` helper matches the five known no-output marker strings. On extraction failure, write `analysis.json` with `scan_skipped: true` and **skip writing `pr_comment.md`**. Real errors (anything else) keep their diagnostic comment so reviewers still see the problem.
- **`security-scan.yml`** — gate the "Post results to PR" step on `hashFiles('pr_comment.md') != ''`. When the file is absent the step no-ops. Existing comments stay untouched; no new comment is created.

## Test plan

- [x] 13 new unit tests at `tests/unit/github_scripts/test_analyze_security_results.py` covering:
  - `is_extraction_failure` classifier across all 5 marker strings and 3 non-matching cases
  - Extraction failure path: no `pr_comment.md` written, `analysis.json` has `scan_skipped: true`
  - Real error path: `pr_comment.md` exists and contains the error text
  - Normal findings path: `pr_comment.md` exists, counts recorded correctly
- [x] Pre-commit hooks pass (black, ruff, bandit, detect-secrets)
- [x] Workflow YAML parses cleanly
- [ ] CI green on this PR (the security-scan workflow itself runs against this change)

## Out of scope

Deferred to `sdk-error-message-fidelity` Phase 7+: surfacing the real `claude` CLI stderr in the comment instead of suppressing. That requires the SDK adapter to propagate stderr — a different surface than this CI infra fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
