### PR TITLE
fix(ci): use encoding="utf-8" in analyze_security_results.py I/O

### DIFF
--- a/.github/scripts/analyze_security_results.py
+++ b/.github/scripts/analyze_security_results.py
@@ -25,7 +25,7 @@ def parse_security_results(results_file: Path) -> dict:
         Dict with parsed findings and metadata
     """
     try:
-        with open(results_file) as f:
+        with open(results_file, encoding="utf-8") as f:
             content = f.read()
 
         if not content.strip():
@@ -342,7 +342,7 @@ def main():
             "scan_skipped": extraction_failure,
         }
 
-        with open(args.output, "w") as f:
+        with open(args.output, "w", encoding="utf-8") as f:
             json.dump(analysis, f, indent=2)
 
         # Suppress PR comment on extraction failure (issue #560): the scan
@@ -350,7 +350,7 @@ def main():
         # alarms contributors when the GH check is actually green. Real
         # errors still get a comment.
         if not extraction_failure:
-            with open("pr_comment.md", "w") as f:
+            with open("pr_comment.md", "w", encoding="utf-8") as f:
                 f.write(
                     f"""## 🔒 Security Scan Results
 
@@ -365,7 +365,7 @@ Please check the workflow logs for details.
                 )
 
         if args.github_output:
-            with open(args.github_output, "a") as f:
+            with open(args.github_output, "a", encoding="utf-8") as f:
                 f.write("has_critical=false\n")
                 f.write("critical_count=0\n")
 
@@ -393,15 +393,15 @@ Please check the workflow logs for details.
     comment = generate_pr_comment(categorized, analysis)
 
     # Write outputs
-    with open(args.output, "w") as f:
+    with open(args.output, "w", encoding="utf-8") as f:
         json.dump(analysis, f, indent=2)
 
-    with open("pr_comment.md", "w") as f:
+    with open("pr_comment.md", "w", encoding="utf-8") as f:
         f.write(comment)
 
     # Write GitHub Actions outputs
     if args.github_output:
-        with open(args.github_output, "a") as f:
+        with open(args.github_output, "a", encoding="utf-8") as f:
             f.write(f"has_critical={'true' if analysis['has_critical'] else 'false'}\n")
             f.write(f"critical_count={analysis['critical_count']}\n")
             f.write(f"medium_count={analysis['medium_count']}\n")

--- a/tests/unit/github_scripts/test_analyze_security_results.py
+++ b/tests/unit/github_scripts/test_analyze_security_results.py
@@ -53,7 +53,7 @@ def _run_main(analyzer_mod, tmp_path: Path, input_data: dict) -> Path:
     gh_output = cwd / "gh_output.txt"
     gh_output.touch()
 
-    input_file.write_text(json.dumps(input_data))
+    input_file.write_text(json.dumps(input_data), encoding="utf-8")
 
     original_cwd = Path.cwd()
     original_argv = sys.argv[:]
@@ -131,7 +131,7 @@ class TestMainSuppressesCommentOnExtractionFailure:
             tmp_path,
             {"findings": [], "error": "No JSON found in output"},
         )
-        analysis = json.loads((cwd / "analysis.json").read_text())
+        analysis = json.loads((cwd / "analysis.json").read_text(encoding="utf-8"))
         assert analysis["scan_skipped"] is True
         assert analysis["has_critical"] is False
         assert analysis["total_findings"] == 0
@@ -146,7 +146,7 @@ class TestMainSuppressesCommentOnExtractionFailure:
         )
         comment_path = cwd / "pr_comment.md"
         assert comment_path.exists(), "Real errors must still surface via PR comment"
-        assert "KeyError" in comment_path.read_text()
+        assert "KeyError" in comment_path.read_text(encoding="utf-8")
 
     def test_real_error_marks_scan_not_skipped(self, analyzer, tmp_path):
         cwd = _run_main(
@@ -154,7 +154,7 @@ class TestMainSuppressesCommentOnExtractionFailure:
             tmp_path,
             {"findings": [], "error": "Disk write error"},
         )
-        analysis = json.loads((cwd / "analysis.json").read_text())
+        analysis = json.loads((cwd / "analysis.json").read_text(encoding="utf-8"))
         assert analysis["scan_skipped"] is False
 
 
@@ -178,7 +178,7 @@ class TestMainHandlesNormalFindings:
         )
         comment_path = cwd / "pr_comment.md"
         assert comment_path.exists()
-        comment = comment_path.read_text()
+        comment = comment_path.read_text(encoding="utf-8")
         assert "Security Scan Results" in comment
 
     def test_normal_findings_record_counts_in_analysis(self, analyzer, tmp_path):
@@ -193,7 +193,7 @@ class TestMainHandlesNormalFindings:
                 ]
             },
         )
-        analysis = json.loads((cwd / "analysis.json").read_text())
+        analysis = json.loads((cwd / "analysis.json").read_text(encoding="utf-8"))
         assert analysis["total_findings"] == 3
         assert analysis["critical_count"] == 1
         assert analysis["medium_count"] == 1


### PR DESCRIPTION
## Summary

Every PR opened since #562 has been failing 4 Windows test lanes (3.10/3.11/3.12/3.13) with:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f512' in position 3
```

Root cause: `.github/scripts/analyze_security_results.py` writes a PR comment whose header contains the 🔒 lock emoji. Windows defaults `open()` to cp1252, which can't encode U+1F512. Tests pass on Ubuntu/macOS (UTF-8 default) but fail identically on Windows.

This is the exact pattern from the existing CLAUDE.md "Windows CI encoding" lesson: *"Always use `encoding='utf-8'` on `Path.read_text()` calls. Windows defaults to cp1252 which fails on any file containing non-ASCII bytes."* The fix extends that to `open()` in write mode (the original bug) and to `read_text()` in test assertions (defensive).

## Impact

- PR #563 (windows-xdist-flakes spec) — blocked on this
- PR #564 (.help regen) — would have hit the same failure
- Every future PR until this lands

## Changes

| File | Sites fixed |
|------|-------------|
| `.github/scripts/analyze_security_results.py` | 7 `open()` calls — added `encoding="utf-8"` everywhere |
| `tests/unit/github_scripts/test_analyze_security_results.py` | 6 `read_text()` / `write_text()` calls — same |

Defensive sweep across all I/O so future non-ASCII content (additional emojis, fancy quotes, etc.) doesn't reintroduce the bug.

## Test plan

- [x] Local verification: all 13 tests pass under `pytest -n auto` on macOS
- [ ] CI: green on all Windows lanes (the actual fix verification)
- [ ] After merge: rebase #563 + #564 onto main; their Windows lanes should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
