### PR TITLE
docs(claude-md): worktree-coordination handoff lesson

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6999,3 +6999,33 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   existing sub-worktree-merge-error lesson — that
   one names the cause; this one names the dance-
   specific consequence.
+
+- **"Create a new worktree to continue last session"
+  usually means "use the existing worktree on that
+  branch," not "create a second one" — git refuses
+  two worktrees on the same branch**: hit 2026-06-02
+  when a session-startup ask was "create a new
+  worktree" with a queued `gh pr create --head
+  <branch>` and the branch already had a worktree at
+  `.claude/worktrees/<slug>` left over from the prior
+  session. Creating a literal "new" worktree on that
+  branch would have failed with `fatal: '<branch>' is
+  already used by worktree at '<path>'`. The "new"
+  framing here means "fresh session context," not
+  "fresh git worktree" — the existing worktree's git
+  state IS what the user wants to continue from.
+  **Diagnostic recipe**: before creating a worktree
+  for a named branch, `git worktree list | grep
+  <branch>`. If a row matches, `cd` into it and reuse;
+  surface the reuse to the user
+  ("an existing worktree at <path> is on this branch
+  — reusing it"). If not, create one off the requested
+  base. Same pattern applies when a queued command
+  references `--head <branch>` or `--base <branch>` —
+  the worktree the command needs may already exist.
+  Pairs with the existing worktree-PYTHONPATH /
+  Write-absolute-path / dirty-state-recovery lessons —
+  all are about correctly locating the right worktree
+  for a piece of work; this one's about the
+  multi-session handoff case where the prior session
+  left state behind.


### PR DESCRIPTION
## Summary

One new lesson from today's session-startup pickup, captured per the
stop-hook lessons-reminder.

## What the lesson covers

When a session-startup ask is "create a new worktree to continue last
session" with a queued command referencing a specific branch, the
right move is usually to reuse the existing worktree on that branch.
Git refuses two worktrees on the same branch, and the "new" framing
in handoffs usually means "fresh session context," not "literally a
fresh git worktree."

Hit today picking up the `sdk-fidelity-spec-close-phase6` work — the
prior session left a worktree on the target branch at
`festive-sammet-aa3433`, and the queued `gh pr create --head <branch>`
needed that worktree's state. Recipe:
``git worktree list | grep <branch>`` before creating one.

## Test plan

- [x] Lesson placed at end of "Lessons Learned" section
- [x] Cross-references existing worktree-PYTHONPATH /
      Write-absolute-path / dirty-state-recovery lessons per the
      "pairs with" pattern
- [x] No code changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)