### PR TITLE
docs(spec): draft attune-verify Phase 1

### DIFF
--- a/docs/specs/attune-verify/design.md
+++ b/docs/specs/attune-verify/design.md
@@ -1,0 +1,260 @@
+# Design: attune-verify — Generation Fact-Checker
+
+**Status:** draft (2026-06-02) — Phase 2, awaiting review
+**Requirements:** [requirements.md](requirements.md) (Phase 1
+approved 2026-06-02)
+
+> This design realizes the Phase-1 decisions: deterministic core +
+> LLM semantic layer behind an injected `Judge` protocol; explicit
+> `VerifyContext`; return-findings with an opt-in gate; library +
+> `/verify` skill surfaces; standalone sibling package.
+
+---
+
+## Architecture overview
+
+Two surfaces over one core:
+
+```text
+                    ┌─────────────────────────────┐
+   library API ───▶ │  attune_verify.verify(...)  │
+   (CI, pipelines)  │   - deterministic checkers  │
+                    │   - semantic layer (opt)    │
+   /verify skill ─▶ │   - Judge protocol (inject) │
+   (Claude Code)    └─────────────┬───────────────┘
+                                  │
+                 ┌────────────────┴────────────────┐
+                 ▼                                  ▼
+        deterministic checkers              Judge (injected)
+        (pure Python, no LLM)        skill-judge | rag adapter | custom
+```
+
+The **deterministic core** has zero LLM dependency and runs
+everywhere. The **semantic layer** is optional and delegates to an
+injected `Judge`; it never imports attune-rag directly.
+
+---
+
+## Module layout (`src/attune_verify/`)
+
+| Module | Responsibility |
+|--------|----------------|
+| `__init__.py` | Public exports: `verify`, `VerifyContext`, `VerifyResult`, `Finding`, `Judge`, `raise_if_failed` |
+| `context.py` | `VerifyContext` dataclass — the declared truth boundaries |
+| `result.py` | `Finding`, `FindingKind`, `VerifyResult`, `raise_if_failed()` |
+| `checkers/imports.py` | AST-walk code fences; resolve imports against the env |
+| `checkers/flags.py` | Extract command+flag refs; resolve vs. captured `--help` |
+| `checkers/links.py` | Resolve markdown link targets against the project root |
+| `checkers/counts.py` | Compare numeric claims against caller-supplied sources |
+| `semantic/protocol.py` | `Judge` protocol + `SemanticVerdict` |
+| `semantic/rag_adapter.py` | Thin adapter over rag's `FaithfulnessJudge` (only under the `[rag]` extra) |
+| `_extract.py` | Shared: pull code fences, links, numeric claims from content |
+
+The `/verify` skill lives in the attune-ai plugin
+(`plugin/skills/verify/`), not in this package — it invokes the
+library for deterministic checks and supplies a skill-judge.
+
+---
+
+## Data model
+
+```python
+class FindingKind(str, Enum):
+    UNRESOLVED_IMPORT = "unresolved_import"
+    UNKNOWN_FLAG      = "unknown_flag"
+    DEAD_LINK         = "dead_link"
+    COUNT_MISMATCH    = "count_mismatch"
+    SEMANTIC          = "semantic"
+
+@dataclass(frozen=True)
+class Finding:
+    kind: FindingKind
+    detail: str            # human-readable
+    evidence: str          # the offending span from the content
+    location: str | None   # line/section if resolvable
+    severity: str          # "error" | "warning"
+
+@dataclass
+class VerifyResult:
+    findings: list[Finding]
+    checked: list[str]     # which checkers ran
+    semantic_ran: bool     # whether the Judge was invoked
+    @property
+    def ok(self) -> bool:
+        return not any(f.severity == "error" for f in self.findings)
+```
+
+`raise_if_failed(result)` raises `VerificationError` when
+`not result.ok` — the opt-in hard gate. Default flow is
+return-and-inspect.
+
+---
+
+## VerifyContext — auto-resolve lookups, caller declares boundaries
+
+```python
+@dataclass
+class VerifyContext:
+    project_root: Path | None = None      # for link resolution
+    env_python: str | None = None         # default: sys.executable
+    help_commands: dict[str, str] = field(default_factory=dict)
+                                          # name -> captured --help text
+    allowed_help_cmds: frozenset[str] = frozenset()
+                                          # commands safe to run --help on
+    count_sources: dict[str, int | Callable[[], int]] = field(default_factory=dict)
+    judge: "Judge | None" = None          # semantic layer; None = skip
+    semantic: bool = False                # opt-in semantic checking
+```
+
+Resolution policy (the Phase-1 decision made concrete):
+
+- **Imports** — verify resolves via `importlib.util.find_spec`
+  against `env_python` (default current interpreter). Caller picks
+  the env; verify does the lookup.
+- **Links** — verify stats targets relative to `project_root`.
+  Caller declares the root; verify resolves.
+- **Flags** — verify resolves a flag against `help_commands[cmd]`
+  if pre-captured, else captures `--help` **only if `cmd in
+  allowed_help_cmds`**. A command not pre-captured and not
+  allow-listed yields a `warning`-severity finding ("could not
+  verify"), never a silent pass and never an un-gated subprocess.
+- **Counts** — never inferred; resolved only against
+  `count_sources`. A numeric claim with no matching source →
+  `warning` ("unverifiable count"), not an error.
+
+**Security:** the `allowed_help_cmds` gate is the boundary that
+keeps `--help` capture from running arbitrary command names lifted
+from generated content. Generated code is never executed (req
+criterion 5); only allow-listed CLIs are introspected.
+
+---
+
+## Judge protocol (Option C) + implementations
+
+```python
+@runtime_checkable
+class Judge(Protocol):
+    def score(self, query: str, answer: str,
+              passages: str | list[str]) -> "SemanticVerdict": ...
+
+@dataclass
+class SemanticVerdict:
+    faithful: bool
+    issues: list[str]      # e.g. "insecure example: host=0.0.0.0, no auth note"
+    raw: object | None     # underlying result, for debugging
+```
+
+The signature mirrors rag's `FaithfulnessJudge.score(query, answer,
+passages)` (verified against installed rag 0.2.0) so the adapter is
+near-trivial.
+
+**Skill-judge (interactive default).** Lives in the `/verify`
+skill, not this package. The skill runs the deterministic checks
+via the library, then the ambient Claude Code agent performs the
+semantic judgment and constructs a `SemanticVerdict` — no API call,
+on-subscription. The skill injects this judge into
+`VerifyContext.judge`.
+
+**rag adapter (headless fallback).** `semantic/rag_adapter.py`,
+imported only when the `[rag]` extra is installed:
+
+```python
+def make_rag_judge(**kw) -> Judge:
+    from attune_rag.eval.faithfulness import FaithfulnessJudge
+    inner = FaithfulnessJudge(**kw)
+    class _Adapter:
+        def score(self, query, answer, passages):
+            r = asyncio.run(inner.score(query, answer, passages))
+            return SemanticVerdict(faithful=r.is_faithful,
+                                   issues=r.unsupported_claims, raw=r)
+    return _Adapter()
+```
+
+Degradation: `semantic=True` with no `judge` and no `[rag]` extra
+→ `VerifyResult.semantic_ran=False` + a single `warning` finding
+("semantic layer requested but no judge available"). Deterministic
+findings are unaffected.
+
+> The exact rag `FaithfulnessResult` field names
+> (`is_faithful` / `unsupported_claims` above) are a **Phase-3
+> verification item** — confirm against installed rag before
+> wiring the adapter.
+
+---
+
+## Public API
+
+```python
+def verify(content: str, context: VerifyContext) -> VerifyResult:
+    """Run deterministic checkers (always) + semantic layer (if
+    context.semantic and a judge is resolvable). Returns findings;
+    never raises on findings (use raise_if_failed)."""
+```
+
+Deterministic checkers run unconditionally and independently — a
+failure in one does not abort the others (each wrapped, errors
+surfaced as `warning` findings, mirroring the discovery-sweep
+source-isolation pattern).
+
+---
+
+## The `/verify` skill (attune-ai plugin)
+
+- `plugin/skills/verify/SKILL.md` — triggers on "verify docs",
+  "fact-check", "check this generated content".
+- Flow: read target content + source → call
+  `attune_verify.verify(content, ctx)` for deterministic findings →
+  agent judges semantics (skill-judge) → present a unified findings
+  report (deterministic + semantic).
+- Adding the skill triggers the three plugin gates (skill count
+  test; attune-hub reference table; `.agents/` mirror sync) — noted
+  for tasks.md.
+
+---
+
+## Packaging (sibling pattern)
+
+- Full source at `../attune-verify/`; pointer stub at
+  `packages/attune-verify/README.md`; `[tool.uv.sources]` editable
+  entry in attune-ai.
+- Extras: `attune-verify` (deterministic core, zero heavy deps);
+  `attune-verify[rag]` (pulls attune-rag for the adapter).
+- Own `pypi` env; **publish 0.1.0 before** wiring the attune-author
+  consumer so the integration is CI-testable (not `importorskip`-ed).
+- **Repo creation (`gh repo create`) is an await-Patrick step** per
+  the autonomous guardrails — not done unattended.
+
+---
+
+## Testing strategy
+
+- **Deterministic checkers** — unit tests per checker; the
+  load-bearing one is a **regression fixture rebuilt from the
+  author-#351 hallucinations** (invented `--allow-run` flag, the
+  `_readers`/`_models` private imports, the four dead "See also"
+  links, the `498 templates` miscount, the `POST /run` route) —
+  verify must flag each.
+- **Semantic layer** — test with a `FakeJudge` (no API): inject a
+  scripted `SemanticVerdict`, assert it surfaces as a `SEMANTIC`
+  finding. Test the no-judge degrade path.
+- **rag adapter** — guard with the `sys.modules[name] = None`
+  sentinel to exercise the "rag absent" path cross-version
+  (per the CLAUDE.md lesson on `find_spec` sentinels).
+- **Security** — assert verify never executes generated code, and
+  never runs `--help` for a command outside `allowed_help_cmds`.
+
+---
+
+## Open items carried to tasks.md / Phase 3
+
+- Exact rag `FaithfulnessResult` field names (verify against
+  installed rag before adapter wiring).
+- `Judge.score` signature: keep rag's `(query, answer, passages)`
+  or adopt a verify-native `(content, source)` and map in the
+  adapter.
+- How the `/verify` skill threads its `SemanticVerdict` back into a
+  `VerifyResult` (skill returns structured findings vs. the library
+  composing them).
+- Whether `verify()` gets an async variant for the rag adapter
+  (currently `asyncio.run` inside a sync wrapper — fine for CLI,
+  awkward inside an existing event loop).

--- a/docs/specs/attune-verify/requirements.md
+++ b/docs/specs/attune-verify/requirements.md
@@ -238,3 +238,29 @@ All six Phase-1 questions were walked with Patrick and decided:
 - Whether the `FaithfulnessJudge` reuse is a hard dependency on
   attune-rag or a duck-typed optional integration (and how it
   degrades when rag isn't installed).
+
+---
+
+## Phase 4 PR conventions (forward note)
+
+The build+test PR for attune-verify is separate from this spec.
+
+Docs follow the attune-ai help pattern: attune-verify gets its own
+attune-author-generated `.help/` corpus (concept/task/reference +
+all-kinds, staleness detection, RAG corpus) — the same living-docs
+treatment attune-ai has.
+
+Doc-update discipline for that PR:
+
+- Update only help/docs that genuinely change from the feature;
+  don't churn unchanged templates.
+- **Exception:** a help template used as ground-truth / test input
+  for the faithfulness-accuracy checks must be made correct even if
+  it otherwise wouldn't change — stale ground truth corrupts the
+  test.
+- attune-verify stays roadmap-only in family docs until it ships
+  (criterion #6).
+
+Dogfood loop: attune-author generates attune-verify's help;
+attune-verify fact-checks that generated help — a self-contained
+loop that doubles as the Q4 first-consumer integration test.

--- a/docs/specs/attune-verify/requirements.md
+++ b/docs/specs/attune-verify/requirements.md
@@ -1,0 +1,240 @@
+# Spec: attune-verify — Generation Fact-Checker
+
+> A standalone library that verifies the *named entities* in
+> LLM-generated content actually exist — imports import, CLI flags
+> are real, links resolve, counts match source — and, via an LLM
+> layer, that the content is semantically faithful, so
+> hallucinations that pass unit tests are caught before they reach
+> a reader.
+
+**Status:** draft (2026-06-02)
+**Created:** 2026-06-02
+**Owner:** TBD
+**Related:** the "Discipline of Agent Collaboration" §7
+(Verification) — this is the *output-side* fact-check mode pulled
+out as its own product; complements **attune-rag** (input-side
+grounding) and **subsumes attune-author**'s planned AST fact-check
+(author#27).
+
+---
+
+## Problem statement
+
+LLM generation pipelines in the attune family — attune-author's
+doc polish, `rag-code-gen`, the `doc-gen` workflow — emit content
+that *reads* correct and passes unit tests, yet invents named
+entities that break any reader who follows the output literally.
+Per the discipline's §7: "unit tests catch zero hallucinations."
+Tests assert the function returned the expected *type*; they cannot
+assert it returned something *true*.
+
+A single attune-author doc regen (ops-dashboard, 15 templates + 4
+docs, 2026-05-14) produced six distinct hallucination classes:
+
+1. **Invented CLI flag** with inverted semantics (`--allow-run`
+   when the real flag is `--read-only`).
+2. **Private-module imports** that raise `ModuleNotFoundError`.
+3. **Dead cross-references** — "See also" links to docs that don't
+   exist.
+4. **Wrong numeric count** (`498 templates` vs. real 259).
+5. **Wrong route paths** (`POST /run` vs. real
+   `POST /workflows/{name}/run`).
+6. **Insecure example** (`host="0.0.0.0"` with no auth callout).
+
+Three of the six actively break readers who follow the docs. The
+root cause: a polish/generation pass has source as *context* but
+isn't *constrained* to it — the model fills surrounding scaffolding
+from priors that "sound right."
+
+Today the only defense is a *planned* AST fact-check buried inside
+attune-author (author#27). It is neither built nor reusable. Every
+other generation pipeline in the family ships unverified.
+
+### Why this is distinct from attune-rag (the "not combined" point)
+
+attune-rag grounds generation in **accurate retrieved sources** and
+citation-forces each claim, so claims are *supported by* real data
+("is this claim *supported*?"). attune-verify checks the
+**output**: the named things in the produced artifact actually
+exist ("is this *real*?").
+
+Grounding can be perfect and the output still invent a flag that
+was never in the retrieved context. The two checks *bracket*
+generation — complementary, not redundant — which is why this is a
+separate product, not a feature of attune-rag.
+
+---
+
+## Scope
+
+### In scope
+
+- A standalone, dependency-light library **`attune-verify`** with a
+  small public API: given generated content + a `VerifyContext`
+  declaring the truth sources, return typed findings naming each
+  unverifiable entity.
+- Deterministic (no-LLM) checkers for the resolvable classes:
+  - **Imports** — every `import`/`from … import …` in code fences
+    resolves against the target environment.
+  - **CLI flags** — flags referenced for a command exist in its
+    `--help` output.
+  - **Links** — markdown link targets resolve to real files/anchors.
+  - **Counts** — numeric/quantitative claims match a source value
+    the caller supplies.
+- An **LLM semantic layer** — ships in v1, flag-controllable —
+  reusing attune-rag's `FaithfulnessJudge` to catch the
+  meaning-level class the deterministic checkers cannot: a missing
+  security callout, an insecure example, claims unsupported by
+  source.
+- A clean integration surface so any pipeline (attune-author
+  polish, `rag-code-gen`, `doc-gen`) can call it as a
+  post-generation gate: returns structured findings; an opt-in
+  `raise_if_failed()` helper is available for callers wanting a
+  hard gate.
+- Family packaging per the sibling pattern: full source at
+  `../attune-verify/`, pointer stub at
+  `packages/attune-verify/README.md`, a `[tool.uv.sources]` entry,
+  own PyPI publish + `pypi` env — **publish 0.1.0 early** so the
+  first consumer's integration is CI-testable.
+
+### Out of scope
+
+- **Executing** LLM-generated code to test it — explicit security
+  boundary; deferred. attune-verify reads and statically resolves;
+  it never runs generated code.
+- **Retrieval grounding / citation enforcement** — that is
+  attune-rag's input-side job and is *not* duplicated here.
+- **Auto-fixing** hallucinations — attune-verify *reports*; repair
+  is the calling pipeline's decision.
+- **Prompt-side prevention** (injecting ground truth into the
+  generation prompt) — a pipeline concern, not a verifier.
+- **`mypy --strict` type-checking of code fences** (design D) —
+  deferred past v1.
+
+---
+
+## Design alternatives
+
+The four interventions surfaced by attune-author's hallucination
+analysis, recast as build options.
+
+### A — Deterministic AST / static entity-resolver (v1 core)
+
+A no-LLM library that parses generated content and resolves named
+entities against ground truth: AST-walk code fences for imports,
+shell out to `--help` for flags, stat link targets, compare counts.
+
+- **Catches:** five of the six classes (imports, flags, links,
+  counts; route paths via link/flag resolution).
+- **Misses:** the semantic class (insecure example with a missing
+  callout) — there is no entity to resolve.
+- **Cost:** cheap, fast, no API spend, fully testable.
+
+### B — Inject ground truth into the generation prompt
+
+Prevention upstream: feed rendered `--help`, `__all__`, dataclass
+fields into the prompt so the model is constrained.
+
+- **Nature:** a *pipeline* change, not a verifier. Reduces the
+  hallucination rate but cannot *prove* the output is clean.
+  Out of scope — belongs to the consuming pipeline.
+
+### C — attune-rag `FaithfulnessJudge` LLM layer (adopted in v1)
+
+An LLM-backed layer (forced tool-use → schema) that catches the
+semantic class A cannot — missing content, insecure examples,
+unsupported claims — by judging the artifact against source.
+
+- **Catches:** the sixth class and other meaning-level gaps.
+- **Cost:** API spend per check; reuses proven rag machinery.
+- **Decision:** adopted in v1 (flag-controllable, so
+  deterministic-only runs still cost nothing). Phase 2 must verify
+  the `FaithfulnessJudge` API in the installed attune-rag before
+  depending on it.
+
+### D — Static analysis (`mypy --strict`) of code fences
+
+Type-check tutorial code fences to catch wrong code that
+import-resolution alone misses. A future checker; deferred past v1.
+
+---
+
+## Recommendation
+
+**Build `attune-verify` as a standalone sibling package whose v1
+covers all six hallucination classes** — intervention A (the
+deterministic entity-resolver for imports, flags, links, counts)
+**plus** intervention C (an LLM layer reusing attune-rag's
+`FaithfulnessJudge`) for the semantic class A cannot reach. The LLM
+layer is flag-controllable so deterministic-only runs cost nothing,
+but it ships in v1 (decided 2026-06-02 — accuracy over a cheaper
+partial v1). **Defer D** (mypy-fence); treat **B** as out of scope
+(a pipeline change). Standalone over a module inside rag/author
+because the check is reusable across all three pipelines and is a
+distinct concern from both grounding and generation.
+
+attune-verify is the output-side complement to attune-rag's
+input-side grounding; together they bracket generation in the §7
+verification story.
+
+---
+
+## Acceptance criteria
+
+For Phase 4 implementation to be considered complete:
+
+1. `attune-verify` exists as a sibling package (full source at
+   `../attune-verify/`, pointer stub at
+   `packages/attune-verify/README.md`, `[tool.uv.sources]` entry,
+   PyPI-ready `pyproject.toml`) and **0.1.0 is published to PyPI**
+   before the consumer integration, so CI can exercise it rather
+   than `importorskip` it.
+2. A small public API — e.g.
+   `verify(content, context: VerifyContext) -> VerifyResult` —
+   returning typed finding kinds (`unresolved_import`,
+   `unknown_flag`, `dead_link`, `count_mismatch`, `semantic`),
+   plus an opt-in `raise_if_failed()` helper.
+3. Deterministic checkers for all four resolvable classes **and**
+   the LLM semantic layer, each with tests **and** a regression
+   fixture drawn from the author-#351 known-hallucination case, so
+   a real past failure is provably caught.
+4. **attune-author polish** wired to call attune-verify as a
+   post-generation gate (the first-consumer integration).
+5. attune-verify never executes generated code (security boundary
+   asserted by test).
+6. **Docs accuracy:** family READMEs/docs describe attune-verify as
+   a real capability **only once it ships**; until then any mention
+   is labeled roadmap/planned — per the website-content-accuracy
+   rule and the "fictional workflows" lesson.
+7. **attune-author#27 is closed** and repointed to this spec; the
+   fact-check capability no longer lives inside author.
+
+---
+
+## Decisions (Phase-1 alignment, 2026-06-02)
+
+All six Phase-1 questions were walked with Patrick and decided:
+
+1. **v1 LLM layer** → ship **A + C in v1** (all six classes from
+   day one; LLM layer flag-controllable but present). Accuracy over
+   a cheaper deterministic-only v1.
+2. **Ground-truth provenance** → an explicit **`VerifyContext`**
+   the caller supplies (project root, env/command, count sources);
+   attune-verify performs the resolution.
+3. **Findings surface** → **return structured findings**; the
+   consumer decides warn/gate/fix. Opt-in `raise_if_failed()` for a
+   hard gate.
+4. **First consumer** → **attune-author polish** (the origin case).
+5. **attune-author#27** → **subsumed**; verify owns the capability,
+   #27 closes and repoints here, author becomes a consumer.
+6. **Repo bring-up** → standard sibling pattern; **publish 0.1.0
+   early** so the author integration is CI-testable.
+
+### Remaining open for Phase 2 design
+
+- The exact `VerifyContext` shape — how much attune-verify
+  auto-resolves (env import resolution, `--help` capture) vs.
+  requires the caller to declare explicitly.
+- Whether the `FaithfulnessJudge` reuse is a hard dependency on
+  attune-rag or a duck-typed optional integration (and how it
+  degrades when rag isn't installed).

--- a/docs/specs/attune-verify/requirements.md
+++ b/docs/specs/attune-verify/requirements.md
@@ -230,14 +230,47 @@ All six Phase-1 questions were walked with Patrick and decided:
 6. **Repo bring-up** → standard sibling pattern; **publish 0.1.0
    early** so the author integration is CI-testable.
 
-### Remaining open for Phase 2 design
+### Phase 2 design — resolved directions (2026-06-02)
 
-- The exact `VerifyContext` shape — how much attune-verify
-  auto-resolves (env import resolution, `--help` capture) vs.
-  requires the caller to declare explicitly.
-- Whether the `FaithfulnessJudge` reuse is a hard dependency on
-  attune-rag or a duck-typed optional integration (and how it
-  degrades when rag isn't installed).
+Both Phase-1 open items were resolved in discussion:
+
+- **`VerifyContext` shape** → verify **auto-resolves the lookups**
+  (import resolution, link stat, `--help` capture) but the caller
+  **declares the boundaries** in the context: which env (default:
+  current interpreter), the project root, the *allowlist of
+  commands* safe to introspect, and the count sources (values or
+  extractors). Two hard constraints: `--help` capture runs a
+  subprocess, so it is gated to caller-declared commands only —
+  never auto-run a command name the generated doc happens to
+  mention; and counts cannot be inferred, so the caller supplies
+  them.
+- **Semantic judge** → **Option C: a `Judge` protocol with
+  injection** (verify imports nothing from rag). Two
+  implementations behind it:
+  - **Skill-judge (default, interactive)** — when verify runs
+    inside a Claude Code session, a `/verify` skill has the
+    ambient agent do the semantic judgment on the subscription:
+    **no API call, no key, no spend**. The family's "runs on your
+    subscription" principle, applied to verification.
+  - **API-judge (headless fallback)** — for CI / the weekly
+    help-freshness workflow / batch regen (no ambient agent), an
+    optional `attune-verify[rag]` extra ships a thin adapter over
+    attune-rag's `FaithfulnessJudge`
+    (`score(query, answer, passages)`, async, needs
+    `ANTHROPIC_API_KEY`).
+  - A caller may inject any other judge satisfying the protocol.
+
+  The deterministic core never touches an LLM and runs everywhere.
+  attune-verify therefore ships **both a library and a `/verify`
+  skill** surface.
+
+Genuinely still open for Phase 2:
+
+- The exact `Judge` protocol signature — mirror rag's
+  `score(query, answer, passages)` or a verify-native shape.
+- Skill-judge mechanics: how the `/verify` skill feeds its verdict
+  back into the library's findings, and the degrade path when no
+  judge is available and the semantic flag is on.
 
 ---
 

--- a/docs/specs/attune-verify/tasks.md
+++ b/docs/specs/attune-verify/tasks.md
@@ -1,0 +1,154 @@
+# Tasks: attune-verify — Generation Fact-Checker
+
+**Status:** draft (2026-06-02) — Phase 3, awaiting review
+**Design:** [design.md](design.md) · **Requirements:**
+[requirements.md](requirements.md)
+
+> Independently shippable units. Order respects dependencies.
+> Two units are **await-Patrick** (repo creation, PyPI publish) per
+> the autonomous guardrails — flagged ⛔.
+
+---
+
+## Dependency order
+
+```text
+T1 (repo skeleton ⛔) ─▶ T2 (model) ─▶ T3 (deterministic checkers)
+                                    └─▶ T4 (Judge + semantic plumbing)
+                                              └─▶ T5 (rag adapter)
+T2,T3 ─▶ T6 (/verify skill)
+T1 ─▶ T8 (publish 0.1.0 ⛔) ─▶ T7 (author integration)
+```
+
+---
+
+## T1 — Sibling repo + package skeleton ⛔ (await-Patrick: repo creation)
+
+**Objective:** stand up `attune-verify` as a family sibling.
+
+- Create `../attune-verify/` (full source), `packages/attune-verify/
+  README.md` pointer stub, `[tool.uv.sources]` editable entry in
+  attune-ai's `pyproject.toml`.
+- `pyproject.toml`: core deps minimal (stdlib-only target); extras
+  `[rag]` → `attune-rag`; `[dev]` → pytest etc.
+- CI mirroring the family (tests matrix, lint, signed releases),
+  `pypi` env.
+
+**Acceptance:** `uv pip install -e ../attune-verify` imports;
+`attune-verify` console entry resolves.
+**Blocked on:** `gh repo create` — Patrick runs or authorizes.
+
+---
+
+## T2 — Data model + VerifyContext
+
+**Objective:** the typed surface everything else builds on.
+
+- `result.py`: `FindingKind`, `Finding` (frozen), `VerifyResult`
+  (`.ok`), `VerificationError`, `raise_if_failed()`.
+- `context.py`: `VerifyContext` (project_root, env_python,
+  help_commands, allowed_help_cmds, count_sources, judge, semantic).
+- `__init__.py` exports.
+
+**Acceptance:** unit tests construct each type; `VerifyResult.ok`
+true/false by severity; `raise_if_failed` raises only on errors.
+
+---
+
+## T3 — Deterministic checkers + author-#351 regression fixture
+
+**Objective:** the no-LLM core (5 of 6 classes).
+
+- `_extract.py`: pull code fences, links, numeric claims.
+- `checkers/imports.py` (`find_spec` vs `env_python`),
+  `flags.py` (vs `help_commands` / gated `--help` capture),
+  `links.py` (vs `project_root`), `counts.py` (vs `count_sources`).
+- Per-checker error isolation (one checker failing → `warning`
+  finding, others still run).
+- `verify()` orchestration (deterministic path).
+
+**Acceptance:** a **regression fixture rebuilt from author-#351**
+(invented `--allow-run`; `_readers`/`_models` imports; 4 dead "See
+also" links; `498 templates` miscount; `POST /run` route) — verify
+flags each. Security test: never runs `--help` for a command
+outside `allowed_help_cmds`; never executes fence code.
+
+---
+
+## T4 — Judge protocol + semantic plumbing
+
+**Objective:** the injected semantic layer (no rag import here).
+
+- `semantic/protocol.py`: `Judge` Protocol, `SemanticVerdict`.
+- `verify()` semantic branch: if `context.semantic` and a judge is
+  present, run it → `SEMANTIC` findings; else degrade path
+  (`semantic_ran=False` + one `warning`).
+
+**Acceptance:** `FakeJudge` (scripted verdict, no API) surfaces a
+`SEMANTIC` finding; no-judge + `semantic=True` → graceful warning,
+deterministic findings intact.
+
+---
+
+## T5 — rag adapter ([rag] extra)
+
+**Objective:** headless semantic judge via attune-rag.
+
+- **Phase-3 pre-step:** verify rag `FaithfulnessResult` field names
+  against installed attune-rag (design used placeholder
+  `is_faithful`/`unsupported_claims`).
+- `semantic/rag_adapter.py`: `make_rag_judge(**kw)` wrapping
+  `FaithfulnessJudge.score`; lazy import under `[rag]`.
+
+**Acceptance:** adapter satisfies `Judge`; `sys.modules[name]=None`
+sentinel test proves clean degradation when rag absent.
+
+---
+
+## T6 — `/verify` skill (attune-ai plugin)
+
+**Objective:** the interactive, on-subscription surface.
+
+- `plugin/skills/verify/SKILL.md` (+ `.agents/skills/verify/`
+  mirror via `scripts/sync_agents_skills.py`).
+- Flow: deterministic checks via library → ambient-agent
+  skill-judge → unified findings report.
+- **Three plugin gates:** bump skill-count test; add row to
+  attune-hub reference table; run the `.agents` mirror sync.
+
+**Acceptance:** the three plugin-config tests pass; skill triggers
+on "fact-check"/"verify docs".
+
+---
+
+## T7 — attune-author polish integration (first consumer)
+
+**Objective:** wire verify as author's post-generation gate.
+
+- author polish calls `attune_verify.verify(content, ctx)` after
+  generation; surfaces findings (return, not hard-gate by default).
+
+**Acceptance:** author's polish run on a known-hallucinated fixture
+reports verify findings.
+**Blocked on:** T8 (verify on PyPI) so author CI exercises it
+rather than `importorskip`.
+
+---
+
+## T8 — Publish 0.1.0 ⛔ (await-Patrick: PyPI publish) + docs flip
+
+**Objective:** make verify resolvable + visible.
+
+- Publish `attune-verify` 0.1.0 (trusted publishing).
+- Flip family docs/README from roadmap → available (criterion 6) —
+  only now that it ships.
+
+**Blocked on:** Patrick (publish + the `pypi` env approval).
+
+---
+
+## Notes
+
+- T1 and T8 are the only Patrick-gated units; T2–T6 are codeable
+  autonomously once T1's repo exists.
+- Tasks may shift if design.md changes on review.


### PR DESCRIPTION
Phase-1 requirements draft for **attune-verify** — a new (5th) attune-family product: a generation fact-checker.

It verifies the *named entities* in LLM-generated content actually exist (imports import, CLI flags are real, links resolve, counts match source) plus an LLM semantic layer for the meaning-level class. Output-side complement to attune-rag's input-side grounding; subsumes attune-author's planned AST fact-check (author#27).

**Phase-1 alignment decisions (2026-06-02)** are recorded in the spec's Decisions section:
- v1 ships deterministic + LLM layer (all six hallucination classes; LLM flag-controllable)
- Explicit `VerifyContext`; verify resolves
- Returns structured findings + opt-in `raise_if_failed()`
- First consumer: attune-author polish
- author#27 subsumed/closed
- Sibling package; publish 0.1.0 early for CI-testable integration

**Awaiting Phase-1 sign-off** before Phase-2 design begins (same gate as #571). Two implementation details remain genuinely open for Phase 2 (exact `VerifyContext` shape; hard-vs-optional rag dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)