### PR TITLE
chore: add attune-verify pointer stub (packages/attune-verify/)

### DIFF
--- a/packages/attune-verify/README.md
+++ b/packages/attune-verify/README.md
@@ -1,0 +1,8 @@
+# attune-verify (pointer stub)
+
+The full source for `attune-verify` lives at
+[`../../../attune-verify/`](../../../attune-verify/) (sibling repo).
+
+This stub exists to satisfy the `packages/` pattern used across the
+attune-\* family. See the sibling directory for all source,
+`pyproject.toml`, tests, and CI.


### PR DESCRIPTION
Adds a pointer-stub README at `packages/attune-verify/` so the new `attune-verify` package follows the `packages/` pattern used across the attune-* family.

The stub just points at the sibling repo (`../../../attune-verify/`), which holds all source, `pyproject.toml`, tests, and CI. attune-verify stays **roadmap-only** here until 0.1.0 ships to PyPI.

- Single new file, +8 lines, brand-new path → no conflict despite the branch trailing main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)