### PR TITLE
docs(specs): claude-cross-session-memory spec — approved requirements + decisions + tasks

### DIFF
--- a/docs/specs/claude-cross-session-memory/decisions.md
+++ b/docs/specs/claude-cross-session-memory/decisions.md
@@ -1,0 +1,58 @@
+# Claude Cross-Session Memory — Decisions
+
+**Status:** approved
+**Ratified:** 2026-06-02
+
+## D1 — Recall trigger
+
+**Decision:** SessionStart hook (auto top-k) + `/recall` skill (user-invoked).
+
+**Rationale:** For a solo developer who is always present, a skill is superior
+to an autonomous MCP tool for on-demand recall: it's explicit, shows what was
+surfaced and why, and puts the user in control. The hook handles "background"
+context that should always be available, while `/recall` handles intentional
+deeper pulls. No Claude-autonomous mid-session recall without user intent.
+
+**Rejected alternatives:**
+- On-demand MCP tool only — Claude autonomously calls it; less transparent for
+  solo dev who wants to see what memory is active.
+- Hook + MCP tool (original design lean) — replaced by Hook + Skill for better
+  solo-dev UX.
+
+---
+
+## D2 — Write / promotion policy
+
+**Decision:** Session findings auto-stash to Redis with a TTL (7 days default).
+Promotion from Redis to the curated `~/.claude/memory/` layer stays
+review-gated (no auto-promotion).
+
+**Rationale:** Consistent with the principle that the curated layer is
+human-tuned. Auto-stash captures useful findings without requiring explicit
+`/remember` invocations. The TTL prevents Redis from becoming a graveyard of
+stale data. Review-gated promotion keeps the curated layer's signal-to-noise
+high and auditable.
+
+**Rejected alternatives:**
+- Auto-promote to curated — risks filling the curated layer with unreviewed
+  content; harder to audit what Claude wrote vs what Patrick wrote.
+- Manual only — loses session findings that seemed trivial at the time.
+
+---
+
+## D3 — Cross-memory reference format
+
+**Decision:** `[[link]]` stays as reference (lint-checkable name resolution
+only); `@import` reserved for explicit inline-composition when content must
+be inlined.
+
+**Rationale:** `[[link]]` is already enforced by `memory_lint.py` and is cheap
+(no content loading). Reserving `@import` for intentional composition keeps
+the distinction clear: a `[[link]]` is "this memory is related," an `@import`
+is "inline this memory's content here." Most cross-references are the former.
+
+**Rejected alternatives:**
+- `@import` everywhere — higher context cost; every reference pulls full file.
+- `[[link]]` only, no inline — loses composition capability for cases where
+  context genuinely needs to be merged (e.g. a meta-memory that aggregates
+  multiple related topics for a complex project).

--- a/docs/specs/claude-cross-session-memory/design.md
+++ b/docs/specs/claude-cross-session-memory/design.md
@@ -1,0 +1,119 @@
+# Claude Cross-Session Memory — Design Draft
+
+> **Status: DRAFT for `/spec` intake — NOT an approved spec.** No `tasks.md`
+> here is executable until this goes through `/spec` and decisions are
+> ratified. Synthesizes three read-only scouts run 2026-06-02 (attune-ai
+> memory subsystem, the `attune` umbrella specs, and the legacy
+> empathy-framework `claude_memory`).
+
+## Problem & honest framing
+
+The goal is to give Claude **richer cross-session memory** — but precisely:
+
+- Cross-session memory means *the next session's Claude can retrieve what a
+  prior session wrote*. It is continuity of **knowledge**, not a running agent
+  that persists between sessions. Design for knowledge-continuity; designing
+  for a persistent process would be wrong.
+- A **static** form already exists: `~/.claude/memory/` + `MEMORY.md` load
+  every session (just hardened with a format spec + lint hook). That is how
+  Claude already "remembers" preferences across sessions.
+- The gap Redis fills is **selective semantic recall**: surface the relevant
+  few memories for *this* task instead of loading all ~45 every session
+  (already a growing context cost), and recall project knowledge that the
+  cwd-keyed file store fragments across worktrees.
+
+## Current state (grounded in the scouts)
+
+**`~/.claude/memory/` — curated, authored (exists, hardened 2026-06-02)**
+- 45 markdown files + `MEMORY.md` index, loaded every session.
+- Spec R1–R4 enforced by `~/.claude/hooks/memory_lint.py` (PostToolUse):
+  `name`≡filename-stem, fixed frontmatter, atomic index pointer, resolving
+  `[[links]]`. Routing rule: cross-project → global, else → project.
+
+**attune-ai — recall infrastructure (mostly exists)**
+- `src/attune/memory/personal.py` `PersonalMemory`: filesystem
+  `~/.attune/memory/<topic>/<kind>.md` (kinds: decision/pattern/
+  troubleshooting/reference) + `summaries_by_path.json` index; semantic
+  search via optional `attune_rag`.
+- `src/attune/memory/short_term/facade.py` `RedisShortTermMemory`: Redis
+  working memory w/ TTL, file fallback (`FileSessionMemory`).
+- `src/attune/memory/long_term.py` + `attune_redis/memory.py` `AMSMemoryBackend`:
+  persistent + semantic long-term (agent-memory-client).
+- `src/attune/memory/unified.py` `UnifiedMemory`: mixin-composed entry point.
+- Validation today: id/slug/classification regex + PII scrubber + secrets
+  detector at the storage boundary. **No markdown-format/link/dedup linting.**
+
+**Legacy empathy-framework `claude_memory` — reusable design ideas**
+- `attune_llm/claude_memory.py`: 3-tier **scope hierarchy**
+  (enterprise→user→project, project wins), `@path/to/file.md` **imports**
+  (inline-include) with circular-detection (stack), depth limit (5), and
+  resilient missing-import handling.
+- `examples/claude_memory/`: security tiers (PUBLIC/INTERNAL/SENSITIVE),
+  auto-classification, audit log shape — runtime policy, not file format.
+- Memory graph (`src/attune/memory/graph.py`): nodes/edges knowledge graph —
+  **orthogonal**, out of scope here.
+
+## Proposed architecture — two layers that compose
+
+**Layer 1 — Curated / authored (small, always-relevant, human-tuned)**
+- The hardened `~/.claude/memory/` file format is the source of truth for
+  durable preferences/process.
+- Adopt from legacy `claude_memory`: the **scope hierarchy** (formalize the
+  global-vs-project routing into enterprise/user/project precedence) and
+  **import/link resolution** (reconcile `@import` vs `[[link]]` — see
+  decisions).
+
+**Layer 2 — Recall (large, accreted, retrieved by relevance)**
+- Reuse attune-ai's `UnifiedMemory` / `PersonalMemory`+rag / Redis backends.
+- Index the curated layer **and** per-session accretions into Redis; retrieve
+  by semantic relevance into a session instead of loading everything.
+
+**How they compose:** curated files stay the authoritative, reviewable record;
+Redis is a derived, rebuildable recall index over them plus session findings.
+Losing Redis never loses authored memory.
+
+## Reuse map (≈80% exists — integration, not greenfield)
+
+| Need | Source | Action |
+|---|---|---|
+| Durable format + lint | `~/.claude/memory` + `memory_lint.py` | reuse as-is |
+| Scope hierarchy / routing | legacy `claude_memory.py` | port concept |
+| Import/link resolution | legacy `@import` + our `[[link]]` | reconcile, port |
+| Semantic recall | attune-ai `PersonalMemory`+rag, AMS | reuse |
+| Working/session memory | attune-ai `RedisShortTermMemory` | reuse |
+| Secrets/PII safety | attune-ai scrubber/detector | reuse at write |
+| The binding into a Claude Code session | — | **build (thin)** |
+
+## Open decisions (resolve in `/spec` — not pre-decided)
+
+1. **Recall trigger** — how relevant memories enter a session:
+   (a) SessionStart hook queries Redis and injects; (b) an MCP `memory_recall`
+   tool Claude calls on demand; (c) extend the existing auto-memory load.
+   *Lean:* (b)+(a) — auto-inject a small top-k at start, plus on-demand tool.
+2. **Write policy** — what gets stashed per session and whether durable
+   promotion needs Patrick's review (vs auto-promote).
+   *Lean:* session findings auto-stash to Redis (ephemeral/TTL); promotion to
+   the curated file layer stays **review-gated** (consistent with the curated
+   layer being human-tuned).
+3. **Format reconciliation** — legacy `@import` *inlines* content; our
+   `[[link]]` is a *reference*. Pick one model for cross-memory references.
+   *Lean:* keep `[[link]]` as reference (cheap, lint-checkable); reserve
+   inline-include for an explicit `@import` only where composition is needed.
+
+## Non-goals
+- Not a persistent/always-running agent.
+- Memory graph (nodes/edges) — orthogonal, separate effort.
+- No weakening of the curated-layer review discipline.
+
+## Risks / constraints
+- Redis is an **optional** dependency (attune-ai pattern) — recall must degrade
+  to file-only gracefully.
+- Reuse the existing PII/secrets gates before anything is written to Redis.
+- Worktree cwd-fragmentation of project memory is a motivating case — semantic
+  recall keyed on content (not exact cwd) helps; confirm in design.
+- Context budget: auto-injected top-k must stay small.
+
+## Next step
+Run `/spec` to take this from draft → approved (requirements + ratified
+decisions + tasks) before any implementation. This is the release-strengthening
+candidate for attune-ai; the release stays held until its scope is decided.

--- a/docs/specs/claude-cross-session-memory/requirements.md
+++ b/docs/specs/claude-cross-session-memory/requirements.md
@@ -1,0 +1,86 @@
+# Claude Cross-Session Memory — Requirements
+
+**Status:** approved
+**Approved:** 2026-06-02
+
+## Problem
+
+Claude's current cross-session memory is static: `~/.claude/memory/` (45 files)
+loads in full every session. Gaps:
+
+1. Context cost grows linearly — loading all memories regardless of relevance.
+2. Worktree fragmentation — project memories are cwd-keyed, so the same project
+   across worktrees splits into separate memory namespaces.
+3. Session findings are lost — Claude learns something useful mid-session but
+   can't persist it unless explicitly asked to write a memory file.
+
+## In scope
+
+### R1 — Automatic context injection at session start
+
+At SessionStart, a hook queries the Redis recall index and injects the
+`top-k` most relevant memories (by semantic similarity to the current
+working context: cwd, open spec, last commit) into the session context.
+`k` stays small enough to be noise-free (target ≤ 5 entries, ≤ 400 tokens).
+
+**Acceptance criteria:**
+- Hook runs in ≤ 1 second; failure degrades silently (no hook error banner).
+- Injected entries are clearly labeled (e.g. `## Recalled memories`).
+- With no Redis available, hook exits 0 (file-only fallback returns empty).
+- Auto-inject does not duplicate entries already in `~/.claude/memory/`
+  (curated layer is already loaded by CLAUDE.md).
+
+### R2 — User-invoked `/recall` skill for on-demand deep pulls
+
+A `/recall [query]` skill lets Patrick explicitly surface relevant memories
+mid-session. It queries both Redis and the curated file layer, presents ranked
+results with relevance rationale, and lets Patrick choose what to inject into
+the conversation.
+
+**Acceptance criteria:**
+- Invocable as `/recall` (no args → infers from conversation context) or
+  `/recall <query>` (explicit topic).
+- Returns results from both Redis working memory and curated files.
+- Shows source, type, and a one-line relevance note for each result.
+- Gracefully degrades: if Redis is absent, returns curated-file results only.
+
+### R3 — Per-session auto-stash to Redis (TTL-gated)
+
+After each session, findings Claude considers notable (patterns, decisions,
+project state, bugs encountered) are auto-stashed to Redis with a 7-day TTL.
+Stashed entries feed the recall index (R1, R2) but do not modify the curated
+`~/.claude/memory/` layer without explicit review.
+
+**Acceptance criteria:**
+- Findings are extracted at session end (Stop hook or explicit command).
+- Each stashed entry carries: timestamp, cwd, session-id, type, content.
+- PII scrubber + secrets detector run at write (reuse attune-ai gates).
+- TTL default: 7 days. Configurable via `~/.attune/config.json`.
+- Promoting a stashed entry to curated files requires explicit user approval
+  (the existing `/remember` workflow or equivalent).
+
+### R4 — Cross-worktree recall (content-keyed, not cwd-keyed)
+
+The recall index keys entries on content/topic, not exact cwd. A memory
+about `RedisShortTermMemory` written in a worktree session surfaces in any
+other worktree or main checkout when queried.
+
+**Acceptance criteria:**
+- Recall works across cwd variants: main checkout, any worktree, sibling repos.
+- No duplicate entries for identical content written from different cwds.
+
+### R5 — Redis-optional: graceful file-only fallback
+
+Redis is an optional dep (attune-ai pattern). The system works without it,
+degrading to file-only with no auto-stash and no semantic search.
+
+**Acceptance criteria:**
+- With no Redis, R1 hook exits 0, R2 returns curated-file results only.
+- No import errors, no console noise when Redis is absent.
+
+## Out of scope
+
+- Memory graph (nodes/edges) — separate effort.
+- Persistent/always-running agent processes.
+- Weakening the curated-layer review discipline.
+- Enterprise/organization-level scope hierarchy (user+project is sufficient).

--- a/docs/specs/claude-cross-session-memory/tasks.md
+++ b/docs/specs/claude-cross-session-memory/tasks.md
@@ -1,0 +1,186 @@
+# Claude Cross-Session Memory — Tasks
+
+**Status:** approved
+**Phase:** ready-to-implement
+
+Phases:
+- **Phase 1** (P1): SessionStart hook + Redis stash infrastructure
+- **Phase 2** (P2): `/recall` skill + promotion UX
+- **Phase 3** (P3): Cross-worktree dedup + polish
+
+---
+
+## Phase 1 — Auto-inject hook + session stash
+
+### T1.1 — SessionStart recall hook
+
+**Objective:** Inject top-k relevant memories at session start from Redis.
+
+**Files to create:**
+- `~/.claude/hooks/session_recall.py` — standalone hook script
+
+**Spec:**
+- Reads `CLAUDE_CODE_SESSION_ID` + cwd for query context.
+- Calls `attune_rag` / `attune.memory.PersonalMemory` for top-k (default 5).
+- Writes a fenced `## Recalled memories` block to stdout (hook inject pattern).
+- Falls back to empty output if Redis absent or `attune_rag` not importable.
+- Exits 0 always (failure is silent).
+
+**Registers in:** `~/.claude/settings.json` under `hooks.SessionStart`.
+
+**Acceptance:**
+- Hook completes in ≤ 1 second on cold Redis query.
+- No error banner when Redis is absent.
+- Output is ≤ 400 tokens.
+
+---
+
+### T1.2 — Session-end stash (Stop hook)
+
+**Objective:** Auto-stash notable session findings to Redis at session end.
+
+**Files to create:**
+- `~/.claude/hooks/session_stash.py` — Stop hook script
+
+**Spec:**
+- Reads recent session transcript (last N messages via `CLAUDE_CODE_SESSION_ID`
+  → `~/.claude/projects/<encoded>/<id>.jsonl`).
+- Extracts notable entries: decisions made, bugs encountered, patterns observed,
+  file paths touched with rationale.
+- Runs attune-ai PII scrubber + secrets detector before writing.
+- Stashes to Redis via `attune.memory.RedisShortTermMemory` or
+  `PersonalMemory.store()` with TTL (7 days default).
+- Falls back to local file `~/.attune/session_stash/<date>.jsonl` if no Redis.
+- Exits 0 always.
+
+**Registers in:** `~/.claude/settings.json` under `hooks.Stop`.
+
+**Acceptance:**
+- Stashed entries appear in `/recall` results in the next session.
+- PII/secrets gates fire before any write.
+- File fallback written when Redis absent.
+
+---
+
+### T1.3 — Redis stash entry schema
+
+**Objective:** Define the canonical shape for a stashed session entry.
+
+**Files to create/modify:**
+- `src/attune/memory/session_stash.py` — `SessionStashEntry` dataclass +
+  `stash_entry()` / `recall_entries()` helpers
+
+**Schema:**
+```python
+@dataclass
+class SessionStashEntry:
+    id: str           # uuid
+    session_id: str   # CLAUDE_CODE_SESSION_ID
+    cwd: str          # project root at write time
+    timestamp: str    # ISO-8601
+    type: str         # "decision" | "pattern" | "bug" | "reference" | "note"
+    content: str      # the memory text (≤ 500 chars)
+    tags: list[str]
+    ttl_days: int = 7
+```
+
+**Acceptance:**
+- `stash_entry()` validates schema, runs PII/secrets gates, writes to backend.
+- `recall_entries(query, top_k, cwd)` returns ranked results cross-cwd.
+- Tests: schema validation, PII gate fires, Redis absent → file fallback.
+
+---
+
+## Phase 2 — `/recall` skill + promotion UX
+
+### T2.1 — `/recall` skill
+
+**Objective:** User-invocable skill that surfaces relevant memories.
+
+**Files to create:**
+- `plugin/skills/recall/SKILL.md`
+
+**Spec:**
+```yaml
+name: recall
+description: Surface relevant memories from prior sessions. Call with no args to infer from context, or /recall <topic> for an explicit query.
+```
+
+**Skill body:**
+- Calls `recall_entries(query, top_k=10)` (R2).
+- Presents results grouped by type with source (curated / Redis stash) and
+  relevance note.
+- Offers to inject selected results into conversation or promote to curated.
+
+**Acceptance:**
+- Returns results in ≤ 2 seconds.
+- Shows source (curated vs stash), type, and relevance.
+- No-Redis path returns curated-file results only (no error).
+- Added to plugin skill count + attune-hub reference table (three gates per
+  "Adding a plugin skill" lesson).
+
+---
+
+### T2.2 — Stash → curated promotion workflow
+
+**Objective:** Let Patrick promote a Redis stash entry to a curated memory file.
+
+**Approach:** Extend the existing `/remember` skill or add a `promote` subcommand
+that:
+1. Shows the stash entry content.
+2. Runs `memory_lint.py` schema validation.
+3. Writes to `~/.claude/memory/<slug>.md` with correct frontmatter.
+4. Adds pointer to `MEMORY.md`.
+5. Deletes the entry from Redis stash.
+
+**Files to modify:**
+- `plugin/skills/remember/SKILL.md` or create `plugin/skills/promote/SKILL.md`
+
+**Acceptance:**
+- Promoted entry passes `memory_lint.py --check-all` with 0 violations.
+- Entry removed from Redis stash after promotion.
+- MEMORY.md updated atomically.
+
+---
+
+## Phase 3 — Cross-worktree dedup + polish
+
+### T3.1 — Content-keyed dedup in recall
+
+**Objective:** Prevent duplicate entries when the same content is stashed from
+multiple cwds (main + worktrees).
+
+**Files to modify:**
+- `src/attune/memory/session_stash.py` — add `content_hash` to schema; dedup
+  on hash at write time.
+
+**Acceptance:**
+- Stashing identical content from two different cwds produces one entry (not two).
+- Recall returns the entry for any cwd query.
+
+---
+
+### T3.2 — TTL + budget guardrails
+
+**Objective:** Prevent Redis stash from growing unbounded; keep context budget safe.
+
+**Files to modify / create:**
+- `src/attune/memory/session_stash.py` — enforce max-entries-per-session (20),
+  max-content-length (500 chars), TTL renewal on recall hit.
+- `~/.claude/hooks/session_recall.py` — enforce top-k ≤ 5 and token budget ≤ 400.
+
+**Acceptance:**
+- Stash write rejects entries > 500 chars (truncate or split).
+- Recall output never exceeds 400 tokens.
+- Expired entries pruned on next stash write (lazy expiry).
+
+---
+
+## Implementation notes
+
+- Redis stays optional everywhere: `try: import redis except ImportError: ...`
+- PII/secrets gates are **required** at every write (R3 AC).
+- The hook scripts live in `~/.claude/hooks/` (user home), not the repo, so
+  they affect all Claude Code sessions. Register via `settings.json`.
+- Skill goes through the three-gate test suite (skill count + attune-hub +
+  sync_agents_skills) per the existing lesson.


### PR DESCRIPTION
## Summary

Approved spec for Claude cross-session memory. Takes the 2026-06-02 design draft from DRAFT → approved with three ratified decisions and six implementation tasks.

**Ratified decisions:**
- **D1** (recall trigger): SessionStart hook (auto top-k ≤ 5) + `/recall` skill (user-invoked on-demand) — no MCP-autonomous mid-session pulls
- **D2** (write policy): session findings auto-stash to Redis (7-day TTL); promotion to `~/.claude/memory/` stays review-gated
- **D3** (reference format): `[[link]]` = reference; `@import` = explicit composition

**Six implementation tasks across 3 phases:**
- P1: `session_recall.py` SessionStart hook, `session_stash.py` Stop hook, `SessionStashEntry` schema in `src/attune/memory/`
- P2: `/recall` plugin skill, stash→curated promotion workflow
- P3: content-keyed cross-worktree dedup, TTL + budget guardrails

**Unblocks:** the held attune-ai release (scope of this spec was the release-strengthening gate).

**Does not implement anything** — docs only. Implementation starts from tasks.md after this merges.

## Test plan

- [ ] Review requirements.md R1–R5 acceptance criteria are testable and complete
- [ ] Review decisions.md rationale matches the conversation
- [ ] Review tasks.md for any missing tasks or gaps before Phase 1 starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)