### PR TITLE
docs(skills/spec): add Opus tier recommendation for spec work

### DIFF
--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -4,6 +4,15 @@ description: "Spec-driven development — brainstorm, plan, review, and execute 
 ---
 # Spec-Driven Development
 
+**Model recommendation:** Spec planning and XML-enhanced-prompt
+authoring benefit from the Opus tier (`claude-opus-4-8`). Before
+proceeding, suggest a model switch once:
+
+> "This is spec work — recommend `/model claude-opus-4-8` for
+> stronger structured reasoning. Want to switch?"
+
+Defer to the user's choice if they've already picked a model.
+
 **IMPORTANT: Start your response with a context preamble.**
 
 Call `help_lookup(topic="spec-engine", mode="preamble")` and

--- a/.help/templates/plugin/concept.md
+++ b/.help/templates/plugin/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: concept
-generated_at: 2026-06-01T11:22:16.304320+00:00
-source_hash: dabe4c5a604a6dee1873da9c2239b8ea78416f31b4bdf292d61a93fe213be717
+generated_at: 2026-06-03T02:46:55.572515+00:00
+source_hash: 57b8e505bab7ccba5ff519e5f59111f1ef50f2e629841d8c034de4c1391df086
 status: generated
 ---
 

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: reference
-generated_at: 2026-06-01T11:22:16.315225+00:00
-source_hash: dabe4c5a604a6dee1873da9c2239b8ea78416f31b4bdf292d61a93fe213be717
+generated_at: 2026-06-03T02:46:55.584320+00:00
+source_hash: 57b8e505bab7ccba5ff519e5f59111f1ef50f2e629841d8c034de4c1391df086
 status: generated
 ---
 

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: task
-generated_at: 2026-06-01T11:22:16.310741+00:00
-source_hash: dabe4c5a604a6dee1873da9c2239b8ea78416f31b4bdf292d61a93fe213be717
+generated_at: 2026-06-03T02:46:55.579766+00:00
+source_hash: 57b8e505bab7ccba5ff519e5f59111f1ef50f2e629841d8c034de4c1391df086
 status: generated
 ---
 

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -6,6 +6,15 @@ argument-hint: "<what to build, or 'resume'>"
 
 # Spec-Driven Development
 
+**Model recommendation:** Spec planning and XML-enhanced-prompt
+authoring benefit from the Opus tier (`claude-opus-4-8`). Before
+proceeding, suggest a model switch once:
+
+> "This is spec work — recommend `/model claude-opus-4-8` for
+> stronger structured reasoning. Want to switch?"
+
+Defer to the user's choice if they've already picked a model.
+
 **IMPORTANT: Start your response with a context preamble.**
 
 Call `help_lookup(topic="spec-engine", mode="preamble")` and


### PR DESCRIPTION
## Summary

Adds a one-line model recommendation at the top of the `/spec` skill:

> "This is spec work — recommend `/model claude-opus-4-8` for stronger structured reasoning. Want to switch?"

The reminder fires when users invoke `/spec`, so the Opus tier suggestion is made at the moment it can act. Per the rationale: spec planning and XML-enhanced-prompt authoring benefit from stronger structured reasoning; the cost delta is justified by the spec artifact's durability.

## Why a skill change instead of a code constant

Spec authoring is conversational, not code-driven. There is no `attune.config.MODELS.spec_planning` constant because no workflow drafts specs programmatically — the model choice is the session model, set via `/model` at session start. The right encoding is at the skill surface (prompts the recommendation when needed) plus a global memory file (durable cross-session preference).

Companion personal memory: `~/.claude/memory/feedback_use_opus_for_spec_work.md` (not in this PR — global memory, not repo-tracked).

## Test plan

- [x] `.agents/skills/spec/SKILL.md` synced via `scripts/sync_agents_skills.py`
- [ ] CI matrix green (sync drift-guard + plugin reference validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
