### PR TITLE
docs(CLAUDE.md): add 2 lessons from 2026-06-02 session

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7093,3 +7093,35 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   the structure/planning doc (not the article body) —
   where article-revision PLANS go, per the "plan in the
   outline doc, not `/spec`, for prose" decision.
+
+- **`AskUserQuestion` first option MUST end with
+  `(Recommended)` — enforced by a PreToolUse hook at
+  `~/.claude/hooks/ask_question_format_guard.py`**: the
+  hook blocks the call entirely and returns an error if
+  the first option label doesn't end with that exact
+  suffix. The error message is clear but only fires at
+  call time, not authoring time. Pre-flight rule: before
+  every `AskUserQuestion`, verify the first option is
+  your genuine recommendation AND its label ends with
+  `(Recommended)`. If you genuinely have no preference,
+  pick the safer/cheaper option as first and mark it.
+  Discovered 2026-06-02 when the intake question for
+  Mission A/B was blocked on the first attempt.
+
+- **For solo-dev interactive recall, a user-invocable
+  Skill is preferable to an autonomous MCP tool**: when
+  designing an on-demand recall/lookup feature for a
+  solo developer who is always present in the session,
+  a Skill (`/recall`) is strictly better than an MCP
+  tool that Claude calls autonomously — because the
+  Skill is transparent (you see exactly when and what
+  was recalled), explicit (you control when it fires),
+  and formatted for human reading. The MCP tool is
+  better when Claude must proactively surface context
+  without a user prompt (background reasoning, complex
+  multi-step tasks). The D1 decision in the
+  cross-session-memory spec (2026-06-02) flipped from
+  "Hook + MCP tool" to "Hook + Skill" for this reason.
+  Generalization: any "on-demand context surface" in an
+  interactive tool where the user is always present
+  should be a Skill first, MCP tool second.


### PR DESCRIPTION
## Summary

Two lessons captured during the 2026-06-02 cross-session-memory spec session that weren't included in PR #579 (which carried only the spec docs).

1. **AskUserQuestion first-option-`(Recommended)` hook enforcement** — the PreToolUse guard at `~/.claude/hooks/ask_question_format_guard.py` blocks any `AskUserQuestion` call whose first option label doesn't end with `(Recommended)`. Pre-flight rule documented.
2. **Skill > MCP tool for solo-dev interactive recall** — the D1 decision rationale from the cross-session-memory spec: for an always-present solo dev, a user-invocable Skill beats an autonomous MCP tool on transparency, control, and formatting.

## Notes

- Append-only to the Lessons Learned section.
- Verified both lessons are absent from `main` via real-phrase grep before landing (per the "grep before appending lessons to avoid parallel-session duplicates" lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
