### PR TITLE
docs(specs/csm): build on Redis AMS this release (D6) + architecture reconciliation (D4/D5)

### DIFF
--- a/docs/specs/claude-cross-session-memory/decisions.md
+++ b/docs/specs/claude-cross-session-memory/decisions.md
@@ -218,3 +218,80 @@ bypass the D2 gate into curated files.
 - No new public-surface or scope beyond the file backend — AMS is reuse.
 - Supersedes the previous-turn "demote Redis to accelerator / drop it" lean:
   AMS is a real, already-built upgrade and stays as the optional high tier.
+
+---
+
+## D6 — This release builds on Redis AMS (file/keyword tier cut)
+
+**Ratified:** 2026-06-03. Patrick: "if we can get it by implementing the
+Redis solution that's fine for this release — no point working extra hard for
+a mediocre result when we can leverage Redis." Confirmed feasible + simpler.
+
+### Decision
+
+For this release, **`AMSMemoryBackend` (Redis Agent Memory Server) is the sole
+implemented recall backend.** The file/keyword `SearchableMemoryBackend`
+(markdown + attune-rag) described in D5 is **deferred, not built** — it was
+both more work and the weaker result.
+
+The protocol seam from D5 is retained at **zero cost**: `recall_entries()` and
+`session_stash.py` target the `SearchableMemoryBackend` protocol, so a file
+fallback is a future drop-in, not a refactor. AMS is simply the only
+implementation wired this release.
+
+### Why this is less work AND better
+
+1. **AMS already implements `stash` / `search` / `promote`** — we wire hooks
+   to a built backend instead of authoring a retriever.
+2. **Sidesteps the B-regression entirely.** AMS uses its own vector/hybrid
+   search, not attune-rag's `KeywordRetriever`, so `MIN_ALIAS_OVERLAP` never
+   touches the recall path. The D4 cross-spec caveat does not apply to the AMS
+   path.
+3. **Curated `~/.claude/memory` files are already auto-loaded every session**
+   (global CLAUDE.md). Recall's distinct job is the *ephemeral session stash*
+   — exactly AMS working + long-term. No need to re-query curated files via
+   attune-rag; that whole tier is cut.
+
+### Setup cost (documented for the hooks' README)
+
+- Run the server: `uv run agent-memory api --task-backend=asyncio` (single
+  process) or `docker compose up api redis`.
+- Redis: already running (cloud + local:6379).
+- Embedding provider (mandatory for vector search): **Ollama** (local, free,
+  private — preferred for *personal* memory so findings never leave the
+  machine) **or** OpenAI (`OPENAI_API_KEY`, zero extra process). Spec default:
+  Ollama; override via AMS env.
+- Dep: `pip install attune-ai[redis]` (pulls `agent-memory-client`).
+- Env: `AMS_BASE_URL` (default `http://localhost:8000`), `AMS_NAMESPACE`,
+  `REDIS_URL`.
+
+### Graceful degradation
+
+AMS unreachable → recall + stash are **silent no-ops** (hooks exit 0, no
+banner), satisfying T1.1/T1.2 acceptance criteria. The feature requires a
+running AMS to function; without it, sessions behave as they do today.
+
+### Tier mapping under D6
+
+- **Session stash (raw, ephemeral):** AMS working memory — `stash()`.
+- **Searchable recall tier:** AMS long-term — `search()`, populated by AMS's
+  background auto-extraction/promotion from working memory.
+- **Curated durable tier:** `~/.claude/memory` files — unchanged; already
+  auto-loaded each session; promotion *into* it stays the existing
+  review-gated `/remember` flow (D2 holds, independent of AMS).
+
+### Consequences for tasks.md
+
+- **Cut from this release:** the file `SearchableMemoryBackend` impl, the
+  attune-rag keyword wiring, the `MIN_ALIAS_OVERLAP=1` override, the
+  keyword/recency stash filter (D4 tier-2 mechanics). All become the future
+  file-fallback drop-in.
+- **T1.3 `session_stash.py`:** wraps `AMSMemoryBackend` behind the
+  `SearchableMemoryBackend` protocol; provides `recall_entries()` →
+  `backend.search()` and the raw stash write → `backend.stash()`.
+- **T1.1 / T1.2 hooks:** call the protocol; silent no-op when AMS is down.
+- **T2.1 `/recall`:** presents `backend.search()` results; promotion to
+  curated files stays the `/remember` path (D2).
+- **Verify-first at build time:** confirm `agent-memory-client` installs and
+  an AMS server responds at `AMS_BASE_URL` before wiring (per the
+  introspect-before-coding lesson).

--- a/docs/specs/claude-cross-session-memory/decisions.md
+++ b/docs/specs/claude-cross-session-memory/decisions.md
@@ -95,6 +95,14 @@ semantic store. Neither naive option is right alone:
 - *(b) build a semantic index over the Redis stash* → unscoped new work
   (embeddings/index over Redis values).
 
+> **Backend refined by D5 (2026-06-03):** the three tiers below are
+> **backend-agnostic** — they run against the existing
+> `SearchableMemoryBackend` protocol. The default backend is file-based
+> (markdown + attune-rag keyword search); Redis Agent Memory Server is an
+> optional upgrade that already implements the protocol with true vector
+> search. See D5. Where tier 1 below names `RedisShortTermMemory.stash()`,
+> read it as "the active backend's write path."
+
 ### Decision — three-tier: cheap-write / semantic-read / gated-promote
 
 1. **Write (Stop hook, T1.2):** stash **raw** findings fast, **no LLM polish**
@@ -134,3 +142,79 @@ addressed by the **alias-overlap-remediation** spec (attune-rag PR #154). C
 should use the documented subclass override (`MIN_ALIAS_OVERLAP = 1`) for the
 personal-memory corpus, **or** measure recall quality and decide. This is a
 concrete instance of that spec's consumer-impact item.
+
+---
+
+## D5 — Backend selection: protocol-agnostic, file default, Redis AMS optional upgrade
+
+**Ratified:** 2026-06-03, after researching Redis's agent-memory stack
+against the existing ecosystem code (Patrick's prompt: "research what Redis
+has vs what we want; demote if we don't need it, add if we do").
+
+### What the research found
+
+attune-ai **already defines** `SearchableMemoryBackend(MemoryBackend,
+Protocol)` ([`src/attune/memory/backend.py:142`](../../../src/attune/memory/backend.py))
+— a `search(query, limit, **filters)` + `promote(session_id)` extension
+"implemented by backends that support vector similarity search (e.g., Redis
+Agent Memory Server)."
+
+`attune_redis.AMSMemoryBackend` **already implements it**, wrapping the
+**Redis Agent Memory Server** (`agent-memory-client>=0.14.0`):
+
+- `stash()` → AMS working memory (session key/value)
+- `search()` → AMS long-term memory, **vector / full-text / hybrid** semantic
+  search with topic/entity/namespace/time filters
+- `promote()` → AMS working → long-term promotion
+
+Redis AMS is a **superset** of the recall need: vector+hybrid search,
+automatic topic/entity extraction, background auto-promotion, and a built-in
+memory lifecycle (creation/promotion/access/aging/forgetting/compaction). Its
+cost is **infrastructure**: a running Agent Memory Server (HTTP service) +
+Redis + the optional `agent-memory-client` dep. (`agent-memory-client` is not
+installed in the default venv.)
+
+### Decision
+
+**Keep Redis — as the optional upgrade, not the baseline. Do not demote; do
+not require.**
+
+- **Recall is backend-agnostic.** `recall_entries()` resolves a
+  `SearchableMemoryBackend` and calls `.search()` / `.promote()`. It never
+  hard-codes Redis or files.
+- **Default backend = file-based, zero-config.** A new file
+  `SearchableMemoryBackend` impl: markdown corpus (`~/.attune/session_stash/`
+  + curated `~/.claude/memory`) searched by attune-rag's `KeywordRetriever`.
+  Works offline, no server, no extra dep. Query is keyword+alias+stemming
+  (attune-rag's model — embeddings were ruled out for the spine corpus).
+- **Optional upgrade = `AMSMemoryBackend`.** When `attune-redis` is installed
+  AND an AMS server is reachable, recall transparently gains vector/hybrid
+  search, auto-extraction, and native promotion — zero extra spec work
+  (already built + protocol-conformant).
+- Backend resolution: prefer a configured/available `SearchableMemoryBackend`
+  (AMS); else fall back to the file backend. Mirrors attune-ai's existing
+  `attune.memory_backends` entry-point + file-fallback pattern.
+
+### Tier mapping (AMS vs the curated layer — do not conflate)
+
+AMS's automatic working→long-term promotion is **not** the same as D2's
+review-gated promotion to curated `~/.claude/memory`. Map three tiers:
+
+- AMS **working memory** ≈ raw session stash (ephemeral).
+- AMS **long-term memory** ≈ an auto-extracted, vector-**searchable** middle
+  tier — surfaced by recall, but **not** human-curated.
+- **`~/.claude/memory` curated files** ≈ the human-reviewed durable tier;
+  promotion *into* it stays review-gated (D2 holds).
+
+So with the AMS backend, recall searches AMS long-term + curated files; AMS's
+background auto-promotion populates its own long-term tier and does **not**
+bypass the D2 gate into curated files.
+
+### Consequences
+
+- The spec targets the **protocol**, not a backend. T1.3's
+  `session_stash.py` ships the **file `SearchableMemoryBackend`** as the
+  default impl; the AMS path is selected when present.
+- No new public-surface or scope beyond the file backend — AMS is reuse.
+- Supersedes the previous-turn "demote Redis to accelerator / drop it" lean:
+  AMS is a real, already-built upgrade and stays as the optional high tier.

--- a/docs/specs/claude-cross-session-memory/decisions.md
+++ b/docs/specs/claude-cross-session-memory/decisions.md
@@ -27,6 +27,11 @@ deeper pulls. No Claude-autonomous mid-session recall without user intent.
 Promotion from Redis to the curated `~/.claude/memory/` layer stays
 review-gated (no auto-promotion).
 
+> **Refined by D4 (2026-06-03):** the *mechanism* for "recall over the
+> ephemeral stash" was under-specified here. `RedisShortTermMemory` is
+> key/value working memory, not a semantic store — see D4 for the
+> three-tier resolution and the corrected API surface.
+
 **Rationale:** Consistent with the principle that the curated layer is
 human-tuned. Auto-stash captures useful findings without requiring explicit
 `/remember` invocations. The TTL prevents Redis from becoming a graveyard of
@@ -56,3 +61,76 @@ is "inline this memory's content here." Most cross-references are the former.
 - `[[link]]` only, no inline — loses composition capability for cases where
   context genuinely needs to be merged (e.g. a meta-memory that aggregates
   multiple related topics for a complex project).
+
+---
+
+## D4 — Recall architecture (resolves the design-vs-reality gap)
+
+**Ratified:** 2026-06-03, after the mandatory verify-first pass against the
+real memory APIs.
+
+### What the verify pass found
+
+The design synthesized its reuse map from scouts and cited method names that
+do not exist. Verified reality:
+
+- `PersonalMemory.capture(topic, content, kind, strict_polish=False,
+  project_local=False) -> Path` — writes a **polished markdown doc** (runs the
+  LLM polish pipeline; **not** a fast path). There is **no** `.store()`.
+- `PersonalMemory.query(query, k=3, kind_filter=None) -> list[dict]` —
+  rag-ranked **semantic** recall over the markdown corpus (global +
+  project-local merged); returns `path`/`summary`/`excerpt`/`score`. This is
+  the semantic-recall primitive.
+- `RedisShortTermMemory.stash(key, data, credentials: AgentCredentials, ttl)
+  -> bool` + `.retrieve(key, credentials) -> Any` — key/value working memory
+  with TTL; **requires `AgentCredentials`**; **key-based, not semantically
+  searchable**. There is **no** `.store()`.
+
+**The gap:** D2's "auto-stash to Redis ephemeral **+ recall semantically**"
+cannot be served as written — Redis short-term memory is key/value, not a
+semantic store. Neither naive option is right alone:
+
+- *(a) recall only over durable files* → ephemeral findings are invisible to
+  recall until promoted; defeats cross-session continuity of raw findings.
+- *(b) build a semantic index over the Redis stash* → unscoped new work
+  (embeddings/index over Redis values).
+
+### Decision — three-tier: cheap-write / semantic-read / gated-promote
+
+1. **Write (Stop hook, T1.2):** stash **raw** findings fast, **no LLM polish**
+   — `RedisShortTermMemory.stash()` if available (TTL), else JSONL fallback
+   `~/.attune/session_stash/<date>.jsonl`. Polishing at write would make the
+   Stop hook slow and costly; the polish is deferred to promotion.
+2. **Recall (SessionStart T1.1 + `/recall` T2.1):** `recall_entries(query,
+   top_k, cwd)` **merges two sources**, each labeled by origin:
+   - **durable/curated:** `PersonalMemory.query()` — semantic, rag-ranked.
+   - **recent stash:** a cheap **keyword + tag + recency + same-cwd filter**
+     over the raw stash. The stash is one user × 7-day TTL — small enough that
+     semantic search is unnecessary; recency + keyword suffices.
+3. **Promote (`/recall` T2.1 + T2.2, user-gated):** `PersonalMemory.capture()`
+   — the **only** LLM-polish path, moving a stash entry into the durable,
+   semantically-searchable tier. The LLM cost lands here, user-gated
+   (consistent with D2's review-gated promotion).
+
+This **rejects (b)** (no new semantic index), **refines (a)** (ephemeral
+findings *are* recalled — via the cheap filter, not semantic search), and maps
+cleanly onto every existing primitive. `recall_entries`'s "semantic" property
+applies to the durable tier; the ephemeral tier is recency/keyword.
+
+### Consequences for tasks.md
+
+- Every `PersonalMemory.store()` → `.capture()` (promote) or `.query()`
+  (recall). Every `RedisShortTermMemory.store()` → `.stash()` / `.retrieve()`.
+- `recall_entries` (T1.3) is a **merge** of two backends, not a single call.
+- T1.2 / T1.3 must obtain an `AgentCredentials` for the Redis calls (construct
+  a session-scoped credential — implementation detail for build time).
+
+### Cross-spec note (B → C)
+
+`PersonalMemory.query()` runs attune-rag's `KeywordRetriever` with
+`MIN_ALIAS_OVERLAP = 2` over `~/.claude/memory`, which is **not** alias-tuned.
+C's recall quality is therefore a direct victim of the alias-overlap regression
+addressed by the **alias-overlap-remediation** spec (attune-rag PR #154). C
+should use the documented subclass override (`MIN_ALIAS_OVERLAP = 1`) for the
+personal-memory corpus, **or** measure recall quality and decide. This is a
+concrete instance of that spec's consumer-impact item.

--- a/docs/specs/claude-cross-session-memory/tasks.md
+++ b/docs/specs/claude-cross-session-memory/tasks.md
@@ -3,6 +3,22 @@
 **Status:** approved
 **Phase:** ready-to-implement
 
+> **API corrections (2026-06-03 verify pass — authoritative: see
+> [decisions.md](decisions.md) D4).** The method names below are confabulated;
+> use the verified APIs:
+>
+> - `PersonalMemory.store()` does **not** exist → use `.capture(topic,
+>   content, kind)` (promote path; runs LLM polish) or `.query(query, k,
+>   kind_filter)` (semantic recall).
+> - `RedisShortTermMemory.store()` does **not** exist → use `.stash(key, data,
+>   credentials, ttl)` / `.retrieve(key, credentials)` (key-based; requires
+>   `AgentCredentials`).
+> - `recall_entries()` (T1.3) is a **merge** of `PersonalMemory.query()`
+>   (semantic, durable) + a cheap keyword/recency/cwd filter over the raw
+>   stash — **not** a semantic query against Redis. See D4.
+> - Stash writes are **raw, no polish** (Stop hook stays fast); polish happens
+>   only at user-gated promotion (T2.2).
+
 Phases:
 - **Phase 1** (P1): SessionStart hook + Redis stash infrastructure
 - **Phase 2** (P2): `/recall` skill + promotion UX

--- a/docs/specs/claude-cross-session-memory/tasks.md
+++ b/docs/specs/claude-cross-session-memory/tasks.md
@@ -18,6 +18,12 @@
 >   stash — **not** a semantic query against Redis. See D4.
 > - Stash writes are **raw, no polish** (Stop hook stays fast); polish happens
 >   only at user-gated promotion (T2.2).
+> - **Backend is protocol-based (D5):** target the existing
+>   `SearchableMemoryBackend` protocol. T1.3 ships a **file** impl (markdown +
+>   attune-rag keyword `.search()`) as the zero-config default;
+>   `attune_redis.AMSMemoryBackend` (Redis Agent Memory Server, vector/hybrid)
+>   is the optional upgrade selected when present. `recall_entries()` calls
+>   `backend.search()` — never hard-codes a backend.
 
 Phases:
 - **Phase 1** (P1): SessionStart hook + Redis stash infrastructure


### PR DESCRIPTION
## Summary

Reconciles the approved cross-session-memory spec with verified reality and sets the release implementation path. Docs-only refinement; no implementation here. Decision chain D4 → D5 → D6.

## D6 — this release builds on Redis AMS (the decisive call)

Build cross-session recall on the **Redis Agent Memory Server** via the already-built `attune_redis.AMSMemoryBackend`, rather than authoring a weaker file/keyword retriever. Verified feasible and **simpler**:

- AMS already implements `stash` / `search` / `promote` — wire hooks to it.
- **Sidesteps the B-regression:** AMS uses its own vector/hybrid search, not attune-rag's `KeywordRetriever` — so `MIN_ALIAS_OVERLAP` never touches recall.
- Curated `~/.claude/memory` files are already auto-loaded each session, so recall's job is the **ephemeral session stash** = AMS working+long-term. The whole file/attune-rag tier is **cut** from this release.

Protocol seam (D5) retained at zero cost — file fallback stays a future drop-in. Graceful no-op when AMS is down. Embedding provider default: **Ollama** (local/free/private for personal memory); OpenAI optional.

**Setup cost (modest for this env):** `uv run agent-memory api` or docker compose · Redis (already running) · Ollama/OpenAI embeddings · `pip install attune-ai[redis]`.

## D4 / D5 — the reasoning trail

- **D4:** the verify-first pass found confabulated APIs (`PersonalMemory.store()`, `RedisShortTermMemory.store()` don't exist) and corrected them; framed the three-tier write/read/promote model.
- **D5:** found attune-ai already defines `SearchableMemoryBackend` and `AMSMemoryBackend` already implements it — established the protocol seam and backend-agnostic recall.
- **D6** then made the release call to build on AMS and cut the file tier.

## Research sources

- [Redis Agent Memory docs](https://redis.io/docs/latest/develop/ai/context-engine/agent-memory/) · [Long-term Memory](https://redis.github.io/agent-memory-server/long-term-memory/) · [redis/agent-memory-server](https://github.com/redis/agent-memory-server)
- Local: `src/attune/memory/backend.py:142`, `attune_redis/memory.py:53`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
