### PR TITLE
fix(ci): correct auto-approve-owner actor guard to silversurfer562

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -21,7 +21,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   auto-approve-owner:
-    if: github.actor == 'patrickroebuck'
+    if: github.actor == 'silversurfer562'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary

One-line fix to the `auto-approve-owner` job guard: `github.actor == 'patrickroebuck'` → `'silversurfer562'` (the repo owner's actual GitHub login).

## Why this matters

The job was **built to eliminate the self-approval merge tax** — wait for CI, then approve owner PRs via `GITHUB_TOKEN` (review attributed to `github-actions[bot]`, a distinct identity from the author, satisfying the 1-review branch-protection rule). But the wrong username meant the guard **never matched**, so the job **skipped on every owner PR**, so every PR required a manual admin-bypass.

This is the root cause of the per-PR merge friction across this whole session — not the (cosmetic, non-required) security-scanner cancel.

## Behavior after merge

Owner opens PR → CI goes green → `auto-approve-owner` approves → mergeable, no admin-bypass.

## Caveats

- **`pull_request_target` runs the base-branch workflow**, so this only takes effect once merged to main. This PR itself needs one (final) admin-bypass.
- **Tradeoff, by design:** owner PRs approve on CI-pass — CI becomes the review gate, no human second-eye. Accepted for solo-dev; worth being conscious of.
- Likely makes the bot-identity (Mission A) unnecessary for *merge friction* (bot-token approval already gives a non-author review); bot identity remains nice-to-have for commit attribution only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
