### PR TITLE
docs(specs): consolidate-claude-md-lessons handoff artifact

### DIFF
--- a/docs/specs/consolidate-claude-md-lessons/README.md
+++ b/docs/specs/consolidate-claude-md-lessons/README.md
@@ -1,0 +1,87 @@
+# Spec: consolidate-claude-md-lessons
+
+> **Status:** handoff artifact (2026-06-03) — ready for a dedicated
+> execution session. Not started. The full pass needs review runway,
+> so it was deliberately spun off rather than tail-ended.
+
+## Goal
+
+Cut `.claude/CLAUDE.md`'s Lessons Learned section (402 lessons /
+**6,973 lines**, loaded every session) by merging genuine
+redundancy — **without losing a distinct lesson**. Target a
+~30–40% line cut, not an arbitrary lesson cap. Efficiency, not
+amputation.
+
+## Cluster inventory (ranked by consolidation yield)
+
+Counts overlap — a lesson can match several keywords — so these are
+**not additive**; they're a heat map of where redundancy concentrates.
+
+| Cluster      | Lessons | Lines |
+|--------------|--------:|------:|
+| test         | 45      | 628   |
+| ci           | 31      | 550   |
+| workflow     | 28      | 510   |
+| path         | 27      | 428   |
+| merge        | 18      | 336   |
+| worktree     | 10      | 308   |
+| windows      | 12      | 223   |
+| spec         | 12      | 219   |
+| sdk          | 12      | 219   |
+| tag          | 14      | 210   |
+| coverage     | 7       | 157   |
+| pypi         | 7       | 143   |
+| gh pr        | 8       | 125   |
+| security     | 6       | 123   |
+| pre-commit   | 9       | 141   |
+| stash        | 5       | 97    |
+| ruff         | 7       | 94    |
+| rebase       | 4       | 90    |
+| css          | 4       | 86    |
+| squash       | 5       | 80    |
+| xdist        | 3       | 76    |
+| codeql       | 5       | 74    |
+
+**60 lessons** carry an explicit cross-reference ("Pairs with…",
+"Companion…", "same root cause…", "extends the existing…") — these
+self-declare their redundancy and are the safest, highest-yield
+merges.
+
+## Method (batch-assisted, reviewable PR)
+
+Extract is batch; **merge is judgment** (no shell can safely delete
+a lesson); verify is batch.
+
+```bash
+# EXTRACT a cluster to a working file (change KW)
+cd /Users/patrickroebuck/attune-ai
+git show origin/main:.claude/CLAUDE.md > /tmp/cm.md
+KW='worktree'
+awk -v kw="$KW" '/^- \*\*/{b=(tolower($0)~tolower(kw))} b' /tmp/cm.md > /tmp/cluster.md
+grep -cE '^- \*\*' /tmp/cluster.md   # lesson count
+wc -l < /tmp/cluster.md              # line count
+```
+
+Then: read `/tmp/cluster.md`, write consolidated lessons, apply to
+`CLAUDE.md` with the Edit tool (not a shell splice — safer on a 7k
+file). Verify per cluster:
+
+```bash
+# after edits, on the working copy
+grep -cE '^- \*\*' .claude/CLAUDE.md   # lesson-count delta
+wc -l .claude/CLAUDE.md                # line delta
+# dangling cross-refs: every "Pairs with X" should still resolve
+```
+
+## Execution order
+
+Work cross-linked lessons first (lowest risk), then the largest
+clusters. One docs PR, cluster-by-cluster commits so each merge is
+reviewable in isolation. See [tasks.md](tasks.md).
+
+## Guardrails (the bar Patrick set)
+
+- Merge genuine redundancy only; **never drop a distinct lesson** —
+  fold specifics into sub-bullets under a richer header.
+- Preserve every still-true cross-reference.
+- Behavior-neutral: this is editorial, not a rules change.

--- a/docs/specs/consolidate-claude-md-lessons/tasks.md
+++ b/docs/specs/consolidate-claude-md-lessons/tasks.md
@@ -1,0 +1,43 @@
+# Tasks: consolidate-claude-md-lessons
+
+> **Status:** handoff (not started). See [README](README.md) for
+> method + inventory.
+
+## Phase 1 — cross-linked lessons (lowest risk, highest yield)
+
+- **T1:** Extract the 60 cross-referenced lessons (grep
+  `Pairs with|Companion|same (shape|root cause|family)|extends the
+  existing`). For each "A pairs with B" pair, merge into one lesson
+  where they describe the same mechanism; keep distinct if the
+  mechanisms differ. Sub-bullet the specifics.
+
+## Phase 2 — largest clusters (descending yield)
+
+One commit per cluster so each is reviewable. Order by lines:
+
+- **T2:** `test` (45 / 628) — likely the biggest win; many are
+  per-module test-scaffold variants that collapse to archetypes.
+- **T3:** `ci` (31 / 550)
+- **T4:** `workflow` (28 / 510)
+- **T5:** `path` (27 / 428) — Windows/path-separator family is dense.
+- **T6:** `merge` + `tag` + `squash` + `rebase` + `stash` (git
+  release-mechanics, ~813 combined across overlaps) — merge as one
+  pass; heavy redundancy in the admin-merge / stacked-PR lessons.
+- **T7:** `worktree` (10 / 308) — proof cluster; collapses to
+  ~3-4 (code/venv resolution · git state · per-worktree gotchas).
+- **T8:** `windows` (12 / 223), `sdk` (12 / 219), `spec` (12 / 219),
+  remaining mid clusters.
+
+## Phase 3 — verify + ship
+
+- **T9:** Final verify: lesson-count delta (expect modest drop, not
+  a cliff), line delta (target -30–40%), zero dangling cross-refs,
+  markdown-lint clean. Open as one docs PR.
+
+## Notes for the executor
+
+- Use Opus (per `feedback_use_opus_for_spec_work` — judgment-heavy).
+- `CLAUDE.md` is auto-loaded every session; edits via the Edit tool
+  on the worktree copy, not shell splice.
+- This is the LESSONS section only; leave the rest of CLAUDE.md
+  (standards, structure, rules) untouched.


### PR DESCRIPTION
Cluster inventory + batch method for the deferred CLAUDE.md lessons consolidation (402 lessons / 6,973 lines → target -30-40%, zero lesson loss). Spun off per the decision to run it in a dedicated session. Not started — this is the map.