### PR TITLE
feat(memory): session_stash module for cross-session memory (T1.3)

### DIFF
--- a/.help/templates/memory/concept.md
+++ b/.help/templates/memory/concept.md
@@ -1,56 +1,43 @@
 ---
-type: concept
-name: memory-concept
 feature: memory
 depth: concept
-generated_at: 2026-05-16T06:14:13.774390+00:00
-source_hash: 54f52a79be1ecfe32e99b4f09f84bda845815a0129b603c252aa4c74c2e1a61c
+generated_at: 2026-06-03T04:28:47.256897+00:00
+source_hash: 762177a9860aee4aa45cfeb762f406a50a3f7c21a4558c69f74815620780172d
 status: generated
 ---
 
 # Memory
 
-Attune's memory system gives agents a structured way to store, retrieve, and search information across two distinct layers: a fast short-term backend (typically Redis) and a file-based long-term layer built from `CLAUDE.md` files loaded at startup.
+## How it works
 
-## Two memory layers
+Memory subsystem — storage, lookup, and security.
 
-Understanding the distinction between the two layers helps you choose the right approach for a given task.
+The main building blocks are:
 
-**Short-term memory** is backed by `MemoryBackend`, a protocol that any compliant implementation must satisfy. It defines five core operations — `stash`, `retrieve`, `delete`, `keys`, and `is_connected` — plus `get_stats` and `close` for observability and lifecycle management. Short-term entries can carry a TTL and are optionally scoped to a specific `agent_id`, which means multiple agents can share one backend without colliding. When you need semantic search on top of basic key-value access, `SearchableMemoryBackend` extends `MemoryBackend` with a `search` method and a `promote` method that graduates session data into longer-lived storage.
+- **`MemoryBackend`** — Protocol for short-term memory backends.
+- **`SearchableMemoryBackend`** — Extended protocol for backends with semantic search.
+- **`ClaudeMemoryConfig`** — Configuration for Claude memory integration
+- **`MemoryFile`** — Represents a loaded CLAUDE.md memory file
+- **`ClaudeMemoryLoader`** — Loads and manages Claude Code memory files (CLAUDE.md).
 
-**Long-term memory** is file-based. `ClaudeMemoryLoader` walks a project's directory tree looking for `CLAUDE.md` files at the enterprise, user, and project levels — controlled by the `load_enterprise`, `load_user`, and `load_project` flags on `ClaudeMemoryConfig`. Each discovered file becomes a `MemoryFile` dataclass that records its level (enterprise/user/project), its path, its raw content, any `imports` it declares, and a `load_order` integer that determines merge precedence. `ClaudeMemoryLoader.load_all_memory()` assembles all of these into a single string your agent can consume.
+Under the hood, this feature spans 74 source
+files covering:
 
-## How the pieces fit together
+- Memory backend protocol for Attune AI.
+- Claude Memory Integration Module
+- Redis Configuration for Attune AI (deprecated).
 
-At runtime, the two layers complement each other:
+## What connects to it
 
-1. On startup, `ClaudeMemoryLoader` reads `CLAUDE.md` files up to `max_import_depth` levels deep (default 5) and no larger than `max_file_size_bytes` (default 1 MB). The result is a static context string injected into the agent's working memory.
-2. During a session, the agent calls `stash` and `retrieve` on a `MemoryBackend` instance — usually `RedisShortTermMemory` — to track transient state such as conversation turns or intermediate results.
-3. If the backend implements `SearchableMemoryBackend`, the agent can issue natural-language `search` queries against stored entries, then call `promote` to surface a session's accumulated knowledge into long-term storage.
+This feature relates to: memory, storage.
 
-The `MemoryControlPanel` sits above both layers. It wraps a `ControlPanelConfig` (Redis host, port, storage directory, audit directory) and exposes administrative operations: `start_redis` / `stop_redis`, `get_statistics`, `list_patterns`, `delete_pattern`, `clear_short_term`, and `export_patterns`. A companion HTTP server (`run_api_server`) exposes these operations as an API with optional API-key authentication (`APIKeyAuth`) and per-IP rate limiting (`RateLimiter`).
+Other parts of the codebase interact with
+memory through these interfaces:
 
-## Security and classification
-
-Patterns stored in long-term memory carry a `Classification` that the `ClassificationRules` engine assigns automatically. Healthcare (`patient`, `hipaa`, `phi`), financial (`credit card`, `pci dss`), and proprietary (`confidential`, `trade secret`) keywords each map to separate classification tiers. `PIIScrubber` and `SecretsDetector` run before storage to strip personally identifiable information and credentials. `AuditLogger` records every write and delete as an `AuditEvent` so you have a full trail of what changed and when.
-
-## When this matters
-
-You interact with the memory system whenever you need an agent to:
-
-- Remember facts across turns in a session (`stash` / `retrieve` with an `agent_id`)
-- Start a session with project-specific context already loaded (`ClaudeMemoryLoader`)
-- Search accumulated knowledge semantically rather than by exact key (`SearchableMemoryBackend.search`)
-- Operate in a regulated environment where stored patterns must be classified and auditable (`Classification`, `AuditLogger`)
-- Deploy on Railway or another hosted environment (`get_railway_redis`, which reads `REDIS_URL` from the environment and raises `OSError` with remediation steps if it is absent)
-
-## Key interfaces at a glance
-
-| Interface | Layer | Purpose |
-|---|---|---|
-| `MemoryBackend` | Short-term | Protocol every backend must implement |
-| `SearchableMemoryBackend` | Short-term | Adds semantic search and promotion to long-term storage |
-| `ClaudeMemoryConfig` | Long-term | Controls which `CLAUDE.md` levels load and how deep |
-| `MemoryFile` | Long-term | One loaded file with level, path, content, and load order |
-| `ClaudeMemoryLoader` | Long-term | Walks the project tree and assembles the context string |
-| `MemoryControlPanel` | Admin | Status, statistics, pattern management, Redis lifecycle |
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `MemoryBackend` | Protocol for short-term memory backends. | `src/attune/memory/backend.py` |
+| `SearchableMemoryBackend` | Extended protocol for backends with semantic search. | `src/attune/memory/backend.py` |
+| `ClaudeMemoryConfig` | Configuration for Claude memory integration | `src/attune/memory/claude_memory.py` |
+| `MemoryFile` | Represents a loaded CLAUDE.md memory file | `src/attune/memory/claude_memory.py` |
+| `ClaudeMemoryLoader` | Loads and manages Claude Code memory files (CLAUDE.md). | `src/attune/memory/claude_memory.py` |

--- a/.help/templates/memory/reference.md
+++ b/.help/templates/memory/reference.md
@@ -1,227 +1,163 @@
 ---
-type: reference
-name: memory-reference
 feature: memory
 depth: reference
-generated_at: 2026-05-16T06:14:13.784755+00:00
-source_hash: 54f52a79be1ecfe32e99b4f09f84bda845815a0129b603c252aa4c74c2e1a61c
+generated_at: 2026-06-03T04:28:47.269880+00:00
+source_hash: 762177a9860aee4aa45cfeb762f406a50a3f7c21a4558c69f74815620780172d
 status: generated
 ---
 
 # Memory reference
 
-Classes, functions, and constants for storing, retrieving, searching, and securing memory across sessions.
-
 ## Classes
 
-| Class | Description |
-|-------|-------------|
-| `MemoryBackend` | Protocol for short-term memory backends. |
-| `SearchableMemoryBackend` | Extended protocol for backends with semantic search. |
-| `ClaudeMemoryConfig` | Configuration for Claude memory integration. |
-| `MemoryFile` | Represents a loaded CLAUDE.md memory file. |
-| `ClaudeMemoryLoader` | Loads and manages Claude Code memory files (CLAUDE.md). |
-| `ControlPanelConfig` | Configuration for the control panel. |
-| `MemoryControlPanel` | Enterprise control panel for Empathy memory management. |
-| `MemoryAPIHandler` | HTTP request handler for the Memory Control Panel API. |
-| `RateLimiter` | Simple in-memory rate limiter by IP address. |
-| `APIKeyAuth` | Simple API key authentication. |
-| `MemoryStats` | Statistics for the memory system. |
-| `CrossSessionCoordinator` | Coordinator for cross-session agent communication. |
-| `SessionType` | Type of session or agent. |
-| `ConflictStrategy` | Strategy for resolving conflicts between agents. |
-| `SessionInfo` | Information about an active session. |
-| `ConflictResult` | Result of a conflict resolution. |
-| `BackgroundService` | Background service daemon for cross-session coordination. |
-| `EdgeType` | Types of relationships between nodes. |
-| `Edge` | An edge connecting two nodes in the memory graph. |
-| `EncryptionManager` | Manages encryption and decryption for SENSITIVE patterns. |
-| `FeatureStatus` | Status of an optional feature. |
-| `FeatureInfo` | Information about a memory feature. |
-| `MemoryFeatures` | Check availability of memory subsystem features. |
-| `FileSessionMemory` | File-based session memory with persistence. |
-| `FileSessionConfig` | Configuration for file-based session memory. |
-| `WorkingEntry` | Entry in working memory. |
-| `StagedPatternFile` | Pattern staged for validation (file-based version). |
-| `SessionState` | Complete state of a session. |
-| `PatternStagingMixin` | Mixin providing pattern staging operations. |
-| `PersistenceMixin` | Mixin providing session persistence operations. |
-| `MemoryGraph` | Knowledge graph for cross-workflow intelligence. |
-| `LessonsManager` | Manages lessons learned from previous sessions. |
-| `SecureMemDocsIntegration` | Secure integration between Claude Memory and MemDocs. |
-| `PatternOperationsMixin` | Mixin providing pattern list, delete, and statistics operations. |
-| `PatternPipelineMixin` | Mixin providing store/retrieve pipeline helpers. |
-| `Classification` | Three-tier classification system for MemDocs patterns. |
-| `ClassificationRules` | Security rules for each classification level. |
-| `PatternMetadata` | Metadata for stored MemDocs patterns. |
-| `SecurePattern` | Represents a securely stored pattern. |
-| `SecurityError` | Raised when a security policy is violated. |
-| `MemoryPermissionError` | Raised when access is denied. |
-| `BackendInitMixin` | Mixin providing backend initialization for `UnifiedMemory`. |
-| `CapabilitiesMixin` | Mixin providing capability detection and health checks for `UnifiedMemory`. |
-| `HandoffAndExportMixin` | Mixin providing session handoff and export capabilities for `UnifiedMemory`. |
-| `LifecycleMixin` | Mixin providing lifecycle management for `UnifiedMemory`. |
-| `LongTermOperationsMixin` | Mixin providing long-term memory operations for `UnifiedMemory`. |
-| `PatternPromotionMixin` | Mixin providing pattern promotion capabilities for `UnifiedMemory`. |
-| `ShortTermOperationsMixin` | Mixin providing short-term memory operations for `UnifiedMemory`. |
-| `NodeType` | Types of nodes in the memory graph. |
-| `Node` | A node in the memory graph. |
-| `BugNode` | Specialized node for bugs. |
-| `VulnerabilityNode` | Specialized node for security vulnerabilities. |
-| `PerformanceNode` | Specialized node for performance issues. |
-| `PatternNode` | Specialized node for code patterns. |
-| `PersonalMemory` | Store and retrieve personal cross-session memory. |
-| `RedisDetectionResult` | Result of Redis auto-detection. |
-| `RedisAutoDetector` | Auto-detects Redis availability and manages user preferences. |
-| `RedisStartMethod` | Methods for starting Redis, in order of preference. |
-| `RedisStatus` | Status of a Redis connection or startup attempt. |
-| `AuditLogger` | Comprehensive audit logging for Attune AI. |
-| `AuditEvent` | Represents a single audit event. |
-| `SecurityViolation` | Represents a security policy violation. |
-| `AuditLogMethodsMixin` | Mixin that adds event-specific logging methods. |
-| `PIIDetection` | Details about a detected PII instance. |
-| `PIIPattern` | Definition of a PII detection pattern. |
-| `PIIScrubber` | Comprehensive PII detection and scrubbing system. |
-| `AuditQueryMixin` | Mixin that adds query capabilities to `AuditLogger`. |
-| `AuditReportMixin` | Mixin that adds reporting capabilities to `AuditLogger`. |
-| `SecretsDetector` | Detects secrets in text content using pattern matching and entropy analysis. |
-| `SecretType` | Types of secrets that can be detected. |
-| `Severity` | Severity levels for secret detections. |
-| `SecretDetection` | Metadata about a detected secret. |
-| `BaseOperations` | CRUD operations and connection management for short-term memory. |
-| `BatchOperations` | Batch operations using Redis pipelines. |
-| `CacheManager` | Local LRU cache manager for two-tier caching. |
-| `ConflictNegotiation` | Conflict context and resolution operations. |
-| `CrossSessionManager` | Cross-session coordination operations. |
-| `RedisShortTermMemory` | Facade composing all short-term memory operations. |
-| `Pagination` | SCAN-based pagination operations. |
-| `PatternStaging` | Pattern staging lifecycle operations. |
-| `PubSubManager` | Real-time publish/subscribe operations. |
-| `QueueManager` | Redis list operations for task queues. |
-| `DataSanitizer` | Handles data sanitization for short-term memory. |
-| `SessionManager` | Collaboration session operations. |
-| `StreamManager` | Redis Streams operations for audit trails and event logs. |
-| `TimelineManager` | Redis sorted set operations for timeline queries. |
-| `TransactionManager` | Atomic operations using Redis transactions. |
-| `WorkingMemory` | Working memory operations for agent data storage. |
-| `LongTermMemory` | Simplified long-term persistent storage interface. |
-| `MemDocsStorage` | Mock/simple MemDocs storage backend. |
-| `AgentContext` | Compact context package for sub-agent handoff. |
-| `ConversationSummaryIndex` | Redis-backed conversation summary with topic indexing. |
-| `AccessTier` | Role-based access tiers per EMPATHY_PHILOSOPHY.md. |
-| `TTLStrategy` | TTL strategies for different memory types. |
-| `RedisConfig` | Enhanced Redis configuration with SSL and retry support. |
-| `RedisMetrics` | Metrics for Redis operations. |
-| `PaginatedResult` | Result of a paginated query. |
-| `TimeWindowQuery` | Query parameters for time-window operations. |
-| `AgentCredentials` | Agent identity and access permissions. |
-| `StagedPattern` | Pattern awaiting validation. |
-| `ConflictContext` | Context for principled negotiation. |
-| `Environment` | Deployment environment for storage configuration. |
-| `MemoryConfig` | Configuration for the unified memory system. |
-| `UnifiedMemory` | Unified interface for short-term and long-term memory. |
-
-### `MemoryBackend` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `stash` | `key: str, value: Any, ttl: int \| None = None, agent_id: str \| None = None` | `bool` | Store a value under the given key. |
-| `retrieve` | `key: str, agent_id: str \| None = None` | `Any \| None` | Retrieve a value by key. |
-| `delete` | `key: str` | `bool` | Delete the entry for a key. |
-| `keys` | `pattern: str = '*'` | `list[str]` | List keys matching a pattern. |
-| `is_connected` | — | `bool` | Return whether the backend is connected. |
-| `get_stats` | — | `dict` | Return backend statistics. |
-| `close` | — | — | Close the backend connection. |
-| `supports_realtime` | — | `bool` | Return whether the backend supports real-time operations. |
-| `supports_distributed` | — | `bool` | Return whether the backend supports distributed access. |
-
-### `SearchableMemoryBackend` methods
-
-`SearchableMemoryBackend` extends `MemoryBackend` with the following additional methods.
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `search` | `query: str, limit: int = 10, **filters: Any` | `list[dict]` | Search memory using a query string with optional filters. |
-| `promote` | `session_id: str \| None = None` | `bool` | Promote staged patterns to long-term memory. |
-
-### `ClaudeMemoryConfig` fields
-
-`ClaudeMemoryConfig` is a dataclass. Configuration for Claude memory integration.
-
-| Field | Type | Default |
-|-------|------|---------|
-| `enabled` | `bool` | `False` |
-| `load_enterprise` | `bool` | `True` |
-| `load_user` | `bool` | `True` |
-| `load_project` | `bool` | `True` |
-| `enterprise_memory_path` | `str \| None` | `None` |
-| `project_root` | `str \| None` | `None` |
-| `max_import_depth` | `int` | `5` |
-| `max_file_size_bytes` | `int` | `1000000` |
-| `validate_files` | `bool` | `True` |
-
-### `MemoryFile` fields
-
-`MemoryFile` is a dataclass. Represents a loaded CLAUDE.md memory file.
-
-| Field | Type | Default |
-|-------|------|---------|
-| `level` | `str` | — |
-| `path` | `str` | — |
-| `content` | `str` | — |
-| `imports` | `list[str]` | `field(default_factory=list)` |
-| `load_order` | `int` | `0` |
-
-### `ClaudeMemoryLoader` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__` | `config: ClaudeMemoryConfig \| None = None` | — | Initialize the loader with an optional configuration. |
-| `load_all_memory` | `project_root: str \| None = None` | `str` | Load all CLAUDE.md memory files and return combined content. |
-| `clear_cache` | — | — | Clear the loaded file cache. |
-| `get_loaded_files` | — | `list[str]` | Return the paths of all currently loaded files. |
-
-### `ControlPanelConfig` fields
-
-`ControlPanelConfig` is a dataclass. Configuration for the control panel.
-
-| Field | Type | Default |
-|-------|------|---------|
-| `redis_host` | `str` | `'localhost'` |
-| `redis_port` | `int` | `6379` |
-| `storage_dir` | `str` | `'./memdocs_storage'` |
-| `audit_dir` | `str` | `'./logs'` |
-| `auto_start_redis` | `bool` | `True` |
-
-### `MemoryControlPanel` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__` | `config: ControlPanelConfig \| None = None` | — | Initialize the control panel with an optional configuration. |
-| `status` | — | `dict[str, Any]` | Return current system status. |
-| `start_redis` | `verbose: bool = True` | `RedisStatus` | Start the Redis backend. |
-| `stop_redis` | — | `bool` | Stop the Redis backend. |
-| `get_statistics` | — | `MemoryStats` | Return memory system statistics. |
-| `list_patterns` | `classification: str \| None = None, limit: int = 100` | `list[dict[str, Any]]` | List stored patterns, optionally filtered by classification. |
-| `delete_pattern` | `pattern_id: str, user_id: str = 'admin@system'` | `bool` | Delete a pattern by ID. |
-| `clear_short_term` | `agent_id: str = 'admin'` | `int` | Clear short-term memory for an agent and return the count of cleared entries. |
-| `export_patterns` | `output_path: str, classification: str \| None = None` | `int` | Export patterns to a file and return the count exported. |
-| `health_check` | — | `dict[str, Any]` | Run a health check and return the results. |
+| Class | Description | File |
+|-------|-------------|------|
+| `MemoryBackend` | Protocol for short-term memory backends. | `src/attune/memory/backend.py` |
+| `SearchableMemoryBackend` | Extended protocol for backends with semantic search. | `src/attune/memory/backend.py` |
+| `ClaudeMemoryConfig` | Configuration for Claude memory integration | `src/attune/memory/claude_memory.py` |
+| `MemoryFile` | Represents a loaded CLAUDE.md memory file | `src/attune/memory/claude_memory.py` |
+| `ClaudeMemoryLoader` | Loads and manages Claude Code memory files (CLAUDE.md). | `src/attune/memory/claude_memory.py` |
+| `ControlPanelConfig` | Configuration for control panel. | `src/attune/memory/control_panel.py` |
+| `MemoryControlPanel` | Enterprise control panel for Empathy memory management. | `src/attune/memory/control_panel.py` |
+| `MemoryAPIHandler` | HTTP request handler for Memory Control Panel API. | `src/attune/memory/control_panel_api.py` |
+| `RateLimiter` | Simple in-memory rate limiter by IP address. | `src/attune/memory/control_panel_support.py` |
+| `APIKeyAuth` | Simple API key authentication. | `src/attune/memory/control_panel_support.py` |
+| `MemoryStats` | Statistics for memory system. | `src/attune/memory/control_panel_support.py` |
+| `CrossSessionCoordinator` | Coordinator for cross-session agent communication. | `src/attune/memory/cross_session/coordinator.py` |
+| `SessionType` | Type of session/agent. | `src/attune/memory/cross_session/models.py` |
+| `ConflictStrategy` | Strategy for resolving conflicts between agents. | `src/attune/memory/cross_session/models.py` |
+| `SessionInfo` | Information about an active session. | `src/attune/memory/cross_session/models.py` |
+| `ConflictResult` | Result of a conflict resolution. | `src/attune/memory/cross_session/models.py` |
+| `BackgroundService` | Background service daemon for cross-session coordination. | `src/attune/memory/cross_session/service.py` |
+| `EdgeType` | Types of relationships between nodes. | `src/attune/memory/edges.py` |
+| `Edge` | An edge connecting two nodes in the memory graph. | `src/attune/memory/edges.py` |
+| `EncryptionManager` | Manages encryption/decryption for SENSITIVE patterns. | `src/attune/memory/encryption.py` |
+| `FeatureStatus` | Status of an optional feature. | `src/attune/memory/features.py` |
+| `FeatureInfo` | Information about a memory feature. | `src/attune/memory/features.py` |
+| `MemoryFeatures` | Check availability of memory subsystem features. | `src/attune/memory/features.py` |
+| `FileSessionMemory` | File-based session memory with persistence. | `src/attune/memory/file_session.py` |
+| `FileSessionConfig` | Configuration for file-based session memory. | `src/attune/memory/file_session_models.py` |
+| `WorkingEntry` | Entry in working memory. | `src/attune/memory/file_session_models.py` |
+| `StagedPatternFile` | Pattern staged for validation (file-based version). | `src/attune/memory/file_session_models.py` |
+| `SessionState` | Complete state of a session. | `src/attune/memory/file_session_models.py` |
+| `PatternStagingMixin` | Mixin providing pattern staging operations. | `src/attune/memory/file_session_patterns.py` |
+| `PersistenceMixin` | Mixin providing session persistence operations. | `src/attune/memory/file_session_persistence.py` |
+| `MemoryGraph` | Knowledge graph for cross-workflow intelligence. | `src/attune/memory/graph.py` |
+| `LessonsManager` | Manages lessons learned from previous sessions. | `src/attune/memory/lessons.py` |
+| `SecureMemDocsIntegration` | Secure integration between Claude Memory and MemDocs. | `src/attune/memory/long_term_integration.py` |
+| `PatternOperationsMixin` | Mixin providing pattern list, delete, and statistics operations. | `src/attune/memory/long_term_operations.py` |
+| `PatternPipelineMixin` | Mixin providing store/retrieve pipeline helpers. | `src/attune/memory/long_term_pipelines.py` |
+| `Classification` | Three-tier classification system for MemDocs patterns | `src/attune/memory/long_term_types.py` |
+| `ClassificationRules` | Security rules for each classification level | `src/attune/memory/long_term_types.py` |
+| `PatternMetadata` | Metadata for stored MemDocs patterns | `src/attune/memory/long_term_types.py` |
+| `SecurePattern` | Represents a securely stored pattern | `src/attune/memory/long_term_types.py` |
+| `SecurityError` | Raised when security policy is violated | `src/attune/memory/long_term_types.py` |
+| `MemoryPermissionError` | Raised when access is denied. | `src/attune/memory/long_term_types.py` |
+| `BackendInitMixin` | Mixin providing backend initialization for UnifiedMemory. | `src/attune/memory/mixins/backend_init_mixin.py` |
+| `CapabilitiesMixin` | Mixin providing capability detection and health checks for UnifiedMemory. | `src/attune/memory/mixins/capabilities_mixin.py` |
+| `HandoffAndExportMixin` | Mixin providing session handoff and export capabilities for UnifiedMemory. | `src/attune/memory/mixins/handoff_mixin.py` |
+| `LifecycleMixin` | Mixin providing lifecycle management for UnifiedMemory. | `src/attune/memory/mixins/lifecycle_mixin.py` |
+| `LongTermOperationsMixin` | Mixin providing long-term memory operations for UnifiedMemory. | `src/attune/memory/mixins/long_term_mixin.py` |
+| `PatternPromotionMixin` | Mixin providing pattern promotion capabilities for UnifiedMemory. | `src/attune/memory/mixins/promotion_mixin.py` |
+| `ShortTermOperationsMixin` | Mixin providing short-term memory operations for UnifiedMemory. | `src/attune/memory/mixins/short_term_mixin.py` |
+| `NodeType` | Types of nodes in the memory graph. | `src/attune/memory/nodes.py` |
+| `Node` | A node in the memory graph. | `src/attune/memory/nodes.py` |
+| `BugNode` | Specialized node for bugs. | `src/attune/memory/nodes.py` |
+| `VulnerabilityNode` | Specialized node for security vulnerabilities. | `src/attune/memory/nodes.py` |
+| `PerformanceNode` | Specialized node for performance issues. | `src/attune/memory/nodes.py` |
+| `PatternNode` | Specialized node for code patterns. | `src/attune/memory/nodes.py` |
+| `PersonalMemory` | Store and retrieve personal cross-session memory. | `src/attune/memory/personal.py` |
+| `RedisDetectionResult` | Result of Redis auto-detection. | `src/attune/memory/redis_auto_detect.py` |
+| `RedisAutoDetector` | Auto-detect Redis availability and manage user preferences. | `src/attune/memory/redis_auto_detect.py` |
+| `RedisStartMethod` | Methods for starting Redis, in order of preference. | `src/attune/memory/redis_bootstrap.py` |
+| `RedisStatus` | Status of Redis connection/startup. | `src/attune/memory/redis_bootstrap.py` |
+| `AuditLogger` | Comprehensive audit logging for Attune AI. | `src/attune/memory/security/audit_logger.py` |
+| `AuditEvent` | Represents a single audit event. | `src/attune/memory/security/events.py` |
+| `SecurityViolation` | Represents a security policy violation. | `src/attune/memory/security/events.py` |
+| `AuditLogMethodsMixin` | Mixin that adds event-specific logging methods. | `src/attune/memory/security/log_methods.py` |
+| `PIIDetection` | Details about a detected PII instance. | `src/attune/memory/security/pii_scrubber.py` |
+| `PIIPattern` | Definition of a PII detection pattern. | `src/attune/memory/security/pii_scrubber.py` |
+| `PIIScrubber` | Comprehensive PII detection and scrubbing system. | `src/attune/memory/security/pii_scrubber.py` |
+| `AuditQueryMixin` | Mixin that adds query capabilities to AuditLogger. | `src/attune/memory/security/query.py` |
+| `AuditReportMixin` | Mixin that adds reporting capabilities to AuditLogger. | `src/attune/memory/security/reports.py` |
+| `SecretsDetector` | Detects secrets in text content using pattern matching and entropy analysis. | `src/attune/memory/security/secrets_detector.py` |
+| `SecretType` | Types of secrets that can be detected | `src/attune/memory/security/secrets_types.py` |
+| `Severity` | Severity levels for secret detections | `src/attune/memory/security/secrets_types.py` |
+| `SecretDetection` | Metadata about a detected secret. | `src/attune/memory/security/secrets_types.py` |
+| `SessionStashEntry` | A single raw cross-session finding awaiting recall or promotion. | `src/attune/memory/session_stash.py` |
+| `BaseOperations` | Core CRUD operations and connection management. | `src/attune/memory/short_term/base.py` |
+| `BatchOperations` | Batch operations using Redis pipelines. | `src/attune/memory/short_term/batch.py` |
+| `CacheManager` | Local LRU cache manager for two-tier caching. | `src/attune/memory/short_term/caching.py` |
+| `ConflictNegotiation` | Conflict context and resolution operations. | `src/attune/memory/short_term/conflicts.py` |
+| `CrossSessionManager` | Cross-session coordination operations. | `src/attune/memory/short_term/cross_session.py` |
+| `RedisShortTermMemory` | Facade composing all short-term memory operations. | `src/attune/memory/short_term/facade.py` |
+| `Pagination` | SCAN-based pagination operations. | `src/attune/memory/short_term/pagination.py` |
+| `PatternStaging` | Pattern staging lifecycle operations. | `src/attune/memory/short_term/patterns.py` |
+| `PubSubManager` | Real-time publish/subscribe operations. | `src/attune/memory/short_term/pubsub.py` |
+| `QueueManager` | Redis list operations for task queues. | `src/attune/memory/short_term/queues.py` |
+| `DataSanitizer` | Handles data sanitization for short-term memory. | `src/attune/memory/short_term/security.py` |
+| `SessionManager` | Collaboration session operations. | `src/attune/memory/short_term/sessions.py` |
+| `StreamManager` | Redis Streams operations for audit trails and event logs. | `src/attune/memory/short_term/streams.py` |
+| `TimelineManager` | Redis sorted set operations for timeline queries. | `src/attune/memory/short_term/timelines.py` |
+| `TransactionManager` | Atomic operations using Redis transactions. | `src/attune/memory/short_term/transactions.py` |
+| `WorkingMemory` | Working memory operations for agent data storage. | `src/attune/memory/short_term/working.py` |
+| `LongTermMemory` | Simplified long-term persistent storage interface. | `src/attune/memory/simple_storage.py` |
+| `MemDocsStorage` | Mock/Simple MemDocs storage backend. | `src/attune/memory/storage_backend.py` |
+| `AgentContext` | Compact context package for sub-agent handoff. | `src/attune/memory/summary_index.py` |
+| `ConversationSummaryIndex` | Redis-backed conversation summary with topic indexing. | `src/attune/memory/summary_index.py` |
+| `AccessTier` | Role-based access tiers per EMPATHY_PHILOSOPHY.md | `src/attune/memory/types.py` |
+| `TTLStrategy` | TTL strategies for different memory types | `src/attune/memory/types.py` |
+| `RedisConfig` | Enhanced Redis configuration with SSL and retry support. | `src/attune/memory/types.py` |
+| `RedisMetrics` | Metrics for Redis operations. | `src/attune/memory/types.py` |
+| `PaginatedResult` | Result of a paginated query. | `src/attune/memory/types.py` |
+| `TimeWindowQuery` | Query parameters for time-window operations. | `src/attune/memory/types.py` |
+| `AgentCredentials` | Agent identity and access permissions | `src/attune/memory/types.py` |
+| `StagedPattern` | Pattern awaiting validation | `src/attune/memory/types.py` |
+| `ConflictContext` | Context for principled negotiation | `src/attune/memory/types.py` |
+| `SecurityError` | Raised when a security policy is violated (e.g., secrets detected in data). | `src/attune/memory/types.py` |
+| `Environment` | Deployment environment for storage configuration. | `src/attune/memory/unified.py` |
+| `MemoryConfig` | Configuration for unified memory system. | `src/attune/memory/unified.py` |
+| `UnifiedMemory` | Unified interface for short-term and long-term memory. | `src/attune/memory/unified.py` |
 
 ## Functions
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `is_redis_available` | — | `bool` | Check whether the Redis subsystem is available without importing it. |
-| `create_default_project_memory` | `project_root: str, framework: str = 'empathy'` | — | Create a default `.claude/CLAUDE.md` file for a project. |
-| `parse_redis_url` | `url: str` | `dict` | Parse a Redis URL into connection parameters. |
-| `get_redis_config` | — | `dict` | Get Redis configuration from environment variables (legacy dict API). |
-| `get_redis_memory` | `url: str \| None = None, use_mock: bool \| None = None` | `RedisShortTermMemory` | Create a `RedisShortTermMemory` instance using environment-based config. |
-| `check_redis_connection` | — | `dict` | Check the Redis connection and return status. |
-| `get_railway_redis` | — | `RedisShortTermMemory` | Get a Redis instance configured for Railway deployment. |
-| `run_api_server` | `panel: MemoryControlPanel, host: str = 'localhost', port: int = 8765, api_key: str \| None = None, enable_rate_limit: bool = True, rate_limit_requests: int = 100, rate_limit_window: int = 60, ssl_certfile: str \| None = None, ssl_keyfile: str \| None = None, allowed_origins: list[str] \| None = None` | — | Run the Memory API server with security features. |
-| `print_status` | `panel: MemoryControlPanel` | — | Print control panel status in a formatted way. |
-| `print_stats` | `panel: MemoryControlPanel` | — | Print memory statistics in a formatted way. |
-| `print_health` | `panel: MemoryControlPanel` | — | Print a health check report in a formatted way. |
-| `main` | — | — | CLI entry point. |
-| `resolve_by_priority` | `agent_id: str, access_tier: AccessTier, session_info: SessionInfo, resource_key: str, other_session: SessionInfo \| None` | `Con
+| Function | Description | File |
+|----------|-------------|------|
+| `is_redis_available()` | Check if Redis subsystem is available without importing it. | `src/attune/memory/__init__.py` |
+| `create_default_project_memory()` | Create a default .claude/CLAUDE.md file for a project. | `src/attune/memory/claude_memory.py` |
+| `parse_redis_url()` | Parse Redis URL into connection parameters. | `src/attune/memory/config.py` |
+| `get_redis_config()` | Get Redis configuration from environment variables (legacy dict API). | `src/attune/memory/config.py` |
+| `get_redis_memory()` | Create a RedisShortTermMemory instance with environment-based config. | `src/attune/memory/config.py` |
+| `check_redis_connection()` | Check Redis connection and return status. | `src/attune/memory/config.py` |
+| `get_railway_redis()` | Get Redis configured for Railway deployment. | `src/attune/memory/config.py` |
+| `run_api_server()` | Run the Memory API server with security features. | `src/attune/memory/control_panel_api.py` |
+| `print_status()` | Print status in a formatted way. | `src/attune/memory/control_panel_display.py` |
+| `print_stats()` | Print statistics in a formatted way. | `src/attune/memory/control_panel_display.py` |
+| `print_health()` | Print health check in a formatted way. | `src/attune/memory/control_panel_display.py` |
+| `main()` | CLI entry point. | `src/attune/memory/control_panel_display.py` |
+| `resolve_by_priority()` | Resolve conflict using priority (access tier). | `src/attune/memory/cross_session/conflicts.py` |
+| `resolve_first_write()` | Resolve conflict using first-write-wins. | `src/attune/memory/cross_session/conflicts.py` |
+| `resolve_last_write()` | Resolve conflict using last-write-wins. | `src/attune/memory/cross_session/conflicts.py` |
+| `generate_agent_id()` | Generate a unique agent ID. | `src/attune/memory/cross_session/models.py` |
+| `check_redis_cross_session_support()` | Check if Redis supports cross-session communication. | `src/attune/memory/cross_session/service.py` |
+| `get_or_start_service()` | Get existing service or start a new one. | `src/attune/memory/cross_session/service.py` |
+| `get_file_session_memory()` | Create a file-based session memory instance. | `src/attune/memory/file_session.py` |
+| `classify_pattern()` | Auto-classify pattern based on content and type. | `src/attune/memory/long_term_classification.py` |
+| `check_access()` | Check if user has access to pattern based on classification. | `src/attune/memory/long_term_classification.py` |
+| `auto_detect_redis()` | Convenience function for auto-detecting Redis. | `src/attune/memory/redis_auto_detect.py` |
+| `ensure_redis()` | Ensure Redis is available, starting it if necessary. | `src/attune/memory/redis_bootstrap.py` |
+| `stop_redis()` | Stop Redis if we started it. | `src/attune/memory/redis_bootstrap.py` |
+| `get_redis_or_mock()` | Get a Redis connection, starting Redis if needed, or return mock. | `src/attune/memory/redis_bootstrap.py` |
+| `detect_secrets()` | Convenience function to detect secrets without creating a detector instance. | `src/attune/memory/security/secrets_detector.py` |
+| `resolve_backend()` | Return a searchable backend, or ``None`` if none is available. | `src/attune/memory/session_stash.py` |
+| `stash_entry()` | Stash a finding to working memory after the PII/secrets gate. | `src/attune/memory/session_stash.py` |
+| `recall_entries()` | Semantic recall over stashed findings. Empty list when unavailable. | `src/attune/memory/session_stash.py` |
+
+
+## Source files
+
+- `src/attune/memory/**`
+
+## Tags
+
+`memory`, `storage`

--- a/.help/templates/memory/task.md
+++ b/.help/templates/memory/task.md
@@ -1,109 +1,57 @@
 ---
-type: task
-name: memory-task
 feature: memory
 depth: task
-generated_at: 2026-05-16T06:14:13.780457+00:00
-source_hash: 54f52a79be1ecfe32e99b4f09f84bda845815a0129b603c252aa4c74c2e1a61c
+generated_at: 2026-06-03T04:28:47.264783+00:00
+source_hash: 762177a9860aee4aa45cfeb762f406a50a3f7c21a4558c69f74815620780172d
 status: generated
 ---
 
 # Work with memory
 
-Use the memory subsystem when you need to store, retrieve, or secure agent memory — whether that means connecting to Redis, loading Claude memory files, or running the Memory Control Panel API.
+Use memory when you need to memory subsystem — storage, lookup, and security.
 
 ## Prerequisites
 
-- Read access to `src/attune/memory/`
-- Redis available locally or via a `REDIS_URL` environment variable (required for short-term memory and control panel features)
-- Python environment with project dependencies installed
-
-## Identify the right entry point
-
-The memory subsystem is divided into focused modules. Choose the function that owns the behavior you need:
-
-| Goal | Function | Module |
-|---|---|---|
-| Check whether Redis is available | `is_redis_available()` | `src/attune/memory/__init__.py` |
-| Create a default `CLAUDE.md` for a project | `create_default_project_memory(project_root, framework)` | `src/attune/memory/claude_memory.py` |
-| Parse a Redis URL into connection parameters | `parse_redis_url(url)` | `src/attune/memory/config.py` |
-| Read Redis config from environment variables | `get_redis_config()` | `src/attune/memory/config.py` |
-| Instantiate a `RedisShortTermMemory` object | `get_redis_memory(url, use_mock)` | `src/attune/memory/config.py` |
-| Verify a live Redis connection | `check_redis_connection()` | `src/attune/memory/config.py` |
-| Get Redis configured for Railway deployment | `get_railway_redis()` | `src/attune/memory/config.py` |
-| Start the Memory Control Panel HTTP API | `run_api_server(panel, host, port, ...)` | `src/attune/memory/control_panel_api.py` |
+- Access to the project source code
+- Familiarity with the files under src/attune/memory/**
 
 ## Steps
 
-1. **Confirm Redis availability** before writing any memory.
+1. **Understand the current behavior.**
+   Read the entry points to see what memory
+   does today before making changes.
+   The primary functions are:
+   - `is_redis_available()` in `src/attune/memory/__init__.py` — Check if Redis subsystem is available without importing it.
+   - `create_default_project_memory()` in `src/attune/memory/claude_memory.py` — Create a default .claude/CLAUDE.md file for a project.
+   - `parse_redis_url()` in `src/attune/memory/config.py` — Parse Redis URL into connection parameters.
+   - `get_redis_config()` in `src/attune/memory/config.py` — Get Redis configuration from environment variables (legacy dict API).
+   - `get_redis_memory()` in `src/attune/memory/config.py` — Create a RedisShortTermMemory instance with environment-based config.
+2. **Locate the right function to change.**
+   Each function has a single responsibility. Read its
+   docstring, parameters, and return type to confirm it
+   owns the behavior you need to modify.
 
-   ```python
-   from attune.memory import is_redis_available
-   if not is_redis_available():
-       raise RuntimeError("Redis is not available. Start Redis or set REDIS_URL.")
-   ```
+3. **Make your change.**
+   Follow existing patterns in the file — naming
+   conventions, error handling style, and logging.
 
-2. **Obtain a memory backend instance** using `get_redis_memory()`. Pass a URL explicitly or let the function read `REDIS_URL` from the environment.
+4. **Run the related tests.**
+   This catches regressions before they reach other
+   developers. Target with `pytest -k "memory"`.
 
-   ```python
-   from attune.memory.config import get_redis_memory
-   memory = get_redis_memory()          # reads REDIS_URL from env
-   # or
-   memory = get_redis_memory(url="redis://localhost:6379")
-   ```
+## Key files
 
-   For Railway deployments, use `get_railway_redis()` instead. This raises `OSError` if `REDIS_URL` is not set in the Railway environment.
+- `src/attune/memory/**`
 
-3. **Store and retrieve values** using the `MemoryBackend` protocol methods.
+## Common modifications
 
-   ```python
-   memory.stash("session:42:goal", "draft PR", ttl=3600, agent_id="agent-1")
-   value = memory.retrieve("session:42:goal", agent_id="agent-1")
-   ```
+Functions you are most likely to modify:
 
-4. **Load Claude memory files** if your workflow depends on `CLAUDE.md` context. Instantiate `ClaudeMemoryLoader` with a `ClaudeMemoryConfig` and call `load_all_memory()`.
-
-   ```python
-   from attune.memory.claude_memory import ClaudeMemoryLoader, ClaudeMemoryConfig
-
-   config = ClaudeMemoryConfig(
-       enabled=True,
-       load_project=True,
-       project_root="/path/to/project",
-       max_import_depth=5,
-   )
-   loader = ClaudeMemoryLoader(config)
-   context = loader.load_all_memory()
-   ```
-
-   To create a default `CLAUDE.md` for a project that does not have one yet:
-
-   ```python
-   from attune.memory.claude_memory import create_default_project_memory
-   create_default_project_memory("/path/to/project", framework="empathy")
-   ```
-
-5. **Start the Memory Control Panel API** when you need HTTP access to memory statistics, pattern management, or audit logs.
-
-   ```python
-   from attune.memory.control_panel_api import run_api_server
-   from attune.memory.control_panel import MemoryControlPanel
-
-   panel = MemoryControlPanel()
-   run_api_server(panel, host="localhost", port=8765, api_key="my-secret-key")
-   ```
-
-6. **Run the memory test suite** to catch regressions before your changes reach other developers.
-
-   ```bash
-   pytest -k "memory"
-   ```
-
-## Verify the task succeeded
-
-- `is_redis_available()` returns `True`.
-- `check_redis_connection()` returns a dict with a `"status"` key equal to `"ok"`.
-- `memory.retrieve(key, agent_id=...)` returns the value you passed to `memory.stash(...)`.
-- `loader.get_loaded_files()` lists the `CLAUDE.md` paths that were found and parsed.
-- The API server responds to `GET /health` (or equivalent) without error when started with `run_api_server()`.
-- `pytest -k "memory"` passes with no failures.
+- `is_redis_available()` in `src/attune/memory/__init__.py`
+- `create_default_project_memory()` in `src/attune/memory/claude_memory.py`
+- `parse_redis_url()` in `src/attune/memory/config.py`
+- `get_redis_config()` in `src/attune/memory/config.py`
+- `get_redis_memory()` in `src/attune/memory/config.py`
+- `check_redis_connection()` in `src/attune/memory/config.py`
+- `get_railway_redis()` in `src/attune/memory/config.py`
+- `run_api_server()` in `src/attune/memory/control_panel_api.py`

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -1,0 +1,231 @@
+"""Cross-session memory stash — write/recall over a SearchableMemoryBackend.
+
+Part of the ``claude-cross-session-memory`` spec. Per decision D6, this
+release backs recall with the Redis Agent Memory Server (AMS) via
+``attune_redis.AMSMemoryBackend``. This module stays **backend-agnostic**:
+it targets the :class:`attune.memory.backend.SearchableMemoryBackend`
+protocol and resolves a concrete backend from the ``attune.memory_backends``
+entry point (or an injected instance), degrading to a **silent no-op** when
+no searchable backend is available.
+
+Tiers (D4/D6):
+
+- **Write** — raw session findings stashed via ``backend.stash`` (working
+  memory). A PII/secrets gate runs *before* any write (R3); polish is
+  deferred to user-gated promotion.
+- **Recall** — ``backend.search`` (semantic, over AMS long-term memory).
+- **Promote to curated** — stays the review-gated ``/remember`` flow,
+  independent of this module (D2).
+
+The hooks that drive this (``~/.claude/hooks/session_recall.py`` and the
+Stop-hook stash) live outside the package and are intentionally NOT shipped
+here; they register against the user's live ``settings.json``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from attune.memory.backend import SearchableMemoryBackend
+
+logger = logging.getLogger(__name__)
+
+#: Entry kinds mirror PersonalMemory's vocabulary plus a generic "note".
+VALID_TYPES = frozenset({"decision", "pattern", "bug", "reference", "note"})
+
+#: Stash entries are short by design (raw findings, not polished docs).
+MAX_CONTENT_CHARS = 500
+
+#: Entry-point group attune plugins register a memory backend under.
+_BACKEND_GROUP = "attune.memory_backends"
+
+#: Default working-memory TTL for a stashed finding.
+DEFAULT_TTL_DAYS = 7
+
+
+@dataclass
+class SessionStashEntry:
+    """A single raw cross-session finding awaiting recall or promotion.
+
+    Attributes:
+        id: UUID4 string, used as the backend stash key.
+        session_id: Originating Claude Code session id.
+        cwd: Project root at write time (used for cwd-scoped recall).
+        timestamp: ISO-8601 UTC creation time.
+        type: One of :data:`VALID_TYPES`.
+        content: The finding text (truncated to :data:`MAX_CONTENT_CHARS`).
+        tags: Free-form tags for filtering.
+        ttl_days: Working-memory TTL in days.
+    """
+
+    id: str
+    session_id: str
+    cwd: str
+    timestamp: str
+    type: str
+    content: str
+    tags: list[str] = field(default_factory=list)
+    ttl_days: int = DEFAULT_TTL_DAYS
+
+    def __post_init__(self) -> None:
+        if self.type not in VALID_TYPES:
+            raise ValueError(f"invalid type {self.type!r}; expected one of {sorted(VALID_TYPES)}")
+        if not self.content or not self.content.strip():
+            raise ValueError("content must be a non-empty string")
+        if len(self.content) > MAX_CONTENT_CHARS:
+            logger.warning(
+                "session stash content truncated %d -> %d chars",
+                len(self.content),
+                MAX_CONTENT_CHARS,
+            )
+            self.content = self.content[:MAX_CONTENT_CHARS]
+
+    @classmethod
+    def create(
+        cls,
+        session_id: str,
+        cwd: str,
+        type: str,
+        content: str,
+        tags: list[str] | None = None,
+        ttl_days: int = DEFAULT_TTL_DAYS,
+    ) -> SessionStashEntry:
+        """Build an entry with a fresh id + UTC timestamp."""
+        return cls(
+            id=str(uuid.uuid4()),
+            session_id=session_id,
+            cwd=cwd,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            type=type,
+            content=content,
+            tags=list(tags or []),
+            ttl_days=ttl_days,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for backend storage."""
+        return asdict(self)
+
+
+def resolve_backend(
+    backend: SearchableMemoryBackend | None = None,
+) -> SearchableMemoryBackend | None:
+    """Return a searchable backend, or ``None`` if none is available.
+
+    Resolution order: an explicitly injected ``backend`` wins; otherwise the
+    first entry registered under the ``attune.memory_backends`` entry point
+    is instantiated (env-configured). Any failure — no plugin installed,
+    construction error, missing search capability — returns ``None`` so the
+    caller degrades to a no-op rather than raising.
+    """
+    if backend is not None:
+        return backend
+    try:
+        from importlib.metadata import entry_points
+
+        from attune.memory.backend import SearchableMemoryBackend as _Searchable
+
+        eps = entry_points(group=_BACKEND_GROUP)
+        for ep in eps:
+            try:
+                instance = ep.load()()
+            except Exception as exc:  # noqa: BLE001
+                # INTENTIONAL: a misconfigured/unavailable backend must not
+                # break the host session — recall simply yields nothing.
+                logger.debug("memory backend %s unavailable: %s", ep.name, exc)
+                continue
+            if isinstance(instance, _Searchable) or (
+                hasattr(instance, "search") and hasattr(instance, "stash")
+            ):
+                return instance
+        logger.debug("no searchable memory backend registered under %s", _BACKEND_GROUP)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: resolution is best-effort; never propagate.
+        logger.debug("backend resolution failed: %s", exc)
+    return None
+
+
+def _sanitize(content: str) -> str | None:
+    """Run the PII/secrets gate before any write (R3). Fail closed.
+
+    Returns the sanitized content, or ``None`` if the gate is unavailable so
+    the caller refuses the write rather than persisting unsanitized text.
+    """
+    try:
+        from attune.memory.short_term.security import DataSanitizer
+    except Exception as exc:  # noqa: BLE001
+        logger.error("PII/secrets gate unavailable; refusing stash write: %s", exc)
+        return None
+    sanitizer = DataSanitizer()
+    sanitized, redactions = sanitizer.sanitize(content)
+    if redactions:
+        logger.info("session stash: %d sensitive value(s) redacted before write", redactions)
+    return sanitized if isinstance(sanitized, str) else str(sanitized)
+
+
+def stash_entry(
+    entry: SessionStashEntry,
+    backend: SearchableMemoryBackend | None = None,
+) -> bool:
+    """Stash a finding to working memory after the PII/secrets gate.
+
+    No-op (returns ``False``) when no backend is available or the gate
+    can't run. Never raises — safe to call from a Stop hook.
+    """
+    target = resolve_backend(backend)
+    if target is None:
+        return False
+    safe_content = _sanitize(entry.content)
+    if safe_content is None:
+        return False
+    entry.content = safe_content
+    ttl_seconds = max(1, entry.ttl_days) * 86_400
+    try:
+        return bool(
+            target.stash(entry.id, entry.to_dict(), ttl=ttl_seconds, agent_id=entry.session_id)
+        )
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: stash is best-effort; a backend error must not break
+        # the host session.
+        logger.warning("session stash write failed: %s", exc)
+        return False
+
+
+def recall_entries(
+    query: str,
+    top_k: int = 5,
+    cwd: str | None = None,
+    backend: SearchableMemoryBackend | None = None,
+) -> list[dict[str, Any]]:
+    """Semantic recall over stashed findings. Empty list when unavailable.
+
+    Args:
+        query: Natural-language recall query.
+        top_k: Max results.
+        cwd: When set, prefer entries from this project root (soft filter;
+            cross-cwd results still returned, cwd matches first).
+        backend: Optional injected backend; resolved from the entry point
+            when omitted.
+
+    Returns:
+        Ranked memory records as dicts (backend-shaped), or ``[]``.
+    """
+    target = resolve_backend(backend)
+    if target is None:
+        return []
+    try:
+        results = target.search(query, limit=top_k)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: recall is best-effort; never break the host session.
+        logger.warning("session recall failed: %s", exc)
+        return []
+    if not isinstance(results, list):
+        return []
+    if cwd:
+        results.sort(key=lambda r: 0 if (isinstance(r, dict) and r.get("cwd") == cwd) else 1)
+    return results

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -85,6 +85,56 @@ def test_resolve_backend_none_when_unavailable(monkeypatch):
     assert resolve_backend(None) is None
 
 
+def test_resolve_backend_from_entry_point(monkeypatch):
+    """A registered, searchable entry-point backend is resolved + returned."""
+    import importlib.metadata as md
+
+    searchable = _FakeBackend()
+
+    class _EP:
+        name = "fake"
+
+        def load(self):
+            def _factory():
+                return searchable
+
+            return _factory
+
+    monkeypatch.setattr(md, "entry_points", lambda group=None: [_EP()])
+    assert resolve_backend(None) is searchable
+
+
+def test_resolve_backend_swallows_resolution_error(monkeypatch):
+    """A failure in entry-point resolution degrades to None, never raises."""
+    import importlib.metadata as md
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("entry point system down")
+
+    monkeypatch.setattr(md, "entry_points", _boom)
+    assert resolve_backend(None) is None
+
+
+def test_resolve_backend_skips_non_searchable_entry_point(monkeypatch):
+    """An entry-point object lacking search/stash is skipped, not returned."""
+    import importlib.metadata as md
+
+    class _NotSearchable:
+        pass
+
+    class _EP:
+        name = "fake"
+
+        def load(self):
+            def _factory():
+                return _NotSearchable()
+
+            return _factory
+
+    monkeypatch.setattr(md, "entry_points", lambda group=None: [_EP()])
+    assert resolve_backend(None) is None
+
+
 # --------------------------------------------------------------------------
 # stash_entry — gate + degradation
 # --------------------------------------------------------------------------

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -102,9 +102,11 @@ def test_stash_noop_without_backend():
 
 def test_stash_calls_backend_with_ttl_seconds(monkeypatch):
     # Make the gate a pass-through so we isolate the stash path.
-    monkeypatch.setattr(
-        security_mod, "DataSanitizer", lambda: type("S", (), {"sanitize": lambda self, d: (d, 0)})()
-    )
+    class _PassThroughGate:
+        def sanitize(self, d):
+            return (d, 0)
+
+    monkeypatch.setattr(security_mod, "DataSanitizer", _PassThroughGate)
     fb = _FakeBackend()
     e = _entry()
     assert stash_entry(e, backend=fb) is True

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -1,0 +1,188 @@
+"""Tests for attune.memory.session_stash (claude-cross-session-memory T1.3).
+
+Backend-agnostic write/recall over the SearchableMemoryBackend protocol,
+with a fail-closed PII/secrets gate at write and silent no-op degradation
+when no backend is available.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import attune.memory.short_term.security as security_mod
+from attune.memory.session_stash import (
+    DEFAULT_TTL_DAYS,
+    MAX_CONTENT_CHARS,
+    SessionStashEntry,
+    recall_entries,
+    resolve_backend,
+    stash_entry,
+)
+
+
+class _FakeBackend:
+    """Minimal SearchableMemoryBackend stand-in."""
+
+    def __init__(self, results=None):
+        self.stashed: list[tuple] = []
+        self._results = results if results is not None else []
+
+    def stash(self, key, value, ttl=None, agent_id=None):
+        self.stashed.append((key, value, ttl, agent_id))
+        return True
+
+    def search(self, query, limit=10, **filters):
+        return list(self._results)
+
+
+# --------------------------------------------------------------------------
+# SessionStashEntry
+# --------------------------------------------------------------------------
+
+
+def test_create_generates_id_and_timestamp():
+    e = SessionStashEntry.create(session_id="s1", cwd="/proj", type="decision", content="x")
+    assert len(e.id) == 36  # uuid4
+    assert e.timestamp.startswith("20")
+    assert e.ttl_days == DEFAULT_TTL_DAYS
+    assert e.tags == []
+
+
+def test_invalid_type_rejected():
+    with pytest.raises(ValueError, match="invalid type"):
+        SessionStashEntry.create(session_id="s", cwd="/p", type="bogus", content="x")
+
+
+def test_empty_content_rejected():
+    with pytest.raises(ValueError, match="non-empty"):
+        SessionStashEntry.create(session_id="s", cwd="/p", type="note", content="   ")
+
+
+def test_content_truncated_to_max(caplog):
+    long = "a" * (MAX_CONTENT_CHARS + 50)
+    e = SessionStashEntry.create(session_id="s", cwd="/p", type="note", content=long)
+    assert len(e.content) == MAX_CONTENT_CHARS
+
+
+def test_to_dict_round_trips():
+    e = SessionStashEntry.create(session_id="s", cwd="/p", type="bug", content="boom", tags=["ci"])
+    d = e.to_dict()
+    assert d["type"] == "bug" and d["tags"] == ["ci"] and d["content"] == "boom"
+
+
+# --------------------------------------------------------------------------
+# resolve_backend
+# --------------------------------------------------------------------------
+
+
+def test_resolve_backend_injected_wins():
+    fb = _FakeBackend()
+    assert resolve_backend(fb) is fb
+
+
+def test_resolve_backend_none_when_unavailable(monkeypatch):
+    # No searchable backend registered in the test env.
+    assert resolve_backend(None) is None
+
+
+# --------------------------------------------------------------------------
+# stash_entry — gate + degradation
+# --------------------------------------------------------------------------
+
+
+def _entry(content="finding"):
+    return SessionStashEntry.create(
+        session_id="sess", cwd="/proj", type="decision", content=content
+    )
+
+
+def test_stash_noop_without_backend():
+    assert stash_entry(_entry(), backend=None) is False
+
+
+def test_stash_calls_backend_with_ttl_seconds(monkeypatch):
+    # Make the gate a pass-through so we isolate the stash path.
+    monkeypatch.setattr(
+        security_mod, "DataSanitizer", lambda: type("S", (), {"sanitize": lambda self, d: (d, 0)})()
+    )
+    fb = _FakeBackend()
+    e = _entry()
+    assert stash_entry(e, backend=fb) is True
+    assert len(fb.stashed) == 1
+    key, value, ttl, agent_id = fb.stashed[0]
+    assert key == e.id
+    assert ttl == DEFAULT_TTL_DAYS * 86_400
+    assert agent_id == "sess"
+    assert value["content"] == "finding"
+
+
+def test_stash_runs_pii_gate_before_write(monkeypatch):
+    calls = {"n": 0}
+
+    class _Gate:
+        def sanitize(self, data):
+            calls["n"] += 1
+            return ("<scrubbed>", 1)
+
+    monkeypatch.setattr(security_mod, "DataSanitizer", _Gate)
+    fb = _FakeBackend()
+    assert stash_entry(_entry("raw secret-ish text"), backend=fb) is True
+    assert calls["n"] == 1, "PII/secrets gate must run before write"
+    assert fb.stashed[0][1]["content"] == "<scrubbed>"
+
+
+def test_stash_fail_closed_when_gate_unavailable(monkeypatch):
+    # Remove DataSanitizer so the in-function import raises -> refuse write.
+    monkeypatch.delattr(security_mod, "DataSanitizer", raising=False)
+    fb = _FakeBackend()
+    assert stash_entry(_entry(), backend=fb) is False
+    assert fb.stashed == [], "must not persist unsanitized content"
+
+
+def test_stash_swallows_backend_error(monkeypatch):
+    monkeypatch.setattr(
+        security_mod, "DataSanitizer", lambda: type("S", (), {"sanitize": lambda self, d: (d, 0)})()
+    )
+
+    class _Boom(_FakeBackend):
+        def stash(self, *a, **k):
+            raise RuntimeError("backend down")
+
+    assert stash_entry(_entry(), backend=_Boom()) is False
+
+
+# --------------------------------------------------------------------------
+# recall_entries
+# --------------------------------------------------------------------------
+
+
+def test_recall_noop_without_backend():
+    assert recall_entries("q", backend=None) == []
+
+
+def test_recall_returns_backend_results():
+    fb = _FakeBackend(results=[{"text": "hit", "cwd": "/proj"}])
+    out = recall_entries("q", top_k=3, backend=fb)
+    assert out == [{"text": "hit", "cwd": "/proj"}]
+
+
+def test_recall_cwd_soft_sort():
+    fb = _FakeBackend(results=[{"text": "other", "cwd": "/x"}, {"text": "mine", "cwd": "/proj"}])
+    out = recall_entries("q", cwd="/proj", backend=fb)
+    assert out[0]["cwd"] == "/proj", "cwd matches should sort first"
+
+
+def test_recall_swallows_backend_error():
+    class _Boom(_FakeBackend):
+        def search(self, *a, **k):
+            raise RuntimeError("search down")
+
+    assert recall_entries("q", backend=_Boom()) == []
+
+
+def test_recall_handles_non_list_result():
+    class _Weird(_FakeBackend):
+        def search(self, *a, **k):
+            return None
+
+    assert recall_entries("q", backend=_Weird()) == []

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -142,9 +142,11 @@ def test_stash_fail_closed_when_gate_unavailable(monkeypatch):
 
 
 def test_stash_swallows_backend_error(monkeypatch):
-    monkeypatch.setattr(
-        security_mod, "DataSanitizer", lambda: type("S", (), {"sanitize": lambda self, d: (d, 0)})()
-    )
+    class _Sanitizer:
+        def sanitize(self, d):
+            return (d, 0)
+
+    monkeypatch.setattr(security_mod, "DataSanitizer", _Sanitizer)
 
     class _Boom(_FakeBackend):
         def stash(self, *a, **k):


### PR DESCRIPTION
## Summary

Package-side implementation of **cross-session-memory T1.3** (`src/attune/memory/session_stash.py` + tests). Built autonomously overnight against the reconciled D4/D5/D6 design.

Backend-agnostic by design: targets the existing `SearchableMemoryBackend` protocol and resolves a concrete backend (Redis AMS, per D6) from the `attune.memory_backends` entry point — degrading to a **silent no-op** when none is available, so it never breaks a host session.

## What's here

- **`SessionStashEntry`** — schema from the spec (id/session_id/cwd/timestamp/type/content/tags/ttl_days) with validation + 500-char truncation.
- **`stash_entry()`** — PII/secrets gate (`DataSanitizer`) runs **before any write** and **fails closed** if the gate is unavailable (R3). Never raises.
- **`recall_entries()`** — semantic search via `backend.search`, optional cwd soft-sort. `[]` when unavailable.
- **`resolve_backend()`** — best-effort entry-point resolution.

## Verify-first (per the session's lesson)

Grounded before coding: installed `agent-memory-client 0.14.0` and introspected the real AMS API + `AMSMemoryBackend` wrapper + `DataSanitizer` gate + the protocol signatures. No confabulated APIs.

## Safety

- **No public-surface change** — not added to any `__all__` (internal infra for the hooks).
- 17 unit tests (fake backend + monkeypatched gate): no-op-without-backend, ttl-seconds, **gate-runs-before-write**, **fail-closed**, error-swallowing, cwd sort, non-list handling. All green; ruff clean.

## Deferred to you (intentionally NOT in this PR)

- `~/.claude/hooks/` scripts + `settings.json` registration (T1.1/T1.2) — touches your live session config; too sensitive to do unattended.
- Standing up the AMS server + the **embedding-provider decision (OpenAI vs Ollama)** — your morning call. This module is provider-agnostic, so the choice doesn't affect it.

## Test plan

- [x] 17 unit tests pass; ruff clean
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
