### PR TITLE
fix(redis): repair AMSMemoryBackend against agent-memory-client 0.14.0

### DIFF
--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import fnmatch
 import logging
+import threading
 from typing import Any
 
 from .config import RedisPluginConfig
@@ -24,12 +25,38 @@ from .config import RedisPluginConfig
 logger = logging.getLogger(__name__)
 
 
-def _run_sync(coro: Any) -> Any:
-    """Run an async coroutine synchronously.
+class _PersistentLoop:
+    """A single event loop running in a daemon thread.
 
-    Handles the case where we're already inside a running
-    event loop (e.g. Jupyter, async web server) by using a
-    thread pool executor.
+    ``MemoryAPIClient`` holds a persistent ``httpx.AsyncClient``
+    bound to the event loop it was first used on. Running each
+    coroutine via a fresh ``asyncio.run`` (which creates *and
+    closes* a new loop per call) leaves that client bound to a
+    closed loop, so the second call onward fails with
+    ``RuntimeError: Event loop is closed``. Routing every
+    coroutine through one long-lived loop keeps the client's
+    connection pool valid for the backend's whole lifetime, and
+    ``run_coroutine_threadsafe`` is safe to call whether or not
+    the caller is itself inside a running loop.
+    """
+
+    def __init__(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._loop.run_forever, name="ams-backend-loop", daemon=True
+        )
+        self._thread.start()
+
+    def run(self, coro: Any) -> Any:
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+
+_LOOP: _PersistentLoop | None = None
+_LOOP_LOCK = threading.Lock()
+
+
+def _run_sync(coro: Any) -> Any:
+    """Run an async coroutine synchronously on a persistent loop.
 
     Args:
         coro: Awaitable coroutine to run.
@@ -37,17 +64,11 @@ def _run_sync(coro: Any) -> Any:
     Returns:
         The coroutine's return value.
     """
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
-
-    if loop and loop.is_running():
-        import concurrent.futures
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(asyncio.run, coro).result()
-    return asyncio.run(coro)
+    global _LOOP
+    with _LOOP_LOCK:
+        if _LOOP is None:
+            _LOOP = _PersistentLoop()
+    return _LOOP.run(coro)
 
 
 class AMSMemoryBackend:
@@ -77,12 +98,10 @@ class AMSMemoryBackend:
             config: Plugin configuration. Uses env-based
                 defaults if None.
         """
-        from agent_memory_client import MemoryAPIClient
+        from agent_memory_client import MemoryAPIClient, MemoryClientConfig
 
         self._config = config or RedisPluginConfig.from_env()
-        self._client = MemoryAPIClient(
-            base_url=self._config.ams_base_url,
-        )
+        self._client = MemoryAPIClient(MemoryClientConfig(base_url=self._config.ams_base_url))
         self._session_id = self._config.default_session_id
         self._namespace = self._config.ams_namespace
         self._user_id = self._config.default_user_id

--- a/tests/memory/test_ams_backend_integration.py
+++ b/tests/memory/test_ams_backend_integration.py
@@ -1,0 +1,103 @@
+"""Integration tests for AMSMemoryBackend against a REAL Agent Memory Server.
+
+These exercise the two integration bugs that unit tests with a mocked
+client could not catch (the backend was never run against a live
+``agent-memory-client`` + server):
+
+1. **Client construction** — ``agent-memory-client`` 0.14.0 takes
+   ``MemoryAPIClient(MemoryClientConfig(base_url=...))``; the old
+   ``MemoryAPIClient(base_url=...)`` call raised ``TypeError`` at
+   instantiation, so the backend silently no-op'd.
+2. **Event-loop lifecycle** — running each coroutine via a fresh
+   ``asyncio.run`` closed the loop the persistent ``httpx.AsyncClient``
+   was bound to, so the *second* call onward failed with
+   ``RuntimeError: Event loop is closed``. The fix routes every
+   coroutine through one persistent loop.
+
+Prerequisites (skipped cleanly when absent):
+    - ``agent-memory-client`` installed (the ``[redis]`` extra)
+    - An Agent Memory Server reachable at ``AMS_BASE_URL``
+      (default ``http://localhost:8000``)
+
+Run locally with AMS up:
+    pytest tests/memory/test_ams_backend_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import urllib.request
+import uuid
+
+import pytest
+
+pytest.importorskip("agent_memory_client")
+
+_AMS_BASE_URL = os.environ.get("AMS_BASE_URL", "http://localhost:8000")
+
+
+def _ams_running() -> bool:
+    """True when an Agent Memory Server answers its health endpoint."""
+    try:
+        with urllib.request.urlopen(f"{_AMS_BASE_URL}/v1/health", timeout=2) as resp:
+            return resp.status == 200
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: any failure means "no server" -> skip integration tests.
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _ams_running(),
+    reason=f"No Agent Memory Server reachable at {_AMS_BASE_URL}",
+)
+
+
+@pytest.fixture
+def backend():
+    from attune_redis.memory import AMSMemoryBackend
+
+    be = AMSMemoryBackend()
+    yield be
+    be.close()
+
+
+def test_backend_instantiates_against_real_client():
+    """Regression: client construction must not raise (bug #1).
+
+    The old ``MemoryAPIClient(base_url=...)`` raised ``TypeError`` with
+    client 0.14.0. Constructing the backend at all proves the fix.
+    """
+    from attune_redis.memory import AMSMemoryBackend
+
+    be = AMSMemoryBackend()
+    try:
+        assert be.is_connected() is True
+    finally:
+        be.close()
+
+
+def test_sequential_calls_survive_persistent_loop(backend):
+    """Regression: two+ sequential calls must not hit a closed loop (bug #2).
+
+    With the per-call ``asyncio.run`` wrapper, the first call closed the
+    loop the httpx client was bound to and ``search`` (a later call)
+    raised ``RuntimeError: Event loop is closed``. The persistent-loop
+    wrapper keeps the client valid across calls.
+    """
+    sid = f"itest-{uuid.uuid4()}"
+    # First call binds the client's connection pool to the persistent loop.
+    assert backend.stash("probe-key", {"v": 1}, agent_id=sid) is True
+    # Second call would have hit "Event loop is closed" pre-fix.
+    results = backend.search("anything", limit=3)
+    assert isinstance(results, list)
+    # A third call on the same loop must also work.
+    assert isinstance(backend.search("another query", limit=1), list)
+
+
+def test_data_dict_round_trip(backend):
+    """The key-value stash/retrieve path (working-memory data dict) works."""
+    sid = f"itest-{uuid.uuid4()}"
+    payload = {"score": 95, "note": "round-trip"}
+    assert backend.stash("results", payload, agent_id=sid) is True
+    got = backend.retrieve("results", agent_id=sid)
+    assert got == payload


### PR DESCRIPTION
## What

Repairs `attune_redis.AMSMemoryBackend` so it actually works against
the published `agent-memory-client` (0.14.0). Discovered while standing
up a local Agent Memory Server for cross-session memory — the backend
had **two** integration bugs that unit tests (mocked client) never
caught, so `session_stash` was silently no-op'ing.

## Bugs fixed

1. **Client construction.** 0.14.0 changed the constructor to
   `MemoryAPIClient(MemoryClientConfig(base_url=...))`. The old
   `MemoryAPIClient(base_url=...)` raised `TypeError` at `__init__`,
   so `resolve_backend()` caught it and returned `None` → silent no-op.

2. **Event-loop lifecycle.** `_run_sync` ran each coroutine via a fresh
   `asyncio.run`, which creates *and closes* a new loop per call. The
   persistent `httpx.AsyncClient` inside `MemoryAPIClient` binds to the
   first loop, so the *second* call onward raised
   `RuntimeError: Event loop is closed` (`stash` worked, `search`
   failed). `_run_sync` now routes every coroutine through a single
   persistent loop in a daemon thread (`run_coroutine_threadsafe`),
   keeping the client's connection pool valid for the backend's life.

## Test

`tests/memory/test_ams_backend_integration.py` — AMS-gated (skips when
no server is reachable at `AMS_BASE_URL`) regression guards for both
bugs, verified against a real local Agent Memory Server (Ollama
embeddings + Redis Stack). Existing mocked protocol tests still pass
and cover the changed lines (so codecov patch coverage holds even
though the integration test skips in CI).

## Verified working

With AMS up locally, the full semantic path is confirmed end-to-end:
a directly-created long-term memory is found by `search_long_term_memory`
(Ollama `nomic-embed-text` @ 768-dim + Redis Stack RediSearch).

## Known gap (tracked separately)

`stash` writes the working-memory **data dict** (`set_working_memory_data`,
correct for the `retrieve()` key-value path) while `search` reads
long-term **memory records** — disconnected subsystems, so stashed
findings aren't yet recallable. Wiring the write-path to searchable
memories is a deliberate spec decision (claude-cross-session-memory
D4/D6) and is out of scope here; this PR makes the backend functional
and correct, which that work builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
