### PR TITLE
feat(memory): D7 — write session findings as searchable long-term memories

### DIFF
--- a/.help/templates/memory/concept.md
+++ b/.help/templates/memory/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: memory
 depth: concept
-generated_at: 2026-06-03T04:28:47.256897+00:00
-source_hash: 762177a9860aee4aa45cfeb762f406a50a3f7c21a4558c69f74815620780172d
+generated_at: 2026-06-03T12:45:43.107743+00:00
+source_hash: aef54dd763ecee5292afdaa47a99e48e4d68ab66ba2bedf0a15d83d09ad51782
 status: generated
 ---
 

--- a/.help/templates/memory/reference.md
+++ b/.help/templates/memory/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: memory
 depth: reference
-generated_at: 2026-06-03T04:28:47.269880+00:00
-source_hash: 762177a9860aee4aa45cfeb762f406a50a3f7c21a4558c69f74815620780172d
+generated_at: 2026-06-03T12:45:43.120749+00:00
+source_hash: aef54dd763ecee5292afdaa47a99e48e4d68ab66ba2bedf0a15d83d09ad51782
 status: generated
 ---
 
@@ -150,7 +150,7 @@ status: generated
 | `get_redis_or_mock()` | Get a Redis connection, starting Redis if needed, or return mock. | `src/attune/memory/redis_bootstrap.py` |
 | `detect_secrets()` | Convenience function to detect secrets without creating a detector instance. | `src/attune/memory/security/secrets_detector.py` |
 | `resolve_backend()` | Return a searchable backend, or ``None`` if none is available. | `src/attune/memory/session_stash.py` |
-| `stash_entry()` | Stash a finding to working memory after the PII/secrets gate. | `src/attune/memory/session_stash.py` |
+| `stash_entry()` | Write a finding to the searchable recall tier after the PII gate. | `src/attune/memory/session_stash.py` |
 | `recall_entries()` | Semantic recall over stashed findings. Empty list when unavailable. | `src/attune/memory/session_stash.py` |
 
 

--- a/.help/templates/memory/task.md
+++ b/.help/templates/memory/task.md
@@ -1,8 +1,8 @@
 ---
 feature: memory
 depth: task
-generated_at: 2026-06-03T04:28:47.264783+00:00
-source_hash: 762177a9860aee4aa45cfeb762f406a50a3f7c21a4558c69f74815620780172d
+generated_at: 2026-06-03T12:45:43.116195+00:00
+source_hash: aef54dd763ecee5292afdaa47a99e48e4d68ab66ba2bedf0a15d83d09ad51782
 status: generated
 ---
 

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -313,6 +313,49 @@ class AMSMemoryBackend:
     # SearchableMemoryBackend extension methods
     # =========================================================================
 
+    def remember(
+        self,
+        content: str,
+        *,
+        memory_id: str | None = None,
+        session_id: str | None = None,
+        topics: list[str] | None = None,
+    ) -> bool:
+        """Write a searchable long-term memory.
+
+        Unlike ``stash`` (working-memory key/value ``data`` dict), this
+        creates an AMS long-term memory record that semantic ``search``
+        can retrieve. Embedding happens server-side on write, so the
+        finding is recallable across sessions.
+
+        Args:
+            content: Text to store and embed.
+            memory_id: Optional stable id (enables dedup on re-write).
+            session_id: Session id override.
+            topics: Free-form tags carried on the record.
+
+        Returns:
+            True if the memory was written.
+        """
+        from agent_memory_client.models import ClientMemoryRecord
+
+        record_kwargs: dict[str, Any] = {
+            "text": content,
+            "session_id": session_id or self._session_id,
+            "namespace": self._namespace,
+            "user_id": self._user_id,
+            "topics": list(topics or []),
+        }
+        if memory_id:
+            record_kwargs["id"] = memory_id
+        try:
+            _run_sync(self._client.create_long_term_memory([ClientMemoryRecord(**record_kwargs)]))
+            return True
+        except Exception as e:  # noqa: BLE001
+            # INTENTIONAL: Graceful degradation for AMS HTTP errors
+            logger.error("remember_failed: id=%s error=%s", memory_id, e)
+            return False
+
     def search(
         self,
         query: str,

--- a/src/attune/memory/backend.py
+++ b/src/attune/memory/backend.py
@@ -173,6 +173,32 @@ class SearchableMemoryBackend(MemoryBackend, Protocol):
         """
         ...
 
+    def remember(
+        self,
+        content: str,
+        *,
+        memory_id: str | None = None,
+        session_id: str | None = None,
+        topics: list[str] | None = None,
+    ) -> bool:
+        """Write a semantically-searchable long-term memory.
+
+        Distinct from ``stash`` (key/value working memory): a
+        ``remember`` write enters the long-term store that ``search``
+        retrieves, so the content is recallable across sessions.
+
+        Args:
+            content: Text to store and embed.
+            memory_id: Optional stable id (enables dedup on re-write).
+            session_id: Originating session id.
+            topics: Free-form tags carried on the record.
+
+        Returns:
+            True if the memory was written.
+
+        """
+        ...
+
     def promote(self, session_id: str | None = None) -> bool:
         """Promote working memories to long-term storage.
 

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -172,10 +172,14 @@ def stash_entry(
     entry: SessionStashEntry,
     backend: SearchableMemoryBackend | None = None,
 ) -> bool:
-    """Stash a finding to working memory after the PII/secrets gate.
+    """Write a finding to the searchable recall tier after the PII gate.
 
-    No-op (returns ``False``) when no backend is available or the gate
-    can't run. Never raises — safe to call from a Stop hook.
+    Per D7, findings are written as long-term memories (recallable via
+    :func:`recall_entries`) through ``backend.remember`` when available.
+    Backends without a searchable write path fall back to the key/value
+    ``stash`` (not recallable, but non-fatal). No-op (returns ``False``)
+    when no backend is available or the gate can't run. Never raises —
+    safe to call from a Stop hook.
     """
     target = resolve_backend(backend)
     if target is None:
@@ -184,13 +188,26 @@ def stash_entry(
     if safe_content is None:
         return False
     entry.content = safe_content
-    ttl_seconds = max(1, entry.ttl_days) * 86_400
+    topics = list(entry.tags) + [f"type:{entry.type}", f"cwd:{entry.cwd}"]
+    remember = getattr(target, "remember", None)
     try:
+        if remember is not None:
+            return bool(
+                remember(
+                    safe_content,
+                    memory_id=entry.id,
+                    session_id=entry.session_id,
+                    topics=topics,
+                )
+            )
+        # Backend without a searchable write path: key/value stash only
+        # (not recallable, but the host session must not break).
+        ttl_seconds = max(1, entry.ttl_days) * 86_400
         return bool(
             target.stash(entry.id, entry.to_dict(), ttl=ttl_seconds, agent_id=entry.session_id)
         )
     except Exception as exc:  # noqa: BLE001
-        # INTENTIONAL: stash is best-effort; a backend error must not break
+        # INTENTIONAL: write is best-effort; a backend error must not break
         # the host session.
         logger.warning("session stash write failed: %s", exc)
         return False

--- a/tests/memory/test_ams_backend_integration.py
+++ b/tests/memory/test_ams_backend_integration.py
@@ -26,6 +26,7 @@ Run locally with AMS up:
 from __future__ import annotations
 
 import os
+import time
 import urllib.request
 import uuid
 
@@ -54,9 +55,17 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def backend():
+    from attune_redis.config import RedisPluginConfig
     from attune_redis.memory import AMSMemoryBackend
 
-    be = AMSMemoryBackend()
+    # Unique namespace per test run: the AMS store is persistent, so without
+    # isolation, near-identical findings from prior runs make semantic recall
+    # of *this* run's record non-deterministic.
+    cfg = RedisPluginConfig(
+        ams_base_url=_AMS_BASE_URL,
+        ams_namespace=f"itest-{uuid.uuid4().hex[:12]}",
+    )
+    be = AMSMemoryBackend(cfg)
     yield be
     be.close()
 
@@ -101,3 +110,66 @@ def test_data_dict_round_trip(backend):
     assert backend.stash("results", payload, agent_id=sid) is True
     got = backend.retrieve("results", agent_id=sid)
     assert got == payload
+
+
+def test_remember_then_search_round_trip(backend):
+    """D7: a remember() write is recallable via search() (Ollama-embedded)."""
+    marker = f"itest-{uuid.uuid4().hex[:10]}"
+    content = f"{marker}: integration finding for the searchable write path."
+    assert backend.remember(content, memory_id=marker, topics=["type:note"]) is True
+
+    # Embedding + indexing is server-side; allow a brief settle then search.
+    # Query by the content text (self-similar embedding ranks the exact doc
+    # highest) rather than the bare hex marker (semantically meaningless).
+    hit = None
+    for _ in range(10):
+        results = backend.search(content, limit=10)
+        hit = next((r for r in results if marker in (r.get("text") or "")), None)
+        if hit is not None:
+            break
+        time.sleep(1)
+    assert hit is not None, f"remember()'d content not found by search for {marker!r}"
+
+
+def test_session_stash_round_trip():
+    """D7 end-to-end: stash_entry -> recall_entries finds the finding.
+
+    This is the round-trip that returned 0 hits before D7 (stash wrote the
+    working-memory data dict; search reads long-term memory). With the
+    remember()-based write path it must now be recallable.
+    """
+    from attune.memory.session_stash import (
+        SessionStashEntry,
+        recall_entries,
+        stash_entry,
+    )
+    from attune_redis.config import RedisPluginConfig
+    from attune_redis.memory import AMSMemoryBackend
+
+    be = AMSMemoryBackend(
+        RedisPluginConfig(
+            ams_base_url=_AMS_BASE_URL,
+            ams_namespace=f"itest-{uuid.uuid4().hex[:12]}",
+        )
+    )
+    try:
+        marker = f"itest-{uuid.uuid4().hex[:10]}"
+        entry = SessionStashEntry.create(
+            session_id=f"itest-{uuid.uuid4()}",
+            cwd="/tmp/itest",
+            type="decision",
+            content=f"{marker}: end-to-end session-stash recall verification.",
+        )
+        assert stash_entry(entry, backend=be) is True
+        # Query by the finding text (self-similar embedding ranks the exact
+        # doc highest) rather than the bare hex marker.
+        hit = None
+        for _ in range(10):
+            results = recall_entries(entry.content, top_k=10, backend=be)
+            hit = next((r for r in results if marker in (r.get("text") or "")), None)
+            if hit is not None:
+                break
+            time.sleep(1)
+        assert hit is not None, f"stashed finding not recalled for {marker!r}"
+    finally:
+        be.close()

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -20,8 +20,25 @@ from attune.memory.session_stash import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_ambient_backend(monkeypatch):
+    """Ensure ``resolve_backend`` finds no ambient plugin backend by default.
+
+    Without this, a dev environment with a memory-backend plugin installed
+    (e.g. attune-redis + a running AMS) makes ``resolve_backend(None)``
+    return a *real* backend, so the no-backend-available tests fail
+    locally even though they pass in CI (which lacks the optional dep).
+    The entry-point lookup is patched to empty so the suite is
+    deterministic regardless of what's installed; tests that need an
+    entry point set their own monkeypatch, which runs after this and wins.
+    """
+    import importlib.metadata as md
+
+    monkeypatch.setattr(md, "entry_points", lambda *a, **k: [])
+
+
 class _FakeBackend:
-    """Minimal SearchableMemoryBackend stand-in."""
+    """Minimal SearchableMemoryBackend stand-in (key/value stash only)."""
 
     def __init__(self, results=None):
         self.stashed: list[tuple] = []
@@ -33,6 +50,18 @@ class _FakeBackend:
 
     def search(self, query, limit=10, **filters):
         return list(self._results)
+
+
+class _RememberBackend(_FakeBackend):
+    """Searchable backend that also implements the remember() write path."""
+
+    def __init__(self, results=None):
+        super().__init__(results)
+        self.remembered: list[tuple] = []
+
+    def remember(self, content, *, memory_id=None, session_id=None, topics=None):
+        self.remembered.append((content, memory_id, session_id, topics))
+        return True
 
 
 # --------------------------------------------------------------------------
@@ -203,6 +232,44 @@ def test_stash_swallows_backend_error(monkeypatch):
             raise RuntimeError("backend down")
 
     assert stash_entry(_entry(), backend=_Boom()) is False
+
+
+def test_stash_uses_remember_when_backend_supports_it(monkeypatch):
+    """D7: with a searchable write path, stash_entry writes via remember().
+
+    The finding must go to the long-term (recallable) tier, carrying its
+    id, session, and type/cwd topics — NOT the key/value stash fallback.
+    """
+
+    class _PassThroughGate:
+        def sanitize(self, d):
+            return (d, 0)
+
+    monkeypatch.setattr(security_mod, "DataSanitizer", _PassThroughGate)
+    rb = _RememberBackend()
+    entry = _entry("a finding worth recalling")
+    assert stash_entry(entry, backend=rb) is True
+    assert len(rb.remembered) == 1
+    content, memory_id, session_id, topics = rb.remembered[0]
+    assert content == "a finding worth recalling"
+    assert memory_id == entry.id
+    assert session_id == "sess"
+    assert "type:decision" in topics
+    assert "cwd:/proj" in topics
+    assert rb.stashed == [], "must use remember(), not the key/value stash fallback"
+
+
+def test_stash_falls_back_to_keyvalue_when_no_remember(monkeypatch):
+    """A backend without remember() degrades to the key/value stash."""
+
+    class _PassThroughGate:
+        def sanitize(self, d):
+            return (d, 0)
+
+    monkeypatch.setattr(security_mod, "DataSanitizer", _PassThroughGate)
+    fb = _FakeBackend()  # no remember attribute
+    assert stash_entry(_entry(), backend=fb) is True
+    assert len(fb.stashed) == 1, "fallback must use the key/value stash"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## What

Implements the ratified **D7** decision (claude-cross-session-memory,
merged in #589): populate the searchable recall tier with a **direct
long-term write at stash time**, instead of D6's auto-extraction
assumption (which needs a generation model and extracts from
*messages*, not the data-dict stash).

This is the change that makes cross-session recall actually work —
before it, `stash_entry → recall_entries` returned **0 hits** (stash
wrote AMS working memory; search reads long-term memory; nothing
bridged them).

## Changes

- **`attune_redis`**: `AMSMemoryBackend.remember()` wrapping
  `create_long_term_memory` — embeds server-side (Ollama) so the
  finding is searchable immediately, **no generation model required**.
  The key/value `stash()`/`retrieve()` path is untouched.
- **protocol**: `remember()` added to `SearchableMemoryBackend`.
- **`session_stash.stash_entry`**: writes via `remember()` (searchable
  tier) when available — carrying the entry id, session, and
  `type:`/`cwd:` topics — and falls back to the key/value `stash` for
  backends without it. The no-op / never-raise contract is preserved.

## Tests

- **unit**: remember-path is used when available; key/value fallback
  otherwise. An autouse fixture isolates entry-point resolution so the
  no-backend tests are deterministic regardless of locally-installed
  plugins or a running AMS (they previously passed only by accident
  pre-#588, when backend construction raised — this PR makes them
  honest).
- **integration** (AMS-gated; skips with no server, so CI is
  unaffected): `remember → search` and the full
  `stash_entry → recall_entries` round-trip. Per-run AMS **namespace
  isolation** keeps semantic recall deterministic against the
  persistent store.

Verified end-to-end against a real local AMS (Ollama
`nomic-embed-text` @ 768-dim + Redis Stack). Builds on #588; ratified
by #589.

## Follow-ups (not in this PR)

- The hooks (T1.1 SessionStart recall, T1.2 Stop-hook stash) + `/recall`
  skill (T2.1) — now unblocked, they touch the live `settings.json`.
- TTL/forget policy for the long-term findings tier (D2's 7-day intent
  vs durable long-term) — a deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
