### PR TITLE
feat(memory): D8 file-fallback — cross-session memory works with zero infra (P1)

### DIFF
--- a/docs/specs/claude-cross-session-memory/decisions.md
+++ b/docs/specs/claude-cross-session-memory/decisions.md
@@ -364,3 +364,59 @@ How should a stashed finding reach the searchable tier?
 - D6's "populated by AMS's background auto-extraction" bullet is
   superseded by "populated by a direct long-term write at stash time."
 - Extraction stays **off**; no generation model required.
+
+## D8 — File-fallback default; AMS becomes the optional upgrade (revisits D6)
+
+> **Ratified with Patrick 2026-06-03**, during release-readiness
+> planning. Partially **reverses D6's "cut the file/keyword tier"** —
+> see rationale below.
+
+### What release-readiness review found
+
+Verified against the installed package:
+
+- The `file` entry point → `FileSessionMemory`, which has **no
+  `search()`** and a constructor requiring `user_id` (so
+  `resolve_backend`'s no-arg `ep.load()()` can't even instantiate it).
+- Only `AMSMemoryBackend` is searchable. So **without a full local
+  AMS standup (Ollama + Redis Stack + agent-memory-server), recall is
+  a silent no-op** — there is no graceful fallback.
+- D6 had cut the file/keyword tier "to build on AMS this release,"
+  which left the feature hard-requiring heavy local infra. For a
+  `pip install attune-ai` dev tool, that means the *majority* of users
+  would get nothing from the feature.
+
+### Decision
+
+**The default backend is a searchable file backend; AMS is an optional
+upgrade for better recall at scale.** This restores D4's design (the
+ephemeral stash tier is recalled by a cheap **keyword + recency + cwd**
+filter — *not* semantic; the stash is one user × short retention, small
+enough that keyword/recency suffices). Cross-session memory then works
+**out-of-box for every install** with zero infra; users who want
+higher-quality recall over a large corpus opt into AMS.
+
+This supersedes D6's tier mapping: D6 said "searchable tier = AMS
+long-term, file/keyword tier cut." D8 reinstates the file tier as the
+default and demotes AMS to optional upgrade. D7's `remember()`-based
+write path is unchanged and applies to both backends.
+
+### Consequences / tasks
+
+- **New `FileStashBackend`** (purpose-built, no-arg constructable):
+  implements the `SearchableMemoryBackend` protocol over a local JSONL
+  stash (`~/.attune/session_stash/`). `remember()` appends a finding;
+  `search()` = keyword + recency + cwd filter; `stash`/`retrieve`
+  key/value; age-based TTL prune. Registered as the `file` entry
+  point (replaces the non-searchable `FileSessionMemory` mapping in
+  the `attune.memory_backends` group — `FileSessionMemory` stays the
+  general session-state facade, used directly, not via this group).
+- **`resolve_backend` preference**: prefer a *connected* upgrade
+  backend (AMS) over the always-available file fallback. Backends mark
+  themselves with an `is_fallback` class attribute; resolve picks the
+  first connected non-fallback, else a connected fallback, else None.
+  (Held for implementation with Patrick — changes shared resolution.)
+- **No-AMS UX**: feature works out-of-box; AMS-not-running just means
+  the file fallback is used (no error, no setup required).
+- Documentation frames AMS as "optional: better recall at scale,"
+  with the standup steps in an advanced section, not a prerequisite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -430,7 +430,7 @@ release-prep = "attune.wizards.builtin.release_prep_wizard:ReleasePrepWizard"
 
 # Memory backend plugin entry points
 [project.entry-points."attune.memory_backends"]
-file = "attune.memory.file_session:FileSessionMemory"
+file = "attune.memory.file_stash:FileStashBackend"
 redis = "attune_redis.memory:AMSMemoryBackend"
 
 [tool.setuptools]

--- a/src/attune/memory/file_stash.py
+++ b/src/attune/memory/file_stash.py
@@ -1,0 +1,284 @@
+"""File-based searchable session stash — the zero-infra default backend.
+
+Per decision **D8** (claude-cross-session-memory): cross-session memory
+works out-of-box with no Redis / AMS / Ollama. This backend implements the
+:class:`attune.memory.backend.SearchableMemoryBackend` protocol over a local
+JSONL stash, so :func:`attune.memory.session_stash.stash_entry` /
+``recall_entries`` function on a plain ``pip install attune-ai``.
+
+Recall is the cheap **keyword + recency + cwd** filter D4 specified — the
+stash is one user with short retention, small enough that semantic search is
+unnecessary. AMS (``attune_redis.AMSMemoryBackend``) remains the optional
+upgrade for higher-quality recall at scale; ``resolve_backend`` prefers it
+when it is connected and falls back to this backend otherwise.
+
+Storage: ``~/.attune/session_stash/findings.jsonl`` (one JSON record per
+line). Key/value ``stash``/``retrieve`` use a sibling ``kv.json``. Records
+past the TTL are pruned lazily on read/write.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+#: Default working-stash retention; matches session_stash DEFAULT_TTL_DAYS.
+DEFAULT_TTL_DAYS = 7
+
+_DAY_SECONDS = 86_400
+#: Recency half-life for the recall score (newer findings rank higher).
+_RECENCY_HALFLIFE_SECONDS = 3 * _DAY_SECONDS
+
+
+def _tokenize(text: str) -> set[str]:
+    """Lowercase alphanumeric tokens of length >= 2."""
+    out: set[str] = set()
+    token: list[str] = []
+    for ch in text.lower():
+        if ch.isalnum():
+            token.append(ch)
+        elif token:
+            if len(token) >= 2:
+                out.add("".join(token))
+            token = []
+    if len(token) >= 2:
+        out.add("".join(token))
+    return out
+
+
+def _cwd_from_topics(topics: list[str]) -> str | None:
+    """Extract the ``cwd:<path>`` marker session_stash writes into topics."""
+    for t in topics:
+        if t.startswith("cwd:"):
+            return t[len("cwd:") :]
+    return None
+
+
+class FileStashBackend:
+    """Searchable, zero-infra session stash backed by a local JSONL file.
+
+    No-arg constructable (so it resolves from the ``attune.memory_backends``
+    entry point), and marked :data:`is_fallback` so ``resolve_backend``
+    prefers a connected AMS upgrade when one is available.
+    """
+
+    #: Marks this as the always-available default, not an upgrade backend.
+    is_fallback = True
+
+    def __init__(
+        self,
+        base_dir: str | Path | None = None,
+        ttl_days: int = DEFAULT_TTL_DAYS,
+    ) -> None:
+        """Initialize the file stash.
+
+        Args:
+            base_dir: Stash directory. Defaults to ``~/.attune/session_stash``.
+            ttl_days: Retention; records older than this are pruned on access.
+        """
+        if base_dir is None:
+            base_dir = Path.home() / ".attune" / "session_stash"
+        self._dir = Path(base_dir)
+        self._findings = self._dir / "findings.jsonl"
+        self._kv = self._dir / "kv.json"
+        self._ttl_seconds = max(1, ttl_days) * _DAY_SECONDS
+        self._closed = False
+        try:
+            self._dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.warning("file_stash_mkdir_failed", error=str(e))
+
+    # ------------------------------------------------------------------ #
+    # internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _load_records(self) -> list[dict[str, Any]]:
+        """Load all non-expired finding records (lazy TTL prune on read)."""
+        if not self._findings.exists():
+            return []
+        cutoff = time.time() - self._ttl_seconds
+        records: list[dict[str, Any]] = []
+        try:
+            for line in self._findings.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(rec, dict) and float(rec.get("ts", 0)) >= cutoff:
+                    records.append(rec)
+        except OSError as e:
+            logger.warning("file_stash_read_failed", error=str(e))
+        return records
+
+    def _rewrite(self, records: list[dict[str, Any]]) -> None:
+        """Atomically rewrite the findings file (used for append + prune)."""
+        tmp = self._findings.with_suffix(".jsonl.tmp")
+        try:
+            tmp.write_text(
+                "".join(json.dumps(r, ensure_ascii=False) + "\n" for r in records),
+                encoding="utf-8",
+            )
+            tmp.replace(self._findings)  # Path.replace: cross-platform overwrite
+        except OSError as e:
+            logger.warning("file_stash_write_failed", error=str(e))
+
+    # ------------------------------------------------------------------ #
+    # SearchableMemoryBackend — searchable write/read
+    # ------------------------------------------------------------------ #
+
+    def remember(
+        self,
+        content: str,
+        *,
+        memory_id: str | None = None,
+        session_id: str | None = None,
+        topics: list[str] | None = None,
+    ) -> bool:
+        """Append a searchable finding to the local stash (prunes expired)."""
+        topics = list(topics or [])
+        record = {
+            "id": memory_id or os.urandom(8).hex(),
+            "text": content,
+            "session_id": session_id,
+            "topics": topics,
+            "cwd": _cwd_from_topics(topics),
+            "ts": time.time(),
+        }
+        try:
+            kept = self._load_records()  # already TTL-pruned
+            kept.append(record)
+            self._rewrite(kept)
+            return True
+        except Exception as e:  # noqa: BLE001
+            # INTENTIONAL: stash is best-effort; never break the host session.
+            logger.warning("file_stash_remember_failed", error=str(e))
+            return False
+
+    def search(self, query: str, limit: int = 10, **filters: Any) -> list[dict]:
+        """Keyword + recency + cwd recall over the stash (D4's cheap tier)."""
+        terms = _tokenize(query)
+        if not terms:
+            return []
+        cwd = filters.get("cwd")
+        now = time.time()
+        scored: list[tuple[float, dict[str, Any]]] = []
+        for rec in self._load_records():
+            doc_terms = _tokenize(rec.get("text", "")) | {
+                t for top in rec.get("topics", []) for t in _tokenize(top)
+            }
+            overlap = len(terms & doc_terms)
+            if overlap == 0:
+                continue
+            age = max(0.0, now - float(rec.get("ts", now)))
+            recency = 0.5 ** (age / _RECENCY_HALFLIFE_SECONDS)
+            score = overlap + recency
+            if cwd and rec.get("cwd") == cwd:
+                score += 1.0  # soft boost for same-project findings
+            scored.append(
+                (
+                    score,
+                    {
+                        "id": rec.get("id"),
+                        "text": rec.get("text"),
+                        "topics": rec.get("topics", []),
+                        "cwd": rec.get("cwd"),
+                        "session_id": rec.get("session_id"),
+                        "score": round(score, 4),
+                    },
+                )
+            )
+        scored.sort(key=lambda s: s[0], reverse=True)
+        return [d for _, d in scored[:limit]]
+
+    def promote(self, session_id: str | None = None) -> bool:
+        """No-op for the file backend (findings are already durable here)."""
+        return True
+
+    # ------------------------------------------------------------------ #
+    # MemoryBackend — key/value
+    # ------------------------------------------------------------------ #
+
+    def _load_kv(self) -> dict[str, Any]:
+        if not self._kv.exists():
+            return {}
+        try:
+            data = json.loads(self._kv.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    def stash(
+        self, key: str, value: Any, ttl: int | None = None, agent_id: str | None = None
+    ) -> bool:
+        """Store a key/value pair (separate from the searchable findings)."""
+        try:
+            data = self._load_kv()
+            data[key] = value
+            tmp = self._kv.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            tmp.replace(self._kv)
+            return True
+        except (OSError, TypeError) as e:
+            logger.warning("file_stash_kv_set_failed", key=key, error=str(e))
+            return False
+
+    def retrieve(self, key: str, agent_id: str | None = None) -> Any | None:
+        """Retrieve a key/value pair."""
+        return self._load_kv().get(key)
+
+    def delete(self, key: str) -> bool:
+        """Delete a key/value pair. Returns False if absent."""
+        data = self._load_kv()
+        if key not in data:
+            return False
+        del data[key]
+        try:
+            tmp = self._kv.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+            tmp.replace(self._kv)
+            return True
+        except OSError as e:
+            logger.warning("file_stash_kv_delete_failed", key=key, error=str(e))
+            return False
+
+    def keys(self, pattern: str = "*") -> list[str]:
+        """List key/value keys (optionally glob-filtered)."""
+        import fnmatch
+
+        ks = list(self._load_kv().keys())
+        return ks if pattern == "*" else [k for k in ks if fnmatch.fnmatch(k, pattern)]
+
+    def is_connected(self) -> bool:
+        """Always available — the stash directory is local and writable."""
+        return self._dir.exists() or not self._closed
+
+    def get_stats(self) -> dict:
+        """Backend statistics."""
+        return {
+            "backend": "file",
+            "findings": len(self._load_records()),
+            "base_dir": str(self._dir),
+            "ttl_days": self._ttl_seconds // _DAY_SECONDS,
+        }
+
+    def close(self) -> None:
+        """No-op close (no persistent connection to release)."""
+        self._closed = True
+
+    def supports_realtime(self) -> bool:
+        """File backend has no realtime pub/sub."""
+        return False
+
+    def supports_distributed(self) -> bool:
+        """File backend is single-host."""
+        return False

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -117,11 +117,16 @@ def resolve_backend(
 ) -> SearchableMemoryBackend | None:
     """Return a searchable backend, or ``None`` if none is available.
 
-    Resolution order: an explicitly injected ``backend`` wins; otherwise the
-    first entry registered under the ``attune.memory_backends`` entry point
-    is instantiated (env-configured). Any failure — no plugin installed,
-    construction error, missing search capability — returns ``None`` so the
-    caller degrades to a no-op rather than raising.
+    An explicitly injected ``backend`` always wins. Otherwise backends are
+    instantiated from the ``attune.memory_backends`` entry point and chosen
+    by preference (D8): a **connected upgrade** backend (e.g. the Redis AMS
+    when it's actually running) is preferred over the always-available
+    **fallback** (the local file backend, which marks itself
+    ``is_fallback=True``). This makes cross-session memory work out-of-box on
+    a plain install while transparently upgrading to AMS when present.
+
+    Any failure — no plugin installed, construction error, missing search
+    capability — degrades to the fallback or ``None`` rather than raising.
     """
     if backend is not None:
         return backend
@@ -130,8 +135,8 @@ def resolve_backend(
 
         from attune.memory.backend import SearchableMemoryBackend as _Searchable
 
-        eps = entry_points(group=_BACKEND_GROUP)
-        for ep in eps:
+        fallback: SearchableMemoryBackend | None = None
+        for ep in entry_points(group=_BACKEND_GROUP):
             try:
                 instance = ep.load()()
             except Exception as exc:  # noqa: BLE001
@@ -139,10 +144,28 @@ def resolve_backend(
                 # break the host session — recall simply yields nothing.
                 logger.debug("memory backend %s unavailable: %s", ep.name, exc)
                 continue
-            if isinstance(instance, _Searchable) or (
-                hasattr(instance, "search") and hasattr(instance, "stash")
+            if not (
+                isinstance(instance, _Searchable)
+                or (hasattr(instance, "search") and hasattr(instance, "stash"))
             ):
-                return instance
+                continue
+            # Connectivity gate: skip an upgrade backend that isn't actually
+            # reachable. Backends without is_connected() are assumed available.
+            connected = True
+            check = getattr(instance, "is_connected", None)
+            if callable(check):
+                try:
+                    connected = bool(check())
+                except Exception:  # noqa: BLE001
+                    connected = False
+            if not connected:
+                continue
+            if getattr(instance, "is_fallback", False):
+                fallback = fallback or instance  # remember; keep looking for an upgrade
+                continue
+            return instance  # connected upgrade backend wins
+        if fallback is not None:
+            return fallback
         logger.debug("no searchable memory backend registered under %s", _BACKEND_GROUP)
     except Exception as exc:  # noqa: BLE001
         # INTENTIONAL: resolution is best-effort; never propagate.

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -1,0 +1,196 @@
+"""Tests for FileStashBackend — the zero-infra searchable default (D8).
+
+Exercises the keyword + recency + cwd recall, TTL pruning, key/value
+path, and the SearchableMemoryBackend protocol surface. All isolated to
+``tmp_path`` (never touches the real ``~/.attune``).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from attune.memory.file_stash import DEFAULT_TTL_DAYS, FileStashBackend
+
+
+@pytest.fixture
+def backend(tmp_path):
+    be = FileStashBackend(base_dir=tmp_path / "stash")
+    yield be
+    be.close()
+
+
+# --------------------------------------------------------------------------
+# remember / search round-trip
+# --------------------------------------------------------------------------
+
+
+def test_remember_then_search_finds_by_keyword(backend):
+    assert backend.remember("the authentication retry loop is flaky", memory_id="m1") is True
+    hits = backend.search("authentication flaky")
+    assert len(hits) == 1
+    assert hits[0]["id"] == "m1"
+    assert "authentication" in hits[0]["text"]
+
+
+def test_search_empty_query_returns_empty(backend):
+    backend.remember("anything at all", memory_id="m1")
+    assert backend.search("") == []
+    assert backend.search("   ") == []
+
+
+def test_search_excludes_zero_overlap(backend):
+    backend.remember("redis connection pooling notes", memory_id="m1")
+    assert backend.search("kubernetes ingress") == []
+
+
+def test_search_respects_limit(backend):
+    for i in range(5):
+        backend.remember(f"shared keyword finding number {i}", memory_id=f"m{i}")
+    hits = backend.search("shared keyword finding", limit=3)
+    assert len(hits) == 3
+
+
+def test_topics_are_searchable(backend):
+    backend.remember("opaque body text", memory_id="m1", topics=["type:bug", "cwd:/proj"])
+    hits = backend.search("bug")
+    assert len(hits) == 1 and hits[0]["id"] == "m1"
+
+
+# --------------------------------------------------------------------------
+# cwd surfacing + boost
+# --------------------------------------------------------------------------
+
+
+def test_cwd_surfaced_from_topics(backend):
+    backend.remember("a finding", memory_id="m1", topics=["cwd:/home/proj"])
+    hits = backend.search("finding")
+    assert hits[0]["cwd"] == "/home/proj"
+
+
+def test_cwd_match_boosts_ranking(backend):
+    backend.remember("matching keyword here", memory_id="other", topics=["cwd:/x"])
+    backend.remember("matching keyword here", memory_id="mine", topics=["cwd:/proj"])
+    hits = backend.search("matching keyword", cwd="/proj")
+    assert hits[0]["id"] == "mine", "same-cwd finding should rank first"
+
+
+# --------------------------------------------------------------------------
+# recency ordering + TTL prune (controlled ts via direct file write)
+# --------------------------------------------------------------------------
+
+
+def _write_records(be: FileStashBackend, records):
+    be._findings.parent.mkdir(parents=True, exist_ok=True)
+    be._findings.write_text("".join(json.dumps(r) + "\n" for r in records), encoding="utf-8")
+
+
+def test_recency_breaks_ties(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [
+            {
+                "id": "old",
+                "text": "same keyword text",
+                "topics": [],
+                "cwd": None,
+                "ts": now - 5 * 86400,
+            },
+            {"id": "new", "text": "same keyword text", "topics": [], "cwd": None, "ts": now - 60},
+        ],
+    )
+    hits = backend.search("same keyword text")
+    assert [h["id"] for h in hits][0] == "new", "more recent finding ranks first"
+
+
+def test_ttl_prunes_expired_on_search(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [
+            {"id": "fresh", "text": "keyword alpha", "topics": [], "cwd": None, "ts": now - 60},
+            {
+                "id": "stale",
+                "text": "keyword alpha",
+                "topics": [],
+                "cwd": None,
+                "ts": now - (DEFAULT_TTL_DAYS + 1) * 86400,
+            },
+        ],
+    )
+    hits = backend.search("keyword alpha")
+    ids = [h["id"] for h in hits]
+    assert "fresh" in ids and "stale" not in ids
+
+
+def test_remember_prunes_expired(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [{"id": "stale", "text": "x y", "topics": [], "cwd": None, "ts": now - 30 * 86400}],
+    )
+    backend.remember("brand new finding", memory_id="new")
+    ids = {r["id"] for r in backend._load_records()}
+    assert ids == {"new"}, "expired record dropped on the next write"
+
+
+# --------------------------------------------------------------------------
+# key/value path + protocol surface
+# --------------------------------------------------------------------------
+
+
+def test_kv_round_trip(backend):
+    assert backend.stash("k", {"v": 1}) is True
+    assert backend.retrieve("k") == {"v": 1}
+    assert backend.retrieve("missing") is None
+
+
+def test_kv_delete_and_keys(backend):
+    backend.stash("a", 1)
+    backend.stash("b", 2)
+    assert sorted(backend.keys()) == ["a", "b"]
+    assert backend.delete("a") is True
+    assert backend.delete("a") is False
+    assert backend.keys() == ["b"]
+
+
+def test_is_fallback_and_protocol_surface(backend):
+    assert FileStashBackend.is_fallback is True
+    assert backend.is_connected() is True
+    assert backend.promote() is True
+    assert backend.supports_realtime() is False
+    assert backend.supports_distributed() is False
+    stats = backend.get_stats()
+    assert stats["backend"] == "file"
+
+
+def test_remember_returns_false_on_unexpected_error(backend, monkeypatch):
+    monkeypatch.setattr(
+        backend, "_load_records", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert backend.remember("x y z") is False
+
+
+def test_search_handles_read_error(backend):
+    # A directory at the findings path makes read_text raise -> [] (no crash).
+    backend._findings.mkdir(parents=True)
+    assert backend.search("anything") == []
+
+
+def test_kv_stash_returns_false_on_write_error(backend):
+    # A directory at the kv path makes the atomic replace fail -> False.
+    backend._kv.mkdir(parents=True)
+    assert backend.stash("k", {"v": 1}) is False
+
+
+def test_corrupt_lines_are_skipped(backend):
+    backend._findings.parent.mkdir(parents=True, exist_ok=True)
+    good = json.dumps(
+        {"id": "ok", "text": "valid keyword", "topics": [], "cwd": None, "ts": time.time()}
+    )
+    backend._findings.write_text(f"not json\n{good}\n", encoding="utf-8")
+    hits = backend.search("valid keyword")
+    assert len(hits) == 1 and hits[0]["id"] == "ok"

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -152,8 +152,11 @@ def test_kv_delete_and_keys(backend):
     backend.stash("a", 1)
     backend.stash("b", 2)
     assert sorted(backend.keys()) == ["a", "b"]
-    assert backend.delete("a") is True
-    assert backend.delete("a") is False
+    # Extract the mutating call before asserting (no side-effect inside assert).
+    deleted = backend.delete("a")
+    assert deleted is True
+    deleted_again = backend.delete("a")
+    assert deleted_again is False
     assert backend.keys() == ["b"]
 
 
@@ -194,3 +197,49 @@ def test_corrupt_lines_are_skipped(backend):
     backend._findings.write_text(f"not json\n{good}\n", encoding="utf-8")
     hits = backend.search("valid keyword")
     assert len(hits) == 1 and hits[0]["id"] == "ok"
+
+
+def test_default_base_dir_is_under_home(tmp_path, monkeypatch):
+    """No-arg construction (the entry-point path) defaults under ~/.attune."""
+    import pathlib
+
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+    be = FileStashBackend()
+    assert str(be._dir).startswith(str(tmp_path))
+    remembered = be.remember("default dir finding", memory_id="d1")
+    assert remembered is True
+
+
+def test_construction_survives_mkdir_failure(tmp_path):
+    """A base_dir that can't be created is logged, not fatal."""
+    blocker = tmp_path / "afile"
+    blocker.write_text("not a dir", encoding="utf-8")
+    be = FileStashBackend(base_dir=blocker / "stash")  # parent is a file
+    assert be is not None  # construction did not raise
+
+
+def test_blank_lines_in_findings_are_skipped(backend):
+    good = json.dumps(
+        {"id": "ok", "text": "keyword here", "topics": [], "cwd": None, "ts": time.time()}
+    )
+    backend._findings.parent.mkdir(parents=True, exist_ok=True)
+    backend._findings.write_text(f"\n\n{good}\n\n", encoding="utf-8")
+    hits = backend.search("keyword here")
+    assert len(hits) == 1
+
+
+def test_remember_survives_rewrite_failure(backend):
+    """A write failure during remember is swallowed (best-effort, non-fatal)."""
+    backend._findings.mkdir(parents=True)  # findings path is a dir -> replace fails
+    # _load_records returns [] (read fails on a dir), _rewrite hits OSError + logs.
+    backend.remember("a finding that cannot persist")  # must not raise
+
+
+def test_kv_delete_swallows_write_error(backend, monkeypatch):
+    """A write error while deleting a present key returns False, no raise."""
+    # Key is present (load patched), but the kv path is a directory so the
+    # atomic replace fails -> the OSError branch returns False.
+    monkeypatch.setattr(backend, "_load_kv", lambda: {"k": 1})
+    backend._kv.mkdir(parents=True)
+    result = backend.delete("k")
+    assert result is False

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -307,3 +307,107 @@ def test_recall_handles_non_list_result():
             return None
 
     assert recall_entries("q", backend=_Weird()) == []
+
+
+# --------------------------------------------------------------------------
+# resolve_backend preference (D8): connected upgrade > file fallback
+# --------------------------------------------------------------------------
+
+
+class _Upgrade(_FakeBackend):
+    """An AMS-like upgrade backend with a connectivity gate."""
+
+    is_fallback = False
+
+    def __init__(self, connected=True, results=None):
+        super().__init__(results)
+        self._connected = connected
+
+    def is_connected(self):
+        return self._connected
+
+
+class _Fallback(_FakeBackend):
+    """A file-like always-available fallback backend."""
+
+    is_fallback = True
+
+    def is_connected(self):
+        return True
+
+
+def _ep(name, factory):
+    class _EP:
+        pass
+
+    _EP.name = name
+    _EP.load = lambda self: factory
+    return _EP()
+
+
+def test_resolve_prefers_connected_upgrade_over_fallback(monkeypatch):
+    import importlib.metadata as md
+
+    upgrade = _Upgrade(connected=True)
+    fallback = _Fallback()
+    # Fallback listed first (mirrors the real ['file', 'redis'] order).
+    monkeypatch.setattr(
+        md,
+        "entry_points",
+        lambda group=None: [_ep("file", lambda: fallback), _ep("redis", lambda: upgrade)],
+    )
+    assert resolve_backend(None) is upgrade
+
+
+def test_resolve_falls_back_when_upgrade_disconnected(monkeypatch):
+    import importlib.metadata as md
+
+    upgrade = _Upgrade(connected=False)
+    fallback = _Fallback()
+    monkeypatch.setattr(
+        md,
+        "entry_points",
+        lambda group=None: [_ep("file", lambda: fallback), _ep("redis", lambda: upgrade)],
+    )
+    assert resolve_backend(None) is fallback
+
+
+def test_resolve_uses_fallback_when_no_upgrade(monkeypatch):
+    import importlib.metadata as md
+
+    fallback = _Fallback()
+    monkeypatch.setattr(md, "entry_points", lambda group=None: [_ep("file", lambda: fallback)])
+    assert resolve_backend(None) is fallback
+
+
+# --------------------------------------------------------------------------
+# D8 zero-infra round-trip: stash_entry -> recall_entries via the file backend
+# --------------------------------------------------------------------------
+
+
+def test_file_fallback_roundtrip_no_infra(tmp_path, monkeypatch):
+    """The headline D8 guarantee: cross-session recall works with no AMS.
+
+    Uses a real FileStashBackend over tmp_path — no Redis, no Ollama, no
+    server — and proves stash_entry -> recall_entries finds the finding.
+    """
+    from attune.memory.file_stash import FileStashBackend
+
+    class _PassThroughGate:
+        def sanitize(self, d):
+            return (d, 0)
+
+    monkeypatch.setattr(security_mod, "DataSanitizer", _PassThroughGate)
+    be = FileStashBackend(base_dir=tmp_path / "stash")
+    entry = SessionStashEntry.create(
+        session_id="s1",
+        cwd="/proj",
+        type="decision",
+        content="the retry loop deadlocks under heavy load",
+        tags=["ci"],
+    )
+    assert stash_entry(entry, backend=be) is True
+    hits = recall_entries("retry loop deadlocks", top_k=5, cwd="/proj", backend=be)
+    assert hits, "stashed finding must be recallable with zero infra"
+    assert any("retry loop" in (h.get("text") or "") for h in hits)
+    assert hits[0]["cwd"] == "/proj"


### PR DESCRIPTION
## What

Implements **D8** end-to-end: cross-session memory works **out-of-box on a
plain `pip install attune-ai`** with zero infra. AMS (Ollama + Redis Stack +
agent-memory-server) becomes a transparent *upgrade* when present, not a
prerequisite.

Before this, recall was a silent no-op without a full AMS standup (the `file`
entry point → `FileSessionMemory` isn't searchable and can't no-arg construct;
only AMS was searchable).

## Changes

**P1a — the backend** (`src/attune/memory/file_stash.py`)
- `FileStashBackend`: SearchableMemoryBackend over a local JSONL stash
  (`~/.attune/session_stash/`). No-arg constructable, `is_fallback=True`.
  `remember()` appends; `search()` = D4's keyword + recency + cwd filter (small
  single-user stash, no embeddings); `stash`/`retrieve` key/value; lazy TTL
  prune; surfaces `cwd` so the recall cwd-sort works.
- 22 unit tests, **100% coverage**.

**P1b — the wiring** (`session_stash.py`, `pyproject.toml`)
- `resolve_backend` prefers a *connected upgrade* (AMS, when its health check
  passes) over the always-available *fallback* (file). Backends without
  `is_connected()` are assumed available (injected/fake backends + the
  no-backend/None contract unchanged).
- `file` entry point repointed to `FileStashBackend`. `FileSessionMemory`
  stays the general session-state facade (used directly, not via this group).
- Tests: preference (upgrade-wins / disconnected-falls-back / no-upgrade) +
  **a zero-infra `stash_entry → recall_entries` round-trip** over a real file
  backend (no Redis/Ollama/server) — the headline D8 guarantee.

D8 decision recorded in `decisions.md`. CodeQL/bot review items addressed
(side-effecting asserts extracted). 100% patch coverage.

## Still to come (separate work, with you)

- **P2** — the hooks + `/recall` skill + `settings.json` wiring (T1.1/T1.2/T2.1),
  the user-facing surface.
- Open follow-ups: TTL/forget tuning, AMS-side cwd surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
