### PR TITLE
fix(models): drop retired 3.5 Sonnet snapshots from test-gen fallback lists

### DIFF
--- a/src/attune/orchestration/tools/test_generation.py
+++ b/src/attune/orchestration/tools/test_generation.py
@@ -205,11 +205,12 @@ Return ONLY the Python test code, starting with imports. No markdown, no explana
 """
 
         try:
-            # Try Sonnet models only (Capable tier) - do NOT downgrade
+            # Try Sonnet models only (Capable tier) - do NOT downgrade.
+            # Stable alias only: it never retires and always routes to the
+            # latest Sonnet checkpoint. The old claude-3-5-sonnet-2024xxxx
+            # dated snapshots were retired by Anthropic 2025-10-28.
             models_to_try = [
-                "claude-sonnet-4-6",  # Sonnet 4.6 (February 2026 - latest)
-                "claude-3-5-sonnet-20241022",  # 3.5 Sonnet Oct 2024
-                "claude-3-5-sonnet-20240620",  # 3.5 Sonnet Jun 2024
+                "claude-sonnet-4-6",  # Sonnet 4.6 (stable alias)
             ]
 
             response = None

--- a/src/attune/orchestration/tools/testing.py
+++ b/src/attune/orchestration/tools/testing.py
@@ -351,11 +351,12 @@ Return ONLY the Python test code, starting with imports. No markdown, no explana
 """
 
         try:
-            # Try Sonnet models only (Capable tier) - do NOT downgrade
+            # Try Sonnet models only (Capable tier) - do NOT downgrade.
+            # Stable alias only: it never retires and always routes to the
+            # latest Sonnet checkpoint. The old claude-3-5-sonnet-2024xxxx
+            # dated snapshots were retired by Anthropic 2025-10-28.
             models_to_try = [
-                "claude-sonnet-4-6",  # Sonnet 4.5 (January 2025 - latest)
-                "claude-3-5-sonnet-20241022",  # 3.5 Sonnet Oct 2024
-                "claude-3-5-sonnet-20240620",  # 3.5 Sonnet Jun 2024
+                "claude-sonnet-4-6",  # Sonnet 4.6 (stable alias)
             ]
 
             response = None

--- a/tests/unit/orchestration/test_no_retired_model_snapshots.py
+++ b/tests/unit/orchestration/test_no_retired_model_snapshots.py
@@ -1,0 +1,53 @@
+"""Drift-guard: orchestration tools must not invoke retired model snapshots.
+
+Anthropic retires dated model snapshots (e.g. ``claude-3-5-sonnet-20241022``)
+on published dates; once retired they 404 at invocation time. The
+``models_to_try`` fallback lists in the orchestration test-generation tools
+once carried two retired 3.5 Sonnet snapshots as Capable-tier fallbacks
+(latent 404 behind the primary ``claude-sonnet-4-6`` alias). This test fails
+if any retired dated snapshot reappears as an invocation target in those
+files.
+
+Stable aliases (e.g. ``claude-sonnet-4-6``) never retire and are the correct
+form for in-code invocation targets.
+"""
+
+from pathlib import Path
+
+import pytest
+
+# Repo root: tests/unit/orchestration/<file>.py -> parents[3]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Dated snapshots Anthropic has retired (or has a near-term retirement date).
+# Source: Anthropic model deprecation table. These must never appear as
+# invocation targets in source code; use the stable alias instead.
+RETIRED_DATED_SNAPSHOTS = frozenset(
+    {
+        "claude-3-5-sonnet-20241022",
+        "claude-3-5-sonnet-20240620",
+        "claude-3-5-haiku-20241022",
+        "claude-3-haiku-20240307",
+        "claude-3-7-sonnet-20250219",
+        "claude-3-opus-20240229",
+    }
+)
+
+# Files that build ``models_to_try`` invocation lists. These intentionally
+# contain NO pricing-table keys or docstring examples, so a plain substring
+# check has no legitimate false positives here.
+INVOCATION_TARGET_FILES = (
+    "src/attune/orchestration/tools/test_generation.py",
+    "src/attune/orchestration/tools/testing.py",
+)
+
+
+@pytest.mark.parametrize("rel_path", INVOCATION_TARGET_FILES)
+def test_no_retired_snapshot_in_invocation_targets(rel_path: str) -> None:
+    """Each orchestration tool file is free of retired dated snapshots."""
+    text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+    found = sorted(snap for snap in RETIRED_DATED_SNAPSHOTS if snap in text)
+    assert not found, (
+        f"{rel_path} references retired model snapshot(s) {found}; "
+        f"use a stable alias (e.g. 'claude-sonnet-4-6') instead"
+    )


### PR DESCRIPTION
## Summary

Two `models_to_try` fallback lists in the orchestration test-generation
tools listed Claude 3.5 Sonnet dated snapshots that Anthropic **retired on
2025-10-28**:

- `claude-3-5-sonnet-20241022`
- `claude-3-5-sonnet-20240620`

They sat as fallbacks *after* the primary `claude-sonnet-4-6`, so they were
a latent 404 — only reached if the primary alias failed, not an active break.

## Changes

- `src/attune/orchestration/tools/test_generation.py` — drop both retired
  snapshots; keep `claude-sonnet-4-6` (stable alias, never retires, routes to
  the latest Sonnet checkpoint). Preserves the "Capable tier, do NOT
  downgrade" intent.
- `src/attune/orchestration/tools/testing.py` — same fix; also corrects a
  stale comment that mislabeled the alias as "Sonnet 4.5 (January 2025)".
- `tests/unit/orchestration/test_no_retired_model_snapshots.py` — new
  drift-guard: fails if any retired dated snapshot reappears as an invocation
  target in these files.

## Scope verification

Grepped `src/` for `claude-*-202xxxxx` dated snapshots and cross-checked
against Anthropic's deprecation table:

| Location | Verdict |
|----------|---------|
| `test_generation.py` / `testing.py` `models_to_try` | **fixed** — were invocation targets |
| `help/polish.py:116` (`claude-sonnet-4-20250514` in comment) | already uses stable `claude-sonnet-4-6` as the actual `model=` arg; no change |
| `cost_tracker.py` (`claude-3-5-sonnet-20241022`, `claude-3-haiku-20240307`, `claude-opus-4-20250514`) | pricing-table keys + docstring example, not invocation targets — out of scope |

The registry (`src/attune/models/registry.py`) defines exactly three current
models — `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6` — and no
older stable Sonnet alias, so `claude-sonnet-4-6` alone is the correct
replacement (no speculative `claude-sonnet-4-5` fallback introduced).

## Testing

- New drift-guard test passes (2 cases).
- Edited files compile; ruff + black + bandit pre-commit hooks pass.

Can ride in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
