### PR TITLE
fix(redis): surface cwd in AMS search results (recall cwd-sort parity)

### DIFF
--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -71,6 +71,19 @@ def _run_sync(coro: Any) -> Any:
     return _LOOP.run(coro)
 
 
+def _cwd_from_topics(topics: list[str] | None) -> str | None:
+    """Extract the ``cwd:<path>`` marker session_stash writes into topics.
+
+    Mirrors ``attune.memory.file_stash._cwd_from_topics`` so AMS search
+    results surface ``cwd`` the same way the file backend does — letting
+    ``recall_entries``'s cwd soft-sort actually work for AMS users.
+    """
+    for t in topics or []:
+        if isinstance(t, str) and t.startswith("cwd:"):
+            return t[len("cwd:") :]
+    return None
+
+
 class AMSMemoryBackend:
     """MemoryBackend implementation backed by Redis Agent Memory Server.
 
@@ -389,6 +402,7 @@ class AMSMemoryBackend:
                     "topics": r.topics,
                     "entities": r.entities,
                     "memory_type": r.memory_type,
+                    "cwd": _cwd_from_topics(r.topics),
                     "created_at": (r.created_at.isoformat() if r.created_at else None),
                 }
                 for r in results.memories

--- a/tests/memory/test_ams_backend_integration.py
+++ b/tests/memory/test_ams_backend_integration.py
@@ -116,7 +116,9 @@ def test_remember_then_search_round_trip(backend):
     """D7: a remember() write is recallable via search() (Ollama-embedded)."""
     marker = f"itest-{uuid.uuid4().hex[:10]}"
     content = f"{marker}: integration finding for the searchable write path."
-    assert backend.remember(content, memory_id=marker, topics=["type:note"]) is True
+    assert (
+        backend.remember(content, memory_id=marker, topics=["type:note", "cwd:/itest-proj"]) is True
+    )
 
     # Embedding + indexing is server-side; allow a brief settle then search.
     # Query by the content text (self-similar embedding ranks the exact doc
@@ -129,6 +131,8 @@ def test_remember_then_search_round_trip(backend):
             break
         time.sleep(1)
     assert hit is not None, f"remember()'d content not found by search for {marker!r}"
+    # cwd surfaced from topics -> recall_entries' cwd soft-sort works for AMS.
+    assert hit["cwd"] == "/itest-proj"
 
 
 def test_session_stash_round_trip():

--- a/tests/unit/memory/test_ams_cwd_surfacing.py
+++ b/tests/unit/memory/test_ams_cwd_surfacing.py
@@ -1,0 +1,39 @@
+"""Unit tests for AMS cwd surfacing (recall cwd soft-sort parity).
+
+`_cwd_from_topics` lets `AMSMemoryBackend.search()` surface a `cwd` field
+the same way the file backend does, so `recall_entries`' cwd soft-sort
+works for AMS users. The helper is importable without the optional
+`agent-memory-client` dep (the client import is function-local), so this
+runs in CI unconditionally.
+"""
+
+from __future__ import annotations
+
+from attune_redis.memory import _cwd_from_topics
+
+
+def test_extracts_cwd_marker():
+    assert _cwd_from_topics(["type:bug", "cwd:/home/proj"]) == "/home/proj"
+
+
+def test_returns_none_when_absent():
+    assert _cwd_from_topics(["type:note", "ci"]) is None
+
+
+def test_handles_none_and_empty():
+    assert _cwd_from_topics(None) is None
+    assert _cwd_from_topics([]) is None
+
+
+def test_first_cwd_marker_wins():
+    assert _cwd_from_topics(["cwd:/a", "cwd:/b"]) == "/a"
+
+
+def test_ignores_non_string_topics():
+    # Defensive: topics from a backend could be non-str; must not raise.
+    assert _cwd_from_topics([123, None, "cwd:/ok"]) == "/ok"
+
+
+def test_preserves_path_with_colons():
+    # Only the leading "cwd:" prefix is stripped; the rest is the path.
+    assert _cwd_from_topics(["cwd:/a/b:c"]) == "/a/b:c"


### PR DESCRIPTION
## What

Closes one of the cited improvement opportunities: `recall_entries` sorts
recall results by `cwd` (prefer same-project findings), but
`AMSMemoryBackend.search()` never included `cwd` in its result dicts — so
the cwd soft-sort was a **silent no-op for AMS users**. The file backend
surfaces `cwd` (added in #593); this brings the AMS backend to parity.

## Change

- `AMSMemoryBackend.search()` now extracts the `cwd:<path>` topic marker
  (written by `session_stash.stash_entry`) into the result dict, via a
  small self-contained `_cwd_from_topics` helper (mirrors
  `file_stash._cwd_from_topics` — no cross-package import).

## Tests

- Unit coverage of `_cwd_from_topics` (importable without the optional
  `agent-memory-client` dep, so it runs in CI).
- The live AMS round-trip (`remember → search`, AMS-gated) now asserts
  `cwd` round-trips end-to-end.

Pure additive fix; no behavior change beyond the new `cwd` key.

## Related (not in this PR)

- TTL/forget on the AMS long-term tier — flagged as a *retention-policy*
  decision rather than a speculative pruner (the file tier already
  age-prunes; whether durable AMS findings should expire is a product call).
- Retired-snapshot fallback cleanup — spawned as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
