### PR TITLE
feat(memory): 30-day retention with explicit prune() across both backends

### DIFF
--- a/.help/templates/memory/concept.md
+++ b/.help/templates/memory/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: memory
 depth: concept
-generated_at: 2026-06-03T12:45:43.107743+00:00
-source_hash: aef54dd763ecee5292afdaa47a99e48e4d68ab66ba2bedf0a15d83d09ad51782
+generated_at: 2026-06-03T16:28:50.316906+00:00
+source_hash: a5579e8907712bf584f1ae5f2c1991e29aa4fdc4f749495b823c67f323543a57
 status: generated
 ---
 
@@ -20,7 +20,7 @@ The main building blocks are:
 - **`MemoryFile`** — Represents a loaded CLAUDE.md memory file
 - **`ClaudeMemoryLoader`** — Loads and manages Claude Code memory files (CLAUDE.md).
 
-Under the hood, this feature spans 74 source
+Under the hood, this feature spans 75 source
 files covering:
 
 - Memory backend protocol for Attune AI.

--- a/.help/templates/memory/reference.md
+++ b/.help/templates/memory/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: memory
 depth: reference
-generated_at: 2026-06-03T12:45:43.120749+00:00
-source_hash: aef54dd763ecee5292afdaa47a99e48e4d68ab66ba2bedf0a15d83d09ad51782
+generated_at: 2026-06-03T16:28:50.327836+00:00
+source_hash: a5579e8907712bf584f1ae5f2c1991e29aa4fdc4f749495b823c67f323543a57
 status: generated
 ---
 
@@ -42,6 +42,7 @@ status: generated
 | `SessionState` | Complete state of a session. | `src/attune/memory/file_session_models.py` |
 | `PatternStagingMixin` | Mixin providing pattern staging operations. | `src/attune/memory/file_session_patterns.py` |
 | `PersistenceMixin` | Mixin providing session persistence operations. | `src/attune/memory/file_session_persistence.py` |
+| `FileStashBackend` | Searchable, zero-infra session stash backed by a local JSONL file. | `src/attune/memory/file_stash.py` |
 | `MemoryGraph` | Knowledge graph for cross-workflow intelligence. | `src/attune/memory/graph.py` |
 | `LessonsManager` | Manages lessons learned from previous sessions. | `src/attune/memory/lessons.py` |
 | `SecureMemDocsIntegration` | Secure integration between Claude Memory and MemDocs. | `src/attune/memory/long_term_integration.py` |

--- a/.help/templates/memory/task.md
+++ b/.help/templates/memory/task.md
@@ -1,8 +1,8 @@
 ---
 feature: memory
 depth: task
-generated_at: 2026-06-03T12:45:43.116195+00:00
-source_hash: aef54dd763ecee5292afdaa47a99e48e4d68ab66ba2bedf0a15d83d09ad51782
+generated_at: 2026-06-03T16:28:50.323109+00:00
+source_hash: a5579e8907712bf584f1ae5f2c1991e29aa4fdc4f749495b823c67f323543a57
 status: generated
 ---
 

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -24,6 +24,11 @@ from .config import RedisPluginConfig
 
 logger = logging.getLogger(__name__)
 
+#: Default retention for pruning long-term findings (days). Mirrors
+#: ``attune.memory.session_stash.DEFAULT_TTL_DAYS`` — kept as a local
+#: constant to avoid a cross-package import into attune-redis.
+_DEFAULT_TTL_DAYS = 30
+
 
 class _PersistentLoop:
     """A single event loop running in a daemon thread.
@@ -435,6 +440,30 @@ class AMSMemoryBackend:
             # INTENTIONAL: Graceful degradation for AMS HTTP errors
             logger.error("promote_failed: session=%s error=%s", sid, e)
             return False
+
+    def prune(self, max_age_days: int | None = None) -> int:
+        """Forget long-term findings older than ``max_age_days`` (default 30).
+
+        Aligns AMS retention with the file backend's age-prune (consistent
+        cross-backend policy). Scoped to this backend's namespace via AMS's
+        ``ForgetPolicy(max_age_days=...)``. Best-effort; returns the number
+        of memories deleted (0 on failure), never raises.
+        """
+        from agent_memory_client.models import ForgetPolicy
+
+        age = _DEFAULT_TTL_DAYS if max_age_days is None else max(1, max_age_days)
+        try:
+            response = _run_sync(
+                self._client.forget_long_term_memories(
+                    ForgetPolicy(max_age_days=age),
+                    namespace=self._namespace,
+                )
+            )
+            return int(getattr(response, "deleted", 0) or 0)
+        except Exception as e:  # noqa: BLE001
+            # INTENTIONAL: Graceful degradation for AMS HTTP errors
+            logger.error("prune_failed: max_age_days=%s error=%s", age, e)
+            return 0
 
     # =========================================================================
     # Context manager

--- a/src/attune/memory/backend.py
+++ b/src/attune/memory/backend.py
@@ -212,5 +212,22 @@ class SearchableMemoryBackend(MemoryBackend, Protocol):
         """
         ...
 
+    def prune(self, max_age_days: int | None = None) -> int:
+        """Forget searchable findings older than ``max_age_days``.
+
+        Applies the retention policy consistently across backends (file
+        age-prune + AMS forget). When ``max_age_days`` is None, the
+        backend's configured default is used. Best-effort; returns the
+        number of entries pruned (0 if none / on failure), never raises.
+
+        Args:
+            max_age_days: Age threshold in days; None uses the backend default.
+
+        Returns:
+            Count of pruned entries (best-effort).
+
+        """
+        ...
+
 
 __all__ = ["MemoryBackend", "SearchableMemoryBackend"]

--- a/src/attune/memory/file_stash.py
+++ b/src/attune/memory/file_stash.py
@@ -29,8 +29,9 @@ import structlog
 
 logger = structlog.get_logger(__name__)
 
-#: Default working-stash retention; matches session_stash DEFAULT_TTL_DAYS.
-DEFAULT_TTL_DAYS = 7
+#: Default working-stash retention (days); keep in sync with
+#: session_stash.DEFAULT_TTL_DAYS. 30d covers realistic project-revisit gaps.
+DEFAULT_TTL_DAYS = 30
 
 _DAY_SECONDS = 86_400
 #: Recency half-life for the recall score (newer findings rank higher).
@@ -203,6 +204,40 @@ class FileStashBackend:
     def promote(self, session_id: str | None = None) -> bool:
         """No-op for the file backend (findings are already durable here)."""
         return True
+
+    def prune(self, max_age_days: int | None = None) -> int:
+        """Drop findings older than ``max_age_days`` (default: backend TTL).
+
+        The file backend also prunes lazily on every read/write, so this is
+        an explicit forced sweep for parity with the AMS backend (which the
+        Stop hook can call uniformly on either backend). Best-effort.
+        """
+        ttl_seconds = (
+            self._ttl_seconds if max_age_days is None else max(1, max_age_days) * _DAY_SECONDS
+        )
+        cutoff = time.time() - ttl_seconds
+        if not self._findings.exists():
+            return 0
+        kept: list[dict[str, Any]] = []
+        dropped = 0
+        try:
+            for line in self._findings.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(rec, dict) and float(rec.get("ts", 0)) >= cutoff:
+                    kept.append(rec)
+                else:
+                    dropped += 1
+            if dropped:
+                self._rewrite(kept)
+        except OSError as e:
+            logger.warning("file_stash_prune_failed", error=str(e))
+        return dropped
 
     # ------------------------------------------------------------------ #
     # MemoryBackend — key/value

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -44,8 +44,13 @@ MAX_CONTENT_CHARS = 500
 #: Entry-point group attune plugins register a memory backend under.
 _BACKEND_GROUP = "attune.memory_backends"
 
-#: Default working-memory TTL for a stashed finding.
-DEFAULT_TTL_DAYS = 7
+#: Default retention for a stashed finding (days). Applied consistently by
+#: both searchable backends (file age-prune + AMS forget). 30d covers
+#: realistic project-revisit gaps so recall isn't empty when you return to a
+#: project after a couple weeks; the curated ``/remember`` tier is the
+#: truly-durable layer for promoted keepers. Keep in sync with
+#: ``file_stash.DEFAULT_TTL_DAYS``.
+DEFAULT_TTL_DAYS = 30
 
 
 @dataclass

--- a/tests/unit/memory/test_ams_prune.py
+++ b/tests/unit/memory/test_ams_prune.py
@@ -1,0 +1,93 @@
+"""Unit tests for ``AMSMemoryBackend.prune`` (30-day retention parity).
+
+The AMS backend retires long-term findings older than the configured TTL
+via the client's ``forget_long_term_memories(ForgetPolicy(...))``, scoped to
+the backend's namespace. These tests run unconditionally in CI (where the
+optional ``agent-memory-client`` dep is absent) by injecting a fake
+``agent_memory_client.models.ForgetPolicy`` into ``sys.modules`` and
+patching ``_run_sync`` to an identity passthrough, so neither a live AMS
+server nor the real client package is required.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+import attune_redis.memory as ams
+from attune_redis.memory import _DEFAULT_TTL_DAYS, AMSMemoryBackend
+
+
+class _FakeForgetPolicy:
+    """Stand-in capturing the ``max_age_days`` the backend forgets with."""
+
+    def __init__(self, max_age_days: int) -> None:
+        self.max_age_days = max_age_days
+
+
+class _FakeResponse:
+    def __init__(self, deleted: int) -> None:
+        self.deleted = deleted
+
+
+@pytest.fixture
+def fake_forget_policy(monkeypatch):
+    """Inject a fake ``agent_memory_client.models`` so the function-local
+    ``from agent_memory_client.models import ForgetPolicy`` resolves."""
+    pkg = types.ModuleType("agent_memory_client")
+    models = types.ModuleType("agent_memory_client.models")
+    models.ForgetPolicy = _FakeForgetPolicy
+    monkeypatch.setitem(sys.modules, "agent_memory_client", pkg)
+    monkeypatch.setitem(sys.modules, "agent_memory_client.models", models)
+    return _FakeForgetPolicy
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    """An ``AMSMemoryBackend`` with a fake client, bypassing the real
+    ``__init__`` (which would construct a live HTTP client)."""
+    be = object.__new__(AMSMemoryBackend)
+    be._client = MagicMock()
+    be._namespace = "itest-ns"
+    # _run_sync would await the coroutine; the fake client returns a plain
+    # value, so pass it straight through.
+    monkeypatch.setattr(ams, "_run_sync", lambda coro: coro)
+    return be
+
+
+def test_prune_default_uses_30_days(backend, fake_forget_policy):
+    backend._client.forget_long_term_memories.return_value = _FakeResponse(deleted=4)
+    deleted = backend.prune()
+    assert deleted == 4
+    policy = backend._client.forget_long_term_memories.call_args.args[0]
+    assert isinstance(policy, _FakeForgetPolicy)
+    assert policy.max_age_days == _DEFAULT_TTL_DAYS == 30
+    assert backend._client.forget_long_term_memories.call_args.kwargs["namespace"] == "itest-ns"
+
+
+def test_prune_explicit_max_age(backend, fake_forget_policy):
+    backend._client.forget_long_term_memories.return_value = _FakeResponse(deleted=1)
+    deleted = backend.prune(max_age_days=10)
+    assert deleted == 1
+    assert backend._client.forget_long_term_memories.call_args.args[0].max_age_days == 10
+
+
+def test_prune_floors_age_at_one_day(backend, fake_forget_policy):
+    # A zero/negative window would forget everything; the backend floors at 1.
+    backend._client.forget_long_term_memories.return_value = _FakeResponse(deleted=0)
+    backend.prune(max_age_days=0)
+    assert backend._client.forget_long_term_memories.call_args.args[0].max_age_days == 1
+
+
+def test_prune_returns_zero_on_missing_deleted(backend, fake_forget_policy):
+    # A response without a usable ``deleted`` count coerces to 0, no raise.
+    backend._client.forget_long_term_memories.return_value = object()
+    assert backend.prune() == 0
+
+
+def test_prune_swallows_client_error(backend, fake_forget_policy):
+    backend._client.forget_long_term_memories.side_effect = RuntimeError("AMS 503")
+    assert backend.prune() == 0

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -306,3 +306,17 @@ def test_prune_swallows_read_error(backend):
     # A directory at the findings path makes read_text raise OSError -> 0, no crash.
     backend._findings.mkdir(parents=True)
     assert backend.prune() == 0
+
+
+def test_prune_skips_blank_and_corrupt_drops_nondict(backend):
+    # Exercises the blank-line skip, the JSONDecodeError skip, and the
+    # non-dict branch (a bare number is dropped) — alongside a kept record.
+    now = time.time()
+    backend._findings.parent.mkdir(parents=True, exist_ok=True)
+    valid = json.dumps({"id": "keep", "text": "x", "topics": [], "cwd": None, "ts": now - 60})
+    backend._findings.write_text(f"\n{valid}\nnot valid json\n123\n", encoding="utf-8")
+    dropped = backend.prune()
+    # Only the non-dict record counts as dropped; blank + corrupt lines are
+    # silently skipped, the fresh dict is kept.
+    assert dropped == 1
+    assert {r["id"] for r in backend._load_records()} == {"keep"}

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -130,7 +130,10 @@ def test_remember_prunes_expired(backend):
     now = time.time()
     _write_records(
         backend,
-        [{"id": "stale", "text": "x y", "topics": [], "cwd": None, "ts": now - 30 * 86400}],
+        # 31 days: unambiguously past the 30-day TTL (avoid the exact-boundary
+        # epsilon trap that flakes on coarse-clock platforms — see CLAUDE.md
+        # "edge-of-bucket time tests fail on Windows").
+        [{"id": "stale", "text": "x y", "topics": [], "cwd": None, "ts": now - 31 * 86400}],
     )
     backend.remember("brand new finding", memory_id="new")
     ids = {r["id"] for r in backend._load_records()}
@@ -243,3 +246,63 @@ def test_kv_delete_swallows_write_error(backend, monkeypatch):
     backend._kv.mkdir(parents=True)
     result = backend.delete("k")
     assert result is False
+
+
+# --------------------------------------------------------------------------
+# explicit prune() — forced age sweep (parity with the AMS backend)
+# --------------------------------------------------------------------------
+
+
+def test_default_ttl_is_30_days():
+    """The zero-infra retention default is 30 days (project-revisit window)."""
+    assert DEFAULT_TTL_DAYS == 30
+
+
+def test_prune_drops_expired_keeps_fresh(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [
+            {"id": "fresh", "text": "a", "topics": [], "cwd": None, "ts": now - 60},
+            {"id": "stale", "text": "b", "topics": [], "cwd": None, "ts": now - 31 * 86400},
+        ],
+    )
+    dropped = backend.prune()
+    assert dropped == 1
+    assert {r["id"] for r in backend._load_records()} == {"fresh"}
+
+
+def test_prune_respects_explicit_max_age(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [
+            {"id": "keep", "text": "a", "topics": [], "cwd": None, "ts": now - 3 * 86400},
+            {"id": "drop", "text": "b", "topics": [], "cwd": None, "ts": now - 10 * 86400},
+        ],
+    )
+    # 5-day window: the 10-day-old record goes, the 3-day-old stays.
+    dropped = backend.prune(max_age_days=5)
+    assert dropped == 1
+    assert {r["id"] for r in backend._load_records()} == {"keep"}
+
+
+def test_prune_no_findings_file_returns_zero(backend):
+    # Nothing stashed yet -> findings.jsonl absent -> clean no-op.
+    assert backend.prune() == 0
+
+
+def test_prune_nothing_expired_returns_zero_and_keeps_all(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [{"id": "a", "text": "x", "topics": [], "cwd": None, "ts": now - 60}],
+    )
+    assert backend.prune() == 0
+    assert {r["id"] for r in backend._load_records()} == {"a"}
+
+
+def test_prune_swallows_read_error(backend):
+    # A directory at the findings path makes read_text raise OSError -> 0, no crash.
+    backend._findings.mkdir(parents=True)
+    assert backend.prune() == 0


### PR DESCRIPTION
Follows #595 (cwd parity). Part of the cross-session-memory release.

## What

Aligns working-stash retention at **30 days** (configurable), applied consistently by both searchable backends, and adds an explicit forced-sweep `prune()` that the P2 Stop hook can call uniformly on either backend.

- `session_stash` + `file_stash`: `DEFAULT_TTL_DAYS` 7 → 30 — covers realistic project-revisit gaps so recall isn't empty when you return to a project after a couple weeks. The curated `/remember` tier stays the durable layer.
- `backend.py`: `prune(max_age_days)` added to the `SearchableMemoryBackend` protocol.
- `file_stash`: `FileStashBackend.prune()` — explicit age-forget + rewrite (best-effort; the file backend also prunes lazily on read/write).
- `attune_redis`: `AMSMemoryBackend.prune()` via namespace-scoped `ForgetPolicy(max_age_days=...)`; returns `ForgetResponse.deleted`.

## Tests

- File prune: expired-drop / explicit-age window / missing-file no-op / nothing-expired no-op / read-error swallow.
- AMS prune: default-30 / explicit / age-floor-at-1 / missing-`deleted` → 0 / client-error → 0. Runs unconditionally in CI (no `agent-memory-client` dep) via an injected fake `ForgetPolicy` + identity `_run_sync`.
- `default_ttl_is_30` assertion.
- Hardened `test_remember_prunes_expired` off the new 30-day boundary (31d) to avoid the coarse-clock edge-of-bucket flake (Windows).

Full `tests/unit/memory/` green locally (1542 passed); ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)