### PR TITLE
chore(ci): remove dead auto-approve-owner job

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -19,24 +19,3 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  auto-approve-owner:
-    if: github.actor == 'silversurfer562'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Wait for CI checks
-        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          running-workflow-name: auto-approve-owner
-          check-regexp: ^(test |lint|Analyze )
-          wait-interval: 30
-          allowed-conclusions: success
-
-      - name: Approve PR after CI passes
-        run: gh pr review "$PR_URL" --approve --body "Auto-approved after CI checks passed"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to the branch-protection fix (reviews dropped to 0). With no required approval on owner PRs, `auto-approve-owner` is dead weight — and it failed on every PR anyway: `timeout-minutes: 5` vs a Wait-for-CI step watching the ~20-min Windows `test ` lanes, so it timed out before approving and left a red (non-required) check.

Removes the job; Dependabot auto-approval (separate job) is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)