### PR TITLE
feat(memory): P2 — Stop stash + SessionStart recall + /recall skill

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -77,6 +77,7 @@ intent so Claude matches the right skill:
 | spec | spec-driven dev, brainstorm and execute |
 | rag-code-gen | grounded code, cite sources, verify against attune (needs `[rag]` extra) |
 | coach | coach, learn, explain, tell me more, deeper |
+| recall | recall, remember, what did I learn, prior session, past findings |
 
 ## MCP Server Not Running
 

--- a/.agents/skills/recall/SKILL.md
+++ b/.agents/skills/recall/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: recall
+description: "Pull relevant findings stashed from past sessions — on demand. Triggers on: recall, remember, what did I learn, prior session, past findings, did I hit this before, what do we know about."
+---
+# Recall
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Recall** — Searching cross-session memory for findings related to
+> your query.
+
+## What It Does
+
+`/recall` is the on-demand companion to the automatic SessionStart
+recall. It searches the findings stashed by the Stop hook across past
+sessions (file backend by default; Redis AMS when connected) and
+surfaces the most relevant ones, formatted for reading.
+
+- **With a query** (`/recall AMS event loop`): keyword + recency search,
+  same-project findings ranked first.
+- **No query** (`/recall`): the most recent findings for this project.
+
+## How To Run It
+
+Recall is exposed through `attune.memory.session_stash`. Run the
+appropriate snippet via Bash from the project root, then present the
+results as a readable list (newest / most-relevant first), grouped or
+annotated by their `[type]`.
+
+**With a query:**
+
+```bash
+python -c "import json, os; from attune.memory.session_stash import recall_entries; print(json.dumps(recall_entries(os.environ['Q'], top_k=8, cwd=os.getcwd()), ensure_ascii=False))"
+```
+
+Pass the user's topic as the `Q` environment variable (avoids quoting
+issues), e.g. `Q="AMS event loop" python -c "..."`.
+
+**No query (recent):**
+
+```bash
+python -c "import json, os; from attune.memory.session_stash import recent_entries; print(json.dumps(recent_entries(top_k=8, cwd=os.getcwd()), ensure_ascii=False))"
+```
+
+Each result is a dict with `text`, `topics` (carrying `type:<kind>` and
+`cwd:<path>`), `cwd`, and `session_id`. Render them as:
+
+```
+- [decision] <text>
+- [bug] <text>
+```
+
+## When Nothing Comes Back
+
+An empty list means no matching findings yet (the store fills as the
+Stop hook stashes findings over sessions), or no searchable backend is
+installed. Say so plainly — do **not** invent findings. Suggest the
+user keep working; the soak fills the store over time.
+
+## Promote A Keeper
+
+If a recalled finding is worth keeping permanently, the user can
+promote it into curated memory with `/remember` — the durable,
+human-curated tier above this raw cross-session stash.

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -417,6 +417,20 @@ class AMSMemoryBackend:
             logger.error("search_failed: query=%s error=%s", query, e)
             return []
 
+    def recent(self, limit: int = 5, **filters: Any) -> list[dict]:
+        """Query-less recent findings (SessionStart recall) — best-effort.
+
+        AMS is semantic-first; a query-less recency *list* is not a verified
+        primitive of the client yet, so this returns ``[]`` for now rather
+        than guess the API. AMS users still get full query-driven recall via
+        ``search`` (the ``/recall`` skill) and AMS's own auto-surfacing; the
+        file backend implements ``recent`` fully and powers SessionStart
+        auto-recall on the default install. Closing this is tracked as a
+        follow-up (verify the client's list/recency path against a live
+        server, then sort by ``created_at`` desc with a soft ``cwd`` filter).
+        """
+        return []
+
     def promote(self, session_id: str | None = None) -> bool:
         """Trigger promotion of working memories to long-term.
 

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -27,6 +27,15 @@
             "timeout": 4000
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_recall.py",
+            "timeout": 3000
+          }
+        ]
       }
     ],
     "Stop": [
@@ -36,6 +45,15 @@
             "type": "command",
             "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/compact_warning.py",
             "timeout": 4000
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_stash.py",
+            "timeout": 15000
           }
         ]
       }

--- a/plugin/hooks/session_recall.py
+++ b/plugin/hooks/session_recall.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""SessionStart hook — surface recent cross-session findings at startup.
+
+SessionStart has no query, so recall is recency-driven: the newest
+stashed findings for the current project (cwd), via
+``attune.memory.session_stash.recent_entries``. Emits a compact
+``## Recalled memories`` block to stdout, which Claude Code splices into
+the model's initial context.
+
+Quiet by design: no backend, no findings, or the ``compact`` source all
+produce no output. Bounded to a small char budget so it never crowds the
+opening context. Never raises — a crash must not break the session.
+
+Tunables (env): ``ATTUNE_MEMORY_RECALL`` (set ``0`` to disable),
+``ATTUNE_MEMORY_RECALL_TOPK`` (default 5).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+_DEFAULT_TOPK = 5
+_CONTENT_BUDGET = 1_400  # ~350 tokens of finding text
+
+
+def _enabled() -> bool:
+    return os.environ.get("ATTUNE_MEMORY_RECALL", "1").strip() not in {"0", "false", "no"}
+
+
+def _type_of(topics: object) -> str:
+    """Pull the ``type:X`` marker out of a record's topics (default note)."""
+    if isinstance(topics, list):
+        for t in topics:
+            if isinstance(t, str) and t.startswith("type:"):
+                return t[len("type:") :] or "note"
+    return "note"
+
+
+def _format(entries: list[dict]) -> str:
+    """Render the recalled findings as a compact markdown block."""
+    lines = [
+        "## Recalled memories",
+        "",
+        "Recent findings from this project (most recent first):",
+        "",
+    ]
+    used = 0
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        content = e.get("text") or e.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        content = content.strip()
+        used += len(content)
+        if used > _CONTENT_BUDGET:
+            break
+        lines.append(f"- [{_type_of(e.get('topics'))}] {content}")
+    lines.append("")
+    lines.append("_Pull more with `/recall <topic>`._")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    try:
+        if not _enabled():
+            return 0
+        try:
+            payload = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            payload = {}
+        source = (payload.get("source") or "startup").lower()
+        if source == "compact":
+            return 0  # post-compact context is handled elsewhere; don't pile on
+        cwd = str(payload.get("cwd") or Path.cwd())
+
+        try:
+            from attune.memory.session_stash import recent_entries
+        except Exception:  # noqa: BLE001 — attune not importable -> silent
+            return 0
+
+        try:
+            topk = int(os.environ.get("ATTUNE_MEMORY_RECALL_TOPK", _DEFAULT_TOPK))
+        except ValueError:
+            topk = _DEFAULT_TOPK
+
+        entries = recent_entries(top_k=topk, cwd=cwd)
+        if not entries:
+            return 0
+        block = _format(entries)
+        # Only print if we actually rendered at least one finding line.
+        if any(line.startswith("- [") for line in block.splitlines()):
+            print(block)
+        return 0
+    except Exception:  # noqa: BLE001 — SessionStart hook must never crash a session
+        traceback.print_exc(file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/hooks/session_stash.py
+++ b/plugin/hooks/session_stash.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Stop-hook session-stash — capture reusable findings once per session.
+
+The ``Stop`` event fires on every turn, so this hook acts ONCE per
+session (a per-session sentinel) and only after the transcript has
+accumulated meaningful content (a utilization gate), so it snapshots a
+substantive session rather than an empty opening turn.
+
+Flow (all best-effort, never blocks a stop):
+
+1. Read the session transcript tail.
+2. Extract <=5 structured findings via a LOCAL Ollama model
+   (``llama3.1:8b`` by default); degrade to a cheap heuristic marker
+   scan when Ollama is unavailable.
+3. Stash each finding through ``attune.memory.session_stash.stash_entry``
+   — which runs the PII/secrets gate and writes to the searchable
+   backend (file by default, AMS when connected).
+4. Prune expired findings once.
+
+Tunables (env): ``ATTUNE_MEMORY_STASH`` (set ``0`` to disable),
+``ATTUNE_MEMORY_STASH_MIN_UTIL`` (gate, default 0.30),
+``ATTUNE_MEMORY_OLLAMA_MODEL`` (default ``llama3.1:8b``),
+``ATTUNE_MEMORY_OLLAMA_URL`` (default ``http://localhost:11434``),
+``ATTUNE_MEMORY_STASH_TIMEOUT`` (LLM timeout secs, default 12).
+
+Exit 0 always; output is irrelevant (Stop-hook stdout is discarded).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import traceback
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Force utf-8 on stdout/stderr (Windows cp1252 would crash on em-dash/
+# emoji, caught by the outer try/except -> silent breakage).
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+_HOOKS_DIR = str(Path(__file__).resolve().parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+# Reuse the transcript size proxy + sentinel dir from the existing hooks.
+try:
+    from _state import _sentinel_dir  # type: ignore[attr-defined]
+    from _transcript_size import estimate_utilization
+except Exception:  # noqa: BLE001 — hook must never crash a session
+    _sentinel_dir = None  # type: ignore[assignment]
+    estimate_utilization = None  # type: ignore[assignment]
+
+_VALID_TYPES = {"decision", "pattern", "bug", "reference", "note"}
+_MAX_FINDINGS = 5
+_TAIL_CHARS = 12_000  # transcript tail handed to the extractor
+_DEFAULT_MIN_UTIL = 0.30
+
+
+def _enabled() -> bool:
+    return os.environ.get("ATTUNE_MEMORY_STASH", "1").strip() not in {"0", "false", "no"}
+
+
+def _stash_sentinel(session_id: str | None) -> Path | None:
+    if _sentinel_dir is None:
+        return None
+    safe = "unknown"
+    if session_id:
+        safe = re.sub(r"[^A-Za-z0-9_-]", "_", session_id)[:64] or "unknown"
+    return _sentinel_dir() / f".stash-done-{safe}"
+
+
+def _read_transcript_tail(transcript_path: str | None, max_chars: int = _TAIL_CHARS) -> str:
+    """Return the human-readable tail of the session transcript.
+
+    Walks the JSONL user/assistant turns, extracts text, and returns the
+    last ``max_chars`` characters. Tolerant of malformed lines / missing
+    files; never raises.
+    """
+    if not transcript_path:
+        return ""
+    path = Path(transcript_path)
+    if not path.is_file():
+        return ""
+    chunks: list[str] = []
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                message = record.get("message")
+                content = (
+                    message.get("content") if isinstance(message, dict) else record.get("content")
+                )
+                role = (
+                    (message or {}).get("role")
+                    if isinstance(message, dict)
+                    else record.get("role") or record.get("type")
+                )
+                text = _text_of(content)
+                if text:
+                    chunks.append(f"{role or '?'}: {text}")
+    except OSError:
+        return ""
+    joined = "\n".join(chunks)
+    return joined[-max_chars:]
+
+
+def _text_of(content: object) -> str:
+    """Collect the string text from a transcript message body (recursive)."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(_text_of(p) for p in content).strip()
+    if isinstance(content, dict):
+        parts: list[str] = []
+        t = content.get("text")
+        if isinstance(t, str):
+            parts.append(t)
+        nested = content.get("content")
+        if nested is not None:
+            parts.append(_text_of(nested))
+        return " ".join(p for p in parts if p).strip()
+    return ""
+
+
+def _extract_via_ollama(text: str) -> list[dict] | None:
+    """Ask a local Ollama model for <=5 findings. None when unavailable."""
+    base = os.environ.get("ATTUNE_MEMORY_OLLAMA_URL", "http://localhost:11434").rstrip("/")
+    model = os.environ.get("ATTUNE_MEMORY_OLLAMA_MODEL", "llama3.1:8b")
+    try:
+        timeout = float(os.environ.get("ATTUNE_MEMORY_STASH_TIMEOUT", "12"))
+    except ValueError:
+        timeout = 12.0
+    prompt = (
+        "You are extracting durable memory from a coding session transcript.\n"
+        "Return ONLY JSON of the form "
+        '{"findings": [{"type": "...", "content": "..."}]}.\n'
+        "Rules:\n"
+        "- At most 5 findings; fewer is better. Skip chit-chat and routine steps.\n"
+        "- Each finding is a single reusable insight worth recalling next session.\n"
+        "- type is one of: decision, pattern, bug, reference, note.\n"
+        "- content is one concise sentence, <= 280 chars, no secrets/paths-as-secrets.\n\n"
+        f"TRANSCRIPT TAIL:\n{text}\n"
+    )
+    payload = json.dumps(
+        {"model": model, "prompt": prompt, "stream": False, "format": "json"}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/api/generate", data=payload, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — localhost
+            body = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError, ValueError):
+        return None  # Ollama not running / model missing / timeout -> heuristic fallback
+    raw = body.get("response") if isinstance(body, dict) else None
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    findings = parsed.get("findings") if isinstance(parsed, dict) else None
+    return findings if isinstance(findings, list) else []
+
+
+_MARKER_RE = re.compile(
+    r"\b(lesson|TIL|gotcha|decided|decision|bug|root cause|pattern|fix(?:ed)?|"
+    r"learned|insight|takeaway)\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_heuristic(text: str) -> list[dict]:
+    """Cheap fallback: surface marker-bearing lines as ``note`` findings."""
+    out: list[dict] = []
+    seen: set[str] = set()
+    for line in text.splitlines():
+        line = line.strip(" -*#>\t")
+        if len(line) < 20 or len(line) > 280:
+            continue
+        if not _MARKER_RE.search(line):
+            continue
+        key = line.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({"type": "note", "content": line})
+        if len(out) >= _MAX_FINDINGS:
+            break
+    return out
+
+
+def _normalize(findings: list[dict]) -> list[dict]:
+    """Validate/clamp raw findings to <=5 well-typed {type, content} dicts."""
+    clean: list[dict] = []
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        content = f.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        ftype = f.get("type")
+        ftype = ftype if ftype in _VALID_TYPES else "note"
+        clean.append({"type": ftype, "content": content.strip()[:500]})
+        if len(clean) >= _MAX_FINDINGS:
+            break
+    return clean
+
+
+def _stash_findings(findings: list[dict], session_id: str, cwd: str) -> int:
+    """Write each finding via the PII-gated stash. Returns count written."""
+    try:
+        from attune.memory.session_stash import (
+            SessionStashEntry,
+            resolve_backend,
+            stash_entry,
+        )
+    except Exception:  # noqa: BLE001 — attune not importable -> silent no-op
+        return 0
+    written = 0
+    for f in findings:
+        try:
+            entry = SessionStashEntry.create(
+                session_id=session_id, cwd=cwd, type=f["type"], content=f["content"]
+            )
+            if stash_entry(entry):
+                written += 1
+        except Exception:  # noqa: BLE001 — one bad finding must not abort the rest
+            continue
+    if written:
+        try:
+            backend = resolve_backend()
+            prune = getattr(backend, "prune", None) if backend else None
+            if callable(prune):
+                prune()
+        except Exception:  # noqa: BLE001 — prune is best-effort
+            pass
+    return written
+
+
+def main() -> int:
+    """Entry point — acts once per substantive session, never raises."""
+    try:
+        if not _enabled():
+            return 0
+        try:
+            payload = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            payload = {}
+        session_id = payload.get("session_id") or "unknown"
+        transcript_path = payload.get("transcript_path")
+        cwd = str(payload.get("cwd") or Path.cwd())
+
+        sentinel = _stash_sentinel(session_id)
+        if sentinel is not None and sentinel.exists():
+            return 0  # already stashed this session
+
+        # Utilization gate: only snapshot once the session has real content.
+        try:
+            min_util = float(os.environ.get("ATTUNE_MEMORY_STASH_MIN_UTIL", _DEFAULT_MIN_UTIL))
+        except ValueError:
+            min_util = _DEFAULT_MIN_UTIL
+        if estimate_utilization is not None and transcript_path:
+            if estimate_utilization(transcript_path) < min_util:
+                return 0  # too little so far; let a later, fuller stop capture it
+
+        text = _read_transcript_tail(transcript_path)
+        if not text.strip():
+            return 0
+
+        raw = _extract_via_ollama(text)
+        findings = _normalize(raw if raw is not None else _extract_heuristic(text))
+        if not findings:
+            return 0
+
+        _stash_findings(findings, session_id=session_id, cwd=cwd)
+
+        # Mark done AFTER work so a crash mid-extract retries next stop.
+        if sentinel is not None:
+            try:
+                sentinel.parent.mkdir(parents=True, exist_ok=True)
+                sentinel.write_text("done\n", encoding="utf-8")
+            except OSError:
+                pass
+        return 0
+    except Exception:  # noqa: BLE001 — a Stop hook must never crash the session
+        traceback.print_exc(file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/hooks/session_stash.py
+++ b/plugin/hooks/session_stash.py
@@ -299,6 +299,8 @@ def main() -> int:
                 sentinel.parent.mkdir(parents=True, exist_ok=True)
                 sentinel.write_text("done\n", encoding="utf-8")
             except OSError:
+                # INTENTIONAL: a missing sentinel only means we may re-stash
+                # next stop (idempotent enough); never worth failing on.
                 pass
         return 0
     except Exception:  # noqa: BLE001 — a Stop hook must never crash the session

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -79,6 +79,7 @@ intent so Claude matches the right skill:
 | spec | spec-driven dev, brainstorm and execute |
 | rag-code-gen | grounded code, cite sources, verify against attune (needs `[rag]` extra) |
 | coach | coach, learn, explain, tell me more, deeper |
+| recall | recall, remember, what did I learn, prior session, past findings |
 
 ## MCP Server Not Running
 

--- a/plugin/skills/recall/SKILL.md
+++ b/plugin/skills/recall/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: recall
+description: "Pull relevant findings stashed from past sessions — on demand. Triggers on: recall, remember, what did I learn, prior session, past findings, did I hit this before, what do we know about."
+argument-hint: "<topic to recall | leave empty for recent>"
+---
+
+# Recall
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Recall** — Searching cross-session memory for findings related to
+> your query.
+
+## What It Does
+
+`/recall` is the on-demand companion to the automatic SessionStart
+recall. It searches the findings stashed by the Stop hook across past
+sessions (file backend by default; Redis AMS when connected) and
+surfaces the most relevant ones, formatted for reading.
+
+- **With a query** (`/recall AMS event loop`): keyword + recency search,
+  same-project findings ranked first.
+- **No query** (`/recall`): the most recent findings for this project.
+
+## How To Run It
+
+Recall is exposed through `attune.memory.session_stash`. Run the
+appropriate snippet via Bash from the project root, then present the
+results as a readable list (newest / most-relevant first), grouped or
+annotated by their `[type]`.
+
+**With a query:**
+
+```bash
+python -c "import json, os; from attune.memory.session_stash import recall_entries; print(json.dumps(recall_entries(os.environ['Q'], top_k=8, cwd=os.getcwd()), ensure_ascii=False))"
+```
+
+Pass the user's topic as the `Q` environment variable (avoids quoting
+issues), e.g. `Q="AMS event loop" python -c "..."`.
+
+**No query (recent):**
+
+```bash
+python -c "import json, os; from attune.memory.session_stash import recent_entries; print(json.dumps(recent_entries(top_k=8, cwd=os.getcwd()), ensure_ascii=False))"
+```
+
+Each result is a dict with `text`, `topics` (carrying `type:<kind>` and
+`cwd:<path>`), `cwd`, and `session_id`. Render them as:
+
+```
+- [decision] <text>
+- [bug] <text>
+```
+
+## When Nothing Comes Back
+
+An empty list means no matching findings yet (the store fills as the
+Stop hook stashes findings over sessions), or no searchable backend is
+installed. Say so plainly — do **not** invent findings. Suggest the
+user keep working; the soak fills the store over time.
+
+## Promote A Keeper
+
+If a recalled finding is worth keeping permanently, the user can
+promote it into curated memory with `/remember` — the durable,
+human-curated tier above this raw cross-session stash.

--- a/src/attune/memory/backend.py
+++ b/src/attune/memory/backend.py
@@ -229,5 +229,24 @@ class SearchableMemoryBackend(MemoryBackend, Protocol):
         """
         ...
 
+    def recent(self, limit: int = 5, **filters: Any) -> list[dict]:
+        """Return the most-recent findings without a query.
+
+        Powers query-less recall (SessionStart): newest findings first.
+        When a ``cwd`` filter is given, same-project findings are surfaced
+        first (soft priority). Best-effort; returns ``[]`` when unavailable,
+        never raises. Backends predating this method are handled by callers
+        via ``getattr``.
+
+        Args:
+            limit: Max results.
+            **filters: Optional soft filters (e.g. ``cwd``).
+
+        Returns:
+            Ranked memory records as dicts (newest first), or ``[]``.
+
+        """
+        ...
+
 
 __all__ = ["MemoryBackend", "SearchableMemoryBackend"]

--- a/src/attune/memory/file_stash.py
+++ b/src/attune/memory/file_stash.py
@@ -201,6 +201,30 @@ class FileStashBackend:
         scored.sort(key=lambda s: s[0], reverse=True)
         return [d for _, d in scored[:limit]]
 
+    def recent(self, limit: int = 5, **filters: Any) -> list[dict]:
+        """Most-recent findings (no query) — powers SessionStart recall.
+
+        Sorted newest-first; when ``cwd`` is given, same-project findings
+        are surfaced ahead of others (soft priority, mirroring ``search``).
+        Returns the same record shape as ``search`` (minus ``score``).
+        """
+        cwd = filters.get("cwd")
+        records = self._load_records()  # already TTL-pruned
+        records.sort(key=lambda r: float(r.get("ts", 0) or 0), reverse=True)
+        if cwd:
+            # Stable secondary sort: cwd matches first, recency preserved within.
+            records.sort(key=lambda r: 0 if r.get("cwd") == cwd else 1)
+        return [
+            {
+                "id": r.get("id"),
+                "text": r.get("text"),
+                "topics": r.get("topics", []),
+                "cwd": r.get("cwd"),
+                "session_id": r.get("session_id"),
+            }
+            for r in records[:limit]
+        ]
+
     def promote(self, session_id: str | None = None) -> bool:
         """No-op for the file backend (findings are already durable here)."""
         return True

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -274,3 +274,40 @@ def recall_entries(
     if cwd:
         results.sort(key=lambda r: 0 if (isinstance(r, dict) and r.get("cwd") == cwd) else 1)
     return results
+
+
+def recent_entries(
+    top_k: int = 5,
+    cwd: str | None = None,
+    backend: SearchableMemoryBackend | None = None,
+) -> list[dict[str, Any]]:
+    """Query-less recall of the most-recent findings (for SessionStart).
+
+    SessionStart has no query, so recall is recency-driven: the newest
+    stashed findings, with same-``cwd`` findings surfaced first. Returns
+    an empty list when no backend is available or the backend predates the
+    ``recent`` method. Never raises — safe to call from a hook.
+
+    Args:
+        top_k: Max results.
+        cwd: When set, prefer entries from this project root (soft filter).
+        backend: Optional injected backend; resolved from the entry point
+            when omitted.
+
+    Returns:
+        Ranked memory records as dicts (newest first), or ``[]``.
+    """
+    target = resolve_backend(backend)
+    if target is None:
+        return []
+    recent = getattr(target, "recent", None)
+    if not callable(recent):
+        # Backend predates query-less recall — degrade quietly.
+        return []
+    try:
+        results = recent(limit=top_k, cwd=cwd)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: recall is best-effort; never break the host session.
+        logger.warning("session recent-recall failed: %s", exc)
+        return []
+    return results if isinstance(results, list) else []

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -1,0 +1,264 @@
+"""Tests for the P2 memory hooks — session_stash (Stop) + session_recall.
+
+The hooks are standalone scripts; they're loaded via importlib so their
+pure helpers (transcript parsing, Ollama extraction, normalization,
+recall formatting) and their gate/sentinel control flow can be exercised
+without a live Claude Code session, Ollama, or a real backend.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
+
+
+def _load_module(name: str):
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    if name in sys.modules:
+        del sys.modules[name]  # fresh load so module-level env reads are clean
+    spec = importlib.util.spec_from_file_location(name, _HOOKS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def stash_mod():
+    return _load_module("session_stash")
+
+
+@pytest.fixture
+def recall_mod():
+    return _load_module("session_recall")
+
+
+def _stdin(monkeypatch, payload: dict) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+
+
+# ==========================================================================
+# session_stash — pure helpers
+# ==========================================================================
+
+
+def test_text_of_handles_str_list_dict(stash_mod):
+    assert stash_mod._text_of("plain") == "plain"
+    assert stash_mod._text_of([{"text": "a"}, {"text": "b"}]) == "a b"
+    assert stash_mod._text_of({"text": "x", "content": [{"text": "y"}]}) == "x y"
+    assert stash_mod._text_of(None) == ""
+
+
+def test_read_transcript_tail(tmp_path, stash_mod):
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        "\n".join(
+            json.dumps(m)
+            for m in [
+                {"message": {"role": "user", "content": "hello there"}},
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "hi back"}],
+                    }
+                },
+                "not json",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    tail = stash_mod._read_transcript_tail(str(p))
+    assert "hello there" in tail and "hi back" in tail
+
+
+def test_read_transcript_tail_missing_file(stash_mod):
+    assert stash_mod._read_transcript_tail(None) == ""
+    assert stash_mod._read_transcript_tail("/no/such/file.jsonl") == ""
+
+
+def test_extract_heuristic_finds_markers(stash_mod):
+    text = (
+        "user: just chatting about the weather today and stuff\n"
+        "assistant: The root cause was a stale lockfile in the build step\n"
+        "assistant: I decided to drop the security check from required gates\n"
+        "assistant: ok\n"
+    )
+    found = stash_mod._extract_heuristic(text)
+    assert 1 <= len(found) <= stash_mod._MAX_FINDINGS
+    assert all(f["type"] == "note" for f in found)
+    assert any("root cause" in f["content"].lower() for f in found)
+
+
+def test_normalize_clamps_type_and_count(stash_mod):
+    raw = [{"type": "bogus", "content": "keep me"}] + [
+        {"type": "bug", "content": f"f{i}"} for i in range(10)
+    ]
+    out = stash_mod._normalize(raw)
+    assert len(out) == stash_mod._MAX_FINDINGS
+    assert out[0] == {"type": "note", "content": "keep me"}  # bogus type -> note
+
+
+def test_normalize_drops_empty_content(stash_mod):
+    assert stash_mod._normalize([{"type": "bug", "content": "  "}, {"type": "bug"}]) == []
+
+
+def test_extract_via_ollama_parses_response(stash_mod, monkeypatch):
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {"response": json.dumps({"findings": [{"type": "bug", "content": "x"}]})}
+            ).encode()
+
+    monkeypatch.setattr(stash_mod.urllib.request, "urlopen", lambda *a, **k: _Resp())
+    out = stash_mod._extract_via_ollama("some transcript")
+    assert out == [{"type": "bug", "content": "x"}]
+
+
+def test_extract_via_ollama_returns_none_when_unreachable(stash_mod, monkeypatch):
+    def _boom(*a, **k):
+        raise stash_mod.urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(stash_mod.urllib.request, "urlopen", _boom)
+    assert stash_mod._extract_via_ollama("x") is None
+
+
+# ==========================================================================
+# session_stash — main() gate / sentinel control flow
+# ==========================================================================
+
+
+def test_stash_main_disabled_via_env(stash_mod, monkeypatch):
+    monkeypatch.setenv("ATTUNE_MEMORY_STASH", "0")
+    _stdin(monkeypatch, {"session_id": "s1"})
+    assert stash_mod.main() == 0
+
+
+def test_stash_main_skips_when_sentinel_exists(stash_mod, monkeypatch, tmp_path):
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path))
+    sent = stash_mod._stash_sentinel("s1")
+    sent.parent.mkdir(parents=True, exist_ok=True)
+    sent.write_text("done\n", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(stash_mod, "_stash_findings", lambda *a, **k: calls.append(a))
+    _stdin(monkeypatch, {"session_id": "s1", "transcript_path": str(tmp_path / "t")})
+    assert stash_mod.main() == 0
+    assert calls == [], "must not stash again when the sentinel is present"
+
+
+def test_stash_main_skips_below_util_gate(stash_mod, monkeypatch, tmp_path):
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path))
+    monkeypatch.setattr(stash_mod, "estimate_utilization", lambda _p: 0.01)
+    calls = []
+    monkeypatch.setattr(stash_mod, "_stash_findings", lambda *a, **k: calls.append(a))
+    _stdin(monkeypatch, {"session_id": "s2", "transcript_path": str(tmp_path / "t.jsonl")})
+    assert stash_mod.main() == 0
+    assert calls == []
+
+
+def test_stash_main_happy_path_writes_sentinel(stash_mod, monkeypatch, tmp_path):
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path))
+    tpath = tmp_path / "t.jsonl"
+    tpath.write_text(
+        json.dumps({"message": {"role": "assistant", "content": "the bug was a race"}}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(stash_mod, "estimate_utilization", lambda _p: 0.9)
+    monkeypatch.setattr(
+        stash_mod, "_extract_via_ollama", lambda _t: [{"type": "bug", "content": "z"}]
+    )
+    written = []
+    monkeypatch.setattr(
+        stash_mod,
+        "_stash_findings",
+        lambda findings, **k: written.extend(findings) or len(findings),
+    )
+    _stdin(monkeypatch, {"session_id": "s3", "transcript_path": str(tpath), "cwd": "/proj"})
+    assert stash_mod.main() == 0
+    assert written == [{"type": "bug", "content": "z"}]
+    assert stash_mod._stash_sentinel("s3").exists(), "sentinel written after a successful stash"
+
+
+# ==========================================================================
+# session_recall
+# ==========================================================================
+
+
+def test_type_of(recall_mod):
+    assert recall_mod._type_of(["cwd:/p", "type:decision"]) == "decision"
+    assert recall_mod._type_of(["cwd:/p"]) == "note"
+    assert recall_mod._type_of(None) == "note"
+
+
+def test_format_renders_typed_lines(recall_mod):
+    block = recall_mod._format(
+        [
+            {"text": "dropped reviews to 0", "topics": ["type:decision"]},
+            {"text": "race in the runner", "topics": ["type:bug"]},
+        ]
+    )
+    assert "## Recalled memories" in block
+    assert "- [decision] dropped reviews to 0" in block
+    assert "- [bug] race in the runner" in block
+
+
+def test_format_respects_budget(recall_mod, monkeypatch):
+    monkeypatch.setattr(recall_mod, "_CONTENT_BUDGET", 10)
+    block = recall_mod._format(
+        [{"text": "x" * 50, "topics": []}, {"text": "should not appear", "topics": []}]
+    )
+    assert "should not appear" not in block
+
+
+def test_recall_main_emits_block(recall_mod, monkeypatch, capsys):
+    import attune.memory.session_stash as ss
+
+    monkeypatch.setattr(
+        ss, "recent_entries", lambda **k: [{"text": "a finding", "topics": ["type:note"]}]
+    )
+    _stdin(monkeypatch, {"source": "startup", "cwd": "/proj"})
+    assert recall_mod.main() == 0
+    out = capsys.readouterr().out
+    assert "## Recalled memories" in out and "- [note] a finding" in out
+
+
+def test_recall_main_silent_when_empty(recall_mod, monkeypatch, capsys):
+    import attune.memory.session_stash as ss
+
+    monkeypatch.setattr(ss, "recent_entries", lambda **k: [])
+    _stdin(monkeypatch, {"source": "startup"})
+    assert recall_mod.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_recall_main_skips_on_compact(recall_mod, monkeypatch, capsys):
+    import attune.memory.session_stash as ss
+
+    monkeypatch.setattr(ss, "recent_entries", lambda **k: [{"text": "x", "topics": []}])
+    _stdin(monkeypatch, {"source": "compact"})
+    assert recall_mod.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_recall_main_disabled_via_env(recall_mod, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_MEMORY_RECALL", "0")
+    _stdin(monkeypatch, {"source": "startup"})
+    assert recall_mod.main() == 0
+    assert capsys.readouterr().out == ""

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -320,3 +320,54 @@ def test_prune_skips_blank_and_corrupt_drops_nondict(backend):
     # silently skipped, the fresh dict is kept.
     assert dropped == 1
     assert {r["id"] for r in backend._load_records()} == {"keep"}
+
+
+# --------------------------------------------------------------------------
+# recent() — query-less recency recall (powers SessionStart)
+# --------------------------------------------------------------------------
+
+
+def test_recent_newest_first(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [
+            {"id": "old", "text": "a", "topics": [], "cwd": None, "ts": now - 3600},
+            {"id": "new", "text": "b", "topics": [], "cwd": None, "ts": now - 60},
+            {"id": "mid", "text": "c", "topics": [], "cwd": None, "ts": now - 600},
+        ],
+    )
+    assert [r["id"] for r in backend.recent()] == ["new", "mid", "old"]
+
+
+def test_recent_cwd_priority(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [
+            # newest overall is /other; /proj is older but should surface first
+            {"id": "other", "text": "a", "topics": [], "cwd": "/other", "ts": now - 60},
+            {"id": "proj", "text": "b", "topics": [], "cwd": "/proj", "ts": now - 600},
+        ],
+    )
+    ids = [r["id"] for r in backend.recent(cwd="/proj")]
+    assert ids[0] == "proj", "same-cwd finding surfaces first despite being older"
+
+
+def test_recent_respects_limit(backend):
+    now = time.time()
+    _write_records(
+        backend,
+        [{"id": f"m{i}", "text": "x", "topics": [], "cwd": None, "ts": now - i} for i in range(5)],
+    )
+    assert len(backend.recent(limit=2)) == 2
+
+
+def test_recent_empty_when_no_records(backend):
+    assert backend.recent() == []
+
+
+def test_recent_returns_search_shape(backend):
+    backend.remember("a finding", memory_id="m1", topics=["cwd:/p"])
+    hit = backend.recent()[0]
+    assert set(hit) == {"id", "text", "topics", "cwd", "session_id"}

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -15,6 +15,7 @@ from attune.memory.session_stash import (
     MAX_CONTENT_CHARS,
     SessionStashEntry,
     recall_entries,
+    recent_entries,
     resolve_backend,
     stash_entry,
 )
@@ -307,6 +308,55 @@ def test_recall_handles_non_list_result():
             return None
 
     assert recall_entries("q", backend=_Weird()) == []
+
+
+# --------------------------------------------------------------------------
+# recent_entries — query-less recency recall (SessionStart)
+# --------------------------------------------------------------------------
+
+
+class _RecentBackend(_FakeBackend):
+    """Backend that implements the query-less recent() path."""
+
+    def __init__(self, results=None):
+        super().__init__(results)
+        self.recent_calls: list[dict] = []
+
+    def recent(self, limit=5, **filters):
+        self.recent_calls.append({"limit": limit, **filters})
+        return list(self._results)
+
+
+def test_recent_noop_without_backend():
+    assert recent_entries(backend=None) == []
+
+
+def test_recent_empty_when_backend_lacks_recent():
+    # _FakeBackend has no recent() — degrade quietly via the getattr guard.
+    assert recent_entries(backend=_FakeBackend(results=[{"text": "x"}])) == []
+
+
+def test_recent_returns_backend_results_and_passes_args():
+    rb = _RecentBackend(results=[{"text": "newest", "cwd": "/proj"}])
+    out = recent_entries(top_k=3, cwd="/proj", backend=rb)
+    assert out == [{"text": "newest", "cwd": "/proj"}]
+    assert rb.recent_calls == [{"limit": 3, "cwd": "/proj"}]
+
+
+def test_recent_swallows_backend_error():
+    class _Boom(_RecentBackend):
+        def recent(self, *a, **k):
+            raise RuntimeError("recent down")
+
+    assert recent_entries(backend=_Boom()) == []
+
+
+def test_recent_handles_non_list_result():
+    class _Weird(_RecentBackend):
+        def recent(self, *a, **k):
+            return None
+
+    assert recent_entries(backend=_Weird()) == []
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -301,8 +301,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 15, (
-            f"Expected 15 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 16, (
+            f"Expected 16 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:


### PR DESCRIPTION
Lights up the **cross-session memory loop** on top of the D7/D8 backends — the surface that begins the dogfood soak.

## What

- **`recent_entries(cwd, top_k)`** — query-less recency-recall primitive. File backend gets a `recent()` (newest-first, soft cwd-priority) + the protocol method. AMS `recent()` is a **documented stub** (`[]`) — query-less recency listing isn't a verified AMS-client primitive yet, so the file backend (the default) powers SessionStart recall fully; AMS users still get query recall via `/recall`. Follow-up tracked in code.
- **Stop hook** (`plugin/hooks/session_stash.py`) — `Stop` fires per-turn, so this acts **once per session** (own sentinel) past a **30% utilization gate** (captures a substantive session, mirroring `compact_warning`). Reads the transcript tail → **local Ollama `llama3.1:8b`** extraction (≤5 findings) with a **heuristic marker-scan fallback** when Ollama's down → PII-gated `stash_entry()` → `prune()`. All env-tunable (`ATTUNE_MEMORY_STASH*`); never blocks a stop.
- **SessionStart hook** (`plugin/hooks/session_recall.py`) — recent-for-cwd → compact `## Recalled memories` block; silent on empty/compact/no-backend.
- **`/recall` skill** (`plugin/skills/recall/`) + its 3 enforcement gates (skill-count 16, attune-hub table row, `.agents/` mirror).
- **`hooks.json`** wires both events.

## Design calls (all env-tunable / reversible)

1. Once-per-session sentinel + 30% util gate (Stop fires per-turn — verified).
2. Local Ollama extraction + heuristic fallback (no OpenAI).
3. AMS `recent()` stub rather than confabulating the client's list API.

## Tests

`recent()` + `recent_entries`, hook helpers (transcript parse, Ollama mock, heuristic, normalize, recall format), and the gate/sentinel control flow. **1665 green** locally; ruff + black clean.

## Not in this PR (the step with you)

Live hook registration — refreshing the editable install so the file backend's entry point resolves in the running session. That's the one live-config step to do together once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)