### PR TITLE
docs(spec): just-in-time-recall — triggered recall at the decision point (draft)

### DIFF
--- a/docs/specs/just-in-time-recall/decisions.md
+++ b/docs/specs/just-in-time-recall/decisions.md
@@ -1,0 +1,65 @@
+# Just-In-Time Recall — Decisions
+
+Irreversible / load-bearing choices, timestamped. The timestamp is the
+arbiter when a later session wants to relitigate.
+
+## D1 — Source = durable lessons/rules, not session findings (2026-06-03)
+
+**Decision:** Just-in-time recall surfaces durable rules
+(`.claude/CLAUDE.md` Lessons + `feedback_*` memories), not the P2
+session-stash findings.
+
+**Why:** The failure this targets is *not-applying* (the rule existed,
+unfired), not *not-knowing*. Rules are the right corpus for "remind me of
+the governing constraint at the moment of the action." Findings-at-
+decision-points is a valid later layer but a different problem (and a
+bigger retrieval surface). Keeps the first cut focused and low-noise.
+
+**Chosen by:** Patrick, via AskUserQuestion, over "session-stash findings"
+and "both unified."
+
+## D2 — Trigger mechanism = PENDING Phase 0 (2026-06-03)
+
+**Decision:** Deferred to Phase 0 measurement. The repo's existing
+PreToolUse hooks only allow/block (no context injection), so whether a
+hook can inject model-readable guidance at a tool-call is unverified.
+Phase 0 verifies PreToolUse `additionalContext` first, then
+UserPromptSubmit injection as fallback. No build past Phase 0 until the
+chosen mechanism is logged here.
+
+**Why:** Verify-first discipline — do not confabulate a hook capability;
+an entire build hangs on whether the injection channel exists.
+
+## D3 — Matching = one explicit curated map, not semantic retrieval (2026-06-03)
+
+**Decision:** A single reviewable decision-point → rule(s) map (one
+file), keyed by tool name, valued by short `{rule_id, one_liner}` lists.
+Not embedding/semantic retrieval; not per-file frontmatter tags (yet).
+
+**Why:** A handful of known slip-points don't justify semantic retrieval
+in the hot path of every tool call (cost + false-match noise →
+nag-fatigue, violating R3). An explicit map is precise, diff-reviewable,
+honest, and cheap to extend. Re-evaluate only if the map outgrows a
+single file (then the frontmatter-tag approach).
+
+## D4 — Surface text = distilled one-liner, not full lesson body (2026-06-03)
+
+**Decision:** The map stores a one-line nudge per rule, not the full
+lesson text.
+
+**Why:** The goal is an at-the-moment nudge, not a wall — and surfacing a
+paragraph would itself violate the concision discipline this feature
+exists to enforce. The full lesson stays in CLAUDE.md / the memory as the
+source of truth.
+
+## D5 — Surface-once cadence = once per (session, rule), revisit (2026-06-03)
+
+**Decision:** Start with a per-session sentinel keyed by
+`(session_id, rule_id)` (reusing the `_state` sentinel pattern). Open
+question carried into implementation: whether once-per-session is too
+sparse (the reminder may scroll out before the slip-prone window ends) —
+a turn/time decay is the candidate refinement, deferred until the proof
+case shows whether it's needed.
+
+**Why:** R3 (no nag-fatigue) is the binding constraint; start conservative
+(quiet) and loosen only with evidence from the proof case.

--- a/docs/specs/just-in-time-recall/design.md
+++ b/docs/specs/just-in-time-recall/design.md
@@ -1,0 +1,125 @@
+# Just-In-Time Recall — Design
+
+**Status:** draft (2026-06-03)
+
+## The core problem: match a rule to a moment
+
+Two sub-problems: (1) a **trigger** that fires at the decision point and
+can inject text the model reads; (2) a **match** from the action context
+to the governing rule(s). Phase 0 settles (1); the design below settles
+(2) and the surrounding control flow.
+
+## Phase 0 — verify the injection mechanism (premise)
+
+The repo's existing PreToolUse hooks (`security_guard.py`) only
+allow (exit 0) / block (exit 2, reason to stderr) — they do **not**
+inject context. So whether a hook can surface *model-readable guidance
+without blocking* is unverified. Phase 0 measures, in order:
+
+1. **PreToolUse `additionalContext`** — does a PreToolUse hook returning
+   JSON `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+   "additionalContext": "..."}}` (or the current-version equivalent)
+   inject text the model sees, while still allowing the call? Verify by
+   instrumenting a throwaway hook and observing whether the text reaches
+   context.
+2. **Fallbacks if (1) fails:**
+   - **UserPromptSubmit `additionalContext`** — inject on the user turn
+     *before* the likely action. Less precise (turn-granular, not
+     call-granular) but reliably injects.
+   - **Degraded "advisory block"** — PreToolUse exit-2 with the rule as
+     the reason, then immediately allow on retry. Rejected unless nothing
+     else works: it interrupts the call (violates R4's spirit) and trains
+     the agent to treat guidance as an error.
+
+Phase 0 output → `decisions.md`: the chosen mechanism + why. No build
+past Phase 0 until this is logged.
+
+## Matching: a curated decision-point → rule map (chosen)
+
+Rejected alternatives first:
+
+- **Semantic retrieval** over the whole lesson corpus per tool call —
+  heavy (attune-rag in the hot path of every call), and high false-match
+  risk (noise → nag-fatigue → R3 violation). Overkill for a handful of
+  known slip-points.
+- **Tag-in-frontmatter** (`triggers: [AskUserQuestion]` on each memory) —
+  cleaner long-term, but spreads the mapping across N files and needs a
+  loader; defer until the curated map outgrows a single file.
+
+**Chosen: one explicit, reviewable map.** A single small data structure
+(e.g. `plugin/hooks/_recall_map.py` or a JSON sidecar) keyed by the
+tool/decision-point name → a short list of `{rule_id, one_line_text}`.
+Precise, low-noise, honest (diff-reviewable), and cheap to extend. The
+rule text is a *distilled one-liner*, not the full lesson body — the goal
+is a nudge at the moment, not a wall (mirrors the §3 "one paragraph"
+discipline and the very rule it surfaces).
+
+Seed entries (proof + obvious neighbors):
+
+| Decision point | Surfaced rule (one-liner) |
+|---|---|
+| `AskUserQuestion` | "Lead with your recommendation; make options selectable and concise — no `and/or`, no buried prose." |
+| (later) `Bash` git push to shared branch | "fetch before assuming up-to-date; verify the right worktree+branch." |
+
+Only `AskUserQuestion` is in scope for R6; the rest are illustrative of
+how the map grows.
+
+## Control flow (the hook)
+
+A new `plugin/hooks/jit_recall.py`, registered for the chosen event:
+
+1. Read the hook payload; get the tool name (or, for UserPromptSubmit,
+   the imminent-action heuristic).
+2. Look up the tool in the curated map. No entry → silent no-op (R3).
+3. **Surface-once gate:** per-session sentinel keyed by
+   `(session_id, rule_id)` so the same rule isn't re-injected every time
+   the action repeats in a session (reuses the `_state` sentinel dir
+   pattern from the Stop-hook lesson). First fire surfaces; subsequent
+   same-rule fires in the session stay silent.
+4. Emit the one-liner via the verified injection channel; allow the call.
+5. Wrapped in try/except → exit 0 on any error (R4).
+
+## Noise budget & the surface-once tension
+
+R3 is the hardest constraint. Two dials: the *map* (only instrument
+genuine slip-points — keep it small) and the *surface-once gate* (once
+per rule per session). Open question for `decisions.md`: is once-per-
+session too sparse (the slip can recur after the reminder scrolls away)?
+A middle option is a **decay** — re-surface a rule if the action recurs
+after N turns / M minutes. Start with once-per-session; revisit if the
+proof case shows the reminder fades before the slip-prone window ends.
+
+## Relationship to the rest of the system
+
+- **Distinct from P2.** P2 recalls *findings* at the *door*; this recalls
+  *rules* at the *decision point*. Same backend philosophy (hooks, fail-
+  safe, sentinels), different corpus + trigger. They compose; neither
+  depends on the other.
+- **Corpus source:** the rule one-liners are authored in the map, *derived
+  from* the durable lessons (CLAUDE.md / `feedback_*`). The map is the
+  curated index; the lessons remain the source of truth. (A future
+  layer could auto-derive map entries from lesson frontmatter — the
+  tag-in-frontmatter alternative above.)
+
+## Prior art (verified 2026-06-03, not reinventing memory)
+
+A web check of Anthropic's memory features confirms this spec's *trigger*
+layer is distinct from existing prior art — all of which is door-layer or
+consolidation-layer, none decision-point-triggered:
+
+- **Claude Code Memory (Mar 2026)** + **CLAUDE.md** — auto-accumulated,
+  file-based, loaded at session start. *Door layer.*
+- **API Memory Tool** — developer-managed file store
+  (view/create/str_replace/insert/delete/rename). Storage, not triggering.
+- **MCP "memory" server** — local knowledge-graph persisted as JSON; the
+  closest "local store for superior recall" prior art. If this spec's
+  storage ever outgrows the curated map, lean here rather than reinvent.
+- **Managed Agents memory + "Dreaming" (research preview, Managed Agents
+  only, access-gated)** — a scheduled *between-sessions* pass that reviews
+  past sessions, extracts patterns, and curates memory. This is the
+  *consolidation* layer (≈ §5 consolidate-memory). Our trigger layer is
+  upstream of it and complementary.
+
+**Takeaway:** the just-in-time *trigger at the decision point* is the novel
+piece. Storage and consolidation have prior art we can adopt later;
+neither obviates this spec.

--- a/docs/specs/just-in-time-recall/requirements.md
+++ b/docs/specs/just-in-time-recall/requirements.md
@@ -1,0 +1,75 @@
+# Just-In-Time Recall — Requirements
+
+**Status:** draft (2026-06-03) · **Owner:** Patrick + agent
+**Born:** chat during the P2 memory build, 2026-06-03.
+
+## Problem
+
+Cross-session memory (P1/P2) closes the *not-knowing* gap: findings
+persist and recall surfaces them at session start. But the failure mode
+observed live on 2026-06-03 was different — a **not-applying** failure.
+The question-shape rule was already stored in *two* places
+(`.claude/CLAUDE.md` Lessons + `feedback_one_question_at_a_time.md`), and
+it was still dropped three times mid-session. The gap wasn't storage or
+breadth; it was **trigger timing**: nothing surfaced the governing rule
+at the moment of the action it governs.
+
+SessionStart recall is breadth-at-the-door. It cannot catch a mid-flow
+slip, because the relevant rule scrolled out of attention twenty turns
+ago. The fix is recall *at the decision point*, not just at the door.
+
+## Outcome
+
+When the agent is about to take an action that a durable rule governs,
+that rule is surfaced into context **at that moment** — so the
+not-applying failure is caught before it happens, not lamented after.
+
+## Scope (this spec)
+
+- **Source:** durable lessons/rules only — `.claude/CLAUDE.md` Lessons
+  and the `feedback_*` memories. NOT the P2 session-stash findings
+  (that's a later layer; decided 2026-06-03).
+- **First trigger target:** the highest-value, most-reliably-slipped
+  decision points — beginning with `AskUserQuestion` (governed by the
+  question-shape rules), as the proof case.
+
+## Requirements
+
+- **R1 — Premise verified first.** Phase 0 must empirically establish
+  whether a hook can inject model-readable guidance at a tool-call
+  decision point (PreToolUse `additionalContext` or equivalent), with a
+  named fallback if it cannot. No design commitment before this is known
+  (the repo's existing PreToolUse hooks only allow/block — they do not
+  inject context, so this is genuinely open).
+- **R2 — Right rule, right moment.** When a governed action is about to
+  fire, the matching rule's text (concise) is surfaced. Matching is
+  precise enough that the *correct* rule appears, not a grab-bag.
+- **R3 — Low noise / no nag-fatigue.** Guidance fires only at instrumented
+  decision points, not on every tool call; and follows the §3 "surface
+  once" discipline so a repeated action in one session isn't nagged
+  repeatedly. Silence is the default when no rule matches.
+- **R4 — Fail-safe.** The mechanism never blocks or breaks a tool call;
+  a crash or missing corpus degrades to silent no-op (the hook
+  conventions already in `plugin/hooks/`).
+- **R5 — Curated, maintainable mapping.** The decision-point → rule(s)
+  mapping is explicit and reviewable (not opaque), so it stays honest as
+  rules are added/renamed. New slip-points are cheap to instrument.
+- **R6 — Proof case passes.** The `AskUserQuestion` → question-shape-rule
+  path demonstrably surfaces the rule before the call, measured against a
+  reproduction of the 2026-06-03 slip.
+
+## Non-goals (this spec)
+
+- Recalling session-stash findings at decision points (later layer).
+- Semantic/embedding retrieval over the full lesson corpus (start with a
+  curated map; revisit only if the map doesn't scale).
+- Instrumenting every tool — start with a curated slip-point set.
+- Auto-editing or enforcing behavior — this **surfaces** guidance; the
+  agent still decides. (No hard blocks; that's a different threat model.)
+
+## Done when
+
+- Phase 0 premise documented in `decisions.md` with the verified
+  injection mechanism (or the fallback) chosen.
+- The `AskUserQuestion` proof case (R6) surfaces the question-shape rule
+  at the decision point, fail-safe and low-noise, with a test.

--- a/docs/specs/just-in-time-recall/tasks.md
+++ b/docs/specs/just-in-time-recall/tasks.md
@@ -1,0 +1,52 @@
+# Just-In-Time Recall — Tasks
+
+Independently shippable units. **Phase 0 gates everything** — no
+implementation past it until the injection mechanism is logged in
+`decisions.md` (D2).
+
+## Phase 0 — verify the injection premise (gate)
+
+- [ ] **T0.1** Instrument a throwaway PreToolUse hook that returns
+  `additionalContext` and observe whether the text reaches model context
+  while the call still proceeds. Record the exact payload shape that
+  works (or fails) for the installed Claude Code version.
+- [ ] **T0.2** If T0.1 fails, repeat for UserPromptSubmit
+  `additionalContext`. Record which channel injects reliably.
+- [ ] **T0.3** Log the chosen mechanism + the working payload shape in
+  `decisions.md` (resolve D2). Stop and confirm with Patrick before
+  Phase 1 if the only working channel is the degraded "advisory block."
+
+## Phase 1 — proof case: AskUserQuestion → question-shape rule
+
+- [ ] **T1.1** Create the curated map (`plugin/hooks/_recall_map.py` or a
+  JSON sidecar) with the single `AskUserQuestion` entry → the
+  question-shape one-liner (D3/D4).
+- [ ] **T1.2** Create `plugin/hooks/jit_recall.py`: read payload → map
+  lookup → `(session_id, rule_id)` surface-once sentinel → inject via the
+  Phase 0 channel → allow → fail-safe try/except (R2–R5). Register in
+  `hooks.json` for the verified event.
+- [ ] **T1.3** Tests: map lookup, surface-once gate (second same-rule fire
+  in a session is silent), no-entry silent no-op, crash → exit 0, and the
+  injected-text content for the AskUserQuestion case. Mirror the
+  `test_session_memory_hooks.py` importlib-loader pattern.
+- [ ] **T1.4** Reproduce the 2026-06-03 slip (an AskUserQuestion call) and
+  confirm the rule surfaces at the decision point (R6). Record the
+  before/after in the PR.
+
+## Phase 2 — grow the map + tune cadence (deferred)
+
+- [ ] **T2.1** Add the next 2–3 highest-value slip-points (e.g. git push
+  to a shared branch → fetch-first rule) once the proof case holds.
+- [ ] **T2.2** Decide the surface-once vs decay question (D5) from proof-
+  case evidence; implement decay only if once-per-session proves too
+  sparse.
+- [ ] **T2.3** (Maybe) auto-derive map entries from lesson frontmatter
+  tags — only if the curated map outgrows a single file.
+
+## Notes
+
+- Each phase is its own PR. Phase 0 may be a tiny throwaway-hook PR or
+  even just a logged measurement; the build is Phase 1.
+- Distinct from the P2 memory hooks — different corpus (rules vs
+  findings), different trigger (decision-point vs door). No dependency
+  either way.


### PR DESCRIPTION
**Draft spec, saved to loop back** — born from the P2 memory-build chat on 2026-06-03.

## The idea
Cross-session memory (P1/P2) closes the *not-knowing* gap (findings persist, recall surfaces them at the door). The failure observed live today was *not-applying*: the question-shape rule was stored in two places and still dropped three times mid-flow. The gap is **trigger timing** — surface the governing rule **at the decision point it governs**, not just at session start.

## What's here
- `requirements.md` — R1 (verify the injection premise first) … R6 (AskUserQuestion proof case).
- `design.md` — curated decision-point→rule map (not semantic retrieval), surface-once gate, **Phase 0** to verify whether a hook can inject context (the repo's PreToolUse hooks only allow/block — genuinely unverified), + a **verified prior-art note** (Claude Code Memory / API Memory Tool / MCP memory server / Managed Agents "Dreaming") so it doesn't read as reinventing memory.
- `decisions.md` — D1 source = durable rules (your call), D2 trigger pending Phase 0, D3 curated map, D4 one-liner nudge, D5 surface-once.
- `tasks.md` — Phase 0 gates everything; Phase 1 = the AskUserQuestion proof case.

No implementation yet. Merging just lands the draft in `docs/specs/` so it shows in session orientation when we pick it back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)