### PR TITLE
test(memory): isolate long-term storage in precedence test (SUT-write-leak)

### DIFF
--- a/tests/unit/memory/test_memory_architecture.py
+++ b/tests/unit/memory/test_memory_architecture.py
@@ -76,9 +76,11 @@ class TestUnifiedMemoryInterface:
     def test_retrieve_checks_both_tiers(self):
         """Test that retrieve checks short-term first, then long-term."""
 
-    def test_short_term_takes_precedence_over_long_term(self):
+    def test_short_term_takes_precedence_over_long_term(self, tmp_path):
         """Test that short-term data overrides long-term if both exist."""
-        config = MemoryConfig(redis_mock=True)
+        # Isolate long-term storage so the test does not write to the
+        # tracked ./memdocs_storage fixture (SUT-write-leak family).
+        config = MemoryConfig(redis_mock=True, storage_dir=str(tmp_path))
         memory = UnifiedMemory(user_id="test_user", config=config)
 
         # Store in long-term with old value


### PR DESCRIPTION
## What

`test_short_term_takes_precedence_over_long_term` constructed `MemoryConfig(redis_mock=True)` with the default `storage_dir="./memdocs_storage"` — a tracked path. The test therefore wrote real files into a tracked fixture dir on every run (SUT-write-leak family).

Fix: pass a `tmp_path`-backed `storage_dir` so the test is hermetic.

## Provenance

Recovered from the abandoned `claude/loving-kirch-faa205` worktree during the worktree-inventory cleanup pass. It was uncommitted working-tree work not present on any branch.

## Verification

- `ruff check` + `black --check`: clean
- Affected test passes (`1 passed in 2.56s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)