### PR TITLE
chore(spec): mark discovery-sweep complete (status was stale at approved)

### DIFF
--- a/docs/specs/discovery-sweep/decisions.md
+++ b/docs/specs/discovery-sweep/decisions.md
@@ -1,6 +1,6 @@
 # Decisions — Discovery Sweep
 
-**Status:** approved
+**Status:** complete (2026-05-13)
 
 Context, motivation, and load-bearing design decisions for a meta-workflow that fans out across the audit-family workflows and triages their findings into act-on-now / drop / ask-human buckets.
 

--- a/docs/specs/discovery-sweep/design.md
+++ b/docs/specs/discovery-sweep/design.md
@@ -1,6 +1,6 @@
 # Design — Discovery Sweep
 
-**Status:** approved with updates
+**Status:** complete (2026-05-13)
 
 Technical shape of the work. See `requirements.md` for what we're building, `tasks.md` for the phase plan, `decisions.md` for why.
 

--- a/docs/specs/discovery-sweep/requirements.md
+++ b/docs/specs/discovery-sweep/requirements.md
@@ -1,6 +1,6 @@
 # Requirements — Discovery Sweep
 
-**Status:** approved with notes
+**Status:** complete (2026-05-13)
 
 User-facing stories and the contracts they imply. See `decisions.md` for context, `design.md` for the technical shape, `tasks.md` for the phase plan.
 

--- a/docs/specs/discovery-sweep/tasks.md
+++ b/docs/specs/discovery-sweep/tasks.md
@@ -1,5 +1,5 @@
 # Tasks — Discovery Sweep
-**Status:** approved (2026-05-13) — Phase 1, 2A, 2B, 3 shipped; Phase 4 closed empty per P2.7 surface evaluation.
+**Status:** complete (2026-05-13) — Phase 1, 2A, 2B, 3 shipped; Phase 4 closed empty per P2.7 surface evaluation.
 | Phase | Status | Shipped via |
 |---|---|---|
 | Phase 1 — Engine + PatternScanSource | done | [#303](https://github.com/Smart-AI-Memory/attune-ai/pull/303), [#306](https://github.com/Smart-AI-Memory/attune-ai/pull/306) FP filter, [#309](https://github.com/Smart-AI-Memory/attune-ai/pull/309) AST filter |


### PR DESCRIPTION
## What

Flips the `**Status:**` header on the discovery-sweep spec files from `approved`-flavored to `complete (2026-05-13)`. Docs-only, no behavior change.

## Why

The spec is fully shipped:
- Phases 1 / 1.5 / 2A / 2B / 2.7 / 3 — all `done` with PR links in `tasks.md`
- Phase 4 (CLI deprecation) — **closed empty** (P2.7 surface evaluation found zero deprecation candidates)
- Follow-up `discovery-sweep-ops-integration` — done 2026-05-16
- `_sequencing.md` already lists both specs under "Done"

Only the per-file `Status` headers lagged at `approved`, which is why the session-start in-flight list rendered discovery-sweep as `(unknown)`.

## Provenance

Surfaced during a worktree-inventory + spec-menu re-rank session. discovery-sweep ranked #1 on a false "4 todo" signal — those 4 `[ ]` were struck-through, closed-empty Phase 4 items, not real work. This is the exact drift `spec-status-self-truthing` is designed to eliminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)