### PR TITLE
feat(redis): int8 embedding quantization for AMS via factory seam (Track A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **int8 embedding quantization for Redis Agent Memory Server** —
+  `attune_redis.vector_db_int8.create_int8_memory_db` plugs into AMS
+  via its `MEMORY_VECTOR_DB_FACTORY` seam (no fork) to store
+  long-term-memory embeddings as int8 instead of float32 (~75% less
+  index memory, ~30% faster search). A thin `Int8VectorIndexProxy`
+  re-encodes vectors to int8 at the RedisVL index boundary (write +
+  query), avoiding ~200 lines of AMS method duplication; drift-guard
+  tests catch upstream changes to the internals it relies on.
+  Phase-0 benchmark on the `.help` corpus showed zero recall loss
+  vs float32 (P@1/recall@5 delta 0.0, 0.925 top-1 agreement).
+  Requires a Redis 8 Query Engine (`TYPE INT8`); fails loudly
+  otherwise. See `docs/specs/ams-int8-quantization/`.
+
+### Changed
+
+- `attune_redis.__init__` now exposes `RedisPlugin` lazily (PEP 562
+  `__getattr__`) so importing submodules like `vector_db_int8` no
+  longer forces an `attune` import — required for the AMS server
+  venv, which loads the int8 factory but does not have `attune`.
+
 ## [7.3.1] — 2026-06-02
 
 ### Added

--- a/attune_redis/__init__.py
+++ b/attune_redis/__init__.py
@@ -13,7 +13,23 @@ Licensed under the Apache License, Version 2.0
 
 from .config import RedisPluginConfig
 from .memory import AMSMemoryBackend
-from .plugin import RedisPlugin
 
 __version__ = "0.1.0"
 __all__ = ["AMSMemoryBackend", "RedisPlugin", "RedisPluginConfig"]
+
+
+def __getattr__(name: str):
+    """Lazily expose RedisPlugin without forcing an ``attune`` import.
+
+    ``RedisPlugin`` imports the attune plugin framework, which is not
+    present in every consumer's environment (e.g. the agent-memory-server
+    venv that imports ``attune_redis.vector_db_int8`` via
+    ``MEMORY_VECTOR_DB_FACTORY``). Deferring the import keeps submodule
+    imports free of the ``attune`` dependency while
+    ``from attune_redis import RedisPlugin`` still works.
+    """
+    if name == "RedisPlugin":
+        from .plugin import RedisPlugin
+
+        return RedisPlugin
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/attune_redis/tests/test_vector_db_int8.py
+++ b/attune_redis/tests/test_vector_db_int8.py
@@ -1,0 +1,189 @@
+"""Tests for the int8 vector backend (attune_redis.vector_db_int8).
+
+Three layers:
+- pure quantization math (numpy only)
+- proxy behavior against a fake index (no Redis)
+- drift guards against agent-memory-server internals the proxy
+  relies on (skipped when agent_memory_server isn't installed)
+
+The live round-trip (factory -> proxy -> RedisVLMemoryVectorDatabase
+-> Redis 8) is validated manually in
+docs/specs/ams-int8-quantization/ — it needs a Redis 8 Query Engine
+plus Ollama, which CI does not provide.
+
+Copyright 2025-2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from attune_redis.vector_db_int8 import (  # noqa: E402
+    Int8VectorIndexProxy,
+    _build_int8_schema,
+    quantize_int8,
+)
+
+# --------------------------------------------------------------------------
+# Quantization math
+# --------------------------------------------------------------------------
+
+
+def test_quantize_within_int8_range():
+    out = quantize_int8([0.13, -0.42, 0.05, -0.9, 0.9])
+    assert all(-127 <= v <= 127 for v in out)
+    assert all(isinstance(v, int) for v in out)
+
+
+def test_quantize_max_abs_maps_to_127():
+    # The largest-magnitude component maps to the int8 extreme.
+    out = quantize_int8([0.5, -1.0, 0.25])
+    assert out[1] == -127
+    assert out == [64, -127, 32]
+
+
+def test_quantize_handles_all_zero_vector():
+    # peak falls back to 1.0; no division by zero.
+    assert quantize_int8([0.0, 0.0, 0.0]) == [0, 0, 0]
+
+
+# --------------------------------------------------------------------------
+# Proxy behavior (fake index, no Redis)
+# --------------------------------------------------------------------------
+
+
+class _FakeIndex:
+    def __init__(self):
+        self.loaded = None
+        self.queried = None
+        self.create_calls = 0
+
+    async def load(self, data, *a, **k):
+        self.loaded = data
+        return ["x"]
+
+    async def query(self, q, *a, **k):
+        self.queried = q
+        return []
+
+    async def create(self, *a, **k):
+        self.create_calls += 1
+        return "created"
+
+    name = "fake-index"
+
+
+class _FakeQuery:
+    def __init__(self, vec):
+        self._vector = vec
+        self._dtype = "float32"
+
+
+def test_proxy_load_reencodes_float32_bytes_to_int8():
+    idx = _FakeIndex()
+    proxy = Int8VectorIndexProxy(idx)
+    blob = np.array([0.5, -1.0, 0.25], dtype=np.float32).tobytes()  # 12 bytes
+    asyncio.run(proxy.load([{"vector": blob, "id_": "m1"}]))
+    out = idx.loaded[0]["vector"]
+    assert isinstance(out, bytes)
+    assert len(out) == 3  # 3 int8 bytes, not 12 float32 bytes
+    assert list(np.frombuffer(out, dtype=np.int8)) == [64, -127, 32]
+
+
+def test_proxy_load_ignores_records_without_bytes_vector():
+    idx = _FakeIndex()
+    proxy = Int8VectorIndexProxy(idx)
+    asyncio.run(proxy.load([{"id_": "m1"}]))  # no vector key
+    assert idx.loaded == [{"id_": "m1"}]
+
+
+def test_proxy_query_quantizes_and_sets_int8_dtype():
+    idx = _FakeIndex()
+    proxy = Int8VectorIndexProxy(idx)
+    q = _FakeQuery([0.5, -1.0, 0.25])
+    asyncio.run(proxy.query(q))
+    assert q._dtype == "int8"
+    assert q._vector == [64, -127, 32]
+    assert idx.queried is q
+
+
+def test_proxy_aggregate_raises_to_force_fallback():
+    proxy = Int8VectorIndexProxy(_FakeIndex())
+    with pytest.raises(NotImplementedError):
+        asyncio.run(proxy.aggregate())
+
+
+def test_proxy_delegates_unknown_attrs():
+    proxy = Int8VectorIndexProxy(_FakeIndex())
+    assert proxy.name == "fake-index"
+
+
+def test_proxy_create_translates_int8_unsupported_error():
+    class _Rejecting(_FakeIndex):
+        async def create(self, *a, **k):
+            raise ValueError(
+                "Bad arguments for vector similarity HNSW index `TYPE`: " "Unknown argument"
+            )
+
+    proxy = Int8VectorIndexProxy(_Rejecting())
+    with pytest.raises(RuntimeError, match="Redis 8 Query Engine"):
+        asyncio.run(proxy.create())
+
+
+def test_proxy_create_passes_through_unrelated_errors():
+    class _Boom(_FakeIndex):
+        async def create(self, *a, **k):
+            raise ValueError("connection refused")
+
+    proxy = Int8VectorIndexProxy(_Boom())
+    with pytest.raises(ValueError, match="connection refused"):
+        asyncio.run(proxy.create())
+
+
+def test_proxy_create_success_delegates():
+    idx = _FakeIndex()
+    proxy = Int8VectorIndexProxy(idx)
+    assert asyncio.run(proxy.create()) == "created"
+    assert idx.create_calls == 1
+
+
+# --------------------------------------------------------------------------
+# Drift guards against agent-memory-server internals
+# --------------------------------------------------------------------------
+
+
+def test_build_int8_schema_sets_vector_datatype():
+    pytest.importorskip("agent_memory_server")
+    schema = _build_int8_schema()
+    vec = [f for f in schema["fields"] if f.get("type") == "vector"]
+    assert len(vec) == 1
+    assert vec[0]["attrs"]["datatype"] == "int8"
+
+
+def test_ams_add_memories_still_encodes_float32():
+    """proxy.load assumes AMS hands it float32 vector bytes."""
+    pytest.importorskip("agent_memory_server")
+    import inspect
+
+    from agent_memory_server.memory_vector_db import RedisVLMemoryVectorDatabase
+
+    src = inspect.getsource(RedisVLMemoryVectorDatabase.add_memories)
+    assert "dtype=np.float32" in src, (
+        "AMS add_memories no longer encodes float32; "
+        "Int8VectorIndexProxy.load assumptions need review"
+    )
+
+
+def test_redisvl_vectorquery_exposes_vector_and_dtype():
+    """proxy.query mutates VectorQuery._vector and ._dtype."""
+    pytest.importorskip("redisvl")
+    from redisvl.query import VectorQuery
+
+    vq = VectorQuery(vector=[0.1, 0.2], vector_field_name="vector")
+    assert hasattr(vq, "_vector")
+    assert hasattr(vq, "_dtype")

--- a/attune_redis/vector_db_int8.py
+++ b/attune_redis/vector_db_int8.py
@@ -1,0 +1,164 @@
+"""int8-quantized vector backend for the Redis Agent Memory Server.
+
+Plugs into agent-memory-server via its ``MEMORY_VECTOR_DB_FACTORY``
+extension seam (no fork of agent-memory-server required)::
+
+    MEMORY_VECTOR_DB_FACTORY=attune_redis.vector_db_int8.create_int8_memory_db
+
+Stores long-term-memory embeddings as int8 instead of float32,
+cutting index memory ~75% and speeding vector search ~30% with no
+measurable recall loss on our corpus (Phase-0 benchmark: int8 vs
+float32 P@1 delta 0.0, recall@5 delta 0.0 — see
+docs/specs/ams-int8-quantization/).
+
+Design — index proxy, not method override
+-----------------------------------------
+Rather than subclass ``RedisVLMemoryVectorDatabase`` and duplicate
+its ~200 lines of add/search logic (high drift risk across AMS
+versions), this wraps the RedisVL ``AsyncSearchIndex`` in a thin
+proxy that re-encodes vectors to int8 at the index boundary:
+
+- **write** (``load``): AMS hands the index float32 vector bytes;
+  the proxy decodes and re-encodes them as int8.
+- **query** (``query``): the proxy quantizes the query vector and
+  flips the ``VectorQuery``/``RangeQuery`` dtype to int8 before
+  execution.
+- **server-side recency** (``aggregate``): not supported on int8;
+  the proxy raises so AMS falls back to its standard query path
+  (which the proxy handles) plus client-side recency reranking.
+
+Quantization is per-vector max-abs scaling to ``[-127, 127]``.
+nomic-embed-text vectors are not unit-normalized, so a per-vector
+scale uses the full int8 range; COSINE distance is invariant to
+positive per-vector scaling, so this is safe.
+
+Requires a **Redis 8 Query Engine** (``TYPE INT8`` vector fields).
+The proxy fails loudly if the server rejects int8 rather than
+silently falling back to float32.
+
+Copyright 2025-2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+#: Field name AMS uses for the embedding vector in its RedisVL schema.
+_VECTOR_FIELD = "vector"
+
+
+def quantize_int8(vec: Any) -> list[int]:
+    """Per-vector max-abs quantize a float embedding to int8 range.
+
+    Args:
+        vec: Sequence of floats (or anything ``np.asarray`` accepts).
+
+    Returns:
+        List of ints in ``[-127, 127]``. COSINE is invariant to the
+        positive per-vector scale, so query and document vectors may
+        be scaled independently.
+    """
+    a = np.asarray(vec, dtype=np.float32)
+    peak = float(np.max(np.abs(a))) or 1.0
+    q = np.clip(np.round(a * (127.0 / peak)), -127, 127)
+    return q.astype(np.int8).tolist()
+
+
+class Int8VectorIndexProxy:
+    """Wrap a RedisVL ``AsyncSearchIndex`` to store/query int8 vectors.
+
+    Delegates everything to the wrapped index except the three
+    vector-touching paths (``load`` / ``query`` / ``aggregate``).
+    """
+
+    def __init__(self, index: Any) -> None:
+        self._index = index
+
+    def __getattr__(self, name: str) -> Any:
+        # Everything not overridden below (exists, create's siblings,
+        # name, schema, etc.) delegates to the real index.
+        return getattr(self._index, name)
+
+    async def create(self, *args: Any, **kwargs: Any) -> Any:
+        """Create the index; translate int8-unsupported into a clear error."""
+        try:
+            return await self._index.create(*args, **kwargs)
+        except Exception as e:  # noqa: BLE001
+            msg = str(e).lower()
+            if "type" in msg and ("int8" in msg or "unknown argument" in msg):
+                raise RuntimeError(
+                    "int8 vector fields require the Redis 8 Query Engine; the "
+                    "configured Redis rejected TYPE INT8. Use a Redis 8 CE "
+                    "backend, or unset MEMORY_VECTOR_DB_FACTORY to use float32."
+                ) from e
+            raise
+
+    async def load(self, data: list[dict], *args: Any, **kwargs: Any) -> Any:
+        """Re-encode each record's float32 vector bytes as int8 before load."""
+        for rec in data:
+            v = rec.get(_VECTOR_FIELD)
+            if isinstance(v, bytes | bytearray):
+                floats = np.frombuffer(v, dtype=np.float32)
+                rec[_VECTOR_FIELD] = np.array(quantize_int8(floats), dtype=np.int8).tobytes()
+        return await self._index.load(data, *args, **kwargs)
+
+    async def query(self, query: Any, *args: Any, **kwargs: Any) -> Any:
+        """Quantize the query vector and flip dtype to int8 before executing."""
+        vec = getattr(query, "_vector", None)
+        if vec is not None:
+            query._vector = quantize_int8(vec)
+            query._dtype = "int8"
+        return await self._index.query(query, *args, **kwargs)
+
+    async def aggregate(self, *args: Any, **kwargs: Any) -> Any:
+        """Server-side recency aggregation is unsupported on int8.
+
+        Raising forces AMS's built-in fallback to the standard query
+        path (handled by ``query`` above) plus client-side recency.
+        """
+        raise NotImplementedError(
+            "int8 backend does not support server-side recency aggregation; "
+            "falling back to standard vector query"
+        )
+
+
+def _build_int8_schema() -> dict:
+    """AMS's RedisVL schema with the vector field's datatype set to int8."""
+    from agent_memory_server.memory_vector_db_factory import _build_redis_schema
+
+    schema = _build_redis_schema()
+    for field in schema.get("fields", []):
+        if field.get("type") == "vector":
+            field.setdefault("attrs", {})["datatype"] = "int8"
+    return schema
+
+
+def create_int8_memory_db(embeddings: Any) -> Any:
+    """Factory for ``MEMORY_VECTOR_DB_FACTORY``: int8 Redis vector DB.
+
+    Args:
+        embeddings: AMS embeddings instance (passed by the server).
+
+    Returns:
+        A ``RedisVLMemoryVectorDatabase`` whose index stores/queries
+        int8 vectors via :class:`Int8VectorIndexProxy`.
+    """
+    from agent_memory_server.config import settings
+    from agent_memory_server.memory_vector_db import RedisVLMemoryVectorDatabase
+    from agent_memory_server.utils.redis import redis_url_for_redisvl
+    from redisvl.index import AsyncSearchIndex
+
+    schema = _build_int8_schema()
+    index = AsyncSearchIndex.from_dict(schema, redis_url=redis_url_for_redisvl(settings.redis_url))
+    proxy = Int8VectorIndexProxy(index)
+    logger.info("int8 memory vector DB created (index=%s)", schema["index"]["name"])
+    return RedisVLMemoryVectorDatabase(proxy, embeddings)
+
+
+__all__ = ["create_int8_memory_db", "quantize_int8", "Int8VectorIndexProxy"]


### PR DESCRIPTION
## Summary

**Track A** of the ams-int8-quantization spec (#608, Phase-0 GO).
Stores Redis Agent Memory Server long-term-memory embeddings as
**int8** instead of float32 — ~75% less index memory, ~30% faster
search — via agent-memory-server's `MEMORY_VECTOR_DB_FACTORY`
extension seam. **No fork of agent-memory-server.**

## How

- `create_int8_memory_db` factory builds AMS's own RedisVL schema
  with the vector datatype flipped to int8.
- `Int8VectorIndexProxy` wraps the RedisVL index and re-encodes
  vectors to int8 at the boundary: **write** (decode AMS's float32
  bytes → int8) and **query** (quantize + flip VectorQuery dtype).
  This avoids duplicating ~200 lines of AMS add/search methods;
  drift-guard tests catch upstream changes to the internals relied
  on.
- Per-vector max-abs scaling to [-127,127] (COSINE-safe; nomic
  vectors aren't unit-normalized).
- Fails loudly if the server lacks the Redis 8 Query Engine
  (`TYPE INT8`) rather than silently using float32.
- `attune_redis.__init__` exposes `RedisPlugin` lazily (PEP 562)
  so the factory submodule imports in the AMS venv without `attune`.

## Enabling

```
MEMORY_VECTOR_DB_FACTORY=attune_redis.vector_db_int8.create_int8_memory_db
```
Requires a Redis 8 CE backend. **Set before the long-term store
fills** — datatype can't change without re-embedding.

## Validation

- 11 unit tests (quantize math + proxy via fake index) + 3 drift
  guards (verified against real AMS/RedisVL).
- Live round-trip on `redis:8` + Ollama: int8 index (dim 768),
  correct semantic ranking. Phase-0 recall vs float32: 0.0 delta.

Pre-existing `test_memory.py` errors in some envs are unrelated
(`agent_memory_client` not installed) and present on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
