### PR TITLE
chore(release): v7.4.0 — int8 embedding quantization for AMS

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "7.3.1"
+    "version": "7.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "7.3.1",
+      "version": "7.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v7.3.1
+# Attune AI Framework v7.4.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 7.3.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 7.4.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/.help/templates/plugin/concept.md
+++ b/.help/templates/plugin/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: concept
-generated_at: 2026-06-03T02:46:55.572515+00:00
-source_hash: 57b8e505bab7ccba5ff519e5f59111f1ef50f2e629841d8c034de4c1391df086
+generated_at: 2026-06-04T10:52:19.406858+00:00
+source_hash: 3564938306a66c3c29641900b4227debc9ca0a266533d177666962f7158ba391
 status: generated
 ---
 
@@ -17,7 +17,7 @@ The main building blocks are:
 - **`SpecInfo`** — One in-flight spec discovered under a workspace root.
 - **`GitState`** — Snapshot of the worktree's git state at hook fire time.
 
-Under the hood, this feature spans 964 source
+Under the hood, this feature spans 967 source
 files covering:
 
 - CLI wrapper for the ``/handoff`` slash command.

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: reference
-generated_at: 2026-06-03T02:46:55.584320+00:00
-source_hash: 57b8e505bab7ccba5ff519e5f59111f1ef50f2e629841d8c034de4c1391df086
+generated_at: 2026-06-04T10:52:19.419823+00:00
+source_hash: 3564938306a66c3c29641900b4227debc9ca0a266533d177666962f7158ba391
 status: generated
 ---
 
@@ -36,6 +36,8 @@ status: generated
 | `validate_bash_command()` | Validate a Bash command against security policies. | `plugin/hooks/security_guard.py` |
 | `validate_file_path()` | Validate a file path against security policies. | `plugin/hooks/security_guard.py` |
 | `main()` | Validate a tool call against security policies. | `plugin/hooks/security_guard.py` |
+| `main()` | — | `plugin/hooks/session_recall.py` |
+| `main()` | Entry point — acts once per substantive session, never raises. | `plugin/hooks/session_stash.py` |
 | `format_orientation()` | Short markdown list of in-flight specs for non-compact starts. | `plugin/hooks/spec_orient.py` |
 | `render_spec_pin()` | Render a spec body for post-compact context restoration. | `plugin/hooks/spec_orient.py` |
 | `main()` | Entry point — branches on ``source``, never raises. | `plugin/hooks/spec_orient.py` |

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -1,8 +1,8 @@
 ---
 feature: plugin
 depth: task
-generated_at: 2026-06-03T02:46:55.579766+00:00
-source_hash: 57b8e505bab7ccba5ff519e5f59111f1ef50f2e629841d8c034de4c1391df086
+generated_at: 2026-06-04T10:52:19.415077+00:00
+source_hash: 3564938306a66c3c29641900b4227debc9ca0a266533d177666962f7158ba391
 status: generated
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Attune AI (formerly Empathy Framework) will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.4.0] — 2026-06-04
 
 ### Added
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 7.3.1
+**Version:** 7.4.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 7.3.1 | **License:** Apache 2.0
+**Version:** 7.4.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "7.3.1"
+    "version": "7.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "7.3.1",
+      "version": "7.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "7.3.1",
+  "version": "7.4.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "7.3.1"
+__version__ = "7.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "7.3.1"
+version = "7.4.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "7.3.1"
+version = "7.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Cut **v7.4.0** — the int8 embedding quantization feature (#609) has been sitting on `main` unreleased since the v7.3.1 tag. This bumps every release-artifact file and promotes the changelog so the release can be tagged.

## What changed

- **Version 7.3.1 → 7.4.0** across all release-artifact files (minor bump — additive feature):
  - `pyproject.toml`, `plugin/.claude-plugin/plugin.json`
  - `plugin/.claude-plugin/marketplace.json` + root `.claude-plugin/marketplace.json` (metadata + plugin version each)
  - `plugin/core/__init__.py`, `.claude/CLAUDE.md` (header + footer), `docs/reference/API_REFERENCE.md` (header + footer)
  - `uv.lock` (own-package pin)
- **CHANGELOG**: promoted `[Unreleased]` → `[7.4.0] — 2026-06-04`
- `.help/templates/plugin/*.md` refreshed by the pre-commit freshness hook (frontmatter + source-file-count, from prior merged work)

## Release contents

The sole feature is **int8 embedding quantization for the Redis Agent Memory Server** (#609): plugs into AMS via its `MEMORY_VECTOR_DB_FACTORY` seam (no fork), ~75% less index memory / ~30% faster search, zero recall loss vs float32 in the Phase-0 benchmark. Requires a Redis 8 Query Engine; fails loudly otherwise. Plus the companion lazy `attune_redis.__init__` change.

## Pre-flight (attune-release-check)

- [x] 7.4.0 not on PyPI (latest 7.3.1)
- [x] `test_all_versions_match` + semver tests pass (29 passed)
- [x] All version surfaces consistent — no drift
- [x] `python -m build` produces `attune_ai-7.4.0` wheel + sdist clean
- [x] Tag `v7.4.0` does not exist

## After merge

Tag `v7.4.0` on the squash commit and trigger `publish-pypi.yml` (your call — publishing + tag are held per standing rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
