### PR TITLE
feat(cli): propagate workflow failure to the exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to Attune AI (formerly Empathy Framework) will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed (Breaking)
+
+- **`attune workflow run` now exits non-zero when the workflow
+  actually failed.** Previously the command exited `0` even when
+  `WorkflowResult.success` was `False` or the SDK adapter swallowed an
+  uncaught exception — an exit-0 lie that forced downstream consumers
+  (the ops dashboard, CI scripts, IDE integrations) to scrape logs to
+  tell success from failure. The new exit-code contract:
+
+  | Code | Meaning |
+  |------|---------|
+  | `0` | Workflow ran and succeeded |
+  | `1` | Workflow ran and reported failure (`success is False`) |
+  | `2` | Workflow raised an uncaught exception (traceback on stderr) |
+  | `3` | CLI-level error (workflow not found, bad path, bad JSON) |
+
+  CLI-level errors that previously returned `1` now return `3`;
+  workflow exceptions that previously returned `1` now return `2`.
+  Workflows returning a plain `dict` / `str` / `None` (no `success`
+  field) still exit `0`.
+
+  `--json` output additively threads `exit_code` and `sdk_error_kind`
+  into the emitted JSON so CI consumers can read the outcome without
+  branching on `$?` (which remains authoritative).
+
+  **Migration** — scripts that relied on the old always-zero exit and
+  want to tolerate a *planned* failure (exit `1`) while still failing
+  on a crash (exit `2`/`3`):
+
+  ```sh
+  attune workflow run X; rc=$?; [ "$rc" -le 1 ] || exit "$rc"
+  ```
+
+  The ops dashboard's defense-in-depth log-scan
+  (`run_view.js` `detectLogErrorLeak`) is retained for one release as
+  a safety net and will be retired in a following release now that the
+  exit code is honest. See
+  `docs/specs/workflow-failure-exit-propagation/`.
+
 ## [7.4.0] — 2026-06-04
 
 ### Added

--- a/docs/specs/workflow-failure-exit-propagation/decisions.md
+++ b/docs/specs/workflow-failure-exit-propagation/decisions.md
@@ -19,22 +19,31 @@
 
 ---
 
-## Open questions (resolve during design phase)
+## Open questions — RESOLVED (design phase)
 
-1. **`_run_workflow_with_exit_code()` helper location.** Could live
-   in `cli_minimal.py` or in a new `cli_commands/_exit_codes.py`.
-   The latter is cleaner long-term; the former is one less file
-   to wire up. Decide during design.
+1. **Helper location → `cli_commands/_exit_codes.py` (new file).**
+   The contract (`EXIT_*` constants + `run_workflow_with_exit_code()`
+   + JSON threading) lives in a dedicated module under the existing
+   `cli_commands/` package, keeping `cli_minimal.py` free of
+   classification logic. The helper takes the workflow *class* and
+   instantiates it inside its own `try`, so constructor failures are
+   classified as exit 2 too. See `design.md` Q1.
 
-2. **Logging interaction.** When exit code is `2`, the traceback is
-   already printed to stderr by Python's default exception handler.
-   Do we also want a structured `--json` mode for CI consumers?
-   Defer to design.
+2. **`--json` mode → thread `exit_code` + `sdk_error_kind`; `$?`
+   stays authoritative.** JSON output additively gains `exit_code`
+   and `sdk_error_kind` (read from `result.metadata`, populated by
+   the sdk-error-message-fidelity primitives — no new classification
+   here). Object outputs get the keys injected (`setdefault`, never
+   clobbering); non-dict results are wrapped in an
+   `{exit_code, success, sdk_error_kind, result}` envelope. The
+   "last `{...}` block" invariant that `security-scan.yml` relies on
+   is preserved. See `design.md` Q2.
 
-3. **Migration message.** Should the CHANGELOG entry include a
-   one-line shell snippet for shop scripts that need to adapt?
-   E.g. `if attune workflow run X || [ $? -eq 1 ]; then …`. Decide
-   when CHANGELOG is drafted.
+3. **Migration snippet → yes, included in the CHANGELOG.** One
+   copy-safe shell line showing how a script tolerates a planned
+   failure (exit 1) while still failing on a crash (exit ≥ 2):
+   `attune workflow run X; rc=$?; [ "$rc" -le 1 ] || exit "$rc"`.
+   See `design.md` Q3.
 
 ---
 
@@ -47,3 +56,7 @@
   Triggered by ops-dashboard QA punch list item P0-2; companion
   defense-in-depth landed in dashboard log-scan PR (see
   `src/attune/ops/static/js/run_view.js` `detectLogErrorLeak`).
+- 2026-06-04 — Open questions Q1–Q3 resolved during the design
+  phase (see `design.md`) and implemented in one PR. No matrix rows
+  were revised. Dashboard log-scan retirement remains deferred to a
+  follow-up release per the matrix.

--- a/docs/specs/workflow-failure-exit-propagation/design.md
+++ b/docs/specs/workflow-failure-exit-propagation/design.md
@@ -1,0 +1,156 @@
+# Spec: Workflow Failure Exit Propagation — Design
+
+> Phase 2 (technical design). Resolves the three open questions from
+> `decisions.md`. The decision matrix itself is pre-committed and not
+> re-litigated here.
+
+---
+
+## Overview
+
+`attune workflow run <name>` dispatches through one path:
+
+```
+cli_minimal.main()
+  → _dispatch_subcommand(args, "workflow")
+    → cmd_workflow_run(args)          # cli_commands/workflow_commands.py
+  → sys.exit(main())                  # process exit = main()'s int
+```
+
+`main()` returns whatever `cmd_workflow_run` returns and
+`sys.exit(main())` makes that the process exit code. So the entire
+fix lives in `cmd_workflow_run`'s return values — no other CLI entry
+point sets the workflow-run exit code (verified by audit:
+`_SUBCOMMAND_DISPATCH["workflow"]["run"] = cmd_workflow_run` is the
+only binding).
+
+The bug: `cmd_workflow_run` returned `0` unconditionally after
+`execute()`, ignoring `WorkflowResult.success`, and returned `1` for
+both CLI-level errors and uncaught exceptions (no distinction).
+
+---
+
+## Resolved open questions
+
+### Q1 — Helper location → `cli_commands/_exit_codes.py` (new file)
+
+A new module `src/attune/cli_commands/_exit_codes.py` houses
+`run_workflow_with_exit_code()` plus the four `EXIT_*` constants and
+the JSON-threading helper. `cli_commands/` is an established package;
+this keeps `cli_minimal.py` (the argparse + dispatch surface) free of
+classification logic and gives the contract one home that any future
+CLI entry point can import.
+
+The helper takes the workflow **class** (not an instance) and
+instantiates it inside its own `try`, so a constructor failure is
+also classified as exit 2 rather than leaking as an unhandled
+exception out of `cmd_workflow_run`.
+
+The human-readable voice-layer print is **injected** as a
+`print_result` callback rather than imported, which (a) avoids an
+import cycle (`workflow_commands` ↔ `_exit_codes`) and (b) preserves
+the existing ops-daemon side-channel emission
+(`_emit_run_meta_for_daemon`) that rides inside `_print_workflow_result`
+— it only fires on the non-JSON path, unchanged.
+
+### Q2 — `--json` mode → thread `exit_code` + `sdk_error_kind`, `$?` authoritative
+
+In `--json` mode the helper threads two fields into the emitted JSON
+so CI consumers parsing stdout don't *also* have to branch on `$?`:
+
+- `exit_code` — the same int returned to the process.
+- `sdk_error_kind` — the classified SDK failure kind from
+  `result.metadata["sdk_error_kind"]` (populated by
+  `BaseWorkflow._error_result()` per the sdk-error-message-fidelity
+  spec), or `null`.
+
+`$?` remains the authoritative signal; the JSON fields are a
+convenience mirror.
+
+Threading strategy (preserves the "last `{...}` block" invariant that
+`.github/workflows/security-scan.yml` relies on):
+
+- If the workflow rendered a JSON **object** in `final_output` (it
+  honored `output_format="json"`), parse it and
+  `setdefault("exit_code", ...)` / `setdefault("sdk_error_kind", ...)`
+  — additive, never clobbering a key the workflow already set.
+- Else if the result is itself a `dict`, inject into a copy of it.
+- Else (string / dataclass / list) wrap in a small envelope:
+  `{"exit_code", "success", "sdk_error_kind", "result"}`.
+
+This keeps the two existing `--json` tests passing (extra keys are
+harmless to consumers that read `status`/`count`) and makes the
+non-dict path *more* useful than the legacy
+`json.dumps(WorkflowResult, default=str)` (which emitted a quoted
+dataclass repr with no braces — security-scan's extractor would have
+fallen through to its placeholder).
+
+### Q3 — CHANGELOG migration snippet → yes, one-line shell example
+
+The CHANGELOG entry documents the behavior change and includes a
+copy-safe migration snippet for scripts that need to tolerate a
+planned failure:
+
+```sh
+# Treat exit 1 (workflow said "no") as non-fatal, still fail on a crash:
+attune workflow run X; rc=$?; [ "$rc" -le 1 ] || exit "$rc"
+```
+
+---
+
+## Exit-code mapping (implementation)
+
+| Outcome | Detected where | Code | Constant |
+|---|---|---|---|
+| Workflow not found / bad JSON / bad path | `cmd_workflow_run`, before `execute()` | 3 | `EXIT_CLI_ERROR` |
+| `execute()` (or constructor) raised | `run_workflow_with_exit_code` `except` | 2 | `EXIT_UNPLANNED_FAILURE` |
+| `WorkflowResult.success is False` | `run_workflow_with_exit_code` | 1 | `EXIT_PLANNED_FAILURE` |
+| `success is True` / legacy dict-str-None result | `run_workflow_with_exit_code` | 0 | `EXIT_SUCCESS` |
+
+**Legacy compatibility:** "planned failure" is detected as
+`getattr(result, "success", None) is False`. Workflows returning a
+plain `dict` / `str` / `None` (no `success` attribute) keep exiting
+`0`. Only a real `WorkflowResult` (or any object exposing a falsey
+`success`) trips exit 1.
+
+**Exit 2 surface:** `traceback.print_exc()` writes the traceback to
+stderr (per acceptance criterion 3); the voiced one-line summary
+(`format_error`) still goes to stdout for humans; `logger.exception`
+preserves the structured log. These coexist — the exit code is the
+contract, the voice block is informational (matches the decision
+matrix row).
+
+---
+
+## Reuse, not duplication
+
+`sdk_error_kind` is read from `result.metadata`, which is set by the
+already-shipped sdk-error-message-fidelity primitives
+(`classify_subprocess_failure`, `SdkSubprocessError`, the
+`_error_result(..., sdk_error_kind=...)` plumbing in
+`workflows/base.py`). This spec adds **no** new classification logic —
+it surfaces the existing kind through the exit-code + JSON contract.
+
+---
+
+## Out of scope (this PR)
+
+- Removing the ops-dashboard log-scan
+  (`src/attune/ops/static/js/run_view.js` `detectLogErrorLeak`). Per
+  the decision matrix it stays for one release after this lands;
+  retirement is noted in the CHANGELOG / decisions log and happens in
+  a follow-up.
+- Version bump / publish — a separate release step (Patrick's call).
+
+---
+
+## Test plan
+
+- New `tests/unit/cli/test_workflow_exit_codes.py` — table-driven,
+  each case names its branch: 0 / 1 / 2 / 3 (sync + async), legacy
+  dict-result → 0, and the `--json` threading (success, planned
+  failure with `sdk_error_kind`, non-dict envelope).
+- Update the existing assertions that encoded the old contract:
+  `tests/unit/cli_commands/test_workflow_commands.py` (CLI errors
+  1 → 3; uncaught exceptions 1 → 2, asserting the stderr traceback)
+  and `tests/unit/voice/test_voice_wiring.py` (exception path 1 → 2).

--- a/docs/specs/workflow-failure-exit-propagation/requirements.md
+++ b/docs/specs/workflow-failure-exit-propagation/requirements.md
@@ -9,7 +9,8 @@
 
 ## Phase 1: Requirements
 
-**Status**: draft
+**Status**: approved (design + tasks complete; implemented in one PR —
+see `design.md`, `tasks.md`)
 
 ### Problem statement
 

--- a/docs/specs/workflow-failure-exit-propagation/tasks.md
+++ b/docs/specs/workflow-failure-exit-propagation/tasks.md
@@ -1,0 +1,39 @@
+# Spec: Workflow Failure Exit Propagation — Tasks
+
+> Phase 3 (task decomposition). One focused PR. Status reflects the
+> implementing PR.
+
+---
+
+## Tasks
+
+| # | Task | Files | Status |
+|---|---|---|---|
+| 1 | Add exit-code contract helper module | `src/attune/cli_commands/_exit_codes.py` (new) | **done** |
+| 2 | Route `cmd_workflow_run` through the helper; CLI-level errors return `EXIT_CLI_ERROR` (3) | `src/attune/cli_commands/workflow_commands.py` | **done** |
+| 3 | Table-driven exit-code test (0/1/2/3, sync+async, legacy, `--json` threading) | `tests/unit/cli/test_workflow_exit_codes.py` (new) | **done** |
+| 4 | Migrate existing assertions encoding the old contract (CLI errors 1→3; exceptions 1→2) | `tests/unit/cli_commands/test_workflow_commands.py`, `tests/unit/voice/test_voice_wiring.py` | **done** |
+| 5 | CHANGELOG: behavior change + migration snippet; note log-scan retirement | `CHANGELOG.md` | **done** |
+| 6 | Record decisions (resolve Q1–Q3) | `docs/specs/workflow-failure-exit-propagation/decisions.md` | **done** |
+
+---
+
+## Acceptance criteria → coverage
+
+| Criterion (requirements.md) | Covered by |
+|---|---|
+| 1. `run security-audit --path /nonexistent` exits 3 | Task 2 (`EXIT_CLI_ERROR` on bad path); Task 3 `test_bad_path_returns_cli_error` |
+| 2. `WorkflowResult(success=False)` exits 1 | Task 1/2; Task 3 `test_planned_failure_returns_one` |
+| 3. `execute()` raises → exit 2, traceback on stderr | Task 1; Task 3 `test_unplanned_failure_returns_two_with_traceback` |
+| 4. Passing workflows exit 0, no behavior change | Task 3 `test_success_returns_zero` + legacy-dict cases; existing 352-test suite green |
+| 5. CHANGELOG documents new exit codes | Task 5 |
+| 6. CI green, one PR | full pre-commit + suite run before push |
+
+---
+
+## Explicitly deferred (follow-up PR)
+
+- Retire the ops-dashboard log-scan
+  (`src/attune/ops/static/js/run_view.js` `detectLogErrorLeak`) one
+  release after this lands (decision-matrix row).
+- No version bump / publish in this PR.

--- a/src/attune/cli_commands/_exit_codes.py
+++ b/src/attune/cli_commands/_exit_codes.py
@@ -1,0 +1,186 @@
+"""Exit-code contract for ``attune workflow run``.
+
+Centralizes the mapping from a workflow's execution outcome to the
+process exit code, so every CLI entry point that runs a workflow
+agrees on what each code means. See
+``docs/specs/workflow-failure-exit-propagation/``.
+
+The contract (decisions.md):
+
+- ``0`` — workflow ran AND ``WorkflowResult.success is True``
+- ``1`` — workflow ran AND ``WorkflowResult.success is False``
+  (planned failure)
+- ``2`` — workflow ran AND raised an uncaught exception
+  (unplanned failure); the traceback is printed to stderr
+- ``3`` — CLI-level error (workflow not found, bad path, bad JSON)
+
+CLI-level errors (exit ``3``) are detected by the caller *before*
+``execute()`` is reached, so this module only owns the ``0``/``1``/``2``
+boundary plus the ``EXIT_CLI_ERROR`` constant the caller returns.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import traceback
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Exit-code contract — see module docstring / decisions.md.
+EXIT_SUCCESS = 0
+EXIT_PLANNED_FAILURE = 1
+EXIT_UNPLANNED_FAILURE = 2
+EXIT_CLI_ERROR = 3
+
+
+def _is_planned_failure(result: Any) -> bool:
+    """Return True only when the result carries an explicit
+    ``success is False``.
+
+    Legacy workflows return plain ``dict`` / ``str`` / ``None`` with no
+    ``success`` attribute — those are treated as success (exit ``0``),
+    preserving backwards compatibility. Only a real ``WorkflowResult``
+    (or any object exposing ``success``) can trip the planned-failure
+    branch.
+    """
+    return getattr(result, "success", None) is False
+
+
+def _sdk_error_kind(result: Any) -> str | None:
+    """Extract the classified SDK failure kind from result metadata.
+
+    Populated by ``BaseWorkflow._error_result()`` on SDK subprocess
+    failures (see the sdk-error-message-fidelity spec). Returns None
+    when absent.
+    """
+    metadata = getattr(result, "metadata", None)
+    if isinstance(metadata, dict):
+        kind = metadata.get("sdk_error_kind")
+        if kind:
+            return str(kind)
+    return None
+
+
+def _coerce_json_dict(result: Any) -> dict[str, Any] | None:
+    """Return a mutable dict to print in ``--json`` mode, or None.
+
+    Prefers the workflow's own JSON object rendered in
+    ``final_output`` (when it honored ``output_format="json"``);
+    falls back to the result itself when it is already a dict. Returns
+    None when the result isn't dict-shaped, signalling the caller to
+    wrap it in an envelope instead.
+    """
+    final_output = getattr(result, "final_output", None)
+    if isinstance(final_output, str) and final_output.lstrip().startswith("{"):
+        try:
+            obj = json.loads(final_output)
+        except (json.JSONDecodeError, ValueError):
+            obj = None
+        if isinstance(obj, dict):
+            return obj
+    if isinstance(result, dict):
+        # Copy so we never mutate the caller's object when injecting
+        # the contract fields below.
+        return dict(result)
+    return None
+
+
+def _emit_json_result(result: Any, *, exit_code: int) -> None:
+    """Print the workflow's JSON output, threading ``exit_code`` and
+    ``sdk_error_kind`` so CI consumers parsing stdout JSON don't also
+    have to branch on ``$?``.
+
+    ``$?`` remains authoritative — these fields are a convenience
+    mirror. The output always contains a single ``{...}`` object so
+    last-brace extractors (e.g. ``.github/workflows/security-scan.yml``)
+    keep working.
+    """
+    sdk_error_kind = _sdk_error_kind(result)
+    payload = _coerce_json_dict(result)
+    if payload is not None:
+        payload.setdefault("exit_code", exit_code)
+        payload.setdefault("sdk_error_kind", sdk_error_kind)
+        print(json.dumps(payload, indent=2, default=str))
+        return
+    # Non-dict result (string / dataclass / list) — wrap in an
+    # envelope that always carries the contract fields.
+    print(
+        json.dumps(
+            {
+                "exit_code": exit_code,
+                "success": not _is_planned_failure(result),
+                "sdk_error_kind": sdk_error_kind,
+                "result": result,
+            },
+            indent=2,
+            default=str,
+        )
+    )
+
+
+def run_workflow_with_exit_code(
+    workflow_cls: type,
+    input_data: dict[str, Any],
+    *,
+    name: str,
+    json_mode: bool,
+    print_result: Callable[[Any], None],
+) -> int:
+    """Instantiate + execute a workflow and return the contract exit code.
+
+    Centralizes the ``0``/``1``/``2`` classification:
+
+    - any uncaught exception (including from the constructor or
+      ``execute()``) → ``EXIT_UNPLANNED_FAILURE`` (2), traceback to
+      stderr;
+    - ``WorkflowResult.success is False`` → ``EXIT_PLANNED_FAILURE`` (1);
+    - otherwise → ``EXIT_SUCCESS`` (0).
+
+    Args:
+        workflow_cls: The workflow class (instantiated here so
+            constructor failures are classified as exit 2).
+        input_data: kwargs forwarded to ``execute()``.
+        name: Workflow name, for log/voice messages.
+        json_mode: When True, emit JSON to stdout (threading the
+            exit code + sdk_error_kind); otherwise call
+            ``print_result``.
+        print_result: Callback rendering the human-readable
+            voice-layer output (injected to avoid an import cycle and
+            to preserve the ops daemon side-channel emission).
+
+    Returns:
+        The process exit code (0, 1, or 2).
+    """
+    try:
+        workflow = workflow_cls()
+        if asyncio.iscoroutinefunction(workflow.execute):
+            result = asyncio.run(workflow.execute(**input_data))
+        else:
+            result = workflow.execute(**input_data)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: any uncaught error from the workflow is the
+        # exit-2 "unplanned failure" branch. Traceback to stderr so
+        # operators/scripts see the real cause; voiced summary to
+        # stdout for humans.
+        logger.exception("Workflow %r raised an uncaught exception", name)
+        traceback.print_exc()
+        from attune.voice import format_error
+
+        print(format_error(str(exc), workflow_name=name))
+        return EXIT_UNPLANNED_FAILURE
+
+    exit_code = EXIT_PLANNED_FAILURE if _is_planned_failure(result) else EXIT_SUCCESS
+
+    if json_mode:
+        _emit_json_result(result, exit_code=exit_code)
+    else:
+        print_result(result)
+
+    return exit_code

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -76,9 +76,12 @@ def cmd_workflow_info(args: Namespace) -> int:
 
 def cmd_workflow_run(args: Namespace) -> int:
     """Execute a workflow."""
-    import asyncio
     import os
 
+    from attune.cli_commands._exit_codes import (
+        EXIT_CLI_ERROR,
+        run_workflow_with_exit_code,
+    )
     from attune.security.path_validation import _validate_file_path
     from attune.workflows import get_workflow
 
@@ -91,11 +94,14 @@ def cmd_workflow_run(args: Namespace) -> int:
             "(opus/sonnet-pinned subagents unaffected)"
         )
 
+    # CLI-level errors (workflow not found, bad JSON, bad path) exit 3 —
+    # distinct from workflow-execution outcomes (0/1/2). See the
+    # workflow-failure-exit-propagation spec.
     try:
         workflow_cls = get_workflow(name)
     except KeyError:
         print(f"❌ Workflow not found: {name}")
-        return 1
+        return EXIT_CLI_ERROR
 
     # Parse input if provided
     input_data = {}
@@ -104,7 +110,7 @@ def cmd_workflow_run(args: Namespace) -> int:
             input_data = json.loads(args.input)
         except json.JSONDecodeError as e:
             print(f"❌ Invalid JSON input: {e}")
-            return 1
+            return EXIT_CLI_ERROR
 
     # Add common options with validation
     if args.path:
@@ -114,7 +120,7 @@ def cmd_workflow_run(args: Namespace) -> int:
             input_data["path"] = str(validated_path)
         except ValueError as e:
             print(f"❌ Invalid path: {e}")
-            return 1
+            return EXIT_CLI_ERROR
     if args.target:
         input_data["target"] = args.target
 
@@ -137,38 +143,16 @@ def cmd_workflow_run(args: Namespace) -> int:
 
     print(f"\n🚀 Running workflow: {name}\n")
 
-    try:
-        workflow = workflow_cls()
-
-        # Run the workflow
-        if asyncio.iscoroutinefunction(workflow.execute):
-            result = asyncio.run(workflow.execute(**input_data))
-        else:
-            result = workflow.execute(**input_data)
-
-        # Output result
-        if args.json:
-            # Prefer the workflow's own JSON rendering in
-            # ``final_output`` when it honored ``output_format="json"``
-            # (cleaner than ``json.dumps(WorkflowResult)`` which serializes
-            # the stages/cost metadata too).
-            final_output = getattr(result, "final_output", "") or ""
-            if final_output.lstrip().startswith(("{", "[")):
-                print(final_output)
-            else:
-                print(json.dumps(result, indent=2, default=str))
-        else:
-            _print_workflow_result(result, workflow_name=name)
-
-        return 0
-
-    except Exception as e:  # noqa: BLE001
-        # INTENTIONAL: CLI commands should catch all errors and report gracefully
-        logger.exception(f"Workflow failed: {e}")
-        from attune.voice import format_error
-
-        print(format_error(str(e), workflow_name=name))
-        return 1
+    # Execution outcomes map to exit codes via the centralized
+    # contract: success -> 0, WorkflowResult.success is False -> 1,
+    # uncaught exception -> 2 (traceback to stderr).
+    return run_workflow_with_exit_code(
+        workflow_cls,
+        input_data,
+        name=name,
+        json_mode=bool(getattr(args, "json", False)),
+        print_result=lambda result: _print_workflow_result(result, workflow_name=name),
+    )
 
 
 def _print_workflow_result(

--- a/tests/unit/cli/test_workflow_exit_codes.py
+++ b/tests/unit/cli/test_workflow_exit_codes.py
@@ -262,6 +262,27 @@ class TestJsonModeThreadsExitCode:
         assert parsed["sdk_error_kind"] == "api_quota"
 
     @patch("attune.workflows.get_workflow")
+    def test_json_malformed_object_output_falls_back_to_envelope(self, mock_get, capsys):
+        """A final_output that looks like JSON but won't parse falls back
+        to the envelope instead of crashing."""
+        import json
+
+        result = _make_result(success=True)
+        # Starts with '{' (so the coercer tries to parse) but is invalid.
+        result.final_output = "{not valid json"
+        mock_get.return_value = _workflow_returning(result)
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        rc = cmd_workflow_run(_make_args(name="wf", json=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        block = out[out.index("{") :]
+        parsed = json.loads(block)
+        assert parsed["exit_code"] == 0
+        assert parsed["success"] is True
+
+    @patch("attune.workflows.get_workflow")
     def test_json_non_dict_output_wrapped_in_envelope(self, mock_get, capsys):
         """Non-dict result is wrapped so contract fields are always present."""
         import json

--- a/tests/unit/cli/test_workflow_exit_codes.py
+++ b/tests/unit/cli/test_workflow_exit_codes.py
@@ -1,0 +1,282 @@
+"""Exit-code contract for ``attune workflow run``.
+
+Table-driven coverage of the four exit codes defined by the
+workflow-failure-exit-propagation spec. Each case names the branch it
+covers so a future refactor that collapses a code can't pass silently.
+
+Contract (docs/specs/workflow-failure-exit-propagation/decisions.md):
+
+- ``0`` — workflow ran AND ``WorkflowResult.success is True``
+- ``1`` — workflow ran AND ``WorkflowResult.success is False``
+- ``2`` — workflow ran AND raised an uncaught exception (traceback to
+  stderr)
+- ``3`` — CLI-level error (workflow not found / bad path / bad JSON)
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import types
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from attune.workflows.data_classes import CostReport, WorkflowResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs) -> types.SimpleNamespace:
+    """Args namespace with cmd_workflow_run defaults."""
+    defaults = {
+        "name": "test-wf",
+        "input": None,
+        "path": None,
+        "target": None,
+        "json": False,
+    }
+    defaults.update(kwargs)
+    return types.SimpleNamespace(**defaults)
+
+
+def _make_result(*, success: bool, error: str | None = None) -> WorkflowResult:
+    """Build a real WorkflowResult with the given success flag."""
+    now = datetime.now(timezone.utc)
+    return WorkflowResult(
+        success=success,
+        stages=[],
+        final_output={"formatted_report": "done"},
+        cost_report=CostReport(
+            total_cost=0.0,
+            baseline_cost=0.0,
+            savings=0.0,
+            savings_percent=0.0,
+        ),
+        started_at=now,
+        completed_at=now,
+        total_duration_ms=10,
+        error=error,
+    )
+
+
+def _workflow_returning(result: WorkflowResult) -> type:
+    """Workflow class whose execute() returns the given result."""
+
+    def execute(self, **kwargs):
+        return result
+
+    return type("ReturningWorkflow", (), {"execute": execute})
+
+
+def _workflow_raising(exc: Exception) -> type:
+    """Workflow class whose execute() raises the given exception."""
+
+    def execute(self, **kwargs):
+        raise exc
+
+    return type("RaisingWorkflow", (), {"execute": execute})
+
+
+# ---------------------------------------------------------------------------
+# The contract, table-driven
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowRunExitCodes:
+    """Each branch of the exit-code contract, named explicitly."""
+
+    @patch("attune.workflows.get_workflow")
+    def test_success_returns_zero(self, mock_get, capsys):
+        """Branch: workflow ran AND success is True → exit 0."""
+        mock_get.return_value = _workflow_returning(_make_result(success=True))
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="ok-wf")) == 0
+
+    @patch("attune.workflows.get_workflow")
+    def test_planned_failure_returns_one(self, mock_get, capsys):
+        """Branch: workflow ran AND success is False → exit 1."""
+        mock_get.return_value = _workflow_returning(
+            _make_result(success=False, error="analysis found blocking issues"),
+        )
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="failing-wf")) == 1
+
+    @patch("attune.workflows.get_workflow")
+    def test_unplanned_failure_returns_two_with_traceback(self, mock_get, capsys):
+        """Branch: execute() raised an uncaught exception → exit 2, traceback to stderr."""
+        mock_get.return_value = _workflow_raising(RuntimeError("boom"))
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="crashing-wf")) == 2
+        captured = capsys.readouterr()
+        assert "Traceback (most recent call last):" in captured.err
+        assert "boom" in captured.err
+
+    @patch("attune.workflows.get_workflow")
+    def test_not_found_returns_cli_error(self, mock_get, capsys):
+        """Branch: CLI-level error (workflow not found) → exit 3."""
+        mock_get.side_effect = KeyError("Unknown workflow: nope")
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="nope")) == 3
+
+    @patch("attune.security.path_validation._validate_file_path")
+    @patch("attune.workflows.get_workflow")
+    def test_bad_path_returns_cli_error(self, mock_get, mock_validate, capsys):
+        """Branch: CLI-level error (bad path) → exit 3, before execute()."""
+        mock_validate.side_effect = ValueError("Cannot write to system directory: /etc")
+        mock_get.return_value = _workflow_returning(_make_result(success=True))
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="wf", path="/etc/passwd")) == 3
+
+    @patch("attune.workflows.get_workflow")
+    def test_bad_json_returns_cli_error(self, mock_get, capsys):
+        """Branch: CLI-level error (bad JSON input) → exit 3, before execute()."""
+        mock_get.return_value = _workflow_returning(_make_result(success=True))
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="wf", input="{not json")) == 3
+
+
+class TestWorkflowRunExitCodesAsync:
+    """The success / planned-failure / unplanned branches for async execute()."""
+
+    @staticmethod
+    def _async_returning(result: WorkflowResult) -> type:
+        async def execute(self, **kwargs):
+            return result
+
+        return type("AsyncReturningWorkflow", (), {"execute": execute})
+
+    @staticmethod
+    def _async_raising(exc: Exception) -> type:
+        async def execute(self, **kwargs):
+            raise exc
+
+        return type("AsyncRaisingWorkflow", (), {"execute": execute})
+
+    @patch("attune.workflows.get_workflow")
+    def test_async_success_returns_zero(self, mock_get, capsys):
+        """Branch: async workflow, success is True → exit 0."""
+        mock_get.return_value = self._async_returning(_make_result(success=True))
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="async-ok")) == 0
+
+    @patch("attune.workflows.get_workflow")
+    def test_async_planned_failure_returns_one(self, mock_get, capsys):
+        """Branch: async workflow, success is False → exit 1."""
+        mock_get.return_value = self._async_returning(_make_result(success=False))
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="async-fail")) == 1
+
+    @patch("attune.workflows.get_workflow")
+    def test_async_unplanned_failure_returns_two(self, mock_get, capsys):
+        """Branch: async workflow raised → exit 2."""
+        mock_get.return_value = self._async_raising(ConnectionError("unreachable"))
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="async-crash")) == 2
+
+
+class TestLegacyDictResultsExitZero:
+    """Workflows returning plain dict/str/None (no ``success`` field) keep
+    exiting 0 — the contract only trips exit 1 on an explicit
+    ``success is False``."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [{"status": "ok"}, "all good", None, {"success": True}],
+        ids=["dict", "string", "none", "dict-success-true"],
+    )
+    @patch("attune.workflows.get_workflow")
+    def test_legacy_result_exits_zero(self, mock_get, value, capsys):
+        """Branch: result without a falsey ``success`` attribute → exit 0."""
+        mock_get.return_value = _workflow_returning(value)
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        assert cmd_workflow_run(_make_args(name="legacy-wf")) == 0
+
+
+class TestJsonModeThreadsExitCode:
+    """``--json`` threads exit_code + sdk_error_kind into stdout JSON,
+    while ``$?`` (the return value) stays authoritative."""
+
+    @patch("attune.workflows.get_workflow")
+    def test_json_success_includes_exit_code_zero(self, mock_get, capsys):
+        """Dict final_output gets exit_code/sdk_error_kind injected; return is 0."""
+        import json
+
+        result = _make_result(success=True)
+        result.final_output = '{"score": 95}'
+        mock_get.return_value = _workflow_returning(result)
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        rc = cmd_workflow_run(_make_args(name="wf", json=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        block = out[out.index("{") :]
+        parsed = json.loads(block)
+        assert parsed["score"] == 95
+        assert parsed["exit_code"] == 0
+        assert parsed["sdk_error_kind"] is None
+
+    @patch("attune.workflows.get_workflow")
+    def test_json_planned_failure_includes_exit_code_one_and_kind(self, mock_get, capsys):
+        """Failed run threads exit_code=1 and the sdk_error_kind metadata."""
+        import json
+
+        result = _make_result(success=False, error="quota reached")
+        result.final_output = '{"findings": []}'
+        result.metadata = {"sdk_error_kind": "api_quota"}
+        mock_get.return_value = _workflow_returning(result)
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        rc = cmd_workflow_run(_make_args(name="wf", json=True))
+        assert rc == 1
+        out = capsys.readouterr().out
+        block = out[out.index("{") :]
+        parsed = json.loads(block)
+        assert parsed["exit_code"] == 1
+        assert parsed["sdk_error_kind"] == "api_quota"
+
+    @patch("attune.workflows.get_workflow")
+    def test_json_non_dict_output_wrapped_in_envelope(self, mock_get, capsys):
+        """Non-dict result is wrapped so contract fields are always present."""
+        import json
+
+        # A legacy workflow that returns a bare string (no WorkflowResult).
+        mock_get.return_value = _workflow_returning("plain text report")
+
+        from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+        rc = cmd_workflow_run(_make_args(name="wf", json=True))
+        assert rc == 0
+        out = capsys.readouterr().out
+        block = out[out.index("{") :]
+        parsed = json.loads(block)
+        assert parsed["exit_code"] == 0
+        assert parsed["success"] is True
+        assert parsed["sdk_error_kind"] is None
+        assert parsed["result"] == "plain text report"

--- a/tests/unit/cli_commands/test_workflow_commands.py
+++ b/tests/unit/cli_commands/test_workflow_commands.py
@@ -291,8 +291,8 @@ class TestCmdWorkflowRunNotFound:
     """Tests for cmd_workflow_run when workflow is not found."""
 
     @patch("attune.workflows.get_workflow")
-    def test_run_not_found_returns_one(self, mock_get, capsys):
-        """Test that running a nonexistent workflow returns 1."""
+    def test_run_not_found_returns_cli_error(self, mock_get, capsys):
+        """A nonexistent workflow is a CLI-level error → exit 3."""
         mock_get.side_effect = KeyError("Unknown workflow: missing-workflow")
 
         from attune.cli_commands.workflow_commands import cmd_workflow_run
@@ -300,7 +300,7 @@ class TestCmdWorkflowRunNotFound:
         args = _make_args(name="missing-workflow")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 3
         captured = capsys.readouterr()
         assert "Workflow not found: missing-workflow" in captured.out
 
@@ -332,8 +332,8 @@ class TestCmdWorkflowRunInputParsing:
         assert call_kwargs["count"] == 42
 
     @patch("attune.workflows.get_workflow")
-    def test_run_invalid_json_returns_one(self, mock_get, capsys):
-        """Test that invalid JSON input returns 1 with error message."""
+    def test_run_invalid_json_returns_cli_error(self, mock_get, capsys):
+        """Invalid JSON input is a CLI-level error → exit 3."""
         mock_get.return_value = _make_workflow_class()
 
         from attune.cli_commands.workflow_commands import cmd_workflow_run
@@ -341,7 +341,7 @@ class TestCmdWorkflowRunInputParsing:
         args = _make_args(name="wf", input="{not valid json")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 3
         captured = capsys.readouterr()
         assert "Invalid JSON input" in captured.out
 
@@ -419,7 +419,7 @@ class TestCmdWorkflowRunPathValidation:
     @patch("attune.security.path_validation._validate_file_path")
     @patch("attune.workflows.get_workflow")
     def test_run_path_traversal_rejected(self, mock_get, mock_validate, capsys):
-        """Test that path traversal is caught and returns 1."""
+        """Path traversal is a CLI-level error → exit 3."""
         mock_validate.side_effect = ValueError("Cannot write to system directory: /etc")
         mock_get.return_value = _make_workflow_class()
 
@@ -428,7 +428,7 @@ class TestCmdWorkflowRunPathValidation:
         args = _make_args(name="wf", path="../../../etc/passwd")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 3
         captured = capsys.readouterr()
         assert "Invalid path" in captured.out
         assert "Cannot write to system directory" in captured.out
@@ -436,7 +436,7 @@ class TestCmdWorkflowRunPathValidation:
     @patch("attune.security.path_validation._validate_file_path")
     @patch("attune.workflows.get_workflow")
     def test_run_null_byte_path_rejected(self, mock_get, mock_validate, capsys):
-        """Test that null bytes in path are rejected."""
+        """Null bytes in path are a CLI-level error → exit 3."""
         mock_validate.side_effect = ValueError("path contains null bytes")
         mock_get.return_value = _make_workflow_class()
 
@@ -445,14 +445,14 @@ class TestCmdWorkflowRunPathValidation:
         args = _make_args(name="wf", path="config\x00.json")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 3
         captured = capsys.readouterr()
         assert "Invalid path" in captured.out
 
     @patch("attune.security.path_validation._validate_file_path")
     @patch("attune.workflows.get_workflow")
     def test_run_system_directory_path_rejected(self, mock_get, mock_validate, capsys):
-        """Test that system directory paths are rejected."""
+        """System directory paths are a CLI-level error → exit 3."""
         mock_validate.side_effect = ValueError("Cannot write to system directory: /sys")
         mock_get.return_value = _make_workflow_class()
 
@@ -461,7 +461,7 @@ class TestCmdWorkflowRunPathValidation:
         args = _make_args(name="wf", path="/sys/kernel/debug")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 3
         captured = capsys.readouterr()
         assert "Invalid path" in captured.out
 
@@ -675,11 +675,16 @@ class TestCmdWorkflowRunJsonOutput:
 
 
 class TestCmdWorkflowRunExceptionHandling:
-    """Tests for exception handling in cmd_workflow_run."""
+    """Tests for exception handling in cmd_workflow_run.
+
+    An uncaught exception from ``execute()`` is the exit-2 "unplanned
+    failure" branch: the traceback goes to stderr, the voiced summary
+    to stdout.
+    """
 
     @patch("attune.workflows.get_workflow")
     def test_run_workflow_raises_runtime_error(self, mock_get, capsys):
-        """Test that a RuntimeError during execute returns 1."""
+        """A RuntimeError during execute is an unplanned failure → exit 2."""
         mock_get.return_value = _make_workflow_class(
             execute_side_effect=RuntimeError("Something broke"),
         )
@@ -689,14 +694,16 @@ class TestCmdWorkflowRunExceptionHandling:
         args = _make_args(name="wf")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 2
         captured = capsys.readouterr()
         assert "Something went wrong" in captured.out
         assert "Something broke" in captured.out
+        # Traceback is printed to stderr per the exit-2 contract.
+        assert "Traceback (most recent call last):" in captured.err
 
     @patch("attune.workflows.get_workflow")
     def test_run_workflow_raises_value_error(self, mock_get, capsys):
-        """Test that a ValueError during execute returns 1."""
+        """A ValueError during execute is an unplanned failure → exit 2."""
         mock_get.return_value = _make_workflow_class(
             execute_side_effect=ValueError("Invalid value"),
         )
@@ -706,13 +713,13 @@ class TestCmdWorkflowRunExceptionHandling:
         args = _make_args(name="wf")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 2
         captured = capsys.readouterr()
         assert "Something went wrong" in captured.out
 
     @patch("attune.workflows.get_workflow")
     def test_run_workflow_raises_key_error(self, mock_get, capsys):
-        """Test that a KeyError during execute returns 1."""
+        """A KeyError during execute is an unplanned failure → exit 2."""
         mock_get.return_value = _make_workflow_class(
             execute_side_effect=KeyError("missing_key"),
         )
@@ -722,13 +729,13 @@ class TestCmdWorkflowRunExceptionHandling:
         args = _make_args(name="wf")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 2
         captured = capsys.readouterr()
         assert "Something went wrong" in captured.out
 
     @patch("attune.workflows.get_workflow")
     def test_run_async_workflow_raises_exception(self, mock_get, capsys):
-        """Test that an exception from an async workflow is caught."""
+        """An exception from an async workflow is an unplanned failure → exit 2."""
         mock_get.return_value = _make_workflow_class(
             execute_side_effect=ConnectionError("API unreachable"),
             is_async=True,
@@ -739,7 +746,7 @@ class TestCmdWorkflowRunExceptionHandling:
         args = _make_args(name="wf")
         result = cmd_workflow_run(args)
 
-        assert result == 1
+        assert result == 2
         captured = capsys.readouterr()
         assert "Something went wrong" in captured.out
         assert "API unreachable" in captured.out

--- a/tests/unit/voice/test_voice_wiring.py
+++ b/tests/unit/voice/test_voice_wiring.py
@@ -181,7 +181,9 @@ class TestErrorPathVoiceWiring:
         from attune.cli_commands.workflow_commands import cmd_workflow_run
 
         rc = cmd_workflow_run(_make_args(name="code-review"))
-        assert rc == 1
+        # Uncaught exception → exit 2 (unplanned failure) per the
+        # workflow-failure-exit-propagation contract.
+        assert rc == 2
         out = capsys.readouterr().out
         assert personality.ERROR_PREFIX in out
         assert "API connection lost" in out


### PR DESCRIPTION
## What

`attune workflow run <name>` now exits **non-zero when the workflow actually failed**. Previously it exited `0` even when `WorkflowResult.success` was `False` or the SDK adapter swallowed an uncaught exception — the exit-0 lie behind every "green-but-failed" symptom (the ops dashboard log-scan workaround in #366 exists precisely because of it).

### Exit-code contract

| Code | Meaning |
|------|---------|
| `0` | Workflow ran and succeeded |
| `1` | Workflow ran and reported failure (`success is False`) |
| `2` | Workflow raised an uncaught exception (traceback on stderr) |
| `3` | CLI-level error (workflow not found, bad path, bad JSON) |

CLI-level errors that previously returned `1` now return `3`; workflow exceptions that previously returned `1` now return `2`. Workflows returning a plain `dict`/`str`/`None` (no `success` field) still exit `0` — backwards compatible.

## How

- New `src/attune/cli_commands/_exit_codes.py` houses `run_workflow_with_exit_code()` + the `EXIT_*` constants + JSON threading — one home for the contract.
- `cmd_workflow_run` routes execution through it; CLI-level errors return `EXIT_CLI_ERROR` (3).
- `--json` additively threads `exit_code` + `sdk_error_kind` (reusing the existing sdk-error-message-fidelity metadata — **no new classification logic**) so CI need not branch on `$?` (which stays authoritative). The "last `{...}` block" invariant `security-scan.yml` relies on is preserved.
- Migrated the existing assertions that encoded the old exit-1-for-everything contract (`test_workflow_commands.py`, `test_voice_wiring.py`).

## Tests

New table-driven `tests/unit/cli/test_workflow_exit_codes.py` — each case names its branch: 0/1/2/3 (sync + async), legacy dict results → 0, and `--json` threading (success, planned failure with `sdk_error_kind`, non-dict envelope). Full local suite green (cli + cli_commands + voice + ops + workflow-execute = 1589 tests; version drift-guard 120 passed).

## Acceptance criteria

- [x] `run security-audit --path /nonexistent` exits **3**
- [x] `WorkflowResult(success=False)` exits **1**
- [x] `execute()` raises → exits **2** with traceback on stderr
- [x] Passing workflows exit **0**, no behavior change
- [x] CHANGELOG documents the new exit codes + migration snippet
- [x] One PR

## Deferred

Per the pre-committed decision matrix, the ops dashboard log-scan (`run_view.js` `detectLogErrorLeak`) stays for **one release** as defense-in-depth, then retires in a follow-up — not removed here.

Spec: `docs/specs/workflow-failure-exit-propagation/` (requirements → design → tasks, decisions Q1–Q3 resolved).

No version bump / publish — separate release step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
