### PR TITLE
docs(spec): public-help-site — render the .help corpus on attune-ai.dev

### DIFF
--- a/docs/specs/public-help-site/decisions.md
+++ b/docs/specs/public-help-site/decisions.md
@@ -1,0 +1,66 @@
+# Spec: Public Help Site — Decisions
+
+> Decisions captured during Phase 1. D4 is intentionally OPEN pending
+> a design conversation; design.md is not authored until it resolves.
+
+---
+
+## Decision matrix
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| D1 | Renderer / loader strategy | **Reuse** the existing corpus loader (`src/attune/help` / `ops/help_data.py`) for feature listing + frontmatter parsing, and `markdown-it-py` for markdown → HTML. No new parser, no new renderer. | `build_discipline.py` already uses `markdown-it-py`; the dashboard already loads + parses the corpus. A static build script is a new *consumer* of those, not a new rendering path. Keeps it to one loader + one markdown lib. |
+| D2 | Search | **Static JSON index + small vanilla-JS client search.** Build emits `help/search-index.json` (feature, kind, title, keywords, url). | Static host can't run server-side attune_rag ranking. A client index over the corpus's keyword-rich frontmatter is enough for browse-and-find; no build-time embeddings, no runtime server. |
+| D3 | Staleness policy | **Accept eventual rebuild.** CI rebuilds help pages on `.help/` change and deploys; drift does NOT hard-fail CI. | Your call. A stale public page for a few hours is low-cost vs the friction of a hard gate. Pairs with the existing staleness-detection lessons — detect + rebuild, don't block. |
+| D4 | Relationship to the mkdocs site | **RESOLVED 2026-06-04 → hybrid.** attune-ai.dev/help is the canonical **user help** = generated `.help/` corpus **+ migrated hand-written tutorials/guides** (`docs/tutorials/`, `docs/how-to/`). mkdocs narrows to **API reference + contributor docs** (mkdocstrings API, CLI reference, glossary, architecture, contributing). | framework-docs is cold (low SEO loss re-homing user help); the corpus is weaker for API reference, so API stays in mkdocs; the tutorials have value and belong in help. Split: learn/do/understand → attune-ai.dev/help; look-up-API/contribute → mkdocs. |
+| D7 | Help-site content sources | **Two markdown inputs**: (1) `.help/templates/*` (generated corpus), (2) selected hand-written `docs/tutorials/*` + `docs/how-to/*` (migrated). Same renderer (D1). | Consequence of D4 — the tutorials/guides join the corpus as a second source. Light redirects from old framework-docs tutorial URLs (low priority; cold). |
+| D8 | Strategic trajectory (informs design, not v1 scope) | **Full consolidation onto attune-ai.dev is the end state** — eventually the whole docs surface (incl. mkdocs API/contributor reference) lives under attune-ai.dev, and smartaimemory.com traffic redirects to attune-ai.dev. The D4 hybrid is the **first step**, not a permanent split. | Patrick's stated plan (2026-06-04). Design must not assume mkdocs stays on a separate domain forever: keep cross-links domain-relative-friendly, structure `/help` so the API/reference sections can later move under attune-ai.dev, and treat the redirect work (T8) as the seed of an eventual full smartaimemory.com → attune-ai.dev redirect. v1 still ships only user help; the rest is sequenced later. |
+| D5 | Site location / deploy | `attune-ai-dev/help/` static dir, served by the existing Vercel project with clean URLs (mirrors `attune-ai-dev/discipline/`). | Reuses the deploy already in place; no new hosting. |
+| D6 | Public-site mutability | **Read-only.** Regen/edit stays in the dashboard admin tools. | The public site is a published artifact; mutation belongs to the maintainer surface (dashboard), per the user-vs-maintainer audience lesson. |
+
+---
+
+## D4 framings (resolved — hybrid; framings kept for the record)
+
+**Option (a) — Canonical shift.** attune-ai.dev/help becomes the
+primary user-facing help; mkdocs (currently
+`smartaimemory.com/framework-docs`) narrows to API reference +
+contributor docs.
+
+- Pros: one obvious place users go; the generated, benchmarked corpus
+  is the front door; consistent brand on attune-ai.dev.
+- Cons: larger blast radius — nav/redirect changes, "where do I go"
+  messaging, possible domain-consolidation work, mkdocs content audit
+  to decide what's "user help" vs "reference."
+
+**Option (b) — Coexist.** attune-ai.dev/help is the generated-corpus
+surface; mkdocs stays the hand-written tutorial + reference surface.
+
+- Pros: additive, smaller, lower risk; ships v1 fast.
+- Cons: two help destinations to reconcile in users' minds;
+  cross-linking discipline needed so they don't feel like rival docs.
+
+**Things to weigh in the chat:** which domain users actually land on;
+whether the hand-written mkdocs tutorials have a home in the
+generated model; whether the generated corpus covers enough to be a
+front door yet; SEO / link-equity of the existing framework-docs.
+
+---
+
+## Decision-change log
+
+- 2026-06-04 — Initial decisions captured during Phase 1 scoping.
+  D1/D2/D3/D5/D6 decided with the user; D4 left OPEN pending a design
+  conversation about the mkdocs relationship.
+- 2026-06-04 — D4 RESOLVED to the hybrid (canonical user help on
+  attune-ai.dev/help = corpus + migrated tutorials; mkdocs → API +
+  contributor reference), after the user confirmed framework-docs is
+  cold, the tutorials belong in help, and the corpus is weaker for
+  API reference. Added D7 (two content sources) as the scope
+  consequence. Parallel-template-*generator* debt remains scoped OUT
+  (separate cleanup).
+- 2026-06-04 — Added D8: Patrick's stated trajectory is FULL
+  consolidation onto attune-ai.dev with smartaimemory.com redirecting
+  there. The hybrid is the first step. Recorded so the design keeps
+  the door open (domain-portable cross-links, /help structured to
+  later absorb API/reference) without expanding v1 scope.

--- a/docs/specs/public-help-site/design.md
+++ b/docs/specs/public-help-site/design.md
@@ -1,0 +1,203 @@
+# Spec: Public Help Site — Design
+
+> Phase 2 (technical design). Resolves how `build_help.py` ingests
+> two sources, merges overlapping guides into feature pages, emits a
+> client-side search index, and deploys — all reusing the existing
+> loader + `markdown-it-py` (no third renderer).
+
+---
+
+## Architecture
+
+`build_help.py` is a **new consumer** of code that already exists,
+not a new subsystem:
+
+```
+.help/templates/*  ─┐
+features.yaml       ├─► attune.ops.help_data (loader, frontmatter,    ┐
+docs/tutorials/*    │    INTENT_GROUPS, EXPECTED_KINDS)                │
+docs/how-to/*      ─┘                                                  ├─► build_help.py
+                         markdown-it-py (commonmark, html=False)       │     │
+                         build_discipline.py TEMPLATE/CSS (shared)     ┘     ▼
+                                                              attune-ai-dev/help/*.html
+                                                              attune-ai-dev/help/search-index.json
+```
+
+**Build-time vs deploy-time** (important): the build runs in **CI /
+locally** (where `attune` is installed) and **commits the rendered
+HTML**. Vercel serves the committed static files as-is and does *not*
+run the build — so `build_help.py` importing `attune.ops.help_data`
+(which pulls `attune_rag` etc.) is fine: that dependency is only
+needed at build time, never at serve time. Mirrors how
+`build_discipline.py` already works.
+
+### Reuse map (D1 — no third renderer)
+
+| Need | Reused from | New code |
+|---|---|---|
+| Feature list, kinds, frontmatter parse | `help_data.list_features`, `get_template`, `EXPECTED_KINDS`, `_parse_template` | none |
+| Intent grouping (do/solve/understand/lookup) | `help_data.INTENT_GROUPS` | none |
+| Markdown → HTML | `markdown-it-py` (`MarkdownIt("commonmark", {"html": False, "linkify": True}).enable("table")`) | none |
+| Brand template + CSS tokens | `build_discipline.py` TEMPLATE block | extracted to a shared `_brand.py` so both build scripts import one copy |
+| Static hosting + clean URLs | existing Vercel project (`vercel.json`) | redirect rules only |
+
+`_brand.py` extraction is the one refactor: today the HTML shell +
+CSS lives inline in `build_discipline.py`. Pull it into
+`attune-ai-dev/_brand.py` (a `page(title, body_html, nav_html,
+…) -> str` helper); both `build_discipline.py` and `build_help.py`
+call it. This keeps brand styling single-sourced rather than copied.
+
+---
+
+## Source ingestion + the overlap problem
+
+Two markdown sources (D7), and they **overlap on names**: `bug-predict`
+exists as a `.help` feature **and** `docs/tutorials/bug-predict.md`
+**and** `docs/how-to/bug-predict.md`. Three resolutions were
+considered:
+
+- **Model A — feature-centric merge (recommended).** Each feature
+  page (`/help/<feature>/`) aggregates its generated kinds **plus**
+  any tutorial/how-to whose slug matches the feature. Unmatched
+  guides (e.g. `build-a-workflow`, `META_ORCHESTRATION_TUTORIAL`,
+  `multi-agent-coordination`) fall into a `/help/guides/` catch-all
+  section. **One place per topic** — best UX, matches the dashboard's
+  feature-centric model.
+- Model B — separate sections (`/help/features/` vs `/help/guides/`).
+  Simpler build (no matching), but two destinations per topic.
+- Model C — corpus only, guides stay in mkdocs. Rejected — D4 says
+  guides belong in help.
+
+**Recommendation: Model A.** Slug-match guides to features by
+filename stem (`bug-predict.md` → feature `bug-predict`); the build
+logs matched vs catch-all so the mapping is auditable.
+
+### Migration set (prune in review)
+
+Proposed to migrate into `/help` (all are user-facing learn/do
+content):
+
+- `docs/tutorials/*` — `installation`, `build-a-workflow`,
+  `META_ORCHESTRATION_TUTORIAL`, `bug-predict`, `deep-review`,
+  `hooks`, `ops-dashboard`, `plugin`, `rag-grounding`,
+  `refactor-plan`, `release-prep`, `spec-engine`, `examples/`
+- `docs/how-to/*` — the 26 how-to guides (agent-factory,
+  auto-chaining, memory-graph, multi-agent-coordination,
+  security-architecture, telemetry-and-signals, … etc.)
+
+Staying in mkdocs (API + contributor — out of scope): `docs/reference/`,
+`docs/architecture/`, `docs/getting-started/` (install dup — TBD in
+review), contributing, `docs/implementation/`.
+
+**Open for your prune in review:** `installation` /
+`getting-started` overlap with the attune-ai.dev landing page's
+install chip — decide whether install lives on the landing page, in
+`/help`, or both.
+
+---
+
+## Output layout (clean URLs)
+
+```
+attune-ai-dev/help/
+├── index.html                    # landing: intent nav + feature grid + search box
+├── search-index.json             # client search index
+├── search.js                     # ~40-line vanilla-JS searcher
+├── <feature>/
+│   ├── index.html                # feature: generated kinds + matched guides
+│   └── <kind>.html               # one template (concept/task/reference/…)
+└── guides/
+    ├── index.html                # catch-all guides not matched to a feature
+    └── <guide-slug>.html
+```
+
+URLs: `attune-ai.dev/help`, `…/help/bug-predict`,
+`…/help/bug-predict/concept`, `…/help/guides/build-a-workflow`.
+Vercel clean-URL config already strips `.html`/`index.html`.
+
+---
+
+## Page template + nav
+
+One shared shell via `_brand.py` `page()`:
+
+- Top nav: `attune-ai.dev` ▸ Help, with a back-link to the site root
+  and a link to mkdocs API reference ("API & contributor docs →").
+- Feature page: H1 + a kind-tab row (the kinds present), the rendered
+  body, and a "Guides" block when matched tutorials/how-tos exist.
+- Markdown bodies rendered with the same `MarkdownIt` config as
+  `build_discipline.py` — `.markdown-body` CSS class so the existing
+  prose styles apply (the server-side-markdown-render lesson:
+  render-fn + template + CSS must all land together).
+
+---
+
+## Search (D2)
+
+Build-time: walk every rendered page; emit `search-index.json` as a
+flat array:
+
+```json
+[
+  {"title": "Bug Predict", "feature": "bug-predict", "kind": "concept",
+   "url": "/help/bug-predict/concept",
+   "keywords": "race conditions memory leaks subprocess injection …",
+   "snippet": "first ~200 chars of body"}
+]
+```
+
+`keywords` is drawn from the corpus's keyword-rich frontmatter /
+first paragraph (the same signal `help_data._build_inline_summaries`
+already extracts). `search.js` does a client-side substring +
+token-overlap rank over the index (no server, no embeddings — D2).
+Index size for ~270 corpus pages + ~40 guides ≈ tens of KB gzipped —
+fine to ship.
+
+---
+
+## Redirects (D4/D7, low priority)
+
+For the migrated tutorials, add Vercel redirects so old
+`smartaimemory.com/framework-docs/...tutorial...` URLs (if any are
+indexed) point at the new `/help/...` homes. Since traffic is cold
+(your read), this is a follow-up task, not a v1 blocker — but the map
+is generated at build time (matched-slug → new URL) so the redirect
+list can be emitted automatically.
+
+---
+
+## CI (D3 — eventual rebuild, no hard-fail)
+
+A workflow step (e.g. in the docs/site workflow) that, on changes to
+`.help/**` or the migrated `docs/tutorials|how-to/**`:
+
+1. runs `python attune-ai-dev/build_help.py`,
+2. commits the regenerated `attune-ai-dev/help/**` (auto-commit, like
+   other generated artifacts),
+3. **does not fail** if pages are stale between runs — drift is
+   tolerated until the next rebuild.
+
+Pairs with the generated-content pre-commit lessons (strip trailing
+whitespace per line; ensure trailing newline) so the auto-commit
+doesn't fight the hooks.
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `build_help.py` importing `attune.ops.help_data` drags heavy deps into the build | Low | Build-time only; CI has `attune` installed. Import the loader funcs lazily; degrade if `attune_rag` absent (loader already does). |
+| Slug-match guides to features wrong (false merge) | Medium | Exact stem match only; log matched vs catch-all; review the mapping before first deploy. |
+| Two parallel build scripts (`build_discipline` + `build_help`) drift on brand | Low | `_brand.py` single-sources the shell + CSS; both import it. |
+| Migrated guides have mkdocs-isms (`!!! note` admonitions, `::: mkdocstrings`) that markdown-it won't render | Medium | Detect + strip/convert admonitions at build; never render `:::` mkdocstrings blocks (those stay in mkdocs API docs, not migrated). |
+| Install-page duplication (landing chip vs tutorial) | Low | Decide in review (flagged above). |
+
+---
+
+## Out of scope (restated)
+
+- mkdocs API/contributor docs (stay; cross-link only).
+- Parallel-template-*generator* cleanup (separate debt).
+- Public-site regen/editing (read-only).
+- Embedding-based search.

--- a/docs/specs/public-help-site/requirements.md
+++ b/docs/specs/public-help-site/requirements.md
@@ -1,0 +1,132 @@
+# Spec: Public Help Site (attune-ai.dev/help)
+
+> Render the `.help/` corpus as browsable, searchable static pages on
+> the public `attune-ai.dev` site — reusing the existing corpus
+> loader and markdown renderer rather than adding a third rendering
+> path.
+
+---
+
+## Phase 1: Requirements
+
+**Status**: draft (D4 resolved 2026-06-04 — hybrid; see
+`decisions.md`). Design + tasks proceed once requirements are
+approved.
+
+### Problem statement
+
+The attune "help system" — 25 features × up to 11 template kinds
+(267 markdown templates in `.help/templates/`, registered in
+`.help/features.yaml`) — is only reachable two ways today:
+
+1. The **ops dashboard `/help` tab** (`src/attune/ops/routes/help.py`
+   + `help_data.py` + Jinja2 templates) — a *live local server*, not
+   public.
+2. The **`/coach` skill** inside Claude Code — interactive, not a
+   browsable web surface.
+
+A `pip install attune-ai` user who lands on `attune-ai.dev` has no
+public, browsable home for this content. The corpus is generated,
+keyword-rich, and benchmarked (RAG p@1 ≈ 1.0 per
+`.help/benchmarks/latest.json`) — it should be the public user-facing
+help surface, not locked behind a local dashboard.
+
+The static site (`attune-ai-dev/`) already has the rendering pattern:
+`build_discipline.py` renders markdown → HTML with `markdown-it-py`
+and an inline brand template, committed as static files served on
+Vercel. This spec extends that pattern to the corpus.
+
+### Scope
+
+**In scope:**
+
+- attune-ai.dev/help is the **canonical user help** (D4): generated
+  corpus **+ migrated hand-written tutorials/guides**. mkdocs narrows
+  to API reference + contributor docs.
+- A build script (`attune-ai-dev/build_help.py`) that ingests **two
+  markdown sources** (D7) — `.help/templates/*` + `features.yaml`
+  (generated corpus) AND selected `docs/tutorials/*` +
+  `docs/how-to/*` (hand-written guides) — and emits static HTML under
+  `attune-ai-dev/help/`:
+  - `help/index.html` — landing: browse-by-intent
+    (do / solve / understand / lookup, the groups already defined in
+    `help_data.py::INTENT_GROUPS`) + a feature grid.
+  - `help/<feature>/index.html` — one feature, links to its kinds.
+  - `help/<feature>/<kind>.html` — a rendered template page.
+- **Reuse, not reinvent**: the build script consumes the existing
+  corpus loader (`src/attune/help` / `help_data.py`) for feature
+  listing + frontmatter parsing, and `markdown-it-py` (already a
+  `build_discipline.py` dependency) for markdown → HTML. No new
+  frontmatter parser, no new markdown renderer.
+- **Client-side search** (you confirmed: support search): the build
+  emits a static `help/search-index.json` (feature, kind, title,
+  keywords, url) and a small vanilla-JS searcher on the landing page.
+  Static-host constraint means no server-side attune_rag ranking — a
+  lightweight client index instead.
+- Brand-consistent styling reusing the `build_discipline.py` token
+  set; nav + a landing-page link into `/help`.
+- A CI step that rebuilds the help pages when `.help/` changes
+  (eventual rebuild — see acceptance criteria 6).
+
+**Out of scope (this spec):**
+
+- **Demoting / re-homing the mkdocs API + contributor docs.** mkdocs
+  keeps the API reference, CLI reference, glossary, architecture, and
+  contributing — this spec does not touch them beyond cross-linking.
+- **The two parallel template *generators* debt.** The CLAUDE.md
+  lessons document two markdown-*generation* pipelines (the in-repo
+  3-depth stub generator vs `attune-author`'s 11-kind polish). That
+  is a *generation* concern, orthogonal to this *rendering* spec.
+  Tracked as related-work; not folded in here.
+- Editing / regenerating templates from the public site — regen
+  stays in the dashboard's admin tools. The public site is
+  read-only.
+- Embedding-based search — keyword/JSON client index only for v1.
+
+### Acceptance criteria
+
+1. `attune-ai-dev/help/index.html` renders a browsable feature grid
+   plus the four intent entry points; opens cleanly on Vercel and in
+   a local file open.
+2. Each of the 25 features has `help/<feature>/index.html` linking
+   every kind it has; each kind renders to a brand-styled HTML page
+   from its markdown body.
+3. Typing a query in the landing search box returns relevant
+   feature/kind hits from the generated `search-index.json`
+   (client-side, no server).
+4. The build is a single command
+   (`python attune-ai-dev/build_help.py`) that **reuses** the
+   existing corpus loader + `markdown-it-py` — verified by the script
+   importing them rather than reimplementing parsing/rendering.
+5. `/help` is reachable from the site nav and the landing page; URLs
+   are clean (`attune-ai.dev/help/<feature>/<kind>`).
+6. CI rebuilds the help pages when `.help/` content changes and
+   commits/deploys the result. Drift does **not** hard-fail CI
+   (eventual rebuild, per your call) — a stale page is acceptable
+   until the next rebuild.
+7. No third markdown renderer is introduced: the dashboard, the
+   build script, and `build_discipline.py` all route markdown → HTML
+   through `markdown-it-py`; corpus loading goes through one shared
+   loader.
+8. The migrated hand-written tutorials/guides (`docs/tutorials/*`,
+   `docs/how-to/*`) render into `/help` alongside the generated
+   corpus, browsable from the same nav (D4/D7).
+9. Old framework-docs tutorial URLs redirect to their new
+   `/help` homes (low priority; cold traffic — a follow-up task is
+   acceptable).
+
+### Non-goals / explicitly deferred
+
+- Parallel-generator cleanup (separate tracked debt).
+- Public-site regen / editing (read-only site).
+- Versioned/multi-release help (single current corpus only).
+- Touching the mkdocs API/contributor docs beyond cross-linking
+  (they stay; this spec only re-homes user help).
+
+### Resolved design driver
+
+- **D4 — mkdocs relationship → hybrid** (resolved 2026-06-04, see
+  `decisions.md`): attune-ai.dev/help is canonical user help
+  (generated corpus + migrated tutorials/guides); mkdocs narrows to
+  API reference + contributor docs. D7 captures the two-source
+  consequence for the build.

--- a/docs/specs/public-help-site/tasks.md
+++ b/docs/specs/public-help-site/tasks.md
@@ -1,0 +1,69 @@
+# Spec: Public Help Site — Tasks
+
+> Phase 3 (task decomposition). Sequenced; each task is a reviewable
+> unit. Most carry an XML-enhanced prompt at execution time per
+> `.claude/rules/attune/xml-enhanced-prompts.md`.
+
+---
+
+## Tasks
+
+| # | Task | Files | Depends on | Status |
+|---|------|-------|------------|--------|
+| T1 | Extract brand shell + CSS into shared `_brand.py`; refactor `build_discipline.py` to use it (no visual change) | `attune-ai-dev/_brand.py` (new), `attune-ai-dev/build_discipline.py` | — | todo |
+| T2 | `build_help.py` core: render the generated corpus (features + kinds) → `help/<feature>/index.html` + `<kind>.html`, reusing `help_data.list_features`/`get_template` + markdown-it-py | `attune-ai-dev/build_help.py` (new) | T1 | todo |
+| T3 | Two-source ingestion (D7, Model A): slug-match `docs/tutorials/*` + `docs/how-to/*` to features; merge matched into feature pages; emit unmatched into `help/guides/`; log the mapping; strip mkdocs admonitions | `attune-ai-dev/build_help.py` | T2 | todo |
+| T4 | Landing page: intent nav (do/solve/understand/lookup via `INTENT_GROUPS`) + feature grid + guides section + search box; site nav + link to mkdocs API docs; landing-page link into `/help` | `attune-ai-dev/build_help.py`, `attune-ai-dev/index.html` | T2 | todo |
+| T5 | Search index + client searcher: emit `help/search-index.json` (title/feature/kind/url/keywords/snippet) + `help/search.js` (substring + token-overlap rank) | `attune-ai-dev/build_help.py`, `attune-ai-dev/help/search.js` | T2, T3 | todo |
+| T6 | Tests: build-script unit tests (renders all features/kinds, search index well-formed, slug-match correctness, admonition stripping) + a link/asset sanity check | `tests/unit/site/test_build_help.py` (new) | T2–T5 | todo |
+| T7 | CI rebuild step (D3): on `.help/**` or migrated `docs/{tutorials,how-to}/**` change, run `build_help.py`, auto-commit `help/**`, no hard-fail; respect generated-content whitespace/newline hooks | `.github/workflows/*.yml` | T2–T5 | todo |
+| T8 | Redirects (low priority, can be follow-up): emit matched-slug → new-URL map at build; add Vercel redirect rules for cold framework-docs tutorial URLs | `attune-ai-dev/vercel.json`, `build_help.py` | T3 | todo |
+
+---
+
+## Acceptance criteria → coverage
+
+| Criterion (requirements.md) | Task(s) |
+|---|---|
+| 1. `/help/index.html` browsable (intent + grid) | T4 |
+| 2. Every feature → `<feature>/index.html` + per-kind pages | T2 |
+| 3. Client-side search over `search-index.json` | T5 |
+| 4. Single command, reuses loader + markdown-it-py | T1, T2 |
+| 5. `/help` in nav + landing link, clean URLs | T4 |
+| 6. CI rebuilds on `.help/` change, no hard-fail | T7 |
+| 7. No third renderer (shared loader + markdown-it-py) | T1, T2 |
+| 8. Migrated tutorials/how-to render into `/help` | T3 |
+| 9. Old tutorial URLs redirect | T8 |
+
+---
+
+## Sequencing notes
+
+- **T1 first** — extract `_brand.py` and prove `build_discipline.py`
+  still renders identically (byte-diff the old vs new
+  `discipline/index.html`) before building anything new on top.
+- **T2 → T3 → T4/T5** is the core build, pipelined. T4 and T5 can run
+  in parallel once T3 lands the page set.
+- **T6 gates merge**; **T7** lands with or just after the build so the
+  public pages don't immediately go stale.
+- **T8 is deferrable** to a follow-up PR (cold traffic) — note it in
+  the PR if split.
+
+---
+
+## Review gates before execution
+
+Two items need your sign-off when T3/T4 are drafted (flagged in
+design.md):
+
+1. **The migration set** — prune which `docs/tutorials/`+`docs/how-to/`
+   pages actually move vs stay.
+2. **Install page** — landing chip vs `/help` tutorial vs both.
+
+---
+
+## Out of scope (restated)
+
+- mkdocs API/contributor docs (stay; cross-link only).
+- Parallel-template-*generator* cleanup (separate debt).
+- Public-site regen/editing (read-only).


### PR DESCRIPTION
## What

A new spec (Phases 1-3: requirements, design, tasks, decisions) for rendering the attune **help system** as browsable, searchable static pages on the public **attune-ai.dev** site. No implementation in this PR — docs only.

## The shape

A `build_help.py` (sibling to the existing `build_discipline.py`) that **reuses** the ops dashboard's corpus loader (`ops/help_data.py`) + `markdown-it-py` to static-render:
- the generated `.help/` corpus (25 features × up to 11 kinds), **and**
- migrated hand-written tutorials/how-tos (`docs/tutorials/`, `docs/how-to/`),

into `attune-ai-dev/help/`, with a client-side JSON search index. **No third markdown renderer** is introduced.

## Key decisions (`decisions.md`)

| | |
|---|---|
| D1 | Reuse loader + markdown-it-py — no new parser/renderer |
| D2 | Client-side JSON search (static host) |
| D3 | Eventual rebuild, no hard CI fail on drift |
| D4 | Hybrid: attune-ai.dev/help = canonical user help (corpus + migrated tutorials); mkdocs narrows to API + contributor reference |
| D7 | Two markdown sources; feature-centric merge for overlapping slugs (e.g. `bug-predict` feature + tutorial + how-to → one page) |
| D8 | Trajectory: full consolidation onto attune-ai.dev, smartaimemory.com redirects there; this hybrid is step 1 |

## Not in this PR

- Implementation (Phase 4, 8 sequenced tasks in `tasks.md`).
- Two review gates need sign-off before T3/T4: the **migration set** (which tutorials/how-tos move) and the **install-page** question.
- The parallel-template-*generator* debt (separate, scoped out).

Spec: `docs/specs/public-help-site/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
