### PR TITLE
fix(tests): repair main breakage from #613 + #623 docs-labeled merges

### DIFF
--- a/tests/unit/help_site/test_build_help.py
+++ b/tests/unit/help_site/test_build_help.py
@@ -64,7 +64,13 @@ class TestHelpers:
         assert "a&lt;b" in c
 
     def test_page_carries_brand_and_help_css(self):
-        page = bh._page(title="T", desc="D", crumbs="C", body="<main></main>")
+        page = bh._page(
+            title="T",
+            desc="D",
+            crumbs="C",
+            body="<main></main>",
+            canonical="https://attune-ai.dev/help",
+        )
         assert "<title>T</title>" in page
         assert "--primary" in page  # brand.css token reused
         assert ".help-nav" in page  # help-specific css

--- a/tests/unit/ops/test_path_support_registry.py
+++ b/tests/unit/ops/test_path_support_registry.py
@@ -163,7 +163,7 @@ class TestRegistryShape:
 def test_audit_doc_exists() -> None:
     """The audit doc backing this registry should be in the repo."""
     repo_root = Path(__file__).resolve().parents[3]
-    audit = repo_root / "docs" / "specs" / "ops-runner-tier2" / "audit.md"
+    audit = repo_root / "docs" / "specs" / "archive" / "ops-runner-tier2" / "audit.md"
     assert audit.is_file(), (
         f"Expected audit doc at {audit} — it's the source of truth for "
         "PATH_ARG_REGISTRY's three-way categorization. If the audit is "


### PR DESCRIPTION
## What

`main` is matrix-wide red — surfaced when #627's CI inherited it. Root cause: **two earlier 'docs-only' PRs were admin-merged past the Python matrix but actually had test dependencies.**

| Broken test | Cause |
|---|---|
| `test_page_carries_brand_and_help_css` | **#623** changed `attune-ai-dev/build_help.py::_page()` to require `canonical=`; the test called it without. |
| `test_audit_doc_exists` | **#613** archived `docs/specs/ops-runner-tier2/`; the test asserted the pre-archive path. |

## Fix
- Pass `canonical=` in the `_page()` test call.
- Point the audit-doc test at `docs/specs/archive/ops-runner-tier2/audit.md`.

Both verified passing locally (`2 passed`). **#627 (attune-rag.dev site) was never the cause** — it inherits this red and goes green once this lands and it rebases.

**Takeaway:** 'docs-only' is a path heuristic, not a CI-safety guarantee — `attune-ai-dev/` build scripts and `docs/specs/` paths are both under test. Verify the matrix on docs PRs touching those areas instead of admin-merging past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)