### PR TITLE
fix(docs): repoint redis-decoupling links broken by spec archival

### DIFF
--- a/docs/migration/redis-plugin-migration.md
+++ b/docs/migration/redis-plugin-migration.md
@@ -102,7 +102,7 @@ if it picks up these candidates.
 
 ## See also
 
-- [`docs/specs/redis-decoupling/audit.md`](../specs/redis-decoupling/audit.md) — Phase A audit findings
-- [`docs/specs/redis-decoupling/decisions.md`](../specs/redis-decoupling/decisions.md) — per-phase decision log
+- [`redis-decoupling/audit.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/archive/redis-decoupling/audit.md) — Phase A audit findings (archived)
+- [`redis-decoupling/decisions.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/archive/redis-decoupling/decisions.md) — per-phase decision log (archived)
 - PR [#279](https://github.com/Smart-AI-Memory/attune-ai/pull/279) — P1 (delete `attune.coordination`)
 - PR [#281](https://github.com/Smart-AI-Memory/attune-ai/pull/281) — P2 (drop `[memory]` extra)


### PR DESCRIPTION
## Summary

Fixes the pre-existing `build` (mkdocs `--strict`) failure that's been
showing red on **every** PR. The #613 backlog triage archived the
`redis-decoupling` spec to `docs/specs/archive/redis-decoupling/`, but
`docs/migration/redis-plugin-migration.md` still linked to the
pre-archive path. Because `archive/` is excluded from the mkdocs build,
`mkdocs build --strict` aborted with:

```
WARNING - ... contains a link '../specs/redis-decoupling/audit.md',
but the target ... is not found among documentation files.
Aborted with 2 warnings in strict mode!
```

## Fix

Repoint both "See also" links to absolute GitHub blob URLs (which
mkdocs strict does not link-validate) and mark them archived. Verified
no other live doc carries a dead relative `../specs/` link.

## Why it matters

Per the CLAUDE.md lesson, a permanently-red `build` check can mask a
*real* docs break later. This clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
