### PR TITLE
feat(curator): Phase 3 Task 3.1 — dashboard /curator page

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7898,3 +7898,32 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   heredocs + `git -C ~/attune-rag` for commits, and
   `git archive <branch> <path> | tar -x` to extract committed files
   from a branch that isn't checked out in the working tree.
+
+- **`claude_agent_sdk.ClaudeAgentOptions` cannot do forced
+  guaranteed-schema tool-use — use the raw `anthropic` SDK for that**:
+  hit 2026-06-05 implementing bulletin-curator Phase 2, whose
+  `design.md` sketched the synthesis call as
+  `ClaudeAgentOptions(tools=[{...schema...}], tool_choice={"type":
+  "tool","name":...})`. Introspecting the SDK (0.1.63 via
+  `dataclasses.fields(ClaudeAgentOptions)`) showed that shape is
+  unsupported: (1) there is **no `tool_choice` field** at all; (2)
+  the `tools` field is `list[str] | ToolsPreset | None` — an
+  ALLOWLIST OF TOOL NAMES, not raw Anthropic tool definitions with
+  `input_schema`. The agent SDK routes through the `claude` CLI's own
+  tool loop and can't force a single schema-guaranteed call. The
+  existing CLAUDE.md "Forced Anthropic tool-use is the cleanest path
+  to guaranteed-schema JSON" lesson is about the **raw `anthropic`
+  SDK** (`client.messages.create(tools=[{...}], tool_choice={"type":
+  "tool","name":...})`), as `attune_rag`'s `FaithfulnessJudge` does —
+  the two SDKs are easy to conflate because both live in this repo.
+  Rule of thumb: a single synthesis/judge call with no agent loop, no
+  subagents, no file tools wants the raw `anthropic` SDK (guaranteed
+  schema, cheap, testable with an injected fake client); reserve
+  `claude_agent_sdk.query()` for actual agentic work (file tools,
+  subagent fan-out, multi-turn). This is the "research subagents
+  confabulate SDK signatures — introspect before coding" lesson with
+  a concrete instance: the SPEC ITSELF (`design.md`, written before
+  introspection) carried the confabulated signature, so spec
+  pseudocode is no more trustworthy than a research agent's — a
+  one-minute `dataclasses.fields()` check is the antidote. Deviation
+  recorded in `docs/specs/bulletin-curator/decisions.md` D1.

--- a/docs/specs/bulletin-curator/decisions.md
+++ b/docs/specs/bulletin-curator/decisions.md
@@ -63,3 +63,37 @@ Implemented strictly: an item survives only if **every** id in its
 `sources` resolves to a real `SourceItem` from the inputs. Strictness
 is the faithfulness lever — a partially-fabricated citation is still a
 fabrication. Drops are logged at WARNING.
+
+---
+
+## Phase 3 — Dashboard surface, Task 3.1 (2026-06-05)
+
+### D5 — `POST /curator/answer` records, does not auto-flip spec status
+
+`design.md` sketched `/curator/answer` calling the spec-status setter
+when a "Mark complete?" item is answered Yes. But the LLM's
+`suggested_action` schema carries `question`/`choices`/`label`/`url`/
+`workflow`/`scope` — it has **no structured "set spec X to status Y"**
+field, so the handler can't generically perform that write. v1
+`/answer` records the `{item_id, choice}` to
+`<attune_home>/curator/answers.jsonl` (audit journal, best-effort) and
+returns. Wiring a real spec-status side-effect needs a richer
+`suggested_action` (e.g. an explicit `spec_slug` + `target_status`) and
+should reuse the existing allow_run-gated setter — deferred to a
+follow-up. `/curator/dismiss` (snooze 14d → `dismissals.json`) is fully
+implemented; the GET route filters snoozed items.
+
+### D6 — Summary `[item_id]` markers render as plain text in v1
+
+`design.md` wants the summary's `[item_id]` citation markers rendered as
+inline anchor chips linking to each source. v1 renders the summary
+verbatim (markers as text) to keep Task 3.1 focused. Chip-linking is a
+self-contained polish follow-up (parse markers → resolve to source
+links).
+
+### D7 — Task 3.1 only; CLI (3.2) + bulletin cross-link (3.3) deferred
+
+Phase 3 ships in two PRs: the `/curator` page first (route + template +
+CSS + answer/dismiss + tests), then `attune curator` CLI and the
+bulletin-strip "View briefing" cross-link in a follow-up. Each surface
+is independently shippable per `tasks.md`.

--- a/docs/specs/bulletin-curator/tasks.md
+++ b/docs/specs/bulletin-curator/tasks.md
@@ -418,6 +418,12 @@ budget) recorded in [`decisions.md`](decisions.md) D1–D4.
 
 ## Phase 3 — Dashboard `/curator` + CLI
 
+**Task 3.1 done (2026-06-05).** `GET /curator` route + `curator.html`
+template + CSS + `POST /curator/{answer,dismiss}` + 6 route tests,
+wired into `server.py` (router + "Briefing" nav). Two v1 deferrals
+recorded in [`decisions.md`](decisions.md) D5–D6. Tasks 3.2 (CLI) and
+3.3 (cross-link) follow in a second PR (D7).
+
 ### Task 3.1 — Dashboard route + template
 
 ```xml

--- a/src/attune/ops/routes/curator.py
+++ b/src/attune/ops/routes/curator.py
@@ -1,0 +1,160 @@
+"""Dashboard surface for the bulletin curator briefing.
+
+Three endpoints:
+
+- ``GET /curator`` — render the executive summary + ranked item cards.
+  Invokes :func:`attune.curator.run_curator` (cached; degrades to an
+  offline briefing on LLM failure) and filters out items the user has
+  snoozed.
+- ``POST /curator/dismiss`` — snooze an item for 14 days. Persists to
+  ``<attune_home>/curator/dismissals.json``.
+- ``POST /curator/answer`` — record the user's response to an item's
+  suggested action (audit journal). The spec-status side-effect the
+  design sketches is deferred — see
+  ``docs/specs/bulletin-curator/decisions.md`` D5.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Body, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from attune.curator import run_curator
+from attune.security.path_validation import _validate_file_path
+
+from .dashboard import _ctx
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_SNOOZE_DAYS = 14
+
+
+def _curator_dir(request: Request) -> Path:
+    return request.app.state.config.attune_home / "curator"
+
+
+def _dismissals_path(request: Request) -> Path:
+    return _curator_dir(request) / "dismissals.json"
+
+
+def _load_dismissals(request: Request) -> dict[str, Any]:
+    """Load the dismissals map; ``{}`` on missing / malformed file."""
+    path = _dismissals_path(request)
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _active_dismissed_ids(request: Request) -> set[str]:
+    """Item ids whose snooze window hasn't elapsed."""
+    now = datetime.now(timezone.utc)
+    active: set[str] = set()
+    for item_id, rec in _load_dismissals(request).items():
+        until = rec.get("snoozed_until") if isinstance(rec, dict) else None
+        if not until:
+            continue
+        try:
+            dt = datetime.fromisoformat(str(until))
+        except (ValueError, TypeError):
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        if dt > now:
+            active.add(item_id)
+    return active
+
+
+@router.get("/curator", response_class=HTMLResponse)
+async def curator_page(request: Request, refresh: int = 0) -> HTMLResponse:
+    """Render the curator briefing, filtering snoozed items."""
+    cfg = request.app.state.config
+    result = await run_curator(
+        project_root=cfg.project_root,
+        force_refresh=bool(refresh),
+    )
+    dismissed = _active_dismissed_ids(request)
+    visible = [item for item in result.items if item.id not in dismissed]
+    templates = request.app.state.templates
+    ctx = _ctx(request, page="curator", result=result, items=visible)
+    return templates.TemplateResponse(request, "curator.html", ctx)
+
+
+@router.post("/curator/dismiss")
+async def curator_dismiss(
+    request: Request,
+    body: dict[str, Any] = Body(...),  # noqa: B008
+) -> JSONResponse:
+    """Snooze an item for 14 days.
+
+    Body: ``{"item_id": "..."}``. Writes
+    ``<attune_home>/curator/dismissals.json`` with the snooze deadline.
+    """
+    item_id = str(body.get("item_id") or "").strip()
+    if not item_id:
+        return JSONResponse({"ok": False, "error": "item_id required"}, status_code=400)
+
+    dismissals = _load_dismissals(request)
+    until = datetime.now(timezone.utc) + timedelta(days=_SNOOZE_DAYS)
+    dismissals[item_id] = {"snoozed_until": until.isoformat()}
+
+    path = _dismissals_path(request)
+    try:
+        validated = _validate_file_path(str(path))
+        validated.parent.mkdir(parents=True, exist_ok=True)
+        tmp = validated.with_suffix(validated.suffix + ".tmp")
+        tmp.write_text(json.dumps(dismissals, sort_keys=True), encoding="utf-8")
+        tmp.replace(validated)
+    except (OSError, ValueError) as exc:
+        logger.warning("curator: dismiss write failed for %s: %s", path, exc)
+        return JSONResponse({"ok": False, "error": "write failed"}, status_code=500)
+
+    return JSONResponse({"ok": True, "item_id": item_id, "snoozed_until": until.isoformat()})
+
+
+@router.post("/curator/answer")
+async def curator_answer(
+    request: Request,
+    body: dict[str, Any] = Body(...),  # noqa: B008
+) -> JSONResponse:
+    """Record a user's response to an item's suggested action.
+
+    Body: ``{"item_id": "...", "choice": "..."}``. Appends to
+    ``<attune_home>/curator/answers.jsonl`` (audit journal). Best-effort:
+    a journal failure is logged, not surfaced as an error.
+    """
+    item_id = str(body.get("item_id") or "").strip()
+    choice = str(body.get("choice") or "").strip()
+    if not item_id or not choice:
+        return JSONResponse(
+            {"ok": False, "error": "item_id and choice required"},
+            status_code=400,
+        )
+
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "item_id": item_id,
+        "choice": choice,
+    }
+    path = _curator_dir(request) / "answers.jsonl"
+    try:
+        validated = _validate_file_path(str(path))
+        validated.parent.mkdir(parents=True, exist_ok=True)
+        with validated.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+    except (OSError, ValueError) as exc:
+        # Best-effort journal — never fail the response on a write hiccup.
+        logger.warning("curator: answer journal append failed for %s: %s", path, exc)
+
+    return JSONResponse({"ok": True, "item_id": item_id, "choice": choice})

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -16,6 +16,7 @@ from attune.ops import sweep_results as sweep_results_mod
 from attune.ops.config import Config
 from attune.ops.interaction_counters import InteractionCounters
 from attune.ops.routes import bulletin as bulletin_routes
+from attune.ops.routes import curator as curator_routes
 from attune.ops.routes import dashboard
 from attune.ops.routes import help as help_routes
 from attune.ops.routes import interaction_counters as interaction_counters_routes
@@ -95,6 +96,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     templates.env.globals["nav_items"] = [
         ("/", "Home"),
         ("/workflows", "Workflows"),
+        ("/curator", "Briefing"),
         ("/specs", "Specs"),
         ("/sessions", "Sessions"),
         ("/telemetry", "Telemetry"),
@@ -127,6 +129,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.include_router(interaction_counters_routes.router)
     app.include_router(pending_writes_routes.router)
     app.include_router(bulletin_routes.router)
+    app.include_router(curator_routes.router)
     app.include_router(help_routes.router)
 
     # Phase 2B of discovery-sweep-ops-integration: when sweep-result

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -2887,3 +2887,123 @@ a.kpi:hover {
   outline-offset: -1px;
   border-color: var(--accent, #2563eb);
 }
+
+/* ── Curator briefing (/curator) ──────────────────────────────── */
+.chip-info {
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+}
+.chip-nudge {
+  background: var(--accent-soft);
+  border-color: var(--accent-soft);
+  color: var(--accent);
+}
+.chip-block {
+  background: var(--danger-soft);
+  border-color: var(--danger-soft);
+  color: var(--danger);
+}
+.btn-primary {
+  font-weight: 600;
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.btn-muted {
+  color: var(--fg-muted);
+}
+.curator-summary {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  margin: 8px 0 20px;
+  box-shadow: var(--shadow);
+}
+.curator-summary p {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.55;
+}
+.curator-cards {
+  display: grid;
+  gap: 14px;
+}
+.curator-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  box-shadow: var(--shadow);
+}
+.curator-card--info { border-left-color: var(--fg-subtle); }
+.curator-card--nudge { border-left-color: var(--accent); }
+.curator-card--warn { border-left-color: var(--warn); }
+.curator-card--block { border-left-color: var(--danger); }
+.curator-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.curator-card-title {
+  font-size: 16px;
+  margin: 0;
+}
+.curator-card-rationale {
+  color: var(--fg);
+  line-height: 1.5;
+  margin: 8px 0;
+}
+.curator-sources {
+  margin: 6px 0;
+}
+.curator-src-chip {
+  display: inline-block;
+  font-size: 12px;
+  padding: 1px 7px;
+  margin: 2px 4px 2px 0;
+  border-radius: 99px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+}
+.curator-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+}
+.curator-ask-q {
+  margin: 0 0 6px;
+  font-weight: 500;
+}
+.curator-ask-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.curator-run-hint {
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+.curator-empty {
+  background: var(--bg-elev);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius);
+  padding: 24px;
+  text-align: center;
+  color: var(--fg-muted);
+}
+.curator-foot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  margin-top: 22px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+  color: var(--fg-muted);
+}

--- a/src/attune/ops/templates/curator.html
+++ b/src/attune/ops/templates/curator.html
@@ -1,0 +1,121 @@
+{% extends "base.html" %}
+{% block title %}Briefing{% endblock %}
+{% block content %}
+<section class="page-head">
+  <h1>Briefing</h1>
+  <p class="page-sub">
+    What needs attention now, ranked across project sources.
+    {% if result.model %}<code>{{ result.model }}</code>{% endif %}
+    {% if result.cost_usd %}· ${{ "%.4f"|format(result.cost_usd) }}{% endif %}
+  </p>
+</section>
+
+{# Hero: the executive summary. [item_id] markers are rendered as
+   plain text in v1; turning them into inline anchor chips is a polish
+   follow-up (see decisions.md D6). #}
+<section class="curator-summary">
+  <p>{{ result.summary }}</p>
+</section>
+
+{% if items %}
+  <div class="curator-cards">
+    {% for item in items %}
+      <article class="curator-card curator-card--{{ item.severity }}"
+               id="card-{{ item.id }}">
+        <div class="curator-card-head">
+          <span class="curator-sev chip chip-{{ item.severity }}">{{ item.severity }}</span>
+          <h2 class="curator-card-title">{{ item.title }}</h2>
+        </div>
+        <p class="curator-card-rationale">{{ item.rationale }}</p>
+
+        {% if item.sources %}
+          <div class="curator-sources">
+            {% for src in item.sources %}
+              <code class="curator-src-chip">{{ src }}</code>
+            {% endfor %}
+          </div>
+        {% endif %}
+
+        <div class="curator-card-actions">
+          {% set action = item.suggested_action %}
+          {% if action and action.kind == "open" and action.url %}
+            <a class="btn btn-primary" href="{{ action.url }}">
+              {{ action.label or "Open" }}
+            </a>
+          {% elif action and action.kind == "ask" and action.question %}
+            <div class="curator-ask">
+              <p class="curator-ask-q">{{ action.question }}</p>
+              <div class="curator-ask-choices">
+                {% for choice in action.choices %}
+                  <button class="btn curator-answer-btn"
+                          data-item-id="{{ item.id }}"
+                          data-choice="{{ choice }}">{{ choice }}</button>
+                {% endfor %}
+              </div>
+            </div>
+          {% elif action and action.kind == "run" and action.workflow %}
+            <span class="curator-run-hint">
+              Suggested: run <code>{{ action.workflow }}</code>
+              {% if action.scope %}on <code>{{ action.scope }}</code>{% endif %}
+              — <a href="/workflows">go to Workflows →</a>
+            </span>
+          {% endif %}
+          <button class="btn btn-muted curator-dismiss-btn"
+                  data-item-id="{{ item.id }}">Snooze 14d</button>
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+{% else %}
+  <section class="curator-empty">
+    <p>Nothing pressing right now. The briefing is quiet — no items rank above noise.</p>
+  </section>
+{% endif %}
+
+<footer class="curator-foot">
+  <a class="btn btn-muted" href="/curator?refresh=1">Refresh</a>
+  {% if result.sources_consulted %}
+    <span class="curator-foot-sources">
+      Sources: {{ result.sources_consulted|join(", ") }}
+    </span>
+  {% endif %}
+  {% if result.cost_usd %}
+    <span class="curator-foot-cost">${{ "%.4f"|format(result.cost_usd) }}</span>
+  {% endif %}
+</footer>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  // Minimal interactivity: dismiss snoozes an item; answer records a
+  // choice. Both POST JSON then reload to reflect the new state.
+  async function _post(url, payload) {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    return resp.ok;
+  }
+  document.querySelectorAll(".curator-dismiss-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      btn.disabled = true;
+      if (await _post("/curator/dismiss", { item_id: btn.dataset.itemId })) {
+        window.location.reload();
+      } else {
+        btn.disabled = false;
+      }
+    });
+  });
+  document.querySelectorAll(".curator-answer-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      btn.disabled = true;
+      await _post("/curator/answer", {
+        item_id: btn.dataset.itemId,
+        choice: btn.dataset.choice,
+      });
+      window.location.reload();
+    });
+  });
+</script>
+{% endblock %}

--- a/tests/unit/ops/test_curator_route.py
+++ b/tests/unit/ops/test_curator_route.py
@@ -1,0 +1,135 @@
+"""Tests for the dashboard /curator route (bulletin-curator Phase 3, Task 3.1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from attune.curator.result import CuratorItem, CuratorResult, SuggestedAction
+from attune.ops.config import Config
+from attune.ops.server import create_app
+
+
+@pytest.fixture
+def attune_home(tmp_path: Path) -> Path:
+    return tmp_path / "ah"
+
+
+@pytest.fixture
+def client(tmp_path: Path, attune_home: Path) -> TestClient:
+    cfg = Config(
+        project_root=tmp_path,
+        attune_home=attune_home,
+        allow_run=False,
+        trusted_hosts=("testserver", "test"),
+    )
+    return TestClient(create_app(cfg))
+
+
+def _result(
+    items: list[CuratorItem], summary: str = "Two things need attention [a:1]."
+) -> CuratorResult:
+    return CuratorResult(
+        summary=summary,
+        items=items,
+        sources_consulted=["bulletin", "specs"],
+        cost_usd=0.0321,
+        model="claude-opus-4-6",
+    )
+
+
+def _inject(monkeypatch, result: CuratorResult) -> None:
+    async def _fake(**kwargs):
+        return result
+
+    monkeypatch.setattr("attune.ops.routes.curator.run_curator", _fake)
+
+
+def _items() -> list[CuratorItem]:
+    return [
+        CuratorItem(
+            id="i1",
+            title="Spec alpha looks ready to close",
+            severity="warn",
+            rationale="All tasks done [a:1].",
+            sources=["spec:alpha"],
+            suggested_action=SuggestedAction(kind="open", label="Open spec", url="/specs/alpha"),
+        ),
+        CuratorItem(
+            id="i2",
+            title="Security finding unreviewed",
+            severity="nudge",
+            rationale="HIGH finding 22 min ago [r:2].",
+            sources=["rec:r2"],
+            suggested_action=SuggestedAction(
+                kind="ask",
+                question="Mark reviewed?",
+                choices=["Yes", "No"],
+            ),
+        ),
+    ]
+
+
+class TestGetCuratorPage:
+    def test_renders_summary_and_items(self, client, monkeypatch):
+        _inject(monkeypatch, _result(_items()))
+        resp = client.get("/curator")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Two things need attention" in body
+        assert "Spec alpha looks ready to close" in body
+        assert "Security finding unreviewed" in body
+        assert "claude-opus-4-6" in body
+
+    def test_empty_items_shows_empty_state(self, client, monkeypatch):
+        _inject(monkeypatch, _result([], summary="Nothing pressing."))
+        resp = client.get("/curator")
+        assert resp.status_code == 200
+        assert "Nothing pressing" in resp.text
+        assert "no items rank above noise" in resp.text
+
+
+class TestDismiss:
+    def test_dismiss_persists_and_filters(self, client, monkeypatch, attune_home):
+        _inject(monkeypatch, _result(_items()))
+
+        resp = client.post("/curator/dismiss", json={"item_id": "i1"})
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        dismissals = json.loads((attune_home / "curator" / "dismissals.json").read_text())
+        assert "i1" in dismissals
+        assert "snoozed_until" in dismissals["i1"]
+
+        # Subsequent GET filters the snoozed item out.
+        page = client.get("/curator")
+        assert "Spec alpha looks ready to close" not in page.text
+        assert "Security finding unreviewed" in page.text
+
+    def test_dismiss_requires_item_id(self, client, monkeypatch):
+        _inject(monkeypatch, _result(_items()))
+        resp = client.post("/curator/dismiss", json={})
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+
+class TestAnswer:
+    def test_answer_journals(self, client, monkeypatch, attune_home):
+        _inject(monkeypatch, _result(_items()))
+        resp = client.post("/curator/answer", json={"item_id": "i2", "choice": "Yes"})
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        journal = attune_home / "curator" / "answers.jsonl"
+        lines = [json.loads(line) for line in journal.read_text().splitlines() if line.strip()]
+        assert len(lines) == 1
+        assert lines[0]["item_id"] == "i2"
+        assert lines[0]["choice"] == "Yes"
+
+    def test_answer_requires_choice(self, client, monkeypatch):
+        _inject(monkeypatch, _result(_items()))
+        resp = client.post("/curator/answer", json={"item_id": "i2"})
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

**Phase 3, Task 3.1** of `bulletin-curator` — the visible `/curator`
briefing page on top of Phase 2's `run_curator`. (Also carries one
docs(CLAUDE.md) lesson commit from the Phase 2 work.)

## What's in it

- **`routes/curator.py`**
  - `GET /curator` — awaits `run_curator` (cached; degrades to an
    offline briefing on LLM failure), filters out snoozed items.
  - `POST /curator/dismiss` — snooze an item 14 days →
    `<attune_home>/curator/dismissals.json`.
  - `POST /curator/answer` — record a choice →
    `<attune_home>/curator/answers.jsonl` (best-effort audit journal).
- **`templates/curator.html`** — hero summary + severity-striped item
  cards (source chips, suggested-action footer, inline dismiss/answer
  JS), honest empty state, footer (refresh / sources / cost).
- **`main.css`** — severity chips (`info`/`nudge`/`block`),
  `btn-primary`/`btn-muted`, curator card/summary/footer styles, all on
  existing design tokens (light + dark).
- **`server.py`** — wire the router + a "Briefing" nav entry.

## v1 deferrals (decisions.md D5–D7)

- `/answer` **records** the choice rather than auto-flipping spec
  status — the LLM `suggested_action` schema has no structured
  `spec_slug`/`target_status`, so a generic write isn't possible yet.
- Summary `[item_id]` markers render as plain text (chip-linking is a
  self-contained follow-up).
- **CLI (3.2)** and the **bulletin "View briefing" cross-link (3.3)**
  ship in a second PR.

## Testing

- 6 route tests: render, empty state, dismiss persist+filter, answer
  journal, 400 guards. Template renders end-to-end through Jinja.
- Full `tests/unit/ops/` green except one pre-existing, local-env
  `test_sessions` failure (verified unrelated — fails with these
  changes stashed; #631's required `test` check passed in CI).
- ruff + black clean.

## Stacking note

Branched off Phase 2 and rebased onto main after #631 merged, so this
targets `main` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
