### PR TITLE
feat(curator): Phase 3 Tasks 3.2 + 3.3 — CLI + bulletin cross-link

### DIFF
--- a/.help/templates/cli/concept.md
+++ b/.help/templates/cli/concept.md
@@ -1,57 +1,37 @@
 ---
-type: concept
-name: cli-concept
 feature: cli
 depth: concept
-generated_at: 2026-06-04T23:39:47.633186+00:00
-source_hash: 4b177dd28a8ce19bb06606b9ae39e4fe255d7f2fe854f3376d3330f151f3ffac
+generated_at: 2026-06-05T16:32:09.109066+00:00
+source_hash: 198ad869d0b029e3926d86fd51b53c7d1a800d65335cb982b9331b5ee6c9bcaa
 status: generated
 ---
 
-# CLI
+# Cli
 
-The `attune` CLI is the command-line surface that lets you run workflows, inspect telemetry and costs, manage memory, and configure providers — all through a single entry point defined in `attune.cli_minimal`.
+## How it works
 
-## How the pieces fit together
+Command-line interface and routing.
 
-The CLI has two distinct layers that work in tandem.
+The main building blocks are:
 
-**The command layer** is built around `create_parser()` and `main()` in `attune.cli_minimal`. When you invoke `attune`, `main()` parses your arguments and delegates to one of the command modules:
+- **`RoutingPreference`** — User's learned routing preferences.
+- **`HybridRouter`** — Routes user input to Claude Code skill invocations.
 
-| Module | Commands |
-|--------|----------|
-| `cli_commands.workflow_commands` | `cmd_workflow_list`, `cmd_workflow_info`, `cmd_workflow_run` |
-| `cli_commands.cost_commands` | `cmd_costs`, `cmd_costs_today`, `cmd_costs_export`, `cmd_costs_reset` |
-| `cli_commands.memory_commands` | `cmd_remember`, `cmd_forget`, `cmd_lessons`, `cmd_memory_capture`, `cmd_memory_recall`, `cmd_memory_topics`, `cmd_memory_forget_topic` |
-| `cli_commands.telemetry_commands` | `cmd_telemetry_show`, `cmd_telemetry_savings`, `cmd_telemetry_export`, `cmd_telemetry_routing_stats`, `cmd_telemetry_routing_check`, `cmd_telemetry_models`, `cmd_telemetry_agents`, `cmd_telemetry_signals` |
-| `cli_commands.provider_commands` | `cmd_provider_show`, `cmd_provider_set` |
-| `cli_commands.utility_commands` | `cmd_setup`, `cmd_validate`, `cmd_version`, `cmd_features`, `cmd_doctor` |
-| `cli_commands.help_commands` | `cmd_help` |
+Under the hood, this feature spans 12 source
+files covering:
 
-Every command function takes an `argparse.Namespace` and returns an integer exit code.
+- Hybrid CLI Router - Skills + Natural Language
+- CLI command modules for attune.
+- Exit-code contract for ``attune workflow run``.
 
-**The routing layer** sits in `attune.cli_router` and handles free-form or slash-command input. When you type a slash command, `is_slash_command()` detects it. `route_user_input()` then resolves the input to a Claude Code skill invocation. Under the hood, `HybridRouter` does this resolution and can learn from your usage over time.
+## What connects to it
 
-## Exit-code contract
+This feature relates to: cli, commands.
 
-`run_workflow_with_exit_code()` in `cli_commands._exit_codes` is the bridge between a workflow class and the shell. It instantiates and executes the workflow, then returns a standardised integer that your shell or CI pipeline can act on. All `cmd_*` functions follow the same contract: return `0` on success, non-zero on failure.
+Other parts of the codebase interact with
+cli through these interfaces:
 
-## Routing preferences
-
-`HybridRouter` personalises routing by building a set of `RoutingPreference` entries. Each entry captures a `keyword`, the `skill` it should map to, optional `args`, and two learned fields — `usage_count` and `confidence` — that improve over time as you use `learn_preference()`. You can call `get_suggestions()` with a partial string to see what the router would suggest completing.
-
-```python
-router = HybridRouter(preferences_path="~/.attune/prefs.json")
-router.learn_preference(keyword="deploy", skill="run-deploy-workflow")
-router.get_suggestions("dep")   # returns completions ranked by confidence
-```
-
-## When this matters
-
-You interact with this layer whenever you:
-
-- Run `attune workflow run` and need a predictable exit code for scripting
-- Use `attune costs today` or `attune costs export` to track spend
-- Manage cross-session memory with `attune remember` or `attune lessons`
-- Inspect routing behaviour with `attune telemetry routing-stats` or `attune telemetry routing-check`
-- Configure or verify your setup with `attune doctor` or `attune validate`
+| Interface | Purpose | File |
+|-----------|---------|------|
+| `RoutingPreference` | User's learned routing preferences. | `src/attune/cli_router.py` |
+| `HybridRouter` | Routes user input to Claude Code skill invocations. | `src/attune/cli_router.py` |

--- a/.help/templates/cli/reference.md
+++ b/.help/templates/cli/reference.md
@@ -1,132 +1,62 @@
 ---
-type: reference
-name: cli-reference
 feature: cli
 depth: reference
-generated_at: 2026-06-04T23:39:47.643616+00:00
-source_hash: 4b177dd28a8ce19bb06606b9ae39e4fe255d7f2fe854f3376d3330f151f3ffac
+generated_at: 2026-06-05T16:32:09.120968+00:00
+source_hash: 198ad869d0b029e3926d86fd51b53c7d1a800d65335cb982b9331b5ee6c9bcaa
 status: generated
 ---
 
-# CLI reference
-
-Use this reference to look up the command handlers, routing utilities, entry point, and data types that make up the attune command-line interface.
+# Cli reference
 
 ## Classes
 
 | Class | Description | File |
 |-------|-------------|------|
-| `RoutingPreference` | User's learned routing preference for a keyword. | `src/attune/cli_router.py` |
+| `RoutingPreference` | User's learned routing preferences. | `src/attune/cli_router.py` |
 | `HybridRouter` | Routes user input to Claude Code skill invocations. | `src/attune/cli_router.py` |
-
-### `RoutingPreference` fields
-
-`RoutingPreference` is a dataclass.
-
-| Field | Type | Default |
-|-------|------|---------|
-| `keyword` | `str` | — |
-| `skill` | `str` | — |
-| `args` | `str` | `''` |
-| `usage_count` | `int` | `0` |
-| `confidence` | `float` | `1.0` |
-
-### `HybridRouter` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__` | `preferences_path: str | None = None` | — | Initialize the router, optionally loading preferences from a file path. |
-| `route` | `user_input: str, context: dict[str, Any] | None = None` | `dict[str, Any]` | Route user input to a skill invocation. |
-| `learn_preference` | `keyword: str, skill: str, args: str = ''` | — | Record a keyword-to-skill mapping as a learned preference. |
-| `get_suggestions` | `partial: str` | `list[str]` | Return completions for a partial keyword string. |
 
 ## Functions
 
-### Entry point
+| Function | Description | File |
+|----------|-------------|------|
+| `get_version()` | Get package version. | `src/attune/cli_minimal.py` |
+| `create_parser()` | Create the argument parser. | `src/attune/cli_minimal.py` |
+| `main()` | Main entry point. | `src/attune/cli_minimal.py` |
+| `route_user_input()` | Quick routing helper. | `src/attune/cli_router.py` |
+| `is_slash_command()` | Check if text is a slash command. | `src/attune/cli_router.py` |
+| `run_workflow_with_exit_code()` | Instantiate + execute a workflow and return the contract exit code. | `src/attune/cli_commands/_exit_codes.py` |
+| `cmd_costs()` | Show cost report for recent period. | `src/attune/cli_commands/cost_commands.py` |
+| `cmd_costs_today()` | Show today's cost summary. | `src/attune/cli_commands/cost_commands.py` |
+| `cmd_costs_export()` | Export cost data to file. | `src/attune/cli_commands/cost_commands.py` |
+| `cmd_costs_reset()` | Clear all cost tracking data. | `src/attune/cli_commands/cost_commands.py` |
+| `cmd_curator()` | Render the curator briefing for the current project. | `src/attune/cli_commands/curator.py` |
+| `cmd_help()` | Handle the `attune help` command. | `src/attune/cli_commands/help_commands.py` |
+| `cmd_remember()` | Add a lesson to the lessons file. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_forget()` | Remove a lesson by line number or keyword. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_lessons()` | List current lessons with line numbers. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_memory_capture()` | Save content to personal cross-session memory. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_memory_recall()` | Search personal cross-session memory. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_memory_topics()` | List all personal memory topics. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_memory_forget_topic()` | Delete a topic (or specific kind) from personal memory. | `src/attune/cli_commands/memory_commands.py` |
+| `cmd_provider_show()` | Show current provider configuration. | `src/attune/cli_commands/provider_commands.py` |
+| `cmd_provider_set()` | Set the LLM provider. | `src/attune/cli_commands/provider_commands.py` |
+| `cmd_telemetry_show()` | Display usage summary. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_savings()` | Show cost savings from tier routing. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_export()` | Export telemetry data to file. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_routing_stats()` | Show adaptive routing statistics. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_routing_check()` | Check for tier upgrade recommendations. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_models()` | Show model performance by provider. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_agents()` | Show active agents and their status. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_signals()` | Show coordination signals. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_setup()` | Install Attune slash commands for Claude Code. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_validate()` | Validate configuration. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_version()` | Show version information. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_features()` | Show available memory and telemetry features. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_doctor()` | Run comprehensive environment health check. | `src/attune/cli_commands/utility_commands.py` |
+| `cmd_workflow_list()` | List available workflows. | `src/attune/cli_commands/workflow_commands.py` |
+| `cmd_workflow_info()` | Show workflow details. | `src/attune/cli_commands/workflow_commands.py` |
+| `cmd_workflow_run()` | Execute a workflow. | `src/attune/cli_commands/workflow_commands.py` |
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `get_version` | — | `str` | Return the installed package version. |
-| `create_parser` | — | `argparse.ArgumentParser` | Build and return the top-level argument parser. |
-| `main` | `argv: list[str] | None = None` | `int` | CLI entry point; parses `argv` and dispatches to the appropriate command handler. |
-
-### Routing
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `route_user_input` | `user_input: str, context: dict[str, Any] | None = None` | `dict[str, Any]` | Route a user input string to a skill invocation and return the result dict. |
-| `is_slash_command` | `text: str` | `bool` | Return `True` if `text` begins with a slash command prefix. |
-
-### Workflow execution
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `run_workflow_with_exit_code` | `workflow_cls: type, input_data: dict[str, Any], *, name: str, json_mode: bool, print_result: Callable[[Any], None]` | `int` | Instantiate and execute a workflow, then return the contract exit code. |
-
-### Cost commands
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_costs` | `args: Namespace` | `int` | Show cost report for recent period. |
-| `cmd_costs_today` | `args: Namespace` | `int` | Show today's cost summary. |
-| `cmd_costs_export` | `args: Namespace` | `int` | Export cost data to file. |
-| `cmd_costs_reset` | `args: Namespace` | `int` | Clear all cost tracking data. |
-
-### Help commands
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_help` | `args: argparse.Namespace` | `int` | Handle the `attune help` command. |
-
-### Memory commands
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_remember` | `args: Namespace` | `int` | Add a lesson to the lessons file. |
-| `cmd_forget` | `args: Namespace` | `int` | Remove a lesson by line number or keyword. |
-| `cmd_lessons` | `args: Namespace` | `int` | List current lessons with line numbers. |
-| `cmd_memory_capture` | `args: Namespace` | `int` | Save content to personal cross-session memory. |
-| `cmd_memory_recall` | `args: Namespace` | `int` | Search personal cross-session memory. |
-| `cmd_memory_topics` | `args: Namespace` | `int` | List all personal memory topics. |
-| `cmd_memory_forget_topic` | `args: Namespace` | `int` | Delete a topic (or specific kind) from personal memory. |
-
-### Provider commands
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_provider_show` | `args: Namespace` | `int` | Show current provider configuration. |
-| `cmd_provider_set` | `args: Namespace` | `int` | Set the LLM provider. |
-
-### Telemetry commands
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_telemetry_show` | `args: Namespace` | `int` | Display usage summary. |
-| `cmd_telemetry_savings` | `args: Namespace` | `int` | Show cost savings from tier routing. |
-| `cmd_telemetry_export` | `args: Namespace` | `int` | Export telemetry data to file. |
-| `cmd_telemetry_routing_stats` | `args: Namespace` | `int` | Show adaptive routing statistics. |
-| `cmd_telemetry_routing_check` | `args: Namespace` | `int` | Check for tier upgrade recommendations. |
-| `cmd_telemetry_models` | `args: Namespace` | `int` | Show model performance by provider. |
-| `cmd_telemetry_agents` | `args: Namespace` | `int` | Show active agents and their status. |
-| `cmd_telemetry_signals` | `args: Namespace` | `int` | Show coordination signals. |
-
-### Utility commands
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_setup` | `args: Namespace` | `int` | Install Attune slash commands for Claude Code. |
-| `cmd_validate` | `args: Namespace` | `int` | Validate configuration. |
-| `cmd_version` | `args: Namespace` | `int` | Show version information. |
-| `cmd_features` | `args: Namespace` | `int` | Show available memory and telemetry features. |
-| `cmd_doctor` | `args: Namespace` | `int` | Run comprehensive environment health check. |
-
-### Workflow commands
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `cmd_workflow_list` | `args: Namespace` | `int` | List available workflows. |
-| `cmd_workflow_info` | `args: Namespace` | `int` | Show workflow details. |
-| `cmd_workflow_run` | `args: Namespace` | `int` | Execute a workflow. |
 
 ## Source files
 

--- a/.help/templates/cli/task.md
+++ b/.help/templates/cli/task.md
@@ -1,143 +1,59 @@
 ---
-type: task
-name: cli-task
 feature: cli
 depth: task
-generated_at: 2026-06-04T23:39:47.639055+00:00
-source_hash: 4b177dd28a8ce19bb06606b9ae39e4fe255d7f2fe854f3376d3330f151f3ffac
+generated_at: 2026-06-05T16:32:09.116036+00:00
+source_hash: 198ad869d0b029e3926d86fd51b53c7d1a800d65335cb982b9331b5ee6c9bcaa
 status: generated
 ---
 
-# Work with the attune CLI
+# Work with cli
 
-Use the attune CLI when you need to run workflows, manage costs, interact with memory, or extend routing behavior from the command line.
+Use cli when you need to command-line interface and routing.
 
 ## Prerequisites
 
 - Access to the project source code
-- Python environment with `attune` installed
-- Familiarity with `src/attune/cli_minimal.py` as the main entry point
+- Familiarity with the files under src/attune/cli_minimal.py
 
-## Run a built-in CLI command
+## Steps
 
-1. **Start with `main()`** in `attune.cli_minimal`. Call it directly in tests or scripts, or let the installed `attune` entry point invoke it. It accepts an optional `argv: list[str]` and returns an integer exit code.
+1. **Understand the current behavior.**
+   Read the entry points to see what cli
+   does today before making changes.
+   The primary functions are:
+   - `get_version()` in `src/attune/cli_minimal.py` — Get package version.
+   - `create_parser()` in `src/attune/cli_minimal.py` — Create the argument parser.
+   - `main()` in `src/attune/cli_minimal.py` — Main entry point.
+   - `route_user_input()` in `src/attune/cli_router.py` — Quick routing helper.
+   - `is_slash_command()` in `src/attune/cli_router.py` — Check if text is a slash command.
+2. **Locate the right function to change.**
+   Each function has a single responsibility. Read its
+   docstring, parameters, and return type to confirm it
+   owns the behavior you need to modify.
 
-2. **Choose the command group that matches your goal:**
+3. **Make your change.**
+   Follow existing patterns in the file — naming
+   conventions, error handling style, and logging.
 
-   | Goal | Function | Module |
-   |---|---|---|
-   | Show cost report | `cmd_costs()` | `cli_commands.cost_commands` |
-   | Show today's costs | `cmd_costs_today()` | `cli_commands.cost_commands` |
-   | Export cost data | `cmd_costs_export()` | `cli_commands.cost_commands` |
-   | Clear cost data | `cmd_costs_reset()` | `cli_commands.cost_commands` |
-   | Browse help templates | `cmd_help()` | `cli_commands.help_commands` |
-   | Save a lesson | `cmd_remember()` | `cli_commands.memory_commands` |
-   | Remove a lesson | `cmd_forget()` | `cli_commands.memory_commands` |
-   | List lessons | `cmd_lessons()` | `cli_commands.memory_commands` |
-   | Save to cross-session memory | `cmd_memory_capture()` | `cli_commands.memory_commands` |
-   | Recall from memory | `cmd_memory_recall()` | `cli_commands.memory_commands` |
-   | List memory topics | `cmd_memory_topics()` | `cli_commands.memory_commands` |
-   | Forget a memory topic | `cmd_memory_forget_topic()` | `cli_commands.memory_commands` |
-   | List workflows | `cmd_workflow_list()` | `cli_commands.workflow_commands` |
-   | Run a workflow | `cmd_workflow_run()` | `cli_commands.workflow_commands` |
-   | Check setup | `cmd_doctor()` | `cli_commands.utility_commands` |
-
-3. **Call the function**, passing a populated `argparse.Namespace` object. Each function returns an integer exit code.
-
-## Run a workflow with an exit code contract
-
-Use `run_workflow_with_exit_code()` from `cli_commands._exit_codes` when you need to execute a workflow class and map its result to a standard exit code.
-
-1. **Import the function:**
-
-   ```python
-   from cli_commands._exit_codes import run_workflow_with_exit_code
-   ```
-
-2. **Call it with the required arguments:**
-
-   ```python
-   exit_code = run_workflow_with_exit_code(
-       workflow_cls=MyWorkflow,
-       input_data={"key": "value"},
-       name="my-workflow",
-       json_mode=False,
-       print_result=print,
-   )
-   ```
-
-   - `workflow_cls` — the workflow class to instantiate and execute
-   - `input_data` — a `dict[str, Any]` passed to the workflow
-   - `name` — a display name used in output
-   - `json_mode` — set to `True` to emit JSON output instead of formatted text
-   - `print_result` — a callable that receives the workflow result for display
-
-3. **Check the return value.** The function returns an integer exit code. Pass it to `sys.exit()` if you are running from a script.
-
-## Route user input with `HybridRouter`
-
-Use `HybridRouter` from `attune.cli_router` when you need to map free-text user input to a skill invocation, or when you want to teach the router a new keyword preference.
-
-1. **Instantiate the router:**
-
-   ```python
-   from attune.cli_router import HybridRouter
-
-   router = HybridRouter()  # uses default preferences path
-   ```
-
-   Pass `preferences_path` to load or persist routing preferences from a specific file.
-
-2. **Route an input string:**
-
-   ```python
-   result = router.route("show me today's costs")
-   ```
-
-   `route()` returns a `dict[str, Any]` describing the matched skill and arguments.
-
-3. **Teach the router a new preference:**
-
-   ```python
-   router.learn_preference(keyword="costs", skill="cost_report", args="--today")
-   ```
-
-   This creates a `RoutingPreference` with `keyword`, `skill`, and optional `args`. The router increments `usage_count` and tracks `confidence` as the preference is used.
-
-4. **Get autocomplete suggestions** for a partial input string:
-
-   ```python
-   suggestions = router.get_suggestions("cos")
-   ```
-
-   Returns a `list[str]` of matching completions.
-
-## Check whether input is a slash command
-
-Call `is_slash_command(text)` from `attune.cli_router` before routing if you need to handle slash commands (`/help`, `/forget`, etc.) separately from natural-language input:
-
-```python
-from attune.cli_router import is_slash_command
-
-if is_slash_command(user_input):
-    # handle as slash command
-```
+4. **Run the related tests.**
+   This catches regressions before they reach other
+   developers. Target with `pytest -k "cli"`.
 
 ## Key files
 
-| File | Purpose |
-|---|---|
-| `src/attune/cli_minimal.py` | Entry point — `main()`, `create_parser()`, `get_version()` |
-| `src/attune/cli_router.py` | `HybridRouter`, `RoutingPreference`, `route_user_input()` |
-| `src/attune/cli_commands/cost_commands.py` | Cost reporting and export commands |
-| `src/attune/cli_commands/memory_commands.py` | Lesson and memory commands |
-| `src/attune/cli_commands/workflow_commands.py` | Workflow list, info, and run commands |
-| `src/attune/cli_commands/utility_commands.py` | Setup, validate, version, features, doctor |
-| `src/attune/cli_commands/_exit_codes.py` | Exit code contract for workflow execution |
+- `src/attune/cli_minimal.py`
+- `src/attune/cli_router.py`
+- `src/attune/cli_commands/**`
 
-## Verify the task worked
+## Common modifications
 
-- **CLI commands** return `0` on success. A non-zero return value indicates an error. Check the printed output against the expected report or confirmation message.
-- **`run_workflow_with_exit_code()`** returns `0` on a successful workflow run. Capture the return value and assert it equals `0` in tests.
-- **`router.route()`** returns a non-empty dict. Inspect the returned dict to confirm the expected skill name is present.
-- **`router.learn_preference()`** takes effect immediately. Call `router.get_suggestions(keyword)` afterward and confirm the keyword appears in the results.
+Functions you are most likely to modify:
+
+- `get_version()` in `src/attune/cli_minimal.py`
+- `create_parser()` in `src/attune/cli_minimal.py`
+- `main()` in `src/attune/cli_minimal.py`
+- `route_user_input()` in `src/attune/cli_router.py`
+- `is_slash_command()` in `src/attune/cli_router.py`
+- `run_workflow_with_exit_code()` in `src/attune/cli_commands/_exit_codes.py`
+- `cmd_costs()` in `src/attune/cli_commands/cost_commands.py`
+- `cmd_costs_today()` in `src/attune/cli_commands/cost_commands.py`

--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-06-03T02:40:23.540079+00:00
-source_hash: 9d40fc6564f1c4cf6ab6839bf1b973ced7daa7230432b038f45b7e79011d84f4
+generated_at: 2026-06-05T16:31:34.129405+00:00
+source_hash: d0b3106e2fbde27c37ade74472102cbda4a87e7f2a061ae53a55d516e5881c21
 status: generated
 ---
 
@@ -20,7 +20,7 @@ The main building blocks are:
 - **`Config`** — Where attune ops reads project + attune state from.
 - **`TelemetrySummary`** — core component
 
-Under the hood, this feature spans 62 source
+Under the hood, this feature spans 64 source
 files covering:
 
 - Run via ``python -m attune.ops``.

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-06-03T02:40:23.550318+00:00
-source_hash: 9d40fc6564f1c4cf6ab6839bf1b973ced7daa7230432b038f45b7e79011d84f4
+generated_at: 2026-06-05T16:31:34.140171+00:00
+source_hash: d0b3106e2fbde27c37ade74472102cbda4a87e7f2a061ae53a55d516e5881c21
 status: generated
 ---
 
@@ -100,6 +100,9 @@ status: generated
 | `make_entry()` | Construct a JournalEntry, filling in defaults from runtime context. | `src/attune/ops/pending_writes.py` |
 | `append_entry()` | Append a journal entry to the JSONL journal. | `src/attune/ops/pending_writes.py` |
 | `list_active()` | Return active bulletin entries across all actors. | `src/attune/ops/routes/bulletin.py` |
+| `curator_page()` | Render the curator briefing, filtering snoozed items. | `src/attune/ops/routes/curator.py` |
+| `curator_dismiss()` | Snooze an item for 14 days. | `src/attune/ops/routes/curator.py` |
+| `curator_answer()` | Record a user's response to an item's suggested action. | `src/attune/ops/routes/curator.py` |
 | `home()` | — | `src/attune/ops/routes/dashboard.py` |
 | `workflows_page()` | — | `src/attune/ops/routes/dashboard.py` |
 | `telemetry_page()` | — | `src/attune/ops/routes/dashboard.py` |

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -1,8 +1,8 @@
 ---
 feature: ops-dashboard
 depth: task
-generated_at: 2026-06-03T02:40:23.545253+00:00
-source_hash: 9d40fc6564f1c4cf6ab6839bf1b973ced7daa7230432b038f45b7e79011d84f4
+generated_at: 2026-06-05T16:31:34.135720+00:00
+source_hash: d0b3106e2fbde27c37ade74472102cbda4a87e7f2a061ae53a55d516e5881c21
 status: generated
 ---
 

--- a/docs/specs/bulletin-curator/tasks.md
+++ b/docs/specs/bulletin-curator/tasks.md
@@ -418,11 +418,20 @@ budget) recorded in [`decisions.md`](decisions.md) D1–D4.
 
 ## Phase 3 — Dashboard `/curator` + CLI
 
-**Task 3.1 done (2026-06-05).** `GET /curator` route + `curator.html`
-template + CSS + `POST /curator/{answer,dismiss}` + 6 route tests,
-wired into `server.py` (router + "Briefing" nav). Two v1 deferrals
-recorded in [`decisions.md`](decisions.md) D5–D6. Tasks 3.2 (CLI) and
-3.3 (cross-link) follow in a second PR (D7).
+**Phase 3 done (2026-06-05).**
+
+- **Task 3.1** — `GET /curator` route + `curator.html` template + CSS +
+  `POST /curator/{answer,dismiss}` + 6 route tests, wired into
+  `server.py` (router + "Briefing" nav). Two v1 deferrals in
+  [`decisions.md`](decisions.md) D5–D6.
+- **Task 3.2** — `attune curator` CLI (`--refresh` / `--json` /
+  `--max-items`) in `cli_commands/curator.py`, dispatched from
+  `cli_minimal.py`; 6 CLI tests.
+- **Task 3.3** — bulletin-strip "View briefing" cross-link on the
+  Workflows page (`workflows.html` + `.bulletin-strip-link` CSS).
+
+Task 4.1 (live verification + prompt iteration) is the remaining
+phase — a manual review cycle, run when desired.
 
 ### Task 3.1 — Dashboard route + template
 

--- a/src/attune/cli_commands/curator.py
+++ b/src/attune/cli_commands/curator.py
@@ -1,0 +1,91 @@
+"""``attune curator`` — terminal rendering of the project briefing.
+
+Consumes the same :class:`attune.curator.CuratorResult` the dashboard
+``/curator`` page renders, so both surfaces stay in lockstep. Flags:
+``--refresh`` (bypass cache), ``--json`` (machine-readable),
+``--max-items N``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from attune.curator import run_curator
+
+logger = logging.getLogger(__name__)
+
+
+def _result_to_dict(result: Any) -> dict[str, Any]:
+    """JSON-serializable view of a CuratorResult (datetime → isoformat)."""
+    data = dataclasses.asdict(result)
+    cached_at = data.get("cached_at")
+    if cached_at is not None and not isinstance(cached_at, str):
+        data["cached_at"] = cached_at.isoformat()
+    return data
+
+
+def _render(result: Any) -> None:
+    """Print the briefing as plain text (no rich dependency)."""
+    header = "Briefing"
+    if result.model:
+        header += f" ({result.model})"
+    if result.cost_usd:
+        header += f" — ${result.cost_usd:.4f}"
+    print(header)
+    print()
+    if result.summary:
+        print(result.summary)
+        print()
+
+    if not result.items:
+        print("Nothing pressing right now — no items rank above noise.")
+        return
+
+    for idx, item in enumerate(result.items, 1):
+        print(f"  {idx} [{item.severity}] {item.title}")
+        if item.rationale:
+            print(f"    {item.rationale}")
+        if item.sources:
+            print(f"    Sources: {', '.join(item.sources)}")
+        action = item.suggested_action
+        if action is not None:
+            print(f"    Suggest: {_action_hint(action)}")
+        print()
+
+
+def _action_hint(action: Any) -> str:
+    if action.kind == "open" and action.url:
+        return f"open {action.url}"
+    if action.kind == "ask" and action.question:
+        choices = f" [{'/'.join(action.choices)}]" if action.choices else ""
+        return f"{action.question}{choices}"
+    if action.kind == "run" and action.workflow:
+        scope = f" on {action.scope}" if action.scope else ""
+        return f"run {action.workflow}{scope}"
+    if action.kind == "dismiss":
+        return "snooze"
+    return action.label or action.kind
+
+
+def cmd_curator(args: Any) -> int:
+    """Render the curator briefing for the current project."""
+    project_root = Path.cwd()
+    result = asyncio.run(
+        run_curator(
+            project_root=project_root,
+            force_refresh=getattr(args, "refresh", False),
+            max_items=getattr(args, "max_items", 5),
+        )
+    )
+
+    if getattr(args, "json", False):
+        print(json.dumps(_result_to_dict(result), indent=2))
+        return 0
+
+    _render(result)
+    return 0

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -61,6 +61,7 @@ from attune.cli_commands.cost_commands import (
     cmd_costs_reset,
     cmd_costs_today,
 )
+from attune.cli_commands.curator import cmd_curator
 from attune.cli_commands.help_commands import cmd_help
 from attune.cli_commands.memory_commands import (
     cmd_forget,
@@ -408,6 +409,21 @@ def _add_misc_subparsers(subparsers: argparse._SubParsersAction) -> None:
     subparsers.add_parser("features", help="Show available features and dependencies")
     subparsers.add_parser("validate", help="Validate configuration")
 
+    curator_parser = subparsers.add_parser(
+        "curator", help="Show the project briefing (ranked attention items)"
+    )
+    curator_parser.add_argument(
+        "--refresh", action="store_true", help="Bypass cache and re-synthesize"
+    )
+    curator_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    curator_parser.add_argument(
+        "--max-items",
+        type=int,
+        default=5,
+        dest="max_items",
+        help="Max attention items to surface (default: 5)",
+    )
+
     version_parser = subparsers.add_parser("version", help="Show version")
     version_parser.add_argument("-v", "--verbose", action="store_true", help="Show detailed info")
 
@@ -541,6 +557,7 @@ _SIMPLE_DISPATCH: dict[str, object] = {
     "validate": cmd_validate,
     "version": cmd_version,
     "ops": cmd_ops,
+    "curator": cmd_curator,
 }
 
 

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1623,6 +1623,18 @@ a.kpi:hover {
   color: var(--fg-muted);
   letter-spacing: 0;
 }
+.bulletin-strip-link {
+  float: right;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--accent);
+  text-decoration: none;
+}
+.bulletin-strip-link:hover {
+  text-decoration: underline;
+}
 .bulletin-strip-chips {
   display: flex;
   flex-wrap: wrap;

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -24,6 +24,7 @@
   <h2 class="bulletin-strip-title">
     Now running across actors
     <span class="bulletin-strip-count" id="bulletin-strip-count">0</span>
+    <a href="/curator" class="bulletin-strip-link">View briefing →</a>
   </h2>
   <div class="bulletin-strip-chips" id="bulletin-strip-chips"></div>
 </section>

--- a/tests/unit/cli_commands/test_curator.py
+++ b/tests/unit/cli_commands/test_curator.py
@@ -1,0 +1,109 @@
+"""Tests for the ``attune curator`` CLI command (Phase 3, Task 3.2)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from attune.cli_commands import curator as cli_curator
+from attune.curator.result import CuratorItem, CuratorResult, SuggestedAction
+
+
+def _result(items=None, summary="Two things need attention [a:1]."):
+    return CuratorResult(
+        summary=summary,
+        items=items or [],
+        sources_consulted=["bulletin", "specs"],
+        cost_usd=0.0321,
+        model="claude-opus-4-6",
+    )
+
+
+def _items():
+    return [
+        CuratorItem(
+            id="i1",
+            title="Spec alpha ready to close",
+            severity="warn",
+            rationale="All tasks done [a:1].",
+            sources=["spec:alpha"],
+            suggested_action=SuggestedAction(kind="open", url="/specs/alpha"),
+        ),
+        CuratorItem(
+            id="i2",
+            title="Security finding unreviewed",
+            severity="nudge",
+            rationale="HIGH finding [r:2].",
+            sources=["rec:r2"],
+            suggested_action=SuggestedAction(
+                kind="ask", question="Mark reviewed?", choices=["Yes", "No"]
+            ),
+        ),
+    ]
+
+
+def _patch(monkeypatch, result, captured: dict | None = None):
+    async def _fake(**kwargs):
+        if captured is not None:
+            captured.update(kwargs)
+        return result
+
+    monkeypatch.setattr("attune.cli_commands.curator.run_curator", _fake)
+
+
+def _args(**kw):
+    base = {"refresh": False, "json": False, "max_items": 5}
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_default_render(monkeypatch, capsys):
+    _patch(monkeypatch, _result(_items()))
+    rc = cli_curator.cmd_curator(_args())
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Briefing (claude-opus-4-6)" in out
+    assert "Two things need attention" in out
+    assert "[warn] Spec alpha ready to close" in out
+    assert "Sources: spec:alpha" in out
+    assert "open /specs/alpha" in out
+
+
+def test_json_output(monkeypatch, capsys):
+    _patch(monkeypatch, _result(_items()))
+    rc = cli_curator.cmd_curator(_args(json=True))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"].startswith("Two things")
+    assert len(payload["items"]) == 2
+    assert payload["model"] == "claude-opus-4-6"
+
+
+def test_empty_state(monkeypatch, capsys):
+    _patch(monkeypatch, _result([], summary="Quiet."))
+    cli_curator.cmd_curator(_args())
+    assert "Nothing pressing right now" in capsys.readouterr().out
+
+
+def test_refresh_flag_reaches_run_curator(monkeypatch):
+    captured: dict = {}
+    _patch(monkeypatch, _result(), captured)
+    cli_curator.cmd_curator(_args(refresh=True))
+    assert captured["force_refresh"] is True
+
+
+def test_max_items_reaches_run_curator(monkeypatch):
+    captured: dict = {}
+    _patch(monkeypatch, _result(), captured)
+    cli_curator.cmd_curator(_args(max_items=3))
+    assert captured["max_items"] == 3
+
+
+def test_json_serializes_cached_at(monkeypatch, capsys):
+    from datetime import datetime, timezone
+
+    result = CuratorResult(summary="s", model="m", cached_at=datetime.now(timezone.utc))
+    _patch(monkeypatch, result)
+    cli_curator.cmd_curator(_args(json=True))
+    payload = json.loads(capsys.readouterr().out)  # must not raise
+    assert isinstance(payload["cached_at"], str)


### PR DESCRIPTION
## Summary

Completes **Phase 3** of `bulletin-curator` — Tasks 3.2 (CLI) and 3.3
(cross-link), on top of the `/curator` page (3.1, #634).

## What's in it

- **Task 3.2 — `attune curator` CLI** (`cli_commands/curator.py`):
  renders the same `CuratorResult` the web route uses, so both surfaces
  stay in lockstep. Flags: `--refresh` (bypass cache), `--json`
  (machine-readable, datetime-safe), `--max-items N`. Wired into
  `cli_minimal.py` (`_SIMPLE_DISPATCH` + argparse subparser).
- **Task 3.3 — bulletin cross-link**: a "View briefing →" link in the
  Workflows page bulletin strip (`workflows.html` +
  `.bulletin-strip-link` CSS). Closes the loop: the strip shows *who's
  running*, the briefing says *what to do about it*.

## Testing

- 6 CLI tests: default render, `--json`, empty state, `--refresh` /
  `--max-items` passthrough, `cached_at` JSON serialization.
- Parser verified via `attune curator --help`; dispatch wired.
- ruff + black clean; workflows-route + dispatch regression tests green.

## Notes

- Includes regenerated `.help/templates/{ops-dashboard,cli}/*` — the
  `workflows.html` and `cli_minimal.py` changes bumped those features'
  source hashes (pre-commit freshness hook).
- Phase 3 is complete after this. Only **Task 4.1** (manual live
  verification + prompt iteration) remains — a review cycle to run when
  desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
