### PR TITLE
docs(spec): collaboration-gates — spend gate + referent gate

### DIFF
--- a/docs/specs/collaboration-gates/decisions.md
+++ b/docs/specs/collaboration-gates/decisions.md
@@ -1,0 +1,135 @@
+# Decisions: Collaboration Gates
+
+> Records design decisions and deviations. Companion to
+> [`requirements.md`](requirements.md) and (later)
+> `design.md` / `tasks.md`. Timestamps are the arbiter when a
+> later session wants to relitigate.
+
+**Status:** in progress
+**Last updated:** 2026-06-05
+
+---
+
+## Phase 1 — Requirements interview (2026-06-05)
+
+### D1 — v1 scope: spend gate enforced, referent gate phased
+
+The A/B enforceability asymmetry routes the scope. v1 ships the
+**spend gate (B)** as real enforced product behavior; the
+**referent gate (A)** ships as guidance hardening in a later
+phase of the same spec, scoped honestly as advisory in the
+broader conversational layer with a partial-enforcement foothold
+in attune's own interactive surfaces. Chosen over "spend gate
+only" (leaves A unaddressed) and "both gates, full treatment"
+(speculative on A's enforceability).
+
+### D2 — Gate model: budget envelope, first-run confirm establishes it
+
+The spend gate is a **budget envelope**, not a per-call confirm.
+The first paid run of a session surfaces the estimate + the
+envelope and requires an explicit go — which both honors the
+discipline's explicit-first-spend rule *and* establishes the
+envelope. Subsequent runs proceed silently within it; a breach
+re-gates.
+
+Chosen over (a) **confirm-per-first-spend** (the literal
+memory wording — but naggy, and reads $0 for subscription users
+so it doesn't align with Anthropic's usage model) and (b)
+**pure budget cap** (most Anthropic-aligned, least naggy — but
+drops the explicit-first-spend "go" entirely; a first surprise
+charge under the cap never surfaces).
+
+Originated from Patrick's pushback on the surface question:
+"should we use [a per-call confirm] OR a budget that aligns and
+works well with Anthropic's system." The envelope model is the
+synthesis — it absorbs the budget framing while preserving the
+discipline's first-spend go.
+
+Reuses the existing `ATTUNE_MAX_BUDGET_USD` + `Budget` dataclass
+rather than inventing a new primitive.
+
+### D3 — Meter alignment: gate against the user's actual meter
+
+"Aligns with Anthropic's system" means the gate gates against
+**whichever meter the user is on** — dollars for API users,
+rate-limit / usage headroom for subscription users — not a
+parallel dollar meter. This avoids the misleading $0 a
+dollars-only gate would show a subscription user (Patrick's own
+case: `feedback_workflow_output` — "cost figures don't apply,
+subscription not API"). Subscription-vs-API detection drives
+the framing.
+
+### D4 — First surface: CLI
+
+The enforced spend-gate confirm lands on the **CLI**
+(`attune workflow run`) first — simplest interactive confirm,
+console-first user, fastest to a shippable PR. Dashboard runner
+(confirm modal) and the workflow/MCP layer (agent-invoked,
+non-interactive — hardest UX) follow in later phases reusing the
+v1 estimate-and-gate core. Patrick leaned to this; taken as the
+working decision, reversible at requirements approval.
+
+### D5 — Guardrail framing, not automation
+
+Per the discipline article's thesis (this is a *discipline*, not
+a tool problem), the spend gate is framed as a **safety net**
+like `security_guard.py` — it catches the surprise-spend failure
+mode; it does not automate the §2 contract or substitute for
+human judgment.
+
+---
+
+## Phase 2 — Design (2026-06-05)
+
+Grounded against the real machinery before writing (per the
+"introspect before coding" lesson): `cmd_workflow_run`
+(`cli_commands/workflow_commands.py`), `AuthStrategy`/`AuthMode`
+(`models/auth_strategy.py`), the `Budget` dataclass
+(`ops/session_summarizer.py:120`), `get_max_budget_usd` +
+`ATTUNE_MAX_BUDGET_USD` (`workflows/agent_sdk_adapter.py`), and
+the `~/.attune/session_stash` state-file pattern
+(`memory/file_stash.py:88`).
+
+### D6 — CLI "session" = a TTL'd envelope file aligned to Anthropic's window
+
+Each `attune workflow run` is a fresh process, so R3's
+session-durable authorization persists in
+`~/.attune/spend_gate/envelope.json`. The "session" is a **TTL
+window** defaulting to Anthropic's rolling usage window (5h), so
+the gate's notion of "this session" matches the meter it gates
+against. Rejected: binding to `CLAUDE_CODE_SESSION_ID` (absent
+in bare-terminal runs), pure in-memory (re-gates every run),
+per-calendar-day (misaligned with the rolling window).
+
+### D7 — Estimate is a budget *band*, not false precision
+
+Pre-call cost is unknowable, so the estimate is the workflow's
+budget band: `get_max_budget_usd(depth)` as the ceiling,
+`AuthStrategy.estimate_cost` as the expected band when a target
+size is known. Presented as "≈ up to $X," never a fake single
+figure. Honest per the §2 honesty-about-limits clause.
+
+### D8 — Meter framing resolves per auth mode
+
+`gates/meter.py` reads `AuthStrategy` → `AuthMode`. API mode →
+dollar framing; subscription mode → usage-headroom framing (no
+dollar figure, no misleading $0, satisfying R5). The envelope
+tracks dollars in API mode and run-count/window in subscription
+mode.
+
+### D9 — Gate logic lives in a shared `attune.gates` core
+
+New package `src/attune/gates/` (`spend_gate.py`, `envelope.py`,
+`meter.py`). The core returns a `GateDecision`
+(`proceed`/`confirm`/`block`); the **surface** owns confirm I/O.
+v1 wires the CLI; dashboard + MCP reuse the core later. Rejected:
+CLI-local code refactored later (would drift between surfaces).
+
+### D10 — Non-interactive fail-safe = block-by-default + explicit env pre-auth
+
+No TTY + first paid call + no pre-auth → **block** (never spend
+silently). `ATTUNE_SPEND_GATE_AUTHORIZED=1` (or a set budget)
+opts CI / the ops daemon in explicitly; the existing
+`ATTUNE_MAX_BUDGET_USD` cap still bounds any proceeding run. This
+translates the discipline's "first paid call gets an explicit
+go" into a machine context as an explicit env grant.

--- a/docs/specs/collaboration-gates/design.md
+++ b/docs/specs/collaboration-gates/design.md
@@ -1,0 +1,237 @@
+# Design: Collaboration Gates
+
+> Technical design for the spend gate (v1, CLI surface) and the
+> shared estimate-and-gate core that later surfaces reuse.
+> Companion to [`requirements.md`](requirements.md) and
+> [`decisions.md`](decisions.md).
+
+**Status:** approved (2026-06-05) — see [`decisions.md`](decisions.md)
+**Last updated:** 2026-06-05
+
+---
+
+## Overview
+
+The spend gate is a **budget envelope** enforced at the moment
+attune is about to make its first billable workflow call of a
+session. It reuses existing machinery wherever possible:
+
+- **Injection point:** `cmd_workflow_run` in
+  `src/attune/cli_commands/workflow_commands.py` — between
+  `get_workflow(name)` (line ~101) and `run_workflow_with_exit_code(...)`
+  (line ~149). The gate runs after the workflow is resolved and
+  input validated, before any paid call.
+- **Meter detection:** `AuthStrategy` / `AuthMode` /
+  `SubscriptionTier` in `src/attune/models/auth_strategy.py`.
+- **Cap primitive:** `get_max_budget_usd(depth)` +
+  `ATTUNE_MAX_BUDGET_USD` (0 = off) in
+  `src/attune/workflows/agent_sdk_adapter.py`; the envelope is
+  modeled on the `Budget` dataclass
+  (`src/attune/ops/session_summarizer.py:120`) and its
+  `cap_usd <= 0` latch.
+- **State persistence:** a TTL'd JSON file under `~/.attune/`,
+  mirroring the `~/.attune/session_stash` pattern
+  (`src/attune/memory/file_stash.py:88`).
+
+The gate is a **guardrail** (per decisions.md D5) — it can only
+*block or confirm*, never silently spend.
+
+---
+
+## Architecture: shared core + thin surfaces
+
+Per open-question 5 (decisions.md D9): the gate logic lives in a
+**shared core module**, callable by all three future surfaces.
+v1 wires only the CLI; the dashboard and MCP layers reuse the
+same core in later phases.
+
+```text
+src/attune/gates/                  # new package
+├── __init__.py
+├── spend_gate.py                  # core: estimate + gate decision
+├── envelope.py                    # persisted session envelope state
+└── meter.py                       # subscription-vs-API meter resolution
+```
+
+Core entry point (signature illustrative, finalized in code):
+
+```python
+def evaluate_spend_gate(
+    workflow_name: str,
+    depth: str,
+    *,
+    now: float | None = None,        # injectable clock for tests
+) -> GateDecision:
+    """Pure-ish decision: read the persisted envelope + the
+    active meter, return whether this run needs a confirm,
+    proceeds silently, or is blocked (non-interactive)."""
+```
+
+`GateDecision` carries: `action` (`proceed` | `confirm` |
+`block`), the estimate, the meter framing string, the current
+envelope state, and a reason. The **surface** (CLI) owns the
+*presentation and the confirm I/O*; the core owns the *logic*.
+This keeps the core testable without a TTY and lets the
+dashboard render a modal / the MCP layer bubble the confirm
+through the agent later.
+
+---
+
+## Resolving the five open questions
+
+### Q1 — What is a "session" for the CLI? (the load-bearing one)
+
+Each `attune workflow run` is a fresh process, so the envelope
+must persist on disk. **Decision (D6): a TTL'd state file whose
+window aligns with Anthropic's rolling usage window.**
+
+- State lives at `~/.attune/spend_gate/envelope.json`.
+- Shape: `{ window_start, ttl_seconds, authorized, cap_usd,
+  spent_usd, meter }`.
+- The "session" is the **TTL window**. Default `ttl_seconds`
+  aligns to Anthropic's rolling usage window (5h) so the gate's
+  notion of "this session" matches the meter it gates against —
+  a subscription user's headroom resets on the same clock.
+- On each run: load the file; if `now - window_start >
+  ttl_seconds`, the window expired → reset (re-gate). Else the
+  envelope is live → apply R3/R4.
+
+Rejected alternatives:
+
+- **Bind to `CLAUDE_CODE_SESSION_ID`.** Only present when the
+  CLI runs *inside* Claude Code; bare-terminal runs have no such
+  id. Too fragile as the primary key. (May be used as a
+  secondary scope later.)
+- **Pure in-memory (no persistence).** Would re-gate every
+  single `attune workflow run` — defeats R3 entirely.
+- **Per-calendar-day budget.** Simpler, but misaligned with
+  Anthropic's rolling window, so the gate and the meter would
+  disagree about when headroom resets.
+
+### Q2 — Estimate source of truth
+
+**Decision (D7): the estimate is the workflow's budget *band*,
+not a precise figure.** Pre-call, the exact cost is unknowable.
+The honest estimate is derived from:
+
+- `get_max_budget_usd(depth)` — the per-workflow cap, as the
+  upper band.
+- `AuthStrategy.estimate_cost(module_lines, mode)` /
+  `estimate_tokens` — a lower/expected band when a target size
+  is known.
+
+Presented as a band ("≈ up to $X for this run") with the cap as
+the ceiling, never a false-precision single number. The
+estimate's accuracy band is documented in the confirm text.
+
+### Q3 — Subscription-meter framing
+
+**Decision (D8): the meter module resolves the active mode and
+frames accordingly.**
+
+- `meter.resolve()` reads `AuthStrategy` (tier +
+  `get_recommended_mode`) → `AuthMode`.
+- **API mode** → dollar framing: "≈ up to $X; counts against
+  your Anthropic API spend."
+- **Subscription mode** → headroom framing: "uses your
+  subscription quota (no per-call charge); counts against your
+  Anthropic usage window." No dollar figure, no misleading $0
+  (R5).
+- The envelope's `cap_usd` is meaningful only in API mode; in
+  subscription mode the envelope tracks *run count / window*
+  rather than dollars (the field name in the persisted state is
+  generalized accordingly).
+
+### Q4 — Fail-safe policy for non-interactive (R7)
+
+**Decision (D10): block-by-default, with explicit env
+pre-authorization.**
+
+- Interactive (TTY) + first paid call → `confirm`.
+- Non-interactive (no TTY) + first paid call + no pre-auth →
+  `block`, with a clear message naming the env override.
+- Pre-auth via `ATTUNE_SPEND_GATE_AUTHORIZED=1` (or a set
+  budget) → `proceed` within the envelope. Lets CI / the ops
+  daemon opt in explicitly.
+- The existing per-workflow `ATTUNE_MAX_BUDGET_USD` cap still
+  bounds any proceeding run, so pre-auth is bounded, not blank.
+
+Rationale: "fail-safe" for *spend* means never spend silently.
+A non-interactive context can't confirm, so the safe default is
+to refuse the first paid call until explicitly authorized —
+mirroring the discipline ("the first paid call gets an explicit
+go"), translated to a machine context as an explicit env grant.
+
+### Q5 — Where the gate logic lives
+
+**Decision (D9): the shared `attune.gates` core** (above). CLI
+v1 calls `evaluate_spend_gate(...)` and owns the confirm I/O.
+Rejected: CLI-local v1 code refactored later — would duplicate
+the estimate/meter logic when the dashboard surface lands and
+risk drift between surfaces.
+
+---
+
+## Data flow (CLI, v1)
+
+```text
+attune workflow run <name>
+  → cmd_workflow_run resolves workflow + input  (free)
+  → evaluate_spend_gate(name, depth)
+       ├─ load ~/.attune/spend_gate/envelope.json
+       ├─ window expired or absent?  → action=confirm/block
+       ├─ authorized & within envelope?  → action=proceed
+       └─ would breach envelope?  → action=confirm (breach)
+  → CLI renders decision:
+       ├─ proceed → run_workflow_with_exit_code(...)
+       ├─ confirm → prompt; on yes, persist authorized envelope,
+       │             then run; on no, exit cleanly (no charge)
+       └─ block   → print env-override hint, exit cleanly
+  → after a paid run, record actual cost to the envelope (R4)
+```
+
+Off switch (R6): `ATTUNE_MAX_BUDGET_USD=0` (existing) **or** a
+dedicated `ATTUNE_SPEND_GATE=off` short-circuits
+`evaluate_spend_gate` to `proceed` — heuristic-free, consistent
+with the `Budget` `cap<=0` latch semantics.
+
+Free/local never gates (R8): the gate only runs for workflows
+that make billable calls. `--no-llm` runs, local/Ollama paths,
+and non-workflow commands never reach `evaluate_spend_gate`.
+
+---
+
+## Testing strategy
+
+- **Core unit tests** (no TTY): `evaluate_spend_gate` returns
+  `confirm` on a fresh window, `proceed` within an authorized
+  envelope, `confirm` on breach, `block` non-interactive without
+  pre-auth, `proceed` with pre-auth. Inject `now` for window
+  expiry (per the edge-of-bucket timing lesson — pin the clock,
+  don't use real time).
+- **Meter tests:** API mode → dollar framing; subscription mode
+  → headroom framing, never $0 (R5). Both auth modes mocked.
+- **Persistence tests:** envelope round-trips through the TTL'd
+  file; expired window resets; corrupt file fails safe.
+- **Off-switch + free/local tests** (R6, R8).
+- **Regression guard:** assert that with the gate on and no
+  authorized envelope, the code path to the first billable call
+  is unreachable without a `confirm` — locks the core invariant.
+- **Dogfood:** a real `attune workflow run <paid-workflow>`
+  shows the confirm, proceeds on yes, and a second run in the
+  window proceeds silently (acceptance criteria, not only unit
+  tests — per the "registered ≠ working" lesson).
+
+Cross-platform: pin the clock for all TTL tests; use `tmp_path`
+for the envelope file (never a literal `~`/`/tmp` path — per the
+Windows path lessons).
+
+---
+
+## What v1 does NOT build
+
+- Dashboard confirm modal (later phase).
+- Workflow/MCP-layer gating for agent-invoked runs (later
+  phase; needs the confirm to bubble through the agent).
+- Referent gate enforcement (later phase; R9–R10).
+- Any change to Anthropic's own account-level usage limits.

--- a/docs/specs/collaboration-gates/requirements.md
+++ b/docs/specs/collaboration-gates/requirements.md
@@ -1,0 +1,214 @@
+# Spec: Collaboration Gates
+
+> Bake the two collaboration gates — the **referent gate**
+> ("go" needs one unambiguous referent) and the **spend gate**
+> (the first billable call gets an explicit, estimated go) —
+> into attune product behavior, so attune's agents *do* them
+> rather than only describe them. v1 ships the enforceable
+> half (spend gate) as a budget-envelope guardrail; the
+> referent gate ships as guidance hardening in a later phase.
+
+**Status:** approved (2026-06-05) — see [`decisions.md`](decisions.md)
+**Created:** 2026-06-05
+**Owner:** Patrick
+**Related:**
+
+- [`feedback_go_referent_and_spend_gates`](~/.claude/memory/feedback_go_referent_and_spend_gates.md)
+  — the two gates as private working discipline (the source)
+- [`project_collaboration_gates_spec`](~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/project_collaboration_gates_spec.md)
+  — the decision to productize them and the A/B asymmetry
+- `attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md` §2 —
+  the mutual contract these gates harden into product
+- `src/attune/hooks/scripts/security_guard.py` /
+  `worktree_path_guard.py` — the guardrail-hook pattern the
+  spend gate mirrors
+- `ATTUNE_MAX_BUDGET_USD` + the `Budget` dataclass — the
+  existing cost-cap primitive the envelope reuses
+
+---
+
+## Problem statement
+
+Two human↔agent failure modes are universal, not specific to
+one collaboration:
+
+1. **Surprise spend.** A terse `go` (or any pre-authorized
+   work) sends an agent into a *first* billable API call with
+   no explicit, estimated confirmation of the spend. A spec
+   that budgets a phase authorizes the *work*, not a silent
+   first charge.
+2. **Ambiguous referent.** A terse `go` / `do it` / `y`
+   executes against the wrong target when the prior turn left
+   more than one candidate on the table.
+
+These were named on 2026-06-05 as private working discipline
+(the `feedback_go_referent_and_spend_gates` memory) after both
+fired at once — an ambiguous `go` that resolved to a first Opus
+charge. The discipline article (§2) frames them as part of the
+**mutual contract**: the spend gate extends the "decision
+point" list (scope expansion, version-bump, admin-merge,
+irreversible side effects) with a new named point — *the first
+billable call*; the referent gate is the *shorthand-as-
+vocabulary primitive* plus *one-question-at-a-time*.
+
+Patrick's call: these should become **attune product
+behavior**, because they "will help users a lot." They are
+universal failure modes, so attune enforcing the enforceable
+half is real user value.
+
+The crux is an **A/B enforceability asymmetry**:
+
+- The **spend gate (B)** is genuinely enforceable inside
+  attune's own surfaces — the CLI, dashboard runner, and
+  workflow layer all control the moment of the first paid call.
+  A guardrail (estimate → confirm → session-durable) is
+  concrete and buildable, mirroring `security_guard.py`.
+- The **referent gate (A)** is mostly advisory — it lives in
+  the Claude Code conversational layer, which attune doesn't
+  control programmatically. But it has a **partial enforcement
+  foothold**: attune's *own* interactive surfaces (wizards, the
+  Socratic `AskUserQuestion` flow, the dashboard run button)
+  can enforce single-referent resolution within attune's UX.
+
+The guardrail is a **safety net, not a replacement for
+judgment** — consistent with the article's thesis that this is
+a *discipline*, not a tool problem. attune catches the failure
+mode; it does not automate the contract.
+
+---
+
+## Goals
+
+1. **Spend gate as enforced product behavior (v1).** Before
+   the first billable call of a session, attune surfaces a cost
+   estimate and an explicit confirm; after the confirm, the
+   spend is durably authorized for the session within a
+   **budget envelope**. Subsequent runs proceed silently within
+   the envelope; a run that would breach it re-gates.
+2. **Align with Anthropic's own model.** The gate gates against
+   *whichever meter the user is actually on* — dollars for API
+   users, rate-limit / usage headroom for subscription users —
+   not a parallel dollar meter that reads $0 for subscription
+   users.
+3. **Referent gate as guidance hardening (later phase).**
+   Strengthen single-referent resolution in attune's own
+   interactive surfaces and via skill/Socratic guidance;
+   document it honestly as advisory in the broader conversation.
+4. **Honest scoping.** Ship the enforceable half well rather
+   than over-claiming enforcement of the advisory half.
+
+---
+
+## Scope
+
+### v1 (this spec, Phase 1 implementation)
+
+- **Spend gate**, enforced, **CLI surface first**
+  (`attune workflow run`), budget-envelope model.
+- Reuses `ATTUNE_MAX_BUDGET_USD` + the `Budget` dataclass and
+  the existing cost-estimation machinery
+  (`cost_mixin`, `tier_recommender`).
+- Subscription-vs-API detection drives which meter the gate
+  reads.
+
+### Later phases (in this spec, deferred)
+
+- Spend gate on the **dashboard runner** (confirm modal) and
+  the **workflow/MCP layer** (agent-invoked runs), reusing the
+  v1 estimate-and-gate core.
+- **Referent gate** guidance hardening + partial enforcement in
+  attune's interactive surfaces.
+
+### Out of scope
+
+- Enforcing the referent gate in the Claude Code conversational
+  layer (not attune-controllable).
+- Replacing or duplicating Anthropic's own account-level usage
+  limits — attune gates *before* hitting them, it does not
+  re-implement them.
+- Per-token live metering UI; the gate is a pre-call envelope,
+  not a streaming meter.
+
+---
+
+## Requirements
+
+Spend gate (v1, CLI surface):
+
+- **R1 — First-call confirm.** The first billable workflow call
+  of a session surfaces, before the call is made: (a) what will
+  run, (b) an estimate against the active meter, (c) the
+  session budget envelope, and requires an explicit confirm.
+- **R2 — Estimate.** The estimate is derived from existing cost
+  machinery (workflow tier × expected calls), presented in the
+  unit of the active meter (≈ dollars for API; usage-headroom
+  framing for subscription).
+- **R3 — Session-durable authorization.** After the confirm,
+  further billable runs within the envelope proceed without
+  re-prompting for the rest of the session (mirrors the §6
+  admin-merge-authorization-durability pattern).
+- **R4 — Envelope breach re-gates.** A run that would push
+  cumulative session spend past the envelope re-prompts with the
+  breach amount, even after R3.
+- **R5 — Meter alignment.** The gate detects subscription-vs-API
+  mode and gates against the correct meter; it never shows a
+  misleading $0 to a subscription user.
+- **R6 — Off switch.** A budget of 0 / a documented env var
+  disables the gate entirely (heuristic-free path), consistent
+  with the existing `ATTUNE_MAX_BUDGET_USD=0` semantics.
+- **R7 — Non-interactive safety.** In a non-interactive context
+  (no TTY), the gate fails *safe* per a documented policy
+  (block-by-default or proceed-within-a-conservative-default —
+  resolved in design), never silently launching an unbounded
+  paid run.
+- **R8 — Free/local actions never trip it.** Reads, tests,
+  Ollama/local models, file ops, `gh`, `git` never gate.
+
+Referent gate (later phase — captured now so the spec is
+whole):
+
+- **R9 — Single-referent resolution in attune UX.** attune's
+  own interactive surfaces resolve a terse confirm to exactly
+  one action, or ask which, before executing.
+- **R10 — Honest advisory framing.** Documentation states
+  plainly that the referent gate is advisory in the broader
+  conversational layer and enforced only within attune's UX.
+
+---
+
+## Acceptance criteria
+
+v1 is done when:
+
+- `attune workflow run <paid-workflow>` surfaces an estimate +
+  confirm on the first billable call of a session and proceeds
+  silently within the envelope thereafter (R1–R4), demonstrated
+  by a real CLI run (dogfood, not only unit tests).
+- A subscription-mode run shows headroom framing, not $0
+  (R5), verified with both auth modes mocked.
+- The off switch disables the gate (R6) and free/local actions
+  never gate (R8), both covered by tests.
+- Non-interactive behavior matches the documented fail-safe
+  policy (R7), covered by a test.
+- `decisions.md` logs the gate model, surface order, meter
+  alignment, and the fail-safe policy.
+- A regression guard locks the "first paid call without confirm
+  is impossible when the gate is on" invariant.
+
+---
+
+## Open design questions (resolved in design.md)
+
+1. **What is a "session" for the CLI?** Each `attune workflow
+   run` is a fresh process. Candidates: a TTL'd state file under
+   `~/.attune/`, a session id, or tying the envelope to
+   Anthropic's own rolling-window. Determines how R3 persists.
+2. **Estimate source of truth.** Which existing function
+   produces the pre-call estimate, and its accuracy band.
+3. **Subscription-meter framing.** Exactly how usage-headroom is
+   surfaced when there is no dollar figure (R5).
+4. **Fail-safe policy for R7** — block-by-default vs
+   conservative-default-proceed.
+5. **Where the gate logic lives** — a shared estimate-and-gate
+   core callable by all three future surfaces, vs CLI-local v1
+   code refactored later.

--- a/docs/specs/collaboration-gates/tasks.md
+++ b/docs/specs/collaboration-gates/tasks.md
@@ -1,0 +1,195 @@
+# Tasks: Collaboration Gates
+
+> Phase 1 implementation — the spend gate, CLI surface, budget
+> envelope. Decomposed into independently-shippable units.
+> Companion to [`requirements.md`](requirements.md),
+> [`design.md`](design.md), [`decisions.md`](decisions.md).
+
+**Status:** approved (2026-06-05)
+**Last updated:** 2026-06-05
+
+Ordering: T1 and T2 are leaf modules (shippable alone, no
+user-facing change). T3 composes them. T4 takes the gate live
+on the CLI. T5 hardens + documents. Each row ships as its own
+PR unless two are trivially small.
+
+---
+
+## T1 — Envelope persistence module
+
+**Status:** todo
+
+**Objective.** Build `src/attune/gates/envelope.py`: a TTL'd,
+on-disk session spend envelope modeled on the `Budget` dataclass
+(`ops/session_summarizer.py:120`) and its `cap<=0` latch.
+
+**Files to create.**
+
+- `src/attune/gates/__init__.py`
+- `src/attune/gates/envelope.py` — `Envelope` dataclass
+  (`window_start`, `ttl_seconds`, `authorized`, `cap_usd`,
+  `spent_usd`, `meter`), load/save to
+  `~/.attune/spend_gate/envelope.json`, `is_expired(now)`,
+  `record(cost)`, `would_breach(cost)`, reset-on-expiry.
+- `tests/unit/gates/test_envelope.py`
+
+**Decisions honored.** D6 (TTL window, default 5h aligned to
+Anthropic's rolling window), D2 (envelope model).
+
+**Validation.**
+
+- Round-trips through the JSON file; `tmp_path`, never a literal
+  `~`/`/tmp` (Windows path lessons).
+- `is_expired` flips on an injected `now` past `window_start +
+  ttl_seconds` (pin the clock — edge-of-bucket timing lesson).
+- Corrupt/missing file → fresh envelope (fail safe).
+- `cap_usd <= 0` latches `authorized=False`-equivalent off
+  semantics (R6).
+
+**Risks.** `low` — leaf module, no callers yet.
+
+---
+
+## T2 — Meter resolution module
+
+**Status:** todo
+
+**Objective.** Build `src/attune/gates/meter.py`: resolve the
+active meter from `AuthStrategy`/`AuthMode` and produce the
+framing string.
+
+**Files to create.**
+
+- `src/attune/gates/meter.py` — `resolve() -> Meter`
+  (`mode`, `framing(estimate) -> str`).
+- `tests/unit/gates/test_meter.py`
+
+**Decisions honored.** D3, D8.
+
+**Validation.**
+
+- API mode → dollar framing ("≈ up to $X; counts against your
+  Anthropic API spend").
+- Subscription mode → usage-headroom framing, **never $0** (R5).
+- Both auth modes mocked (don't read real auth state in tests).
+
+**Risks.** `low`.
+
+---
+
+## T3 — Spend-gate core (compose envelope + meter)
+
+**Status:** todo
+**Depends on:** T1, T2
+
+**Objective.** Build `src/attune/gates/spend_gate.py`:
+`evaluate_spend_gate(workflow_name, depth, *, now=None) ->
+GateDecision` returning `proceed` | `confirm` | `block` per the
+design data-flow. Pure logic; no TTY, no I/O beyond the envelope
+store.
+
+**Files to create.**
+
+- `src/attune/gates/spend_gate.py` — `GateDecision` +
+  `evaluate_spend_gate`; the off-switch short-circuit
+  (`ATTUNE_SPEND_GATE=off` / `ATTUNE_MAX_BUDGET_USD=0`);
+  estimate band from `get_max_budget_usd(depth)` (D7).
+- `tests/unit/gates/test_spend_gate.py`
+
+**Decisions honored.** D7, D9, D10 (non-interactive →
+`block` unless pre-authorized; the core returns `block`, the
+surface enforces the TTY check by passing interactivity in).
+
+**Validation.**
+
+- Fresh/expired window → `confirm`.
+- Authorized & within envelope → `proceed`.
+- Would-breach → `confirm` (breach amount in the decision).
+- Off switch → `proceed` (heuristic-free).
+- Non-interactive without pre-auth → `block`; with
+  `ATTUNE_SPEND_GATE_AUTHORIZED=1` → `proceed`.
+- Inject `now` for all window logic.
+
+**Risks.** `medium` — this is the invariant-bearing module; the
+regression guard (T5) locks its core property.
+
+---
+
+## T4 — CLI wiring (gate goes live)
+
+**Status:** todo
+**Depends on:** T3
+
+**Objective.** Wire `evaluate_spend_gate` into `cmd_workflow_run`
+between `get_workflow()` and `run_workflow_with_exit_code()`;
+render the decision; own the confirm I/O; persist the authorized
+envelope on yes; record actual cost after a paid run.
+
+**Files to modify.**
+
+- `src/attune/cli_commands/workflow_commands.py` —
+  call the core, branch on `GateDecision.action`, prompt on
+  `confirm`, print env-override hint on `block`, exit cleanly on
+  decline (no charge), persist on yes.
+- `tests/unit/cli_commands/test_workflow_commands.py` (or a new
+  `test_workflow_spend_gate.py`)
+
+**Decisions honored.** D4 (CLI surface), D1.
+
+**Validation.**
+
+- `confirm` path: yes → runs + persists envelope; no → exits 0,
+  no workflow run, no charge.
+- `proceed` path within an authorized window: no prompt.
+- `block` path (non-interactive): prints the env hint, exits
+  cleanly, no run.
+- Free/local (`--no-llm`) and non-billable workflows never reach
+  the gate (R8).
+- The post-run cost record updates the envelope (R4).
+
+**Risks.** `medium` — touches the live workflow-run path;
+must not change exit-code semantics for non-gated runs
+(workflow-failure-exit-propagation contract).
+
+---
+
+## T5 — Regression guard, docs, dogfood
+
+**Status:** todo
+**Depends on:** T4
+
+**Objective.** Lock the core invariant, document the gate, and
+verify end-to-end against a real run.
+
+**Files to create/modify.**
+
+- `tests/unit/gates/test_spend_gate_regression.py` — assert that
+  with the gate on and no authorized envelope, the first
+  billable call is unreachable without a `confirm` (the locked
+  invariant).
+- Docs: the gate's env vars (`ATTUNE_SPEND_GATE`,
+  `ATTUNE_SPEND_GATE_AUTHORIZED`), behavior, off switch — in the
+  CLI reference + a `.help` entry if the help corpus covers
+  workflow-run.
+- CHANGELOG entry.
+
+**Validation (dogfood — not only unit tests).**
+
+- A real `attune workflow run <paid-workflow>` shows the confirm
+  on the first call of a window, proceeds on yes; a second run
+  in the window proceeds silently. (Spends real budget — gated
+  by the spend gate itself; run only with an explicit go.)
+- Subscription-mode run shows headroom framing, not $0.
+
+**Risks.** `low` — hardening; the dogfood is the receipt
+(§7 verification).
+
+---
+
+## Deferred to later phases (not Phase 1)
+
+- **Dashboard runner** confirm modal (reuses the T3 core).
+- **Workflow/MCP-layer** gating for agent-invoked runs (confirm
+  bubbles through the agent).
+- **Referent gate** (A) — guidance hardening + partial
+  enforcement in attune's interactive surfaces (R9–R10).


### PR DESCRIPTION
## Summary

Spec-first feature: bake the two **collaboration gates** into
attune product behavior so attune's agents *do* them, not just
describe them.

- **Spend gate (B)** — enforceable. v1 ships it as a
  **budget-envelope guardrail** on the CLI: the first billable
  call of a session surfaces an estimate + confirm, then is
  session-durable within the envelope; a breach re-gates.
- **Referent gate (A)** — advisory. Captured for a later phase
  (guidance hardening + partial enforcement in attune's own
  interactive surfaces).

Frames the gates as productizing the §2 mutual-contract
disciplines from the collaboration-discipline article — the
spend gate adds "first billable call" to the decision-point list.

## What this PR contains

Docs-only — four approved spec artifacts, no code:

- `requirements.md` — R1–R10, acceptance criteria, scope
- `design.md` — shared `attune.gates` core + CLI surface;
  resolves all 5 open questions (Q1 CLI-session = TTL'd envelope
  aligned to Anthropic's 5h window; meter alignment; fail-safe)
- `tasks.md` — Phase 1 units T1–T5
- `decisions.md` — D1–D10 logged

Grounded against real machinery (`cmd_workflow_run`,
`AuthStrategy`, the `Budget` dataclass, `get_max_budget_usd`,
the `~/.attune` state-file pattern) — not confabulated signatures.

Lands the decisions on main ahead of implementation (the
"spec as docs-only PR" pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
