### PR TITLE
feat(gates): T1 — spend-gate envelope (collaboration-gates Phase 1)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7927,3 +7927,27 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   pseudocode is no more trustworthy than a research agent's — a
   one-minute `dataclasses.fields()` check is the antidote. Deviation
   recorded in `docs/specs/bulletin-curator/decisions.md` D1.
+
+- **Don't run an INTERNAL state-file path through
+  `_validate_file_path()` (or `.resolve()`) in `save` when `load`
+  reads the unresolved path — on macOS the `/var` → `/private/var`
+  symlink desyncs them**: the production-code companion to the
+  existing "macOS `/var` → `/private/var` symlink breaks path
+  assertions" lesson (which is about *test assertions* of `f.name`
+  vs resolved). New angle: when a module persists a state file with
+  separate `save`/`load` functions, resolving the path in only one
+  of them (e.g. `save` calls `_validate_file_path`, which
+  `.resolve()`s `/var/folders/...` → `/private/var/folders/...`,
+  while `load` reads the unresolved path) writes to one location and
+  reads from another. Symptom on macOS: the state "never loads /
+  always reads fresh" — a confusing, macOS-only, silent-fail bug
+  (here it would have made the spend-gate envelope re-gate every
+  run). The coding-standard "ALWAYS validate file paths" rule
+  (Rule 2) targets **user-controlled** paths; an internal state-file
+  path constructed by the module itself (or supplied by tests as
+  `tmp_path`) carries no traversal risk and should NOT be resolved —
+  write and read the SAME unresolved `Path` object, and use atomic
+  `Path.replace` (not `rename`) for the swap. Discovered designing
+  `attune.gates.envelope.save_envelope` (collaboration-gates T1,
+  PR #637); the fix was to skip `_validate_file_path` in `save` with
+  a comment explaining the desync, keeping save/load path-symmetric.

--- a/src/attune/gates/__init__.py
+++ b/src/attune/gates/__init__.py
@@ -1,0 +1,28 @@
+"""Collaboration gates — productized human↔agent guardrails.
+
+The spend gate enforces a budget-envelope confirm before the first
+billable workflow call of a session. See
+``docs/specs/collaboration-gates/`` for the design.
+
+Submodules are imported directly (``from attune.gates.envelope
+import Envelope``) to keep the package import dependency-light —
+the envelope module is pure stdlib.
+"""
+
+from __future__ import annotations
+
+from attune.gates.envelope import (
+    DEFAULT_TTL_SECONDS,
+    Envelope,
+    load_envelope,
+    load_or_new,
+    save_envelope,
+)
+
+__all__ = [
+    "DEFAULT_TTL_SECONDS",
+    "Envelope",
+    "load_envelope",
+    "load_or_new",
+    "save_envelope",
+]

--- a/src/attune/gates/envelope.py
+++ b/src/attune/gates/envelope.py
@@ -1,0 +1,178 @@
+"""Persisted, TTL'd session spend envelope for the spend gate.
+
+The envelope is the durable state behind the budget-envelope spend
+gate (``docs/specs/collaboration-gates/``). Each ``attune workflow
+run`` is a fresh process, so the envelope persists on disk under
+``~/.attune/spend_gate/`` keyed by a TTL window aligned to
+Anthropic's rolling usage window — so the gate's notion of "this
+session" resets on the same clock as the meter it gates against.
+
+Modeled on the ``Budget`` dataclass
+(``src/attune/ops/session_summarizer.py``) and its ``cap_usd <= 0``
+off-switch latch.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Anthropic's rolling usage window is ~5h; the envelope TTL defaults
+# to match so the gate's "session" resets on the same clock as the
+# meter it gates against (decisions.md D6).
+DEFAULT_TTL_SECONDS: float = 5 * 60 * 60  # 18000
+
+
+def _default_envelope_path() -> Path:
+    """Return the on-disk location of the persisted envelope.
+
+    Mirrors the ``~/.attune/session_stash`` state-file pattern
+    (``src/attune/memory/file_stash.py``).
+    """
+    return Path.home() / ".attune" / "spend_gate" / "envelope.json"
+
+
+@dataclass
+class Envelope:
+    """One session's spend envelope.
+
+    The envelope is established (``authorized=True``) by an explicit
+    first-run confirm and is then session-durable within its TTL
+    window. A run that would push ``spent_usd`` past ``cap_usd``
+    re-gates (see :meth:`would_breach`).
+    """
+
+    window_start: float
+    ttl_seconds: float = DEFAULT_TTL_SECONDS
+    authorized: bool = False
+    cap_usd: float = 0.0
+    spent_usd: float = 0.0
+    meter: str = "api"
+
+    @classmethod
+    def new(
+        cls,
+        now: float,
+        *,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        cap_usd: float = 0.0,
+        meter: str = "api",
+    ) -> Envelope:
+        """Create a fresh, unauthorized envelope opening a new window."""
+        return cls(
+            window_start=now,
+            ttl_seconds=ttl_seconds,
+            authorized=False,
+            cap_usd=cap_usd,
+            spent_usd=0.0,
+            meter=meter,
+        )
+
+    @property
+    def disabled(self) -> bool:
+        """True when ``cap_usd <= 0`` marks the gate off.
+
+        Mirrors the ``Budget`` ``cap_usd <= 0`` latch — the gate core
+        reads a disabled envelope as "proceed" (R6 off switch). A
+        disabled envelope never breaches on dollars.
+        """
+        return self.cap_usd <= 0
+
+    def is_expired(self, now: float) -> bool:
+        """True once the TTL window has elapsed (``now`` is epoch s)."""
+        return (now - self.window_start) >= self.ttl_seconds
+
+    def would_breach(self, cost_usd: float) -> bool:
+        """True if adding ``cost_usd`` would exceed the dollar cap.
+
+        Only meaningful for a dollar-metered (``api``) envelope with a
+        positive cap; a disabled envelope never breaches.
+        """
+        if self.disabled:
+            return False
+        return (self.spent_usd + cost_usd) > self.cap_usd
+
+    def record(self, cost_usd: float) -> None:
+        """Add a completed run's actual cost to the ledger."""
+        if cost_usd < 0:
+            raise ValueError("cost_usd must be non-negative")
+        self.spent_usd += cost_usd
+
+
+def load_envelope(path: Path | None = None) -> Envelope | None:
+    """Load the persisted envelope, or ``None`` if missing/corrupt.
+
+    Fail-safe: a missing or unreadable file returns ``None`` so the
+    caller opens a fresh window rather than crashing (R7).
+    """
+    path = path or _default_envelope_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+        return Envelope(
+            window_start=float(data["window_start"]),
+            ttl_seconds=float(data.get("ttl_seconds", DEFAULT_TTL_SECONDS)),
+            authorized=bool(data.get("authorized", False)),
+            cap_usd=float(data.get("cap_usd", 0.0)),
+            spent_usd=float(data.get("spent_usd", 0.0)),
+            meter=str(data.get("meter", "api")),
+        )
+    except (ValueError, KeyError, TypeError) as e:
+        logger.warning(
+            "spend-gate envelope unreadable (fail-safe to fresh): %s",
+            e,
+        )
+        return None
+
+
+def save_envelope(env: Envelope, path: Path | None = None) -> None:
+    """Persist the envelope atomically.
+
+    The path is internal (constructed by this module or supplied by
+    tests), never user-controlled, so it isn't run through
+    ``_validate_file_path`` — doing so would resolve the macOS
+    ``/var`` -> ``/private/var`` symlink and desync from the
+    caller's load path. Uses ``Path.replace`` for a cross-platform
+    atomic rename (Windows ``Path.rename`` fails when the target
+    exists).
+    """
+    path = path or _default_envelope_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.parent / (path.name + ".tmp")
+    tmp.write_text(json.dumps(asdict(env), indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def load_or_new(
+    now: float,
+    path: Path | None = None,
+    *,
+    ttl_seconds: float = DEFAULT_TTL_SECONDS,
+    cap_usd: float = 0.0,
+    meter: str = "api",
+) -> Envelope:
+    """Load the live envelope, or a fresh one if missing/corrupt/expired.
+
+    The single entry point the gate core uses: it never has to think
+    about expiry or absence — a stale or absent envelope yields a
+    fresh, unauthorized window (fail-safe, R7).
+    """
+    env = load_envelope(path)
+    if env is None or env.is_expired(now):
+        return Envelope.new(
+            now,
+            ttl_seconds=ttl_seconds,
+            cap_usd=cap_usd,
+            meter=meter,
+        )
+    return env

--- a/tests/unit/gates/test_envelope.py
+++ b/tests/unit/gates/test_envelope.py
@@ -1,0 +1,155 @@
+"""Tests for the spend-gate envelope (T1).
+
+Clock is pinned for all window logic (edge-of-bucket timing
+lesson) and the envelope file lives under ``tmp_path`` (never a
+literal ``~``/``/tmp`` — Windows path lessons).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from attune.gates.envelope import (
+    DEFAULT_TTL_SECONDS,
+    Envelope,
+    load_envelope,
+    load_or_new,
+    save_envelope,
+)
+
+# Pinned clock — a fixed epoch so window math is deterministic.
+NOW = 1_700_000_000.0
+
+
+def test_default_ttl_aligns_to_anthropic_window() -> None:
+    assert DEFAULT_TTL_SECONDS == 5 * 60 * 60
+
+
+def test_new_envelope_is_unauthorized_and_empty() -> None:
+    env = Envelope.new(NOW, cap_usd=5.0, meter="api")
+    assert env.window_start == NOW
+    assert env.authorized is False
+    assert env.spent_usd == 0.0
+    assert env.cap_usd == 5.0
+    assert env.meter == "api"
+    assert env.ttl_seconds == DEFAULT_TTL_SECONDS
+
+
+def test_round_trip_through_file(tmp_path) -> None:
+    path = tmp_path / "spend_gate" / "envelope.json"
+    env = Envelope(
+        window_start=NOW,
+        authorized=True,
+        cap_usd=10.0,
+        spent_usd=2.5,
+        meter="api",
+    )
+    save_envelope(env, path)
+    assert path.exists()
+    loaded = load_envelope(path)
+    assert loaded == env
+
+
+def test_saved_file_is_valid_json_with_trailing_newline(tmp_path) -> None:
+    path = tmp_path / "envelope.json"
+    save_envelope(Envelope.new(NOW, cap_usd=1.0), path)
+    text = path.read_text(encoding="utf-8")
+    assert text.endswith("\n")
+    json.loads(text)  # parses
+
+
+def test_load_missing_returns_none(tmp_path) -> None:
+    assert load_envelope(tmp_path / "nope.json") is None
+
+
+def test_load_corrupt_returns_none(tmp_path) -> None:
+    path = tmp_path / "envelope.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    assert load_envelope(path) is None
+
+
+def test_load_missing_required_field_returns_none(tmp_path) -> None:
+    path = tmp_path / "envelope.json"
+    path.write_text(json.dumps({"ttl_seconds": 10}), encoding="utf-8")
+    # No window_start -> KeyError -> fail-safe None.
+    assert load_envelope(path) is None
+
+
+def test_is_expired_at_and_past_window() -> None:
+    env = Envelope.new(NOW, ttl_seconds=100.0)
+    assert env.is_expired(NOW + 99.0) is False
+    assert env.is_expired(NOW + 100.0) is True  # boundary is expired
+    assert env.is_expired(NOW + 101.0) is True
+
+
+def test_is_expired_within_window() -> None:
+    env = Envelope.new(NOW, ttl_seconds=DEFAULT_TTL_SECONDS)
+    assert env.is_expired(NOW + 60.0) is False
+
+
+def test_would_breach() -> None:
+    env = Envelope(window_start=NOW, cap_usd=5.0, spent_usd=4.0)
+    assert env.would_breach(0.5) is False
+    assert env.would_breach(1.0) is False  # exactly at cap, not over
+    assert env.would_breach(1.5) is True
+
+
+def test_disabled_envelope_never_breaches() -> None:
+    env = Envelope(window_start=NOW, cap_usd=0.0, spent_usd=100.0)
+    assert env.disabled is True
+    assert env.would_breach(50.0) is False
+
+
+def test_disabled_latch_on_nonpositive_cap() -> None:
+    assert Envelope(window_start=NOW, cap_usd=0.0).disabled is True
+    assert Envelope(window_start=NOW, cap_usd=-1.0).disabled is True
+    assert Envelope(window_start=NOW, cap_usd=0.01).disabled is False
+
+
+def test_record_accumulates() -> None:
+    env = Envelope.new(NOW, cap_usd=10.0)
+    env.record(1.5)
+    env.record(2.0)
+    assert env.spent_usd == 3.5
+
+
+def test_record_rejects_negative() -> None:
+    env = Envelope.new(NOW, cap_usd=10.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        env.record(-1.0)
+
+
+def test_load_or_new_fresh_when_missing(tmp_path) -> None:
+    env = load_or_new(NOW, tmp_path / "nope.json", cap_usd=5.0)
+    assert env.window_start == NOW
+    assert env.authorized is False
+    assert env.cap_usd == 5.0
+
+
+def test_load_or_new_fresh_when_expired(tmp_path) -> None:
+    path = tmp_path / "envelope.json"
+    save_envelope(
+        Envelope(window_start=NOW, ttl_seconds=100.0, authorized=True),
+        path,
+    )
+    env = load_or_new(NOW + 200.0, path, cap_usd=5.0)
+    assert env.window_start == NOW + 200.0  # fresh window
+    assert env.authorized is False
+
+
+def test_load_or_new_returns_live_envelope(tmp_path) -> None:
+    path = tmp_path / "envelope.json"
+    live = Envelope(
+        window_start=NOW,
+        ttl_seconds=DEFAULT_TTL_SECONDS,
+        authorized=True,
+        cap_usd=5.0,
+        spent_usd=1.0,
+    )
+    save_envelope(live, path)
+    env = load_or_new(NOW + 60.0, path)
+    assert env.authorized is True
+    assert env.spent_usd == 1.0
+    assert env.window_start == NOW  # unchanged — same window


### PR DESCRIPTION
## Summary

First implementation unit of the **collaboration-gates** spend
gate ([spec](docs/specs/collaboration-gates/), tasks.md **T1**).

Adds `src/attune/gates/envelope.py` — a TTL-d, on-disk session
spend envelope, the durable state behind the budget-envelope
spend gate. Modeled on the `Budget` dataclass and its `cap<=0`
off-switch latch; the TTL window defaults to 5h, aligned to
Anthropic's rolling usage window (decisions.md **D6**) so the
gate's session resets on the same clock as the meter it gates.

## API

- `Envelope` — `is_expired(now)`, `would_breach(cost)`,
  `record(cost)`, `disabled` (cap<=0 latch)
- `load_envelope` — fail-safe `None` on missing/corrupt (R7)
- `save_envelope` — atomic, cross-platform `Path.replace`
- `load_or_new` — the single entry point the gate core (T3) uses

## Notes

- Pure stdlib, no `attune` deps — keeps the package import light.
- **No callers yet** — behavior goes live in T4 (CLI wiring).
- 17 unit tests: round-trip, fail-safe load, boundary expiry
  (pinned clock per the timing lesson), breach, disabled latch,
  `load_or_new` fresh/live; `tmp_path` throughout (Windows paths).

Stacked context: this is T1 of T1-T5; the decision-routine
discipline-doc fold lands in T5 (docs) per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
