### PR TITLE
feat(gates): T2 + T3 — meter resolution + spend-gate core (collaboration-gates Phase 1)

### DIFF
--- a/src/attune/gates/__init__.py
+++ b/src/attune/gates/__init__.py
@@ -26,6 +26,11 @@ from attune.gates.meter import (
     resolve,
 )
 
+# Note: ``spend_gate`` is intentionally NOT eagerly imported here — it
+# pulls ``attune.workflows.agent_sdk_adapter`` (the Agent SDK), which
+# would weigh down ``import attune.gates``. Consumers import it
+# directly: ``from attune.gates.spend_gate import evaluate_spend_gate``.
+
 __all__ = [
     "DEFAULT_TTL_SECONDS",
     "METER_API",

--- a/src/attune/gates/__init__.py
+++ b/src/attune/gates/__init__.py
@@ -6,7 +6,8 @@ billable workflow call of a session. See
 
 Submodules are imported directly (``from attune.gates.envelope
 import Envelope``) to keep the package import dependency-light —
-the envelope module is pure stdlib.
+the envelope module is pure stdlib; the meter module pulls only
+``attune.models.auth_strategy``.
 """
 
 from __future__ import annotations
@@ -18,11 +19,21 @@ from attune.gates.envelope import (
     load_or_new,
     save_envelope,
 )
+from attune.gates.meter import (
+    METER_API,
+    METER_SUBSCRIPTION,
+    Meter,
+    resolve,
+)
 
 __all__ = [
     "DEFAULT_TTL_SECONDS",
+    "METER_API",
+    "METER_SUBSCRIPTION",
     "Envelope",
+    "Meter",
     "load_envelope",
     "load_or_new",
+    "resolve",
     "save_envelope",
 ]

--- a/src/attune/gates/meter.py
+++ b/src/attune/gates/meter.py
@@ -1,0 +1,86 @@
+"""Active-meter resolution for the spend gate.
+
+Resolves whether the user is on the dollar meter (Anthropic API,
+pay-per-token) or the subscription meter (usage quota / rolling
+window), and produces the human framing string the confirm surface
+shows. This keeps the gate honest per ``decisions.md`` D3/D8: a
+subscription user never sees a misleading ``$0`` dollar figure
+(``feedback_workflow_output`` — "cost figures don't apply,
+subscription not API").
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from attune.models.auth_strategy import AuthMode, AuthStrategy
+
+# Public mode tokens — also stored in the envelope's ``meter`` field.
+METER_API = "api"
+METER_SUBSCRIPTION = "subscription"
+
+
+@dataclass(frozen=True)
+class Meter:
+    """The user's active billing meter and how to frame a spend."""
+
+    mode: str  # "api" | "subscription"
+
+    @property
+    def is_dollars(self) -> bool:
+        """True when spend is denominated in dollars (API mode)."""
+        return self.mode == METER_API
+
+    def framing(self, estimate_usd: float) -> str:
+        """Frame a spend estimate in the user's actual meter.
+
+        API mode shows the dollar band; subscription mode shows
+        usage-headroom framing with no dollar figure — never a
+        misleading ``$0`` (R5 / D8).
+
+        Args:
+            estimate_usd: The run's estimated dollar ceiling. Used
+                only in API mode; ignored in subscription mode.
+
+        Returns:
+            A one-line framing string for the confirm surface.
+        """
+        if self.is_dollars:
+            return (
+                f"≈ up to ${estimate_usd:.2f} for this run "
+                "— counts against your Anthropic API spend."
+            )
+        return (
+            "uses your subscription quota (no per-call charge) "
+            "— counts against your Anthropic usage window."
+        )
+
+
+def resolve(
+    strategy: AuthStrategy | None = None,
+    *,
+    module_lines: int = 0,
+) -> Meter:
+    """Resolve the active meter from the user's auth strategy.
+
+    Reads ``AuthStrategy`` -> ``AuthMode`` (D8). ``AUTO`` is resolved
+    to a concrete mode via ``get_recommended_mode``, which never
+    returns ``AUTO``. ``module_lines`` lets a caller that knows the
+    target size refine an ``AUTO`` decision; the gate's default (0)
+    resolves ``AUTO`` the same way a small run would.
+
+    Args:
+        strategy: Auth strategy to read; loaded from disk when None.
+        module_lines: Target size hint for ``AUTO`` resolution.
+
+    Returns:
+        The active :class:`Meter`.
+    """
+    strategy = strategy or AuthStrategy.load()
+    mode = strategy.get_recommended_mode(module_lines)
+    if mode == AuthMode.SUBSCRIPTION:
+        return Meter(mode=METER_SUBSCRIPTION)
+    return Meter(mode=METER_API)

--- a/src/attune/gates/spend_gate.py
+++ b/src/attune/gates/spend_gate.py
@@ -1,0 +1,166 @@
+"""Spend-gate core — compose the envelope and the meter into a decision.
+
+``evaluate_spend_gate`` is the pure decision the spend gate rests on:
+it reads the persisted session envelope (T1) and the active billing
+meter (T2) and returns a :class:`GateDecision` of ``proceed`` |
+``confirm`` | ``block``. It performs **no TTY I/O and makes no
+billable call** — the surface (CLI in v1) owns the confirm prompt and
+passes interactivity in (D9, D10). This keeps the core testable
+without a terminal and lets the dashboard / MCP layers reuse it later.
+
+Off switch (R6, heuristic-free): ``ATTUNE_SPEND_GATE=off`` or
+``ATTUNE_MAX_BUDGET_USD=0`` (the latter makes ``get_max_budget_usd``
+return ``None``) short-circuits to ``proceed``.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from attune.gates.envelope import Envelope, load_or_new
+from attune.gates.meter import Meter, resolve
+from attune.models.auth_strategy import AuthStrategy
+from attune.workflows.agent_sdk_adapter import get_max_budget_usd
+
+# Decision actions.
+ACTION_PROCEED = "proceed"
+ACTION_CONFIRM = "confirm"
+ACTION_BLOCK = "block"
+
+_OFF_VALUES = {"off", "0", "false", "no"}
+_ON_VALUES = {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """The spend gate's verdict for one run.
+
+    The surface presents ``framing`` + the estimate and, on
+    ``confirm``, owns the yes/no prompt; on ``block`` it prints the
+    env-override hint; on ``proceed`` it runs the workflow. ``envelope``
+    is the (possibly fresh) state the surface persists once authorized.
+    """
+
+    action: str  # "proceed" | "confirm" | "block"
+    estimate_usd: float
+    framing: str
+    envelope: Envelope
+    reason: str
+    breach_usd: float = 0.0
+
+
+def _spend_gate_off() -> bool:
+    """True when ``ATTUNE_SPEND_GATE`` explicitly disables the gate."""
+    raw = os.environ.get("ATTUNE_SPEND_GATE")
+    return raw is not None and raw.strip().lower() in _OFF_VALUES
+
+
+def _pre_authorized() -> bool:
+    """True when ``ATTUNE_SPEND_GATE_AUTHORIZED`` opts a context in (D10)."""
+    raw = os.environ.get("ATTUNE_SPEND_GATE_AUTHORIZED")
+    return raw is not None and raw.strip().lower() in _ON_VALUES
+
+
+def evaluate_spend_gate(
+    workflow_name: str,
+    depth: str = "standard",
+    *,
+    interactive: bool = True,
+    now: float | None = None,
+    strategy: AuthStrategy | None = None,
+    envelope_path: Path | None = None,
+) -> GateDecision:
+    """Decide whether a billable run may proceed, needs a confirm, or is blocked.
+
+    Pure logic: reads the persisted envelope and the active meter,
+    returns a :class:`GateDecision`. The surface owns all I/O.
+
+    Args:
+        workflow_name: The workflow about to run (for the reason text).
+        depth: Analysis depth — drives the estimate band via
+            ``get_max_budget_usd`` (D7).
+        interactive: Whether the surface can prompt. ``False`` (no TTY)
+            blocks a first paid call absent pre-authorization (D10).
+        now: Injectable epoch clock for window logic; ``time.time()``
+            when None.
+        strategy: Auth strategy for meter resolution; loaded when None.
+        envelope_path: Override the envelope file (tests pass tmp_path).
+
+    Returns:
+        The :class:`GateDecision`.
+    """
+    now = time.time() if now is None else now
+    meter: Meter = resolve(strategy)
+
+    # Off switch (R6) — heuristic-free. get_max_budget_usd returns None
+    # exactly when ATTUNE_MAX_BUDGET_USD=0, the existing cap-disable.
+    cap = get_max_budget_usd(depth)
+    if _spend_gate_off() or cap is None:
+        env = load_or_new(now, envelope_path, cap_usd=0.0, meter=meter.mode)
+        return GateDecision(
+            action=ACTION_PROCEED,
+            estimate_usd=0.0,
+            framing=meter.framing(0.0),
+            envelope=env,
+            reason="spend gate disabled",
+        )
+
+    estimate = cap
+    env = load_or_new(now, envelope_path, cap_usd=estimate, meter=meter.mode)
+    framing = meter.framing(estimate)
+    authorized = env.authorized or _pre_authorized()
+
+    if not authorized:
+        if interactive:
+            return GateDecision(
+                action=ACTION_CONFIRM,
+                estimate_usd=estimate,
+                framing=framing,
+                envelope=env,
+                reason=f"first paid run of this window for '{workflow_name}'",
+            )
+        return GateDecision(
+            action=ACTION_BLOCK,
+            estimate_usd=estimate,
+            framing=framing,
+            envelope=env,
+            reason=(
+                "non-interactive run with no prior authorization — set "
+                "ATTUNE_SPEND_GATE_AUTHORIZED=1 to allow"
+            ),
+        )
+
+    # Authorized — re-gate only if this run would breach the envelope.
+    if env.would_breach(estimate):
+        breach = (env.spent_usd + estimate) - env.cap_usd
+        if interactive:
+            return GateDecision(
+                action=ACTION_CONFIRM,
+                estimate_usd=estimate,
+                framing=framing,
+                envelope=env,
+                reason="this run would exceed the session spend envelope",
+                breach_usd=breach,
+            )
+        return GateDecision(
+            action=ACTION_BLOCK,
+            estimate_usd=estimate,
+            framing=framing,
+            envelope=env,
+            reason="non-interactive run would exceed the session spend envelope",
+            breach_usd=breach,
+        )
+
+    return GateDecision(
+        action=ACTION_PROCEED,
+        estimate_usd=estimate,
+        framing=framing,
+        envelope=env,
+        reason="within the authorized session envelope",
+    )

--- a/tests/unit/gates/test_meter.py
+++ b/tests/unit/gates/test_meter.py
@@ -1,0 +1,103 @@
+"""Tests for the spend-gate meter resolution (T2).
+
+Auth modes are constructed directly (never reading real on-disk
+auth state) so the tests are deterministic across environments.
+"""
+
+from __future__ import annotations
+
+from attune.gates.meter import (
+    METER_API,
+    METER_SUBSCRIPTION,
+    Meter,
+    resolve,
+)
+from attune.models.auth_strategy import AuthMode, AuthStrategy, SubscriptionTier
+
+# --- framing -------------------------------------------------------------
+
+
+def test_api_framing_shows_dollar_band() -> None:
+    framing = Meter(mode=METER_API).framing(2.5)
+    assert "$2.50" in framing
+    assert "Anthropic API spend" in framing
+
+
+def test_subscription_framing_shows_headroom_never_dollars() -> None:
+    framing = Meter(mode=METER_SUBSCRIPTION).framing(2.5)
+    assert "subscription quota" in framing
+    assert "usage window" in framing
+    assert "$" not in framing
+
+
+def test_subscription_framing_never_shows_zero_even_at_zero_estimate() -> None:
+    # R5: a subscription user must never see a misleading $0.
+    framing = Meter(mode=METER_SUBSCRIPTION).framing(0.0)
+    assert "$0" not in framing
+    assert "$" not in framing
+
+
+def test_is_dollars_property() -> None:
+    assert Meter(mode=METER_API).is_dollars is True
+    assert Meter(mode=METER_SUBSCRIPTION).is_dollars is False
+
+
+# --- resolution ----------------------------------------------------------
+
+
+def test_resolve_explicit_api_mode() -> None:
+    strategy = AuthStrategy(default_mode=AuthMode.API)
+    assert resolve(strategy).mode == METER_API
+
+
+def test_resolve_explicit_subscription_mode() -> None:
+    strategy = AuthStrategy(default_mode=AuthMode.SUBSCRIPTION)
+    assert resolve(strategy).mode == METER_SUBSCRIPTION
+
+
+def test_resolve_auto_pro_user_is_api() -> None:
+    # Pro on AUTO → API (pay-per-token is more economical for low usage).
+    strategy = AuthStrategy(
+        default_mode=AuthMode.AUTO,
+        subscription_tier=SubscriptionTier.PRO,
+    )
+    assert resolve(strategy).mode == METER_API
+
+
+def test_resolve_auto_api_only_user_is_api() -> None:
+    strategy = AuthStrategy(
+        default_mode=AuthMode.AUTO,
+        subscription_tier=SubscriptionTier.API_ONLY,
+    )
+    assert resolve(strategy).mode == METER_API
+
+
+def test_resolve_auto_max_user_unknown_size_is_subscription() -> None:
+    # Max/Enterprise on AUTO with unknown size (module_lines=0) resolves
+    # the way a small run would → subscription, keeping the user off a
+    # misleading $0 (D3).
+    strategy = AuthStrategy(
+        default_mode=AuthMode.AUTO,
+        subscription_tier=SubscriptionTier.MAX,
+    )
+    assert resolve(strategy).mode == METER_SUBSCRIPTION
+
+
+def test_resolve_auto_max_user_large_module_is_api() -> None:
+    # A large target overrides AUTO toward API (1M context window).
+    strategy = AuthStrategy(
+        default_mode=AuthMode.AUTO,
+        subscription_tier=SubscriptionTier.MAX,
+    )
+    assert resolve(strategy, module_lines=5000).mode == METER_API
+
+
+def test_resolve_defaults_to_loaded_strategy(monkeypatch) -> None:
+    # When no strategy is passed, resolve loads one — patched here so
+    # the test never touches real on-disk auth state.
+    sentinel = AuthStrategy(default_mode=AuthMode.SUBSCRIPTION)
+    monkeypatch.setattr(
+        "attune.gates.meter.AuthStrategy.load",
+        classmethod(lambda cls, path=None: sentinel),
+    )
+    assert resolve().mode == METER_SUBSCRIPTION

--- a/tests/unit/gates/test_spend_gate.py
+++ b/tests/unit/gates/test_spend_gate.py
@@ -1,0 +1,258 @@
+"""Tests for the spend-gate core (T3).
+
+Clock is pinned for all window logic, the envelope file lives under
+``tmp_path``, and the auth strategy is injected (never reads real
+on-disk auth state). Gate env vars are cleared per-test so the host
+environment can't leak in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.gates.envelope import (
+    DEFAULT_TTL_SECONDS,
+    Envelope,
+    load_envelope,
+    save_envelope,
+)
+from attune.gates.spend_gate import (
+    ACTION_BLOCK,
+    ACTION_CONFIRM,
+    ACTION_PROCEED,
+    evaluate_spend_gate,
+)
+from attune.models.auth_strategy import AuthMode, AuthStrategy, SubscriptionTier
+
+# Pinned clock — deterministic window math.
+NOW = 1_700_000_000.0
+
+# Deterministic API-mode strategy → dollar framing without disk reads.
+API_STRATEGY = AuthStrategy(default_mode=AuthMode.API)
+SUB_STRATEGY = AuthStrategy(
+    default_mode=AuthMode.SUBSCRIPTION,
+    subscription_tier=SubscriptionTier.MAX,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_gate_env(monkeypatch):
+    """Clear gate env vars so the host environment never leaks in."""
+    for var in (
+        "ATTUNE_SPEND_GATE",
+        "ATTUNE_SPEND_GATE_AUTHORIZED",
+        "ATTUNE_MAX_BUDGET_USD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def env_path(tmp_path):
+    return tmp_path / "spend_gate" / "envelope.json"
+
+
+def _authorized_envelope(path, *, cap_usd, spent_usd, window_start=NOW):
+    save_envelope(
+        Envelope(
+            window_start=window_start,
+            authorized=True,
+            cap_usd=cap_usd,
+            spent_usd=spent_usd,
+            meter="api",
+        ),
+        path,
+    )
+
+
+# --- core decisions ------------------------------------------------------
+
+
+def test_fresh_window_confirms(env_path):
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_CONFIRM
+    assert decision.estimate_usd == 10.0  # standard depth default
+
+
+def test_authorized_within_envelope_proceeds(env_path):
+    _authorized_envelope(env_path, cap_usd=100.0, spent_usd=5.0)
+    decision = evaluate_spend_gate(
+        "code-review",
+        "standard",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_PROCEED
+
+
+def test_would_breach_confirms_with_breach_amount(env_path):
+    # cap 10, already spent 9.5, a standard run estimates +10 → breach.
+    _authorized_envelope(env_path, cap_usd=10.0, spent_usd=9.5)
+    decision = evaluate_spend_gate(
+        "deep-review",
+        "standard",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_CONFIRM
+    assert decision.breach_usd == pytest.approx(9.5)  # (9.5 + 10) - 10
+
+
+def test_expired_window_regates(env_path):
+    _authorized_envelope(env_path, cap_usd=100.0, spent_usd=5.0)
+    later = NOW + DEFAULT_TTL_SECONDS + 1
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        now=later,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_CONFIRM
+
+
+# --- off switch (R6) -----------------------------------------------------
+
+
+def test_off_switch_spend_gate_env_proceeds(env_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_SPEND_GATE", "off")
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_PROCEED
+    assert decision.reason == "spend gate disabled"
+
+
+def test_off_switch_max_budget_zero_proceeds(env_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_MAX_BUDGET_USD", "0")
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_PROCEED
+
+
+# --- non-interactive fail-safe (D10) -------------------------------------
+
+
+def test_non_interactive_without_preauth_blocks(env_path):
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        interactive=False,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_BLOCK
+    assert "ATTUNE_SPEND_GATE_AUTHORIZED" in decision.reason
+
+
+def test_non_interactive_with_preauth_proceeds(env_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_SPEND_GATE_AUTHORIZED", "1")
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        interactive=False,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_PROCEED
+
+
+def test_non_interactive_preauth_breach_blocks(env_path, monkeypatch):
+    # Pre-auth lets a non-interactive run proceed, but a breach can't be
+    # confirmed without a TTY → block (fail-safe).
+    monkeypatch.setenv("ATTUNE_SPEND_GATE_AUTHORIZED", "1")
+    _authorized_envelope(env_path, cap_usd=10.0, spent_usd=9.5)
+    decision = evaluate_spend_gate(
+        "deep-review",
+        "standard",
+        interactive=False,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_BLOCK
+
+
+# --- estimate band + meter framing (D7, D8) ------------------------------
+
+
+@pytest.mark.parametrize(
+    ("depth", "expected"),
+    [("quick", 2.0), ("standard", 10.0), ("deep", 25.0)],
+)
+def test_estimate_band_matches_depth_default(env_path, depth, expected):
+    decision = evaluate_spend_gate(
+        "security-audit",
+        depth,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.estimate_usd == expected
+
+
+def test_max_budget_override_sets_estimate(env_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_MAX_BUDGET_USD", "3.5")
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.estimate_usd == 3.5
+
+
+def test_api_meter_framing_shows_dollars(env_path):
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert "$10.00" in decision.framing
+
+
+def test_subscription_meter_framing_never_shows_dollars(env_path):
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        now=NOW,
+        strategy=SUB_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert "$" not in decision.framing
+    assert decision.envelope.meter == "subscription"
+
+
+def test_decision_carries_envelope_state(env_path):
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert isinstance(decision.envelope, Envelope)
+    # Fresh window persisted nothing yet — file absent until the surface
+    # authorizes and saves.
+    assert load_envelope(env_path) is None


### PR DESCRIPTION
## T2 + T3 — Meter resolution + spend-gate core (collaboration-gates Phase 1)

Two tightly-coupled leaf/compose modules of the spend gate, folded into one PR (both small; T3 composes T2; spec permits combining trivially-small tasks).

### T2 — `src/attune/gates/meter.py`
Resolve the user's **active billing meter** and produce the confirm framing.
- `Meter` + `resolve()`: reads `AuthStrategy` → `AuthMode` (D8). `AUTO` resolves via `get_recommended_mode` with an overridable `module_lines` hint (default 0).
- **API** → `≈ up to $X for this run — counts against your Anthropic API spend.`
- **Subscription** → `uses your subscription quota (no per-call charge) — counts against your Anthropic usage window.` Never a dollar figure — no misleading `$0` (D3/R5).

### T3 — `src/attune/gates/spend_gate.py`
Compose the T1 envelope + T2 meter into `evaluate_spend_gate` → `GateDecision` (`proceed` | `confirm` | `block`). **Pure logic — no TTY I/O, no billable call**; the surface owns confirm I/O and passes interactivity in (D9, D10).
- **Off switch (R6, heuristic-free):** `ATTUNE_SPEND_GATE=off` or `ATTUNE_MAX_BUDGET_USD=0` (`get_max_budget_usd` returns `None`) → `proceed`.
- Fresh/expired window → `confirm`; authorized & within → `proceed`; would-breach → `confirm` (breach amount carried) (D7).
- Non-interactive + no pre-auth → `block`; `ATTUNE_SPEND_GATE_AUTHORIZED=1` → `proceed`; non-interactive breach → `block` (D10).
- `spend_gate` is intentionally **not** eagerly imported in `gates/__init__.py` (it pulls the Agent SDK adapter) — consumers import the submodule.

### Decisions honored
D3, D7, D8, D9, D10.

### Tests
`test_meter.py` (11) + `test_spend_gate.py` (16). Full `tests/unit/gates/` suite: **44 passed**. Clock pinned, `tmp_path` envelope, injected auth strategy, gate env vars cleared per-test.

### Scope / risk
T2 leaf (low). T3 is the invariant-bearing core (medium) — its locked property gets the regression guard in T5. No callers yet; T4 wires the CLI.

Spec: `docs/specs/collaboration-gates/` · follows #637 (T1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
