### PR TITLE
feat(gates): T4 — spend gate goes live on the CLI (collaboration-gates Phase 1)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7951,3 +7951,26 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   `attune.gates.envelope.save_envelope` (collaboration-gates T1,
   PR #637); the fix was to skip `_validate_file_path` in `save` with
   a comment explaining the desync, keeping save/load path-symmetric.
+
+- **Detect an off-switch through an existing primitive's return
+  contract, not by re-parsing the env var it already reads**: when
+  layering a NEW budget/spend check on top of the existing cap
+  machinery, `get_max_budget_usd(depth)`
+  (`workflows/agent_sdk_adapter.py`) returns `None` **exactly** when
+  `ATTUNE_MAX_BUDGET_USD=0` (the documented cap-disable) — so the
+  spend gate's off-switch is `cap is None`, single-sourced with the
+  existing cap-disable, rather than a second independent
+  `os.environ["ATTUNE_MAX_BUDGET_USD"] == "0"` read that could drift
+  out of sync. Used in `attune.gates.spend_gate.evaluate_spend_gate`
+  (collaboration-gates T3, PR #638). This is now the THIRD place
+  encoding the same "0 / `<=0` / `None` = off" budget semantics —
+  the `Budget` `cap_usd <= 0` `__post_init__` latch
+  (`ops/session_summarizer.py`, see the "Budget/cap ledgers need
+  `__post_init__` to latch `cap <= 0`" lesson), `get_max_budget_usd`'s
+  `None` return, and the spend gate — so when adding a fourth, reuse
+  the nearest existing signal (the `None` return or the `disabled`
+  property) instead of re-deriving "is it off?" from the raw env var.
+  General rule: a function that already encodes the off/disabled
+  state in its return value (here `None`) is the single source of
+  truth for that state; layered callers should branch on the return,
+  not re-read the underlying config.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Run security audit
         id: security_scan
         continue-on-error: true  # Don't fail job, we'll control blocking in next step
+        env:
+          # Non-interactive CI run — opt into the spend gate explicitly
+          # (collaboration-gates D10). Without this the gate would block
+          # the run by default in a context that can't confirm.
+          ATTUNE_SPEND_GATE_AUTHORIZED: "1"
         run: |
           # Run security audit and capture raw output
           # --json flag outputs JSON but CLI also prints rich text (progress, panels)

--- a/docs/specs/collaboration-gates/decisions.md
+++ b/docs/specs/collaboration-gates/decisions.md
@@ -133,3 +133,38 @@ opts CI / the ops daemon in explicitly; the existing
 `ATTUNE_MAX_BUDGET_USD` cap still bounds any proceeding run. This
 translates the discipline's "first paid call gets an explicit
 go" into a machine context as an explicit env grant.
+
+---
+
+## Phase 1 — Implementation deviations
+
+### D11 — T4 touches more files than tasks.md listed (machine-caller opt-ins)
+
+`tasks.md` T4 named only `workflow_commands.py` + its test. But the
+gated path (`attune workflow run`) is **shared by non-interactive
+machine callers** that the D10 fail-safe would otherwise block —
+discovered when wiring the CLI (verify-first against the real
+callers, not the spec's assumption). T4 therefore also:
+
+- **`src/attune/cli_commands/_exit_codes.py`** — added an optional,
+  additive `on_result` hook (best-effort, guarded) so the CLI can
+  record actual cost into the envelope (R4) without the runner
+  returning the result. Exit-code semantics unchanged
+  (workflow-failure-exit-propagation contract preserved).
+- **`src/attune/ops/runner.py`** — the dashboard daemon spawns the
+  CLI non-interactively, so its subprocess env gets
+  `ATTUNE_SPEND_GATE_AUTHORIZED=1` (the D10 machine-context "go").
+  The dashboard's *own confirm modal* remains a later phase; this
+  just keeps today's dashboard runs working rather than blocking.
+- **`.github/workflows/security-scan.yml`** — the one CI workflow
+  that actually runs `attune workflow run` (security-audit) gets the
+  same explicit opt-in. (`scorecard.yml` / `windows-debug.yml` only
+  mention "workflow run" in prose — they don't invoke the CLI.)
+- **Test opt-out** — `ATTUNE_SPEND_GATE=off` autouse fixtures in the
+  three pre-gate test files that exercise `cmd_workflow_run`
+  (`test_workflow_commands.py`, `test_workflow_exit_codes.py`,
+  `test_voice_wiring.py`) so they test dispatch/exit-codes/voice, not
+  the gate. New `test_workflow_spend_gate.py` covers the CLI surface.
+
+Approved 2026-06-05 (Patrick: "Full T4 with opt-ins"). The MCP-layer
+gating for agent-invoked runs remains deferred to a later phase.

--- a/docs/specs/collaboration-gates/decisions.md
+++ b/docs/specs/collaboration-gates/decisions.md
@@ -168,3 +168,32 @@ callers, not the spec's assumption). T4 therefore also:
 
 Approved 2026-06-05 (Patrick: "Full T4 with opt-ins"). The MCP-layer
 gating for agent-invoked runs remains deferred to a later phase.
+
+### D12 — Re-gate on actual exhaustion, not pre-emptive worst-case (dogfood fix)
+
+The T5 live dogfood surfaced a bug: after a confirm, the **second**
+run re-prompted, contradicting the confirm's "later runs won't
+re-prompt" promise. Root cause: the gate re-gated when
+`spent_usd + next_run_estimate > cap_usd`, and the envelope `cap_usd`
+was set to the per-run budget band (`get_max_budget_usd(depth)`). So
+after a single $0.16 run on a $2 quick window, the *next* run's
+worst-case estimate ($2) added to $0.16 exceeded the $2 cap → instant
+re-prompt.
+
+Fix: the envelope re-gates **post-hoc** — when cumulative `spent_usd`
+has actually reached `cap_usd` (`Envelope.is_exhausted`), not
+pre-emptively on the next run's worst case. `would_breach(cost)` is
+removed in favor of the `is_exhausted` property. Per-run spend is
+still bounded separately by the existing `ATTUNE_MAX_BUDGET_USD` SDK
+cap, so dropping the gate's pre-emptive per-run check loses no real
+protection — it only fixes the false re-prompt. The confirm framing
+drops "for this run" → "this session window," and the re-gate message
+becomes "this session's spend window is used up." Regression locked by
+`test_partial_spend_proceeds_silently` (core) and
+`test_partial_spend_below_cap_is_not_exhausted` (envelope).
+
+Touches `gates/envelope.py`, `gates/spend_gate.py`, `gates/meter.py`
+(framing wording), `cli_commands/workflow_commands.py` (confirm
+message) — modules introduced in #637/#638 but corrected here on the
+T4 branch before Phase 1 merges. Approved 2026-06-05 (Patrick: "fold a
+fix into Phase 1 — yes").

--- a/docs/specs/collaboration-gates/tasks.md
+++ b/docs/specs/collaboration-gates/tasks.md
@@ -17,7 +17,7 @@ PR unless two are trivially small.
 
 ## T1 — Envelope persistence module
 
-**Status:** todo
+**Status:** done (2026-06-05) — merged #637
 
 **Objective.** Build `src/attune/gates/envelope.py`: a TTL'd,
 on-disk session spend envelope modeled on the `Budget` dataclass
@@ -52,7 +52,7 @@ Anthropic's rolling window), D2 (envelope model).
 
 ## T2 — Meter resolution module
 
-**Status:** todo
+**Status:** done (2026-06-05) — merged #638
 
 **Objective.** Build `src/attune/gates/meter.py`: resolve the
 active meter from `AuthStrategy`/`AuthMode` and produce the
@@ -79,7 +79,7 @@ framing string.
 
 ## T3 — Spend-gate core (compose envelope + meter)
 
-**Status:** todo
+**Status:** done (2026-06-05) — merged #638
 **Depends on:** T1, T2
 
 **Objective.** Build `src/attune/gates/spend_gate.py`:
@@ -117,7 +117,7 @@ regression guard (T5) locks its core property.
 
 ## T4 — CLI wiring (gate goes live)
 
-**Status:** todo
+**Status:** done (2026-06-05) — wider file set per [decisions.md](decisions.md) D11
 **Depends on:** T3
 
 **Objective.** Wire `evaluate_spend_gate` into `cmd_workflow_run`

--- a/src/attune/cli_commands/_exit_codes.py
+++ b/src/attune/cli_commands/_exit_codes.py
@@ -132,6 +132,7 @@ def run_workflow_with_exit_code(
     name: str,
     json_mode: bool,
     print_result: Callable[[Any], None],
+    on_result: Callable[[Any], None] | None = None,
 ) -> int:
     """Instantiate + execute a workflow and return the contract exit code.
 
@@ -154,6 +155,11 @@ def run_workflow_with_exit_code(
         print_result: Callback rendering the human-readable
             voice-layer output (injected to avoid an import cycle and
             to preserve the ops daemon side-channel emission).
+        on_result: Optional side-effect callback invoked with the
+            result after a (non-exception) run, in both json and
+            human modes — used by the spend gate to record the run's
+            actual cost into the session envelope (R4). Wrapped in a
+            best-effort guard so it can never alter the exit code.
 
     Returns:
         The process exit code (0, 1, or 2).
@@ -182,5 +188,14 @@ def run_workflow_with_exit_code(
         _emit_json_result(result, exit_code=exit_code)
     else:
         print_result(result)
+
+    if on_result is not None:
+        try:
+            on_result(result)
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: the post-run hook (spend-gate cost record)
+            # is best-effort; a failure here must never change the
+            # exit-code contract.
+            logger.exception("on_result hook failed for workflow %r", name)
 
     return exit_code

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -192,25 +192,23 @@ def cmd_workflow_run(args: Namespace) -> int:
 def _confirm_spend(decision: object) -> bool:
     """Prompt the user to authorize the session spend window.
 
-    Returns True on an explicit yes. A breach decision (the run would
-    exceed an already-authorized envelope) is framed as "proceed
-    anyway."
+    Returns True on an explicit yes. An exhausted-window decision (the
+    session has spent its authorized budget) is framed as "extend it."
     """
     breach = getattr(decision, "breach_usd", 0.0)
     framing = getattr(decision, "framing", "")
     if breach > 0:
         print(
-            f"\n💰 Spend gate — this run would exceed your session spend "
-            f"envelope (over by ${breach:.2f})."
+            f"\n💰 Spend gate — this session's spend window is used up " f"(over by ${breach:.2f})."
         )
         print(f"   {framing}")
-        prompt = "Proceed anyway? [y/N]: "
+        prompt = "Extend the window and proceed? [y/N]: "
     else:
         print("\n💰 Spend gate — first paid run of this session.")
         print(f"   {framing}")
         print(
             "   Proceeding authorizes this session's spend window (~5h); "
-            "later runs won't re-prompt."
+            "later runs proceed silently until the budget is used up."
         )
         prompt = "Proceed? [y/N]: "
     try:

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -77,9 +77,11 @@ def cmd_workflow_info(args: Namespace) -> int:
 def cmd_workflow_run(args: Namespace) -> int:
     """Execute a workflow."""
     import os
+    import sys
 
     from attune.cli_commands._exit_codes import (
         EXIT_CLI_ERROR,
+        EXIT_SUCCESS,
         run_workflow_with_exit_code,
     )
     from attune.security.path_validation import _validate_file_path
@@ -141,6 +143,37 @@ def cmd_workflow_run(args: Namespace) -> int:
         # for nested dataclasses).
         input_data["output_format"] = "json"
 
+    # Spend gate (collaboration-gates Phase 1) — guard the first
+    # billable run of the session. Free/local runs never reach it
+    # (R8): a ``--no-llm`` run makes no billable call. The gate's own
+    # off switch (``ATTUNE_SPEND_GATE=off`` / ``ATTUNE_MAX_BUDGET_USD=0``)
+    # short-circuits to proceed. ``record_cost`` stays False unless an
+    # enforced (non-disabled) envelope is in play, so the off path and
+    # ``--no-llm`` never touch the envelope store.
+    record_cost = False
+    if not getattr(args, "no_llm", False):
+        from attune.gates.spend_gate import (
+            ACTION_BLOCK,
+            ACTION_CONFIRM,
+            evaluate_spend_gate,
+        )
+
+        depth = input_data.get("depth", "standard")
+        interactive = sys.stdin.isatty() and sys.stdout.isatty()
+        decision = evaluate_spend_gate(name, depth, interactive=interactive)
+
+        if decision.action == ACTION_BLOCK:
+            _print_spend_block(decision)
+            return EXIT_SUCCESS
+        if decision.action == ACTION_CONFIRM:
+            if not _confirm_spend(decision):
+                print("Skipped — no workflow run, no charge.")
+                return EXIT_SUCCESS
+            _authorize_envelope(decision)
+        # Record actual cost into the envelope only when the gate is
+        # enforced (a real dollar-capped window), never on the off path.
+        record_cost = not decision.envelope.disabled
+
     print(f"\n🚀 Running workflow: {name}\n")
 
     # Execution outcomes map to exit codes via the centralized
@@ -152,7 +185,86 @@ def cmd_workflow_run(args: Namespace) -> int:
         name=name,
         json_mode=bool(getattr(args, "json", False)),
         print_result=lambda result: _print_workflow_result(result, workflow_name=name),
+        on_result=_record_envelope_cost if record_cost else None,
     )
+
+
+def _confirm_spend(decision: object) -> bool:
+    """Prompt the user to authorize the session spend window.
+
+    Returns True on an explicit yes. A breach decision (the run would
+    exceed an already-authorized envelope) is framed as "proceed
+    anyway."
+    """
+    breach = getattr(decision, "breach_usd", 0.0)
+    framing = getattr(decision, "framing", "")
+    if breach > 0:
+        print(
+            f"\n💰 Spend gate — this run would exceed your session spend "
+            f"envelope (over by ${breach:.2f})."
+        )
+        print(f"   {framing}")
+        prompt = "Proceed anyway? [y/N]: "
+    else:
+        print("\n💰 Spend gate — first paid run of this session.")
+        print(f"   {framing}")
+        print(
+            "   Proceeding authorizes this session's spend window (~5h); "
+            "later runs won't re-prompt."
+        )
+        prompt = "Proceed? [y/N]: "
+    try:
+        answer = input(prompt).strip().lower()
+    except EOFError:
+        return False
+    return answer in {"y", "yes"}
+
+
+def _print_spend_block(decision: object) -> None:
+    """Explain a non-interactive block and name the env override (D10)."""
+    print("\n🚫 Spend gate — not spending silently in a non-interactive run.")
+    print(f"   {getattr(decision, 'framing', '')}")
+    print(
+        "   To allow: set ATTUNE_SPEND_GATE_AUTHORIZED=1 (or "
+        "ATTUNE_SPEND_GATE=off to disable the gate)."
+    )
+
+
+def _authorize_envelope(decision: object) -> None:
+    """Mark the decision's envelope authorized and persist it.
+
+    Establishes the session spend window after an explicit yes so
+    subsequent runs within the window proceed silently (R3).
+    """
+    from attune.gates.envelope import save_envelope
+
+    envelope = getattr(decision, "envelope", None)
+    if envelope is None:
+        return
+    envelope.authorized = True
+    save_envelope(envelope)
+
+
+def _record_envelope_cost(result: object) -> None:
+    """Record a completed run's actual cost into the session envelope (R4).
+
+    Best-effort: reads ``result.cost_report.total_cost`` and adds it to
+    the live envelope. Subscription-mode runs report ``$0`` and are a
+    no-op. Never raises into the caller (the runner guards it too).
+    """
+    import time
+
+    from attune.gates.envelope import load_envelope, save_envelope
+
+    cost_report = getattr(result, "cost_report", None)
+    cost = float(getattr(cost_report, "total_cost", 0.0) or 0.0)
+    if cost <= 0:
+        return
+    envelope = load_envelope()
+    if envelope is None or envelope.is_expired(time.time()):
+        return
+    envelope.record(cost)
+    save_envelope(envelope)
 
 
 def _print_workflow_result(

--- a/src/attune/gates/envelope.py
+++ b/src/attune/gates/envelope.py
@@ -45,8 +45,9 @@ class Envelope:
 
     The envelope is established (``authorized=True``) by an explicit
     first-run confirm and is then session-durable within its TTL
-    window. A run that would push ``spent_usd`` past ``cap_usd``
-    re-gates (see :meth:`would_breach`).
+    window. Runs proceed silently until cumulative ``spent_usd``
+    reaches the window budget ``cap_usd``, at which point the window
+    is exhausted and the next run re-gates (see :attr:`is_exhausted`).
     """
 
     window_start: float
@@ -81,7 +82,7 @@ class Envelope:
 
         Mirrors the ``Budget`` ``cap_usd <= 0`` latch — the gate core
         reads a disabled envelope as "proceed" (R6 off switch). A
-        disabled envelope never breaches on dollars.
+        disabled envelope is never exhausted.
         """
         return self.cap_usd <= 0
 
@@ -89,15 +90,22 @@ class Envelope:
         """True once the TTL window has elapsed (``now`` is epoch s)."""
         return (now - self.window_start) >= self.ttl_seconds
 
-    def would_breach(self, cost_usd: float) -> bool:
-        """True if adding ``cost_usd`` would exceed the dollar cap.
+    @property
+    def is_exhausted(self) -> bool:
+        """True once cumulative spend has used up the window budget.
 
-        Only meaningful for a dollar-metered (``api``) envelope with a
-        positive cap; a disabled envelope never breaches.
+        Post-hoc, not pre-emptive: runs proceed silently until actual
+        ``spent_usd`` reaches ``cap_usd``, then the window re-gates.
+        This is what lets the confirm's "later runs won't re-prompt"
+        promise hold — a per-run worst-case check would re-gate after
+        the very first run when ``cap_usd`` equals a single run's
+        budget band. Per-run spend is still bounded separately by the
+        ``ATTUNE_MAX_BUDGET_USD`` SDK cap. A disabled envelope is never
+        exhausted; subscription runs report ``$0`` so never exhaust.
         """
         if self.disabled:
             return False
-        return (self.spent_usd + cost_usd) > self.cap_usd
+        return self.spent_usd >= self.cap_usd
 
     def record(self, cost_usd: float) -> None:
         """Add a completed run's actual cost to the ledger."""

--- a/src/attune/gates/meter.py
+++ b/src/attune/gates/meter.py
@@ -50,7 +50,7 @@ class Meter:
         """
         if self.is_dollars:
             return (
-                f"≈ up to ${estimate_usd:.2f} for this run "
+                f"≈ up to ${estimate_usd:.2f} this session window "
                 "— counts against your Anthropic API spend."
             )
         return (

--- a/src/attune/gates/spend_gate.py
+++ b/src/attune/gates/spend_gate.py
@@ -136,16 +136,21 @@ def evaluate_spend_gate(
             ),
         )
 
-    # Authorized — re-gate only if this run would breach the envelope.
-    if env.would_breach(estimate):
-        breach = (env.spent_usd + estimate) - env.cap_usd
+    # Authorized — re-gate only once the window's budget is actually
+    # used up (cumulative spend >= cap), not pre-emptively on the next
+    # run's worst-case estimate. Pre-emptive checking would re-prompt
+    # after the very first run when the cap equals one run's budget
+    # band, breaking the "later runs won't re-prompt" promise; per-run
+    # spend is bounded separately by the ATTUNE_MAX_BUDGET_USD SDK cap.
+    if env.is_exhausted:
+        breach = env.spent_usd - env.cap_usd
         if interactive:
             return GateDecision(
                 action=ACTION_CONFIRM,
                 estimate_usd=estimate,
                 framing=framing,
                 envelope=env,
-                reason="this run would exceed the session spend envelope",
+                reason="this session's spend window is used up",
                 breach_usd=breach,
             )
         return GateDecision(
@@ -153,7 +158,7 @@ def evaluate_spend_gate(
             estimate_usd=estimate,
             framing=framing,
             envelope=env,
-            reason="non-interactive run would exceed the session spend envelope",
+            reason="non-interactive run: session spend window is used up",
             breach_usd=breach,
         )
 

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -718,7 +718,18 @@ class RunnerService:
         # see the marker lines.
         import os as _os
 
-        proc_env = {**_os.environ, "ATTUNE_RUN_META_EMIT": "1"}
+        # The dashboard runner spawns the CLI non-interactively, so the
+        # spend gate (collaboration-gates) would block it by default
+        # (D10 fail-safe). Until the dashboard grows its own confirm
+        # modal (a later phase of the gates spec), opt the daemon's
+        # subprocess in explicitly — the machine-context equivalent of
+        # the human "go". The per-workflow ATTUNE_MAX_BUDGET_USD cap
+        # still bounds any run, so this is bounded authorization.
+        proc_env = {
+            **_os.environ,
+            "ATTUNE_RUN_META_EMIT": "1",
+            "ATTUNE_SPEND_GATE_AUTHORIZED": "1",
+        }
         try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,

--- a/tests/unit/cli/test_workflow_exit_codes.py
+++ b/tests/unit/cli/test_workflow_exit_codes.py
@@ -26,6 +26,17 @@ import pytest
 
 from attune.workflows.data_classes import CostReport, WorkflowResult
 
+
+@pytest.fixture(autouse=True)
+def _disable_spend_gate(monkeypatch):
+    """Disable the spend gate so these exit-code-contract tests run the
+    workflow (the gate, collaboration-gates, would otherwise block a
+    non-TTY run before execution). The gate must not change exit-code
+    semantics for non-gated runs; with it off, behavior is unchanged.
+    """
+    monkeypatch.setenv("ATTUNE_SPEND_GATE", "off")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_workflow_exit_codes.py
+++ b/tests/unit/cli/test_workflow_exit_codes.py
@@ -312,3 +312,39 @@ class TestJsonModeThreadsExitCode:
         assert parsed["success"] is True
         assert parsed["sdk_error_kind"] is None
         assert parsed["result"] == "plain text report"
+
+
+class TestOnResultHookGuard:
+    """The optional on_result hook must never alter the exit code."""
+
+    def test_on_result_failure_does_not_change_exit_code(self):
+        from attune.cli_commands._exit_codes import run_workflow_with_exit_code
+
+        def _boom(_result):
+            raise RuntimeError("hook blew up")
+
+        rc = run_workflow_with_exit_code(
+            _workflow_returning(_make_result(success=True)),
+            {},
+            name="ok-wf",
+            json_mode=False,
+            print_result=lambda _r: None,
+            on_result=_boom,
+        )
+        assert rc == 0  # success exit code preserved despite the hook raising
+
+    def test_on_result_receives_result_on_success(self):
+        from attune.cli_commands._exit_codes import run_workflow_with_exit_code
+
+        seen = []
+        result = _make_result(success=True)
+        rc = run_workflow_with_exit_code(
+            _workflow_returning(result),
+            {},
+            name="ok-wf",
+            json_mode=False,
+            print_result=lambda _r: None,
+            on_result=seen.append,
+        )
+        assert rc == 0
+        assert seen == [result]

--- a/tests/unit/cli_commands/test_workflow_commands.py
+++ b/tests/unit/cli_commands/test_workflow_commands.py
@@ -13,6 +13,20 @@ import json
 import types
 from unittest.mock import patch
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_spend_gate(monkeypatch):
+    """Disable the spend gate for these pre-gate tests.
+
+    These exercise workflow-run dispatch, not the gate; without this
+    the gate (collaboration-gates) would block every non-TTY run.
+    The gate has dedicated tests in ``test_workflow_spend_gate.py``.
+    """
+    monkeypatch.setenv("ATTUNE_SPEND_GATE", "off")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli_commands/test_workflow_spend_gate.py
+++ b/tests/unit/cli_commands/test_workflow_spend_gate.py
@@ -1,0 +1,196 @@
+"""Tests for the spend gate wired into ``cmd_workflow_run`` (T4).
+
+The gate *core* is covered in ``tests/unit/gates/test_spend_gate.py``;
+these tests cover the CLI surface: how ``cmd_workflow_run`` handles
+each ``GateDecision`` action (block / confirm / proceed), the confirm
+I/O, envelope authorization on yes, the post-run cost record (R4), and
+that ``--no-llm`` never reaches the gate (R8).
+
+The envelope file is redirected to ``tmp_path`` so no test touches the
+real ``~/.attune`` store.
+"""
+
+from __future__ import annotations
+
+import time
+import types
+
+import pytest
+
+from attune.cli_commands import workflow_commands
+from attune.gates.envelope import Envelope, load_envelope, save_envelope
+from attune.gates.spend_gate import (
+    ACTION_BLOCK,
+    ACTION_CONFIRM,
+    ACTION_PROCEED,
+    GateDecision,
+)
+
+
+def _make_args(**kwargs) -> types.SimpleNamespace:
+    base = {
+        "name": "security-audit",
+        "input": None,
+        "path": None,
+        "target": None,
+        "json": False,
+        "no_llm": False,
+        "depth": None,
+        "cheap": False,
+        "verbose": False,
+        "source": None,
+    }
+    base.update(kwargs)
+    return types.SimpleNamespace(**base)
+
+
+def _decision(action, *, envelope=None, breach=0.0) -> GateDecision:
+    env = envelope or Envelope.new(time.time(), cap_usd=10.0)
+    return GateDecision(
+        action=action,
+        estimate_usd=10.0,
+        framing="≈ up to $10.00 for this run — counts against your Anthropic API spend.",
+        envelope=env,
+        reason="test",
+        breach_usd=breach,
+    )
+
+
+@pytest.fixture(autouse=True)
+def env_file(tmp_path, monkeypatch):
+    """Redirect the envelope store to tmp_path for every test here."""
+    path = tmp_path / "spend_gate" / "envelope.json"
+    monkeypatch.setattr("attune.gates.envelope._default_envelope_path", lambda: path)
+    return path
+
+
+@pytest.fixture
+def fake_runner(monkeypatch):
+    """Patch the workflow runner; capture whether it ran + its on_result."""
+    captured = {"called": False, "on_result": "unset"}
+
+    def _runner(*_args, **kwargs):
+        captured["called"] = True
+        captured["on_result"] = kwargs.get("on_result")
+        return 0
+
+    monkeypatch.setattr("attune.cli_commands._exit_codes.run_workflow_with_exit_code", _runner)
+    # Avoid real workflow resolution (runner is stubbed anyway).
+    monkeypatch.setattr("attune.workflows.get_workflow", lambda name: object)
+    return captured
+
+
+def _patch_decision(monkeypatch, decision):
+    monkeypatch.setattr(
+        "attune.gates.spend_gate.evaluate_spend_gate",
+        lambda *a, **k: decision,
+    )
+
+
+# --- block ---------------------------------------------------------------
+
+
+def test_block_does_not_run_and_exits_clean(monkeypatch, fake_runner, capsys):
+    _patch_decision(monkeypatch, _decision(ACTION_BLOCK))
+    rc = workflow_commands.cmd_workflow_run(_make_args())
+    assert rc == 0
+    assert fake_runner["called"] is False
+    out = capsys.readouterr().out
+    assert "ATTUNE_SPEND_GATE_AUTHORIZED" in out
+
+
+# --- confirm -------------------------------------------------------------
+
+
+def test_confirm_decline_does_not_run(monkeypatch, fake_runner, capsys):
+    _patch_decision(monkeypatch, _decision(ACTION_CONFIRM))
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+    rc = workflow_commands.cmd_workflow_run(_make_args())
+    assert rc == 0
+    assert fake_runner["called"] is False
+    assert "no charge" in capsys.readouterr().out.lower()
+
+
+def test_confirm_yes_runs_and_authorizes_envelope(monkeypatch, fake_runner, env_file):
+    _patch_decision(monkeypatch, _decision(ACTION_CONFIRM))
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+    rc = workflow_commands.cmd_workflow_run(_make_args())
+    assert rc == 0
+    assert fake_runner["called"] is True
+    # Envelope persisted + authorized by the yes.
+    persisted = load_envelope(env_file)
+    assert persisted is not None
+    assert persisted.authorized is True
+    # Enforced (non-disabled) window → cost recorder wired in.
+    assert fake_runner["on_result"] is not None
+
+
+# --- proceed -------------------------------------------------------------
+
+
+def test_proceed_runs_without_prompt(monkeypatch, fake_runner):
+    _patch_decision(monkeypatch, _decision(ACTION_PROCEED))
+
+    def _no_input(_prompt):  # pragma: no cover - must not be called
+        raise AssertionError("proceed must not prompt")
+
+    monkeypatch.setattr("builtins.input", _no_input)
+    rc = workflow_commands.cmd_workflow_run(_make_args())
+    assert rc == 0
+    assert fake_runner["called"] is True
+    assert fake_runner["on_result"] is not None
+
+
+def test_off_switch_envelope_skips_cost_record(monkeypatch, fake_runner):
+    # A disabled envelope (gate off) → proceed, but no cost recorder.
+    disabled_env = Envelope.new(time.time(), cap_usd=0.0)
+    _patch_decision(monkeypatch, _decision(ACTION_PROCEED, envelope=disabled_env))
+    rc = workflow_commands.cmd_workflow_run(_make_args())
+    assert rc == 0
+    assert fake_runner["called"] is True
+    assert fake_runner["on_result"] is None
+
+
+# --- R8: --no-llm never reaches the gate ---------------------------------
+
+
+def test_no_llm_skips_gate_entirely(monkeypatch, fake_runner):
+    def _boom(*_a, **_k):  # pragma: no cover - must not be called
+        raise AssertionError("--no-llm must not reach the spend gate")
+
+    monkeypatch.setattr("attune.gates.spend_gate.evaluate_spend_gate", _boom)
+    rc = workflow_commands.cmd_workflow_run(_make_args(no_llm=True))
+    assert rc == 0
+    assert fake_runner["called"] is True
+    assert fake_runner["on_result"] is None
+
+
+# --- R4: post-run cost record --------------------------------------------
+
+
+def test_record_envelope_cost_adds_actual_cost(env_file):
+    save_envelope(
+        Envelope(
+            window_start=time.time(), authorized=True, cap_usd=10.0, spent_usd=1.0, meter="api"
+        ),
+        env_file,
+    )
+    result = types.SimpleNamespace(cost_report=types.SimpleNamespace(total_cost=2.5))
+    workflow_commands._record_envelope_cost(result)
+    assert load_envelope(env_file).spent_usd == pytest.approx(3.5)
+
+
+def test_record_envelope_cost_zero_is_noop(env_file):
+    save_envelope(
+        Envelope(
+            window_start=time.time(),
+            authorized=True,
+            cap_usd=10.0,
+            spent_usd=1.0,
+            meter="subscription",
+        ),
+        env_file,
+    )
+    result = types.SimpleNamespace(cost_report=types.SimpleNamespace(total_cost=0.0))
+    workflow_commands._record_envelope_cost(result)
+    assert load_envelope(env_file).spent_usd == pytest.approx(1.0)

--- a/tests/unit/cli_commands/test_workflow_spend_gate.py
+++ b/tests/unit/cli_commands/test_workflow_spend_gate.py
@@ -199,11 +199,11 @@ def test_record_envelope_cost_zero_is_noop(env_file):
 # --- confirm-prompt helper branches --------------------------------------
 
 
-def test_confirm_spend_breach_branch_frames_overage(monkeypatch, capsys):
+def test_confirm_spend_exhausted_branch_frames_overage(monkeypatch, capsys):
     monkeypatch.setattr("builtins.input", lambda _prompt: "y")
     assert workflow_commands._confirm_spend(_decision(ACTION_CONFIRM, breach=3.25)) is True
     out = capsys.readouterr().out
-    assert "would exceed" in out
+    assert "used up" in out
     assert "over by $3.25" in out
 
 

--- a/tests/unit/cli_commands/test_workflow_spend_gate.py
+++ b/tests/unit/cli_commands/test_workflow_spend_gate.py
@@ -194,3 +194,35 @@ def test_record_envelope_cost_zero_is_noop(env_file):
     result = types.SimpleNamespace(cost_report=types.SimpleNamespace(total_cost=0.0))
     workflow_commands._record_envelope_cost(result)
     assert load_envelope(env_file).spent_usd == pytest.approx(1.0)
+
+
+# --- confirm-prompt helper branches --------------------------------------
+
+
+def test_confirm_spend_breach_branch_frames_overage(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+    assert workflow_commands._confirm_spend(_decision(ACTION_CONFIRM, breach=3.25)) is True
+    out = capsys.readouterr().out
+    assert "would exceed" in out
+    assert "over by $3.25" in out
+
+
+def test_confirm_spend_eof_returns_false(monkeypatch):
+    def _eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _eof)
+    assert workflow_commands._confirm_spend(_decision(ACTION_CONFIRM)) is False
+
+
+def test_authorize_envelope_with_no_envelope_is_noop():
+    # A decision carrying no envelope must not crash or persist anything.
+    workflow_commands._authorize_envelope(types.SimpleNamespace(envelope=None))
+
+
+def test_record_envelope_cost_no_live_envelope_is_noop(env_file):
+    # cost > 0 but no envelope on disk (off-switch/proceed path never
+    # wrote one) → no crash, nothing persisted.
+    result = types.SimpleNamespace(cost_report=types.SimpleNamespace(total_cost=2.5))
+    workflow_commands._record_envelope_cost(result)
+    assert load_envelope(env_file) is None

--- a/tests/unit/gates/test_envelope.py
+++ b/tests/unit/gates/test_envelope.py
@@ -89,17 +89,26 @@ def test_is_expired_within_window() -> None:
     assert env.is_expired(NOW + 60.0) is False
 
 
-def test_would_breach() -> None:
-    env = Envelope(window_start=NOW, cap_usd=5.0, spent_usd=4.0)
-    assert env.would_breach(0.5) is False
-    assert env.would_breach(1.0) is False  # exactly at cap, not over
-    assert env.would_breach(1.5) is True
+def test_is_exhausted_post_hoc() -> None:
+    # Below cap → not exhausted (later runs proceed silently).
+    assert Envelope(window_start=NOW, cap_usd=5.0, spent_usd=4.0).is_exhausted is False
+    # At cap → exhausted (>= , not just >).
+    assert Envelope(window_start=NOW, cap_usd=5.0, spent_usd=5.0).is_exhausted is True
+    # Over cap → exhausted.
+    assert Envelope(window_start=NOW, cap_usd=5.0, spent_usd=6.0).is_exhausted is True
 
 
-def test_disabled_envelope_never_breaches() -> None:
+def test_partial_spend_below_cap_is_not_exhausted() -> None:
+    # The dogfood regression: one run's spend on a cap-sized-as-band
+    # window must NOT re-gate the next run.
+    env = Envelope(window_start=NOW, cap_usd=2.0, spent_usd=0.16, authorized=True)
+    assert env.is_exhausted is False
+
+
+def test_disabled_envelope_never_exhausted() -> None:
     env = Envelope(window_start=NOW, cap_usd=0.0, spent_usd=100.0)
     assert env.disabled is True
-    assert env.would_breach(50.0) is False
+    assert env.is_exhausted is False
 
 
 def test_disabled_latch_on_nonpositive_cap() -> None:

--- a/tests/unit/gates/test_spend_gate.py
+++ b/tests/unit/gates/test_spend_gate.py
@@ -91,9 +91,23 @@ def test_authorized_within_envelope_proceeds(env_path):
     assert decision.action == ACTION_PROCEED
 
 
-def test_would_breach_confirms_with_breach_amount(env_path):
-    # cap 10, already spent 9.5, a standard run estimates +10 → breach.
-    _authorized_envelope(env_path, cap_usd=10.0, spent_usd=9.5)
+def test_partial_spend_proceeds_silently(env_path):
+    # Dogfood regression: cap == one run's band ($2 quick), one run
+    # spent $0.16 → the next run must PROCEED, not re-prompt.
+    _authorized_envelope(env_path, cap_usd=2.0, spent_usd=0.16)
+    decision = evaluate_spend_gate(
+        "simplify-code",
+        "quick",
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=env_path,
+    )
+    assert decision.action == ACTION_PROCEED
+
+
+def test_exhausted_window_confirms_with_overage(env_path):
+    # cap 10, cumulative spend 10.5 → window used up → re-gate.
+    _authorized_envelope(env_path, cap_usd=10.0, spent_usd=10.5)
     decision = evaluate_spend_gate(
         "deep-review",
         "standard",
@@ -102,7 +116,7 @@ def test_would_breach_confirms_with_breach_amount(env_path):
         envelope_path=env_path,
     )
     assert decision.action == ACTION_CONFIRM
-    assert decision.breach_usd == pytest.approx(9.5)  # (9.5 + 10) - 10
+    assert decision.breach_usd == pytest.approx(0.5)  # 10.5 - 10
 
 
 def test_expired_window_regates(env_path):
@@ -175,11 +189,11 @@ def test_non_interactive_with_preauth_proceeds(env_path, monkeypatch):
     assert decision.action == ACTION_PROCEED
 
 
-def test_non_interactive_preauth_breach_blocks(env_path, monkeypatch):
-    # Pre-auth lets a non-interactive run proceed, but a breach can't be
-    # confirmed without a TTY → block (fail-safe).
+def test_non_interactive_preauth_exhausted_blocks(env_path, monkeypatch):
+    # Pre-auth lets a non-interactive run proceed, but an exhausted
+    # window can't be re-confirmed without a TTY → block (fail-safe).
     monkeypatch.setenv("ATTUNE_SPEND_GATE_AUTHORIZED", "1")
-    _authorized_envelope(env_path, cap_usd=10.0, spent_usd=9.5)
+    _authorized_envelope(env_path, cap_usd=10.0, spent_usd=10.5)
     decision = evaluate_spend_gate(
         "deep-review",
         "standard",

--- a/tests/unit/voice/test_voice_wiring.py
+++ b/tests/unit/voice/test_voice_wiring.py
@@ -19,6 +19,16 @@ import pytest
 from attune.voice import personality
 from attune.workflows.data_classes import CostReport, WorkflowResult
 
+
+@pytest.fixture(autouse=True)
+def _disable_spend_gate(monkeypatch):
+    """Disable the spend gate so these voice-wiring tests run the
+    workflow (the gate, collaboration-gates, would otherwise block a
+    non-TTY run before execution).
+    """
+    monkeypatch.setenv("ATTUNE_SPEND_GATE", "off")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## T4 — Spend gate goes live on `attune workflow run` (collaboration-gates Phase 1)

Wires the T3 core into the CLI: between workflow resolution and execution, `evaluate_spend_gate` decides `proceed | confirm | block`; the CLI owns the confirm prompt, persists the authorized envelope on yes, and records actual cost after a paid run.

### Behavior
- **confirm** (first paid run of the window): prompts; **yes** → authorizes the session window + runs; **no** → exits 0, no run, no charge.
- **proceed** (within an authorized window): runs, no prompt.
- **block** (non-interactive, no pre-auth, D10): prints the `ATTUNE_SPEND_GATE_AUTHORIZED=1` hint, exits 0, no run.
- **off** (`ATTUNE_SPEND_GATE=off` / `ATTUNE_MAX_BUDGET_USD=0`) and **`--no-llm`** (R8): never reach the gate / never touch the envelope store.
- **R4:** actual cost (`result.cost_report.total_cost`) recorded into the envelope after a paid run; subscription/$0 runs are a no-op.

### Files
- `cli_commands/workflow_commands.py` — gate wiring + 4 helpers.
- `cli_commands/_exit_codes.py` — **additive, guarded** `on_result` hook (records cost without the runner returning the result). **Exit-code contract unchanged** (workflow-failure-exit-propagation preserved).
- `ops/runner.py` — daemon subprocess env gets `ATTUNE_SPEND_GATE_AUTHORIZED=1` (D10 machine opt-in; the dashboard's own confirm modal stays a later phase).
- `.github/workflows/security-scan.yml` — same opt-in for the one CI workflow that runs `attune workflow run`.

### Scope note (D11)
T4 touches more than tasks.md listed: the gated CLI path is **shared by non-interactive machine callers** (daemon + CI) that the D10 fail-safe would otherwise block. Opting them in explicitly keeps the dashboard/CI green; recorded as `decisions.md` D11. Discovered by verifying against the real callers, not the spec's file list.

### Tests
New `test_workflow_spend_gate.py` (CLI surface: each action + confirm I/O + envelope authorize + R4 cost record + R8 skip). `ATTUNE_SPEND_GATE=off` autouse fixtures added to the 3 pre-gate test files so they test dispatch/exit-codes/voice unchanged. Local: **119 passed** across the gate + 3 affected files + gates suite; **102 passed** across ops runner/run_meta (env change is presence-checked, not pinned).

Also folds a cross-session lessons entry (separate commit). Spec: `docs/specs/collaboration-gates/` · follows #637 (T1), #638 (T2+T3). Phase 1 remaining: **T5** (regression guard + docs + dogfood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
