### PR TITLE
feat(gates): T5 — regression guard + docs (collaboration-gates Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exit code is honest. See
   `docs/specs/workflow-failure-exit-propagation/`.
 
+### Added
+
+- **Spend gate on `attune workflow run`.** The first billable run of a
+  session surfaces an estimate and asks for an explicit go before any
+  paid call, then establishes a ~5h spend window (aligned to
+  Anthropic's rolling usage window) so later runs proceed silently
+  until it expires or a run would exceed it. Framing matches your
+  meter — a dollar band for API users, usage-headroom (no misleading
+  `$0`) for subscription users. A non-interactive run with no
+  pre-authorization **blocks** rather than spending silently. Knobs:
+  `ATTUNE_SPEND_GATE=off` (or `ATTUNE_MAX_BUDGET_USD=0`) disables it;
+  `ATTUNE_SPEND_GATE_AUTHORIZED=1` opts a CI / daemon context in.
+  `--no-llm` runs never reach the gate. See
+  `docs/specs/collaboration-gates/` and the CLI reference's
+  "Spend gate" section. (Phase 1: T1–T5.)
+
 ## [7.4.0] — 2026-06-04
 
 ### Added

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -146,6 +146,31 @@ security/vuln/architect → opus; quality/plan/research → sonnet;
 complexity/lint/coverage/dep/scanner/finder/detector → haiku;
 reviewer → inherit (override hook).
 
+### Spend gate
+
+The first billable `attune workflow run` of a session surfaces an
+estimate and asks for an explicit go before any paid call. Once you
+confirm, a session **spend window** (~5h, aligned to Anthropic's
+rolling usage window) is established and later runs proceed silently
+until the window expires or a run would exceed it. A `--no-llm` run
+never reaches the gate.
+
+The framing matches your billing meter: API users see a dollar band
+(`≈ up to $X`), subscription users see usage-headroom framing (no
+dollar figure).
+
+| Env var | Effect |
+|---------|--------|
+| `ATTUNE_SPEND_GATE=off` | Disable the gate entirely (always proceed). |
+| `ATTUNE_MAX_BUDGET_USD=0` | Also disables the gate (the existing cap-disable; `0` = no cap). |
+| `ATTUNE_MAX_BUDGET_USD=<n>` | Sets the per-run estimate band / cap (positive float). |
+| `ATTUNE_SPEND_GATE_AUTHORIZED=1` | Pre-authorize a **non-interactive** run (CI, the ops daemon) — required because a context that can't prompt blocks by default rather than spending silently. |
+
+In a non-interactive run (no TTY) with no pre-authorization, the gate
+**blocks** rather than spend silently, and prints the
+`ATTUNE_SPEND_GATE_AUTHORIZED=1` hint. The ops dashboard and the
+`security-scan` CI workflow set this opt-in automatically.
+
 ---
 
 ## Telemetry Commands

--- a/docs/specs/collaboration-gates/tasks.md
+++ b/docs/specs/collaboration-gates/tasks.md
@@ -155,7 +155,8 @@ must not change exit-code semantics for non-gated runs
 
 ## T5 — Regression guard, docs, dogfood
 
-**Status:** todo
+**Status:** in progress (2026-06-05) — guard + docs + CHANGELOG done;
+live dogfood deferred (spends real budget, needs an explicit go)
 **Depends on:** T4
 
 **Objective.** Lock the core invariant, document the gate, and

--- a/tests/unit/gates/test_spend_gate_regression.py
+++ b/tests/unit/gates/test_spend_gate_regression.py
@@ -1,0 +1,121 @@
+"""Regression guard — lock the spend gate's core invariant (T5).
+
+The invariant: **with the gate on and no authorized envelope, the
+first billable call is never reached as ``proceed``.** It can only
+become ``proceed`` via an explicit human confirm (which authorizes the
+envelope), an explicit machine opt-in
+(``ATTUNE_SPEND_GATE_AUTHORIZED=1``), or the off switch
+(``ATTUNE_SPEND_GATE=off`` / ``ATTUNE_MAX_BUDGET_USD=0``).
+
+If a future change lets an unauthorized first run silently proceed,
+these tests fail — that is the whole point.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.gates.spend_gate import (
+    ACTION_BLOCK,
+    ACTION_CONFIRM,
+    ACTION_PROCEED,
+    evaluate_spend_gate,
+)
+from attune.models.auth_strategy import AuthMode, AuthStrategy
+
+NOW = 1_700_000_000.0
+API_STRATEGY = AuthStrategy(default_mode=AuthMode.API)
+DEPTHS = ["quick", "standard", "deep"]
+
+
+@pytest.fixture(autouse=True)
+def _clear_gate_env(monkeypatch):
+    for var in (
+        "ATTUNE_SPEND_GATE",
+        "ATTUNE_SPEND_GATE_AUTHORIZED",
+        "ATTUNE_MAX_BUDGET_USD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def fresh_env(tmp_path):
+    # No file written → load_or_new yields a fresh, unauthorized window.
+    return tmp_path / "envelope.json"
+
+
+@pytest.mark.parametrize("depth", DEPTHS)
+def test_interactive_first_run_never_proceeds_silently(fresh_env, depth):
+    decision = evaluate_spend_gate(
+        "security-audit",
+        depth,
+        interactive=True,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=fresh_env,
+    )
+    # The locked invariant: an unauthorized first run must confirm,
+    # never proceed.
+    assert decision.action == ACTION_CONFIRM
+    assert decision.action != ACTION_PROCEED
+
+
+@pytest.mark.parametrize("depth", DEPTHS)
+def test_non_interactive_first_run_blocks_never_proceeds(fresh_env, depth):
+    decision = evaluate_spend_gate(
+        "security-audit",
+        depth,
+        interactive=False,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=fresh_env,
+    )
+    assert decision.action == ACTION_BLOCK
+    assert decision.action != ACTION_PROCEED
+
+
+@pytest.mark.parametrize("interactive", [True, False])
+def test_only_explicit_optin_unlocks_proceed_on_first_run(fresh_env, monkeypatch, interactive):
+    # Without any opt-in: must NOT proceed (confirm or block).
+    before = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        interactive=interactive,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=fresh_env,
+    )
+    assert before.action != ACTION_PROCEED
+
+    # The explicit machine opt-in is the ONLY env that turns a first
+    # run into proceed (short of the off switch).
+    monkeypatch.setenv("ATTUNE_SPEND_GATE_AUTHORIZED", "1")
+    after = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        interactive=interactive,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=fresh_env,
+    )
+    assert after.action == ACTION_PROCEED
+
+
+@pytest.mark.parametrize(
+    ("var", "value"),
+    [("ATTUNE_SPEND_GATE", "off"), ("ATTUNE_MAX_BUDGET_USD", "0")],
+)
+def test_off_switch_is_the_documented_bypass(fresh_env, monkeypatch, var, value):
+    # The off switch is an intentional, documented bypass — proceed
+    # with no envelope enforcement.
+    monkeypatch.setenv(var, value)
+    decision = evaluate_spend_gate(
+        "security-audit",
+        "standard",
+        interactive=True,
+        now=NOW,
+        strategy=API_STRATEGY,
+        envelope_path=fresh_env,
+    )
+    assert decision.action == ACTION_PROCEED
+    assert decision.envelope.disabled is True


### PR DESCRIPTION
## T5 — Regression guard + docs + CHANGELOG (collaboration-gates Phase 1)

> **Stacked on #639 (T4).** This branch sits on top of the T4 branch, so until #639 merges the diff also shows T4's commits. Once #639 lands I'll rebase onto `main` and the diff collapses to just the T5 commit. Review T5 on its own commit (`4f2ba6ee`) if easier.

Locks the spend gate's core invariant and documents it.

### Regression guard
`tests/unit/gates/test_spend_gate_regression.py` asserts the locked invariant: **with the gate on and no authorized envelope, the first billable call is never reached as `proceed`** — only an explicit confirm, the machine opt-in (`ATTUNE_SPEND_GATE_AUTHORIZED=1`), or the off switch unlock it. Parametrized across depths + both interactivity modes. Fails loudly if a future change lets an unauthorized first run proceed silently.

### Docs
- `docs/reference/cli-reference.md` — new **Spend gate** section: env vars table, meter-aware framing, non-interactive block-by-default.
- `CHANGELOG.md` — Unreleased **Added** entry.
- No `.help` entry: the help corpus has no workflow-run feature dir (spec said add one only "if the corpus covers it").

### Dogfood — deferred
The live dogfood (a real `attune workflow run` showing the confirm, proceeding on yes, silent on the second run in-window) **spends real budget and is gated by the gate itself**. Left for an explicit go rather than spent unprompted. `tasks.md` T5 marked in-progress for this reason.

Local: **54 passed** across `tests/unit/gates/` (envelope + meter + core + regression). Spec: `docs/specs/collaboration-gates/` · follows #637, #638, #639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
