### PR TITLE
feat(ops): per-process client-token gate on mutating endpoints

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7974,3 +7974,39 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   state in its return value (here `None`) is the single source of
   truth for that state; layered callers should branch on the return,
   not re-read the underlying config.
+
+- **Adding a FastAPI `Depends` auth/gate to existing routes — three
+  interlocking testing facts**: discovered 2026-06-05 executing
+  ops-mutating-endpoint-auth (the per-process `X-Attune-Client` token
+  gate on `attune.ops`'s 7 mutating routes). (1) **`Depends` captures
+  the dependency callable by reference at route-definition time**, so
+  monkeypatching the source module (`attune.ops.security.require_client_token`)
+  does NOT disable the gate — the route already holds the original
+  function object. To bypass in tests, either use
+  `app.dependency_overrides[require_client_token] = lambda: None`
+  (needs the app instance) OR null the *module global the dependency
+  reads at call time* — `require_client_token` compares
+  `x_attune_client != _SESSION_TOKEN`, so a conftest autouse fixture
+  doing `monkeypatch.setattr("attune.ops.security._SESSION_TOKEN", None)`
+  makes no-header requests pass (`None == None`) for every pre-gate
+  route test in the directory. (2) **The gate's OWN test file
+  re-enables the gate by overriding the conftest fixture by name** —
+  define a module-level `@pytest.fixture(autouse=True) def
+  _bypass_client_token(...)` that sets a real token; a same-name
+  module fixture deterministically shadows the conftest one (cleaner
+  than relying on autouse ordering). (3) **A route can return 403 for
+  more than one reason** — the ops `/run` route 403s for `--read-only`
+  (`allow_run=False`, the Config dataclass default, though the CLI
+  default is True) with a *string* `detail`, AND for the token gate
+  with a `{"code": "invalid_client"}` *dict* detail. A test asserting
+  "the token gate passed" must distinguish them: assert on the detail
+  shape/code, or use an `allow_run=True` client so the token gate is
+  the only 403 source. Adding the gate broke 74 existing ops route
+  tests across 8 files at once (the expected blast radius — same shape
+  as the spend-gate `ATTUNE_SPEND_GATE=off` fixture lesson, but here
+  there's no env off-switch so the conftest-null-the-global technique
+  is the equivalent). Pairs with the "migrating tests when adding a
+  layer" and "formatter strips imports added before usage" lessons
+  (the latter re-bit across all 5 route files — re-adding the stripped
+  `Depends`/`require_client_token` imports via Bash, which doesn't
+  trigger the Edit PostToolUse formatter, was the fix).

--- a/docs/reference/ops-dashboard.md
+++ b/docs/reference/ops-dashboard.md
@@ -67,6 +67,33 @@ The dashboard UI is then available in your browser at the printed URL. API respo
 | `ATTUNE_HOME` | Overrides the default attune home directory (`~/.attune`) |
 | `ATTUNE_OPS_SWEEP_RESULTS` | When set to a non-empty value, enables persistence of discovery-sweep results under `<attune_home>/ops/sweep-results/` |
 
+## Localhost security model
+
+The dashboard is a single-user, same-machine tool. Its protection is
+layered, not a multi-user auth system (network exposure is an explicit
+non-goal):
+
+1. **Loopback bind.** The server binds `127.0.0.1` by default — not
+   reachable off the machine.
+2. **Trusted-host middleware.** Requests whose `Host` header isn't on
+   the allowlist are rejected (`--trusted-host` extends it).
+3. **Read-only flag.** `--read-only` disables all mutation (workflow
+   runs, status writes) — purely observational.
+4. **Per-process client token.** Every mutating endpoint
+   (`POST /workflows/{name}/run`, `PUT /api/specs/{slug}/{phase}/status`,
+   the curator/help/dismiss mutations, …) requires an `X-Attune-Client`
+   header matching a token minted at startup. The page reads the token
+   once (a `<meta name="attune-client-token">` tag) and echoes it on
+   mutating requests; `GET /api/session/token` exposes it for
+   bootstrap. A client that never loaded the page — a stray `curl`, a
+   browser extension, an a11y-traversing tool — gets `403` and cannot
+   mutate state. The token resets each server run.
+
+The token gate closes the "accidental mutation from a non-page client"
+bug class (see `docs/specs/ops-mutating-endpoint-auth/`). It is *not* a
+defense against a local attacker who can read process memory or the
+page — that's out of scope for a localhost dev tool.
+
 ## Related commands
 
 - `attune help-docs` — browse the help template library with optional `--tag` filters

--- a/docs/specs/ops-mutating-endpoint-auth/tasks.md
+++ b/docs/specs/ops-mutating-endpoint-auth/tasks.md
@@ -1,42 +1,54 @@
 # Tasks — Ops mutating-endpoint auth
 
-**Status:** approved
+**Status:** done (2026-06-05) — implemented; live-smoke verified
 
 
 ## Phase 1 — Inventory + scaffold
 
-- [ ] **1.1** Inventory every `@router.(put|post|delete|patch)` route under `src/attune/ops/routes/`. Produce a table in this file: route, method, file:line, "needs token?" (default yes; document any "no" with reason).
-- [ ] **1.2** Add `src/attune/ops/security.py` (mirror `attune-gui/sidecar/attune_gui/security.py`):
+- [x] **1.1** Inventory every `@router.(put|post|delete|patch)` route under `src/attune/ops/routes/`. Produce a table in this file: route, method, file:line, "needs token?" (default yes; document any "no" with reason).
+
+  Inventory (all gated — no exceptions):
+
+  | Route | Method | File | Gated |
+  |---|---|---|---|
+  | `/api/specs/{slug}/{phase}/status` | PUT | `routes/specs.py` | yes |
+  | `/api/specs/{slug}/completion-candidates/dismiss` | POST | `routes/specs.py` | yes |
+  | `/workflows/{name}/run` | POST | `routes/runner.py` | yes |
+  | `/api/help/regen` | POST | `routes/help.py` | yes |
+  | `/api/telemetry/interaction` | POST | `routes/interaction_counters.py` | yes |
+  | `/curator/dismiss` | POST | `routes/curator.py` | yes |
+  | `/curator/answer` | POST | `routes/curator.py` | yes |
+- [x] **1.2** Add `src/attune/ops/security.py` (mirror `attune-gui/sidecar/attune_gui/security.py`):
   - `_SESSION_TOKEN = secrets.token_urlsafe(32)`
   - `current_session_token()` getter
   - `require_client_token` Depends function (reads `x_attune_client: str | None = Header(default=None)`)
-  - Unit tests in `tests/unit/ops/test_security.py`
+  - Unit tests: consolidated into `tests/unit/ops/test_mutating_endpoint_auth.py` (covers token + endpoint + gate together) rather than a separate `test_security.py`.
 
 ## Phase 2 — Session-token endpoint
 
-- [ ] **2.1** New route `GET /api/session/token` returning `{"token": "..."}`. No auth. Place in a new file `src/attune/ops/routes/session.py` or inline in `server.py` near the app factory.
-- [ ] **2.2** Inject the token into the rendered page via a `<meta name="attune-client-token" content="...">` tag in `templates/base.html`. Reading via meta avoids a second fetch on every page load.
-- [ ] **2.3** Tests: the endpoint returns 200 with a non-empty token; the meta tag appears on every server-rendered page.
+- [x] **2.1** New route `GET /api/session/token` returning `{"token": "..."}`. No auth. Place in a new file `src/attune/ops/routes/session.py` or inline in `server.py` near the app factory.
+- [x] **2.2** Inject the token into the rendered page via a `<meta name="attune-client-token" content="...">` tag in `templates/base.html`. Reading via meta avoids a second fetch on every page load.
+- [x] **2.3** Tests: the endpoint returns 200 with a non-empty token; the meta tag appears on every server-rendered page.
 
 ## Phase 3 — Apply the gate
 
 For each mutating route surfaced in 1.1:
 
-- [ ] **3.1** Add `Depends(require_client_token)` to the route signature.
-- [ ] **3.2** Add tests: PUT/POST without header → 403; with wrong token → 403; with correct token → expected 2xx.
+- [x] **3.1** Add `Depends(require_client_token)` to the route signature.
+- [x] **3.2** Add tests: PUT/POST without header → 403; with wrong token → 403; with correct token → expected 2xx.
 
 Workflows already covered if 1.1 surfaces them.
 
 ## Phase 4 — Wire the client side
 
-- [ ] **4.1** Add a tiny helper at the top of every JS file that does mutating fetches: read the meta tag once at module load, store in a module-scoped const. Inject `X-Attune-Client` on every mutating `fetch()`.
+- [x] **4.1** Add a tiny helper at the top of every JS file that does mutating fetches: read the meta tag once at module load, store in a module-scoped const. Inject `X-Attune-Client` on every mutating `fetch()`.
   - Files known so far: `static/js/specs.js`, `static/js/completion_candidates.js`, `static/js/runner.js`. Confirm via grep for `method: "PUT"`, `method: "POST"`, `method: "DELETE"`.
-- [ ] **4.2** Manual smoke: launch ops, do each mutating action via the dashboard (status flip, completion-confirm, completion-dismiss, workflow run, run cancel). All should still work.
+- [x] **4.2** Manual smoke: launch ops, do each mutating action via the dashboard (status flip, completion-confirm, completion-dismiss, workflow run, run cancel). All should still work.
 
 ## Phase 5 — Docs + close
 
-- [ ] **5.1** README section: "Localhost security model" — explain the layered approach (loopback bind, trusted Host, read-only flag, X-Attune-Client token).
-- [ ] **5.2** Close `docs/specs/ops-specs-features/phase4-findings.md` Finding 0 with a forward reference to this spec.
+- [x] **5.1** README section: "Localhost security model" — explain the layered approach (loopback bind, trusted Host, read-only flag, X-Attune-Client token).
+- [x] **5.2** Close `docs/specs/ops-specs-features/phase4-findings.md` Finding 0 with a forward reference to this spec.
 
 ## Out of scope (firm — do not creep)
 

--- a/docs/specs/ops-specs-features/phase4-findings.md
+++ b/docs/specs/ops-specs-features/phase4-findings.md
@@ -9,6 +9,14 @@
 
 ## 0. Critical issue surfaced during the review
 
+> **RESOLVED (2026-06-05).** Closed by
+> [`docs/specs/ops-mutating-endpoint-auth/`](../ops-mutating-endpoint-auth/) —
+> every mutating endpoint now requires a per-process `X-Attune-Client`
+> token, so a client that never loaded the page (the a11y-tool /
+> stray-fetch trigger class here) cannot mutate state. The original
+> JS trigger was separately fixed in PR #446 (cancel-on-blur); this
+> reduces the blast radius for any future trigger.
+
 ⚠️ **Spec status files were mutated without explicit user confirmation during the review session.** Nine `PUT /api/specs/{slug}/{phase}/status` requests fired while driving the dashboard via the preview MCP tool, modifying six spec files. All mutations were reverted via `git checkout HEAD -- docs/specs/<paths>` before any commit; no data was lost.
 
 This is Finding 0 — high-priority either way:

--- a/src/attune/ops/routes/curator.py
+++ b/src/attune/ops/routes/curator.py
@@ -22,10 +22,11 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
 from attune.curator import run_curator
+from attune.ops.security import require_client_token
 from attune.security.path_validation import _validate_file_path
 
 from .dashboard import _ctx
@@ -95,6 +96,7 @@ async def curator_page(request: Request, refresh: int = 0) -> HTMLResponse:
 async def curator_dismiss(
     request: Request,
     body: dict[str, Any] = Body(...),  # noqa: B008
+    _client: None = Depends(require_client_token),  # noqa: B008
 ) -> JSONResponse:
     """Snooze an item for 14 days.
 
@@ -127,6 +129,7 @@ async def curator_dismiss(
 async def curator_answer(
     request: Request,
     body: dict[str, Any] = Body(...),  # noqa: B008
+    _client: None = Depends(require_client_token),  # noqa: B008
 ) -> JSONResponse:
     """Record a user's response to an item's suggested action.
 

--- a/src/attune/ops/routes/help.py
+++ b/src/attune/ops/routes/help.py
@@ -18,10 +18,11 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from attune.ops import help_data
+from attune.ops.security import require_client_token
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,10 @@ async def help_recent(request: Request, limit: int = 5) -> JSONResponse:
 
 
 @router.post("/api/help/regen")
-async def help_regen_start(request: Request) -> JSONResponse:
+async def help_regen_start(
+    request: Request,
+    _client: None = Depends(require_client_token),  # noqa: B008
+) -> JSONResponse:
     """Start an attune-author regen job.
 
     Body shape (JSON)::

--- a/src/attune/ops/routes/interaction_counters.py
+++ b/src/attune/ops/routes/interaction_counters.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, Field
 
 from attune.ops.interaction_counters import EVENTS, InteractionCounters
+from attune.ops.security import require_client_token
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,11 @@ def _counters(request: Request) -> InteractionCounters:
 
 
 @router.post("/api/telemetry/interaction")
-async def record_interaction(payload: InteractionEvent, request: Request) -> Response:
+async def record_interaction(
+    payload: InteractionEvent,
+    request: Request,
+    _client: None = Depends(require_client_token),  # noqa: B008
+) -> Response:
     """Increment a UI interaction counter.
 
     Returns 204 No Content on success AND on unknown events (so a

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -7,11 +7,12 @@ import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from attune.ops import data
 from attune.ops.runner import RunnerBusyError, RunnerService
+from attune.ops.security import require_client_token
 from attune.security.path_validation import _validate_file_path
 
 
@@ -83,7 +84,11 @@ async def _read_scope(request: Request) -> str | None:
 
 
 @router.post("/workflows/{name}/run")
-async def start_run(name: str, request: Request) -> JSONResponse:
+async def start_run(
+    name: str,
+    request: Request,
+    _client: None = Depends(require_client_token),  # noqa: B008
+) -> JSONResponse:
     _ensure_allowed(request)
     svc = _service(request)
 

--- a/src/attune/ops/routes/session.py
+++ b/src/attune/ops/routes/session.py
@@ -1,0 +1,22 @@
+"""Session-token bootstrap route for the ops dashboard.
+
+``GET /api/session/token`` returns the per-process client token. It is
+intentionally **unauthenticated** — it's how a freshly-loaded page
+bootstraps the token it then echoes on mutating requests. The token
+grants nothing on its own; it only lets a client pass
+``require_client_token`` on the mutating routes.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from attune.ops.security import current_session_token
+
+router = APIRouter()
+
+
+@router.get("/api/session/token")
+async def get_session_token() -> dict[str, str]:
+    """Return the in-process client token for page bootstrap."""
+    return {"token": current_session_token()}

--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -28,9 +28,10 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Body, HTTPException, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
 
 from attune.ops import dismiss_store, pending_writes
+from attune.ops.security import require_client_token
 
 logger = logging.getLogger(__name__)
 
@@ -496,6 +497,7 @@ async def update_phase_status(
     phase: str,
     request: Request,
     body: dict[str, Any] = Body(...),  # noqa: B008
+    _client: None = Depends(require_client_token),  # noqa: B008
 ) -> dict[str, Any]:
     """Rewrite the ``**Status**`` line in the named phase file.
 
@@ -589,6 +591,7 @@ async def dismiss_completion_candidate(
     slug: str,
     request: Request,
     body: dict[str, Any] = Body(...),  # noqa: B008
+    _client: None = Depends(require_client_token),  # noqa: B008
 ) -> dict[str, Any]:
     """Suppress a completion candidate for the default TTL (14 days).
 

--- a/src/attune/ops/security.py
+++ b/src/attune/ops/security.py
@@ -1,0 +1,61 @@
+"""Per-process client-token gate for the ops dashboard's mutating routes.
+
+The ops server binds to loopback and serves a single local user, but
+once ``--allow-run`` is on (the default) any client that can reach the
+bind can issue mutations (`PUT .../status`, `POST .../run`, etc.).
+A drive-by trigger — a stray ``curl``, a browser extension, an
+a11y-traversing tool — could mutate state with no explicit user
+action (see ops-specs-features Finding 0).
+
+Defense in depth, mirrored from attune-gui's ``security.py``: mint a
+per-process session token at startup, expose it via
+``GET /api/session/token`` (and a ``<meta>`` tag the page reads at
+load), and require it as the ``X-Attune-Client`` header on every
+mutating route. A client that never loaded the page (raw ``curl``,
+automation that didn't bootstrap the token) cannot mutate.
+
+Not a multi-user or network-exposure security story — the loopback
+bind + trusted-host middleware own that; this closes the
+accidental-mutation-from-a-non-page-client bug class.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import secrets
+
+from fastapi import Header, HTTPException
+
+# Minted once per process start. A new ops run invalidates old tokens,
+# which is fine — the page reloads and picks up the new one.
+_SESSION_TOKEN = secrets.token_urlsafe(32)
+
+
+def current_session_token() -> str:
+    """Return the in-process session token.
+
+    Exposed via ``GET /api/session/token`` and injected into rendered
+    pages as a ``<meta name="attune-client-token">`` tag.
+    """
+    return _SESSION_TOKEN
+
+
+def require_client_token(
+    x_attune_client: str | None = Header(default=None),
+) -> None:
+    """FastAPI dependency: 403 unless ``X-Attune-Client`` matches the token.
+
+    Applied via ``Depends(require_client_token)`` on every mutating
+    route. A missing or mismatched header is rejected before the route
+    body runs.
+    """
+    if x_attune_client != _SESSION_TOKEN:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "invalid_client",
+                "message": "Missing or invalid X-Attune-Client header.",
+            },
+        )

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -23,10 +23,12 @@ from attune.ops.routes import interaction_counters as interaction_counters_route
 from attune.ops.routes import pending_writes as pending_writes_routes
 from attune.ops.routes import runner as runner_routes
 from attune.ops.routes import runs_history as runs_history_routes
+from attune.ops.routes import session as session_routes
 from attune.ops.routes import sessions as sessions_routes
 from attune.ops.routes import specs as specs_routes
 from attune.ops.routes import sweep_results as sweep_results_routes
 from attune.ops.runner import RunnerService, prune_old_runs
+from attune.ops.security import current_session_token
 from attune.ops.sweep_results_watcher import watch_and_persist
 
 
@@ -93,6 +95,10 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
 
     templates = Jinja2Templates(directory=str(templates_dir))
     templates.env.globals["attune_version"] = __version__
+    # Per-process client token injected into every page (base.html meta
+    # tag); the page echoes it as X-Attune-Client on mutating fetches.
+    # See attune.ops.security / docs/specs/ops-mutating-endpoint-auth/.
+    templates.env.globals["client_token"] = current_session_token()
     templates.env.globals["nav_items"] = [
         ("/", "Home"),
         ("/workflows", "Workflows"),
@@ -120,6 +126,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
 
     app.state.help_regen = HelpRegenRunner()
 
+    app.include_router(session_routes.router)
     app.include_router(dashboard.router)
     app.include_router(runner_routes.router)
     app.include_router(runs_history_routes.router)

--- a/src/attune/ops/static/js/client_token.js
+++ b/src/attune/ops/static/js/client_token.js
@@ -1,0 +1,21 @@
+// Per-process client-token helper for the ops dashboard.
+//
+// Reads the token from the <meta name="attune-client-token"> tag that
+// base.html renders once at page load, and exposes a header-merger that
+// every mutating fetch() echoes as the X-Attune-Client header. The
+// server's require_client_token dependency 403s any mutating request
+// without it — blocking drive-by fetches from clients that never
+// loaded the page. See docs/specs/ops-mutating-endpoint-auth/.
+(function () {
+  var meta = document.querySelector('meta[name="attune-client-token"]');
+  var TOKEN = meta ? meta.getAttribute("content") || "" : "";
+
+  // Merge the client token into a headers object (or a fresh one).
+  // Use on every mutating fetch: fetch(url, { method: "POST",
+  // headers: attuneClientHeaders({ "Content-Type": "application/json" }) }).
+  window.attuneClientHeaders = function (extra) {
+    var headers = Object.assign({}, extra || {});
+    headers["X-Attune-Client"] = TOKEN;
+    return headers;
+  };
+})();

--- a/src/attune/ops/static/js/completion_candidates.js
+++ b/src/attune/ops/static/js/completion_candidates.js
@@ -163,7 +163,7 @@
       "/api/specs/" + encodeURIComponent(candidate.slug) + "/decisions/status";
     fetchJson(url, {
       method: "PUT",
-      headers: { "Content-Type": "application/json" },
+      headers: attuneClientHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify({ status: "complete" }),
     })
       .then(function () {
@@ -189,7 +189,7 @@
       "/completion-candidates/dismiss";
     fetchJson(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: attuneClientHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify({ snapshot_hash: candidate.snapshot_hash }),
     })
       .then(function () {

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -305,7 +305,7 @@
     pill.classList.add("pill-disabled");
     fetch("/workflows/" + encodeURIComponent(target) + "/run", {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      headers: attuneClientHeaders({ "Content-Type": "application/json", Accept: "application/json" }),
       body: JSON.stringify(body)
     })
       .then(function (resp) {
@@ -527,7 +527,7 @@
         }
         fetch("/workflows/" + encodeURIComponent(name) + "/run", {
           method: "POST",
-          headers: {"Content-Type": "application/json"},
+          headers: attuneClientHeaders({"Content-Type": "application/json"}),
           body: JSON.stringify(body_json)
         }).then(function (resp) {
           if (resp.status === 201) {
@@ -667,7 +667,7 @@
       }
       fetch("/workflows/" + encodeURIComponent(suggestion.name) + "/run", {
         method: "POST",
-        headers: {"Content-Type": "application/json"},
+        headers: attuneClientHeaders({"Content-Type": "application/json"}),
         body: JSON.stringify(body)
       }).then(function (resp) {
         if (resp.status === 201) {

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -173,7 +173,7 @@
     try {
       fetch("/api/telemetry/interaction", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: attuneClientHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify(body),
         // keepalive lets the request survive a navigation away
         // from the page (e.g. pill-click → navigate to new run).
@@ -644,9 +644,11 @@
       setStatus(row, "starting…");
       try {
         var scope = getScope(row);
-        var fetchOpts = { method: "POST" };
+        // Always send the client token; add Content-Type + body only
+        // when a scope path is set (else it's a bare project-wide run).
+        var fetchOpts = { method: "POST", headers: attuneClientHeaders() };
         if (scope !== null) {
-          fetchOpts.headers = { "Content-Type": "application/json" };
+          fetchOpts.headers = attuneClientHeaders({ "Content-Type": "application/json" });
           fetchOpts.body = JSON.stringify({ path: scope });
         }
         var resp = await fetch("/workflows/" + encodeURIComponent(name) + "/run", fetchOpts);

--- a/src/attune/ops/static/js/specs.js
+++ b/src/attune/ops/static/js/specs.js
@@ -104,7 +104,7 @@
           "/status",
         {
           method: "PUT",
-          headers: { "Content-Type": "application/json" },
+          headers: attuneClientHeaders({ "Content-Type": "application/json" }),
           body: JSON.stringify({ status: next }),
         }
       );

--- a/src/attune/ops/templates/base.html
+++ b/src/attune/ops/templates/base.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {# Per-process client token; mutating fetches echo it as the
+       X-Attune-Client header (see static/js/client_token.js and
+       docs/specs/ops-mutating-endpoint-auth/). #}
+    <meta name="attune-client-token" content="{{ client_token }}" />
     <title>{% block title %}attune ops{% endblock %} · attune ops</title>
     {# Release-keyed cache-bust: version pinning lets browsers cache the
        file BETWEEN requests within a release while busting reliably on
@@ -53,6 +57,9 @@
       </div>
     </header>
     <main class="main">{% block content %}{% endblock %}</main>
+    {# Loaded before per-page scripts so every mutating fetch can read
+       the client token (window.attuneClientHeaders). #}
+    <script src="{{ url_for('static', path='js/client_token.js') }}?v={{ attune_version }}"></script>
     {% block scripts %}{% endblock %}
     <footer class="footer">
       attune ops · reads from <code>{{ attune_home }}</code> · refresh page for live data

--- a/src/attune/ops/templates/curator.html
+++ b/src/attune/ops/templates/curator.html
@@ -92,7 +92,7 @@
   async function _post(url, payload) {
     const resp = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: attuneClientHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(payload),
     });
     return resp.ok;

--- a/src/attune/ops/templates/help_admin.html
+++ b/src/attune/ops/templates/help_admin.html
@@ -194,7 +194,7 @@
     if (opts && opts.dry_run) body.dry_run = true;
     fetch("/api/help/regen", {
       method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      headers: attuneClientHeaders({ "Content-Type": "application/json", Accept: "application/json" }),
       body: JSON.stringify(body),
     })
       .then(function (r) {

--- a/tests/unit/ops/conftest.py
+++ b/tests/unit/ops/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for the ops dashboard tests.
+
+The client-token gate (docs/specs/ops-mutating-endpoint-auth/) 403s
+every mutating route whose request lacks an ``X-Attune-Client`` header
+matching the per-process token. The route/page tests in this directory
+predate the gate and exercise route *logic*, not the gate — so this
+autouse fixture nulls the session token, which makes
+``require_client_token`` accept the no-header requests they send
+(``None == None``).
+
+The gate's own behavior is covered in ``test_mutating_endpoint_auth.py``,
+which **overrides** this fixture (same name) to re-establish a real
+token so its 403/pass assertions are meaningful.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _bypass_client_token(monkeypatch):
+    # require_client_token reads the module global at call time, so
+    # nulling it here makes missing-header requests pass the gate.
+    monkeypatch.setattr("attune.ops.security._SESSION_TOKEN", None)

--- a/tests/unit/ops/test_mutating_endpoint_auth.py
+++ b/tests/unit/ops/test_mutating_endpoint_auth.py
@@ -1,0 +1,118 @@
+"""Tests for the ops dashboard's per-process client-token gate.
+
+Covers docs/specs/ops-mutating-endpoint-auth/: the session-token
+endpoint + meta tag (Phase 2), and the X-Attune-Client gate on every
+mutating route (Phase 3) — missing/wrong header → 403, correct header
+passes the gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from attune.ops.config import Config
+from attune.ops.security import current_session_token
+from attune.ops.server import create_app
+
+# Every mutating route under the dashboard (the inventory from Phase 1).
+# A request to each WITHOUT the client token must be rejected.
+MUTATING_ROUTES = [
+    ("PUT", "/api/specs/demo/decisions/status"),
+    ("POST", "/api/specs/demo/completion-candidates/dismiss"),
+    ("POST", "/workflows/security-audit/run"),
+    ("POST", "/api/help/regen"),
+    ("POST", "/api/telemetry/interaction"),
+    ("POST", "/curator/dismiss"),
+    ("POST", "/curator/answer"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _bypass_client_token(monkeypatch):
+    """Override the conftest bypass — this file MUST test the real gate,
+    so re-establish a concrete session token.
+    """
+    monkeypatch.setattr("attune.ops.security._SESSION_TOKEN", "fixed-test-client-token")
+
+
+@pytest.fixture()
+def cfg(tmp_path: Path) -> Config:
+    project = tmp_path / "project"
+    project.mkdir()
+    return Config(project_root=project, attune_home=tmp_path / "attune-home")
+
+
+@pytest.fixture()
+def client(cfg: Config) -> TestClient:
+    app = create_app(cfg)
+    c = TestClient(app)
+    c.headers["Host"] = f"{cfg.host}:{cfg.port}"
+    return c
+
+
+@pytest.fixture()
+def client_allow_run(tmp_path: Path) -> TestClient:
+    """Client with allow_run=True (the CLI default) so the token gate is
+    the only 403 source — the read-only gate that also guards
+    specs/run mutations doesn't mask it."""
+    project = tmp_path / "project"
+    project.mkdir()
+    cfg = Config(
+        project_root=project,
+        attune_home=tmp_path / "attune-home",
+        allow_run=True,
+    )
+    c = TestClient(create_app(cfg))
+    c.headers["Host"] = f"{cfg.host}:{cfg.port}"
+    return c
+
+
+# --- Phase 2: token endpoint + meta tag ----------------------------------
+
+
+def test_session_token_endpoint_returns_token(client: TestClient) -> None:
+    resp = client.get("/api/session/token")
+    assert resp.status_code == 200
+    token = resp.json()["token"]
+    assert token and isinstance(token, str)
+    assert token == current_session_token()
+
+
+def test_rendered_page_carries_client_token_meta(client: TestClient) -> None:
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert 'name="attune-client-token"' in resp.text
+    # The minted token is embedded so the page JS can read it.
+    assert current_session_token() in resp.text
+
+
+# --- Phase 3: the gate ----------------------------------------------------
+
+
+@pytest.mark.parametrize(("method", "path"), MUTATING_ROUTES)
+def test_mutating_route_without_token_is_403(client: TestClient, method: str, path: str) -> None:
+    resp = client.request(method, path, json={})
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["code"] == "invalid_client"
+
+
+@pytest.mark.parametrize(("method", "path"), MUTATING_ROUTES)
+def test_mutating_route_with_wrong_token_is_403(client: TestClient, method: str, path: str) -> None:
+    resp = client.request(method, path, json={}, headers={"X-Attune-Client": "nope"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize(("method", "path"), MUTATING_ROUTES)
+def test_mutating_route_with_correct_token_passes_gate(
+    client_allow_run: TestClient, method: str, path: str
+) -> None:
+    # With the right token (and allow_run on) the gate lets the request
+    # through — the route may then 400/422/etc. on the empty body, but it
+    # must NOT be the 403 the token gate produces.
+    resp = client_allow_run.request(
+        method, path, json={}, headers={"X-Attune-Client": current_session_token()}
+    )
+    assert resp.status_code != 403


### PR DESCRIPTION
## Per-process client-token gate on the ops dashboard's mutating endpoints

Executes the approved **ops-mutating-endpoint-auth** spec — closes Finding 0 (spec status files were mutated without explicit user action when an a11y-traversing tool hit the dashboard).

### What & why
Every mutating ops route was gated only by `--read-only`; once runs are enabled (the default), any client that reaches the loopback bind could mutate. Now each requires an `X-Attune-Client` header matching a per-process token (mirrors attune-gui's `security.py`). A client that never loaded the page — stray `curl`, browser extension, a11y tool — gets `403`.

**Timely:** the collaboration-gates daemon opt-in (#639) lets dashboard-triggered runs bypass the spend gate, so an unauth endpoint that triggers paid runs was exactly the blast radius to close.

### Changes
- `security.py` (token + `require_client_token` Depends), `routes/session.py` (`GET /api/session/token` bootstrap).
- `base.html` `<meta name="attune-client-token">` + global `client_token.js`; server injects the token as a template global.
- `Depends(require_client_token)` on **all 7** mutating routes (specs PUT-status + dismiss, runner `/run`, help regen, interaction, curator dismiss + answer).
- `attuneClientHeaders()` wired into every mutating `fetch` (incl. the `runner.js` project-wide path that previously sent no headers).
- Docs: "Localhost security model" in the ops reference; Finding 0 closed with a forward ref.

### Tests / verification
- `test_mutating_endpoint_auth.py`: token endpoint, meta tag, and **403-without / 403-wrong-token / pass-with-token** for all 7 routes.
- `conftest.py` nulls the token for the pre-gate ops route tests (the auth file overrides it to test the real gate).
- **Live-server smoke:** `/run` returns **403 without token, 201 with**; `/` serves the meta tag + `client_token.js`.
- Full ops suite: **1236 passed**. (One pre-existing `test_sessions` render failure is unrelated — fails identically on the base commit; env-gated session-summary.)

### Notes
- Spec 1.2 said `test_security.py`; consolidated into `test_mutating_endpoint_auth.py` (token + endpoint + gate in one cohesive file). Noted in `tasks.md`.
- Branched off `main`; independent of the collaboration-gates stack (#639/#640).

Spec: `docs/specs/ops-mutating-endpoint-auth/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
