### PR TITLE
docs(specs): close spec-status-self-truthing (shipped in #567)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8010,3 +8010,43 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   (the latter re-bit across all 5 route files — re-adding the stripped
   `Depends`/`require_client_token` imports via Bash, which doesn't
   trigger the Edit PostToolUse formatter, was the fix).
+
+- **"Approved & unexecuted" is ~80% noise — code-grep a
+  spec's primary artifact before executing, because whole
+  specs ship in PRs without their docs ever being marked
+  complete, and the shipped self-truthing reconciler CANNOT
+  catch this**: 2026-06-05, executing the post-7.4.0 spec
+  backlog, a code-grounded re-triage of ~25 non-draft specs
+  found only 3-4 genuinely unexecuted+valuable+in-repo; the
+  rest were either **shipped-but-status-stale** (~11: e.g.
+  `spec-status-self-truthing` itself shipped in #567 but read
+  "approved"; `anthropic-cost-integration` Phase 1 fully wired
+  in `ops/anthropic_cost.py`; `docs-wiring-audit` v1 live;
+  `ops-sessions-page`/`ops-path-picker` shipped) or
+  **not-a-feature** (orchestration/audit/QA/triage docs,
+  ongoing programs). Five+ "approved" specs this session
+  turned out already-done. **Crucial blind spot:** the
+  self-truthing reconciler (`plugin/hooks/_state.py`,
+  shipped #567) reads completion signals *inside* a spec's
+  files (terminal `Status: complete` line or a fully-checked
+  `## Completion checklist`) — it does NOT cross-reference
+  merged PRs. So a spec whose work landed in a PR but whose
+  docs were never given a terminal marker stays "approved"
+  **forever, undetectably** (spec-status-self-truthing's own
+  header was the last such liar — it had no tasks.md /
+  checklist / terminal line, so nothing to read). **Rule:**
+  before executing any "approved"/"in-flight" spec, identify
+  its primary artifact (a file / symbol / CLI command / CI
+  workflow / hook) from requirements+design and grep the code
+  for it FIRST. If present → the work is "execute = close it
+  out" (flip the header to `complete` + pointer to the
+  shipping PR), not re-implement. Pairs with the existing
+  "Re-validate a spec's premise" and "Spec-named work-scope
+  drifts — grep the actual instances" lessons (same family:
+  the spec docs are a stale hypothesis; the code is ground
+  truth) — this one adds the *whole-spec-already-shipped* case
+  and the reconciler's cross-PR blind spot. Corollary: a
+  periodic code-grounded re-triage (grep each in-flight spec's
+  artifact, bucket shipped/partial/unexecuted/not-a-feature)
+  is worth more than trusting the in-flight list, and doubles
+  as the status-cleanup the reconciler can't do.

--- a/docs/specs/spec-status-self-truthing/decisions.md
+++ b/docs/specs/spec-status-self-truthing/decisions.md
@@ -149,3 +149,26 @@ Phase 2's design.md will translate these into concrete regexes,
 exact `SpecInfo` field shapes, and the precise `spec_orient`
 output format. No further user-facing decisions are required
 between this approval and Phase 2 authoring.
+
+---
+
+## Close-out (2026-06-05)
+
+Implementation + tests shipped in **#567** ("feat(hooks): self-truthing
+spec status (impl + tests)"): the `_TERMINAL_LINE` / `_CHECKLIST_*` /
+`_DEFERRED_MARKERS` regexes, `_completion_signal()`, `_reconcile_status()`,
+the additive `SpecInfo` fields (`effective_status` / `status_source` /
+`status_conflict`), `_is_in_flight(effective_status)`, and the
+`spec_orient` conflict-hint rendering — all per design.md. 8
+`TestStatusReconciliation` cases pass. Verified live: the reconciler
+runs clean over the 39-spec corpus.
+
+Status flipped to **complete** here on 2026-06-05. Fittingly, this
+spec's *own* header was the last stale one — it read "approved" while
+the work had landed in #567. The reconciler couldn't auto-catch it
+because this spec has no `tasks.md`, no completion checklist, and no
+terminal status line in its body, so there was no in-file completion
+signal to read (the reconciler reads a spec's own files; it doesn't
+cross-reference merged PRs — a known scope boundary). The fix was a
+human marking it done — exactly the "header lags reality" drift the
+spec was written to surface.

--- a/docs/specs/spec-status-self-truthing/design.md
+++ b/docs/specs/spec-status-self-truthing/design.md
@@ -1,6 +1,6 @@
 # Design — Self-truthing spec status
 
-**Status:** approved
+**Status:** complete (shipped in #567)
 **Phase 1:** [requirements.md](./requirements.md) — locked 2026-05-31
 **Decisions:** [decisions.md](./decisions.md) — 3 DECIDEs ratified
 
@@ -320,4 +320,4 @@ long completion checklist; even then a single regex scan over
 
 ---
 
-## Phase 3: Tasks — *(not started; will be authored after design approval if needed; XML prompt at `~/.attune/next_session_xml_prompts.md` already decomposes implementation)*
+## Phase 3: Tasks — implemented + tested in #567 (no separate tasks.md needed; design.md was the implementation contract)

--- a/docs/specs/spec-status-self-truthing/requirements.md
+++ b/docs/specs/spec-status-self-truthing/requirements.md
@@ -1,6 +1,6 @@
 # Spec: Self-truthing spec status (derive from completion state, not the header line)
 
-**Status**: approved (2026-05-31; see [decisions.md](./decisions.md))
+**Status**: complete (shipped in #567, 2026-06-05; see [decisions.md](./decisions.md))
 **Created**: 2026-05-29
 **Layer**: attune-ai plugin — session hooks (`plugin/hooks/_state.py`, `spec_orient.py`)
 **Origin**: 2026-05-29 session. The spec-orientation hook reported
@@ -189,6 +189,6 @@ locks them and the exact checklist/terminal-line regexes.
 
 ---
 
-## Phase 2: Design — *(not started; awaiting requirements approval)*
+## Phase 2: Design — complete (see [design.md](./design.md))
 
-## Phase 3: Tasks — *(not started)*
+## Phase 3: Tasks — folded into design.md; implemented + tested in #567


### PR DESCRIPTION
## Close spec-status-self-truthing (already shipped in #567)

Premise-checked the approved spec against `main` before executing — and found it **already implemented**. The self-truthing status reconciler shipped in **#567**:
- `_TERMINAL_LINE` / `_CHECKLIST_HEADING` / `_CHECKLIST_LINE` / `_DEFERRED_MARKERS` regexes
- `_completion_signal()` + `_reconcile_status()`
- additive `SpecInfo` fields (`effective_status`, `status_source`, `status_conflict`)
- `_is_in_flight(effective_status)` + `spec_orient` conflict-hint rendering
- 8 `TestStatusReconciliation` cases (all pass)

So the only remaining work was the spec's **own** status: requirements/design read `approved` while the work had landed — the exact "header lags reality" drift the spec was written to surface. This PR flips them to **complete**, points at #567, and records the close-out (and the irony) in decisions.md.

**No code change.** Verified the merged reconciler runs clean over the live 39-spec corpus (0 internal conflicts) and the 8 reconciliation tests pass.

Note on the scope boundary it exposed: the reconciler reads a spec's *own* files for completion signals (terminal line / checklist) — it doesn't cross-reference merged PRs. This spec has no tasks.md/checklist/terminal line, so its drift wasn't auto-detectable; a human marking it done is the intended path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
