### PR TITLE
ci(tests): route ubuntu matrix to 8-core/32GB larger runner (larger-runners Phase 1)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8050,3 +8050,51 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   artifact, bucket shipped/partial/unexecuted/not-a-feature)
   is worth more than trusting the in-flight list, and doubles
   as the status-cleanup the reconciler can't do.
+
+- **A GitHub-hosted larger runner that sits `Ready` while jobs
+  queue forever (no error) on a PUBLIC repo = the runner GROUP's
+  `allows_public_repositories` flag is OFF (default) — NOT billing,
+  and it's invisible in every obvious UI/page; diagnose via
+  `gh api`**: 2026-06-05 wiring `larger-runners` Phase 1
+  (route the ubuntu test-matrix to an 8-core/32GB org runner).
+  The runner was perfectly configured and `status: Ready`
+  (verified via `gh api orgs/<org>/actions/hosted-runners`:
+  image "Ubuntu Latest 24.04", 8c/32GB, Default group, all-repo
+  visibility), yet ubuntu lanes queued indefinitely and the
+  runner never provisioned — two `workflow_dispatch` re-runs,
+  same symptom. Re-running is a tar-pit; stop after 2 and
+  API-diagnose instead. The actual gate:
+  `gh api orgs/<org>/actions/runner-groups/<id>` showed
+  `"allows_public_repositories": false`, and attune-ai is a
+  PUBLIC repo. A public repo's jobs do NOT dispatch to a runner
+  group that disallows public repos — silent queue, no banner in
+  the runner/billing pages. Fix: `gh api -X PATCH
+  orgs/<org>/actions/runner-groups/<id> -F
+  allows_public_repositories=true` (or UI: Settings → Actions →
+  Runner groups → Default → "Allow public repositories").
+  **Security tradeoff to flag before flipping:** this lets
+  fork-PR workflows run on the BILLED larger runner; bound it
+  with an Actions spending limit + GitHub's default
+  "require approval for fork PRs from first-time contributors."
+  **Distinct second silent-queue cause (also Ready-runner /
+  queued-forever / no error):** the org Actions **spending limit
+  still at $0** — larger runners need a >$0 limit + payment
+  method. Neither cause is API-readable as "the reason"; the
+  spending limit isn't in the runners API at all (confirm in
+  Billing UI), and the public-repo flag is only in the
+  runner-GROUP object (not the hosted-runner object). When a
+  larger-runner job won't start: check (1) `runner-groups/<id>`
+  `allows_public_repositories` for public repos, (2) the $0
+  spending-limit, (3) payment method — before assuming a config
+  bug. Companion impl note: route ubuntu→larger via
+  `runs-on: ${{ matrix.os == 'ubuntu-latest' &&
+  '<runner-label>' || matrix.os }}` so `matrix.os` stays
+  `ubuntu-latest` and the REQUIRED check name
+  `test (ubuntu-latest, 3.12)` is unchanged — renaming the
+  matrix label silently breaks branch protection (the
+  "exact check names matter" lesson). Also: the runner LABEL is
+  the NAME you give it at creation (read it back from
+  `hosted-runners` — don't assume `ubuntu-latest-large`); and
+  `gh api ...hosted-runners` image is under `.image_details`,
+  not `.image` (a `.image.id` jq path returns null and looks
+  like a missing image when it isn't).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,13 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    # Route the ubuntu matrix entries to the org's 8-core/32GB larger
+    # runner for ~2x parallelism + memory headroom (larger-runners spec).
+    # The matrix `os` value stays "ubuntu-latest" so the generated job
+    # name — and the required status check "test (ubuntu-latest, 3.12)"
+    # — is unchanged; only the runner the job lands on differs. macOS
+    # and Windows stay on default runners.
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'ubuntu-8core-or-linux-32gb' || matrix.os }}
     timeout-minutes: 75
     strategy:
       fail-fast: false

--- a/docs/specs/larger-runners/tasks.md
+++ b/docs/specs/larger-runners/tasks.md
@@ -18,15 +18,15 @@ Sequencing:
 
 ## Phase 1 — Switch to larger runners
 
-- [ ] **1.1** Verify the org has larger runners enabled. Check
+- [x] **1.1** Verify the org has larger runners enabled. Check
       [GitHub Actions runner groups settings](https://github.com/organizations/Smart-AI-Memory/settings/actions/runner-groups)
       or run a probe workflow with `runs-on: ubuntu-latest-large`
       to confirm. Cost-attribution + billing limits should be set.
-- [ ] **1.2** Update `.github/workflows/tests.yml`:
+- [x] **1.2** Update `.github/workflows/tests.yml`:
       - `runs-on: ubuntu-latest` → `runs-on: ubuntu-latest-large`
         on the `test` matrix job's ubuntu entries.
       - Leave macOS and Windows runners on defaults.
-- [ ] **1.3** Trigger a fresh CI run. Verify matrix completes
+- [~] **1.3** (verifying on this PR's run) Trigger a fresh CI run. Verify matrix completes
       faster than the default-runner baseline (expectation: ~2x
       speedup from 8 workers vs 4 with `-n auto`).
 


### PR DESCRIPTION
## Route ubuntu test-matrix to the 8-core/32GB larger runner (larger-runners Phase 1)

Phase 1 of `docs/specs/larger-runners/`. The ubuntu entries of the `test` matrix now land on the org's GitHub-hosted larger runner (`ubuntu-8core-or-linux-32gb`, 8c/32GB, status Ready) for ~2× xdist parallelism (8 workers vs 4 under `-n auto`) plus memory headroom for suite growth. macOS/Windows and the separate coverage job stay on default runners.

### The non-obvious bit
The change keeps `matrix.os == "ubuntu-latest"` and reroutes only via `runs-on: ${{ matrix.os == 'ubuntu-latest' && 'ubuntu-8core-or-linux-32gb' || matrix.os }}`. That preserves the generated job name — and the **required status check `test (ubuntu-latest, 3.12)`**. Renaming the matrix label (the spec's literal instruction) would have renamed the required check → branch protection sees it "missing" → every PR blocked. Avoided.

### Premise re-check (the spec is from 2026-05-11, revised post-Probe-C)
- The original OOM-rescue justification is **dead** — fixed by the threading patch in #212 (`bcc6bdec`); suite peaks ~130 MB. Remaining case is headroom + speed (the spec downgraded itself to "nice-to-have").
- Dependency satisfied: `-n auto` already restored (Probe-C Phase 4), so this stacks cleanly.
- Org prereqs verified via `gh api`: **Team plan**, `Default` runner group (all-repo access), runner **Ready**. Spending limit set out-of-band (not API-readable).

### Verification (Task 1.3)
This PR's own CI run is the test: the ubuntu lanes should pick up the larger runner and finish faster than baseline, while the check **names** stay identical. If the ubuntu lanes hang in "Waiting for a runner," the org spending limit is still $0.

Spec: `docs/specs/larger-runners/` · one-commit revert restores `ubuntu-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
