### PR TITLE
docs(specs): self-truth 10 stale spec status headers (triage capstone)

### DIFF
--- a/docs/specs/anthropic-cost-integration/requirements.md
+++ b/docs/specs/anthropic-cost-integration/requirements.md
@@ -1,5 +1,5 @@
 # Requirements — Anthropic Cost Integration
-**Status:** approved
+**Status:** partial — Phases 1–2 shipped (anthropic_cost.py backend + home KPI wired in dashboard.py); Phases 3–4 (telemetry per-day panel, setup-billing CLI) deferred
 **Owner:** Patrick
 
 ---

--- a/docs/specs/bulletin-curator/requirements.md
+++ b/docs/specs/bulletin-curator/requirements.md
@@ -5,7 +5,7 @@
 > summary, and dispatches focused follow-ups via
 > `AskUserQuestion`. Fires on-demand when Patrick opens the
 > bulletin — not continuously.
-**Status:** approved
+**Status:** complete (Phases 2–3 shipped #631–#635; Task 4.1 optional manual verify)
 **Created:** 2026-05-17
 **Owner:** TBD
 **Related:**

--- a/docs/specs/claude-cross-session-memory/requirements.md
+++ b/docs/specs/claude-cross-session-memory/requirements.md
@@ -1,6 +1,6 @@
 # Claude Cross-Session Memory — Requirements
 
-**Status:** approved
+**Status:** complete (shipped — session_recall/session_stash hooks + /recall skill; live-hook activation is a deploy step)
 **Approved:** 2026-06-02
 
 ## Problem

--- a/docs/specs/docs-wiring-audit/requirements.md
+++ b/docs/specs/docs-wiring-audit/requirements.md
@@ -9,7 +9,7 @@
 > **Orthogonal to content correctness.** This spec does not touch what
 > docs *say* — only how they connect.
 
-**Status:** approved (2026-05-31; see [decisions.md](./decisions.md))
+**Status:** partial — v1 shipped (scripts/audit_docs_wiring.py + anchor check, #518/#523); later Phase 4 tasks (nav/features.yaml sync, orphans.yml) remaining
 **Created:** 2026-05-30
 **Owner:** TBD
 **Related:**

--- a/docs/specs/ops-dashboard-polish/decisions.md
+++ b/docs/specs/ops-dashboard-polish/decisions.md
@@ -1,5 +1,5 @@
 # Decisions — Ops Dashboard Polish
-**Status:** approved
+**Status:** partial — Phase A complete; Phase B (4/5), C (Sessions shipped, Memory not started), D (1/6) in progress
 **Owner:** Patrick
 **Opened:** 2026-05-14
 **Predecessors:**

--- a/docs/specs/ops-path-picker/requirements.md
+++ b/docs/specs/ops-path-picker/requirements.md
@@ -8,7 +8,7 @@
 ---
 
 ## Phase 1: Requirements
-**Status:** approved
+**Status:** complete (shipped — scope picker in static/js/runner.js)
 ### Problem statement
 
 The 2026-05-14 QA punch list flagged P2-7 (run-view scope path

--- a/docs/specs/ops-sessions-page/requirements.md
+++ b/docs/specs/ops-sessions-page/requirements.md
@@ -14,7 +14,7 @@
 ---
 
 ## Phase 1: Requirements
-**Status:** approved
+**Status:** complete (shipped — routes/sessions.py + sessions.html, S2/S3)
 ### Problem statement
 
 The 2026-05-14 QA punch list flagged that `/sessions` returns 404 —

--- a/docs/specs/ops-specs-completion-candidates/requirements.md
+++ b/docs/specs/ops-specs-completion-candidates/requirements.md
@@ -9,7 +9,7 @@
 
 ## Phase 1: Requirements
 
-**Status**: approved
+**Status**: complete (shipped — completion_candidates.js + dismiss route)
 
 ### Problem statement
 

--- a/docs/specs/ops-specs-features/decisions.md
+++ b/docs/specs/ops-specs-features/decisions.md
@@ -1,6 +1,6 @@
 # Decisions — Port spec-handling features from attune-gui to attune ops
 
-**Status:** Approved & Prioritized (2026-05-11) — gate relaxed; ready when next main CI settles
+**Status:** complete (Phases 1–3 shipped — routes/specs.py; Phase 4 closed empty)
 **Owner:** Patrick
 
 ---

--- a/docs/specs/workflow-failure-exit-propagation/requirements.md
+++ b/docs/specs/workflow-failure-exit-propagation/requirements.md
@@ -9,7 +9,7 @@
 
 ## Phase 1: Requirements
 
-**Status**: approved (design + tasks complete; implemented in one PR —
+**Status**: complete (shipped — cli_commands/_exit_codes.py exit-code contract)
 see `design.md`, `tasks.md`)
 
 ### Problem statement


### PR DESCRIPTION
## Self-truth 10 stale spec status headers (triage capstone)

The grounded re-triage exposed that ~80% of "approved & unexecuted" specs had actually shipped — their headers lied. The self-truthing reconciler (#567) can't catch this (it reads in-file signals, not merged PRs), so this is the human pass it structurally needs.

**Code-grep-verified each spec's primary artifact, then set an ACCURATE status** — deliberately *not* a blanket `complete`, which would just create new lying headers (the exact failure self-truthing fights):

### → complete (whole spec shipped)
- `ops-sessions-page`, `ops-path-picker`, `ops-specs-completion-candidates`
- `ops-specs-features` (Phases 1–3; Phase 4 closed empty)
- `workflow-failure-exit-propagation` (`_exit_codes.py` contract)
- `bulletin-curator` (Phases 2–3, #631–#635)
- `claude-cross-session-memory` (recall hooks + `/recall` skill)

### → partial (multi-phase; only some shipped — marked truthfully)
- `anthropic-cost-integration` — Phases 1–2 (backend + home KPI) shipped; 3–4 deferred
- `docs-wiring-audit` — v1 shipped (#518/#523); Phase-4 task list remaining
- `ops-dashboard-polish` — Phase A done; B/C/D in progress

Docs-only: 10 files, status-line only (10+/10−). The new `check-doc-audit-blocks` pre-commit hook (from #644) ran clean on these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
