### PR TITLE
fix(ops): pin RunnerService executor task to prevent GC mid-flight

### DIFF
--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -370,6 +370,13 @@ class RunnerService:
         # Maps run_id -> heartbeat asyncio task so _finish_run can
         # cancel cleanly. Pruned when the task is cancelled.
         self._heartbeat_tasks: dict[str, asyncio.Task[None]] = {}
+        # Maps run_id -> the workflow-executor asyncio task. The event
+        # loop only holds *weak* references to tasks created via
+        # ``asyncio.create_task``; if we discard the return value the GC
+        # can reap the task mid-flight (cpython.discard-task-issue). A
+        # ``done_callback`` pops the entry on completion so the dict
+        # stays bounded at ``len(active_runs)``.
+        self._executor_tasks: dict[str, asyncio.Task[None]] = {}
 
     @property
     def persistence_dir(self) -> Path | None:
@@ -618,8 +625,16 @@ class RunnerService:
         # Bulletin start record. Errors swallowed by the backend — never
         # blocks workflow start. See multi-actor-bulletin spec.
         self._bulletin_write(run, "running")
-        # Fire and forget — execution streams events via the run's subscribers
-        asyncio.create_task(self._executor(run))
+        # Fire and forget — execution streams events via the run's
+        # subscribers. The task is pinned in ``self._executor_tasks``
+        # because the event loop only holds weak references to tasks
+        # created via ``asyncio.create_task``; a discarded reference can
+        # be GC'd mid-flight and the workflow silently dies. The
+        # done-callback pops the entry on completion (success, failure,
+        # or cancellation), so the dict stays bounded at ``len(active_runs)``.
+        task = asyncio.create_task(self._executor(run))
+        self._executor_tasks[run.id] = task
+        task.add_done_callback(lambda _t, rid=run.id: self._executor_tasks.pop(rid, None))
         return run
 
     def _finish_run(self, run: Run, exit_code: int) -> None:

--- a/tests/unit/ops/test_runner.py
+++ b/tests/unit/ops/test_runner.py
@@ -488,3 +488,59 @@ async def test_subscriber_queue_does_not_block_fast_subscribers(tmp_path, monkey
     assert fast_queue.qsize() == 10
     received = [fast_queue.get_nowait() for _ in range(10)]
     assert received == [("line", f"event-{i}") for i in range(10)]
+
+
+@pytest.mark.asyncio
+async def test_executor_task_is_pinned_while_running_and_popped_on_completion(
+    tmp_path, monkeypatch
+):
+    """Regression: the workflow-executor task must be stored in
+    ``RunnerService._executor_tasks`` while in flight (asyncio holds
+    only weak references to tasks; a discarded ``create_task`` return
+    value can be GC'd mid-flight and the workflow silently dies). On
+    completion the entry must be popped by the done-callback so the
+    dict stays bounded at ``len(active_runs)``.
+    """
+    proceed = asyncio.Event()
+
+    async def _slow_executor(run):
+        # Hold here until the test releases us, so we can observe the
+        # in-flight state of _executor_tasks deterministically.
+        await proceed.wait()
+        run.mark_done(0)
+
+    app, runner = _make_app(
+        tmp_path,
+        monkeypatch,
+        allow_run=True,
+        command_builder=_echo_cmd,
+        executor=_slow_executor,
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/workflows/code-review/run")
+        assert resp.status_code == 201
+        run_id = resp.json()["run_id"]
+
+        # Yield so start() returns and the executor task is scheduled.
+        await asyncio.sleep(0)
+
+        # While the run is still in flight the executor task must be pinned.
+        assert run_id in runner._executor_tasks, (
+            "executor task was not stored in _executor_tasks — "
+            "could be GC'd mid-flight (cpython weak-ref task issue)"
+        )
+
+        # Release the executor and wait for terminal status.
+        proceed.set()
+        await _wait_terminal(runner, run_id)
+
+        # Give the done-callback one event-loop iteration to fire.
+        await asyncio.sleep(0)
+
+        # After completion the entry must be popped so the dict stays
+        # bounded — no per-run memory leak.
+        assert run_id not in runner._executor_tasks, (
+            "executor task entry was not popped on completion — "
+            "done_callback wiring is broken (dict will grow unbounded)"
+        )


### PR DESCRIPTION
## Summary

Fix a real bug in `RunnerService.start` surfaced by bug-predict on `src/attune/ops/` (2026-06-06): the workflow-executor task was created via `asyncio.create_task(self._executor(run))` with the return value discarded. asyncio holds only **weak references** to tasks, so under GC pressure the task can be reaped mid-flight and the workflow silently dies.

Heartbeat tasks at `runner.py:699` were already pinned in `self._heartbeat_tasks` — the executor was an inconsistency, not a deliberate choice.

## Fix

- Add `self._executor_tasks: dict[str, asyncio.Task[None]] = {}` in `__init__`.
- Store the task: `self._executor_tasks[run.id] = asyncio.create_task(self._executor(run))`.
- Auto-prune via `task.add_done_callback(lambda _t, rid=run.id: self._executor_tasks.pop(rid, None))`. Dict stays bounded at `len(active_runs)` — no per-run leak.

## Regression test

`test_executor_task_is_pinned_while_running_and_popped_on_completion` uses a slow injected executor gated on an `asyncio.Event` to deterministically observe both states (pinned in flight, popped after terminal).

## Why this matters

The bug is intermittent — under low load you'd never see it; under GC pressure (long sessions, many concurrent ops) the executor task can vanish mid-stream and the run hangs in 'running' status until the heartbeat-cancel side-channel kicks in (or doesn't). Without the dashboard, this would manifest as 'workflow started, never finished, no error'.

## Test plan

- [x] `tests/unit/ops/test_runner.py` — 48 tests pass locally (1 new + 47 pre-existing)
- [x] pre-commit black + ruff clean
- [ ] CI matrix
