### PR TITLE
fix(tests): isolate test_sessions.py from leaked ANTHROPIC_API_KEY

### DIFF
--- a/tests/unit/ops/test_sessions.py
+++ b/tests/unit/ops/test_sessions.py
@@ -524,7 +524,26 @@ def test_list_recent_sessions_handles_no_content_events(tmp_path, monkeypatch):
 
 
 def _make_app(tmp_path, monkeypatch):
+    """Build a TestClient-ready app with the heuristic-only data layer.
+
+    Default-disables the Haiku summarizer so a developer with
+    ``ANTHROPIC_API_KEY`` exported in their shell doesn't silently
+    trigger real LLM calls on test runs — manifests as the route
+    REPLACING heuristic ``starter_prompt`` strings with the
+    real-Haiku summary, breaking any assertion that checks for
+    fixture content in the rendered output. The CI matrix has no
+    key set so the failure only surfaces locally for keys-exported
+    devs, which makes it doubly easy to miss.
+
+    Tests in this file all target the deterministic heuristic
+    path (see file docstring). Tests that EXERCISE the LLM live
+    in ``test_sessions_route_s3b.py`` and install their own fake
+    ``anthropic`` module via ``_install_fake_anthropic`` (and use
+    their own ``_make_app`` in that file).
+    """
     monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("ATTUNE_OPS_SESSIONS_LLM", "0")
     _patch_home(monkeypatch, tmp_path / "home")
     config = build_config(
         project_root=tmp_path / "project",


### PR DESCRIPTION
## Summary

Fixes a flaky-on-some-dev-machines test in `tests/unit/ops/test_sessions.py` that fails when the developer has `ANTHROPIC_API_KEY` exported in their shell — CI passes (no key set), local dev fails (key inherited via pytest's process env).

## Root cause

`test_sessions.py` targets the deterministic heuristic data layer + page rendering. It asserts fixture content (e.g. `"Test prompt for session listing."`) appears in the `/sessions` route's rendered HTML.

When `ANTHROPIC_API_KEY` is exported in the parent shell:
1. pytest inherits the key via process env
2. The route's `enrich_with_summaries` sees a live key
3. The real Anthropic Haiku is called
4. The heuristic starter is REPLACED with the LLM summary
5. `"Test prompt"` no longer appears → assertion fails

Surfaced while reviewing PR #652 (where the key was exported earlier in the same session for dashboard work).

## Fix

Default-disable the Haiku path in this file's `_make_app` helper:

```python
monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
monkeypatch.setenv("ATTUNE_OPS_SESSIONS_LLM", "0")
```

Both `_make_app` callers in this file target heuristic-only paths. Tests that EXERCISE the LLM live in `test_sessions_route_s3b.py`, which has its own `_make_app` helper and uses `_install_fake_anthropic` to mock the SDK — unaffected by this change.

## Verification

Pre-fix (with `ANTHROPIC_API_KEY` exported):

```
FAILED test_sessions_page_renders_session_rows_when_data_present
1 failed, 23 passed
```

Post-fix:

```
24 passed in 0.29s
```

## Why not a conftest autouse fixture

Considered, but the leak is currently scoped to this one file (only `_make_app` callers here touch the LLM-bearing route). Adding it to `tests/unit/ops/conftest.py` would clobber the s3b tests' explicit `monkeypatch.setenv("ANTHROPIC_API_KEY", ...)` setup. Helper-level fix is the least-invasive choice that still prevents the entire class of bug for any new test added to this file.

## Test plan

- [x] 24/24 `tests/unit/ops/test_sessions.py` pass locally with `ANTHROPIC_API_KEY` set
- [x] pre-commit black + ruff clean
- [ ] CI matrix
