### PR TITLE
docs(specs): decisions backlog catchup from PR #484 post-mortem

### DIFF
--- a/docs/specs/dashboard-pending-writes-journal/requirements.md
+++ b/docs/specs/dashboard-pending-writes-journal/requirements.md
@@ -46,6 +46,24 @@ a question to Patrick, manual review, and a confirmation cycle
 that wouldn't have been needed if the writes had been surfaced
 proactively.
 
+**Recurrence (2026-05-26 → 2026-05-27):** the same shape fired
+again in the `vigorous-pike-a1325f` worktree. A session ended
+at 22:25 on 2026-05-26 with 4 dashboard-driven spec status
+flips uncommitted (`bulletin-curator/design.md`,
+`bulletin-curator/tasks.md`,
+`dashboard-pending-writes-journal/design.md`,
+`dashboard-pending-writes-journal/requirements.md` — all
+flipping `draft → approved`). They sat invisible for 11 hours
+until the 2026-05-27 session opened that worktree to address
+unrelated PR #484 review comments and discovered 43 dirty
+files including the status flips. Recovery via a tar-snapshot
++ 3-way-merge dance against a fresh branch off origin/main
+(see PR #488); the status flips landed cleanly as part of the
+recovery commit `docs(specs): mark bulletin-curator +
+dashboard-pending-writes-journal approved`. Note the irony:
+two of the four silently-lost writes were status flips on
+THIS spec, the one that exists to prevent exactly this.
+
 This is **a class of bug**, not a one-off: any long-running
 service that holds a session-scoped concept of work but
 mutates a shared filesystem outside that scope has the same

--- a/docs/specs/test-discipline-controls/decisions.md
+++ b/docs/specs/test-discipline-controls/decisions.md
@@ -133,3 +133,57 @@ with the executed set.
 **Reference:** PR #485's second codecov-failure cycle
 (2026-05-27); see commit c4099ac2 which closed the partials
 that line coverage missed.
+
+---
+
+## D6 — Threshold scope: patch-level, not file-level (2026-05-27)
+
+**Question:** does the pre-push hook gate at the patch level
+(matches codecov: aggregate coverage of all lines touched in
+the push) or at the file level (each touched file must
+individually meet the threshold)?
+
+**Decision:** **Patch-level.** The hook computes
+`(executed lines in patch) / (total lines in patch)` across
+all touched files and compares against the 90% threshold.
+Individual files inside a patch may sit below 90% as long as
+the aggregate clears the bar.
+
+**Rationale:**
+
+1. **Matches codecov's gate.** Codecov's `codecov/patch`
+   check is patch-level. The pre-push hook's whole purpose
+   is to catch what codecov will reject — running a stricter
+   file-level gate would block pushes that codecov would
+   accept, creating the inverse drift this spec is built to
+   eliminate.
+2. **PR #484 is the worked example.** That PR shipped 92.05%
+   patch coverage with `help_regen.py` at 89.25% — codecov
+   passed, the work was meaningfully covered, and a
+   file-level gate would have blocked it without producing
+   a real quality improvement. Borderline files inside
+   strong patches are normal; they should not block a push
+   when the overall surface is well-tested.
+3. **Hot files self-correct over time.** A file that
+   chronically sits at 89% will eventually be touched by a
+   commit that's small enough that 89% is the patch result,
+   not just a file-within-a-patch result. The hook fires
+   then. Over a series of commits, weak files self-correct
+   because the patch-level gate forces incremental
+   improvement at each touch.
+4. **File-level is a knob we can add later.** If the
+   patch-level gate proves insufficient (e.g. a feature ships
+   over many small commits and persistently keeps one file
+   at 70%), the hook can grow an opt-in
+   `--per-file-threshold` flag. Default stays patch-level.
+
+**Implication for Phase 1 design:** the
+`scripts/coverage_gate/check_patch.py` script computes one
+aggregate ratio. No per-file breakdown in the failure
+message beyond "these files contributed missing lines",
+ranked by missing-line count, for diagnostic value only —
+not as separate gate conditions.
+
+**Reference:** opportunity surfaced 2026-05-27 during
+post-merge review of PR #484 (`docs/specs/ops-help-page`);
+locked here so Phase 1 implementation doesn't re-litigate.


### PR DESCRIPTION
## Summary

Two decision-only edits surfaced during the 2026-05-27 post-merge review of PR #484. Both lock in evidence/decisions that would otherwise decay over time.

## Changes

### 1. \`docs/specs/dashboard-pending-writes-journal/requirements.md\`

Append a **Recurrence (2026-05-26 → 2026-05-27)** entry under the existing "Today's evidence" block, documenting how the same class of bug fired in the \`vigorous-pike-a1325f\` worktree:

- 4 dashboard-driven spec status flips uncommitted at 22:25 on 2026-05-26
- Sat invisible for 11 hours
- Only discovered when a fresh session opened the worktree for unrelated PR #484 review-comment work
- Recovered via tar-snapshot + 3-way-merge dance (PR #488)
- **2 of the 4 lost writes were status flips on this spec** — the one designed to prevent exactly this

Hard evidence for prioritization when the spec advances to Phase 1.

### 2. \`docs/specs/test-discipline-controls/decisions.md\` (new D6)

Lock the pre-push coverage gate at **patch-level**, not file-level, to match codecov. PR #484 is the worked example:
- 92.05% patch coverage passed codecov's \`codecov/patch\` check
- But \`help_regen.py\` inside that patch sat at 89.25%
- File-level gate would have blocked work codecov accepted, creating inverse drift
- D6 prevents Phase 1 implementation from re-litigating

Per-file diagnostic in the failure message is fine; per-file as a separate gate condition is not.

## Test plan

- [ ] CI passes (docs-only; no code changes)
- [ ] No mkdocs nav changes needed
- [ ] Both spec files render cleanly on the site

## Out of scope

This PR does NOT touch the underlying specs' scope, status, or other decisions. Just appends. Pre-existing dashboard pending writes (on \`ops-path-picker\` and \`spec-status-self-truthing\`) are left in the working tree — those are a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)