### PR TITLE
release: v8.0.0 — exit-code contract (breaking) + spend-gate + curator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "7.4.0"
+    "version": "8.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "7.4.0",
+      "version": "8.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.github/workflows/help-freshness.yml
+++ b/.github/workflows/help-freshness.yml
@@ -31,7 +31,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[author]'
-          pip install PyYAML
+          # attune-help provides the bundled corpus that attune-rag's
+          # AttuneHelpCorpus loads for RAG-grounded regen. Without it,
+          # `attune-author generate` raises (ModuleNotFoundError:
+          # attune_help) and the set -e regen step fails.
+          pip install PyYAML attune-help
 
       - name: Check completeness (pre-regen)
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,15 @@ concurrency:
 
 jobs:
   test:
-    # Route the ubuntu matrix entries to the org's 8-core/32GB larger
-    # runner for ~2x parallelism + memory headroom (larger-runners spec).
-    # The matrix `os` value stays "ubuntu-latest" so the generated job
-    # name — and the required status check "test (ubuntu-latest, 3.12)"
-    # — is unchanged; only the runner the job lands on differs. macOS
-    # and Windows stay on default runners.
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'ubuntu-8core-or-linux-32gb' || matrix.os }}
+    # TEMPORARY (2026-06-07): ubuntu matrix entries run on default
+    # GitHub-hosted `ubuntu-latest` runners. The 8-core/32GB larger
+    # runner (`ubuntu-8core-or-linux-32gb`) was de-provisioned, which left
+    # the ubuntu Tests jobs unschedulable (no runner matched the label) —
+    # so the routing was reverted to unblock CI. Follow-up: re-provision a
+    # working larger runner and restore the conditional routing for the
+    # ~2x parallelism + memory headroom (see the larger-runners spec).
+    # macOS and Windows stay on default runners as before.
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 75
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.0] — 2026-06-07
+
+A major release. The headline is a **breaking change to the exit-code
+contract of `attune workflow run`** (an honest `0/1/2/3` instead of an
+always-zero exit — see Migration below), shipped alongside two substantial
+new feature lines — **collaboration spend-gates** and the **curator** — plus
+ops/workflow reliability fixes. Library APIs are otherwise unchanged.
+
+### Added
+
+- **Spend gate on `attune workflow run`.** The first billable run of a
+  session surfaces an estimate and asks for an explicit go before any
+  paid call, then establishes a ~5h spend window (aligned to Anthropic's
+  rolling usage window) so later runs proceed silently until it expires or
+  a run would exceed it. Framing matches your meter — a dollar band for
+  API users, usage-headroom (no misleading `$0`) for subscription users. A
+  non-interactive run with no pre-authorization **blocks** rather than
+  spending silently. Knobs: `ATTUNE_SPEND_GATE=off` (or
+  `ATTUNE_MAX_BUDGET_USD=0`) disables it; `ATTUNE_SPEND_GATE_AUTHORIZED=1`
+  opts a CI / daemon context in. `--no-llm` runs never reach the gate. See
+  `docs/specs/collaboration-gates/` and the CLI reference's "Spend gate"
+  section. (Phase 1: T1–T5; #637–#640)
+- **Curator.** An agent-backed curation feature: agent invocation with
+  structured output (Phase 2), a `/curator` page on the ops dashboard, and
+  a CLI with bulletin cross-linking (Phase 3). (#631, #634, #635)
+- **`WorkflowReport` data model.** Structured, machine-readable workflow
+  run reporting (Section ABC + tiers). (#649)
+- **Per-process client-token gate on mutating ops endpoints.** The ops
+  dashboard API now requires a per-process client token on mutating
+  endpoints — defense-in-depth against cross-process request forgery. (#641)
+- **Doc cross-reference link pre-validation.** A pre-commit reader flags
+  unresolved documentation cross-ref links before they land
+  (docs-link-prevalidation Phase 4). (#644)
+- **Public help pages on `attune-ai.dev`.** The `.help` corpus now renders
+  as browsable web pages. (#615)
+
 ### Changed (Breaking)
 
 - **`attune workflow run` now exits non-zero when the workflow
@@ -46,21 +82,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exit code is honest. See
   `docs/specs/workflow-failure-exit-propagation/`.
 
-### Added
+### Fixed
 
-- **Spend gate on `attune workflow run`.** The first billable run of a
-  session surfaces an estimate and asks for an explicit go before any
-  paid call, then establishes a ~5h spend window (aligned to
-  Anthropic's rolling usage window) so later runs proceed silently
-  until it expires or a run would exceed it. Framing matches your
-  meter — a dollar band for API users, usage-headroom (no misleading
-  `$0`) for subscription users. A non-interactive run with no
-  pre-authorization **blocks** rather than spending silently. Knobs:
-  `ATTUNE_SPEND_GATE=off` (or `ATTUNE_MAX_BUDGET_USD=0`) disables it;
-  `ATTUNE_SPEND_GATE_AUTHORIZED=1` opts a CI / daemon context in.
-  `--no-llm` runs never reach the gate. See
-  `docs/specs/collaboration-gates/` and the CLI reference's
-  "Spend gate" section. (Phase 1: T1–T5.)
+- **Workflow error fidelity** — the capture-call path now surfaces the
+  real underlying error instead of masking it as an `IndexError`. (#650)
+- **Ops `/sessions` no longer blocks the event loop** — the synchronous
+  Anthropic SDK call is deferred to a thread so the dashboard stays
+  responsive during a session fetch. (#652)
+- **Runner stability** — `RunnerService`'s executor task is pinned so it
+  can't be garbage-collected mid-flight. (#651)
 
 ## [7.4.0] — 2026-06-04
 

--- a/docs/migration/redis-plugin-migration.md
+++ b/docs/migration/redis-plugin-migration.md
@@ -57,6 +57,18 @@ with TTL, glob scan, pattern staging, and an in-process EventBus
 "decouple Redis." Not in scope for this spec; deferred to a
 hypothetical follow-up.
 
+> **Deprecation schedule (updated for v8.0.0).** The legacy facade
+> modules (`attune.redis_memory`, `attune.redis_memory_storage`,
+> `attune.redis_memory_coordination`, `attune.redis_memory_patterns`,
+> `attune.redis_config`, and the deprecated parts of
+> `attune.memory.config`) carried `REMOVE IN v8.0.0` markers gated on
+> redis-decoupling spec P3. Because P3 (full removal) was descoped and
+> the spec archived — and because these still power live subsystems —
+> the markers were **rescheduled to `REMOVE IN v9.0.0`** at the 8.0.0
+> cut. They remain supported, deprecated, and Redis-coupled by design;
+> actual removal still awaits the memory-subsystem rewrite described
+> above.
+
 ## Install path
 
 ### Vanilla — Redis-free

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "7.4.0"
+    "version": "8.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "7.4.0",
+      "version": "8.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "7.4.0",
+  "version": "8.0.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "7.4.0"
+__version__ = "8.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "7.4.0"
+version = "8.0.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/src/attune/memory/config.py
+++ b/src/attune/memory/config.py
@@ -8,7 +8,7 @@ Copyright 2025 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0
 """
 
-# REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
+# REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
 
 import os
 from urllib.parse import urlparse

--- a/src/attune/redis_config.py
+++ b/src/attune/redis_config.py
@@ -1,6 +1,6 @@
 """Redis Configuration for Attune AI (deprecated).
 
-REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
+REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
 
 .. deprecated::
     Use ``attune_redis.config.RedisPluginConfig`` for new code.

--- a/src/attune/redis_memory.py
+++ b/src/attune/redis_memory.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis.AMSMemoryBackend.
 
-REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
+REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
 
 Legacy facade for RedisShortTermMemory. Kept for backward
 compatibility. New code should use the ``attune_redis``

--- a/src/attune/redis_memory_coordination.py
+++ b/src/attune/redis_memory_coordination.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis for coordination.
 
-REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
+REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
 
 Legacy coordination mixins kept for backward compatibility.
 New code should use ``attune_redis.signals.RedisSignalBus``.

--- a/src/attune/redis_memory_patterns.py
+++ b/src/attune/redis_memory_patterns.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis for pattern promotion.
 
-REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
+REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
 
 Legacy pattern staging mixins kept for backward
 compatibility. New code should use

--- a/src/attune/redis_memory_storage.py
+++ b/src/attune/redis_memory_storage.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis.AMSMemoryBackend.
 
-REMOVE IN v8.0.0 — gated on redis-decoupling spec P3 (docs/specs/redis-decoupling/); migration path: docs/migration/redis-plugin-migration.md
+REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
 
 Legacy storage engine kept for backward compatibility.
 New code should use ``attune_redis.memory.AMSMemoryBackend``.

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "7.4.0"
+version = "8.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## release: v8.0.0 — exit-code contract (breaking) + spend-gate + curator

Major bump. Completes the release notes from the **43 commits since v7.4.0** and clears the deprecation gate honestly (see below). **No risky public-API removal** — see the redis-facade note.

### Highlights
- 🔴 **Breaking:** `attune workflow run` now has an honest exit-code contract (`0/1/2/3`) instead of always-zero. Full migration snippet in the CHANGELOG.
- **Spend gate (Phase 1)** on `attune workflow run` — estimate + go-ahead before paid calls, ~5h spend window, blocks non-interactive unpaid runs. (#637–#640)
- **Curator** — agent invocation + structured output, `/curator` dashboard page, CLI + bulletin cross-link. (#631/#634/#635)
- `WorkflowReport` data model (#649); per-process client-token gate on mutating ops endpoints (#641); doc cross-ref pre-validation (#644); public help pages on attune-ai.dev (#615).
- Fixes: workflow error fidelity (#650), ops `/sessions` event-loop blocking (#652), runner GC stability (#651).
- **CI fix:** `help-freshness` workflow installs `attune-help` so RAG-grounded regen stops failing with `ModuleNotFoundError: attune_help`.

### Redis-facade deprecation markers — rescheduled, not removed
The version bump tripped the `check-deprecation-markers` gate: 6 redis-facade modules carried `REMOVE IN v8.0.0`. **Investigation (migration doc) showed full removal was descoped** when the redis-decoupling spec was scoped down in v6.8.0 — these subsystems power live unified memory / MCP memory tools / telemetry and removing them is "a memory-subsystem rewrite, not in scope." So the markers were **rescheduled to `v9.0.0`** with a note; the code stays, deprecated and supported. (Avoided gutting a live subsystem mid-release.)

### Gates
Pre-commit fully green locally (deprecation markers, help-regen, ruff, bandit, secrets). `python -m build` + `twine check` passed for sdist+wheel. Publishing is via GitHub Release → OIDC, gated after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
