### PR TITLE
release: v8.0.1 — docs/metadata patch (attune-ai.dev + chips + links)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.0.0"
+    "version": "8.0.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "15 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.1] — 2026-06-07
+
+Docs/metadata patch — no code or library-behaviour changes (identical to 8.0.0).
+
+### Changed
+- **PyPI Homepage → [attune-ai.dev](https://attune-ai.dev)** and a "Docs &
+  guides" link added to the README header. The `smartaimemory.com/framework-docs`
+  Documentation / Getting-Started / FAQ links are unchanged.
+- **README chips refreshed** — tests badge `19,000+` → `20,000+` passing
+  (actual on 8.0.0 CI: 20,379); coverage badge `94%` → `95%` (actual 94.65%).
+- **Fixed 3 repo-relative README links** that 404'd on the PyPI page (now
+  absolute GitHub URLs).
+
 ## [8.0.0] — 2026-06-07
 
 A major release. The headline is a **breaking change to the exit-code

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 
 **Multi-agent developer workflows for Claude Code.**
 
+🌐 **Docs & guides: [attune-ai.dev](https://attune-ai.dev)**
+
 [![PyPI](https://img.shields.io/pypi/v/attune-ai?color=blue)](https://pypi.org/project/attune-ai/)
 [![Downloads](https://static.pepy.tech/badge/attune-ai)](https://pepy.tech/projects/attune-ai)
 [![Downloads/month](https://static.pepy.tech/badge/attune-ai/month)](https://pepy.tech/projects/attune-ai)
 [![Downloads/week](https://static.pepy.tech/badge/attune-ai/week)](https://pepy.tech/projects/attune-ai)
-[![Tests](https://img.shields.io/badge/tests-19%2C000%2B%20passing-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/tests.yml)
-[![Coverage](https://img.shields.io/badge/coverage-94%25-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai)
+[![Tests](https://img.shields.io/badge/tests-20%2C000%2B%20passing-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/tests.yml)
+[![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai)
 [![Security](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml/badge.svg)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml)
 [![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE)
@@ -243,8 +245,8 @@ related-but-different things, and the per-claim number is the right
 The gain comes from the prompting contract (citation-per-claim), not
 from retrieval. Full methodology:
 
-- [`docs/rag/faithfulness-decision-2026-04-19.md`](docs/rag/faithfulness-decision-2026-04-19.md)
-- [`docs/rag/ab-report-2026-04-19.json`](docs/rag/ab-report-2026-04-19.json)
+- [`docs/rag/faithfulness-decision-2026-04-19.md`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/rag/faithfulness-decision-2026-04-19.md)
+- [`docs/rag/ab-report-2026-04-19.json`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/rag/ab-report-2026-04-19.json)
 
 ### Help resolver — 48/48 benchmark queries pass at P@1
 
@@ -254,7 +256,7 @@ from retrieval. Full methodology:
 | medium | 26 | 26/26 (100%) | paraphrases + industry terminology |
 | hard | 4 | 0/4 (XFAIL) | shared-tag collisions — structural ambiguity |
 
-- [`tests/unit/help/fixtures/golden_queries.yaml`](tests/unit/help/fixtures/golden_queries.yaml)
+- [`tests/unit/help/fixtures/golden_queries.yaml`](https://github.com/Smart-AI-Memory/attune-ai/blob/main/tests/unit/help/fixtures/golden_queries.yaml)
 
 ---
 

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.0.0"
+    "version": "8.0.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.0.0"
+__version__ = "8.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.0.0"
+version = "8.0.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
@@ -378,7 +378,7 @@ attune = "attune.cli_minimal:main"
 # Use 'attune' CLI instead
 
 [project.urls]
-Homepage = "https://www.smartaimemory.com"
+Homepage = "https://attune-ai.dev"
 Documentation = "https://www.smartaimemory.com/framework-docs/"
 "Getting Started" = "https://www.smartaimemory.com/framework-docs/tutorials/quickstart/"
 FAQ = "https://www.smartaimemory.com/framework-docs/reference/FAQ/"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.0.0"
+version = "8.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## release: v8.0.1 — docs/metadata patch

**No code or library-behaviour changes** (identical to 8.0.0). Refreshes the PyPI page after a few stale/broken bits were spotted post-release.

### Changed
- **PyPI Homepage → [attune-ai.dev](https://attune-ai.dev)** + a "🌐 Docs & guides" link in the README header (mirrors attune-rag). The `smartaimemory.com/framework-docs` Documentation/Getting-Started/FAQ links are kept.
- **README chips refreshed** (they're static/hand-maintained and had gone stale): tests `19,000+` → `20,000+` passing (actual on 8.0.0 CI: **20,379**); coverage `94%` → `95%` (actual **94.65%**).
- **Fixed 3 repo-relative README links** that 404'd on the PyPI page → absolute GitHub URLs.
- version `8.0.0` → `8.0.1` across pyproject + all plugin manifests + uv.lock.

`build` + `twine check` pass. Follow-up (separate PR): auto-maintain the tests/coverage chips from CI so they never go stale again.
