### PR TITLE
chore(ci): self-maintaining README chips (dynamic coverage + freshness gate)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,6 +114,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
+    # Catch README badge rot: fails if the tests-count floor over-claims or
+    # drifts far below the real collected count, or if coverage regressed to a
+    # hardcoded value instead of the dynamic Codecov badge. Cheap (collect-only).
+    - name: Check README badge freshness
+      run: python scripts/check_badge_freshness.py
+
     - name: Run tests with coverage
       run: |
         echo "[mem-baseline $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "total="$2"MB used="$3"MB avail="$7"MB"}')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Self-maintaining README chips.** The coverage badge is now a live
+  Codecov badge (auto-updates, zero upkeep) instead of a hardcoded `NN%`.
+  The tests badge stays a round floor (`20,000+`); a new
+  `scripts/check_badge_freshness.py` (wired into the coverage CI job)
+  fails if that floor ever over-claims or drifts far below the real
+  collected count, or if coverage regresses to a hardcoded value — so the
+  chips can't silently rot (the issue that prompted 8.0.1).
+
 ## [8.0.1] — 2026-06-07
 
 Docs/metadata patch — no code or library-behaviour changes (identical to 8.0.0).

--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@
 
 🌐 **Docs & guides: [attune-ai.dev](https://attune-ai.dev)**
 
+<!-- Badge maintenance: PyPI/Downloads/Coverage/Security are LIVE (auto-update,
+     no upkeep). The tests count is a manually-maintained round FLOOR — bump it
+     only on major drift (e.g. once the suite clears 25,000); a round floor
+     can't go subtly stale the way a precise value does. `scripts/check_badge_freshness.py`
+     (CI) fails if the floor ever over-claims or drifts too far below reality. -->
 [![PyPI](https://img.shields.io/pypi/v/attune-ai?color=blue)](https://pypi.org/project/attune-ai/)
 [![Downloads](https://static.pepy.tech/badge/attune-ai)](https://pepy.tech/projects/attune-ai)
 [![Downloads/month](https://static.pepy.tech/badge/attune-ai/month)](https://pepy.tech/projects/attune-ai)
 [![Downloads/week](https://static.pepy.tech/badge/attune-ai/week)](https://pepy.tech/projects/attune-ai)
 [![Tests](https://img.shields.io/badge/tests-20%2C000%2B%20passing-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/tests.yml)
-[![Coverage](https://img.shields.io/badge/coverage-95%25-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai)
+[![Coverage](https://img.shields.io/codecov/c/github/Smart-AI-Memory/attune-ai?branch=main)](https://codecov.io/gh/Smart-AI-Memory/attune-ai)
 [![Security](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml/badge.svg)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml)
 [![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE)

--- a/scripts/check_badge_freshness.py
+++ b/scripts/check_badge_freshness.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Guard the manually-maintained README badges against drift.
+
+Coverage is a *live* Codecov badge (zero upkeep). The tests badge is a round
+**floor** (`tests-20,000+`) — a round floor can't go subtly stale the way a
+precise value does, but it shouldn't *over-claim* or fall *far* behind reality.
+This check fails when:
+
+  1. the tests floor OVER-CLAIMS — actual collected tests < the badge floor, or
+  2. the tests floor is STALE — actual exceeds the floor by more than ``MARGIN``
+     (time to bump the round number), or
+  3. the coverage badge has regressed to a HARDCODED ``coverage-NN%`` instead of
+     the dynamic Codecov badge.
+
+Usage::
+
+    python scripts/check_badge_freshness.py     # exit 1 on any violation
+
+Run in CI (the coverage job already has the suite installed). Pure floor-check,
+not an auto-updater — markers/values that drift get *caught*, not silently rot.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+#: How far the actual test count may exceed the round floor before we nag.
+MARGIN = 5000
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+README = REPO_ROOT / "README.md"
+
+
+def collected_test_count() -> int | None:
+    """Return pytest's collected-test count, or None if collection fails."""
+    try:
+        out = subprocess.run(
+            [sys.executable, "-m", "pytest", "--collect-only", "-q", "--no-header"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            timeout=600,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    blob = out.stdout + out.stderr
+    m = re.search(r"(\d[\d,]*)\s+tests?\s+collected", blob)
+    if m:
+        return int(m.group(1).replace(",", ""))
+    n = sum(1 for ln in out.stdout.splitlines() if "::" in ln)
+    return n or None
+
+
+def main() -> int:
+    text = README.read_text(encoding="utf-8")
+    problems: list[str] = []
+
+    # 1/2 — tests floor. The badge URL encodes the comma as %2C and the
+    # trailing "+" as %2B, e.g. ``tests-20%2C000%2B`` (also accept the
+    # literal ``tests-20,000+`` form).
+    m = re.search(r"tests-([0-9][0-9,]*(?:%2C[0-9]+)*)(?:%2B|\+)", text)
+    if not m:
+        problems.append("tests badge not found, or not a round floor (`tests-N,000+`).")
+    else:
+        floor = int(m.group(1).replace("%2C", "").replace(",", ""))
+        actual = collected_test_count()
+        if actual is None:
+            print("  (note: could not collect tests; skipping floor comparison)")
+        elif actual < floor:
+            problems.append(
+                f"tests badge OVER-CLAIMS: floor {floor:,} > actual collected {actual:,}."
+            )
+        elif actual - floor > MARGIN:
+            problems.append(
+                f"tests badge STALE: actual {actual:,} exceeds floor {floor:,} by "
+                f">{MARGIN:,} — bump the round floor."
+            )
+
+    # 3 — coverage must stay the dynamic Codecov badge
+    if re.search(r"badge/coverage-\d+%", text) or re.search(r"coverage-\d+%25", text):
+        problems.append(
+            "coverage badge is hardcoded; use the dynamic Codecov badge "
+            "(img.shields.io/codecov/c/github/...)."
+        )
+
+    if problems:
+        print("Badge freshness check FAILED:")
+        for p in problems:
+            print("  -", p)
+        print("\nFix: bump the README tests floor and/or restore the dynamic coverage badge.")
+        return 1
+
+    print("Badge freshness OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## chore(ci): self-maintaining README chips

Follow-up to 8.0.1 — kills the badge-rot at the root rather than relying on "remember to bump it each release." (8.0.1 had to fix a stale `19,000+ tests` / `94%` chip and 3 broken links by hand.)

### The durable pick: dynamic where it drifts, guarded where it doesn't
- **Coverage → live Codecov badge** (`img.shields.io/codecov/c/github/...`). You already upload to Codecov in the coverage job, so this **auto-tracks real coverage forever — zero maintenance.** Replaces the hardcoded `coverage-NN%`.
- **Tests count → round floor (`20,000+`)** — a round floor can't go subtly stale the way a precise number does. New **`scripts/check_badge_freshness.py`** (wired into the coverage CI job) **fails** if:
  1. the floor *over-claims* (badge floor > actual collected tests),
  2. the floor is *stale* (actual exceeds it by >5,000 → time to bump the round number), or
  3. coverage regresses to a hardcoded value instead of the dynamic badge.

So a future drift gets **caught in CI**, not silently shipped.

### Why not auto-rewrite the count?
A dynamic test-count badge needs either a committed JSON-endpoint (CI commit loops) or per-run hosting — more fragile machinery than it's worth. A generous round floor + a drift-guard is the low-risk durable answer. (Reasoning documented in the README badge comment + the script docstring.)

### Verification
`check_badge_freshness.py` runs clean locally (parses the `%2C`-encoded floor = 20,000; coverage now dynamic → OK). In CI the coverage job collects ~20,379 tests → 379 under the 5,000 margin → passes. Docs/CI only; no library code touched.
