### PR TITLE
feat(redis): implement AMS recent() for SessionStart auto-recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **AMS backend now powers SessionStart auto-recall.** The
+  `attune-redis` `AMSMemoryBackend.recent()` method is no longer a
+  stub — query-less recency listing is implemented, so users on the
+  Redis Agent Memory Server backend get the same newest-first
+  SessionStart recall (with soft same-project `cwd` priority) that the
+  default file backend already provides. Ordering is applied
+  client-side by `created_at` because AMS's server-side ordering is
+  relevance-based, not recency-based (verified against a live server).
+  Best-effort: degrades to `[]` on any AMS error, never raises.
+
 ### Changed
 - **Self-maintaining README chips.** The coverage badge is now a live
   Codecov badge (auto-updates, zero upkeep) instead of a hardcoded `NN%`.

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -418,18 +418,57 @@ class AMSMemoryBackend:
             return []
 
     def recent(self, limit: int = 5, **filters: Any) -> list[dict]:
-        """Query-less recent findings (SessionStart recall) — best-effort.
+        """Most-recent long-term findings (no query) — powers SessionStart recall.
 
-        AMS is semantic-first; a query-less recency *list* is not a verified
-        primitive of the client yet, so this returns ``[]`` for now rather
-        than guess the API. AMS users still get full query-driven recall via
-        ``search`` (the ``/recall`` skill) and AMS's own auto-surfacing; the
-        file backend implements ``recent`` fully and powers SessionStart
-        auto-recall on the default install. Closing this is tracked as a
-        follow-up (verify the client's list/recency path against a live
-        server, then sort by ``created_at`` desc with a soft ``cwd`` filter).
+        Mirrors the file backend's ``recent``: newest-first, with same-project
+        findings surfaced ahead of others when ``cwd`` is given (soft priority).
+        Returns the same record shape as ``search`` (minus ``score``).
+
+        AMS has no query-less recency *list* primitive, but an empty-text
+        ``search_long_term_memory`` returns the namespace's memories, and the
+        server's ordering is relevance-based (verified not reliably recency-
+        sorted even with ``server_side_recency``), so the recency ordering is
+        applied client-side by ``created_at``. We over-fetch a bounded window
+        (the server can't sort by recency for us) and truncate after sorting.
+        Best-effort; returns ``[]`` on any AMS error, never raises.
         """
-        return []
+        cwd = filters.get("cwd")
+        # Over-fetch: server ordering isn't recency, so pull a window wide
+        # enough that the true most-recent ``limit`` are within it, then sort
+        # client-side. 30-day pruning keeps per-namespace counts bounded.
+        overscan = max(limit * 10, 50)
+        try:
+            results = _run_sync(
+                self._client.search_long_term_memory(
+                    text="",
+                    namespace={"eq": self._namespace},
+                    limit=overscan,
+                )
+            )
+        except Exception as e:  # noqa: BLE001
+            # INTENTIONAL: Graceful degradation for AMS HTTP errors
+            logger.error("recent_failed: limit=%s error=%s", limit, e)
+            return []
+
+        memories = list(results.memories)
+        # Newest-first by created_at (None sorts last via epoch-0 fallback).
+        memories.sort(
+            key=lambda m: (m.created_at.timestamp() if m.created_at else 0.0),
+            reverse=True,
+        )
+        if cwd:
+            # Stable secondary sort: cwd matches first, recency preserved within.
+            memories.sort(key=lambda m: 0 if _cwd_from_topics(m.topics) == cwd else 1)
+        return [
+            {
+                "id": m.id,
+                "text": m.text,
+                "topics": m.topics,
+                "cwd": _cwd_from_topics(m.topics),
+                "session_id": m.session_id,
+            }
+            for m in memories[:limit]
+        ]
 
     def promote(self, session_id: str | None = None) -> bool:
         """Trigger promotion of working memories to long-term.

--- a/attune_redis/tests/conftest.py
+++ b/attune_redis/tests/conftest.py
@@ -46,6 +46,7 @@ class FakeMemoryRecord:
         entities: list[str] | None = None,
         memory_type: str = "semantic",
         created_at: Any = None,
+        session_id: str = "test-session",
     ) -> None:
         self.id = record_id
         self.text = text
@@ -53,6 +54,7 @@ class FakeMemoryRecord:
         self.entities = entities or []
         self.memory_type = memory_type
         self.created_at = created_at
+        self.session_id = session_id
 
 
 class FakeMemoryRecordResults:

--- a/attune_redis/tests/test_integration.py
+++ b/attune_redis/tests/test_integration.py
@@ -167,6 +167,63 @@ class TestConnectionLifecycle:
         b2.close()
 
 
+class TestRecentLongTerm:
+    """Test query-less recency listing against live AMS (SessionStart recall)."""
+
+    def test_recent_newest_first_with_cwd_priority(self):
+        """recent() returns long-term findings newest-first, cwd-prioritized.
+
+        Uses a per-run namespace for isolation (a persistent semantic store
+        accumulates across runs) and polls for eventual indexing. Findings
+        are phrased distinctly to avoid AMS's semantic dedup on write.
+        """
+        import time
+
+        from attune_redis.memory import AMSMemoryBackend
+
+        ns = f"recent-itest-{uuid.uuid4().hex[:8]}"
+        config = RedisPluginConfig(
+            ams_base_url=os.environ.get("AMS_BASE_URL", "http://localhost:8000"),
+            ams_namespace=ns,
+        )
+        b = AMSMemoryBackend(config=config)
+        try:
+            findings = [
+                ("Repaired the event-loop reuse defect in the wrapper", "/proj/alpha"),
+                ("Switched the corpus loader to direct filesystem reads", "/proj/beta"),
+                ("Wired int8 vector quantization through the factory seam", "/proj/alpha"),
+                ("Observed server ordering is relevance rather than recency", "/proj/beta"),
+            ]
+            for text, cwd in findings:
+                assert b.remember(text, topics=[f"cwd:{cwd}"]) is True
+                time.sleep(0.5)
+
+            # Eventual indexing: poll until all four are visible.
+            out: list = []
+            for _ in range(20):
+                time.sleep(1.0)
+                out = b.recent(limit=10)
+                if len(out) >= 4:
+                    break
+            assert len(out) >= 4, f"only {len(out)} findings indexed"
+
+            # Newest-first: the last-written finding leads.
+            assert out[0]["text"].startswith("Observed server ordering")
+
+            # Soft cwd priority: same-project findings surface first.
+            out_alpha = b.recent(limit=10, cwd="/proj/alpha")
+            assert out_alpha[0]["cwd"] == "/proj/alpha"
+            assert out_alpha[1]["cwd"] == "/proj/alpha"
+
+            # File-backend record shape (no score).
+            assert set(out[0].keys()) == {"id", "text", "topics", "cwd", "session_id"}
+
+            # Limit honored.
+            assert len(b.recent(limit=2)) == 2
+        finally:
+            b.close()
+
+
 class TestErrorHandling:
     """Test graceful degradation with bad config."""
 

--- a/attune_redis/tests/test_memory.py
+++ b/attune_redis/tests/test_memory.py
@@ -242,3 +242,99 @@ class TestSearchable:
             session_id="s-42",
             namespace="test",
         )
+
+
+# =================================================================
+# SearchableMemoryBackend: recent (query-less SessionStart recall)
+# =================================================================
+
+
+def _rec(record_id, text, ts, *, topics=None):
+    """Build a FakeMemoryRecord with a created_at offset by ``ts`` seconds."""
+    from datetime import datetime, timedelta, timezone
+
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return FakeMemoryRecord(
+        record_id=record_id,
+        text=text,
+        topics=topics or [],
+        created_at=base + timedelta(seconds=ts),
+    )
+
+
+class TestRecent:
+    """Test query-less recency listing (powers SessionStart recall)."""
+
+    def test_recent_empty_returns_empty_list(self, backend):
+        """recent() returns [] when the namespace has no memories."""
+        assert backend.recent() == []
+
+    def test_recent_uses_empty_text_query(self, backend, mock_ams_client):
+        """recent() issues an empty-text long-term search scoped to the namespace."""
+        backend.recent(limit=3)
+        _, kwargs = mock_ams_client.search_long_term_memory.call_args
+        assert kwargs["text"] == ""
+        assert kwargs["namespace"] == {"eq": "test"}
+        # Over-fetches a bounded window (server can't recency-sort for us).
+        assert kwargs["limit"] >= 3
+
+    def test_recent_sorts_newest_first(self, backend, mock_ams_client):
+        """recent() orders records by created_at descending, regardless of
+        the order the server returned them in."""
+        mock_ams_client.search_long_term_memory.return_value = FakeMemoryRecordResults(
+            memories=[
+                _rec("old", "oldest", 0),
+                _rec("new", "newest", 100),
+                _rec("mid", "middle", 50),
+            ]
+        )
+        out = backend.recent(limit=10)
+        assert [d["text"] for d in out] == ["newest", "middle", "oldest"]
+
+    def test_recent_cwd_soft_priority(self, backend, mock_ams_client):
+        """recent(cwd=X) surfaces same-cwd findings first, recency preserved
+        within each group."""
+        mock_ams_client.search_long_term_memory.return_value = FakeMemoryRecordResults(
+            memories=[
+                _rec("b-new", "beta newer", 100, topics=["cwd:/proj/beta"]),
+                _rec("a-old", "alpha older", 10, topics=["cwd:/proj/alpha"]),
+                _rec("a-new", "alpha newer", 90, topics=["cwd:/proj/alpha"]),
+            ]
+        )
+        out = backend.recent(limit=10, cwd="/proj/alpha")
+        # alpha group first (newer before older), then beta.
+        assert [d["text"] for d in out] == ["alpha newer", "alpha older", "beta newer"]
+        assert out[0]["cwd"] == "/proj/alpha"
+
+    def test_recent_honors_limit(self, backend, mock_ams_client):
+        """recent() truncates to ``limit`` after sorting."""
+        mock_ams_client.search_long_term_memory.return_value = FakeMemoryRecordResults(
+            memories=[_rec(f"m{i}", f"finding {i}", i) for i in range(10)]
+        )
+        assert len(backend.recent(limit=2)) == 2
+
+    def test_recent_maps_record_shape(self, backend, mock_ams_client):
+        """recent() returns the file-backend record shape (no score)."""
+        mock_ams_client.search_long_term_memory.return_value = FakeMemoryRecordResults(
+            memories=[_rec("m1", "a finding", 5, topics=["cwd:/p", "tag"])]
+        )
+        out = backend.recent(limit=1)
+        assert set(out[0].keys()) == {"id", "text", "topics", "cwd", "session_id"}
+        assert out[0]["cwd"] == "/p"
+        assert out[0]["topics"] == ["cwd:/p", "tag"]
+
+    def test_recent_handles_missing_created_at(self, backend, mock_ams_client):
+        """recent() tolerates records with created_at=None (sorts them last)."""
+        mock_ams_client.search_long_term_memory.return_value = FakeMemoryRecordResults(
+            memories=[
+                FakeMemoryRecord(record_id="none", text="no-ts", created_at=None),
+                _rec("dated", "dated", 50),
+            ]
+        )
+        out = backend.recent(limit=10)
+        assert [d["text"] for d in out] == ["dated", "no-ts"]
+
+    def test_recent_returns_empty_on_error(self, backend, mock_ams_client):
+        """recent() degrades gracefully to [] on AMS errors, never raises."""
+        mock_ams_client.search_long_term_memory.side_effect = ConnectionError("boom")
+        assert backend.recent() == []


### PR DESCRIPTION
## What

Implements `AMSMemoryBackend.recent()` — previously a stub returning `[]`. AMS-backend users now get the same query-less, newest-first **SessionStart auto-recall** that the default file backend already provides (with soft same-project `cwd` priority).

## Why

`recent()` powers SessionStart recall. The file backend implemented it; the AMS backend returned `[]`, so AMS users silently got no auto-surfaced recent findings. The stub's own comment tracked this as a follow-up pending a live-server verification of the client's recency path.

## How

- Empty-text `search_long_term_memory(text="", namespace={"eq": ns})` returns the namespace's long-term findings.
- **Sort newest-first client-side by `created_at`** — verified against a live AMS that server-side ordering is relevance-based, *not* recency-based, even with `RecencyConfig(server_side_recency=True)`.
- Soft `cwd` priority via stable secondary sort (mirrors the file backend).
- Returns the file-backend record shape `{id, text, topics, cwd, session_id}`; degrades to `[]` on any AMS error, never raises.

## Verification

- Unit: 8 new mocked tests (sort, cwd-priority, limit, shape, `None` `created_at`, error path).
- Integration: 1 live round-trip test (per-run namespace, polls for eventual indexing) — auto-skips when AMS is unavailable.
- `attune_redis` suite: **102 passed, 1 skipped**; ruff + black clean.
- **Live dogfood** against AMS 0.14.0 (redis-stack + Ollama nomic-768): asserted newest-first, cwd-priority, record shape, and limit.

## Out of scope (flagged, not touched)

- `remember()` uses `create_long_term_memory(deduplicate=True)`; AMS semantic dedup can silently merge a distinct-but-similar finding. Arguably desirable, but a footgun — candidate follow-up.
- Pre-existing `TestKeys` integration tests fail against live AMS 0.14.0 (working-memory `keys()` returns `[]` after `stash`) — reproduces with this PR's changes stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
