### PR TITLE
fix(redis): dedup-safe remember() + clamp recent() over-fetch to AMS cap

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6997,3 +6997,32 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   `pytest.ini` injects `-n auto`). Integration tests gate on
   `@pytest.mark.integration` + an `_ams_available()` skip, so they
   no-op in CI (no AMS) and only run locally with `AMS_BASE_URL` set.
+
+- **AMS 0.14.0 working-memory `set_working_memory_data(preserve_existing=
+  True)` REPLACES the whole `data` dict on every call — it does NOT merge
+  keys** (found fixing the `keys()` clobber, PR #667). `preserve_existing`
+  preserves the session's *messages/memories*, not existing `data` keys, so
+  a second `stash("b")` over `set_working_memory_data` wiped the first key —
+  breaking `keys()` AND multi-key `retrieve()` (`stash("a"); stash("b");
+  retrieve("a")` → `None`). The single-key retrieve test passed only because
+  it never did a second stash. **The merge primitive is
+  `update_working_memory_data(merge_strategy="merge")`** (verified live; also
+  auto-creates the session). Diagnosis ruled out eventual-consistency (reads
+  were immediately consistent) and session-creation prerequisites — it's an
+  API behavior. The mocked test double HID it: its fake `preserve_existing`
+  merged, so the unit suite was green while the real backend was broken — fix
+  the mock to match AMS's real replace-semantics so it can't mask the class
+  of bug again (pairs with "duck-typed fakes fall through silently").
+
+- **`get_or_create_working_memory` (the recommended replacement for the
+  deprecated `get_working_memory` in agent-memory-client 0.14.0) INTERNALLY
+  calls `get_working_memory` and emits its own DeprecationWarning** —
+  migrating call sites off the directly-deprecated method is forward-correct
+  (future-proofs for when `get_working_memory` is removed; the client must
+  fix its own `get_or_create` then) but does NOT silence the warning under
+  0.14.0; that's an upstream quirk to track, not something a consumer can fix.
+  Caveat caught via `-W error::DeprecationWarning`: turning the warning into
+  an error makes the backend's broad `except Exception` SWALLOW it (a Warning
+  subclasses Exception), so a "graceful degradation" catch returns `None`/`[]`
+  and tests fail confusingly — don't run AMS integration tests with
+  `-W error::DeprecationWarning`; the warning is benign upstream noise.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6938,3 +6938,62 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   bleeding across process/session boundaries in unexpected
   ways), different surface (parent-shell env into pytest, vs
   IDE config into cloud sync).
+
+- **AMS (`agent-memory-client`/`-server` 0.14.0) long-term memory has
+  four live-verified behaviors that shape any `attune_redis` backend
+  code — and a mocked unit suite is BLIND to all of them** (found
+  building `AMSMemoryBackend.recent()` + `remember()` dedup, PRs #660 +
+  #666): (1) **Server-side ordering is RELEVANCE-based, not
+  recency-based** — even `search_long_term_memory(..., recency=
+  RecencyConfig(recency_weight=1.0, server_side_recency=True))`
+  returned timestamped records oldest-first and inconsistently across
+  calls. For "most-recent N" you MUST sort client-side by `created_at`
+  desc (None-safe). (2) **Empty-text search is a usable query-less
+  listing primitive** — `search_long_term_memory(text="", namespace=
+  {"eq": ns}, limit=N)` returns the namespace's records (semantic
+  search applies a relevance cutoff and is NOT a reliable count — use
+  empty-text to count/list). (3) **The search `limit` is HARD-CAPPED
+  at 100 — exceeding it is a Pydantic validation error that returns
+  NOTHING, not a clamp.** A `recent(limit*10)` over-fetch silently
+  returned `[]` for `limit>=11` (shipped in #660, caught only when a
+  later dogfood used a bigger limit — the original dogfood used
+  `limit<=10`). Clamp any over-fetch window to 100. (4) **Default
+  `create_long_term_memory(deduplicate=True)` applies SEMANTIC dedup
+  that MERGES distinct-but-similar findings (near in embedding space),
+  and a distinct record `id` does NOT prevent it — the merge is
+  content-driven, not id-keyed.** The only reliable guard is
+  `deduplicate=False`; a stable `id` is the UPSERT key (identical
+  re-write → same id → no duplicate), NOT a merge guard. For an
+  accumulate-style store (session findings) write with
+  `deduplicate=False` + a stable id (caller-supplied or content-hash).
+  **Meta-lesson that nearly cost a wrong fix**: an early single probe
+  ("distinct id + dedup=True → 3 survived") was a TIMING/eventual-
+  consistency FLAKE; re-running with a reliable count (empty-text, not
+  semantic search) showed the merge still happened. Eventual-indexing
+  + relevance-filtered counting make AMS probes easy to misread — poll
+  until a stable count via the empty-text path, vary nothing else, and
+  re-confirm before concluding. Pairs with "passing tests don't prove
+  integration" (all four behaviors were invisible to 100+ green mocked
+  tests; only live round-trips surfaced them) and the existing AMS-
+  setup lesson (Redis Stack / version-pairing / Ollama 768-dim).
+
+- **`agent-memory-server` lives in the uv-tool isolated env;
+  `agent-memory-client` is in attune-ai's `.venv` — introspect each
+  from the right python, and the worktree `.venv` lacks pytest**: read
+  `agent_memory_server.config.Settings.model_fields` (env surface:
+  `REDIS_URL`, `EMBEDDING_MODEL`, `REDISVL_VECTOR_DIMENSIONS`,
+  `ENABLE_DISCRETE_MEMORY_EXTRACTION`, …) via
+  `~/.local/share/uv/tools/agent-memory-server/bin/python`; introspect
+  client signatures (`search_long_term_memory`'s `recency`/`created_at`
+  params, `RecencyConfig` fields) via the MAIN `.venv`. Start the
+  server with `~/.local/bin/agent-memory api --port 8000` under env
+  matching the EXISTING redis-stack index dim (`redis-cli -p 6379
+  FT.INFO memory_records | tr ',' '\n' | grep -A2 -i dim` → 768 for
+  Ollama nomic; a mismatch is a silent embed/index failure). To RUN
+  attune_redis tests from a worktree: the worktree `.venv` has no
+  pytest, so invoke the MAIN venv python explicitly
+  (`/Users/patrickroebuck/attune-ai/.venv/bin/python -m pytest`) with
+  `PYTHONPATH=/abs/main/src:.` and `-o addopts=""` (worktree
+  `pytest.ini` injects `-n auto`). Integration tests gate on
+  `@pytest.mark.integration` + an `_ams_available()` skip, so they
+  no-op in CI (no AMS) and only run locally with `AMS_BASE_URL` set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   persist; exact repeats don't pile up.
 
 ### Fixed
-- **`attune-redis` `AMSMemoryBackend.recent()` returned `[]` for
-  `limit ≥ 11`.** The over-fetch window (`limit × 10`) exceeded AMS's
-  hard search-limit cap of 100, which is a validation error rather
-  than a clamp, so larger recall requests silently came back empty.
-  The window is now clamped to 100. (Fixes the recency listing added
-  earlier this cycle, before any release.)
+- **`attune-redis` semantic queries silently returned `[]` for large
+  limits.** AMS hard-caps `search_long_term_memory`'s `limit` at 100 —
+  a larger value is a request-validation error, not a clamp. Both
+  `recent()` (whose `limit × 10` over-fetch tripped it for `limit ≥ 11`)
+  and `search()` (which passed `limit` straight through) now bound the
+  limit by a single `_AMS_MAX_SEARCH_LIMIT = 100` constant. (Fixes the
+  recency listing added earlier this cycle, before any release.)
 - **`attune-redis` working-memory `stash()` clobbered earlier keys.**
   Against AMS 0.14.0, `set_working_memory_data(preserve_existing=True)`
   was verified (live) to REPLACE the entire working-memory `data` dict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `get_or_create_working_memory` still calls `get_working_memory`
   internally and emits it (an upstream quirk to track); the migration
   future-proofs our call sites regardless.
+- **`attune-redis` `remember()` no longer loses distinct findings to
+  AMS semantic dedup.** Long-term writes now use `deduplicate=False`,
+  because AMS's default `deduplicate=True` was verified (live) to
+  silently *merge* distinct-but-similar findings (records near in
+  embedding space) — and a distinct record id does not prevent it.
+  Each record is keyed on a stable id (a caller-supplied `memory_id`,
+  else a derived content hash) so identical re-writes still upsert
+  instead of accumulating duplicates. Distinct insights now all
+  persist; exact repeats don't pile up.
 
 ### Fixed
+- **`attune-redis` `AMSMemoryBackend.recent()` returned `[]` for
+  `limit ≥ 11`.** The over-fetch window (`limit × 10`) exceeded AMS's
+  hard search-limit cap of 100, which is a validation error rather
+  than a clamp, so larger recall requests silently came back empty.
+  The window is now clamped to 100. (Fixes the recency listing added
+  earlier this cycle, before any release.)
 - **`attune-redis` working-memory `stash()` clobbered earlier keys.**
   Against AMS 0.14.0, `set_working_memory_data(preserve_existing=True)`
   was verified (live) to REPLACE the entire working-memory `data` dict

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 #: constant to avoid a cross-package import into attune-redis.
 _DEFAULT_TTL_DAYS = 30
 
+#: AMS hard-caps ``search_long_term_memory``'s ``limit`` at 100 — passing a
+#: larger value is a request-validation error that returns nothing, not a
+#: clamp. Every search/recency call must bound its limit by this.
+_AMS_MAX_SEARCH_LIMIT = 100
+
 
 class _PersistentLoop:
     """A single event loop running in a daemon thread.
@@ -425,7 +430,8 @@ class AMSMemoryBackend:
 
         Args:
             query: Natural language search query.
-            limit: Maximum results to return.
+            limit: Maximum results to return. Clamped to AMS's hard cap of
+                100 (a larger value is a validation error, not a clamp).
             **filters: Additional AMS filters (topics,
                 entities, memory_type, etc.).
 
@@ -437,7 +443,7 @@ class AMSMemoryBackend:
                 self._client.search_long_term_memory(
                     text=query,
                     namespace={"eq": self._namespace},
-                    limit=limit,
+                    limit=min(limit, _AMS_MAX_SEARCH_LIMIT),
                     **filters,
                 )
             )
@@ -477,9 +483,9 @@ class AMSMemoryBackend:
         # Over-fetch: server ordering isn't recency, so pull a window wide
         # enough that the true most-recent ``limit`` are within it, then sort
         # client-side. 30-day pruning keeps per-namespace counts bounded.
-        # AMS hard-caps the search ``limit`` at 100 — exceeding it is a
-        # validation error (returns nothing), so clamp the window.
-        overscan = min(max(limit * 10, 50), 100)
+        # Server can't recency-sort for us, so the window must hold the true
+        # most-recent ``limit`` while staying under AMS's search-limit cap.
+        overscan = min(max(limit * 10, 50), _AMS_MAX_SEARCH_LIMIT)
         try:
             results = _run_sync(
                 self._client.search_long_term_memory(

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import fnmatch
+import hashlib
 import logging
 import threading
 from typing import Any
@@ -74,6 +75,19 @@ def _run_sync(coro: Any) -> Any:
         if _LOOP is None:
             _LOOP = _PersistentLoop()
     return _LOOP.run(coro)
+
+
+def _content_hash_id(content: str) -> str:
+    """Derive a stable long-term-memory id from a finding's content.
+
+    Used by ``remember`` when no explicit ``memory_id`` is given so that an
+    identical re-write maps to the same id and upserts (instead of piling up
+    duplicates), while distinct content yields a distinct id. Merge-avoidance
+    of *similar* findings is handled separately by writing with
+    ``deduplicate=False`` — the id is the upsert key, not the merge guard.
+    """
+    digest = hashlib.sha256(content.encode("utf-8")).hexdigest()[:32]
+    return f"sha256-{digest}"
 
 
 def _cwd_from_topics(topics: list[str] | None) -> str | None:
@@ -353,9 +367,24 @@ class AMSMemoryBackend:
         can retrieve. Embedding happens server-side on write, so the
         finding is recallable across sessions.
 
+        Deduplication note (both verified against a live AMS): AMS's
+        ``create_long_term_memory(deduplicate=True)`` — the client DEFAULT —
+        applies *semantic* dedup that silently MERGES distinct-but-similar
+        findings (two records near in embedding space), and a distinct ``id``
+        does NOT prevent it (the merge is content-driven, not id-keyed). For
+        an accumulate-style store of findings, losing distinct insights that
+        way is the wrong default, so we pass ``deduplicate=False``. To keep
+        exact re-writes from piling up duplicates, we also key each record on
+        a stable id: a caller-supplied ``memory_id`` when given, otherwise a
+        derived content hash. Same id → AMS upserts (no duplicate); distinct
+        content → distinct id and (with dedup off) every distinct finding
+        survives.
+
         Args:
             content: Text to store and embed.
-            memory_id: Optional stable id (enables dedup on re-write).
+            memory_id: Optional stable id. When omitted, a content-hash id
+                is derived so identical re-writes upsert instead of
+                duplicating.
             session_id: Session id override.
             topics: Free-form tags carried on the record.
 
@@ -364,21 +393,26 @@ class AMSMemoryBackend:
         """
         from agent_memory_client.models import ClientMemoryRecord
 
+        record_id = memory_id or _content_hash_id(content)
         record_kwargs: dict[str, Any] = {
+            "id": record_id,
             "text": content,
             "session_id": session_id or self._session_id,
             "namespace": self._namespace,
             "user_id": self._user_id,
             "topics": list(topics or []),
         }
-        if memory_id:
-            record_kwargs["id"] = memory_id
         try:
-            _run_sync(self._client.create_long_term_memory([ClientMemoryRecord(**record_kwargs)]))
+            _run_sync(
+                self._client.create_long_term_memory(
+                    [ClientMemoryRecord(**record_kwargs)],
+                    deduplicate=False,
+                )
+            )
             return True
         except Exception as e:  # noqa: BLE001
             # INTENTIONAL: Graceful degradation for AMS HTTP errors
-            logger.error("remember_failed: id=%s error=%s", memory_id, e)
+            logger.error("remember_failed: id=%s error=%s", record_id, e)
             return False
 
     def search(
@@ -443,7 +477,9 @@ class AMSMemoryBackend:
         # Over-fetch: server ordering isn't recency, so pull a window wide
         # enough that the true most-recent ``limit`` are within it, then sort
         # client-side. 30-day pruning keeps per-namespace counts bounded.
-        overscan = max(limit * 10, 50)
+        # AMS hard-caps the search ``limit`` at 100 — exceeding it is a
+        # validation error (returns nothing), so clamp the window.
+        overscan = min(max(limit * 10, 50), 100)
         try:
             results = _run_sync(
                 self._client.search_long_term_memory(

--- a/attune_redis/tests/test_integration.py
+++ b/attune_redis/tests/test_integration.py
@@ -238,6 +238,68 @@ class TestRecentLongTerm:
             b.close()
 
 
+class TestRememberDedup:
+    """Live guard for the dedup-safe id derivation in remember()."""
+
+    def _backend(self, ns: str):
+        from attune_redis.memory import AMSMemoryBackend
+
+        return AMSMemoryBackend(
+            config=RedisPluginConfig(
+                ams_base_url=os.environ.get("AMS_BASE_URL", "http://localhost:8000"),
+                ams_namespace=ns,
+            )
+        )
+
+    def test_similar_findings_all_survive_without_explicit_id(self):
+        """Distinct-but-similar findings written via id-less remember() must
+        all persist — AMS's default semantic dedup would otherwise merge
+        near-in-embedding-space records (regression guard for the #660
+        finding)."""
+        import time
+
+        ns = f"dedup-itest-{uuid.uuid4().hex[:8]}"
+        b = self._backend(ns)
+        try:
+            similar = [
+                "alpha apple finding",
+                "beta banana finding",
+                "gamma grape finding",
+            ]
+            for text in similar:
+                assert b.remember(text) is True  # no explicit memory_id
+                time.sleep(0.5)
+            # Count via the query-less recall path (empty-text search returns
+            # the namespace's records); semantic search applies a relevance
+            # cutoff and is not a reliable count.
+            total = 0
+            for _ in range(20):
+                time.sleep(1.0)
+                total = len(b.recent(limit=50))
+                if total >= 3:
+                    break
+            assert total >= 3, f"only {total}/3 similar findings survived (semantic merge)"
+        finally:
+            b.close()
+
+    def test_identical_content_upserts(self):
+        """Re-writing identical content maps to the same derived id, so it
+        upserts rather than accumulating duplicates."""
+        import time
+
+        ns = f"upsert-itest-{uuid.uuid4().hex[:8]}"
+        b = self._backend(ns)
+        try:
+            for _ in range(3):
+                assert b.remember("one repeated identical finding") is True
+                time.sleep(0.5)
+            time.sleep(3.0)
+            results = b.recent(limit=50)
+            assert len(results) == 1, f"expected 1 upserted record, got {len(results)}"
+        finally:
+            b.close()
+
+
 class TestErrorHandling:
     """Test graceful degradation with bad config."""
 

--- a/attune_redis/tests/test_memory.py
+++ b/attune_redis/tests/test_memory.py
@@ -304,6 +304,13 @@ class TestSearchable:
         results = backend.search("test query")
         assert isinstance(results, list)
 
+    def test_search_clamps_limit_to_ams_cap(self, backend, mock_ams_client):
+        """search() never passes a limit above AMS's hard cap of 100 (a
+        larger value is a validation error that returns nothing)."""
+        backend.search("q", limit=500)
+        _, kwargs = mock_ams_client.search_long_term_memory.call_args
+        assert kwargs["limit"] <= 100
+
     def test_search_maps_records(self, backend, mock_ams_client):
         """search() maps AMS records to dicts."""
         mock_ams_client.search_long_term_memory.return_value = FakeMemoryRecordResults(

--- a/attune_redis/tests/test_memory.py
+++ b/attune_redis/tests/test_memory.py
@@ -225,6 +225,73 @@ class TestLifecycle:
 
 
 # =================================================================
+# SearchableMemoryBackend: remember (searchable long-term write)
+# =================================================================
+
+
+def _last_record(mock_ams_client):
+    """Return the single ClientMemoryRecord passed to the last
+    create_long_term_memory call."""
+    args, _ = mock_ams_client.create_long_term_memory.call_args
+    return args[0][0]
+
+
+class TestRemember:
+    """Test searchable long-term writes and dedup-safe id derivation."""
+
+    def test_remember_returns_true(self, backend):
+        """remember() returns True on success."""
+        assert backend.remember("a durable finding") is True
+
+    def test_remember_derives_content_hash_id(self, backend, mock_ams_client):
+        """remember() derives a stable sha256 id when none is supplied."""
+        backend.remember("the event-loop reuse bug")
+        rec = _last_record(mock_ams_client)
+        assert rec.id.startswith("sha256-")
+
+    def test_remember_distinct_content_distinct_ids(self, backend, mock_ams_client):
+        """Different findings get different ids (so AMS won't merge them)."""
+        backend.remember("alpha apple finding")
+        id_a = _last_record(mock_ams_client).id
+        backend.remember("beta banana finding")
+        id_b = _last_record(mock_ams_client).id
+        assert id_a != id_b
+
+    def test_remember_identical_content_same_id(self, backend, mock_ams_client):
+        """Identical content maps to the same id (upsert, not duplicate)."""
+        backend.remember("repeated identical finding")
+        id_1 = _last_record(mock_ams_client).id
+        backend.remember("repeated identical finding")
+        id_2 = _last_record(mock_ams_client).id
+        assert id_1 == id_2
+
+    def test_remember_explicit_id_wins(self, backend, mock_ams_client):
+        """An explicit memory_id is used verbatim, not the derived hash."""
+        backend.remember("some finding", memory_id="finding-42")
+        assert _last_record(mock_ams_client).id == "finding-42"
+
+    def test_remember_disables_semantic_dedup(self, backend, mock_ams_client):
+        """remember() writes with deduplicate=False so distinct-but-similar
+        findings are not silently merged (the stable id handles exact
+        re-writes via upsert instead)."""
+        backend.remember("a finding")
+        _, kwargs = mock_ams_client.create_long_term_memory.call_args
+        assert kwargs.get("deduplicate") is False
+
+    def test_remember_carries_topics_and_session(self, backend, mock_ams_client):
+        """remember() puts topics and session_id on the record."""
+        backend.remember("x", session_id="s-7", topics=["cwd:/p", "type:insight"])
+        rec = _last_record(mock_ams_client)
+        assert rec.topics == ["cwd:/p", "type:insight"]
+        assert rec.session_id == "s-7"
+
+    def test_remember_returns_false_on_error(self, backend, mock_ams_client):
+        """remember() degrades to False on AMS errors, never raises."""
+        mock_ams_client.create_long_term_memory.side_effect = ConnectionError("boom")
+        assert backend.remember("will fail") is False
+
+
+# =================================================================
 # SearchableMemoryBackend: search / promote
 # =================================================================
 
@@ -300,6 +367,13 @@ class TestRecent:
         assert kwargs["namespace"] == {"eq": "test"}
         # Over-fetches a bounded window (server can't recency-sort for us).
         assert kwargs["limit"] >= 3
+
+    def test_recent_clamps_overscan_to_ams_cap(self, backend, mock_ams_client):
+        """recent()'s over-fetch window never exceeds AMS's hard limit cap of
+        100 — a larger value is a validation error that returns nothing."""
+        backend.recent(limit=50)  # naive overscan would be 500
+        _, kwargs = mock_ams_client.search_long_term_memory.call_args
+        assert kwargs["limit"] <= 100
 
     def test_recent_sorts_newest_first(self, backend, mock_ams_client):
         """recent() orders records by created_at descending, regardless of


### PR DESCRIPTION
## What

Two `attune-redis` AMS-backend correctness fixes, both surfaced by **dogfooding #660** against a live Agent Memory Server.

### 1. `remember()` was losing distinct findings to AMS semantic dedup

AMS's default `create_long_term_memory(deduplicate=True)` was verified (live) to silently **merge** distinct-but-similar findings — records near in embedding space (e.g. "alpha apple finding" / "beta banana finding") — and **a distinct record id does not prevent it** (the merge is content-driven, not id-keyed). For an accumulate-style finding store, dropping distinct insights is the wrong default.

Fix: write with `deduplicate=False`, and key each record on a stable id (caller-supplied `memory_id`, else a derived content hash) so identical re-writes **upsert** instead of accumulating duplicates.

| Live probe | Result |
|---|---|
| 3 distinct similar findings, id-less `remember()` | **all 3 survive** |
| identical content written ×3 | **collapses to 1 (upsert)** |

The production write path (`session_stash.stash_entry`) already passed `memory_id`, so real findings were not being lost — this hardens the **id-less convenience path** and corrects the default.

### 2. `recent()` returned `[]` for `limit >= 11`

The over-fetch window (`limit × 10`) exceeded AMS's hard search-limit cap of **100**, which is a *validation error*, not a clamp — so larger recall requests silently came back empty. Window is now clamped to 100. Shipped in #660 but pre-release (never on PyPI); #660's dogfood only used `limit<=10`, so it never tripped.

## Verification

- Unit: **111 passed, 1 skipped** — 8 new `remember()` tests (id derivation, distinct-vs-identical content, explicit-id-wins, `deduplicate=False`, error path) closing the prior zero-coverage gap on `remember()`, plus a `recent()` overscan-cap guard.
- Live integration (auto-skips without AMS): similar findings all survive id-less; identical content upserts; recency listing intact — **green against AMS 0.14.0**.
- ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
