### PR TITLE
fix(redis): stash() must merge — set_working_memory_data clobbers keys on AMS 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collected count, or if coverage regresses to a hardcoded value — so the
   chips can't silently rot (the issue that prompted 8.0.1).
 
+### Fixed
+- **`attune-redis` working-memory `stash()` clobbered earlier keys.**
+  Against AMS 0.14.0, `set_working_memory_data(preserve_existing=True)`
+  was verified (live) to REPLACE the entire working-memory `data` dict
+  on every call (`preserve_existing` preserves the session's
+  messages/memories, not existing data keys), so a second `stash(...)`
+  wiped the first — breaking multi-key `retrieve()` and `keys()`.
+  `stash()` now merges via
+  `update_working_memory_data(merge_strategy="merge")`. The mocked test
+  double was corrected to match AMS's real replace-semantics (it
+  previously merged, masking the bug), and a live regression guard now
+  asserts a second stash preserves the first key.
+
 ## [8.0.1] — 2026-06-07
 
 Docs/metadata patch — no code or library-behaviour changes (identical to 8.0.0).

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -138,9 +138,16 @@ class AMSMemoryBackend:
     ) -> bool:
         """Store data in AMS working memory.
 
-        Maps to ``set_working_memory_data`` with
-        ``preserve_existing=True`` so other keys are
-        not overwritten.
+        Maps to ``update_working_memory_data`` with
+        ``merge_strategy="merge"`` so other keys are preserved.
+
+        NOTE: ``set_working_memory_data(preserve_existing=True)`` was
+        verified against AMS 0.14.0 to REPLACE the whole working-memory
+        ``data`` dict on every call (``preserve_existing`` preserves the
+        session's *messages/memories*, not existing data keys), so a second
+        ``stash`` clobbered the first — breaking ``keys`` and multi-key
+        ``retrieve``. ``update_working_memory_data(merge_strategy="merge")``
+        is the server-side merge primitive that keeps prior keys.
 
         Args:
             key: Storage key.
@@ -154,11 +161,11 @@ class AMSMemoryBackend:
         session_id = agent_id or self._session_id
         try:
             _run_sync(
-                self._client.set_working_memory_data(
+                self._client.update_working_memory_data(
                     session_id=session_id,
-                    data={key: value},
+                    data_updates={key: value},
                     namespace=self._namespace,
-                    preserve_existing=True,
+                    merge_strategy="merge",
                 )
             )
             return True

--- a/attune_redis/tests/conftest.py
+++ b/attune_redis/tests/conftest.py
@@ -93,11 +93,13 @@ def mock_ams_client() -> AsyncMock:
         namespace: str | None = None,
         preserve_existing: bool = True,
     ) -> FakeWorkingMemoryResponse:
-        if preserve_existing:
-            _data.update(data)
-        else:
-            _data.clear()
-            _data.update(data)
+        # Matches AMS 0.14.0 behavior (verified live): set_working_memory_data
+        # REPLACES the whole data dict regardless of preserve_existing
+        # (preserve_existing preserves messages/memories, not data keys). A
+        # mock that merged here would mask the multi-key clobber bug — to
+        # MERGE data keys, callers must use update_working_memory_data.
+        _data.clear()
+        _data.update(data)
         return FakeWorkingMemoryResponse(data=dict(_data))
 
     async def _update_working_memory_data(

--- a/attune_redis/tests/test_integration.py
+++ b/attune_redis/tests/test_integration.py
@@ -93,6 +93,20 @@ class TestStashRetrieveRoundTrip:
         result = backend.retrieve("complex")
         assert result == data
 
+    def test_second_stash_preserves_first_key(self, backend):
+        """A second stash must not clobber the first key.
+
+        Regression guard: AMS 0.14.0's set_working_memory_data REPLACES the
+        whole data dict (preserve_existing only preserves messages/memories),
+        so the prior stash(...) over set_working_memory_data wiped earlier
+        keys — breaking multi-key retrieve and keys(). stash() now merges via
+        update_working_memory_data(merge_strategy="merge").
+        """
+        backend.stash("first", "one")
+        backend.stash("second", "two")
+        assert backend.retrieve("first") == "one"
+        assert backend.retrieve("second") == "two"
+
 
 class TestDelete:
     """Test real delete against AMS."""

--- a/attune_redis/tests/test_memory.py
+++ b/attune_redis/tests/test_memory.py
@@ -84,11 +84,11 @@ class TestStashRetrieve:
     def test_stash_with_agent_id(self, backend, mock_ams_client):
         """agent_id maps to AMS session_id."""
         backend.stash("k", "v", agent_id="session-42")
-        mock_ams_client.set_working_memory_data.assert_called_with(
+        mock_ams_client.update_working_memory_data.assert_called_with(
             session_id="session-42",
-            data={"k": "v"},
+            data_updates={"k": "v"},
             namespace="test",
-            preserve_existing=True,
+            merge_strategy="merge",
         )
 
 


### PR DESCRIPTION
## Diagnosis

The `TestKeys` integration tests failed because `keys()` returned `[]` after `stash()`. Probing the working-memory round-trip step-by-step against live AMS 0.14.0 ruled out the hypotheses:

- **Not eventual-consistency** — the read was immediately consistent with the write.
- **Not a session-creation prerequisite** — the session resolved fine.
- **It's an API behavior:** `set_working_memory_data(preserve_existing=True)` **REPLACES the entire working-memory `data` dict on every call**. `preserve_existing` preserves the session's *messages/memories*, not existing `data` keys.

```
stash k1 -> get .data = {'k1': 1}
stash k2 -> get .data = {'k2': 2}   # k1 gone — second stash clobbered the first
```

So the bug was broader than `keys()`: multi-key `retrieve()` was also broken (`stash("a"); stash("b"); retrieve("a")` → `None`). The single-key `retrieve` test passed only because it never did a second stash. The **mocked test double hid it** — its fake `preserve_existing` merged, so the unit suite was green while the real backend was broken.

## Fix

`stash()` now merges via `update_working_memory_data(merge_strategy="merge")` — the verified server-side merge primitive (also auto-creates the session).

- `memory.py`: switch primitive + document the replace-vs-merge semantics.
- `conftest.py`: the `set_working_memory_data` mock now **replaces** (matches real AMS) so it can't mask this class of bug again.
- `test_memory.py`: `test_stash_with_agent_id` asserts the new call.
- `test_integration.py`: live regression guard — a second stash preserves the first key.

## Verification

- Mocked: **102 passed, 1 skipped**; ruff + black clean.
- Live integration vs AMS 0.14.0: **16/16 green** (was 2 failing).

## Follow-up (flagged, not bundled)

`get_working_memory` is deprecated in 0.14.0 in favor of `get_or_create_working_memory` (used by `retrieve`/`delete`/`keys`). Mechanical migration, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
