### PR TITLE
refactor(redis): migrate working-memory reads off deprecated get_working_memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fails if that floor ever over-claims or drifts far below the real
   collected count, or if coverage regresses to a hardcoded value — so the
   chips can't silently rot (the issue that prompted 8.0.1).
+- **`attune-redis` migrated off the deprecated `get_working_memory`.**
+  Working-memory reads (`retrieve`/`delete`/`keys`) now use
+  `get_or_create_working_memory`, which `agent-memory-client` 0.14.0
+  recommends as the replacement, so the call sites keep working once
+  `get_working_memory` is removed. Note: this does **not** silence the
+  deprecation warning under 0.14.0 — the client's own
+  `get_or_create_working_memory` still calls `get_working_memory`
+  internally and emits it (an upstream quirk to track); the migration
+  future-proofs our call sites regardless.
 
 ### Fixed
 - **`attune-redis` working-memory `stash()` clobbered earlier keys.**

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -190,8 +190,8 @@ class AMSMemoryBackend:
         """
         session_id = agent_id or self._session_id
         try:
-            response = _run_sync(
-                self._client.get_working_memory(
+            _, response = _run_sync(
+                self._client.get_or_create_working_memory(
                     session_id=session_id,
                     namespace=self._namespace,
                 )
@@ -217,8 +217,8 @@ class AMSMemoryBackend:
             True if deleted, False if not found.
         """
         try:
-            response = _run_sync(
-                self._client.get_working_memory(
+            _, response = _run_sync(
+                self._client.get_or_create_working_memory(
                     session_id=self._session_id,
                     namespace=self._namespace,
                 )
@@ -251,8 +251,8 @@ class AMSMemoryBackend:
             List of matching key names.
         """
         try:
-            response = _run_sync(
-                self._client.get_working_memory(
+            _, response = _run_sync(
+                self._client.get_or_create_working_memory(
                     session_id=self._session_id,
                     namespace=self._namespace,
                 )

--- a/attune_redis/tests/conftest.py
+++ b/attune_redis/tests/conftest.py
@@ -87,6 +87,13 @@ def mock_ams_client() -> AsyncMock:
     async def _get_working_memory(**kwargs: Any) -> FakeWorkingMemoryResponse:
         return FakeWorkingMemoryResponse(data=dict(_data))
 
+    async def _get_or_create_working_memory(
+        **kwargs: Any,
+    ) -> tuple[bool, FakeWorkingMemoryResponse]:
+        # AMS 0.14.0's get_or_create returns (created: bool, WorkingMemory);
+        # the backend unpacks ``_, response`` and reads ``response.data``.
+        return (False, FakeWorkingMemoryResponse(data=dict(_data)))
+
     async def _set_working_memory_data(
         session_id: str,
         data: dict[str, Any],
@@ -116,6 +123,7 @@ def mock_ams_client() -> AsyncMock:
         return FakeWorkingMemoryResponse(data=dict(_data))
 
     client.get_working_memory.side_effect = _get_working_memory
+    client.get_or_create_working_memory.side_effect = _get_or_create_working_memory
     client.set_working_memory_data.side_effect = _set_working_memory_data
     client.update_working_memory_data.side_effect = _update_working_memory_data
     client.health_check.return_value = FakeHealthCheckResponse()

--- a/attune_redis/tests/test_error_paths.py
+++ b/attune_redis/tests/test_error_paths.py
@@ -63,6 +63,7 @@ def failing_backend(redis_config):
         error = ConnectionError("AMS unreachable")
         client.set_working_memory_data.side_effect = error
         client.get_working_memory.side_effect = error
+        client.get_or_create_working_memory.side_effect = error
         client.update_working_memory_data.side_effect = error
         client.health_check.side_effect = error
         client.list_sessions.side_effect = error
@@ -125,10 +126,12 @@ class TestRetrieveNoneData:
         with patch("agent_memory_client.MemoryAPIClient") as mock_cls:
             client = AsyncMock()
 
-            async def _get_wm(**kwargs):
-                return FakeWorkingMemoryResponse(data=None)
+            async def _get_or_create_wm(**kwargs):
+                # retrieve() reads via get_or_create_working_memory, which
+                # returns (created, WorkingMemory); exercise the data=None branch.
+                return (False, FakeWorkingMemoryResponse(data=None))
 
-            client.get_working_memory.side_effect = _get_wm
+            client.get_or_create_working_memory.side_effect = _get_or_create_wm
             mock_cls.return_value = client
 
             b = AMSMemoryBackend(config=redis_config)

--- a/attune_redis/tests/test_memory.py
+++ b/attune_redis/tests/test_memory.py
@@ -144,6 +144,29 @@ class TestKeys:
         assert backend.keys() == []
 
 
+class TestWorkingMemoryReadIsNotDeprecated:
+    """Reads use get_or_create_working_memory, not the deprecated
+    get_working_memory (deprecated in agent-memory-client 0.14.0)."""
+
+    def test_retrieve_uses_get_or_create(self, backend, mock_ams_client):
+        """retrieve() reads via get_or_create_working_memory."""
+        backend.retrieve("k")
+        mock_ams_client.get_or_create_working_memory.assert_called()
+        mock_ams_client.get_working_memory.assert_not_called()
+
+    def test_delete_uses_get_or_create(self, backend, mock_ams_client):
+        """delete() reads via get_or_create_working_memory."""
+        backend.delete("k")
+        mock_ams_client.get_or_create_working_memory.assert_called()
+        mock_ams_client.get_working_memory.assert_not_called()
+
+    def test_keys_uses_get_or_create(self, backend, mock_ams_client):
+        """keys() reads via get_or_create_working_memory."""
+        backend.keys()
+        mock_ams_client.get_or_create_working_memory.assert_called()
+        mock_ams_client.get_working_memory.assert_not_called()
+
+
 # =================================================================
 # is_connected / get_stats / close
 # =================================================================

--- a/tests/unit/memory/test_memory_backend_protocol.py
+++ b/tests/unit/memory/test_memory_backend_protocol.py
@@ -229,6 +229,11 @@ class TestAMSMemoryBackendProtocol:
         async def _get_wm(**kw):
             return FakeWorkingMemoryResponse(data=dict(_data))
 
+        async def _get_or_create_wm(**kw):
+            # AMS 0.14.0 get_or_create returns (created, WorkingMemory); the
+            # backend unpacks `_, response`. retrieve/delete/keys read via this.
+            return (False, FakeWorkingMemoryResponse(data=dict(_data)))
+
         async def _set_wm(session_id, data, namespace=None, preserve_existing=True):
             if preserve_existing:
                 _data.update(data)
@@ -246,6 +251,7 @@ class TestAMSMemoryBackendProtocol:
             return FakeWorkingMemoryResponse(data=dict(_data))
 
         mock_client.get_working_memory.side_effect = _get_wm
+        mock_client.get_or_create_working_memory.side_effect = _get_or_create_wm
         mock_client.set_working_memory_data.side_effect = _set_wm
         mock_client.update_working_memory_data.side_effect = _update_wm
         mock_client.health_check.return_value = FakeHealthCheckResponse()


### PR DESCRIPTION
## What

Migrates `attune_redis` working-memory reads (`retrieve`/`delete`/`keys`) off the deprecated `get_working_memory` onto `get_or_create_working_memory`, which `agent-memory-client` 0.14.0 recommends as the replacement.

**Stacked on #667** (the stash-merge fix) — needs it for `TestKeys` to pass.

## Honest scope

This **future-proofs the call sites** for when `get_working_memory` is removed — but it does **not** silence the deprecation warning under 0.14.0: the client's own `get_or_create_working_memory` calls `get_working_memory` internally and emits it (verified). That's an upstream quirk to track, not something we can fix consumer-side.

## Changes

- `memory.py`: `retrieve`/`delete`/`keys` unpack `_, response` from `get_or_create_working_memory`.
- `conftest.py`: mock `get_or_create` returns the `(created, WorkingMemory)` tuple.
- `test_memory.py`: `TestWorkingMemoryReadIsNotDeprecated` guards that reads use `get_or_create`, never the deprecated method.

## Verification

- 38 mocked passed; ruff + black clean; full live integration **16/16 green** against AMS 0.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
