### PR TITLE
docs(redis): best-practice alignment + 3 morning-review specs

### DIFF
--- a/docs/redis/best-practice-alignment.md
+++ b/docs/redis/best-practice-alignment.md
@@ -1,0 +1,131 @@
+# Redis & Anthropic Best-Practice Alignment
+
+> What attune-ai can **verifiably** claim about following Redis's and
+> Anthropic's recommended patterns for agent memory — and the small
+> gaps to close before that claim goes into external copy.
+
+**Created:** 2026-06-08 (overnight autonomous pass)
+**Owner:** Patrick + agent
+**Status:** findings for morning review — claims verified against
+current vendor sources; wording flagged where it should be softened.
+
+---
+
+## TL;DR
+
+attune-ai is already well-aligned with both vendors' reference
+architectures. The strongest claim — *"built on Redis's official
+Agent Memory Server (RedisVL) and integrated through Anthropic's
+Claude Agent SDK + MCP + Skills"* — is **true today**. One concrete
+bridge (implement Anthropic's Memory tool backend over the AMS
+backend) makes the Anthropic half demonstrable rather than
+analogous. The "contribute back" upstream PR (RedisVL datatype
+settings) is the highest-integrity alignment move and is still
+needed (upstream hasn't shipped it as of v0.15.2).
+
+---
+
+## Redis alignment — verified
+
+| Claim | Evidence | Status |
+|---|---|---|
+| Built **on** Redis's official Agent Memory Server (not a hand-rolled Redis integration) | `attune_redis.AMSMemoryBackend` is a thin client over `redis/agent-memory-server`; controls no schema/index config | ✅ true |
+| Uses **RedisVL** for vector search the way Redis recommends | All vector-index decisions live server-side in AMS + RedisVL; attune sets none | ✅ true |
+| Uses the documented **extension seam**, not a fork | int8 quantization ships via the `MEMORY_VECTOR_DB_FACTORY` plug-in point (a documented pluggable factory), not a patched fork | ✅ true |
+| Rides Redis's **vector-quantization** investment | int8 embedding quantization shipped in attune v7.4.0 (a Redis 8 / RedisVL capability) | ✅ true |
+| **Contributes back** upstream | Planned PR to make `_build_redis_schema`'s datatype settings-driven so the consumer-side override can retire | 🔜 planned — still needed (upstream hasn't shipped it as of v0.15.2) |
+
+**Source notes (2026-06-08):**
+
+- Redis positions Agent Memory Server as the dual-tier
+  (working + long-term) memory stack, with RedisVL as the
+  recommended Python abstraction for storing memories as vector
+  embeddings.
+- Redis publishes vector benchmarks reporting higher throughput at
+  recall ≥ 0.98 than other vector DBs in their tests.
+- A 2025 Stack Overflow survey reported Redis as the most-used tool
+  for AI-agent memory (~43% of developers).
+- agent-memory-server latest release is **v0.15.2** (2026-04-10);
+  attune pins **0.14.0**. The vector datatype is not yet
+  settings-driven upstream, so the int8 factory override remains
+  load-bearing.
+
+**Wording to soften before external copy:**
+
+- Don't claim "fastest vector DB" — cite Redis's own benchmark
+  framing ("higher throughput at recall ≥ 0.98 in Redis's published
+  tests"), attributed, not as our independent result.
+- Don't imply attune contributes to RedisVL core — our contribution
+  target is `agent-memory-server` (the datatype-settings PR), which
+  is the accurate, verifiable statement.
+
+---
+
+## Anthropic alignment — verified, with one bridge to add
+
+| Claim | Evidence | Status |
+|---|---|---|
+| Built on the **Claude Agent SDK** (native) | Workflows are SDK-native; `claude-agent-sdk` is a core dependency | ✅ true |
+| Exposes capabilities through an **MCP server** | `attune.mcp.server` ships the MCP tool surface | ✅ true |
+| Uses **Skills** for progressive disclosure | The plugin ships Skills (`/coach`, `/recall`, workflow skills, …) | ✅ true |
+| Cross-session memory follows Anthropic's **"give agents memory"** direction | SessionStart recall + Stop-hook stash + searchable long-term findings | ✅ true (pattern-level) |
+| attune's memory is a **drop-in backend for Anthropic's Memory tool** (`memory_20250818`) | — | 🔜 **bridge to build** (see spec) |
+
+**The one gap worth closing.** Anthropic's **Memory tool**
+(`memory_20250818`) is a *client-side* tool: Claude issues
+`view`/`create`/`str_replace`/`insert`/`delete`/`rename` commands
+against a `/memories` directory, and *you* implement the storage
+backend (subclass `BetaAbstractMemoryTool`). attune already has a
+durable, Redis-backed memory store (`AMSMemoryBackend`). Wiring
+that store behind Anthropic's Memory tool interface turns an
+*analogous* claim ("we do memory the way Anthropic suggests") into
+a *demonstrable* one ("our memory layer is a drop-in backend for
+Anthropic's Memory tool, persisted on Redis's Agent Memory
+Server"). Spec: [`anthropic-memory-tool-backend`](../specs/anthropic-memory-tool-backend/requirements.md).
+
+---
+
+## How this resolves the dormant-coordination question
+
+The best-practice lens settles what to do with the old in-tree
+Redis coordination mixins better than "user demand" did:
+
+- **Coordination mixins** (conflict-negotiation, signals, shared
+  sessions) → **retire.** Anthropic now ships native multi-agent
+  coordination — **subagents** (Agent SDK / Claude Code) and the
+  **Managed Agents `multiagent` coordinator** (threads +
+  cross-thread messaging). Reviving custom Redis pub/sub
+  coordination primitives would reimplement a vendor-native
+  capability — the opposite of "align with best practice."
+- **PatternStaging** (stage → review → promote/reject) → **capture.**
+  No vendor-native equivalent; it's an attune-domain workflow.
+  Spec: [`pattern-review-queue`](../specs/pattern-review-queue/requirements.md).
+- **AMS/Redis memory path** → **invest.** Strongest alignment, most
+  claimable; add the Memory-tool bridge.
+
+See [`redis-facade-direction/decisions.md`](../specs/redis-facade-direction/decisions.md)
+for the proposed direction (relabel-not-remove; retire mixins;
+keep PatternStaging) — a proposal to ratify, not yet executed.
+
+---
+
+## Follow-ups surfaced
+
+1. **Bump `agent-memory-server` 0.14.0 → 0.15.2** and re-verify the
+   int8 factory override + the working-memory behaviors (PR #667/#668
+   findings) against the newer release. Separate, scoped change.
+2. **Ship the RedisVL datatype contribute-back PR** to
+   `agent-memory-server` — the highest-integrity alignment move.
+3. **Build the Anthropic Memory-tool backend bridge** (the one item
+   that makes the claim true on both vendor sides at once).
+
+---
+
+## Sources
+
+- [Redis — A developer's guide to agent memory (whitepaper)](https://redis.io/resources/redis-whitepaper-ai-agent-memory.pdf)
+- [Redis — AI Agent Architecture: Build Systems That Work in 2026](https://redis.io/blog/ai-agent-architecture/)
+- [Redis — Build smarter AI agents: short- and long-term memory with Redis](https://redis.io/blog/build-smarter-ai-agents-manage-short-term-and-long-term-memory-with-redis/)
+- [Redis Agent Memory docs](https://redis.io/docs/latest/develop/ai/context-engine/agent-memory/)
+- [redis/agent-memory-server (GitHub)](https://github.com/redis/agent-memory-server)
+- Anthropic Memory tool (`memory_20250818`) — `claude-api` skill reference (Anthropic SDK docs)

--- a/docs/specs/anthropic-memory-tool-backend/design.md
+++ b/docs/specs/anthropic-memory-tool-backend/design.md
@@ -1,0 +1,117 @@
+# Design: Anthropic Memory-Tool Backend
+
+> Technical design for the `BetaAbstractMemoryTool` adapter over
+> attune's memory backends. See
+> [`requirements.md`](requirements.md) for scope.
+
+**Status:** draft (2026-06-08) — for morning review
+
+---
+
+## Interface (what Anthropic gives us)
+
+Anthropic's Memory tool is **client-side**: the model emits commands;
+the SDK's tool runner dispatches them to a backend you implement by
+subclassing `BetaAbstractMemoryTool` (from
+`anthropic.lib.tools`). The six commands:
+
+| Command | Semantics (file model) | Maps to attune backend |
+|---|---|---|
+| `view` | List a dir / read a file under `/memories` | `keys(prefix*)` + `retrieve(path)` |
+| `create` | Write a new file | `stash(path, content)` |
+| `str_replace` | Replace a substring in a file | `retrieve` → `str.replace` → `stash` |
+| `insert` | Insert text at a line | `retrieve` → splice → `stash` |
+| `delete` | Remove a file | `delete(path)` |
+| `rename` | Move a file | `retrieve(old)` → `stash(new)` → `delete(old)` |
+
+The backend is the storage; the model never sees attune internals.
+
+## Mapping decision: working-memory KV, not long-term
+
+The Memory tool is **file/path-addressed with in-place text edits**
+(`str_replace`, `insert`). That is a key/value document model, not a
+semantic-search model. So:
+
+- **v1 stores memory files as working-memory KV** keyed by path:
+  `stash(path, text)` / `retrieve(path)` / `keys()` / `delete(path)`.
+  This is exactly the surface PR #667 just made correct against AMS
+  0.14.0 (`update_working_memory_data(merge_strategy="merge")` so
+  multi-key writes don't clobber).
+- **Long-term semantic recall stays on `/recall`** (the
+  `remember`/`search` surface). The Memory tool is not the place to
+  expose embeddings — keep the two interfaces honest about what they
+  do (R-non-goal).
+
+> Consequence for R5 (shared store): the Memory-tool view and
+> SessionStart recall share the *backend and namespace*, but the
+> Memory tool reads/writes the KV tier while SessionStart recall
+> reads the long-term tier. v1 keeps them in one namespace so an
+> operator can see both; a later phase can add an opt-in "promote a
+> memory file to a searchable finding" bridge if wanted. Flag this
+> as a design question for the morning.
+
+## Component shape
+
+```
+attune_redis/ (or attune.memory)
+  memory_tool.py
+    class AttuneMemoryTool(BetaAbstractMemoryTool):
+        def __init__(self, backend: MemoryBackend, *, root="/memories",
+                     user_id: str | None = None): ...
+        # six command handlers, each:
+        #   1. _validate_path(cmd.path)         # traversal guard
+        #   2. _redact(content)                 # session-redaction gate
+        #   3. backend.<op>(...)                # stash/retrieve/keys/delete
+        #   4. return the Anthropic-shaped result / raise -> is_error
+```
+
+- `backend` is attune's `MemoryBackend` (file by default, AMS when
+  configured) — **R2**, no new storage.
+- `_validate_path` reuses `attune.security.path_validation` semantics
+  adapted to the virtual `/memories` root — **R4**.
+- `_redact` reuses the session-redaction gate so secrets never
+  persist — **R4**.
+- `user_id` namespaces the key prefix when present — **R4**.
+
+## Why client-side Memory tool, not Managed-Agents memory stores
+
+Anthropic has **two** memory surfaces:
+
+1. **Memory tool** (`memory_20250818`) — client-side, you own the
+   backend. Works on the **first-party API and the subscription/Agent
+   SDK path** attune already targets. ← **this spec**.
+2. **Managed Agents memory stores** — server-side, Anthropic-hosted,
+   requires the Managed Agents product (API-keyed, hosted
+   orchestration).
+
+attune is subscription-first and self-hosts its memory on Redis, so
+the **client-side Memory tool is the correct alignment surface** —
+it lets attune *be the backend* rather than hand memory to Anthropic's
+hosted store. (Confirmed against the `claude-api` skill reference.)
+
+## Testing (R6)
+
+- **Mocked unit tests:** all six commands against a mock backend —
+  path validation, redaction, read-modify-write correctness for
+  `str_replace`/`insert`, `rename` = copy+delete, `view` of dir vs
+  file.
+- **Live integration test:** drive the adapter through the SDK
+  `tool_runner` (or call the handlers directly) against AMS 0.14.0;
+  write via Memory tool → read back via `backend.retrieve`; auto-skip
+  without AMS (mirrors `test_integration.py`).
+- **Drift guard:** assert the adapter implements every abstract
+  method of `BetaAbstractMemoryTool` (so an SDK bump that adds a
+  command fails loudly).
+
+## Open questions for the morning
+
+1. **Home:** `attune_redis/memory_tool.py` (rides the Redis package)
+   vs `attune.memory.memory_tool` (backend-agnostic, file default).
+   Leaning `attune.memory` so the file backend works with zero infra
+   and AMS is the upgrade.
+2. **Shared-namespace vs separate:** KV tier (Memory tool) and
+   long-term tier (recall) in one namespace (operator sees both) vs
+   separate (cleaner isolation). v1 proposal: one namespace,
+   document the tier split.
+3. **Promote-to-searchable bridge:** ship in v1 or defer? Proposal:
+   defer — keep v1 honest about file-vs-semantic.

--- a/docs/specs/anthropic-memory-tool-backend/requirements.md
+++ b/docs/specs/anthropic-memory-tool-backend/requirements.md
@@ -1,0 +1,99 @@
+# Spec: Anthropic Memory-Tool Backend
+
+> Make attune's memory store a **drop-in backend for Anthropic's
+> Memory tool** (`memory_20250818`). Anthropic's Memory tool is
+> client-side — Claude issues file-style commands
+> (`view`/`create`/`str_replace`/`insert`/`delete`/`rename`) against
+> a `/memories` directory and *you* implement the storage. We
+> implement it over attune's existing memory backends (file +
+> `attune_redis.AMSMemoryBackend`), so the same durable, Redis-backed
+> store that powers SessionStart recall also serves Anthropic's
+> native memory interface. This turns "we do memory the way Anthropic
+> suggests" into "our memory layer **is** a backend for Anthropic's
+> Memory tool, persisted on Redis's Agent Memory Server."
+
+**Status:** draft (2026-06-08) — overnight autonomous draft for
+morning review
+**Owner:** Patrick + agent
+**Related:**
+
+- [`docs/redis/best-practice-alignment.md`](../../redis/best-practice-alignment.md)
+  — why this is the one bridge that makes the dual-vendor claim
+  demonstrable
+- `claude-api` skill → Memory tool (`memory_20250818`,
+  `BetaAbstractMemoryTool`) — the interface we implement
+- `attune_redis.AMSMemoryBackend` / `attune.memory.file_stash` —
+  the backends we map onto
+- [`project_redis_strategy_leverage`](~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/project_redis_strategy_leverage.md)
+  — "leverage their work" strategy this serves
+
+---
+
+## Problem
+
+attune already has a durable cross-session memory store (file
+backend by default, AMS/Redis when configured) and uses it for
+SessionStart recall, Stop-hook stash, and `/recall`. But that store
+is wired to attune's *own* internal `MemoryBackend` protocol. It is
+**not** exposed through Anthropic's native **Memory tool**
+interface, so:
+
+1. We can only claim *analogy* with Anthropic's memory guidance, not
+   a demonstrable integration.
+2. Any agent built on the raw Claude API + Memory tool can't reuse
+   attune's Redis-backed store without bespoke glue.
+
+## Goal
+
+Ship a `BetaAbstractMemoryTool` subclass that implements Anthropic's
+six memory commands over attune's backends, so:
+
+- A raw-API or Agent-SDK caller can pass attune's memory tool to
+  `tool_runner()` and get a Redis-backed `/memories` directory.
+- The same store is shared with attune's SessionStart recall (one
+  memory, two interfaces).
+
+## Requirements
+
+- **R1 — Implement the six commands.** `view`, `create`,
+  `str_replace`, `insert`, `delete`, `rename` over a path-addressed
+  memory namespace, matching Anthropic's Memory tool contract.
+- **R2 — Back it with attune's existing backends.** Default to the
+  file backend (zero infra); use `AMSMemoryBackend` when AMS is
+  configured. No new storage layer.
+- **R3 — Path↔key mapping.** Memory file paths (`/memories/foo.md`)
+  map to backend keys; file *content* is the stored value.
+  `str_replace`/`insert` are read-modify-write on the retrieved
+  text. `view` of a directory lists keys under the path prefix.
+- **R4 — Security parity.** Enforce attune's path-validation rules on
+  memory paths (no traversal, no absolute escapes); never persist
+  provider secrets (reuse the session-redaction gate). Per-user
+  namespacing when a user id is available.
+- **R5 — Shared store, not a parallel one.** The Memory-tool view and
+  attune's SessionStart recall read/write the *same* namespace, so a
+  finding written by one surface is visible to the other (subject to
+  the kv-vs-long-term distinction in design.md).
+- **R6 — Graceful + tested.** Best-effort error handling (never crash
+  the agent loop); mocked unit tests for all six commands + one live
+  round-trip integration test (auto-skips without AMS), matching the
+  existing attune_redis test discipline.
+
+## Non-goals
+
+- Not replacing attune's internal `MemoryBackend` protocol — this is
+  an *adapter onto* it.
+- Not implementing Anthropic's server-side Managed-Agents memory
+  stores (different product; see design.md note).
+- No semantic-search exposure through the Memory tool in v1 (the
+  Memory tool is file-addressed; long-term semantic recall stays on
+  `/recall`).
+
+## Done when
+
+- The adapter passes Anthropic's Memory tool contract for all six
+  commands (mocked).
+- A live round-trip writes via the Memory tool and reads back via
+  attune's recall path (and vice versa) against AMS 0.14.0.
+- `docs/redis/best-practice-alignment.md` can cite this as shipped.
+- The README / docs can state the dual-vendor claim with a code
+  pointer.

--- a/docs/specs/pattern-review-queue/requirements.md
+++ b/docs/specs/pattern-review-queue/requirements.md
@@ -1,0 +1,113 @@
+# Spec: Pattern Review Queue
+
+> Put a **human in the loop** before discovered patterns enter the
+> active pattern library. Today `PatternLibrary.contribute_pattern()`
+> adds patterns directly. This spec adds a **review queue**:
+> discovered patterns are *staged*, surfaced for review (CLI + ops
+> dashboard), and only **promoted** into the active library on
+> approval — or **rejected**. It captures the design of the dormant
+> `PatternStagingMixin` (the one piece of the old in-tree Redis
+> coordination code with genuine, vendor-unique user value) and
+> re-homes it on the current backend stack, off the deprecated
+> Redis coupling.
+
+**Status:** draft (2026-06-08) — overnight autonomous draft for
+morning review
+**Owner:** Patrick + agent
+**Related:**
+
+- [`docs/redis/best-practice-alignment.md`](../../redis/best-practice-alignment.md)
+  — why PatternStaging is "capture" and the coordination mixins are
+  "retire"
+- [`redis-facade-direction/decisions.md`](../redis-facade-direction/decisions.md)
+  — the facade direction this implements one half of
+- `src/attune/memory/types.py::StagedPattern` — the data model
+  (already exists, **not** deprecated)
+- `src/attune/pattern_library.py::PatternLibrary.contribute_pattern`
+  — the promote target
+- `src/attune/redis_memory_patterns.py::PatternStagingMixin`
+  (DEPRECATED) — the design we capture (stage/get/list/promote/reject),
+  re-homed off Redis
+
+---
+
+## Problem
+
+attune's `PatternLibrary` accepts contributed patterns directly via
+`contribute_pattern(agent_id, pattern)` — there is no review step.
+Auto-discovered patterns (from bug fixes, workflow runs, agent
+contributions) land in the active library unfiltered, so:
+
+1. Low-confidence or noisy patterns can pollute matching/recall.
+2. There's no human checkpoint to curate what the system "learns."
+
+The old `PatternStagingMixin` solved exactly this (stage → review →
+promote/reject) but is coupled to the deprecated in-tree Redis
+`RedisShortTermMemory` and is not wired to any live surface.
+
+## Goal
+
+A review queue, re-homed on the current backend stack:
+
+- Discovered patterns are **staged** (persisted as `StagedPattern`)
+  instead of contributed directly.
+- A reviewer **sees the queue** (CLI + ops dashboard) with name,
+  type, confidence, source agent, code preview.
+- Reviewer **promotes** (→ `PatternLibrary.contribute_pattern`) or
+  **rejects** (drops from the queue).
+
+## Requirements
+
+- **R1 — Stage.** A `stage_pattern(StagedPattern)` path that persists
+  to attune's memory backend (file by default; AMS when configured),
+  **not** the deprecated Redis mixin.
+- **R2 — List/inspect.** `list_staged_patterns()` (filterable by
+  type/agent/confidence) and `get_staged_pattern(id)`.
+- **R3 — Promote.** `promote_pattern(id)` converts the `StagedPattern`
+  to a `Pattern` and calls `PatternLibrary.contribute_pattern`, then
+  removes it from the queue.
+- **R4 — Reject.** `reject_pattern(id, reason)` drops it (with the
+  reason recorded for audit).
+- **R5 — CLI surface.** `attune patterns review` (list) /
+  `attune patterns promote <id>` / `attune patterns reject <id>` —
+  the human-in-the-loop entry point.
+- **R6 — Dashboard surface.** A "Pattern review" panel in the ops
+  dashboard: queue list + promote/reject actions (defense-in-depth
+  via the existing `X-Attune-Client` token gate on the mutating
+  routes).
+- **R7 — Opt-in routing.** Discovery paths route to *staging* only
+  when review is enabled (config flag); default behavior unchanged
+  until a reviewer opts in (no surprise gating of existing
+  auto-contribution).
+- **R8 — Tested.** Mocked unit tests for stage/list/promote/reject +
+  the CLI; one live round-trip (stage → promote → assert in library)
+  auto-skipping without a backend where relevant.
+
+## Non-goals
+
+- No multi-agent *negotiation* over patterns (that's the
+  `ConflictNegotiationMixin` surface — explicitly **retired**, not
+  revived; Anthropic subagents/Managed-Agents cover real multi-agent
+  coordination).
+- No change to how patterns are *matched* at runtime — only how they
+  *enter* the library.
+- No Redis dependency — the queue persists on the same backend
+  abstraction as the rest of attune memory (file/AMS).
+
+## Done when
+
+- A discovered pattern can be staged, reviewed in CLI + dashboard,
+  and promoted into `PatternLibrary` or rejected.
+- `PatternStagingMixin` (deprecated) has no remaining unique
+  capability the queue doesn't cover → it can be retired with the
+  rest of the coordination mixins.
+- Tests green; the feature is opt-in and default-off.
+
+## Phase 0 (verify before building)
+
+Grep the live discovery/contribution paths
+(`agent_monitoring.py`, `pattern_persistence.py`,
+`core_modules/shared_library.py`, `core.py`) to confirm where
+`contribute_pattern` is actually called, so R7's opt-in routing taps
+the real seam rather than an assumed one. (One-hour check; mirrors
+the "verify the seam before wiring" discipline.)

--- a/docs/specs/redis-facade-direction/decisions.md
+++ b/docs/specs/redis-facade-direction/decisions.md
@@ -1,0 +1,135 @@
+# Decisions: Redis Facade Direction
+
+> **A proposal to ratify, not executed work.** This doc records the
+> direction that came out of the 2026-06-07/08 facade review. No
+> code has been changed on the strength of it. Bring corrections to
+> the morning meeting; once ratified, each decision spawns its own
+> scoped change.
+
+**Status:** PROPOSAL — awaiting Patrick's ratification (2026-06-08)
+**Owner:** Patrick
+**Related:**
+
+- [`docs/redis/best-practice-alignment.md`](../../redis/best-practice-alignment.md)
+- [`anthropic-memory-tool-backend`](../anthropic-memory-tool-backend/requirements.md)
+- [`pattern-review-queue`](../pattern-review-queue/requirements.md)
+- [`project_redis_strategy_leverage`](~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/project_redis_strategy_leverage.md)
+  — "leverage their work, don't decouple" (the governing strategy)
+- [`release_state`](~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/release_state.md)
+  — currently records the (now-superseded) "removal deferred to
+  v9.0.0" framing
+
+---
+
+## Context (what was reviewed)
+
+The 6 in-tree `attune.redis_*` / `memory/config` modules (1,492
+lines) carry `REMOVE IN v9.0.0` "deprecated" markers. Patrick flagged
+the deprecate/remove decision as hasty and asked for a review. The
+review found:
+
+1. The governing strategy is **leverage, not decouple** (2026-06-03
+   directive). The `REMOVE IN v9.0.0` markers contradict it — they
+   signal "exiting Redis" when the direction is "doubling down."
+2. There are **two distinct Redis codebases**, conflated by the
+   markers: the **old in-tree** code (`RedisShortTermMemory` +
+   coordination mixins + `redis_config`) and the **new leverage path**
+   (`attune_redis.AMSMemoryBackend` + int8 factory). "The work" is the
+   new path.
+3. The old code's distinctive value is its **coordination mixins**
+   (pattern staging, conflict negotiation, signals, shared sessions)
+   — but those are **dormant** (no live MCP/CLI reaches them; only
+   `control_panel` instantiates `RedisShortTermMemory`, for
+   `clear_short_term` + health).
+4. Best-practice lens: Anthropic now ships **native multi-agent
+   coordination** (subagents, Managed-Agents `multiagent`). Reviving
+   custom Redis coordination primitives would reimplement a
+   vendor-native capability.
+
+---
+
+## D1 — Do NOT remove the facades. Relabel them.
+
+**Decision (proposed):** Keep the 6 modules. Replace the
+`REMOVE IN v9.0.0` markers with **"superseded by `attune_redis`,
+retained for compatibility"**. The strategy is leverage; the markers
+should stop signaling exit.
+
+**Why:** `RedisShortTermMemory` is still live via `control_panel`;
+removal is a memory-subsystem change, not a facade delete; and the
+markers contradict the leverage strategy. Relabel is a low-risk text
+change (a few module headers + the migration doc), not a code change.
+
+**Not yet done.** Proposed as a small, reviewable PR after
+ratification.
+
+## D2 — Retire the coordination mixins (do not revive).
+
+**Decision (proposed):** Treat `ConflictNegotiationMixin`,
+`CoordinationSignalsMixin`, `SessionManagementMixin` as **retired** —
+keep as reference (don't delete blindly per the relabel decision),
+but do **not** build product surface on them. If multi-live-agent
+coordination becomes a real feature, build it on **Anthropic
+subagents / Managed-Agents `multiagent`**, not custom Redis pub/sub.
+
+**Why:** dormant (no live caller), and reviving them reimplements a
+vendor-native capability — the opposite of "align with best practice"
+(see alignment doc). `RedisStorageBase` is superseded by
+`AMSMemoryBackend`.
+
+## D3 — Capture PatternStaging as a user feature.
+
+**Decision (proposed):** The **one** dormant piece with genuine,
+vendor-unique value is `PatternStagingMixin`. Capture its design
+(stage → review → promote/reject) as the **pattern-review queue**,
+re-homed on the current backend stack (file/AMS), off the deprecated
+Redis coupling. Spec:
+[`pattern-review-queue`](../pattern-review-queue/requirements.md).
+
+**Why:** no vendor-native equivalent (it's an attune-domain
+curation workflow); the data model (`StagedPattern`) and promote
+target (`PatternLibrary.contribute_pattern`) already exist and are
+not deprecated.
+
+## D4 — Invest in the AMS/Redis leverage path; add the Anthropic bridge.
+
+**Decision (proposed):** Continue the `attune_redis`/AMS line (the
+real "Redis work"): land the in-flight fixes (#666/#667/#668), ship
+the **Anthropic Memory-tool backend bridge** (the one item that
+makes "follows both vendors' best practices" demonstrable), bump
+`agent-memory-server` 0.14.0 → 0.15.2 and re-verify, and ship the
+upstream RedisVL **datatype contribute-back PR**. Spec:
+[`anthropic-memory-tool-backend`](../anthropic-memory-tool-backend/requirements.md).
+
+**Why:** strongest, most-claimable alignment; "contribute back" is
+the highest-integrity leverage move.
+
+## D5 — Update `release_state` once ratified.
+
+**Decision (proposed):** After ratification, update the
+`release_state` memory: the "removal deferred to v9.0.0" line is
+superseded by "relabel-not-remove; leverage path is the work." 9.0.0
+is **not** a facade-removal release.
+
+---
+
+## What this does NOT decide (open for the meeting)
+
+- Whether to ever fully remove the in-tree `RedisShortTermMemory`
+  (a real memory-subsystem migration) — out of scope here; the
+  proposal is to stop *signaling* removal, not to schedule one.
+- Whether the Memory-tool bridge lives in `attune.memory` or
+  `attune_redis` (design.md open question).
+- Sequencing of the leverage-track items relative to the next
+  release cut.
+
+---
+
+## Ratification checklist (for the morning)
+
+- [ ] D1 relabel-not-remove — agree / amend?
+- [ ] D2 retire coordination mixins — agree / amend?
+- [ ] D3 capture PatternStaging as pattern-review queue — agree?
+- [ ] D4 AMS bridge + upstream contribute-back + 0.15.2 bump — agree
+      / sequence?
+- [ ] D5 update `release_state` framing — agree?


### PR DESCRIPTION
## Overnight review artifacts (no code changed)

Deliverables from the autonomous overnight pass on the **Redis-leverage direction**, for the morning meeting. All four are review docs — decisions to ratify, not executed work.

### 1. Best-practice alignment (verified)
`docs/redis/best-practice-alignment.md` — what attune can **verifiably** claim about following Redis's and Anthropic's recommended patterns, with current sources. Headlines:
- **Redis:** built on `redis/agent-memory-server` + RedisVL via the documented `MEMORY_VECTOR_DB_FACTORY` seam (not a fork); int8 quant shipped; contribute-back PR still needed (upstream `agent-memory-server` is at **v0.15.2**, datatype still not settings-driven; we pin 0.14.0).
- **Anthropic:** Agent SDK + MCP + Skills already native; cross-session memory matches the Memory-tool pattern. **One bridge** makes it demonstrable.
- Wording flagged where it should be softened before external copy.

### 2. Anthropic Memory-tool backend bridge (spec)
`docs/specs/anthropic-memory-tool-backend/` — implement Anthropic's Memory tool (`memory_20250818`) over `AMSMemoryBackend`, so "our memory layer **is** a backend for Anthropic's Memory tool, persisted on Redis's Agent Memory Server." The single item that makes the dual-vendor claim true.

### 3. Pattern review queue (spec)
`docs/specs/pattern-review-queue/` — capture `PatternStaging` (the one dormant coordination piece with vendor-unique value) as a human-in-the-loop review queue, re-homed off the deprecated Redis mixin. `StagedPattern` + `contribute_pattern` already exist.

### 4. Facade direction (PROPOSAL to ratify)
`docs/specs/redis-facade-direction/decisions.md` — D1 relabel-not-remove the markers; D2 retire the coordination mixins (Anthropic subagents/Managed-Agents supersede them); D3 capture PatternStaging; D4 invest in the AMS bridge + upstream contribute-back + 0.15.2 bump; D5 update `release_state` framing. **Ratification checklist at the bottom.**

## What's also in flight (separate PRs)
- #666 (dedup + limit clamp) — green-ready
- #667 (stash merge fix) — coverage re-run triggered (was a transient xdist worker-crash flake, unrelated to attune_redis)
- #668 (deprecation migration, stacked on #667)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
