### PR TITLE
feat(memory): Anthropic Memory-tool backend over attune's MemoryBackend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **attune's memory store is now a drop-in backend for Anthropic's
+  Memory tool.** `attune.memory.memory_tool.make_memory_tool()` returns
+  a real `anthropic` `BetaAbstractMemoryTool` (the `memory_20250818`
+  client-side tool) whose `view`/`create`/`str_replace`/`insert`/
+  `delete`/`rename` commands persist through any attune `MemoryBackend`
+  — the file backend by default (zero infra), `attune_redis`'s
+  Agent-Memory-Server backend when configured. Pass it to the Anthropic
+  SDK `tool_runner` to give an agent a `/memories` directory backed by
+  attune (and, with AMS, by Redis). Memory paths are traversal-validated
+  and optionally per-user namespaced. This makes the "follows both
+  Redis's and Anthropic's memory best practices" posture demonstrable:
+  Anthropic's native memory interface, persisted on Redis's reference
+  Agent Memory Server. See
+  `docs/specs/anthropic-memory-tool-backend/`. (Phase 1: the adapter +
+  tests; MCP/CLI surfacing is a follow-up.)
 - **AMS backend now powers SessionStart auto-recall.** The
   `attune-redis` `AMSMemoryBackend.recent()` method is no longer a
   stub — query-less recency listing is implemented, so users on the

--- a/src/attune/memory/memory_tool.py
+++ b/src/attune/memory/memory_tool.py
@@ -1,0 +1,315 @@
+"""Anthropic Memory-tool backend over attune's MemoryBackend.
+
+Implements Anthropic's client-side **Memory tool** (``memory_20250818``)
+on top of attune's existing memory backends (the file backend by
+default, ``attune_redis.AMSMemoryBackend`` when AMS is configured).
+
+Anthropic's Memory tool is file-addressed: the model issues
+``view`` / ``create`` / ``str_replace`` / ``insert`` / ``delete`` /
+``rename`` commands against a ``/memories`` directory, and the host
+implements the storage. This adapter maps that file model onto the
+``MemoryBackend`` key/value surface — a memory file *path* becomes a
+backend *key* (prefixed so memory-tool files are enumerable), and the
+file *content* is the stored value. The result: the same durable,
+optionally-Redis-backed store that powers attune's SessionStart recall
+also serves Anthropic's native memory interface.
+
+Pass an instance to the Anthropic SDK's ``tool_runner`` (or call
+``execute``/``call`` directly) to give an agent a ``/memories``
+directory persisted on attune's backend.
+
+See ``docs/specs/anthropic-memory-tool-backend/`` for the design.
+
+Copyright 2025-2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from anthropic.types.beta import (
+        BetaMemoryTool20250818CreateCommand,
+        BetaMemoryTool20250818DeleteCommand,
+        BetaMemoryTool20250818InsertCommand,
+        BetaMemoryTool20250818RenameCommand,
+        BetaMemoryTool20250818StrReplaceCommand,
+        BetaMemoryTool20250818ViewCommand,
+    )
+
+    from .backend import MemoryBackend
+
+logger = logging.getLogger(__name__)
+
+#: Virtual root the Anthropic Memory tool addresses files under.
+_DEFAULT_ROOT = "/memories"
+
+#: Backend-key prefix so memory-tool files are enumerable (``view`` of a
+#: directory) and distinct from other ``stash`` keys in the same namespace.
+_KEY_PREFIX = "memtool"
+
+
+def _import_base() -> type:
+    """Import ``BetaAbstractMemoryTool`` lazily.
+
+    Kept out of module import so ``attune.memory`` stays importable when an
+    older ``anthropic`` without the memory-tool helper is installed; the
+    factory raises a clear error only when the bridge is actually used.
+    """
+    try:
+        from anthropic.lib.tools import BetaAbstractMemoryTool
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise RuntimeError(
+            "Anthropic Memory-tool bridge requires the `anthropic` SDK with "
+            "memory-tool support (anthropic.lib.tools.BetaAbstractMemoryTool)."
+        ) from exc
+    return BetaAbstractMemoryTool
+
+
+class _PathError(ValueError):
+    """Raised for an invalid/unsafe memory path (caught, returned as text)."""
+
+
+def _normalize_path(path: str, root: str) -> str:
+    """Validate a Memory-tool path and return its root-relative form.
+
+    Args:
+        path: The model-supplied path (e.g. ``/memories/notes/todo.md``).
+        root: The virtual root (default ``/memories``).
+
+    Returns:
+        The path relative to ``root`` with no leading slash (``""`` for the
+        root itself).
+
+    Raises:
+        _PathError: On null bytes, traversal (``..``), or a path outside root.
+    """
+    if not isinstance(path, str) or "\x00" in path:
+        raise _PathError("path must be a non-empty string without null bytes")
+    cleaned = path.strip()
+    if not cleaned.startswith(root):
+        # Tolerate paths given relative to the root, too.
+        rel = cleaned.lstrip("/")
+    else:
+        rel = cleaned[len(root) :].lstrip("/")
+    parts = [p for p in rel.split("/") if p not in ("", ".")]
+    if any(p == ".." for p in parts):
+        raise _PathError(f"path traversal is not allowed: {path!r}")
+    return "/".join(parts)
+
+
+def _with_line_numbers(text: str) -> str:
+    """Render file content with 1-indexed line numbers (Memory-tool view)."""
+    lines = text.splitlines()
+    width = len(str(len(lines))) if lines else 1
+    return "\n".join(f"{i:>{width}}\t{line}" for i, line in enumerate(lines, 1))
+
+
+class AttuneMemoryTool:  # mixed with BetaAbstractMemoryTool in __new__
+    """Anthropic Memory tool backed by an attune ``MemoryBackend``.
+
+    Example::
+
+        from attune.memory.memory_tool import AttuneMemoryTool
+        from attune.memory.file_stash import FileStashBackend
+
+        tool = AttuneMemoryTool(FileStashBackend())
+        # pass `tool` to anthropic tool_runner, or:
+        tool.execute(create_command)
+    """
+
+    def __init__(
+        self,
+        backend: MemoryBackend,
+        *,
+        root: str = _DEFAULT_ROOT,
+        user_id: str | None = None,
+    ) -> None:
+        """Initialize the bridge.
+
+        Args:
+            backend: Any attune ``MemoryBackend`` (file by default, AMS when
+                configured). Provides ``stash``/``retrieve``/``keys``/``delete``.
+            root: Virtual root the model addresses files under.
+            user_id: When set, namespaces keys so memory is per-user.
+        """
+        # BetaAbstractMemoryTool.__init__ takes no args; call it via super
+        # through the dynamically-composed class (see __init_subclass shim).
+        super().__init__()  # type: ignore[misc]
+        self._backend = backend
+        self._root = root.rstrip("/") or "/"
+        self._user_id = user_id
+
+    # -- key mapping ------------------------------------------------------ #
+
+    def _key(self, rel: str) -> str:
+        """Backend key for a root-relative memory path."""
+        scope = self._user_id or "_"
+        return f"{_KEY_PREFIX}:{scope}:{rel}"
+
+    def _key_prefix(self, rel: str = "") -> str:
+        """Backend-key glob for enumerating files under a relative dir."""
+        scope = self._user_id or "_"
+        base = f"{_KEY_PREFIX}:{scope}:{rel}".rstrip(":")
+        return f"{base}*" if not rel else f"{base}/*"
+
+    def _read(self, rel: str) -> str | None:
+        val = self._backend.retrieve(self._key(rel))
+        if val is None:
+            return None
+        return val if isinstance(val, str) else str(val)
+
+    # -- the six Memory-tool commands ------------------------------------ #
+
+    def view(self, command: BetaMemoryTool20250818ViewCommand) -> str:
+        """Read a file (optionally a line range) or list a directory."""
+        try:
+            rel = _normalize_path(command.path, self._root)
+        except _PathError as e:
+            return f"Error: {e}"
+        text = self._read(rel)
+        if text is not None:
+            view_range = getattr(command, "view_range", None)
+            if view_range:
+                lines = text.splitlines()
+                start, end = view_range[0], view_range[1]
+                end = len(lines) if end == -1 else end
+                start = max(1, start)
+                sliced = lines[start - 1 : end]
+                width = len(str(end)) if end else 1
+                return "\n".join(f"{i:>{width}}\t{ln}" for i, ln in enumerate(sliced, start))
+            return _with_line_numbers(text)
+        # Not a file — treat as a directory listing under the prefix.
+        prefix = f"{_KEY_PREFIX}:{self._user_id or '_'}:"
+        try:
+            all_keys = self._backend.keys(self._key_prefix(rel))
+        except Exception as e:  # noqa: BLE001 - best-effort listing
+            logger.error("memory_tool view list failed: %s", e)
+            return f"Error: could not list {command.path}"
+        entries = sorted(k[len(prefix) :] for k in all_keys if k.startswith(prefix))
+        if not entries:
+            return f"Error: path not found: {command.path}"
+        listing = "\n".join(f"{self._root}/{e}" for e in entries)
+        return f"Directory {command.path}:\n{listing}"
+
+    def create(self, command: BetaMemoryTool20250818CreateCommand) -> str:
+        """Create (or overwrite) a memory file."""
+        try:
+            rel = _normalize_path(command.path, self._root)
+        except _PathError as e:
+            return f"Error: {e}"
+        if not rel:
+            return "Error: cannot create the root directory as a file"
+        ok = self._backend.stash(self._key(rel), command.file_text)
+        return f"Created {command.path}" if ok else f"Error: write failed: {command.path}"
+
+    def str_replace(self, command: BetaMemoryTool20250818StrReplaceCommand) -> str:
+        """Replace the first occurrence of ``old_str`` with ``new_str``."""
+        try:
+            rel = _normalize_path(command.path, self._root)
+        except _PathError as e:
+            return f"Error: {e}"
+        text = self._read(rel)
+        if text is None:
+            return f"Error: path not found: {command.path}"
+        if command.old_str not in text:
+            return f"Error: no match for old_str in {command.path}"
+        updated = text.replace(command.old_str, command.new_str, 1)
+        ok = self._backend.stash(self._key(rel), updated)
+        return f"Edited {command.path}" if ok else f"Error: write failed: {command.path}"
+
+    def insert(self, command: BetaMemoryTool20250818InsertCommand) -> str:
+        """Insert text after the given (1-indexed) line."""
+        try:
+            rel = _normalize_path(command.path, self._root)
+        except _PathError as e:
+            return f"Error: {e}"
+        text = self._read(rel)
+        if text is None:
+            return f"Error: path not found: {command.path}"
+        lines = text.splitlines()
+        at = command.insert_line
+        if at < 0 or at > len(lines):
+            return f"Error: insert_line {at} out of range for {command.path}"
+        new_lines = lines[:at] + command.insert_text.splitlines() + lines[at:]
+        ok = self._backend.stash(self._key(rel), "\n".join(new_lines))
+        return f"Inserted into {command.path}" if ok else f"Error: write failed: {command.path}"
+
+    def delete(self, command: BetaMemoryTool20250818DeleteCommand) -> str:
+        """Delete a memory file."""
+        try:
+            rel = _normalize_path(command.path, self._root)
+        except _PathError as e:
+            return f"Error: {e}"
+        ok = self._backend.delete(self._key(rel))
+        return f"Deleted {command.path}" if ok else f"Error: path not found: {command.path}"
+
+    def rename(self, command: BetaMemoryTool20250818RenameCommand) -> str:
+        """Rename/move a memory file (copy then delete)."""
+        try:
+            old_rel = _normalize_path(command.old_path, self._root)
+            new_rel = _normalize_path(command.new_path, self._root)
+        except _PathError as e:
+            return f"Error: {e}"
+        text = self._read(old_rel)
+        if text is None:
+            return f"Error: path not found: {command.old_path}"
+        if self._read(new_rel) is not None:
+            return f"Error: destination exists: {command.new_path}"
+        if not self._backend.stash(self._key(new_rel), text):
+            return f"Error: write failed: {command.new_path}"
+        self._backend.delete(self._key(old_rel))
+        return f"Renamed {command.old_path} to {command.new_path}"
+
+    def clear_all_memory(self) -> None:
+        """Delete every memory-tool file for this scope (best-effort)."""
+        prefix = f"{_KEY_PREFIX}:{self._user_id or '_'}:"
+        try:
+            for k in self._backend.keys(self._key_prefix()):
+                if k.startswith(prefix):
+                    self._backend.delete(k)
+        except Exception as e:  # noqa: BLE001 - best-effort teardown
+            logger.error("memory_tool clear_all failed: %s", e)
+
+
+def make_memory_tool(
+    backend: MemoryBackend | None = None,
+    *,
+    root: str = _DEFAULT_ROOT,
+    user_id: str | None = None,
+) -> Any:
+    """Build an Anthropic Memory-tool instance backed by an attune backend.
+
+    Composes ``AttuneMemoryTool`` with the SDK's ``BetaAbstractMemoryTool``
+    at call time (so importing this module never requires the SDK helper),
+    and resolves a default backend when none is given.
+
+    Args:
+        backend: An attune ``MemoryBackend``. Defaults to the resolved
+            backend (file by default; AMS when configured).
+        root: Virtual root the model addresses files under.
+        user_id: When set, namespaces memory per-user.
+
+    Returns:
+        A ``BetaAbstractMemoryTool`` subclass instance ready to pass to the
+        Anthropic SDK ``tool_runner``.
+    """
+    base = _import_base()
+
+    # Compose the concrete tool with the SDK's abstract base. The handler
+    # bodies live on AttuneMemoryTool; the base supplies execute/call/name.
+    composed = type("AttuneMemoryTool", (AttuneMemoryTool, base), {})
+
+    if backend is None:
+        from .session_stash import resolve_backend
+
+        backend = resolve_backend(None)
+        if backend is None:  # pragma: no cover - depends on environment
+            raise RuntimeError("no memory backend available")
+
+    return composed(backend, root=root, user_id=user_id)
+
+
+__all__ = ["AttuneMemoryTool", "make_memory_tool"]

--- a/tests/unit/memory/test_memory_tool.py
+++ b/tests/unit/memory/test_memory_tool.py
@@ -226,3 +226,120 @@ class TestSDKComposition:
         tool.clear_all_memory()
         assert "Error" in _view(tool, "/memories/a.md")
         assert "Error" in _view(tool, "/memories/b.md")
+
+
+# =====================================================================
+# error / edge branches (per-command path validation + backend failures)
+# =====================================================================
+
+
+class _RaisingKeysBackend(FileStashBackend):
+    """File backend whose keys() always raises (best-effort list/clear paths)."""
+
+    def keys(self, pattern: str = "*"):  # type: ignore[override]
+        raise RuntimeError("boom")
+
+
+class _FailStashBackend(FileStashBackend):
+    """File backend whose stash() always reports failure."""
+
+    def stash(self, key, value, ttl=None, agent_id=None):  # type: ignore[override]
+        return False
+
+
+class TestErrorBranches:
+    @pytest.mark.parametrize(
+        "make",
+        [
+            lambda t: t.str_replace(
+                StrReplaceCommand(
+                    command="str_replace", path="/memories/../x", old_str="a", new_str="b"
+                )
+            ),
+            lambda t: t.insert(
+                InsertCommand(
+                    command="insert", path="/memories/../x", insert_line=0, insert_text="y"
+                )
+            ),
+            lambda t: t.delete(DeleteCommand(command="delete", path="/memories/../x")),
+            lambda t: t.rename(
+                RenameCommand(
+                    command="rename", old_path="/memories/../x", new_path="/memories/y.md"
+                )
+            ),
+        ],
+    )
+    def test_traversal_blocked_on_every_command(self, tool, make):
+        assert "traversal" in make(tool).lower()
+
+    def test_rename_destination_traversal_blocked(self, tool):
+        _create(tool, "/memories/a.md", "x")
+        out = tool.rename(
+            RenameCommand(command="rename", old_path="/memories/a.md", new_path="/memories/../y")
+        )
+        assert "traversal" in out.lower()
+
+    def test_insert_missing_file_is_error(self, tool):
+        out = tool.insert(
+            InsertCommand(command="insert", path="/memories/no.md", insert_line=0, insert_text="x")
+        )
+        assert "not found" in out.lower()
+
+    def test_create_root_path_is_error(self, tool):
+        out = _create(tool, "/memories", "x")
+        assert "root" in out.lower()
+
+    def test_view_directory_list_error_when_keys_raises(self, tmp_path):
+        backend = _RaisingKeysBackend(base_dir=str(tmp_path))
+        tool = AttuneMemoryTool(backend, user_id="u")
+        out = _view(tool, "/memories")
+        assert "could not list" in out.lower()
+
+    def test_create_write_failure_is_error(self, tmp_path):
+        backend = _FailStashBackend(base_dir=str(tmp_path))
+        tool = AttuneMemoryTool(backend, user_id="u")
+        assert "write failed" in _create(tool, "/memories/a.md", "x").lower()
+
+    def test_rename_write_failure_is_error(self):
+        # Source reads back, but the copy stash fails -> rename reports failure.
+        class _ReadOkStashFails:
+            def retrieve(self, key, agent_id=None):
+                return "payload" if key.endswith("a.md") else None
+
+            def stash(self, key, value, ttl=None, agent_id=None):
+                return False
+
+            def delete(self, key):
+                return True
+
+            def keys(self, pattern="*"):
+                return []
+
+        tool = AttuneMemoryTool(_ReadOkStashFails(), user_id="u")
+        out = tool.rename(
+            RenameCommand(command="rename", old_path="/memories/a.md", new_path="/memories/b.md")
+        )
+        assert "write failed" in out.lower()
+
+    def test_clear_all_swallows_keys_error(self, tmp_path):
+        backend = _RaisingKeysBackend(base_dir=str(tmp_path))
+        tool = AttuneMemoryTool(backend, user_id="u")
+        tool.clear_all_memory()  # must not raise
+
+    def test_clear_all_skips_non_prefixed_keys(self, tmp_path):
+        backend = FileStashBackend(base_dir=str(tmp_path))
+        tool = AttuneMemoryTool(backend, user_id="u")
+        _create(tool, "/memories/a.md", "x")
+        backend.stash("unrelated:key", "keep")  # not a memtool: key
+        tool.clear_all_memory()
+        assert backend.retrieve("unrelated:key") == "keep"
+
+    def test_make_memory_tool_resolves_default_backend(self, tmp_path, monkeypatch):
+        backend = FileStashBackend(base_dir=str(tmp_path))
+        monkeypatch.setattr("attune.memory.session_stash.resolve_backend", lambda _x: backend)
+        tool = make_memory_tool(None, user_id="u")
+        tool.execute(CreateCommand(command="create", path="/memories/a.md", file_text="hi"))
+        assert (
+            tool.execute(ViewCommand(command="view", path="/memories/a.md", view_range=None))
+            == "1\thi"
+        )

--- a/tests/unit/memory/test_memory_tool.py
+++ b/tests/unit/memory/test_memory_tool.py
@@ -1,0 +1,228 @@
+"""Tests for the Anthropic Memory-tool bridge over attune's backend.
+
+Exercises ``attune.memory.memory_tool`` against the real file backend
+(zero infra) so the six Memory-tool commands round-trip through
+``stash``/``retrieve``/``keys``/``delete``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.memory.file_stash import FileStashBackend
+from attune.memory.memory_tool import AttuneMemoryTool, make_memory_tool
+
+# Real Anthropic command types — skip the whole module if the installed
+# anthropic SDK predates the memory tool.
+beta = pytest.importorskip("anthropic.types.beta")
+
+CreateCommand = beta.BetaMemoryTool20250818CreateCommand
+ViewCommand = beta.BetaMemoryTool20250818ViewCommand
+StrReplaceCommand = beta.BetaMemoryTool20250818StrReplaceCommand
+InsertCommand = beta.BetaMemoryTool20250818InsertCommand
+DeleteCommand = beta.BetaMemoryTool20250818DeleteCommand
+RenameCommand = beta.BetaMemoryTool20250818RenameCommand
+
+
+@pytest.fixture()
+def tool(tmp_path):
+    """An AttuneMemoryTool over a file backend in a temp dir."""
+    backend = FileStashBackend(base_dir=str(tmp_path))
+    return AttuneMemoryTool(backend, user_id="tester")
+
+
+def _create(tool, path, text):
+    return tool.create(CreateCommand(command="create", path=path, file_text=text))
+
+
+def _view(tool, path, view_range=None):
+    return tool.view(ViewCommand(command="view", path=path, view_range=view_range))
+
+
+# =====================================================================
+# create / view
+# =====================================================================
+
+
+class TestCreateView:
+    def test_create_then_view_with_line_numbers(self, tool):
+        _create(tool, "/memories/a.md", "alpha\nbeta")
+        out = _view(tool, "/memories/a.md")
+        assert out == "1\talpha\n2\tbeta"
+
+    def test_create_returns_confirmation(self, tool):
+        assert _create(tool, "/memories/a.md", "x") == "Created /memories/a.md"
+
+    def test_view_range_slices_lines(self, tool):
+        _create(tool, "/memories/a.md", "l1\nl2\nl3\nl4")
+        assert _view(tool, "/memories/a.md", [2, 3]) == "2\tl2\n3\tl3"
+
+    def test_view_range_negative_end_means_to_end(self, tool):
+        _create(tool, "/memories/a.md", "l1\nl2\nl3")
+        assert _view(tool, "/memories/a.md", [2, -1]) == "2\tl2\n3\tl3"
+
+    def test_view_directory_lists_files(self, tool):
+        _create(tool, "/memories/a.md", "x")
+        _create(tool, "/memories/sub/b.md", "y")
+        out = _view(tool, "/memories")
+        assert out.startswith("Directory /memories:")
+        assert "/memories/a.md" in out
+        assert "/memories/sub/b.md" in out
+
+    def test_view_missing_file_is_error(self, tool):
+        assert "Error" in _view(tool, "/memories/nope.md")
+
+    def test_relative_path_is_tolerated(self, tool):
+        _create(tool, "notes.md", "x")
+        assert _view(tool, "/memories/notes.md") == "1\tx"
+
+
+# =====================================================================
+# str_replace / insert
+# =====================================================================
+
+
+class TestEdit:
+    def test_str_replace_first_occurrence(self, tool):
+        _create(tool, "/memories/a.md", "foo bar foo")
+        tool.str_replace(
+            StrReplaceCommand(
+                command="str_replace", path="/memories/a.md", old_str="foo", new_str="X"
+            )
+        )
+        assert _view(tool, "/memories/a.md") == "1\tX bar foo"
+
+    def test_str_replace_no_match_is_error(self, tool):
+        _create(tool, "/memories/a.md", "hello")
+        out = tool.str_replace(
+            StrReplaceCommand(
+                command="str_replace", path="/memories/a.md", old_str="zzz", new_str="X"
+            )
+        )
+        assert "no match" in out.lower()
+
+    def test_str_replace_missing_file_is_error(self, tool):
+        out = tool.str_replace(
+            StrReplaceCommand(
+                command="str_replace", path="/memories/no.md", old_str="a", new_str="b"
+            )
+        )
+        assert "not found" in out.lower()
+
+    def test_insert_after_line(self, tool):
+        _create(tool, "/memories/a.md", "l1\nl2")
+        tool.insert(
+            InsertCommand(command="insert", path="/memories/a.md", insert_line=1, insert_text="INS")
+        )
+        assert _view(tool, "/memories/a.md") == "1\tl1\n2\tINS\n3\tl2"
+
+    def test_insert_at_zero_prepends(self, tool):
+        _create(tool, "/memories/a.md", "l1")
+        tool.insert(
+            InsertCommand(command="insert", path="/memories/a.md", insert_line=0, insert_text="top")
+        )
+        assert _view(tool, "/memories/a.md") == "1\ttop\n2\tl1"
+
+    def test_insert_out_of_range_is_error(self, tool):
+        _create(tool, "/memories/a.md", "l1")
+        out = tool.insert(
+            InsertCommand(command="insert", path="/memories/a.md", insert_line=99, insert_text="x")
+        )
+        assert "out of range" in out.lower()
+
+
+# =====================================================================
+# delete / rename
+# =====================================================================
+
+
+class TestDeleteRename:
+    def test_delete_removes_file(self, tool):
+        _create(tool, "/memories/a.md", "x")
+        assert (
+            tool.delete(DeleteCommand(command="delete", path="/memories/a.md"))
+            == "Deleted /memories/a.md"
+        )
+        assert "Error" in _view(tool, "/memories/a.md")
+
+    def test_delete_missing_is_error(self, tool):
+        out = tool.delete(DeleteCommand(command="delete", path="/memories/no.md"))
+        assert "not found" in out.lower()
+
+    def test_rename_moves_content(self, tool):
+        _create(tool, "/memories/a.md", "payload")
+        tool.rename(
+            RenameCommand(command="rename", old_path="/memories/a.md", new_path="/memories/b.md")
+        )
+        assert _view(tool, "/memories/b.md") == "1\tpayload"
+        assert "Error" in _view(tool, "/memories/a.md")
+
+    def test_rename_missing_source_is_error(self, tool):
+        out = tool.rename(
+            RenameCommand(command="rename", old_path="/memories/x.md", new_path="/memories/y.md")
+        )
+        assert "not found" in out.lower()
+
+    def test_rename_existing_dest_is_error(self, tool):
+        _create(tool, "/memories/a.md", "1")
+        _create(tool, "/memories/b.md", "2")
+        out = tool.rename(
+            RenameCommand(command="rename", old_path="/memories/a.md", new_path="/memories/b.md")
+        )
+        assert "exists" in out.lower()
+
+
+# =====================================================================
+# security + isolation
+# =====================================================================
+
+
+class TestSecurity:
+    def test_path_traversal_blocked(self, tool):
+        out = _view(tool, "/memories/../etc/passwd")
+        assert "traversal" in out.lower()
+
+    def test_null_byte_blocked(self, tool):
+        out = _create(tool, "/memories/a\x00.md", "x")
+        assert "Error" in out
+
+    def test_user_id_namespaces_memory(self, tmp_path):
+        backend = FileStashBackend(base_dir=str(tmp_path))
+        alice = AttuneMemoryTool(backend, user_id="alice")
+        bob = AttuneMemoryTool(backend, user_id="bob")
+        _create(alice, "/memories/secret.md", "alice-only")
+        # Bob cannot see Alice's file (different key scope).
+        assert "Error" in _view(bob, "/memories/secret.md")
+        assert _view(alice, "/memories/secret.md") == "1\talice-only"
+
+
+# =====================================================================
+# SDK composition
+# =====================================================================
+
+
+class TestSDKComposition:
+    def test_make_memory_tool_is_real_sdk_tool(self, tmp_path):
+        from anthropic.lib.tools import BetaAbstractMemoryTool
+
+        backend = FileStashBackend(base_dir=str(tmp_path))
+        tool = make_memory_tool(backend, user_id="u")
+        assert isinstance(tool, BetaAbstractMemoryTool)
+        assert not getattr(type(tool), "__abstractmethods__", set())
+        assert tool.name == "memory"
+
+    def test_execute_dispatches_to_backend(self, tmp_path):
+        backend = FileStashBackend(base_dir=str(tmp_path))
+        tool = make_memory_tool(backend, user_id="u")
+        tool.execute(CreateCommand(command="create", path="/memories/a.md", file_text="hi"))
+        assert (
+            tool.execute(ViewCommand(command="view", path="/memories/a.md", view_range=None))
+            == "1\thi"
+        )
+
+    def test_clear_all_memory(self, tool):
+        _create(tool, "/memories/a.md", "x")
+        _create(tool, "/memories/b.md", "y")
+        tool.clear_all_memory()
+        assert "Error" in _view(tool, "/memories/a.md")
+        assert "Error" in _view(tool, "/memories/b.md")


### PR DESCRIPTION
## What

Implements the **Anthropic Memory-tool backend bridge** (D4 from the facade-direction review / spec `docs/specs/anthropic-memory-tool-backend/`). `attune.memory.memory_tool.make_memory_tool()` returns a real `anthropic` `BetaAbstractMemoryTool` (the client-side `memory_20250818` tool) whose six commands — `view`/`create`/`str_replace`/`insert`/`delete`/`rename` — persist through any attune `MemoryBackend`:

- **file backend by default** (zero infra),
- **`attune_redis.AMSMemoryBackend`** (Redis Agent Memory Server) when configured.

Pass it to the Anthropic SDK `tool_runner` and an agent gets a `/memories` directory backed by attune — and, with AMS, by Redis.

## Why

This is the one item that makes attune's "follows both Redis's and Anthropic's memory best practices" posture **demonstrable** rather than analogous: it's Anthropic's *native* memory interface, persisted on Redis's *reference* Agent Memory Server. (See `docs/redis/best-practice-alignment.md`.)

## How

- Maps the Memory-tool file model onto `stash`/`retrieve`/`keys`/`delete`: a memory path → a prefixed backend key, file content → the stored value; `str_replace`/`insert` are read-modify-write; `view` of a directory lists keys under the prefix.
- Path traversal/null-byte validation; optional per-user namespacing.
- `make_memory_tool()` composes the concrete handlers with the SDK's abstract base at call time, so importing `attune.memory` never requires the SDK helper.

## Tests (24, all green)

All six commands against the **real file backend** (zero infra): view with line numbers / range / directory listing, `str_replace` no-match + missing-file errors, `insert` ordering + out-of-range, `rename` copy-then-delete + existing-dest guard, traversal + null-byte blocked, **per-user isolation**, and **SDK composition** (`isinstance(BetaAbstractMemoryTool)`, no abstract methods, `execute()` dispatch).

## Scope

Phase 1 = the adapter + tests. **MCP/CLI surfacing is a deliberate follow-up** (Phase 2). The bridge does not depend on ratifying the facade-direction proposals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
