### PR TITLE
chore: weekly report 2026-06-08

### DIFF
--- a/weekly-reports/2026-06-08.md
+++ b/weekly-reports/2026-06-08.md
@@ -1,0 +1,144 @@
+# Anthropic Ecosystem Weekly — 2026-06-08
+
+## Summary
+
+One week to June 15. `cost_tracker.py` still has the retiring snapshot key — this is now urgent. The bigger surprise this week: **June 15 also introduces separate billing for Agent SDK programmatic usage** from interactive plan usage, drawing from a new monthly credit pool. Max 20x plan gets $200/month at standard API rates for SDK calls — not a fallback from interactive. Claude Code shipped five releases (v2.1.160–v2.1.166); the standout is **Stop/SubagentStop hooks can now return `additionalContext`** (v2.1.163) — directly useful for attune-ai's session-stash hook. One sampling-parameter change on Opus 4.8 adds a pre-flight check before upgrading the PREMIUM tier.
+
+---
+
+## Recommendations
+
+**1. June 15 is 7 days out — fix `cost_tracker.py` now**
+
+Same as last week except the deadline is real. `cost_tracker.py:52` still has:
+
+```python
+"claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
+```
+
+in the `legacy_models` dict. Replace the key with `claude-opus-4-6`. Also run
+`grep -r "4-20250514" src/ attune-author/ attune-rag/ attune-help/` across sibling
+repos — `polish.py` is clean ✅ but siblings haven't been confirmed.
+
+- **Applies to:** `src/attune/cost_tracker.py`, sibling repos
+- **Urgency:** CRITICAL — 7 days.
+
+---
+
+**2. Pre-flight check before Opus 4.8 upgrade: non-default sampling params now return 400**
+
+Before updating `adaptive_routing.py:31` from `claude-opus-4-6` → `claude-opus-4-8`
+(June-1 Rec #1, still open), run one grep:
+`grep -r "temperature\|top_p\|top_k" src/attune/workflows/ src/attune/agents/`.
+Opus 4.8 returns HTTP 400 for any non-default value of these params. If zero hits
+or all hits use defaults, the upgrade is safe. Effort defaults to `high` on 4.8,
+which is already consistent with how the SDK adapter routes.
+
+- **Applies to:** Pre-flight before `src/attune/models/adaptive_routing.py:31` change
+- **Urgency:** High (gate for June-1 Rec #1).
+
+---
+
+**3. June 15 also = separate Agent SDK billing — confirm your exposure**
+
+The June 15 change is broader than model deprecations. SDK programmatic usage
+(`claude_agent_sdk.query()`) will draw from a **separate monthly credit pool**, not
+from the interactive plan. Max 20x plan gets $200/month at standard API rates for
+SDK calls — not a fallback from interactive. Runs that exhaust the pool fail; there
+is no fallback.
+
+A deep-review at Opus 4.8 rates costs ~$5–10/run; 20–40 runs drains the pool.
+
+Action: Confirm `ANTHROPIC_API_KEY` is the live routing path for SDK calls (not
+subscription), and that `ATTUNE_MAX_BUDGET_USD` is set per-run. The pool cap is
+monthly and hard.
+
+- **Applies to:** `src/attune/workflows/agent_sdk_adapter.py`, user config
+- **Urgency:** High — know your exposure before June 15.
+
+---
+
+**4. Stop hooks can return `additionalContext` (v2.1.163) — upgrade session-stash**
+
+New in Claude Code v2.1.163: Stop and SubagentStop hooks can return
+`hookSpecificOutput.additionalContext` to inject text into the agent's next-turn
+context. For attune-ai's session-stash Stop hook, this means findings can be
+surfaced into the current session instead of only written to disk for the next
+one — no `/recall` required.
+
+Implementation: return
+`{"hookSpecificOutput": {"additionalContext": "<compact findings summary>"}}`
+alongside the disk write.
+
+- **Applies to:** `plugin/hooks/session_stash.py` (or equivalent Stop hook)
+- **Urgency:** Low — additive, no deadline.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| May-25 #1 | 2026-05-25 | Fix deprecated model IDs before June 15 | **CRITICAL** — `polish.py` ✅, `cost_tracker.py` ❌ still has snapshot key. Now Rec #1 above. 7 days. |
+| May-25 #2 | 2026-05-25 | Switch attune-ops to `claude agents --json` | Open. v2.1.162 added `waitingFor` field — schema more complete now. |
+| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish pipeline | Open. |
+| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open — minor doc edit. |
+| May-18 #1 | 2026-05-18 | Cap Agent SDK below v0.2.82 | Open — lockfile safe at 0.1.63. June 15 billing split adds another reason to avoid an uncontrolled bump. |
+| May-18 #2 | 2026-05-18 | mcp>=1.23.0 | **Resolved** ✅ — mcp at 1.27.0 in lockfile. |
+| May-18 #3 | 2026-05-18 | `CLAUDE_PROJECT_DIR` in MCP `workspace_root` | Open — one-line fix in `EmpathyMCPServer.__init__`. |
+| May-11 #6 | 2026-05-11 | `ENABLE_PROMPT_CACHING_1H` for attune-author | Open. |
+| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | Open. |
+| June-1 #1 | 2026-06-01 | Upgrade PREMIUM to Opus 4.8 | Open — run sampling-param pre-flight (Rec #2) first. |
+| June-1 #4 | 2026-06-01 | Add SDK upper bound `<0.2.82` to pyproject.toml | Open — lockfile at 0.1.63 is safe today. |
+
+---
+
+## Watch list
+
+- **Agent SDK credit pool exhaustion UX**: When the $200/month programmatic pool
+  runs out mid-session, runs fail with no interactive fallback. `ATTUNE_MAX_BUDGET_USD`
+  guards per-run cost but not monthly pool total. If Anthropic exposes a balance
+  endpoint, a pool-aware check in the adapter would prevent surprise failures late
+  in the month.
+
+- **`fallbackModel` setting (v2.1.166)**: Claude Code now supports up to 3 fallback
+  model IDs. Could partially replace attune-ai's tier routing for Claude Code users.
+  Worth evaluating whether the plugin can defer to this for interactive sessions.
+
+- **`requiredMinimumVersion`/`requiredMaximumVersion` (v2.1.163)**: New managed
+  settings to enforce Claude Code version bounds. Useful for attune-ai plugin to
+  declare `requiredMinimumVersion: "2.1.163"` when shipping features that depend on
+  hook `additionalContext` support.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Claude Mythos expansion | Invite-only cybersecurity preview; not accessible to the stack |
+| Computer Use expansion | Not used in stack |
+| Citations API | GA since Jun 2025; no new changes this week |
+| Files API beta | Not used in stack |
+| Claude Managed Agents webhooks | Stack uses Agent SDK directly |
+| `OTEL_RESOURCE_ATTRIBUTES` labels (v2.1.161) | Not using OTel currently |
+| Notion/Stripe/Cloudflare/Slack/Vercel MCP servers | Third-party MCPs; no stack impact |
+| Advisor Tool `max_tokens` | Not used in stack |
+| Batch API 300k output limit | Not using Batch API |
+| wl-copy/xclip clipboard fix (v2.1.161) | Linux display fix; macOS dev |
+| Devin Desktop rename (v2.1.162) | UI rename only |
+| Structured Outputs GA | Stack uses JSON via tool_use; no change needed |
+| Refusal no-billing change | Positive but no stack code impact |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes` (through June 6, 2026)
+- `www.anthropic.com/news` (June 2026)
+- Claude Code releases: v2.1.160–v2.1.166 (June 2–6, 2026)
+- PyPI: `claude-agent-sdk` — no new releases this week (last: 0.2.87, May 23)
+- Repo audit: `src/attune/cost_tracker.py`, `src/attune/models/adaptive_routing.py`,
+  `pyproject.toml`, `uv.lock`, `src/attune/mcp/server.py`,
+  `src/attune/models/registry.py`
+- Prior week report: `weekly-reports/2026-06-01.md`


### PR DESCRIPTION
Weekly Anthropic ecosystem report for June 2–8, 2026.

## What's in this report

**Critical (7 days):** `cost_tracker.py:52` still has `"claude-opus-4-20250514"` — June 15 retirement is one week out.

**High:** Opus 4.8 upgrade (June-1 Rec #1) is gated by a pre-flight check — non-default `temperature`/`top_p`/`top_k` now return HTTP 400 on Opus 4.8. Run the grep before updating `adaptive_routing.py`.

**High:** June 15 also introduces separate Agent SDK billing on Max 20x — $200/month credit pool for programmatic usage, separate from interactive. Confirm `ATTUNE_MAX_BUDGET_USD` exposure before the cutover.

**Low:** Stop/SubagentStop hooks (v2.1.163) can return `additionalContext` — upgrade the session-stash hook to inject a compact findings summary into the next turn's context.

## Carry-over status

- May-25 #1 / Jun-1 #2: `cost_tracker.py` snapshot key — **still open, CRITICAL**
- Jun-1 #1: Opus 4.8 upgrade — open, gated on sampling-param pre-flight
- Jun-1 #4: Agent SDK upper bound in `pyproject.toml` — still open
- May-18 #2: MCP security fix — **resolved** (mcp==1.27.0 in uv.lock)
- May-18 #3: `CLAUDE_PROJECT_DIR` in workspace_root — still open
- May-11 #6: `ENABLE_PROMPT_CACHING_1H` — still open
- May-11 #7: `api_error_status` surface — still open

---
_Generated by [Claude Code](https://claude.ai/code/session_01GobsV5kwM8VhVpdh5tJCtZ)_