### PR TITLE
fix(agent_factory): strip Opus 4.7+-rejected sampling params in langchain/langgraph adapters

### DIFF
--- a/src/attune/agent_factory/adapters/langchain_adapter.py
+++ b/src/attune/agent_factory/adapters/langchain_adapter.py
@@ -239,16 +239,24 @@ class LangChainAdapter(BaseAdapter):
         if self.provider == "anthropic":
             from langchain_anthropic import ChatAnthropic
 
+            from attune.llm.providers.anthropic import (
+                _normalize_api_kwargs_for_model,
+            )
+
             # LangChain API varies between versions - use type: ignore for flexibility
             # ChatAnthropic requires api_key as SecretStr (not None)
             if not self.api_key:
                 raise ValueError("API key required for Anthropic provider")
-            return ChatAnthropic(  # type: ignore[call-arg]
-                model=model_id,
-                api_key=SecretStr(self.api_key),
-                temperature=config.temperature,
-                max_tokens_to_sample=config.max_tokens,
-            )
+            # Opus 4.7+ reject temperature/top_p/top_k (HTTP 400). Reuse the
+            # provider helper to strip those params for matching models.
+            chat_kwargs: dict[str, Any] = {
+                "model": model_id,
+                "api_key": SecretStr(self.api_key),
+                "temperature": config.temperature,
+                "max_tokens_to_sample": config.max_tokens,
+            }
+            _normalize_api_kwargs_for_model(chat_kwargs)
+            return ChatAnthropic(**chat_kwargs)  # type: ignore[call-arg]
         if self.provider == "openai":
             from langchain_openai import ChatOpenAI
 

--- a/src/attune/agent_factory/adapters/langgraph_adapter.py
+++ b/src/attune/agent_factory/adapters/langgraph_adapter.py
@@ -244,16 +244,24 @@ class LangGraphAdapter(BaseAdapter):
         if self.provider == "anthropic":
             from langchain_anthropic import ChatAnthropic
 
+            from attune.llm.providers.anthropic import (
+                _normalize_api_kwargs_for_model,
+            )
+
             # LangChain API varies between versions - use type: ignore for flexibility
             # ChatAnthropic requires api_key as SecretStr (not None)
             if not self.api_key:
                 raise ValueError("API key required for Anthropic provider")
-            return ChatAnthropic(  # type: ignore[call-arg]
-                model=model_id,
-                api_key=SecretStr(self.api_key),
-                temperature=config.temperature,
-                max_tokens_to_sample=config.max_tokens,  # Anthropic uses max_tokens_to_sample
-            )
+            # Opus 4.7+ reject temperature/top_p/top_k (HTTP 400). Reuse the
+            # provider helper to strip those params for matching models.
+            chat_kwargs: dict[str, Any] = {
+                "model": model_id,
+                "api_key": SecretStr(self.api_key),
+                "temperature": config.temperature,
+                "max_tokens_to_sample": config.max_tokens,
+            }
+            _normalize_api_kwargs_for_model(chat_kwargs)
+            return ChatAnthropic(**chat_kwargs)  # type: ignore[call-arg]
         if self.provider == "openai":
             from langchain_openai import ChatOpenAI
 

--- a/tests/unit/agent_factory/test_langchain_adapter.py
+++ b/tests/unit/agent_factory/test_langchain_adapter.py
@@ -1,0 +1,54 @@
+"""Tests for attune.agent_factory.adapters.langchain_adapter._get_llm.
+
+Focus: Opus 4.7+ sampling-param normalization. Opus 4.7 and later reject
+temperature/top_p/top_k with HTTP 400, so the Anthropic branch must omit
+them for those models while keeping them for older models and OpenAI.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import attune.agent_factory.adapters.langchain_adapter as mod
+from attune.agent_factory.adapters.langchain_adapter import LangChainAdapter
+from attune.agent_factory.base import AgentConfig, AgentRole
+
+
+def _config(model_id: str) -> AgentConfig:
+    return AgentConfig(name="t", role=AgentRole.COORDINATOR, model_override=model_id)
+
+
+@pytest.mark.unit
+class TestLangChainAdapterGetLLMNormalization:
+    def setup_method(self):
+        mod._langchain_available = True  # force is_available() True
+
+    def teardown_method(self):
+        mod._langchain_available = None
+
+    def test_anthropic_omits_temperature_for_opus_4_8(self):
+        """Opus 4.7+ reject temperature/top_p/top_k → not passed to ChatAnthropic."""
+        with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+            adapter = LangChainAdapter(provider="anthropic", api_key="sk-test")
+            adapter._get_llm(_config("claude-opus-4-8"))
+        kwargs = mock_chat.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+        assert "top_k" not in kwargs
+        assert kwargs["model"] == "claude-opus-4-8"
+
+    def test_anthropic_keeps_temperature_for_sonnet(self):
+        """Sonnet still accepts temperature → passed through."""
+        with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+            adapter = LangChainAdapter(provider="anthropic", api_key="sk-test")
+            adapter._get_llm(_config("claude-sonnet-4-6"))
+        assert "temperature" in mock_chat.call_args.kwargs
+
+    def test_anthropic_keeps_temperature_for_opus_4_6(self):
+        """Opus 4.6 still accepts temperature → passed through."""
+        with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+            adapter = LangChainAdapter(provider="anthropic", api_key="sk-test")
+            adapter._get_llm(_config("claude-opus-4-6"))
+        assert "temperature" in mock_chat.call_args.kwargs

--- a/tests/unit/agent_factory/test_langgraph_adapter.py
+++ b/tests/unit/agent_factory/test_langgraph_adapter.py
@@ -555,6 +555,42 @@ class TestLangGraphAdapterGetLLM:
             with pytest.raises(ValueError, match="API key required"):
                 adapter._get_llm(config)
 
+    def test_anthropic_omits_temperature_for_opus_4_8(self):
+        """Opus 4.7+ reject temperature/top_p/top_k → not passed to ChatAnthropic."""
+        with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+            adapter = LangGraphAdapter(provider="anthropic", api_key="sk-test")
+            config = AgentConfig(
+                name="t", role=AgentRole.COORDINATOR, model_override="claude-opus-4-8"
+            )
+            adapter._get_llm(config)
+        kwargs = mock_chat.call_args.kwargs
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+        assert "top_k" not in kwargs
+        assert kwargs["model"] == "claude-opus-4-8"
+
+    def test_anthropic_keeps_temperature_for_sonnet(self):
+        """Sonnet still accepts temperature → passed through."""
+        with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+            adapter = LangGraphAdapter(provider="anthropic", api_key="sk-test")
+            config = AgentConfig(
+                name="t", role=AgentRole.COORDINATOR, model_override="claude-sonnet-4-6"
+            )
+            adapter._get_llm(config)
+        kwargs = mock_chat.call_args.kwargs
+        assert "temperature" in kwargs
+
+    def test_anthropic_keeps_temperature_for_opus_4_6(self):
+        """Opus 4.6 still accepts temperature → passed through."""
+        with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+            adapter = LangGraphAdapter(provider="anthropic", api_key="sk-test")
+            config = AgentConfig(
+                name="t", role=AgentRole.COORDINATOR, model_override="claude-opus-4-6"
+            )
+            adapter._get_llm(config)
+        kwargs = mock_chat.call_args.kwargs
+        assert "temperature" in kwargs
+
     def test_openai_returns_chat_openai(self):
         """Lines 257-265: OpenAI provider creates ChatOpenAI."""
         mock_chat = MagicMock()


### PR DESCRIPTION
## What

Opus 4.7+ (including the current PREMIUM `claude-opus-4-8`) return HTTP 400 for `temperature` / `top_p` / `top_k`. The langchain and langgraph adapters built langchain's `ChatAnthropic(...)` with `temperature=config.temperature`, so wiring either to an Opus 4.7+ model 400s.

This reuses the helper shipped in #674 — `attune.llm.providers.anthropic._normalize_api_kwargs_for_model` (regex `opus-4-(?:[7-9]|\d{2,})`) — to drop the rejected params for matching models in the Anthropic branch of both adapters. Older models (Sonnet, Haiku, Opus 4.6) keep `temperature`. OpenAI branches are unaffected.

## Sites

- `src/attune/agent_factory/adapters/langchain_adapter.py` — Anthropic branch in `_get_llm`
- `src/attune/agent_factory/adapters/langgraph_adapter.py` — Anthropic branch in `_get_llm`

## Tests

New unit tests assert `ChatAnthropic` is built **without** `temperature`/`top_p`/`top_k` for `claude-opus-4-8`, and **with** `temperature` for `claude-sonnet-4-6` and `claude-opus-4-6`, for both adapters.

```
60 passed (tests/unit/agent_factory/test_langchain_adapter.py + test_langgraph_adapter.py)
```

Follow-up to #674; closes the langchain/langgraph half noted in `project_opus_47plus_rejects_sampling_params`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)