### PR TITLE
feat(agent_sdk_adapter): surface ResultMessage stop_reason/subtype/errors

### DIFF
--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -48,6 +48,9 @@ class AgentRunResult:
     num_turns: int = 0
     session_id: str | None = None
     is_error: bool = False
+    stop_reason: str | None = None
+    subtype: str | None = None
+    errors: list[str] | None = None
 
 
 def collect_agent_output(
@@ -91,6 +94,9 @@ def collect_agent_output(
             num_turns=message.num_turns,
             session_id=message.session_id,
             is_error=message.is_error,
+            stop_reason=getattr(message, "stop_reason", None),
+            subtype=getattr(message, "subtype", None),
+            errors=getattr(message, "errors", None),
         )
 
     return None
@@ -1067,6 +1073,14 @@ class AgentSDKResultAdapter:
             result_metadata["num_turns"] = agent_run_result.num_turns
             result_metadata["session_id"] = agent_run_result.session_id
             result_metadata["duration_api_ms"] = agent_run_result.duration_api_ms
+            # SDK ResultMessage error signals — surfaced so a failed run
+            # records *why* (stop_reason/subtype/errors) instead of only a
+            # boolean is_error. Speeds diagnosis of the "Command failed with
+            # exit code 1" class of SDK failures.
+            result_metadata["is_error"] = agent_run_result.is_error
+            result_metadata["stop_reason"] = agent_run_result.stop_reason
+            result_metadata["subtype"] = agent_run_result.subtype
+            result_metadata["errors"] = agent_run_result.errors
         if metadata:
             result_metadata.update(metadata)
 

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -18,6 +18,7 @@ import pytest
 from attune.workflows.agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
+    collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
@@ -367,6 +368,9 @@ class TestAgentRunResultDataclass:
         assert r.num_turns == 0
         assert r.session_id is None
         assert r.is_error is False
+        assert r.stop_reason is None
+        assert r.subtype is None
+        assert r.errors is None
 
 
 @pytest.mark.unit
@@ -451,6 +455,118 @@ class TestAgentSDKResultAdapterCostExtraction:
         assert result.metadata["num_turns"] == 15
         assert result.metadata["session_id"] == "sess-abc123"
         assert result.metadata["duration_api_ms"] == 5000
+
+    def test_error_signals_surfaced_on_error_path(self) -> None:
+        """A failed run records stop_reason/subtype/errors, not just a bool."""
+        run = AgentRunResult(
+            result_text="",
+            is_error=True,
+            stop_reason="max_tokens",
+            subtype="error_during_execution",
+            errors=["subprocess exited 1", "budget cap reached"],
+        )
+        result = AgentSDKResultAdapter.from_agent_output(
+            result_text="",
+            subagent_names=_SUBAGENT_NAMES,
+            started_at=_now(),
+            completed_at=_now(),
+            agent_run_result=run,
+        )
+        assert result.metadata["is_error"] is True
+        assert result.metadata["stop_reason"] == "max_tokens"
+        assert result.metadata["subtype"] == "error_during_execution"
+        assert result.metadata["errors"] == [
+            "subprocess exited 1",
+            "budget cap reached",
+        ]
+
+    def test_error_signals_surfaced_on_success_path(self) -> None:
+        """Success runs still record the (None/False) error signals."""
+        run = AgentRunResult(
+            result_text=_SAMPLE_REVIEW,
+            is_error=False,
+            stop_reason="end_turn",
+            subtype="success",
+            errors=None,
+        )
+        result = AgentSDKResultAdapter.from_agent_output(
+            result_text=_SAMPLE_REVIEW,
+            subagent_names=_SUBAGENT_NAMES,
+            started_at=_now(),
+            completed_at=_now(),
+            agent_run_result=run,
+        )
+        assert result.metadata["is_error"] is False
+        assert result.metadata["stop_reason"] == "end_turn"
+        assert result.metadata["subtype"] == "success"
+        assert result.metadata["errors"] is None
+
+    def test_error_signals_absent_without_agent_run_result(self) -> None:
+        """No agent_run_result → no error-signal keys (backward compat)."""
+        result = AgentSDKResultAdapter.from_agent_output(
+            result_text=_SAMPLE_REVIEW,
+            subagent_names=_SUBAGENT_NAMES,
+            started_at=_now(),
+            completed_at=_now(),
+        )
+        assert "stop_reason" not in result.metadata
+        assert "subtype" not in result.metadata
+        assert "errors" not in result.metadata
+
+
+@pytest.mark.unit
+class TestCollectAgentOutputErrorFields:
+    """collect_agent_output extracts error signals from ResultMessage."""
+
+    def _result_message(self, **overrides: object) -> object:
+        """Build a real SDK ResultMessage with the required args."""
+        import claude_agent_sdk
+
+        kwargs: dict[str, object] = {
+            "subtype": "error_during_execution",
+            "duration_ms": 1200,
+            "duration_api_ms": 900,
+            "is_error": True,
+            "num_turns": 3,
+            "session_id": "sess-err",
+        }
+        kwargs.update(overrides)
+        return claude_agent_sdk.ResultMessage(**kwargs)
+
+    def test_populates_error_fields_from_result_message(self) -> None:
+        """A real ResultMessage's error signals reach AgentRunResult."""
+        msg = self._result_message(
+            stop_reason="max_tokens",
+            errors=["boom"],
+        )
+        run = collect_agent_output(msg, [], [])
+        assert run is not None
+        assert run.is_error is True
+        assert run.stop_reason == "max_tokens"
+        assert run.subtype == "error_during_execution"
+        assert run.errors == ["boom"]
+
+    def test_getattr_fallback_when_fields_absent(self) -> None:
+        """A ResultMessage-shaped stub missing the fields degrades to None.
+
+        Guards the ``getattr(message, ..., None)`` probe for older SDKs
+        that may not expose stop_reason/subtype/errors.
+        """
+        # Build with only the required args, then strip the optional
+        # error-signal attributes to simulate an older SDK shape.
+        msg = self._result_message()
+        for attr in ("stop_reason", "subtype", "errors"):
+            try:
+                delattr(msg, attr)
+            except AttributeError:
+                pass
+
+        run = collect_agent_output(msg, [], [])
+        assert run is not None
+        # Stripped attributes → getattr falls back to None
+        assert run.stop_reason is None
+        assert run.subtype is None
+        assert run.errors is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

The SDK's `ResultMessage` carries richer error signals than the single
`is_error` boolean that `AgentRunResult` captured. This surfaces
`stop_reason`, `subtype`, and `errors` so a failed run records **why** it
failed — speeding diagnosis of the `Command failed with exit code 1` class
of SDK failures.

## Changes

- `AgentRunResult` gains `stop_reason: str | None`, `subtype: str | None`,
  `errors: list[str] | None` (all optional, default `None`).
- `collect_agent_output()` populates them via `getattr(message, ..., None)`
  so older SDKs that lack a field degrade gracefully (repo `getattr`-probe
  pattern).
- `AgentSDKResultAdapter.from_agent_output()` records all four error
  signals (`is_error` + the three new ones) into `WorkflowResult.metadata`
  on both the error and success paths.

## Validation

Re-introspected the installed SDK (0.1.63): `stop_reason`, `subtype`,
`errors` all exist on `ResultMessage`; the weekly report's `api_error_status`
does **not** — not added. Grep confirmed none were already surfaced.

Tests (86 pass in `test_agent_sdk_adapter.py`): dataclass defaults, metadata
surfacing on error/success/absent paths, real-`ResultMessage` population,
and the `getattr` fallback when fields are stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
