### PR TITLE
feat(mcp): add CLAUDE_PROJECT_DIR to workspace_root fallback chain

### DIFF
--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -100,17 +100,25 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         Args:
             workspace_root: Root directory for workspace path
                 containment. Resolution order: explicit argument >
-                ``ATTUNE_MCP_WORKSPACE_ROOT`` env var > current
-                working directory. Setting the env var lets users
-                broaden the sandbox to a parent directory (e.g. the
-                main checkout when the MCP launches in a worktree)
-                without code changes.
+                ``ATTUNE_MCP_WORKSPACE_ROOT`` env var >
+                ``CLAUDE_PROJECT_DIR`` env var > current working
+                directory. Setting ``ATTUNE_MCP_WORKSPACE_ROOT`` lets
+                users broaden the sandbox to a parent directory (e.g.
+                the main checkout when the MCP launches in a worktree)
+                without code changes. ``CLAUDE_PROJECT_DIR`` is set by
+                Claude Code in the spawned MCP server's environment to
+                the project root, so the sandbox tracks the project
+                even when the server's cwd differs (it is a no-op in
+                environments that don't export the variable).
             user_id: Identity for memory operations. Defaults
                 to the OS login name or "mcp-session".
 
         """
         self._workspace_root = (
-            workspace_root or os.environ.get("ATTUNE_MCP_WORKSPACE_ROOT") or os.getcwd()
+            workspace_root
+            or os.environ.get("ATTUNE_MCP_WORKSPACE_ROOT")
+            or os.environ.get("CLAUDE_PROJECT_DIR")
+            or os.getcwd()
         )
         self._user_id = user_id or _get_default_user_id()
         self.tools = self._register_tools()

--- a/tests/unit/mcp/test_server.py
+++ b/tests/unit/mcp/test_server.py
@@ -99,6 +99,50 @@ class TestServerInit:
         server = EmpathyMCPServer(workspace_root=str(arg_path))
         assert server._workspace_root == str(arg_path)
 
+    def test_claude_project_dir_workspace_root(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """CLAUDE_PROJECT_DIR is used when no explicit arg / ATTUNE var.
+
+        Claude Code sets CLAUDE_PROJECT_DIR in the spawned MCP server's
+        environment to the project root, so the sandbox tracks the
+        project even when the server's cwd differs.
+        """
+        from attune.mcp.server import EmpathyMCPServer
+
+        monkeypatch.delenv("ATTUNE_MCP_WORKSPACE_ROOT", raising=False)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+        server = EmpathyMCPServer()
+        assert server._workspace_root == str(tmp_path)
+
+    def test_attune_var_overrides_claude_project_dir(self, tmp_path: Any, monkeypatch: Any) -> None:
+        """ATTUNE_MCP_WORKSPACE_ROOT wins over CLAUDE_PROJECT_DIR."""
+        from attune.mcp.server import EmpathyMCPServer
+
+        attune_path = tmp_path / "from-attune"
+        attune_path.mkdir()
+        claude_path = tmp_path / "from-claude"
+        claude_path.mkdir()
+
+        monkeypatch.setenv("ATTUNE_MCP_WORKSPACE_ROOT", str(attune_path))
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(claude_path))
+        server = EmpathyMCPServer()
+        assert server._workspace_root == str(attune_path)
+
+    def test_explicit_arg_overrides_claude_project_dir(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """Explicit workspace_root argument wins over CLAUDE_PROJECT_DIR."""
+        from attune.mcp.server import EmpathyMCPServer
+
+        claude_path = tmp_path / "from-claude"
+        claude_path.mkdir()
+        arg_path = tmp_path / "from-arg"
+        arg_path.mkdir()
+
+        monkeypatch.delenv("ATTUNE_MCP_WORKSPACE_ROOT", raising=False)
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(claude_path))
+        server = EmpathyMCPServer(workspace_root=str(arg_path))
+        assert server._workspace_root == str(arg_path)
+
     def test_custom_user_id(self) -> None:
         server = _make_server(user_id="test-user")
         assert server._user_id == "test-user"


### PR DESCRIPTION
## Summary

`EmpathyMCPServer.__init__` resolved `workspace_root` as
`workspace_root or ATTUNE_MCP_WORKSPACE_ROOT or os.getcwd()` — it never
consulted `CLAUDE_PROJECT_DIR`. This adds it to the fallback chain.

## Why this is real (not just defense-in-depth)

The prior session believed `CLAUDE_PROJECT_DIR` might not reach MCP
subprocesses (it was absent in a Cowork session). Re-validated against the
official docs: per
[code.claude.com/docs/en/mcp](https://code.claude.com/docs/en/mcp.md),
Claude Code **does** set `CLAUDE_PROJECT_DIR` in the spawned MCP server's
process environment to the project root, and explicitly recommends reading
it via `os.environ["CLAUDE_PROJECT_DIR"]` from inside the server. So this
lets the sandbox track the project root even when the server's cwd differs
(e.g. launched from a worktree). It is a harmless no-op in environments
that don't export the variable.

## Change

Resolution order is now: explicit arg > `ATTUNE_MCP_WORKSPACE_ROOT` >
`CLAUDE_PROJECT_DIR` > `os.getcwd()`. One line + docstring update.

## Tests

Three precedence tests added to `TestServerInit` (12 pass total):
`CLAUDE_PROJECT_DIR` used when no arg/ATTUNE var; `ATTUNE_MCP_WORKSPACE_ROOT`
overrides it; explicit arg overrides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
