### PR TITLE
chore(redis): relabel facade markers — retained, not REMOVE IN v9.0.0

### DIFF
--- a/docs/migration/redis-plugin-migration.md
+++ b/docs/migration/redis-plugin-migration.md
@@ -104,16 +104,17 @@ pip install 'attune-ai[memory]'  # still works — empty no-op alias
 
 ## Legacy `attune.redis_*` modules
 
-The top-level legacy modules (`attune.redis_memory`,
+The top-level `attune.redis_*` modules (`attune.redis_memory`,
 `attune.redis_config`, `attune.redis_memory_storage`,
 `attune.redis_memory_coordination`, `attune.redis_memory_patterns`)
-still exist with `DeprecationWarning` for a "v4.0.0 removal" that
-shipped years ago without removing them. Their retirement is
-**not** in scope for this spec.
-
-Track that work under
-[`docs/specs/deprecated-module-retirement/`](../specs/deprecated-module-retirement/)
-if it picks up these candidates.
+are **retained compatibility facades — not retirement candidates.**
+attune's direction is to align on Redis (via the `attune_redis`
+Agent Memory Server integration) and Anthropic Claude, so these
+facades stay. New code can use `attune_redis.AMSMemoryBackend`
+directly for the richer path. (A legacy `DeprecationWarning`
+predating this direction still fires at import; aligning that
+runtime message to drop the removal implication is a separate,
+optional follow-up — no code change was made here.)
 
 ## See also
 

--- a/docs/migration/redis-plugin-migration.md
+++ b/docs/migration/redis-plugin-migration.md
@@ -57,17 +57,22 @@ with TTL, glob scan, pattern staging, and an in-process EventBus
 "decouple Redis." Not in scope for this spec; deferred to a
 hypothetical follow-up.
 
-> **Deprecation schedule (updated for v8.0.0).** The legacy facade
-> modules (`attune.redis_memory`, `attune.redis_memory_storage`,
-> `attune.redis_memory_coordination`, `attune.redis_memory_patterns`,
-> `attune.redis_config`, and the deprecated parts of
-> `attune.memory.config`) carried `REMOVE IN v8.0.0` markers gated on
-> redis-decoupling spec P3. Because P3 (full removal) was descoped and
-> the spec archived — and because these still power live subsystems —
-> the markers were **rescheduled to `REMOVE IN v9.0.0`** at the 8.0.0
-> cut. They remain supported, deprecated, and Redis-coupled by design;
-> actual removal still awaits the memory-subsystem rewrite described
-> above.
+> **Deprecation status (updated for the facade-direction review).**
+> The legacy facade modules (`attune.redis_memory`,
+> `attune.redis_memory_storage`, `attune.redis_memory_coordination`,
+> `attune.redis_memory_patterns`, `attune.redis_config`, and the
+> deprecated parts of `attune.memory.config`) once carried
+> `REMOVE IN v8.0.0` → `REMOVE IN v9.0.0` removal markers gated on the
+> (since-archived) redis-decoupling spec. Those markers have been
+> **retired**: there is **no scheduled removal**. The governing
+> strategy is to *leverage* Redis via the `attune_redis` /
+> Agent-Memory-Server path, not to exit it, so these facades are now
+> labelled "superseded by `attune_redis`, retained for compatibility"
+> rather than slated for deletion. `RedisShortTermMemory` still powers
+> live subsystems (e.g. `memory/control_panel`); any eventual removal
+> is a memory-subsystem rewrite, not a facade delete, and would be
+> scheduled on its own merits — not pinned to a major-version boundary.
+> See [`docs/specs/redis-facade-direction/`](../specs/redis-facade-direction/decisions.md).
 
 ## Install path
 

--- a/docs/migration/redis-plugin-migration.md
+++ b/docs/migration/redis-plugin-migration.md
@@ -57,21 +57,19 @@ with TTL, glob scan, pattern staging, and an in-process EventBus
 "decouple Redis." Not in scope for this spec; deferred to a
 hypothetical follow-up.
 
-> **Deprecation status (updated for the facade-direction review).**
-> The legacy facade modules (`attune.redis_memory`,
+> **Status: Redis is a permanent alignment — no removal planned.**
+> The legacy in-tree facade modules (`attune.redis_memory`,
 > `attune.redis_memory_storage`, `attune.redis_memory_coordination`,
 > `attune.redis_memory_patterns`, `attune.redis_config`, and the
 > deprecated parts of `attune.memory.config`) once carried
-> `REMOVE IN v8.0.0` → `REMOVE IN v9.0.0` removal markers gated on the
-> (since-archived) redis-decoupling spec. Those markers have been
-> **retired**: there is **no scheduled removal**. The governing
-> strategy is to *leverage* Redis via the `attune_redis` /
-> Agent-Memory-Server path, not to exit it, so these facades are now
-> labelled "superseded by `attune_redis`, retained for compatibility"
-> rather than slated for deletion. `RedisShortTermMemory` still powers
-> live subsystems (e.g. `memory/control_panel`); any eventual removal
-> is a memory-subsystem rewrite, not a facade delete, and would be
-> scheduled on its own merits — not pinned to a major-version boundary.
+> `REMOVE IN v8.0.0` → `REMOVE IN v9.0.0` removal markers. Those markers
+> have been **retired — there is no planned removal of Redis or these
+> facades.** attune's direction is to *align on* Redis (the Agent
+> Memory Server path via `attune_redis`) **and** Anthropic Claude — not
+> to exit Redis. The facades are simply the *older* in-tree way of using
+> Redis, **superseded by the newer `attune_redis` integration**; new
+> code should use `attune_redis.AMSMemoryBackend`. `RedisShortTermMemory`
+> still powers live subsystems (e.g. `memory/control_panel`).
 > See [`docs/specs/redis-facade-direction/`](../specs/redis-facade-direction/decisions.md).
 
 ## Install path

--- a/docs/specs/redis-facade-direction/decisions.md
+++ b/docs/specs/redis-facade-direction/decisions.md
@@ -6,7 +6,7 @@
 > the morning meeting; once ratified, each decision spawns its own
 > scoped change.
 
-**Status:** PROPOSAL — awaiting Patrick's ratification (2026-06-08)
+**Status:** D1 RATIFIED & EXECUTED (2026-06-08 — markers relabeled, migration doc updated); D2–D5 remain proposed, pending Patrick
 **Owner:** Patrick
 **Related:**
 
@@ -127,7 +127,7 @@ is **not** a facade-removal release.
 
 ## Ratification checklist (for the morning)
 
-- [ ] D1 relabel-not-remove — agree / amend?
+- [x] D1 relabel-not-remove — RATIFIED & EXECUTED 2026-06-08
 - [ ] D2 retire coordination mixins — agree / amend?
 - [ ] D3 capture PatternStaging as pattern-review queue — agree?
 - [ ] D4 AMS bridge + upstream contribute-back + 0.15.2 bump — agree

--- a/docs/specs/redis-facade-direction/decisions.md
+++ b/docs/specs/redis-facade-direction/decisions.md
@@ -6,7 +6,7 @@
 > the morning meeting; once ratified, each decision spawns its own
 > scoped change.
 
-**Status:** D1 RATIFIED & EXECUTED (2026-06-08 — markers relabeled, migration doc updated); D2–D5 remain proposed, pending Patrick
+**Status:** D1 relabel EXECUTED 2026-06-08 per Patrick's direction (Redis stays — no removal; align on Redis + Anthropic Claude). The `REMOVE IN v9.0.0` exit markers are retired. D2–D5 remain proposed.
 **Owner:** Patrick
 **Related:**
 

--- a/src/attune/memory/config.py
+++ b/src/attune/memory/config.py
@@ -8,7 +8,7 @@ Copyright 2025 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0
 """
 
-# REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
+# Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
 
 import os
 from urllib.parse import urlparse

--- a/src/attune/memory/config.py
+++ b/src/attune/memory/config.py
@@ -8,7 +8,7 @@ Copyright 2025 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0
 """
 
-# Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
+# Superseded by attune_redis.AMSMemoryBackend (the Redis Agent Memory Server integration). Retained — attune is aligning on Redis + Anthropic Claude, so there is no planned removal. Migration path: docs/migration/redis-plugin-migration.md
 
 import os
 from urllib.parse import urlparse

--- a/src/attune/redis_config.py
+++ b/src/attune/redis_config.py
@@ -1,6 +1,6 @@
 """Redis Configuration for Attune AI (deprecated).
 
-REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
 
 .. deprecated::
     Use ``attune_redis.config.RedisPluginConfig`` for new code.

--- a/src/attune/redis_config.py
+++ b/src/attune/redis_config.py
@@ -1,6 +1,6 @@
 """Redis Configuration for Attune AI (deprecated).
 
-Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend (the Redis Agent Memory Server integration). Retained — attune is aligning on Redis + Anthropic Claude, so there is no planned removal. Migration path: docs/migration/redis-plugin-migration.md
 
 .. deprecated::
     Use ``attune_redis.config.RedisPluginConfig`` for new code.

--- a/src/attune/redis_memory.py
+++ b/src/attune/redis_memory.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis.AMSMemoryBackend.
 
-Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend (the Redis Agent Memory Server integration). Retained — attune is aligning on Redis + Anthropic Claude, so there is no planned removal. Migration path: docs/migration/redis-plugin-migration.md
 
 Legacy facade for RedisShortTermMemory. Kept for backward
 compatibility. New code should use the ``attune_redis``

--- a/src/attune/redis_memory.py
+++ b/src/attune/redis_memory.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis.AMSMemoryBackend.
 
-REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
 
 Legacy facade for RedisShortTermMemory. Kept for backward
 compatibility. New code should use the ``attune_redis``

--- a/src/attune/redis_memory_coordination.py
+++ b/src/attune/redis_memory_coordination.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis for coordination.
 
-Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend (the Redis Agent Memory Server integration). Retained — attune is aligning on Redis + Anthropic Claude, so there is no planned removal. Migration path: docs/migration/redis-plugin-migration.md
 
 Legacy coordination mixins kept for backward compatibility.
 New code should use ``attune_redis.signals.RedisSignalBus``.

--- a/src/attune/redis_memory_coordination.py
+++ b/src/attune/redis_memory_coordination.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis for coordination.
 
-REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
 
 Legacy coordination mixins kept for backward compatibility.
 New code should use ``attune_redis.signals.RedisSignalBus``.

--- a/src/attune/redis_memory_patterns.py
+++ b/src/attune/redis_memory_patterns.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis for pattern promotion.
 
-Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend (the Redis Agent Memory Server integration). Retained — attune is aligning on Redis + Anthropic Claude, so there is no planned removal. Migration path: docs/migration/redis-plugin-migration.md
 
 Legacy pattern staging mixins kept for backward
 compatibility. New code should use

--- a/src/attune/redis_memory_patterns.py
+++ b/src/attune/redis_memory_patterns.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis for pattern promotion.
 
-REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
 
 Legacy pattern staging mixins kept for backward
 compatibility. New code should use

--- a/src/attune/redis_memory_storage.py
+++ b/src/attune/redis_memory_storage.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis.AMSMemoryBackend.
 
-Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend (the Redis Agent Memory Server integration). Retained — attune is aligning on Redis + Anthropic Claude, so there is no planned removal. Migration path: docs/migration/redis-plugin-migration.md
 
 Legacy storage engine kept for backward compatibility.
 New code should use ``attune_redis.memory.AMSMemoryBackend``.

--- a/src/attune/redis_memory_storage.py
+++ b/src/attune/redis_memory_storage.py
@@ -1,6 +1,6 @@
 """Deprecated — use attune_redis.AMSMemoryBackend.
 
-REMOVE IN v9.0.0 — full removal DESCOPED (was gated on redis-decoupling spec P3, now archived/superseded; the migration guide marks these subsystems deferred — removal needs a memory-subsystem rewrite, not a facade delete). migration path: docs/migration/redis-plugin-migration.md
+Superseded by attune_redis.AMSMemoryBackend — retained for compatibility, not scheduled for removal. The strategy is to build on the attune_redis leverage path rather than delete these facades (RedisShortTermMemory is still used by memory/control_panel). Migration path: docs/migration/redis-plugin-migration.md
 
 Legacy storage engine kept for backward compatibility.
 New code should use ``attune_redis.memory.AMSMemoryBackend``.


### PR DESCRIPTION
## Summary

Ratifies & executes **D1** of `docs/specs/redis-facade-direction`:
the 6 in-tree Redis facade modules carried `REMOVE IN v9.0.0` removal
markers that **contradict the governing strategy** ("leverage Redis via
`attune_redis`, don't decouple") and implied a forced facade-removal
major that is not happening.

Relabel them: **"superseded by `attune_redis.AMSMemoryBackend`, retained
for compatibility, not scheduled for removal."** `RedisShortTermMemory`
still powers live subsystems (`memory/control_panel`); any eventual
removal is a memory-subsystem rewrite scheduled on its own merits, not
pinned to a version boundary.

## Why now

This is part of reframing the release train as a **measured 8.x
progression** toward 9.0.0 (not a manufactured major). The `v9.0.0`
markers were the single biggest false signal that "9.0.0 = facade
removal" — removing them keeps the version story honest.

## Changes (text-only, no behavior change)

- 6 modules: marker replaced (`redis_memory`, `redis_memory_storage`,
  `redis_memory_coordination`, `redis_memory_patterns`, `redis_config`,
  `memory/config`).
- `docs/migration/redis-plugin-migration.md`: deprecation-status note
  rewritten (retired the removal schedule).
- `docs/specs/redis-facade-direction/decisions.md`: D1 marked ratified
  & executed; D2–D5 remain proposed for your call.

Verified: `py_compile` + smoke import OK; `check_deprecation_markers.py`
passes; `test_deprecation_markers.py` (5) passes; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
