### PR TITLE
docs(specs): correct stale status headers to match code-verified reality

### DIFF
--- a/docs/specs/agent-surface-parallelism-evaluation/tasks.md
+++ b/docs/specs/agent-surface-parallelism-evaluation/tasks.md
@@ -1,5 +1,5 @@
 # Tasks — Agent Surface Parallelism Evaluation
-**Status:** approved (2026-05-16)
+**Status:** RETIRED (2026-05-29) — orchestrator already ships in `deep_review.py`; see requirements.md / decisions.md
 | Phase | Status | Owner | Notes |
 |---|---|---|---|
 | Phase 0 — Telemetry + A/B measurement | in progress | | 0.1 done 2026-05-16, see `phase0-findings.md` |

--- a/docs/specs/anthropic-memory-tool-backend/design.md
+++ b/docs/specs/anthropic-memory-tool-backend/design.md
@@ -4,7 +4,7 @@
 > attune's memory backends. See
 > [`requirements.md`](requirements.md) for scope.
 
-**Status:** draft (2026-06-08) — for morning review
+**Status:** partial — Phase 1 shipped (`memory/memory_tool.py`, PR #671); Phase 2 (MCP/CLI surfacing) is forward work — verified 2026-06-08 spec triage
 
 ---
 

--- a/docs/specs/anthropic-memory-tool-backend/requirements.md
+++ b/docs/specs/anthropic-memory-tool-backend/requirements.md
@@ -12,7 +12,7 @@
 > suggests" into "our memory layer **is** a backend for Anthropic's
 > Memory tool, persisted on Redis's Agent Memory Server."
 
-**Status:** draft (2026-06-08) — overnight autonomous draft for
+**Status:** partial — Phase 1 shipped (`memory/memory_tool.py`, PR #671); Phase 2 (MCP/CLI surfacing) is forward work — verified 2026-06-08 spec triage
 morning review
 **Owner:** Patrick + agent
 **Related:**

--- a/docs/specs/doc-fiction-cleanup/requirements.md
+++ b/docs/specs/doc-fiction-cleanup/requirements.md
@@ -7,7 +7,7 @@
 > source, retiring what describes nothing real and rewriting
 > what describes a real feature through a fictional API.
 
-**Status:** draft
+**Status:** complete — cleanup executed (see decisions.md); audit/process doc, not a shippable feature — verified 2026-06-08 spec triage
 **Created:** 2026-05-28
 **Owner:** TBD
 **Related:** [`sdk-error-message-fidelity`](../sdk-error-message-fidelity/)

--- a/docs/specs/ops-help-page/requirements.md
+++ b/docs/specs/ops-help-page/requirements.md
@@ -5,7 +5,7 @@
 > `.help/templates/` corpus directly from the browser —
 > independent of any chat / CLI flow.
 
-**Status:** draft
+**Status:** complete — shipped (`ops/routes/help.py` + `ops/help_data.py`); Phase 3–4 polish optional — verified 2026-06-08 spec triage
 **Created:** 2026-05-26
 **Owner:** TBD
 **Related:**

--- a/docs/specs/public-help-site/requirements.md
+++ b/docs/specs/public-help-site/requirements.md
@@ -9,7 +9,7 @@
 
 ## Phase 1: Requirements
 
-**Status**: draft (D4 resolved 2026-06-04 — hybrid; see
+**Status**: complete — shipped (`attune-ai-dev/build_help.py` + `build-help-site.yml` CI) — verified 2026-06-08 spec triage
 `decisions.md`). Design + tasks proceed once requirements are
 approved.
 

--- a/docs/specs/workflow-path-arg-unification/design.md
+++ b/docs/specs/workflow-path-arg-unification/design.md
@@ -1,6 +1,6 @@
 # Design: Workflow `path` Kwarg Unification
 
-**Status**: draft
+**Status**: complete (4/5 workflows shipped); remaining gap: `doc-orchestrator` still maps `project_root` in PATH_ARG_REGISTRY — verified 2026-06-08 spec triage
 
 ---
 

--- a/docs/specs/workflow-path-arg-unification/tasks.md
+++ b/docs/specs/workflow-path-arg-unification/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Workflow `path` Kwarg Unification
 
-**Status**: draft
+**Status**: complete (4/5 workflows shipped); remaining gap: `doc-orchestrator` still maps `project_root` in PATH_ARG_REGISTRY — verified 2026-06-08 spec triage
 
 Five per-workflow migrations + one registry-simplification PR. Each
 per-workflow PR is independent and shippable in any order; PR-5 is


### PR DESCRIPTION
## Summary

Backlog-hygiene from the 2026-06-08 Phase 1 spec triage. Each spec's
primary artifact was verified against the codebase; several status
headers misreported reality (the exact drift `spec-status-self-truthing`
exists to catch). **Status lines only — no other content changed.**

| Spec | Was | Now (code-verified) |
|---|---|---|
| anthropic-memory-tool-backend | draft | partial — Phase 1 shipped (`memory/memory_tool.py`, #671) |
| ops-help-page | draft | complete — `ops/routes/help.py` + `help_data.py` shipped |
| public-help-site | draft | complete — `attune-ai-dev/build_help.py` + CI shipped |
| workflow-path-arg-unification | draft | complete — 4/5 shipped; `doc-orchestrator` gap noted |
| agent-surface-parallelism-evaluation (tasks.md) | approved | RETIRED — matches its own requirements.md |
| doc-fiction-cleanup | draft | complete — cleanup executed (audit doc) |

After this, the in-flight list tells the truth: these stop showing as
unstarted work, and the genuinely-forward specs stand out cleanly for
sequencing into the 8.x release train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
