### PR TITLE
feat(doc-orchestrator): accept `path` kwarg — closes PATH_ARG_REGISTRY gap

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -96,7 +96,7 @@ PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
     "release-prep": PathArgSpec(kwarg="path"),
     "secure-release": PathArgSpec(kwarg="path"),
     # Category C — aliased to a different kwarg name
-    "doc-orchestrator": PathArgSpec(kwarg="project_root"),
+    "doc-orchestrator": PathArgSpec(kwarg="path"),
     # health-check + orchestrated-health-check migrated to `path` in
     # workflow-path-arg-unification PR-1 (2026-05-13).
     "health-check": PathArgSpec(kwarg="path"),

--- a/src/attune/workflows/documentation_orchestrator.py
+++ b/src/attune/workflows/documentation_orchestrator.py
@@ -20,6 +20,7 @@ Licensed under the Apache License, Version 2.0
 
 import asyncio
 import logging
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -284,6 +285,7 @@ class DocumentationOrchestrator(
         self.export_path = (
             Path(export_path) if export_path else self.project_root / "docs" / "generated"
         )
+        self._export_path_explicit = export_path is not None
         self.include_stale = include_stale
         self.include_missing = include_missing
         self.min_severity = min_severity
@@ -351,6 +353,10 @@ class DocumentationOrchestrator(
         """Execute the full documentation orchestration pipeline.
 
         Args:
+            path: Project root to scope the run to. Canonical kwarg;
+                replaces the deprecated `project_root=` alias.
+            project_root: Deprecated alias for `path` (emits
+                DeprecationWarning).
             context: Additional context for the workflows
             **kwargs: Additional arguments
 
@@ -361,19 +367,45 @@ class DocumentationOrchestrator(
         started_at = datetime.now()
         result = OrchestratorResult(success=False, phase="scout")
         errors: list[str] = []
-        warnings: list[str] = []
+        warning_msgs: list[str] = []
+
+        # Scope resolution (PATH_ARG_REGISTRY unification): `path=` is the
+        # canonical kwarg; `project_root=` is a deprecated alias. Honoring it
+        # here lets the ops scope-picker actually re-scope the run.
+        scope = kwargs.get("path") or kwargs.get("project_root")
+        if kwargs.get("project_root") and kwargs.get("path"):
+            warnings.warn(
+                "DocumentationOrchestrator.execute(): both `path=` and "
+                "`project_root=` supplied; `path=` takes precedence and "
+                "`project_root=` is deprecated.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        elif kwargs.get("project_root"):
+            warnings.warn(
+                "DocumentationOrchestrator.execute(project_root=...) is "
+                "deprecated; use execute(path=...) instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if scope:
+            self.project_root = Path(scope).resolve()
+            if not self._export_path_explicit:
+                self.export_path = self.project_root / "docs" / "generated"
 
         # Validate dependencies
         if not HAS_SCOUT:
-            warnings.append("ManageDocumentationCrew not available - using ProjectIndex fallback")
+            warning_msgs.append(
+                "ManageDocumentationCrew not available - using ProjectIndex fallback"
+            )
         if not HAS_WRITER:
             errors.append("DocumentGenerationWorkflow not available - cannot generate docs")
             if not self.dry_run:
                 result.errors = errors
-                result.warnings = warnings
+                result.warnings = warning_msgs
                 return result
         if not HAS_PROJECT_INDEX:
-            warnings.append("ProjectIndex not available - limited file tracking")
+            warning_msgs.append("ProjectIndex not available - limited file tracking")
 
         # Phase 1: Scout
         print("\n" + "=" * 60)
@@ -427,7 +459,7 @@ class DocumentationOrchestrator(
             result.success = True
             result.phase = "awaiting_approval"
             result.docs_skipped = [i.file_path for i in priority_items]
-            result.warnings = warnings
+            result.warnings = warning_msgs
             result.duration_ms = int((datetime.now() - started_at).total_seconds() * 1000)
             result.total_cost = self._total_cost
             result.summary = self._generate_summary(result, priority_items)
@@ -453,7 +485,7 @@ class DocumentationOrchestrator(
         result.phase = "complete"
         result.total_cost = self._total_cost
         result.errors = errors
-        result.warnings = warnings
+        result.warnings = warning_msgs
         result.duration_ms = int((datetime.now() - started_at).total_seconds() * 1000)
         result.summary = self._generate_summary(result, priority_items)
 

--- a/tests/unit/workflows/test_documentation_orchestrator.py
+++ b/tests/unit/workflows/test_documentation_orchestrator.py
@@ -1580,3 +1580,62 @@ class TestProjectIndexEdgeCases:
         assert len(items) <= 1
         if len(items) > 0:
             assert "requirements.txt" not in items[0].file_path
+
+
+class TestExecutePathKwarg:
+    """execute() honors the canonical `path=` kwarg and the deprecated alias.
+
+    Scout is mocked to return no items so execute() short-circuits right
+    after scope resolution, without running the generation pipeline.
+    """
+
+    @pytest.fixture
+    def orchestrator(self, tmp_path):
+        return DocumentationOrchestrator(project_root=str(tmp_path), dry_run=True)
+
+    async def test_execute_accepts_path_kwarg(self, orchestrator, tmp_path):
+        target = tmp_path / "scoped"
+        target.mkdir()
+        orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        result = await orchestrator.execute(path=str(target))
+        assert result.success is True
+        assert orchestrator.project_root == target.resolve()
+
+    async def test_execute_legacy_project_root_warns(self, orchestrator, tmp_path):
+        target = tmp_path / "legacy"
+        target.mkdir()
+        orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        with pytest.warns(DeprecationWarning, match="project_root"):
+            result = await orchestrator.execute(project_root=str(target))
+        assert result.success is True
+        assert orchestrator.project_root == target.resolve()
+
+    async def test_execute_both_kwargs_path_wins(self, orchestrator, tmp_path):
+        win = tmp_path / "win"
+        win.mkdir()
+        lose = tmp_path / "lose"
+        lose.mkdir()
+        orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        with pytest.warns(DeprecationWarning, match="precedence"):
+            result = await orchestrator.execute(path=str(win), project_root=str(lose))
+        assert result.success is True
+        assert orchestrator.project_root == win.resolve()
+
+    async def test_execute_default_export_path_rederived_under_scope(self, orchestrator, tmp_path):
+        target = tmp_path / "scoped2"
+        target.mkdir()
+        orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        await orchestrator.execute(path=str(target))
+        assert orchestrator.export_path == target.resolve() / "docs" / "generated"
+
+    async def test_execute_explicit_export_path_preserved(self, tmp_path):
+        export = tmp_path / "custom-export"
+        orchestrator = DocumentationOrchestrator(
+            project_root=str(tmp_path), export_path=str(export), dry_run=True
+        )
+        target = tmp_path / "scoped3"
+        target.mkdir()
+        orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        await orchestrator.execute(path=str(target))
+        # An explicitly-set export_path must NOT be re-derived on re-scope.
+        assert orchestrator.export_path == export


### PR DESCRIPTION
## Summary

Closes the one gap in the otherwise-ready 8.1.0 SHIPPED bucket:
`doc-orchestrator` was the last workflow whose `PATH_ARG_REGISTRY` entry
mapped to `project_root`, and its `execute()` **ignored the kwarg
entirely** (scope was only settable in the constructor) — so the ops
scope-picker's path silently never reached the run.

## Changes

- `execute()` now reads `path=` (canonical) or `project_root=` (deprecated
  alias → `DeprecationWarning`; both-supplied → `path` wins + warns) and
  re-scopes `self.project_root`. The default `export_path` is re-derived
  under the new root; an explicitly-set `export_path` is preserved.
- `PATH_ARG_REGISTRY`: `doc-orchestrator` kwarg `project_root` → `path`.
  The drift-guard test (`test_path_support_registry.py`) now validates it.
- Renamed the local `warnings: list[str]` in `execute()` → `warning_msgs`
  so the stdlib `warnings` module (the deprecation warning) isn't shadowed.

## Tests

5 new tests (`TestExecutePathKwarg`): accepts-path, legacy-warns,
both-path-wins, default-export-rederived, explicit-export-preserved.
Full file 95 pass; registry guard 26 pass; ruff clean.

Completes workflow-path-arg-unification **PR-2** — all 5 target workflows
now accept `path`. (The Phase-2 registry simplification, PR-5, remains
optional.) After this + #684 land, the spec's "doc-orchestrator gap" note
is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
