### PR TITLE
feat(patterns): pattern review queue + backend-persisted library (Theme A)

### DIFF
--- a/src/attune/cli_commands/pattern_review.py
+++ b/src/attune/cli_commands/pattern_review.py
@@ -1,0 +1,87 @@
+"""``attune patterns`` — the human-in-the-loop pattern review queue CLI.
+
+``attune patterns review`` lists staged patterns; ``promote <id>`` moves
+one into the active (backend-persisted) :class:`PersistentPatternLibrary`;
+``reject <id>`` drops it. The queue and the library share one memory
+backend (file by default, Redis AMS when configured), so a promote is
+durable across processes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from attune.pattern_review import PatternReviewQueue, PersistentPatternLibrary
+
+logger = logging.getLogger(__name__)
+
+
+def cmd_patterns_review(args: Any) -> int:
+    """List staged patterns awaiting review."""
+    queue = PatternReviewQueue()
+    staged = queue.list(
+        pattern_type=getattr(args, "type", None),
+        agent_id=getattr(args, "agent", None),
+        min_confidence=getattr(args, "min_confidence", None),
+    )
+
+    if getattr(args, "json", False):
+        print(json.dumps([p.to_dict() for p in staged], indent=2))
+        return 0
+
+    if not staged:
+        print("No patterns staged for review.")
+        return 0
+
+    print(f"{len(staged)} pattern(s) staged for review:\n")
+    for p in staged:
+        print(f"  [{p.confidence:.2f}] {p.pattern_id}  ({p.pattern_type}, by {p.agent_id})")
+        print(f"        {p.name}")
+        if p.code:
+            preview = " ".join(p.code.split())
+            if len(preview) > 80:
+                preview = preview[:77] + "..."
+            print(f"        {preview}")
+    print("\nPromote with: attune patterns promote <id>   (or reject <id>)")
+    return 0
+
+
+def cmd_patterns_promote(args: Any) -> int:
+    """Promote a staged pattern into the active library."""
+    pattern_id = getattr(args, "pattern_id", None)
+    if not pattern_id:
+        print("Error: a pattern id is required: attune patterns promote <id>")
+        return 2
+
+    queue = PatternReviewQueue()
+    library = PersistentPatternLibrary()
+    try:
+        promoted = queue.promote(pattern_id, library)
+    except ValueError as exc:
+        print(f"Cannot promote {pattern_id!r}: {exc}")
+        return 1
+
+    if promoted is None:
+        print(f"No staged pattern with id {pattern_id!r}.")
+        return 1
+
+    print(f"Promoted {pattern_id!r} into the pattern library.")
+    return 0
+
+
+def cmd_patterns_reject(args: Any) -> int:
+    """Reject (drop) a staged pattern."""
+    pattern_id = getattr(args, "pattern_id", None)
+    if not pattern_id:
+        print("Error: a pattern id is required: attune patterns reject <id>")
+        return 2
+
+    queue = PatternReviewQueue()
+    reason = getattr(args, "reason", None) or ""
+    if queue.reject(pattern_id, reason=reason):
+        print(f"Rejected {pattern_id!r}.")
+        return 0
+    print(f"No staged pattern with id {pattern_id!r}.")
+    return 1

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -640,7 +640,8 @@ def _show_welcome() -> int:
     except Exception:  # noqa: BLE001
         # INTENTIONAL: version is non-critical for welcome message
         ver = "?"
-    print(f"""Attune AI v{ver} — AI-powered developer workflows
+    print(
+        f"""Attune AI v{ver} — AI-powered developer workflows
 
 Get started:
   attune workflow list        See all available workflows
@@ -654,7 +655,8 @@ For interactive development in Claude Code:
   /testing      Run tests, coverage, generate tests
   /wizard run   Guided multi-step wizards
 
-More: attune --help | Docs: https://smartaimemory.com/framework-docs/""")
+More: attune --help | Docs: https://smartaimemory.com/framework-docs/"""
+    )
     return 0
 
 

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -73,6 +73,11 @@ from attune.cli_commands.memory_commands import (
     cmd_memory_topics,
     cmd_remember,
 )
+from attune.cli_commands.pattern_review import (
+    cmd_patterns_promote,
+    cmd_patterns_reject,
+    cmd_patterns_review,
+)
 from attune.cli_commands.provider_commands import (
     cmd_provider_set,
     cmd_provider_show,
@@ -445,6 +450,27 @@ def _add_misc_subparsers(subparsers: argparse._SubParsersAction) -> None:
         help="Max output tokens per turn (default: 4096)",
     )
 
+    patterns_parser = subparsers.add_parser(
+        "patterns",
+        help="Review staged patterns before they enter the library",
+    )
+    patterns_sub = patterns_parser.add_subparsers(dest="patterns_command")
+    review_p = patterns_sub.add_parser("review", help="List staged patterns")
+    review_p.add_argument("--type", help="Filter by pattern type")
+    review_p.add_argument("--agent", help="Filter by source agent id")
+    review_p.add_argument(
+        "--min-confidence",
+        dest="min_confidence",
+        type=float,
+        help="Only show patterns at or above this confidence",
+    )
+    review_p.add_argument("--json", action="store_true", help="Output as JSON")
+    promote_p = patterns_sub.add_parser("promote", help="Promote a staged pattern")
+    promote_p.add_argument("pattern_id", help="Id of the staged pattern to promote")
+    reject_p = patterns_sub.add_parser("reject", help="Reject a staged pattern")
+    reject_p.add_argument("pattern_id", help="Id of the staged pattern to reject")
+    reject_p.add_argument("--reason", help="Rejection reason (recorded for audit)")
+
     version_parser = subparsers.add_parser("version", help="Show version")
     version_parser.add_argument("-v", "--verbose", action="store_true", help="Show detailed info")
 
@@ -523,6 +549,12 @@ Documentation: https://smartaimemory.com/framework-docs/
 
 
 _SUBCOMMAND_DISPATCH: dict[str, dict[str, object]] = {
+    "patterns": {
+        "_attr": "patterns_command",
+        "review": cmd_patterns_review,
+        "promote": cmd_patterns_promote,
+        "reject": cmd_patterns_reject,
+    },
     "workflow": {
         "_attr": "workflow_command",
         "list": cmd_workflow_list,
@@ -608,8 +640,7 @@ def _show_welcome() -> int:
     except Exception:  # noqa: BLE001
         # INTENTIONAL: version is non-critical for welcome message
         ver = "?"
-    print(
-        f"""Attune AI v{ver} — AI-powered developer workflows
+    print(f"""Attune AI v{ver} — AI-powered developer workflows
 
 Get started:
   attune workflow list        See all available workflows
@@ -623,8 +654,7 @@ For interactive development in Claude Code:
   /testing      Run tests, coverage, generate tests
   /wizard run   Guided multi-step wizards
 
-More: attune --help | Docs: https://smartaimemory.com/framework-docs/"""
-    )
+More: attune --help | Docs: https://smartaimemory.com/framework-docs/""")
     return 0
 
 

--- a/src/attune/pattern_review.py
+++ b/src/attune/pattern_review.py
@@ -1,0 +1,257 @@
+"""Pattern review queue — a human checkpoint before the active library.
+
+Discovered patterns are *staged* (persisted as :class:`StagedPattern` on
+attune's memory backend — the local file backend by default, the Redis
+Agent Memory Server when ``attune_redis`` is configured), surfaced for
+review (CLI + ops dashboard), and only **promoted** into the active
+:class:`~attune.pattern_library.PatternLibrary` on approval, or
+**rejected**.
+
+This re-homes the design of the deprecated, Redis-coupled
+``PatternStagingMixin`` (stage → list → get → promote → reject) onto the
+:class:`~attune.memory.backend.MemoryBackend` abstraction, dropping the
+agent-tier permission model in favour of a human reviewer (CLI/dashboard).
+It adds no Redis dependency: the queue persists on the same backend
+abstraction as the rest of attune memory.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from attune.memory.types import StagedPattern
+from attune.pattern_library import Pattern, PatternLibrary
+
+if TYPE_CHECKING:
+    from attune.memory.backend import MemoryBackend
+
+logger = logging.getLogger(__name__)
+
+#: Key prefix for staged patterns in the backend KV namespace.
+STAGED_PREFIX = "staged_pattern:"
+#: Key prefix for active (promoted) library patterns in the same store.
+ACTIVE_PREFIX = "pattern:"
+
+
+def _default_backend() -> MemoryBackend:
+    """Resolve the memory backend: AMS when connected, else the file backend.
+
+    Mirrors how SessionStart recall and the Memory-tool bridge resolve
+    their backend, so the review queue persists in the same store.
+    """
+    from attune.memory.file_stash import FileStashBackend
+    from attune.memory.session_stash import resolve_backend
+
+    backend = resolve_backend(None)
+    if backend is None:
+        backend = FileStashBackend()
+    return backend
+
+
+class PatternReviewQueue:
+    """Stage → review → promote/reject queue over a :class:`MemoryBackend`.
+
+    Args:
+        backend: An attune memory backend. Defaults to the resolved backend
+            (file by default; AMS when configured).
+    """
+
+    def __init__(self, backend: MemoryBackend | None = None) -> None:
+        self._backend = backend or _default_backend()
+
+    def stage(self, pattern: StagedPattern) -> str:
+        """Persist a :class:`StagedPattern` to the queue.
+
+        Returns the pattern's id. Staging the same id again overwrites the
+        prior staged copy (last write wins), matching backend KV semantics.
+        """
+        self._backend.stash(STAGED_PREFIX + pattern.pattern_id, pattern.to_dict())
+        logger.info("staged pattern %s for review", pattern.pattern_id)
+        return pattern.pattern_id
+
+    def get(self, pattern_id: str) -> StagedPattern | None:
+        """Return one staged pattern, or ``None`` if not staged / unreadable."""
+        raw = self._backend.retrieve(STAGED_PREFIX + pattern_id)
+        if not raw:
+            return None
+        return _parse(raw, pattern_id)
+
+    def list(
+        self,
+        *,
+        pattern_type: str | None = None,
+        agent_id: str | None = None,
+        min_confidence: float | None = None,
+    ) -> list[StagedPattern]:
+        """Return staged patterns, newest-highest-confidence first.
+
+        Optional filters narrow by ``pattern_type`` / ``agent_id`` /
+        ``min_confidence``. Unparseable entries are skipped, not fatal.
+        """
+        out: list[StagedPattern] = []
+        for key in self._backend.keys(STAGED_PREFIX + "*"):
+            raw = self._backend.retrieve(key)
+            if not raw:
+                continue
+            staged = _parse(raw, key)
+            if staged is None:
+                continue
+            if pattern_type and staged.pattern_type != pattern_type:
+                continue
+            if agent_id and staged.agent_id != agent_id:
+                continue
+            if min_confidence is not None and staged.confidence < min_confidence:
+                continue
+            out.append(staged)
+        out.sort(key=lambda p: p.confidence, reverse=True)
+        return out
+
+    def promote(self, pattern_id: str, library: PatternLibrary) -> Pattern | None:
+        """Convert + contribute the staged pattern to ``library``, then drop it.
+
+        Returns the promoted :class:`Pattern`, or ``None`` if ``pattern_id``
+        isn't staged. If ``contribute_pattern`` raises (e.g. a duplicate id),
+        the error propagates and the pattern stays staged so the reviewer can
+        retry or reject — the queue is only cleared on a successful contribute.
+        """
+        staged = self.get(pattern_id)
+        if staged is None:
+            return None
+        pattern = self._to_pattern(staged)
+        # May raise ValueError (e.g. duplicate id) — intentionally NOT caught:
+        # leave the entry staged so the reviewer can act on the conflict.
+        library.contribute_pattern(staged.agent_id, pattern)
+        self._backend.delete(STAGED_PREFIX + pattern_id)
+        logger.info("promoted staged pattern %s into the library", pattern_id)
+        return pattern
+
+    def reject(self, pattern_id: str, reason: str = "") -> bool:
+        """Drop a staged pattern. The reason is logged for audit.
+
+        Returns ``True`` if the pattern was present and removed.
+        """
+        logger.info(
+            "rejected staged pattern %s (reason: %s)",
+            pattern_id,
+            reason or "<none>",
+        )
+        return self._backend.delete(STAGED_PREFIX + pattern_id)
+
+    @staticmethod
+    def _to_pattern(staged: StagedPattern) -> Pattern:
+        """Map a :class:`StagedPattern` onto a library :class:`Pattern`."""
+        return Pattern(
+            id=staged.pattern_id,
+            agent_id=staged.agent_id,
+            pattern_type=staged.pattern_type,
+            name=staged.name,
+            description=staged.description,
+            context=dict(staged.context),
+            code=staged.code,
+            confidence=staged.confidence,
+        )
+
+
+def _parse(raw: object, key: str) -> StagedPattern | None:
+    """Best-effort decode of a stored value into a StagedPattern."""
+    if not isinstance(raw, dict):
+        logger.warning("staged pattern at %s is not a dict; skipping", key)
+        return None
+    try:
+        return StagedPattern.from_dict(raw)
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning("staged pattern at %s is unparseable (%s); skipping", key, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Backend-persisted pattern library
+# ---------------------------------------------------------------------------
+
+
+def _pattern_to_dict(pattern: Pattern) -> dict:
+    """Serialize a library :class:`Pattern` to a JSON-safe dict."""
+    return {
+        "id": pattern.id,
+        "agent_id": pattern.agent_id,
+        "pattern_type": pattern.pattern_type,
+        "name": pattern.name,
+        "description": pattern.description,
+        "context": pattern.context,
+        "code": pattern.code,
+        "confidence": pattern.confidence,
+        "usage_count": pattern.usage_count,
+        "success_count": pattern.success_count,
+        "failure_count": pattern.failure_count,
+        "tags": pattern.tags,
+        "discovered_at": pattern.discovered_at.isoformat(),
+        "last_used": pattern.last_used.isoformat() if pattern.last_used else None,
+    }
+
+
+def _pattern_from_dict(data: object) -> Pattern | None:
+    """Reconstruct a :class:`Pattern` from a stored dict (best-effort)."""
+    if not isinstance(data, dict):
+        return None
+    try:
+        last_used = data.get("last_used")
+        return Pattern(
+            id=data["id"],
+            agent_id=data["agent_id"],
+            pattern_type=data["pattern_type"],
+            name=data["name"],
+            description=data["description"],
+            context=data.get("context", {}),
+            code=data.get("code"),
+            confidence=data.get("confidence", 0.5),
+            usage_count=data.get("usage_count", 0),
+            success_count=data.get("success_count", 0),
+            failure_count=data.get("failure_count", 0),
+            tags=data.get("tags", []),
+            discovered_at=datetime.fromisoformat(data["discovered_at"]),
+            last_used=datetime.fromisoformat(last_used) if last_used else None,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning("stored pattern is unparseable (%s); skipping", exc)
+        return None
+
+
+class PersistentPatternLibrary(PatternLibrary):
+    """A :class:`PatternLibrary` that persists on the memory backend.
+
+    Contributions are written under the ``pattern:`` prefix on the same
+    :class:`MemoryBackend` the review queue uses — the local file backend by
+    default, the **Redis Agent Memory Server when configured**. The library
+    is reconstructed from the backend on construction, so promotes survive
+    across processes (and are Redis-durable under AMS) without the orphaned
+    ``PatternPersistence`` JSON-file path.
+
+    Args:
+        backend: An attune memory backend. Defaults to the resolved backend
+            (file by default; AMS when configured).
+    """
+
+    def __init__(self, backend: MemoryBackend | None = None) -> None:
+        super().__init__()
+        self._backend = backend or _default_backend()
+        self._load()
+
+    def _load(self) -> None:
+        """Reconstruct the in-memory library from the backend (no re-persist)."""
+        for key in self._backend.keys(ACTIVE_PREFIX + "*"):
+            pattern = _pattern_from_dict(self._backend.retrieve(key))
+            if pattern is None:
+                continue
+            try:
+                # Base method: in-memory bookkeeping only (our override persists).
+                PatternLibrary.contribute_pattern(self, pattern.agent_id, pattern)
+            except ValueError:
+                # Duplicate id already loaded — skip the redundant copy.
+                continue
+
+    def contribute_pattern(self, agent_id: str, pattern: Pattern) -> None:
+        """Validate + add in memory (base behaviour), then persist to the backend."""
+        PatternLibrary.contribute_pattern(self, agent_id, pattern)
+        self._backend.stash(ACTIVE_PREFIX + pattern.id, _pattern_to_dict(pattern))

--- a/tests/unit/cli_commands/test_pattern_review_cli.py
+++ b/tests/unit/cli_commands/test_pattern_review_cli.py
@@ -1,0 +1,95 @@
+"""Tests for the ``attune patterns`` CLI (review / promote / reject).
+
+The CLI handlers build ``PatternReviewQueue()`` / ``PersistentPatternLibrary()``
+with the default backend; the fixture redirects that to a temp file backend
+so queue + library share one isolated store (no ~/.attune writes).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from attune.cli_commands import pattern_review as cli
+from attune.memory.file_stash import FileStashBackend
+from attune.memory.types import StagedPattern
+from attune.pattern_review import PatternReviewQueue, PersistentPatternLibrary
+
+
+@pytest.fixture
+def backend(tmp_path, monkeypatch):
+    be = FileStashBackend(base_dir=str(tmp_path))
+    monkeypatch.setattr("attune.pattern_review._default_backend", lambda: be)
+    return be
+
+
+def _stage(backend, pattern_id="p1", **kw):
+    base = {
+        "agent_id": "a1",
+        "pattern_type": "behavioral",
+        "name": "n",
+        "description": "d",
+        "confidence": 0.8,
+    }
+    base.update(kw)
+    PatternReviewQueue(backend=backend).stage(StagedPattern(pattern_id=pattern_id, **base))
+
+
+def _args(**kw):
+    return SimpleNamespace(**kw)
+
+
+class TestReview:
+    def test_empty_queue(self, backend, capsys):
+        rc = cli.cmd_patterns_review(_args(type=None, agent=None, min_confidence=None, json=False))
+        assert rc == 0
+        assert "No patterns staged" in capsys.readouterr().out
+
+    def test_lists_staged(self, backend, capsys):
+        _stage(backend, "p1", name="cool pattern")
+        rc = cli.cmd_patterns_review(_args(type=None, agent=None, min_confidence=None, json=False))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "p1" in out and "cool pattern" in out
+
+    def test_json_output(self, backend, capsys):
+        _stage(backend, "p1")
+        rc = cli.cmd_patterns_review(_args(type=None, agent=None, min_confidence=None, json=True))
+        import json as _json
+
+        data = _json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert data[0]["pattern_id"] == "p1"
+
+
+class TestPromote:
+    def test_promote_durable(self, backend, capsys):
+        _stage(backend, "p1")
+        rc = cli.cmd_patterns_promote(_args(pattern_id="p1"))
+        assert rc == 0
+        assert "Promoted" in capsys.readouterr().out
+        # Durable: a fresh persistent library over the same store has it.
+        assert "p1" in PersistentPatternLibrary(backend=backend).patterns
+        # And it's gone from the queue.
+        assert PatternReviewQueue(backend=backend).get("p1") is None
+
+    def test_promote_absent_returns_1(self, backend, capsys):
+        rc = cli.cmd_patterns_promote(_args(pattern_id="nope"))
+        assert rc == 1
+        assert "No staged pattern" in capsys.readouterr().out
+
+    def test_promote_no_id_returns_2(self, backend):
+        assert cli.cmd_patterns_promote(_args(pattern_id=None)) == 2
+
+
+class TestReject:
+    def test_reject_drops(self, backend, capsys):
+        _stage(backend, "p1")
+        rc = cli.cmd_patterns_reject(_args(pattern_id="p1", reason="noisy"))
+        assert rc == 0
+        assert "Rejected" in capsys.readouterr().out
+        assert PatternReviewQueue(backend=backend).get("p1") is None
+
+    def test_reject_absent_returns_1(self, backend):
+        assert cli.cmd_patterns_reject(_args(pattern_id="nope", reason=None)) == 1

--- a/tests/unit/cli_commands/test_pattern_review_cli.py
+++ b/tests/unit/cli_commands/test_pattern_review_cli.py
@@ -93,3 +93,31 @@ class TestReject:
 
     def test_reject_absent_returns_1(self, backend):
         assert cli.cmd_patterns_reject(_args(pattern_id="nope", reason=None)) == 1
+
+
+class TestEdgeBranches:
+    def test_review_truncates_long_code(self, backend, capsys):
+        _stage(backend, "p1", code="x = " + "a" * 200)
+        cli.cmd_patterns_review(_args(type=None, agent=None, min_confidence=None, json=False))
+        assert "..." in capsys.readouterr().out
+
+    def test_promote_duplicate_returns_1(self, backend, capsys):
+        from attune.pattern_library import Pattern
+
+        PersistentPatternLibrary(backend=backend).contribute_pattern(
+            "a1",
+            Pattern(id="p1", agent_id="a1", pattern_type="behavioral", name="x", description="d"),
+        )
+        _stage(backend, "p1")
+        rc = cli.cmd_patterns_promote(_args(pattern_id="p1"))
+        assert rc == 1
+        assert "Cannot promote" in capsys.readouterr().out
+
+    def test_reject_no_id_returns_2(self, backend):
+        assert cli.cmd_patterns_reject(_args(pattern_id=None, reason=None)) == 2
+
+    def test_review_shows_short_code_untruncated(self, backend, capsys):
+        _stage(backend, "p1", code="y = 2")
+        cli.cmd_patterns_review(_args(type=None, agent=None, min_confidence=None, json=False))
+        out = capsys.readouterr().out
+        assert "y = 2" in out and "..." not in out

--- a/tests/unit/test_pattern_review.py
+++ b/tests/unit/test_pattern_review.py
@@ -1,0 +1,165 @@
+"""Tests for the pattern review queue (PatternReviewQueue).
+
+Exercised against the real ``FileStashBackend`` (zero infra) so the
+stage/list/promote/reject lifecycle round-trips through the actual backend
+KV surface, and against a real in-memory ``PatternLibrary`` for promote.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.memory.file_stash import FileStashBackend
+from attune.memory.types import StagedPattern
+from attune.pattern_library import Pattern, PatternLibrary
+from attune.pattern_review import (
+    ACTIVE_PREFIX,
+    STAGED_PREFIX,
+    PatternReviewQueue,
+    PersistentPatternLibrary,
+)
+
+
+@pytest.fixture
+def queue(tmp_path):
+    return PatternReviewQueue(backend=FileStashBackend(base_dir=str(tmp_path)))
+
+
+def _staged(
+    pattern_id="p1",
+    *,
+    agent_id="a1",
+    pattern_type="behavioral",
+    confidence=0.8,
+    name="n",
+    code="x = 1",
+):
+    return StagedPattern(
+        pattern_id=pattern_id,
+        agent_id=agent_id,
+        pattern_type=pattern_type,
+        name=name,
+        description="desc",
+        code=code,
+        confidence=confidence,
+    )
+
+
+class TestStageAndGet:
+    def test_stage_then_get_round_trips(self, queue):
+        assert queue.stage(_staged("p1", code="y = 2")) == "p1"
+        got = queue.get("p1")
+        assert got is not None
+        assert got.pattern_id == "p1"
+        assert got.code == "y = 2"
+        assert got.confidence == 0.8
+
+    def test_get_absent_returns_none(self, queue):
+        assert queue.get("nope") is None
+
+    def test_stage_same_id_overwrites(self, queue):
+        queue.stage(_staged("p1", name="first"))
+        queue.stage(_staged("p1", name="second"))
+        assert queue.get("p1").name == "second"
+        assert len(queue.list()) == 1
+
+
+class TestList:
+    def test_lists_sorted_by_confidence_desc(self, queue):
+        queue.stage(_staged("low", confidence=0.2))
+        queue.stage(_staged("high", confidence=0.9))
+        queue.stage(_staged("mid", confidence=0.5))
+        ids = [p.pattern_id for p in queue.list()]
+        assert ids == ["high", "mid", "low"]
+
+    def test_filter_by_type_agent_confidence(self, queue):
+        queue.stage(_staged("a", pattern_type="behavioral", agent_id="x", confidence=0.9))
+        queue.stage(_staged("b", pattern_type="temporal", agent_id="x", confidence=0.9))
+        queue.stage(_staged("c", pattern_type="behavioral", agent_id="y", confidence=0.3))
+        assert [p.pattern_id for p in queue.list(pattern_type="behavioral")] == ["a", "c"]
+        assert [p.pattern_id for p in queue.list(agent_id="y")] == ["c"]
+        assert [p.pattern_id for p in queue.list(min_confidence=0.5)] == ["a", "b"]
+
+    def test_empty_queue_lists_nothing(self, queue):
+        assert queue.list() == []
+
+    def test_unparseable_entry_is_skipped(self, queue, tmp_path):
+        queue.stage(_staged("good"))
+        # Write a garbage value directly under the staged prefix.
+        queue._backend.stash(STAGED_PREFIX + "bad", {"not": "a staged pattern"})
+        ids = [p.pattern_id for p in queue.list()]
+        assert ids == ["good"]
+
+
+class TestPromote:
+    def test_promote_contributes_and_drops_from_queue(self, queue):
+        queue.stage(_staged("p1", agent_id="a1"))
+        library = PatternLibrary()
+        promoted = queue.promote("p1", library)
+        assert isinstance(promoted, Pattern)
+        assert promoted.id == "p1"
+        assert "p1" in library.patterns
+        assert queue.get("p1") is None  # dropped from the queue
+
+    def test_promote_absent_returns_none(self, queue):
+        assert queue.promote("nope", PatternLibrary()) is None
+
+    def test_promote_duplicate_propagates_and_keeps_staged(self, queue):
+        library = PatternLibrary()
+        library.contribute_pattern(
+            "a1",
+            Pattern(
+                id="p1", agent_id="a1", pattern_type="behavioral", name="existing", description="d"
+            ),
+        )
+        queue.stage(_staged("p1"))
+        with pytest.raises(ValueError):
+            queue.promote("p1", library)
+        # Stays staged so the reviewer can retry/reject.
+        assert queue.get("p1") is not None
+
+
+class TestReject:
+    def test_reject_drops_and_returns_true(self, queue):
+        queue.stage(_staged("p1"))
+        assert queue.reject("p1", reason="noisy") is True
+        assert queue.get("p1") is None
+
+    def test_reject_absent_returns_false(self, queue):
+        assert queue.reject("nope") is False
+
+
+class TestPersistentLibrary:
+    def test_contribute_persists_and_reloads(self, tmp_path):
+        be = FileStashBackend(base_dir=str(tmp_path))
+        lib = PersistentPatternLibrary(backend=be)
+        lib.contribute_pattern(
+            "a1",
+            Pattern(id="p1", agent_id="a1", pattern_type="behavioral", name="n", description="d"),
+        )
+        # A fresh library over the same store reconstructs the pattern.
+        reloaded = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        assert "p1" in reloaded.patterns
+        assert reloaded.patterns["p1"].name == "n"
+
+    def test_promote_into_persistent_library_is_durable(self, tmp_path):
+        queue = PatternReviewQueue(backend=FileStashBackend(base_dir=str(tmp_path)))
+        lib = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        queue.stage(_staged("p9", agent_id="a9"))
+        queue.promote("p9", lib)
+        # Survives in a brand-new library over the same backend; queue cleared.
+        reloaded = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        assert "p9" in reloaded.patterns
+        assert queue.get("p9") is None
+
+    def test_load_skips_unparseable_active_entry(self, tmp_path):
+        be = FileStashBackend(base_dir=str(tmp_path))
+        lib = PersistentPatternLibrary(backend=be)
+        lib.contribute_pattern(
+            "a1",
+            Pattern(id="good", agent_id="a1", pattern_type="behavioral", name="n", description="d"),
+        )
+        be.stash(ACTIVE_PREFIX + "bad", {"not": "a pattern"})
+        reloaded = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        assert "good" in reloaded.patterns
+        assert "bad" not in reloaded.patterns

--- a/tests/unit/test_pattern_review.py
+++ b/tests/unit/test_pattern_review.py
@@ -163,3 +163,46 @@ class TestPersistentLibrary:
         reloaded = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
         assert "good" in reloaded.patterns
         assert "bad" not in reloaded.patterns
+
+
+class TestInternals:
+    def test_default_backend_falls_back_to_file(self, monkeypatch):
+        import attune.pattern_review as pr
+        from attune.memory.file_stash import FileStashBackend
+
+        monkeypatch.setattr("attune.memory.session_stash.resolve_backend", lambda b=None: None)
+        assert isinstance(pr._default_backend(), FileStashBackend)
+
+    def test_default_backend_prefers_resolved(self, monkeypatch):
+        import attune.pattern_review as pr
+
+        sentinel = object()
+        monkeypatch.setattr("attune.memory.session_stash.resolve_backend", lambda b=None: sentinel)
+        assert pr._default_backend() is sentinel
+
+    def test_list_skips_falsy_value(self, queue):
+        queue.stage(_staged("good"))
+        queue._backend.stash(STAGED_PREFIX + "empty", None)
+        assert [p.pattern_id for p in queue.list()] == ["good"]
+
+    def test_list_skips_non_dict_value(self, queue):
+        queue.stage(_staged("good"))
+        queue._backend.stash(STAGED_PREFIX + "str", "not a dict at all")
+        assert [p.pattern_id for p in queue.list()] == ["good"]
+
+    def test_load_skips_non_dict_active_entry(self, tmp_path):
+        be = FileStashBackend(base_dir=str(tmp_path))
+        be.stash(ACTIVE_PREFIX + "weird", "not a dict")
+        assert "weird" not in PersistentPatternLibrary(backend=be).patterns
+
+    def test_load_skips_duplicate_active_id(self, tmp_path):
+        import attune.pattern_review as pr
+
+        be = FileStashBackend(base_dir=str(tmp_path))
+        d = pr._pattern_to_dict(
+            Pattern(id="dup", agent_id="a", pattern_type="behavioral", name="n", description="d")
+        )
+        be.stash(ACTIVE_PREFIX + "k1", d)
+        be.stash(ACTIVE_PREFIX + "k2", d)  # same id under a second key
+        lib = PersistentPatternLibrary(backend=be)
+        assert "dup" in lib.patterns  # loaded once, dup skipped without error


### PR DESCRIPTION
## Summary

**Theme A — pattern review queue + backend-persisted library.** A human
checkpoint before discovered patterns enter the active library, re-homing
the dormant (deprecated, Redis-coupled) `PatternStagingMixin` onto the
`MemoryBackend` abstraction — file by default, **Redis AMS when
configured**. No Redis dependency, no agent-tier permissions (human
reviewer via CLI).

## What's here

- **`PatternReviewQueue`** — `stage / get / list (filter + confidence
  sort) / promote(id, library) / reject(id, reason)`, under the
  `staged_pattern:` prefix.
- **`PersistentPatternLibrary`** — a `PatternLibrary` that persists
  contributions under the `pattern:` prefix on the **same** backend and
  reconstructs on construction, so a promote is durable across processes
  and Redis-backed under AMS. **Two prefixes, one store**:
  `staged_pattern:*` (queue) + `pattern:*` (active).
- **CLI** — `attune patterns review | promote <id> | reject <id>` (R5).

## Why backend-persistence (confirmed)

Chosen over the orphaned, file-only `PatternPersistence.save_to_json`
(zero callers, off the Redis-alignment line). Keeps **one** persistence
story; Redis durability for free under AMS — advancing Theme A.

## Verify-first finding

The active `PatternLibrary` is **not persisted anywhere canonical** today
(`PatternPersistence` has no non-test callers) — so "promote into the
library" had no home. This PR establishes that home on the backend.

## Tests (23)

Real `FileStashBackend` round-trips + a real `PatternLibrary`; persistent-
library reload + durable promote verified end-to-end. 82 pass alongside the
existing CLI suite (rebased over #688).

## Scope

pattern-review-queue **R1–R5 + R8(unit)**. Follow-ups: dashboard panel
(R6) and opt-in discovery routing (R7, gated on the Phase-0
contribute-seam grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
