### PR TITLE
docs(lessons): agent SDK can't take the Anthropic Memory tool — raw-SDK only

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2279,6 +2279,23 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
     tools) → raw `anthropic` SDK; reserve
     `claude_agent_sdk.query()` for agentic work (file tools,
     subagent fan-out, multi-turn).
+  - **The agent SDK CANNOT take a client-side
+    `BetaAbstractMemoryTool` (Anthropic Memory tool,
+    `memory_20250818`) — that bridge is raw-`anthropic`-
+    `tool_runner`-ONLY** (verified claude-agent-sdk 0.1.63 /
+    anthropic 0.96.0): `ClaudeAgentOptions.tools` is a name
+    allowlist, `betas` accepts only `['context-1m-2025-08-07']`
+    (NOT `memory_20250818`), and there is no field for a tool
+    object. So `attune.memory.make_memory_tool()`'s bridge
+    composes ONLY with `client.beta.messages.tool_runner(
+    tools=[tool], betas=["context-management-2025-06-27"])`
+    (the `attune memory-agent` CLI). To give agent-SDK
+    *workflows* persistent memory you must instead expose it as
+    an **SDK-MCP tool** (`create_sdk_mcp_server` + `@tool`) — a
+    different surface (function calls, not the `/memories` file
+    model). This is why "wire the Memory tool into SDK-native
+    workflows" (the would-be option ③) is a dead end. See
+    `docs/specs/anthropic-memory-tool-backend/design.md` Phase 2.
 
 - **`getattr(module, "name", None)` at call site is the
   clean degradation pattern for optional SDK surface**:


### PR DESCRIPTION
Captures the verified Theme A finding (#688): the Memory-tool bridge (`BetaAbstractMemoryTool` / `memory_20250818`) composes only with the raw `anthropic` `tool_runner`, NOT `claude_agent_sdk` (`tools` is a name allowlist; `betas` lacks `memory_20250818`). Extends the existing introspect-the-SDK lesson so the 'why option ③ is a dead end' fact is discoverable in the SDK lesson family, not just the spec's design.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)