### PR TITLE
feat(ops): pattern review queue dashboard panel (pattern-review-queue R6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Pattern review queue now has an ops-dashboard panel.** A new
+  "Patterns" page (`GET /patterns`) lists staged patterns awaiting
+  review — name, type, confidence, source agent, and a code preview —
+  with **Promote** and **Reject** actions, the dashboard half of the
+  `attune patterns review|promote|reject` CLI. Promote moves the
+  pattern into the durable `PersistentPatternLibrary` (file backend by
+  default, Redis Agent Memory Server when configured) and clears it
+  from the queue; a duplicate id in the active library returns 409 and
+  leaves the pattern staged so the reviewer can rename or reject. The
+  mutating routes are guarded by the existing `X-Attune-Client` token
+  gate (defense in depth, matching the curator/specs/runner routes).
+  Dashboard and CLI share one backend store, so they show one queue.
+  See `docs/specs/pattern-review-queue/` (R6).
 - **attune's memory store is now a drop-in backend for Anthropic's
   Memory tool.** `attune.memory.memory_tool.make_memory_tool()` returns
   a real `anthropic` `BetaAbstractMemoryTool` (the `memory_20250818`

--- a/docs/specs/pattern-review-queue/requirements.md
+++ b/docs/specs/pattern-review-queue/requirements.md
@@ -11,8 +11,9 @@
 > re-homes it on the current backend stack, off the deprecated
 > Redis coupling.
 
-**Status:** draft (2026-06-08) — overnight autonomous draft for
-morning review
+**Status:** in progress (2026-06-09) — R1–R5 + R8(unit) shipped in
+#689; R6 (dashboard panel) shipped this session. R7 (opt-in discovery
+routing) remains.
 **Owner:** Patrick + agent
 **Related:**
 

--- a/src/attune/ops/routes/patterns.py
+++ b/src/attune/ops/routes/patterns.py
@@ -1,0 +1,124 @@
+"""Dashboard surface for the pattern review queue (pattern-review-queue R6).
+
+A human-in-the-loop checkpoint, mirrored from the CLI
+(``attune patterns review|promote|reject``):
+
+- ``GET /patterns`` — render the staged-pattern queue as review cards
+  (name, type, confidence, source agent, description, code preview).
+- ``POST /patterns/promote`` — promote a staged pattern into the durable
+  :class:`~attune.pattern_review.PersistentPatternLibrary`, then drop it
+  from the queue. Token-gated.
+- ``POST /patterns/reject`` — drop a staged pattern with an audit reason.
+  Token-gated.
+
+The mutating routes use the existing ``X-Attune-Client`` token gate
+(:func:`attune.ops.security.require_client_token`) for defense in depth,
+matching the curator / specs / runner mutating routes.
+
+The queue and the promote target share one backend so the
+``staged_pattern:`` and ``pattern:`` prefixes live in the same store
+(the local file backend by default, the Redis Agent Memory Server when
+configured) — the same store the CLI manages, so the dashboard and CLI
+show one queue.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, Body, Depends, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from attune.ops.security import require_client_token
+from attune.pattern_review import PatternReviewQueue, PersistentPatternLibrary
+
+from .dashboard import _ctx
+
+if TYPE_CHECKING:
+    from attune.memory.backend import MemoryBackend
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _backend(request: Request) -> MemoryBackend | None:
+    """Backend override from ``app.state`` (tests inject a tmp backend).
+
+    ``None`` in production → the queue/library resolve their own default
+    backend (file by default; AMS when configured), the same store the
+    ``attune patterns`` CLI manages.
+    """
+    return getattr(request.app.state, "pattern_backend", None)
+
+
+def _queue(request: Request) -> PatternReviewQueue:
+    return PatternReviewQueue(_backend(request))
+
+
+def _library(request: Request) -> PersistentPatternLibrary:
+    return PersistentPatternLibrary(_backend(request))
+
+
+@router.get("/patterns", response_class=HTMLResponse)
+async def patterns_page(request: Request) -> HTMLResponse:
+    """Render the staged-pattern review queue (newest-highest-confidence first)."""
+    staged = _queue(request).list()
+    templates = request.app.state.templates
+    ctx = _ctx(request, page="patterns", staged=staged)
+    return templates.TemplateResponse(request, "patterns.html", ctx)
+
+
+@router.post("/patterns/promote")
+async def patterns_promote(
+    request: Request,
+    body: dict[str, Any] = Body(...),  # noqa: B008
+    _client: None = Depends(require_client_token),  # noqa: B008
+) -> JSONResponse:
+    """Promote a staged pattern into the durable library, then drop it.
+
+    Body: ``{"pattern_id": "..."}``. Returns 404 if the id isn't staged,
+    409 if the active library already holds that id (the pattern stays
+    staged so the reviewer can rename or reject).
+    """
+    pattern_id = str(body.get("pattern_id") or "").strip()
+    if not pattern_id:
+        return JSONResponse({"ok": False, "error": "pattern_id required"}, status_code=400)
+
+    queue = _queue(request)
+    try:
+        promoted = queue.promote(pattern_id, _library(request))
+    except ValueError as exc:
+        # Duplicate id in the active library — leave it staged for the reviewer.
+        logger.info("patterns: promote conflict for %s: %s", pattern_id, exc)
+        return JSONResponse({"ok": False, "error": "already in library"}, status_code=409)
+
+    if promoted is None:
+        return JSONResponse({"ok": False, "error": "not staged"}, status_code=404)
+    return JSONResponse({"ok": True, "pattern_id": pattern_id})
+
+
+@router.post("/patterns/reject")
+async def patterns_reject(
+    request: Request,
+    body: dict[str, Any] = Body(...),  # noqa: B008
+    _client: None = Depends(require_client_token),  # noqa: B008
+) -> JSONResponse:
+    """Drop a staged pattern. The reason is recorded in the audit log.
+
+    Body: ``{"pattern_id": "...", "reason": "..."}``. ``removed`` is
+    ``False`` (with 404) when the id wasn't staged.
+    """
+    pattern_id = str(body.get("pattern_id") or "").strip()
+    if not pattern_id:
+        return JSONResponse({"ok": False, "error": "pattern_id required"}, status_code=400)
+    reason = str(body.get("reason") or "").strip()
+
+    removed = _queue(request).reject(pattern_id, reason)
+    if not removed:
+        return JSONResponse({"ok": False, "error": "not staged"}, status_code=404)
+    return JSONResponse({"ok": True, "pattern_id": pattern_id, "removed": True})

--- a/src/attune/ops/server.py
+++ b/src/attune/ops/server.py
@@ -20,6 +20,7 @@ from attune.ops.routes import curator as curator_routes
 from attune.ops.routes import dashboard
 from attune.ops.routes import help as help_routes
 from attune.ops.routes import interaction_counters as interaction_counters_routes
+from attune.ops.routes import patterns as patterns_routes
 from attune.ops.routes import pending_writes as pending_writes_routes
 from attune.ops.routes import runner as runner_routes
 from attune.ops.routes import runs_history as runs_history_routes
@@ -104,6 +105,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
         ("/workflows", "Workflows"),
         ("/curator", "Briefing"),
         ("/specs", "Specs"),
+        ("/patterns", "Patterns"),
         ("/sessions", "Sessions"),
         ("/telemetry", "Telemetry"),
         ("/health", "Health"),
@@ -134,6 +136,7 @@ def create_app(config: Config, *, runner: RunnerService | None = None) -> FastAP
     app.include_router(specs_routes.router)
     app.include_router(sweep_results_routes.router)
     app.include_router(interaction_counters_routes.router)
+    app.include_router(patterns_routes.router)
     app.include_router(pending_writes_routes.router)
     app.include_router(bulletin_routes.router)
     app.include_router(curator_routes.router)

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -3008,6 +3008,13 @@ a.kpi:hover {
   text-align: center;
   color: var(--fg-muted);
 }
+/* Pattern-review card: code preview (pattern-review-queue R6). */
+.pattern-code {
+  max-height: 220px;
+  overflow: auto;
+  margin: 10px 0 0;
+  font-size: 12px;
+}
 .curator-foot {
   display: flex;
   flex-wrap: wrap;

--- a/src/attune/ops/templates/patterns.html
+++ b/src/attune/ops/templates/patterns.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% block title %}Pattern review{% endblock %}
+{% block content %}
+<section class="page-head">
+  <h1>Pattern review</h1>
+  <p class="page-sub">
+    Discovered patterns awaiting a human checkpoint before they enter the
+    active library. Promote to keep, reject to drop.
+    {% if staged %}· {{ staged|length }} staged{% endif %}
+  </p>
+</section>
+
+{% if staged %}
+  <div class="curator-cards">
+    {% for p in staged %}
+      <article class="curator-card" id="pattern-{{ p.pattern_id }}">
+        <div class="curator-card-head">
+          <span class="chip">{{ p.pattern_type }}</span>
+          <h2 class="curator-card-title">{{ p.name }}</h2>
+          <span class="curator-src-chip">{{ "%.0f"|format(p.confidence * 100) }}% confidence</span>
+        </div>
+        <p class="curator-card-rationale">{{ p.description }}</p>
+
+        <div class="curator-sources">
+          <code class="curator-src-chip">agent: {{ p.agent_id }}</code>
+          <code class="curator-src-chip">id: {{ p.pattern_id }}</code>
+        </div>
+
+        {% if p.code %}
+          <pre class="pattern-code"><code>{{ p.code }}</code></pre>
+        {% endif %}
+
+        <div class="curator-card-actions">
+          <button class="btn btn-primary pattern-promote-btn"
+                  data-pattern-id="{{ p.pattern_id }}">Promote</button>
+          <button class="btn btn-muted pattern-reject-btn"
+                  data-pattern-id="{{ p.pattern_id }}">Reject</button>
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+{% else %}
+  <section class="curator-empty">
+    <p>The review queue is empty — no patterns are staged for review.</p>
+  </section>
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+<script>
+  // Promote/reject POST JSON (token-gated), then reload to reflect state.
+  async function _post(url, payload) {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: attuneClientHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify(payload),
+    });
+    return resp.ok;
+  }
+  document.querySelectorAll(".pattern-promote-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      btn.disabled = true;
+      if (await _post("/patterns/promote", { pattern_id: btn.dataset.patternId })) {
+        window.location.reload();
+      } else {
+        btn.disabled = false;
+      }
+    });
+  });
+  document.querySelectorAll(".pattern-reject-btn").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      const reason = window.prompt("Reason for rejecting (optional):", "") ?? "";
+      btn.disabled = true;
+      if (await _post("/patterns/reject", {
+        pattern_id: btn.dataset.patternId,
+        reason: reason,
+      })) {
+        window.location.reload();
+      } else {
+        btn.disabled = false;
+      }
+    });
+  });
+</script>
+{% endblock %}

--- a/tests/unit/ops/test_patterns_route.py
+++ b/tests/unit/ops/test_patterns_route.py
@@ -1,0 +1,166 @@
+"""Tests for the dashboard /patterns route (pattern-review-queue R6).
+
+Exercised against a real ``FileStashBackend`` (injected via
+``app.state.pattern_backend``) so the stage → render → promote/reject
+lifecycle round-trips through the actual backend, not a mock. The
+``tests/unit/ops/conftest.py`` autouse fixture nulls the session token,
+so the no-header POSTs here satisfy ``require_client_token``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from attune.memory.file_stash import FileStashBackend
+from attune.memory.types import StagedPattern
+from attune.ops.config import Config
+from attune.ops.server import create_app
+from attune.pattern_review import (
+    ACTIVE_PREFIX,
+    STAGED_PREFIX,
+    PatternReviewQueue,
+    PersistentPatternLibrary,
+)
+
+
+@pytest.fixture
+def backend(tmp_path: Path) -> FileStashBackend:
+    return FileStashBackend(base_dir=str(tmp_path / "stash"))
+
+
+@pytest.fixture
+def client(tmp_path: Path, backend: FileStashBackend) -> TestClient:
+    cfg = Config(
+        project_root=tmp_path,
+        attune_home=tmp_path / "ah",
+        allow_run=False,
+        trusted_hosts=("testserver", "test"),
+    )
+    app = create_app(cfg)
+    # Route reads app.state.pattern_backend; the queue/library share it so
+    # the dashboard and the test see one store.
+    app.state.pattern_backend = backend
+    return TestClient(app)
+
+
+def _staged(
+    pattern_id: str = "p1",
+    *,
+    agent_id: str = "a1",
+    pattern_type: str = "behavioral",
+    name: str = "Retry on 503",
+    confidence: float = 0.8,
+    code: str | None = "x = 1",
+) -> StagedPattern:
+    return StagedPattern(
+        pattern_id=pattern_id,
+        agent_id=agent_id,
+        pattern_type=pattern_type,
+        name=name,
+        description="desc",
+        code=code,
+        confidence=confidence,
+    )
+
+
+def _stage(backend: FileStashBackend, *patterns: StagedPattern) -> None:
+    queue = PatternReviewQueue(backend=backend)
+    for p in patterns:
+        queue.stage(p)
+
+
+class TestGetPatternsPage:
+    def test_renders_staged_patterns(self, client, backend):
+        _stage(
+            backend,
+            _staged("p1", name="Retry on 503", pattern_type="behavioral"),
+            _staged("p2", name="Cache the parse", pattern_type="performance"),
+        )
+        resp = client.get("/patterns")
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Retry on 503" in body
+        assert "Cache the parse" in body
+        assert "behavioral" in body
+        assert "2 staged" in body
+
+    def test_empty_queue_shows_empty_state(self, client):
+        resp = client.get("/patterns")
+        assert resp.status_code == 200
+        assert "The review queue is empty" in resp.text
+
+
+class TestPromote:
+    def test_promote_moves_to_library_and_clears_queue(self, client, backend):
+        _stage(backend, _staged("p1"))
+
+        resp = client.post("/patterns/promote", json={"pattern_id": "p1"})
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+        # Dropped from the staging queue...
+        assert backend.retrieve(STAGED_PREFIX + "p1") in (None, {}, "")
+        # ...and durable in the active library prefix.
+        lib = PersistentPatternLibrary(backend=backend)
+        assert lib.get_pattern("p1") is not None
+        assert backend.retrieve(ACTIVE_PREFIX + "p1") is not None
+
+    def test_promote_unknown_id_returns_404(self, client):
+        resp = client.post("/patterns/promote", json={"pattern_id": "nope"})
+        assert resp.status_code == 404
+        assert resp.json()["ok"] is False
+
+    def test_promote_requires_pattern_id(self, client):
+        resp = client.post("/patterns/promote", json={})
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+    def test_promote_duplicate_in_library_returns_409_and_keeps_staged(self, client, backend):
+        # Pre-seed the active library with p1, then stage another p1.
+        lib = PersistentPatternLibrary(backend=backend)
+        lib.contribute_pattern("a1", PatternReviewQueue._to_pattern(_staged("p1")))
+        _stage(backend, _staged("p1", name="dup"))
+
+        resp = client.post("/patterns/promote", json={"pattern_id": "p1"})
+        assert resp.status_code == 409
+        assert resp.json()["ok"] is False
+        # Still staged — reviewer can rename or reject.
+        assert PatternReviewQueue(backend=backend).get("p1") is not None
+
+
+class TestReject:
+    def test_reject_drops_from_queue(self, client, backend):
+        _stage(backend, _staged("p1"))
+
+        resp = client.post("/patterns/reject", json={"pattern_id": "p1", "reason": "noise"})
+        assert resp.status_code == 200
+        assert resp.json()["removed"] is True
+        assert PatternReviewQueue(backend=backend).get("p1") is None
+
+    def test_reject_unknown_id_returns_404(self, client):
+        resp = client.post("/patterns/reject", json={"pattern_id": "nope"})
+        assert resp.status_code == 404
+        assert resp.json()["ok"] is False
+
+    def test_reject_requires_pattern_id(self, client):
+        resp = client.post("/patterns/reject", json={})
+        assert resp.status_code == 400
+        assert resp.json()["ok"] is False
+
+
+class TestTokenGate:
+    def test_promote_rejected_without_token_when_gate_active(self, client, backend, monkeypatch):
+        # Re-arm the token (conftest nulls it) to prove the gate is wired.
+        monkeypatch.setattr("attune.ops.security._SESSION_TOKEN", "real-token")
+        _stage(backend, _staged("p1"))
+        resp = client.post("/patterns/promote", json={"pattern_id": "p1"})
+        assert resp.status_code == 403
+
+    def test_reject_rejected_without_token_when_gate_active(self, client, backend, monkeypatch):
+        monkeypatch.setattr("attune.ops.security._SESSION_TOKEN", "real-token")
+        _stage(backend, _staged("p1"))
+        resp = client.post("/patterns/reject", json={"pattern_id": "p1"})
+        assert resp.status_code == 403


### PR DESCRIPTION
## Pattern review queue — dashboard panel (pattern-review-queue R6)

The dashboard half of the `attune patterns review|promote|reject` CLI
shipped in #689. A new **Patterns** page puts a human checkpoint in the
ops UI before discovered patterns enter the active library.

### What's here
- **`GET /patterns`** — renders the staged-pattern queue as review cards
  (name, type, confidence, source agent, description, code preview),
  newest-highest-confidence first; empty-state when the queue is clear.
- **`POST /patterns/promote`** — promotes a staged pattern into the
  durable `PersistentPatternLibrary` and clears it from the queue.
  Returns 404 if not staged, **409** if the active library already holds
  that id (the pattern stays staged so the reviewer can rename/reject).
- **`POST /patterns/reject`** — drops a staged pattern with an audit
  reason.

### Defense in depth
The two mutating routes use the existing `X-Attune-Client` token gate
(`require_client_token`), mirroring the curator/specs/runner routes. The
queue and library share **one backend** (file by default, Redis Agent
Memory Server when configured), so the dashboard and CLI show one queue.

### Tests
11 route tests against a real `FileStashBackend` (injected via
`app.state.pattern_backend`): render, empty state, promote→library
round-trip, reject, 400/404/409 paths, and the token gate (re-armed to
prove it's wired). Full rendered-HTML structure verified manually
(card, confidence %, both action buttons, code block, client-token meta,
nav link).

Scope is R6 only. R7 (opt-in discovery routing) is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
