### PR TITLE
feat(patterns): opt-in review routing for contributed patterns (pattern-review-queue R7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate (defense in depth, matching the curator/specs/runner routes).
   Dashboard and CLI share one backend store, so they show one queue.
   See `docs/specs/pattern-review-queue/` (R6).
+- **Opt-in review routing for contributed patterns.** Set
+  `ATTUNE_PATTERN_REVIEW=1` (default off) and pattern contributions
+  route to the review queue for human approval instead of entering the
+  active library directly. Two live seams honour the flag — the
+  agent-facing `SharedLibraryMixin.contribute_pattern` and the
+  meta-orchestrator's `ConfigurationStore._contribute_to_pattern_library`
+  — so a reviewer can opt into curation without changing default
+  behaviour. (A Phase-0 audit confirmed these are the only real
+  contribution seams; the spec's other named paths turned out to be
+  metrics counters and storage-load paths, which are correctly left
+  untouched.) Staged patterns surface in `attune patterns review` and
+  the dashboard Patterns panel. See `docs/specs/pattern-review-queue/`
+  (R7).
 - **attune's memory store is now a drop-in backend for Anthropic's
   Memory tool.** `attune.memory.memory_tool.make_memory_tool()` returns
   a real `anthropic` `BetaAbstractMemoryTool` (the `memory_20250818`

--- a/docs/specs/pattern-review-queue/requirements.md
+++ b/docs/specs/pattern-review-queue/requirements.md
@@ -11,9 +11,13 @@
 > re-homes it on the current backend stack, off the deprecated
 > Redis coupling.
 
-**Status:** in progress (2026-06-09) — R1–R5 + R8(unit) shipped in
-#689; R6 (dashboard panel) shipped this session. R7 (opt-in discovery
-routing) remains.
+**Status:** complete (2026-06-09) — R1–R5 + R8(unit) shipped in #689,
+R6 (dashboard panel) and R7 (opt-in routing) shipped 2026-06-09. R7's
+Phase-0 audit found the only live contribution seams are
+`SharedLibraryMixin.contribute_pattern` and
+`ConfigurationStore._contribute_to_pattern_library`; the other
+spec-named paths (`agent_monitoring.py`, `pattern_persistence.py`,
+`core.py`) are metrics/load paths, correctly left untouched.
 **Owner:** Patrick + agent
 **Related:**
 

--- a/src/attune/core_modules/shared_library.py
+++ b/src/attune/core_modules/shared_library.py
@@ -97,6 +97,15 @@ class SharedLibraryMixin:
             >>> agent.contribute_pattern(pattern)
 
         """
+        from attune.pattern_review import review_routing_enabled, stage_for_review
+
+        if review_routing_enabled():
+            # R7 opt-in: stage for human review instead of contributing
+            # straight to the live library. Default off — see
+            # docs/specs/pattern-review-queue/ (R7).
+            stage_for_review(self.user_id, pattern)
+            return
+
         if self.shared_library is None:
             raise RuntimeError(
                 "No shared library configured. Pass shared_library to __init__ "

--- a/src/attune/orchestration/config_store.py
+++ b/src/attune/orchestration/config_store.py
@@ -462,6 +462,16 @@ class ConfigurationStore:
             tags=config.tags,
         )
 
+        from attune.pattern_review import review_routing_enabled, stage_for_review
+
+        if review_routing_enabled():
+            # R7 opt-in: stage for human review instead of contributing
+            # straight to the live library. Default off — see
+            # docs/specs/pattern-review-queue/ (R7).
+            stage_for_review("meta_orchestrator", pattern)
+            logger.info(f"Staged pattern for {config.task_pattern} for review")
+            return
+
         try:
             self.pattern_library.contribute_pattern("meta_orchestrator", pattern)
             logger.info(f"Contributed pattern for {config.task_pattern} to pattern library")

--- a/src/attune/pattern_review.py
+++ b/src/attune/pattern_review.py
@@ -18,6 +18,7 @@ abstraction as the rest of attune memory.
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -33,6 +34,10 @@ logger = logging.getLogger(__name__)
 STAGED_PREFIX = "staged_pattern:"
 #: Key prefix for active (promoted) library patterns in the same store.
 ACTIVE_PREFIX = "pattern:"
+#: Env var gating opt-in review routing of contributed patterns (R7).
+REVIEW_ENABLED_ENV = "ATTUNE_PATTERN_REVIEW"
+#: Truthy spellings that turn review routing on.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 
 def _default_backend() -> MemoryBackend:
@@ -152,6 +157,43 @@ class PatternReviewQueue:
             code=staged.code,
             confidence=staged.confidence,
         )
+
+
+def review_routing_enabled() -> bool:
+    """True when contributed patterns should route to the review queue (R7).
+
+    Default **OFF** — existing ``contribute_pattern`` behaviour is unchanged
+    until a reviewer opts in by setting ``ATTUNE_PATTERN_REVIEW`` to a truthy
+    value (``1`` / ``true`` / ``yes`` / ``on``). This keeps the opt-in promise:
+    no surprise gating of auto-contribution.
+    """
+    return os.environ.get(REVIEW_ENABLED_ENV, "").strip().lower() in _TRUTHY
+
+
+def stage_for_review(
+    agent_id: str,
+    pattern: Pattern,
+    *,
+    backend: MemoryBackend | None = None,
+) -> str:
+    """Stage a would-be-contributed :class:`Pattern` into the review queue.
+
+    Converts the library ``Pattern`` to a :class:`StagedPattern` and stages it
+    on the same backend the dashboard/CLI read (file by default, AMS when
+    configured), so it surfaces for human review instead of entering the
+    active library directly. Returns the staged pattern id.
+    """
+    staged = StagedPattern(
+        pattern_id=pattern.id,
+        agent_id=agent_id,
+        pattern_type=pattern.pattern_type,
+        name=pattern.name,
+        description=pattern.description,
+        code=pattern.code,
+        context=dict(pattern.context),
+        confidence=pattern.confidence,
+    )
+    return PatternReviewQueue(backend).stage(staged)
 
 
 def _parse(raw: object, key: str) -> StagedPattern | None:

--- a/tests/unit/test_pattern_review_routing.py
+++ b/tests/unit/test_pattern_review_routing.py
@@ -1,0 +1,158 @@
+"""Tests for opt-in review routing of contributed patterns (R7).
+
+Covers the env-var flag (:func:`review_routing_enabled`), the
+:func:`stage_for_review` helper, and the two live contribution seams that
+honour the flag (verified in Phase 0 to be the only real ones):
+
+- ``SharedLibraryMixin.contribute_pattern`` (the agent-facing API), and
+- ``ConfigurationStore._contribute_to_pattern_library`` (meta-orchestrator).
+
+Default is OFF: with the flag unset, both seams contribute straight to the
+library exactly as before — no surprise gating.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.core import EmpathyOS
+from attune.memory.file_stash import FileStashBackend
+from attune.orchestration.config_store import AgentConfiguration, ConfigurationStore
+from attune.pattern_library import Pattern, PatternLibrary
+from attune.pattern_review import (
+    REVIEW_ENABLED_ENV,
+    PatternReviewQueue,
+    review_routing_enabled,
+    stage_for_review,
+)
+
+
+@pytest.fixture
+def routing_backend(tmp_path: Path, monkeypatch) -> FileStashBackend:
+    """Pin the default backend so ``stage_for_review`` writes to tmp.
+
+    ``stage_for_review`` constructs ``PatternReviewQueue(None)``, which falls
+    back to ``_default_backend()`` — patch it to a tmp file backend so the
+    seam tests can assert against the same store without touching real state.
+    """
+    backend = FileStashBackend(base_dir=str(tmp_path / "stash"))
+    monkeypatch.setattr("attune.pattern_review._default_backend", lambda: backend)
+    return backend
+
+
+def _pattern(pattern_id: str = "p1") -> Pattern:
+    return Pattern(
+        id=pattern_id,
+        agent_id="agent7",
+        pattern_type="behavioral",
+        name="Retry on 503",
+        description="Back off and retry transient 503s.",
+        code="x = 1",
+        confidence=0.8,
+    )
+
+
+class TestReviewRoutingEnabled:
+    def test_unset_is_off(self, monkeypatch):
+        monkeypatch.delenv(REVIEW_ENABLED_ENV, raising=False)
+        assert review_routing_enabled() is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "ON", " True "])
+    def test_truthy_values_on(self, monkeypatch, val):
+        monkeypatch.setenv(REVIEW_ENABLED_ENV, val)
+        assert review_routing_enabled() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_falsy_values_off(self, monkeypatch, val):
+        monkeypatch.setenv(REVIEW_ENABLED_ENV, val)
+        assert review_routing_enabled() is False
+
+
+class TestStageForReview:
+    def test_converts_and_stages(self, routing_backend):
+        staged_id = stage_for_review("agent7", _pattern("p1"))
+        assert staged_id == "p1"
+        got = PatternReviewQueue(backend=routing_backend).get("p1")
+        assert got is not None
+        assert got.agent_id == "agent7"
+        assert got.pattern_type == "behavioral"
+        assert got.confidence == 0.8
+        assert got.code == "x = 1"
+
+
+class TestSharedLibrarySeam:
+    def test_flag_on_stages_instead_of_contributing(self, routing_backend, monkeypatch):
+        monkeypatch.setenv(REVIEW_ENABLED_ENV, "1")
+        library = PatternLibrary()
+        agent = EmpathyOS(user_id="agent7", shared_library=library)
+
+        agent.contribute_pattern(_pattern("p1"))
+
+        # Routed to the queue, NOT the live library.
+        assert "p1" not in library.patterns
+        assert PatternReviewQueue(backend=routing_backend).get("p1") is not None
+
+    def test_flag_off_contributes_directly(self, routing_backend, monkeypatch):
+        monkeypatch.delenv(REVIEW_ENABLED_ENV, raising=False)
+        library = PatternLibrary()
+        agent = EmpathyOS(user_id="agent7", shared_library=library)
+
+        agent.contribute_pattern(_pattern("p1"))
+
+        assert "p1" in library.patterns
+        assert PatternReviewQueue(backend=routing_backend).get("p1") is None
+
+
+class TestConfigStoreSeam:
+    def _proven_config(self) -> AgentConfiguration:
+        return AgentConfiguration(
+            id="abc",
+            task_pattern="release_prep",
+            agents=[{"role": "tester", "tier": "CHEAP"}],
+            strategy="parallel",
+            quality_gates={"min_score": 80},
+            success_rate=0.9,
+            usage_count=5,
+            success_count=4,
+        )
+
+    def test_flag_on_stages_instead_of_contributing(self, tmp_path, routing_backend, monkeypatch):
+        monkeypatch.setenv(REVIEW_ENABLED_ENV, "1")
+        library = PatternLibrary()
+        store = ConfigurationStore(storage_dir=str(tmp_path / "cfg"), pattern_library=library)
+        store._contribute_to_pattern_library(self._proven_config())
+
+        assert "orchestration_abc" not in library.patterns
+        assert PatternReviewQueue(backend=routing_backend).get("orchestration_abc") is not None
+
+    def test_flag_off_contributes_directly(self, tmp_path, routing_backend, monkeypatch):
+        monkeypatch.delenv(REVIEW_ENABLED_ENV, raising=False)
+        library = PatternLibrary()
+        store = ConfigurationStore(storage_dir=str(tmp_path / "cfg"), pattern_library=library)
+        store._contribute_to_pattern_library(self._proven_config())
+
+        assert "orchestration_abc" in library.patterns
+        assert PatternReviewQueue(backend=routing_backend).get("orchestration_abc") is None
+
+    def test_unproven_config_contributes_nothing_either_way(
+        self, tmp_path, routing_backend, monkeypatch
+    ):
+        # The success-threshold guard fires before any routing decision.
+        monkeypatch.setenv(REVIEW_ENABLED_ENV, "1")
+        library = PatternLibrary()
+        store = ConfigurationStore(storage_dir=str(tmp_path / "cfg"), pattern_library=library)
+        weak = AgentConfiguration(
+            id="weak",
+            task_pattern="t",
+            agents=[],
+            strategy="sequential",
+            quality_gates={},
+            success_rate=0.1,
+            usage_count=1,
+        )
+        store._contribute_to_pattern_library(weak)
+
+        assert library.patterns == {}
+        assert PatternReviewQueue(backend=routing_backend).list() == []


### PR DESCRIPTION
## Opt-in review routing for contributed patterns (pattern-review-queue R7)

The last piece of the pattern-review-queue spec: a default-off flag that
routes pattern contributions through the review queue (R6 dashboard /
CLI) instead of straight into the active library.

### Phase 0 finding (verify-the-seam)
The spec named four "discovery paths." Grepping every `contribute_pattern`
call site against the code showed the assumed list was mostly wrong:

| Spec-named file | Reality | Gated? |
|---|---|---|
| `agent_monitoring.py` | metrics counters only — no `contribute_pattern` | no |
| `pattern_persistence.py` (×2) | storage **load** paths (re-hydrate approved patterns) | no — gating would be wrong |
| `core.py` | docstring mention | no |
| `core_modules/shared_library.py` | `SharedLibraryMixin.contribute_pattern` — the agent-facing API | **yes** |
| `config_store.py` (not spec-named) | `_contribute_to_pattern_library` — meta-orchestrator | **yes** |

So the two real seams are gated; the metrics/load paths are left untouched.

### What's here
- `ATTUNE_PATTERN_REVIEW` (default off) via `review_routing_enabled()` +
  a `stage_for_review(agent_id, pattern)` helper in `pattern_review.py`.
- Both seams: flag on → `stage_for_review(...)`; flag off → unchanged
  `contribute_pattern(...)`. Deferred imports (no cycle, no F401 strip).
- 18 tests: flag parsing (truthy/falsy/unset), `stage_for_review`
  round-trip, both seams (on stages / off contributes), unproven-config
  guard. Existing `pattern_review` / `core` / `config_store` suites green.

Independent of #692 (R6) — disjoint files. With both merged the queue has
a front door (R7), a dashboard (R6), and a CLI (#689).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
