### PR TITLE
feat(skills): referent-gate guidance in attune-hub (collaboration-gates R9/R10)

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -59,6 +59,23 @@ intent so Claude matches the right skill:
 | "refactor", "tech debt", "simplify" | refactor-plan skill |
 | "spec", "brainstorm", "plan and execute" | spec skill |
 
+## Single-referent resolution
+
+Before acting on a terse confirmation (`go`, `do it`, `y`, `1`),
+make sure exactly **one** referent is obvious from the prior turn —
+that you can fill in "go [doing **X**]" with a single, unambiguous X.
+
+- If the prior turn left **multiple** proposals on the table, the
+  referent is unresolved — ask which one before executing, don't
+  guess the most likely.
+- **Restate the referent as you act** ("Running the security audit
+  on `src/` —") so the user can catch a mismatch immediately.
+
+This is advisory guidance for the broader conversation; the one
+*enforceable* foothold is the `AskUserQuestion` one-question-per-turn
+rule (a single turn can't bundle multiple ambiguous decisions). See
+`docs/specs/collaboration-gates/` (R9/R10).
+
 ## Skills Reference
 
 | Skill | Triggers |

--- a/docs/specs/collaboration-gates/decisions.md
+++ b/docs/specs/collaboration-gates/decisions.md
@@ -197,3 +197,39 @@ Touches `gates/envelope.py`, `gates/spend_gate.py`, `gates/meter.py`
 message) — modules introduced in #637/#638 but corrected here on the
 T4 branch before Phase 1 merges. Approved 2026-06-05 (Patrick: "fold a
 fix into Phase 1 — yes").
+
+---
+
+## Phase 3 — Referent gate guidance hardening (2026-06-09)
+
+### D13 — R9/R10 ship as advisory guidance in attune-hub, not a hook
+
+**Decision:** The referent gate (R9 single-referent resolution, R10
+honest advisory framing) ships as a "Single-referent resolution"
+guidance section in `plugin/skills/attune-hub/SKILL.md` — the router
+surface where terse user intent is resolved to an action — rather than
+as a PreToolUse hook.
+
+**Why:** An overnight literature review (`morning_report_2026-06-09.md`)
+confirmed D1's framing: clarification-before-acting is an *agent
+decision*, not something an external gate can enforce, because the
+deciding context (what was said, how many proposals were pending) lives
+in the conversation, which a PreToolUse hook (it sees only `tool_name` +
+`tool_input`) cannot observe. The literature consistently treats
+referent resolution as an agent action (Disambiguate / Ask-before-Plan /
+Active Task Disambiguation), reinforcing advisory-not-enforceable.
+
+**What shipped (R9 + R10):**
+- R9 — the `attune-hub` guidance: resolve a terse `go`/`do it`/`y` to
+  exactly one obvious referent before acting; if multiple proposals are
+  pending, ask which; restate the referent as you act.
+- R10 — the section names itself advisory and points at the one
+  *enforceable* foothold: the `AskUserQuestion` one-question-per-turn
+  guard (`ask_question_format_guard.py`), which structurally prevents
+  bundling multiple ambiguous decisions into a single turn.
+
+**Explicitly NOT built:** a PreToolUse "referent gate" that tries to
+detect conversational ambiguity — it structurally can't (no
+conversation context), and building it would over-claim enforcement of
+the advisory half (the spec's stated anti-goal). Approved 2026-06-09
+(Patrick: "ship as drafted").

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -61,6 +61,23 @@ intent so Claude matches the right skill:
 | "refactor", "tech debt", "simplify" | refactor-plan skill |
 | "spec", "brainstorm", "plan and execute" | spec skill |
 
+## Single-referent resolution
+
+Before acting on a terse confirmation (`go`, `do it`, `y`, `1`),
+make sure exactly **one** referent is obvious from the prior turn —
+that you can fill in "go [doing **X**]" with a single, unambiguous X.
+
+- If the prior turn left **multiple** proposals on the table, the
+  referent is unresolved — ask which one before executing, don't
+  guess the most likely.
+- **Restate the referent as you act** ("Running the security audit
+  on `src/` —") so the user can catch a mismatch immediately.
+
+This is advisory guidance for the broader conversation; the one
+*enforceable* foothold is the `AskUserQuestion` one-question-per-turn
+rule (a single turn can't bundle multiple ambiguous decisions). See
+`docs/specs/collaboration-gates/` (R9/R10).
+
 ## Skills Reference
 
 | Skill | Triggers |


### PR DESCRIPTION
## Referent-gate guidance hardening (collaboration-gates R9/R10)

Ships the deferred advisory half of the referent gate as a
**Single-referent resolution** section in the `attune-hub` router skill
— the surface where terse user intent is resolved to an action.

### What it says
Before acting on a terse `go`/`do it`/`y`, confirm exactly one referent
is obvious from the prior turn; if multiple proposals are pending, ask
which; restate the referent as you act.

### Why advisory, not a hook (R10)
An overnight literature review (`morning_report_2026-06-09.md`)
confirmed the spec's D1 framing: clarification-before-acting is an
*agent decision*, not something an external gate can enforce — a
PreToolUse hook sees only `tool_name` + `tool_input`, never the
conversation, so it can't detect "terse `go` while 3 proposals were
pending." The section names the one *enforceable* foothold instead: the
`AskUserQuestion` one-question-per-turn guard. No enforcement hook is
built (that would over-claim — the spec's stated anti-goal).

### Files
- `plugin/skills/attune-hub/SKILL.md` — guidance section (ships to users)
- `.agents/skills/attune-hub/SKILL.md` — regenerated mirror (`sync_agents_skills.py`)
- `docs/specs/collaboration-gates/decisions.md` — D13

Drift-guards green (81 plugin/skill tests). Completes collaboration-gates
R9/R10; the spend gate (R1–R8) shipped earlier in #637/#638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
