### PR TITLE
fix(hooks): recognize informative + bold-variant terminal spec status (self-truthing DECIDE-4)

### DIFF
--- a/docs/specs/spec-status-self-truthing/decisions.md
+++ b/docs/specs/spec-status-self-truthing/decisions.md
@@ -172,3 +172,52 @@ signal to read (the reconciler reads a spec's own files; it doesn't
 cross-reference merged PRs — a known scope boundary). The fix was a
 human marking it done — exactly the "header lags reality" drift the
 spec was written to surface.
+
+---
+
+## Phase 2 — Informative-status recognition (2026-06-09)
+
+### DECIDE-4 — Recognize terminal status by FIRST WORD, across bold variants
+
+**Problem found.** The reconciler only treated a status as terminal
+when it was the *bare* word: `effective_status in _TERMINAL_VERDICTS`
+(exact set membership) and a `$`-anchored `_TERMINAL_LINE`. So the
+**informative** form everyone naturally writes —
+`**Status:** complete (2026-06-09) — shipped #694` — matched neither,
+and the spec stayed in-flight *forever* despite being correctly marked
+done. Worse, `_STATUS_LINE` didn't even parse the `**Status:**` markdown
+variant (colon inside the bold), so several specs had an empty parsed
+status. Demonstrated live: `discover_specs` returned 34 in-flight; after
+the fix, 24 — ten specs were correctly-marked-done but unrecognized
+(collaboration-gates, pattern-review-queue, dashboard-pending-writes-
+journal, spec-status-self-truthing itself, …).
+
+**Decision.** Recognize terminal/ongoing status by the status value's
+**first alphabetic word** (`_leading_verdict`), not exact-string
+membership, and make `_STATUS_LINE`/`_TERMINAL_LINE` robust to bold
+variants (`Status:`, `**Status**:`, `**Status:**`, `*Status*:`). Also:
+- broaden the terminal vocabulary to natural done-words
+  (`completed`, `shipped`, `done` alongside `closed`/`complete`/
+  `retired`/`superseded`), since excluding them perpetuates the same
+  bug class;
+- add an **ongoing-by-design** category (`living`, `ongoing`) excluded
+  from in-flight — a continuous program / living roadmap is not pending
+  work, but it is not "done" either.
+
+This is the *parser* half of closing the "specs ship without status
+update" trap. The *detection* half (cross-reference a spec's named
+artifact against the codebase, so a never-flipped spec is flagged) is
+the advisory audit recorded in `artifact-triage-2026-06-09.md`.
+
+### Known follow-up — status lives in the highest-phase file
+
+`_phase_for_dir` reads the status from the **most-advanced** phase file
+present (tasks › design › requirements). So editing a status header in
+`requirements.md` is **inert** when a `tasks.md` exists with an older
+status — the reconciler reads `tasks.md`. (Hit live: a
+`test-quality-program` relabel to `living` in `requirements.md` was
+ignored because its `tasks.md` still said `approved`.) Two options for a
+follow-up: (a) reconcile a terminal/ongoing signal found in **any**
+phase file, not just the chosen one; or (b) document "edit the
+highest-phase file's status." Deferred — out of scope for the parser
+fix.

--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -37,16 +37,29 @@ _PHASE_FILES: tuple[tuple[str, str], ...] = (
     ("requirements", "requirements.md"),
 )
 
+# Robust to markdown bold variants around the label and colon:
+# ``Status:``, ``**Status**:``, ``**Status:**`` (colon inside the bold),
+# ``*Status*:``. Brittleness here was a real bug — a ``**Status:**
+# complete`` header matched none of the old pattern and the spec stayed
+# in-flight despite being marked done (see decisions.md DECIDE-2).
 _STATUS_LINE = re.compile(
-    r"^\s*\*\*?Status\*\*?\s*:\s*(.+?)\s*$",
+    r"^\s*\**\s*Status\**\s*:\s*\**\s*(.+?)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
 
 # Self-truthing additions — match terminal signals anywhere in
 # the spec file (not just the header), so a stale "draft" header
 # above a closed checklist doesn't keep the spec in-flight.
+#
+# NB: no ``$`` anchor and a ``\b`` after the verdict, so an
+# *informative* terminal line — ``Status: complete (2026-06-09) —
+# shipped #694`` — is recognized, not just the bare ``Status:
+# complete``. Before this, the natural human format was silently
+# ignored and the spec stayed in-flight forever despite being marked
+# done (see decisions.md DECIDE-2).
 _TERMINAL_LINE = re.compile(
-    r"^\s*(?:Spec\s+)?Status\s*:\s*(closed|complete|retired|superseded)\s*$",
+    r"^\s*\**\s*(?:Spec\s+)?Status\**\s*:\s*\**\s*"
+    r"(closed|complete|completed|retired|superseded|shipped|done)\b",
     re.IGNORECASE | re.MULTILINE,
 )
 _CHECKLIST_HEADING = re.compile(
@@ -62,7 +75,33 @@ _DEFERRED_MARKERS = re.compile(
     re.IGNORECASE,
 )
 _NEXT_H2 = re.compile(r"^##\s+", re.MULTILINE)
-_TERMINAL_VERDICTS = frozenset({"closed", "complete", "retired", "superseded"})
+_TERMINAL_VERDICTS = frozenset(
+    {"closed", "complete", "completed", "retired", "superseded", "shipped", "done"}
+)
+# Ongoing-by-design statuses: a living roadmap / continuous program is not
+# pending work, so it should NOT show as in-flight — but it is also not
+# "done". Excluded from the in-flight list, kept distinct from terminal.
+_ONGOING_VERDICTS = frozenset({"living", "ongoing"})
+
+# Leading alphabetic word of a status value, for first-word tokenization:
+# ``complete (2026-06-09) — shipped #694`` -> ``complete``.
+_LEADING_WORD = re.compile(r"[a-zA-Z]+")
+
+
+def _leading_verdict(status: str) -> str:
+    """Return the lowercased leading word of a status value, or ``""``.
+
+    Status headers are written informatively (``complete (date) —
+    reason``), so terminal/ongoing recognition keys off the FIRST word,
+    not exact-string membership. This is the fix for the class of bug
+    where a correctly-marked-``complete`` spec stayed in-flight forever
+    because ``"complete (date) — ..."`` is not in ``_TERMINAL_VERDICTS``.
+    """
+    # search (not match) so a stray leading ``**``/punctuation doesn't
+    # swallow the verdict — the first alphabetic run is the word we want.
+    m = _LEADING_WORD.search(status)
+    return m.group(0).lower() if m else ""
+
 
 # Sentinel TTL: anything older than this on a SessionStart prune
 # sweep is considered orphaned from an ungraceful exit.
@@ -222,7 +261,11 @@ def _reconcile_status(header_status: str, phase_text: str) -> tuple[str, str, bo
         return header_status, "header", False
 
     # Terminal signal exists. Per DECIDE-1, terminal wins.
-    header_is_terminal = header_status in _TERMINAL_VERDICTS
+    # First-word tokenization so an informative header (``complete
+    # (date) — reason``) is recognized as terminal, not just the bare
+    # word — otherwise we'd flag a spurious conflict against a header
+    # that actually agrees with the body signal.
+    header_is_terminal = _leading_verdict(header_status) in _TERMINAL_VERDICTS
     return verdict, source, not header_is_terminal
 
 
@@ -271,20 +314,24 @@ def _phase_for_dir(
 def _is_in_flight(phase: str, effective_status: str) -> bool:
     """Decide whether a spec is in-flight per the reconciled verdict.
 
-    Rules:
-    - Any terminal ``effective_status`` (closed / complete / retired
-      / superseded) → done, exclude — regardless of phase.
+    Rules (keyed off the status's FIRST WORD, so an informative
+    header like ``complete (2026-06-09) — shipped #694`` is recognized,
+    not just the bare verdict — see DECIDE-2):
+    - First word is terminal (closed / complete / completed / retired
+      / superseded / shipped / done) → done, exclude — regardless of
+      phase.
+    - First word is ongoing-by-design (living / ongoing) → a continuous
+      program / living roadmap is not pending work, exclude.
     - Empty status (malformed) → still in-flight (don't drop a
       working spec because the heading was malformed).
-    - Anything else → in-flight.
+    - Anything else (draft / approved / in-progress / …) → in-flight.
 
-    The historical "tasks + complete only" rule is now subsumed:
-    a tasks.md whose header says ``complete`` reaches this function
-    with ``effective_status == "complete"`` and is excluded the
-    same way; a requirements.md with a body ``Status: closed`` is
-    ALSO excluded now, which is the self-truthing improvement.
+    The historical "tasks + complete only" rule is subsumed; a
+    requirements.md with a body ``Status: closed`` is excluded too
+    (the self-truthing improvement).
     """
-    if effective_status in _TERMINAL_VERDICTS:
+    lead = _leading_verdict(effective_status)
+    if lead in _TERMINAL_VERDICTS or lead in _ONGOING_VERDICTS:
         return False
     return True
 

--- a/tests/unit/hooks/test_session_continuity_state.py
+++ b/tests/unit/hooks/test_session_continuity_state.py
@@ -510,3 +510,57 @@ def _commit(path: Path, filename: str, content: str, message: str) -> None:
         check=True,
         capture_output=True,
     )
+
+
+class TestInformativeStatusRecognition:
+    """Regression guard: terminal status must be recognized in the
+    *informative* form people actually write — ``complete (date) —
+    reason`` — and across markdown bold variants, not just the bare
+    word. Before this fix a correctly-marked spec stayed in-flight
+    forever because ``"complete (date) — ..." not in _TERMINAL_VERDICTS``.
+    """
+
+    def test_leading_verdict_tokenizes_first_word(self, state_mod) -> None:
+        lv = state_mod._leading_verdict
+        assert lv("complete (2026-06-09) — shipped #694") == "complete"
+        assert lv("  living (ongoing program)") == "living"
+        assert lv("draft") == "draft"
+        assert lv("") == ""
+        assert lv("**complete**") == "complete"
+
+    def test_informative_complete_header_excluded(self, tmp_path: Path, state_mod) -> None:
+        spec = tmp_path / "specs" / "done-informative"
+        _write_spec(
+            spec,
+            requirements_status="complete (2026-06-09) — shipped #694",
+        )
+        assert state_mod.discover_specs([tmp_path]) == []
+
+    def test_colon_inside_bold_variant_parsed(self, tmp_path: Path, state_mod) -> None:
+        # ``**Status:** complete`` — colon inside the bold — was the
+        # exact format the old regex missed (collaboration-gates).
+        spec = tmp_path / "specs" / "colon-inside-bold"
+        spec.mkdir(parents=True)
+        (spec / "requirements.md").write_text(
+            "# Requirements\n\n**Status:** complete (2026-06-09) — shipped\n",
+            encoding="utf-8",
+        )
+        assert state_mod.discover_specs([tmp_path]) == []
+
+    def test_ongoing_living_excluded_not_in_flight(self, tmp_path: Path, state_mod) -> None:
+        spec = tmp_path / "specs" / "living-program"
+        _write_spec(spec, requirements_status="living (ongoing program)")
+        assert state_mod.discover_specs([tmp_path]) == []
+
+    @pytest.mark.parametrize("word", ["shipped", "done", "completed"])
+    def test_done_synonyms_excluded(self, tmp_path: Path, state_mod, word: str) -> None:
+        spec = tmp_path / "specs" / f"done-{word}"
+        _write_spec(spec, requirements_status=f"{word} 2026-06-09")
+        assert state_mod.discover_specs([tmp_path]) == []
+
+    @pytest.mark.parametrize("word", ["draft", "approved", "in-progress"])
+    def test_non_terminal_still_in_flight(self, tmp_path: Path, state_mod, word: str) -> None:
+        spec = tmp_path / "specs" / f"open-{word}"
+        _write_spec(spec, requirements_status=f"{word} (2026-06-09)")
+        result = state_mod.discover_specs([tmp_path])
+        assert [s.slug for s in result] == [f"open-{word}"]


### PR DESCRIPTION
## Recognize informative + bold-variant terminal spec status (spec-status-self-truthing Phase 2 / DECIDE-4)

The deeper root of the "specs ship without status update" trap — and the durable fix (PR B of two; PR A #696 did the flips + triage).

### The bug
The reconciler only treated a status as terminal when it was the **bare word**:
```python
if effective_status in _TERMINAL_VERDICTS: return False   # exact set membership
_TERMINAL_LINE = r"...Status\s*:\s*(closed|complete|...)\s*$"  # $-anchored
```
So the **informative** form everyone naturally writes — `**Status:** complete (2026-06-09) — shipped #694` — matched *neither*, and the spec stayed in-flight **forever** despite being correctly marked done. `_STATUS_LINE` also didn't parse the `**Status:**` markdown variant (colon inside the bold) at all.

**Demonstrated live:** `discover_specs` returned **34** in-flight; after the fix, **24** — ten specs were correctly-marked-done but unrecognized (collaboration-gates, pattern-review-queue, dashboard-pending-writes-journal, spec-status-self-truthing itself, …). People *were* marking specs done; the parser just didn't see it.

### The fix
- `_leading_verdict()` — recognize terminal/ongoing by the status's **first word**, not exact-string membership.
- `_STATUS_LINE`/`_TERMINAL_LINE` robust to bold variants (`Status:`, `**Status**:`, `**Status:**`, `*Status*:`); drop the `$` anchor so an informative trailing reason is allowed.
- Broaden terminal vocab (`completed`/`shipped`/`done`) + add an **ongoing-by-design** category (`living`/`ongoing`) excluded from in-flight (a living roadmap isn't pending work).

10 new regression tests; **all 268 hook tests pass**. Logged as DECIDE-4, with the "status lives in the highest-phase file" finding noted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
