### PR TITLE
docs(specs): truthful status pass — flip shipped, label parked (backlog prune)

### DIFF
--- a/docs/specs/anthropic-cost-integration/tasks.md
+++ b/docs/specs/anthropic-cost-integration/tasks.md
@@ -1,5 +1,5 @@
 # Tasks — Anthropic Cost Integration
-**Status:** approved
+**Status:** complete (2026-06-09) — shipped: `src/attune/ops/anthropic_cost.py` wired; confirmed by spec triage.
 Each phase is independently shippable and reversible.
 
 ---

--- a/docs/specs/consolidate-claude-md-lessons/tasks.md
+++ b/docs/specs/consolidate-claude-md-lessons/tasks.md
@@ -1,8 +1,9 @@
 # Tasks: consolidate-claude-md-lessons
 
-> **Status:** complete (2026-06-06, PRs #646 + #647). Phases 1–3
-> executed as 12 per-cluster commits; editorial ceiling reached at
-> ~15%. See [decisions.md](decisions.md) D1.
+**Status:** complete (2026-06-06, PRs #646 + #647).
+
+> Phases 1–3 executed as 12 per-cluster commits; editorial ceiling
+> reached at ~15%. See [decisions.md](decisions.md) D1.
 
 ## Phase 1 — cross-linked lessons (lowest risk, highest yield)
 

--- a/docs/specs/doc-fiction-cleanup/tasks.md
+++ b/docs/specs/doc-fiction-cleanup/tasks.md
@@ -1,5 +1,8 @@
 # Tasks: Documentation Fiction Cleanup
 
+**Status:** complete (2026-06-09) — cleanup executed (see decisions.md);
+the TROUBLESHOOTING.md rewrite was explicitly deferred, not outstanding.
+
 Phased so each phase ships independently and keeps
 `mkdocs build --strict` green.
 

--- a/docs/specs/doc-stack-reference-subtypes/tasks.md
+++ b/docs/specs/doc-stack-reference-subtypes/tasks.md
@@ -1,5 +1,5 @@
 # Tasks — Doc-Stack Reference Subtypes
-**Status:** approved (2026-05-16)
+**Status:** deferred (parked 2026-06-09) — approved 2026-05-16, no movement since; a planned doc-quality idea (see `project_doc_stack_next` memory), not active work.
 | Phase | Status | Owner | Notes |
 |---|---|---|---|
 | Phase 0 — Inventory + hand-crafted samples | in progress | | 0.1 + 0.2 done 2026-05-26 (see `phase0-data/`). 0.3–0.6 await editorial pass. |

--- a/docs/specs/integration-coverage/tasks.md
+++ b/docs/specs/integration-coverage/tasks.md
@@ -1,5 +1,5 @@
 # Tasks: Integration Coverage Program
-**Status:** approved
+**Status:** deferred (parked 2026-06-09) — Phase 1+ deferred until Phase 0 lands; a parked idea, not active work. Revive or retire when the integration-vs-mocked question resurfaces.
 ---
 
 ## Phase 0 — Audit before design

--- a/docs/specs/public-help-site/tasks.md
+++ b/docs/specs/public-help-site/tasks.md
@@ -1,5 +1,9 @@
 # Spec: Public Help Site — Tasks
 
+**Status:** complete (2026-06-09) — shipped: `attune-ai-dev/build_help.py`
+renders the `.help/` corpus as the public `/help` site; confirmed by
+spec triage.
+
 > Phase 3 (task decomposition). Sequenced; each task is a reviewable
 > unit. Most carry an XML-enhanced prompt at execution time per
 > `.claude/rules/attune/xml-enhanced-prompts.md`.

--- a/docs/specs/test-discipline-controls/tasks.md
+++ b/docs/specs/test-discipline-controls/tasks.md
@@ -5,7 +5,7 @@
 > Companion to [`requirements.md`](requirements.md) and
 > [`design.md`](design.md).
 
-**Status:** draft
+**Status:** partial (2026-06-09) — decisions recorded (D1–D5); D5 ("pre-push hook MUST run `--branch`") is adopted as live policy (cited in CLAUDE.md); D1 decided (TDD rejected). Remaining controls' implementation deferred.
 **Last updated:** 2026-05-27
 **Total estimate:** ~5.5h across 3 phases.
 

--- a/docs/specs/test-quality-program/tasks.md
+++ b/docs/specs/test-quality-program/tasks.md
@@ -1,5 +1,5 @@
 # Tasks: Test Quality Program
-**Status:** approved
+**Status:** living (ongoing program — continuous use; never one-shot "complete")
 ---
 
 ## Phase 3: Tasks

--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -1,8 +1,11 @@
 # Tasks: Workflow result formatting
 
-> **Status:** plan (2026-06-06). Bounded PRs; see [design.md](design.md)
-> for the decisions each task implements. Implementation begins after
-> approval.
+**Status:** partial (2026-06-09) — T1 (the `WorkflowReport` / Section
+data model in `src/attune/workflows/output.py`) shipped in #649 and is
+in use (e.g. `discovery_sweep`); remaining tasks pending.
+
+> Bounded PRs; see [design.md](design.md) for the decisions each task
+> implements.
 
 ## T0 — Test-surface audit (no code)
 


### PR DESCRIPTION
## Truthful spec-status pass (backlog prune — the honest outcome)

The prune you asked for — but verifying each candidate against the code changed the conclusion: **there are almost no dead specs to delete.** The backlog is *stale-status* (shipped, never flipped) + *parked ideas* (deferred, not dead). So this is a **truth pass with zero archives**.

### My kill-list was wrong — verification caught it
I recommended archiving four; per-spec code reads overturned all four:
- `enforcement-vs-documentation` — **alive**: `worktree_path_guard.py` (shipped, tested hook) is "the first concrete enforcement under [this] framework."
- `test-discipline-controls` — **adopted**: its D5 is cited in CLAUDE.md as live policy.
- `integration-coverage` / `doc-stack-reference-subtypes` — **parked-but-wanted** (the latter is in a project memory as planned), not dead.

This is exactly the case the "verify before deleting a spec" rule exists for.

### What this PR does (9 status edits, 0 deletions)
**Flipped → complete** (verified shipped): `anthropic-cost-integration`, `consolidate-claude-md-lessons`, `doc-fiction-cleanup`, `public-help-site`.
**Relabelled → accurate**: `workflow-result-formatting` → *partial* (only T1/`output.py` shipped in #649, not the whole spec), `test-quality-program` → *living*, `test-discipline-controls` → *partial*, `integration-coverage` + `doc-stack-reference-subtypes` → *deferred/parked*.

All edits target `tasks.md` (the highest-phase file the reconciler actually reads — a `requirements.md` flip is inert when `tasks.md` exists; DECIDE-4 follow-up).

**Effect:** in-flight 24 → 19, and the rest now read honestly instead of a blanket "approved."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
