### PR TITLE
docs(specs): just-in-time-recall Phase 0 — GO (PreToolUse additionalContext confirmed)

### DIFF
--- a/docs/specs/just-in-time-recall/decisions.md
+++ b/docs/specs/just-in-time-recall/decisions.md
@@ -18,17 +18,36 @@ bigger retrieval surface). Keeps the first cut focused and low-noise.
 **Chosen by:** Patrick, via AskUserQuestion, over "session-stash findings"
 and "both unified."
 
-## D2 — Trigger mechanism = PENDING Phase 0 (2026-06-03)
+## D2 — Trigger mechanism = PreToolUse `additionalContext` (RESOLVED, Phase 0, 2026-06-09)
 
-**Decision:** Deferred to Phase 0 measurement. The repo's existing
-PreToolUse hooks only allow/block (no context injection), so whether a
-hook can inject model-readable guidance at a tool-call is unverified.
-Phase 0 verifies PreToolUse `additionalContext` first, then
-UserPromptSubmit injection as fallback. No build past Phase 0 until the
-chosen mechanism is logged here.
+**Decision:** **PreToolUse `additionalContext`.** Phase 0 verified
+(2026-06-09) against the official Claude Code hooks docs: a PreToolUse
+hook's JSON output supports `hookSpecificOutput.additionalContext` —
+text that is injected into the model's context next to the tool result
+and read on the next model request, *before* the governed action
+proceeds. This is the exact decision-point injection the feature needs;
+no fallback to the coarser UserPromptSubmit channel is required (it's
+available as a backup). The feature is **buildable as designed.**
 
-**Why:** Verify-first discipline — do not confabulate a hook capability;
-an entire build hangs on whether the injection channel exists.
+**Evidence:** docs JSON schema for PreToolUse includes
+`additionalContext` ("context injected for Claude") alongside
+`permissionDecision`/`permissionDecisionReason`. Corroborated in-repo by
+`plugin/hooks/session_stash.py`, which already emits
+`hookSpecificOutput.additionalContext` (for the Stop event, CC ≥ 2.1.163)
+— the same channel, a different event.
+
+**Caveat / Phase 1 first task:** the docs don't pin a minimum CC version
+for *PreToolUse* `additionalContext` (Stop/SubagentStop got it in
+v2.1.169, 2026-06-08). A ~5-minute empirical smoke test — a trivial
+PreToolUse hook emitting `additionalContext`, observe whether it reaches
+context on the current CC version — is the first Phase 1 task before
+building the real recall map. Unknown fields are silently ignored by
+older CC, so the failure mode is graceful.
+
+**Original (2026-06-03):** Deferred to Phase 0 — the repo's existing
+PreToolUse hooks only allow/block, so injection capability was unverified;
+verify-first discipline (don't confabulate a hook capability) required
+confirming the channel exists before any build.
 
 ## D3 — Matching = one explicit curated map, not semantic retrieval (2026-06-03)
 

--- a/docs/specs/just-in-time-recall/tasks.md
+++ b/docs/specs/just-in-time-recall/tasks.md
@@ -1,8 +1,15 @@
 # Just-In-Time Recall — Tasks
 
+**Status:** in progress (2026-06-09) — Phase 0 RESOLVED: the injection
+mechanism is **PreToolUse `additionalContext`** (verified against the CC
+hooks docs + corroborated in-repo; see decisions.md D2). Feature is
+buildable as designed. Phase 1 first task = a ~5-min empirical smoke test
+of PreToolUse `additionalContext` on the current CC version, then the
+curated recall map.
+
 Independently shippable units. **Phase 0 gates everything** — no
 implementation past it until the injection mechanism is logged in
-`decisions.md` (D2).
+`decisions.md` (D2). *(Gate cleared 2026-06-09.)*
 
 ## Phase 0 — verify the injection premise (gate)
 


### PR DESCRIPTION
Second roadmap Phase-0 audit. This spec **gated everything** on one capability question (verify-first — *don't confabulate a hook capability*): can a PreToolUse hook inject model-readable guidance at the tool-call decision point?

## Answer: YES — verified, not guessed
Checked the official Claude Code hooks docs (via the claude-code-guide agent, with citations) and corroborated in-repo: a **PreToolUse** hook's JSON output supports `hookSpecificOutput.additionalContext` — text injected next to the tool result and read by the model on its next request, **before** the governed action proceeds. `plugin/hooks/session_stash.py` already uses the same channel (for the Stop event), confirming it works here.

That's the exact decision-point injection the feature needs. No fallback to the coarser UserPromptSubmit channel required.

## Outcome
- **D2 RESOLVED** → PreToolUse `additionalContext`. Feature **buildable as designed** (recall at the decision point, not just the door).
- **Phase 1 first task:** a ~5-min empirical smoke test on the current CC version (docs don't pin a min version for *PreToolUse* additionalContext; unknown fields degrade gracefully), then the curated recall map.
- Status: gate cleared, parked → in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)