### PR TITLE
ci(integration): wire the green integration subset into a (non-required) CI job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,63 @@
+name: Integration Tests
+
+# Runs the *green subset* of the previously-dormant integration suite
+# (docs/specs/integration-coverage/) so it stops rotting from never
+# running. Keyless (no ANTHROPIC_API_KEY) → CI-representative; the
+# auth-required integration tests run separately (opt-in nightly, TODO).
+#
+# This job is intentionally NOT in branch-protection's required checks
+# yet — it's advisory while the cleanup backlog in
+# docs/specs/integration-coverage/phase1-triage.md is worked down (11
+# files still red: discovery_sweep timeouts, a stale rag assertion, etc).
+# Promote to required once the full no-auth suite is green and the file
+# list below is replaced with `tests/integration/ -k "not with_auth"`.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, develop ]
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: integration (green subset)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Run integration green subset (keyless)
+        # No ANTHROPIC_API_KEY in env → exercises the integration wiring
+        # without real API calls. -m "" overrides the repo default
+        # `-m "not integration"`. Explicit file list = the verified-green
+        # subset (140 passed / 15 skipped / 0 fail locally, 2026-06-09).
+        env:
+          ANTHROPIC_API_KEY: ""
+        run: |
+          pytest -m "" -o addopts="" -p no:cacheprovider \
+            -n auto --timeout=120 --timeout-method=thread \
+            tests/integration/test_agents_integration.py \
+            tests/integration/test_commands_integration.py \
+            tests/integration/test_context_integration.py \
+            tests/integration/test_full_workflow.py \
+            tests/integration/test_hooks_integration.py \
+            tests/integration/test_intelligence_integration.py \
+            tests/integration/test_learning_integration.py \
+            tests/integration/test_mcp_dispatch.py \
+            tests/integration/test_meta_workflow_e2e.py \
+            tests/integration/test_natural_language_routing_v5_1.py


### PR DESCRIPTION
Phase 1 of integration-coverage — **make the dormant integration suite run** so it stops rotting. (Phase 0 #701 found 351 tests that never execute; prune #703 removed the dead files.)

## What
Adds `.github/workflows/integration-tests.yml` — runs the **verified-green** no-auth subset (10 files; **140 passed / 15 skipped / 0 fail** keyless, 2026-06-09) on every PR + push to main:
- **Keyless** (`ANTHROPIC_API_KEY: ""`) → exercises the integration wiring without real API calls.
- `-n auto --timeout=120`, `-m ""` (overrides the repo's default `-m "not integration"`).
- Conforms to the repo CI guardrails — `test_workflow_yaml.py` green (pip cache, job timeout, valid YAML).

## Deliberately non-required (advisory)
Not added to branch-protection required checks yet — it runs and reports while the **11-file cleanup backlog** ([phase1-triage.md](docs/specs/integration-coverage/phase1-triage.md)) is worked down (6 `discovery_sweep` timeouts, a stale rag assertion, etc). **Promote to required** once the full no-auth suite is green — then swap the explicit file list for `tests/integration/ -k "not with_auth"`. Auth-required 8 → opt-in nightly (TODO).

Independent of #703 (the dead-file prune) — this job runs an explicit green-file list, so it doesn't touch the dead files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)