### PR TITLE
docs(specs): attune-verify status = built-not-shipped (status-lies trap across a repo boundary)

### DIFF
--- a/docs/specs/attune-verify/tasks.md
+++ b/docs/specs/attune-verify/tasks.md
@@ -1,6 +1,16 @@
 # Tasks: attune-verify — Generation Fact-Checker
 
-**Status:** draft (2026-06-02) — Phase 3, awaiting review
+**Status:** in progress (2026-06-09) — **library BUILT + green**, not yet
+shipped. The `attune-verify` package exists at `../attune-verify/` (GitHub
+repo `Smart-AI-Memory/attune-verify`, v0.1.0): T1 (skeleton), T2 (model),
+T3 (deterministic checkers + the author-#351 regression fixture), T4
+(semantic Judge), T5 (rag adapter) are implemented — **14 tests pass**
+(`PYTHONPATH=src pytest`). The status said "draft" only because the work
+landed in a sibling repo the spec-status reconciler can't see (caught
+2026-06-09 spec triage — the status-lies trap across a repo boundary).
+**Remaining (the ship phase):** T8 publish 0.1.0 ⛔ (await-Patrick;
+unblocker), then wire into attune-ai `[tool.uv.sources]`, T6 `/verify`
+skill (`plugin/skills/verify/`), T7 attune-author integration.
 **Design:** [design.md](design.md) · **Requirements:**
 [requirements.md](requirements.md)
 


### PR DESCRIPTION
While starting to *build* attune-verify (BUILD-NEXT #1), checking whether `~/attune-verify/` existed revealed **it's already built** — the spec status was lying.

## What's actually true
`attune-verify` exists at `../attune-verify/` (GitHub repo `Smart-AI-Memory/attune-verify`, v0.1.0):
- T1 (skeleton), T2 (model), T3 (deterministic checkers + **author-#351 regression fixture**), T4 (semantic Judge), T5 (rag adapter) — **implemented**.
- **14 tests pass** (`PYTHONPATH=src pytest`), including the regression fixture that is the spec's load-bearing acceptance criterion.

## Why the status lied
The build landed in a **sibling repo** the spec-status reconciler structurally cannot see (it reads only attune-ai's own files — not even cross-PR, let alone cross-repo). This is the **third status-lies catch today** and the worst case. Verify-before-building (checking the dir existed) is the only reason a working package wasn't rebuilt from scratch by heredoc.

## What's left (the ship phase)
T8 publish 0.1.0 ⛔ (await-Patrick — the unblocker) → wire into attune-ai `[tool.uv.sources]` → T6 `/verify` skill (`plugin/skills/verify/`) → T7 attune-author integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)