### PR TITLE
docs(specs): attune-verify 0.1.0 PUBLISHED (T8 done)

### DIFF
--- a/docs/specs/attune-verify/tasks.md
+++ b/docs/specs/attune-verify/tasks.md
@@ -1,16 +1,16 @@
 # Tasks: attune-verify — Generation Fact-Checker
 
-**Status:** in progress (2026-06-09) — **library BUILT + green**, not yet
-shipped. The `attune-verify` package exists at `../attune-verify/` (GitHub
-repo `Smart-AI-Memory/attune-verify`, v0.1.0): T1 (skeleton), T2 (model),
-T3 (deterministic checkers + the author-#351 regression fixture), T4
-(semantic Judge), T5 (rag adapter) are implemented — **14 tests pass**
-(`PYTHONPATH=src pytest`). The status said "draft" only because the work
-landed in a sibling repo the spec-status reconciler can't see (caught
-2026-06-09 spec triage — the status-lies trap across a repo boundary).
-**Remaining (the ship phase):** T8 publish 0.1.0 ⛔ (await-Patrick;
-unblocker), then wire into attune-ai `[tool.uv.sources]`, T6 `/verify`
-skill (`plugin/skills/verify/`), T7 attune-author integration.
+**Status:** in progress (2026-06-09) — **library built + green AND
+PUBLISHED**. `attune-verify` 0.1.0 is **live on PyPI** (trusted
+publishing, OIDC; smoke-verified: `pip install attune-verify==0.1.0`
+imports + `verify()` runs). Done: T1 (skeleton), T2 (model), T3
+(deterministic checkers + author-#351 regression fixture), T4 (semantic
+Judge), T5 (rag adapter) — 14 tests pass — and **T8 (publish 0.1.0)**.
+The "draft" status had been a lie because the work lived in a sibling
+repo the reconciler can't see (status-lies trap across a repo boundary).
+**Remaining:** depend on `attune-verify` from PyPI in attune-ai (now
+resolvable — no editable-sibling CI break), **T6** `/verify` skill
+(`plugin/skills/verify/`), **T7** attune-author polish integration.
 **Design:** [design.md](design.md) · **Requirements:**
 [requirements.md](requirements.md)
 


### PR DESCRIPTION
attune-verify **0.1.0 is live on PyPI** — https://pypi.org/project/attune-verify/0.1.0/ — published via OIDC trusted publishing (no token), build + `twine check` pre-verified, smoke-tested (`pip install attune-verify==0.1.0` imports + `verify()` runs).

Flips T8 done in the spec. The library (T1–T5, 14 green tests incl. the author-#351 regression fixture) was already built in the sibling repo — the spec had said 'draft' purely because the reconciler can't see across a repo boundary.

**Remaining:** depend on attune-verify from PyPI in attune-ai (now resolvable), T6 `/verify` skill, T7 attune-author integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)