### PR TITLE
feat(verify): ship /verify skill + attune-verify core dependency (T6/T8)

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -95,6 +95,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | rag-code-gen | grounded code, cite sources, verify against attune (needs `[rag]` extra) |
 | coach | coach, learn, explain, tell me more, deeper |
 | recall | recall, remember, what did I learn, prior session, past findings |
+| verify | verify docs, fact-check, did the model hallucinate, check generated content |
 
 ## MCP Server Not Running
 

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: verify
+description: "Fact-check LLM-generated content against source-of-truth — confirm imports import, CLI flags are real, links resolve, counts match. Triggers on: verify docs, fact-check, did the model hallucinate, check generated content, are these claims real."
+---
+# Verify
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Verify** — Fact-checking the named entities in this content
+> against the project as source-of-truth.
+
+## What It Does
+
+`/verify` is the output-side fact-checker for LLM-generated content
+(docs, READMEs, tutorials). It catches the hallucination classes that
+unit tests never see — an invented CLI flag, an import of a package
+that doesn't exist, a dead cross-reference, a wrong count — by
+confirming the *named entities* in the content actually exist.
+
+It runs in two layers:
+
+1. **Deterministic checkers** (`attune_verify`, authoritative): the
+   *top-level package* of each import resolves via `find_spec`, CLI
+   flags appear in `--help`, markdown links resolve under the project
+   root, numeric claims match a declared count source. These are ground
+   truth — no LLM, no guessing.
+2. **Ambient semantic cross-check** (you, the agent): after the
+   deterministic pass, read the content against its source and flag
+   claims the checkers can't see (a security caveat dropped, a route
+   path that's plausible-but-wrong, a *private submodule* of an
+   installed package that doesn't actually exist — the import checker
+   only validates the top-level package, so `from pkg.fake_sub import X`
+   passes deterministically when `pkg` is installed). This layer is a
+   *cross-check only* — it over-flags on truncated context, so never let
+   it override a deterministic pass. If the deterministic layer says a
+   top-level import resolves, it resolves.
+
+## How To Run It
+
+The deterministic layer is `attune_verify.verify(content, context)`.
+The caller declares the truth boundaries; verify performs the lookups —
+it never auto-discovers them. Run this via Bash from the project root,
+passing the file under test as `F`:
+
+```bash
+F="<path/to/generated.md>" python -c "
+import json, os
+from pathlib import Path
+from attune_verify import verify, VerifyContext
+content = Path(os.environ['F']).read_text(encoding='utf-8')
+ctx = VerifyContext(project_root=Path.cwd())
+result = verify(content, ctx)
+print(json.dumps({
+    'ok': result.ok,
+    'checked': result.checked,
+    'findings': [
+        {'kind': f.kind.value, 'severity': f.severity,
+         'detail': f.detail, 'evidence': f.evidence, 'location': f.location}
+        for f in result.findings
+    ],
+}, ensure_ascii=False, indent=2))
+"
+```
+
+Then present the findings as a readable report (errors first, then
+warnings), grouped by kind. Each finding carries `kind`
+(`unresolved_import` / `unknown_flag` / `dead_link` / `count_mismatch`),
+`severity` (`error` | `warning`), `detail`, `evidence`, and `location`.
+
+## Declaring Tighter Boundaries
+
+The default context only checks imports and links (project root). To
+catch flag and count hallucinations, declare the sources the content
+claims against — `VerifyContext` is the single place to do it:
+
+- **CLI flags** — pre-capture `--help` and pass it so the checker
+  knows the real flags:
+
+  ```python
+  ctx = VerifyContext(
+      project_root=Path.cwd(),
+      help_commands={"attune": <captured --help text>},
+      allowed_help_cmds=frozenset({"attune"}),  # safe to shell out to
+  )
+  ```
+
+- **Counts** — declare what a number should be, by label. Values may be
+  plain ints or zero-arg callables:
+
+  ```python
+  ctx = VerifyContext(
+      project_root=Path.cwd(),
+      count_sources={"templates": 259, "skills": lambda: len(skill_dirs)},
+  )
+  ```
+
+A flag whose command is neither pre-captured nor in `allowed_help_cmds`
+yields a **warning, not a silent pass** — surface it so the user knows
+it went unchecked.
+
+## Reading The Report
+
+- **`result.ok is False`** → at least one error-severity finding. These
+  are confirmed hallucinations (the import does not resolve, the flag is
+  not in `--help`). Quote the `evidence` line and point at where to fix.
+- **Warnings** → something couldn't be checked (no count source
+  declared, a command not on the allow-list). Not a failure — a gap in
+  the declared boundaries. Tell the user what to declare to close it.
+- **Empty findings** → the deterministic layer found nothing wrong.
+  Then do the ambient semantic cross-check and report any claims worth a
+  human's eye, clearly labeled as cross-check (not deterministic).
+
+Do **not** invent findings, and do **not** soften a deterministic error
+into a "maybe" — the checkers are authoritative for entity existence.
+
+## When It Belongs In A Pipeline
+
+For a hard gate (fail the run on any error finding), the library
+exposes `raise_if_failed(result)`. The `/verify` skill itself is the
+interactive, report-only surface — it never hard-gates. The hard gate
+is for callers like attune-author's post-generation step.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7382,3 +7382,46 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   BEFORE cutting the release — publishing is irreversible (PyPI rejects
   re-publishing a version). Prefer this over a local token upload
   (tokens must never be pasted into this environment).
+
+- **attune-verify 0.1.0's import checker validates only the TOP-LEVEL
+  package — a fake SUBMODULE of an INSTALLED package passes
+  deterministically, so it misses exactly the author-#351 private-import
+  hallucination class unless the parent isn't installed** (found
+  dogfooding the `/verify` skill, 2026-06-09, #708): `checkers/imports.py
+  ::_module_from_node` does `node.module.split(".")[0]`, then resolves
+  that one top-level name via `find_spec` in a subprocess. So `from
+  attune.ops._readers import _read_templates` is checked as just
+  `attune` — which RESOLVES when attune is installed → no finding.
+  Counter-intuitively, the checker only catches a fully-fake top-level
+  package (`import totally_fake_pkg`) OR a real-package submodule when
+  the *parent* isn't importable in `env_python`. The author-#351
+  regression fixture is green precisely because it PATCHES `_resolves` to
+  simulate "attune not installed" — the exact condition under which the
+  PR-#351 hallucinated import broke; in a normal venv where attune IS
+  installed, 0.1.0 would pass those imports. Two consequences: (1) when
+  documenting/marketing `/verify`, say it catches "an import of a package
+  that doesn't exist" (top-level), NOT "a private-module import" — the
+  latter overstates 0.1.0 and is a faithfulness bug (route fake
+  submodules to the semantic cross-check layer instead); (2) a future
+  attune-verify minor that drills into submodules (`find_spec` on the
+  full dotted path) would close this gap and should re-validate the
+  author-#351 fixture WITHOUT the `_resolves` patch. Separately: calling
+  `check_imports(..., env_python=None)` crashes (`subprocess.run([None,
+  ...])` → `TypeError`); the real skill path is safe because
+  `VerifyContext.env_python` defaults to `sys.executable` (a real
+  string) — only direct callers passing `None` hit it.
+
+- **Promote a stdlib-only sibling package to a CORE dep, not a `[extra]`
+  — the extra-gating convention exists to keep heavy transitive deps
+  optional, and doesn't apply when the package pulls nothing** (#708,
+  wiring `attune-verify` into attune-ai): the repo gates `rag-code-gen`
+  behind `[rag]` because attune-rag historically pulled weight, but
+  attune-rag is ITSELF a core dep now (required for accuracy), and
+  `attune-verify` has `dependencies = []` (pure stdlib). Making it core
+  (`attune-verify>=0.1.0,<0.2`) costs one tiny pure-Python wheel and lets
+  `/verify` work out of the box with no extra caveat in the skill or the
+  attune-hub table. Decision rule for "core vs extra" on a sibling
+  package: weigh the package's TRANSITIVE-dep weight, not a reflex to
+  gate. Zero/light deps + backs a shipped surface → core; heavy deps or
+  niche surface → extra. `uv lock` after adding confirmed a clean
+  single-package add (no cascade), consistent with the lighter footprint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`/verify` skill — output-side generation fact-checker.** A new
+  `verify` skill (`plugin/skills/verify/`) fact-checks LLM-generated
+  content (docs, READMEs, tutorials) against the project as
+  source-of-truth: it confirms imports' top-level packages resolve, CLI
+  flags appear in `--help`, markdown links exist under the project root,
+  and numeric claims match a declared count source — the hallucination
+  classes unit tests never see. Deterministic checks run via the new
+  `attune-verify` library (now a **core dependency**, `>=0.1.0,<0.2`,
+  stdlib-only with zero transitive deps); the agent then acts as an
+  ambient semantic cross-check (the deterministic layer is authoritative,
+  the cross-check never overrides it). The skill is report-only; callers
+  wanting a hard gate use the library's `raise_if_failed`. See
+  `docs/specs/attune-verify/`.
 - **Pattern review queue now has an ops-dashboard panel.** A new
   "Patterns" page (`GET /patterns`) lists staged patterns awaiting
   review — name, type, confidence, source agent, and a code preview —

--- a/docs/specs/attune-verify/tasks.md
+++ b/docs/specs/attune-verify/tasks.md
@@ -1,16 +1,20 @@
 # Tasks: attune-verify — Generation Fact-Checker
 
-**Status:** in progress (2026-06-09) — **library built + green AND
-PUBLISHED**. `attune-verify` 0.1.0 is **live on PyPI** (trusted
-publishing, OIDC; smoke-verified: `pip install attune-verify==0.1.0`
-imports + `verify()` runs). Done: T1 (skeleton), T2 (model), T3
-(deterministic checkers + author-#351 regression fixture), T4 (semantic
-Judge), T5 (rag adapter) — 14 tests pass — and **T8 (publish 0.1.0)**.
-The "draft" status had been a lie because the work lived in a sibling
-repo the reconciler can't see (status-lies trap across a repo boundary).
-**Remaining:** depend on `attune-verify` from PyPI in attune-ai (now
-resolvable — no editable-sibling CI break), **T6** `/verify` skill
-(`plugin/skills/verify/`), **T7** attune-author polish integration.
+**Status:** in progress (2026-06-09) — **library SHIPPED, /verify skill
+SHIPPED; one task (T7) remains.** The `attune-verify` package is published
+to PyPI as v0.1.0 (`Smart-AI-Memory/attune-verify`): T1 (skeleton), T2
+(model), T3 (deterministic checkers + the author-#351 regression fixture),
+T4 (semantic Judge), T5 (rag adapter), T8 (publish) **done**. On the
+attune-ai side: `attune-verify>=0.1.0,<0.2` is now a **core dependency**
+(stdlib-only, zero transitive deps) and the **T6 `/verify` skill** is
+shipped (`plugin/skills/verify/`, all three plugin gates green:
+skill-count, attune-hub reference row, `.agents` mirror sync). The status
+once said "draft" only because the library work landed in a sibling repo
+the spec-status reconciler can't see (caught 2026-06-09 spec triage — the
+status-lies trap across a repo boundary).
+**Remaining:** T7 attune-author polish integration (sibling repo, now
+unblocked — verify is on PyPI so author CI can exercise it, not
+`importorskip`).
 **Design:** [design.md](design.md) · **Requirements:**
 [requirements.md](requirements.md)
 
@@ -136,7 +140,12 @@ sentinel test proves clean degradation when rag absent.
 
 ---
 
-## T6 — `/verify` skill (attune-ai plugin)
+## T6 — `/verify` skill (attune-ai plugin) ✅ DONE
+
+**Status:** shipped. `plugin/skills/verify/SKILL.md` + `.agents` mirror;
+all three plugin gates green; `attune-verify` wired as a core dependency.
+Dogfooded against a known-bad doc (caught the dead link; documented the
+top-level-only import-checker limitation in the skill body).
 
 **Objective:** the interactive, on-subscription surface.
 
@@ -166,7 +175,11 @@ rather than `importorskip`.
 
 ---
 
-## T8 — Publish 0.1.0 ⛔ (await-Patrick: PyPI publish) + docs flip
+## T8 — Publish 0.1.0 ⛔ (await-Patrick: PyPI publish) + docs flip ✅ DONE
+
+**Status:** `attune-verify` 0.1.0 published to PyPI via trusted publishing
+(2026-06-09, first-publish pending-publisher). Now resolvable as a core dep
+in attune-ai.
 
 **Objective:** make verify resolvable + visible.
 

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -97,6 +97,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | rag-code-gen | grounded code, cite sources, verify against attune (needs `[rag]` extra) |
 | coach | coach, learn, explain, tell me more, deeper |
 | recall | recall, remember, what did I learn, prior session, past findings |
+| verify | verify docs, fact-check, did the model hallucinate, check generated content |
 
 ## MCP Server Not Running
 

--- a/plugin/skills/verify/SKILL.md
+++ b/plugin/skills/verify/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: verify
+description: "Fact-check LLM-generated content against source-of-truth — confirm imports import, CLI flags are real, links resolve, counts match. Triggers on: verify docs, fact-check, did the model hallucinate, check generated content, are these claims real."
+argument-hint: "<path to the generated file to fact-check>"
+---
+
+# Verify
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Verify** — Fact-checking the named entities in this content
+> against the project as source-of-truth.
+
+## What It Does
+
+`/verify` is the output-side fact-checker for LLM-generated content
+(docs, READMEs, tutorials). It catches the hallucination classes that
+unit tests never see — an invented CLI flag, an import of a package
+that doesn't exist, a dead cross-reference, a wrong count — by
+confirming the *named entities* in the content actually exist.
+
+It runs in two layers:
+
+1. **Deterministic checkers** (`attune_verify`, authoritative): the
+   *top-level package* of each import resolves via `find_spec`, CLI
+   flags appear in `--help`, markdown links resolve under the project
+   root, numeric claims match a declared count source. These are ground
+   truth — no LLM, no guessing.
+2. **Ambient semantic cross-check** (you, the agent): after the
+   deterministic pass, read the content against its source and flag
+   claims the checkers can't see (a security caveat dropped, a route
+   path that's plausible-but-wrong, a *private submodule* of an
+   installed package that doesn't actually exist — the import checker
+   only validates the top-level package, so `from pkg.fake_sub import X`
+   passes deterministically when `pkg` is installed). This layer is a
+   *cross-check only* — it over-flags on truncated context, so never let
+   it override a deterministic pass. If the deterministic layer says a
+   top-level import resolves, it resolves.
+
+## How To Run It
+
+The deterministic layer is `attune_verify.verify(content, context)`.
+The caller declares the truth boundaries; verify performs the lookups —
+it never auto-discovers them. Run this via Bash from the project root,
+passing the file under test as `F`:
+
+```bash
+F="<path/to/generated.md>" python -c "
+import json, os
+from pathlib import Path
+from attune_verify import verify, VerifyContext
+content = Path(os.environ['F']).read_text(encoding='utf-8')
+ctx = VerifyContext(project_root=Path.cwd())
+result = verify(content, ctx)
+print(json.dumps({
+    'ok': result.ok,
+    'checked': result.checked,
+    'findings': [
+        {'kind': f.kind.value, 'severity': f.severity,
+         'detail': f.detail, 'evidence': f.evidence, 'location': f.location}
+        for f in result.findings
+    ],
+}, ensure_ascii=False, indent=2))
+"
+```
+
+Then present the findings as a readable report (errors first, then
+warnings), grouped by kind. Each finding carries `kind`
+(`unresolved_import` / `unknown_flag` / `dead_link` / `count_mismatch`),
+`severity` (`error` | `warning`), `detail`, `evidence`, and `location`.
+
+## Declaring Tighter Boundaries
+
+The default context only checks imports and links (project root). To
+catch flag and count hallucinations, declare the sources the content
+claims against — `VerifyContext` is the single place to do it:
+
+- **CLI flags** — pre-capture `--help` and pass it so the checker
+  knows the real flags:
+
+  ```python
+  ctx = VerifyContext(
+      project_root=Path.cwd(),
+      help_commands={"attune": <captured --help text>},
+      allowed_help_cmds=frozenset({"attune"}),  # safe to shell out to
+  )
+  ```
+
+- **Counts** — declare what a number should be, by label. Values may be
+  plain ints or zero-arg callables:
+
+  ```python
+  ctx = VerifyContext(
+      project_root=Path.cwd(),
+      count_sources={"templates": 259, "skills": lambda: len(skill_dirs)},
+  )
+  ```
+
+A flag whose command is neither pre-captured nor in `allowed_help_cmds`
+yields a **warning, not a silent pass** — surface it so the user knows
+it went unchecked.
+
+## Reading The Report
+
+- **`result.ok is False`** → at least one error-severity finding. These
+  are confirmed hallucinations (the import does not resolve, the flag is
+  not in `--help`). Quote the `evidence` line and point at where to fix.
+- **Warnings** → something couldn't be checked (no count source
+  declared, a command not on the allow-list). Not a failure — a gap in
+  the declared boundaries. Tell the user what to declare to close it.
+- **Empty findings** → the deterministic layer found nothing wrong.
+  Then do the ambient semantic cross-check and report any claims worth a
+  human's eye, clearly labeled as cross-check (not deterministic).
+
+Do **not** invent findings, and do **not** soften a deterministic error
+into a "maybe" — the checkers are authoritative for entity existence.
+
+## When It Belongs In A Pipeline
+
+For a hard gate (fail the run on any error finding), the library
+exposes `raise_if_failed(result)`. The `/verify` skill itself is the
+interactive, report-only surface — it never hard-gates. The hard gate
+is for callers like attune-author's post-generation step.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "python-frontmatter>=1.0.0,<2.0.0",  # YAML frontmatter parsing for help templates — required by attune.help.engine which backs the help_lookup MCP tool (progressive/workflow_help/precursor/search_tag modes all parse template files). Vanilla pip install attune-ai without this breaks every help_lookup mode except `preamble`.
     "attune-rag>=0.1.5,<0.6",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap raised to <0.3 in 7.1.2 to admit attune-rag 0.2.0 (purely additive SemVer-binding cut, no breaking API changes); next breaking minor still requires explicit re-validation.
+    "attune-verify>=0.1.0,<0.2",  # Generation fact-checker backing the /verify skill (deterministic entity checks: imports/flags/links/counts). Core dep — stdlib-only (zero transitive deps), so promoting to core is cheap and lets /verify work out of the box without an extra. Semantic layer is opt-in (the skill acts as the ambient judge).
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib fallback for Python 3.10. Used by attune.utils.coverage (loaded transitively from release-prep + orchestrated-health-check workflows). Without this, those workflows fail to load on 3.10.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
@@ -759,9 +760,10 @@ exclude_lines = [
 ]
 
 # Sibling repos — all published to PyPI:
-#   attune-rag     — core dep (>=0.1.5,<0.3) — promoted from optional; required for accuracy
-#   attune-author  — [author] optional extra (>=0.4.1,<0.5)
-#   attune-rag     — [rag] optional extra (>=0.1.5,<0.3) — no-op alias since rag is core
+#   attune-rag     — core dep (>=0.1.5,<0.6) — promoted from optional; required for accuracy
+#   attune-verify  — core dep (>=0.1.0,<0.2) — backs /verify; stdlib-only, zero transitive deps
+#   attune-author  — [author] optional extra (>=0.6.2,<0.15)
+#   attune-rag     — [rag] optional extra (>=0.1.5,<0.6) — no-op alias since rag is core
 #
 # No [tool.uv.sources] overrides needed: CI resolves all three
 # from PyPI (https://pypi.org/simple). For local iteration against

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -301,8 +301,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 16, (
-            f"Expected 16 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 17, (
+            f"Expected 17 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -241,6 +241,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "attune-rag" },
+    { name = "attune-verify" },
     { name = "claude-agent-sdk" },
     { name = "cryptography" },
     { name = "defusedxml" },
@@ -439,6 +440,7 @@ requires-dist = [
     { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.6.2,<0.15" },
     { name = "attune-rag", specifier = ">=0.1.5,<0.6" },
     { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.6" },
+    { name = "attune-verify", specifier = ">=0.1.0,<0.2" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "bcrypt", marker = "extra == 'all'", specifier = ">=4.0.0,<6.0.0" },
@@ -619,6 +621,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/da/5de2d3a5e6f9f1830c19998b504f4fbd8e24d77e2a32709403389166bb30/attune_rag-0.2.0.tar.gz", hash = "sha256:d8d5f26bfa4b2379845492d2c36d29359e09ef8c7d03f47435cd06baacba4711", size = 102841, upload-time = "2026-05-25T03:53:32.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/49/005cf1581d99227c15bf4afddfa115cada1d666d9836296fd28f3619de29/attune_rag-0.2.0-py3-none-any.whl", hash = "sha256:a8c1b46e18c3336a654cf3609d628fcf2087d4e00459a22ad6ede3c4d88e33ae", size = 114144, upload-time = "2026-05-25T03:53:31.013Z" },
+]
+
+[[package]]
+name = "attune-verify"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/80/0bc0f6571897c9d1050b98d15d2d4ecb2726de5b57e416d20de72efa876f/attune_verify-0.1.0.tar.gz", hash = "sha256:e38927168db70ecc0dacf82df6b5b112f9b891343045eb37e57698d172671a9a", size = 14995, upload-time = "2026-06-09T13:56:14.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/7f/3dcfd375f3844fc4fe1386fa1c0dad819f16e22eeedf4a1b4f8790093222/attune_verify-0.1.0-py3-none-any.whl", hash = "sha256:ee7ac81987a3bba8b7231342c2cebfcfc241fab3d19b5eae69de10a1705206ff", size = 15052, upload-time = "2026-06-09T13:56:13.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Ships the attune-ai-side of attune-verify (T6 + T8 done) now that
`attune-verify` 0.1.0 is published to PyPI. The `/verify` skill is the
interactive, output-side generation fact-checker — it confirms the named
entities in LLM-generated content actually exist.

## Changes
- **Core dependency:** `attune-verify>=0.1.0,<0.2` (stdlib-only, zero
  transitive deps — cheap to promote to core, so `/verify` works out of
  the box without an extra). `uv.lock` updated; clean, only attune-verify
  added (no cascade).
- **T6 `/verify` skill** (`plugin/skills/verify/SKILL.md`): deterministic
  checks via the library -> agent ambient semantic cross-check -> unified
  findings report. Report-only; the hard gate is the library's
  `raise_if_failed`. Description 244 chars (<250 limit).
- **Three plugin gates green:** skill-count 16->17; `verify` row in the
  attune-hub Skills Reference table; `.agents/skills/verify/` mirror via
  `scripts/sync_agents_skills.py`. (93 passed, 3 skipped in
  `tests/unit/plugins/`.)
- **Spec status flipped:** tasks.md marks T6 + T8 done; CHANGELOG entry.

## Dogfood (registered != working)
Installed attune-verify from PyPI and ran the exact skill snippet against a
known-bad doc — caught the dead link. Found and documented a real 0.1.0
limitation faithfully: the import checker validates only the **top-level**
package, so a fake submodule of an installed package
(`from pkg.fake_sub import X`) passes deterministically. The skill body now
states this and routes it to the semantic cross-check.

## Out of scope
T7 (attune-author polish integration) lives in the sibling repo — now
unblocked since verify is on PyPI. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
