### PR TITLE
fix(tests): mock network in TestComplianceAlerts to stop xdist worker crashes

### DIFF
--- a/tests/agents/test_notifications.py
+++ b/tests/agents/test_notifications.py
@@ -6,6 +6,8 @@ Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from agents.notifications import NotificationConfig, NotificationService
@@ -118,6 +120,26 @@ class TestSMSNotifications:
 
 class TestComplianceAlerts:
     """Test compliance alert multi-channel delivery."""
+
+    @pytest.fixture(autouse=True)
+    def _no_real_network(self):
+        """Mock the network boundary so these tests never do real I/O.
+
+        ``send_compliance_alert`` reaches ``send_email`` (``smtplib.SMTP``)
+        and ``send_slack`` (``requests.post``). With the test config's real
+        host/webhook, the unmocked calls attempt real DNS/TCP/HTTP, which
+        intermittently crashed xdist workers under parallelism (the
+        coverage job's "worker crashed" + spurious low-coverage failures).
+        """
+        smtp_cm = MagicMock()
+        with (
+            patch("agents.notifications.smtplib.SMTP") as smtp,
+            patch("agents.notifications.requests.post") as post,
+        ):
+            smtp.return_value.__enter__.return_value = smtp_cm
+            post.return_value.status_code = 200
+            post.return_value.text = ""
+            yield
 
     def test_compliance_alert_structure(self, notification_service):
         """Test compliance alert message structure."""


### PR DESCRIPTION
## What
Mock the network boundary in `tests/agents/test_notifications.py::TestComplianceAlerts`
so those tests never do real I/O.

## Why
`send_compliance_alert` reaches `send_email` (`smtplib.SMTP`) and
`send_slack` (`requests.post`). The test config carries a real SMTP host
and a real Slack webhook URL, so the **unmocked** calls attempted real
DNS/TCP/HTTP. Under xdist those blocking sockets intermittently **crashed
workers** — surfacing on the `coverage` job as `worker gwN crashed` on
`test_compliance_alert_structure` + `test_sms_only_for_critical_high`,
plus a spurious `coverage 22.13%` failure (incomplete data from the dead
workers).

**This is a pre-existing flake, not a regression** — it passed on a
sibling PR running the identical current-main suite, and failed on an
unrelated docs-only PR (#707). The test comment even *claimed* "won't
actually send" — this makes that true.

## Change
- Autouse fixture on `TestComplianceAlerts` patches
  `agents.notifications.smtplib.SMTP` and `.requests.post`. Test bodies
  and assertions are unchanged.
- Verified under `pytest -n 4` (the parallel crash condition): 10 passed.
  `test_notifications.py` is the only file invoking these send paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
