### PR TITLE
fix(tests): mock real Redis I/O in xdist worker-crash flakes (windows-xdist-flakes Probe A)

### DIFF
--- a/docs/specs/windows-xdist-flakes/investigation-report-2026-06-09.md
+++ b/docs/specs/windows-xdist-flakes/investigation-report-2026-06-09.md
@@ -1,0 +1,88 @@
+# Investigation Report — xdist Worker-Crash Flakes (2026-06-09)
+
+Phase 4 execution of [design.md](./design.md). Probe A (inventory) was
+run; the decision tree self-selected the **fix-the-polluter** branch; the
+polluters were fixed.
+
+---
+
+## Probe A — inventory
+
+**Method:** scanned the 40 most-recent failed `tests.yml` runs
+(`gh run list --workflow tests.yml --status failure`), fetched each run's
+failed-job log, and grepped the xdist crash signature
+`worker '<id>' crashed while running '<testid>'`. 23 crash instances
+found across the window (2026-06-03 → 2026-06-09).
+
+> Note: the crashes are **not Windows-only** — the dominant entry
+> surfaced on the ubuntu `coverage` job. The investigation cast a wider
+> net than the spec title (all `tests.yml` failures, every OS lane).
+
+### Crashes by test (aggregated)
+
+| Test file | Crashes | Unique tests | Disposition |
+|---|---|---|---|
+| `tests/memory/test_unified_memory.py` | 13 | 1 (`TestUnifiedMemoryBackendInit::test_init_with_auto_start_file_first_fallback`) | **fixed here** |
+| `tests/agents/test_notifications.py` | 6 | 2 (`TestComplianceAlerts::test_compliance_alert_structure`, `::test_sms_only_for_critical_high`) | fixed in #709 |
+| `tests/unit/memory/test_redis_bootstrap.py` | 2 | 1 (`TestCheckRedisRunning::test_uses_custom_host_and_port`) | **fixed here** |
+
+**3 distinct files** → per the design's stop conditions
+(`<5 distinct files`), the decision tree selects the
+**fix-the-polluter** branch (not marker-based xfail).
+
+---
+
+## Root causes — all the same class: real I/O in a unit test
+
+Every crash is a test doing real network/subprocess I/O that, under xdist
+parallelism, intermittently crashed its worker — the CLAUDE.md
+"Windows xdist worker crashes often come from real socket probes" pattern.
+
+1. **`test_init_with_auto_start_file_first_fallback`** (13 — dominant) —
+   constructs `UnifiedMemory(MemoryConfig(redis_auto_start=True,
+   redis_mock=False))`. The auto-start path calls
+   `redis_bootstrap.ensure_redis(auto_start=True)`, which **spawns real
+   subprocesses** (`brew`/`systemctl`/`docker` to start redis-server) and
+   socket-probes Redis. The test only asserts *file-session* behaviour —
+   the Redis auto-start is incidental to its intent.
+
+2. **`test_uses_custom_host_and_port`** (2) — calls
+   `_check_redis_running(host="nonexistent-host", ...)`, which does
+   `redis.Redis(host="nonexistent-host").ping()` → a real DNS
+   `getaddrinfo()` on a bogus hostname that hangs/crashes a worker.
+
+3. **`test_notifications.py::TestComplianceAlerts`** (6) — already fixed
+   in #709: `send_compliance_alert` reached real `smtplib.SMTP` +
+   `requests.post` calls.
+
+---
+
+## Fixes applied
+
+- **#1** — mock `attune.memory.redis_bootstrap.ensure_redis` to return an
+  unavailable `RedisStatus`. This exercises the exact file-first fallback
+  the test asserts, with zero subprocess/socket I/O.
+- **#2** — replace the bogus hostname with the literal loopback IP
+  `127.0.0.1` + a closed port. No DNS; an instant connection-refused
+  yields the same graceful `False`, matching the proven-safe sibling test
+  (`test_returns_false_when_not_running`, which already uses
+  `localhost:16379`).
+- **#3** — shipped in #709 (`smtplib.SMTP` + `requests.post` mocked).
+
+All verified under `pytest -n 4` (the parallel crash condition).
+
+xfail teardown (design DECIDE-3): none of the three crash sites carried
+`xfail` markers — they crashed rather than being xfailed — so there is
+nothing to remove.
+
+---
+
+## Follow-up (systemic, not done here)
+
+The per-polluter fixes close the current inventory. A stronger guard
+against regressions would be an `autouse` conftest fixture over the memory
+test tree that fails fast on (a) real `ensure_redis` subprocess starts and
+(b) `_check_redis_running` against non-loopback hosts — so a future test
+re-introducing real Redis I/O is caught at authoring time, not via a CI
+worker crash. Deferred: the three known polluters are fixed and the
+inventory is clean.

--- a/tests/memory/test_unified_memory.py
+++ b/tests/memory/test_unified_memory.py
@@ -242,7 +242,21 @@ class TestUnifiedMemoryBackendInit:
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             config = MemoryConfig(storage_dir=tmpdir, redis_auto_start=True, redis_mock=False)
-            memory = UnifiedMemory(user_id="test_user", config=config)
+            # Mock ensure_redis so the auto-start path does NOT spawn real
+            # subprocesses (brew/systemctl/docker) or socket-probe Redis.
+            # Those real-I/O calls under xdist intermittently crashed
+            # workers (the dominant entry in the windows-xdist-flakes
+            # inventory). Returning an unavailable status exercises the
+            # exact file-first fallback this test asserts, deterministically.
+            with patch(
+                "attune.memory.redis_bootstrap.ensure_redis",
+                return_value=RedisStatus(
+                    available=False,
+                    method=RedisStartMethod.MOCK,
+                    message="mocked: redis unavailable (test isolation)",
+                ),
+            ):
+                memory = UnifiedMemory(user_id="test_user", config=config)
 
             # File-first: file session is always available
             assert memory._file_session is not None

--- a/tests/unit/memory/test_redis_bootstrap.py
+++ b/tests/unit/memory/test_redis_bootstrap.py
@@ -98,8 +98,12 @@ class TestCheckRedisRunning:
 
     def test_uses_custom_host_and_port(self):
         """Test uses custom host and port without error."""
-        # Just verify it doesn't crash with custom params
-        result = _check_redis_running(host="nonexistent-host", port=6380)
+        # Use a literal IP, NOT a bogus hostname. "nonexistent-host"
+        # triggered a real DNS getaddrinfo() that intermittently crashed
+        # xdist workers under parallelism (windows-xdist-flakes inventory).
+        # A loopback IP + closed port resolves with no DNS and refuses
+        # instantly, exercising the same graceful-False path safely.
+        result = _check_redis_running(host="127.0.0.1", port=16380)
         assert result is False
 
 


### PR DESCRIPTION
## What
Executes **Probe A** of the `windows-xdist-flakes` spec (design approved)
and fixes the two remaining xdist worker-crash flakes it surfaced.

## Probe A inventory
Scanned the 40 most-recent failed `tests.yml` runs, grepped the crash
signature `worker '<id>' crashed while running '<test>'` — 23 instances
across **3 files** (2026-06-03 → 06-09):

| File | Crashes | Disposition |
|---|---|---|
| `tests/memory/test_unified_memory.py` | 13 | **fixed here** |
| `tests/agents/test_notifications.py` | 6 | fixed in #709 |
| `tests/unit/memory/test_redis_bootstrap.py` | 2 | **fixed here** |

3 distinct files (<5) → the design's decision tree selects the
**fix-the-polluter** branch. (Not Windows-only — the dominant flake hit
the ubuntu `coverage` job; the probe cast a wider net than the title.)

## Root causes — all real I/O in a unit test
- **#1 (13, dominant):** `redis_auto_start=True, redis_mock=False` makes
  `ensure_redis()` **spawn real `brew`/`systemctl`/`docker` subprocesses**
  + socket-probe. The test only asserts *file-session* behaviour.
  → mock `attune.memory.redis_bootstrap.ensure_redis` to unavailable.
- **#2 (2):** `_check_redis_running(host="nonexistent-host")` does a real
  DNS `getaddrinfo()` that crashes workers. → literal `127.0.0.1` + closed
  port (no DNS; instant refused → same graceful `False`).

Both verified under `pytest -n 4` (the parallel crash condition); both
files green (145 tests). No `xfail` markers to tear down.

## Artifact
`docs/specs/windows-xdist-flakes/investigation-report-2026-06-09.md` —
the design's named Phase 4 report, with a follow-up note on a systemic
autouse-conftest guard (deferred; inventory is clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
