### PR TITLE
chore(deps): admit attune-verify 0.2.0 (cap <0.2 -> <0.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "python-frontmatter>=1.0.0,<2.0.0",  # YAML frontmatter parsing for help templates — required by attune.help.engine which backs the help_lookup MCP tool (progressive/workflow_help/precursor/search_tag modes all parse template files). Vanilla pip install attune-ai without this breaks every help_lookup mode except `preamble`.
     "attune-rag>=0.1.5,<0.6",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap raised to <0.3 in 7.1.2 to admit attune-rag 0.2.0 (purely additive SemVer-binding cut, no breaking API changes); next breaking minor still requires explicit re-validation.
-    "attune-verify>=0.1.0,<0.2",  # Generation fact-checker backing the /verify skill (deterministic entity checks: imports/flags/links/counts). Core dep — stdlib-only (zero transitive deps), so promoting to core is cheap and lets /verify work out of the box without an extra. Semantic layer is opt-in (the skill acts as the ambient judge).
+    "attune-verify>=0.1.0,<0.3",  # Generation fact-checker backing the /verify skill (deterministic entity checks: imports/flags/links/counts). Core dep — stdlib-only (zero transitive deps), so promoting to core is cheap and lets /verify work out of the box without an extra. Semantic layer is opt-in (the skill acts as the ambient judge). Cap raised to <0.3 to admit 0.2.0 (full dotted-path import resolution — catches private-submodule hallucinations the 0.1.0 top-level-only checker missed; purely additive, no API break).
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib fallback for Python 3.10. Used by attune.utils.coverage (loaded transitively from release-prep + orchestrated-health-check workflows). Without this, those workflows fail to load on 3.10.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
@@ -761,7 +761,7 @@ exclude_lines = [
 
 # Sibling repos — all published to PyPI:
 #   attune-rag     — core dep (>=0.1.5,<0.6) — promoted from optional; required for accuracy
-#   attune-verify  — core dep (>=0.1.0,<0.2) — backs /verify; stdlib-only, zero transitive deps
+#   attune-verify  — core dep (>=0.1.0,<0.3) — backs /verify; stdlib-only, zero transitive deps
 #   attune-author  — [author] optional extra (>=0.6.2,<0.15)
 #   attune-rag     — [rag] optional extra (>=0.1.5,<0.6) — no-op alias since rag is core
 #

--- a/uv.lock
+++ b/uv.lock
@@ -440,7 +440,7 @@ requires-dist = [
     { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.6.2,<0.15" },
     { name = "attune-rag", specifier = ">=0.1.5,<0.6" },
     { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.6" },
-    { name = "attune-verify", specifier = ">=0.1.0,<0.2" },
+    { name = "attune-verify", specifier = ">=0.1.0,<0.3" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
     { name = "bcrypt", marker = "extra == 'all'", specifier = ">=4.0.0,<6.0.0" },
@@ -625,11 +625,11 @@ wheels = [
 
 [[package]]
 name = "attune-verify"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/80/0bc0f6571897c9d1050b98d15d2d4ecb2726de5b57e416d20de72efa876f/attune_verify-0.1.0.tar.gz", hash = "sha256:e38927168db70ecc0dacf82df6b5b112f9b891343045eb37e57698d172671a9a", size = 14995, upload-time = "2026-06-09T13:56:14.333Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/2b/a2d6760bbcabe2e5650104dbe78d05780355fd73a3dd71ea1551944bbcb1/attune_verify-0.2.0.tar.gz", hash = "sha256:99c40e21ee073a603ef93e45d14c0426518944a69a651030b2cf2195e4f4b84d", size = 15904, upload-time = "2026-06-09T17:39:05.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/7f/3dcfd375f3844fc4fe1386fa1c0dad819f16e22eeedf4a1b4f8790093222/attune_verify-0.1.0-py3-none-any.whl", hash = "sha256:ee7ac81987a3bba8b7231342c2cebfcfc241fab3d19b5eae69de10a1705206ff", size = 15052, upload-time = "2026-06-09T13:56:13.073Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4e/fb981eacea35ac80defabb66bb1972f75bc556774fe7517dc69074ff261c/attune_verify-0.2.0-py3-none-any.whl", hash = "sha256:254251bb1d05ab0c7f09fb20446bc0c495286b871397190d96e576c88ec5f295", size = 15315, upload-time = "2026-06-09T17:39:04.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
Raise the `attune-verify` core-dep cap `<0.2` -> `<0.3` and pull **0.2.0** into the lockfile, now that 0.2.0 is published to PyPI.

## Why
0.2.0 resolves the **full dotted import path** (catches a private submodule of an installed package — the attune-author PR-#351 hallucination class that the 0.1.0 top-level-only checker missed). Purely additive, no API break. This gives the `/verify` skill the parity import checker.

uv.lock diff is the single-package bump (0.1.0 -> 0.2.0), no cascade.

## Sequence
This is the cheap half of T7. The other half (wire `verify()` into attune-author polish vs. keep author's existing `fact_check/`) is a design decision in the author repo — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)