### PR TITLE
docs(attune-verify): T7 decision — author already fact-checks; keep both, defer consolidation

### DIFF
--- a/docs/specs/attune-verify/decisions.md
+++ b/docs/specs/attune-verify/decisions.md
@@ -111,3 +111,65 @@ the author-#351 regression fixture committed. Implementation has
 started; the spec status should be reconciled with reality (per the
 `spec-status-self-truthing` concern). Out of scope for this decision —
 noted for a status pass.
+
+---
+
+## D-T7 — author integration: keep both, defer consolidation (2026-06-09)
+
+**Context.** T7 was framed as "wire `attune_verify.verify()` into
+attune-author's polish pass (return, not hard-gate)." Investigating it
+after shipping attune-verify 0.2.0 found the premise is **obsolete**:
+attune-author **already fact-checks post-polish via its own mature
+`fact_check/` subsystem** (its own `polish-fact-check` spec).
+
+**What author already has** (verified in `~/attune-author`):
+
+- `generator._run_fact_check()` runs after every polished file
+  (`generator.py:619`); CLI exposes `--fact-check` / `--no-fact-check`.
+- Modes via `ATTUNE_AUTHOR_FACT_CHECK`: `soft` (default — appends an
+  `## Unresolved references` block), `strict` (raise `FactCheckError`,
+  opt-in), `off`. Opportunistic — never breaks the polish pipeline.
+- A 1191-LOC subsystem: `check_polished_file()` →
+  `FactCheckReport`/`FactCheckConfig` (per-project config from
+  `pyproject.toml`, per-file skips), `report.py` formatting,
+  `apply_soft_fail`, plus **five** checks — `python_refs` (resolves full
+  dotted paths + attributes), `cli_refs` (version-aware `--help`),
+  `md_links`, `numeric_refs`, and `tutorial_static_check` (a
+  static-analysis check attune-verify does not have).
+
+So author's polish **already does exactly what T7 specified** — just via
+its own implementation, not the `attune_verify` library. With the 0.2.0
+backport (full dotted-path resolution), the two are now at **functional
+parity on the four shared checks**.
+
+**Decision: keep both; do NOT force author to delegate now.**
+
+- **attune-verify** stays the standalone family library for *other*
+  consumers — the attune-ai `/verify` skill, future external users, and
+  the semantic/Judge + rag layers author lacks.
+- **author `fact_check/`** stays as author's integrated, richer,
+  already-shipped subsystem (config, report formatting, soft-fail block,
+  tutorial static check).
+- Forcing author to delegate to `attune_verify` today would be a
+  **downgrade** (lose `tutorial_static_check`, report/config richness)
+  unless attune-verify first absorbs those — a multi-release effort with
+  no acute pain to justify it.
+
+**T7 disposition: satisfied-independently / consolidation deferred.**
+The integration T7 called for already exists; the *real* remaining work
+is consolidation, tracked below as future, not blocking.
+
+**Future path (option C, when it bites).** Single source of truth =
+attune-verify absorbs author's richness (`tutorial_static_check`,
+config-from-pyproject, report/soft-fail formatting), then author's
+`fact_check/` becomes a thin delegation shim. Gate this on a real
+trigger: drift pain between the two implementations (the "two parallel
+generators drift" lesson), or a third consumer needing the richer
+surface. The 0.2.0 backport already narrowed the drift surface (imports
+now match).
+
+**Drift mitigation until then.** Both resolve imports/flags/links/counts;
+the 0.2.0 backport aligned the import checker. If they diverge again,
+prefer porting the improvement into *both* (cheap) or starting the
+consolidation (option C). A periodic parity check across the two
+`python_refs`/`imports` checkers is worth a follow-up if drift recurs.

--- a/docs/specs/attune-verify/tasks.md
+++ b/docs/specs/attune-verify/tasks.md
@@ -1,20 +1,20 @@
 # Tasks: attune-verify — Generation Fact-Checker
 
-**Status:** in progress (2026-06-09) — **library SHIPPED, /verify skill
-SHIPPED; one task (T7) remains.** The `attune-verify` package is published
-to PyPI as v0.1.0 (`Smart-AI-Memory/attune-verify`): T1 (skeleton), T2
-(model), T3 (deterministic checkers + the author-#351 regression fixture),
-T4 (semantic Judge), T5 (rag adapter), T8 (publish) **done**. On the
-attune-ai side: `attune-verify>=0.1.0,<0.2` is now a **core dependency**
-(stdlib-only, zero transitive deps) and the **T6 `/verify` skill** is
-shipped (`plugin/skills/verify/`, all three plugin gates green:
-skill-count, attune-hub reference row, `.agents` mirror sync). The status
-once said "draft" only because the library work landed in a sibling repo
-the spec-status reconciler can't see (caught 2026-06-09 spec triage — the
-status-lies trap across a repo boundary).
-**Remaining:** T7 attune-author polish integration (sibling repo, now
-unblocked — verify is on PyPI so author CI can exercise it, not
-`importorskip`).
+**Status:** effectively complete (2026-06-09) — **all build tasks
+shipped; T7 dispositioned, no blocking work left.** `attune-verify` is
+published to PyPI (now **0.2.0** — full dotted-path import resolution):
+T1 (skeleton), T2 (model), T3 (deterministic checkers + the author-#351
+regression fixture), T4 (semantic Judge), T5 (rag adapter), T8 (publish)
+**done**. On the attune-ai side: `attune-verify>=0.1.0,<0.3` is a **core
+dependency** and the **T6 `/verify` skill** is shipped
+(`plugin/skills/verify/`, all three plugin gates green). The status once
+said "draft" only because the library work landed in a sibling repo the
+spec-status reconciler can't see (the status-lies trap across a repo
+boundary).
+**T7 (author integration):** SATISFIED INDEPENDENTLY — author already
+fact-checks post-polish via its own `fact_check/` subsystem; consolidation
+deferred (see [decisions.md](decisions.md) **D-T7**). No blocking work
+remains; consolidation is future, trigger-gated.
 **Design:** [design.md](design.md) · **Requirements:**
 [requirements.md](requirements.md)
 
@@ -161,17 +161,22 @@ on "fact-check"/"verify docs".
 
 ---
 
-## T7 — attune-author polish integration (first consumer)
+## T7 — attune-author polish integration ⏸️ SATISFIED INDEPENDENTLY / CONSOLIDATION DEFERRED
 
-**Objective:** wire verify as author's post-generation gate.
+**Status:** the premise is obsolete — attune-author **already
+fact-checks post-polish** via its own mature `fact_check/` subsystem
+(`generator._run_fact_check`, soft-default, `--fact-check` CLI flag,
+from its own `polish-fact-check` spec). After the 0.2.0 backport the two
+are at functional parity on the four shared checks. T7 was reframed: the
+integration it specified already exists independently; the real
+remaining work is **consolidation** (attune-verify absorbs author's
+richness → author delegates), deferred until drift pain or a third
+consumer justifies it. Full rationale in [decisions.md](decisions.md)
+**D-T7** (2026-06-09).
 
-- author polish calls `attune_verify.verify(content, ctx)` after
-  generation; surfaces findings (return, not hard-gate by default).
-
-**Acceptance:** author's polish run on a known-hallucinated fixture
-reports verify findings.
-**Blocked on:** T8 (verify on PyPI) so author CI exercises it
-rather than `importorskip`.
+**Original objective (now satisfied by author's own subsystem):** wire a
+post-generation fact-check gate into author's polish, surfacing findings
+(soft by default).
 
 ---
 


### PR DESCRIPTION
## What
Records the **T7 decision (D-T7)** in \`decisions.md\` and reframes T7 in \`tasks.md\`, after investigating it post-0.2.0.

## The finding
T7 was framed as \"wire \`attune_verify.verify()\` into author's polish.\" Investigation found the premise **obsolete**: attune-author **already fact-checks post-polish** via its own mature \`fact_check/\` subsystem (\`generator._run_fact_check\`, soft-default, \`--fact-check\` CLI flag, from its own \`polish-fact-check\` spec — a 1191-LOC subsystem with config, report formatting, soft-fail block, and a \`tutorial_static_check\` attune-verify lacks). After the 0.2.0 backport, the two are at **functional parity** on the four shared checks.

## Decision: keep both, defer consolidation
- **attune-verify** = standalone family library (the \`/verify\` skill, future consumers, the semantic + rag layers author lacks).
- **author \`fact_check/\`** = author's integrated, richer, already-shipped subsystem.
- Forcing author to delegate now would be a **downgrade**. Consolidation (verify absorbs author's richness → author delegates) is **future, trigger-gated** (drift pain or a third consumer).
- **T7 disposition: satisfied-independently / consolidation deferred** — no blocking work remains.

This makes the attune-verify spec effectively complete. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)