### PR TITLE
docs(completeness-audit): Phase 1 triage worklist + version-fiction fixes

### DIFF
--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,10 +1,14 @@
 # Attune AI — Project Overview
 
-**Version:** 5.1.1 | **License:** Apache 2.0 |
-**Python:** 3.10+ | **PyPI:** `attune-ai`
+**License:** Apache 2.0 | **Python:** 3.10+ | **PyPI:** `attune-ai`
+
+> For the current version, see the
+> [PyPI page](https://pypi.org/project/attune-ai/) or the
+> README badge. This overview is intentionally version-agnostic
+> so it stays accurate across releases.
 
 Attune AI is a production-ready AI workflow operating system
-for Claude Code. It provides 15 multi-agent workflows for
+for Claude Code. It provides multi-agent workflows for
 code review, security, testing, and release — each backed by
 specialized Claude subagents with intelligent model routing,
 budget controls, and structured output.
@@ -43,17 +47,17 @@ automatic API fallback when `ANTHROPIC_API_KEY` is set. Run
 
 ```text
 src/attune/
-├── workflows/         # 15 multi-agent workflows (BaseWorkflow)
+├── workflows/         # Multi-agent workflows (BaseWorkflow)
 ├── agents/            # Agent SDK integration + state persistence
 │   ├── release/       # ReleaseAgent, ReleasePrepTeam
 │   └── state/         # AgentStateStore, AgentRecoveryManager
-├── wizards/           # 5 interactive guided workflows
-├── mcp/               # MCP server (30 tools for Claude Code)
+├── wizards/           # Interactive guided workflows
+├── mcp/               # MCP server (tools for Claude Code)
 ├── models/            # LLM provider abstraction + auth strategy
 ├── memory/            # Two-tier memory (Redis + MemDocs)
 ├── orchestration/     # Dynamic teams, workflow composition
 ├── plugins/           # BasePlugin + register_mcp_tools() hook
-├── agent_factory/     # 14 built-in agent templates
+├── agent_factory/     # Built-in agent templates
 ├── cli_commands/      # CLI subcommands (cost, telemetry, auth)
 ├── meta_workflows/    # Intent detection + NL routing
 ├── telemetry/         # FeedbackLoop, UsageTracker, cost reports
@@ -68,7 +72,7 @@ src/attune/
 
 plugin/                # Claude Code plugin
 ├── commands/          # Slash commands (attune, review, test, security)
-├── skills/            # 7 skill groups (MCP-exposed tasks)
+├── skills/            # Skill groups (MCP-exposed tasks)
 └── agents/            # Agent definitions
 
 attune_redis/          # Redis plugin (pip install attune-redis)
@@ -94,19 +98,24 @@ attune_software/       # Software plugin (bundled)
 
 ## Workflows
 
-All 15 workflows inherit from `BaseWorkflow` and use the
-Agent SDK for multi-agent execution.
+Workflows inherit from `BaseWorkflow` and use the Agent SDK
+for multi-agent execution. Run `attune workflow list` for the
+canonical, always-current set — the table below is
+representative.
 
 | Workflow | Agents | Description |
 | --- | --- | --- |
 | **code-review** | security, quality, perf, architect | 4-perspective code review |
 | **security-audit** | vuln-scanner, secret-detector, auth-reviewer, remediation-planner | Find vulnerabilities, secrets, auth issues |
 | **bug-predict** | pattern-scanner, risk-correlator, prevention-advisor | Predict bug-prone patterns |
+| **discovery-sweep** | pattern scanners | Sweep a codebase for review candidates |
 | **perf-audit** | complexity-analyzer, bottleneck-finder, optimization-advisor | Find bottlenecks and O(n²) patterns |
 | **test-gen** | function-identifier, test-designer, test-writer | Generate pytest code |
 | **test-audit** | coverage-auditor, gap-analyzer, test-planner | Audit test coverage |
 | **doc-gen** | outline-planner, content-writer, polish-reviewer | Generate docs from source |
 | **doc-audit** | staleness-checker, accuracy-reviewer, gap-finder | Check docs for staleness |
+| **doc-orchestrator** | doc planners | Coordinate multi-doc generation/update |
+| **rag-code-gen** | retriever, code-writer | RAG-grounded code generation |
 | **refactor-plan** | debt-scanner, impact-analyzer, plan-generator | Plan tech debt refactors |
 | **dependency-check** | inventory-assessor, update-advisor | Audit dependencies |
 | **simplify-code** | complexity-scanner, simplification-designer, safety-reviewer | Reduce over-engineered code |
@@ -226,7 +235,8 @@ per-run cost.
 
 ## Wizards
 
-5 interactive guided workflows using Socratic discovery:
+Interactive guided workflows using Socratic discovery
+(run `attune wizard list` for the current set):
 
 | Wizard | Purpose |
 | --- | --- |
@@ -254,7 +264,7 @@ attune wizard run debug
 | `/attune-test` | Testing hub |
 | `/attune-security` | Security audit shortcut |
 
-### Skill Groups (7)
+### Skill Groups
 
 | Skill Group | Purpose |
 | --- | --- |
@@ -268,7 +278,7 @@ attune wizard run debug
 
 ### MCP Server
 
-30 tools exposed via Model Context Protocol (stdio
+Tools exposed via Model Context Protocol (stdio
 transport). Configured in `.mcp.json`. Rate-limited to 60
 calls/min per tool.
 
@@ -333,7 +343,7 @@ attune auth reset --confirm   # Clear config
 
 ## Security
 
-### v5.0.1 Security Controls
+### Security Controls
 
 | Feature | Description |
 | --- | --- |
@@ -355,7 +365,7 @@ attune auth reset --confirm   # Clear config
 
 ## Testing
 
-**15,555+ tests** | **85%+ coverage** | **pytest + pytest-cov**
+**Comprehensive test suite** | **85%+ coverage** | **pytest + pytest-cov**
 
 ```bash
 pytest tests/                              # Full suite
@@ -368,10 +378,10 @@ pytest -n auto                             # Parallel (4-8x faster)
 
 | Directory | Purpose |
 | --- | --- |
-| tests/unit/ | Unit tests (~13k) |
-| tests/integration/ | End-to-end workflow tests (~500) |
-| `tests/agent_factory/` | Agent template tests (~200) |
-| tests/memory/ | Memory system tests (~400) |
+| tests/unit/ | Unit tests |
+| tests/integration/ | End-to-end workflow tests |
+| `tests/agent_factory/` | Agent template tests |
+| tests/memory/ | Memory system tests |
 
 ---
 
@@ -398,7 +408,7 @@ pytest -n auto                             # Parallel (4-8x faster)
 
 ## Agent Templates
 
-14 built-in templates in
+Built-in templates in
 `src/attune/orchestration/agent_templates/builtin_templates.py`:
 
 | Template | Role |

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 7.4.0
+**Version:** 8.0.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 7.4.0 | **License:** Apache 2.0
+**Version:** 8.0.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/docs/specs/docs-completeness-audit/completeness-audit-triage.md
+++ b/docs/specs/docs-completeness-audit/completeness-audit-triage.md
@@ -1,0 +1,176 @@
+# Completeness Audit — Phase 1 Triage Worklist
+
+**Generated:** 2026-06-09 | **Package version at audit:** 8.0.1
+**Scope:** the in-scope set defined by [requirements.md](./requirements.md#scope)
+and [decisions.md](./decisions.md) (Q1–Q3).
+
+> **What this is:** the Stage-A triage artefact required by the
+> acceptance criteria. It classifies in-scope docs into the four
+> buckets (MECHANICAL / REWRITE / RETIRE / CLEAN) and is the
+> durable inventory that drives the Stage-B bucket PRs.
+>
+> **Honesty note (faithfulness):** rows are marked **CONFIRMED**
+> (verified against current `src/` or by dated-artefact convention)
+> or **PENDING** (structural classification by cluster, not yet
+> read line-by-line against source). The spec's own risk note
+> warns that heuristics miss drift — so PENDING rows carry a
+> *recommended* bucket, not an asserted one, and must pass a
+> content read before any Stage-B fix lands. This is a first-pass
+> worklist within the session effort cap; the PENDING queue is the
+> explicit follow-up, per requirements §5 ("anything not landed
+> defers … with the triage artefact preserved").
+
+---
+
+## Inventory baseline (re-run 2026-06-09)
+
+| Bucket | Count |
+|--------|-------|
+| `find docs -name '*.md'` (excl `archive/`, `specs/`) | 226 |
+| Tracked in `features.yaml` `doc_paths` (owned by doc-fiction-cleanup / help system) | 45 |
+| Untracked, in-scope (before blog rule) | 181 |
+| — of which blog (`docs/blog/`, `docs/BLOG_*`) | 55 |
+| **Non-blog in-scope (this worklist)** | **126** |
+
+Blog cohort (55) needs a git-date classification pass per Q1
+(6-month cutoff) before content audit — deferred to a dedicated
+blog pass (no date frontmatter exists; git first-commit date is
+the signal). Not classified here.
+
+---
+
+## Summary by bucket (non-blog, 126 docs)
+
+| Bucket | Confirmed | Pending | Total |
+|--------|-----------|---------|-------|
+| MECHANICAL | 6 | 4 | 10 |
+| REWRITE | 1 (done) + 2 | 0 | 3 |
+| RETIRE / archive-candidate | 0 | 4 | 4 |
+| CLEAN (incl. dated-historical) | 16 | 0 | 16 |
+| **PENDING content-verify (Stage A queue)** | — | 93 | 93 |
+
+---
+
+## CONFIRMED — version-fiction (deterministic: stale `**Version:**` header vs 8.0.1)
+
+| doc | bucket | stale claim | evidence | action |
+|-----|--------|-------------|----------|--------|
+| docs/PROJECT_OVERVIEW.md | REWRITE | hdr 5.1.1; "15 workflows"/"30 tools"/"7 skills"/"14 templates"/"15,555 tests" | real: 8.0.1, 17 workflows (`attune.workflows.list_workflows`), 17 skill dirs | **DONE this PR** — evergreen rewrite, counts stripped, 3 missing workflows added, PyPI pointer |
+| docs/reference/API_REFERENCE.md | MECHANICAL | hdr+footer 7.4.0 | `pyproject.toml` 8.0.1 | **DONE this PR** — bumped to 8.0.1 |
+| docs/ARCHITECTURE.md | MECHANICAL | hdr 6.3.0 ("Living Document") | living doc; version on an evergreen doc → strip or bump | Stage B: strip version (evergreen) |
+| docs/index.md | MECHANICAL | 3.9.0 | landing doc | Stage B: strip/bump |
+| docs/rag/index.md | MECHANICAL | 6.1.0 | rag surface current | Stage B: strip/bump |
+| docs/getting-started/mcp-integration.md | MECHANICAL | 6.3.0 | MCP integration real | Stage B: strip/bump |
+| docs/ORCHESTRATION_API.md | REWRITE | hdr 4.0.0, 1596 lines | `src/attune/orchestration/meta_orchestrator.py` EXISTS → real module, but 4 majors of API drift likely | Stage B: verify API surface, rewrite drifted sections |
+| docs/ORCHESTRATION_USER_GUIDE.md | REWRITE | hdr 3.12.0, 1262 lines | companion to above; same drift risk | Stage B: verify + rewrite |
+
+## CONFIRMED — CLEAN (self-disambiguated version)
+
+| doc | evidence |
+|-----|----------|
+| docs/CODING_STANDARDS.md | hdr "3.9.1 (doc revision, not framework version)" — explicitly a doc-revision number, not a framework-version claim; not fiction |
+| docs/EXCEPTION_HANDLING_GUIDE.md | hdr "3.9.0 (doc revision, not framework version)" — same; got partial PR #508 cleanup |
+
+## CONFIRMED — CLEAN, dated-historical (intentionally point-in-time; like blog history)
+
+| doc | why historical |
+|-----|----------------|
+| docs/rag/embeddings-decision-2026-04-17.md | dated decision record (Q-style pre-committed matrix) |
+| docs/rag/faithfulness-decision-2026-04-19.md | dated decision record |
+| docs/security/security-fixes-2026-03-17.md | dated fix log |
+| docs/testing-audit-2026-04-23.md | dated audit snapshot |
+| docs/conversations/ai-consciousness-dialogue-2025-12-28.md | dated transcript |
+| docs/conversations/social-post-ai-consciousness.md | companion social post |
+| docs/COVERAGE_BUG_LOG.md | append-only log |
+| docs/cost-analysis/COST_SAVINGS_BY_ROLE_AND_PROVIDER.md | dated analysis |
+| docs/cost-analysis/TIER_ROUTING_SENSITIVITY_ANALYSIS.md | dated analysis |
+| docs/examples/generated-plan-release-prep.md | dated generated artefact |
+| docs/MULTI_PACKAGE_RELEASE_PATTERNS.md | release-pattern reference (versions are examples) |
+| docs/process/COLLABORATION_DISCIPLINE_outline.md | planning outline (per project memory) |
+| docs/plans/MONITORING_SPRINT_PLAN.md | dated sprint plan |
+| docs/plans/mcp-server-refactor.md | planning artefact |
+
+## PENDING MECHANICAL (recommended bucket; needs read before fix)
+
+| doc | stale signal | note |
+|-----|-------------|------|
+| docs/pitch/VC_PITCH_DECK.md | 4.4.0 | marketing; strip version, low priority |
+| docs/pitch/EXECUTIVE_SUMMARY.md | 4.4.0 | marketing |
+| docs/pitch/TECHNICAL_BRIEF.md | 4.4.0 | marketing |
+| docs/governance.md | 1.6.1 / 2.0.0 | verify governance content current |
+
+## PENDING RETIRE / archive-candidate (needs decision)
+
+| doc | why candidate |
+|-----|---------------|
+| docs/CLAUDE_NATIVE.md | "Migration Guide … Complete … v3.0.4" — a *completed* v3 migration record; archival, not current docs |
+| docs/AUTH_INTEGRATION_COMPLETE.md | "…COMPLETE" completion record (point-in-time) |
+| docs/AUTH_CLI_IMPLEMENTATION.md | implementation record (point-in-time) |
+| docs/ARCHITECTURAL_GAPS_ANALYSIS.md | analysis snapshot — verify still relevant |
+
+---
+
+## PENDING — Stage A content-verify queue (93 docs)
+
+These are structurally classified by cluster but **not yet read
+line-by-line against `src/`**. Most are expected CLEAN/MECHANICAL
+(the feature-doc quad is attune-author-generated from source and
+typically tracks current), but per the spec's anti-rubber-stamp
+rule they require a content read before a bucket is asserted.
+Recommended execution: the Stage-A subagent fan-out (batches of
+~15) when the server rate-limiter is cooperative — it tripped a
+transient limit on the first attempt this session.
+
+**Feature-doc quad (per real workflow/feature — likely CLEAN, attune-author-generated):**
+
+- `architecture/`: bug-predict, cli, deep-review, help-system, hooks, memory, ops-dashboard, rag-grounding, refactor-plan, release-prep, resilience, security-audit, smart-test, spec-engine, telemetry (15)
+- `how-to/`: bug-predict, deep-review, discovery-sweep-on-the-dashboard, hooks, ops-dashboard, plugin, rag-grounding, refactor-plan, release-prep, spec-engine, triage-code-quality (11)
+- `reference/`: bug-predict, deep-review, hooks, ops-dashboard, plugin, rag-grounding, refactor-plan, release-prep, smart-test, spec-engine (10)
+- `tutorials/`: bug-predict, deep-review, hooks, ops-dashboard, plugin, rag-grounding, refactor-plan, release-prep, spec-engine (9)
+
+**Onboarding / guides (verify install commands, flags, counts):**
+
+- `getting-started/`: choose-your-path, first-steps, index, installation, redis-setup (5)
+- `guides/`: DISTRIBUTION_POLICY, MCP_PUBLISH_INSTRUCTIONS, WORKFLOW_PATTERNS, foreword, pattern-catalog, preface, trust-circuit-breaker, wizard-architecture, wizards-getting-started (9)
+- `quickstart.md` + `quickstart/index.md` (2) — **possible redundancy** (27 vs 15 lines); hand off dup-check to docs-wiring-audit
+
+**Pitch / marketing (verify metrics, claims):**
+
+- `pitch/`: CASE_STUDIES, COMPETITIVE_ANALYSIS, HEALTHCARE_ONE_PAGER (3) — (VC_PITCH_DECK/EXECUTIVE_SUMMARY/TECHNICAL_BRIEF already flagged MECHANICAL above)
+
+**Philosophy / implementation / integration / misc root:**
+
+- `philosophy/`: ENHANCED_PATTERN_TRACKING_DEMO, XML_ENHANCED_AGENT_COMMUNICATION (2)
+- `implementation/`: AGENT_SDK_EVALUATION, MCP_SDK_MIGRATION (2)
+- `integration/`: claude-code-integration (1)
+- `migration/`: redis-plugin-migration (1) — version timeline doc, likely CLEAN-historical
+- `redis/`: best-practice-alignment (1)
+- root: DEVELOPER_GUIDE, FEATURES, FEATURE_OVERVIEW_PROJECT_INDEX, PERFORMANCE_OPTIMIZATION_ROADMAP, REDIS_SETUP, SECURITY_REVIEW, SKILLS_REFERENCE, about-the-author, book-cover, commands, comparison, context-management, continuous-learning, contributing, feature-overview-meta-workflows, hooks, keyboard-shortcuts, markdown-agents, repo-hygiene (19)
+- `examples/`: adaptive-learning-system, multi-agent-team-coordination, sbar-clinical-handoff, simple-chatbot (4)
+- `plans/`: simplify-sweep (1)
+
+---
+
+## Recommended Stage-B sequencing
+
+1. **DONE (this PR):** PROJECT_OVERVIEW evergreen rewrite +
+   API_REFERENCE version bump + this triage artefact.
+2. **MECHANICAL version-header sweep PR:** ARCHITECTURE (strip),
+   index, rag/index, getting-started/mcp-integration, pitch trio,
+   governance — each read-then-fixed (confirm body matches current
+   behavior before bumping; strip on evergreen-shaped docs).
+3. **REWRITE PRs (one per doc):** ORCHESTRATION_API,
+   ORCHESTRATION_USER_GUIDE — verify the meta-orchestration API
+   surface against `src/attune/orchestration/` first.
+4. **RETIRE decision:** CLAUDE_NATIVE + the two AUTH completion
+   records → archive to `docs/archive/` (grep `tests/` and the
+   PyPI long-description for inbound links first per requirements §5).
+5. **Stage-A content-verify of the 93 PENDING docs** (subagent
+   fan-out) — promotes each to a confirmed bucket; feeds further
+   Stage-B PRs.
+6. **Blog date-classification pass** (Q1 6-month cutoff via git
+   dates) — separate from this non-blog worklist.
+
+Closing the spec requires the PENDING queue worked through (or
+formally deferred to a follow-up release in decisions.md) and a
+final `mkdocs build --strict`.


### PR DESCRIPTION
## docs-completeness-audit — Phase 1 (Stage A)

Executes the third BUILD-NEXT pick from the disposition trio (attune-verify
and windows-xdist-flakes shipped earlier). Decisions Q1–Q3 were already
approved 2026-05-31; this is execution.

### Canonical version-fiction fixes
- **PROJECT_OVERVIEW.md** — evergreen rewrite per decision Q2. Stripped the
  stale `5.1.1` header and every drift-prone hardcoded count (15 workflows,
  30 MCP tools, 7 skill groups, 14 templates, 15,555 tests). Now points to
  PyPI + live `attune workflow list` / `attune wizard list`. Added the 3
  workflows the table omitted — `discovery-sweep`, `doc-orchestrator`,
  `rag-code-gen` (real count is **17**, doc claimed 15).
- **reference/API_REFERENCE.md** — mechanical bump `7.4.0 → 8.0.1`
  (header + footer). This is the doc the "version bumps touch 7+ files"
  lesson flags as silently lagging.

### Triage worklist (the Stage-A deliverable)
`docs/specs/docs-completeness-audit/completeness-audit-triage.md` — classifies
the **126 non-blog in-scope docs**:
- **CONFIRMED** (evidence-backed): 8 version-fiction, 2 self-disambiguated
  CLEAN (CODING_STANDARDS / EXCEPTION_HANDLING_GUIDE note "doc revision, not
  framework version"), 14 dated-historical CLEAN.
- **PENDING content-verify queue**: 93 docs grouped by cluster with a
  *recommended* (not asserted) bucket — anti-rubber-stamp per the spec risk
  note. To be promoted via a Stage-A subagent fan-out (a transient
  server-side rate limit blocked the fan-out this session).
- Stage-B sequencing + RETIRE candidates (CLAUDE_NATIVE completed-migration
  record, AUTH completion docs) recorded.

### Scope / cap
Per the session contract: Phase 1 triage + high-traffic version-fiction fixes.
The 93-doc PENDING queue and blog date-classification (Q1 cutoff) are explicit
follow-ups, preserved in the artefact per requirements §5.

### Notes
- Docs-only; `docs/specs/**` add is additive (no drift-guard path removed).
- All PROJECT_OVERVIEW related-doc links verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
