### PR TITLE
docs(completeness-audit): B2 mechanical version-fiction sweep

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,6 @@ description: Attune AI - Architecture Overview: System architecture overview wit
 
 # Attune AI - Architecture Overview
 
-**Version:** 6.3.0
 **Last Updated:** April 23, 2026
 **Status:** Living Document
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -122,7 +122,7 @@ The project follows **Semantic Versioning** (SemVer):
 - **MINOR**: New features, backward compatible
 - **PATCH**: Bug fixes, backward compatible
 
-**Current Version**: 1.6.1
+**Current version**: see [PyPI](https://pypi.org/project/attune-ai/)
 
 ### Release Cadence
 
@@ -235,7 +235,6 @@ By contributing to this project, you agree that:
 
 ### Near-Term (Q1-Q2 2025)
 
-- PyPI v2.0.0 release (after 90% coverage)
 - Claude Code partnership case study
 - MemDocs integration showcase
 - Book chapter publication (Q1 2026)

--- a/docs/pitch/EXECUTIVE_SUMMARY.md
+++ b/docs/pitch/EXECUTIVE_SUMMARY.md
@@ -18,7 +18,7 @@ Attune AI is a production-ready anticipatory intelligence platform that transfor
 - **10 smart wizards** for security, testing, documentation, and more
 - **HIPAA-ready** with built-in PII scrubbing and audit logging
 
-We're seeking strategic partnership with the Anthropic ecosystem to scale enterprise adoption and deepen Claude integration. The framework is open source (Apache License 2.0), production-stable at v4.4.0, and optimized for Claude Code workflows.
+We're seeking strategic partnership with the Anthropic ecosystem to scale enterprise adoption and deepen Claude integration. The framework is open source (Apache License 2.0), production-stable, and optimized for Claude Code workflows.
 
 **Website:** [smartaimemory.com](https://smartaimemory.com)
 **GitHub:** [Smart-AI-Memory/attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
@@ -29,7 +29,7 @@ We're seeking strategic partnership with the Anthropic ecosystem to scale enterp
 
 | Metric | Value |
 |--------|-------|
-| Version | v4.4.0 (Production/Stable) |
+| Status | Production/Stable |
 | Test Coverage | 125+ tests |
 | Smart Wizards | 10 |
 | Integrated Workflows | 14 |

--- a/docs/pitch/TECHNICAL_BRIEF.md
+++ b/docs/pitch/TECHNICAL_BRIEF.md
@@ -12,7 +12,7 @@ description: Attune AI — Technical Brief: **For:** Technical due diligence, en
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                     Attune AI v4.4.0                     │
+│                        Attune AI                         │
 ├─────────────────────────────────────────────────────────────────┤
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────────┐  │
 │  │  CLI/API    │  │  VSCode     │  │  MCP Server             │  │
@@ -82,7 +82,7 @@ result = router.route(
 # Automatically selects Sonnet for code fix
 ```
 
-### 2. SocraticWorkflowBuilder (v4.4.0)
+### 2. SocraticWorkflowBuilder
 
 Creates optimized agent configurations through guided questions:
 
@@ -102,7 +102,7 @@ session = builder.submit_answers(session, answers)
 workflow = builder.generate_workflow(session)
 ```
 
-### 3. MetaOrchestrator (v4.4.0)
+### 3. MetaOrchestrator
 
 Automatically composes agent teams using 6 composition patterns:
 

--- a/docs/pitch/VC_PITCH_DECK.md
+++ b/docs/pitch/VC_PITCH_DECK.md
@@ -43,7 +43,7 @@ A 5-level maturity model that progresses AI from reactive responses to predictin
 | **Integrated Workflows** | 14 (including 4 meta-workflows) |
 | **Agent Templates** | 7 with 6 composition patterns |
 | **Test Coverage** | 125+ tests, production-stable |
-| **Version** | v4.4.0 (January 2026) |
+| **Status** | Production/Stable |
 
 ---
 
@@ -93,7 +93,7 @@ A 5-level maturity model that progresses AI from reactive responses to predictin
 ### Traction
 
 - **Open source:** GitHub at [Smart-AI-Memory/attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
-- **Production-ready:** v4.4.0 stable release
+- **Production-ready:** stable release
 - **Documentation:** Full MkDocs site + tutorials
 - **VSCode Extension:** Real-time dashboard integration
 


### PR DESCRIPTION
## Stage B2 — mechanical version-fiction sweep

Second cluster PR of the **docs-completeness-audit** spec
(`docs/specs/docs-completeness-audit/`). Phase 1 triage + the
PROJECT_OVERVIEW rewrite + API_REFERENCE bump shipped in #714;
this is the MECHANICAL version-header sweep from
`completeness-audit-triage.md`.

### What changed (version strings only)

| Doc | Fix |
|-----|-----|
| `ARCHITECTURE.md` | Strip `Version: 6.3.0` line — it's a Living Document (evergreen); kept Last Updated + Status |
| `governance.md` | `Current Version: 1.6.1` → PyPI pointer; dropped moot `PyPI v2.0.0` roadmap item (long past at 8.0.1) |
| `pitch/EXECUTIVE_SUMMARY.md` | Strip `v4.4.0` (prose + Quick Facts row → Status) |
| `pitch/VC_PITCH_DECK.md` | Strip `v4.4.0` (table row → Status, traction line) |
| `pitch/TECHNICAL_BRIEF.md` | Strip `v4.4.0` (ASCII banner + 2 section tags) |

### Verification

- `SocraticWorkflowBuilder` (`src/attune/socratic/engine.py:61`) and
  `MetaOrchestrator` (`src/attune/orchestration/meta_orchestrator.py`)
  both **exist in src/** → version strip, not retire.
- READ-then-fixed each doc; no blind bumps.

### Scope discipline

B2 strips **version** fiction only. Stale **counts** (125+ tests,
14 workflows, 10 wizards, 7 templates in the pitch docs) are a
separate fiction class the triage routed to the **B5 PENDING
content-verify queue** — left untouched here to keep bucket
discipline clean.

Skipped 3 docs the worklist pre-listed as MECHANICAL but are CLEAN
(true historical refs): `docs/index.md` (Security Hardening v3.9.0),
`docs/rag/index.md` (Introduced in v6.1.0),
`docs/getting-started/mcp-integration.md` (deprecated in v6.3.0+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
