### PR TITLE
test(integration): clear the 16-failure revival backlog + promote CI job to full no-auth suite

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,16 +1,18 @@
 name: Integration Tests
 
-# Runs the *green subset* of the previously-dormant integration suite
-# (docs/specs/integration-coverage/) so it stops rotting from never
-# running. Keyless (no ANTHROPIC_API_KEY) → CI-representative; the
-# auth-required integration tests run separately (opt-in nightly, TODO).
+# Runs the FULL no-auth integration suite (docs/specs/integration-
+# coverage/) so it stops rotting from never running. Keyless (empty
+# ANTHROPIC_API_KEY) → CI-representative; auth-required tests (the
+# `*_with_auth` files + the env-gated discovery_sweep files) skip here
+# and run separately (opt-in nightly, TODO).
 #
-# This job is intentionally NOT in branch-protection's required checks
-# yet — it's advisory while the cleanup backlog in
-# docs/specs/integration-coverage/phase1-triage.md is worked down (11
-# files still red: discovery_sweep timeouts, a stale rag assertion, etc).
-# Promote to required once the full no-auth suite is green and the file
-# list below is replaced with `tests/integration/ -k "not with_auth"`.
+# History: started as an explicit green-subset file list while the
+# 11-file cleanup backlog in
+# docs/specs/integration-coverage/phase1-triage.md was worked down.
+# Backlog cleared 2026-06-09 (295 passed / 41 skipped / 0 fail
+# locally) → promoted to the full `-k "not with_auth"` selector.
+# Still advisory (not in branch-protection required checks); promote
+# to required after a few weeks of green runs.
 
 on:
   push:
@@ -24,7 +26,7 @@ concurrency:
 
 jobs:
   integration:
-    name: integration (green subset)
+    name: integration (no-auth)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -41,23 +43,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
 
-      - name: Run integration green subset (keyless)
-        # No ANTHROPIC_API_KEY in env → exercises the integration wiring
-        # without real API calls. -m "" overrides the repo default
-        # `-m "not integration"`. Explicit file list = the verified-green
-        # subset (140 passed / 15 skipped / 0 fail locally, 2026-06-09).
+      - name: Run no-auth integration suite (keyless)
+        # Empty ANTHROPIC_API_KEY → exercises the integration wiring
+        # without real API calls (real-API tests env-gate themselves).
+        # -m "" overrides the repo default `-m "not integration"`.
         env:
           ANTHROPIC_API_KEY: ""
         run: |
           pytest -m "" -o addopts="" -p no:cacheprovider \
             -n auto --timeout=120 --timeout-method=thread \
-            tests/integration/test_agents_integration.py \
-            tests/integration/test_commands_integration.py \
-            tests/integration/test_context_integration.py \
-            tests/integration/test_full_workflow.py \
-            tests/integration/test_hooks_integration.py \
-            tests/integration/test_intelligence_integration.py \
-            tests/integration/test_learning_integration.py \
-            tests/integration/test_mcp_dispatch.py \
-            tests/integration/test_meta_workflow_e2e.py \
-            tests/integration/test_natural_language_routing_v5_1.py
+            tests/integration -k "not with_auth"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Integration CI job promoted to the full no-auth suite.** The
+  `integration-tests.yml` job (advisory, #704) now runs
+  `tests/integration -k "not with_auth"` — 295 tests — instead of an
+  explicit 10-file green-subset list. Enabled by clearing the entire
+  16-failure revival backlog (integration-coverage Phase 1): all
+  failures were stale tests or broken test infrastructure, zero
+  production bugs. Highlights: the 6 `test_discovery_sweep_*` files
+  hit the real Anthropic API by design and are now env-gated to the
+  auth bucket; `test_tier1_tracking`'s telemetry fixture had been
+  silently inert since a singleton rename (tests polluted a
+  cwd-relative `.attune/`); two graceful-degradation tests asserted a
+  raise-ImportError contract that production replaced with graceful
+  mock-mode fallback; the telemetry cache-hit test exercised the
+  removed client-side cache and was rewritten against the live
+  `_try_cache_lookup` branch. Full triage record:
+  `docs/specs/integration-coverage/phase1-triage.md`.
+
 ### Added
 - **`/verify` skill — output-side generation fact-checker.** A new
   `verify` skill (`plugin/skills/verify/`) fact-checks LLM-generated

--- a/docs/specs/integration-coverage/phase1-triage.md
+++ b/docs/specs/integration-coverage/phase1-triage.md
@@ -27,22 +27,30 @@ tests opportunistically call the real API — including one surfacing the
 Opus-4.8 `max_tokens` vs `thinking.budget_tokens` 400. Keyless is the
 CI-true number.)
 
-## Cleanup backlog — the 11 files still red (next PRs, before wiring as required)
+## Cleanup backlog — CLEARED (2026-06-09, follow-up PR)
 
-| File | Cause (sampled) | Fix shape |
+Full triage verdict: **zero production bugs** — every red file was a
+stale test or broken test infrastructure. The fixes:
+
+| File | Root cause (verified) | Fix |
 |---|---|---|
-| `test_discovery_sweep_{bug_predict,dependency_check,doc_audit,perf_audit,security_audit,test_audit}_integration.py` (×6) | **Timeout >25s / worker crash** — real heavy workflow analysis on fixtures | longer timeout + serialize (not `-n`), or trim fixtures |
-| `rag/test_rag_workflow.py` | Stale assertion — asserts the **pre-#543** error-result shape | update to the sdk-error-message-fidelity shape |
-| `test_tier1_tracking.py` (×3) | (to triage) | — |
-| `test_graceful_degradation.py` (×3) | (to triage) | — |
-| `test_llm_integration.py` (×2) | (to triage; some are real-API-shaped) | mock the boundary or mark auth-gated |
-| `test_telemetry_integration.py` (×1) | (to triage) | — |
+| `test_discovery_sweep_*_integration.py` (×6) | NOT timeouts — these hit the **real Anthropic API by design** ("Hits the real Anthropic API" in each docstring; keyless they spawn the subscription `claude` CLI → prose instead of stream-json, ~105 s, then fail). Pre-date the keyless CI job. | Env-gated: `pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"))` — they join the auth bucket and skip keyless. |
+| `rag/test_rag_workflow.py` (×1) | Stale **pre-#543** error-shape assertion (`"Agent SDK failure"`). | Updated to the #543 fidelity shape: `"claude CLI subprocess failed"` + `metadata.sdk_error_kind == "unknown"`. |
+| `test_tier1_tracking.py` (×1) | **Three-layer fixture rot**: (a) `mock_telemetry_dir` reset `_telemetry_store`, but a refactor renamed the singleton to `_store_instance` — isolation silently inert; (b) `TelemetryStore()` defaults to cwd-relative `.attune/` so tests polluted a real dir; (c) `_read_jsonl` returns oldest-first, so `executions[0]` ("latest") read a stale `workflow_id=None` record. `EMPATHY_TELEMETRY_DIR` is a ghost env var (read nowhere). | Fixture now monkeypatches `_store_instance` with a temp-dir store. |
+| `test_graceful_degradation.py` (×3) | (a+b) Production moved from `raise ImportError` to **graceful degradation** (facade auto-falls-back to mock mode; coordinator sets `_degraded` + warns) — tests asserted the old contract; the `attune.memory.is_redis_available` patch target was also stale (production checks `MemoryFeatures.check_redis`). (c) `UsageTracker` buffers writes (`buffer_size=50`) — asserting `usage.jsonl` exists after one call needs a `flush()`. | Rewrote the two redis tests to assert degradation; added `tracker.flush()`. Fixed the coordinator's stale "Raises ImportError" docstring (only production change, docs-only). |
+| `test_llm_integration.py` (×1) | Real-API test (`test_thinking_mode`) — only fails when a key leaks in from `~/.attune/anthropic.env` via `load_dotenv` (env var **unset**). With CI's `ANTHROPIC_API_KEY: ""` (empty) it skips correctly. | No change needed for keyless CI. (Its Opus-4.8 `max_tokens` vs `thinking.budget_tokens` 400 is the nightly-auth job's concern.) |
+| `test_telemetry_integration.py` (×1) | Tested **removed functionality**: client-side response cache (mocked `workflow._cache`, which nothing reads — `_try_cache_lookup` is a permanent no-op since the semantic-cache retirement). | Rewrote to patch `_try_cache_lookup` directly, exercising the live cache-hit telemetry branch in `_call_llm`. |
 
-## Next (the CI job)
+Verified: `pytest tests/integration -k "not with_auth"` keyless →
+**295 passed · 41 skipped · 0 failed (6 s, `-n auto`)**.
 
-Wire a CI job (likely a separate `integration-tests.yml`, **non-required**
-initially) that runs the **green subset** (the ~9 passing no-auth files),
-keyless, `--timeout` + serialized for the slow ones, so 300+ tests run on
-every PR and stop rotting. Promote to required once the 11-file backlog is
-cleared. The 8 auth-required files → opt-in nightly / `workflow_dispatch`
-gated on `ANTHROPIC_API_KEY`.
+## CI job — wired, then promoted to the full suite
+
+`.github/workflows/integration-tests.yml` (#704) ran an explicit
+green-subset file list; with the backlog cleared it now runs
+`tests/integration -k "not with_auth"` (job name
+`integration (no-auth)`). Still **non-required** — promote to a
+required check after a few weeks of green runs. Remaining follow-up:
+the auth bucket (8 `*_with_auth` files + the 6 env-gated
+discovery_sweep files) → opt-in nightly / `workflow_dispatch` gated on
+`ANTHROPIC_API_KEY`.

--- a/docs/specs/integration-coverage/tasks.md
+++ b/docs/specs/integration-coverage/tasks.md
@@ -1,5 +1,5 @@
 # Tasks: Integration Coverage Program
-**Status:** in progress (2026-06-09) — Phase 0 complete (see [phase0-findings.md](phase0-findings.md)): decision is **GO, reframed** — a 351-test integration suite already exists but is dormant + rotting; revive/wire it rather than build new infra. Phase 1 = prune rot + wire the 22 no-auth files into CI; auth nightly is a follow-up.
+**Status:** in progress (2026-06-09) — Phase 0 complete (see [phase0-findings.md](phase0-findings.md)): decision **GO, reframed** — revive the existing 351-test suite, don't build new infra. Phase 1 **complete**: rot pruned (#703), green subset wired to CI (#704), 16-failure backlog cleared + job promoted to the full no-auth suite (295 passed / 0 failed — see [phase1-triage.md](phase1-triage.md)). Remaining: the opt-in nightly auth job (8 `*_with_auth` files + 6 env-gated discovery_sweep files), then promote the CI job to a required check after a few weeks green.
 ---
 
 ## Phase 0 — Audit before design

--- a/src/attune/memory/cross_session/coordinator.py
+++ b/src/attune/memory/cross_session/coordinator.py
@@ -66,15 +66,18 @@ class CrossSessionCoordinator:
         """Initialize cross-session coordinator.
 
         Args:
-            memory: RedisShortTermMemory instance (must not be mock)
+            memory: RedisShortTermMemory instance (mock mode allowed —
+                coordination runs in degraded mode without Redis)
             session_type: Type of this session
             access_tier: Access tier for this session
             capabilities: List of capabilities this session supports
             auto_announce: Whether to announce presence on init
 
-        Raises:
-            ValueError: If memory is in mock mode (Redis required)
-            ImportError: If Redis package is not installed
+        Note:
+            When memory is in mock mode or Redis is unavailable, the
+            coordinator initializes in degraded mode (logs a warning;
+            cross-process coordination features are unavailable) rather
+            than raising.
 
         """
         # Verify Redis is available -- degrade gracefully in mock mode

--- a/tests/integration/rag/test_rag_workflow.py
+++ b/tests/integration/rag/test_rag_workflow.py
@@ -268,10 +268,11 @@ def test_execute_surfaces_sdk_generic_exception_as_error_result() -> None:
 
     assert result.success is False
     assert result.error is not None
-    # PR #357 (2026-04-17) reshaped sdk_error_message output:
-    # "Agent SDK error" → "Agent SDK failure (<ExceptionType>)".
-    assert "Agent SDK failure" in result.error
-    assert "ValueError" in result.error
+    # PR #543 (sdk-error-message-fidelity) reshaped error results:
+    # unknown exceptions surface as a subprocess-failure message with
+    # metadata.sdk_error_kind == "unknown".
+    assert "claude CLI subprocess failed" in result.error
+    assert result.metadata.get("sdk_error_kind") == "unknown"
 
 
 def test_execute_passes_model_override_to_sdk_options() -> None:

--- a/tests/integration/test_discovery_sweep_bug_predict_integration.py
+++ b/tests/integration/test_discovery_sweep_bug_predict_integration.py
@@ -15,6 +15,7 @@ The test runs against a tiny on-disk fixture so spend stays low
 
 from __future__ import annotations
 
+import os
 import textwrap
 from pathlib import Path
 
@@ -22,7 +23,13 @@ import pytest
 
 from attune.workflows.discovery_sweep.sources.bug_predict import BugPredictSource
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="hits the real Anthropic API — auth-gated (nightly auth job)",
+    ),
+]
 
 
 _FIXTURE_BUGGY_SOURCE = textwrap.dedent(

--- a/tests/integration/test_discovery_sweep_dependency_check_integration.py
+++ b/tests/integration/test_discovery_sweep_dependency_check_integration.py
@@ -17,6 +17,7 @@ mostly Bash/Read calls) — well within the cap.
 
 from __future__ import annotations
 
+import os
 import textwrap
 from pathlib import Path
 
@@ -26,7 +27,13 @@ from attune.workflows.discovery_sweep.sources.dependency_check import (
     DependencyCheckSource,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="hits the real Anthropic API — auth-gated (nightly auth job)",
+    ),
+]
 
 
 # Deliberately pinned to OLD versions of well-known packages so the

--- a/tests/integration/test_discovery_sweep_doc_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_doc_audit_integration.py
@@ -15,6 +15,7 @@ spend stays low (~$2 SDK cap per :func:`get_max_budget_usd`).
 
 from __future__ import annotations
 
+import os
 import textwrap
 from pathlib import Path
 
@@ -22,7 +23,13 @@ import pytest
 
 from attune.workflows.discovery_sweep.sources.doc_audit import DocAuditSource
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="hits the real Anthropic API — auth-gated (nightly auth job)",
+    ),
+]
 
 
 _FIXTURE_STALE_README = textwrap.dedent(

--- a/tests/integration/test_discovery_sweep_perf_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_perf_audit_integration.py
@@ -15,6 +15,7 @@ spend stays low (~$2 SDK cap per :func:`get_max_budget_usd`).
 
 from __future__ import annotations
 
+import os
 import textwrap
 from pathlib import Path
 
@@ -22,7 +23,13 @@ import pytest
 
 from attune.workflows.discovery_sweep.sources.perf_audit import PerfAuditSource
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="hits the real Anthropic API — auth-gated (nightly auth job)",
+    ),
+]
 
 
 _FIXTURE_SLOW_SOURCE = textwrap.dedent(

--- a/tests/integration/test_discovery_sweep_security_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_security_audit_integration.py
@@ -17,6 +17,7 @@ three; budget accordingly when iterating.
 
 from __future__ import annotations
 
+import os
 import textwrap
 from pathlib import Path
 
@@ -24,7 +25,13 @@ import pytest
 
 from attune.workflows.discovery_sweep.sources.security_audit import SecurityAuditSource
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="hits the real Anthropic API — auth-gated (nightly auth job)",
+    ),
+]
 
 
 _FIXTURE_VULNERABLE_SOURCE = textwrap.dedent(

--- a/tests/integration/test_discovery_sweep_test_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_test_audit_integration.py
@@ -15,6 +15,7 @@ spend stays low (~$2 SDK cap per :func:`get_max_budget_usd`).
 
 from __future__ import annotations
 
+import os
 import textwrap
 from pathlib import Path
 
@@ -22,7 +23,13 @@ import pytest
 
 from attune.workflows.discovery_sweep.sources.test_audit import TestAuditSource
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="hits the real Anthropic API — auth-gated (nightly auth job)",
+    ),
+]
 
 
 _FIXTURE_UNDER_TESTED_SOURCE = textwrap.dedent(

--- a/tests/integration/test_graceful_degradation.py
+++ b/tests/integration/test_graceful_degradation.py
@@ -9,8 +9,6 @@ Licensed under the Apache License, Version 2.0
 
 from unittest.mock import patch
 
-import pytest
-
 
 class TestGracefulDegradationMemory:
     """Test memory module graceful degradation without Redis."""
@@ -28,34 +26,38 @@ class TestGracefulDegradationMemory:
 
         assert result == {"data": "value"}
 
-    def test_redis_short_term_memory_requires_redis(self):
-        """Test RedisShortTermMemory raises helpful error without Redis."""
-        with patch("attune.memory.is_redis_available", return_value=False):
-            with pytest.raises(ImportError) as exc_info:
-                from attune.memory import RedisShortTermMemory
+    def test_redis_short_term_memory_falls_back_to_mock_without_redis(self):
+        """RedisShortTermMemory degrades to in-memory mock mode without Redis.
 
-                # Should fail with helpful message
-                RedisShortTermMemory()
+        Production behavior changed from raising ImportError to graceful
+        degradation: the constructor auto-enables mock mode (with a logged
+        warning) when no Redis server is reachable.
+        """
+        with patch(
+            "attune.memory.short_term.facade.MemoryFeatures.check_redis",
+            return_value=False,
+        ):
+            from attune.memory import RedisShortTermMemory
 
-            error_message = str(exc_info.value)
-            assert "requires Redis" in error_message
-            assert "pip install" in error_message
+            memory = RedisShortTermMemory()
 
-    def test_cross_session_coordinator_requires_redis(self):
-        """Test CrossSessionCoordinator raises error without Redis."""
-        with patch("attune.memory.is_redis_available", return_value=False):
-            from attune.memory import CrossSessionCoordinator
-            from attune.memory.types import RedisConfig
+            assert memory.use_mock is True
 
-            # Create mock memory with use_mock=True
-            with pytest.raises(ImportError) as exc_info:
-                from attune.memory.short_term import RedisShortTermMemory
+    def test_cross_session_coordinator_degrades_without_redis(self):
+        """CrossSessionCoordinator runs in degraded mode without Redis.
 
-                memory = RedisShortTermMemory(config=RedisConfig(use_mock=True))
-                CrossSessionCoordinator(memory)
+        Production behavior changed from raising ImportError to graceful
+        degradation: with a mock-mode memory the coordinator initializes,
+        logs a warning, and sets its internal degraded flag.
+        """
+        from attune.memory import CrossSessionCoordinator
+        from attune.memory.short_term import RedisShortTermMemory
+        from attune.memory.types import RedisConfig
 
-            error_message = str(exc_info.value)
-            assert "requires Redis" in error_message
+        memory = RedisShortTermMemory(config=RedisConfig(use_mock=True))
+        coordinator = CrossSessionCoordinator(memory)
+
+        assert coordinator._degraded is True
 
     def test_long_term_memory_works_without_redis(self, tmp_path):
         """Test long-term memory works without Redis."""
@@ -108,6 +110,10 @@ class TestGracefulDegradationTelemetry:
             cache_type=None,
             duration_ms=100,
         )
+
+        # UsageTracker buffers writes (buffer_size=50 default) and only
+        # persists on flush — flush explicitly before asserting the file.
+        tracker.flush()
 
         # Verify file was created
         assert (tmp_path / "telemetry" / "usage.jsonl").exists()

--- a/tests/integration/test_telemetry_integration.py
+++ b/tests/integration/test_telemetry_integration.py
@@ -86,27 +86,34 @@ async def test_workflow_tracks_llm_calls(tracker):
 
 @pytest.mark.asyncio
 async def test_workflow_tracks_cache_hits(tracker):
-    """Test that cache hits are tracked in telemetry."""
-    # Create workflow with caching enabled
-    workflow = TestWorkflow(enable_cache=True)
+    """Test that cache hits are tracked in telemetry.
 
-    # Mock cache that returns a hit
-    mock_cache = MagicMock()
-    mock_cache.get = MagicMock(
-        return_value={
-            "content": "Cached response",
-            "input_tokens": 100,
-            "output_tokens": 50,
-        },
+    Client-side response caching was removed in favor of Anthropic's
+    server-side prompt caching, so ``_try_cache_lookup`` is a no-op by
+    default (a ``ctx.cache`` service can still supply hits). Patch the
+    lookup directly to exercise the live cache-hit telemetry branch in
+    ``_call_llm``.
+    """
+    from attune.workflows.caching import CachedResponse
+
+    workflow = TestWorkflow()
+
+    cached = CachedResponse(
+        content="Cached response",
+        input_tokens=100,
+        output_tokens=50,
     )
-    workflow._cache = mock_cache
+    workflow._try_cache_lookup = MagicMock(return_value=cached)
 
-    # Call _call_llm to trigger cache hit
+    # Call _call_llm to trigger the cache-hit branch
     content, in_tokens, out_tokens = await workflow._call_llm(
         tier=ModelTier.CAPABLE,
         system="Test system",
         user_message="Test message",
     )
+
+    assert content == "Cached response"
+    assert (in_tokens, out_tokens) == (100, 50)
 
     # Check telemetry
     entries = tracker.get_recent_entries(limit=1)

--- a/tests/integration/test_tier1_tracking.py
+++ b/tests/integration/test_tier1_tracking.py
@@ -30,15 +30,22 @@ def temp_dir():
 
 @pytest.fixture
 def mock_telemetry_dir(temp_dir, monkeypatch):
-    """Mock the telemetry directory for testing."""
-    # Reset the global telemetry store singleton
-    import attune.models.telemetry
+    """Isolate the telemetry store singleton to a temp directory.
+
+    The singleton consulted by ``get_telemetry_store()`` is
+    ``attune.models.telemetry._store_instance`` — an earlier version of
+    this fixture set a ``_telemetry_store`` attribute that nothing reads
+    (the singleton was renamed in a refactor), so tests silently wrote
+    to a cwd-relative ``.attune/`` directory instead of ``temp_dir``.
+    """
+    import attune.models.telemetry as telemetry_pkg
     from attune.models.telemetry import TelemetryStore
 
-    # Create a fresh telemetry store with the temp directory
-    attune.models.telemetry._telemetry_store = TelemetryStore(storage_dir=str(temp_dir))
-
-    monkeypatch.setenv("EMPATHY_TELEMETRY_DIR", str(temp_dir))
+    monkeypatch.setattr(
+        telemetry_pkg,
+        "_store_instance",
+        TelemetryStore(storage_dir=str(temp_dir)),
+    )
     return temp_dir
 
 


### PR DESCRIPTION
## Summary

integration-coverage **Phase 1 completion**: clears the entire 16-failure revival backlog recorded in `docs/specs/integration-coverage/phase1-triage.md` and promotes the advisory `integration-tests.yml` job from a hand-picked 10-file green subset to the **full no-auth suite** (`tests/integration -k "not with_auth"`, 295 tests).

**Triage verdict: zero production bugs.** Every red file was a stale test or broken test infrastructure:

| Cluster | Root cause (verified) | Fix |
|---|---|---|
| `test_discovery_sweep_*` (×6) | Not timeouts — they hit the **real Anthropic API by design** (each docstring says so); keyless they spawn the subscription `claude` CLI and get prose instead of stream-json (~105 s, then fail). They pre-date the keyless CI job. | Env-gated (`skipif` on `ANTHROPIC_API_KEY`) — they join the auth bucket for the future nightly job. |
| `rag/test_rag_workflow.py` | Stale pre-#543 error-shape assertion. | Updated to the sdk-error-message-fidelity shape. |
| `test_tier1_tracking.py` | Three-layer fixture rot: `mock_telemetry_dir` reset `_telemetry_store`, but the singleton was renamed `_store_instance` — isolation silently inert; tests polluted a cwd-relative `.attune/`; `_read_jsonl` returns oldest-first so "latest_execution" read a stale record. | Fixture now monkeypatches `_store_instance` with a temp-dir store. |
| `test_graceful_degradation.py` (×3) | Two tests asserted the old raise-ImportError contract; production moved to graceful degradation (facade mock-mode fallback, coordinator `_degraded` flag). `UsageTracker` buffers writes, so the file-exists assertion needed a flush. | Rewrote the two redis tests to assert degradation; added `tracker.flush()`. Fixed the coordinator's stale "Raises ImportError" docstring (only production-file change, docs-only). |
| `test_telemetry_integration.py` | Tested **removed functionality** — the client-side cache (`workflow._cache`, read by nothing since the semantic-cache retirement). | Rewritten to patch `_try_cache_lookup`, exercising the live cache-hit telemetry branch. |

## Verification

Keyless (CI-exact `ANTHROPIC_API_KEY=""`), `-n auto`:

```
295 passed, 41 skipped in 5.55s
```

The job stays **advisory/non-required**; promote to a required check after a few weeks of green runs. Remaining Phase 1 follow-up: the opt-in nightly auth job (8 `*_with_auth` files + the 6 newly env-gated discovery_sweep files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
