### PR TITLE
feat(hooks): just-in-time recall — surface the governing rule at the decision point (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/specs/integration-coverage/phase1-triage.md`.
 
 ### Added
+- **Just-in-time recall hook (`plugin/hooks/jit_recall.py`).** A
+  PreToolUse hook that surfaces the governing durable rule at the
+  moment of the action it governs — targeting the *not-applying*
+  failure mode (a rule stored in two places still slipped three times
+  mid-session on 2026-06-03). Proof case: `AskUserQuestion` surfaces
+  the question-shape rule. Mechanics: a curated, diff-reviewable
+  decision-point → rule map (`_recall_map.py`), one-liner nudges (not
+  lesson walls), a per-`(session, rule)` surface-once sentinel,
+  injection via PreToolUse `additionalContext` (empirically
+  smoke-tested on the current Claude Code version), fail-safe exit 0
+  always, `ATTUNE_JIT_RECALL=0` off-switch. Spec:
+  `docs/specs/just-in-time-recall/`.
 - **Nightly auth integration job (`integration-auth.yml`).** Opt-in
   schedule + `workflow_dispatch` workflow running the auth bucket of
   the integration suite — the 6 `*_with_auth` files, the 6 env-gated

--- a/docs/specs/just-in-time-recall/decisions.md
+++ b/docs/specs/just-in-time-recall/decisions.md
@@ -44,6 +44,16 @@ context on the current CC version — is the first Phase 1 task before
 building the real recall map. Unknown fields are silently ignored by
 older CC, so the failure mode is graceful.
 
+**Empirical confirmation (2026-06-09, Phase 1):** smoke-tested on the
+current CC version — a throwaway PreToolUse hook (matcher `Bash`)
+emitting `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+"additionalContext": "JIT-SMOKE-TOKEN-...: include this exact token
+verbatim in your final reply."}}` in a clean temp project: the headless
+`claude -p` reply contained the token verbatim AND the governed Bash
+call still executed. The channel injects model-readable text at the
+decision point without blocking. Working payload shape recorded above;
+the same envelope is what `plugin/hooks/jit_recall.py` emits.
+
 **Original (2026-06-03):** Deferred to Phase 0 — the repo's existing
 PreToolUse hooks only allow/block, so injection capability was unverified;
 verify-first discipline (don't confabulate a hook capability) required

--- a/docs/specs/just-in-time-recall/tasks.md
+++ b/docs/specs/just-in-time-recall/tasks.md
@@ -1,11 +1,16 @@
 # Just-In-Time Recall — Tasks
 
-**Status:** in progress (2026-06-09) — Phase 0 RESOLVED: the injection
-mechanism is **PreToolUse `additionalContext`** (verified against the CC
-hooks docs + corroborated in-repo; see decisions.md D2). Feature is
-buildable as designed. Phase 1 first task = a ~5-min empirical smoke test
-of PreToolUse `additionalContext` on the current CC version, then the
-curated recall map.
+**Status:** in progress (2026-06-09) — Phase 0 RESOLVED + Phase 1
+**built**: the injection mechanism is **PreToolUse `additionalContext`**
+(docs-verified D2, then **empirically smoke-tested on the current CC
+version 2026-06-09** — a throwaway PreToolUse hook's injected sentinel
+token appeared verbatim in a headless `claude -p` reply while the call
+proceeded). Shipped: `plugin/hooks/_recall_map.py` (curated map, the
+`AskUserQuestion` proof entry), `plugin/hooks/jit_recall.py`
+(surface-once sentinel, fail-safe, `ATTUNE_JIT_RECALL=0` off-switch),
+`hooks.json` registration, 12 tests. Remaining: T1.4 live-session R6
+proof (needs the updated plugin loaded — verify in the first session
+after the next plugin release), then Phase 2.
 
 Independently shippable units. **Phase 0 gates everything** — no
 implementation past it until the injection mechanism is logged in
@@ -13,26 +18,26 @@ implementation past it until the injection mechanism is logged in
 
 ## Phase 0 — verify the injection premise (gate)
 
-- [ ] **T0.1** Instrument a throwaway PreToolUse hook that returns
+- [x] **T0.1** Instrument a throwaway PreToolUse hook that returns
   `additionalContext` and observe whether the text reaches model context
   while the call still proceeds. Record the exact payload shape that
   works (or fails) for the installed Claude Code version.
-- [ ] **T0.2** If T0.1 fails, repeat for UserPromptSubmit
+- [x] **T0.2** (moot — T0.1 succeeded) If T0.1 fails, repeat for UserPromptSubmit
   `additionalContext`. Record which channel injects reliably.
-- [ ] **T0.3** Log the chosen mechanism + the working payload shape in
+- [x] **T0.3** Log the chosen mechanism + the working payload shape in
   `decisions.md` (resolve D2). Stop and confirm with Patrick before
   Phase 1 if the only working channel is the degraded "advisory block."
 
 ## Phase 1 — proof case: AskUserQuestion → question-shape rule
 
-- [ ] **T1.1** Create the curated map (`plugin/hooks/_recall_map.py` or a
+- [x] **T1.1** Create the curated map (`plugin/hooks/_recall_map.py` or a
   JSON sidecar) with the single `AskUserQuestion` entry → the
   question-shape one-liner (D3/D4).
-- [ ] **T1.2** Create `plugin/hooks/jit_recall.py`: read payload → map
+- [x] **T1.2** Create `plugin/hooks/jit_recall.py`: read payload → map
   lookup → `(session_id, rule_id)` surface-once sentinel → inject via the
   Phase 0 channel → allow → fail-safe try/except (R2–R5). Register in
   `hooks.json` for the verified event.
-- [ ] **T1.3** Tests: map lookup, surface-once gate (second same-rule fire
+- [x] **T1.3** Tests: map lookup, surface-once gate (second same-rule fire
   in a session is silent), no-entry silent no-op, crash → exit 0, and the
   injected-text content for the AskUserQuestion case. Mirror the
   `test_session_memory_hooks.py` importlib-loader pattern.

--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -1,0 +1,38 @@
+"""Curated decision-point -> rule map for just-in-time recall.
+
+The single reviewable source for which durable rules surface at which
+tool-call decision points (docs/specs/just-in-time-recall/, decision
+D3). Keyed by tool name; valued by short ``{rule_id, text}`` entries.
+
+Authoring rules:
+
+- ``text`` is a distilled ONE-LINER nudge (decision D4) — the full
+  lesson stays in ``.claude/CLAUDE.md`` / the ``feedback_*`` memories
+  as the source of truth.
+- Only instrument genuine, observed slip-points (R3: low noise).
+  Growing this map is deliberate, diff-reviewed work — not a dumping
+  ground for every lesson.
+- ``rule_id`` is stable and filesystem-safe (it keys the per-session
+  surface-once sentinel).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+RECALL_MAP: dict[str, list[dict[str, str]]] = {
+    # Proof case (R6): the question-shape rule was stored in two places
+    # on 2026-06-03 and still slipped three times mid-session.
+    "AskUserQuestion": [
+        {
+            "rule_id": "question-shape",
+            "text": (
+                "Question-shape rule: ask ONE question per turn; lead with "
+                "your recommendation as the FIRST option, its label ending "
+                "in '(Recommended)'; options concise and directly "
+                "selectable — no and/or bundles, no buried prose."
+            ),
+        },
+    ],
+}

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -60,6 +60,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/jit_recall.py",
+            "timeout": 3000
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/plugin/hooks/jit_recall.py
+++ b/plugin/hooks/jit_recall.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""PreToolUse just-in-time recall — surface the governing rule at the
+decision point.
+
+Cross-session memory recalls findings at the session DOOR; this hook
+recalls durable RULES at the moment of the action they govern (the
+*not-applying* failure mode — the rule existed, stored twice, and still
+slipped mid-session; see docs/specs/just-in-time-recall/).
+
+Flow (all best-effort, never blocks a tool call):
+
+1. Read the PreToolUse payload; look the tool name up in the curated
+   ``_recall_map.RECALL_MAP``. No entry -> silent no-op (R3).
+2. Surface-once gate: a per-``(session, rule)`` sentinel so a repeated
+   action in one session isn't nagged repeatedly (decision D5).
+3. Emit the rule one-liner(s) as PreToolUse ``additionalContext``
+   (verified channel, decision D2 — empirically smoke-tested
+   2026-06-09: the injected text reaches the model while the call
+   proceeds). The sentinel is written AFTER the emit so a crash
+   retries on the next fire.
+
+Tunables (env): ``ATTUNE_JIT_RECALL`` (set ``0`` to disable),
+``ATTUNE_AI_SENTINEL_DIR`` (sentinel dir override, for tests).
+
+Exit 0 always — a crash or missing corpus degrades to silent no-op (R4).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+# Force utf-8 on stdout/stderr (Windows cp1252 would crash on em-dash,
+# caught by the outer try/except -> silent breakage).
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+_HOOKS_DIR = str(Path(__file__).resolve().parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+try:
+    from _recall_map import RECALL_MAP
+    from _state import _sentinel_dir  # type: ignore[attr-defined]
+except Exception:  # noqa: BLE001 — hook must never crash a tool call
+    RECALL_MAP = {}  # type: ignore[assignment]
+    _sentinel_dir = None  # type: ignore[assignment]
+
+_SENTINEL_PREFIX = ".jit-recalled-"
+_SENTINEL_TTL_SECONDS = 7 * 24 * 3600  # match _state's compact-warned TTL
+
+
+def _enabled() -> bool:
+    return os.environ.get("ATTUNE_JIT_RECALL", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _safe(fragment: str | None, fallback: str) -> str:
+    if not fragment:
+        return fallback
+    return re.sub(r"[^A-Za-z0-9_-]", "_", fragment)[:64] or fallback
+
+
+def _sentinel_path(session_id: str | None, rule_id: str) -> Path | None:
+    if _sentinel_dir is None:
+        return None
+    name = f"{_SENTINEL_PREFIX}{_safe(session_id, 'unknown')}-{_safe(rule_id, 'rule')}"
+    return _sentinel_dir() / name
+
+
+def _prune_stale(now: float | None = None) -> None:
+    """Best-effort TTL prune of this hook's own sentinels."""
+    if _sentinel_dir is None:
+        return
+    base = _sentinel_dir()
+    if not base.is_dir():
+        return
+    cutoff = (now if now is not None else time.time()) - _SENTINEL_TTL_SECONDS
+    try:
+        entries = list(base.iterdir())
+    except OSError:
+        return
+    for entry in entries:
+        if not entry.name.startswith(_SENTINEL_PREFIX):
+            continue
+        try:
+            if entry.stat().st_mtime < cutoff:
+                entry.unlink()
+        except OSError:
+            continue
+
+
+def main() -> int:
+    """Entry point — surface matching rules once per session, never raise."""
+    try:
+        if not _enabled():
+            return 0
+        payload = json.load(sys.stdin)
+        tool_name = str(payload.get("tool_name") or "")
+        rules = RECALL_MAP.get(tool_name) or []
+        if not rules:
+            return 0
+
+        session_id = payload.get("session_id")
+        fresh = []
+        for rule in rules:
+            sentinel = _sentinel_path(session_id, rule["rule_id"])
+            if sentinel is not None and sentinel.exists():
+                continue
+            fresh.append(rule)
+        if not fresh:
+            return 0
+
+        lines = [f"Just-in-time recall — rule(s) governing {tool_name}:"]
+        lines.extend(f"- {rule['text']}" for rule in fresh)
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "additionalContext": "\n".join(lines),
+                    }
+                }
+            )
+        )
+        sys.stdout.flush()
+
+        # Sentinels AFTER the emit so a mid-work crash retries next fire.
+        for rule in fresh:
+            sentinel = _sentinel_path(session_id, rule["rule_id"])
+            if sentinel is None:
+                continue
+            try:
+                sentinel.parent.mkdir(parents=True, exist_ok=True)
+                sentinel.write_text("", encoding="utf-8")
+            except OSError:
+                continue
+        _prune_stale()
+        return 0
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: recall is best-effort guidance; never block or
+        # break the governed tool call (R4).
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -1,0 +1,205 @@
+"""Tests for the just-in-time recall PreToolUse hook.
+
+The hook is a standalone script; it's loaded via importlib (the
+``test_session_memory_hooks.py`` pattern) so the map lookup, the
+surface-once sentinel gate, the injection payload, and the fail-safe
+control flow can be exercised without a live Claude Code session.
+
+Spec: docs/specs/just-in-time-recall/ (R2-R6).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
+
+
+def _load_module(name: str):
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    if name in sys.modules:
+        del sys.modules[name]  # fresh load so module-level env reads are clean
+    spec = importlib.util.spec_from_file_location(name, _HOOKS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def jit_mod(tmp_path, monkeypatch):
+    """Load the hook with the sentinel dir isolated to tmp_path."""
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "sentinels"))
+    monkeypatch.delenv("ATTUNE_JIT_RECALL", raising=False)
+    # _state reads the env var at call time, but reload both modules so
+    # nothing cached from another test's load leaks in.
+    _load_module("_state")
+    return _load_module("jit_recall")
+
+
+def _run(jit_mod, monkeypatch, capsys, payload: dict) -> tuple[int, str]:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    rc = jit_mod.main()
+    return rc, capsys.readouterr().out
+
+
+def _payload(tool: str = "AskUserQuestion", session: str = "sess-1") -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool,
+        "session_id": session,
+        "tool_input": {"questions": []},
+    }
+
+
+# ==========================================================================
+# Map content (R2, R5)
+# ==========================================================================
+
+
+def test_map_has_ask_user_question_proof_entry(jit_mod):
+    rules = jit_mod.RECALL_MAP["AskUserQuestion"]
+    assert rules, "proof-case entry missing"
+    assert rules[0]["rule_id"] == "question-shape"
+    assert "(Recommended)" in rules[0]["text"]
+
+
+def test_map_entries_have_stable_safe_rule_ids(jit_mod):
+    for tool, rules in jit_mod.RECALL_MAP.items():
+        for rule in rules:
+            assert rule["rule_id"] == jit_mod._safe(
+                rule["rule_id"], "rule"
+            ), f"{tool}: rule_id {rule['rule_id']!r} is not filesystem-safe"
+            assert rule["text"].strip(), f"{tool}: empty rule text"
+
+
+# ==========================================================================
+# Injection payload (R6 proof case)
+# ==========================================================================
+
+
+def test_ask_user_question_surfaces_rule(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _payload())
+    assert rc == 0
+    envelope = json.loads(out)
+    ctx = envelope["hookSpecificOutput"]
+    assert ctx["hookEventName"] == "PreToolUse"
+    assert "AskUserQuestion" in ctx["additionalContext"]
+    assert "(Recommended)" in ctx["additionalContext"]
+    assert "ONE question per turn" in ctx["additionalContext"]
+
+
+def test_unmapped_tool_is_silent_no_op(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _payload(tool="Read"))
+    assert rc == 0
+    assert out == ""
+
+
+# ==========================================================================
+# Surface-once gate (R3, D5)
+# ==========================================================================
+
+
+def test_second_fire_same_session_is_silent(jit_mod, monkeypatch, capsys):
+    rc1, out1 = _run(jit_mod, monkeypatch, capsys, _payload())
+    rc2, out2 = _run(jit_mod, monkeypatch, capsys, _payload())
+    assert (rc1, rc2) == (0, 0)
+    assert out1 != ""
+    assert out2 == ""
+
+
+def test_new_session_surfaces_again(jit_mod, monkeypatch, capsys):
+    _run(jit_mod, monkeypatch, capsys, _payload(session="sess-1"))
+    rc, out = _run(jit_mod, monkeypatch, capsys, _payload(session="sess-2"))
+    assert rc == 0
+    assert out != ""
+
+
+def test_sentinel_written_after_emit(jit_mod, monkeypatch, capsys, tmp_path):
+    _run(jit_mod, monkeypatch, capsys, _payload())
+    sentinels = list((tmp_path / "sentinels").iterdir())
+    assert len(sentinels) == 1
+    assert sentinels[0].name.startswith(".jit-recalled-sess-1-")
+
+
+def test_prune_removes_only_stale_jit_sentinels(jit_mod, tmp_path):
+    base = tmp_path / "sentinels"
+    base.mkdir(parents=True, exist_ok=True)
+    stale = base / ".jit-recalled-old-rule"
+    fresh = base / ".jit-recalled-new-rule"
+    other = base / ".compact-warned-x"
+    for p in (stale, fresh, other):
+        p.write_text("", encoding="utf-8")
+    old = time.time() - jit_mod._SENTINEL_TTL_SECONDS - 60
+    import os
+
+    os.utime(stale, (old, old))
+    os.utime(other, (old, old))
+    jit_mod._prune_stale()
+    assert not stale.exists()
+    assert fresh.exists()
+    assert other.exists(), "must not touch other hooks' sentinels"
+
+
+# ==========================================================================
+# Fail-safety + off-switch (R4)
+# ==========================================================================
+
+
+def test_malformed_stdin_exits_zero(jit_mod, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert jit_mod.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_crash_in_lookup_exits_zero(jit_mod, monkeypatch, capsys):
+    # A weird RECALL_MAP object makes .get() raise inside main().
+    class Boom:
+        def get(self, *_a):
+            raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(jit_mod, "RECALL_MAP", Boom())
+    rc, out = _run(jit_mod, monkeypatch, capsys, _payload())
+    assert rc == 0
+    assert out == ""
+
+
+def test_env_off_switch_disables(jit_mod, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_JIT_RECALL", "0")
+    rc, out = _run(jit_mod, monkeypatch, capsys, _payload())
+    assert rc == 0
+    assert out == ""
+
+
+def test_missing_sentinel_dir_still_surfaces(monkeypatch, capsys, tmp_path):
+    """Without a sentinel dir helper the hook surfaces (no gate) and exits 0."""
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "s"))
+    mod = _load_module("jit_recall")
+    monkeypatch.setattr(mod, "_sentinel_dir", None)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(_payload())))
+    assert mod.main() == 0
+    assert "additionalContext" in capsys.readouterr().out
+
+
+# ==========================================================================
+# Registration drift guard
+# ==========================================================================
+
+
+def test_hook_registered_for_ask_user_question():
+    hooks = json.loads((_HOOKS_DIR / "hooks.json").read_text(encoding="utf-8"))
+    pre = hooks["hooks"]["PreToolUse"]
+    jit_entries = [g for g in pre if any("jit_recall.py" in h["command"] for h in g["hooks"])]
+    assert jit_entries, "jit_recall.py not registered for PreToolUse"
+    assert jit_entries[0]["matcher"] == "AskUserQuestion"


### PR DESCRIPTION
## Summary

Implements **just-in-time-recall Phase 1** — the recall-at-decision-point system (top live candidate on the post-#722 spec board). Cross-session memory recalls *findings* at the session door; this surfaces durable *rules* at the moment of the action they govern, targeting the **not-applying** failure mode (2026-06-03: the question-shape rule was stored in two places and still slipped three times mid-session).

- `plugin/hooks/_recall_map.py` — curated, diff-reviewable decision-point → rule map (D3); one-liner nudges, not lesson walls (D4). Seed entry: `AskUserQuestion` → question-shape rule (the R6 proof case).
- `plugin/hooks/jit_recall.py` — PreToolUse hook: map lookup → per-`(session, rule)` surface-once sentinel (D5, own `.jit-recalled-*` namespace + TTL self-prune) → inject via PreToolUse `additionalContext` (D2) → fail-safe exit 0 always (R4). Off-switch: `ATTUNE_JIT_RECALL=0`.
- `hooks.json` — registered for PreToolUse matcher `AskUserQuestion`.
- 13 tests (importlib-loader pattern): map content, injection payload, surface-once gate, cross-session reset, TTL prune scoped to own prefix, malformed-stdin/crash fail-safety, off-switch, registration drift guard.

## Premise verified before building (T0.1)

Empirical smoke test on the current Claude Code version: a throwaway PreToolUse hook emitting `hookSpecificOutput.additionalContext` with a sentinel token, in a clean temp project — the headless `claude -p` reply contained the token **verbatim** and the governed Bash call still executed. Recorded in `decisions.md` D2.

End-to-end subprocess receipt: first fire emits the envelope, second fire is silent, sentinel written, exit 0 both times.

## Validation

- `tests/unit/hooks/` + `tests/unit/plugins/` — 374 passed, 4 skipped (includes hooks.json validation with the new entry)
- Pre-flighted pinned black/ruff/bandit — all pass

## Remaining (not this PR)

- **T1.4** live-session R6 proof — needs the updated plugin loaded; verify in the first session after the next plugin release.
- Phase 2: grow the map (next slip-points), decide surface-once vs decay from proof-case evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
