### PR TITLE
docs(discipline): update stale attune-verify status in the Discipline article

### DIFF
--- a/attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md
+++ b/attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md
@@ -558,8 +558,9 @@ it. Our implementation is the
 `attune-ai` as the tool belt (the plugin that orchestrates the
 disciplines), with `attune-author` (authoring help content),
 `attune-gui` (the ops dashboard), `attune-help` (the living-doc
-help layer), and `attune-rag` (retrieval over the help corpus) as
-the specialized tools the belt carries. The patterns above don't
+help layer), `attune-rag` (retrieval over the help corpus), and
+`attune-verify` (fact-checking generated content) as the
+specialized tools the belt carries. The patterns above don't
 require these specific tools — they require *some* tools that play
 these roles. If you'd rather wire your own, the disciplines stand
 alone; if you'd rather skip the wiring, the family is on PyPI.
@@ -899,9 +900,11 @@ link resolves, every numeric claim matches its source. The failure
 modes recur and are therefore automatable — fabricated symbols,
 flags, cross-references, route shapes, version-mismatched samples,
 insecure examples, fabricated counts — so a pass that checks them
-by name catches most of what slips past taste. (We are extracting
-this into a standalone fact-checker, attune-verify, so any
-generation pipeline can call it; it is specced, not yet shipped.)
+by name catches most of what slips past taste. (That pass now
+ships as a standalone fact-checker,
+[attune-verify](https://pypi.org/project/attune-verify/) —
+stdlib-only, on PyPI, wired into attune-ai as the `/verify`
+skill — so any generation pipeline can call it.)
 Grounding verifies the input; fact-checking verifies the output;
 together they bracket generation.
 
@@ -1143,7 +1146,8 @@ development plus earlier years in coordination-heavy roles outside
 engineering — patterns that shape his approach to contracts,
 pacing, and multi-party work. The past year-plus has been spent
 building the [attune-\* ecosystem](https://github.com/Smart-AI-Memory)
-— five PyPI packages (attune-ai, attune-rag, attune-author,
-attune-help, attune-gui) that together ship the workflow patterns
-described above. The evidence base for the claims here is that
-codebase and the multi-month working history that produced it.
+— six PyPI packages (attune-ai, attune-rag, attune-author,
+attune-help, attune-gui, attune-verify) that together ship the
+workflow patterns described above. The evidence base for the
+claims here is that codebase and the multi-month working history
+that produced it.

--- a/attune-ai-dev/discipline/index.html
+++ b/attune-ai-dev/discipline/index.html
@@ -745,8 +745,9 @@ it. Our implementation is the
 <code>attune-ai</code> as the tool belt (the plugin that orchestrates the
 disciplines), with <code>attune-author</code> (authoring help content),
 <code>attune-gui</code> (the ops dashboard), <code>attune-help</code> (the living-doc
-help layer), and <code>attune-rag</code> (retrieval over the help corpus) as
-the specialized tools the belt carries. The patterns above don't
+help layer), <code>attune-rag</code> (retrieval over the help corpus), and
+<code>attune-verify</code> (fact-checking generated content) as the
+specialized tools the belt carries. The patterns above don't
 require these specific tools — they require <em>some</em> tools that play
 these roles. If you'd rather wire your own, the disciplines stand
 alone; if you'd rather skip the wiring, the family is on PyPI.</p>
@@ -1049,9 +1050,11 @@ link resolves, every numeric claim matches its source. The failure
 modes recur and are therefore automatable — fabricated symbols,
 flags, cross-references, route shapes, version-mismatched samples,
 insecure examples, fabricated counts — so a pass that checks them
-by name catches most of what slips past taste. (We are extracting
-this into a standalone fact-checker, attune-verify, so any
-generation pipeline can call it; it is specced, not yet shipped.)
+by name catches most of what slips past taste. (That pass now
+ships as a standalone fact-checker,
+<a href="https://pypi.org/project/attune-verify/">attune-verify</a> —
+stdlib-only, on PyPI, wired into attune-ai as the <code>/verify</code>
+skill — so any generation pipeline can call it.)
 Grounding verifies the input; fact-checking verifies the output;
 together they bracket generation.</p>
 <h3>Verifying behavior — &quot;does it do the true thing?&quot;</h3>
@@ -1265,10 +1268,11 @@ development plus earlier years in coordination-heavy roles outside
 engineering — patterns that shape his approach to contracts,
 pacing, and multi-party work. The past year-plus has been spent
 building the <a href="https://github.com/Smart-AI-Memory">attune-* ecosystem</a>
-— five PyPI packages (attune-ai, attune-rag, attune-author,
-attune-help, attune-gui) that together ship the workflow patterns
-described above. The evidence base for the claims here is that
-codebase and the multi-month working history that produced it.</p>
+— six PyPI packages (attune-ai, attune-rag, attune-author,
+attune-help, attune-gui, attune-verify) that together ship the
+workflow patterns described above. The evidence base for the
+claims here is that codebase and the multi-month working history
+that produced it.</p>
 
   </article>
   <footer>


### PR DESCRIPTION
## What

The live Discipline article (`attune-ai-dev/discipline/`, served at attune-ai.dev/discipline) said attune-verify was "specced, not yet shipped" — stale since attune-verify 0.2.0 shipped to PyPI and became a core dep of attune-ai backing the `/verify` skill.

Three sites updated in one coherent pass:

1. **§7 fact-checking parenthetical** — now states it ships (PyPI link, stdlib-only, wired in as `/verify`).
2. **§4 family list** — attune-verify added as the sixth specialized tool.
3. **Authorship note** — "five PyPI packages" → six, with attune-verify in the list.

§1's "five PyPI packages tracked" dashboard line is a dated morning snapshot and intentionally left as-is.

`index.html` regenerated via `build_discipline.py` (both committed per the build convention).

## Verification

- All replacement claims verified against ground truth before writing: PyPI JSON API (0.2.0 live), `pyproject.toml` (`attune-verify>=0.1.0,<0.3` core dep), `plugin/skills/verify/SKILL.md` (skill exists).
- Rendered HTML grep: "specced, not yet shipped" gone; PyPI link + "six PyPI packages" present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)