### PR TITLE
fix(discovery-sweep): preserve raw agent text so the structured-emit JSON block survives result adaptation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7603,3 +7603,66 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   with_auth files still collect/run under the override. Same family
   as "spec-named work-scope drifts — grep the actual instances": the
   handoff is a hypothesis, the collection run is the receipt.
+
+- **`WorkflowResult.final_output` is NOT the raw agent text —
+  `AgentSDKResultAdapter.from_agent_output()` REWRITES it as formatted
+  markdown whenever its category parser extracts findings, dropping
+  anything else the raw text carried (e.g. a requested ```json
+  block)**: caught by the first valid-key nightly auth run
+  (27249886475, 2026-06-10) — every discovery-sweep LLM adapter
+  degraded to text-only fallback on every SUCCESSFUL run because the
+  model's STRUCTURED_EMIT_FOOTER JSON block never survived into
+  final_output. Fix (#729): the adapter preserves the unmodified text
+  on `metadata["raw_result_text"]`; consumers needing raw output read
+  that channel (`llm_source_base.findings_from_workflow_result()`
+  prefers it, final_output fallback). Rule: any consumer that asks the
+  model to embed machine-readable structure in its response must read
+  the RAW channel, never final_output. Companion assertion hole found
+  in the same triage: the sweep tests rejected only
+  `text-only-fallback` tags, so outright workflow FAILURES
+  (`source-failure` tags — e.g. the broken-key run) read as passes;
+  reject every non-organic tag, not just the one you expect.
+
+- **xdist worker-crash source #3: an "allows valid input" test that
+  deliberately lets the real SDK workflow run after validation —
+  spawns a `claude` CLI subprocess inside the worker**: extends the
+  windows-xdist-flakes crash inventory (subprocess spawns / DNS
+  probes). `test_mcp_path_containment.py::test_allows_in_workspace_path`
+  said "we're not mocking the workflow — that's OK"; after validation
+  passed, the real `claude_agent_sdk.query()` subprocess spawned and
+  crashed workers across ubuntu/macOS/windows + coverage lanes (main
+  red 2026-06-10, surfaced when #722's test-file churn shifted worker
+  distribution). Fix (#728): mock the workflow class at its SOURCE
+  module — the MCP handlers validate BEFORE the lazy workflow import,
+  so the mock preserves exactly the validation contract under test,
+  and the test can additionally assert the validated path reached
+  `execute()`. Rule: "the happy path will just fail later without an
+  API key" is never an acceptable substitute for mocking — keyless
+  failure modes include subprocess churn that kills xdist workers.
+
+- **Keyless-CI-faithful local runs need `ANTHROPIC_API_KEY=""`
+  (EMPTY), not `env -u` (UNSET) — unset lets `load_dotenv` inject the
+  real key from `~/.attune/anthropic.env` and the "keyless" run spends
+  real money**: `env -u ANTHROPIC_API_KEY pytest tests/integration`
+  ran 6 real SDK workflows (~$3, 8m46s) because dotenv only skips
+  variables that EXIST; CI sets the secret to the empty string, which
+  both blocks dotenv's injection AND makes `skipif(not
+  os.environ.get(...))` gates fire. The empty-string run matched CI
+  exactly (295 passed / 41 skipped, 5.8 s). Rule for any
+  provider-key-gated suite: simulate CI-keyless with `KEY="" pytest`,
+  never by unsetting.
+
+- **A lazily-constructed optional collaborator needs ONE no-mocks
+  construction test — cache-seeded and import-error path tests can't
+  catch a constructor that always raises**: the security wizard's
+  `_get_or_create_workflow()` passed four dead pre-SDK kwargs to
+  `SecurityAuditWorkflow`; the TypeError was swallowed by the
+  graceful-degradation `except` and the wizard silently ALWAYS used
+  its LLM fallback. Its tests covered only the pre-seeded-cache and
+  import-error paths, so the real construction never ran in CI
+  (#727's fix added `test_get_or_create_workflow_constructs_real_
+  workflow`). Same family as "registered ≠ working" and "passing
+  tests don't prove integration" — the specific rule: for every
+  `try: construct() except: return None` optional-enhancement
+  pattern, one test must execute the REAL constructor and assert
+  non-None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kwarg-free construction + a no-mocks regression test on the real
   construction path.
 
+- **Discovery-sweep structured-emit contract: the model's ```json block
+  was silently dropped.** `AgentSDKResultAdapter.from_agent_output()`
+  rewrites `final_output` as formatted markdown whenever its category
+  parser extracts findings — discarding the raw agent text, including
+  the JSON block `STRUCTURED_EMIT_FOOTER` requests. Every LLM sweep
+  adapter therefore degraded to the text-only fallback (caught by the
+  first valid-key nightly auth run, 27249886475). The adapter now
+  preserves the unmodified agent text on `metadata["raw_result_text"]`,
+  and the six sweep sources parse findings via a shared
+  `findings_from_workflow_result()` helper that prefers the raw channel
+  (with `final_output` fallback). The six discovery_sweep integration
+  tests additionally reject `source-failure` findings, closing the hole
+  that let outright workflow failures read as passes.
 ### Removed
 - **The 6 rotted `test_*_with_auth.py` integration files.** All
   pre-dated the SDK migration (dead constructor kwargs), and 5 of 6

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -1068,6 +1068,13 @@ class AgentSDKResultAdapter:
             "source": "agent_sdk",
             "subagent_count": len(subagent_names),
             "findings": findings,
+            # The UNMODIFIED agent text. final_output below may be
+            # REWRITTEN as formatted markdown when _parse_findings
+            # fires, which drops content the raw text carried — e.g.
+            # the ```json block discovery-sweep's STRUCTURED_EMIT_FOOTER
+            # requests (its adapters parse this field first; see
+            # llm_source_base.findings_from_workflow_result).
+            "raw_result_text": text,
         }
         if agent_run_result:
             result_metadata["num_turns"] = agent_run_result.num_turns

--- a/src/attune/workflows/discovery_sweep/llm_source_base.py
+++ b/src/attune/workflows/discovery_sweep/llm_source_base.py
@@ -204,6 +204,43 @@ def parse_findings_json(text: str, source_name: str) -> list[Finding]:
     return findings
 
 
+def findings_from_workflow_result(result: object, source_name: str) -> list[Finding]:
+    """Parse structured findings from a WorkflowResult.
+
+    Prefers ``metadata["raw_result_text"]`` — the UNMODIFIED agent
+    text — over ``final_output``. ``AgentSDKResultAdapter`` rewrites
+    ``final_output`` as formatted markdown whenever its category
+    parser extracts findings, which silently drops the ```json block
+    that :data:`STRUCTURED_EMIT_FOOTER` requests (caught by the
+    nightly auth run 27249886475 — every adapter fell back to the
+    text-only path). The raw channel carries the block intact;
+    ``final_output`` remains the fallback for results produced
+    before the channel existed.
+
+    Args:
+        result: A WorkflowResult (or duck-typed equivalent) from a
+            wrapped workflow.
+        source_name: Name of the calling adapter — threaded through
+            to :func:`parse_findings_json`.
+
+    Returns:
+        List of Finding objects (never empty — see
+        :func:`parse_findings_json`).
+    """
+    metadata = getattr(result, "metadata", None)
+    raw_text = ""
+    if isinstance(metadata, dict):
+        raw = metadata.get("raw_result_text")
+        if isinstance(raw, str):
+            raw_text = raw
+
+    final_output = getattr(result, "final_output", "") or ""
+    if not isinstance(final_output, str):
+        final_output = str(final_output)
+
+    return parse_findings_json(raw_text or final_output, source_name)
+
+
 class LLMSource:
     """Optional marker base for LLM-backed FindingSource adapters.
 

--- a/src/attune/workflows/discovery_sweep/sources/bug_predict.py
+++ b/src/attune/workflows/discovery_sweep/sources/bug_predict.py
@@ -5,7 +5,7 @@ lives at the workflow-instance level, NEVER class": this adapter
 constructs a fresh :class:`BugPredictionWorkflow` per call with
 :data:`STRUCTURED_EMIT_FOOTER` passed as the ``system_prompt_suffix``
 kwarg, invokes ``execute()`` once per path, and parses each
-workflow's ``final_output`` via :func:`parse_findings_json`. The
+workflow's each result via :func:`findings_from_workflow_result`. The
 wrapped workflow is unchanged for every other caller.
 
 The ``claude_agent_sdk`` import lives inside :meth:`discover` so the
@@ -21,7 +21,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..llm_source_base import (
+    STRUCTURED_EMIT_FOOTER,
+    LLMSource,
+    findings_from_workflow_result,
+)
 from ..workflow import Finding
 
 logger = logging.getLogger(__name__)
@@ -85,7 +89,7 @@ class BugPredictSource(LLMSource):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
-            findings.extend(parse_findings_json(result.final_output or "", self.name))
+            findings.extend(findings_from_workflow_result(result, self.name))
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/dependency_check.py
+++ b/src/attune/workflows/discovery_sweep/sources/dependency_check.py
@@ -5,7 +5,7 @@ pattern: constructs a fresh :class:`DependencyCheckWorkflow` per
 call with :data:`STRUCTURED_EMIT_FOOTER` passed via
 ``system_prompt_suffix`` (workflow-INSTANCE level augmentation per
 Phase 1.5 ``design.md``), invokes ``execute()`` once per path, and
-parses each result's ``final_output`` via :func:`parse_findings_json`.
+parses each result via :func:`findings_from_workflow_result`.
 
 ``budget_multiplier = 0.5`` reflects the dependency-check
 workflow's narrower spend profile — two subagents
@@ -27,7 +27,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..llm_source_base import (
+    STRUCTURED_EMIT_FOOTER,
+    LLMSource,
+    findings_from_workflow_result,
+)
 from ..workflow import Finding
 
 logger = logging.getLogger(__name__)
@@ -94,7 +98,7 @@ class DependencyCheckSource(LLMSource):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
-            findings.extend(parse_findings_json(result.final_output or "", self.name))
+            findings.extend(findings_from_workflow_result(result, self.name))
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/doc_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/doc_audit.py
@@ -6,8 +6,8 @@ pattern: constructs a fresh :class:`DocAuditWorkflow` per call
 with :data:`STRUCTURED_EMIT_FOOTER` passed via
 ``system_prompt_suffix`` (workflow-INSTANCE level augmentation
 per Phase 1.5 ``design.md``), invokes ``execute()`` once per
-path, and parses each result's ``final_output`` via
-:func:`parse_findings_json`.
+path, and parses each result via
+:func:`findings_from_workflow_result`.
 
 ``budget_multiplier = 1.0`` — doc-audit sits at the default slot
 in Phase 1.5's ratio table (security=4 / deps=0.5 / default=1).
@@ -27,7 +27,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..llm_source_base import (
+    STRUCTURED_EMIT_FOOTER,
+    LLMSource,
+    findings_from_workflow_result,
+)
 from ..workflow import Finding
 
 logger = logging.getLogger(__name__)
@@ -93,7 +97,7 @@ class DocAuditSource(LLMSource):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
-            findings.extend(parse_findings_json(result.final_output or "", self.name))
+            findings.extend(findings_from_workflow_result(result, self.name))
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/perf_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/perf_audit.py
@@ -6,7 +6,7 @@ Mirrors the :class:`BugPredictSource` / :class:`SecurityAuditSource`
 :data:`STRUCTURED_EMIT_FOOTER` passed via ``system_prompt_suffix``
 (workflow-INSTANCE level augmentation per Phase 1.5
 ``design.md``), invokes ``execute()`` once per path, and parses
-each result's ``final_output`` via :func:`parse_findings_json`.
+each result via :func:`findings_from_workflow_result`.
 
 ``budget_multiplier = 1.0`` — perf-audit sits at the default
 slot in the Phase 1.5 ratio table (security=4 / deps=0.5 /
@@ -26,7 +26,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..llm_source_base import (
+    STRUCTURED_EMIT_FOOTER,
+    LLMSource,
+    findings_from_workflow_result,
+)
 from ..workflow import Finding
 
 logger = logging.getLogger(__name__)
@@ -92,7 +96,7 @@ class PerfAuditSource(LLMSource):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
-            findings.extend(parse_findings_json(result.final_output or "", self.name))
+            findings.extend(findings_from_workflow_result(result, self.name))
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/security_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/security_audit.py
@@ -5,7 +5,7 @@ fresh :class:`SecurityAuditWorkflow` per call with
 :data:`STRUCTURED_EMIT_FOOTER` passed via ``system_prompt_suffix``
 (workflow-INSTANCE level augmentation per Phase 1.5 ``design.md``),
 invokes ``execute()`` once per path, and parses each result's
-``final_output`` via :func:`parse_findings_json`.
+each result via :func:`findings_from_workflow_result`.
 
 ``budget_multiplier = 4.0`` reflects the security-audit workflow's
 four specialized subagents (vuln-scanner, secret-detector,
@@ -27,7 +27,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..llm_source_base import (
+    STRUCTURED_EMIT_FOOTER,
+    LLMSource,
+    findings_from_workflow_result,
+)
 from ..workflow import Finding
 
 logger = logging.getLogger(__name__)
@@ -94,7 +98,7 @@ class SecurityAuditSource(LLMSource):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
-            findings.extend(parse_findings_json(result.final_output or "", self.name))
+            findings.extend(findings_from_workflow_result(result, self.name))
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/test_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/test_audit.py
@@ -8,7 +8,7 @@ The final Phase 2B adapter. Mirrors the
 :data:`STRUCTURED_EMIT_FOOTER` passed via ``system_prompt_suffix``
 (workflow-INSTANCE level augmentation per Phase 1.5
 ``design.md``), invokes ``execute()`` once per path, and parses
-each result's ``final_output`` via :func:`parse_findings_json`.
+each result via :func:`findings_from_workflow_result`.
 
 ``budget_multiplier = 1.0`` — test-audit sits at the default slot
 in Phase 1.5's ratio table (security=4 / deps=0.5 / default=1).
@@ -28,7 +28,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from ..llm_source_base import STRUCTURED_EMIT_FOOTER, LLMSource, parse_findings_json
+from ..llm_source_base import (
+    STRUCTURED_EMIT_FOOTER,
+    LLMSource,
+    findings_from_workflow_result,
+)
 from ..workflow import Finding
 
 logger = logging.getLogger(__name__)
@@ -94,7 +98,7 @@ class TestAuditSource(LLMSource):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
-            findings.extend(parse_findings_json(result.final_output or "", self.name))
+            findings.extend(findings_from_workflow_result(result, self.name))
 
         return findings
 

--- a/tests/integration/test_discovery_sweep_bug_predict_integration.py
+++ b/tests/integration/test_discovery_sweep_bug_predict_integration.py
@@ -76,3 +76,9 @@ async def test_bug_predict_source_returns_findings_for_buggy_fixture(
     assert not any(
         "text-only-fallback" in f.tags for f in findings
     ), "structured-emit contract failed — adapter fell back to text-only path"
+    # source-failure = the wrapped workflow raised or returned
+    # success=False. Without this assertion a broken key / dead SDK
+    # "passes" the test (it did on run 27249292521 — 18 s, zero spend).
+    assert not any(
+        "source-failure" in f.tags for f in findings
+    ), "wrapped workflow failed — findings are failure markers, not analysis"

--- a/tests/integration/test_discovery_sweep_dependency_check_integration.py
+++ b/tests/integration/test_discovery_sweep_dependency_check_integration.py
@@ -75,3 +75,9 @@ async def test_dependency_check_source_returns_findings_for_outdated_pyproject(
     assert not any(
         "text-only-fallback" in f.tags for f in findings
     ), "structured-emit contract failed — adapter fell back to text-only path"
+    # source-failure = the wrapped workflow raised or returned
+    # success=False. Without this assertion a broken key / dead SDK
+    # "passes" the test (it did on run 27249292521 — 18 s, zero spend).
+    assert not any(
+        "source-failure" in f.tags for f in findings
+    ), "wrapped workflow failed — findings are failure markers, not analysis"

--- a/tests/integration/test_discovery_sweep_doc_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_doc_audit_integration.py
@@ -86,3 +86,9 @@ async def test_doc_audit_source_returns_findings_for_stale_readme(
     assert not any(
         "text-only-fallback" in f.tags for f in findings
     ), "structured-emit contract failed — adapter fell back to text-only path"
+    # source-failure = the wrapped workflow raised or returned
+    # success=False. Without this assertion a broken key / dead SDK
+    # "passes" the test (it did on run 27249292521 — 18 s, zero spend).
+    assert not any(
+        "source-failure" in f.tags for f in findings
+    ), "wrapped workflow failed — findings are failure markers, not analysis"

--- a/tests/integration/test_discovery_sweep_perf_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_perf_audit_integration.py
@@ -87,3 +87,9 @@ async def test_perf_audit_source_returns_findings_for_slow_fixture(
     assert not any(
         "text-only-fallback" in f.tags for f in findings
     ), "structured-emit contract failed — adapter fell back to text-only path"
+    # source-failure = the wrapped workflow raised or returned
+    # success=False. Without this assertion a broken key / dead SDK
+    # "passes" the test (it did on run 27249292521 — 18 s, zero spend).
+    assert not any(
+        "source-failure" in f.tags for f in findings
+    ), "wrapped workflow failed — findings are failure markers, not analysis"

--- a/tests/integration/test_discovery_sweep_security_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_security_audit_integration.py
@@ -80,3 +80,9 @@ async def test_security_audit_source_returns_findings_for_vulnerable_fixture(
     assert not any(
         "text-only-fallback" in f.tags for f in findings
     ), "structured-emit contract failed — adapter fell back to text-only path"
+    # source-failure = the wrapped workflow raised or returned
+    # success=False. Without this assertion a broken key / dead SDK
+    # "passes" the test (it did on run 27249292521 — 18 s, zero spend).
+    assert not any(
+        "source-failure" in f.tags for f in findings
+    ), "wrapped workflow failed — findings are failure markers, not analysis"

--- a/tests/integration/test_discovery_sweep_test_audit_integration.py
+++ b/tests/integration/test_discovery_sweep_test_audit_integration.py
@@ -91,3 +91,9 @@ async def test_test_audit_source_returns_findings_for_under_tested_fixture(
     assert not any(
         "text-only-fallback" in f.tags for f in findings
     ), "structured-emit contract failed — adapter fell back to text-only path"
+    # source-failure = the wrapped workflow raised or returned
+    # success=False. Without this assertion a broken key / dead SDK
+    # "passes" the test (it did on run 27249292521 — 18 s, zero spend).
+    assert not any(
+        "source-failure" in f.tags for f in findings
+    ), "wrapped workflow failed — findings are failure markers, not analysis"

--- a/tests/unit/workflows/discovery_sweep/test_llm_source_base.py
+++ b/tests/unit/workflows/discovery_sweep/test_llm_source_base.py
@@ -14,6 +14,7 @@ from attune.workflows.discovery_sweep import Finding
 from attune.workflows.discovery_sweep.llm_source_base import (
     STRUCTURED_EMIT_FOOTER,
     LLMSource,
+    findings_from_workflow_result,
     parse_findings_json,
 )
 
@@ -262,3 +263,72 @@ def test_structured_emit_footer_documents_findings_schema() -> None:
     assert '"findings"' in STRUCTURED_EMIT_FOOTER
     assert '"severity"' in STRUCTURED_EMIT_FOOTER
     assert '"confidence"' in STRUCTURED_EMIT_FOOTER
+
+
+# ---------------------------------------------------------------------------
+# findings_from_workflow_result — raw-text channel preference
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    """Duck-typed WorkflowResult carrying just what the helper reads."""
+
+    def __init__(self, final_output: object, metadata: object = None) -> None:
+        self.final_output = final_output
+        self.metadata = metadata
+
+
+def _payload() -> dict:
+    return {
+        "findings": [
+            {
+                "severity": "high",
+                "title": "eval() in handler",
+                "description": "untrusted input reaches eval",
+                "confidence": 0.9,
+            }
+        ]
+    }
+
+
+def test_prefers_raw_result_text_over_rewritten_final_output() -> None:
+    """REGRESSION (nightly auth run 27249886475): the adapter rewrites
+    final_output as formatted markdown when its category parser fires,
+    dropping the ```json block. The raw channel must win.
+    """
+    result = _FakeResult(
+        final_output="**Overall Risk Score: 87 / 100**\n\nformatted markdown, no block",
+        metadata={"raw_result_text": _wrap(_payload())},
+    )
+    findings = findings_from_workflow_result(result, SOURCE)
+    assert len(findings) == 1
+    assert findings[0].title == "eval() in handler"
+    assert "text-only-fallback" not in findings[0].tags
+
+
+def test_falls_back_to_final_output_without_raw_channel() -> None:
+    """Results predating the raw channel still parse from final_output."""
+    result = _FakeResult(final_output=_wrap(_payload()), metadata={})
+    findings = findings_from_workflow_result(result, SOURCE)
+    assert len(findings) == 1
+    assert findings[0].severity == "high"
+
+
+def test_missing_metadata_and_empty_output_yields_fallback() -> None:
+    """No metadata + empty output degrades to the fallback Finding."""
+    result = _FakeResult(final_output="", metadata=None)
+    findings = findings_from_workflow_result(result, SOURCE)
+    assert len(findings) == 1
+    assert "text-only-fallback" in findings[0].tags
+
+
+def test_non_string_raw_and_dict_final_output_coerced() -> None:
+    """Defensive shapes: non-str raw ignored, dict final_output stringified."""
+    result = _FakeResult(
+        final_output={"not": "a string"},
+        metadata={"raw_result_text": 12345},
+    )
+    findings = findings_from_workflow_result(result, SOURCE)
+    # No fenced json block anywhere -> fallback, but never a crash.
+    assert len(findings) == 1
+    assert "text-only-fallback" in findings[0].tags

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -105,6 +105,26 @@ class TestAgentSDKResultAdapterConversion:
         assert result.metadata["source"] == "agent_sdk"
         assert result.metadata["subagent_count"] == 4
 
+    def test_raw_result_text_preserved_when_final_output_rewritten(self) -> None:
+        """metadata["raw_result_text"] carries the UNMODIFIED agent text.
+
+        REGRESSION (nightly auth run 27249886475): when _parse_findings
+        fires, final_output is rewritten as formatted markdown — which
+        dropped the ```json block discovery-sweep's structured-emit
+        contract relies on. The raw channel must survive the rewrite.
+        """
+        result = AgentSDKResultAdapter.from_agent_output(
+            result_text=_SAMPLE_REVIEW,
+            subagent_names=_SUBAGENT_NAMES,
+            started_at=_now(),
+            completed_at=_now(),
+        )
+
+        # final_output WAS rewritten (formatted from parsed findings)…
+        assert result.final_output != _SAMPLE_REVIEW
+        # …but the raw channel is byte-identical to the agent text.
+        assert result.metadata["raw_result_text"] == _SAMPLE_REVIEW
+
     def test_custom_metadata_merged(self) -> None:
         """Given extra metadata, it is merged into result metadata."""
         result = AgentSDKResultAdapter.from_agent_output(


### PR DESCRIPTION
## Summary

Fixes the real bug the first valid-key nightly auth run ([27249886475](https://github.com/Smart-AI-Memory/attune-ai/actions/runs/27249886475)) caught: all 6 discovery_sweep integration tests failed with "structured-emit contract failed — adapter fell back to text-only path". Diagnosis recorded in [auth-run-triage.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/integration-coverage/auth-run-triage.md).

**Root cause:** `AgentSDKResultAdapter.from_agent_output()` rewrites `final_output` as formatted markdown whenever its category parser extracts findings — silently dropping the model's ```json block that `STRUCTURED_EMIT_FOOTER` requests. Every LLM sweep adapter degraded to the text-only fallback on every *successful* run.

## Changes

- `from_agent_output()` preserves the unmodified agent text on `metadata["raw_result_text"]` (final_output behavior unchanged for all other consumers).
- New `llm_source_base.findings_from_workflow_result()` prefers the raw channel with `final_output` fallback; all six sweep sources now use it.
- The 6 discovery_sweep integration tests additionally reject `source-failure` findings — closing the hole that let outright workflow failures (e.g. the broken-key run 27249292521) read as 18-second passes.

## Test plan

- **Live end-to-end receipt (real API):** `BugPredictSource.discover()` on the integration test's own fixture returned **8 structured findings** (severities, tags, confidences) — VERDICT PASS. Before the fix the same run produced 1 text-only-fallback finding.
- 275 unit tests (`tests/unit/workflows/discovery_sweep/` + `test_agent_sdk_adapter.py`) incl. 4 new helper tests + 1 new adapter regression test (raw channel survives the final_output rewrite).
- Pinned black + ruff pre-flighted.

Note: two of the three live receipt attempts hit transient SDK startup failures (`Command failed with exit code 1` at ~3-10 s) — unrelated to this diff (the pre-fix direct-workflow repro reproduced the same flake); the new `source-failure` assertion correctly flagged both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
