### PR TITLE
fix(llm): make deprecated use_thinking path send a valid thinking request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Deprecated `use_thinking` path 400'd whenever `max_tokens` ≤
+  `thinking_budget`.** `AnthropicProvider.generate()` sent
+  `thinking.budget_tokens=10000` regardless of `max_tokens`, and the
+  API requires `max_tokens > budget_tokens` (thinking output counts
+  toward `max_tokens`) plus `temperature=1`. Seen as the standing
+  `test_thinking_mode` failure in the nightly integration-auth run.
+  The provider now grows `max_tokens` above the budget when needed
+  (never shrinking the configured budget) and forces
+  `temperature=1.0` while thinking is enabled — also fixing the
+  latent 400 for thinking callers using the default
+  `temperature=0.7`.
+
 - **Security wizard silently never used `SecurityAuditWorkflow`.**
   `security_wizard._get_or_create_workflow()` passed legacy
   pre-SDK-migration kwargs (`skip_remediate_if_clean`,

--- a/docs/specs/integration-coverage/auth-run-triage.md
+++ b/docs/specs/integration-coverage/auth-run-triage.md
@@ -141,3 +141,25 @@ the sweep adapter can read (e.g. `metadata["raw_result_text"]` in
 `from_agent_output`), point `parse_findings_json` callers at it
 with `final_output` as fallback, and tighten the 6 tests to also
 reject `source-failure` tags.
+
+## Run 3 verdict — 2026-06-10 05:03 UTC dispatch (post-#727/#728/#729)
+
+Run 27254452440 (`workflow_dispatch`, main at 7e5969a1):
+**23 passed, 1 failed in 5m30s.**
+
+- **The 6 discovery_sweep tests GENUINELY passed.** With the #729
+  fix on main and the tightened assertions (which now reject
+  `source-failure` tags too), a pass means real structured
+  findings via the `metadata["raw_result_text"]` channel — the
+  Finding 3 contract is closed end-to-end on CI, not just in the
+  local receipt.
+- **The transient SDK-startup flake did not fire** this run
+  (seen 2-of-3 locally on 2026-06-10 early AM; keep watching the
+  scheduled nightlies before investing in a probe).
+- **Sole failure: `test_thinking_mode`** — the known 400
+  (`max_tokens must be greater than thinking.budget_tokens`,
+  request_id req_011CbtzxDskegSyNBjZRRqbc) on the deprecated
+  `use_thinking` path. Fix shipped as PR #730: the provider grows
+  `max_tokens` above the budget when needed and forces
+  `temperature=1.0` while thinking is enabled. Expected: the next
+  nightly after #730 merges is the first fully-green auth run.

--- a/src/attune/llm/providers/anthropic.py
+++ b/src/attune/llm/providers/anthropic.py
@@ -164,10 +164,17 @@ class AnthropicProvider(BaseLLMProvider):
 
         # Enable extended thinking for complex tasks (Claude-specific)
         if self.use_thinking:
+            # The API requires max_tokens > thinking.budget_tokens (thinking
+            # output counts toward max_tokens) and temperature=1 — otherwise
+            # the request fails with HTTP 400. Grow max_tokens so the answer
+            # keeps its requested room; never shrink the caller's budget.
+            if api_kwargs["max_tokens"] <= self.thinking_budget:
+                api_kwargs["max_tokens"] = self.thinking_budget + max_tokens
             api_kwargs["thinking"] = {
                 "type": "enabled",
                 "budget_tokens": self.thinking_budget,
             }
+            api_kwargs["temperature"] = 1.0
 
         # Add any additional kwargs
         api_kwargs.update(kwargs)

--- a/tests/llm/test_llm_toolkit_providers.py
+++ b/tests/llm/test_llm_toolkit_providers.py
@@ -233,6 +233,72 @@ class TestAnthropicProvider:
         assert result.content == "Final answer"
 
     @patch("anthropic.AsyncAnthropic")
+    @pytest.mark.asyncio
+    async def test_thinking_grows_max_tokens_above_budget(self, mock_anthropic_class):
+        """Regression: thinking with max_tokens <= budget_tokens must not 400.
+
+        The API requires max_tokens > thinking.budget_tokens (thinking
+        output counts toward max_tokens). The provider must grow
+        max_tokens — never shrink the configured budget — and force
+        temperature=1.0 (thinking rejects any other value).
+        """
+        mock_response = MagicMock()
+        mock_block = MagicMock()
+        mock_block.type = "text"
+        mock_block.text = "ok"
+        mock_response.content = [mock_block]
+        mock_response.model = "claude-sonnet-4-6"
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=5)
+        mock_response.stop_reason = "end_turn"
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        mock_anthropic_class.return_value = mock_client
+
+        provider = AnthropicProvider(api_key="sk-test", use_thinking=True)
+
+        # Default thinking_budget=10000, max_tokens=2048 — the exact shape
+        # that 400'd in the nightly integration-auth run.
+        await provider.generate(
+            messages=[{"role": "user", "content": "Q"}],
+            temperature=0.7,
+            max_tokens=2048,
+        )
+
+        call_kwargs = mock_client.messages.create.call_args[1]
+        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 10000}
+        assert call_kwargs["max_tokens"] > 10000
+        assert call_kwargs["temperature"] == 1.0
+
+    @patch("anthropic.AsyncAnthropic")
+    @pytest.mark.asyncio
+    async def test_thinking_keeps_max_tokens_when_already_large_enough(self, mock_anthropic_class):
+        """A max_tokens already above the budget is passed through unchanged."""
+        mock_response = MagicMock()
+        mock_block = MagicMock()
+        mock_block.type = "text"
+        mock_block.text = "ok"
+        mock_response.content = [mock_block]
+        mock_response.model = "claude-sonnet-4-6"
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=5)
+        mock_response.stop_reason = "end_turn"
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        mock_anthropic_class.return_value = mock_client
+
+        provider = AnthropicProvider(api_key="sk-test", use_thinking=True, thinking_budget=2000)
+
+        await provider.generate(
+            messages=[{"role": "user", "content": "Q"}],
+            max_tokens=8192,
+        )
+
+        call_kwargs = mock_client.messages.create.call_args[1]
+        assert call_kwargs["max_tokens"] == 8192
+        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 2000}
+
+    @patch("anthropic.AsyncAnthropic")
     def test_get_model_info_known_model(self, mock_anthropic_class):
         """Test getting model info for known model."""
         provider = AnthropicProvider(


### PR DESCRIPTION
## Summary

The deprecated `use_thinking` path in `AnthropicProvider.generate()` sent `thinking.budget_tokens=10000` regardless of `max_tokens`. The API requires `max_tokens > budget_tokens` (thinking output counts toward `max_tokens`) and `temperature=1`, so:

- any thinking call with `max_tokens <= 10000` 400'd — this is the standing `test_thinking_mode` failure in the nightly integration-auth run (handoff item 2 from 2026-06-10)
- any thinking call at the provider's default `temperature=0.7` would also 400 (latent — the integration test masks it by passing `temperature=1.0` explicitly)

## Fix

In the thinking branch of `generate()`:

- grow `max_tokens` to `thinking_budget + max_tokens` when `max_tokens <= thinking_budget`, so the answer keeps its requested room and the configured budget is never shrunk
- force `temperature=1.0` while thinking is enabled

`_normalize_api_kwargs_for_model()` still runs after, so Opus 4.7+ continues to get the `adaptive` conversion + sampling-param strip.

Chose clamp over retiring `use_thinking` because `test_gen_parallel` actively opts in (`_use_thinking = True` → `executor_mixin` → `EmpathyLLMExecutor`); retirement is a behavior change for that workflow and belongs in its own decision.

## Tests

Two mocked regression tests pin the request shape (budget preserved + `max_tokens` grown + temperature forced; pass-through when `max_tokens` already exceeds the budget). 53/53 pass in `tests/llm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
