### PR TITLE
chore: docs version-drift guard + jit-recall release rule (T1.4 proven)

### DIFF
--- a/docs/specs/just-in-time-recall/tasks.md
+++ b/docs/specs/just-in-time-recall/tasks.md
@@ -8,9 +8,9 @@ token appeared verbatim in a headless `claude -p` reply while the call
 proceeded). Shipped: `plugin/hooks/_recall_map.py` (curated map, the
 `AskUserQuestion` proof entry), `plugin/hooks/jit_recall.py`
 (surface-once sentinel, fail-safe, `ATTUNE_JIT_RECALL=0` off-switch),
-`hooks.json` registration, 12 tests. Remaining: T1.4 live-session R6
-proof (needs the updated plugin loaded — verify in the first session
-after the next plugin release), then Phase 2.
+`hooks.json` registration, 12 tests. T1.4 live-proven 2026-06-10;
+Phase 2 started: optional `match_substring` content filter + the
+`release-verify-merge-sha` Bash entry (first T2.1 slip-point).
 
 Independently shippable units. **Phase 0 gates everything** — no
 implementation past it until the injection mechanism is logged in
@@ -41,14 +41,20 @@ implementation past it until the injection mechanism is logged in
   in a session is silent), no-entry silent no-op, crash → exit 0, and the
   injected-text content for the AskUserQuestion case. Mirror the
   `test_session_memory_hooks.py` importlib-loader pattern.
-- [ ] **T1.4** Reproduce the 2026-06-03 slip (an AskUserQuestion call) and
-  confirm the rule surfaces at the decision point (R6). Record the
-  before/after in the PR.
+- [x] **T1.4** Reproduce the 2026-06-03 slip (an AskUserQuestion call) and
+  confirm the rule surfaces at the decision point (R6). **Live-proven
+  2026-06-10** (8.1.0 release session): the session's first
+  AskUserQuestion — the pypi-approval question — received the
+  question-shape rule via PreToolUse `additionalContext`, and the
+  question conformed (one question, '(Recommended)' first option).
 
 ## Phase 2 — grow the map + tune cadence (deferred)
 
 - [ ] **T2.1** Add the next 2–3 highest-value slip-points (e.g. git push
   to a shared branch → fetch-first rule) once the proof case holds.
+  *(1 of 2-3 added 2026-06-10: `release-verify-merge-sha` on
+  `Bash`+`gh release create`, via the new `match_substring` filter —
+  broad tools MUST scope rules this way, drift-guarded in tests.)*
 - [ ] **T2.2** Decide the surface-once vs decay question (D5) from proof-
   case evidence; implement decay only if once-per-session proves too
   sparse.

--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -14,6 +14,10 @@ Authoring rules:
   ground for every lesson.
 - ``rule_id`` is stable and filesystem-safe (it keys the per-session
   surface-once sentinel).
+- Optional ``match_substring`` scopes a rule to tool calls whose
+  serialized ``tool_input`` contains the substring — REQUIRED for
+  broad tools like ``Bash`` so the rule fires only at the actual
+  decision point, not on the session's first bash call.
 
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0
@@ -32,6 +36,21 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
                 "your recommendation as the FIRST option, its label ending "
                 "in '(Recommended)'; options concise and directly "
                 "selectable — no and/or bundles, no buried prose."
+            ),
+        },
+    ],
+    # Release tagging (added 2026-06-10): tags cut from the wrong ref
+    # have shipped before (attune-rag 0.5.0 — a late branch push missed
+    # the merge SHA and auto-published unpolished content).
+    "Bash": [
+        {
+            "rule_id": "release-verify-merge-sha",
+            "match_substring": "gh release create",
+            "text": (
+                "Before `gh release create`: verify the release content "
+                "is IN the target commit (`git show <sha>:pyproject.toml "
+                "| grep version`; changelog section present) and pass the "
+                "FULL 40-char merge SHA via --target, never a branch name."
             ),
         },
     ],

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -60,7 +60,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "AskUserQuestion",
+        "matcher": "AskUserQuestion|Bash",
         "hooks": [
           {
             "type": "command",

--- a/plugin/hooks/jit_recall.py
+++ b/plugin/hooks/jit_recall.py
@@ -114,8 +114,15 @@ def main() -> int:
             return 0
 
         session_id = payload.get("session_id")
+        tool_input_text = json.dumps(payload.get("tool_input") or {})
         fresh = []
         for rule in rules:
+            # Optional content filter (e.g. a Bash rule scoped to one
+            # command shape) — without it a Bash-keyed rule would fire
+            # on the first bash call of every session (R3: low noise).
+            needle = rule.get("match_substring")
+            if needle and needle not in tool_input_text:
+                continue
             sentinel = _sentinel_path(session_id, rule["rule_id"])
             if sentinel is not None and sentinel.exists():
                 continue

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -84,6 +84,17 @@ def test_map_entries_have_stable_safe_rule_ids(jit_mod):
             assert rule["text"].strip(), f"{tool}: empty rule text"
 
 
+def test_broad_tool_entries_require_match_substring(jit_mod):
+    """A rule keyed on a broad tool MUST scope itself via match_substring,
+    or it fires on the session's first such call (R3: low noise)."""
+    for tool in ("Bash", "Edit", "Write", "Read"):
+        for rule in jit_mod.RECALL_MAP.get(tool, []):
+            assert rule.get("match_substring"), (
+                f"{tool}/{rule['rule_id']}: broad-tool rule without "
+                "match_substring would fire on every session's first call"
+            )
+
+
 # ==========================================================================
 # Injection payload (R6 proof case)
 # ==========================================================================
@@ -104,6 +115,52 @@ def test_unmapped_tool_is_silent_no_op(jit_mod, monkeypatch, capsys):
     rc, out = _run(jit_mod, monkeypatch, capsys, _payload(tool="Read"))
     assert rc == 0
     assert out == ""
+
+
+# ==========================================================================
+# match_substring content filter (release-verify entry)
+# ==========================================================================
+
+
+def _bash_payload(command: str, session: str = "sess-1") -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "session_id": session,
+        "tool_input": {"command": command},
+    }
+
+
+def test_release_rule_fires_on_gh_release_create(jit_mod, monkeypatch, capsys):
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("gh release create v9.9.9 --target abc123"),
+    )
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "40-char merge SHA" in ctx
+
+
+def test_release_rule_silent_on_ordinary_bash(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("git status"))
+    assert rc == 0
+    assert out == ""
+
+
+def test_non_matching_rule_writes_no_sentinel(jit_mod, monkeypatch, capsys, tmp_path):
+    """A filtered-out rule must stay eligible to fire later in the session."""
+    _run(jit_mod, monkeypatch, capsys, _bash_payload("git status"))
+    base = tmp_path / "sentinels"
+    assert not base.exists() or not list(base.iterdir())
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("gh release create v9.9.9 --target abc123"),
+    )
+    assert out != ""
 
 
 # ==========================================================================
@@ -197,9 +254,16 @@ def test_missing_sentinel_dir_still_surfaces(monkeypatch, capsys, tmp_path):
 # ==========================================================================
 
 
-def test_hook_registered_for_ask_user_question():
+def test_hook_registered_for_all_mapped_tools(jit_mod):
+    """The hooks.json matcher must cover every tool keyed in RECALL_MAP —
+    a map entry whose tool isn't matched never fires (silent dead rule)."""
     hooks = json.loads((_HOOKS_DIR / "hooks.json").read_text(encoding="utf-8"))
     pre = hooks["hooks"]["PreToolUse"]
     jit_entries = [g for g in pre if any("jit_recall.py" in h["command"] for h in g["hooks"])]
     assert jit_entries, "jit_recall.py not registered for PreToolUse"
-    assert jit_entries[0]["matcher"] == "AskUserQuestion"
+    matched = set(jit_entries[0]["matcher"].split("|"))
+    assert matched == set(jit_mod.RECALL_MAP.keys()), (
+        f"hooks.json matcher {matched} != RECALL_MAP tools "
+        f"{set(jit_mod.RECALL_MAP.keys())} — update the matcher when "
+        "adding a tool to the map"
+    )

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -10,6 +10,7 @@ Licensed under the Apache License, Version 2.0
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -399,6 +400,25 @@ class TestVersionConsistency:
                 versions["plugin/core/__init__.py"] = (
                     line.split("=")[1].strip().strip('"').strip("'")
                 )
+
+        # Docs surfaces that have silently lagged releases before:
+        # .claude/CLAUDE.md sat at 7.4.0 through three releases until
+        # 8.1.0; API_REFERENCE lagged two minors through v6.0-v6.3.
+        claude_md = REPO_ROOT / ".claude" / "CLAUDE.md"
+        text = claude_md.read_text(encoding="utf-8")
+        header = re.search(r"^# Attune AI Framework v(\d+\.\d+\.\d+)", text)
+        assert header, ".claude/CLAUDE.md header version line missing"
+        versions[".claude/CLAUDE.md:header"] = header.group(1)
+        footers = re.findall(r"\*\*Version:\*\* (\d+\.\d+\.\d+)", text)
+        assert footers, ".claude/CLAUDE.md footer version line missing"
+        versions[".claude/CLAUDE.md:footer"] = footers[-1]
+
+        api_ref = REPO_ROOT / "docs" / "reference" / "API_REFERENCE.md"
+        text = api_ref.read_text(encoding="utf-8")
+        found = re.findall(r"\*\*Version:\*\* (\d+\.\d+\.\d+)", text)
+        assert len(found) >= 2, "API_REFERENCE.md version header/footer missing"
+        versions["docs/reference/API_REFERENCE.md:header"] = found[0]
+        versions["docs/reference/API_REFERENCE.md:footer"] = found[-1]
 
         return versions
 


### PR DESCRIPTION
Three hardening items surfaced by the 8.1.0 release session (opportunities #2 and #4 from the session feedback pass):

## Version-drift guard extended to docs surfaces
`test_all_versions_match` (`_get_versions`) now also reads `.claude/CLAUDE.md` (header + footer) and `docs/reference/API_REFERENCE.md` (header + footer). Both have silently lagged before — CLAUDE.md sat at **7.4.0 through three releases** until today's 8.1.0 bump caught it by hand. Now the test catches it.

## jit-recall: `match_substring` filter + first Phase-2 entry
- New optional `match_substring` on map entries — scopes a rule to tool calls whose serialized `tool_input` contains the substring. Required for broad tools (`Bash`): without it a rule fires on the session's *first* bash call, which is pure noise (R3).
- First Phase-2 slip-point: `release-verify-merge-sha` on `Bash` + `"gh release create"` — encodes the attune-rag 0.5.0 wrong-ref-tag lesson ("verify content is IN the target commit; pass the full 40-char SHA").
- `hooks.json` matcher extended to `AskUserQuestion|Bash`, with two new drift guards: the matcher must equal the map's key set (a mapped-but-unmatched tool is a silent dead rule), and broad-tool entries must carry `match_substring`.
- A filtered-out rule writes **no sentinel**, so it stays eligible to fire later in the same session (tested).

## T1.4 checked off — live proof
The 2026-06-03 slip reproduction happened naturally today: the session's first `AskUserQuestion` (the pypi-approval question) received the question-shape rule via PreToolUse `additionalContext`, and the question conformed. Recorded in `docs/specs/just-in-time-recall/tasks.md`.

Tests: 46 passed (17 jit-recall incl. 4 new, 29 plugin config validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
