### PR TITLE
chore(release): attune-ai v8.1.1 (docs/metadata patch)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.1.0"
+    "version": "8.1.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.1.0
+# Attune AI Framework v8.1.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.1.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.1] — 2026-06-10
+
+Docs/metadata patch — no code or library-behaviour changes. Regenerates the
+4 stale `.help/templates/` features (`plugin`, `cli`, `ops-dashboard`,
+`memory`) post-8.1.0 with source-verified fact-check fixes: corrected
+import paths in the memory docs, the plugin quickstart rewritten to
+user-facing steps (it previously instructed importing internal hook
+modules), and its skill count corrected to 17. `.help/` is not part of the
+wheel/sdist — this release keeps PyPI ≡ repo ≡ plugin manifests in
+lockstep per the docs-only release policy.
+
 ## [8.1.0] — 2026-06-10
 
 Minor release rolling up the 2026-06-09 → 06-10 cycle (~50 PRs). Highlights:

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.1.0
+**Version:** 8.1.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.1.0 | **License:** Apache 2.0
+**Version:** 8.1.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.1.0"
+    "version": "8.1.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.1.0"
+__version__ = "8.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.1.0"
+version = "8.1.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.1.0"
+version = "8.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Docs/metadata patch release: version bumps across all 7 sites + changelog entry for the post-8.1.0 help-template regeneration (#732). No code changes — keeps PyPI ≡ repo ≡ plugin manifests in lockstep per the docs-only release policy. `.help/` is not in the wheel/sdist, so the PyPI artifact differs only in version metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)