### PR TITLE
feat(docs-pipeline): polish-cost lever 1 — LLM polish only at release-prep

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7666,3 +7666,25 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   `try: construct() except: return None` optional-enhancement
   pattern, one test must execute the REAL constructor and assert
   non-None.
+
+- **A phantom regenerator can rewrite `.help/templates/` outside every
+  known regen path — and pre-commit's stash/restore RESETS mtimes, so
+  post-commit forensics mislead**: extends the "Two parallel
+  help-template generators drift silently" lesson with a live-incident
+  shape (3× on 2026-06-10). Symptom: `gh pr create` warns "N
+  uncommitted changes" right after a clean commit, and `git status`
+  shows the 3 CORE depths (`concept`/`reference`/`task`) of a feature
+  modified with the 3-depth in-repo generator's frontmatter shape
+  (feature/depth only — no `type:`/`name:`/`source_hash`). Both
+  pre-commit regen hooks were ruled out by their `files:` filters and
+  `ATTUNE_DOCS_AUTOREGEN` unset; prime suspects are the running
+  `attune.mcp.server` processes (one per live session + leaked ones).
+  Two durable rules: (1) when pre-commit prints "[WARNING] Unstaged
+  files detected … Stashing", the listed files were modified BEFORE
+  the commit began, and their post-commit mtime is the stash-RESTORE
+  time, not the original write time — don't use mtime to identify the
+  writer; (2) treat unexplained 3-file core-depth modifications as
+  discard-don't-commit (`git checkout -- .help/templates/<feat>/`) —
+  the stub output would overwrite polished content. Open question +
+  diagnostic recipe tracked in
+  docs/specs/polish-cost-reduction/requirements.md Q1.

--- a/.github/workflows/help-freshness.yml
+++ b/.github/workflows/help-freshness.yml
@@ -1,10 +1,18 @@
 name: Help Freshness
 
+# Report-only by default (polish-cost-reduction lever 1, 2026-06-10):
+# the weekly schedule REPORTS staleness; polish-bearing regeneration
+# runs only on explicit dispatch with regen=true (release-prep cadence).
 on:
   schedule:
     # Sunday 12:00 UTC
     - cron: '0 12 * * 0'
   workflow_dispatch:
+    inputs:
+      regen:
+        description: 'Actually regenerate (LLM polish spend) instead of report-only'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -53,8 +61,21 @@ jobs:
           count=$(wc -l < /tmp/stale.txt | tr -d ' ')
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
+      - name: Report staleness (report-only mode)
+        if: steps.list_stale.outputs.count != '0' && github.event.inputs.regen != 'true'
+        run: |
+          {
+            echo "## Help freshness report (no regen run)"
+            echo
+            echo "Stale features:"
+            sed 's/^/- /' /tmp/stale.txt
+            echo
+            echo "Regenerate deliberately at release-prep, or dispatch this"
+            echo "workflow with regen=true."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Regenerate stale features
-        if: steps.list_stale.outputs.count != '0'
+        if: steps.list_stale.outputs.count != '0' && github.event.inputs.regen == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
@@ -73,6 +94,7 @@ jobs:
           cat /tmp/completeness-after.json
 
       - name: Open PR if there are changes
+        if: github.event.inputs.regen == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.help/templates/plugin/quickstart.md
+++ b/.help/templates/plugin/quickstart.md
@@ -5,7 +5,7 @@ feature: plugin
 depth: quickstart
 generated_at: 2026-06-10T07:07:04.681583+00:00
 source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
-status: generated
+status: manual
 ---
 
 # Quickstart: Install the attune-ai plugin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,14 +139,12 @@ repos:
           ^src/attune/mcp/tool_schemas\.py$
         stages: [pre-commit]
 
-      # .help/templates/ per-feature regeneration on source changes.
+      # .help/templates/ staleness WARNING on source changes (check-only).
       # Detects which features' source globs match the changed files in
-      # this commit (via `attune_author.load_manifest`), runs
-      # `attune-author generate <feature> --all-kinds` for each, and
-      # auto-stages the resulting `.help/templates/<feature>/`.
-      # Gated on ATTUNE_DOCS_AUTOREGEN=1 (matching check-docs-freshness)
-      # — warn-only otherwise. Never blocks the commit. See
-      # docs/specs/ops-specs-completion-candidates/ (B-real-1 follow-up).
+      # this commit (via `attune_author.load_manifest`) and prints them.
+      # Never regenerates, never spends LLM budget, never blocks the
+      # commit — polish-bearing regen runs at release-prep cadence
+      # (docs/specs/polish-cost-reduction/, lever 1).
       - id: regenerate-help-templates
         name: Regenerate .help/templates for changed source files
         entry: uv run python scripts/regenerate_help_templates.py

--- a/docs/specs/polish-cost-reduction/decisions.md
+++ b/docs/specs/polish-cost-reduction/decisions.md
@@ -1,0 +1,76 @@
+# Polish-Cost Reduction — Decisions
+
+**Status:** approved (2026-06-10)
+
+## D1 — Two complementary levers, both wanted (ratified 2026-06-10)
+
+Patrick's directive: "only polish files that require changing …
+only files with stale or missing content … minimize API calls to
+polish documentation whether it be in .help or docs directories."
+Patrick proposed the cadence half ("polish only as part of
+release-prep") and ratified both levers explicitly.
+
+- **Lever 1 (cadence — cuts WHEN we pay):** no polish in pre-commit
+  or unattended schedules; release-prep is the polish moment.
+  Shipped 2026-06-10: `scripts/regenerate_help_templates.py` is now
+  check-only (auto-regen path deleted); `help-freshness.yml` is
+  report-only unless dispatched with `regen=true`.
+- **Lever 2 (incrementality — cuts HOW MUCH we pay):** per-kind
+  scaffold-hash skip in attune-author. Design in D3.
+
+## D2 — Accepted trade-off: mid-cycle staleness
+
+Between releases the in-repo `.help` corpus (feeding
+`rag_knowledge_query` and attune-ai.dev) runs stale. Accepted: the
+freshness surfaces already only warn, and feature-doc staleness
+mid-cycle is low-harm. If the site ever deploys mid-cycle, treat
+"site publish" as a second polish trigger using the same dispatch.
+
+## D3 — Lever 2 design (attune-author)
+
+Investigated 2026-06-10 (generator.py / polish.py / staleness.py):
+
+- Phase 1 of `generate_feature_templates` (`prepare_polish_phase`)
+  already renders the per-kind deterministic scaffold BEFORE any LLM
+  call. Insertion point: after rendering kind K's scaffold, compute
+  `scaffold_hash` = SHA-256 of the scaffold with volatile
+  frontmatter fields (`generated_at`) normalized. Compare to a
+  `scaffold_hash` stored in the existing on-disk file's frontmatter
+  (help templates) / HTML footer (project docs). Equal → skip the
+  kind entirely: no polish call, no write, file keeps its polished
+  content and timestamps. Different or missing file → polish as
+  today (the existing polish cache may still hit).
+- Write `scaffold_hash: <sha>` into frontmatter on every generate so
+  the next run can compare. Backward-compatible: files without the
+  field are treated as stale once, then carry it.
+- Rationale for scaffold-hash over cache-key surgery: the polish
+  cache key correctly includes `source_summary` (it IS part of the
+  LLM input — changing it can change output). The waste isn't a
+  wrong cache key; it's polishing kinds whose CONTENT didn't change.
+  "Scaffold unchanged = content not stale = skip" implements
+  Patrick's directive directly.
+- Feature-level staleness (`check_staleness` reading concept.md's
+  `source_hash`) stays as the cheap outer filter; per-kind skip is
+  the inner filter.
+
+## D4 — Override mechanism
+
+- Short-term: `status: manual` (existing) on hand-fixed templates;
+  applied to `.help/templates/plugin/quickstart.md` 2026-06-10 (its
+  regen-produced body instructed users to import internal hook
+  modules; hand-rewritten, must not be overwritten).
+- The fact-check `skip` config (`[tool.attune-author.fact-check]` in
+  pyproject) suppresses findings only — it is NOT content
+  preservation; don't confuse the two.
+- Durable fix: extend ground-truth injection (the seam exists,
+  generator.py `_maybe_polish`) so the generator stops producing the
+  fiction classes that required hand-fixes (internal-module imports,
+  wrong counts). Tracked as lever-2 follow-up.
+
+## D5 — Release-prep wiring
+
+The release flow (and the /release-execute skill) gains a step:
+`attune-author regenerate --help-dir .help --project-root .`
+(stale-only), review output (show-before-stage rule), ship as a
+docs PR alongside the release-prep PR. With lever 2 landed this
+costs only genuinely-changed kinds.

--- a/docs/specs/polish-cost-reduction/requirements.md
+++ b/docs/specs/polish-cost-reduction/requirements.md
@@ -1,0 +1,79 @@
+# Polish-Cost Reduction — Requirements
+
+**Status:** approved (2026-06-10) — levers ratified by Patrick in-session;
+lever 1 shipped same day, lever 2 is attune-author work.
+
+## Problem
+
+LLM polish of generated documentation (`.help/templates/` and
+generated `docs/`) is paid repeatedly for content that did not
+meaningfully change. Cost surfaces observed 2026-06-10:
+
+1. **Per-commit:** the `regenerate-help-templates` pre-commit hook
+   (with `ATTUNE_DOCS_AUTOREGEN=1`) ran `attune-author generate
+   <feature> --all-kinds` — a full 11-kind LLM re-polish — on every
+   commit touching a feature's source glob. A 40-line hook change
+   triggered a 3-template re-polish.
+2. **Weekly:** `help-freshness.yml` regenerated every stale feature
+   (`--all-kinds`) and opened a PR, on a schedule.
+3. **Per-run waste:** `--all-kinds` polishes all 11 template kinds per
+   feature even when only some kinds' content changed. The 2026-06-10
+   4-feature regen made 44 polish calls; ~10 kinds had real drift.
+4. **Cache misses by design:** attune-author HAS a polish cache
+   (`~/.attune/polish_cache/`, 30-day TTL) but its key includes the
+   full per-feature `source_summary` — any source change in the
+   feature's glob busts the cache for ALL kinds at once.
+
+## Requirements
+
+- **R1 (lever 1 — cadence):** no LLM polish in the commit path or on
+  an unattended schedule. Polish-bearing regeneration runs at
+  RELEASE-PREP cadence (and, when needed, deliberate manual dispatch).
+  Pre-commit and scheduled CI surfaces are check/report-only.
+- **R2 (lever 2 — incrementality):** a regeneration run polishes only
+  template kinds whose content is stale or missing. "Stale" = the
+  deterministic pre-polish scaffold for that kind differs from the
+  scaffold that produced the existing on-disk file. "Missing" = no
+  file on disk. Unchanged-scaffold kinds are skipped entirely (no
+  polish call, file untouched).
+- **R3 (overrides):** hand-fixes to generated templates survive
+  regeneration. Short-term: `status: manual` frontmatter (existing
+  attune-author mechanism — skips the file unless `--overwrite`).
+  Durable: ground-truth injection into the polish prompt so the
+  fixes aren't needed (attune-author already has the injection seam).
+- **R4 (no silent staleness):** check-only surfaces still WARN
+  loudly: pre-commit prints lagging features; the weekly workflow
+  publishes a staleness report to the job summary.
+- **R5 (scope):** applies to both the `.help/templates/` corpus and
+  attune-author-generated project docs (`docs/how-to/`, etc.) — both
+  flow through the same generate/polish pipeline.
+
+## Acceptance criteria
+
+- AC1: committing a source change produces zero LLM calls. ✅ lever 1
+- AC2: the weekly workflow run produces zero LLM calls unless
+  dispatched with `regen=true`. ✅ lever 1
+- AC3: regenerating a feature where only 2 of 11 kinds' scaffolds
+  changed makes exactly 2 polish calls (cache misses at most 2).
+  (lever 2, attune-author)
+- AC4: a `status: manual` template is untouched by regeneration. ✅
+  (existing attune-author behavior; applied to plugin/quickstart.md)
+
+## Open questions
+
+- **Q1:** an unidentified process regenerated the 3 core-depth
+  templates (`concept`/`reference`/`task` — the in-repo 3-depth
+  generator's fingerprint) of the `plugin` feature twice on
+  2026-06-10 around commit time, with `ATTUNE_DOCS_AUTOREGEN` unset
+  and both pre-commit regen paths ruled out by their `files:`
+  filters. Trigger unknown. Recurred a THIRD time ~03:36-03:43 ET the
+  same day (caught live: the files were already modified when
+  pre-commit stashed them — note the post-restore mtime is the stash
+  RESTORE time, not the write time). Prime suspects: the running
+  `attune.mcp.server` processes (one per live session, plus leaked
+  ones from prior sessions — `pgrep -f attune.mcp.server`) invoking
+  the in-repo 3-depth generator via `help_update`/`help_maintain`.
+  Diagnostic next occurrence: `pgrep -f attune.mcp.server`, then
+  check each server's recent activity for help-tool calls in that
+  window; or temporarily `chmod -w .help/templates/plugin` and see
+  what errors.

--- a/scripts/regenerate_help_templates.py
+++ b/scripts/regenerate_help_templates.py
@@ -1,35 +1,28 @@
 #!/usr/bin/env python3
-"""Pre-commit hook: regenerate `.help/templates/<feature>/` for changed source.
+"""Pre-commit hook: WARN when `.help/templates/<feature>/` lags changed source.
 
-Runs `attune-author generate <feature> --all-kinds` for every feature
-whose source files were modified in the current commit, then stages
-the regenerated template directories so they land in the same commit
-as the source change.
-
-Gated on `ATTUNE_DOCS_AUTOREGEN=1` (matching the precedent set by
-`scripts/check_docs_freshness.py`). Default mode is warn-only — the
-hook prints which features are stale and exits 0 without modifying
-the tree. Users opt in by setting the env var (typically in shell
-profile) so the auto-regen is per-user, not per-repo.
+Detects which features' source globs match the files in the current
+commit and prints the list. Check-only — this hook never regenerates
+and never spends LLM budget. Polish-bearing regeneration happens at
+RELEASE-PREP cadence instead (`attune-author regenerate`), per the
+polish-cost-reduction spec (lever 1, ratified 2026-06-10): per-commit
+auto-regen re-polished whole features on every source touch, which is
+exactly the repeat-API-spend the spec eliminates.
 
 Failure modes never block the commit:
 
 - `attune-author` not installed → silent exit 0
 - `.help/features.yaml` missing → silent exit 0
-- Per-feature regen failure → log to stderr, continue with others
-- `git add` failure → log to stderr, continue
 
 Pre-commit passes changed file paths on argv. Empty argv → exit 0.
 
-Spec: docs/specs/ops-specs-completion-candidates/ — companion to the
-post-merge follow-up captured in PR #400's process notes.
+Specs: docs/specs/polish-cost-reduction/ (lever 1);
+docs/specs/ops-specs-completion-candidates/ (original hook).
 """
 
 from __future__ import annotations
 
-import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -87,79 +80,6 @@ def _affected_features(changed_paths: list[Path], manifest_features: dict) -> se
     return affected
 
 
-def _regen_one(feature: str, help_dir: Path, repo_root: Path) -> tuple[bool, str | None]:
-    """Run ``attune-author generate <feature> --all-kinds``.
-
-    Returns (success, error_message). On non-zero exit / timeout /
-    missing binary, returns (False, <error>) — never raises.
-    """
-    try:
-        result = subprocess.run(
-            [
-                "attune-author",
-                "generate",
-                feature,
-                "--help-dir",
-                str(help_dir),
-                "--project-root",
-                str(repo_root),
-                "--all-kinds",
-            ],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=120,
-            cwd=str(repo_root),
-            check=False,
-        )
-    except (subprocess.TimeoutExpired, OSError) as exc:
-        return False, str(exc)
-    if result.returncode != 0:
-        # stderr first, fall back to stdout — attune-author errors land
-        # in stderr but some failure modes still print to stdout.
-        msg = (result.stderr or result.stdout or "").strip()
-        return False, msg or f"exit {result.returncode}"
-    return True, None
-
-
-def _summarize_error(err: str | None) -> str:
-    """Reduce a multi-line subprocess error to a compact one-liner.
-
-    Tracebacks dumped by `attune-author` (or any subprocess) on
-    failure are useful for debugging but noisy in commit-cycle
-    output. Returns the LAST non-blank line (typically the actual
-    exception message after a long traceback), capped at 200 chars.
-    """
-    if not err:
-        return "(no error message)"
-    last_line = next(
-        (line for line in reversed(err.splitlines()) if line.strip()),
-        err.strip(),
-    )
-    if len(last_line) > 200:
-        return last_line[:197] + "..."
-    return last_line
-
-
-def _stage_dir(dir_path: Path, repo_root: Path) -> bool:
-    """``git add <dir_path>``; return True on success."""
-    try:
-        result = subprocess.run(
-            ["git", "add", str(dir_path)],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=10,
-            cwd=str(repo_root),
-            check=False,
-        )
-    except (subprocess.TimeoutExpired, OSError):
-        return False
-    return result.returncode == 0
-
-
 def main(argv: list[str]) -> int:
     if not argv:
         return 0  # No matching files in commit; nothing to do.
@@ -187,48 +107,10 @@ def main(argv: list[str]) -> int:
     if not affected:
         return 0
 
-    autoregen = os.environ.get("ATTUNE_DOCS_AUTOREGEN", "0") == "1"
     feat_list = ", ".join(sorted(affected))
-
-    if not autoregen:
-        # Warn-only mode (default). Matches `check_docs_freshness.py`
-        # precedent — the user opts in by setting the env var.
-        print(f"attune: {len(affected)} .help/templates feature(s) need regen: {feat_list}")
-        print(
-            "  run: ATTUNE_DOCS_AUTOREGEN=1 git commit --amend --no-edit"
-            "  (or `attune-author generate <feat> --all-kinds`)"
-        )
-        return 0
-
-    print(f"attune: auto-regenerating {len(affected)} feature(s): {feat_list}")
-
-    regenerated: list[str] = []
-    for feature in sorted(affected):
-        ok, err = _regen_one(feature, help_dir, repo_root)
-        if ok:
-            regenerated.append(feature)
-        else:
-            # Trim to first line + 200 char cap — full tracebacks are
-            # noise in the commit output; the user can re-run manually
-            # for the full error.
-            summary = _summarize_error(err)
-            print(
-                f"  WARN: attune-author generate {feature} failed: {summary}",
-                file=sys.stderr,
-            )
-
-    for feature in regenerated:
-        template_dir = help_dir / "templates" / feature
-        if not template_dir.is_dir():
-            continue
-        if not _stage_dir(template_dir, repo_root):
-            print(
-                f"  WARN: git add {template_dir} failed; stage it manually",
-                file=sys.stderr,
-            )
-
-    if regenerated:
-        print(f"attune: regenerated and staged {len(regenerated)} feature(s).")
+    print(f"attune: {len(affected)} .help/templates feature(s) lag this change: {feat_list}")
+    print("  (check-only — polish-bearing regen runs at release-prep:")
+    print("   `attune-author regenerate --help-dir .help --project-root .`)")
     return 0
 
 

--- a/tests/unit/scripts/test_regenerate_help_templates.py
+++ b/tests/unit/scripts/test_regenerate_help_templates.py
@@ -148,38 +148,3 @@ class TestAffectedFeatures:
 # ---------------------------------------------------------------------------
 # _summarize_error
 # ---------------------------------------------------------------------------
-
-
-class TestSummarizeError:
-    def test_none_returns_placeholder(self) -> None:
-        assert regen_module._summarize_error(None) == "(no error message)"
-
-    def test_empty_string_returns_placeholder(self) -> None:
-        assert regen_module._summarize_error("") == "(no error message)"
-
-    def test_single_line_returned_as_is(self) -> None:
-        assert regen_module._summarize_error("just one line") == "just one line"
-
-    def test_multi_line_returns_last_nonblank(self) -> None:
-        # Mirrors a Python traceback shape: last line is the exception
-        # message, which is what we want to surface.
-        err = (
-            "Traceback (most recent call last):\n"
-            '  File "x.py", line 1, in <module>\n'
-            "    raise ValueError('bad input')\n"
-            "ValueError: bad input"
-        )
-        assert regen_module._summarize_error(err) == "ValueError: bad input"
-
-    def test_trailing_blank_lines_ignored(self) -> None:
-        err = "Real error\n\n\n"
-        assert regen_module._summarize_error(err) == "Real error"
-
-    def test_long_line_truncated_at_200(self) -> None:
-        long = "x" * 500
-        out = regen_module._summarize_error(long)
-        assert len(out) == 200
-        assert out.endswith("...")
-
-    def test_short_line_not_truncated(self) -> None:
-        assert regen_module._summarize_error("short") == "short"


### PR DESCRIPTION
**Lever 1 of the polish-cost-reduction spec** (ratified in-session 2026-06-10): LLM polish of generated docs now runs ONLY at release-prep cadence — never in the commit path, never on an unattended schedule.

## Why

Polish spend was recurring at three surfaces: per-commit auto-regen (`ATTUNE_DOCS_AUTOREGEN=1` ran a full 11-kind `--all-kinds` re-polish per touched feature — a 40-line hook change re-polished 3 templates today), the weekly `help-freshness.yml` regen-and-PR, and `--all-kinds` over-polishing within each run (today's 4-feature regen = 44 polish calls for ~10 kinds of real drift).

## What changed

- **`scripts/regenerate_help_templates.py`** → check-only. The auto-regen path (`_regen_one`, `_stage_dir`, `_summarize_error`, env-gated regen+staging) is deleted; the hook prints which features lag and points at the release-prep command. Tests for removed helpers dropped; 14 remain green.
- **`help-freshness.yml`** → report-only by default: the weekly schedule publishes the staleness list to the job summary, zero API calls. Regeneration + PR creation now require an explicit `workflow_dispatch` with `regen=true` (the deliberate release-prep / site-publish trigger).
- **`.help/templates/plugin/quickstart.md`** → `status: manual` (attune-author's existing skip mechanism) so today's hand-rewrite — the regen body told users to import internal hook modules — survives future regens until ground-truth injection lands.
- **`docs/specs/polish-cost-reduction/`** — requirements + decisions recording both ratified levers. **Lever 2** (per-kind scaffold-hash skip: polish only kinds whose deterministic pre-polish scaffold changed; AC: 2-of-11 changed kinds = exactly 2 polish calls) is designed in D3 and lands in attune-author separately.
- Spec Q1 logs the still-unidentified process that regenerated the 3 core-depth `plugin` templates three times today (3-depth-generator fingerprint, all known regen paths ruled out) with a diagnostic recipe for the next occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
