### PR TITLE
chore(release): attune-ai v8.2.0 + CI keyless hotfix

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7688,3 +7688,46 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   the stub output would overwrite polished content. Open question +
   diagnostic recipe tracked in
   docs/specs/polish-cost-reduction/requirements.md Q1.
+
+- **A repo CI secret becoming VALID is a spend event — tests.yml passed
+  `secrets.ANTHROPIC_API_KEY` to every push/PR × 12 matrix lanes and
+  burned ~$1200 in ~6 hours the night the dead key was replaced with a
+  live one (2026-06-10 02:52 UTC)**: tests that change behavior when a
+  key is present (mismarked `HAS_API_KEY`-gated tests, real-SDK
+  spawners of the #728 class, keyed Haiku-summary paths) made real API
+  calls at CI scale the moment the secret went live — for weeks prior
+  the key was invalid so the same workflow config burned nothing.
+  Diagnostic chain that pinned it: (1) sum LOCAL telemetry
+  (`~/.attune/telemetry/usage.jsonl` by day — showed only ~$126/month,
+  so the burn wasn't local); (2) `grep -l ANTHROPIC_API_KEY
+  .github/workflows/*.yml` + read HOW each uses it
+  (`integration-tests.yml` sets it to `""` keyless-by-design;
+  `tests.yml` passed the real secret); (3) `gh api .../actions/secrets`
+  `updated_at` correlates the spend window. Rule: per-push/PR test
+  workflows get `ANTHROPIC_API_KEY: ""` ALWAYS; the real secret
+  belongs only to deliberately-scheduled, budget-capped jobs
+  (`integration-auth.yml` with `ATTUNE_MAX_BUDGET_USD`). Pairs with
+  the "keyless-CI-faithful local runs need EMPTY not unset" lesson —
+  same empty-string discipline, opposite direction (CI side).
+
+- **Anthropic API billing forensics from the terminal — org-bound
+  keys, rename-vs-switch, and no-value-exposure diagnostics**: when an
+  API key 400s "credit balance too low": (1) the key is permanently
+  BOUND to the org it was created in — a new key created while the
+  console sits on the same org inherits the same block, and RENAMING
+  an org looks like switching but changes nothing (we burned a cycle
+  on both); (2) identify the key's org without exposing secrets:
+  `curl -si .../v1/messages ... | grep -i anthropic-organization-id`
+  (the 400 response carries it), plus key tail
+  `...${ANTHROPIC_API_KEY: -6}` and length `${#ANTHROPIC_API_KEY}`;
+  (3) `GET /v1/models` is NOT billing-gated — "models list works +
+  messages 400s" = valid key, billing block (vs "invalid x-api-key" =
+  revoked); (4) error-message transitions are signal: "balance too
+  low" → "invalid x-api-key" means the key was revoked, not fixed;
+  (5) top-ups apply against OWED balance first and take minutes to
+  propagate — poll with a 1-token haiku call, don't re-ask the user;
+  (6) when hand-editing `~/.attune/anthropic.env` fails silently,
+  remember the line is `export ANTHROPIC_API_KEY=...` (an
+  unanchored-for-`export` sed matches nothing yet exits 0), and the
+  no-chat-exposure swap is `pbpaste` → validate `sk-ant-` prefix →
+  `printf > file` → report tail only.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
           echo "[mem-final $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"
         fi
       env:
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 
     - name: Run security and workflow tests
       run: pytest tests/unit/memory/test_long_term_security.py tests/unit/scanner/test_file_traversal.py tests/unit/workflows/test_workflow_execution.py -v --tb=short
@@ -129,7 +129,7 @@ jobs:
         pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=85 --timeout=60 --timeout-method=thread -m "not network and not integration"
         echo "[mem-final $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"
       env:
-        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 
     - name: Track per-file test results
       run: |


### PR DESCRIPTION
Release prep for **attune-ai 8.2.0**, carrying the **CI keyless hotfix** in front of it (deliberately bundled: the hotfix must be on main before any future valid `ANTHROPIC_API_KEY` secret meets per-push CI again).

## Commit 1 — fix(ci): make tests.yml keyless

The repo secret became a *valid* key at 2026-06-10 02:52 UTC (nightly-auth setup). `tests.yml` passed it into the main test steps on every push/PR × 12 matrix lanes; tests that go live when keyed burned **~$1200 in ~6 hours**. Local telemetry shows only ~$126 all month — the burn was CI. Fix: `ANTHROPIC_API_KEY: ""` in both steps, matching `integration-tests.yml`'s keyless-by-design discipline. The real secret remains for `integration-auth.yml` (nightly, budget-capped) and deliberate dispatches only. Follow-up tracked: audit tests that change behavior when keyed — the empty string now keeps them honest permanently.

## Commit 2 — chore(release): v8.2.0

- Version bumps 8.1.1 → 8.2.0 across all 7 sites (drift test covers them)
- CHANGELOG `[Unreleased]` → `[8.2.0] — 2026-06-10`, writing the missing entries for #733 (jit-recall `match_substring` + release rule, docs-surface version-drift guard), #735 (polish-cost lever 1), #736 (attune-author 0.15.0 + explicit attune-help pin)
- `uv.lock` regenerated (version-only diff)
- Release-prep regen step **deferred** (API billing block; spec D2 accepts mid-cycle corpus staleness — `.help/` is not in the wheel)
- Two lessons appended (CI live-key burn incident; Anthropic billing forensics)

After merge: tag `v8.2.0` from the merge SHA → trusted-publishing (OIDC — no API key involved) → verify on the simple index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
