### PR TITLE
chore(release): attune-ai v8.2.0 (take 2 — prep commit recovered)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.1.1"
+    "version": "8.2.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.1.1",
+      "version": "8.2.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.1.1
+# Attune AI Framework v8.2.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.1.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.2.0] — 2026-06-10
+
+The polish-cost-reduction release: LLM polish of generated docs now runs
+only at release-prep cadence, and within a run only template kinds whose
+content actually changed are polished. Plus the first Phase-2 jit-recall
+rule and the attune-author 0.15.0 / attune-help dependency wiring.
+
+### Added
+- **jit-recall content filter + release rule.** Map entries may carry
+  `match_substring`, scoping a rule to tool calls whose input contains
+  the substring — required for broad tools like `Bash` so rules fire at
+  the actual decision point, not the session's first call. First
+  Phase-2 entry: `release-verify-merge-sha` surfaces the
+  "verify content is IN the target commit; pass the full 40-char SHA"
+  rule on `gh release create`. Drift guards: the hooks.json matcher
+  must equal the map's tool set; broad-tool entries must be scoped.
+  (T1.4 live-proven the same day: the hook surfaced the question-shape
+  rule on a real AskUserQuestion via PreToolUse `additionalContext`.)
+- **Version-drift guard extended to docs surfaces.**
+  `test_all_versions_match` now also covers `.claude/CLAUDE.md` and
+  `docs/reference/API_REFERENCE.md` header+footer versions — both had
+  silently lagged releases before (CLAUDE.md sat at 7.4.0 through
+  three releases).
+
+### Changed
+- **No LLM polish outside release-prep (polish-cost lever 1).** The
+  `regenerate-help-templates` pre-commit hook is check-only (the
+  auto-regen path is deleted); the weekly `help-freshness.yml` is
+  report-only unless dispatched with `regen=true`. Polish-bearing
+  regeneration is a deliberate release-prep step. Combined with
+  attune-author 0.15.0's per-kind `scaffold_hash` skip (lever 2), a
+  regen run now polishes only kinds whose deterministic pre-polish
+  content changed. Spec: `docs/specs/polish-cost-reduction/`.
+- **attune-author cap raised to `<0.16`** (admits 0.15.0, validated)
+  and **attune-help pinned explicitly in `[author]`** — 0.15.0 moved
+  attune-help out of attune-author's core deps, which silently
+  dropped it from the lockfile; `rag_knowledge_query` and the
+  help-corpus tests need it, so the dependency is now intentional
+  rather than transitive luck.
+- `.help/templates/plugin/quickstart.md` is `status: manual` — the
+  hand-rewritten body (the generated one instructed importing
+  internal hook modules) survives regeneration until ground-truth
+  injection lands in the generator.
+
 ## [8.1.1] — 2026-06-10
 
 Docs/metadata patch — no code or library-behaviour changes. Regenerates the

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.1.1
+**Version:** 8.2.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.1.1 | **License:** Apache 2.0
+**Version:** 8.2.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.1.1"
+    "version": "8.2.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.1.1",
+      "version": "8.2.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.1.1"
+__version__ = "8.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.1.1"
+version = "8.2.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.1.1"
+version = "8.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
The actual 8.2.0 release prep. #737 was supposed to carry this but its squash landed only the CI hotfix + lessons — the prep commit had been parked on a branch that got deleted locally before the push (recovered from the dangling commit `bf88edb1`; remote head verified = local head this time).

Content (identical to what #737's description promised):
- Version bumps 8.1.1 → 8.2.0 across all 7 sites (29 drift tests green incl. the new docs-surface coverage)
- CHANGELOG `[8.2.0] — 2026-06-10`: jit-recall `match_substring` + release rule (#733), polish-cost lever 1 (#735), attune-author 0.15.0 + attune-help pin (#736)
- `uv.lock` version-only regen; release-prep regen step deferred on the API billing block (spec D2)

After merge: verify content IN the merge SHA (step 10 — it caught #737's gap), tag `v8.2.0`, trusted publishing, simple-index verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)