### PR TITLE
docs(specs): status flips — attune-verify + windows-xdist-flakes complete

### DIFF
--- a/docs/specs/attune-verify/decisions.md
+++ b/docs/specs/attune-verify/decisions.md
@@ -6,8 +6,7 @@ Phase-1 requirements and Phase-2 design. Newest first.
 ---
 
 ## D1 (2026-06-04): Deterministic resolution is authoritative for entity existence; the semantic judge must be cross-checked against it
-
-**Status:** decided — folds into a `design.md` Phase-2 revision and a
+**Status:** approved — folds into a `design.md` Phase-2 revision and a
 `tasks.md` item.
 
 ### Evidence — dogfood, 2026-06-04

--- a/docs/specs/attune-verify/design.md
+++ b/docs/specs/attune-verify/design.md
@@ -1,6 +1,5 @@
 # Design: attune-verify — Generation Fact-Checker
-
-**Status:** draft (2026-06-02) — Phase 2, awaiting review
+**Status:** complete (2026-06-10) — design realized and shipped: attune-verify 0.2.0 on PyPI (full dotted-path import resolution), core dep of attune-ai (`>=0.1.0,<0.3`), `/verify` skill live (#708). tasks.md has the per-task ship record.
 **Requirements:** [requirements.md](requirements.md) (Phase 1
 approved 2026-06-02)
 

--- a/docs/specs/attune-verify/requirements.md
+++ b/docs/specs/attune-verify/requirements.md
@@ -6,8 +6,7 @@
 > layer, that the content is semantically faithful, so
 > hallucinations that pass unit tests are caught before they reach
 > a reader.
-
-**Status:** draft (2026-06-02)
+**Status:** approved (2026-06-02)
 **Created:** 2026-06-02
 **Owner:** TBD
 **Related:** the "Discipline of Agent Collaboration" §7

--- a/docs/specs/attune-verify/tasks.md
+++ b/docs/specs/attune-verify/tasks.md
@@ -1,6 +1,5 @@
 # Tasks: attune-verify — Generation Fact-Checker
-
-**Status:** effectively complete (2026-06-09) — **all build tasks
+**Status:** complete (2026-06-09) — **all build tasks
 shipped; T7 dispositioned, no blocking work left.** `attune-verify` is
 published to PyPI (now **0.2.0** — full dotted-path import resolution):
 T1 (skeleton), T2 (model), T3 (deterministic checkers + the author-#351

--- a/docs/specs/windows-xdist-flakes/design.md
+++ b/docs/specs/windows-xdist-flakes/design.md
@@ -1,10 +1,10 @@
 # Design — Windows xdist Worker-Crash Flake Investigation
 
-**Status:** partial (2026-06-09) — Probe A + the three known
-xdist-worker-crash polluters fixed (#709/#710, lessons #713);
-remaining xfails + Probe D (gated Windows VM repro) deferred to a
-follow-up. Relabelled from "approved" by docs-completeness-audit B5
-re-triage (core work had shipped without a status flip).
+**Status:** complete (v1, 2026-06-10) — Probe A run, the three known
+xdist-worker-crash polluters fixed (#709/#710 + the #728 SDK-spawner),
+Probe B/C tooling shipped (`scripts/probe_xdist_flakes/`). Remaining
+xfails + Probe D (gated Windows VM repro) are DEFERRED BY DESIGN
+(DECIDE-1 caps v1 at Probe C) — reopen only if crashes recur.
 **Phase 1:** [requirements.md](./requirements.md) — locked 2026-06-02 (merged via #563)
 
 Translates Phase 1's three DECIDEs into concrete probe-execution


### PR DESCRIPTION
Status-flip pass from the spec-backlog implementation plan: both specs' reconciler-read files (tasks.md) already said complete; the design.md headers lagged. Verified against reality before flipping (attune-verify 0.2.0 on PyPI + core dep + live skill; windows-xdist Probe A done, polluters fixed, Probe D deferred by DECIDE-1). Also folds in Patrick's status-vocab normalization — 'effectively complete' parses as NON-terminal in the reconciler's first-word keying, so attune-verify's tasks.md was invisibly done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)