### PR TITLE
feat(voice): workflow-result-formatting T2 — markdown report renderer

### DIFF
--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -1,8 +1,9 @@
 # Tasks: Workflow result formatting
 
-**Status:** partial (2026-06-09) — T1 (the `WorkflowReport` / Section
-data model in `src/attune/workflows/output.py`) shipped in #649 and is
-in use (e.g. `discovery_sweep`); remaining tasks pending.
+**Status:** partial (2026-06-10) — T1 (the `WorkflowReport` / Section
+data model, #649) and T2 (the markdown renderer
+`attune.voice.report_renderer` — `render()` + crash-visible
+`render_safe()`, all 4 test layers, 98% branch) shipped; T3+ pending.
 
 > Bounded PRs; see [design.md](design.md) for the decisions each task
 > implements.

--- a/src/attune/voice/report_renderer.py
+++ b/src/attune/voice/report_renderer.py
@@ -1,0 +1,243 @@
+"""Render a :class:`~attune.workflows.output.WorkflowReport` as markdown.
+
+The ONLY place that knows markdown (workflow-result-formatting design
+D1): workflows own content (`WorkflowReport` sections), this module
+owns formatting. Consumers feed the output onward — the CLI through
+``rich.markdown.Markdown``, the dashboard parses to HTML, MCP returns
+it verbatim.
+
+Disclosure contract (proposal §3):
+
+- ``disclosure="summary"`` — essential + useful sections inline;
+  detail-tier sections wrapped in native ``<details>`` collapsibles.
+- ``disclosure="full"`` — every section inline, no ``<details>``.
+
+``show_cost`` gates cost/duration/model metadata lines (proposal §4 —
+cost figures don't apply for subscription users; the data stays in
+``WorkflowReport.metadata`` either way).
+
+:func:`render_safe` is the crash-visible wrapper (proposal §5): a
+renderer bug emits a one-line error banner plus a generic pretty-print
+of the report, never a silent swallow and never a bare repr.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from attune.workflows.output import (
+    CalloutSection,
+    FindingsSection,
+    ListSection,
+    NextAction,
+    NextStepsSection,
+    ProseSection,
+    Section,
+    TableSection,
+    WorkflowReport,
+)
+
+logger = logging.getLogger(__name__)
+
+Disclosure = Literal["summary", "full"]
+
+_EMPHASIS_ICON = {"info": "ℹ️", "ok": "✅", "warn": "⚠️", "danger": "🚨"}
+_SEVERITY_ORDER = {"high": 0, "medium": 1, "low": 2, "info": 3}
+
+#: metadata keys the cost line knows how to label (proposal §4)
+_COST_KEYS = (
+    ("cost_usd", lambda v: f"${float(v):.2f}"),
+    ("duration_s", lambda v: f"{float(v):.1f}s"),
+    ("model", str),
+    ("tier", str),
+    ("confidence", lambda v: f"confidence {float(v):.2f}"),
+)
+
+
+def render(
+    report: WorkflowReport,
+    *,
+    disclosure: Disclosure = "summary",
+    show_cost: bool = False,
+) -> str:
+    """Render ``report`` as markdown per the disclosure contract."""
+    blocks: list[str] = [f"# {report.title}".rstrip()]
+    if report.summary:
+        blocks.append(report.summary.strip())
+    if report.score is not None:
+        blocks.append(f"**Score:** {report.score}/100")
+    if show_cost:
+        cost_line = _render_cost_line(report.metadata)
+        if cost_line:
+            blocks.append(cost_line)
+
+    # NextStepsSection always renders last (tasks.md T2); empty → omitted.
+    ordinary = [s for s in report.sections if not isinstance(s, NextStepsSection)]
+    next_steps = [s for s in report.sections if isinstance(s, NextStepsSection) and s.items]
+
+    for section in [*ordinary, *next_steps]:
+        body = _render_section(section)
+        if not body:
+            continue
+        if disclosure == "summary" and section.tier == "detail":
+            blocks.append(f"<details><summary>{section.title}</summary>\n\n{body}\n\n</details>")
+        else:
+            blocks.append(body)
+
+    return "\n\n".join(blocks) + "\n"
+
+
+def render_safe(
+    report: WorkflowReport,
+    *,
+    disclosure: Disclosure = "summary",
+    show_cost: bool = False,
+) -> str:
+    """:func:`render`, but a renderer crash stays visible (proposal §5).
+
+    On any exception: log it, emit a one-line error banner, and fall
+    back to a generic pretty-print so the user still sees the content.
+    """
+    try:
+        return render(report, disclosure=disclosure, show_cost=show_cost)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a rendering bug must never hide the report —
+        # banner + fallback instead of a crash or a silent repr.
+        logger.exception("Report renderer error")
+        banner = f"⚠ Report renderer error: {type(exc).__name__}: {exc}"
+        return f"{banner}\n\n{_fallback_pretty(report)}"
+
+
+# =============================================================================
+# Per-section emitters (one isinstance dispatch — proposal §3)
+# =============================================================================
+
+
+def _render_section(section: Section) -> str:
+    if isinstance(section, CalloutSection):
+        return _render_callout(section)
+    if isinstance(section, ProseSection):
+        return _render_prose(section)
+    if isinstance(section, TableSection):
+        return _render_table(section)
+    if isinstance(section, ListSection):
+        return _render_list(section)
+    if isinstance(section, FindingsSection):
+        return _render_findings(section)
+    if isinstance(section, NextStepsSection):
+        return _render_next_steps(section)
+    # Unknown subclass: fail soft with its title so content isn't lost.
+    logger.warning("Unknown section kind %r — rendering title only", type(section).__name__)
+    return f"## {section.title}" if section.title else ""
+
+
+def _render_callout(s: CalloutSection) -> str:
+    icon = _EMPHASIS_ICON.get(s.emphasis, _EMPHASIS_ICON["info"])
+    head = f"> {icon} **{s.title}**" if s.title else f"> {icon}"
+    if not s.text:
+        return head
+    quoted = "\n".join(f"> {line}".rstrip() for line in s.text.strip().splitlines())
+    return f"{head}\n>\n{quoted}"
+
+
+def _render_prose(s: ProseSection) -> str:
+    parts = [f"## {s.title}"] if s.title else []
+    if s.text:
+        parts.append(s.text.strip())
+    return "\n\n".join(parts)
+
+
+def _render_table(s: TableSection) -> str:
+    if not s.columns or not s.rows:
+        return f"## {s.title}" if s.title else ""
+    head = "| " + " | ".join(s.columns) + " |"
+    sep = "| " + " | ".join("---" for _ in s.columns) + " |"
+    lines = [head, sep]
+    for row in s.rows:
+        lines.append("| " + " | ".join(_cell(row.get(c, "")) for c in s.columns) + " |")
+    table = "\n".join(lines)
+    return f"## {s.title}\n\n{table}" if s.title else table
+
+
+def _render_list(s: ListSection) -> str:
+    if not s.items:
+        return f"## {s.title}" if s.title else ""
+    items = "\n".join(f"- {item}" for item in s.items)
+    return f"## {s.title}\n\n{items}" if s.title else items
+
+
+def _render_findings(s: FindingsSection) -> str:
+    if not s.findings:
+        return f"## {s.title}" if s.title else ""
+    ordered = sorted(
+        s.findings, key=lambda f: _SEVERITY_ORDER.get(f.severity, len(_SEVERITY_ORDER))
+    )
+    lines = ["| Severity | Location | Message |", "| --- | --- | --- |"]
+    for f in ordered:
+        lines.append(f"| {_cell(f.severity)} | `{f.location}` | {_cell(f.message)} |")
+    table = "\n".join(lines)
+    return f"## {s.title}\n\n{table}" if s.title else table
+
+
+def _render_next_steps(s: NextStepsSection) -> str:
+    if not s.items:
+        return ""
+    parts: list[str] = [f"## {s.title or 'Next steps'}"]
+    bullets: list[str] = []
+    for action in s.items:
+        bullets.append(_render_next_action(action))
+    parts.append("\n".join(bullets))
+    return "\n\n".join(parts)
+
+
+def _render_next_action(a: NextAction) -> str:
+    text = a.text or ""
+    if a.file:
+        text = f"{text} (`{a.file}`)" if text else f"`{a.file}`"
+    bullet = f"- {text}".rstrip()
+    if a.command:
+        # Fenced one-liner under the bullet so the CLI can highlight it
+        # and the dashboard can grow a Run button (proposal §3).
+        bullet += f"\n\n  ```\n  {a.command}\n  ```"
+    return bullet
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _cell(value: object) -> str:
+    """One table cell: stringify and keep the row on one line."""
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def _render_cost_line(metadata: dict[str, object]) -> str:
+    parts = []
+    for key, fmt in _COST_KEYS:
+        if key in metadata and metadata[key] is not None:
+            try:
+                parts.append(fmt(metadata[key]))  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                continue
+    return f"*Cost & time:* {' · '.join(parts)}" if parts else ""
+
+
+def _fallback_pretty(report: WorkflowReport) -> str:
+    """Generic pretty-print used when :func:`render` crashes.
+
+    Deliberately repr-free: titles and counts only, so the safety net
+    never leaks dataclass reprs to a reader (proposal §6).
+    """
+    lines = [f"# {getattr(report, 'title', 'Workflow report')}"]
+    summary = getattr(report, "summary", "")
+    if summary:
+        lines.append(str(summary))
+    for section in getattr(report, "sections", []) or []:
+        title = getattr(section, "title", "") or type(section).__name__
+        lines.append(f"- {title}")
+    return "\n\n".join(lines)

--- a/tests/unit/voice/test_report_renderer.py
+++ b/tests/unit/voice/test_report_renderer.py
@@ -1,0 +1,314 @@
+"""Tests for attune.voice.report_renderer (workflow-result-formatting T2).
+
+Four layers per the proposal's test strategy:
+
+1. repr-leak drift guard — rendered output never contains dataclass
+   reprs or serialized-dict noise, in normal AND crash paths.
+2. tier-classification guard — detail-tier sections wrap in
+   ``<details>`` under summary disclosure, render inline under full;
+   essential/useful always inline.
+3. structural renderer assertions — each section kind's markdown shape.
+4. renderer-crash visibility — a broken report yields the error banner
+   AND the fallback block, never an exception.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.voice import report_renderer
+from attune.voice.report_renderer import render, render_safe
+from attune.workflows.output import (
+    CalloutSection,
+    Finding,
+    FindingsSection,
+    ListSection,
+    NextAction,
+    NextStepsSection,
+    ProseSection,
+    TableSection,
+    WorkflowReport,
+)
+
+
+def _full_report() -> WorkflowReport:
+    """One report exercising every section kind and every tier."""
+    return WorkflowReport(
+        title="Security audit",
+        summary="2 findings across 14 files.",
+        score=87,
+        metadata={"cost_usd": 1.25, "duration_s": 42.0, "model": "sonnet"},
+        sections=[
+            CalloutSection(
+                title="Heads up",
+                tier="essential",
+                text="One high-severity finding.",
+                emphasis="warn",
+            ),
+            ProseSection(title="Overview", tier="useful", text="Scanned src/ and plugin/."),
+            TableSection(
+                title="Files by risk",
+                tier="useful",
+                columns=["File", "Risk"],
+                rows=[{"File": "a.py", "Risk": "high"}, {"File": "b.py", "Risk": "low"}],
+            ),
+            ListSection(title="Skipped paths", tier="detail", items=["vendor/", "dist/"]),
+            FindingsSection(
+                title="Findings",
+                tier="essential",
+                findings=[
+                    Finding(severity="low", file="b.py", line=7, message="weak hash"),
+                    Finding(severity="high", file="a.py", line=12, message="eval use"),
+                ],
+            ),
+            NextStepsSection(
+                title="Next steps",
+                tier="essential",
+                items=[
+                    NextAction(text="Fix the eval", file="a.py:12"),
+                    NextAction(
+                        text="Re-run the audit", command="attune workflow run security-audit"
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+# =========================================================================
+# Layer 1 — repr-leak drift guard
+# =========================================================================
+
+
+REPR_MARKERS = (
+    "WorkflowReport(",
+    "FindingsSection(",
+    "Finding(",
+    "NextAction(",
+    "'_type'",
+    '"_type"',
+    "dataclass",
+)
+
+
+@pytest.mark.parametrize("disclosure", ["summary", "full"])
+def test_render_never_leaks_reprs(disclosure):
+    out = render(_full_report(), disclosure=disclosure, show_cost=True)
+    for marker in REPR_MARKERS:
+        assert marker not in out, f"repr leak: {marker!r}"
+
+
+def test_crash_path_never_leaks_reprs(monkeypatch):
+    monkeypatch.setattr(report_renderer, "_render_section", _boom, raising=True)
+    out = render_safe(_full_report())
+    for marker in REPR_MARKERS:
+        assert marker not in out, f"repr leak in fallback: {marker!r}"
+
+
+def _boom(*_a, **_k):
+    raise AttributeError("'NoneType' object has no attribute 'value'")
+
+
+# =========================================================================
+# Layer 2 — tier classification
+# =========================================================================
+
+
+def test_detail_tier_wraps_in_details_under_summary():
+    out = render(_full_report(), disclosure="summary")
+    assert "<details><summary>Skipped paths</summary>" in out
+    assert "- vendor/" in out  # content still present inside the wrap
+
+
+def test_detail_tier_inline_under_full():
+    out = render(_full_report(), disclosure="full")
+    assert "<details>" not in out
+    assert "- vendor/" in out
+
+
+def test_essential_and_useful_never_wrapped():
+    out = render(_full_report(), disclosure="summary")
+    # Only the one detail section produces a <details> block.
+    assert out.count("<details>") == 1
+
+
+# =========================================================================
+# Layer 3 — structural assertions per section kind
+# =========================================================================
+
+
+def test_header_summary_and_score():
+    out = render(_full_report())
+    assert out.startswith("# Security audit\n")
+    assert "2 findings across 14 files." in out
+    assert "**Score:** 87/100" in out
+
+
+def test_callout_renders_as_quote_with_emphasis_icon():
+    out = render(_full_report())
+    assert "> ⚠️ **Heads up**" in out
+    assert "> One high-severity finding." in out
+
+
+def test_table_renders_markdown_table():
+    out = render(_full_report(), disclosure="full")
+    assert "| File | Risk |" in out
+    assert "| a.py | high |" in out
+
+
+def test_findings_sorted_by_severity_with_location_code():
+    out = render(_full_report())
+    assert "| Severity | Location | Message |" in out
+    assert out.index("| high | `a.py:12` |") < out.index("| low | `b.py:7` |")
+
+
+def test_next_steps_renders_last_with_command_fence_and_file_code():
+    out = render(_full_report())
+    assert out.rstrip().split("\n\n")[-2].startswith("- Re-run the audit") or (
+        "## Next steps" in out
+    )
+    assert "(`a.py:12`)" in out
+    assert "attune workflow run security-audit" in out
+    # next-steps is the LAST section even though findings follow it in shape
+    assert out.index("## Next steps") > out.index("## Findings")
+
+
+def test_empty_next_steps_omitted():
+    report = WorkflowReport(
+        title="T",
+        sections=[NextStepsSection(title="Next steps", tier="essential", items=[])],
+    )
+    out = render(report)
+    assert "Next steps" not in out
+
+
+def test_next_steps_always_last_regardless_of_position():
+    report = WorkflowReport(
+        title="T",
+        sections=[
+            NextStepsSection(
+                title="Next steps", tier="essential", items=[NextAction(text="do it")]
+            ),
+            ProseSection(title="After", tier="essential", text="body"),
+        ],
+    )
+    out = render(report)
+    assert out.index("## After") < out.index("## Next steps")
+
+
+def test_cost_line_gated_by_show_cost():
+    report = _full_report()
+    assert "Cost & time" not in render(report, show_cost=False)
+    with_cost = render(report, show_cost=True)
+    assert "*Cost & time:* $1.25 · 42.0s · sonnet" in with_cost
+
+
+def test_pipe_and_newline_escaped_in_cells():
+    report = WorkflowReport(
+        title="T",
+        sections=[TableSection(title="", tier="useful", columns=["A"], rows=[{"A": "x|y\nz"}])],
+    )
+    out = render(report)
+    assert "x\\|y z" in out
+
+
+def test_round_trip_through_dict_renders_identically():
+    """from_dict(to_dict(r)) renders byte-identical — the MCP/SDK path."""
+    report = _full_report()
+    rebuilt = WorkflowReport.from_dict(report.to_dict())
+    assert render(rebuilt, show_cost=True) == render(report, show_cost=True)
+
+
+# =========================================================================
+# Layer 4 — renderer-crash visibility
+# =========================================================================
+
+
+def test_crash_emits_banner_and_fallback(monkeypatch):
+    monkeypatch.setattr(report_renderer, "_render_section", _boom, raising=True)
+    out = render_safe(_full_report())
+    assert "⚠ Report renderer error: AttributeError" in out
+    assert "# Security audit" in out  # fallback still shows the content
+    assert "- Findings" in out  # section titles listed
+
+
+def test_render_safe_passthrough_when_healthy():
+    report = _full_report()
+    assert render_safe(report) == render(report)
+
+
+# =========================================================================
+# Edge paths (empty sections, unknown kinds, malformed metadata)
+# =========================================================================
+
+
+def test_empty_sections_render_title_only_or_nothing():
+    report = WorkflowReport(
+        title="T",
+        sections=[
+            TableSection(title="Empty table", tier="useful"),
+            ListSection(title="Empty list", tier="useful"),
+            FindingsSection(title="No findings", tier="useful"),
+            TableSection(title="", tier="useful"),
+        ],
+    )
+    out = render(report)
+    assert "## Empty table" in out
+    assert "## Empty list" in out
+    assert "## No findings" in out
+    assert "| " not in out  # no table machinery for empty content
+
+
+def test_unknown_section_subclass_fails_soft_with_title():
+    class WeirdSection(ProseSection.__mro__[1]):  # subclass of Section
+        pass
+
+    report = WorkflowReport(
+        title="T",
+        sections=[WeirdSection(title="Mystery", tier="useful")],
+    )
+    out = render(report)
+    assert "## Mystery" in out
+
+
+def test_callout_without_title_or_text():
+    report = WorkflowReport(
+        title="T",
+        sections=[
+            CalloutSection(title="", tier="essential", text="", emphasis="ok"),
+            CalloutSection(title="", tier="essential", text="body only"),
+        ],
+    )
+    out = render(report)
+    assert "> ✅" in out
+    assert "> body only" in out
+
+
+def test_cost_line_skips_malformed_values():
+    report = WorkflowReport(title="T", metadata={"cost_usd": "not-a-number", "duration_s": 2.0})
+    out = render(report, show_cost=True)
+    assert "*Cost & time:* 2.0s" in out
+
+
+def test_cost_line_absent_when_no_known_keys():
+    report = WorkflowReport(title="T", metadata={"irrelevant": 1})
+    assert "Cost & time" not in render(report, show_cost=True)
+
+
+def test_next_action_file_only_and_bare():
+    report = WorkflowReport(
+        title="T",
+        sections=[
+            NextStepsSection(
+                title="Next steps",
+                tier="essential",
+                items=[NextAction(text="", file="x.py:1"), NextAction(text="just text")],
+            )
+        ],
+    )
+    out = render(report)
+    assert "- `x.py:1`" in out
+    assert "- just text" in out


### PR DESCRIPTION
T2 of `docs/specs/workflow-result-formatting/` (T1 = the `WorkflowReport`/Section data model, #649).

`attune.voice.report_renderer` — the ONLY place that knows markdown (design D1):
- `render(report, *, disclosure="summary"|"full", show_cost=False) -> str` with one isinstance dispatch per Section kind
- detail-tier sections wrap in native `<details>` under summary disclosure, inline under full
- `NextStepsSection` always renders last, omitted when empty; `NextAction` command → fenced one-liner (CLI copy / dashboard Run-button hook), file → inline code
- findings tables sorted by severity, `file:line` as inline code
- cost/duration/model metadata gated behind `show_cost` (proposal §4 — subscription users see no cost lines)
- `render_safe()`: crash-visible wrapper (proposal §5) — error banner + a deliberately repr-free fallback, never a silent swallow

Tests: all 4 spec layers, 24 tests, 98% branch coverage on the module — repr-leak drift guard (normal AND crash paths), tier-classification guard, structural assertions per kind including a `to_dict`/`from_dict` render round-trip (the MCP/SDK boundary), renderer-crash visibility. Spec status flipped in the same PR.

Next: T3 (voice wiring + safety net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)