### PR TITLE
docs(spec): opus-4-8-platform-fit — design + pre-committed Phase-0 matrix

### DIFF
--- a/docs/specs/opus-4-8-platform-fit/decisions.md
+++ b/docs/specs/opus-4-8-platform-fit/decisions.md
@@ -1,0 +1,37 @@
+# Decisions — Opus 4.8 Platform Fit
+
+**Status:** draft (2026-06-10) — matrix pre-committed with the design,
+BEFORE any measurement run (the "pre-committed decision matrices
+survive contact with data" discipline). Numbers below are the
+contract; the run routes each axis strictly by them.
+
+## D1 — Pre-committed Phase-0 decision matrix (2026-06-10)
+
+Committed before `scripts/phase0/opus48_behavior.py` exists or runs.
+Baseline = the Opus-4.6 leg of the same harness, same corpus.
+
+| Axis | TUNE threshold | Knob if TUNE |
+|---|---|---|
+| Narration volume | mean inter-tool TextBlock run > 800 chars, OR end-of-task wrap-up > 2,500 chars, on ≥ 2 of 3 workflows | silence-default clause in subagent/orchestrator prompts (Phase 2) |
+| Subagent under-use | 4.8 Task-spawn count < 70% of the 4.6 baseline on ≥ 2 of 3 workflows | explicit delegation-trigger guidance in workflow prompts (Phase 2) |
+| Tool/memory under-use | 4.8 tool-call count < 60% of baseline, or zero file-memory use where 4.6 used it | "when to use tools/memory" guidance (Phase 2) |
+| Ask-rate | ANY clarifying question in a headless SDK run (AskUserQuestion tool-use or interrogative terminal turn) | "decide, don't ask" clause in SDK system prompts (Phase 2) |
+| Effort fit | `xhigh` token cost ≥ 1.3× `high` AND findings delta < 10% (count + severity-weighted) | premium depth map defaults to `high` in `agent_sdk_adapter` (Phase 1) |
+| Cost | 4.8 $/run > 1.5× 4.6 at equal effort with findings delta < 10% | revisit premium depth→effort mapping (Phase 1) |
+
+Verdict rule: an axis crosses → TUNE in `phase0-findings.md`; below →
+LEAVE, no churn. All-LEAVE → retire the spec with the measurement
+artifact (explicitly a valid outcome).
+
+## D2 — Authoring/run decoupling (2026-06-10)
+
+Design + matrix + harness + instrumentation are authored and merged
+with zero API spend; the measurement run is gated on (a) the org
+billing block clearing, (b) Patrick ratifying the budget (ceiling
+$90, expected ~$50, $10/run hard cap).
+
+## Open-question answers folded into design.md
+
+- OQ-1 corpus: frozen in-tree snapshots under `scripts/phase0/corpus/`.
+- OQ-2 baseline: one-off Opus-4.6 A/B leg, not telemetry.
+- OQ-3 budget: $10/run cap, $90 matrix ceiling — pending ratification.

--- a/docs/specs/opus-4-8-platform-fit/design.md
+++ b/docs/specs/opus-4-8-platform-fit/design.md
@@ -1,0 +1,71 @@
+# Design — Opus 4.8 Platform Fit (Phase 0 harness)
+
+**Status:** draft (2026-06-10) — awaiting Patrick's review
+**Phase 1:** [requirements.md](./requirements.md) — approved 2026-06-08 (#679)
+
+Realizes Phase 0 (measure-first). Authoring is decoupled from
+running: everything here is buildable with zero API spend; the
+measurement run itself is gated on the API billing block clearing
+and a ratified budget (OQ-3 answer below).
+
+## Instrumentation: env-gated stream dump in the adapter
+
+One additive change to `agent_sdk_adapter.collect_agent_output()` —
+the single funnel every SDK workflow's message loop passes through:
+
+- When `ATTUNE_SDK_STREAM_DUMP=<dir>` is set, append one JSON line
+  per SDK message to `<dir>/<workflow>-<ts>.jsonl`: message type,
+  per-block records (`kind`, `chars` for TextBlocks, `tool_name` for
+  ToolUseBlocks, `parent_tool_use_id`), and the full ResultMessage
+  metadata (cost, usage, turns, duration).
+- Off by default; zero behavior change when unset (drift-guarded by
+  a test asserting no dump file appears without the env var).
+- Post-run, the harness also calls `collect_subagent_transcripts()`
+  for per-subagent volume.
+
+Rationale: every Phase-0 axis is derivable from this one dump —
+narration volume (TextBlock chars between ToolUseBlocks; wrap-up =
+trailing TextBlock run), subagent spawn count (Task/Agent tool-use
+blocks), tool mix (tool_name histogram), ask-rate (AskUserQuestion
+tool uses + interrogative terminal TextBlocks), effort fit + cost
+(ResultMessage usage/duration/cost). No per-workflow changes.
+
+## Harness: `scripts/phase0/opus48_behavior.py`
+
+- **Corpus (OQ-1 answer): frozen in-tree snapshots.** Copy two
+  bounded targets into `scripts/phase0/corpus/` at authoring time
+  (`gates/` ~150 LOC — the proven bug-predict target — and
+  `voice/report_renderer.py` + tests ~600 LOC). Live `src/` paths
+  drift between runs; frozen copies make every re-run measure the
+  same input forever.
+- **Run matrix (9 runs):**
+  - 3 workflows (`security-audit`, `code-review`, `deep-review`) ×
+    1 corpus target × 2 models (4.8 premium map vs 4.6 pin) = 6 —
+    the A/B for narration / subagents / tools / ask-rate / cost.
+  - `security-audit` × 3 efforts (`medium`/`high`/`xhigh`) on 4.8
+    = 3 — the effort-fit curve.
+- **Baseline (OQ-2 answer): one-off Opus-4.6 A/B**, not telemetry —
+  `usage.jsonl` lacks per-run subagent/tool counts; 4.6 is still an
+  active model so a clean same-harness A/B is cheap and like-for-like.
+- Each run: real API, `ATTUNE_MAX_BUDGET_USD=10` per run, dumps to
+  `scripts/phase0/phase0-data/` (gitignored raw, committed
+  `phase0-findings.md` summary). The harness computes the per-axis
+  metrics table and emits it as markdown.
+- Model pinning: a `--model-override` env passed through the premium
+  tier map for the 4.6 leg (mechanism verified at implementation
+  time against `adaptive_routing` — introspect, don't assume).
+
+## Budget (OQ-3 answer — needs Patrick's ratification)
+
+9 runs × multi-subagent on premium ≈ $3–8/run → **ceiling $90,
+expected ~$50**. Hard per-run cap $10; the harness aborts the matrix
+when cumulative spend crosses $90. Not running until the org billing
+block clears.
+
+## Decision flow
+
+`decisions.md` carries the pre-committed per-axis matrix (committed
+BEFORE any run — same PR as this design). After the run:
+`phase0-findings.md` routes each axis TUNE/LEAVE strictly per the
+matrix; all-LEAVE retires the spec with the artifact (a valid
+outcome, per requirements).


### PR DESCRIPTION
Phase 2 (design) for the approved opus-4-8-platform-fit requirements (#679), authored with **zero API spend** — the measurement run stays gated on the billing block + budget ratification.

- **Instrumentation**: one additive env-gated stream dump (`ATTUNE_SDK_STREAM_DUMP`) in `collect_agent_output` — the single funnel all SDK workflows pass through; every Phase-0 axis derives from this one dump. Zero behavior change when unset (drift-guarded).
- **Harness**: 9-run matrix — 3 workflows × Opus-4.8-vs-4.6 A/B (answers OQ-2: clean same-harness baseline, not telemetry) + a 3-effort curve, over **frozen corpus snapshots** (answers OQ-1: live paths drift; frozen copies measure the same input forever).
- **Pre-committed decision matrix** in decisions.md with concrete numeric thresholds per axis (narration > 800 chars inter-tool, subagent spawns < 70% baseline, any headless ask, xhigh ≥ 1.3× tokens for < 10% findings gain, etc.) — committed BEFORE any run, per the standing discipline.
- **Budget (OQ-3, needs your ratification):** $10/run hard cap, $90 matrix ceiling, ~$50 expected.

Per the /spec approval loop: review the design + thresholds; harness implementation follows approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)