### PR TITLE
feat(adapter): ATTUNE_SDK_STREAM_DUMP — opus48 Phase-0 instrumentation

### DIFF
--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -9,11 +9,13 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
 import shutil
 import subprocess
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -53,6 +55,59 @@ class AgentRunResult:
     errors: list[str] | None = None
 
 
+def _maybe_dump_message(message: Any) -> None:
+    """Append one JSON line describing an SDK message when
+    ``ATTUNE_SDK_STREAM_DUMP=<dir>`` is set.
+
+    Phase-0 instrumentation for the opus-4-8-platform-fit spec: every
+    measured axis (narration volume, subagent/tool counts, ask-rate,
+    effort fit, cost) derives from this dump. Content-free by design —
+    TextBlocks record only ``chars`` and an ``interrogative`` flag,
+    never the text itself, so dump dirs carry no code or prose.
+
+    Off by default; best-effort — never raises into the stream loop.
+    """
+    dump_dir = os.environ.get("ATTUNE_SDK_STREAM_DUMP")
+    if not dump_dir:
+        return
+    try:
+        record: dict[str, Any] = {"ts": time.time(), "type": type(message).__name__}
+        parent_id = getattr(message, "parent_tool_use_id", None)
+        if parent_id is not None:
+            record["parent_tool_use_id"] = parent_id
+        content = getattr(message, "content", None)
+        if isinstance(content, list):
+            blocks: list[dict[str, Any]] = []
+            for block in content:
+                entry: dict[str, Any] = {"kind": type(block).__name__}
+                text = getattr(block, "text", None)
+                if isinstance(text, str):
+                    entry["chars"] = len(text)
+                    entry["interrogative"] = text.rstrip().endswith("?")
+                tool_name = getattr(block, "name", None)
+                if isinstance(tool_name, str):
+                    entry["tool_name"] = tool_name
+                blocks.append(entry)
+            record["blocks"] = blocks
+        if isinstance(message, claude_agent_sdk.ResultMessage):
+            record["result"] = {
+                "total_cost_usd": message.total_cost_usd,
+                "usage": message.usage,
+                "num_turns": message.num_turns,
+                "duration_ms": message.duration_ms,
+                "duration_api_ms": message.duration_api_ms,
+                "is_error": message.is_error,
+                "session_id": message.session_id,
+            }
+        path = Path(dump_dir) / f"stream-{os.getpid()}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, default=str) + "\n")
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: instrumentation must never break the stream loop.
+        logger.debug("ATTUNE_SDK_STREAM_DUMP write failed", exc_info=True)
+
+
 def collect_agent_output(
     message: Any,
     assistant_parts: list[str],
@@ -75,6 +130,8 @@ def collect_agent_output(
         ``run_result.result_text`` after the loop completes using
         ``build_result_text(assistant_parts, result_parts)``.
     """
+    _maybe_dump_message(message)
+
     if isinstance(message, claude_agent_sdk.AssistantMessage):
         for block in message.content:
             if isinstance(block, claude_agent_sdk.types.TextBlock):

--- a/tests/unit/workflows/test_sdk_stream_dump.py
+++ b/tests/unit/workflows/test_sdk_stream_dump.py
@@ -1,0 +1,111 @@
+"""Tests for the ATTUNE_SDK_STREAM_DUMP instrumentation
+(opus-4-8-platform-fit Phase 0, design D-instrumentation).
+
+The dump is the measurement substrate for every Phase-0 axis, so the
+guards here are: OFF by default (zero behavior change), content-free
+records (chars/flags, never text), full ResultMessage metadata, and
+fail-soft on unwritable destinations.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import claude_agent_sdk
+import pytest
+from claude_agent_sdk import types as sdk_types
+
+from attune.workflows.agent_sdk_adapter import collect_agent_output
+
+
+def _assistant(*blocks: object) -> claude_agent_sdk.AssistantMessage:
+    return claude_agent_sdk.AssistantMessage(content=list(blocks), model="claude-opus-4-8")
+
+
+def _result(**overrides: object) -> claude_agent_sdk.ResultMessage:
+    kwargs: dict[str, object] = {
+        "subtype": "success",
+        "duration_ms": 1200,
+        "duration_api_ms": 900,
+        "is_error": False,
+        "num_turns": 3,
+        "session_id": "sess-1",
+        "total_cost_usd": 1.23,
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+    kwargs.update(overrides)
+    return claude_agent_sdk.ResultMessage(**kwargs)
+
+
+def _dump_lines(dump_dir: Path) -> list[dict]:
+    files = list(dump_dir.glob("stream-*.jsonl"))
+    if not files:
+        return []
+    return [json.loads(line) for line in files[0].read_text().splitlines()]
+
+
+@pytest.mark.unit
+class TestStreamDumpOffByDefault:
+    def test_no_env_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ATTUNE_SDK_STREAM_DUMP", raising=False)
+        monkeypatch.chdir(tmp_path)
+        collect_agent_output(_assistant(sdk_types.TextBlock(text="hello")), [], [])
+        assert list(tmp_path.rglob("stream-*.jsonl")) == []
+
+    def test_collect_behavior_unchanged_when_dumping(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_SDK_STREAM_DUMP", str(tmp_path))
+        parts: list[str] = []
+        collect_agent_output(_assistant(sdk_types.TextBlock(text="analysis")), parts, [])
+        assert parts == ["analysis"]
+        run = collect_agent_output(_result(), [], [])
+        assert run is not None and run.total_cost_usd == 1.23
+
+
+@pytest.mark.unit
+class TestStreamDumpRecords:
+    def test_assistant_blocks_content_free(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_SDK_STREAM_DUMP", str(tmp_path))
+        msg = _assistant(
+            sdk_types.TextBlock(text="Should I proceed with the scan?"),
+            sdk_types.ToolUseBlock(id="t1", name="Task", input={"prompt": "secret payload"}),
+        )
+        collect_agent_output(msg, [], [])
+        (rec,) = _dump_lines(tmp_path)
+        assert rec["type"] == "AssistantMessage"
+        text_block, tool_block = rec["blocks"]
+        assert text_block["kind"] == "TextBlock"
+        assert text_block["chars"] == len("Should I proceed with the scan?")
+        assert text_block["interrogative"] is True
+        assert "Should I proceed" not in json.dumps(rec), "dump must be content-free"
+        assert "secret payload" not in json.dumps(rec), "tool input must not be dumped"
+        assert tool_block == {"kind": "ToolUseBlock", "tool_name": "Task"}
+
+    def test_result_message_metadata(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_SDK_STREAM_DUMP", str(tmp_path))
+        collect_agent_output(_result(), [], [])
+        (rec,) = _dump_lines(tmp_path)
+        assert rec["type"] == "ResultMessage"
+        assert rec["result"]["total_cost_usd"] == 1.23
+        assert rec["result"]["usage"] == {"input_tokens": 10, "output_tokens": 5}
+        assert rec["result"]["num_turns"] == 3
+
+    def test_appends_across_messages(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_SDK_STREAM_DUMP", str(tmp_path))
+        collect_agent_output(_assistant(sdk_types.TextBlock(text="a")), [], [])
+        collect_agent_output(_result(), [], [])
+        assert len(_dump_lines(tmp_path)) == 2
+
+
+@pytest.mark.unit
+class TestStreamDumpFailSoft:
+    def test_unwritable_dir_never_breaks_collection(self, tmp_path, monkeypatch):
+        blocker = tmp_path / "blocked"
+        blocker.write_text("a file, not a dir", encoding="utf-8")
+        monkeypatch.setenv("ATTUNE_SDK_STREAM_DUMP", str(blocker / "sub"))
+        parts: list[str] = []
+        collect_agent_output(_assistant(sdk_types.TextBlock(text="x")), parts, [])
+        assert parts == ["x"], "collection must survive a dump failure"


### PR DESCRIPTION
First implementation PR under the just-merged opus-4-8-platform-fit design (#742): the env-gated stream dump in `collect_agent_output` — the single funnel every SDK workflow's message loop passes through, so every Phase-0 measurement axis derives from this one dump with zero per-workflow changes.

- **Content-free records**: TextBlocks dump `chars` + an `interrogative` flag (the ask-rate signal), never the text; ToolUseBlocks dump the tool name, never inputs — dump dirs carry no code or prose (tested).
- **Off by default**: no env var → no file, zero behavior change (drift-guarded).
- **Fail-soft**: an unwritable destination logs at debug and the stream loop continues (tested).
- ResultMessage records carry cost/usage/turns/duration — the effort-fit and cost axes.

Next: the 9-run harness script + frozen corpus snapshots (separate PR); the measurement run itself stays gated on the billing fix, budget already ratified via #742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)