### PR TITLE
feat(voice): workflow-result-formatting T3 — WorkflowReport wiring + safety net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Voice wiring for structured workflow reports (workflow-result-formatting
+  T3).** `_extract_from_workflow_result` now detects a serialized
+  `WorkflowReport` (`_type` discriminator) in `final_output` and renders it
+  through `attune.voice.report_renderer.render_safe` (summary disclosure);
+  the report's score travels through, and the formatter's own cost line is
+  suppressed for rendered reports (the renderer owns cost). New
+  `resolve_show_cost()` + `AttuneConfig.show_cost_metrics` (tri-state:
+  explicit override, else auto — on for API-key users, off for
+  subscription users; design D3). The bare `str(final_output)` branch is
+  now a safety net: a visible "Renderer not yet migrated for X" banner
+  plus a repr-free field pretty-printer (proposal §6). Plain-string
+  `final_output` still passes through untouched.
+
 ## [8.2.0] — 2026-06-10
 
 The polish-cost-reduction release: LLM polish of generated docs now runs

--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -1,9 +1,12 @@
 # Tasks: Workflow result formatting
 
 **Status:** partial (2026-06-10) — T1 (the `WorkflowReport` / Section
-data model, #649) and T2 (the markdown renderer
+data model, #649), T2 (the markdown renderer
 `attune.voice.report_renderer` — `render()` + crash-visible
-`render_safe()`, all 4 test layers, 98% branch) shipped; T3+ pending.
+`render_safe()`, all 4 test layers, 98% branch, #741), and T3 (voice
+wiring: `WorkflowReport` detection branch + safety-net banner +
+`resolve_show_cost()` / `config.show_cost_metrics`) shipped; T4+
+pending.
 
 > Bounded PRs; see [design.md](design.md) for the decisions each task
 > implements.

--- a/src/attune/config.py
+++ b/src/attune/config.py
@@ -78,6 +78,11 @@ class AttuneConfig:
     feedback_loop_monitoring: bool = True
     leverage_point_analysis: bool = True
 
+    # Output settings — None means auto: show cost metrics only for
+    # API-key users (cost figures don't apply to subscription users).
+    # Resolved by attune.voice.formatter.resolve_show_cost().
+    show_cost_metrics: bool | None = None
+
     # Custom metadata
     metadata: dict[str, Any] = field(default_factory=dict)
 
@@ -246,6 +251,7 @@ class AttuneConfig:
                     "async_enabled",
                     "feedback_loop_monitoring",
                     "leverage_point_analysis",
+                    "show_cost_metrics",
                 ):
                     data[field_name] = value.lower() in ("true", "1", "yes")
                 else:

--- a/src/attune/voice/formatter.py
+++ b/src/attune/voice/formatter.py
@@ -11,6 +11,10 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import logging
+import os
+from dataclasses import fields as dataclass_fields
+from dataclasses import is_dataclass
+from enum import Enum
 from types import SimpleNamespace
 from typing import Any
 
@@ -218,6 +222,39 @@ def _extract_result_data(
     return (True, None, str(result) if result else None, None, None)
 
 
+def resolve_show_cost(config: Any | None = None) -> bool:
+    """Resolve whether human-facing output should include cost metrics.
+
+    Design D3 (workflow-result-formatting): an explicit
+    ``config.show_cost_metrics`` wins; ``None`` means auto — on for
+    API-key users, off for subscription users (cost figures don't
+    apply to them). Metadata stays in ``WorkflowReport.metadata`` and
+    ``--json`` either way; only human rendering is gated.
+
+    Args:
+        config: Optional ``AttuneConfig``. Loaded via ``load_config()``
+            when omitted.
+
+    Returns:
+        True if cost/duration/model lines should be rendered.
+
+    """
+    if config is None:
+        try:
+            from attune.config import load_config
+
+            config = load_config()
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: config loading must never break output formatting
+            logger.debug("Could not load config for show_cost", exc_info=True)
+            config = None
+
+    explicit = getattr(config, "show_cost_metrics", None)
+    if explicit is not None:
+        return bool(explicit)
+    return bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+
 def _extract_from_workflow_result(
     result: Any,
 ) -> tuple[bool, int | None, str | None, str | None, str | None]:
@@ -230,18 +267,46 @@ def _extract_from_workflow_result(
         Tuple of (success, score, report_text, cost_line, error_msg).
 
     """
+    from attune.workflows.output import WorkflowReport
+
+    from . import report_renderer
+
     report_text = None
     score = None
+    rendered_report = False
 
     # Extract formatted report from final_output
-    if isinstance(result.final_output, dict):
-        report_text = result.final_output.get("formatted_report")
-        score = result.final_output.get("score")
-    elif result.final_output is not None:
-        report_text = str(result.final_output)
+    fo = result.final_output
+    if WorkflowReport.is_report_dict(fo):
+        # Migrated workflow: reconstruct + render (design D2).
+        try:
+            report = WorkflowReport.from_dict(fo)
+            report_text = report_renderer.render_safe(
+                report,
+                disclosure="summary",
+                show_cost=resolve_show_cost(),
+            )
+            score = report.score
+            rendered_report = True
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: a malformed payload must not crash output —
+            # fall through to the plain-dict handling below.
+            logger.exception("WorkflowReport reconstruction failed")
+
+    if not rendered_report:
+        if isinstance(fo, dict):
+            report_text = fo.get("formatted_report")
+            score = fo.get("score")
+        elif isinstance(fo, str):
+            report_text = fo
+        elif fo is not None:
+            # Safety net (proposal §6): bespoke result object with no
+            # converter yet — banner + generic pretty-print, never a repr.
+            report_text = _safety_net_text(fo)
 
     # Fallback: use summary + metadata findings if report_text is sparse
-    if not report_text or len(report_text.strip()) < 50:
+    # (a rendered WorkflowReport is authoritative — never overridden).
+    if not rendered_report and (not report_text or len(report_text.strip()) < 50):
         fallback_parts: list[str] = []
         summary = getattr(result, "summary", None)
         if summary:
@@ -258,10 +323,12 @@ def _extract_from_workflow_result(
         if fallback_parts:
             report_text = "\n".join(fallback_parts)
 
-    # Build cost line (guard against None cost_report)
+    # Build cost line (guard against None cost_report). A rendered
+    # WorkflowReport owns its own cost line (gated by resolve_show_cost),
+    # so skip the formatter's to avoid double display.
     cost_line = None
     cr = result.cost_report
-    if cr is not None:
+    if cr is not None and not rendered_report:
         cost_parts = [f"${cr.total_cost:.4f}"]
         if cr.savings_percent > 0:
             cost_parts.append(f"(saved {cr.savings_percent:.0f}% vs premium)")
@@ -271,6 +338,48 @@ def _extract_from_workflow_result(
     error_msg = result.error if not result.success else None
 
     return (result.success, score, report_text, cost_line, error_msg)
+
+
+def _safety_net_text(obj: Any) -> str:
+    """Generic pretty-printer for unmigrated bespoke result objects.
+
+    Proposal §6: intentionally not pretty — it satisfies "no repr ever"
+    without satisfying "designed output." The visible banner makes the
+    missing converter obvious so it gets addressed.
+
+    Args:
+        obj: A bespoke result object (dataclass or otherwise) found in
+            ``final_output`` with no ``WorkflowReport`` converter.
+
+    Returns:
+        Banner plus an indented field listing.
+
+    """
+    type_name = type(obj).__name__
+    if is_dataclass(obj) and not isinstance(obj, type):
+        items = [(f.name, getattr(obj, f.name, None)) for f in dataclass_fields(obj)]
+    elif hasattr(obj, "__dict__"):
+        items = [(k, v) for k, v in vars(obj).items() if not k.startswith("_")]
+    else:
+        return f"⚠ Renderer not yet migrated for {type_name}.\n\n  {obj}"
+
+    lines = [f"⚠ Renderer not yet migrated for {type_name}. Raw fields:", ""]
+    for name, value in items:
+        lines.append(f"  {name}: {_safety_net_value(value)}")
+    return "\n".join(lines)
+
+
+def _safety_net_value(value: Any) -> str:
+    """One safety-net field value: counts for containers, no reprs."""
+    if isinstance(value, Enum):
+        return str(value.value)
+    if isinstance(value, list | tuple | set):
+        return f"[{len(value)} items]" if value else "(empty)"
+    if isinstance(value, dict):
+        return f"[{len(value)} keys]" if value else "(empty)"
+    if is_dataclass(value) and not isinstance(value, type):
+        return type(value).__name__
+    return str(value)
 
 
 def _extract_from_dict(

--- a/tests/unit/voice/test_formatter_report_wiring.py
+++ b/tests/unit/voice/test_formatter_report_wiring.py
@@ -1,0 +1,306 @@
+"""Tests for T3 voice wiring: WorkflowReport detection, the safety
+net, and resolve_show_cost (workflow-result-formatting design D2/D3).
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from unittest.mock import patch
+
+from attune.config import AttuneConfig
+from attune.voice.formatter import (
+    _extract_from_workflow_result,
+    _safety_net_text,
+    format_output,
+    resolve_show_cost,
+)
+from attune.workflows.data_classes import CostReport, WorkflowResult
+from attune.workflows.output import (
+    Finding,
+    ProseSection,
+    WorkflowReport,
+)
+
+
+def _make_result(final_output, success: bool = True) -> WorkflowResult:
+    now = datetime.now(timezone.utc)
+    return WorkflowResult(
+        success=success,
+        stages=[],
+        final_output=final_output,
+        cost_report=CostReport(
+            total_cost=0.0042,
+            baseline_cost=0.01,
+            savings=0.0058,
+            savings_percent=58.0,
+        ),
+        started_at=now,
+        completed_at=now,
+        total_duration_ms=1500,
+    )
+
+
+def _report(**kwargs) -> WorkflowReport:
+    defaults = {
+        "title": "Security Audit",
+        "summary": "Looked at 12 files, found 2 issues worth your time.",
+        "score": 87,
+        "sections": [
+            ProseSection(title="Overview", tier="essential", text="All quiet."),
+        ],
+    }
+    defaults.update(kwargs)
+    return WorkflowReport(**defaults)
+
+
+class TestWorkflowReportBranch:
+    """_extract_from_workflow_result detects serialized WorkflowReports."""
+
+    def test_renders_report_dict_as_markdown(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(_report().to_dict())
+
+        success, score, report_text, cost_line, error = _extract_from_workflow_result(result)
+
+        assert success is True
+        assert "# Security Audit" in report_text
+        assert "All quiet." in report_text
+        assert error is None
+
+    def test_score_comes_from_report(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(_report(score=64).to_dict())
+
+        _, score, _, _, _ = _extract_from_workflow_result(result)
+
+        assert score == 64
+
+    def test_cost_line_suppressed_for_rendered_report(self, monkeypatch):
+        """The renderer owns cost for migrated workflows — no double display."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(_report().to_dict())
+
+        _, _, _, cost_line, _ = _extract_from_workflow_result(result)
+
+        assert cost_line is None
+
+    def test_no_cost_line_when_cost_report_missing(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result({"formatted_report": "plain report text " * 5})
+        result.cost_report = None
+
+        _, _, _, cost_line, _ = _extract_from_workflow_result(result)
+
+        assert cost_line is None
+
+    def test_minimal_report_not_overridden_by_sparse_fallback(self, monkeypatch):
+        """A rendered report under 50 chars is authoritative, not 'sparse'."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        tiny = WorkflowReport(title="Hi")
+        result = _make_result(tiny.to_dict())
+        result.metadata = {"findings": {"bugs": ["should not appear"]}}
+
+        _, _, report_text, _, _ = _extract_from_workflow_result(result)
+
+        assert report_text.strip() == "# Hi"
+        assert "should not appear" not in report_text
+
+    def test_show_cost_true_renders_cost_line_from_metadata(self, monkeypatch):
+        report = _report(metadata={"cost_usd": 0.42, "duration_s": 12.5})
+        result = _make_result(report.to_dict())
+
+        with patch("attune.voice.formatter.resolve_show_cost", return_value=True):
+            _, _, report_text, _, _ = _extract_from_workflow_result(result)
+
+        assert "Cost & time" in report_text
+        assert "$0.42" in report_text
+
+    def test_show_cost_false_hides_cost_line(self, monkeypatch):
+        report = _report(metadata={"cost_usd": 0.42, "duration_s": 12.5})
+        result = _make_result(report.to_dict())
+
+        with patch("attune.voice.formatter.resolve_show_cost", return_value=False):
+            _, _, report_text, _, _ = _extract_from_workflow_result(result)
+
+        assert "Cost & time" not in report_text
+
+    def test_malformed_report_dict_degrades_without_crash(self, monkeypatch):
+        """from_dict failure falls through to plain-dict handling."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        bad = {"_type": "WorkflowReport", "title": "X", "sections": 42}
+        result = _make_result(bad)
+
+        success, score, report_text, _, _ = _extract_from_workflow_result(result)
+
+        assert success is True  # no exception escaped
+
+    def test_format_output_end_to_end_with_report(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        report = WorkflowReport.from_findings(
+            "Bug Predict",
+            [Finding(severity="high", file="a.py", line=1, message="eval misuse")],
+            score=70,
+        )
+        result = _make_result(report.to_dict())
+
+        with patch("attune.voice.formatter.get_next_steps", return_value=[]):
+            out = format_output("bug-predict", result)
+
+        assert "# Bug Predict" in out
+        assert "eval misuse" in out
+        assert "object at 0x" not in out
+
+
+class _Confidence(Enum):
+    HIGH = "high"
+
+
+@dataclass
+class _BespokeReport:
+    approved: bool = True
+    confidence: _Confidence = _Confidence.HIGH
+    blockers: list = field(default_factory=list)
+    gates: list = field(default_factory=lambda: ["a", "b", "c"])
+
+
+class TestSafetyNet:
+    """The bare str() branch is now a banner'd pretty-printer."""
+
+    def test_bespoke_dataclass_gets_banner_and_fields(self):
+        result = _make_result(_BespokeReport())
+
+        _, _, report_text, _, _ = _extract_from_workflow_result(result)
+
+        assert "Renderer not yet migrated for _BespokeReport" in report_text
+        assert "approved: True" in report_text
+        assert "confidence: high" in report_text  # enum -> .value
+        assert "blockers: (empty)" in report_text
+        assert "gates: [3 items]" in report_text
+        assert "object at 0x" not in report_text
+
+    def test_plain_string_passes_through_without_banner(self):
+        result = _make_result("Everything looks great. " * 5)
+
+        _, _, report_text, _, _ = _extract_from_workflow_result(result)
+
+        assert "Renderer not yet migrated" not in report_text
+        assert "Everything looks great." in report_text
+
+    def test_primitive_gets_banner_with_value(self):
+        text = _safety_net_text(42)
+
+        assert "Renderer not yet migrated for int" in text
+        assert "42" in text
+
+    def test_plain_object_lists_public_attrs_only(self):
+        class Thing:
+            def __init__(self):
+                self.visible = "yes"
+                self._hidden = "no"
+
+        text = _safety_net_text(Thing())
+
+        assert "visible: yes" in text
+        assert "_hidden" not in text
+
+    def test_dict_and_nested_dataclass_values(self):
+        @dataclass
+        class Inner:
+            x: int = 1
+
+        @dataclass
+        class Outer:
+            meta: dict = field(default_factory=lambda: {"a": 1, "b": 2})
+            empty_meta: dict = field(default_factory=dict)
+            child: Inner = field(default_factory=Inner)
+
+        text = _safety_net_text(Outer())
+
+        assert "meta: [2 keys]" in text
+        assert "empty_meta: (empty)" in text
+        assert "child: Inner" in text
+        assert "object at 0x" not in text
+
+    def test_none_final_output_uses_summary_fallback(self):
+        result = _make_result(None)
+        result.metadata = {"findings": {"bugs": ["found one"]}}
+
+        _, _, report_text, _, _ = _extract_from_workflow_result(result)
+
+        assert "found one" in report_text
+        assert "Renderer not yet migrated" not in report_text
+
+
+class TestResolveShowCost:
+    """Design D3: explicit config wins; None means auto via API key."""
+
+    def test_explicit_true_wins_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        cfg = AttuneConfig(show_cost_metrics=True)
+
+        assert resolve_show_cost(cfg) is True
+
+    def test_explicit_false_wins_over_api_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        cfg = AttuneConfig(show_cost_metrics=False)
+
+        assert resolve_show_cost(cfg) is False
+
+    def test_auto_on_for_api_key_users(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        cfg = AttuneConfig()  # show_cost_metrics defaults to None
+
+        assert resolve_show_cost(cfg) is True
+
+    def test_auto_off_for_subscription_users(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        cfg = AttuneConfig()
+
+        assert resolve_show_cost(cfg) is False
+
+    def test_empty_api_key_counts_as_absent(self, monkeypatch):
+        """CI sets the secret to '' — empty must mean off, not on."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        cfg = AttuneConfig()
+
+        assert resolve_show_cost(cfg) is False
+
+    def test_loads_config_when_omitted(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)  # no repo config files in scope
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        assert resolve_show_cost() is False
+
+    def test_config_load_failure_degrades_to_auto(self, monkeypatch):
+        """A broken config must never break output formatting."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("config exploded")
+
+        monkeypatch.setattr("attune.config.load_config", _boom)
+
+        assert resolve_show_cost() is True
+
+
+class TestConfigField:
+    """AttuneConfig.show_cost_metrics field + env parsing."""
+
+    def test_defaults_to_none(self):
+        assert AttuneConfig().show_cost_metrics is None
+
+    def test_from_env_parses_true(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_SHOW_COST_METRICS", "true")
+
+        assert AttuneConfig.from_env().show_cost_metrics is True
+
+    def test_from_env_parses_false(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_SHOW_COST_METRICS", "false")
+
+        assert AttuneConfig.from_env().show_cost_metrics is False
+
+    def test_from_env_absent_stays_none(self, monkeypatch):
+        monkeypatch.delenv("ATTUNE_SHOW_COST_METRICS", raising=False)
+        monkeypatch.delenv("EMPATHY_SHOW_COST_METRICS", raising=False)
+
+        assert AttuneConfig.from_env().show_cost_metrics is None


### PR DESCRIPTION
## Summary

Workflow-result-formatting **T3** — the voice layer now consumes the T1 data model (#649) + T2 renderer (#741):

- **`WorkflowReport` detection** (design D2): `_extract_from_workflow_result` checks `final_output` for the `_type: "WorkflowReport"` discriminator before the `str()` fallback, reconstructs via `from_dict`, and renders through `report_renderer.render_safe(disclosure="summary", show_cost=resolve_show_cost())`. Score comes from the report; the formatter's own cost line is suppressed for rendered reports (the renderer owns cost — no double display). A rendered report is authoritative: never overridden by the sparse-text fallback. Malformed payloads log + degrade to plain-dict handling, never crash.
- **Safety net** (proposal §6): the bare `str(final_output)` branch is now a visible `⚠ Renderer not yet migrated for <Type>` banner + repr-free pretty-printer (enums → `.value`, containers → counts, nested dataclasses → type name). Plain-string `final_output` passes through untouched — that's a normal text report, not a repr leak.
- **`resolve_show_cost()` + `AttuneConfig.show_cost_metrics`** (design D3): tri-state — explicit config wins; `None` = auto (on for API-key users, off for subscription users; empty `ANTHROPIC_API_KEY` counts as absent, matching CI). `ATTUNE_SHOW_COST_METRICS` parsed in `from_env`. Config-load failure degrades to auto, never breaks output.

## Test plan

- 26 new tests in `tests/unit/voice/test_formatter_report_wiring.py` (report branch, safety net, show-cost resolution, config field/env parsing)
- All 91 pre-existing voice tests + 266 config tests + MCP/ops/CLI formatter consumers pass unchanged
- `attune.voice.formatter` at 94% branch coverage; every remaining miss is a pre-existing line outside this diff

Spec: `docs/specs/workflow-result-formatting` (tasks.md updated; T4 CLI is next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
