### PR TITLE
feat(voice): workflow-result-formatting T3 — render WorkflowReport, safety-net banner, show_cost_metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Voice layer renders `WorkflowReport` results**
+  (workflow-result-formatting T3). `_extract_from_workflow_result`
+  detects a serialized `WorkflowReport` (`_type` discriminator) in
+  `final_output`, reconstructs it, and renders summary-mode markdown
+  via `attune.voice.report_renderer.render_safe`. Unmigrated bespoke
+  result objects no longer leak dataclass reprs — they get a visible
+  "Renderer not yet migrated for <Type>" banner plus a generic field
+  pretty-print (enums as values, collections as counts, one level of
+  nested-dataclass indent). SDK string output passes through
+  unchanged.
+- **`show_cost_metrics` config + `resolve_show_cost()`** (design D3).
+  `AttuneConfig.show_cost_metrics: bool | None` — `None` (default)
+  auto-resolves to "show cost iff `ANTHROPIC_API_KEY` is set", so
+  subscription users never see inapplicable cost figures; explicit
+  `True`/`False` (file, env `ATTUNE_SHOW_COST_METRICS`) overrides.
+  Cost data always stays in `WorkflowReport.metadata` and `--json`.
+
 ## [8.2.0] — 2026-06-10
 
 The polish-cost-reduction release: LLM polish of generated docs now runs

--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -1,9 +1,14 @@
 # Tasks: Workflow result formatting
 
 **Status:** partial (2026-06-10) — T1 (the `WorkflowReport` / Section
-data model, #649) and T2 (the markdown renderer
+data model, #649), T2 (the markdown renderer
 `attune.voice.report_renderer` — `render()` + crash-visible
-`render_safe()`, all 4 test layers, 98% branch) shipped; T3+ pending.
+`render_safe()`, all 4 test layers, 98% branch, #741), and T3 (voice
+wiring + safety net + `show_cost_metrics`/`resolve_show_cost()`)
+shipped; T4+ pending. T4 note: the rendered report embeds
+`**Score:** N/100` and `format_output` appends its own plain
+`Score: N/100` line — resolve the duplication when reworking the CLI
+surface.
 
 > Bounded PRs; see [design.md](design.md) for the decisions each task
 > implements.
@@ -44,14 +49,20 @@ data model, #649) and T2 (the markdown renderer
   renderer-crash visibility.
 - One PR.
 
-## T3 — Voice wiring + safety net
+## T3 — Voice wiring + safety net — DONE
 
 - `_extract_from_workflow_result`: add the `_type=="WorkflowReport"`
   branch before the `str()` fallback → reconstruct + render; turn the
   bare `str()` branch into the safety-net pretty-printer + "renderer not
   migrated" banner. Add `resolve_show_cost()` + `config.show_cost_metrics`.
   (Design D2/D3.)
-- One PR.
+- One PR. Shipped: `WorkflowReport.is_report_dict` branch renders via
+  `render_safe(disclosure="summary", show_cost=resolve_show_cost())`;
+  plain-`str` final_output (SDK markdown) passes through unchanged; the
+  bespoke-object branch emits the §6 banner + field pretty-print;
+  rendered branches are exempt from the sparse summary fallback.
+  `resolve_show_cost()` lives in `attune.config` (env var
+  `ATTUNE_SHOW_COST_METRICS` also parsed as bool by `from_env`).
 
 ## T4 — CLI
 

--- a/src/attune/config.py
+++ b/src/attune/config.py
@@ -11,6 +11,7 @@ Licensed under the Apache License, Version 2.0
 """
 
 import json
+import logging
 import os
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -62,6 +63,12 @@ class AttuneConfig:
     # Metrics settings
     metrics_enabled: bool = True
     metrics_path: str = "./metrics.db"
+
+    # Output settings
+    # None = auto: show cost metrics iff ANTHROPIC_API_KEY is set
+    # (cost figures don't apply to subscription users; see
+    # resolve_show_cost()).
+    show_cost_metrics: bool | None = None
 
     # Logging settings
     log_level: str = "INFO"
@@ -246,6 +253,7 @@ class AttuneConfig:
                     "async_enabled",
                     "feedback_loop_monitoring",
                     "leverage_point_analysis",
+                    "show_cost_metrics",
                 ):
                     data[field_name] = value.lower() in ("true", "1", "yes")
                 else:
@@ -507,6 +515,45 @@ def load_config(
     config.validate()
 
     return config
+
+
+def resolve_show_cost(config: "AttuneConfig | None" = None) -> bool:
+    """Resolve whether human-facing output should show cost metrics.
+
+    Resolution order (workflow-result-formatting design D3):
+
+    1. ``config.show_cost_metrics`` when explicitly set (``True``/``False``).
+    2. Auto default: ``True`` iff ``ANTHROPIC_API_KEY`` is set — cost
+       figures only apply to pay-per-call API users, not subscription
+       users.
+
+    Cost data always stays in ``WorkflowReport.metadata`` and ``--json``
+    output; this flag only gates the human-readable rendering.
+
+    Args:
+        config: Configuration to read the override from. ``None`` loads
+            the ambient configuration via :func:`load_config`.
+
+    Returns:
+        True if cost metrics should be rendered.
+
+    """
+    if config is None:
+        try:
+            config = load_config()
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: a malformed user config must never break
+            # output formatting — fall through to the env auto default.
+            logging.getLogger(__name__).warning(
+                "Failed to load config for show_cost resolution",
+                exc_info=True,
+            )
+            config = None
+
+    if config is not None and config.show_cost_metrics is not None:
+        return bool(config.show_cost_metrics)
+
+    return bool(os.environ.get("ANTHROPIC_API_KEY"))
 
 
 # Backward-compatible alias (deprecated: use AttuneConfig)

--- a/src/attune/config/__init__.py
+++ b/src/attune/config/__init__.py
@@ -34,11 +34,13 @@ if spec and spec.loader:
     AttuneConfig: Any = legacy_config.AttuneConfig
     EmpathyConfig: Any = legacy_config.EmpathyConfig  # backward-compat alias
     load_config: Any = legacy_config.load_config
+    resolve_show_cost: Any = legacy_config.resolve_show_cost
 else:
     # Fallback if import fails
     AttuneConfig = None
     EmpathyConfig = None
     load_config = None
+    resolve_show_cost = None
 
 # Import XML enhancement configs
 # Import agent configuration models
@@ -71,6 +73,7 @@ __all__ = [
     "AttuneConfig",
     "EmpathyConfig",
     "load_config",
+    "resolve_show_cost",
     "YAML_AVAILABLE",
     "_validate_file_path",
     # XML enhancement configs

--- a/src/attune/voice/formatter.py
+++ b/src/attune/voice/formatter.py
@@ -10,6 +10,8 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import dataclasses
+import enum
 import logging
 from types import SimpleNamespace
 from typing import Any
@@ -232,16 +234,42 @@ def _extract_from_workflow_result(
     """
     report_text = None
     score = None
+    # True when report_text is designed output (rendered WorkflowReport or
+    # the safety-net pretty-print) — exempt from the sparse fallback below.
+    rendered = False
 
     # Extract formatted report from final_output
-    if isinstance(result.final_output, dict):
-        report_text = result.final_output.get("formatted_report")
-        score = result.final_output.get("score")
-    elif result.final_output is not None:
-        report_text = str(result.final_output)
+    fo = result.final_output
+    if isinstance(fo, dict):
+        from attune.workflows.output import WorkflowReport
+
+        if WorkflowReport.is_report_dict(fo):
+            # Migrated workflow: reconstruct + render (design D2).
+            from attune.config import resolve_show_cost
+            from attune.voice import report_renderer
+
+            report = WorkflowReport.from_dict(fo)
+            report_text = report_renderer.render_safe(
+                report,
+                disclosure="summary",
+                show_cost=resolve_show_cost(),
+            )
+            score = report.score
+            rendered = True
+        else:
+            report_text = fo.get("formatted_report")
+            score = fo.get("score")
+    elif isinstance(fo, str):
+        # SDK workflows emit markdown text directly — pass through.
+        report_text = fo
+    elif fo is not None:
+        # Unmigrated bespoke result object: safety net instead of a raw
+        # repr (proposal §6) — banner + generic field pretty-print.
+        report_text = _format_unmigrated(fo)
+        rendered = True
 
     # Fallback: use summary + metadata findings if report_text is sparse
-    if not report_text or len(report_text.strip()) < 50:
+    if not rendered and (not report_text or len(report_text.strip()) < 50):
         fallback_parts: list[str] = []
         summary = getattr(result, "summary", None)
         if summary:
@@ -271,6 +299,62 @@ def _extract_from_workflow_result(
     error_msg = result.error if not result.success else None
 
     return (result.success, score, report_text, cost_line, error_msg)
+
+
+def _format_unmigrated(value: Any) -> str:
+    """Safety net for bespoke result objects with no renderer yet.
+
+    Emits a visible "renderer not yet migrated" banner plus a generic
+    field pretty-print (proposal §6): enums become ``.value``, nested
+    dataclasses indent one level, collections show counts, empties show
+    ``(empty)``. Intentionally not pretty — it satisfies "no repr ever"
+    while making the migration gap obvious.
+
+    Args:
+        value: The unmigrated ``final_output`` object.
+
+    Returns:
+        Banner + indented field summary text.
+
+    """
+    type_name = type(value).__name__
+    lines = [f"⚠ Renderer not yet migrated for {type_name}. Raw fields:", ""]
+    lines.extend(_pretty_fields(value, indent="  ", depth=0))
+    return "\n".join(lines)
+
+
+def _pretty_fields(value: Any, *, indent: str, depth: int) -> list[str]:
+    """One line per field of ``value``; nested dataclasses indent once."""
+    pairs: list[tuple[str, Any]]
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        pairs = [(f.name, getattr(value, f.name, None)) for f in dataclasses.fields(value)]
+    elif hasattr(value, "__dict__"):
+        pairs = [(k, v) for k, v in vars(value).items() if not k.startswith("_")]
+    else:
+        return [f"{indent}{value}"]
+
+    lines: list[str] = []
+    for name, val in pairs:
+        if dataclasses.is_dataclass(val) and not isinstance(val, type) and depth < 1:
+            lines.append(f"{indent}{name}: {type(val).__name__}")
+            lines.extend(_pretty_fields(val, indent=indent + "  ", depth=depth + 1))
+        else:
+            lines.append(f"{indent}{name}: {_summarize_field(val)}")
+    return lines
+
+
+def _summarize_field(val: Any) -> str:
+    """Scalar summary for one field value — counts, not contents."""
+    if isinstance(val, enum.Enum):
+        return str(val.value)
+    if dataclasses.is_dataclass(val) and not isinstance(val, type):
+        return type(val).__name__
+    if isinstance(val, list | tuple | set):
+        return f"[{len(val)} items]" if val else "(empty)"
+    if isinstance(val, dict):
+        return f"[{len(val)} keys]" if val else "(empty)"
+    text = str(val)
+    return text if len(text) <= 120 else text[:117] + "..."
 
 
 def _extract_from_dict(

--- a/tests/unit/test_config_module.py
+++ b/tests/unit/test_config_module.py
@@ -10,7 +10,7 @@ import tempfile
 
 import pytest
 
-from attune.config import YAML_AVAILABLE, EmpathyConfig
+from attune.config import YAML_AVAILABLE, EmpathyConfig, resolve_show_cost
 from attune.workflows.config import ModelConfig
 
 
@@ -242,3 +242,76 @@ class TestEmpathyConfigEnvironment:
         config = EmpathyConfig.from_env()
         assert config.confidence_threshold == pytest.approx(0.95)
         assert config.trust_building_rate == pytest.approx(0.1)
+
+    def test_show_cost_metrics_env_boolean_conversion(self, monkeypatch):
+        """ATTUNE_SHOW_COST_METRICS parses as a boolean, not a string."""
+        monkeypatch.setenv("ATTUNE_SHOW_COST_METRICS", "true")
+        assert EmpathyConfig.from_env().show_cost_metrics is True
+
+        monkeypatch.setenv("ATTUNE_SHOW_COST_METRICS", "false")
+        assert EmpathyConfig.from_env().show_cost_metrics is False
+
+    def test_show_cost_metrics_defaults_to_none(self, monkeypatch):
+        """Unset show_cost_metrics stays None (auto mode)."""
+        monkeypatch.delenv("ATTUNE_SHOW_COST_METRICS", raising=False)
+        monkeypatch.delenv("EMPATHY_SHOW_COST_METRICS", raising=False)
+        assert EmpathyConfig().show_cost_metrics is None
+        assert EmpathyConfig.from_env().show_cost_metrics is None
+
+
+@pytest.mark.unit
+class TestResolveShowCost:
+    """resolve_show_cost (workflow-result-formatting design D3)."""
+
+    def test_explicit_true_wins_without_api_key(self, monkeypatch):
+        """Config True overrides the missing-key auto default."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        config = EmpathyConfig(show_cost_metrics=True)
+        assert resolve_show_cost(config) is True
+
+    def test_explicit_false_wins_with_api_key(self, monkeypatch):
+        """Config False overrides the key-present auto default."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "FAKE_key_NOT_REAL")
+        config = EmpathyConfig(show_cost_metrics=False)
+        assert resolve_show_cost(config) is False
+
+    def test_auto_on_when_api_key_set(self, monkeypatch):
+        """None (auto) shows cost for pay-per-call API users."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "FAKE_key_NOT_REAL")
+        assert resolve_show_cost(EmpathyConfig()) is True
+
+    def test_auto_off_when_api_key_missing(self, monkeypatch):
+        """None (auto) hides cost for subscription users (no key)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert resolve_show_cost(EmpathyConfig()) is False
+
+    def test_auto_off_when_api_key_empty(self, monkeypatch):
+        """Empty-string key (the CI convention) counts as no key."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        assert resolve_show_cost(EmpathyConfig()) is False
+
+    def test_loads_ambient_config_when_none(self, tmp_path, monkeypatch):
+        """config=None reads the cwd config file's explicit override."""
+        (tmp_path / ".attune.json").write_text('{"show_cost_metrics": true}')
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert resolve_show_cost() is True
+
+    def test_ambient_config_false_wins_over_key(self, tmp_path, monkeypatch):
+        """An explicit file-level False beats a present API key."""
+        (tmp_path / ".attune.json").write_text('{"show_cost_metrics": false}')
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "FAKE_key_NOT_REAL")
+        assert resolve_show_cost() is False
+
+    def test_config_load_failure_falls_back_to_env(self, monkeypatch):
+        """A crashing load_config degrades to the env auto default."""
+
+        def _boom(*args, **kwargs):
+            raise ValueError("malformed user config")
+
+        monkeypatch.setitem(resolve_show_cost.__globals__, "load_config", _boom)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "FAKE_key_NOT_REAL")
+        assert resolve_show_cost() is True
+        monkeypatch.delenv("ANTHROPIC_API_KEY")
+        assert resolve_show_cost() is False

--- a/tests/unit/voice/test_formatter.py
+++ b/tests/unit/voice/test_formatter.py
@@ -1,6 +1,9 @@
 """Tests for the unified voice formatter."""
 
+from dataclasses import dataclass
+from dataclasses import field as dc_field
 from datetime import datetime, timezone
+from enum import Enum
 from unittest.mock import patch
 
 from attune.voice import personality
@@ -259,3 +262,263 @@ class TestExtractResultData:
         success, score, text, cost, error = _extract_result_data(None)
         assert success is True
         assert text is None
+
+
+class TestWorkflowReportRendering:
+    """The _type=="WorkflowReport" branch (workflow-result-formatting T3)."""
+
+    def _report_dict(self, **overrides):
+        """Serialized WorkflowReport fixture, as final_output carries it."""
+        from attune.workflows.output import (
+            NextAction,
+            NextStepsSection,
+            ProseSection,
+            WorkflowReport,
+        )
+
+        kwargs = {
+            "title": "Code review",
+            "summary": "3 issues found across 2 files.",
+            "score": 88,
+            "metadata": {"cost_usd": 1.23, "duration_s": 42.0},
+            "sections": [
+                ProseSection(
+                    title="Overview",
+                    tier="essential",
+                    text="Looks solid overall.",
+                ),
+                NextStepsSection(
+                    title="Next steps",
+                    tier="essential",
+                    items=[
+                        NextAction(
+                            text="Fix the loop",
+                            command="attune workflow run fix-test",
+                        )
+                    ],
+                ),
+            ],
+        }
+        kwargs.update(overrides)
+        return WorkflowReport(**kwargs).to_dict()
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_rendered_markdown_included(self, _mock, monkeypatch, tmp_path):
+        """A serialized report renders via the markdown renderer."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(final_output=self._report_dict())
+        output = format_output("code-review", result)
+        assert "# Code review" in output
+        assert "Looks solid overall." in output
+        assert "Fix the loop" in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_score_extracted_from_report(self, _mock, monkeypatch, tmp_path):
+        """report.score drives the score commentary and score line."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(final_output=self._report_dict())
+        output = format_output("code-review", result)
+        assert personality.score_commentary(88) in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_no_repr_leak(self, _mock, monkeypatch, tmp_path):
+        """Rendered output never contains dataclass repr fragments."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(final_output=self._report_dict())
+        output = format_output("code-review", result)
+        assert "<class '" not in output
+        assert "WorkflowReport(" not in output
+        assert "ProseSection(" not in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_cost_hidden_without_api_key(self, _mock, monkeypatch, tmp_path):
+        """Auto show_cost: metadata cost line hidden for subscription users."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(final_output=self._report_dict(), cost_report=None)
+        output = format_output("code-review", result)
+        assert "Cost & time" not in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_cost_shown_with_api_key(self, _mock, monkeypatch, tmp_path):
+        """Auto show_cost: metadata cost line shown for API users."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "FAKE_key_NOT_REAL")
+        result = _make_result(final_output=self._report_dict(), cost_report=None)
+        output = format_output("code-review", result)
+        assert "Cost & time" in output
+        assert "$1.23" in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_rendered_report_skips_sparse_fallback(self, _mock, monkeypatch, tmp_path):
+        """A short rendered report is authoritative — no findings fallback."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(
+            final_output=self._report_dict(
+                title="T", summary="", score=None, metadata={}, sections=[]
+            ),
+        )
+        result.metadata = {"findings": {"security_issues": ["issue one"]}}
+        output = format_output("security-audit", result)
+        assert "# T" in output
+        # The metadata-findings fallback heading must NOT replace the report.
+        assert "## Security Issues" not in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_renderer_crash_shows_banner(self, _mock, monkeypatch, tmp_path):
+        """A renderer bug stays visible (render_safe banner + fallback)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with patch(
+            "attune.voice.report_renderer.render",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = _make_result(final_output=self._report_dict())
+            output = format_output("code-review", result)
+        assert "Report renderer error" in output
+        assert "Code review" in output  # safety-net fallback still shows content
+
+
+class TestUnmigratedSafetyNet:
+    """The bare-object branch: banner + pretty-print (proposal §6)."""
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_banner_names_type_and_no_repr(self, _mock):
+        """Bespoke dataclass gets the migration banner, never a repr."""
+
+        @dataclass
+        class FakeReadinessReport:
+            approved: bool = True
+            blockers: list = dc_field(default_factory=list)
+
+        result = _make_result(final_output=FakeReadinessReport())
+        output = format_output("release-prep", result)
+        assert "Renderer not yet migrated for FakeReadinessReport" in output
+        assert "FakeReadinessReport(" not in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_field_summaries(self, _mock):
+        """Enums show .value; collections show counts; empties show (empty)."""
+
+        class Confidence(Enum):
+            HIGH = "high"
+
+        @dataclass
+        class FakeReport:
+            confidence: Confidence = Confidence.HIGH
+            gates: list = dc_field(default_factory=lambda: [1, 2, 3, 4])
+            blockers: list = dc_field(default_factory=list)
+            extras: dict = dc_field(default_factory=lambda: {"a": 1, "b": 2})
+
+        result = _make_result(final_output=FakeReport())
+        output = format_output("release-prep", result)
+        assert "confidence: high" in output
+        assert "gates: [4 items]" in output
+        assert "blockers: (empty)" in output
+        assert "extras: [2 keys]" in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_nested_dataclass_indents(self, _mock):
+        """One level of nested dataclass expands with deeper indentation."""
+
+        @dataclass
+        class Inner:
+            passed: bool = True
+
+        @dataclass
+        class Outer:
+            inner: Inner = dc_field(default_factory=Inner)
+
+        result = _make_result(final_output=Outer())
+        output = format_output("release-prep", result)
+        assert "  inner: Inner" in output
+        assert "    passed: True" in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_long_string_field_truncated(self, _mock):
+        """A long string field is capped, keeping lines readable."""
+
+        @dataclass
+        class FakeReport:
+            notes: str = "x" * 300
+
+        result = _make_result(final_output=FakeReport())
+        output = format_output("release-prep", result)
+        assert "x" * 300 not in output
+        assert "..." in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_plain_object_with_dict(self, _mock):
+        """Non-dataclass objects pretty-print their public attributes."""
+
+        class Legacy:
+            def __init__(self):
+                self.status = "ok"
+                self._private = "hidden"
+
+        result = _make_result(final_output=Legacy())
+        output = format_output("release-prep", result)
+        assert "Renderer not yet migrated for Legacy" in output
+        assert "status: ok" in output
+        assert "_private" not in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_fieldless_value_stringifies(self, _mock):
+        """A value with no fields still shows under the banner."""
+        result = _make_result(final_output=42)
+        output = format_output("release-prep", result)
+        assert "Renderer not yet migrated for int" in output
+        assert "42" in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_string_final_output_passes_through(self, _mock):
+        """SDK markdown text keeps passing through with no banner."""
+        result = _make_result(final_output="## Findings\n\n- one\n- two\n- three!")
+        output = format_output("bug-predict", result)
+        assert "Renderer not yet migrated" not in output
+        assert "## Findings" in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_none_final_output_uses_summary_fallback(self, _mock):
+        """final_output=None still reaches the summary fallback, no banner."""
+        now = datetime.now(timezone.utc)
+        result = WorkflowResult(
+            success=True,
+            stages=[],
+            final_output=None,
+            cost_report=None,
+            started_at=now,
+            completed_at=now,
+            total_duration_ms=1000,
+            summary="Run finished with no structured output.",
+        )
+        output = format_output("code-review", result)
+        assert "Renderer not yet migrated" not in output
+        assert "Run finished with no structured output." in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_deep_nesting_collapses_to_type_name(self, _mock):
+        """Past the indent depth cap, nested dataclasses summarize by name."""
+
+        @dataclass
+        class Innermost:
+            value: int = 1
+
+        @dataclass
+        class Inner:
+            deepest: Innermost = dc_field(default_factory=Innermost)
+
+        @dataclass
+        class Outer:
+            inner: Inner = dc_field(default_factory=Inner)
+
+        result = _make_result(final_output=Outer())
+        output = format_output("release-prep", result)
+        assert "  inner: Inner" in output
+        # Depth cap: the second nesting level shows the type name only.
+        assert "deepest: Innermost" in output
+        assert "value: 1" not in output


### PR DESCRIPTION
## Summary

Workflow-result-formatting **T3** — the voice layer now renders structured `WorkflowReport` results, and unmigrated bespoke result objects get a visible safety-net banner instead of a raw dataclass repr. Follows T1 (#649, data model) and T2 (#741, markdown renderer).

### Voice wiring (design D2)

`_extract_from_workflow_result` gains a branch before the legacy paths: a `final_output` dict carrying the `_type: "WorkflowReport"` discriminator is reconstructed via `WorkflowReport.from_dict` and rendered with `report_renderer.render_safe(disclosure="summary", show_cost=resolve_show_cost())`. The crash-visible wrapper means a renderer bug surfaces as an error banner + fallback, never a swallow.

- Plain-`str` `final_output` (SDK markdown) passes through unchanged.
- The legacy `{"formatted_report": ...}` dict branch stays for not-yet-migrated workflows.
- Rendered branches are exempt from the sparse summary fallback — a rendered report is authoritative and the migration banner must stay visible.

### Safety net (proposal §6)

A bespoke result object (e.g. `ReleaseReadinessReport`) now emits:

```
⚠ Renderer not yet migrated for FakeReadinessReport. Raw fields:

  approved: True
  confidence: high
  gates: [4 items]
  blockers: (empty)
```

Enums show `.value`, collections show counts, empties show `(empty)`, nested dataclasses indent one level then collapse to the type name, long strings cap at 120 chars. Intentionally not pretty — it satisfies "no repr ever" while keeping the migration gap obvious.

### `show_cost_metrics` (design D3)

`AttuneConfig.show_cost_metrics: bool | None = None` + `resolve_show_cost()` in `attune.config`. `None` (default) auto-resolves to "show cost iff `ANTHROPIC_API_KEY` is set" — subscription users never see inapplicable cost figures. Explicit `True`/`False` (config file or `ATTUNE_SHOW_COST_METRICS`, parsed as bool by `from_env`) overrides. A malformed user config degrades to the env default rather than breaking output formatting. Cost data always stays in `WorkflowReport.metadata` and `--json`.

## Tests

- 11 new formatter tests: render path, score extraction, repr-leak guard, cost gating both directions, sparse-fallback exemption, renderer-crash banner, safety-net field shapes (enum/counts/nesting/truncation/plain-object/fieldless), str passthrough, `final_output=None`.
- 9 new config tests: explicit override beats env both ways, auto on/off/empty-key (the CI empty-string convention), ambient-file resolution, load-crash fallback, `from_env` bool parse + None default.
- Changed-line branch coverage complete (`coverage run --branch`); remaining module misses are pre-existing untouched lines.
- 302 voice+config tests pass locally.

## Notes

- tasks.md flips T3 to DONE and records a T4 touchpoint: the renderer embeds `**Score:** N/100` and `format_output` appends its own plain score line — resolve the duplication when reworking the CLI surface in T4.
- The `.help` configuration-feature regen the pre-commit hook produced was discarded per the standing stub-overwrite rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
