### PR TITLE
docs(spec): sdk-subprocess-isolation — subscription users can run SDK workflows

### DIFF
--- a/docs/specs/sdk-subprocess-isolation/decisions.md
+++ b/docs/specs/sdk-subprocess-isolation/decisions.md
@@ -1,0 +1,31 @@
+# Spec: SDK Subprocess Isolation — Decisions
+
+> Pre-committed per the "decision matrices survive contact with
+> data" lesson. D1/D2 were ratified by Patrick in-session 2026-06-10
+> before drafting; the rest are design decisions recorded with
+> rationale so later sessions don't re-litigate.
+
+---
+
+## Decision matrix
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| D1 | Hook gating scope | **Gate ALL 12 plugin hooks**, not a selective subset | Ratified 2026-06-10 (overrode the selective recommendation). Simplest mental model: an SDK subprocess is not an interactive session, so no hook applies. **Recorded tradeoff:** `security_guard` (eval/exec Bash blocking) and `format_on_save` are also inactive inside SDK workflow subprocesses. Revisit if a workflow agent demonstrably needs either; the gate helper makes re-enabling per-hook a one-line change. |
+| D2 | Filesystem settings in SDK subprocesses | **Exclude via `setting_sources=[]`** once the empty flag value is live-verified; keep the hook gate as belt-and-suspenders | Ratified 2026-06-10. No hooks, no CLAUDE.md injection, faster + cheaper + deterministic startup; workflows carry their own system prompts. The hook gate stays for older SDKs and spawn paths that bypass the adapter. |
+| D3 | Detection signal | **Dual**: `CLAUDE_CODE_ENTRYPOINT` prefix `sdk-` OR `ATTUNE_SDK_SUBPROCESS=1` | The SDK stamps `CLAUDE_CODE_ENTRYPOINT=sdk-py` into every subprocess env (findings F2) — free coverage for end users running their own SDK scripts with the plugin installed. The explicit marker survives SDK renames and covers non-SDK spawn paths attune controls. Interactive values observed: `claude-desktop` (desktop), so prefix-match `sdk-` cannot false-positive there. |
+| D4 | Marker env var name | `ATTUNE_SDK_SUBPROCESS=1` | Named for what it marks (an SDK-spawned subprocess session), per the "name the env var after what it does, not who flips it" lesson. NOT `CLAUDE_CODE_SDK_SUBPROCESS` (the 2026-06-06 lesson's sketch) — that prefix implies Claude Code owns it; it's ours. |
+| D5 | Where the marker is set | `agent_sdk_adapter` only, via `ClaudeAgentOptions(env={...})` | Env inherits down the whole chain (CLI → MCP → dashboard runner all reach the SDK through the adapter), so one site covers every path. The runner's `proc_env` stays unchanged — adding it there would be redundant. |
+| D6 | Gate helper location | One shared `plugin/hooks/_sdk_gate.py` (or extend the existing `_state.py`-style shared module), imported by every hook script | 12 copies of a two-line check WILL drift. The R6a drift guard asserts every hooks.json script references the gate. |
+| D7 | Repo's own `.claude/settings.json` hooks | Out of scope for the product fix; MAY adopt the same gate opportunistically | The shipped plugin is the user-facing surface. The dev repo's hooks polluting Patrick's own dogfooding is real but fixable the same way at any time. |
+
+## Calibration record
+
+- 2026-06-10 — Phase 0 ran via direct venv introspection instead of a
+  committed probe script first; `scripts/probe_sdk_subprocess_env.py`
+  captures the same checks reproducibly (re-run it when bumping
+  claude-agent-sdk).
+
+## Live receipts (Phase 3)
+
+- _pending_

--- a/docs/specs/sdk-subprocess-isolation/findings.md
+++ b/docs/specs/sdk-subprocess-isolation/findings.md
@@ -1,0 +1,62 @@
+# Spec: SDK Subprocess Isolation — Phase 0 Findings
+
+**Probed:** 2026-06-10, claude-agent-sdk **0.1.63** (main venv).
+Re-run `scripts/probe_sdk_subprocess_env.py` after any SDK bump.
+
+---
+
+## F1 — `setting_sources` exists; `None` means "CLI default", not "none"
+
+`ClaudeAgentOptions.setting_sources: list[Literal["user","project","local"]] | None`.
+The transport (`_internal/transport/subprocess_cli.py`) only emits
+`--setting-sources=<csv>` when the value is **not None** — so the
+adapter's current state (never sets it) leaves the CLI's own default
+in charge, which loads user+project settings (observed live
+2026-06-06/10: SessionStart hooks fired, CLAUDE.md injected).
+Excluding settings therefore requires passing `[]`, which emits
+`--setting-sources=` (empty value). **Open item for Phase 2:** verify
+the CLI parses the empty value as "no sources" (one live check).
+
+## F2 — The SDK stamps a detection signal for free
+
+The transport builds the subprocess env as
+`{**inherited, "CLAUDE_CODE_ENTRYPOINT": "sdk-py", **options.env, "CLAUDE_AGENT_SDK_VERSION": ...}`
+and **filters `CLAUDECODE` out** of the inherited env (upstream #573).
+Hook processes inherit the CLI's env, so a hook can detect "I'm in an
+SDK-spawned session" via `CLAUDE_CODE_ENTRYPOINT.startswith("sdk-")`.
+Interactive sessions carry different values (observed:
+`claude-desktop`). Consequences:
+
+- Detection works even for **third-party SDK scripts** that never
+  touch attune's adapter — the broadest end-user exposure.
+- `CLAUDECODE` is NOT usable as a signal (scrubbed).
+- `options.env` merges over inherited → clean home for the explicit
+  `ATTUNE_SDK_SUBPROCESS=1` marker (D4/D5).
+
+## F3 — `ClaudeAgentOptions.env: dict[str, str]` is first-class
+
+No need to mutate `os.environ` in the adapter; the marker rides the
+options object and only affects the spawned subprocess.
+
+## F4 — TRAP: `options.skills` silently re-enables settings loading
+
+`_apply_skills_defaults()`: when `options.skills` is set and
+`setting_sources` is None, the SDK forces
+`setting_sources=["user","project"]` "so the CLI discovers installed
+skills". The adapter does not use `skills` today, but if a future
+change adds it without an explicit `setting_sources`, isolation
+silently reverts. → drift guard R6b.
+
+## F5 — Current adapter/runner state
+
+- `agent_sdk_adapter` sets neither `env` nor `setting_sources` on
+  `ClaudeAgentOptions` today.
+- The dashboard runner's `proc_env` already carries
+  `ATTUNE_RUN_META_EMIT`, `ATTUNE_SPEND_GATE_AUTHORIZED`,
+  `ATTUNE_SDK_ERROR_PROBE` — precedent for env-marker plumbing, but
+  the adapter is the single sufficient site (D5).
+- Shipped plugin hook inventory (all gate targets, D1):
+  SessionStart ×4 (`welcome`, `help_freshness_check`, `spec_orient`,
+  `session_recall`), Stop ×2 (`compact_warning`, `session_stash`),
+  PreToolUse ×3 (`jit_recall`, `security_guard` ×2), PostToolUse ×3
+  (`format_on_save`, `help_on_error`, `help_post_commit`).

--- a/docs/specs/sdk-subprocess-isolation/requirements.md
+++ b/docs/specs/sdk-subprocess-isolation/requirements.md
@@ -1,0 +1,105 @@
+# Spec: SDK Subprocess Isolation — Requirements
+
+**Status:** draft (2026-06-10) — awaiting approval. Phase 0 (SDK
+introspection) already executed; see [findings.md](findings.md).
+
+---
+
+## Problem
+
+SDK-native workflows (code-review, bug-predict, security-audit,
+test-gen, …) spawn a `claude` CLI subprocess in stream-json mode via
+`claude_agent_sdk.query()`. That subprocess starts a full Claude Code
+session: SessionStart hooks fire, project/user settings load, and
+CLAUDE.md is injected. Two failure modes follow:
+
+1. **Subscription users (no `ANTHROPIC_API_KEY`) get a hard failure.**
+   SessionStart hook output poisons the stream-json channel — the CLI
+   responds with conversational prose ("I see the session
+   orientation…") instead of stream-json, the SDK reader raises, and
+   the workflow dies with an opaque `Command failed with exit code 1`
+   (observed live 2026-06-10; see CLAUDE.md lesson "Subscription
+   `claude` CLI is structurally broken for `claude_agent_sdk.query()`").
+   The shipped plugin registers 4 SessionStart hooks, so **every
+   plugin user on a Claude subscription hits this** — the plugin's
+   primary audience cannot run its flagship feature set.
+2. **All users pay an avoidable tax.** Stop hooks run at every
+   subprocess turn end (`session_stash` can block ~40 s on a cold
+   Ollama), and the injected session context (CLAUDE.md, orientation
+   output) inflates tokens and startup latency for workflows that
+   already carry their own system prompts.
+
+The auth itself is fine: the sibling-subscription-auth spec's Phase 0
+proved `claude_agent_sdk.query()` succeeds without an API key inside
+Claude Code. The breakage is session-content pollution, not auth.
+
+## Requirements
+
+- **R1 — Hooks are silent in SDK subprocesses.** ALL attune plugin
+  hooks (SessionStart ×4, Stop ×2, PreToolUse ×3, PostToolUse ×3)
+  exit immediately, with no output, when running inside an
+  SDK-spawned subprocess session. (Ratified 2026-06-10: gate
+  everything, not a selective subset — see decisions.md D1.)
+- **R2 — Dual detection, no false positives in interactive
+  sessions.** A hook detects "SDK subprocess" via EITHER signal:
+  (a) `CLAUDE_CODE_ENTRYPOINT` starts with `sdk-` (stamped by the
+  Agent SDK itself — covers third-party SDK scripts run with the
+  plugin installed); (b) `ATTUNE_SDK_SUBPROCESS=1` (explicit marker
+  set by attune's adapter — survives SDK renames). Interactive
+  sessions (`claude-desktop`, `cli`) must never match.
+- **R3 — Adapter excludes filesystem settings.** The SDK adapter
+  passes `setting_sources=[]` so user/project/local settings (and
+  their hooks + CLAUDE.md injection) never load in workflow
+  subprocesses — gated on the Phase-1 live check that the CLI
+  accepts an empty `--setting-sources=` value. The hook gate (R1/R2)
+  stays regardless, as the fallback for older SDKs and non-adapter
+  spawn paths. (Ratified 2026-06-10 — decisions.md D2.)
+- **R4 — Subscription end-to-end works.** A subscription-only
+  environment (`ANTHROPIC_API_KEY` empty) inside Claude Code can run
+  an SDK workflow to a successful `WorkflowResult`. Acceptance is a
+  live receipt, not a unit test (the "registered ≠ working" lesson).
+- **R5 — Failures stay diagnosable.** The `ATTUNE_SDK_ERROR_PROBE`
+  capture path is preserved; if isolation regresses, the run record
+  still shows the real subprocess error.
+- **R6 — Drift guards.** (a) A test asserts every hook script in
+  `plugin/hooks/hooks.json` calls the shared SDK-subprocess gate;
+  (b) a test asserts the adapter never sets `options.skills` without
+  an explicit `setting_sources` (the SDK silently forces
+  `["user","project"]` back on when skills are set — findings.md F4).
+
+## Acceptance criteria
+
+- AC1: With `CLAUDE_CODE_ENTRYPOINT=sdk-py` in the env, every plugin
+  hook exits 0 with empty stdout/stderr in <100 ms (unit-testable per
+  hook via subprocess).
+- AC2: With `ATTUNE_SDK_SUBPROCESS=1`, same as AC1.
+- AC3: In a normal interactive env (neither signal), hooks behave
+  exactly as today (existing hook tests stay green).
+- AC4: The adapter's `ClaudeAgentOptions` carries
+  `env={"ATTUNE_SDK_SUBPROCESS": "1", ...}` and (post live check)
+  `setting_sources=[]` — asserted by adapter unit tests.
+- AC5: Live receipt recorded in decisions.md: one SDK workflow run
+  with `ANTHROPIC_API_KEY=""` completing successfully via
+  subscription, before/after.
+
+## Out of scope
+
+- Sibling packages' auth routing (attune-author / attune-rag) — owned
+  by the `sibling-subscription-auth` spec.
+- Plain `claude -p` invocations not going through the Agent SDK.
+- The repo's own `.claude/settings.json` hooks (dev-environment
+  concern; the same gate helper is available to them, but the product
+  surface is the shipped plugin).
+
+## Phasing
+
+- **Phase 0 — SDK introspection.** DONE; [findings.md](findings.md).
+- **Phase 1 — Hook gate (plugin).** Shared `is_sdk_subprocess()`
+  helper + gate call at the top of all 12 hook scripts + drift guard
+  R6a + per-hook AC1–AC3 tests. Ships in a plugin release.
+- **Phase 2 — Adapter isolation.** Live-verify empty
+  `--setting-sources=` parse; set `env` marker +
+  `setting_sources=[]` in `agent_sdk_adapter`; drift guard R6b.
+- **Phase 3 — Live receipt.** Subscription-mode run of one SDK
+  workflow (bug-predict on a small leaf module) recorded in
+  decisions.md; flip spec to complete.

--- a/scripts/probe_sdk_subprocess_env.py
+++ b/scripts/probe_sdk_subprocess_env.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Probe claude-agent-sdk subprocess-environment semantics.
+
+Phase-0 probe for the sdk-subprocess-isolation spec
+(docs/specs/sdk-subprocess-isolation/). Re-run after any
+claude-agent-sdk bump; if any check FLIPS, the spec's findings are
+stale and the hook gate / adapter isolation need re-validation.
+
+Checks (introspection, no API spend):
+
+1. ``ClaudeAgentOptions`` exposes ``setting_sources`` and ``env``.
+2. The subprocess transport stamps ``CLAUDE_CODE_ENTRYPOINT=sdk-py``
+   and filters ``CLAUDECODE`` from the inherited env.
+3. The ``skills`` trap: setting ``options.skills`` with
+   ``setting_sources=None`` forces ``["user", "project"]`` back on.
+
+With ``--live``, additionally verifies the installed ``claude`` CLI
+accepts an empty ``--setting-sources=`` value (one ``-p`` call with
+``--max-turns 1``; needs auth, costs one tiny turn).
+
+Usage:
+    python scripts/probe_sdk_subprocess_env.py [--live]
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import inspect
+import shutil
+import subprocess
+import sys
+
+
+def _check(label: str, ok: bool, detail: str = "") -> bool:
+    mark = "PASS" if ok else "FAIL"
+    print(f"[{mark}] {label}" + (f" — {detail}" if detail else ""))
+    return ok
+
+
+def probe_introspection() -> bool:
+    """Run the no-spend introspection checks. Returns True if all pass."""
+    import claude_agent_sdk
+    from claude_agent_sdk import ClaudeAgentOptions
+    from claude_agent_sdk._internal.transport import subprocess_cli
+
+    version = getattr(claude_agent_sdk, "__version__", "?")
+    print(f"claude-agent-sdk {version}\n")
+
+    fields = {f.name for f in dataclasses.fields(ClaudeAgentOptions)}
+    ok = _check(
+        "ClaudeAgentOptions has setting_sources + env",
+        {"setting_sources", "env"} <= fields,
+        f"fields present: {sorted({'setting_sources', 'env'} & fields)}",
+    )
+
+    transport_src = inspect.getsource(subprocess_cli)
+    ok &= _check(
+        "transport stamps CLAUDE_CODE_ENTRYPOINT",
+        '"CLAUDE_CODE_ENTRYPOINT": "sdk-py"' in transport_src,
+    )
+    ok &= _check(
+        "transport filters CLAUDECODE from inherited env",
+        'k != "CLAUDECODE"' in transport_src,
+    )
+    ok &= _check(
+        "--setting-sources only emitted when not None",
+        "if effective_setting_sources is not None" in transport_src,
+    )
+    ok &= _check(
+        "skills trap present (forces user+project when skills set)",
+        'setting_sources = ["user", "project"]' in transport_src,
+        "adapter must never set skills without explicit setting_sources",
+    )
+    return ok
+
+
+def probe_live() -> bool:
+    """Verify the CLI parses an empty --setting-sources= value."""
+    cli = shutil.which("claude")
+    if cli is None:
+        return _check("live: claude CLI on PATH", False)
+    try:
+        result = subprocess.run(  # noqa: S603
+            [cli, "-p", "Reply with exactly: ok", "--setting-sources=", "--max-turns", "1"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=120,
+            input="",
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return _check("live: empty --setting-sources= accepted", False, "timeout")
+    detail = (result.stderr or result.stdout or "").strip()[:120]
+    return _check(
+        "live: empty --setting-sources= accepted",
+        result.returncode == 0,
+        f"exit={result.returncode} {detail}",
+    )
+
+
+def main() -> int:
+    """Run the probe; exit non-zero if any check fails."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="also run the one-turn CLI flag-parse check (needs auth)",
+    )
+    args = parser.parse_args()
+
+    ok = probe_introspection()
+    if args.live:
+        ok &= probe_live()
+    print("\nall checks passed" if ok else "\nFAILURES — spec findings are stale")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Drafts the spec for the top reliability gap surfaced in today's triage: **SDK workflows fail for subscription users** (the plugin's primary audience) because SessionStart hook output poisons the SDK's stream-json channel, and session context (CLAUDE.md, hooks) loads into every workflow subprocess.

Deliverables (spec authoring phases 0–1; no production code yet):

- **requirements.md** — R1–R6 + acceptance criteria + 3-phase plan (hook gate → adapter isolation → live subscription receipt).
- **decisions.md** — D1–D7 pre-committed. D1 (gate ALL 12 hooks) and D2 (exclude settings via `setting_sources=[]`, hook gate stays as fallback) were ratified by Patrick in-session 2026-06-10; D1 records the tradeoff (security_guard/format_on_save inactive in subprocesses).
- **findings.md** — Phase-0 results against claude-agent-sdk 0.1.63: free `CLAUDE_CODE_ENTRYPOINT=sdk-py` detection signal, first-class `options.env` for the explicit marker, `setting_sources=None` = CLI-default (the observed pollution), and the `options.skills` trap that silently re-enables settings loading.
- **scripts/probe_sdk_subprocess_env.py** — reusable probe (introspection free; `--live` adds the empty `--setting-sources=` flag-parse check). All introspection checks pass today.

Next: Phase 1 (hook gate, plugin release) on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)