### PR TITLE
feat(cli): workflow-result-formatting T4 — styled terminal rendering for WorkflowReport results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **CLI renders `WorkflowReport` results as styled terminal markdown**
+  (workflow-result-formatting T4). On a TTY, report-carrying results
+  render through `rich.markdown` (headings, tables, bullets); piped
+  output stays plain markdown. Default disclosure is `summary` —
+  detail-tier sections collapse to a `(section "X" collapsed — run
+  with --verbose to expand)` hint; `--verbose` renders the full
+  report inline. The voice wrapper no longer duplicates the score
+  line or next-steps around a rendered report (the report's own
+  sections own both). Legacy results keep the plain text path
+  unchanged.
 - **Voice layer renders `WorkflowReport` results**
   (workflow-result-formatting T3). `_extract_from_workflow_result`
   detects a serialized `WorkflowReport` (`_type` discriminator) in

--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -5,10 +5,7 @@ data model, #649), T2 (the markdown renderer
 `attune.voice.report_renderer` — `render()` + crash-visible
 `render_safe()`, all 4 test layers, 98% branch, #741), and T3 (voice
 wiring + safety net + `show_cost_metrics`/`resolve_show_cost()`)
-shipped; T4+ pending. T4 note: the rendered report embeds
-`**Score:** N/100` and `format_output` appends its own plain
-`Score: N/100` line — resolve the duplication when reworking the CLI
-surface.
+and T4 (CLI terminal rendering) shipped; T5+ pending.
 
 > Bounded PRs; see [design.md](design.md) for the decisions each task
 > implements.
@@ -64,13 +61,20 @@ surface.
   `resolve_show_cost()` lives in `attune.config` (env var
   `ATTUNE_SHOW_COST_METRICS` also parsed as bool by `from_env`).
 
-## T4 — CLI
+## T4 — CLI — DONE
 
 - `cli_commands/workflow_commands.py:_print_workflow_result`: render
   `disclosure="summary"` default, `"full"` on `--verbose`; pipe markdown
   through a minimally-themed `rich.markdown.Markdown`; `<details>` → a
   "(run with --verbose to expand: …)" closing line. (Proposal §3,
   Surface map.)
+- Shipped: `format_output(disclosure=...)` threads to the renderer;
+  rich markdown only for report-carrying results AND only on a TTY
+  (legacy results + piped output keep plain text). The CLI converts
+  `<details>` pre-render because `rich.markdown` renders straight
+  through HTML tags. Score-line + voice-next-steps duplication
+  resolved: the wrapper suppresses both for rendered reports (the
+  report's `**Score:**` and `NextStepsSection` own them).
 
 ## T5 — MCP
 

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -184,7 +185,11 @@ def cmd_workflow_run(args: Namespace) -> int:
         input_data,
         name=name,
         json_mode=bool(getattr(args, "json", False)),
-        print_result=lambda result: _print_workflow_result(result, workflow_name=name),
+        print_result=lambda result: _print_workflow_result(
+            result,
+            workflow_name=name,
+            verbose=bool(getattr(args, "verbose", False)),
+        ),
         on_result=_record_envelope_cost if record_cost else None,
     )
 
@@ -265,23 +270,76 @@ def _record_envelope_cost(result: object) -> None:
     save_envelope(envelope)
 
 
+# Matches the renderer's exact <details> shape (report_renderer.render):
+# <details><summary>{title}</summary>\n\n{body}\n\n</details>
+_DETAILS_BLOCK_RE = re.compile(
+    r"<details><summary>(?P<title>.*?)</summary>\n\n.*?\n\n</details>",
+    re.DOTALL,
+)
+
+
+def _collapse_details_for_terminal(text: str) -> str:
+    """Replace ``<details>`` blocks with a run-with-verbose hint.
+
+    Terminals have no collapsibles, and ``rich.markdown`` renders
+    straight through the HTML tags (the "collapsed" content would show
+    anyway) — so summary mode swaps each block for a one-line pointer.
+    MCP and the dashboard keep the raw ``<details>`` markdown.
+    """
+    return _DETAILS_BLOCK_RE.sub(
+        lambda m: f'*(section "{m.group("title")}" collapsed — run with --verbose to expand)*',
+        text,
+    )
+
+
 def _print_workflow_result(
     result: object,
     workflow_name: str = "unknown",
+    verbose: bool = False,
 ) -> None:
     """Print a workflow result using the unified voice layer.
 
     Routes through attune.voice.format_output() for consistent
     personality, formatting, and contextual next-step suggestions.
+    Results carrying a serialized ``WorkflowReport`` render as styled
+    markdown on a TTY (``rich.markdown``); everything else keeps the
+    plain text path unchanged.
 
     Args:
         result: Workflow execution result (WorkflowResult, dict, or other)
         workflow_name: Name of the workflow that produced this result
+        verbose: Render the full report (detail sections inline) instead
+            of the summary view
 
     """
-    from attune.voice import format_output
+    import sys
 
-    print(format_output(workflow_name, result))
+    from attune.voice import format_output
+    from attune.voice.formatter import _is_report_result
+
+    is_report = _is_report_result(result)
+    text = format_output(
+        workflow_name,
+        result,
+        disclosure="full" if verbose else "summary",
+    )
+    if is_report and not verbose:
+        text = _collapse_details_for_terminal(text)
+
+    printed = False
+    if is_report and sys.stdout.isatty():
+        try:
+            from rich.console import Console
+            from rich.markdown import Markdown
+
+            Console().print(Markdown(text))
+            printed = True
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: terminal styling is best-effort — fall back
+            # to plain text rather than lose the report.
+            logger.debug("rich markdown rendering failed", exc_info=True)
+    if not printed:
+        print(text)
     _emit_run_meta_for_daemon(result)
 
 

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -162,7 +162,10 @@ def _add_workflow_subparsers(subparsers: argparse._SubParsersAction) -> None:
         "--verbose",
         "-v",
         action="store_true",
-        help="Discovery-sweep: include rejected bucket in markdown output",
+        help=(
+            "Full report disclosure (detail sections inline); "
+            "discovery-sweep: include rejected bucket in markdown output"
+        ),
     )
     run_parser.add_argument(
         "--no-llm",

--- a/src/attune/voice/formatter.py
+++ b/src/attune/voice/formatter.py
@@ -266,6 +266,10 @@ def _extract_from_workflow_result(
     # the safety-net pretty-print) — exempt from the sparse fallback below.
     rendered = False
 
+    # True only when a WorkflowReport actually rendered — the renderer
+    # then owns the cost display (show_cost gate), not the voice wrapper.
+    report_rendered = False
+
     # Extract formatted report from final_output
     fo = result.final_output
     if isinstance(fo, dict):
@@ -273,18 +277,25 @@ def _extract_from_workflow_result(
 
         if WorkflowReport.is_report_dict(fo):
             # Migrated workflow: reconstruct + render (design D2).
-            from attune.config import resolve_show_cost
-            from attune.voice import report_renderer
+            try:
+                from attune.config import resolve_show_cost
+                from attune.voice import report_renderer
 
-            report = WorkflowReport.from_dict(fo)
-            report_text = report_renderer.render_safe(
-                report,
-                disclosure="full" if disclosure == "full" else "summary",
-                show_cost=resolve_show_cost(),
-            )
-            score = report.score
-            rendered = True
-        else:
+                report = WorkflowReport.from_dict(fo)
+                report_text = report_renderer.render_safe(
+                    report,
+                    disclosure="full" if disclosure == "full" else "summary",
+                    show_cost=resolve_show_cost(),
+                )
+                score = report.score
+                rendered = True
+                report_rendered = True
+            except Exception:  # noqa: BLE001
+                # INTENTIONAL: a malformed report payload degrades to the
+                # legacy dict handling below — never a crash, never a
+                # repr leak of the whole WorkflowResult.
+                logger.exception("WorkflowReport reconstruction failed")
+        if not report_rendered:
             report_text = fo.get("formatted_report")
             score = fo.get("score")
     elif isinstance(fo, str):
@@ -314,10 +325,12 @@ def _extract_from_workflow_result(
         if fallback_parts:
             report_text = "\n".join(fallback_parts)
 
-    # Build cost line (guard against None cost_report)
+    # Build cost line (guard against None cost_report). A rendered
+    # report's show_cost gate owns cost display — no wrapper duplicate,
+    # and no inapplicable cost line for subscription users (design D3).
     cost_line = None
     cr = result.cost_report
-    if cr is not None:
+    if cr is not None and not report_rendered:
         cost_parts = [f"${cr.total_cost:.4f}"]
         if cr.savings_percent > 0:
             cost_parts.append(f"(saved {cr.savings_percent:.0f}% vs premium)")

--- a/src/attune/voice/formatter.py
+++ b/src/attune/voice/formatter.py
@@ -27,6 +27,7 @@ def format_output(
     result: Any,
     *,
     compact: bool = False,
+    disclosure: str = "summary",
 ) -> str:
     """Format a workflow result in the attune voice.
 
@@ -37,6 +38,9 @@ def format_output(
         workflow_name: Name of the workflow that produced this result.
         result: WorkflowResult, dict, or string to format.
         compact: If True, produce shorter output (for MCP responses).
+        disclosure: ``"summary"`` (default) collapses detail-tier report
+            sections; ``"full"`` inlines everything. Only affects results
+            carrying a serialized ``WorkflowReport``.
 
     Returns:
         Voiced, formatted output string ready for display.
@@ -44,9 +48,14 @@ def format_output(
     """
     lines: list[str] = []
 
+    # A rendered WorkflowReport owns its own score line and next-steps
+    # section — the voice wrapper must not duplicate them around it.
+    rendered_report = _is_report_result(result)
+
     # --- Detect result type and extract data ---
     success, score, report_text, cost_line, error_msg = _extract_result_data(
         result,
+        disclosure=disclosure,
     )
 
     # --- Opening line ---
@@ -66,7 +75,7 @@ def format_output(
         lines.append(report_text)
 
     # --- Score ---
-    if score is not None:
+    if score is not None and not rendered_report:
         lines.append(f"\nScore: {score}/100")
 
     # --- Cost & duration ---
@@ -86,11 +95,15 @@ def format_output(
         lines.append(f"  {error_msg}")
 
     # --- Next steps ---
-    steps = get_next_steps(
-        workflow_name,
-        result,
-        max_steps=2 if compact else 3,
-        compact=compact,
+    steps = (
+        []
+        if rendered_report
+        else get_next_steps(
+            workflow_name,
+            result,
+            max_steps=2 if compact else 3,
+            compact=compact,
+        )
     )
     if steps:
         lines.append("")
@@ -187,13 +200,25 @@ def format_mcp_response(
 # -------------------------------------------------------------------
 
 
+def _is_report_result(result: Any) -> bool:
+    """True when ``result.final_output`` is a serialized WorkflowReport."""
+    try:
+        from attune.workflows.output import WorkflowReport
+    except ImportError:
+        return False
+    return WorkflowReport.is_report_dict(getattr(result, "final_output", None))
+
+
 def _extract_result_data(
     result: Any,
+    *,
+    disclosure: str = "summary",
 ) -> tuple[bool, int | None, str | None, str | None, str | None]:
     """Extract display data from various result types.
 
     Args:
         result: WorkflowResult, dict, or string.
+        disclosure: Report disclosure mode (see :func:`format_output`).
 
     Returns:
         Tuple of (success, score, report_text, cost_line, error_msg).
@@ -206,7 +231,7 @@ def _extract_result_data(
 
     if WorkflowResult is not None and isinstance(result, WorkflowResult):
         try:
-            return _extract_from_workflow_result(result)
+            return _extract_from_workflow_result(result, disclosure=disclosure)
         except Exception:  # noqa: BLE001
             # INTENTIONAL: Degrade gracefully if result fields are unexpected
             logger.debug("Failed to extract from WorkflowResult", exc_info=True)
@@ -222,11 +247,14 @@ def _extract_result_data(
 
 def _extract_from_workflow_result(
     result: Any,
+    *,
+    disclosure: str = "summary",
 ) -> tuple[bool, int | None, str | None, str | None, str | None]:
     """Extract data from a WorkflowResult dataclass.
 
     Args:
         result: WorkflowResult instance.
+        disclosure: Report disclosure mode (see :func:`format_output`).
 
     Returns:
         Tuple of (success, score, report_text, cost_line, error_msg).
@@ -251,7 +279,7 @@ def _extract_from_workflow_result(
             report = WorkflowReport.from_dict(fo)
             report_text = report_renderer.render_safe(
                 report,
-                disclosure="summary",
+                disclosure="full" if disclosure == "full" else "summary",
                 show_cost=resolve_show_cost(),
             )
             score = report.score

--- a/tests/unit/cli_commands/test_workflow_report_terminal.py
+++ b/tests/unit/cli_commands/test_workflow_report_terminal.py
@@ -1,0 +1,164 @@
+"""Terminal rendering of WorkflowReport results (workflow-result-formatting T4).
+
+Covers ``_collapse_details_for_terminal`` and the
+``_print_workflow_result`` markdown/plain split: report-carrying
+results render styled markdown on a TTY, summary mode swaps
+``<details>`` blocks for a --verbose hint, and legacy results keep the
+plain text path untouched.
+"""
+
+import sys
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from attune.cli_commands.workflow_commands import (
+    _collapse_details_for_terminal,
+    _print_workflow_result,
+)
+from attune.workflows.data_classes import WorkflowResult
+from attune.workflows.output import (
+    ProseSection,
+    TableSection,
+    WorkflowReport,
+)
+
+_DETAILS_BLOCK = "<details><summary>Hotspots</summary>\n\n| file |\n| --- |\n| a.py |\n\n</details>"
+
+
+def _report_result(*, detail_section: bool = True) -> WorkflowResult:
+    """A WorkflowResult whose final_output is a serialized report."""
+    sections = [ProseSection(title="Overview", tier="essential", text="Solid.")]
+    if detail_section:
+        sections.append(
+            TableSection(
+                title="Hotspots",
+                tier="detail",
+                columns=["file"],
+                rows=[{"file": "a.py"}],
+            )
+        )
+    report = WorkflowReport(title="Code review", summary="ok", sections=sections)
+    now = datetime.now(timezone.utc)
+    return WorkflowResult(
+        success=True,
+        stages=[],
+        final_output=report.to_dict(),
+        cost_report=None,
+        started_at=now,
+        completed_at=now,
+        total_duration_ms=1000,
+    )
+
+
+def _legacy_result() -> WorkflowResult:
+    now = datetime.now(timezone.utc)
+    return WorkflowResult(
+        success=True,
+        stages=[],
+        final_output={"formatted_report": "plain legacy report"},
+        cost_report=None,
+        started_at=now,
+        completed_at=now,
+        total_duration_ms=1000,
+    )
+
+
+class TestCollapseDetailsForTerminal:
+    """The <details> -> verbose-hint conversion."""
+
+    def test_block_becomes_hint_line(self):
+        """A details block collapses to the run-with-verbose pointer."""
+        out = _collapse_details_for_terminal(f"before\n\n{_DETAILS_BLOCK}\n\nafter")
+        assert "<details>" not in out
+        assert '(section "Hotspots" collapsed — run with --verbose to expand)' in out
+
+    def test_collapsed_body_is_hidden(self):
+        """The detail body must not leak into the collapsed view."""
+        out = _collapse_details_for_terminal(_DETAILS_BLOCK)
+        assert "a.py" not in out
+
+    def test_text_without_details_passes_through(self):
+        """No-op on text with no details blocks."""
+        text = "# Title\n\nplain body"
+        assert _collapse_details_for_terminal(text) == text
+
+    def test_multiple_blocks_all_collapse(self):
+        """Every details block converts, not just the first."""
+        second = _DETAILS_BLOCK.replace("Hotspots", "Appendix")
+        out = _collapse_details_for_terminal(f"{_DETAILS_BLOCK}\n\n{second}")
+        assert "<details>" not in out
+        assert '"Hotspots" collapsed' in out
+        assert '"Appendix" collapsed' in out
+
+
+class TestPrintWorkflowResultTerminal:
+    """_print_workflow_result rendering split."""
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_non_tty_prints_plain_markdown(self, _mock, capsys, monkeypatch, tmp_path):
+        """Piped output: plain markdown text, details collapsed to hint."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        _print_workflow_result(_report_result(), workflow_name="code-review")
+        out = capsys.readouterr().out
+        assert "\x1b[" not in out  # no ANSI styling off-TTY
+        assert "# Code review" in out
+        assert "run with --verbose to expand" in out
+        assert "a.py" not in out
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_verbose_inlines_detail_sections(self, _mock, capsys, monkeypatch, tmp_path):
+        """verbose=True renders the full report — detail body visible."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        _print_workflow_result(_report_result(), workflow_name="code-review", verbose=True)
+        out = capsys.readouterr().out
+        assert "a.py" in out
+        assert "<details>" not in out
+        assert "run with --verbose to expand" not in out
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_tty_renders_styled_markdown(self, _mock, capsys, monkeypatch, tmp_path):
+        """On a TTY, the markdown heading renders styled (no raw '# ')."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        _print_workflow_result(_report_result(), workflow_name="code-review")
+        out = capsys.readouterr().out
+        assert "Code review" in out
+        assert "# Code review" not in out  # heading was markdown-rendered
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_legacy_result_keeps_plain_path_on_tty(self, _mock, capsys, monkeypatch):
+        """Non-report results never go through the markdown renderer."""
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        _print_workflow_result(_legacy_result(), workflow_name="code-review")
+        out = capsys.readouterr().out
+        assert "plain legacy report" in out
+        assert "\x1b[" not in out
+
+    def test_verbose_threads_full_disclosure(self, monkeypatch, tmp_path):
+        """verbose=True asks the voice layer for disclosure='full'."""
+        monkeypatch.chdir(tmp_path)
+        captured: dict = {}
+
+        def fake_format_output(name, result, **kwargs):
+            captured.update(kwargs)
+            return "out"
+
+        with patch("attune.voice.format_output", side_effect=fake_format_output):
+            _print_workflow_result(_legacy_result(), workflow_name="code-review", verbose=True)
+        assert captured.get("disclosure") == "full"
+
+    def test_default_threads_summary_disclosure(self, monkeypatch, tmp_path):
+        """Default asks the voice layer for disclosure='summary'."""
+        monkeypatch.chdir(tmp_path)
+        captured: dict = {}
+
+        def fake_format_output(name, result, **kwargs):
+            captured.update(kwargs)
+            return "out"
+
+        with patch("attune.voice.format_output", side_effect=fake_format_output):
+            _print_workflow_result(_legacy_result(), workflow_name="code-review")
+        assert captured.get("disclosure") == "summary"

--- a/tests/unit/voice/test_formatter.py
+++ b/tests/unit/voice/test_formatter.py
@@ -522,3 +522,89 @@ class TestUnmigratedSafetyNet:
         # Depth cap: the second nesting level shows the type name only.
         assert "deepest: Innermost" in output
         assert "value: 1" not in output
+
+
+class TestReportDisclosureAndDedup:
+    """T4: disclosure threading + wrapper dedup for report results."""
+
+    def _detail_report_result(self):
+        from attune.workflows.output import (
+            NextAction,
+            NextStepsSection,
+            ProseSection,
+            TableSection,
+            WorkflowReport,
+        )
+
+        report = WorkflowReport(
+            title="Code review",
+            summary="3 issues found",
+            score=88,
+            sections=[
+                ProseSection(title="Overview", tier="essential", text="Solid."),
+                TableSection(
+                    title="Hotspots",
+                    tier="detail",
+                    columns=["file", "risk"],
+                    rows=[{"file": "a.py", "risk": "high"}],
+                ),
+                NextStepsSection(
+                    title="Next steps",
+                    tier="essential",
+                    items=[NextAction(text="Fix the loop")],
+                ),
+            ],
+        )
+        return _make_result(final_output=report.to_dict(), cost_report=None)
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_summary_wraps_detail_sections(self, _mock, monkeypatch, tmp_path):
+        """Default disclosure keeps detail sections inside <details>."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        out = format_output("code-review", self._detail_report_result())
+        assert "<details><summary>Hotspots</summary>" in out
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_full_disclosure_inlines_detail_sections(self, _mock, monkeypatch, tmp_path):
+        """disclosure='full' renders detail sections inline, no <details>."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        out = format_output("code-review", self._detail_report_result(), disclosure="full")
+        assert "<details>" not in out
+        assert "a.py" in out
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_score_line_not_duplicated(self, _mock, monkeypatch, tmp_path):
+        """The renderer owns the score line; the wrapper must not repeat it."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        out = format_output("code-review", self._detail_report_result())
+        assert out.count("88/100") == 1
+        # Score commentary (greeting) still applies.
+        assert personality.score_commentary(88) in out
+
+    @patch(
+        "attune.voice.formatter.get_next_steps",
+        return_value=["I'd run `attune workflow run test-gen` next"],
+    )
+    def test_voice_next_steps_suppressed_for_reports(self, _mock, monkeypatch, tmp_path):
+        """The report's NextStepsSection owns guidance — no voice dup."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        out = format_output("code-review", self._detail_report_result())
+        assert personality.HEADER_NEXT_STEPS not in out
+        assert "Fix the loop" in out  # the report's own next steps render
+
+    @patch(
+        "attune.voice.formatter.get_next_steps",
+        return_value=["I'd run `attune workflow run test-gen` next"],
+    )
+    def test_legacy_results_keep_score_line_and_next_steps(self, _mock):
+        """Non-report results keep today's wrapper behavior unchanged."""
+        result = _make_result(
+            final_output={"formatted_report": "plain report text", "score": 70},
+        )
+        out = format_output("code-review", result)
+        assert "Score: 70/100" in out
+        assert personality.HEADER_NEXT_STEPS in out

--- a/tests/unit/voice/test_formatter.py
+++ b/tests/unit/voice/test_formatter.py
@@ -608,3 +608,47 @@ class TestReportDisclosureAndDedup:
         out = format_output("code-review", result)
         assert "Score: 70/100" in out
         assert personality.HEADER_NEXT_STEPS in out
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_malformed_report_dict_degrades_to_legacy_handling(self, _mock, monkeypatch, tmp_path):
+        """A corrupt report payload falls back to dict handling, no repr leak.
+
+        Ported from PR #745 (parallel T3): reconstruction failure must
+        not crash and must not surface str(WorkflowResult).
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        result = _make_result(
+            final_output={
+                "_type": "WorkflowReport",
+                "sections": [{"kind": "no-such-kind"}],
+                "formatted_report": "legacy fallback text",
+            },
+        )
+        output = format_output("code-review", result)
+        assert "WorkflowResult(" not in output
+        assert "legacy fallback text" in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_voice_cost_line_suppressed_for_rendered_reports(self, _mock, monkeypatch, tmp_path):
+        """The renderer's show_cost gate owns cost display (ported from #745)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        # _make_result default cost_report carries $0.0042 / 58% savings.
+        result = _make_result(final_output=self._detail_report_result().final_output)
+        output = format_output("code-review", result)
+        assert personality.HEADER_COST not in output
+        assert "$0.0042" not in output
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_voice_cost_line_kept_for_safety_net_results(self, _mock):
+        """Unmigrated bespoke results keep the wrapper cost line."""
+
+        @dataclass
+        class FakeReport:
+            approved: bool = True
+
+        result = _make_result(final_output=FakeReport())
+        output = format_output("release-prep", result)
+        assert personality.HEADER_COST in output
+        assert "$0.0042" in output


### PR DESCRIPTION
## Summary

**T4** of [workflow-result-formatting]: the CLI now renders `WorkflowReport` results as styled terminal markdown. Follows T3 (#746).

- **TTY**: report-carrying results render through `rich.markdown` — real headings, tables, bullets. **Piped/redirected output** stays plain markdown (clean files). **Legacy results** (string/dict/bespoke final_output) keep today's plain text path — zero regression surface.
- **Disclosure**: `summary` by default — each detail-tier `<details>` block becomes a `(section "X" collapsed — run with --verbose to expand)` hint. `--verbose` renders the full report inline. The conversion happens CLI-side and pre-render because `rich.markdown` renders straight through HTML tags (empirically verified — the "collapsed" body would show anyway); MCP (T5) and the dashboard (T6) keep raw `<details>` markdown.
- **Dedup fixes** (closes the T4 note recorded in #746): for rendered reports the voice wrapper suppresses its plain `Score: N/100` line and its "What I'd Do Next" block — the report's own `**Score:**` line and `NextStepsSection` own those. Score *commentary* greeting stays. Legacy results keep both wrapper features unchanged.
- `format_output()` gains a backward-compatible `disclosure` kwarg, threaded to the renderer.

## Tests

- 5 new formatter tests (disclosure both modes, score-dedup, next-steps suppression, legacy unchanged).
- 10 new CLI tests in `test_workflow_report_terminal.py` (collapse conversion incl. multi-block + no-op passthrough + body-hidden, non-TTY plain, verbose inline, TTY styled render, legacy-on-TTY plain, disclosure threading).
- Full voice (122) and cli_commands (256) suites green locally.

Remaining in the spec: T5 (MCP verbatim), T6 (dashboard panel), T7 (release-prep migration — next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)