### PR TITLE
feat(release-prep): workflow-result-formatting T7 — migrate to WorkflowReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **release-prep emits a structured `WorkflowReport`**
+  (workflow-result-formatting T7, the motivating case).
+  `ReleasePrepTeamWorkflow.execute()` returns a `WorkflowResult`
+  carrying the serialized report — verdict callout, quality-gates
+  table, per-agent breakdown (collapsed in summary mode),
+  blockers/warnings, and outcome-conditional next steps — instead of
+  the bespoke dataclass + `format_console_output()` dump. Rendered by
+  the T2–T4 pipeline on every surface.
 - **CLI renders `WorkflowReport` results as styled terminal markdown**
   (workflow-result-formatting T4). On a TTY, report-carrying results
   render through `rich.markdown` (headings, tables, bullets); piped

--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -5,7 +5,8 @@ data model, #649), T2 (the markdown renderer
 `attune.voice.report_renderer` — `render()` + crash-visible
 `render_safe()`, all 4 test layers, 98% branch, #741), and T3 (voice
 wiring + safety net + `show_cost_metrics`/`resolve_show_cost()`)
-and T4 (CLI terminal rendering) shipped; T5+ pending.
+T4 (CLI terminal rendering), and T7 (release-prep
+migration — the motivating case) shipped; T5/T6/T8+ pending.
 
 > Bounded PRs; see [design.md](design.md) for the decisions each task
 > implements.
@@ -91,12 +92,18 @@ and T4 (CLI terminal rendering) shipped; T5+ pending.
   → "Run" button (reuse runner infra); `.file` → link. (Surface map,
   proposal §3.) Largest task; may split.
 
-## T7 — Migrate release-prep (motivating case)
+## T7 — Migrate release-prep (motivating case) — DONE
 
 - Add `_to_workflow_report(ReleaseReadinessReport)` (proposal's worked
   example); `execute()` sets `final_output = report.to_dict()`. Update
   the T0 will-change tests in the same commit. Verify the success-
   criteria example renders (proposal §"Illustrative target").
+- Shipped: converter in `release_prep_team.py`; `execute()` returns a
+  real `WorkflowResult` (it previously returned the bespoke dataclass
+  directly — bypassing even the T3 safety net) and no longer prints
+  `format_console_output()`. Note: the MCP `release_prep` handler uses
+  the SDK-native `ReleasePreparationWorkflow`, a separate surface —
+  its migration rides T8+ (adapter-level findings → report).
 
 ## T8+ — Migrate remaining workflows (D5 rank)
 

--- a/src/attune/agents/release/release_prep_team.py
+++ b/src/attune/agents/release/release_prep_team.py
@@ -26,10 +26,21 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from datetime import datetime
 from typing import Any
 
 from attune.workflows.base import BaseWorkflow
 from attune.workflows.compat import ModelTier
+from attune.workflows.data_classes import WorkflowResult
+from attune.workflows.output import (
+    CalloutSection,
+    ListSection,
+    NextAction,
+    NextStepsSection,
+    Section,
+    TableSection,
+    WorkflowReport,
+)
 
 # Re-export agent classes and helpers
 from .release_agents import (  # noqa: F401
@@ -397,7 +408,7 @@ class ReleasePrepTeamWorkflow(BaseWorkflow):
         path: str = ".",
         context: dict[str, Any] | None = None,
         **kwargs: Any,
-    ) -> ReleaseReadinessReport:
+    ) -> WorkflowResult:
         """Execute release preparation workflow.
 
         Args:
@@ -406,7 +417,11 @@ class ReleasePrepTeamWorkflow(BaseWorkflow):
             **kwargs: Extra parameters (target, etc.)
 
         Returns:
-            ReleaseReadinessReport with consolidated results
+            WorkflowResult whose ``final_output`` carries the serialized
+            :class:`~attune.workflows.output.WorkflowReport` (design D2);
+            the voice layer / CLI render it. ``success`` reflects that
+            the assessment RAN — the release verdict lives in the report
+            (``metadata["approved"]``), so a BLOCKED release still exits 0.
 
         """
         # Map 'target' to 'path' for VSCode/CLI compatibility
@@ -417,9 +432,109 @@ class ReleasePrepTeamWorkflow(BaseWorkflow):
             quality_gates=self.quality_gates,
         )
 
+        started_at = datetime.now()
         report = await team.assess_readiness(codebase_path=path)
+        completed_at = datetime.now()
 
-        # Print formatted output for CLI users
-        print(report.format_console_output())
+        return WorkflowResult(
+            success=True,
+            stages=[],
+            final_output=_to_workflow_report(report).to_dict(),
+            cost_report=None,
+            started_at=started_at,
+            completed_at=completed_at,
+            total_duration_ms=int((completed_at - started_at).total_seconds() * 1000),
+            summary=report.summary,
+            metadata={"approved": report.approved, "confidence": report.confidence},
+        )
 
-        return report
+
+def _to_workflow_report(report: ReleaseReadinessReport) -> WorkflowReport:
+    """Convert the team's bespoke report to the universal WorkflowReport.
+
+    Design D2 (workflow-result-formatting): the converter is co-located
+    with the workflow that owns the semantics; the bespoke type stays
+    rendering-free. Content tiers per the proposal — verdict, gates,
+    blockers/warnings, and next steps are essential; the per-agent
+    breakdown is detail (collapsed in summary mode).
+
+    Args:
+        report: The team's consolidated readiness assessment.
+
+    Returns:
+        WorkflowReport ready for ``to_dict()`` into ``final_output``.
+
+    """
+    verdict = "APPROVED" if report.approved else "BLOCKED"
+    passed = sum(1 for g in report.quality_gates if g.passed)
+
+    sections: list[Section] = [
+        CalloutSection(
+            title="Verdict",
+            tier="essential",
+            text=f"Release **{verdict}** — confidence: {report.confidence}",
+            emphasis="ok" if report.approved else "danger",
+        ),
+        TableSection(
+            title=f"Quality gates ({passed}/{len(report.quality_gates)} passed)",
+            tier="essential",
+            columns=["Gate", "Actual", "Threshold", "Pass"],
+            rows=[
+                {
+                    "Gate": g.name,
+                    "Actual": f"{g.actual:.1f}",
+                    "Threshold": f"{g.threshold:.1f}",
+                    "Pass": "✓" if g.passed else "✗",
+                }
+                for g in report.quality_gates
+            ],
+        ),
+        TableSection(
+            title="Per-agent breakdown",
+            tier="detail",
+            columns=["Agent", "Score", "Confidence", "Tier", "Time"],
+            rows=[
+                {
+                    "Agent": r.agent_role,
+                    "Score": f"{r.score:.1f}",
+                    "Confidence": f"{r.confidence:.2f}",
+                    "Tier": r.tier_used.value,
+                    "Time": f"{r.execution_time_ms / 1000:.1f}s",
+                }
+                for r in report.agent_results
+            ],
+        ),
+    ]
+    if report.blockers:
+        sections.append(
+            ListSection(title="Blockers", tier="essential", items=list(report.blockers))
+        )
+    if report.warnings:
+        sections.append(
+            ListSection(title="Warnings", tier="essential", items=list(report.warnings))
+        )
+
+    if report.approved:
+        next_actions = [
+            NextAction(
+                text="All gates pass — run the composite security pipeline next.",
+                command="attune workflow run secure-release",
+            )
+        ]
+    else:
+        next_actions = [
+            NextAction(text=f"Resolve blocker: {blocker}") for blocker in report.blockers
+        ]
+    sections.append(NextStepsSection(title="Next steps", tier="essential", items=next_actions))
+
+    return WorkflowReport(
+        title="Release readiness",
+        summary=report.summary or f"Release {verdict} — confidence: {report.confidence}",
+        metadata={
+            "cost_usd": report.total_cost,
+            "duration_s": report.total_duration,
+            "approved": report.approved,
+            "confidence": report.confidence,
+        },
+        sections=sections,
+    )

--- a/tests/unit/agents/test_release_prep_team_report.py
+++ b/tests/unit/agents/test_release_prep_team_report.py
@@ -1,0 +1,199 @@
+"""release-prep WorkflowReport migration (workflow-result-formatting T7).
+
+Covers ``_to_workflow_report`` (the bespoke-to-universal converter) and
+the migrated ``ReleasePrepTeamWorkflow.execute()`` contract: a
+``WorkflowResult`` whose ``final_output`` is the serialized report, no
+console printing from the workflow itself, and repr-leak / tier drift
+guards over the rendered markdown (proposal test layers 1–2).
+"""
+
+import asyncio
+import io
+from contextlib import redirect_stdout
+from unittest.mock import AsyncMock, patch
+
+from attune.agents.release.release_models import (
+    QualityGate,
+    ReleaseAgentResult,
+    ReleaseReadinessReport,
+    Tier,
+)
+from attune.agents.release.release_prep_team import (
+    ReleasePrepTeamWorkflow,
+    _to_workflow_report,
+)
+from attune.voice.report_renderer import render
+from attune.workflows.data_classes import WorkflowResult
+from attune.workflows.output import (
+    CalloutSection,
+    ListSection,
+    NextStepsSection,
+    TableSection,
+    WorkflowReport,
+)
+
+
+def _make_report(*, approved: bool = False) -> ReleaseReadinessReport:
+    """Realistic readiness report covering every converter branch."""
+    return ReleaseReadinessReport(
+        approved=approved,
+        confidence="medium",
+        quality_gates=[
+            QualityGate(name="coverage", threshold=80.0, actual=72.5, passed=False),
+            QualityGate(name="security", threshold=0.0, actual=0.0, passed=True),
+        ],
+        agent_results=[
+            ReleaseAgentResult(
+                agent_id="h1",
+                agent_role="health",
+                success=True,
+                tier_used=Tier.CAPABLE,
+                score=88.0,
+                confidence=0.9,
+                execution_time_ms=4200,
+            ),
+        ],
+        blockers=[] if approved else ["coverage below 80%"],
+        warnings=["2 TODOs in src/"],
+        summary="1 blocker found" if not approved else "All gates green",
+        total_duration=42.0,
+        total_cost=1.23,
+    )
+
+
+class TestToWorkflowReport:
+    """The converter's section shapes and tiers."""
+
+    def test_blocked_verdict_callout(self):
+        """A blocked release gets a danger callout naming the verdict."""
+        report = _to_workflow_report(_make_report(approved=False))
+        callout = report.sections[0]
+        assert isinstance(callout, CalloutSection)
+        assert callout.emphasis == "danger"
+        assert "BLOCKED" in callout.text
+
+    def test_approved_verdict_callout(self):
+        """An approved release gets an ok callout."""
+        report = _to_workflow_report(_make_report(approved=True))
+        callout = report.sections[0]
+        assert callout.emphasis == "ok"
+        assert "APPROVED" in callout.text
+
+    def test_gates_table_essential_with_pass_counts(self):
+        """Quality gates render as an essential table, title carries counts."""
+        report = _to_workflow_report(_make_report())
+        gates = report.sections[1]
+        assert isinstance(gates, TableSection)
+        assert gates.tier == "essential"
+        assert "1/2 passed" in gates.title
+        assert len(gates.rows) == 2
+
+    def test_agent_breakdown_is_detail_tier(self):
+        """Per-agent breakdown is detail — collapsed in summary mode."""
+        report = _to_workflow_report(_make_report())
+        agents = report.sections[2]
+        assert isinstance(agents, TableSection)
+        assert agents.tier == "detail"
+        assert agents.rows[0]["Tier"] == "capable"
+
+    def test_blockers_and_warnings_sections(self):
+        """Blockers/warnings appear as essential lists when present."""
+        report = _to_workflow_report(_make_report(approved=False))
+        lists = [s for s in report.sections if isinstance(s, ListSection)]
+        titles = {s.title for s in lists}
+        assert titles == {"Blockers", "Warnings"}
+        assert all(s.tier == "essential" for s in lists)
+
+    def test_no_blockers_section_when_approved(self):
+        """An approved report (no blockers) omits the Blockers section."""
+        report = _to_workflow_report(_make_report(approved=True))
+        titles = [s.title for s in report.sections if isinstance(s, ListSection)]
+        assert "Blockers" not in titles
+
+    def test_next_steps_blocked_names_each_blocker(self):
+        """Blocked release: one actionable next step per blocker."""
+        report = _to_workflow_report(_make_report(approved=False))
+        steps = report.sections[-1]
+        assert isinstance(steps, NextStepsSection)
+        assert any("coverage below 80%" in a.text for a in steps.items)
+
+    def test_next_steps_approved_points_at_secure_release(self):
+        """Approved release: forward momentum to the security pipeline."""
+        report = _to_workflow_report(_make_report(approved=True))
+        steps = report.sections[-1]
+        assert any(a.command == "attune workflow run secure-release" for a in steps.items)
+
+    def test_metadata_carries_renderer_cost_keys(self):
+        """cost_usd/duration_s match the renderer's _COST_KEYS names."""
+        report = _to_workflow_report(_make_report())
+        assert report.metadata["cost_usd"] == 1.23
+        assert report.metadata["duration_s"] == 42.0
+        assert report.metadata["approved"] is False
+
+    def test_round_trips_through_dict(self):
+        """to_dict()/from_dict() survives the serialization boundary."""
+        d = _to_workflow_report(_make_report()).to_dict()
+        assert WorkflowReport.is_report_dict(d)
+        rebuilt = WorkflowReport.from_dict(d)
+        assert rebuilt.title == "Release readiness"
+        assert len(rebuilt.sections) == 6
+
+
+class TestRenderedMarkdownGuards:
+    """Proposal test layers 1–2 over the real converter output."""
+
+    def test_no_repr_leak_in_rendered_markdown(self):
+        """Layer 1: no dataclass repr fragments survive rendering."""
+        markdown = render(_to_workflow_report(_make_report()))
+        for fragment in (
+            "ReleaseReadinessReport(",
+            "QualityGate(",
+            "ReleaseAgentResult(",
+            "<class '",
+            "Tier.CAPABLE",
+        ):
+            assert fragment not in markdown, fragment
+
+    def test_tier_classification_in_summary_mode(self):
+        """Layer 2: essential inline, detail collapsed, in summary mode."""
+        markdown = render(_to_workflow_report(_make_report()), disclosure="summary")
+        assert "Quality gates" in markdown.split("<details>")[0]
+        assert "<details><summary>Per-agent breakdown</summary>" in markdown
+
+
+class TestMigratedExecute:
+    """ReleasePrepTeamWorkflow.execute() returns a WorkflowResult."""
+
+    def _run(self, report: ReleaseReadinessReport) -> tuple[WorkflowResult, str]:
+        with patch("attune.agents.release.release_prep_team.ReleasePrepTeam") as mock_team:
+            mock_team.return_value.assess_readiness = AsyncMock(return_value=report)
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                result = asyncio.run(ReleasePrepTeamWorkflow().execute(path="."))
+        return result, buf.getvalue()
+
+    def test_returns_workflow_result_with_report_dict(self):
+        """final_output carries the serialized WorkflowReport."""
+        result, _ = self._run(_make_report())
+        assert isinstance(result, WorkflowResult)
+        assert WorkflowReport.is_report_dict(result.final_output)
+
+    def test_success_true_even_when_blocked(self):
+        """The assessment RAN; the verdict lives in the report metadata."""
+        result, _ = self._run(_make_report(approved=False))
+        assert result.success is True
+        assert result.metadata["approved"] is False
+
+    def test_no_console_print_from_workflow(self):
+        """The old format_console_output() dump is gone — surfaces render."""
+        _, stdout = self._run(_make_report())
+        assert stdout == ""
+
+    def test_target_kwarg_maps_to_path(self):
+        """VSCode/CLI compatibility: target= overrides the default path."""
+        with patch("attune.agents.release.release_prep_team.ReleasePrepTeam") as mock_team:
+            mock_team.return_value.assess_readiness = AsyncMock(return_value=_make_report())
+            asyncio.run(ReleasePrepTeamWorkflow().execute(target="src/attune"))
+            mock_team.return_value.assess_readiness.assert_awaited_once_with(
+                codebase_path="src/attune"
+            )


### PR DESCRIPTION
## Summary

**T7** — the motivating case of [workflow-result-formatting]. `release-prep` (the CLI registry's `ReleasePrepTeamWorkflow`) now emits a structured `WorkflowReport` rendered by the T2–T4 pipeline, replacing the bespoke-dataclass return + `print(format_console_output())` console dump.

**Premise re-validated before executing** (per the spec-drift lesson): the spec's worked example targeted "release-prep's execute()", and there are TWO release-prep classes today — the SDK-native `ReleasePreparationWorkflow` (used by MCP, already adapter-formatted) and the team wrapper `ReleasePrepTeamWorkflow` (what `attune workflow run release-prep` resolves to). The wrapper returned the raw `ReleaseReadinessReport` — not even inside a `WorkflowResult` — so it bypassed the T3 safety net entirely and repr-leaked through the voice layer's final `str()` branch. This PR migrates the wrapper; the MCP-side class rides T8+.

- `_to_workflow_report()` converter (proposal's worked example, co-located per design D2): danger/ok **verdict callout**, **quality-gates table** with pass counts (essential), **per-agent breakdown** (detail — collapses to a `--verbose` hint on the CLI), **blockers/warnings** lists, **outcome-conditional next steps** (approved → `attune workflow run secure-release`; blocked → one actionable step per blocker).
- `execute()` returns a real `WorkflowResult`; `success=True` means the assessment *ran* — the verdict lives in `metadata["approved"]`, so a BLOCKED release still exits 0 (unchanged behavior).
- Renderer cost keys (`cost_usd`/`duration_s`) carried in report metadata, so `show_cost` gating applies (subscription users see no cost line).
- No more printing from library code — surfaces own presentation.

## Tests

17 new in `test_release_prep_team_report.py`: converter section shapes/tiers/metadata/dict round-trip, **repr-leak + tier-classification drift guards over real rendered markdown** (proposal test layers 1–2), and the migrated execute contract (WorkflowResult, success-when-blocked, zero stdout, `target=` mapping). Full agents (165) + voice (115) suites green; no existing test asserted the old return type (T0 audit).

Remaining in the spec: T5 (MCP verbatim), T6 (dashboard panel), T8+ (per-workflow migrations by D5 rank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)