### PR TITLE
docs(redis): fix install instructions — attune-redis was never published

### DIFF
--- a/attune_redis/README.md
+++ b/attune_redis/README.md
@@ -12,7 +12,7 @@ search over long-term memory, and pub/sub coordination.
 ## Installation
 
 ```bash
-pip install attune-redis
+pip install 'attune-ai[redis]'
 ```
 
 Or as an extra of the core framework:

--- a/attune_redis/mcp_tools.py
+++ b/attune_redis/mcp_tools.py
@@ -169,7 +169,7 @@ async def handle_redis_memory_store(server: Any, args: dict[str, Any]) -> dict[s
     except ImportError:
         return {
             "success": False,
-            "error": "attune-redis not installed. Run: pip install attune-redis",
+            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -203,7 +203,7 @@ async def handle_redis_memory_retrieve(server: Any, args: dict[str, Any]) -> dic
     except ImportError:
         return {
             "success": False,
-            "error": "attune-redis not installed. Run: pip install attune-redis",
+            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -237,7 +237,7 @@ async def handle_redis_memory_search(server: Any, args: dict[str, Any]) -> dict[
     except ImportError:
         return {
             "success": False,
-            "error": "attune-redis not installed. Run: pip install attune-redis",
+            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -267,7 +267,7 @@ async def handle_redis_memory_promote(server: Any, args: dict[str, Any]) -> dict
     except ImportError:
         return {
             "success": False,
-            "error": "attune-redis not installed. Run: pip install attune-redis",
+            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -298,7 +298,7 @@ async def handle_redis_health_check(server: Any, args: dict[str, Any]) -> dict[s
     except ImportError:
         return {
             "success": False,
-            "error": "attune-redis not installed. Run: pip install attune-redis",
+            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -75,7 +75,7 @@ plugin/                # Claude Code plugin
 ├── skills/            # Skill groups (MCP-exposed tasks)
 └── agents/            # Agent definitions
 
-attune_redis/          # Redis plugin (pip install attune-redis)
+attune_redis/          # Redis plugin (pip install 'attune-ai[redis]')
 attune_software/       # Software plugin (bundled)
 ```
 

--- a/docs/getting-started/mcp-integration.md
+++ b/docs/getting-started/mcp-integration.md
@@ -175,7 +175,7 @@ Claude: [Invokes analyze_image with image_path="screenshots/bug.png"]
 
 ### Redis Plugin Tools (attune-redis)
 
-Installed with `pip install attune-redis`. Adds 5 additional tools:
+Installed with `pip install 'attune-ai[redis]'`. Adds 5 additional tools:
 `redis_memory_store`, `redis_memory_retrieve`, `redis_memory_search`,
 `redis_memory_promote`, `redis_health_check`.
 

--- a/plugin/help/generated/notes/project-structure.md
+++ b/plugin/help/generated/notes/project-structure.md
@@ -26,7 +26,7 @@ src/attune/
 ├── telemetry/         # FeedbackLoop, UsageTracker (MemoryBackend protocol)
 └── cli_router.py      # Natural language command routing
 
-attune_redis/          # attune-redis plugin (pip install attune-redis)
+attune_redis/          # attune-redis plugin (pip install 'attune-ai[redis]')
 ```
 
 ## Related Topics


### PR DESCRIPTION
## Summary

Closes the documented-but-uninstallable gap: every live surface said `pip install attune-redis`, but that package was never published to PyPI — the `attune_redis` plugin ships **bundled inside attune-ai's wheel**, with runtime deps behind the `[redis]` extra. All live sites now say `pip install 'attune-ai[redis]'`.

Sites fixed (sweep verified — zero remaining outside `docs/specs/archive/`):

- `docs/PROJECT_OVERVIEW.md` + `docs/getting-started/mcp-integration.md`
- `attune_redis/README.md`
- `plugin/help/generated/notes/project-structure.md`
- **The five runtime MCP error messages** in `attune_redis/mcp_tools.py` — these told users to run the failing command at the exact moment they needed working guidance (no tests asserted the old string).

Decision ratified in-session 2026-06-10: fix docs rather than publish a standalone package (no release ceremony, no second version stream to keep in lockstep). attune_redis tests green (115 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)