### PR TITLE
feat(sdk): subprocess isolation Phase 2 — setting_sources=[] + env marker on every ClaudeAgentOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blockers/warnings, and outcome-conditional next steps — instead of
   the bespoke dataclass + `format_console_output()` dump. Rendered by
   the T2–T4 pipeline on every surface.
+- **SDK workflow subprocesses are now isolated from session settings**
+  (sdk-subprocess-isolation Phase 2) — the fix that makes SDK
+  workflows work for subscription users. Every `ClaudeAgentOptions`
+  construction (15 workflows) splats `sdk_isolation_kwargs()`:
+  `setting_sources=[]` keeps user/project settings, SessionStart
+  hooks, and CLAUDE.md injection out of the spawned `claude` session
+  (hook stdout previously poisoned the stream-json channel →
+  `Command failed with exit code 1` for keyless users), and
+  `ATTUNE_SDK_SUBPROCESS=1` rides the subprocess env so attune hooks
+  can self-gate (Phase 1). Drift-guarded like `resolve_cwd_for_path`.
 - **CLI renders `WorkflowReport` results as styled terminal markdown**
   (workflow-result-formatting T4). On a TTY, report-carrying results
   render through `rich.markdown` (headings, tables, bullets); piped

--- a/docs/specs/sdk-subprocess-isolation/decisions.md
+++ b/docs/specs/sdk-subprocess-isolation/decisions.md
@@ -15,11 +15,16 @@
 | D2 | Filesystem settings in SDK subprocesses | **Exclude via `setting_sources=[]`** once the empty flag value is live-verified; keep the hook gate as belt-and-suspenders | Ratified 2026-06-10. No hooks, no CLAUDE.md injection, faster + cheaper + deterministic startup; workflows carry their own system prompts. The hook gate stays for older SDKs and spawn paths that bypass the adapter. |
 | D3 | Detection signal | **Dual**: `CLAUDE_CODE_ENTRYPOINT` prefix `sdk-` OR `ATTUNE_SDK_SUBPROCESS=1` | The SDK stamps `CLAUDE_CODE_ENTRYPOINT=sdk-py` into every subprocess env (findings F2) — free coverage for end users running their own SDK scripts with the plugin installed. The explicit marker survives SDK renames and covers non-SDK spawn paths attune controls. Interactive values observed: `claude-desktop` (desktop), so prefix-match `sdk-` cannot false-positive there. |
 | D4 | Marker env var name | `ATTUNE_SDK_SUBPROCESS=1` | Named for what it marks (an SDK-spawned subprocess session), per the "name the env var after what it does, not who flips it" lesson. NOT `CLAUDE_CODE_SDK_SUBPROCESS` (the 2026-06-06 lesson's sketch) — that prefix implies Claude Code owns it; it's ours. |
-| D5 | Where the marker is set | `agent_sdk_adapter` only, via `ClaudeAgentOptions(env={...})` | Env inherits down the whole chain (CLI → MCP → dashboard runner all reach the SDK through the adapter), so one site covers every path. The runner's `proc_env` stays unchanged — adding it there would be redundant. |
+| D5 | Where the marker is set | `agent_sdk_adapter.sdk_isolation_kwargs()` helper, splatted into EVERY `ClaudeAgentOptions` construction (15 workflow sites), drift-guarded | REVISED during Phase 2 (2026-06-10): the original "adapter only, one site" premise was wrong — each workflow constructs its own `ClaudeAgentOptions`; there is no single construction site. The helper + `TestSdkWorkflowsUseIsolationKwargs` drift guard (the `resolve_cwd_for_path` pattern) is the equivalent single source. Runner `proc_env` unchanged. |
 | D6 | Gate helper location | One shared `plugin/hooks/_sdk_gate.py` (or extend the existing `_state.py`-style shared module), imported by every hook script | 12 copies of a two-line check WILL drift. The R6a drift guard asserts every hooks.json script references the gate. |
 | D7 | Repo's own `.claude/settings.json` hooks | Out of scope for the product fix; MAY adopt the same gate opportunistically | The shipped plugin is the user-facing surface. The dev repo's hooks polluting Patrick's own dogfooding is real but fixable the same way at any time. |
 
 ## Calibration record
+
+- 2026-06-10 — Phase 2: live probe confirmed the CLI accepts an empty
+  `--setting-sources=` (exit 0, keyless/subscription) — R3's gate passed.
+  D5's "one adapter site" premise corrected on contact with code (see
+  revised D5).
 
 - 2026-06-10 — Phase 0 ran via direct venv introspection instead of a
   committed probe script first; `scripts/probe_sdk_subprocess_env.py`

--- a/docs/specs/sdk-subprocess-isolation/requirements.md
+++ b/docs/specs/sdk-subprocess-isolation/requirements.md
@@ -1,7 +1,8 @@
 # Spec: SDK Subprocess Isolation — Requirements
 
-**Status:** draft (2026-06-10) — awaiting approval. Phase 0 (SDK
-introspection) already executed; see [findings.md](findings.md).
+**Status:** approved (2026-06-10, "GO") — Phase 0 done
+([findings.md](findings.md)); Phase 2 (adapter isolation) implemented
+first (it directly unblocks the subscription receipt), Phase 1 next.
 
 ---
 

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -903,6 +903,43 @@ def get_max_budget_usd(depth: str = "standard") -> float | None:
     return _DEFAULT_BUDGET_USD.get(depth, 10.00)
 
 
+#: Env marker every SDK-spawned ``claude`` subprocess carries so attune
+#: hooks can self-gate (sdk-subprocess-isolation spec, D3/D4).
+SDK_SUBPROCESS_ENV_VAR = "ATTUNE_SDK_SUBPROCESS"
+
+
+def sdk_isolation_kwargs() -> dict[str, Any]:
+    """``ClaudeAgentOptions`` kwargs isolating the SDK subprocess session.
+
+    sdk-subprocess-isolation spec (D2–D5): ``setting_sources=[]`` keeps
+    user/project/local settings — and with them SessionStart hooks and
+    CLAUDE.md injection — out of workflow subprocesses, which is what
+    makes SDK workflows usable for subscription users (hook stdout
+    otherwise poisons the stream-json channel). The env marker lets
+    attune hooks self-gate on older SDKs and non-adapter spawn paths.
+
+    Splat into every ``ClaudeAgentOptions`` construction::
+
+        claude_agent_sdk.ClaudeAgentOptions(
+            **sdk_isolation_kwargs(),
+            system_prompt=...,
+        )
+
+    A drift-guard test asserts every construction site uses it. NOTE:
+    never pass ``options.skills`` without an explicit
+    ``setting_sources`` — the SDK silently forces ``["user","project"]``
+    back on (spec findings F4).
+
+    Returns:
+        Kwargs dict with ``setting_sources`` and ``env``.
+
+    """
+    return {
+        "setting_sources": [],
+        "env": {SDK_SUBPROCESS_ENV_VAR: "1"},
+    }
+
+
 def resolve_cwd_for_path(path: str | Path) -> Path:
     """Return a directory path suitable for the Agent SDK ``cwd=`` arg.
 

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -33,6 +33,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .bug_predict_patterns import (
@@ -241,6 +242,7 @@ class BugPredictionWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=system_prompt,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/code_review.py
+++ b/src/attune/workflows/code_review.py
@@ -40,6 +40,7 @@ from .agent_sdk_adapter import (
     get_task_budget,
     get_thinking_config,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -324,6 +325,7 @@ class CodeReviewWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=_SYSTEM_PROMPT,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/deep_review.py
+++ b/src/attune/workflows/deep_review.py
@@ -39,6 +39,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -294,6 +295,7 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=_SYSTEM_PROMPT,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/dependency_check.py
+++ b/src/attune/workflows/dependency_check.py
@@ -29,6 +29,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -222,6 +223,7 @@ class DependencyCheckWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=system_prompt,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -29,6 +29,7 @@ from ..agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
@@ -197,6 +198,7 @@ class DocAuditWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=system_prompt,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/document_gen/workflow.py
+++ b/src/attune/workflows/document_gen/workflow.py
@@ -28,6 +28,7 @@ from ..agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from ..base import BaseWorkflow, ModelTier
 from ..context import WorkflowContext
@@ -202,6 +203,7 @@ class DocumentGenerationWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=_SYSTEM_PROMPT,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/perf_audit.py
+++ b/src/attune/workflows/perf_audit.py
@@ -33,6 +33,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -223,6 +224,7 @@ class PerformanceAuditWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=system_prompt,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -37,6 +37,7 @@ from .agent_sdk_adapter import (
     get_task_budget,
     get_thinking_config,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -383,7 +384,7 @@ class RagCodeGenWorkflow(BaseWorkflow):
 
         async for message in claude_agent_sdk.query(
             prompt=augmented_prompt,
-            options=claude_agent_sdk.ClaudeAgentOptions(**options_kwargs),
+            options=claude_agent_sdk.ClaudeAgentOptions(**sdk_isolation_kwargs(), **options_kwargs),
         ):
             sdk_result = collect_agent_output(message, assistant_parts, result_parts)
             if sdk_result is not None:

--- a/src/attune/workflows/refactor_plan.py
+++ b/src/attune/workflows/refactor_plan.py
@@ -31,6 +31,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -221,6 +222,7 @@ class RefactorPlanWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=_SYSTEM_PROMPT,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -28,6 +28,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -190,6 +191,7 @@ class ReleasePreparationWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=_SYSTEM_PROMPT,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/research_synthesis.py
+++ b/src/attune/workflows/research_synthesis.py
@@ -34,6 +34,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -214,6 +215,7 @@ class ResearchSynthesisWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=_SYSTEM_PROMPT,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/security_audit.py
+++ b/src/attune/workflows/security_audit.py
@@ -38,6 +38,7 @@ from .agent_sdk_adapter import (
     get_task_budget,
     get_thinking_config,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -245,6 +246,7 @@ class SecurityAuditWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=system_prompt,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/simplify_code.py
+++ b/src/attune/workflows/simplify_code.py
@@ -34,6 +34,7 @@ from .agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
@@ -208,6 +209,7 @@ class SimplifyCodeWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=_SYSTEM_PROMPT,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -30,6 +30,7 @@ from ..agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
@@ -227,6 +228,7 @@ class TestAuditWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(src_path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=system_prompt,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/src/attune/workflows/test_gen/workflow.py
+++ b/src/attune/workflows/test_gen/workflow.py
@@ -31,6 +31,7 @@ from ..agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     resolve_cwd_for_path,
+    sdk_isolation_kwargs,
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
@@ -190,6 +191,7 @@ class TestGenerationWorkflow(BaseWorkflow):
         async for message in claude_agent_sdk.query(
             prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
             options=claude_agent_sdk.ClaudeAgentOptions(
+                **sdk_isolation_kwargs(),
                 system_prompt=_SYSTEM_PROMPT,
                 cwd=resolve_cwd_for_path(resolved_path),
                 max_budget_usd=get_max_budget_usd(depth),

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -1199,3 +1199,96 @@ class TestAgentSDKResultAdapterStructuredOutput:
         )
         # Empty dict is falsy, so falls back to text parsing
         assert "85/100" in result.summary
+
+
+@pytest.mark.unit
+class TestSdkIsolationKwargs:
+    """sdk_isolation_kwargs contract (sdk-subprocess-isolation Phase 2)."""
+
+    def test_excludes_all_setting_sources(self) -> None:
+        """setting_sources=[] keeps hooks + CLAUDE.md out of subprocesses."""
+        from attune.workflows.agent_sdk_adapter import sdk_isolation_kwargs
+
+        kwargs = sdk_isolation_kwargs()
+        assert kwargs["setting_sources"] == []
+
+    def test_carries_subprocess_marker_env(self) -> None:
+        """The env marker lets attune hooks self-gate (spec D3/D4)."""
+        from attune.workflows.agent_sdk_adapter import (
+            SDK_SUBPROCESS_ENV_VAR,
+            sdk_isolation_kwargs,
+        )
+
+        kwargs = sdk_isolation_kwargs()
+        assert SDK_SUBPROCESS_ENV_VAR == "ATTUNE_SDK_SUBPROCESS"
+        assert kwargs["env"] == {SDK_SUBPROCESS_ENV_VAR: "1"}
+
+    def test_fresh_dict_per_call(self) -> None:
+        """Callers may mutate the result without cross-call leakage."""
+        from attune.workflows.agent_sdk_adapter import sdk_isolation_kwargs
+
+        a = sdk_isolation_kwargs()
+        a["env"]["EXTRA"] = "x"
+        assert "EXTRA" not in sdk_isolation_kwargs()["env"]
+
+    def test_accepted_by_claude_agent_options(self) -> None:
+        """The kwargs splat cleanly into a real ClaudeAgentOptions."""
+        claude_agent_sdk = pytest.importorskip("claude_agent_sdk")
+        from attune.workflows.agent_sdk_adapter import sdk_isolation_kwargs
+
+        options = claude_agent_sdk.ClaudeAgentOptions(**sdk_isolation_kwargs())
+        assert options.setting_sources == []
+        assert options.env["ATTUNE_SDK_SUBPROCESS"] == "1"
+
+
+@pytest.mark.unit
+class TestSdkWorkflowsUseIsolationKwargs:
+    """Drift-guard (spec R6): every ClaudeAgentOptions site is isolated.
+
+    A future workflow constructing ClaudeAgentOptions without
+    sdk_isolation_kwargs() silently reloads user/project settings in
+    the subprocess — SessionStart hook output then poisons the
+    stream-json channel and the workflow fails for subscription users.
+    Also guards the skills trap (findings F4): options.skills with no
+    explicit setting_sources forces ["user","project"] back on.
+    """
+
+    def _workflow_files(self):
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[3] / "src" / "attune" / "workflows"
+        return [
+            p
+            for p in root.rglob("*.py")
+            # The adapter is the helper's home (docstring example), not a site.
+            if p.name != "agent_sdk_adapter.py"
+            and "ClaudeAgentOptions(" in p.read_text(encoding="utf-8")
+        ]
+
+    def test_every_options_site_uses_isolation_kwargs(self) -> None:
+        """Each file constructing ClaudeAgentOptions splats the helper."""
+        offenders = [
+            str(p)
+            for p in self._workflow_files()
+            if "sdk_isolation_kwargs" not in p.read_text(encoding="utf-8")
+        ]
+        assert not offenders, (
+            f"ClaudeAgentOptions constructed without sdk_isolation_kwargs() — "
+            f"subscription users' workflows will fail on hook pollution. "
+            f"Offenders: {offenders}"
+        )
+
+    def test_no_workflow_passes_skills(self) -> None:
+        """skills= would silently force setting_sources back on (F4)."""
+        offenders = [
+            str(p) for p in self._workflow_files() if "skills=" in p.read_text(encoding="utf-8")
+        ]
+        assert not offenders, (
+            f"options.skills with setting_sources unset re-enables "
+            f"user+project settings loading (SDK _apply_skills_defaults). "
+            f"Pass an explicit setting_sources alongside. Offenders: {offenders}"
+        )
+
+    def test_sweep_covers_known_workflow_count(self) -> None:
+        """The sweep found the expected 15 construction sites."""
+        assert len(self._workflow_files()) == 15


### PR DESCRIPTION
## Summary

**Phase 2 of [sdk-subprocess-isolation]** (#748) — the change that makes SDK workflows work for **subscription users**, the plugin's primary audience.

Every `ClaudeAgentOptions` construction (15 workflow sites) now splats `agent_sdk_adapter.sdk_isolation_kwargs()`:

- **`setting_sources=[]`** — user/project/local settings (and with them SessionStart hooks + CLAUDE.md injection) never load in the spawned `claude` session. Hook stdout previously poisoned the stream-json channel: every SDK workflow died with an opaque `Command failed with exit code 1` for keyless users. Side benefits for everyone: faster startup, fewer injected tokens, deterministic subprocess sessions.
- **`env={"ATTUNE_SDK_SUBPROCESS": "1"}`** — the explicit marker attune hooks self-gate on (Phase 1, next PR), complementing the SDK's own `CLAUDE_CODE_ENTRYPOINT=sdk-py` stamp.

**Gate passed before building** (spec R3): the live probe confirmed the CLI accepts an empty `--setting-sources=` — exit 0, and the probe itself ran keyless via subscription.

**D5 revised on contact with code**: the spec assumed one adapter-level construction site; each workflow actually builds its own options. The helper + `TestSdkWorkflowsUseIsolationKwargs` drift guard (the `resolve_cwd_for_path` pattern) is the equivalent single source, plus a skills-trap guard (findings F4: `options.skills` with unset `setting_sources` silently re-enables settings loading). decisions.md updated in this PR.

## Tests

- 4 helper-contract tests (incl. splatting into a real `ClaudeAgentOptions`).
- 3 drift guards: every construction site isolated, no `skills=` anywhere, expected site count.
- Options-asserting per-workflow scaffolds unaffected (additive kwargs) — spot-verified on the 5 most assertion-heavy files.

Phase 1 (hook gate) and Phase 3 (live subscription receipt) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)