### PR TITLE
feat(hooks): subprocess isolation Phase 1 — all hooks self-gate in SDK sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Command failed with exit code 1` for keyless users), and
   `ATTUNE_SDK_SUBPROCESS=1` rides the subprocess env so attune hooks
   can self-gate (Phase 1). Drift-guarded like `resolve_cwd_for_path`.
+- **All attune hooks self-gate inside SDK subprocess sessions**
+  (sdk-subprocess-isolation Phase 1). Every registered hook — the 11
+  shipped plugin scripts and the 5 repo-level scripts — exits silently
+  when `ATTUNE_SDK_SUBPROCESS=1` or `CLAUDE_CODE_ENTRYPOINT=sdk-*` is
+  present (`_sdk_gate.exit_if_sdk_subprocess()`, first statement of
+  every `__main__`). Belt-and-suspenders under Phase 2's
+  `setting_sources=[]`: covers older SDKs and third-party SDK scripts
+  run with the plugin installed. Drift-guarded against both hook
+  registries.
 - **CLI renders `WorkflowReport` results as styled terminal markdown**
   (workflow-result-formatting T4). On a TTY, report-carrying results
   render through `rich.markdown` (headings, tables, bullets); piped

--- a/plugin/hooks/_sdk_gate.py
+++ b/plugin/hooks/_sdk_gate.py
@@ -1,0 +1,42 @@
+"""Detect SDK-spawned subprocess sessions so hooks can self-gate.
+
+sdk-subprocess-isolation spec (R1/R2, decision D1: gate everything):
+an SDK-spawned ``claude`` subprocess is not an interactive session —
+no attune hook applies there, and SessionStart hook stdout poisons
+the SDK's stream-json channel (the failure that broke every SDK
+workflow for subscription users). Every hook script calls
+:func:`exit_if_sdk_subprocess` as its first ``__main__`` statement.
+
+Two detection signals (spec D3):
+
+- ``ATTUNE_SDK_SUBPROCESS=1`` — attune's explicit marker, set by
+  ``agent_sdk_adapter.sdk_isolation_kwargs()`` (Phase 2).
+- ``CLAUDE_CODE_ENTRYPOINT`` starting with ``sdk-`` — stamped by the
+  Agent SDK itself into every subprocess env, so the gate also covers
+  third-party SDK scripts that never touch attune's adapter.
+  Interactive sessions carry other values (``claude-desktop``, etc.).
+
+Twin copy: ``src/attune/hooks/scripts/_sdk_gate.py`` (repo-level
+hooks). Keep both in sync — each is imported from its own script dir.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def is_sdk_subprocess() -> bool:
+    """True when running inside an SDK-spawned ``claude`` subprocess."""
+    if os.environ.get("ATTUNE_SDK_SUBPROCESS") == "1":
+        return True
+    return os.environ.get("CLAUDE_CODE_ENTRYPOINT", "").startswith("sdk-")
+
+
+def exit_if_sdk_subprocess() -> None:
+    """Exit 0 with no output when inside an SDK subprocess session."""
+    if is_sdk_subprocess():
+        sys.exit(0)

--- a/plugin/hooks/compact_warning.py
+++ b/plugin/hooks/compact_warning.py
@@ -114,4 +114,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     raise SystemExit(main())

--- a/plugin/hooks/format_on_save.py
+++ b/plugin/hooks/format_on_save.py
@@ -102,4 +102,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     main()

--- a/plugin/hooks/help_freshness_check.py
+++ b/plugin/hooks/help_freshness_check.py
@@ -97,4 +97,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     main()

--- a/plugin/hooks/help_on_error.py
+++ b/plugin/hooks/help_on_error.py
@@ -82,4 +82,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     main()

--- a/plugin/hooks/help_post_commit.py
+++ b/plugin/hooks/help_post_commit.py
@@ -112,4 +112,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     main()

--- a/plugin/hooks/jit_recall.py
+++ b/plugin/hooks/jit_recall.py
@@ -163,4 +163,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     sys.exit(main())

--- a/plugin/hooks/security_guard.py
+++ b/plugin/hooks/security_guard.py
@@ -218,6 +218,9 @@ def _read_stdin_context() -> dict[str, Any]:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     logging.basicConfig(level=logging.WARNING, format="%(message)s")
     context = _read_stdin_context()
 

--- a/plugin/hooks/session_recall.py
+++ b/plugin/hooks/session_recall.py
@@ -109,4 +109,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     sys.exit(main())

--- a/plugin/hooks/session_stash.py
+++ b/plugin/hooks/session_stash.py
@@ -392,4 +392,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     sys.exit(main())

--- a/plugin/hooks/spec_orient.py
+++ b/plugin/hooks/spec_orient.py
@@ -168,4 +168,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     raise SystemExit(main())

--- a/plugin/hooks/welcome.py
+++ b/plugin/hooks/welcome.py
@@ -37,4 +37,7 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     main()

--- a/src/attune/hooks/scripts/_sdk_gate.py
+++ b/src/attune/hooks/scripts/_sdk_gate.py
@@ -1,0 +1,42 @@
+"""Detect SDK-spawned subprocess sessions so hooks can self-gate.
+
+sdk-subprocess-isolation spec (R1/R2, decision D1: gate everything):
+an SDK-spawned ``claude`` subprocess is not an interactive session —
+no attune hook applies there, and SessionStart hook stdout poisons
+the SDK's stream-json channel (the failure that broke every SDK
+workflow for subscription users). Every hook script calls
+:func:`exit_if_sdk_subprocess` as its first ``__main__`` statement.
+
+Two detection signals (spec D3):
+
+- ``ATTUNE_SDK_SUBPROCESS=1`` — attune's explicit marker, set by
+  ``agent_sdk_adapter.sdk_isolation_kwargs()`` (Phase 2).
+- ``CLAUDE_CODE_ENTRYPOINT`` starting with ``sdk-`` — stamped by the
+  Agent SDK itself into every subprocess env, so the gate also covers
+  third-party SDK scripts that never touch attune's adapter.
+  Interactive sessions carry other values (``claude-desktop``, etc.).
+
+Twin copy: ``plugin/hooks/_sdk_gate.py`` (shipped plugin hooks).
+Keep both in sync — each is imported from its own script dir.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def is_sdk_subprocess() -> bool:
+    """True when running inside an SDK-spawned ``claude`` subprocess."""
+    if os.environ.get("ATTUNE_SDK_SUBPROCESS") == "1":
+        return True
+    return os.environ.get("CLAUDE_CODE_ENTRYPOINT", "").startswith("sdk-")
+
+
+def exit_if_sdk_subprocess() -> None:
+    """Exit 0 with no output when inside an SDK subprocess session."""
+    if is_sdk_subprocess():
+        sys.exit(0)

--- a/src/attune/hooks/scripts/help_freshness_nudge.py
+++ b/src/attune/hooks/scripts/help_freshness_nudge.py
@@ -123,6 +123,9 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     try:
         sys.exit(main())
     except Exception:  # noqa: BLE001

--- a/src/attune/hooks/scripts/lessons_reminder.py
+++ b/src/attune/hooks/scripts/lessons_reminder.py
@@ -66,4 +66,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     sys.exit(main())

--- a/src/attune/hooks/scripts/security_guard.py
+++ b/src/attune/hooks/scripts/security_guard.py
@@ -206,6 +206,9 @@ def _read_stdin_context() -> dict[str, Any]:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     logging.basicConfig(level=logging.WARNING, format="%(message)s")
     context = _read_stdin_context()
 

--- a/src/attune/hooks/scripts/starter_prompt_nudge.py
+++ b/src/attune/hooks/scripts/starter_prompt_nudge.py
@@ -81,6 +81,9 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     try:
         sys.exit(main())
     except Exception as exc:  # noqa: BLE001

--- a/src/attune/hooks/scripts/worktree_path_guard.py
+++ b/src/attune/hooks/scripts/worktree_path_guard.py
@@ -167,6 +167,9 @@ def _read_stdin_context() -> dict[str, Any]:
 
 
 if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
     # The hook MAY be invoked outside Claude Code (smoke tests,
     # local manual runs); in that case stdin is empty and we
     # silently allow.

--- a/tests/unit/plugins/test_sdk_subprocess_gate.py
+++ b/tests/unit/plugins/test_sdk_subprocess_gate.py
@@ -1,0 +1,187 @@
+"""Hook gating for SDK-spawned subprocess sessions (sdk-subprocess-isolation Phase 1).
+
+Spec R1/R2 + AC1–AC3: every registered hook script exits 0 with zero
+output when either detection signal is present (the explicit
+``ATTUNE_SDK_SUBPROCESS=1`` marker or the SDK's own
+``CLAUDE_CODE_ENTRYPOINT=sdk-*`` stamp), and behaves normally in
+interactive sessions (AC3 = the existing hook test suites). The R6a
+drift guard pins the gate call into every script the plugin's
+hooks.json (and the repo's settings.json) registers.
+"""
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_HOOKS = REPO_ROOT / "plugin" / "hooks"
+
+
+def _plugin_hook_scripts() -> list[Path]:
+    """Every script plugin/hooks/hooks.json registers (deduped)."""
+    config = json.loads((PLUGIN_HOOKS / "hooks.json").read_text(encoding="utf-8"))
+    scripts: set[str] = set()
+    for groups in config["hooks"].values():
+        for group in groups:
+            for hook in group.get("hooks", []):
+                match = re.search(r"hooks/(\w+\.py)", hook.get("command", ""))
+                if match:
+                    scripts.add(match.group(1))
+    return sorted(PLUGIN_HOOKS / name for name in scripts)
+
+
+def _repo_hook_scripts() -> list[Path]:
+    """Every script .claude/settings.json registers (deduped)."""
+    config = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    scripts: set[str] = set()
+    for groups in config.get("hooks", {}).values():
+        for group in groups:
+            for hook in group.get("hooks", []):
+                match = re.search(r"src/attune/hooks/scripts/(\w+\.py)", hook.get("command", ""))
+                if match:
+                    scripts.add(match.group(1))
+    return sorted(REPO_ROOT / "src" / "attune" / "hooks" / "scripts" / name for name in scripts)
+
+
+def _load_gate():
+    """Import plugin/hooks/_sdk_gate.py (not a package) by path."""
+    spec = importlib.util.spec_from_file_location("_plugin_sdk_gate", PLUGIN_HOOKS / "_sdk_gate.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestIsSdkSubprocess:
+    """The detection predicate (spec D3)."""
+
+    def test_explicit_marker_detected(self, monkeypatch):
+        """ATTUNE_SDK_SUBPROCESS=1 is the attune-set signal."""
+        gate = _load_gate()
+        monkeypatch.setenv("ATTUNE_SDK_SUBPROCESS", "1")
+        monkeypatch.delenv("CLAUDE_CODE_ENTRYPOINT", raising=False)
+        assert gate.is_sdk_subprocess() is True
+
+    def test_sdk_entrypoint_detected(self, monkeypatch):
+        """CLAUDE_CODE_ENTRYPOINT=sdk-py covers third-party SDK scripts."""
+        gate = _load_gate()
+        monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-py")
+        assert gate.is_sdk_subprocess() is True
+
+    @pytest.mark.parametrize("entrypoint", ["claude-desktop", "cli", ""])
+    def test_interactive_sessions_not_detected(self, monkeypatch, entrypoint):
+        """Interactive entrypoints never match (AC3 precondition)."""
+        gate = _load_gate()
+        monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
+        if entrypoint:
+            monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", entrypoint)
+        else:
+            monkeypatch.delenv("CLAUDE_CODE_ENTRYPOINT", raising=False)
+        assert gate.is_sdk_subprocess() is False
+
+    def test_marker_other_values_not_detected(self, monkeypatch):
+        """Only the literal '1' arms the explicit marker."""
+        gate = _load_gate()
+        monkeypatch.setenv("ATTUNE_SDK_SUBPROCESS", "0")
+        monkeypatch.delenv("CLAUDE_CODE_ENTRYPOINT", raising=False)
+        assert gate.is_sdk_subprocess() is False
+
+
+class TestGateDriftGuards:
+    """R6a: every registered hook script calls the gate."""
+
+    def test_every_plugin_hook_gated(self):
+        """All hooks.json scripts call exit_if_sdk_subprocess."""
+        scripts = _plugin_hook_scripts()
+        assert scripts, "hooks.json parsed to zero scripts — parser drift?"
+        offenders = [
+            str(p) for p in scripts if "exit_if_sdk_subprocess" not in p.read_text(encoding="utf-8")
+        ]
+        assert not offenders, (
+            f"Plugin hooks without the SDK-subprocess gate will fire inside "
+            f"SDK workflow subprocesses and poison the stream-json channel "
+            f"for subscription users: {offenders}"
+        )
+
+    def test_every_repo_hook_gated(self):
+        """All .claude/settings.json scripts call exit_if_sdk_subprocess."""
+        scripts = _repo_hook_scripts()
+        assert scripts, "settings.json parsed to zero scripts — parser drift?"
+        offenders = [
+            str(p) for p in scripts if "exit_if_sdk_subprocess" not in p.read_text(encoding="utf-8")
+        ]
+        assert not offenders, f"Repo hook scripts missing the gate: {offenders}"
+
+    def test_gate_twins_have_identical_logic(self):
+        """The two _sdk_gate copies must not drift (docstrings may differ)."""
+
+        def logic(path: Path) -> str:
+            text = path.read_text(encoding="utf-8")
+            # Strip the module docstring; compare executable content only.
+            return re.sub(r'^"""[\s\S]*?"""', "", text, count=1).strip()
+
+        plugin_gate = logic(PLUGIN_HOOKS / "_sdk_gate.py")
+        repo_gate = logic(REPO_ROOT / "src" / "attune" / "hooks" / "scripts" / "_sdk_gate.py")
+        assert plugin_gate == repo_gate
+
+
+class TestHooksSilentInSdkSubprocess:
+    """AC1/AC2: each registered hook exits 0 with zero output."""
+
+    @pytest.mark.parametrize("script", _plugin_hook_scripts(), ids=lambda p: p.name)
+    def test_plugin_hook_silent_with_marker(self, script):
+        """AC1: the explicit marker silences every plugin hook."""
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, str(script)],
+            env={**os.environ, "ATTUNE_SDK_SUBPROCESS": "1"},
+            input="",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+        assert result.returncode == 0, f"{script.name}: exit {result.returncode}"
+        assert result.stdout == "" and result.stderr == "", (
+            f"{script.name} emitted output despite the SDK marker: "
+            f"stdout={result.stdout[:120]!r} stderr={result.stderr[:120]!r}"
+        )
+
+    def test_plugin_hook_silent_with_sdk_entrypoint(self):
+        """AC2: the SDK's own entrypoint stamp silences hooks too."""
+        env = {**os.environ, "CLAUDE_CODE_ENTRYPOINT": "sdk-py"}
+        env.pop("ATTUNE_SDK_SUBPROCESS", None)
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, str(PLUGIN_HOOKS / "welcome.py")],
+            env=env,
+            input="",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert result.stdout == "" and result.stderr == ""
+
+    def test_repo_hook_silent_with_marker(self):
+        """The repo-level scripts honor the same gate."""
+        script = REPO_ROOT / "src" / "attune" / "hooks" / "scripts" / "lessons_reminder.py"
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, str(script)],
+            env={**os.environ, "ATTUNE_SDK_SUBPROCESS": "1"},
+            input="",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+        assert result.returncode == 0
+        assert result.stdout == "" and result.stderr == ""

--- a/tests/unit/plugins/test_sdk_subprocess_gate.py
+++ b/tests/unit/plugins/test_sdk_subprocess_gate.py
@@ -185,3 +185,53 @@ class TestHooksSilentInSdkSubprocess:
         )
         assert result.returncode == 0
         assert result.stdout == "" and result.stderr == ""
+
+
+class TestRepoGateTwin:
+    """Direct coverage of attune.hooks.scripts._sdk_gate (the repo twin).
+
+    The subprocess-based tests above exercise the plugin twin invisibly
+    to coverage; this class imports the packaged twin and exercises the
+    same contract in-process.
+    """
+
+    def test_marker_detected(self, monkeypatch):
+        """ATTUNE_SDK_SUBPROCESS=1 arms the repo twin too."""
+        from attune.hooks.scripts import _sdk_gate
+
+        monkeypatch.setenv("ATTUNE_SDK_SUBPROCESS", "1")
+        monkeypatch.delenv("CLAUDE_CODE_ENTRYPOINT", raising=False)
+        assert _sdk_gate.is_sdk_subprocess() is True
+
+    def test_sdk_entrypoint_detected(self, monkeypatch):
+        """The sdk- entrypoint prefix arms the repo twin too."""
+        from attune.hooks.scripts import _sdk_gate
+
+        monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-ts")
+        assert _sdk_gate.is_sdk_subprocess() is True
+
+    def test_interactive_not_detected(self, monkeypatch):
+        """No signal → not an SDK subprocess."""
+        from attune.hooks.scripts import _sdk_gate
+
+        monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "claude-desktop")
+        assert _sdk_gate.is_sdk_subprocess() is False
+
+    def test_exit_helper_exits_zero_when_armed(self, monkeypatch):
+        """exit_if_sdk_subprocess raises SystemExit(0) under the marker."""
+        from attune.hooks.scripts import _sdk_gate
+
+        monkeypatch.setenv("ATTUNE_SDK_SUBPROCESS", "1")
+        with pytest.raises(SystemExit) as excinfo:
+            _sdk_gate.exit_if_sdk_subprocess()
+        assert excinfo.value.code == 0
+
+    def test_exit_helper_noop_when_interactive(self, monkeypatch):
+        """No signal → the helper returns without exiting."""
+        from attune.hooks.scripts import _sdk_gate
+
+        monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_ENTRYPOINT", raising=False)
+        assert _sdk_gate.exit_if_sdk_subprocess() is None


### PR DESCRIPTION
## Summary

**Phase 1 of [sdk-subprocess-isolation]** (#748; Phase 2 is #752). Every registered attune hook — the **11 shipped plugin scripts** (`plugin/hooks/hooks.json`) and the **5 repo-level scripts** (`.claude/settings.json`, the D7 opportunistic adoption) — exits 0 with zero output as the first `__main__` statement when running inside an SDK-spawned `claude` subprocess.

Detection (spec D3, dual signal):
- `ATTUNE_SDK_SUBPROCESS=1` — attune's explicit marker (Phase 2 sets it via `sdk_isolation_kwargs()`).
- `CLAUDE_CODE_ENTRYPOINT` starting with `sdk-` — stamped by the Agent SDK itself, so the gate also protects **third-party SDK scripts** run by users who have the plugin installed. Interactive sessions (`claude-desktop`, `cli`) never match.

This is the belt-and-suspenders layer under #752's `setting_sources=[]`: it covers older SDK versions and spawn paths that bypass attune's adapter. Per ratified D1 the gate covers **everything**, including `security_guard` and `format_on_save` (tradeoff recorded in decisions.md; re-enabling any single hook is a one-line change).

The gate lives in `_sdk_gate.py` twins (each script dir imports its own); a parity drift-guard keeps their executable logic identical.

## Tests (22 new, all green; existing hook suites unaffected — AC3)

- Detection predicate: marker, sdk-entrypoint, never on `claude-desktop`/`cli`/unset, marker value must be literal `"1"`.
- **R6a drift guards** parsing both hook registries — a future hook added without the gate fails CI with the subscription-breakage explanation.
- Twin-parity guard.
- **Live subprocess runs** of every plugin hook under the marker (parametrized: exit 0, zero bytes on both streams) + the entrypoint variant + a repo-script run.

Phase 3 (live subscription receipt) follows once this and #752 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)