### PR TITLE
chore(release): 8.3.0 — the subscription release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.2.0"
+    "version": "8.3.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.2.0
+# Attune AI Framework v8.3.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.3.0] — 2026-06-10
+
+The subscription release: SDK workflows now work for Claude
+subscription users (no API key required) — the sdk-subprocess-isolation
+spec shipped end-to-end in one day with a live keyless receipt — and
+workflow results render as structured, readable reports on the voice
+and CLI surfaces (workflow-result-formatting T3/T4/T7).
+
 ### Added
+- **The Bash security guard travels with the SDK adapter**
+  (sdk-subprocess-isolation Phase 4, D8). `sdk_isolation_kwargs()`
+  carries an in-process `PreToolUse` hook (`HookMatcher` on `Bash`)
+  reusing the hook script's own `validate_bash_command` — settings
+  exclusion strips filesystem hooks, so the eval/exec protection now
+  rides inside every workflow subprocess, denying with a reason
+  instead of crashing.
 - **release-prep emits a structured `WorkflowReport`**
   (workflow-result-formatting T7, the motivating case).
   `ReleasePrepTeamWorkflow.execute()` returns a `WorkflowResult`
@@ -61,6 +76,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subscription users never see inapplicable cost figures; explicit
   `True`/`False` (file, env `ATTUNE_SHOW_COST_METRICS`) overrides.
   Cost data always stays in `WorkflowReport.metadata` and `--json`.
+
+### Fixed
+- **Install docs for Redis support pointed at a package that was
+  never published.** Every live `pip install attune-redis` claim —
+  docs, README, and the five runtime MCP error messages — now says
+  `pip install 'attune-ai[redis]'` (the plugin ships bundled inside
+  attune-ai's wheel; the extra pulls its runtime deps).
 
 ## [8.2.0] — 2026-06-10
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.2.0
+**Version:** 8.3.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.2.0 | **License:** Apache 2.0
+**Version:** 8.3.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.2.0"
+    "version": "8.3.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.2.0"
+__version__ = "8.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.2.0"
+version = "8.3.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.2.0"
+version = "8.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

**8.3.0** — the subscription release. Headline: **SDK workflows now work for Claude subscription users** (no API key required) — the sdk-subprocess-isolation spec shipped end-to-end today (#748/#752/#753/#755) with a live keyless receipt (bug-predict, 249.5s, real findings) — plus structured, readable workflow results on the voice and CLI surfaces (workflow-result-formatting T3/#746, T4/#749, T7/#750) and the redis install-docs truth fix (#751).

- All 7 version sites bumped — `test_all_versions_match` green locally.
- Changelog promoted with a release intro + the two bullets that missed their PRs (Phase 4 traveling guard, redis docs fix).
- `uv.lock`: self-version line only, no dep cascade.
- Docs regen (release-prep cadence) deferred with cause: API billing still blocked; it's the standing post-billing follow-up and doubles as the lever-2 receipt.

Reminder for the merge: marketplace plugin users get the hook gate on `claude plugin update` from main; **pip users need this release on PyPI for the adapter isolation**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)