### PR TITLE
fix(install-ux): honest install docs + actionable optional-dep errors

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7846,3 +7846,32 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   one function with zero edits to the 15 construction sites — the
   answer to "monster refactor?" was no, by construction (spec D8,
   #755).
+
+- **pip extras drift from reality in THREE ways, and two are
+  silent — audit error messages and docs against pyproject's
+  actual extras, because pip only warns on UNDEFINED extras**
+  (install-UX pass, #758): (1) **defined-but-EMPTY extras install
+  silently with no warning** — `rag = []` is a back-compat
+  placeholder, so the rag-code-gen / rag_knowledge_query error
+  "Install with: pip install 'attune-ai[rag]'" sent users into an
+  unfixable loop (command succeeds, installs nothing, error
+  persists). Error messages must point at the real package
+  (attune-rag is CORE) or a NON-empty extra. attune-ai's empty
+  placeholders: rag, memory, cache, agent-sdk, software, socratic.
+  (2) **fictional extras in docs** — FEATURES.md advertised a
+  `crewai` extra that never existed in pyproject (pip at least
+  warns on these). (3) **alias drift** — `full` and `developer`
+  are byte-identical package sets, and `[all]` is features PLUS
+  the whole contributor toolchain (~30 packages: pytest, black,
+  mypy, ruff, pre-commit, mkdocs), so docs calling `[all]` "all
+  features" steered users into polluting their envs. Verification
+  recipe: extract the extras table from pyproject
+  (`awk '/^\[project.optional-dependencies\]/...'`), then grep
+  src/ + docs/ for `attune-ai[` and check every referenced extra
+  exists AND is non-empty. Known open gap from the audit:
+  `[developer]` promises LangChain agent teams but lacks
+  `langchain-anthropic`, which the agent_factory adapters require
+  — add it to the extra or document. Pairs with the existing
+  "Promote a stdlib-only sibling package to a CORE dep, not an
+  extra" lesson — same family (extras hygiene), this one is the
+  consumer-facing surface (messages + docs vs the actual table).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Install docs now match the real extras.** README and
+  getting-started docs recommended `[developer]` as the default
+  (core already covers CLI/workflows/MCP/RAG/Agent SDK) and
+  advertised `[all]` as "all features" (it also drags in the
+  contributor toolchain — pytest, black, mypy, ruff, pre-commit,
+  mkdocs). Docs now lead with the plain install and a per-surface
+  extras table (`developer`/`ops`/`redis`/`author`), drop `[all]`
+  from user guidance, remove the nonexistent `crewai` extra from
+  FEATURES.md, and quote every bracketed install command (zsh
+  glob trap).
+
 ## [8.3.0] — 2026-06-10
 
 The subscription release: SDK workflows now work for Claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from user guidance, remove the nonexistent `crewai` extra from
   FEATURES.md, and quote every bracketed install command (zsh
   glob trap).
+- **Optional-dependency errors now name an install command that
+  works.** The rag-code-gen workflow and `rag_knowledge_query` MCP
+  tool pointed users at the empty back-compat `[rag]` extra
+  (installing it does nothing — attune-rag is a core dependency);
+  both now say `pip install attune-rag`. RAG setup errors that
+  mention attune-help get an actionable hint (`pip install
+  'attune-ai[author]'` — the extra that ships it). The OTEL backend
+  docstring still referenced the pre-rename `empathy-framework[otel]`
+  package; now `'attune-ai[otel]'`.
 
 ## [8.3.0] — 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,12 @@ Then say "what can attune do?" in Claude Code.
 ### Add Python Package (unlocks CLI + MCP)
 
 ```bash
-pip install 'attune-ai[developer]'
+pip install attune-ai
 ```
+
+The core install includes the CLI, all workflows, and the MCP
+server. See [Installation Options](#installation-options) for
+per-surface extras (API-mode agents, ops dashboard, Redis memory).
 
 ### What Each Layer Adds
 
@@ -280,20 +284,25 @@ from retrieval. Full methodology:
 
 ## Installation Options
 
+`pip install attune-ai` works out of the box — the CLI, all
+workflows, the MCP server, RAG, and the Agent SDK are core
+dependencies. Add extras only for the surfaces you use:
+
+| You want | Install |
+| -------- | ------- |
+| Everything most users need | `pip install attune-ai` |
+| Claude API mode + LangChain/LangGraph agent teams | `pip install 'attune-ai[developer]'` |
+| The ops dashboard (`attune ops`) | `pip install 'attune-ai[ops]'` |
+| Redis / Agent Memory Server memory backend | `pip install 'attune-ai[redis]'` |
+| Help authoring (generate / maintain `.help/` templates) | `pip install 'attune-ai[author]'` |
+
+Extras combine — for example
+`pip install 'attune-ai[developer,ops,redis]'`. Keep the quotes:
+zsh and bash treat square brackets as glob characters.
+
+Contributing? Clone and install the dev toolchain instead:
+
 ```bash
-# Recommended (agents, memory, RAG)
-pip install 'attune-ai[developer]'
-
-# Minimal (CLI + workflows + RAG)
-pip install attune-ai
-
-# With help authoring (generate / maintain .help/ templates)
-pip install 'attune-ai[author]'
-
-# All features
-pip install 'attune-ai[all]'
-
-# Development (contributing)
 git clone https://github.com/Smart-AI-Memory/attune-ai.git
 cd attune-ai && pip install -e '.[dev]'
 ```

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -208,14 +208,10 @@ pip install attune-ai
 - CI/CD pipelines
 - Simple automation scripts
 
-### Full Install (All Features)
+### Redis Install (Multi-Session Coordination)
 
 ```bash
-# Option 1: Install with Redis support
 pip install 'attune-ai[redis]'
-
-# Option 2: Install everything
-pip install 'attune-ai[all]'
 ```
 
 **Additional features:**
@@ -234,14 +230,16 @@ pip install 'attune-ai[all]'
 
 ## Installation Extras
 
+Extras combine (e.g. `'attune-ai[developer,ops,redis]'`). Keep the
+quotes — zsh and bash treat square brackets as glob characters.
+
 | Extra | Features | Install Command |
 |-------|----------|-----------------|
+| `developer` | Claude API provider, LangChain/LangGraph agent teams, MemDocs | `pip install 'attune-ai[developer]'` |
+| `ops` | Web ops dashboard (`attune ops`) | `pip install 'attune-ai[ops]'` |
 | `redis` | Redis-based short-term memory, event streaming | `pip install 'attune-ai[redis]'` |
-| `socratic` | Socratic workflow discovery | `pip install 'attune-ai[socratic]'` |
-| `crewai` | CrewAI integration (legacy) | `pip install 'attune-ai[crewai]'` |
-| `llm` | Anthropic LLM provider | `pip install 'attune-ai[llm]'` |
-| `agents` | Agent orchestration support | `pip install 'attune-ai[agents]'` |
-| `all` | Everything | `pip install 'attune-ai[all]'` |
+| `author` | Help authoring (`.help/` template generation) | `pip install 'attune-ai[author]'` |
+| `llm` | Anthropic LLM provider only | `pip install 'attune-ai[llm]'` |
 
 ---
 

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -21,14 +21,14 @@ beat one clever abstraction."
 ## Installation
 
 ```bash
-# Recommended (agents, memory, caching)
-pip install 'attune-ai[developer]'
-
-# Minimal (CLI + workflows only)
+# Recommended — CLI, all workflows, MCP server, RAG, Agent SDK
 pip install attune-ai
 
-# All features
-pip install 'attune-ai[all]'
+# Claude API mode + LangChain/LangGraph agent teams
+pip install 'attune-ai[developer]'
+
+# Ops dashboard / Redis memory (extras combine)
+pip install 'attune-ai[ops,redis]'
 
 # Development
 git clone https://github.com/Smart-AI-Memory/attune-ai.git

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -114,7 +114,7 @@ Natural language routing means you describe what you need, not which tool to inv
 ## Quick Start
 
 ```bash
-pip install attune-ai[developer]
+pip install attune-ai
 attune setup
 ```
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -28,7 +28,7 @@ If you're in a hurry:
 
 ```bash
 # Install
-pip install attune-ai[developer]
+pip install attune-ai
 
 # Set API key
 export ANTHROPIC_API_KEY="sk-ant-..."

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,5 @@
 ---
-description: Install Attune AI with pip in 2 minutes. Choose from developer, minimal, or full packages. Includes CLI tools, the Claude Code plugin, and workflow support.
+description: Install Attune AI with pip in 2 minutes. The core install covers the CLI, workflows, and MCP server; add extras per surface (API agents, ops dashboard, Redis).
 ---
 
 # Installation
@@ -10,32 +10,23 @@ Get Attune AI installed and configured in about 2 minutes.
 
 ## Step 1: Install the Package
 
-Choose your installation option:
+The core install covers most users — the CLI, all workflows, the
+MCP server, RAG, and the Agent SDK are core dependencies:
 
-=== "Recommended (Developer)"
+```bash
+pip install attune-ai
+```
 
-    ```bash
-    pip install 'attune-ai[developer]'
-    ```
+Add extras only for the surfaces you use (they combine, e.g.
+`'attune-ai[developer,ops]'` — keep the quotes; zsh and bash treat
+square brackets as glob characters):
 
-    Includes: CLI tools, the Claude Code plugin, all workflows, local telemetry.
-
-=== "Minimal"
-
-    ```bash
-    pip install attune-ai
-    ```
-
-    Core functionality only. Add extras later as needed.
-
-=== "All Features"
-
-    ```bash
-    pip install 'attune-ai[all]'
-    ```
-
-    Everything: agents, memory, semantic caching, enterprise
-    features.
+| You want | Install |
+| -------- | ------- |
+| Claude API mode + LangChain/LangGraph agent teams | `pip install 'attune-ai[developer]'` |
+| The ops dashboard (`attune ops`) | `pip install 'attune-ai[ops]'` |
+| Redis / Agent Memory Server memory backend | `pip install 'attune-ai[redis]'` |
+| Help authoring (`.help/` templates) | `pip install 'attune-ai[author]'` |
 
 ### Verify Installation
 
@@ -138,7 +129,7 @@ attune provider show
 
 ```bash
 # Reinstall
-pip install --upgrade attune-ai[developer]
+pip install --upgrade attune-ai
 
 # Or for development
 pip install -e '.[dev]'

--- a/docs/getting-started/mcp-integration.md
+++ b/docs/getting-started/mcp-integration.md
@@ -27,7 +27,7 @@ Attune AI includes `.claude/mcp.json` configuration. Claude Code automatically d
 1. **Install Attune AI:**
 
 ```bash
-pip install attune-ai[developer]
+pip install attune-ai
 ```
 
 2. **Open project in Claude Code**
@@ -319,7 +319,7 @@ echo $ANTHROPIC_API_KEY
 
 **Check workflow dependencies:**
 ```bash
-pip install attune-ai[developer]
+pip install attune-ai
 ```
 
 **Review error logs:**

--- a/docs/how-to/prerequisites.md
+++ b/docs/how-to/prerequisites.md
@@ -123,11 +123,11 @@ Get your key: [console.anthropic.com](https://console.anthropic.com/)
 # Core framework
 pip install attune-ai
 
-# With Redis support (recommended)
-pip install attune-ai[redis]
+# With Redis support
+pip install 'attune-ai[redis]'
 
-# With all optional dependencies
-pip install attune-ai[all]
+# With the ops dashboard
+pip install 'attune-ai[ops]'
 ```
 
 **Verify installation**:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ This page has moved to the **Getting Started** guide.
 
 ```bash
 # Install
-pip install attune-ai[developer]
+pip install attune-ai
 
 # Set API key
 export ANTHROPIC_API_KEY="sk-ant-..."

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -586,11 +586,15 @@ class WorkflowHandlersMixin:
         try:
             from attune_rag import RagPipeline
         except ImportError as exc:
+            # attune-rag is a CORE dependency (the legacy [rag] extra
+            # is an empty back-compat placeholder — pointing users at
+            # it would install nothing).
             return {
                 "success": False,
                 "error": (
-                    "rag_knowledge_query requires the [rag] extra. "
-                    "Install with: pip install 'attune-ai[rag]'"
+                    "rag_knowledge_query needs the attune-rag package, "
+                    "a core dependency this environment is missing. "
+                    "Reinstall with: pip install attune-rag"
                 ),
                 "cause": str(exc),
             }
@@ -599,9 +603,12 @@ class WorkflowHandlersMixin:
             pipeline = RagPipeline()
             result = pipeline.run(query, k=k)
         except RuntimeError as exc:
-            # Typical cause: AttuneHelpCorpus can't find the
-            # [attune-help] extra. Return a structured error.
-            return {"success": False, "error": f"RAG setup error: {exc}"}
+            # Typical cause: AttuneHelpCorpus can't find attune-help.
+            # Name the extra that ships it so the fix is one command.
+            hint = ""
+            if "attune-help" in str(exc) or "attune_help" in str(exc):
+                hint = " (attune-help ships via: pip install 'attune-ai[author]')"
+            return {"success": False, "error": f"RAG setup error: {exc}{hint}"}
         except Exception:  # noqa: BLE001
             # INTENTIONAL: best-effort — return structured error
             logger.exception("RAG knowledge query failed")

--- a/src/attune/monitoring/otel_backend.py
+++ b/src/attune/monitoring/otel_backend.py
@@ -12,7 +12,7 @@ Exports telemetry data to OTEL-compatible collectors (SigNoz, Datadog, New Relic
 **Setup:**
 ```bash
 export ATTUNE_OTEL_ENDPOINT=http://localhost:4317
-pip install empathy-framework[otel]
+pip install 'attune-ai[otel]'
 ```
 
 Copyright 2025 Smart-AI-Memory

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -144,9 +144,13 @@ class RagCodeGenWorkflow(BaseWorkflow):
             try:
                 from attune_rag import RagPipeline
             except ImportError as exc:
+                # attune-rag is a CORE dependency (the legacy [rag]
+                # extra is an empty back-compat placeholder — pointing
+                # users at it would install nothing).
                 raise RuntimeError(
-                    "The rag-code-gen workflow requires the [rag] extra. "
-                    "Install with: pip install 'attune-ai[rag]'"
+                    "The rag-code-gen workflow needs the attune-rag "
+                    "package, a core dependency this environment is "
+                    "missing. Reinstall with: pip install attune-rag"
                 ) from exc
             self._pipeline = RagPipeline()
         return self._pipeline

--- a/tests/unit/rag/test_missing_extra.py
+++ b/tests/unit/rag/test_missing_extra.py
@@ -4,7 +4,8 @@ These tests run regardless of whether the [rag] extra is
 installed — they use a sys.modules sentinel to force
 attune_rag imports to raise ImportError, then assert that
 the workflow and MCP handler both surface a helpful
-"install attune-ai[rag]" error rather than crashing.
+"reinstall attune-rag" error rather than crashing
+(attune-rag is a core dep; the legacy [rag] extra is empty).
 
 Complements tests/integration/rag/test_rag_workflow.py and
 tests/unit/rag/test_mcp_tool.py which exercise the happy
@@ -41,7 +42,7 @@ def _unblock_attune_rag(saved: dict[str, object]) -> None:
 
 def test_workflow_raises_helpful_error_when_attune_rag_missing() -> None:
     """RagCodeGenWorkflow._get_pipeline raises RuntimeError
-    pointing at the [rag] extra when attune_rag can't import."""
+    naming the attune-rag core dep when it can't import."""
     from attune.workflows.rag_code_gen import RagCodeGenWorkflow
 
     saved = _block_attune_rag()
@@ -50,8 +51,8 @@ def test_workflow_raises_helpful_error_when_attune_rag_missing() -> None:
         result = asyncio.run(workflow.execute(query="anything"))
         assert result.success is False
         assert result.error is not None
-        assert "[rag] extra" in result.error
-        assert "pip install" in result.error.lower()
+        assert "attune-rag" in result.error
+        assert "pip install attune-rag" in result.error
     finally:
         _unblock_attune_rag(saved)
 
@@ -74,7 +75,7 @@ def test_workflow_empty_query_rejected_without_attune_rag() -> None:
 
 def test_mcp_handler_returns_structured_error_when_attune_rag_missing() -> None:
     """_run_rag_knowledge_query returns a structured dict
-    pointing at the [rag] extra when attune_rag can't import.
+    naming the attune-rag core dep when it can't import.
     No exception escapes to the MCP dispatcher."""
     from attune.mcp.server import EmpathyMCPServer
 
@@ -84,9 +85,63 @@ def test_mcp_handler_returns_structured_error_when_attune_rag_missing() -> None:
     try:
         result = asyncio.run(server._run_rag_knowledge_query({"query": "security audit"}))
         assert result["success"] is False
-        assert "[rag] extra" in result["error"]
-        assert "pip install" in result["error"].lower()
+        assert "attune-rag" in result["error"]
+        assert "pip install attune-rag" in result["error"]
         assert "cause" in result  # original ImportError message
+    finally:
+        _unblock_attune_rag(saved)
+
+
+def _fake_attune_rag_with_failing_pipeline(message: str) -> object:
+    """A stand-in attune_rag whose RagPipeline raises at construction."""
+    import types
+
+    fake = types.ModuleType("attune_rag")
+
+    class _BoomPipeline:
+        def __init__(self) -> None:
+            raise RuntimeError(message)
+
+    fake.RagPipeline = _BoomPipeline  # type: ignore[attr-defined]
+    return fake
+
+
+def test_mcp_handler_names_author_extra_on_help_corpus_error() -> None:
+    """A RuntimeError mentioning attune-help gets the [author]-extra
+    hint appended — attune-help ships via that extra, so the fix is
+    one command."""
+    from attune.mcp.server import EmpathyMCPServer
+
+    server = EmpathyMCPServer()
+
+    saved = _block_attune_rag()
+    sys.modules["attune_rag"] = _fake_attune_rag_with_failing_pipeline(  # type: ignore[assignment]
+        "attune-help corpus unavailable"
+    )
+    try:
+        result = asyncio.run(server._run_rag_knowledge_query({"query": "q"}))
+        assert result["success"] is False
+        assert "RAG setup error" in result["error"]
+        assert "attune-ai[author]" in result["error"]
+    finally:
+        _unblock_attune_rag(saved)
+
+
+def test_mcp_handler_omits_author_hint_for_unrelated_setup_errors() -> None:
+    """RuntimeErrors that don't mention attune-help stay un-hinted."""
+    from attune.mcp.server import EmpathyMCPServer
+
+    server = EmpathyMCPServer()
+
+    saved = _block_attune_rag()
+    sys.modules["attune_rag"] = _fake_attune_rag_with_failing_pipeline(  # type: ignore[assignment]
+        "corpus directory is empty"
+    )
+    try:
+        result = asyncio.run(server._run_rag_knowledge_query({"query": "q"}))
+        assert result["success"] is False
+        assert "RAG setup error" in result["error"]
+        assert "[author]" not in result["error"]
     finally:
         _unblock_attune_rag(saved)
 


### PR DESCRIPTION
## Summary

Install/extras UX pass, prompted by "should users install `attune-ai[all]`?" — the answer was no, and the docs were actively steering people wrong. Two commits:

**1. `docs(install)` — lead with the plain install; per-surface extras table**

- README + getting-started recommended `[developer]` as the default, but core already covers CLI / workflows / MCP / RAG / Agent SDK. Plain `pip install attune-ai` is now the lead everywhere.
- `[all]` was advertised as "All features" but it's features **plus the contributor toolchain** (pytest, black, mypy, ruff, pre-commit, mkdocs — ~30 packages). Dropped from all user guidance; contributors keep `pip install -e '.[dev]'`.
- FEATURES.md advertised a **`crewai` extra that doesn't exist** in pyproject, plus empty/internal extras (`socratic`). Replaced with the real surface table: `developer` / `ops` / `redis` / `author` / `llm`.
- installation.md's "All Features" tab claimed semantic caching + enterprise features (removed/empty). Rewritten.
- `[ops]` (the dashboard) was missing from every install doc; added.
- Quoted 5 unquoted bracketed install commands (zsh glob trap).

**2. `fix(errors)` — optional-dep messages name an install command that works**

- rag-code-gen + `rag_knowledge_query` told users to install the **empty** `[rag]` extra — the command succeeds, installs nothing, error persists. attune-rag is core; messages now say `pip install attune-rag`.
- RAG setup errors mentioning attune-help now append the `'attune-ai[author]'` hint (the extra that ships it).
- OTEL backend docstring still said `empathy-framework[otel]` (pre-rename package); fixed.
- Audited-and-correct surfaces left alone: ops, redis, agent_factory adapters (their deps are in no extra, raw pip is right), websockets, cryptography, core-dep guards.

## Worth a follow-up decision (not in this PR)

`[developer]` promises "LangChain agent teams" but ships **without `langchain-anthropic`**, which the langchain/langgraph adapters require — a `[developer]` user hits ImportError on first agent_factory use. Options: add it to `developer`/`agents` extras (dep + lock change), or document the gap.

## Test plan

- Updated the 2 assertions on the old `[rag]` message in the same commit; added hint-present/hint-absent tests via a fake `attune_rag` whose `RagPipeline` raises at construction
- `tests/unit/rag/` + `tests/unit/mcp/` + `tests/unit/monitoring/`: 418 passed
- Pinned black/ruff pre-flighted clean; doc_audit's extras-vs-pyproject fixtures unaffected (tmp_path-scoped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
