### PR TITLE
docs: SDK structured-output lessons + sibling-subscription-auth complete

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2279,17 +2279,23 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   - **`ClaudeAgentOptions(tools=[{schema}], tool_choice={...})`
     is unsupported** — there's NO `tool_choice` field, and
     `tools` is `list[str] | ToolsPreset | None` (a tool-name
-    ALLOWLIST, not Anthropic tool defs). The agent SDK routes
-    through the `claude` CLI's tool loop and can't force a
-    schema-guaranteed call. For forced guaranteed-schema JSON
-    use the RAW `anthropic` SDK
+    ALLOWLIST, not Anthropic tool defs). **PARTIAL CORRECTION
+    (2026-06-11, SDK 0.1.63): the agent SDK CAN now produce
+    schema-guaranteed JSON** via
+    `ClaudeAgentOptions(output_format={"type": "json_schema",
+    "schema": {...}})` — maps to the `claude` CLI's
+    `--json-schema`; the validated payload arrives on
+    `ResultMessage.structured_output` (see the dedicated
+    output_format lesson below for the max_turns trap). So the
+    routing rule is now: a single synthesis/judge call with an
+    API key → raw `anthropic` SDK forced `tool_choice`
     (`client.messages.create(tools=[...], tool_choice={"type":
-    "tool","name":...})`, as `attune_rag`'s `FaithfulnessJudge`
-    does) — the two SDKs are easy to conflate. Rule: a single
-    synthesis/judge call (no agent loop, no subagents, no file
-    tools) → raw `anthropic` SDK; reserve
-    `claude_agent_sdk.query()` for agentic work (file tools,
-    subagent fan-out, multi-turn).
+    "tool","name":...})`); the same call on the SUBSCRIPTION
+    path → agent SDK `output_format` (this is how
+    `attune_rag.auth.query_subscription_structured` preserves
+    `FaithfulnessJudge`'s schema contract keyless, attune-rag
+    0.7.0); agentic work (file tools, subagent fan-out,
+    multi-turn) → `claude_agent_sdk.query()` as before.
   - **The agent SDK CANNOT take a client-side
     `BetaAbstractMemoryTool` (Anthropic Memory tool,
     `memory_20250818`) — that bridge is raw-`anthropic`-
@@ -7907,3 +7913,25 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   CLAUDE_CODE_ENTRYPOINT and SCRUBS CLAUDECODE" lesson — that's
   about the env INSIDE SDK subprocesses; this is about the agent's
   own Bash shell not carrying the marker INTO a sibling CLI.
+
+- **Agent-SDK structured output (`output_format` json_schema)
+  needs `max_turns=2` — with `max_turns=1` the run dies "Reached
+  maximum number of turns (1)" with NO `structured_output`**
+  (live-verified 2026-06-11, SDK 0.1.63, building attune-rag's
+  judge shim): `ClaudeAgentOptions(output_format={"type":
+  "json_schema", "schema": {...}})` maps to the `claude` CLI's
+  `--json-schema` and the validated dict arrives on
+  `ResultMessage.structured_output` — but the CLI spends an extra
+  turn synthesizing the schema-validated payload, so the
+  `max_turns=1` that works for plain-text single-turn completions
+  (attune-author's polish shim) is one short for structured ones.
+  Set `max_turns=2` and add a drift-guard test asserting it.
+  Mocked unit tests are structurally blind to this (the fake SDK
+  doesn't enforce turn budgets) — it surfaced ONLY in the live
+  keyless receipt run, the "registered ≠ working / dogfood the
+  live loop" lesson doing its job. Companion fact from the same
+  session: `gh api .../runs/<id>/pending_deployments` returning
+  empty while the BUILD job is still running means nothing — the
+  pending deployment only EXISTS once the publish job itself is
+  `waiting`; re-check then before concluding "no env gate"
+  (attune-rag's pypi env looked gate-less mid-build, then gated).

--- a/docs/specs/sibling-subscription-auth/tasks.md
+++ b/docs/specs/sibling-subscription-auth/tasks.md
@@ -1,6 +1,6 @@
 # Spec: Subscription-First Auth for Sibling Packages — Tasks
 
-**Status**: in progress — Phase 0 shipped (see `findings.md`); Phase 1 shipped (attune-author PR #55, 2026-06-10; v0.16.0 on PyPI 2026-06-11); Phase 2 core shipped (attune-rag PR #183, 2026-06-11) — 2.5 + the rag release remain.
+**Status**: complete (2026-06-11) — Phase 0 shipped (`findings.md`); Phase 1 shipped (attune-author #55, v0.16.0 on PyPI); Phase 2 shipped end-to-end (attune-rag #183 + v0.7.0 on PyPI; 2.5 in attune-author #57). Phase 3 (shared-helper extraction) intentionally not taken — two mirrored adapters, revisit at a third consumer.
 
 > Phase 0 is mandatory and lands before any implementation. The
 > design rests on assumptions about how `claude_agent_sdk` and
@@ -88,13 +88,13 @@ adapter shape; may extract to a shared helper).
 | 2.2 | Wire into `FaithfulnessJudge.__init__` so callers don't pass api_key when subscription is detected | attune-rag | **done** | `auth_mode=` param; injected client always wins (API route); sub route skips `AsyncAnthropic` construction; auto falls back to API on sub failure, forced sub never falls back |
 | 2.3 | Update `attune-rag eval` CLI commands with the same `--auth-mode` flag | attune-rag | **done** | Premise correction: no `attune-rag eval` subcommand exists — the judge's CLI surface is `attune-rag-benchmark`, which got `--auth-mode {auto,api,sub}` (judge route only; answer GENERATION via `ClaudeProvider` stays API-key-only per the Phase-0 scope note, so the `--with-faithfulness` key gate stays) |
 | 2.4 | Tests: judge routing under each mode | attune-rag | **done** | 16 tests in `tests/unit/test_auth_routing.py`; suite conftest pins `ATTUNE_RAG_AUTH_MODE=api` + clears `CLAUDECODE` (mirrors attune-author) |
-| 2.5 | Telemetry: annotate `subscription` vs `API` cost in attune-author's faithfulness summary log | attune-author | todo | Cross-package; needs Phase 2 RELEASED on PyPI (attune-rag 0.7.0) + attune-author cap/floor bump |
+| 2.5 | Telemetry: annotate `subscription` vs `API` cost in attune-author's faithfulness summary log | attune-author | **done** | attune-author #57 (2026-06-11): `Faithfulness judge auth: N call(s) subscription, M API` after the cost line; graceful skip on attune-rag <0.7; `[rag]` cap widened `<0.3`→`<0.8` |
 | 2.6 | Update CHANGELOG + README in attune-rag | attune-rag | **done** | New README "Authentication" section; `claude-agent-sdk>=0.1.63` added to `[claude]` extra |
 
 ### Phase 2 exit checklist
 
-- [ ] Tasks 2.1–2.6 done (2.1–2.4 + 2.6 shipped in attune-rag
-      PR #183; 2.5 waits on the rag release)
+- [x] Tasks 2.1–2.6 done (2.1–2.4 + 2.6 in attune-rag #183,
+      released as v0.7.0; 2.5 in attune-author #57)
 - [x] Judge runs against subscription without an API key — live
       receipt (2026-06-11): route=sub, keyless, 14.6 s, judge
       caught a planted fake-flag hallucination (score 0.5,


### PR DESCRIPTION
Docs-only (CLAUDE.md + spec tasks.md):

- **Lesson:** Agent-SDK `output_format` json_schema needs `max_turns=2` — found live building the rag judge shim (mocks structurally blind to it)
- **Correction:** the "agent SDK can't force schema-guaranteed JSON" lesson is partially superseded by 0.1.63's `output_format` → updated routing rule (API key → raw SDK tool_choice; subscription → agent SDK output_format)
- **Spec:** sibling-subscription-auth → **complete** — Phase 2 shipped end-to-end (attune-rag#183 + v0.7.0 on PyPI; task 2.5 in attune-author#57)

🤖 Generated with [Claude Code](https://claude.com/claude-code)