### PR TITLE
feat(workflows): adapter-level WorkflowReport output for all SDK-native workflows (wrf T8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **All 15 SDK-native workflows now emit structured WorkflowReport
+  results** (workflow-result-formatting T8). The shared
+  `AgentSDKResultAdapter` serializes parsed findings into a
+  `WorkflowReport` — per-category findings/list sections, a trailing
+  Next steps section, score (from structured output or the text
+  summary), and cost/duration metadata — instead of rewriting
+  `final_output` as flat markdown. The voice and CLI layers render it
+  with tiered disclosure, and the subscription-mode `$0.0000` cost
+  line disappears (the renderer's `show_cost` gate owns cost display).
+  Findings-free prose responses still pass through unchanged;
+  `metadata["raw_result_text"]` keeps carrying the unmodified agent
+  text.
+
 ### Fixed
 - **Install docs now match the real extras.** README and
   getting-started docs recommended `[developer]` as the default

--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -1,12 +1,13 @@
 # Tasks: Workflow result formatting
 
-**Status:** partial (2026-06-10) — T1 (the `WorkflowReport` / Section
+**Status:** partial (2026-06-11) — T1 (the `WorkflowReport` / Section
 data model, #649), T2 (the markdown renderer
 `attune.voice.report_renderer` — `render()` + crash-visible
-`render_safe()`, all 4 test layers, 98% branch, #741), and T3 (voice
-wiring + safety net + `show_cost_metrics`/`resolve_show_cost()`)
-T4 (CLI terminal rendering), and T7 (release-prep
-migration — the motivating case) shipped; T5/T6/T8+ pending.
+`render_safe()`, all 4 test layers, 98% branch, #741), T3 (voice
+wiring + safety net + `show_cost_metrics`/`resolve_show_cost()`),
+T4 (CLI terminal rendering), T7 (release-prep
+migration — the motivating case), and T8 (adapter-level migration of
+all 15 SDK-native workflows) shipped; T5/T6 pending.
 
 > Bounded PRs; see [design.md](design.md) for the decisions each task
 > implements.
@@ -105,12 +106,27 @@ migration — the motivating case) shipped; T5/T6/T8+ pending.
   the SDK-native `ReleasePreparationWorkflow`, a separate surface —
   its migration rides T8+ (adapter-level findings → report).
 
-## T8+ — Migrate remaining workflows (D5 rank)
+## T8+ — Migrate remaining workflows (D5 rank) — DONE
 
-- code-review → dependency-check → bug-predict → test-gen →
+- ~~code-review → dependency-check → bug-predict → test-gen →
   document-manager → refactor-plan → perf-audit → doc-audit. One small
   PR each (converter + repr-leak drift-guard test). Safety-net banner
-  covers the not-yet-migrated tail.
+  covers the not-yet-migrated tail.~~
+- Shipped 2026-06-11 as ONE adapter-level PR, not 8 per-workflow
+  converters: every SDK-native workflow routes through
+  `AgentSDKResultAdapter.from_agent_output`, so the converter lives
+  there — when findings parse (text categories or structured output),
+  `final_output` becomes `WorkflowReport.to_dict()` (dict items →
+  `FindingsSection`, string bullets → `ListSection`, suggestions →
+  `NextStepsSection`, score from `summary.score` or a text regex,
+  cost/duration in report metadata where the renderer's `show_cost`
+  gate reads them). All 15 SDK workflows pass `report_title`;
+  findings-free prose still passes through as plain markdown. This
+  also fixes the cost-line-on-subscription nit (`report_rendered`
+  now True → the wrapper's `$0.0000` line is suppressed; design D3).
+  Out of scope: document-manager (legacy multi-stage `BaseWorkflow`,
+  not adapter-routed — covered by the T3 safety net; migrate only if
+  its output surface ever matters).
 
 ## Notes
 

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -477,7 +477,10 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             "success": result.success,
             "approved": final_output.get("approved"),
             "health_score": final_output.get("health_score"),
-            "recommendation": final_output.get("recommendation"),
+            # Serialized WorkflowReport dicts carry no "recommendation"
+            # key — fall back to the result summary so the field stays
+            # populated now that SDK workflows emit report payloads.
+            "recommendation": final_output.get("recommendation") or result.summary,
             "cost": result.cost_report.total_cost,
         }
 

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -27,6 +27,15 @@ from attune.ops.session_redaction import redact
 
 from .base import ModelTier
 from .data_classes import CostReport, NextAction, WorkflowResult, WorkflowStage
+from .output import (
+    Finding,
+    FindingsSection,
+    ListSection,
+    NextStepsSection,
+    Section,
+    WorkflowReport,
+)
+from .output import NextAction as ReportNextAction
 
 logger = logging.getLogger(__name__)
 
@@ -1154,6 +1163,7 @@ class AgentSDKResultAdapter:
         completed_at: datetime,
         metadata: dict[str, Any] | None = None,
         agent_run_result: AgentRunResult | None = None,
+        report_title: str | None = None,
     ) -> WorkflowResult:
         """Build a WorkflowResult from raw agent text output.
 
@@ -1166,10 +1176,20 @@ class AgentSDKResultAdapter:
             agent_run_result: Optional rich result data from the SDK
                 including cost, usage, and timing. When provided,
                 populates CostReport and WorkflowStage fields.
+            report_title: Human title for the rendered WorkflowReport
+                (e.g. ``"Code review"``). Used when findings parse and
+                ``final_output`` becomes a serialized report.
 
         Returns:
             A WorkflowResult populated with parsed findings,
-            suggestions, stages, and cost/usage data.
+            suggestions, stages, and cost/usage data. When findings
+            parse (text categories or structured output),
+            ``final_output`` carries a serialized
+            :class:`~attune.workflows.output.WorkflowReport` (design
+            D2 of workflow-result-formatting) that the voice / CLI
+            layers render with tiered disclosure and the
+            ``show_cost`` gate; otherwise the raw markdown text
+            passes through unchanged.
         """
         if not result_text:
             logger.warning("Empty result_text passed to AgentSDKResultAdapter")
@@ -1196,13 +1216,14 @@ class AgentSDKResultAdapter:
             and agent_run_result.structured_output
             and isinstance(agent_run_result.structured_output, dict)
         ):
-            findings, suggestions, summary = cls._from_structured_output(
+            findings, suggestions, summary, score = cls._from_structured_output(
                 agent_run_result.structured_output,
             )
         else:
             findings = cls._parse_findings(text)
             suggestions = cls._extract_suggestions(text)
             summary = cls._extract_summary(text)
+            score = cls._extract_score(text)
 
         result_metadata: dict[str, Any] = {
             "source": "agent_sdk",
@@ -1231,13 +1252,21 @@ class AgentSDKResultAdapter:
         if metadata:
             result_metadata.update(metadata)
 
-        # Build final_output: prefer structured findings as markdown,
-        # fall back to collected text
+        # Build final_output: when findings parsed, serialize a
+        # WorkflowReport (the voice/CLI renderers own formatting +
+        # the show_cost gate — design D2/D3); otherwise the raw SDK
+        # markdown passes through unchanged.
         final_output: str | dict[str, Any] = text
         if findings:
-            formatted = cls._format_findings_markdown(findings, summary)
-            if formatted:
-                final_output = formatted
+            final_output = cls._to_workflow_report(
+                title=report_title or "Workflow report",
+                summary=summary,
+                score=score,
+                findings=findings,
+                suggestions=suggestions,
+                total_cost=total_cost,
+                duration_ms=duration_ms,
+            ).to_dict()
 
         return WorkflowResult(
             success=True,
@@ -1463,70 +1492,114 @@ class AgentSDKResultAdapter:
         return suggestions
 
     @classmethod
-    def _format_findings_markdown(
+    def _to_workflow_report(
         cls,
+        *,
+        title: str,
+        summary: str,
+        score: int | None,
         findings: dict[str, Any],
-        summary: str = "",
-    ) -> str:
-        """Render findings dict as readable markdown.
+        suggestions: list[NextAction],
+        total_cost: float | None,
+        duration_ms: int,
+    ) -> WorkflowReport:
+        """Build the universal WorkflowReport from parsed agent output.
 
-        Args:
-            findings: Category-keyed dict of finding lists.
-            summary: Optional summary to prepend.
-
-        Returns:
-            Markdown string, or empty string if no findings.
+        The adapter is the shared converter for every SDK-native
+        workflow (workflow-result-formatting T8): per category, dict
+        items (structured output) become a :class:`FindingsSection`;
+        plain-string bullets (text parsing) become a
+        :class:`ListSection`. Suggestions become the trailing
+        NextStepsSection. Cost/duration land in ``metadata`` where the
+        renderer's ``show_cost`` gate reads them — ``cost_usd`` is
+        omitted for subscription runs (``total_cost is None``).
         """
-        parts: list[str] = []
-        if summary:
-            parts.append(summary)
-            parts.append("")
-
+        sections: list[Section] = []
         for category, items in findings.items():
             if not items:
                 continue
             heading = category.replace("_", " ").title()
-            parts.append(f"## {heading}")
-            parts.append("")
-            if isinstance(items, list):
-                for item in items:
-                    if isinstance(item, dict):
-                        desc = item.get("description", str(item))
-                        loc = item.get("file", "")
-                        if loc:
-                            line = item.get("line", "")
-                            loc_str = f"{loc}:{line}" if line else loc
-                            parts.append(f"- **{loc_str}** — {desc}")
-                        else:
-                            parts.append(f"- {desc}")
-                    else:
-                        parts.append(f"- {item}")
+            if isinstance(items, list) and all(isinstance(i, dict) for i in items):
+                sections.append(
+                    FindingsSection(
+                        title=heading,
+                        tier="essential",
+                        findings=[
+                            Finding(
+                                severity=str(i.get("severity", "info")),
+                                file=str(i.get("file") or "unknown"),
+                                line=i.get("line"),
+                                message=str(i.get("description", "")),
+                            )
+                            for i in items
+                        ],
+                    )
+                )
             else:
-                parts.append(str(items))
-            parts.append("")
+                str_items = [
+                    str(i.get("description", i)) if isinstance(i, dict) else str(i)
+                    for i in (items if isinstance(items, list) else [items])
+                ]
+                sections.append(ListSection(title=heading, tier="essential", items=str_items))
 
-        return "\n".join(parts).strip()
+        if suggestions:
+            sections.append(
+                NextStepsSection(
+                    title="Next steps",
+                    tier="essential",
+                    items=[ReportNextAction(text=s.description) for s in suggestions],
+                )
+            )
+
+        report_metadata: dict[str, object] = {"duration_s": duration_ms / 1000}
+        if total_cost is not None:
+            report_metadata["cost_usd"] = total_cost
+
+        return WorkflowReport(
+            title=title,
+            summary=summary,
+            score=score,
+            metadata=report_metadata,
+            sections=sections,
+        )
+
+    @classmethod
+    def _extract_score(cls, result_text: str) -> int | None:
+        """Pull a 0-100 score from text like ``score: 85/100``.
+
+        SDK workflows prompt for "Overall code health score (0-100)"
+        in the summary; the structured-output path carries it as
+        ``summary.score`` instead. Returns None when absent.
+        """
+        match = re.search(r"\bscore:?\s*(\d{1,3})\s*/\s*100", result_text, re.IGNORECASE)
+        if not match:
+            return None
+        value = int(match.group(1))
+        return value if 0 <= value <= 100 else None
 
     @classmethod
     def _from_structured_output(
         cls,
         data: dict[str, Any],
-    ) -> tuple[dict[str, Any], list[NextAction], str]:
-        """Extract findings, suggestions, and summary from structured JSON.
+    ) -> tuple[dict[str, Any], list[NextAction], str, int | None]:
+        """Extract findings, suggestions, summary, and score from JSON.
 
         Called when the SDK returns ``structured_output`` instead of
-        free-form markdown. Produces the same triple that the text-
+        free-form markdown. Produces the same shape that the text-
         parsing path yields so the caller can use either transparently.
 
         Args:
             data: Parsed JSON dict from ``ResultMessage.structured_output``.
 
         Returns:
-            Tuple of (findings dict, suggestions list, summary string).
+            Tuple of (findings dict, suggestions list, summary string,
+            score or None).
         """
         findings: dict[str, Any] = data.get("findings", {})
         summary_data = data.get("summary", {})
         summary = summary_data.get("text", "") if isinstance(summary_data, dict) else ""
+        score_raw = summary_data.get("score") if isinstance(summary_data, dict) else None
+        score = score_raw if isinstance(score_raw, int) else None
 
         suggestions = [
             NextAction(
@@ -1539,4 +1612,4 @@ class AgentSDKResultAdapter:
             for item in data.get("suggestions", [])
             if isinstance(item, dict) and item.get("description")
         ]
-        return findings, suggestions, summary
+        return findings, suggestions, summary, score

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -174,6 +174,7 @@ class BugPredictionWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Bug prediction",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/code_review.py
+++ b/src/attune/workflows/code_review.py
@@ -252,6 +252,7 @@ class CodeReviewWorkflow(BaseWorkflow):
             _emit_security_recommendation_if_warranted(run_result.result_text, resolved_path)
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Code review",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/deep_review.py
+++ b/src/attune/workflows/deep_review.py
@@ -224,6 +224,7 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Deep review",
                 result_text=run_result.result_text,
                 subagent_names=active_agents,
                 started_at=started_at,

--- a/src/attune/workflows/dependency_check.py
+++ b/src/attune/workflows/dependency_check.py
@@ -164,6 +164,7 @@ class DependencyCheckWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Dependency check",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -143,6 +143,7 @@ class DocAuditWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Documentation audit",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/document_gen/workflow.py
+++ b/src/attune/workflows/document_gen/workflow.py
@@ -150,6 +150,7 @@ class DocumentGenerationWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Document generation",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/perf_audit.py
+++ b/src/attune/workflows/perf_audit.py
@@ -160,6 +160,7 @@ class PerformanceAuditWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Performance audit",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -333,6 +333,7 @@ class RagCodeGenWorkflow(BaseWorkflow):
         }
 
         wf_result = AgentSDKResultAdapter.from_agent_output(
+            report_title="RAG code generation",
             result_text=combined_text,
             subagent_names=["rag-generator"],
             started_at=started_at,

--- a/src/attune/workflows/refactor_plan.py
+++ b/src/attune/workflows/refactor_plan.py
@@ -165,6 +165,7 @@ class RefactorPlanWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Refactor plan",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -138,6 +138,7 @@ class ReleasePreparationWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Release preparation",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/research_synthesis.py
+++ b/src/attune/workflows/research_synthesis.py
@@ -162,6 +162,7 @@ class ResearchSynthesisWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Research synthesis",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/security_audit.py
+++ b/src/attune/workflows/security_audit.py
@@ -170,6 +170,7 @@ class SecurityAuditWorkflow(BaseWorkflow):
                 )
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Security audit",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/simplify_code.py
+++ b/src/attune/workflows/simplify_code.py
@@ -157,6 +157,7 @@ class SimplifyCodeWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Code simplification",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -174,6 +174,7 @@ class TestAuditWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Test audit",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/src/attune/workflows/test_gen/workflow.py
+++ b/src/attune/workflows/test_gen/workflow.py
@@ -144,6 +144,7 @@ class TestGenerationWorkflow(BaseWorkflow):
             completed_at = datetime.now()
 
             return AgentSDKResultAdapter.from_agent_output(
+                report_title="Test generation",
                 result_text=run_result.result_text,
                 subagent_names=_SUBAGENT_NAMES,
                 started_at=started_at,

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -86,10 +86,18 @@ class TestAgentSDKResultAdapterConversion:
 
         assert isinstance(result, WorkflowResult)
         assert result.success is True
-        # final_output is formatted from parsed findings
-        assert "No eval/exec usage found" in result.final_output
-        assert "Good naming conventions" in result.final_output
-        assert "Clean module boundaries" in result.final_output
+        # final_output is a serialized WorkflowReport built from the
+        # parsed findings (workflow-result-formatting T8) — every
+        # category's content must survive into the report sections.
+        from attune.workflows.output import WorkflowReport
+
+        assert WorkflowReport.is_report_dict(result.final_output)
+        report = WorkflowReport.from_dict(result.final_output)
+        section_items = [item for s in report.sections if hasattr(s, "items") for item in s.items]
+        flat = " ".join(str(i) for i in section_items)
+        assert "No eval/exec usage found" in flat
+        assert "Good naming conventions" in flat
+        assert "Clean module boundaries" in flat
         assert result.provider == "anthropic"
         assert result.error is None
 
@@ -120,7 +128,7 @@ class TestAgentSDKResultAdapterConversion:
             completed_at=_now(),
         )
 
-        # final_output WAS rewritten (formatted from parsed findings)…
+        # final_output WAS rewritten (serialized WorkflowReport)…
         assert result.final_output != _SAMPLE_REVIEW
         # …but the raw channel is byte-identical to the agent text.
         assert result.metadata["raw_result_text"] == _SAMPLE_REVIEW
@@ -1199,6 +1207,147 @@ class TestAgentSDKResultAdapterStructuredOutput:
         )
         # Empty dict is falsy, so falls back to text parsing
         assert "85/100" in result.summary
+
+
+@pytest.mark.unit
+class TestAgentSDKResultAdapterReportOutput:
+    """final_output is a serialized WorkflowReport when findings parse.
+
+    workflow-result-formatting T8: the adapter is the shared converter
+    for all SDK-native workflows. These tests pin the report contract —
+    discriminator, sections, score, next steps, cost metadata — plus
+    the passthrough guard for findings-free text.
+    """
+
+    _STRUCTURED_DATA: dict = {
+        "summary": {"score": 90, "text": "Code is solid."},
+        "findings": {
+            "security": [
+                {
+                    "description": "No eval usage",
+                    "severity": "low",
+                    "file": "src/app.py",
+                    "line": 12,
+                },
+            ],
+        },
+        "suggestions": [
+            {"description": "Add input validation", "priority": "high"},
+        ],
+    }
+
+    def _result(self, **kwargs):
+        defaults = {
+            "result_text": _SAMPLE_REVIEW,
+            "subagent_names": _SUBAGENT_NAMES,
+            "started_at": _now(),
+            "completed_at": _now(),
+        }
+        defaults.update(kwargs)
+        return AgentSDKResultAdapter.from_agent_output(**defaults)
+
+    def test_findings_produce_report_dict_with_title(self) -> None:
+        """Parsed findings → final_output is a report dict with the
+        caller's title."""
+        from attune.workflows.output import WorkflowReport
+
+        result = self._result(report_title="Code review")
+        assert WorkflowReport.is_report_dict(result.final_output)
+        report = WorkflowReport.from_dict(result.final_output)
+        assert report.title == "Code review"
+
+    def test_default_title_when_not_passed(self) -> None:
+        """No report_title → generic fallback title."""
+        from attune.workflows.output import WorkflowReport
+
+        report = WorkflowReport.from_dict(self._result().final_output)
+        assert report.title == "Workflow report"
+
+    def test_text_categories_become_list_sections(self) -> None:
+        """Text-parsed string bullets land in per-category ListSections."""
+        from attune.workflows.output import ListSection, WorkflowReport
+
+        report = WorkflowReport.from_dict(self._result().final_output)
+        list_sections = [s for s in report.sections if isinstance(s, ListSection)]
+        titles = {s.title for s in list_sections}
+        assert "Security" in titles
+        assert "Quality" in titles
+        security = next(s for s in list_sections if s.title == "Security")
+        assert "No eval/exec usage found" in security.items
+
+    def test_text_score_extracted_from_summary(self) -> None:
+        """'Code health score: 85/100' in text → report.score == 85."""
+        from attune.workflows.output import WorkflowReport
+
+        report = WorkflowReport.from_dict(self._result().final_output)
+        assert report.score == 85
+
+    def test_structured_findings_become_findings_section(self) -> None:
+        """Structured dict items → FindingsSection with typed Findings."""
+        from attune.workflows.output import FindingsSection, WorkflowReport
+
+        run = AgentRunResult(
+            result_text="fallback text",
+            structured_output=self._STRUCTURED_DATA,
+        )
+        result = self._result(result_text="fallback text", agent_run_result=run)
+        report = WorkflowReport.from_dict(result.final_output)
+        assert report.score == 90
+        findings_sections = [s for s in report.sections if isinstance(s, FindingsSection)]
+        assert len(findings_sections) == 1
+        finding = findings_sections[0].findings[0]
+        assert finding.message == "No eval usage"
+        assert finding.severity == "low"
+        assert finding.file == "src/app.py"
+        assert finding.line == 12
+
+    def test_suggestions_become_next_steps_section(self) -> None:
+        """Adapter suggestions land as the trailing NextStepsSection."""
+        from attune.workflows.output import NextStepsSection, WorkflowReport
+
+        report = WorkflowReport.from_dict(self._result().final_output)
+        next_steps = [s for s in report.sections if isinstance(s, NextStepsSection)]
+        assert len(next_steps) == 1
+        texts = [a.text for a in next_steps[0].items]
+        assert "Consider adding input validation" in texts
+
+    def test_cost_metadata_present_for_api_runs(self) -> None:
+        """total_cost_usd set → cost_usd + duration_s in report metadata."""
+        from attune.workflows.output import WorkflowReport
+
+        run = AgentRunResult(result_text=_SAMPLE_REVIEW, total_cost_usd=0.42)
+        report = WorkflowReport.from_dict(self._result(agent_run_result=run).final_output)
+        assert report.metadata["cost_usd"] == 0.42
+        assert "duration_s" in report.metadata
+
+    def test_cost_metadata_omitted_for_subscription_runs(self) -> None:
+        """total_cost None (subscription) → no cost_usd key; the
+        renderer's cost line then shows no inapplicable $0.00."""
+        from attune.workflows.output import WorkflowReport
+
+        report = WorkflowReport.from_dict(self._result().final_output)
+        assert "cost_usd" not in report.metadata
+        assert "duration_s" in report.metadata
+
+    def test_findings_free_text_passes_through_unchanged(self) -> None:
+        """No parsed findings → final_output stays the raw markdown str."""
+        plain = "Just a prose answer with no category sections."
+        result = self._result(result_text=plain)
+        assert result.final_output == plain
+
+    def test_report_renders_through_voice_renderer(self) -> None:
+        """Round-trip: serialized report renders with content intact and
+        no raw dict/repr leakage."""
+        from attune.voice import report_renderer
+        from attune.workflows.output import WorkflowReport
+
+        result = self._result(report_title="Code review")
+        report = WorkflowReport.from_dict(result.final_output)
+        rendered = report_renderer.render(report, disclosure="summary")
+        assert "# Code review" in rendered
+        assert "No eval/exec usage found" in rendered
+        assert "{'kind'" not in rendered
+        assert "WorkflowReport(" not in rendered
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

workflow-result-formatting **T8** — migrate the remaining SDK-native workflows to structured `WorkflowReport` output. Shipped as **one adapter-level change** instead of the spec's 8 per-workflow converter PRs: every SDK-native workflow (15, not 8 — the spec's list predated the full census) routes through `AgentSDKResultAdapter.from_agent_output`, so the converter lives there. Spec scope note recorded in `tasks.md`.

## What changed

- **`agent_sdk_adapter.py`**: when findings parse (text categories or structured output), `final_output` becomes `WorkflowReport.to_dict()` — dict items → `FindingsSection`, string bullets → `ListSection`, suggestions → trailing `NextStepsSection`, score from `summary.score` (structured) or a `score: N/100` text regex, cost/duration in report metadata (`cost_usd` omitted on subscription runs). Findings-free prose passes through unchanged; `metadata["raw_result_text"]` still carries the unmodified agent text (discovery-sweep contract, #729). The now-dead `_format_findings_markdown` is removed.
- **15 workflow call sites** pass a human `report_title` ("Code review", "Bug prediction", …).
- **MCP `release_prep` handler**: `recommendation` falls back to `result.summary` (report dicts carry no `recommendation` key).
- **Fixes the cost-line-on-subscription nit** (handoff receipt from the 8.3.0 isolation run): these workflows now take the `report_rendered` path, so the voice wrapper's `$0.0000` line is suppressed and the renderer's `show_cost` gate owns cost display (design D3).

## Out of scope

- document-manager (legacy multi-stage `BaseWorkflow`, not adapter-routed; T3 safety net covers it)
- T5 (MCP verbatim rendering) and T6 (dashboard panel) — next in the spec

## Tests

- New `TestAgentSDKResultAdapterReportOutput` (10 tests): report discriminator + title, list/findings sections, text + structured score, next-steps, cost-metadata presence/omission, plain-text passthrough guard, renderer round-trip (no repr leak).
- Updated the legacy markdown `final_output` assertions in the same commit.
- Green locally: 110 adapter tests, 2,417 `tests/unit/workflows`, voice/MCP/CLI suites; branch coverage on the new code paths is complete (remaining gaps are pre-existing helpers covered elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
