### PR TITLE
fix(memory): make the cross-session recall loop deliver

### DIFF
--- a/.agents/skills/recall/SKILL.md
+++ b/.agents/skills/recall/SKILL.md
@@ -30,7 +30,7 @@ annotated by their `[type]`.
 **With a query:**
 
 ```bash
-python -c "import json, os; from attune.memory.session_stash import recall_entries; print(json.dumps(recall_entries(os.environ['Q'], top_k=8, cwd=os.getcwd()), ensure_ascii=False))"
+python -c "import json, os; from attune.memory.session_stash import recall_entries, backend_status; print(json.dumps({'status': backend_status(), 'hits': recall_entries(os.environ['Q'], top_k=8, cwd=os.getcwd())}, ensure_ascii=False))"
 ```
 
 Pass the user's topic as the `Q` environment variable (avoids quoting
@@ -39,10 +39,10 @@ issues), e.g. `Q="AMS event loop" python -c "..."`.
 **No query (recent):**
 
 ```bash
-python -c "import json, os; from attune.memory.session_stash import recent_entries; print(json.dumps(recent_entries(top_k=8, cwd=os.getcwd()), ensure_ascii=False))"
+python -c "import json, os; from attune.memory.session_stash import recent_entries, backend_status; print(json.dumps({'status': backend_status(), 'hits': recent_entries(top_k=8, cwd=os.getcwd())}, ensure_ascii=False))"
 ```
 
-Each result is a dict with `text`, `topics` (carrying `type:<kind>` and
+Each hit is a dict with `text`, `topics` (carrying `type:<kind>` and
 `cwd:<path>`), `cwd`, and `session_id`. Render them as:
 
 ```
@@ -50,12 +50,22 @@ Each result is a dict with `text`, `topics` (carrying `type:<kind>` and
 - [bug] <text>
 ```
 
+**Always name the answering backend** (from `status.backend`) in one
+short line, e.g. "(searched via AMSMemoryBackend)". If
+`status.unreachable_upgrade` is set, lead with a warning before any
+results: the named upgrade backend (e.g. Redis AMS) is down, recall is
+degraded to the local file tier, and findings stored in the upgrade
+tier are unreachable until it's restarted.
+
 ## When Nothing Comes Back
 
-An empty list means no matching findings yet (the store fills as the
-Stop hook stashes findings over sessions), or no searchable backend is
-installed. Say so plainly — do **not** invent findings. Suggest the
-user keep working; the soak fills the store over time.
+An empty `hits` list means no matching findings yet (the store fills as
+the Stop hook stashes findings over sessions), or no searchable backend
+is installed. Say so plainly — do **not** invent findings, and do name
+the backend that answered: "no hits" from the file tier while
+`status.unreachable_upgrade` is set means the real store may simply be
+dark, not empty. Suggest the user keep working; the soak fills the
+store over time.
 
 ## Promote A Keeper
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8007,3 +8007,31 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   signatures before coding": one `vars(hits[0])` print in the
   harness would have caught it pre-run; build that introspection
   into the first iteration of any scoring loop.
+
+- **The recall-loop "never stored a real finding" triage — three
+  durable rules for any hook-consumed optional-dep feature**
+  (2026-06-11, #769; full receipts in
+  docs/specs/just-in-time-recall/recall-loop-triage-2026-06-11.md):
+  (1) **Plugin hooks run in their OWN interpreter env (pyenv
+  `python`), which has the editable attune but NOT the venv's
+  optional deps** — `agent-memory-client` was missing there, so
+  every stash silently fell to the file tier even with AMS healthy.
+  Any optional-dep feature reached from a hook must be verified IN
+  the hook's interpreter (`python -c "import <dep>"`), not the venv;
+  extends the "pyenv shim has ancient package versions" lesson with
+  the optional-dep-absent variant. (2) **Too-graceful degradation
+  is a failure class: ship the fallback's "you are degraded" signal
+  in the same PR as the fallback** — resolve_backend's connectivity
+  gate silently downgraded recall to an empty file tier for a week
+  (AMS died on reboot; nohup doesn't survive). Pattern:
+  `backend_status()` + a SessionStart health line that prints EVEN
+  when there are no results — silence is exactly what hides the
+  outage. (3) **Stop-hook stdout/stderr are discarded on exit 0 —
+  diagnostics must go to a FILE** (`stash.log` beside the
+  sentinels); also calibrate threshold gates against a real-input
+  receipt, not intuition (the utilization estimator counts only
+  message-body chars, so a substantive 1.2 MB tool-heavy transcript
+  measured 0.18 vs the 0.30 gate and sessions never stashed —
+  default now 0.05). Sentinel design note: on write-failure keep
+  the sentinel and log loudly; skipping it would re-run Ollama
+  extraction on every Stop turn.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Cross-session recall loop actually delivers** (recall-loop triage
+  2026-06-11). Three compounding gaps had kept the store empty of real
+  findings since the feature shipped: (1) the Stop-hook utilization
+  gate was miscalibrated — the estimator counts only message-body
+  chars, so substantive tool-heavy sessions plateaued at ~0.18 against
+  the 0.30 gate and never stashed; default lowered to 0.05. (2) Silent
+  degradation: an unreachable upgrade backend (e.g. Redis AMS down)
+  was invisible — new `backend_status()` in
+  `attune.memory.session_stash`, a SessionStart health line in the
+  recall hook, and backend naming in the `/recall` skill now surface
+  it. (3) The Stop hook left no forensic trail — it now appends
+  gate/extraction/write outcomes to `stash.log` beside its sentinels,
+  flagging zero-written runs loudly. Receipts and root-cause record:
+  `docs/specs/just-in-time-recall/recall-loop-triage-2026-06-11.md`.
+
 ### Changed
 - **All 15 SDK-native workflows now emit structured WorkflowReport
   results** (workflow-result-formatting T8). The shared

--- a/docs/process/LEGIBLE_FAILURE_outline.md
+++ b/docs/process/LEGIBLE_FAILURE_outline.md
@@ -105,11 +105,26 @@ verification beats taste.)
 - Prior-instance sources: AMS four-behaviors lesson, P2-hooks
   "registered ≠ working" lesson
 
-## Open questions for Patrick
+## Decisions (Patrick, 2026-06-11)
 
-- Audience: the Discipline article's audience (practitioners
-  working with AI agents), or broader (anyone shipping fallback
-  paths)? The story works for both; the framing differs.
-- Venue: attune-ai.dev alongside /discipline, or external first?
-- How much of the AI-collaboration angle to foreground — the
-  triage was agent-driven dogfooding, which is itself a point.
+- **Audience: broad** — anyone shipping fallback paths. Engineering
+  framing leads; the AI-collaboration angle is woven in, not the
+  premise. (This also widens the LinkedIn reach.)
+- **Venue: both** — attune-ai.dev alongside /discipline (cross-link
+  both ways) AND a LinkedIn version. NOTE for the LinkedIn cut: use
+  ASCII code-block markers, never Unicode arrows (known
+  editor-mangling lesson), and expect to trim the spine to one
+  layer of the detective story.
+- **AI-collaboration angle: foreground it, with the origin story.**
+  Patrick is proud of how the collaboration works, and the framing
+  he gave is the article's human core: the discipline (specs as the
+  key to planning, team management) came from his team-lead years
+  building enterprise web solutions. *"I don't treat you in a
+  unique way for human interaction — but usually you only find this
+  in solid companies."* The practice is ordinary good engineering
+  management, applied to an AI teammate — and it works at any
+  project size, not just enterprise. That's the closing move: the
+  reason agent-driven dogfooding caught what tests missed isn't
+  exotic AI technique; it's that the agent was managed like a
+  colleague at a well-run company — given specs, asked for
+  receipts, and trusted to walk the live loop.

--- a/docs/process/LEGIBLE_FAILURE_outline.md
+++ b/docs/process/LEGIBLE_FAILURE_outline.md
@@ -1,0 +1,115 @@
+# Article outline — "Too Graceful: When Your Fallbacks Lie to You"
+
+**Status:** outline seed (2026-06-11) — Patrick to shape; structure
+and case material captured same-day while receipts were fresh.
+**Relationship to the Discipline article:** standalone companion
+piece, per the "article is generative — synergies tied to the
+discipline, not new sections" decision. Cross-link both ways.
+**Working titles:** "Too Graceful" / "Make Failure Legible" /
+"Every Fallback Borrows Observability From Your Future Self"
+
+## Thesis
+
+Graceful degradation is taught as an unalloyed good. It isn't.
+A fallback so smooth that nobody notices the primary is dead is a
+failure mode wearing a feature's clothes. The fix is not to make
+failure loud (loud breaks the user's flow) — it's to make failure
+**legible**: the system stays graceful, the human stays informed.
+
+One-line design rule: **any change that adds a fallback path must
+ship the "you are degraded" signal in the same change.**
+Design-review question: *"when this falls back, who knows, and how
+fast?"*
+
+## The spine: one true story (2026-06-11 recall-loop triage)
+
+Narrative arc, all receipts real
+(docs/specs/just-in-time-recall/recall-loop-triage-2026-06-11.md):
+
+1. The innocent question: "are the memory enhancements helping yet?"
+2. The dogfood: `/recall` on a topic with rich history → `[]`.
+3. Layer 1: the semantic-memory server had been dead for a WEEK
+   (died on a reboot; nohup). Nothing surfaced it — the resolver's
+   connectivity gate politely degraded to a file tier.
+4. Layer 2: the file tier held 2 entries — both test fixtures. The
+   store had NEVER held a real finding.
+5. Layer 3: 19 "done" sentinels said the capture hook had run.
+   Three silent mechanisms compounded: a miscalibrated threshold
+   gate (most sessions never captured), a hook interpreter missing
+   an optional dependency (captures went to the wrong tier), and a
+   capture step that returned 0 on failure while the "done" marker
+   was written anyway.
+6. The kicker: every individual component WORKED. 100+ tests green.
+   The extraction quality, tested live, was genuinely good. Only
+   the live loop, walked end-to-end with receipts demanded at each
+   step, exposed that the system had been performing the motions of
+   memory without remembering anything.
+
+## The pattern, generalized — three instances, one shape
+
+Each previously named separately; the article unifies them:
+
+- **"Registered ≠ working"** — a hook/skill/integration that's
+  wired up and exits 0 is not evidence it does anything. The
+  receipt is a non-mocked round-trip.
+- **"Mocked-green / live-broken"** — 100+ passing tests where the
+  mocks encode the developer's belief about the dependency, not
+  the dependency's behavior (the AMS dedup/ordering/limit traps).
+- **"Degraded-silently"** — this article's headline case: the
+  fallback works so well it conceals the outage.
+
+Unifying claim: all three are the system being *polite about
+failure*, and the politeness is what makes the failure expensive.
+`except Exception: return fallback` borrows observability from
+your future self — with interest.
+
+## The fix pattern — legible, not loud
+
+Three concrete mechanisms (each maps to a fix that shipped in #769):
+
+1. **A status function** — `backend_status()`-style: cheap,
+   queryable, names the unreachable tier rather than summarizing
+   "ok/not ok".
+2. **A health line at a natural attention point** — session start,
+   CLI output footer — that prints **even when there are zero
+   results**. Silence is exactly what hides the outage; "no results
+   (file tier; semantic tier unreachable)" is a different fact than
+   "no results".
+3. **A forensic file trail** — when a process's stdout is
+   structurally invisible (Stop hooks, daemons, cron), a one-line
+   append-only log beside its state files turns the next hour-long
+   triage into a 30-second grep.
+
+Counterpoint to address honestly: why not just crash / alert?
+Because the degraded mode IS valuable (the file tier kept working;
+the session must not break). Loudness taxes the user every time;
+legibility taxes them only when they look — but guarantees there's
+something true to see.
+
+## The epistemics tie-in (closing section)
+
+This is the receipts discipline pointed inward. Receipts make the
+*agent's* claims legible to the human; legible failure makes the
+*system's* state legible to both. Same principle at both layers:
+trust is built by making it cheap to verify and impossible to be
+silently wrong. (Cross-link: Discipline article §7,
+verification beats taste.)
+
+## Material inventory (for drafting)
+
+- Triage doc with full command-level receipts (link above)
+- attune-ai #769 — the three fixes + tests, diff-able
+- CLAUDE.md lesson (2026-06-11) — the compact three-rule form
+- Global memory `feedback_legible_failure_principle` — the
+  ratified one-liner
+- Prior-instance sources: AMS four-behaviors lesson, P2-hooks
+  "registered ≠ working" lesson
+
+## Open questions for Patrick
+
+- Audience: the Discipline article's audience (practitioners
+  working with AI agents), or broader (anyone shipping fallback
+  paths)? The story works for both; the framing differs.
+- Venue: attune-ai.dev alongside /discipline, or external first?
+- How much of the AI-collaboration angle to foreground — the
+  triage was agent-driven dogfooding, which is itself a point.

--- a/docs/specs/just-in-time-recall/recall-loop-triage-2026-06-11.md
+++ b/docs/specs/just-in-time-recall/recall-loop-triage-2026-06-11.md
@@ -1,0 +1,96 @@
+# Cross-session recall loop — live triage 2026-06-11
+
+**Trigger:** Patrick asked "are the Redis memory enhancements
+helping yet?" Answer required receipts; this is the dogfood record.
+
+## Verdict
+
+**Not yet — until today the recall loop had never delivered a real
+cross-session finding.** Every individual component works; the
+losses come from three specific integration/ops gaps, all fixable
+with small PRs. The track itself is right: the quality of what the
+extractor pulls from a real transcript is genuinely worth recalling.
+
+## Receipts (all live, 2026-06-11)
+
+1. **`/recall` returned `[]`** for "MCP workflow tool handlers
+   integration coverage" — a topic with rich history. Backend had
+   silently degraded to `FileStashBackend`.
+2. **AMS server was down** (0 processes; died ~Jun 4–5, `nohup`
+   doesn't survive reboot). Redis Stack itself was up, holding
+   51 long-term records — **all 51 are test/probe residue**
+   (`itest-*`, `probe*`, `dogfood` namespaces). Zero real session
+   findings had ever landed in AMS.
+3. **File tier equally starved**: `findings.jsonl` held 2 entries,
+   both from a `/tmp` dogfood fixture; `kv.json` empty, born Jun 9.
+4. **Restarted AMS** with the prior env (recovered from
+   `~/.attune/ams/server.log`: `EMBEDDING_MODEL=ollama/nomic-embed-text`,
+   `GENERATION_MODEL=ollama/llama3.1:8b`,
+   `REDISVL_VECTOR_DIMENSIONS=768`, port 8000; index dim 768
+   verified matching). Health 200.
+5. **Post-restart round-trip passes**: `stash_entry` → AMS →
+   `recall_entries` returns the new finding ranked #1.
+6. **Extraction quality is good**: `_extract_via_ollama` on a real
+   1.2 MB transcript tail returned 5 genuinely useful findings in
+   14 s (warm model) — e.g. the pip-extras-drift lesson, the
+   CI-watcher SHA-keying pattern.
+7. **The cached 8.0.1 Stop hook, run exactly as Claude Code runs
+   it, stored ZERO entries** (exit 0, no sentinel) — reproducing
+   the historical silent loss on demand.
+
+## Root causes (three, compounding)
+
+1. **Utilization gate miscalibrated.** The 1.2 MB transcript
+   scored `estimate_utilization = 0.18` against the 0.30 default
+   gate (`ATTUNE_MEMORY_STASH_MIN_UTIL`). Most real sessions never
+   stash at all — this is why the store is starved despite weeks
+   of sessions. (19 sentinels exist from Jun 6–10, so *some*
+   sessions crossed it; most don't.)
+2. **The hook's interpreter can't reach AMS.** Hooks run `python`
+   → pyenv 3.10.11, which imports attune (editable, 8.3.0) but has
+   **no `agent-memory-client`** — so AMS backend construction
+   fails and every stash that does happen goes to the FILE tier,
+   even with AMS healthy. AMS-side recall then misses them.
+3. **AMS has no keep-alive and no surfaced health.** It died on
+   (likely) a reboot ~Jun 4–5 and nothing noticed for a week:
+   `resolve_backend`'s connectivity gate degraded recall to the
+   file tier silently. The degradation is *too* graceful.
+
+Compounding design issue: `_stash_findings` returns 0 on import or
+write failure and the sentinel is written whenever findings were
+non-empty — so "done" sentinels accumulate while nothing is stored.
+
+## Fix list (small PRs, ranked)
+
+| # | Fix | Where | Size |
+|---|-----|-------|------|
+| 1 | Recalibrate the utilization gate (lower default and/or fix the estimator's denominator so a 1 MB+ transcript clears it) | `plugin/hooks/session_stash.py`, `plugin/hooks/_transcript_size.py` | S |
+| 2 | Surface the resolved backend + AMS reachability in `/recall` output ("file backend; AMS unreachable — N records dark") and as a SessionStart health line | recall skill, `session_recall.py` | S |
+| 3 | Get `agent-memory-client` into the hook's interpreter (install into pyenv global, or have the hook prefer the project venv python when present) | env / hook shebang strategy | S |
+| 4 | Keep AMS alive: launchd agent (or `brew services`-style) + document the env | ops/setup docs, optional plist | S |
+| 5 | Don't write the sentinel when `written == 0` with non-empty findings; emit a stderr warning instead | `plugin/hooks/session_stash.py` | XS |
+
+## State after this triage
+
+- AMS running again (pid in `~/.attune/ams/server.pid`, log in
+  `~/.attune/ams/server.log`); recall verified live.
+- Store now contains the first real findings (from the
+  instrumented hook run, session `pyenv-e2e-0611`, plus one
+  `live-diagnosis-0611` probe entry) — the soak starts today.
+- **Fixes 1–3 + 5 landed same day** (this PR): gate default
+  0.30 → 0.05 with calibration comment; `backend_status()` +
+  SessionStart health line + `/recall` backend naming; `stash.log`
+  forensic trail beside the sentinels (zero-written runs flagged
+  loudly, so fix 5 ships as "sentinel kept, loss logged" — the
+  no-sentinel variant would re-run Ollama on every Stop turn);
+  `agent-memory-client==0.14.0` installed into the hook's pyenv
+  interpreter (machine-level; the version pins to the AMS 0.14.0
+  server per the pairing lesson).
+- **Fix 4 (AMS keep-alive) still open** — current restart is a
+  `nohup` that dies on reboot; a launchd agent is the durable form.
+  Mitigated meanwhile by the new health line, which makes the next
+  outage visible at the first session start instead of invisible
+  for a week.
+- Note: marketplace-plugin users get the hook fixes on the next
+  plugin release + `claude plugin update`; the locally cached
+  8.0.1 hooks keep the old gate until then.

--- a/docs/specs/polish-cost-reduction/requirements.md
+++ b/docs/specs/polish-cost-reduction/requirements.md
@@ -82,3 +82,29 @@ meaningfully change. Cost surfaces observed 2026-06-10:
   check each server's recent activity for help-tool calls in that
   window; or temporarily `chmod -w .help/templates/plugin` and see
   what errors.
+
+  **2026-06-11 occurrence — new evidence (PR #769):** the phantom
+  struck `memory` + `plugin` (3 core depths each, same
+  stripped-frontmatter fingerprint) with `generated_at: 21:09:27Z`
+  — the exact minute a commit touching
+  `src/attune/memory/session_stash.py` + `plugin/hooks/*.py` ran
+  its pre-commit chain. Same-session investigation RULED OUT the
+  whole pre-commit chain: `scripts/regenerate_help_templates.py`
+  has zero write calls (verified — check-only despite its name),
+  `check_docs_freshness.py` only writes under
+  `ATTUNE_DOCS_AUTOREGEN=1` (unset) and targets
+  `plugin/help/generated/` anyway, and `generate_all.py --stale`
+  early-returns into a read-only `check_staleness()`. Also ruled
+  out: a `core.hooksPath` writer (it points at the standard
+  pre-commit shim; no post-commit exists — the attune-author
+  `.githooks` mechanism has no attune-ai counterpart). Note the
+  feature selection is NOT commit-coupling evidence: the commit's
+  source edits made exactly `memory`+`plugin` STALE (source-hash
+  drift), so ANY staleness-driven regenerator firing afterwards
+  would pick those two. What remains: an actor outside the commit
+  process that regenerates stale features with the in-repo 3-depth
+  generator, active within the commit minute — the MCP-server
+  suspicion (this machine runs one per live Claude session plus
+  leaked ones) survives and is now the only suspect left standing.
+  Next diagnostic unchanged: `pgrep -f attune.mcp.server` at the
+  next occurrence + the `chmod -w` tripwire.

--- a/plugin/hooks/session_recall.py
+++ b/plugin/hooks/session_recall.py
@@ -95,13 +95,36 @@ def main() -> int:
         except ValueError:
             topk = _DEFAULT_TOPK
 
+        # Health line: a registered upgrade backend (e.g. Redis AMS) that is
+        # unreachable means recall is silently degraded and findings stored
+        # in that tier are dark. Surfacing this at session start is the fix
+        # for the 2026-06-11 incident where AMS was down for a week unnoticed.
+        health = ""
+        try:
+            from attune.memory.session_stash import backend_status
+
+            status = backend_status()
+            dark = status.get("unreachable_upgrade")
+            if dark:
+                health = (
+                    f"⚠ cross-session recall degraded: memory backend '{dark}' is "
+                    "unreachable — findings stored there are dark until it's back "
+                    "(e.g. restart the Agent Memory Server)."
+                )
+        except Exception:  # noqa: BLE001 — health line is best-effort
+            pass
+
         entries = recent_entries(top_k=topk, cwd=cwd)
         if not entries:
+            if health:
+                print(health)
             return 0
         block = _format(entries)
         # Only print if we actually rendered at least one finding line.
         if any(line.startswith("- [") for line in block.splitlines()):
             print(block)
+        if health:
+            print(health)
         return 0
     except Exception:  # noqa: BLE001 — SessionStart hook must never crash a session
         traceback.print_exc(file=sys.stderr)

--- a/plugin/hooks/session_stash.py
+++ b/plugin/hooks/session_stash.py
@@ -70,11 +70,40 @@ except Exception:  # noqa: BLE001 — hook must never crash a session
 _VALID_TYPES = {"decision", "pattern", "bug", "reference", "note"}
 _MAX_FINDINGS = 5
 _TAIL_CHARS = 8_000  # transcript tail handed to the extractor (smaller = faster LLM)
-_DEFAULT_MIN_UTIL = 0.30
+# Calibrated 2026-06-11: the estimator counts only user/assistant message-body
+# chars (tool results excluded), so a substantive tool-heavy session plateaus
+# far below the old 0.30 gate — a real 1.2 MB transcript measured 0.18 and
+# never stashed. 0.05 (~10k message-body tokens) separates trivial sessions
+# from substantive ones. Receipts:
+# docs/specs/just-in-time-recall/recall-loop-triage-2026-06-11.md
+_DEFAULT_MIN_UTIL = 0.05
 
 
 def _enabled() -> bool:
     return os.environ.get("ATTUNE_MEMORY_STASH", "1").strip() not in {"0", "false", "no"}
+
+
+def _diag(msg: str) -> None:
+    """Append a one-line diagnostic to ``stash.log`` in the sentinel dir.
+
+    Stop-hook stdout/stderr are discarded on exit 0, so this file is the only
+    forensic trail for "the hook ran but nothing was stored" — the failure
+    class the 2026-06-11 triage had to reconstruct from scratch. Best-effort:
+    never raises. The sentinel dir is env-overridable
+    (``ATTUNE_AI_SENTINEL_DIR``), so tests redirect automatically.
+    """
+    if _sentinel_dir is None:
+        return
+    try:
+        from datetime import datetime
+
+        d = _sentinel_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        with (d / "stash.log").open("a", encoding="utf-8") as fh:
+            fh.write(f"{datetime.now().isoformat(timespec='seconds')} {msg}\n")
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: diagnostics must never break the host session.
+        pass
 
 
 def _stash_sentinel(session_id: str | None) -> Path | None:
@@ -354,7 +383,9 @@ def main() -> int:
         except ValueError:
             min_util = _DEFAULT_MIN_UTIL
         if estimate_utilization is not None and transcript_path:
-            if estimate_utilization(transcript_path) < min_util:
+            util = estimate_utilization(transcript_path)
+            if util < min_util:
+                _diag(f"skip session={session_id} util={util:.3f} < gate {min_util}")
                 return 0  # too little so far; let a later, fuller stop capture it
 
         text = _read_transcript_tail(transcript_path)
@@ -368,9 +399,14 @@ def main() -> int:
             # fall back to the heuristic rather than stash nothing.
             findings = _normalize(_extract_heuristic(text))
         if not findings:
+            _diag(f"skip session={session_id} extraction yielded no findings")
             return 0
 
         written = _stash_findings(findings, session_id=session_id, cwd=cwd)
+        _diag(
+            f"stash session={session_id} findings={len(findings)} written={written}"
+            + (" — WRITE PATH FAILED (attune import or backend write)" if written == 0 else "")
+        )
 
         # Mark done AFTER work so a crash mid-extract retries next stop.
         if sentinel is not None:

--- a/plugin/skills/recall/SKILL.md
+++ b/plugin/skills/recall/SKILL.md
@@ -32,7 +32,7 @@ annotated by their `[type]`.
 **With a query:**
 
 ```bash
-python -c "import json, os; from attune.memory.session_stash import recall_entries; print(json.dumps(recall_entries(os.environ['Q'], top_k=8, cwd=os.getcwd()), ensure_ascii=False))"
+python -c "import json, os; from attune.memory.session_stash import recall_entries, backend_status; print(json.dumps({'status': backend_status(), 'hits': recall_entries(os.environ['Q'], top_k=8, cwd=os.getcwd())}, ensure_ascii=False))"
 ```
 
 Pass the user's topic as the `Q` environment variable (avoids quoting
@@ -41,10 +41,10 @@ issues), e.g. `Q="AMS event loop" python -c "..."`.
 **No query (recent):**
 
 ```bash
-python -c "import json, os; from attune.memory.session_stash import recent_entries; print(json.dumps(recent_entries(top_k=8, cwd=os.getcwd()), ensure_ascii=False))"
+python -c "import json, os; from attune.memory.session_stash import recent_entries, backend_status; print(json.dumps({'status': backend_status(), 'hits': recent_entries(top_k=8, cwd=os.getcwd())}, ensure_ascii=False))"
 ```
 
-Each result is a dict with `text`, `topics` (carrying `type:<kind>` and
+Each hit is a dict with `text`, `topics` (carrying `type:<kind>` and
 `cwd:<path>`), `cwd`, and `session_id`. Render them as:
 
 ```
@@ -52,12 +52,22 @@ Each result is a dict with `text`, `topics` (carrying `type:<kind>` and
 - [bug] <text>
 ```
 
+**Always name the answering backend** (from `status.backend`) in one
+short line, e.g. "(searched via AMSMemoryBackend)". If
+`status.unreachable_upgrade` is set, lead with a warning before any
+results: the named upgrade backend (e.g. Redis AMS) is down, recall is
+degraded to the local file tier, and findings stored in the upgrade
+tier are unreachable until it's restarted.
+
 ## When Nothing Comes Back
 
-An empty list means no matching findings yet (the store fills as the
-Stop hook stashes findings over sessions), or no searchable backend is
-installed. Say so plainly — do **not** invent findings. Suggest the
-user keep working; the soak fills the store over time.
+An empty `hits` list means no matching findings yet (the store fills as
+the Stop hook stashes findings over sessions), or no searchable backend
+is installed. Say so plainly — do **not** invent findings, and do name
+the backend that answered: "no hits" from the file tier while
+`status.unreachable_upgrade` is set means the real store may simply be
+dark, not empty. Suggest the user keep working; the soak fills the
+store over time.
 
 ## Promote A Keeper
 

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -178,6 +178,57 @@ def resolve_backend(
     return None
 
 
+def backend_status() -> dict:
+    """Report which backend recall resolves to, for health surfacing.
+
+    Returns a dict with:
+
+    - ``backend``: class name of the resolved backend, or ``None``
+    - ``fallback``: True when the resolved backend marks itself as the
+      always-available local fallback (e.g. the file tier)
+    - ``unreachable_upgrade``: entry-point name of a registered upgrade
+      backend (e.g. the Redis AMS) that failed construction or its
+      connectivity check — i.e. recall is silently degraded and findings
+      stored in that tier are dark. ``None`` when no upgrade is registered
+      or the upgrade is the resolved backend.
+
+    Motivation: the 2026-06-11 triage found AMS had been down for a week
+    with 51 records unreachable and nothing surfacing it — degradation was
+    too graceful. Consumers (the ``/recall`` skill, the SessionStart recall
+    hook) print a one-line warning when ``unreachable_upgrade`` is set.
+    """
+    status: dict = {"backend": None, "fallback": False, "unreachable_upgrade": None}
+    resolved = resolve_backend(None)
+    if resolved is not None:
+        status["backend"] = type(resolved).__name__
+        status["fallback"] = bool(getattr(resolved, "is_fallback", False))
+    if resolved is not None and not status["fallback"]:
+        return status  # upgrade backend healthy — nothing to warn about
+    try:
+        from importlib.metadata import entry_points
+
+        for ep in entry_points(group=_BACKEND_GROUP):
+            try:
+                instance = ep.load()()
+            except Exception:  # noqa: BLE001
+                # INTENTIONAL: construction failure IS the signal here.
+                status["unreachable_upgrade"] = ep.name
+                continue
+            if getattr(instance, "is_fallback", False):
+                continue
+            check = getattr(instance, "is_connected", None)
+            if callable(check):
+                try:
+                    if not check():
+                        status["unreachable_upgrade"] = ep.name
+                except Exception:  # noqa: BLE001
+                    status["unreachable_upgrade"] = ep.name
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: health reporting is best-effort; never propagate.
+        logger.debug("backend status probe failed: %s", exc)
+    return status
+
+
 def _sanitize(content: str) -> str | None:
     """Run the PII/secrets gate before any write (R3). Fail closed.
 

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -203,6 +203,31 @@ def test_stash_main_skips_below_util_gate(stash_mod, monkeypatch, tmp_path):
     _stdin(monkeypatch, {"session_id": "s2", "transcript_path": str(tmp_path / "t.jsonl")})
     assert stash_mod.main() == 0
     assert calls == []
+    # The skip must leave a forensic trail (2026-06-11 triage: silent
+    # gate-skips made "why is the store empty" an hour of archaeology).
+    log = (tmp_path / "stash.log").read_text(encoding="utf-8")
+    assert "skip session=s2" in log and "util=0.010" in log
+
+
+def test_stash_main_logs_write_path_failure(stash_mod, monkeypatch, tmp_path):
+    # findings extracted but zero written (attune unimportable / backend
+    # write failed) — the sentinel is still set to avoid per-turn Ollama
+    # re-runs, so the log line is the ONLY visible signal of the loss.
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path))
+    tpath = tmp_path / "t.jsonl"
+    tpath.write_text(
+        json.dumps({"message": {"role": "assistant", "content": "the bug was a race"}}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(stash_mod, "estimate_utilization", lambda _p: 0.9)
+    monkeypatch.setattr(
+        stash_mod, "_extract_via_ollama", lambda _t: [{"type": "bug", "content": "z"}]
+    )
+    monkeypatch.setattr(stash_mod, "_stash_findings", lambda findings, **k: 0)
+    _stdin(monkeypatch, {"session_id": "s9", "transcript_path": str(tpath), "cwd": "/proj"})
+    assert stash_mod.main() == 0
+    log = (tmp_path / "stash.log").read_text(encoding="utf-8")
+    assert "findings=1 written=0" in log and "WRITE PATH FAILED" in log
 
 
 def test_stash_main_happy_path_writes_sentinel(stash_mod, monkeypatch, tmp_path):
@@ -356,25 +381,62 @@ def test_format_respects_budget(recall_mod, monkeypatch):
     assert "should not appear" not in block
 
 
+_HEALTHY = {"backend": "FileStashBackend", "fallback": True, "unreachable_upgrade": None}
+_DEGRADED = {"backend": "FileStashBackend", "fallback": True, "unreachable_upgrade": "redis"}
+
+
 def test_recall_main_emits_block(recall_mod, monkeypatch, capsys):
     import attune.memory.session_stash as ss
 
     monkeypatch.setattr(
         ss, "recent_entries", lambda **k: [{"text": "a finding", "topics": ["type:note"]}]
     )
+    monkeypatch.setattr(ss, "backend_status", lambda: dict(_HEALTHY))
     _stdin(monkeypatch, {"source": "startup", "cwd": "/proj"})
     assert recall_mod.main() == 0
     out = capsys.readouterr().out
     assert "## Recalled memories" in out and "- [note] a finding" in out
+    assert "degraded" not in out
 
 
 def test_recall_main_silent_when_empty(recall_mod, monkeypatch, capsys):
     import attune.memory.session_stash as ss
 
     monkeypatch.setattr(ss, "recent_entries", lambda **k: [])
+    monkeypatch.setattr(ss, "backend_status", lambda: dict(_HEALTHY))
     _stdin(monkeypatch, {"source": "startup"})
     assert recall_mod.main() == 0
     assert capsys.readouterr().out == ""
+
+
+def test_recall_main_warns_when_upgrade_unreachable_even_with_no_entries(
+    recall_mod, monkeypatch, capsys
+):
+    # The 2026-06-11 incident: AMS down for a week, recall silently degraded
+    # to an empty file tier. The health line must surface even when there is
+    # nothing to recall — silence is exactly what hid the outage.
+    import attune.memory.session_stash as ss
+
+    monkeypatch.setattr(ss, "recent_entries", lambda **k: [])
+    monkeypatch.setattr(ss, "backend_status", lambda: dict(_DEGRADED))
+    _stdin(monkeypatch, {"source": "startup"})
+    assert recall_mod.main() == 0
+    out = capsys.readouterr().out
+    assert "degraded" in out and "'redis'" in out
+
+
+def test_recall_main_appends_warning_after_block_when_degraded(recall_mod, monkeypatch, capsys):
+    import attune.memory.session_stash as ss
+
+    monkeypatch.setattr(
+        ss, "recent_entries", lambda **k: [{"text": "a finding", "topics": ["type:note"]}]
+    )
+    monkeypatch.setattr(ss, "backend_status", lambda: dict(_DEGRADED))
+    _stdin(monkeypatch, {"source": "startup", "cwd": "/proj"})
+    assert recall_mod.main() == 0
+    out = capsys.readouterr().out
+    assert "- [note] a finding" in out
+    assert "degraded" in out and "'redis'" in out
 
 
 def test_recall_main_skips_on_compact(recall_mod, monkeypatch, capsys):

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -431,6 +431,92 @@ def test_resolve_uses_fallback_when_no_upgrade(monkeypatch):
 
 
 # --------------------------------------------------------------------------
+# backend_status — health surfacing (recall-loop triage 2026-06-11):
+# an unreachable upgrade backend must be NAMED, not silently degraded past.
+# --------------------------------------------------------------------------
+
+
+def test_backend_status_healthy_upgrade_no_warning(monkeypatch):
+    import importlib.metadata as md
+
+    from attune.memory.session_stash import backend_status
+
+    upgrade = _Upgrade(connected=True)
+    fallback = _Fallback()
+    monkeypatch.setattr(
+        md,
+        "entry_points",
+        lambda group=None: [_ep("file", lambda: fallback), _ep("redis", lambda: upgrade)],
+    )
+    status = backend_status()
+    assert status["backend"] == "_Upgrade"
+    assert status["fallback"] is False
+    assert status["unreachable_upgrade"] is None
+
+
+def test_backend_status_names_disconnected_upgrade(monkeypatch):
+    import importlib.metadata as md
+
+    from attune.memory.session_stash import backend_status
+
+    upgrade = _Upgrade(connected=False)
+    fallback = _Fallback()
+    monkeypatch.setattr(
+        md,
+        "entry_points",
+        lambda group=None: [_ep("file", lambda: fallback), _ep("redis", lambda: upgrade)],
+    )
+    status = backend_status()
+    assert status["backend"] == "_Fallback"
+    assert status["fallback"] is True
+    assert status["unreachable_upgrade"] == "redis"
+
+
+def test_backend_status_names_upgrade_whose_constructor_raises(monkeypatch):
+    import importlib.metadata as md
+
+    from attune.memory.session_stash import backend_status
+
+    fallback = _Fallback()
+
+    def _boom():
+        raise RuntimeError("agent-memory-client not installed")
+
+    monkeypatch.setattr(
+        md,
+        "entry_points",
+        lambda group=None: [_ep("file", lambda: fallback), _ep("redis", _boom)],
+    )
+    status = backend_status()
+    assert status["fallback"] is True
+    assert status["unreachable_upgrade"] == "redis"
+
+
+def test_backend_status_fallback_only_is_not_degraded(monkeypatch):
+    # A plain install with only the file tier is normal, not degraded.
+    import importlib.metadata as md
+
+    from attune.memory.session_stash import backend_status
+
+    fallback = _Fallback()
+    monkeypatch.setattr(md, "entry_points", lambda group=None: [_ep("file", lambda: fallback)])
+    status = backend_status()
+    assert status["fallback"] is True
+    assert status["unreachable_upgrade"] is None
+
+
+def test_backend_status_no_backends():
+    # autouse fixture already patches entry_points to [].
+    from attune.memory.session_stash import backend_status
+
+    assert backend_status() == {
+        "backend": None,
+        "fallback": False,
+        "unreachable_upgrade": None,
+    }
+
+
+# --------------------------------------------------------------------------
 # D8 zero-infra round-trip: stash_entry -> recall_entries via the file backend
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Patrick asked whether the Redis memory enhancements were helping with cross-session recall yet. A live dogfood found the loop had **never stored a real finding** — all 51 AMS records were test residue, despite 19 stash sentinels. This PR ships the triage record plus fixes 1–3 (+5) from its ranked list.

## Root causes → fixes

| # | Cause | Fix |
|---|-------|-----|
| 1 | Utilization gate miscalibrated — estimator counts only message-body chars, so a real 1.2 MB session measured 0.18 vs the 0.30 gate and never stashed | Default gate 0.30 → **0.05**, calibration comment cites the receipt |
| 2 | AMS down for a week, recall silently degraded to an empty file tier — nothing surfaced it | New `backend_status()`; SessionStart recall hook prints a health warning (even with zero entries); `/recall` skill names its backend and leads with the warning when degraded |
| 3 | Hook's pyenv interpreter lacked `agent-memory-client` — stashes went to the file tier even with AMS healthy | Installed `agent-memory-client==0.14.0` into the hook interpreter (machine-level, pinned to the AMS 0.14.0 server); documented in the triage doc |
| 5 | Sentinels written with `written == 0` — losses invisible | `stash.log` forensic trail beside the sentinels; zero-written runs flagged `WRITE PATH FAILED`. Sentinel kept (a no-sentinel retry would re-run Ollama on every Stop turn) |

Fix 4 (AMS launchd keep-alive) stays open; the health line makes the next outage visible at first session start instead of invisible for a week.

## Receipts

Full live-probe record in [recall-loop-triage-2026-06-11.md](docs/specs/just-in-time-recall/recall-loop-triage-2026-06-11.md): pre-restart `/recall` → `[]`; post-restart stash→recall round-trip ranked #1; the cached hook reproduced the silent zero-store on demand; Ollama extraction quality verified (5 genuinely useful findings from one transcript tail in 14 s).

## Verification

- 66 passed: `tests/unit/memory/test_session_stash.py` + `tests/unit/hooks/test_session_memory_hooks.py` (new: `backend_status` matrix, health-line paths, `stash.log` assertions; existing recall-hook tests pinned to a healthy status so they stay deterministic on dev machines where AMS state varies)
- Plugin drift guards green (56 passed); `.agents/skills` mirror synced; ruff + pinned black clean
- Live: hook interpreter now resolves `AMSMemoryBackend`, `backend_status()` healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
