### PR TITLE
docs(process): legible-failure article draft v1 (publication gated)

### DIFF
--- a/docs/process/LEGIBLE_FAILURE_draft_v1.md
+++ b/docs/process/LEGIBLE_FAILURE_draft_v1.md
@@ -1,0 +1,206 @@
+# Too Graceful: When Your Fallbacks Lie to You
+
+<!-- STATUS: draft v1, Patrick-reviewed 2026-06-11. DO NOT publish
+to attune-ai-dev yet — publication is gated on the Redis/recall
+memory features working reliably (Patrick's call, 2026-06-11): the
+article ships once its own subject is proven fixed. Outline +
+decisions: LEGIBLE_FAILURE_outline.md. -->
+
+*Every fallback borrows observability from your future self.*
+
+You were taught that graceful degradation is an unalloyed good.
+Primary unavailable? Fall back. Service down? Degrade. Never let a
+missing dependency break the user's flow. It's in every resilience
+talk you've sat through, every system-design interview, every code
+review checklist.
+
+Here's what the checklist doesn't say: a fallback so smooth that
+nobody notices the primary is dead is not resilience. It's a
+failure mode wearing a feature's clothes — one that's all too easy
+to ship, and that earns the label "AI slop" when it finally
+surfaces.
+
+I know because I shipped one, and it lied to me from the day it
+shipped.
+
+## A simple question
+
+Recently I asked my AI agent a simple question about attune-ai,
+the developer-workflow product I build: "Are the memory
+enhancements helping yet with cross-session recall? Are we on the
+right track?"
+
+The feature gives the agent persistent memory across
+work sessions. At the end of each session, a hook extracts the
+useful findings — bugs found, decisions made, patterns worth
+keeping — and stashes them in a semantic store backed by Redis. At
+the start of the next session, relevant findings come back. I'd
+invested real engineering in it: embedding pipelines, deduplication
+semantics, a connectivity-gated backend resolver with a clean file
+fallback. The test suite was green. The status, by every visible
+signal, was "working."
+
+Instead of answering from impressions, the agent did the right
+thing: it ran the feature, live, and demanded a receipt at every
+step.
+
+The recall query — on a topic with weeks of relevant history —
+returned an empty list.
+
+## Peeling the layers
+
+What followed was a detective story in three layers, each one
+hidden by the layer above it being *too polite to mention anything
+was wrong*.
+
+**Layer one: the server had been dead for a week.** The semantic
+memory service had died in a reboot days earlier — it had been
+launched with `nohup`, which doesn't survive restarts. Nothing
+surfaced this. The backend resolver's connectivity gate did
+exactly what it was designed to do: it noticed the primary was
+unreachable and quietly degraded to the local file tier. No error,
+no warning, no log line anyone would see. Graceful.
+
+**Layer two: the fallback tier was empty too.** The file store
+held exactly two entries — both test fixtures from a development
+probe. Which forced the real question: forget this week. Had the
+system *ever* stored a real finding?
+
+**Layer three: no. It never had.** The Redis store held 51
+records, and every single one was residue from integration tests
+and probes. Meanwhile, nineteen "done" markers showed the capture
+hook had run, session after session, reporting success. Three
+silent mechanisms had compounded:
+
+- A threshold gate meant to skip trivial sessions was
+  miscalibrated — its estimator counted only conversation text and
+  ignored tool output, so real working sessions measured 0.18
+  against a 0.30 gate and never captured anything. Forever.
+- The hook ran in a different Python environment than the
+  application — one missing an optional client library. So on the
+  rare occasions a session did cross the gate, the write silently
+  fell back to the wrong storage tier.
+- And when a write failed outright, the code returned zero,
+  swallowed the failure, and wrote the "done" marker anyway.
+
+Here is the part that should bother you: **every individual
+component worked.** The extraction model, tested live, pulled
+useful findings from a real session transcript in
+fourteen seconds. The storage layer round-tripped perfectly once
+the server was up. Every unit test was green, because each test
+verified its component against a mock of its neighbors — and the
+mocks encoded what I believed about the neighbors, not what was
+true. The system had been performing the motions of memory,
+flawlessly, without remembering a single thing.
+
+## One shape, three disguises
+
+Once you see it, you find it everywhere. Over months of build
+logs, I had named this failure three different ways before
+realizing it was one pattern:
+
+- **Registered isn't working.** A hook, plugin, or integration
+  that's wired up and exits cleanly is not evidence that it does
+  anything. I had hooks that "ran successfully" for weeks while
+  accomplishing nothing.
+- **Mocked-green, live-broken.** A hundred passing tests where
+  the mocks faithfully implement your assumptions — and the real
+  dependency behaves differently in four separate ways, every one
+  invisible until first live contact.
+- **Degraded silently.** This article's headline case: the
+  fallback works so well it conceals the outage.
+
+Three names, one shape: **the system being polite about failure —
+and the politeness is what makes the failure expensive.** Every
+`except: return fallback` you write is a small loan against your
+future self's ability to know what's true. The interest compounds
+in the dark.
+
+## Legible, not loud
+
+The obvious counterargument: fine, then crash. Alert on
+everything. Fail fast.
+
+No. The degraded mode is valuable — the file tier kept
+the feature alive; a session must not break because a sidecar
+service is down. Loudness taxes the user on every failure, which
+is precisely why developers route around it with silent fallbacks
+in the first place.
+
+The fix isn't to make failure loud. It's to make failure
+**legible**: the system stays graceful, and the human stays
+informed. Three mechanisms, each cheap, each shipped the same day
+as the diagnosis:
+
+**1. A status function.** Not a boolean health check — a function
+that *names* the degradation: which backend answered, whether it's
+the fallback, and which upgrade tier is unreachable. The interface
+that reports state must be as queryable as the interface that
+serves requests.
+
+**2. A health line at a natural attention point — that prints
+even when there are zero results.** attune-ai's session-start
+recall now
+says, in one line, "recall degraded: semantic backend unreachable
+— findings stored there are dark until it's restarted." The
+crucial design choice is printing it *especially* when there is
+nothing else to show. "No results" and "no results, because the
+real store is unreachable" are different facts, and silence is
+exactly what hid the outage for a week.
+
+**3. A forensic trail where stdout can't go.** Background hooks,
+daemons, and cron jobs often have structurally invisible output —
+ours discards it by design on success. So the hook now appends one
+line per run to a log beside its state files: gate result,
+findings extracted, findings written, and a loud flag when those
+last two numbers don't match. The next investigation of "why is
+the store empty" will take thirty seconds of grep instead of an
+hour of archaeology.
+
+One rule captures all three, and it's the rule I'd put in any
+team's review checklist:
+
+> **Any change that adds a fallback path ships its "you are
+> degraded" signal in the same change.** And in design review,
+> ask: *when this falls back, who knows, and how fast?*
+
+## The part where I tell you the trick
+
+I should be honest about how this got caught, because it's the
+actual point.
+
+It wasn't a monitoring dashboard. It wasn't a clever test. It was
+an AI agent, asked an open question, that responded by dogfooding
+the live system and refusing to report anything it couldn't show a
+receipt for. Empty result — receipt. Dead server — receipt.
+Fixture-only store — receipt. The diagnosis, the fixes, the tests,
+and this article's raw material came out of one working session.
+
+The failure mode that gets dismissed as "AI slop" wasn't caught by
+a human reviewer or a test suite. It was caught by the AI —
+managed with discipline.
+
+There's a lot of writing right now that treats working with AI
+agents as an exotic new discipline requiring exotic new instincts.
+My experience is the opposite. I learned the practices that made
+this work decades ago, leading teams building enterprise web
+solutions: specs before execution, receipts over promises, clean
+handoffs, and trusting a teammate to walk the live loop and report
+what's there — including the bad news. I don't treat my
+agent in some unique way invented for AI. I treat it the way solid
+companies treat colleagues. That management practice predates the
+technology by half a century, and it turns out to be exactly what
+the technology needed. It worked on enterprise teams; it works on
+a team of one human and one agent; it works at any size in
+between.
+
+Which closes the loop, because the two ideas are the same idea.
+Receipts make a teammate's claims legible to you. Status
+functions, health lines, and forensic trails make a *system's*
+state legible to everyone. Trust — in a colleague, in an agent, in
+a fallback path — isn't built by things never failing. It's built
+by making it cheap to verify and impossible to be silently wrong.
+
+My system's failures became legible the same week my
+collaboration did. That's not a coincidence. It's the same
+discipline, pointed in both directions.

--- a/docs/process/LEGIBLE_FAILURE_outline.md
+++ b/docs/process/LEGIBLE_FAILURE_outline.md
@@ -1,7 +1,11 @@
 # Article outline — "Too Graceful: When Your Fallbacks Lie to You"
 
-**Status:** outline seed (2026-06-11) — Patrick to shape; structure
-and case material captured same-day while receipts were fresh.
+**Status:** draft v1 written + Patrick-reviewed same day
+(LEGIBLE_FAILURE_draft_v1.md, ~1,490 words). **Publication gated**
+on the Redis/recall memory features working reliably (Patrick,
+2026-06-11) — the article ships once its own subject is proven
+fixed; the recall-loop soak (#769) is the readiness signal. Then:
+attune-ai-dev page + LinkedIn cut (~600–800 words).
 **Relationship to the Discipline article:** standalone companion
 piece, per the "article is generative — synergies tied to the
 discipline, not new sections" decision. Cross-link both ways.


### PR DESCRIPTION
Draft v1 of the "Too Graceful" article, Patrick-reviewed in session. Lives in docs/process/ only — **not** wired into attune-ai-dev; publication is gated on the Redis/recall memory features working reliably (gate in the draft's status header + outline). Companion outline updated to reflect draft-exists + gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)