### PR TITLE
feat(lessons): attune.lessons retrieval index (lessons-corpus-rag T1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`attune.lessons` — retrieval index over the lessons corpus**
+  (lessons-corpus-rag T1). The Phase 0 harness's wrap-aware splitter
+  moves to `attune.lessons.split_lessons()` (single source of truth;
+  the benchmark imports it). New: `split_atomic()` generates child
+  docs from mega-lessons' bolded sub-bullets (design D3), and
+  `LessonsIndex` — an mtime-cached, attune-rag `CorpusProtocol`
+  corpus with parent-deduped `retrieve(query, k)` so one
+  mega-lesson's children can't crowd out other lessons. Benchmark
+  receipt on the frozen golden set: P@1 84%, P@3 96% (Phase 0: 84%),
+  high-severity 7/7 — clears the D6 cutover gate (>= 80%). No
+  behavior change anywhere else yet (T2-T5 follow).
+
 ### Fixed
 - **Cross-session recall loop actually delivers** (recall-loop triage
   2026-06-11). Three compounding gaps had kept the store empty of real

--- a/docs/specs/lessons-corpus-rag/tasks.md
+++ b/docs/specs/lessons-corpus-rag/tasks.md
@@ -1,9 +1,9 @@
 # Lessons Corpus via RAG — Tasks
 
-**Status:** draft (2026-06-11) — pending design approval. Bounded
+**Status:** in progress (2026-06-11) — T1 done; T2–T6 open. Bounded
 PRs; each task names its receipt.
 
-## T1 — `attune.lessons` module
+## T1 — `attune.lessons` module — DONE 2026-06-11
 
 - `split_lessons()` (moved from the Phase 0 harness, which then
   imports it), atomic sub-splitting of multi-bullet lessons (D3),
@@ -13,6 +13,19 @@ PRs; each task names its receipt.
   generation, mtime invalidation, retrieval smoke against 3 golden
   queries. Benchmark script re-run green via the shared splitter.
 - One PR. No behavior change anywhere else yet.
+- **Receipt:** benchmark on the frozen golden set via the real
+  `LessonsIndex`: corpus 514 docs (380 lessons + 134 children);
+  **P@1 84%, P@3 96%, high-severity 7/7** — clears the D6 gate.
+  Two design findings recorded along the way: (a) naive child docs
+  REGRESSED P@3 to 72% by displacing their parents in the top-3, so
+  children carry `metadata["parent_path"]` and the benchmark credits
+  child hits to their lesson; (b) `LessonsIndex.retrieve()` dedups
+  the candidate pool by lesson (one mega-lesson's children can't
+  occupy multiple top-k slots) — this also flipped the
+  three-children-of-the-wrong-parent crowd-out. Remaining miss:
+  `subscription-sdk-fail` (vocabulary collision with the
+  diagnosing-sdk-failures family — the known structural-ambiguity
+  class). Tests: 23, module branch coverage 100%.
 
 ## T2 — `/recall` extension
 

--- a/scripts/phase0/lessons_rag_benchmark.py
+++ b/scripts/phase0/lessons_rag_benchmark.py
@@ -1,10 +1,10 @@
-"""Phase 0 benchmark for the lessons-corpus-rag spec.
+"""Golden-query benchmark for the lessons-corpus-rag spec.
 
-Splits the ``.claude/CLAUDE.md`` Lessons section into one document per
-top-level lesson, builds an attune-rag ``DirectoryCorpus`` (summary =
-the lesson's bold title), and scores the golden trap-moment queries in
-``docs/specs/lessons-corpus-rag/golden_queries.json`` with the shipped
-``KeywordRetriever``.
+Scores the trap-moment queries in
+``docs/specs/lessons-corpus-rag/golden_queries.json`` against the
+REAL ``attune.lessons.LessonsIndex`` (D6: the benchmark exercises the
+shipped module — splitter, atomic child docs, parent-deduped
+retrieval — not a harness-private corpus build).
 
 Usage::
 
@@ -12,8 +12,9 @@ Usage::
 
 Reports P@1 / P@3 overall and P@3 for the high-severity subset — the
 inputs to the pre-committed go/no-go matrix in the spec's
-``decisions.md`` (D1). Re-run whenever the corpus split strategy or
-retriever changes; the fixture stays frozen.
+``decisions.md`` (D1) and the T5 cutover gate (P@3 >= 80%, D6).
+Scoring credits a hit on a child doc to its parent lesson (the
+fixture's ``expected`` slugs are top-level lessons).
 
 Copyright 2026 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
@@ -22,121 +23,57 @@ Licensed under the Apache License, Version 2.0
 from __future__ import annotations
 
 import json
-import re
-import shutil
-import tempfile
+import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LESSONS_FILE = REPO_ROOT / ".claude" / "CLAUDE.md"
 FIXTURE = REPO_ROOT / "docs" / "specs" / "lessons-corpus-rag" / "golden_queries.json"
 
+sys.path.insert(0, str(REPO_ROOT / "src"))
 
-def split_lessons(text: str) -> list[tuple[str, list[str]]]:
-    """Split the Lessons section into ``(title, body_lines)`` docs.
-
-    A lesson starts at a top-level ``- **`` bullet. Titles may wrap
-    across lines (the file is wrapped at ~72 chars), so the title is
-    extracted from the joined body, not the first line alone.
-    """
-    lessons_text = text[text.find("## Lessons Learned") :]
-    docs: list[list[str]] = []
-    current: list[str] | None = None
-    for ln in lessons_text.splitlines():
-        if ln.startswith("- **"):
-            if current:
-                docs.append(current)
-            current = [ln]
-        elif ln.startswith("### ") or ln.startswith("## "):
-            if current:
-                docs.append(current)
-            current = None
-        elif current is not None:
-            current.append(ln)
-    if current:
-        docs.append(current)
-
-    out: list[tuple[str, list[str]]] = []
-    for body in docs:
-        joined = " ".join(line.strip() for line in body)
-        m = re.match(r"- \*\*(.+?)\*\*", joined)
-        title = (m.group(1) if m else joined[:80]).rstrip(": —")
-        out.append((title, body))
-    return out
-
-
-def build_corpus_dir(docs: list[tuple[str, list[str]]], root: Path) -> dict[str, str]:
-    """Write one markdown file per lesson; return path → title summaries."""
-    summaries: dict[str, str] = {}
-    seen: set[str] = set()
-    for title, body in docs:
-        slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:70] or "lesson"
-        base, n = slug, 2
-        while slug in seen:
-            slug = f"{base}-{n}"
-            n += 1
-        seen.add(slug)
-        rel = f"{slug}.md"
-        (root / rel).write_text(f"# {title}\n\n" + "\n".join(body) + "\n", encoding="utf-8")
-        summaries[rel] = title
-    return summaries
+from attune.lessons import LessonsIndex  # noqa: E402
 
 
 def main() -> int:
     """Run the benchmark and print the matrix inputs."""
-    from attune_rag import DirectoryCorpus, KeywordRetriever
+    index = LessonsIndex(LESSONS_FILE)
+    entries = index.entries()
+    parents = sum(1 for e in entries if "parent_path" not in e.metadata)
+    print(f"corpus: {len(entries)} docs ({parents} lessons + {len(entries) - parents} children)")
 
-    text = LESSONS_FILE.read_text(encoding="utf-8")
-    docs = split_lessons(text)
+    queries = json.loads(FIXTURE.read_text(encoding="utf-8"))["queries"]
+    known = {Path(e.path).stem for e in entries}
+    missing = [(q["id"], slug) for q in queries for slug in q["expected"] if slug not in known]
+    if missing:
+        print(f"MISSING expected slugs (fixture vs corpus drift): {missing}")
+        return 1
 
-    tmp = Path(tempfile.mkdtemp(prefix="lessons-rag-"))
-    try:
-        summaries = build_corpus_dir(docs, tmp)
-        corpus = DirectoryCorpus(tmp, extra_summaries=summaries)
-        entries = list(corpus.entries())
-        with_summary = sum(1 for e in entries if getattr(e, "summary", None))
-        print(f"corpus: {len(entries)} lessons, {with_summary} with summaries")
-        if with_summary != len(entries):
-            print("WARNING: summaries not reaching the retriever — fix before scoring")
+    p1 = p3 = hs_total = hs_p3 = 0
+    misses: list[str] = []
+    for q in queries:
+        hits = index.retrieve(q["query"], k=3)
+        # Credit child-doc hits to their parent lesson.
+        got = [Path(h.entry.metadata.get("parent_path", h.entry.path)).stem for h in hits]
+        expected = set(q["expected"])
+        hit1 = bool(got) and got[0] in expected
+        hit3 = any(g in expected for g in got)
+        p1 += hit1
+        p3 += hit3
+        if q["severity"] == "high":
+            hs_total += 1
+            hs_p3 += hit3
+        if not hit3:
+            misses.append(f"  {q['id']} -> {[g[:45] for g in got]}")
 
-        queries = json.loads(FIXTURE.read_text(encoding="utf-8"))["queries"]
-        missing = [
-            (q["id"], slug)
-            for q in queries
-            for slug in q["expected"]
-            if not (tmp / f"{slug}.md").is_file()
-        ]
-        if missing:
-            print(f"MISSING expected slugs (fixture vs corpus drift): {missing}")
-            return 1
-
-        retriever = KeywordRetriever()
-        p1 = p3 = hs_total = hs_p3 = 0
-        misses: list[str] = []
-        for q in queries:
-            hits = retriever.retrieve(q["query"], corpus, k=3)
-            got = [Path(h.entry.path).stem for h in hits]
-            expected = set(q["expected"])
-            hit1 = bool(got) and got[0] in expected
-            hit3 = any(g in expected for g in got)
-            p1 += hit1
-            p3 += hit3
-            if q["severity"] == "high":
-                hs_total += 1
-                hs_p3 += hit3
-            if not hit3:
-                misses.append(f"  {q['id']} -> {[g[:45] for g in got]}")
-
-        n = len(queries)
-        print(f"P@1: {p1}/{n} = {p1 / n:.0%}")
-        print(f"P@3: {p3}/{n} = {p3 / n:.0%}")
-        print(f"high-severity P@3: {hs_p3}/{hs_total}")
-        if misses:
-            print("misses:")
-            print("\n".join(misses))
-        return 0
-    finally:
-        shutil.rmtree(tmp, ignore_errors=True)
+    n = len(queries)
+    print(f"P@1: {p1}/{n} = {p1 / n:.0%}")
+    print(f"P@3: {p3}/{n} = {p3 / n:.0%}")
+    print(f"high-severity P@3: {hs_p3}/{hs_total}")
+    if misses:
+        print("misses:")
+        print("\n".join(misses))
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/attune/lessons/__init__.py
+++ b/src/attune/lessons/__init__.py
@@ -1,0 +1,272 @@
+"""Lessons corpus retrieval (lessons-corpus-rag T1).
+
+Splits the repo's Lessons section (``## Lessons Learned`` in
+``.claude/lessons.md``, falling back to ``.claude/CLAUDE.md`` until
+the T5 cutover) into one retrievable document per top-level lesson,
+plus one child document per bolded second-level bullet of the
+consolidated mega-lessons (design D3 "atomic sub-splitting").
+
+Retrieval rides attune-rag's shipped ``KeywordRetriever`` against an
+in-memory corpus implementing ``CorpusProtocol`` with real
+``RetrievalEntry`` instances (summary = the lesson title, which the
+retriever weights 1.5x).
+
+Usage::
+
+    from attune.lessons import LessonsIndex
+
+    index = LessonsIndex()  # auto-locates the lessons file
+    for hit in index.retrieve("tag a release after squash merge"):
+        print(hit.entry.summary, hit.score)
+
+The index is mtime-cached: every ``entries()``/``retrieve()`` call
+stats the file and rebuilds only when it changed (a rebuild on the
+current ~380-lesson corpus is well under a second).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from attune_rag import RetrievalEntry, RetrievalHit
+
+logger = logging.getLogger(__name__)
+
+_LESSONS_HEADING = "## Lessons Learned"
+_SUB_BULLET_RE = re.compile(r"^\s{2,}- \*\*")
+_TITLE_RE = re.compile(r"- \*\*(.+?)\*\*")
+
+__all__ = [
+    "LessonsIndex",
+    "find_lessons_file",
+    "retrieve",
+    "split_atomic",
+    "split_lessons",
+]
+
+
+def find_lessons_file(start: Path | None = None) -> Path:
+    """Locate the lessons corpus file by walking up from ``start``.
+
+    Prefers ``.claude/lessons.md`` (the post-cutover home, design D3)
+    over ``.claude/CLAUDE.md`` at each level.
+
+    Args:
+        start: Directory to begin the upward walk (default: cwd).
+
+    Returns:
+        Path to the first lessons file found.
+
+    Raises:
+        FileNotFoundError: If no candidate exists up to the
+            filesystem root.
+    """
+    here = (start or Path.cwd()).resolve()
+    for base in (here, *here.parents):
+        for name in ("lessons.md", "CLAUDE.md"):
+            candidate = base / ".claude" / name
+            if candidate.is_file():
+                return candidate
+    raise FileNotFoundError(
+        f"no .claude/lessons.md or .claude/CLAUDE.md found walking up from {here}"
+    )
+
+
+def split_lessons(text: str) -> list[tuple[str, list[str]]]:
+    """Split the Lessons section into ``(title, body_lines)`` docs.
+
+    A lesson starts at a top-level ``- **`` bullet. Titles may wrap
+    across lines (the file is wrapped at ~72 chars), so the title is
+    extracted from the joined body, not the first line alone.
+    """
+    lessons_text = text[text.find(_LESSONS_HEADING) :]
+    docs: list[list[str]] = []
+    current: list[str] | None = None
+    for ln in lessons_text.splitlines():
+        if ln.startswith("- **"):
+            if current:
+                docs.append(current)
+            current = [ln]
+        elif ln.startswith("### ") or ln.startswith("## "):
+            if current:
+                docs.append(current)
+            current = None
+        elif current is not None:
+            current.append(ln)
+    if current:
+        docs.append(current)
+
+    out: list[tuple[str, list[str]]] = []
+    for body in docs:
+        joined = " ".join(line.strip() for line in body)
+        m = _TITLE_RE.match(joined)
+        title = (m.group(1) if m else joined[:80]).rstrip(": —")
+        out.append((title, body))
+    return out
+
+
+def split_atomic(
+    docs: list[tuple[str, list[str]]],
+) -> list[tuple[str, list[str], int]]:
+    """Generate child docs from mega-lessons' bolded sub-bullets (D3).
+
+    A consolidated mega-lesson carries two or more second-level
+    ``- **Title** — ...`` bullets, each a distinct lesson in its own
+    right. Each becomes a child doc titled
+    ``"<parent title> — <sub-bullet title>"`` so trap-moment queries
+    can land on the specific sub-lesson instead of competing with the
+    whole consolidated body.
+
+    Plain (non-bolded) sub-bullets are ordinary list items, not
+    atomic sub-lessons, and produce no children.
+
+    Returns:
+        ``(child_title, body_lines, parent_index)`` triples, where
+        ``parent_index`` points into ``docs`` (children must stay
+        linked to their lesson — retrieval dedups and the benchmark
+        scores by parent).
+    """
+    children: list[tuple[str, list[str], int]] = []
+    for parent_index, (title, body) in enumerate(docs):
+        groups: list[list[str]] = []
+        current: list[str] | None = None
+        for ln in body:
+            if _SUB_BULLET_RE.match(ln):
+                if current:
+                    groups.append(current)
+                current = [ln]
+            elif current is not None:
+                if ln.startswith("- **"):
+                    groups.append(current)
+                    current = None
+                else:
+                    current.append(ln)
+        if current:
+            groups.append(current)
+        if len(groups) < 2:
+            continue
+        for group in groups:
+            joined = " ".join(line.strip() for line in group)
+            m = _TITLE_RE.search(joined)
+            head = (m.group(1) if m else joined[:60]).rstrip(": —")
+            children.append((f"{title} — {head}", group, parent_index))
+    return children
+
+
+def _slugify(title: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:70] or "lesson"
+
+
+class LessonsIndex:
+    """Mtime-cached retrieval index over the lessons corpus file.
+
+    Implements attune-rag's ``CorpusProtocol`` (``entries()``,
+    ``get()``, ``name``, ``version``) so it plugs straight into the
+    shipped ``KeywordRetriever``.
+    """
+
+    def __init__(self, path: Path | str | None = None) -> None:
+        """Create an index over ``path`` (auto-located when None)."""
+        self._path = Path(path) if path else find_lessons_file()
+        self._stamp: tuple[int, int] | None = None
+        self._entries: dict[str, Any] = {}
+
+    @property
+    def path(self) -> Path:
+        """The lessons file backing this index."""
+        return self._path
+
+    @property
+    def name(self) -> str:
+        """Corpus name (CorpusProtocol)."""
+        return "lessons"
+
+    @property
+    def version(self) -> str:
+        """Corpus version: the backing file's mtime (CorpusProtocol)."""
+        try:
+            return str(self._path.stat().st_mtime_ns)
+        except OSError:
+            return "0"
+
+    def entries(self) -> list[RetrievalEntry]:
+        """All lesson entries, rebuilding from disk if the file changed."""
+        self._refresh()
+        return list(self._entries.values())
+
+    def get(self, path: str) -> RetrievalEntry | None:
+        """Look up one entry by its corpus path (CorpusProtocol)."""
+        self._refresh()
+        return self._entries.get(path)
+
+    def retrieve(self, query: str, k: int = 3) -> list[RetrievalHit]:
+        """Return the top-``k`` distinct lessons matching ``query``.
+
+        Retrieves a larger candidate pool, then collapses child docs
+        onto their lesson (highest-scored representative wins) so a
+        mega-lesson's children can't crowd out other lessons from the
+        top-``k``. A returned hit may be a child entry — its
+        ``entry.metadata["parent_path"]`` names the lesson it belongs
+        to.
+        """
+        from attune_rag import KeywordRetriever
+
+        pool = KeywordRetriever().retrieve(query, self, k=max(k * 4, 12))
+        out: list[RetrievalHit] = []
+        seen: set[str] = set()
+        for hit in pool:
+            lesson = hit.entry.metadata.get("parent_path", hit.entry.path)
+            if lesson in seen:
+                continue
+            seen.add(lesson)
+            out.append(hit)
+            if len(out) == k:
+                break
+        return out
+
+    def _refresh(self) -> None:
+        st = self._path.stat()
+        stamp = (st.st_mtime_ns, st.st_size)
+        if stamp == self._stamp:
+            return
+        from attune_rag import RetrievalEntry
+
+        text = self._path.read_text(encoding="utf-8")
+        parents = split_lessons(text)
+        entries: dict[str, Any] = {}
+
+        def _add(title: str, body: list[str], metadata: dict[str, Any]) -> str:
+            slug = _slugify(title)
+            base, n = slug, 2
+            while f"{slug}.md" in entries:
+                slug = f"{base}-{n}"
+                n += 1
+            rel = f"{slug}.md"
+            entries[rel] = RetrievalEntry(
+                path=rel,
+                category="lesson",
+                content="\n".join(body),
+                summary=title,
+                metadata=metadata,
+            )
+            return rel
+
+        parent_rels = [_add(title, body, {}) for title, body in parents]
+        for title, body, parent_index in split_atomic(parents):
+            _add(title, body, {"parent_path": parent_rels[parent_index]})
+
+        self._entries = entries
+        self._stamp = stamp
+        logger.debug("lessons index rebuilt: %d entries from %s", len(entries), self._path)
+
+
+def retrieve(query: str, k: int = 3, path: Path | str | None = None) -> list[RetrievalHit]:
+    """Convenience one-shot retrieval (builds a fresh index)."""
+    return LessonsIndex(path).retrieve(query, k=k)

--- a/tests/unit/lessons/test_lessons.py
+++ b/tests/unit/lessons/test_lessons.py
@@ -1,0 +1,244 @@
+"""Tests for ``attune.lessons`` (lessons-corpus-rag T1).
+
+Covers the splitter (wrap-aware titles, counts on the real corpus),
+atomic child-doc generation (D3), the mtime-cached ``LessonsIndex``,
+parent-deduped retrieval, and a golden-query smoke subset.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from attune.lessons import (
+    LessonsIndex,
+    find_lessons_file,
+    retrieve,
+    split_atomic,
+    split_lessons,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REAL_LESSONS = REPO_ROOT / ".claude" / "CLAUDE.md"
+FIXTURE = REPO_ROOT / "docs" / "specs" / "lessons-corpus-rag" / "golden_queries.json"
+
+SAMPLE = """\
+# Header
+
+## Lessons Learned
+
+- **Short lesson title**: body line one
+  continues on a second line.
+
+- **A long lesson title that wraps across two physical lines because the
+  file is wrapped at seventy-two characters**: the body starts here and
+  keeps going.
+
+- **Mega lesson about two related traps**:
+  - **First trap** — details of the first trap, which has
+    its own wrapped body.
+  - **Second trap** — details of the second trap.
+
+### A subsection heading
+
+- **Lesson after a subsection**: still a lesson.
+"""
+
+
+class TestSplitLessons:
+    def test_splits_top_level_bullets(self):
+        docs = split_lessons(SAMPLE)
+        assert len(docs) == 4
+
+    def test_wrap_aware_title_extraction(self):
+        docs = split_lessons(SAMPLE)
+        titles = [t for t, _ in docs]
+        assert (
+            "A long lesson title that wraps across two physical lines because the"
+            " file is wrapped at seventy-two characters" in titles
+        )
+
+    def test_title_strips_trailing_colon(self):
+        docs = split_lessons(SAMPLE)
+        assert docs[0][0] == "Short lesson title"
+        assert not any(t.endswith(":") for t, _ in docs)
+
+    def test_real_corpus_count_floor(self):
+        # 375 measured at Phase 0 (2026-06-11); assert >=, not == —
+        # the corpus grows with every session.
+        docs = split_lessons(REAL_LESSONS.read_text(encoding="utf-8"))
+        assert len(docs) >= 375
+
+    def test_no_lessons_heading_yields_empty_or_all(self):
+        # text.find() returns -1 -> whole text scanned; no top-level
+        # bullets means no docs.
+        assert split_lessons("# Nothing here\n\nplain text\n") == []
+
+
+class TestSplitAtomic:
+    def test_mega_lesson_yields_children_with_parent_index(self):
+        docs = split_lessons(SAMPLE)
+        children = split_atomic(docs)
+        assert len(children) == 2
+        titles = [t for t, _, _ in children]
+        assert "Mega lesson about two related traps — First trap" in titles
+        assert "Mega lesson about two related traps — Second trap" in titles
+        mega_index = next(i for i, (t, _) in enumerate(docs) if t.startswith("Mega"))
+        assert all(pi == mega_index for _, _, pi in children)
+
+    def test_single_sub_bullet_produces_no_children(self):
+        text = (
+            "## Lessons Learned\n\n"
+            "- **Parent**: intro\n"
+            "  - **Only one bold sub-bullet** — not a mega lesson.\n"
+        )
+        assert split_atomic(split_lessons(text)) == []
+
+    def test_stray_top_level_bullet_closes_group(self):
+        # Direct-call contract: a column-0 "- **" line inside a body
+        # (impossible via split_lessons, possible for direct callers)
+        # closes the open sub-bullet group.
+        body = [
+            "- **T**:",
+            "  - **A** — first.",
+            "- **stray** top-level line",
+            "  - **B** — second.",
+        ]
+        children = split_atomic([("T", body)])
+        titles = [t for t, _, _ in children]
+        assert titles == ["T — A", "T — B"]
+
+    def test_plain_sub_bullets_produce_no_children(self):
+        text = (
+            "## Lessons Learned\n\n"
+            "- **Parent**: intro\n"
+            "  - plain list item one\n"
+            "  - plain list item two\n"
+        )
+        assert split_atomic(split_lessons(text)) == []
+
+
+class TestFindLessonsFile:
+    def test_prefers_lessons_md_over_claude_md(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "CLAUDE.md").write_text("x", encoding="utf-8")
+        (tmp_path / ".claude" / "lessons.md").write_text("y", encoding="utf-8")
+        assert find_lessons_file(tmp_path).name == "lessons.md"
+
+    def test_walks_up_to_parent(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        target = tmp_path / ".claude" / "CLAUDE.md"
+        target.write_text("x", encoding="utf-8")
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        assert find_lessons_file(nested) == target
+
+    def test_raises_when_absent(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            find_lessons_file(tmp_path)
+
+
+def _write_lessons(path: Path, n: int = 2, mega: bool = False) -> None:
+    parts = ["## Lessons Learned", ""]
+    for i in range(n):
+        parts.append(f"- **Lesson number {i} about topic{i}**: body for topic{i}.")
+        parts.append("")
+    if mega:
+        parts += [
+            "- **Mega lesson on deploy traps**:",
+            "  - **Rollback trap** — always snapshot before rollback.",
+            "  - **Cache trap** — bust the cache after deploy.",
+            "",
+        ]
+    path.write_text("\n".join(parts), encoding="utf-8")
+
+
+class TestLessonsIndex:
+    def test_entries_and_protocol_surface(self, tmp_path):
+        f = tmp_path / "lessons.md"
+        _write_lessons(f, n=2)
+        index = LessonsIndex(f)
+        entries = index.entries()
+        assert len(entries) == 2
+        assert index.name == "lessons"
+        assert index.version != "0"
+        first = entries[0]
+        assert index.get(first.path) is first
+        assert index.get("nope.md") is None
+
+    def test_children_carry_parent_path_metadata(self, tmp_path):
+        f = tmp_path / "lessons.md"
+        _write_lessons(f, n=1, mega=True)
+        index = LessonsIndex(f)
+        children = [e for e in index.entries() if "parent_path" in e.metadata]
+        assert len(children) == 2
+        parent_paths = {e.metadata["parent_path"] for e in children}
+        assert parent_paths == {"mega-lesson-on-deploy-traps.md"}
+        assert index.get("mega-lesson-on-deploy-traps.md") is not None
+
+    def test_mtime_invalidation_rebuilds(self, tmp_path):
+        f = tmp_path / "lessons.md"
+        _write_lessons(f, n=2)
+        index = LessonsIndex(f)
+        assert len(index.entries()) == 2
+        _write_lessons(f, n=3)
+        assert len(index.entries()) == 3
+
+    def test_cached_between_unchanged_reads(self, tmp_path):
+        f = tmp_path / "lessons.md"
+        _write_lessons(f, n=2)
+        index = LessonsIndex(f)
+        first = index.entries()
+        second = index.entries()
+        # Same objects -> no rebuild happened.
+        assert first[0] is second[0]
+
+    def test_retrieve_dedups_children_onto_lesson(self, tmp_path):
+        f = tmp_path / "lessons.md"
+        _write_lessons(f, n=1, mega=True)
+        index = LessonsIndex(f)
+        hits = index.retrieve("deploy rollback cache trap", k=3)
+        lessons = [h.entry.metadata.get("parent_path", h.entry.path) for h in hits]
+        assert len(lessons) == len(set(lessons)), "same lesson returned twice"
+
+    def test_default_path_auto_located(self, tmp_path, monkeypatch):
+        (tmp_path / ".claude").mkdir()
+        f = tmp_path / ".claude" / "lessons.md"
+        _write_lessons(f, n=1)
+        monkeypatch.chdir(tmp_path)
+        index = LessonsIndex()
+        assert index.path == f
+
+    def test_version_zero_when_file_unreadable(self, tmp_path):
+        f = tmp_path / "lessons.md"
+        _write_lessons(f, n=1)
+        index = LessonsIndex(f)
+        f.unlink()
+        assert index.version == "0"
+
+    def test_module_level_retrieve(self, tmp_path):
+        f = tmp_path / "lessons.md"
+        _write_lessons(f, n=2)
+        hits = retrieve("topic0", path=f)
+        assert hits
+        assert hits[0].entry.summary == "Lesson number 0 about topic0"
+
+
+class TestGoldenSmoke:
+    """Retrieval smoke against 3 frozen golden queries (real corpus)."""
+
+    @pytest.mark.parametrize(
+        "query_id", ["pytest-cov-keyerror", "windows-crlf", "tag-before-squash"]
+    )
+    def test_golden_query_hits_top3(self, query_id):
+        queries = json.loads(FIXTURE.read_text(encoding="utf-8"))["queries"]
+        q = next(q for q in queries if q["id"] == query_id)
+        index = LessonsIndex(REAL_LESSONS)
+        hits = index.retrieve(q["query"], k=3)
+        got = {Path(h.entry.metadata.get("parent_path", h.entry.path)).stem for h in hits}
+        assert got & set(q["expected"]), f"{query_id}: top-3 missed, got {got}"


### PR DESCRIPTION
## Summary

lessons-corpus-rag **T1**: the `attune.lessons` module — splitter, atomic child docs, mtime-cached retrieval index. One PR, no behavior change anywhere else (T2–T5 follow).

- `split_lessons()` moves from `scripts/phase0/lessons_rag_benchmark.py` to `attune.lessons` (the harness now imports it — single source of truth).
- `split_atomic()` (design D3): each bolded second-level bullet of a consolidated mega-lesson becomes a child doc titled `"<parent> — <sub-title>"`, linked via `parent_index`.
- `LessonsIndex`: mtime-cached corpus implementing attune-rag's `CorpusProtocol` with real `RetrievalEntry` objects (summary = lesson title → 1.5x retriever weight). Children carry `metadata["parent_path"]`. `retrieve(query, k)` pulls a 4k candidate pool and dedups by lesson, so one mega-lesson's children can't occupy multiple top-k slots.

## Benchmark receipt (D6 gate)

Frozen golden set, scored against the real index (child hits credited to their parent lesson):

| Metric | Phase 0 | T1 |
|---|---|---|
| corpus | 375 docs | 514 (380 lessons + 134 children) |
| P@1 | 60% | **84%** |
| P@3 | 84% | **96%** |
| high-severity P@3 | 7/7 | **7/7** |

Design finding worth keeping: naive child docs (no parent linkage) **regressed** P@3 to 72% — children displaced their own parents in the top-3 while the fixture expects parent slugs, and one mega-lesson's three children crowded out everything else for one query. The `parent_path` metadata + lesson-level dedup is the fix; recorded in tasks.md. Remaining miss: `subscription-sdk-fail` (vocabulary collision with the diagnosing-sdk-failures family — the known structural-ambiguity class).

## Tests

23 unit tests (`tests/unit/lessons/`), module branch coverage **100%**. Splitter floor asserts >= 375 on the real corpus (grows with every session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
