### PR TITLE
feat(lessons): /recall lessons search + UserPromptSubmit recall hook (T2+T3)

### DIFF
--- a/.agents/skills/recall/SKILL.md
+++ b/.agents/skills/recall/SKILL.md
@@ -12,13 +12,18 @@ description: "Pull relevant findings stashed from past sessions — on demand. T
 ## What It Does
 
 `/recall` is the on-demand companion to the automatic SessionStart
-recall. It searches the findings stashed by the Stop hook across past
-sessions (file backend by default; Redis AMS when connected) and
-surfaces the most relevant ones, formatted for reading.
+recall. It searches TWO stores and labels results by source:
 
-- **With a query** (`/recall AMS event loop`): keyword + recency search,
-  same-project findings ranked first.
-- **No query** (`/recall`): the most recent findings for this project.
+1. **Session findings** — stashed by the Stop hook across past
+   sessions (file backend by default; Redis AMS when connected).
+2. **The lessons corpus** — the repo's accumulated engineering
+   lessons, retrieved via `attune.lessons.LessonsIndex` (query mode
+   only; lessons have no recency, so the no-query mode skips them).
+
+- **With a query** (`/recall AMS event loop`): both stores; session
+  findings keyword + recency ranked, lessons by retrieval score.
+- **No query** (`/recall`): the most recent session findings for
+  this project.
 
 ## How To Run It
 
@@ -42,12 +47,26 @@ issues), e.g. `Q="AMS event loop" python -c "..."`.
 python -c "import json, os; from attune.memory.session_stash import recent_entries, backend_status; print(json.dumps({'status': backend_status(), 'hits': recent_entries(top_k=8, cwd=os.getcwd())}, ensure_ascii=False))"
 ```
 
-Each hit is a dict with `text`, `topics` (carrying `type:<kind>` and
-`cwd:<path>`), `cwd`, and `session_id`. Render them as:
+**Lessons corpus (query mode only — run alongside the findings
+search):**
+
+```bash
+Q="<topic>" python -c "import json, os; from attune.lessons import LessonsIndex; idx = LessonsIndex(); print(json.dumps([{'title': h.entry.summary, 'score': h.score, 'body': h.entry.content[:600]} for h in idx.retrieve(os.environ['Q'], k=3)], ensure_ascii=False))"
+```
+
+If this raises (older install without `attune.lessons`, or
+attune-rag missing), skip the lessons section silently — session
+findings still render.
+
+Each session-finding hit is a dict with `text`, `topics` (carrying
+`type:<kind>` and `cwd:<path>`), `cwd`, and `session_id`; each
+lesson hit has `title`, `score`, and a `body` excerpt. Render them
+in two labeled groups — findings first, lessons after:
 
 ```
 - [decision] <text>
 - [bug] <text>
+- [lesson] <title> — <one-line gist from the body>
 ```
 
 **Always name the answering backend** (from `status.backend`) in one

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8058,3 +8058,22 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   one-paste remainder in the session summary. A plist that DOES land
   in LaunchAgents but isn't loaded still activates at next login via
   RunAtLoad — half-installed is functional-after-reboot, not inert.
+
+- **Atomic/child docs in a RAG corpus REGRESS retrieval unless they
+  carry parent linkage and retrieval dedups by parent — children
+  displace their own parents in the top-k**: lessons-corpus-rag T1
+  (2026-06-11). Splitting mega-lessons' bolded sub-bullets into child
+  docs (to fix split-related misses) dropped golden P@3 from 84% to
+  72% on first contact: a child outranks its parent, the fixture/
+  consumer expects the parent identity, and one mega-lesson's three
+  children can occupy ALL top-3 slots, crowding out other lessons
+  entirely. Fix shape (both halves required): (a) every child entry
+  carries `metadata["parent_path"]` and scoring/display credits a
+  child hit to its parent lesson; (b) `retrieve()` pulls a larger
+  candidate pool (k*4) then dedups by lesson identity, returning the
+  highest-scored representative per lesson. Result: P@1 60%→84%,
+  P@3 84%→96% — the children then do exactly what they were for
+  (the trap-moment query lands the SPECIFIC sub-lesson first).
+  Generalizes to any hierarchical-chunking RAG design: chunk-level
+  recall + document-level identity are different contracts; conflate
+  them and finer chunking makes retrieval WORSE.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Automatic lesson recall on user prompts** (lessons-corpus-rag
+  T3). New `UserPromptSubmit` hook (`plugin/hooks/lesson_recall.py`)
+  retrieves the top lessons scoring against each prompt and injects
+  them as `additionalContext`. Noise controls: score floor
+  (`ATTUNE_LESSON_RECALL_FLOOR`, default 8.0), minimum prompt
+  length, slash-command skip, surface-once-per-(session, lesson)
+  sentinel (children gate on their parent lesson),
+  `ATTUNE_LESSON_RECALL=0` off-switch, SDK-subprocess gate,
+  fail-safe exit 0.
 - **`attune.lessons` — retrieval index over the lessons corpus**
   (lessons-corpus-rag T1). The Phase 0 harness's wrap-aware splitter
   moves to `attune.lessons.split_lessons()` (single source of truth;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/specs/just-in-time-recall/recall-loop-triage-2026-06-11.md`.
 
 ### Changed
+- **`/recall` now searches the lessons corpus too**
+  (lessons-corpus-rag T2). Query mode runs
+  `attune.lessons.LessonsIndex` alongside the session-findings store
+  and renders `[lesson]`-labeled hits after the findings; no-query
+  (recent) mode is findings-only. Degrades silently to findings-only
+  on installs without `attune.lessons`.
 - **All 15 SDK-native workflows now emit structured WorkflowReport
   results** (workflow-result-formatting T8). The shared
   `AgentSDKResultAdapter` serializes parsed findings into a

--- a/docs/specs/lessons-corpus-rag/tasks.md
+++ b/docs/specs/lessons-corpus-rag/tasks.md
@@ -1,6 +1,6 @@
 # Lessons Corpus via RAG — Tasks
 
-**Status:** in progress (2026-06-11) — T1+T2 done; T3–T6 open.
+**Status:** in progress (2026-06-11) — T1+T2+T3 done; T4–T6 open.
 Bounded PRs; each task names its receipt.
 
 ## T1 — `attune.lessons` module — DONE 2026-06-11
@@ -40,7 +40,7 @@ Bounded PRs; each task names its receipt.
   (older installs). `.agents/` mirror regenerated via
   `sync_agents_skills.py`.
 
-## T3 — UserPromptSubmit hook
+## T3 — UserPromptSubmit hook — DONE 2026-06-11
 
 - `plugin/hooks/lesson_recall.py`: score floor, top-3,
   surface-once-per-(session, lesson) sentinel, `additionalContext`
@@ -48,8 +48,19 @@ Bounded PRs; each task names its receipt.
   SDK-subprocess gate (`is_sdk_subprocess()` — the isolation rule).
 - Tests mirror `jit_recall.py`'s suite (sentinel, no-match silence,
   crash → exit 0, injected payload shape).
-- Receipt: live session shows a relevant lesson surfacing on a
-  realistic prompt, and an unrelated prompt surfacing nothing.
+- **Receipt (process-level, real corpus):** payload prompt *"I need
+  to tag the release now that the squash merge landed on main"* →
+  injected the Tag-mechanics lesson as `additionalContext`; an
+  unrelated prompt (dashboard color tweak) emitted nothing; both
+  exited 0. Extra noise gates beyond the design: min prompt length
+  (20 chars — short acks never query) and slash-command skip
+  (`/recall` IS the manual surface). Floor tunable via
+  `ATTUNE_LESSON_RECALL_FLOOR` (default 8.0) for soak calibration.
+  Children sentinel on their PARENT lesson id, so one mega-lesson
+  isn't re-surfaced via a different child. 17 tests.
+  **In-CC-session receipt is gated on the next plugin release +
+  `claude plugin update`** (same gating as the recall-loop fixes —
+  live sessions run the cached plugin).
 
 ## T4 — jit-recall `lesson_ref` integration
 

--- a/docs/specs/lessons-corpus-rag/tasks.md
+++ b/docs/specs/lessons-corpus-rag/tasks.md
@@ -1,7 +1,7 @@
 # Lessons Corpus via RAG — Tasks
 
-**Status:** in progress (2026-06-11) — T1 done; T2–T6 open. Bounded
-PRs; each task names its receipt.
+**Status:** in progress (2026-06-11) — T1+T2 done; T3–T6 open.
+Bounded PRs; each task names its receipt.
 
 ## T1 — `attune.lessons` module — DONE 2026-06-11
 
@@ -27,11 +27,18 @@ PRs; each task names its receipt.
   diagnosing-sdk-failures family — the known structural-ambiguity
   class). Tests: 23, module branch coverage 100%.
 
-## T2 — `/recall` extension
+## T2 — `/recall` extension — DONE 2026-06-11
 
 - The recall skill queries `LessonsIndex` alongside the AMS findings
   store; results labeled by source ("lesson" vs "session finding").
-- Receipt: a trap-moment query answered in a live session.
+- **Receipt:** live trap-moment query `"tag a release after a squash
+  merge"` through `LessonsIndex().retrieve(k=3)` returned the exact
+  child sub-lesson first — *"Tag mechanics … — Don't tag before a
+  squash-merge"* (score 16.0), then the post-squash-local-main and
+  branch-recreation lessons. The skill degrades silently to
+  findings-only when `attune.lessons`/attune-rag is unavailable
+  (older installs). `.agents/` mirror regenerated via
+  `sync_agents_skills.py`.
 
 ## T3 — UserPromptSubmit hook
 

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -121,6 +121,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/lesson_recall.py",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugin/hooks/lesson_recall.py
+++ b/plugin/hooks/lesson_recall.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit lesson recall — surface matching lessons with the
+prompt that needs them.
+
+The lessons corpus (``attune.lessons``) holds hundreds of trap-moment
+lessons; this hook retrieves the top few that score against the user's
+prompt and injects their titles + truncated bodies as
+``additionalContext`` (lessons-corpus-rag design D5 surface 2).
+
+Noise controls (all from the design):
+
+- Score floor (``ATTUNE_LESSON_RECALL_FLOOR``, default 8.0) — most
+  prompts inject nothing.
+- Minimum prompt length (short acks like ``y`` / ``go`` never query).
+- Slash-command prompts are skipped (``/recall`` IS the manual surface).
+- Surface-once per ``(session, lesson)`` sentinel.
+- ``ATTUNE_LESSON_RECALL=0`` off-switch; fail-safe exit 0 always.
+
+Test/ops knob: ``ATTUNE_LESSONS_FILE`` pins the corpus file (default:
+walk up from the payload cwd via ``attune.lessons.find_lessons_file``).
+
+Exit 0 always — a crash, missing attune install, or missing corpus
+degrades to silent no-op.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+# Force utf-8 on stdout/stderr (Windows cp1252 would crash on em-dash,
+# caught by the outer try/except -> silent breakage).
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+_HOOKS_DIR = str(Path(__file__).resolve().parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+try:
+    from _state import _sentinel_dir  # type: ignore[attr-defined]
+except Exception:  # noqa: BLE001 — hook must never crash a prompt
+    _sentinel_dir = None  # type: ignore[assignment]
+
+_SENTINEL_PREFIX = ".lesson-recalled-"
+_SENTINEL_TTL_SECONDS = 7 * 24 * 3600  # match the jit-recall TTL
+_MIN_PROMPT_CHARS = 20
+_BODY_EXCERPT_CHARS = 400
+_TOP_K = 3
+
+
+def _enabled() -> bool:
+    return os.environ.get("ATTUNE_LESSON_RECALL", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
+def _floor() -> float:
+    try:
+        return float(os.environ.get("ATTUNE_LESSON_RECALL_FLOOR", "8.0"))
+    except ValueError:
+        return 8.0
+
+
+def _safe(fragment: str | None, fallback: str) -> str:
+    if not fragment:
+        return fallback
+    return re.sub(r"[^A-Za-z0-9_-]", "_", fragment)[:64] or fallback
+
+
+def _sentinel_path(session_id: str | None, lesson_id: str) -> Path | None:
+    if _sentinel_dir is None:
+        return None
+    name = f"{_SENTINEL_PREFIX}{_safe(session_id, 'unknown')}-{_safe(lesson_id, 'lesson')}"
+    return _sentinel_dir() / name
+
+
+def _prune_stale(now: float | None = None) -> None:
+    """Best-effort TTL prune of this hook's own sentinels."""
+    if _sentinel_dir is None:
+        return
+    base = _sentinel_dir()
+    if not base.is_dir():
+        return
+    cutoff = (now if now is not None else time.time()) - _SENTINEL_TTL_SECONDS
+    try:
+        entries = list(base.iterdir())
+    except OSError:
+        return
+    for entry in entries:
+        if not entry.name.startswith(_SENTINEL_PREFIX):
+            continue
+        try:
+            if entry.stat().st_mtime < cutoff:
+                entry.unlink()
+        except OSError:
+            continue
+
+
+def _lessons_index(cwd: str | None):
+    """Build a LessonsIndex, honoring the ATTUNE_LESSONS_FILE override."""
+    from attune.lessons import LessonsIndex, find_lessons_file
+
+    override = os.environ.get("ATTUNE_LESSONS_FILE")
+    if override:
+        return LessonsIndex(override)
+    start = Path(cwd) if cwd else None
+    return LessonsIndex(find_lessons_file(start))
+
+
+def main() -> int:
+    """Surface top-scoring lessons for this prompt, once per session each."""
+    try:
+        if not _enabled():
+            return 0
+        payload = json.load(sys.stdin)
+        prompt = str(payload.get("prompt") or "").strip()
+        if len(prompt) < _MIN_PROMPT_CHARS or prompt.startswith("/"):
+            return 0
+
+        index = _lessons_index(payload.get("cwd"))
+        floor = _floor()
+        hits = [h for h in index.retrieve(prompt, k=_TOP_K) if h.score >= floor]
+        if not hits:
+            return 0
+
+        session_id = payload.get("session_id")
+        fresh = []
+        for hit in hits:
+            lesson_id = Path(hit.entry.metadata.get("parent_path", hit.entry.path)).stem
+            sentinel = _sentinel_path(session_id, lesson_id)
+            if sentinel is not None and sentinel.exists():
+                continue
+            fresh.append((hit, lesson_id))
+        if not fresh:
+            return 0
+
+        lines = ["Lessons that may apply to this prompt:"]
+        for hit, _lesson_id in fresh:
+            body = " ".join(hit.entry.content.split())
+            # The doc body opens with its own "- **title**:" line —
+            # drop it so the excerpt doesn't repeat the summary.
+            body = re.sub(r"^- \*\*.+?\*\*[ :—-]*", "", body)
+            if len(body) > _BODY_EXCERPT_CHARS:
+                body = body[:_BODY_EXCERPT_CHARS] + "…"
+            lines.append(f"- **{hit.entry.summary}**: {body}")
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptSubmit",
+                        "additionalContext": "\n".join(lines),
+                    }
+                }
+            )
+        )
+        sys.stdout.flush()
+
+        # Sentinels AFTER the emit so a mid-work crash retries next fire.
+        for _hit, lesson_id in fresh:
+            sentinel = _sentinel_path(session_id, lesson_id)
+            if sentinel is None:
+                continue
+            try:
+                sentinel.parent.mkdir(parents=True, exist_ok=True)
+                sentinel.write_text("", encoding="utf-8")
+            except OSError:
+                continue
+        _prune_stale()
+        return 0
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: lesson recall is best-effort guidance; never block
+        # or break the prompt (missing attune install, missing corpus,
+        # malformed payload all land here).
+        return 0
+
+
+if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    sys.exit(main())

--- a/plugin/skills/recall/SKILL.md
+++ b/plugin/skills/recall/SKILL.md
@@ -14,13 +14,18 @@ argument-hint: "<topic to recall | leave empty for recent>"
 ## What It Does
 
 `/recall` is the on-demand companion to the automatic SessionStart
-recall. It searches the findings stashed by the Stop hook across past
-sessions (file backend by default; Redis AMS when connected) and
-surfaces the most relevant ones, formatted for reading.
+recall. It searches TWO stores and labels results by source:
 
-- **With a query** (`/recall AMS event loop`): keyword + recency search,
-  same-project findings ranked first.
-- **No query** (`/recall`): the most recent findings for this project.
+1. **Session findings** — stashed by the Stop hook across past
+   sessions (file backend by default; Redis AMS when connected).
+2. **The lessons corpus** — the repo's accumulated engineering
+   lessons, retrieved via `attune.lessons.LessonsIndex` (query mode
+   only; lessons have no recency, so the no-query mode skips them).
+
+- **With a query** (`/recall AMS event loop`): both stores; session
+  findings keyword + recency ranked, lessons by retrieval score.
+- **No query** (`/recall`): the most recent session findings for
+  this project.
 
 ## How To Run It
 
@@ -44,12 +49,26 @@ issues), e.g. `Q="AMS event loop" python -c "..."`.
 python -c "import json, os; from attune.memory.session_stash import recent_entries, backend_status; print(json.dumps({'status': backend_status(), 'hits': recent_entries(top_k=8, cwd=os.getcwd())}, ensure_ascii=False))"
 ```
 
-Each hit is a dict with `text`, `topics` (carrying `type:<kind>` and
-`cwd:<path>`), `cwd`, and `session_id`. Render them as:
+**Lessons corpus (query mode only — run alongside the findings
+search):**
+
+```bash
+Q="<topic>" python -c "import json, os; from attune.lessons import LessonsIndex; idx = LessonsIndex(); print(json.dumps([{'title': h.entry.summary, 'score': h.score, 'body': h.entry.content[:600]} for h in idx.retrieve(os.environ['Q'], k=3)], ensure_ascii=False))"
+```
+
+If this raises (older install without `attune.lessons`, or
+attune-rag missing), skip the lessons section silently — session
+findings still render.
+
+Each session-finding hit is a dict with `text`, `topics` (carrying
+`type:<kind>` and `cwd:<path>`), `cwd`, and `session_id`; each
+lesson hit has `title`, `score`, and a `body` excerpt. Render them
+in two labeled groups — findings first, lessons after:
 
 ```
 - [decision] <text>
 - [bug] <text>
+- [lesson] <title> — <one-line gist from the body>
 ```
 
 **Always name the answering backend** (from `status.backend`) in one

--- a/tests/unit/hooks/test_lesson_recall.py
+++ b/tests/unit/hooks/test_lesson_recall.py
@@ -1,0 +1,260 @@
+"""Tests for the UserPromptSubmit lesson-recall hook.
+
+Mirrors ``test_jit_recall.py``'s suite shape (the spec's T3
+requirement): injection payload, noise gates (length, slash command,
+score floor), surface-once sentinel, fail-safe control flow, and the
+hooks.json registration drift guard.
+
+Spec: docs/specs/lessons-corpus-rag/ (design D5 surface 2).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
+
+
+def _load_module(name: str):
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    if name in sys.modules:
+        del sys.modules[name]  # fresh load so nothing cached leaks in
+    spec = importlib.util.spec_from_file_location(name, _HOOKS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+LESSONS = """\
+## Lessons Learned
+
+- **Squash merge tagging requires the merge SHA**: after a squash
+  merge always tag the squash merge commit SHA, never the feature
+  branch tip. Tagging before the squash points at a pre-squash hash.
+
+- **Rebase replays commits unsigned**: a rebase drops GPG signatures;
+  amend with -S before pushing rebased commits.
+"""
+
+
+@pytest.fixture
+def hook_mod(tmp_path, monkeypatch):
+    """Load the hook with sentinel dir + lessons file isolated to tmp_path."""
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "sentinels"))
+    lessons = tmp_path / "lessons.md"
+    lessons.write_text(LESSONS, encoding="utf-8")
+    monkeypatch.setenv("ATTUNE_LESSONS_FILE", str(lessons))
+    monkeypatch.delenv("ATTUNE_LESSON_RECALL", raising=False)
+    monkeypatch.delenv("ATTUNE_LESSON_RECALL_FLOOR", raising=False)
+    _load_module("_state")
+    return _load_module("lesson_recall")
+
+
+def _run(hook_mod, monkeypatch, capsys, payload: dict) -> tuple[int, str]:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    rc = hook_mod.main()
+    return rc, capsys.readouterr().out
+
+
+def _payload(prompt: str, session: str = "sess-1") -> dict:
+    return {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": prompt,
+        "session_id": session,
+        "cwd": "/tmp",
+    }
+
+
+MATCHING_PROMPT = "how do I tag the release after the squash merge lands"
+
+
+# ==========================================================================
+# Injection payload
+# ==========================================================================
+
+
+def test_matching_prompt_surfaces_lesson(hook_mod, monkeypatch, capsys):
+    rc, out = _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    assert rc == 0
+    envelope = json.loads(out)
+    ctx = envelope["hookSpecificOutput"]
+    assert ctx["hookEventName"] == "UserPromptSubmit"
+    assert "Squash merge tagging requires the merge SHA" in ctx["additionalContext"]
+    assert "Lessons that may apply" in ctx["additionalContext"]
+
+
+def test_unrelated_prompt_is_silent(hook_mod, monkeypatch, capsys):
+    rc, out = _run(
+        hook_mod,
+        monkeypatch,
+        capsys,
+        _payload("please recolor the dashboard purple with sparkles"),
+    )
+    assert rc == 0
+    assert out == ""
+
+
+def test_body_excerpt_is_truncated(hook_mod, monkeypatch, capsys, tmp_path):
+    long_body = "tag the squash merge commit " * 60
+    (tmp_path / "lessons.md").write_text(
+        f"## Lessons Learned\n\n- **Squash tag lesson**: {long_body}\n",
+        encoding="utf-8",
+    )
+    rc, out = _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "…" in ctx
+    assert len(ctx) < hook_mod._BODY_EXCERPT_CHARS + 300
+
+
+# ==========================================================================
+# Noise gates
+# ==========================================================================
+
+
+def test_short_prompt_is_silent(hook_mod, monkeypatch, capsys):
+    rc, out = _run(hook_mod, monkeypatch, capsys, _payload("squash merge"))
+    assert rc == 0
+    assert out == ""
+
+
+def test_slash_command_prompt_is_silent(hook_mod, monkeypatch, capsys):
+    rc, out = _run(hook_mod, monkeypatch, capsys, _payload("/recall squash merge tagging rules"))
+    assert rc == 0
+    assert out == ""
+
+
+def test_score_floor_filters_weak_matches(hook_mod, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_LESSON_RECALL_FLOOR", "9999")
+    rc, out = _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    assert rc == 0
+    assert out == ""
+
+
+def test_bad_floor_value_falls_back(hook_mod, monkeypatch):
+    monkeypatch.setenv("ATTUNE_LESSON_RECALL_FLOOR", "not-a-number")
+    assert hook_mod._floor() == 8.0
+
+
+# ==========================================================================
+# Surface-once gate
+# ==========================================================================
+
+
+def test_second_fire_same_session_is_silent(hook_mod, monkeypatch, capsys):
+    rc1, out1 = _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    rc2, out2 = _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    assert (rc1, rc2) == (0, 0)
+    assert out1 != ""
+    assert out2 == ""
+
+
+def test_new_session_surfaces_again(hook_mod, monkeypatch, capsys):
+    _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT, session="sess-1"))
+    rc, out = _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT, session="sess-2"))
+    assert rc == 0
+    assert out != ""
+
+
+def test_sentinel_written_after_emit(hook_mod, monkeypatch, capsys, tmp_path):
+    _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    sentinels = list((tmp_path / "sentinels").iterdir())
+    assert sentinels
+    assert all(s.name.startswith(".lesson-recalled-sess-1-") for s in sentinels)
+
+
+def test_child_hit_sentinels_on_parent_lesson(hook_mod, monkeypatch, capsys, tmp_path):
+    """A child-doc hit must gate on the PARENT lesson id, so the same
+    mega-lesson isn't re-surfaced via a different child."""
+    (tmp_path / "lessons.md").write_text(
+        "## Lessons Learned\n\n"
+        "- **Mega tagging lesson**:\n"
+        "  - **Squash merge tagging** — tag the squash merge commit SHA.\n"
+        "  - **Tag protection** — protected tags cannot be force pushed.\n",
+        encoding="utf-8",
+    )
+    _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    sentinels = [s.name for s in (tmp_path / "sentinels").iterdir()]
+    assert any("mega-tagging-lesson" in s for s in sentinels)
+
+
+def test_prune_removes_only_stale_own_sentinels(hook_mod, tmp_path):
+    base = tmp_path / "sentinels"
+    base.mkdir(parents=True, exist_ok=True)
+    stale = base / ".lesson-recalled-old-x"
+    fresh = base / ".lesson-recalled-new-x"
+    other = base / ".jit-recalled-y"
+    for p in (stale, fresh, other):
+        p.write_text("", encoding="utf-8")
+    old = time.time() - hook_mod._SENTINEL_TTL_SECONDS - 60
+    import os
+
+    os.utime(stale, (old, old))
+    os.utime(other, (old, old))
+    hook_mod._prune_stale()
+    assert not stale.exists()
+    assert fresh.exists()
+    assert other.exists(), "must not touch other hooks' sentinels"
+
+
+# ==========================================================================
+# Fail-safety + off-switch
+# ==========================================================================
+
+
+def test_malformed_stdin_exits_zero(hook_mod, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook_mod.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_missing_lessons_file_exits_zero(hook_mod, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_LESSONS_FILE", "/nonexistent/lessons.md")
+    rc, out = _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    assert rc == 0
+    assert out == ""
+
+
+def test_env_off_switch_disables(hook_mod, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_LESSON_RECALL", "0")
+    rc, out = _run(hook_mod, monkeypatch, capsys, _payload(MATCHING_PROMPT))
+    assert rc == 0
+    assert out == ""
+
+
+def test_missing_sentinel_dir_still_surfaces(monkeypatch, capsys, tmp_path):
+    """Without a sentinel dir helper the hook surfaces (no gate) and exits 0."""
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "s"))
+    lessons = tmp_path / "lessons.md"
+    lessons.write_text(LESSONS, encoding="utf-8")
+    monkeypatch.setenv("ATTUNE_LESSONS_FILE", str(lessons))
+    mod = _load_module("lesson_recall")
+    monkeypatch.setattr(mod, "_sentinel_dir", None)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(_payload(MATCHING_PROMPT))))
+    assert mod.main() == 0
+    assert "additionalContext" in capsys.readouterr().out
+
+
+# ==========================================================================
+# Registration drift guard
+# ==========================================================================
+
+
+def test_hook_registered_for_user_prompt_submit(hook_mod):
+    hooks = json.loads((_HOOKS_DIR / "hooks.json").read_text(encoding="utf-8"))
+    groups = hooks["hooks"].get("UserPromptSubmit") or []
+    assert any(
+        "lesson_recall.py" in h["command"] for g in groups for h in g["hooks"]
+    ), "lesson_recall.py not registered for UserPromptSubmit"


### PR DESCRIPTION
## Summary

lessons-corpus-rag **T2 + T3** (folded into one PR — same spec, both small, T3 builds directly on T2's surface).

### T2 — `/recall` searches the lessons corpus
- Query mode runs `attune.lessons.LessonsIndex` (shipped in #771) next to `recall_entries()`; results render in two labeled groups — `[bug]`/`[decision]` session findings first, `[lesson]` hits after.
- No-query (recent) mode stays findings-only — lessons have no recency dimension.
- Degrades silently to findings-only on installs without `attune.lessons`. `.agents/` mirror regenerated.

### T3 — UserPromptSubmit lesson-recall hook
- `plugin/hooks/lesson_recall.py`: retrieves top lessons scoring against each prompt, injects titles + truncated bodies as `additionalContext`.
- Noise controls: score floor (`ATTUNE_LESSON_RECALL_FLOOR`, default 8.0), min prompt length, slash-command skip, surface-once-per-(session, lesson) sentinel (children gate on their PARENT lesson), `ATTUNE_LESSON_RECALL=0` off-switch, SDK-subprocess gate, fail-safe exit 0.
- 17 tests mirroring the `jit_recall.py` suite; hooks.json gains its first `UserPromptSubmit` registration.

## Receipts (live, this session)

- **T2:** query `"tag a release after a squash merge"` → top hit is the exact child sub-lesson **"Tag mechanics … — Don't tag before a squash-merge"** (score 16.0).
- **T3 (process-level, real corpus):** the tag-after-squash prompt injected the Tag-mechanics lesson; an unrelated prompt (dashboard color tweak) emitted nothing; both exited 0. In-CC-session receipt is gated on the next plugin release + `claude plugin update` (cached-plugin rule).

T4 (jit-recall `lesson_ref`) and T5 (cutover, gated on these receipts + Patrick's core review) are next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)