### PR TITLE
chore(release): 8.4.0 — lessons brain + recall reliability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.3.0"
+    "version": "8.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.3.0
+# Attune AI Framework v8.4.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.4.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 <!-- attune-lessons-start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.4.0] — 2026-06-11
+
+Cross-session memory grows a lessons brain: the repo's ~380-lesson
+engineering corpus becomes retrievable (`attune.lessons`), `/recall`
+searches it, and a new UserPromptSubmit hook surfaces matching
+lessons automatically. Plus the recall-loop reliability fixes —
+this release puts both into live plugin sessions.
+
 ### Added
 - **Automatic lesson recall on user prompts** (lessons-corpus-rag
   T3). New `UserPromptSubmit` hook (`plugin/hooks/lesson_recall.py`)

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.3.0
+**Version:** 8.4.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.3.0 | **License:** Apache 2.0
+**Version:** 8.4.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.3.0"
+    "version": "8.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.3.0"
+__version__ = "8.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.3.0"
+version = "8.4.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.3.0"
+version = "8.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 8.4.0

**Headline:** cross-session memory grows a lessons brain — the ~380-lesson engineering corpus becomes retrievable (`attune.lessons`, P@3 96%), `/recall` searches it, and a new UserPromptSubmit hook surfaces matching lessons automatically. This release also puts the recall-loop reliability fixes (#769) and SDK workflow improvements into live plugin sessions.

- Version bumped across all 7 sites (pyproject, plugin manifests ×4 fields, API_REFERENCE, CLAUDE.md) — PyPI ≡ plugin manifest policy.
- Changelog promoted to `[8.4.0] — 2026-06-11`; fresh `[Unreleased]` above.
- `uv.lock`: self-version line only.

Post-merge: tag from the merge SHA, publish via trusted publishing, then `claude plugin update attune-ai` puts the new hooks into live sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)