### PR TITLE
fix(website): correct stale counts/versions + OS-layer section

### DIFF
--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -40,7 +40,7 @@ const faqItems = [
   {
     question: 'What Claude Code skills are included?',
     answer:
-      '14 auto-invoking skills: security audit, smart test, code review, deep review, doc generation, refactoring, bug prediction, release prep, planning, brainstorming, workflow orchestration, fix-test, spec-driven development, and the coach help system.',
+      '17 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, the coach help system, and the attune hub router.',
   },
   {
     question: 'Where do I install attune-help and attune-author from?',
@@ -61,11 +61,14 @@ const workflows = [
   { name: 'Release Prep', description: 'Changelog, version bump, health checks' },
 ];
 
+// The 17 plugin skills — keep in sync with plugin/skills/
+// (test_skill_count asserts the directory count).
 const skills = [
-  '/security', '/smart-test', '/code-quality', '/deep-review',
-  '/doc-gen', '/refactor', '/release', '/plan',
-  '/brainstorm', '/spec', '/fix-test', '/bulk',
-  '/coach', '/attune',
+  'security-audit', 'smart-test', 'code-quality', 'bug-predict',
+  'doc-gen', 'refactor-plan', 'release-prep', 'planning',
+  'spec', 'fix-test', 'workflow-orchestration', 'rag-code-gen',
+  'verify', 'recall', 'memory-and-context', 'coach',
+  'attune-hub',
 ];
 
 export default function DocsPage() {
@@ -165,7 +168,7 @@ export default function DocsPage() {
                   <h3 className="text-lg font-bold mb-2">attune-ai</h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     Generate, maintain, and serve help from your codebase.
-                    15 workflows, 14 skills, MCP server.
+                    17 workflows, 17 skills, MCP server.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -182,7 +185,7 @@ export default function DocsPage() {
                   </div>
                   <h3 className="text-lg font-bold mb-2">attune-author</h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
-                    Generate 11 kinds of source-grounded templates with
+                    Generate 15 kinds of source-grounded templates with
                     per-type polish prompts. Pairs with attune-help.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3 break-all">
@@ -492,7 +495,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 Install from the marketplace. Progressive help, project
-                bootstrapping, and 14 skills right in your terminal.
+                bootstrapping, and 17 skills right in your terminal.
               </p>
 
               <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 mb-8">
@@ -558,7 +561,7 @@ export default function DocsPage() {
                 Workflows &amp; Skills
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                attune-ai includes 15 multi-stage workflows, 14
+                attune-ai includes 17 multi-stage workflows, 17
                 auto-invoking Claude Code skills, and an MCP server
                 with 41 registered tools.
               </p>
@@ -585,7 +588,7 @@ export default function DocsPage() {
 
                 <div>
                   <h3 className="font-bold text-lg mb-4">
-                    14 Claude Code Skills
+                    17 Claude Code Skills
                   </h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-4">
                     Skills auto-invoke from natural language. Type the topic

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -206,9 +206,11 @@ export default function Home() {
                 <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-3 block">Sister Family</span>
                 <h2 className="text-3xl font-extrabold mb-6">The Documentation Toolchain</h2>
                 <p className="text-[var(--text-secondary)] mb-8 leading-relaxed">
-                  We built attune-ai to make our own docs better. The
-                  doc toolchain split off as four standalone packages
-                  &mdash; an end-to-end author &rarr; reader loop. Use
+                  We built attune-ai to assist engineers working with
+                  Claude and Redis. The documentation toolchain came
+                  later &mdash; built with the same development
+                  discipline, and split off as four standalone packages
+                  forming an end-to-end author &rarr; reader loop. Use
                   the full stack, or drop in just the piece you need.
                 </p>
                 <ul className="space-y-5">

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v6.5.4</span>
+                  <span>v8.4.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">AI Workflow OS for Claude Code</span>
                 </div>
@@ -56,7 +56,7 @@ export default function Home() {
                   <span className="text-gradient">Claude Code</span>
                 </h1>
                 <p className="text-lg md:text-xl text-[var(--text-secondary)] mb-10 max-w-xl leading-relaxed">
-                  15 workflows, 14 auto-triggering skills, MCP server with 41 tools.
+                  17 workflows, 17 auto-triggering skills, MCP server with 41 tools.
                   Plus the documentation toolchain we built along the way &mdash;
                   now four standalone packages.
                 </p>
@@ -166,7 +166,7 @@ export default function Home() {
                     <div>
                       <div className="font-semibold text-sm"><code className="font-mono">attune-author</code></div>
                       <p className="text-xs text-[var(--text-secondary)] leading-relaxed mt-1">
-                        Generates 11 kinds of source-grounded templates with
+                        Generates 15 kinds of source-grounded templates with
                         per-type LLM polish. Runs at dev time or in CI.
                       </p>
                     </div>
@@ -227,6 +227,57 @@ export default function Home() {
         </section>
 
         {/* Four Product Cards */}
+        {/* OS layer: workflows + memory */}
+        <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="The OS layer">
+          <div className="text-center mb-20">
+            <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">The OS Layer</span>
+            <h2 className="text-4xl md:text-5xl font-extrabold">Workflows That Remember</h2>
+            <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
+              What makes it an OS, not a toolbox: orchestrated workflows
+              on top, persistent memory underneath. Your AI collaborator
+              stops starting from zero.
+            </p>
+          </div>
+          <div className="grid md:grid-cols-3 gap-6">
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
+                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#9881;&#65039;</span>
+              </div>
+              <h3 className="text-xl font-bold mb-3">Orchestrated Workflows</h3>
+              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
+                17 multi-stage workflows — security audit, code review,
+                bug prediction, release prep — with cost-tiered model
+                routing and structured, readable reports. Works on a
+                Claude subscription or an API key.
+              </p>
+            </div>
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--secondary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--secondary)] transition-colors">
+                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#129504;</span>
+              </div>
+              <h3 className="text-xl font-bold mb-3">Cross-Session Memory</h3>
+              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
+                Findings from each session are stashed and recalled in
+                the next. A retrievable lessons corpus surfaces the
+                right engineering lesson at the moment a prompt needs
+                it — automatically, or on demand with /recall.
+              </p>
+            </div>
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--accent)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--accent)] transition-colors">
+                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#128190;</span>
+              </div>
+              <h3 className="text-xl font-bold mb-3">Redis Semantic Tier</h3>
+              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
+                Local-first by default; plug in Redis Agent Memory
+                Server for semantic search over your memory — local
+                Ollama embeddings, no cloud required. Our int8 vector
+                quantization work is an open upstream PR to Redis.
+              </p>
+            </div>
+          </div>
+        </section>
+
         <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="Products">
           <div className="text-center mb-20">
             <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">Core Capabilities</span>
@@ -245,7 +296,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Full framework. Workflows, staleness detection, MCP server, and 14 auto-triggering skills for Claude Code.
+                Full framework. Workflows, staleness detection, MCP server, and 17 auto-triggering skills for Claude Code.
               </p>
             </div>
 
@@ -267,7 +318,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-author</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                AI authoring companion. Generates 11 kinds of source-grounded templates with per-type polish prompts.
+                AI authoring companion. Generates 15 kinds of source-grounded templates with per-type polish prompts.
               </p>
             </div>
 

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -148,6 +148,57 @@ export default function Home() {
         </section>
 
         {/* Platform overview — one code sample, three packages */}
+        {/* OS layer: workflows + memory */}
+        <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="The OS layer">
+          <div className="text-center mb-20">
+            <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">The OS Layer</span>
+            <h2 className="text-4xl md:text-5xl font-extrabold">Workflows That Remember</h2>
+            <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
+              What makes it an OS, not a toolbox: orchestrated workflows
+              on top, persistent memory underneath. Your AI collaborator
+              stops starting from zero.
+            </p>
+          </div>
+          <div className="grid md:grid-cols-3 gap-6">
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
+                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#9881;&#65039;</span>
+              </div>
+              <h3 className="text-xl font-bold mb-3">Orchestrated Workflows</h3>
+              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
+                17 multi-stage workflows — security audit, code review,
+                bug prediction, release prep — with cost-tiered model
+                routing and structured, readable reports. Works on a
+                Claude subscription or an API key.
+              </p>
+            </div>
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--secondary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--secondary)] transition-colors">
+                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#129504;</span>
+              </div>
+              <h3 className="text-xl font-bold mb-3">Cross-Session Memory</h3>
+              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
+                Findings from each session are stashed and recalled in
+                the next. A retrievable lessons corpus surfaces the
+                right engineering lesson at the moment a prompt needs
+                it — automatically, or on demand with /recall.
+              </p>
+            </div>
+            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
+              <div className="w-14 h-14 rounded-xl bg-[var(--accent)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--accent)] transition-colors">
+                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#128190;</span>
+              </div>
+              <h3 className="text-xl font-bold mb-3">Redis Semantic Tier</h3>
+              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
+                Local-first by default; plug in Redis Agent Memory
+                Server for semantic search over your memory — local
+                Ollama embeddings, no cloud required. Our int8 vector
+                quantization work is an open upstream PR to Redis.
+              </p>
+            </div>
+          </div>
+        </section>
+
         <section className="py-24 bg-[var(--surface-container-low)]" aria-label="Platform overview">
           <div className="max-w-7xl mx-auto px-6">
             <div className="flex flex-col md:flex-row gap-16 items-start">
@@ -227,57 +278,6 @@ export default function Home() {
         </section>
 
         {/* Four Product Cards */}
-        {/* OS layer: workflows + memory */}
-        <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="The OS layer">
-          <div className="text-center mb-20">
-            <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">The OS Layer</span>
-            <h2 className="text-4xl md:text-5xl font-extrabold">Workflows That Remember</h2>
-            <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
-              What makes it an OS, not a toolbox: orchestrated workflows
-              on top, persistent memory underneath. Your AI collaborator
-              stops starting from zero.
-            </p>
-          </div>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
-                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#9881;&#65039;</span>
-              </div>
-              <h3 className="text-xl font-bold mb-3">Orchestrated Workflows</h3>
-              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                17 multi-stage workflows — security audit, code review,
-                bug prediction, release prep — with cost-tiered model
-                routing and structured, readable reports. Works on a
-                Claude subscription or an API key.
-              </p>
-            </div>
-            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--secondary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--secondary)] transition-colors">
-                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#129504;</span>
-              </div>
-              <h3 className="text-xl font-bold mb-3">Cross-Session Memory</h3>
-              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Findings from each session are stashed and recalled in
-                the next. A retrievable lessons corpus surfaces the
-                right engineering lesson at the moment a prompt needs
-                it — automatically, or on demand with /recall.
-              </p>
-            </div>
-            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--accent)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--accent)] transition-colors">
-                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#128190;</span>
-              </div>
-              <h3 className="text-xl font-bold mb-3">Redis Semantic Tier</h3>
-              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Local-first by default; plug in Redis Agent Memory
-                Server for semantic search over your memory — local
-                Ollama embeddings, no cloud required. Our int8 vector
-                quantization work is an open upstream PR to Redis.
-              </p>
-            </div>
-          </div>
-        </section>
-
         <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="Products">
           <div className="text-center mb-20">
             <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">Core Capabilities</span>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -206,9 +206,10 @@ export default function Home() {
                 <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-3 block">Sister Family</span>
                 <h2 className="text-3xl font-extrabold mb-6">The Documentation Toolchain</h2>
                 <p className="text-[var(--text-secondary)] mb-8 leading-relaxed">
-                  We built attune-ai to assist engineers working with
-                  Claude and Redis. The documentation toolchain came
-                  later &mdash; built with the same development
+                  attune-ai began as a tool to help people work with
+                  AI, then grew into an engineering toolkit focused on
+                  Claude &mdash; and later Redis. The documentation
+                  toolchain came after, built with the same development
                   discipline, and split off as four standalone packages
                   forming an end-to-end author &rarr; reader loop. Use
                   the full stack, or drop in just the piece you need.

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -192,8 +192,10 @@ export default function Home() {
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
                 Local-first by default; plug in Redis Agent Memory
                 Server for semantic search over your memory — local
-                Ollama embeddings, no cloud required. Our int8 vector
-                quantization work is an open upstream PR to Redis.
+                Ollama embeddings, no cloud required. Enable it with{' '}
+                <code className="text-xs">pip install &apos;attune-ai[redis]&apos;</code>{' '}
+                plus a local AMS service. Our int8 vector quantization
+                work is an open upstream PR to Redis.
               </p>
             </div>
           </div>

--- a/website/app/pricing/page.tsx
+++ b/website/app/pricing/page.tsx
@@ -15,7 +15,7 @@ const includedItems = [
   'Help content generation from source code',
   'Progressive depth templates (concept / task / reference)',
   'Staleness detection and auto-regeneration',
-  'Claude Code plugin with 14 skills',
+  'Claude Code plugin with 17 skills',
   'Standalone reader (attune-help)',
   'Full source code access',
   'Community support on GitHub',

--- a/website/components/TestsBadge.tsx
+++ b/website/components/TestsBadge.tsx
@@ -3,8 +3,10 @@ interface TestsBadgeProps {
   coverage?: number;
 }
 
+// Defaults verified 2026-06-11: `pytest --collect-only` = 21,386;
+// coverage floor enforced by --cov-fail-under=85 in pyproject.
 export default function TestsBadge({
-  tests = 10860,
+  tests = 21386,
   coverage = 85
 }: TestsBadgeProps) {
   return (

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -30,7 +30,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "5.10.1",
+    version: "8.4.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -44,7 +44,7 @@ export const PRODUCTS: Product[] = [
       "Generate concept, task, and reference templates",
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
-      "14 Claude Code skills included",
+      "17 Claude Code skills included",
       "MCP server with 41 registered tools",
     ],
   },
@@ -52,7 +52,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-help",
     name: "Attune Help",
     pypiName: "attune-help",
-    version: "0.3.1",
+    version: "0.11.1",
     tagline: "Lightweight reader for help templates",
     installCommand: "pip install attune-help",
     marketplaceInstall:
@@ -74,19 +74,20 @@ export const PRODUCTS: Product[] = [
     id: "attune-author",
     name: "Attune Author",
     pypiName: "attune-author",
-    version: "0.2.0",
+    version: "0.16.0",
     tagline: "Author and polish help content with AI",
     installCommand: "pip install 'attune-author[plugin]'",
     marketplaceInstall:
       "claude plugin install attune-author@attune-docs",
     description:
-      "The AI authoring companion for attune-help. Generates 11 kinds " +
-      "of source-grounded templates — concept, task, reference, error, " +
-      "warning, troubleshooting, faq, quickstart, tip, note, and " +
-      "comparison — with per-type LLM polish prompts and typed source " +
-      "summaries so the output stays accurate.",
+      "The AI authoring companion for attune-help. Generates 15 kinds " +
+      "of source-grounded templates — concept, task, reference, " +
+      "how-to, tutorial, architecture, cli-reference, error, warning, " +
+      "troubleshooting, faq, quickstart, tip, note, and comparison — " +
+      "with per-type LLM polish prompts and typed source summaries so " +
+      "the output stays accurate.",
     features: [
-      "11 meta-template kinds (up from 3 in v0.1.0)",
+      "15 meta-template kinds (up from 3 in v0.1.0)",
       "Per-type LLM polish prompts with anti-pattern lists",
       "Signature-aware source summaries (typed args + return)",
       "Strict polish mode for CI (ATTUNE_AUTHOR_STRICT_POLISH)",
@@ -98,7 +99,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "5.10.1",
+    version: "8.4.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",
@@ -114,7 +115,7 @@ export const PRODUCTS: Product[] = [
       "/coach status — check template freshness",
       "/coach maintain — regenerate stale templates",
       "Auto-triggers on natural language (help, explain, learn)",
-      "14 auto-triggering skills (security, testing, review, etc.)",
+      "17 auto-triggering skills (security, testing, review, etc.)",
     ],
   },
 ];
@@ -245,21 +246,25 @@ export const DIFFERENTIATORS: Differentiator[] = [
 /**
  * Counts that appear in prose and stat callouts across the
  * site. Verified against the live Python code per the
- * website-content-accuracy rule:
+ * website-content-accuracy rule (last verified 2026-06-11,
+ * attune-ai 8.4.0):
  *
  *   workflows: attune.workflows.list_workflows() with stages
- *   skills: plugin/skills/ directory count
- *   mcpTools: EmpathyMCPServer().tools length
+ *   skills: plugin/skills/ directory count (test_skill_count)
+ *   mcpTools: attune.mcp.tool_schemas get_*_tools() total
  *   templateKinds: attune_author.generator._ALL_TEMPLATE_NAMES length
+ *   wizards: attune.wizards.list_wizards() length
+ *
+ * (agentTemplates / compositionPatterns were dropped 2026-06-11:
+ * the registries they referenced no longer exist in that shape
+ * and no page consumed them.)
  */
 export const CAPABILITIES = {
-  workflows: 15,
-  skills: 14,
+  workflows: 17,
+  skills: 17,
   mcpTools: 41,
-  templateKinds: 11,
+  templateKinds: 15,
   wizards: 5,
-  agentTemplates: 14,
-  compositionPatterns: 6,
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

smartaimemory.com accuracy pass (Patrick-requested), every count verified against live code per the website-content-accuracy rule:

| Claim | Was | Is | Verified against |
|---|---|---|---|
| Workflows | 15 | **17** | `list_workflows()` with stages |
| Skills | 14 | **17** | `plugin/skills/` (+ `test_skill_count`) — chips now name the real 17 |
| Template kinds | 11 | **15** | `attune_author.generator._ALL_TEMPLATE_NAMES` |
| Hero version | v6.5.4 | **v8.4.0** | PyPI |
| features.ts versions | 5.10.1 / 0.3.1 / 0.2.0 | 8.4.0 / 0.11.1 / 0.16.0 | PyPI |
| Tests badge | 10,860 | **21,386** | `pytest --collect-only` (2026-06-11) |

Plus: `CAPABILITIES` corrected (dropped two keys whose registries no longer exist; zero consumers), and a new landing-page section **"The OS Layer — Workflows That Remember"** covering orchestrated workflows, cross-session memory, and the Redis semantic tier. Redis claims pre-verified: no `pip install attune-redis` (unpublished); int8 quantization described as an open upstream PR (redis/agent-memory-server#302).

Blog posts intentionally untouched (historical artifacts, per the phase0-audit convention).

Rendering verified in local preview (snapshot + screenshot, hero + new section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)