### PR TITLE
docs(.help): regenerate memory + plugin templates (8.4.0 regen)

### DIFF
--- a/.help/templates/memory/concept.md
+++ b/.help/templates/memory/concept.md
@@ -3,53 +3,52 @@ type: concept
 name: memory-concept
 feature: memory
 depth: concept
-generated_at: 2026-06-10T07:07:04.767860+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-12T00:20:52.581029+00:00
+source_hash: 439162c85525d4aff627199f05d3f52d259589b86b947c5b2f62b832a0d15fae
 status: generated
+scaffold_hash: fc0d9984517f8c22ce4ac76cb18edf9fd2a3bcc4d42b5edbc949332d6846906e
 ---
 
 # Memory
 
-Attune's memory system gives agents a structured way to store, retrieve, search, and secure information across sessions — from ephemeral key-value entries held in Redis to project-scoped knowledge loaded from `CLAUDE.md` files.
+Attune AI memory is a three-layer system that gives agents short-term working storage, searchable long-term pattern recall, and static project context — all with built-in classification, PII scrubbing, and secrets detection before anything reaches persistent storage.
 
-## Two storage tiers
+## Memory layers
 
-The system separates memory into two distinct tiers that serve different lifespans and access patterns.
+Each layer serves a different retention horizon and access pattern.
 
-**Short-term memory** is governed by the `MemoryBackend` protocol. Any backend that implements this protocol exposes five core operations: `stash`, `retrieve`, `delete`, `keys`, and `close`, plus diagnostic methods (`is_connected`, `get_stats`). The `stash` method accepts an optional `ttl` and an optional `agent_id`, so entries can be scoped to a specific agent and expire automatically. Redis is the default short-term backend; `is_redis_available()` lets you check whether the Redis subsystem is reachable before attempting a connection.
+**Short-term agent memory** is a keyed store scoped per `agent_id`, backed by any class that implements the `MemoryBackend` protocol. The core operations are `stash(key, value, ttl, agent_id)`, `retrieve(key, agent_id)`, `delete(key)`, and `keys(pattern)`. An optional `ttl` argument expires entries automatically. Two capability flags determine backend fitness for your deployment: `supports_realtime()` and `supports_distributed()`. A Redis-backed store passes both; an in-process mock typically passes neither. Call `is_connected()` before use and `get_stats()` for runtime metrics.
 
-**Long-term, searchable memory** extends the base protocol through `SearchableMemoryBackend`. This layer adds semantic operations — `search`, `remember`, `recent`, `promote`, and `prune` — that let agents query by meaning rather than exact key. `promote` moves entries from a session into durable storage; `prune` removes entries older than a configurable `max_age_days`.
+**Long-term searchable memory** extends `MemoryBackend` through the `SearchableMemoryBackend` protocol. Rather than retrieving by exact key, you query by content: `search(query, limit)` returns ranked results, and `recent(limit)` surfaces the most recently stored entries. Use `remember(content, topics=[...])` to store an entry, `promote(session_id)` to graduate session-scoped memories into the durable store, and `prune(max_age_days)` to expire stale entries.
 
-## CLAUDE.md memory files
+**Static project context** comes from CLAUDE.md files resolved at enterprise, user, and project levels. `ClaudeMemoryLoader` reads these files in order — controlled by the `load_enterprise`, `load_user`, and `load_project` fields on `ClaudeMemoryConfig` — and returns a single merged string from `load_all_memory()`. Files that import other paths are followed recursively up to `max_import_depth` (default `5`). Set `validate_files=True` to reject any file that exceeds `max_file_size_bytes` (default `1000000` bytes). To bootstrap a new project, `create_default_project_memory(project_root, framework='empathy')` writes a starter `.claude/CLAUDE.md` with the expected structure.
 
-A separate mechanism handles project-scoped knowledge: `CLAUDE.md` files that live in the repository and are loaded at startup. `ClaudeMemoryLoader` reads these files according to a `ClaudeMemoryConfig`, which controls which levels are loaded (`load_enterprise`, `load_user`, `load_project`), where to look for them (`enterprise_memory_path`, `project_root`), and how deep to follow `@import` chains (`max_import_depth`, default `5`). Each file that is loaded becomes a `MemoryFile` dataclass carrying its `level`, `path`, `content`, `imports`, and `load_order`.
+## Security controls
 
-`load_all_memory` returns the combined content as a single string ready for injection into a model context. `get_loaded_files` lists the paths that contributed to that string, which is useful for debugging import chains. You can create a starter file for a new project with `create_default_project_memory(project_root, framework)`.
+Classification and scrubbing run before any pattern reaches durable storage. `ClassificationRules` assigns a `Classification` level using keyword lists (`HEALTHCARE_KEYWORDS`, `FINANCIAL_KEYWORDS`, `PROPRIETARY_KEYWORDS`) and type lists (`SENSITIVE_PATTERN_TYPES`, `INTERNAL_PATTERN_TYPES`). The `PIIScrubber` strips personally identifiable information, and `SecretsDetector` flags credential-like content. `EncryptionManager` handles at-rest encryption for patterns that require it. `AuditLogger` records every write and access as an `AuditEvent` for compliance trails.
 
-## Security and classification
+## Enterprise control surface
 
-Content stored in long-term memory is classified before it is persisted. The `Classification` system recognises healthcare (`HEALTHCARE_KEYWORDS`), financial (`FINANCIAL_KEYWORDS`), and proprietary (`PROPRIETARY_KEYWORDS`) content, and maps pattern types to sensitivity tiers via `SENSITIVE_PATTERN_TYPES` and `INTERNAL_PATTERN_TYPES`. `PIIScrubber` and `SecretsDetector` run as guards to prevent personally identifiable information and secrets from reaching storage. Access control is enforced through `check_access` and surfaces as `MemoryPermissionError` or `SecurityError` when a caller lacks the required tier.
+`MemoryControlPanel` exposes runtime operations without requiring code changes. You can check `status()` and `health_check()`, browse stored patterns with `list_patterns(classification=None, limit=100)`, remove a specific pattern with `delete_pattern(pattern_id, user_id)`, bulk-clear short-term entries with `clear_short_term(agent_id)`, and export pattern sets to disk with `export_patterns(output_path)`.
 
-## Enterprise control panel
+The panel is configured through `ControlPanelConfig`, which defaults Redis to `localhost:6379` and uses `./memdocs_storage` for pattern documents. When `auto_start_redis=True`, the panel starts Redis automatically if it isn't already running.
 
-`MemoryControlPanel` (configured via `ControlPanelConfig`) exposes operational controls for the short-term store: `start_redis`, `stop_redis`, `clear_short_term`, `list_patterns`, `delete_pattern`, `export_patterns`, and `health_check`. `get_statistics` returns a `MemoryStats` snapshot. These operations are also available over HTTP through `MemoryAPIHandler`, which applies `RateLimiter` (per-IP, sliding window) and `APIKeyAuth` before forwarding requests to the panel. Use `run_api_server` to start the HTTP interface.
+`run_api_server(panel, host, port)` wraps the panel in an HTTP server backed by `MemoryAPIHandler`, which handles `GET`, `POST`, `DELETE`, and `OPTIONS` requests. Optional arguments let you add TLS (`ssl_certfile`, `ssl_keyfile`), restrict access with `APIKeyAuth` (via `api_key`), and enforce request budgets with `RateLimiter` (`rate_limit_requests`, `rate_limit_window`). Set `allowed_origins` for CORS control.
 
-## How the pieces fit together
+For Railway deployments, `get_railway_redis()` reads `REDIS_URL` from the environment and raises `OSError` with setup instructions if the variable is absent.
 
-```
-Agent
-  │
-  ├─► MemoryBackend (stash / retrieve)          ← short-term, keyed, TTL-aware
-  │       └─► RedisShortTermMemory              ← default implementation
-  │
-  ├─► SearchableMemoryBackend (search / remember / promote)
-  │       └─► long-term semantic store          ← promoted from sessions
-  │
-  ├─► ClaudeMemoryLoader (load_all_memory)      ← project knowledge at startup
-  │       └─► MemoryFile[]                      ← one per CLAUDE.md in the tree
-  │
-  └─► MemoryControlPanel                        ← operational management
-          └─► MemoryAPIHandler (HTTP)            ← remote access with auth + rate limiting
-```
+## Integration surface
 
-Short-term entries flow up to long-term storage through `promote`. Long-term entries are kept fresh by `prune` and surfaced by `search` and `recent`. Project-level knowledge from `CLAUDE.md` files is read-only at runtime and injected directly into model context by `load_all_memory`.
+| Type | Name | Role |
+|------|------|------|
+| Protocol | `MemoryBackend` | Short-term key-value store with TTL and agent scoping |
+| Protocol | `SearchableMemoryBackend` | Extends `MemoryBackend` with semantic search, promotion, and pruning |
+| Dataclass | `ClaudeMemoryConfig` | Controls which CLAUDE.md levels load, import depth, and file-size limits |
+| Dataclass | `MemoryFile` | One resolved CLAUDE.md file: `level`, `path`, `content`, `imports`, `load_order` |
+| Class | `ClaudeMemoryLoader` | Resolves and merges CLAUDE.md files; primary entry point is `load_all_memory()` |
+| Class | `MemoryControlPanel` | Runtime management for patterns, short-term entries, and Redis lifecycle |
+| Dataclass | `ControlPanelConfig` | Redis coordinates (`redis_host`, `redis_port`) and storage paths for the control panel |
+| Function | `is_redis_available()` | Lightweight probe that checks Redis availability without importing the subsystem |
+| Function | `get_redis_memory(url, use_mock)` | Factory that reads environment config and returns a `RedisShortTermMemory` instance |
+| Function | `get_railway_redis()` | Railway-specific factory; raises `OSError` if `REDIS_URL` is absent |
+| Function | `create_default_project_memory(project_root, framework)` | Writes a starter CLAUDE.md to bootstrap a new project |

--- a/.help/templates/memory/reference.md
+++ b/.help/templates/memory/reference.md
@@ -3,14 +3,15 @@ type: reference
 name: memory-reference
 feature: memory
 depth: reference
-generated_at: 2026-06-10T07:07:04.779091+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-12T00:20:52.589323+00:00
+source_hash: 439162c85525d4aff627199f05d3f52d259589b86b947c5b2f62b832a0d15fae
 status: generated
+scaffold_hash: 8c6258d4a61cd8f4917baaa8a00c3f4054394b40ba97c4386f7c2f7279eb584f
 ---
 
 # Memory reference
 
-Store, retrieve, search, and secure persistent memory across sessions — short-term Redis-backed storage, long-term pattern storage, CLAUDE.md file loading, cross-session coordination, and security controls including PII scrubbing, secret detection, and audit logging.
+Layered storage API for Attune AI agents. Use `MemoryBackend` and `SearchableMemoryBackend` to write short-term data and recall it by semantic query. Use `UnifiedMemory` to combine short-term Redis storage with long-term MemDocs pattern storage in a single interface. Use `ClaudeMemoryLoader` to inject project-level CLAUDE.md files into agent context. Use `MemoryControlPanel` to administer Redis, inspect patterns, and export audit data. The security subpackage provides PII scrubbing, secrets detection, and audit logging. Version: `2.2.0`.
 
 ## Classes
 
@@ -24,21 +25,21 @@ Store, retrieve, search, and secure persistent memory across sessions — short-
 | `ControlPanelConfig` | Configuration for the memory control panel. | `src/attune/memory/control_panel.py` |
 | `MemoryControlPanel` | Enterprise control panel for Empathy memory management. | `src/attune/memory/control_panel.py` |
 | `MemoryAPIHandler` | HTTP request handler for the Memory Control Panel API. | `src/attune/memory/control_panel_api.py` |
-| `RateLimiter` | In-memory rate limiter keyed by IP address. | `src/attune/memory/control_panel_support.py` |
-| `APIKeyAuth` | API key authentication for the control panel. | `src/attune/memory/control_panel_support.py` |
+| `RateLimiter` | Simple in-memory rate limiter by IP address. | `src/attune/memory/control_panel_support.py` |
+| `APIKeyAuth` | Simple API key authentication. | `src/attune/memory/control_panel_support.py` |
 | `MemoryStats` | Statistics for the memory system. | `src/attune/memory/control_panel_support.py` |
 | `CrossSessionCoordinator` | Coordinator for cross-session agent communication. | `src/attune/memory/cross_session/coordinator.py` |
-| `SessionType` | Type of session or agent. | `src/attune/memory/cross_session/models.py` |
+| `SessionType` | Type of session/agent. | `src/attune/memory/cross_session/models.py` |
 | `ConflictStrategy` | Strategy for resolving conflicts between agents. | `src/attune/memory/cross_session/models.py` |
 | `SessionInfo` | Information about an active session. | `src/attune/memory/cross_session/models.py` |
 | `ConflictResult` | Result of a conflict resolution. | `src/attune/memory/cross_session/models.py` |
 | `BackgroundService` | Background service daemon for cross-session coordination. | `src/attune/memory/cross_session/service.py` |
-| `EdgeType` | Types of relationships between nodes. | `src/attune/memory/edges.py` |
+| `EdgeType` | Types of relationships between memory-graph nodes. | `src/attune/memory/edges.py` |
 | `Edge` | An edge connecting two nodes in the memory graph. | `src/attune/memory/edges.py` |
 | `EncryptionManager` | Manages encryption and decryption for `SENSITIVE` patterns. | `src/attune/memory/encryption.py` |
 | `FeatureStatus` | Status of an optional memory feature. | `src/attune/memory/features.py` |
 | `FeatureInfo` | Information about a memory feature. | `src/attune/memory/features.py` |
-| `MemoryFeatures` | Checks availability of memory subsystem features. | `src/attune/memory/features.py` |
+| `MemoryFeatures` | Check availability of memory subsystem features. | `src/attune/memory/features.py` |
 | `FileSessionMemory` | File-based session memory with persistence. | `src/attune/memory/file_session.py` |
 | `FileSessionConfig` | Configuration for file-based session memory. | `src/attune/memory/file_session_models.py` |
 | `WorkingEntry` | Entry in working memory. | `src/attune/memory/file_session_models.py` |
@@ -61,10 +62,10 @@ Store, retrieve, search, and secure persistent memory across sessions — short-
 | `AttuneMemoryTool` | Anthropic Memory tool backed by an attune `MemoryBackend`. | `src/attune/memory/memory_tool.py` |
 | `BackendInitMixin` | Mixin providing backend initialization for `UnifiedMemory`. | `src/attune/memory/mixins/backend_init_mixin.py` |
 | `CapabilitiesMixin` | Mixin providing capability detection and health checks for `UnifiedMemory`. | `src/attune/memory/mixins/capabilities_mixin.py` |
-| `HandoffAndExportMixin` | Mixin providing session handoff and export capabilities for `UnifiedMemory`. | `src/attune/memory/mixins/handoff_mixin.py` |
+| `HandoffAndExportMixin` | Mixin providing session handoff and export for `UnifiedMemory`. | `src/attune/memory/mixins/handoff_mixin.py` |
 | `LifecycleMixin` | Mixin providing lifecycle management for `UnifiedMemory`. | `src/attune/memory/mixins/lifecycle_mixin.py` |
 | `LongTermOperationsMixin` | Mixin providing long-term memory operations for `UnifiedMemory`. | `src/attune/memory/mixins/long_term_mixin.py` |
-| `PatternPromotionMixin` | Mixin providing pattern promotion capabilities for `UnifiedMemory`. | `src/attune/memory/mixins/promotion_mixin.py` |
+| `PatternPromotionMixin` | Mixin providing pattern promotion for `UnifiedMemory`. | `src/attune/memory/mixins/promotion_mixin.py` |
 | `ShortTermOperationsMixin` | Mixin providing short-term memory operations for `UnifiedMemory`. | `src/attune/memory/mixins/short_term_mixin.py` |
 | `NodeType` | Types of nodes in the memory graph. | `src/attune/memory/nodes.py` |
 | `Node` | A node in the memory graph. | `src/attune/memory/nodes.py` |
@@ -72,21 +73,21 @@ Store, retrieve, search, and secure persistent memory across sessions — short-
 | `VulnerabilityNode` | Specialized node for security vulnerabilities. | `src/attune/memory/nodes.py` |
 | `PerformanceNode` | Specialized node for performance issues. | `src/attune/memory/nodes.py` |
 | `PatternNode` | Specialized node for code patterns. | `src/attune/memory/nodes.py` |
-| `PersonalMemory` | Stores and retrieves personal cross-session memory. | `src/attune/memory/personal.py` |
+| `PersonalMemory` | Store and retrieve personal cross-session memory. | `src/attune/memory/personal.py` |
 | `RedisDetectionResult` | Result of Redis auto-detection. | `src/attune/memory/redis_auto_detect.py` |
-| `RedisAutoDetector` | Auto-detects Redis availability and manages user preferences. | `src/attune/memory/redis_auto_detect.py` |
+| `RedisAutoDetector` | Auto-detect Redis availability and manage user preferences. | `src/attune/memory/redis_auto_detect.py` |
 | `RedisStartMethod` | Methods for starting Redis, in order of preference. | `src/attune/memory/redis_bootstrap.py` |
 | `RedisStatus` | Status of a Redis connection or startup attempt. | `src/attune/memory/redis_bootstrap.py` |
 | `AuditLogger` | Comprehensive audit logging for Attune AI. | `src/attune/memory/security/audit_logger.py` |
 | `AuditEvent` | Represents a single audit event. | `src/attune/memory/security/events.py` |
 | `SecurityViolation` | Represents a security policy violation. | `src/attune/memory/security/events.py` |
-| `AuditLogMethodsMixin` | Mixin that adds event-specific logging methods. | `src/attune/memory/security/log_methods.py` |
+| `AuditLogMethodsMixin` | Mixin that adds event-specific logging methods to `AuditLogger`. | `src/attune/memory/security/log_methods.py` |
 | `PIIDetection` | Details about a detected PII instance. | `src/attune/memory/security/pii_scrubber.py` |
 | `PIIPattern` | Definition of a PII detection pattern. | `src/attune/memory/security/pii_scrubber.py` |
 | `PIIScrubber` | Comprehensive PII detection and scrubbing system. | `src/attune/memory/security/pii_scrubber.py` |
 | `AuditQueryMixin` | Mixin that adds query capabilities to `AuditLogger`. | `src/attune/memory/security/query.py` |
 | `AuditReportMixin` | Mixin that adds reporting capabilities to `AuditLogger`. | `src/attune/memory/security/reports.py` |
-| `SecretsDetector` | Detects secrets in text content using pattern matching and entropy analysis. | `src/attune/memory/security/secrets_detector.py` |
+| `SecretsDetector` | Detects secrets using pattern matching and entropy analysis. | `src/attune/memory/security/secrets_detector.py` |
 | `SecretType` | Types of secrets that can be detected. | `src/attune/memory/security/secrets_types.py` |
 | `Severity` | Severity levels for secret detections. | `src/attune/memory/security/secrets_types.py` |
 | `SecretDetection` | Metadata about a detected secret. | `src/attune/memory/security/secrets_types.py` |
@@ -101,7 +102,7 @@ Store, retrieve, search, and secure persistent memory across sessions — short-
 | `PatternStaging` | Pattern staging lifecycle operations. | `src/attune/memory/short_term/patterns.py` |
 | `PubSubManager` | Real-time publish/subscribe operations. | `src/attune/memory/short_term/pubsub.py` |
 | `QueueManager` | Redis list operations for task queues. | `src/attune/memory/short_term/queues.py` |
-| `DataSanitizer` | Handles data sanitization for short-term memory. | `src/attune/memory/short_term/security.py` |
+| `DataSanitizer` | Data sanitization for short-term memory. | `src/attune/memory/short_term/security.py` |
 | `SessionManager` | Collaboration session operations. | `src/attune/memory/short_term/sessions.py` |
 | `StreamManager` | Redis Streams operations for audit trails and event logs. | `src/attune/memory/short_term/streams.py` |
 | `TimelineManager` | Redis sorted set operations for timeline queries. | `src/attune/memory/short_term/timelines.py` |
@@ -120,17 +121,225 @@ Store, retrieve, search, and secure persistent memory across sessions — short-
 | `AgentCredentials` | Agent identity and access permissions. | `src/attune/memory/types.py` |
 | `StagedPattern` | Pattern awaiting validation. | `src/attune/memory/types.py` |
 | `ConflictContext` | Context for principled negotiation. | `src/attune/memory/types.py` |
-| `SecurityError` | Raised when a security policy is violated (for example, secrets detected in data). | `src/attune/memory/types.py` |
+| `SecurityError` | Raised when a security policy is violated (e.g., secrets detected in data). | `src/attune/memory/types.py` |
 | `Environment` | Deployment environment for storage configuration. | `src/attune/memory/unified.py` |
 | `MemoryConfig` | Configuration for the unified memory system. | `src/attune/memory/unified.py` |
 | `UnifiedMemory` | Unified interface for short-term and long-term memory. | `src/attune/memory/unified.py` |
 
-## Protocols
-
-`MemoryBackend` and `SearchableMemoryBackend` define the pluggable backend contracts. Any class that implements all required methods satisfies the protocol without inheriting from it.
-
 ### `MemoryBackend`
 
+`MemoryBackend` is the protocol every short-term storage backend must implement. Pass any conforming backend to `UnifiedMemory`, `AttuneMemoryTool`, or `make_memory_tool`.
+
+#### Methods
+
 | Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `stash` | `key: str
+|--------|-----------|---------|-------------|
+| `stash` | `key: str, value: Any, ttl: int \| None = None, agent_id: str \| None = None` | `bool` | Write a value; returns `True` on success. |
+| `retrieve` | `key: str, agent_id: str \| None = None` | `Any \| None` | Read a value by key, or `None` if absent. |
+| `delete` | `key: str` | `bool` | Remove a key; returns `True` on success. |
+| `keys` | `pattern: str = '*'` | `list[str]` | List keys matching a glob pattern. |
+| `is_connected` | — | `bool` | Return `True` when the backend is reachable. |
+| `get_stats` | — | `dict` | Return backend-specific statistics. |
+| `close` | — | `None` | Release the backend connection. |
+| `supports_realtime` | — | `bool` | Return `True` if the backend supports pub/sub. |
+| `supports_distributed` | — | `bool` | Return `True` if the backend supports distributed access. |
+
+### `SearchableMemoryBackend`
+
+`SearchableMemoryBackend` extends `MemoryBackend` with semantic search, session promotion, and pruning. Use it anywhere you need `search` or `remember` in addition to the base CRUD operations.
+
+#### Methods
+
+Inherits all `MemoryBackend` methods, plus:
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `search` | `query: str, limit: int = 10, **filters: Any` | `list[dict]` | Semantic search over stored memory. |
+| `remember` | `content: str, *, memory_id: str \| None = None, session_id: str \| None = None, topics: list[str] \| None = None` | `bool` | Store content with optional topic metadata. |
+| `promote` | `session_id: str \| None = None` | `bool` | Promote session memory to long-term storage. |
+| `prune` | `max_age_days: int \| None = None` | `int` | Remove stale entries; returns the count removed. |
+| `recent` | `limit: int = 5, **filters: Any` | `list[dict]` | Return the most-recent entries, newest first. |
+
+### `ClaudeMemoryConfig`
+
+Configuration for Claude memory integration. Controls which CLAUDE.md files are loaded and imposes safety limits on file size and import depth.
+
+#### Fields
+
+| Field | Type | Default |
+|-------|------|---------|
+| `enabled` | `bool` | `False` |
+| `load_enterprise` | `bool` | `True` |
+| `load_user` | `bool` | `True` |
+| `load_project` | `bool` | `True` |
+| `enterprise_memory_path` | `str \| None` | `None` |
+| `project_root` | `str \| None` | `None` |
+| `max_import_depth` | `int` | `5` |
+| `max_file_size_bytes` | `int` | `1000000` |
+| `validate_files` | `bool` | `True` |
+
+### `MemoryFile`
+
+Represents a loaded CLAUDE.md memory file with its content and import graph.
+
+#### Fields
+
+| Field | Type | Default |
+|-------|------|---------|
+| `level` | `str` | — |
+| `path` | `str` | — |
+| `content` | `str` | — |
+| `imports` | `list[str]` | `field(default_factory=list)` |
+| `load_order` | `int` | `0` |
+
+### `ControlPanelConfig`
+
+Configuration for the memory control panel, including Redis connection details and storage paths.
+
+#### Fields
+
+| Field | Type | Default |
+|-------|------|---------|
+| `redis_host` | `str` | `'localhost'` |
+| `redis_port` | `int` | `6379` |
+| `storage_dir` | `str` | `'./memdocs_storage'` |
+| `audit_dir` | `str` | `'./logs'` |
+| `auto_start_redis` | `bool` | `True` |
+
+### `ClaudeMemoryLoader`
+
+Loads and manages Claude Code memory files (CLAUDE.md).
+
+#### Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `__init__` | `config: ClaudeMemoryConfig \| None = None` | — | Initialize the loader with optional config. |
+| `load_all_memory` | `project_root: str \| None = None` | `str` | Load and concatenate all CLAUDE.md files into a single string. |
+| `clear_cache` | — | — | Clear the in-memory file cache. |
+| `get_loaded_files` | — | `list[str]` | Return paths of all currently loaded memory files. |
+
+### `MemoryControlPanel`
+
+Enterprise control panel for Empathy memory management. Gives you operational control over Redis, stored patterns, and short-term memory.
+
+#### Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `__init__` | `config: ControlPanelConfig \| None = None` | — | Initialize the panel with optional config. |
+| `status` | — | `dict[str, Any]` | Return current panel and Redis status. |
+| `start_redis` | `verbose: bool = True` | `RedisStatus` | Start Redis and return its status. |
+| `stop_redis` | — | `bool` | Stop Redis; returns `True` on success. |
+| `get_statistics` | — | `MemoryStats` | Return memory usage statistics. |
+| `list_patterns` | `classification: str \| None = None, limit: int = 100` | `list[dict[str, Any]]` | List stored patterns, optionally filtered by classification. |
+| `delete_pattern` | `pattern_id: str, user_id: str = 'admin@system'` | `bool` | Delete a pattern by ID. |
+| `clear_short_term` | `agent_id: str = 'admin'` | `int` | Clear short-term memory for an agent; returns the count removed. |
+| `export_patterns` | `output_path: str, classification: str \| None = None` | `int` | Export patterns to a file; returns the count exported. |
+| `health_check` | — | `dict[str, Any]` | Run a health check and return results. |
+
+### `RateLimiter`
+
+Sliding-window, in-memory rate limiter keyed by client IP address.
+
+#### Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `__init__` | `window_seconds: int = 60, max_requests: int = 100` | — | Initialize with sliding-window parameters. |
+| `is_allowed` | `client_ip: str` | `bool` | Return `True` when the client IP is within its rate limit. |
+| `get_remaining` | `client_ip: str` | `int` | Return the number of requests remaining for the client IP in the current window. |
+
+### `APIKeyAuth`
+
+Single-key API authentication for the Memory Control Panel.
+
+#### Methods
+
+| Method | Parameters | Returns | Description |
+|--------|-----------|---------|-------------|
+| `__init__` | `api_key: str \| None = None` | — | Initialize with an optional API key. |
+| `is_valid` | `provided_key: str \| None` | `bool` | Return `True` when the provided key matches the configured key. |
+
+## Functions
+
+| Function | Parameters | Returns | Description | File |
+|----------|-----------|---------|-------------|------|
+| `is_redis_available` | — | `bool` | Check whether the Redis subsystem is available without importing it. | `src/attune/memory/__init__.py` |
+| `create_default_project_memory` | `project_root: str, framework: str = 'empathy'` | — | Create a default `.claude/CLAUDE.md` file for a project. | `src/attune/memory/claude_memory.py` |
+| `parse_redis_url` | `url: str` | `dict` | Parse a Redis URL into connection parameters. | `src/attune/memory/config.py` |
+| `get_redis_config` | — | `dict` | Return Redis configuration from environment variables (legacy dict API). | `src/attune/memory/config.py` |
+| `get_redis_memory` | `url: str \| None = None, use_mock: bool \| None = None` | `RedisShortTermMemory` | Create a `RedisShortTermMemory` instance using environment-based config. | `src/attune/memory/config.py` |
+| `check_redis_connection` | — | `dict` | Check the Redis connection and return its status. | `src/attune/memory/config.py` |
+| `get_railway_redis` | — | `RedisShortTermMemory` | Return Redis configured for Railway deployment. | `src/attune/memory/config.py` |
+| `run_api_server` | `panel: MemoryControlPanel, host: str = 'localhost', port: int = 8765, api_key: str \| None = None, enable_rate_limit: bool = True, rate_limit_requests: int = 100, rate_limit_window: int = 60, ssl_certfile: str \| None = None, ssl_keyfile: str \| None = None, allowed_origins: list[str] \| None = None` | — | Run the Memory API server with security features enabled. | `src/attune/memory/control_panel_api.py` |
+| `print_status` | `panel: MemoryControlPanel` | — | Print panel status in formatted output. | `src/attune/memory/control_panel_display.py` |
+| `print_stats` | `panel: MemoryControlPanel` | — | Print memory statistics in formatted output. | `src/attune/memory/control_panel_display.py` |
+| `print_health` | `panel: MemoryControlPanel` | — | Print the health check results in formatted output. | `src/attune/memory/control_panel_display.py` |
+| `main` | — | — | CLI entry point for the control panel. | `src/attune/memory/control_panel_display.py` |
+| `resolve_by_priority` | `agent_id: str, access_tier: AccessTier, session_info: SessionInfo, resource_key: str, other_session: SessionInfo \| None` | `ConflictResult` | Resolve a resource conflict using access-tier priority. | `src/attune/memory/cross_session/conflicts.py` |
+| `resolve_first_write` | `agent_id: str, client: Any, resource_key: str, other_session: SessionInfo \| None` | `ConflictResult` | Resolve a conflict using first-write-wins. | `src/attune/memory/cross_session/conflicts.py` |
+| `resolve_last_write` | `agent_id: str, resource_key: str, other_session: SessionInfo \| None` | `ConflictResult` | Resolve a conflict using last-write-wins. | `src/attune/memory/cross_session/conflicts.py` |
+| `generate_agent_id` | `session_type: SessionType` | `str` | Generate a unique agent ID for the given session type. | `src/attune/memory/cross_session/models.py` |
+| `check_redis_cross_session_support` | `memory: RedisShortTermMemory` | `bool` | Check whether Redis supports cross-session communication. | `src/attune/memory/cross_session/service.py` |
+| `get_or_start_service` | `memory: RedisShortTermMemory` | `BackgroundService \| None` | Return the running background service, or start one if none exists. | `src/attune/memory/cross_session/service.py` |
+| `get_file_session_memory` | `user_id: str, base_dir: str = '.attune', **kwargs: Any` | `FileSessionMemory` | Create a file-based session memory instance for a user. | `src/attune/memory/file_session.py` |
+| `classify_pattern` | `content: str, pattern_type: str` | `Classification` | Auto-classify a pattern based on its content and type. | `src/attune/memory/long_term_classification.py` |
+| `check_access` | `user_id: str, classification: Classification, metadata: dict[str, Any]` | `bool` | Return `True` when the user has access to a pattern at the given classification level. | `src/attune/memory/long_term_classification.py` |
+| `make_memory_tool` | `backend: MemoryBackend \| None = None, *, root: str = _DEFAULT_ROOT, user_id: str \| None = None` | `Any` | Build an Anthropic Memory-tool instance backed by an attune backend. | `src/attune/memory/memory_tool.py` |
+| `auto_detect_redis` | — | `RedisDetectionResult` | Auto-detect Redis availability. | `src/attune/memory/redis_auto_detect.py` |
+| `ensure_redis` | `host: str = 'localhost', port: int = 6379, auto_start: bool = True, verbose: bool = True` | `RedisStatus` | Ensure Redis is available, starting it if necessary. | `src/attune/memory/redis_bootstrap.py` |
+| `stop_redis` | `method: RedisStartMethod` | `bool` | Stop Redis if this process started it; returns `True` on success. | `src/attune/memory/redis_bootstrap.py` |
+| `get_redis_or_mock` | `host: str = 'localhost', port: int = 6379` | — | Return a Redis connection, starting Redis if needed, or fall back to a mock. | `src/attune/memory/redis_bootstrap.py` |
+| `detect_secrets` | `content: str, **kwargs` | `list[SecretDetection]` | Detect secrets in text without instantiating a `SecretsDetector`. | `src/attune/memory/security/secrets_detector.py` |
+| `resolve_backend` | `backend: SearchableMemoryBackend \| None = None` | `SearchableMemoryBackend \| None` | Return a searchable backend, or `None` if none is available. | `src/attune/memory/session_stash.py` |
+| `backend_status` | — | `dict` | Report which backend recall resolves to, for health surfacing. | `src/attune/memory/session_stash.py` |
+| `stash_entry` | `entry: SessionStashEntry, backend: SearchableMemoryBackend \| None = None` | `bool` | Write a finding to the searchable recall tier after the PII gate. | `src/attune/memory/session_stash.py` |
+| `recall_entries` | `query: str, top_k: int = 5, cwd: str \| None = None, backend: SearchableMemoryBackend \| None = None` | `list[dict[str, Any]]` | Semantic recall over stashed findings; returns an empty list when unavailable. | `src/attune/memory/session_stash.py` |
+| `recent_entries` | `top_k: int = 5, cwd: str \| None = None, backend: SearchableMemoryBackend \| None = None` | `list[dict[str, Any]]` | Query-less recall of the most-recent findings, for use at session start. | `src/attune/memory/session_stash.py` |
+
+### Raises
+
+#### `get_railway_redis`
+
+| Raises | Message |
+|--------|---------|
+| `OSError` | `'REDIS_URL not found. Make sure Redis is added to your Railway project.\nRun: railway add --database redis\nFor external access, use REDIS_PUBLIC_URL'` |
+
+## Constants
+
+### Cross-session Redis keys
+
+| Constant | Type | Value |
+|---------|------|-------|
+| `CHANNEL_SESSIONS` | `str` | `'empathy:sessions'` |
+| `KEY_ACTIVE_AGENTS` | `str` | `'empathy:active_agents'` |
+| `KEY_SERVICE_LOCK` | `str` | `'empathy:service_lock'` |
+| `KEY_SERVICE_HEARTBEAT` | `str` | `'empathy:service_heartbeat'` |
+
+### CLAUDE.md delimiters
+
+| Constant | Type | Value |
+|---------|------|-------|
+| `_CLAUDE_MD_START` | `str` | `'<!-- attune-lessons-start -->'` |
+| `_CLAUDE_MD_END` | `str` | `'<!-- attune-lessons-end -->'` |
+
+### Classification keywords
+
+These lists drive auto-classification in `classify_pattern`. A pattern whose content matches keywords from one of these constants is assigned the corresponding classification level.
+
+| Constant | Members |
+|---------|---------|
+| `HEALTHCARE_KEYWORDS` | `'patient'`, `'medical'`, `'diagnosis'`, `'treatment'`, `'healthcare'`, `'clinical'`, `'hipaa'`, `'phi'`, `'medical record'`, `'prescription'` |
+| `FINANCIAL_KEYWORDS` | `'financial'`, `'payment'`, `'credit card'`, `'banking'`, `'transaction'`, `'pci dss'`, `'payment card'` |
+| `PROPRIETARY_KEYWORDS` | `'proprietary'`, `'confidential'`, `'internal'`, `'trade secret'`, `'company confidential'`, `'restricted'` |
+| `SENSITIVE_PATTERN_TYPES` | `'clinical_protocol'`, `'medical_guideline'`, `'patient_workflow'`, `'financial_procedure'` |
+| `INTERNAL_PATTERN_TYPES` | `'architecture'`, `'business_logic'`, `'company_process'` |
+
+## Source files
+
+- `src/attune/memory/**`
+
+## Tags
+
+`memory`, `storage`

--- a/.help/templates/memory/task.md
+++ b/.help/templates/memory/task.md
@@ -3,85 +3,152 @@ type: task
 name: memory-task
 feature: memory
 depth: task
-generated_at: 2026-06-10T07:07:04.773986+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-12T00:20:52.586192+00:00
+source_hash: 439162c85525d4aff627199f05d3f52d259589b86b947c5b2f62b832a0d15fae
 status: generated
+scaffold_hash: de9d8b9e160093b1f9e12b058655c619120213c3afb90087452e3c0a307ae0a9
 ---
 
 # Work with memory
 
-Use the memory subsystem when you need to configure, query, or secure agent memory — including short-term Redis-backed storage, Claude memory file loading, and the enterprise control panel.
+Use the memory module when you need agents to stash and retrieve short-term data across sessions, load project-level `CLAUDE.md` context files, or run an HTTP control panel for enterprise memory management.
 
 ## Prerequisites
 
-- Read access to the project source under `src/attune/memory/`
-- A running Redis instance, or the ability to use a mock backend (see `get_redis_memory(use_mock=True)`)
-- `pytest` installed for verification
+- Redis running and reachable—locally at `localhost:6379` or remotely via `REDIS_URL`—for Redis-backed workflows
+- `attune-ai` installed in your Python environment
+- (Railway only) Redis service added to your Railway project and `REDIS_URL` exported
 
-## Steps
+## Connect to Redis memory
 
-1. **Identify the entry point for your use case.**
+1. **Check Redis availability.**
+   Call `is_redis_available()` before attempting a connection. A return value of `False` means the Redis subsystem is not installed; subsequent calls to `get_redis_memory()` will fail.
 
-   Choose the function or class that owns the behavior you need:
+   ```python
+   from attune.memory import is_redis_available
 
-   | Goal | Entry point | Location |
-   |---|---|---|
-   | Check Redis availability before connecting | `is_redis_available()` | `src/attune/memory/__init__.py` |
-   | Create a project-level `CLAUDE.md` memory file | `create_default_project_memory(project_root, framework)` | `src/attune/memory/claude_memory.py` |
-   | Parse a Redis URL into connection parameters | `parse_redis_url(url)` | `src/attune/memory/config.py` |
-   | Load Redis config from environment variables | `get_redis_config()` | `src/attune/memory/config.py` |
-   | Instantiate a `RedisShortTermMemory` backend | `get_redis_memory(url, use_mock)` | `src/attune/memory/config.py` |
-   | Verify the Redis connection status | `check_redis_connection()` | `src/attune/memory/config.py` |
-   | Connect to a Railway-hosted Redis instance | `get_railway_redis()` | `src/attune/memory/config.py` |
-   | Start the Memory API server | `run_api_server(panel, host, port, api_key, ...)` | `src/attune/memory/control_panel_api.py` |
-   | Manage enterprise memory patterns and statistics | `MemoryControlPanel` | `src/attune/memory/control_panel_api.py` |
-   | Load and cache `CLAUDE.md` files | `ClaudeMemoryLoader` | `src/attune/memory/claude_memory.py` |
-
-2. **Configure the backend for your environment.**
-
-   - For short-term Redis-backed memory, call `get_redis_memory()`. Pass a `url` argument to override the default environment variable lookup, or set `use_mock=True` to run without a Redis server.
-   - For Claude memory file loading, instantiate `ClaudeMemoryLoader` with a `ClaudeMemoryConfig`. Set `enabled=True` and configure `load_enterprise`, `load_user`, and `load_project` to control which memory scopes are imported. Use `max_import_depth` and `max_file_size_bytes` to cap resource usage.
-   - For the enterprise control panel, instantiate `MemoryControlPanel` with a `ControlPanelConfig`. Set `redis_host`, `redis_port`, and `storage_dir` to match your deployment. Set `auto_start_redis=True` if you want the panel to manage the Redis process.
-
-3. **Call the appropriate protocol methods on the backend.**
-
-   If you are working with a `MemoryBackend` directly, use these methods:
-
-   - `stash(key, value, ttl, agent_id)` — write a value
-   - `retrieve(key, agent_id)` — read a value
-   - `delete(key)` — remove a value
-   - `keys(pattern)` — list keys matching a glob pattern
-   - `is_connected()` — confirm the backend is reachable
-   - `get_stats()` — retrieve usage statistics
-
-   If your backend implements `SearchableMemoryBackend`, you also have:
-
-   - `remember(content, memory_id, session_id, topics)` — store a memory with metadata
-   - `search(query, limit, **filters)` — run a semantic search
-   - `recent(limit, **filters)` — fetch the most recent memories
-   - `promote(session_id)` — promote session memories to long-term storage
-   - `prune(max_age_days)` — remove memories older than the given age
-
-4. **Load Claude memory files into your project.**
-
-   Call `ClaudeMemoryLoader.load_all_memory(project_root)` to read and concatenate all `CLAUDE.md` files in the hierarchy. Use `get_loaded_files()` to inspect which files were included, and `clear_cache()` to force a fresh load on the next call.
-
-   To bootstrap a new project with a default memory file, call `create_default_project_memory(project_root, framework)`. This creates `.claude/CLAUDE.md` under the given `project_root`.
-
-5. **Run the memory test suite.**
-
-   ```
-   pytest -k "memory"
+   if not is_redis_available():
+       raise RuntimeError("Redis subsystem not available")
    ```
 
-   All tests must pass before you commit changes to this subsystem.
+2. **Create a memory instance.**
+   Call `get_redis_memory()` to build a `RedisShortTermMemory` configured from your environment. Pass `url` to override the default endpoint, or set `use_mock=True` to substitute a test double.
 
-## Verify success
+   ```python
+   from attune.memory import get_redis_memory
 
-You have completed this task successfully when:
+   memory = get_redis_memory()
+   ```
 
-- `is_redis_available()` returns `True` (or your mock backend initializes without error)
-- `check_redis_connection()` returns a dict with a positive connection status
-- `ClaudeMemoryLoader.load_all_memory()` returns a non-empty string containing the expected memory content
-- `MemoryControlPanel.health_check()` returns without errors if you are using the control panel
-- `pytest -k "memory"` passes with no failures
+   For Railway deployments, call `get_railway_redis()` instead. It reads `REDIS_URL` from the Railway environment and raises `OSError` with remediation instructions if the variable is absent.
+
+3. **Verify the connection.**
+   Call `check_redis_connection()` and inspect the returned dict for error keys before starting any agent workloads.
+
+   ```python
+   from attune.memory import check_redis_connection
+
+   status = check_redis_connection()
+   ```
+
+4. **Stash and retrieve values.**
+   Use `stash(key, value, ttl, agent_id)` to write and `retrieve(key, agent_id)` to read. Supply `agent_id` to scope entries to a specific agent.
+
+   ```python
+   memory.stash("last_query", "What is attune?", ttl=300, agent_id="agent-1")
+   result = memory.retrieve("last_query", agent_id="agent-1")
+   ```
+
+**You have succeeded when** `check_redis_connection()` returns without an `error` key and `memory.is_connected()` returns `True`.
+
+## Load Claude Code memory files
+
+1. **Configure the loader.**
+   Build a `ClaudeMemoryConfig` with `enabled=True`. Toggle `load_enterprise`, `load_user`, and `load_project` to control which hierarchy levels are included. Set `project_root` to pin the search location.
+
+   ```python
+   from attune.memory import ClaudeMemoryConfig, ClaudeMemoryLoader
+
+   config = ClaudeMemoryConfig(
+       enabled=True,
+       load_project=True,
+       load_user=True,
+       project_root="/path/to/your/project",
+   )
+   loader = ClaudeMemoryLoader(config)
+   ```
+
+2. **Load the files.**
+   Call `load_all_memory()` to discover, read, and merge all applicable `CLAUDE.md` files. The return value is combined text ready to inject into a system prompt.
+
+   ```python
+   context = loader.load_all_memory()
+   ```
+
+3. **Inspect and refresh.**
+   Call `get_loaded_files()` to see which files were resolved and in what order. If the files on disk have changed, call `clear_cache()` before the next `load_all_memory()` call.
+
+   ```python
+   print(loader.get_loaded_files())
+   loader.clear_cache()
+   ```
+
+4. **Bootstrap a project with no `CLAUDE.md`.**
+   Call `create_default_project_memory(project_root, framework)` to write a starter file at `.claude/CLAUDE.md`. The `framework` argument defaults to `'empathy'`.
+
+   ```python
+   from attune.memory import create_default_project_memory
+
+   create_default_project_memory("/path/to/your/project")
+   ```
+
+**You have succeeded when** `loader.get_loaded_files()` returns a non-empty list and `load_all_memory()` returns non-empty text.
+
+## Run the memory control panel
+
+1. **Configure the panel.**
+   Create a `ControlPanelConfig` pointing at your Redis instance and storage directories, then pass it to `MemoryControlPanel`.
+
+   ```python
+   from attune.memory import ControlPanelConfig, MemoryControlPanel
+
+   config = ControlPanelConfig(
+       redis_host="localhost",
+       redis_port=6379,
+       storage_dir="./memdocs_storage",
+       audit_dir="./logs",
+   )
+   panel = MemoryControlPanel(config)
+   ```
+
+2. **Start the API server.**
+   Call `run_api_server()` with the panel. Set `api_key` to require authentication on every request, and supply `ssl_certfile` and `ssl_keyfile` for TLS. Tune request limits with `rate_limit_requests` and `rate_limit_window`.
+
+   ```python
+   from attune.memory import run_api_server
+
+   run_api_server(
+       panel,
+       host="localhost",
+       port=8765,
+       api_key="your-secret-key",
+       enable_rate_limit=True,
+   )
+   ```
+
+3. **Confirm the server is healthy.**
+   Call `panel.health_check()` before routing production traffic. Use `panel.get_statistics()` to review memory usage and pattern counts, and `print_stats(panel)` for a formatted summary.
+
+   ```python
+   print(panel.health_check())
+   print(panel.get_statistics())
+   ```
+
+**You have succeeded when** `panel.health_check()` returns without error and the server responds on the configured host and port.
+
+## Key files
+
+- `src/attune/memory/__init__.py` — top-level exports and `is_redis_available()`
+- `src/attune/memory/config.py` — `get_redis_memory()`, `parse_redis_url()`, `get_redis_config()`, `check_redis_connection()`, `get_railway_redis()`
+- `src/attune/memory/claude_memory.py` — `ClaudeMemoryConfig`, `ClaudeMemoryLoader`, `create_default_project_memory()`
+- `src/attune/memory/control_panel_api.py` — `MemoryControlPanel`, `ControlPanelConfig`, `run_api_server()`

--- a/.help/templates/plugin/concept.md
+++ b/.help/templates/plugin/concept.md
@@ -3,50 +3,36 @@ type: concept
 name: plugin-concept
 feature: plugin
 depth: concept
-generated_at: 2026-06-11T04:47:10.944816+00:00
-source_hash: bb1dd6bc42134bdd5537798d5887c1172d0c43bf4a6c4c2dc064f90213e6a7b3
+generated_at: 2026-06-12T00:37:02.517564+00:00
+source_hash: e7e856d3cca09a12fdc753f3691d81dfaa025bb8ad4c1459e92ca254b38a9438
 status: generated
-scaffold_hash: 3d3395b06e9c2911139c4e55ee7c889cc29a128f3757a3f2a936cdbc08cafd68
+scaffold_hash: 41c8ef7e7320fa5ba02ff6bb2c51cab36592879c3e7ac3505bbb510d6b91be64
 ---
 
 # Plugin
 
-The attune-ai plugin extends Claude Code with a set of hooks, slash commands, skills, and MCP configuration that orient the AI within your workspace at key moments in a session.
+The attune-ai plugin is a Claude Code extension that installs hooks, slash commands, and MCP configuration to give Claude continuous awareness of your workspace — its in-flight specs, git state, context utilization, and safety boundaries.
 
-## Session lifecycle and hooks
+## Hook responsibilities
 
-The plugin is organized as a collection of hooks, each bound to a specific event in the Claude Code session lifecycle. Understanding when each hook fires gives you a clear picture of what the plugin does and why.
+The plugin's hooks fire at specific Claude Code lifecycle moments. They fall into five categories.
 
-At session start, `welcome.main()` displays workspace orientation and `session_recall.main()` restores context from the previous session. During a session, `jit_recall.main()` injects curated decision-point → rule mappings when the AI reaches a recognized decision point, and `compact_warning.main()` calls `estimate_utilization()` to warn you before context fills. Before any bash command executes, `security_guard.main()` calls `validate_bash_command()` and `validate_file_path()`, blocking writes to system directories such as `/etc`, `/sys`, and `/proc` listed in `SYSTEM_DIRECTORIES`. Commands whose first token appears in `SEARCH_COMMAND_PREFIXES` — for example, `grep`, `rg`, or `git log` — are treated as read-only and validated under more permissive rules. When you save a file, `format_on_save.main()` applies formatting. At session end, `session_stash.main()` persists state for the next session, and `_handoff_cli.main()` backs the `/handoff` slash command.
+**Session continuity** — `welcome`, `session_recall`, and `session_stash` orient Claude at session start and preserve state across interruptions. `spec_orient` calls `discover_specs()` to find in-flight specs under your workspace roots, then formats them into an orientation prompt using `format_orientation()` and `render_spec_pin()`.
 
-Two hooks serve the help system: `help_on_error.main()` surfaces relevant docs when a tool fails, and `help_post_commit.main()` together with `help_freshness_check.main()` flag stale help content after commits.
+**Recall** — `jit_recall` consults a curated decision-point → rule map and injects the matching rule at the moment of decision. `lesson_recall` surfaces stored lessons relevant to the current context.
 
-## Workspace state model
+**Compact warning** — `compact_warning` calls `estimate_utilization()` to measure context window consumption and emits a warning via `format_warning()` when utilization crosses a threshold. A session sentinel keyed by `session_sentinel_path()` ensures the warning fires at most once per session; `prune_stale_sentinels()` removes sentinels that outlive their TTL.
 
-Most hooks share two dataclasses that describe the current workspace.
+**Safety** — `security_guard` validates bash commands against `SEARCH_COMMAND_PREFIXES` and file paths against `SYSTEM_DIRECTORIES` before Claude executes them.
 
-`SpecInfo` represents a single in-flight spec. Call `workspace_roots(cwd)` to locate the roots to scan, then pass the result to `discover_specs(roots)`, which walks the `specs/` and `docs/specs/` subdirectories and returns one `SpecInfo` per file. Each record carries a `slug`, `path`, `layer`, `phase`, `status`, and `mtime`. The derived `effective_status` field resolves any conflict between the spec's own header status and an external override; `status_conflict` is `True` when they disagree. A spec is considered terminal when `effective_status` matches one of the `_TERMINAL_VERDICTS` values — for example, `"shipped"`, `"done"`, or `"superseded"` — and still active when it matches an `_ONGOING_VERDICTS` value such as `"living"` or `"ongoing"`.
+**Help and formatting** — `help_on_error`, `help_post_commit`, and `help_freshness_check` surface relevant help at key moments. `format_on_save` formats files when Claude writes them.
 
-`GitState` is a lightweight snapshot of the worktree at hook-fire time. `git_state(cwd)` returns the current `branch`, the `last_sha` and `last_subject` of the most recent commit, and a `tuple` of `uncommitted` file paths.
+Every hook that must not run inside an SDK-spawned subprocess calls `exit_if_sdk_subprocess()` at startup. You can inspect the gate condition directly with `is_sdk_subprocess()`.
 
-`build_resume_prompt(spec_info, git_state)` combines both into the standard resume-prompt body used by session-boundary hooks. You can pass an optional `todo_summary` and set `workspace_path` (default `~/attune`) to match your layout.
+## Shared state model
 
-## SDK subprocess gating
+Two dataclasses form the shared vocabulary that hooks pass between each other at fire time.
 
-When attune-ai invokes Claude Code through the Agent SDK, it spawns a `claude` subprocess. Interactive hooks must not fire in that context — the output is invisible to you and can interfere with the parent session.
+`SpecInfo` represents one in-flight spec discovered under a workspace root. Its core fields are `slug`, `path`, `layer`, `phase`, `status`, and `mtime`. When a status is ambiguous — for example, when the spec header conflicts with an external source — `effective_status` holds the resolved value, `status_source` records where it came from, and `status_conflict` flags the disagreement. `spec_orient` uses two status categories to decide what to surface: terminal statuses (`closed`, `complete`, `completed`, `retired`, `superseded`, `shipped`, `done`) and ongoing statuses (`living`, `ongoing`).
 
-`is_sdk_subprocess()` detects this condition. Any hook that should self-gate calls `exit_if_sdk_subprocess()` at startup; the call silently exits with code 0 when the subprocess condition is true, leaving the parent session undisturbed. This pattern lets every hook share a single detection path without duplicating logic.
-
-## Public interfaces
-
-Other parts of the codebase interact with the plugin through these interfaces:
-
-| Interface | Purpose | Module |
-|-----------|---------|--------|
-| `SpecInfo` | One in-flight spec discovered under a workspace root | `hooks._state` |
-| `GitState` | Snapshot of the worktree's git state at hook-fire time | `hooks._state` |
-| `discover_specs` | Walks workspace roots and returns all in-flight `SpecInfo` records | `hooks._state` |
-| `build_resume_prompt` | Renders the standard resume-prompt body from workspace state | `hooks._resume_prompt` |
-| `validate_bash_command` | Returns `(allowed, reason)` for a proposed bash command | `hooks.security_guard` |
-| `validate_file_path` | Returns `(allowed, reason)` for a proposed file path | `hooks.security_guard` |
-| `is_sdk_subprocess` | Returns `True` when running inside an SDK-spawned subprocess | `hooks._sdk_gate` |
+`GitState` is a lightweight worktree snapshot carrying the current `branch`, the `last_sha` and `last_subject` of the most recent commit, and any `uncommitted` file paths. `build_resume_prompt()` in `hooks._resume_prompt` accepts both a `SpecInfo` and a `GitState` to assemble the `/handoff` resume prompt — it is the single source of truth for that format.

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -3,33 +3,37 @@ type: reference
 name: plugin-reference
 feature: plugin
 depth: reference
-generated_at: 2026-06-11T04:47:10.950871+00:00
-source_hash: bb1dd6bc42134bdd5537798d5887c1172d0c43bf4a6c4c2dc064f90213e6a7b3
+generated_at: 2026-06-12T00:37:02.524584+00:00
+source_hash: e7e856d3cca09a12fdc753f3691d81dfaa025bb8ad4c1459e92ca254b38a9438
 status: generated
-scaffold_hash: 7d28fde9c63be053e410fbb26d3b2da226e16e2ab69de2f5d5acd275801fc037
+scaffold_hash: 6f4dd2b63d52d539274f6852ceaf44e9ec2a4b35ec27f4d69ffcdcd7d8193d4f
 ---
 
 # Plugin reference
 
-Use this API to manage workspace state, validate shell commands, build session-resume prompts, and hook into Claude Code lifecycle events. Plugin version: `8.3.0`.
+Claude Code plugin — hooks, session management, and security APIs
+
+Use the `hooks` package to build on or extend the attune-ai Claude Code plugin. The package lets you discover in-flight specs, snapshot git state, gate execution in SDK subprocess sessions, validate shell commands, and compose session-start or resume prompts.
 
 ## Classes
 
-| Class | Description | Module |
-|-------|-------------|--------|
-| `SpecInfo` | One in-flight spec discovered under a workspace root. | `hooks._state` |
-| `GitState` | Snapshot of the worktree's git state at hook fire time. | `hooks._state` |
+| Class | Description |
+|-------|-------------|
+| `SpecInfo` | One in-flight spec discovered under a workspace root. |
+| `GitState` | Snapshot of the worktree's git state at hook fire time. |
+
+Both are dataclasses defined in `plugin/hooks/_state.py`.
 
 ### `SpecInfo` fields
 
 | Field | Type | Default |
 |-------|------|---------|
-| `slug` | `str` | — |
-| `path` | `Path` | — |
-| `layer` | `str` | — |
-| `phase` | `str` | — |
-| `status` | `str` | — |
-| `mtime` | `float` | — |
+| `slug` | `str` | |
+| `path` | `Path` | |
+| `layer` | `str` | |
+| `phase` | `str` | |
+| `status` | `str` | |
+| `mtime` | `float` | |
 | `effective_status` | `str` | `''` |
 | `status_source` | `str` | `'header'` |
 | `status_conflict` | `bool` | `False` |
@@ -38,133 +42,56 @@ Use this API to manage workspace state, validate shell commands, build session-r
 
 | Field | Type | Default |
 |-------|------|---------|
-| `branch` | `str` | — |
-| `last_sha` | `str` | — |
-| `last_subject` | `str` | — |
-| `uncommitted` | `tuple[str, ...]` | — |
+| `branch` | `str` | |
+| `last_sha` | `str` | |
+| `last_subject` | `str` | |
+| `uncommitted` | `tuple[str, ...]` | |
 
 ## Functions
 
-Functions are grouped by module.
-
-### `hooks._state`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `discover_specs` | `roots: list[Path]` | `list[SpecInfo]` | Walk `specs/` directories under each root for in-flight specs. |
-| `git_state` | `cwd: Path` | `GitState` | Return branch, last commit, and uncommitted files for `cwd`. |
-| `session_sentinel_path` | `session_id: str | None` | `Path` | Path to the once-per-session compact-warning sentinel. |
-| `prune_stale_sentinels` | `now: float | None = None` | `int` | Delete sentinel files older than the TTL. |
-| `workspace_roots` | `cwd: Path | None = None` | `list[Path]` | Best-effort guess at workspace roots to scan for specs. |
-
-### `hooks._resume_prompt`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `build_resume_prompt` | `spec_info: SpecInfo | None, git_state: GitState, *, workspace_path: str = '~/attune', todo_summary: str | None = None` | `str` | Render the user-facing resume prompt body. |
-
-### `hooks._sdk_gate`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `is_sdk_subprocess` | — | `bool` | True when running inside an SDK-spawned `claude` subprocess. |
-| `exit_if_sdk_subprocess` | — | `None` | Exit 0 with no output when inside an SDK subprocess session. |
-
-### `hooks._transcript_size`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `estimate_utilization` | `transcript_path: str | Path` | `float` | Return estimated context utilization in `[0.0, 1.0]`. |
-
-### `hooks._handoff_cli`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `int` | Entry point for the `/handoff` slash command. Always returns `0`. |
-
-### `hooks.compact_warning`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `format_warning` | `util: float, threshold: float, resume_body: str` | `str` | Compose the user-facing compact warning and resume prompt. |
-| `main` | — | `int` | Entry point — never raises. |
-
-### `hooks.format_on_save`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `None` | Read tool result from stdin and format Python files. |
-
-### `hooks.help_freshness_check`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `None` | Check help template freshness on session start. |
-
-### `hooks.help_on_error`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `None` | Read PostToolUse payload and suggest help if applicable. |
-
-### `hooks.help_post_commit`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `None` | Check for stale help after git commit. |
-
-### `hooks.jit_recall`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `int` | Entry point — surface matching rules once per session, never raises. |
-
-### `hooks.security_guard`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `validate_bash_command` | `command: str` | `tuple[bool, str]` | Validate a Bash command against security policies. |
-| `validate_file_path` | `file_path: str` | `tuple[bool, str]` | Validate a file path against security policies. |
-| `main` | `context: dict[str, Any]` | `dict[str, Any]` | Validate a tool call against security policies. |
-
-### `hooks.session_recall`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `int` | — |
-
-### `hooks.session_stash`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `int` | Entry point — acts once per substantive session, never raises. |
-
-### `hooks.spec_orient`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `format_orientation` | `specs: list[SpecInfo]` | `str` | Short markdown list of in-flight specs for non-compact starts. |
-| `render_spec_pin` | `spec: SpecInfo, char_budget: int = _POST_COMPACT_CHAR_BUDGET` | `str` | Render a spec body for post-compact context restoration. |
-| `main` | — | `int` | Entry point — branches on `source`, never raises. |
-
-### `hooks.welcome`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `main` | — | `None` | Print welcome message to stderr (Claude Code surfaces stderr). |
+| Function | Parameters | Returns | Description | File |
+|----------|------------|---------|-------------|------|
+| `main` | — | `int` | Entry point for the `/handoff` slash command; always returns `0`. | `plugin/hooks/_handoff_cli.py` |
+| `build_resume_prompt` | `spec_info: SpecInfo \| None, git_state: GitState, *, workspace_path: str = '~/attune', todo_summary: str \| None = None` | `str` | Render the user-facing resume prompt body. | `plugin/hooks/_resume_prompt.py` |
+| `is_sdk_subprocess` | — | `bool` | True when running inside an SDK-spawned `claude` subprocess. | `plugin/hooks/_sdk_gate.py` |
+| `exit_if_sdk_subprocess` | — | `None` | Exit 0 with no output when inside an SDK subprocess session. | `plugin/hooks/_sdk_gate.py` |
+| `discover_specs` | `roots: list[Path]` | `list[SpecInfo]` | Walk `specs/` directories under each root for in-flight specs. | `plugin/hooks/_state.py` |
+| `git_state` | `cwd: Path` | `GitState` | Return branch, last commit, and uncommitted files for `cwd`. | `plugin/hooks/_state.py` |
+| `session_sentinel_path` | `session_id: str \| None` | `Path` | Path to the once-per-session compact-warning sentinel. | `plugin/hooks/_state.py` |
+| `prune_stale_sentinels` | `now: float \| None = None` | `int` | Delete sentinel files older than the TTL. | `plugin/hooks/_state.py` |
+| `workspace_roots` | `cwd: Path \| None = None` | `list[Path]` | Best-effort guess at workspace roots to scan for specs. | `plugin/hooks/_state.py` |
+| `estimate_utilization` | `transcript_path: str \| Path` | `float` | Return estimated context utilization in `[0.0, 1.0]`. | `plugin/hooks/_transcript_size.py` |
+| `format_warning` | `util: float, threshold: float, resume_body: str` | `str` | Compose the user-facing compact warning and resume prompt. | `plugin/hooks/compact_warning.py` |
+| `main` | — | `int` | Entry point for compact warning; never raises. | `plugin/hooks/compact_warning.py` |
+| `main` | — | `None` | Read tool result from stdin and format Python files. | `plugin/hooks/format_on_save.py` |
+| `main` | — | `None` | Check help template freshness on session start. | `plugin/hooks/help_freshness_check.py` |
+| `main` | — | `None` | Read `PostToolUse` payload and suggest help if applicable. | `plugin/hooks/help_on_error.py` |
+| `main` | — | `None` | Check for stale help after git commit. | `plugin/hooks/help_post_commit.py` |
+| `main` | — | `int` | Surface matching rules once per session; never raises. | `plugin/hooks/jit_recall.py` |
+| `main` | — | `int` | Surface top-scoring lessons for this prompt, once per session each. | `plugin/hooks/lesson_recall.py` |
+| `validate_bash_command` | `command: str` | `tuple[bool, str]` | Validate a Bash command against security policies. | `plugin/hooks/security_guard.py` |
+| `validate_file_path` | `file_path: str` | `tuple[bool, str]` | Validate a file path against security policies. | `plugin/hooks/security_guard.py` |
+| `main` | `context: dict[str, Any]` | `dict[str, Any]` | Validate a tool call against security policies. | `plugin/hooks/security_guard.py` |
+| `main` | — | `int` | Entry point for session recall. | `plugin/hooks/session_recall.py` |
+| `main` | — | `int` | Act once per substantive session; never raises. | `plugin/hooks/session_stash.py` |
+| `format_orientation` | `specs: list[SpecInfo]` | `str` | Short markdown list of in-flight specs for non-compact starts. | `plugin/hooks/spec_orient.py` |
+| `render_spec_pin` | `spec: SpecInfo, char_budget: int = _POST_COMPACT_CHAR_BUDGET` | `str` | Render a spec body for post-compact context restoration. | `plugin/hooks/spec_orient.py` |
+| `main` | — | `int` | Branch on `source`; never raises. | `plugin/hooks/spec_orient.py` |
+| `main` | — | `None` | Print welcome message to stderr (Claude Code surfaces stderr). | `plugin/hooks/welcome.py` |
 
 ## Constants
 
-| Constant | Type | Value |
-|----------|------|-------|
-| `__version__` | `str` | `'8.3.0'` |
-| `_TERMINAL_VERDICTS` | `frozenset` | `{'closed', 'complete', 'completed', 'retired', 'superseded', 'shipped', 'done'}` |
-| `_ONGOING_VERDICTS` | `frozenset` | `{'living', 'ongoing'}` |
-| `_SPEC_SUBDIRS` | `tuple` | `{'specs', 'docs/specs'}` |
-| `_SENTINEL_PREFIX` | `str` | `'.jit-recalled-'` |
-| `SYSTEM_DIRECTORIES` | `frozenset` | `{'/etc', '/sys', '/proc', '/dev', '/boot', '/sbin', '/usr/sbin', '/private/etc', '/private/var'}` |
-| `SEARCH_COMMAND_PREFIXES` | `frozenset` | `{'grep', 'rg', 'ack', 'ag', 'git grep', 'git log', 'git diff'}` |
-| `_VALID_TYPES` | `set` | `{'decision', 'pattern', 'bug', 'reference', 'note'}` |
+| Constant | Type | Values | Description |
+|----------|------|--------|-------------|
+| `__version__` | `str` | `'8.4.0'` | Package version string. |
+| `_TERMINAL_VERDICTS` | `frozenset` | `{'closed', 'complete', 'completed', 'retired', 'superseded', 'shipped', 'done'}` | Spec status values that mark a spec as finished. |
+| `_ONGOING_VERDICTS` | `frozenset` | `{'living', 'ongoing'}` | Spec status values that mark a spec as actively in progress. |
+| `_SPEC_SUBDIRS` | `tuple` | `{'specs', 'docs/specs'}` | Directory names searched for spec files under each workspace root. |
+| `_SENTINEL_PREFIX` | `str` | `'.jit-recalled-'` | File prefix for per-session JIT recall sentinels (`hooks/jit_recall`). |
+| `_SENTINEL_PREFIX` | `str` | `'.lesson-recalled-'` | File prefix for per-session lesson recall sentinels (`hooks/lesson_recall`). |
+| `SYSTEM_DIRECTORIES` | `frozenset` | `{'/etc', '/sys', '/proc', '/dev', '/boot', '/sbin', '/usr/sbin', '/private/etc', '/private/var'}` | Filesystem paths blocked by the security guard. |
+| `SEARCH_COMMAND_PREFIXES` | `frozenset` | `{'grep', 'rg', 'ack', 'ag', 'git grep', 'git log', 'git diff'}` | Read-only search prefixes that bypass security blocking. |
+| `_VALID_TYPES` | `set` | `{'decision', 'pattern', 'bug', 'reference', 'note'}` | Allowed values for a spec's `type` field. |
 
 ## Source files
 

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -3,8 +3,8 @@ type: task
 name: plugin-task
 feature: plugin
 depth: task
-generated_at: 2026-06-11T04:47:10.948028+00:00
-source_hash: bb1dd6bc42134bdd5537798d5887c1172d0c43bf4a6c4c2dc064f90213e6a7b3
+generated_at: 2026-06-12T00:37:02.521196+00:00
+source_hash: e7e856d3cca09a12fdc753f3691d81dfaa025bb8ad4c1459e92ca254b38a9438
 status: generated
 scaffold_hash: 50c1caa20aa764e3b2db2159a2560e5480f7bfc5f82efed9516912df86eebf1d
 ---


### PR DESCRIPTION
Release-prep step-7 regen, subscription-routed (5 polish calls, 0 API). Two stale features: memory (3 templates) + plugin (2 polished, 1 metadata-only). Frontmatter is the polished-pipeline shape, zero fact-check flags; memory/concept spot-verified against the real MemoryBackend/SearchableMemoryBackend protocols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)