### PR TITLE
docs(lessons): D6 live receipts — 8.4.0 recall loop verified end-to-end

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8133,3 +8133,27 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
   apply" means ALREADY-OPEN sessions (including the one that ran the
   update) keep running the OLD cached hooks; only fresh sessions get
   the new version.
+
+- **A parked MAIN checkout silently darkens every plugin hook — the
+  plugin ships hook SCRIPTS, but their `import attune` resolves to
+  `~/attune-ai` via the pyenv shim's editable install, so updating
+  the plugin is NOT enough if main is on a stale branch**: first
+  8.4.0 session (2026-06-12) had the plugin correctly updated and
+  AMS/redis healthy, yet the SessionStart health line, lesson_recall,
+  and backend_status were all dark — the main checkout was parked on
+  a late-May branch that predates `attune.lessons` (#771) and
+  `backend_status` (#769); every hook's ImportError was swallowed by
+  the fail-safe `except`. Extends the recall-loop triage lesson's
+  rule 1 (missing optional DEPS in the hook interpreter) with the
+  stale-VERSION variant — verify BOTH in the hook's interpreter:
+  `python -c "import attune; print(attune.__file__)"` then check
+  that checkout's branch/commit. Two recovery facts: (a) hooks are
+  fresh subprocesses per fire, so unparking main fixes all later
+  hook fires in ALREADY-OPEN sessions — no restart needed (the
+  opposite of the plugin-cache rule above); (b) if `git checkout
+  main` fails "already used by worktree", a Cowork worktree may be
+  squatting on `main` directly — `git switch -C claude/<its-slug>`
+  inside it (force-move is safe when the old branch pointer is
+  `-` in `git cherry` / contained in merged work) frees `main` for
+  the parent. Plugin-release checklist addition: after `claude
+  plugin update`, also confirm `~/attune-ai` is on current main.

--- a/docs/specs/lessons-corpus-rag/decisions.md
+++ b/docs/specs/lessons-corpus-rag/decisions.md
@@ -129,6 +129,11 @@ scores; session-findings store answered via AMSMemoryBackend
 (fallback: false) with recent stashed notes — none tag-specific yet
 (young soak), reported honestly as such.
 
-**Outstanding for the T5 gate:** the Stop-hook stash receipt
-(`~/.attune` stash.log + a new finding written at a real session
-end on the fixed code) — the soak is now running on current code.
+**Receipt 4 — Stop-hook stash (captured same session, mid-PR).**
+The Stop hook fired at the first turn-end after the unpark and
+stashed 4 findings (decision/bug/reference/note); `stash.log`
+recorded `findings=4 written=4`, and a recall query immediately
+returned the fresh bug finding as the #1 hit from AMS — the full
+write → searchable → retrieve loop on fixed code. Nothing
+outstanding: all four receipts are in; T5 is gated only on
+Patrick's core-list review + the post-move benchmark re-run.

--- a/docs/specs/lessons-corpus-rag/decisions.md
+++ b/docs/specs/lessons-corpus-rag/decisions.md
@@ -80,3 +80,55 @@ ingest; (2) summaries-as-titles is sufficient signal — no LLM polish
 pass needed for v1; (3) the splitter must be wrap-aware (titles span
 lines at the 72-char wrap — first naive split captured 69/375 docs;
 the harness's `split_lessons` handles it).
+
+## D6 — 8.4.0 live receipts (2026-06-12, first post-restart session)
+
+The three receipts the cutover (T5) is gated on, captured in the
+first session running the 8.4.0 plugin hooks — with one load-bearing
+root-cause find along the way.
+
+**Root cause first: ALL hooks were dark at session start.** Plugin
+hooks run under the pyenv shim, whose editable install resolves
+`attune` from the MAIN `~/attune-ai` checkout — which was still
+parked on `docs/decisions-backlog-catchup` (late May). That checkout
+predates `attune.lessons` (#771) and `backend_status` (#769), so the
+SessionStart health line swallowed an ImportError and
+`lesson_recall.py` was silent on every prompt — while AMS +
+redis-stack (launchd-managed) were healthy the whole time. Unparked
+the checkout (stale branch's unique commit verified `-` in
+`git cherry`; dirty edits snapshotted to a patch), and every hook
+went live immediately — hooks are fresh subprocesses per fire, so no
+session restart was needed.
+
+**Receipt 1 — SessionStart health line.** Silence is the HEALTHY
+state: the shipped line is warn-only (prints only when
+`unreachable_upgrade` is set). Verified directly:
+`backend_status()` → `{"backend": "AMSMemoryBackend",
+"fallback": false, "unreachable_upgrade": null}`. Caveat recorded:
+warn-only silence is ambiguous with import-failure silence (exactly
+how the parked-checkout outage hid) — an info-level one-liner naming
+the backend would disambiguate; left as a possible tweak, not a
+blocker.
+
+**Receipt 2 — recall hooks fire live in-session.** `jit_recall.py`
+(PreToolUse) fired organically on an `AskUserQuestion` call in the
+live session, injecting the question-shape rule. `lesson_recall.py`
+(UserPromptSubmit) probed via the real plugin-cache hook against the
+real corpus: the squash-merge-tag trap prompt injected the
+Tag-mechanics lesson as `additionalContext`, exit 0; "Auto run 4"
+(below the 20-char floor) correctly stayed silent. Organic
+injection on a substantive user prompt is expected from the next
+prompt onward (pre-unpark prompts were silent for the import
+reason above).
+
+**Receipt 3 — `/recall` two-store search.** Query "tagging a release
+after a squash merge": lessons store returned the exact child
+sub-lesson *"Don't tag before a squash-merge"* plus the
+post-squash-local-main and AFK-pull lessons, labeled `[lesson]` with
+scores; session-findings store answered via AMSMemoryBackend
+(fallback: false) with recent stashed notes — none tag-specific yet
+(young soak), reported honestly as such.
+
+**Outstanding for the T5 gate:** the Stop-hook stash receipt
+(`~/.attune` stash.log + a new finding written at a real session
+end on the fixed code) — the soak is now running on current code.

--- a/docs/specs/lessons-corpus-rag/tasks.md
+++ b/docs/specs/lessons-corpus-rag/tasks.md
@@ -58,9 +58,14 @@ Bounded PRs; each task names its receipt.
   `ATTUNE_LESSON_RECALL_FLOOR` (default 8.0) for soak calibration.
   Children sentinel on their PARENT lesson id, so one mega-lesson
   isn't re-surfaced via a different child. 17 tests.
-  **In-CC-session receipt is gated on the next plugin release +
-  `claude plugin update`** (same gating as the recall-loop fixes —
-  live sessions run the cached plugin).
+- **In-CC-session receipt — CAPTURED 2026-06-12** (first 8.4.0
+  session post-restart): see decisions.md D6. Short version: hooks
+  were initially dark because the parked main checkout predated
+  `attune.lessons`; after unparking, `jit_recall` fired organically
+  on an AskUserQuestion call, the lesson_recall trap prompt injected
+  Tag-mechanics via the real plugin-cache hook, and `/recall`
+  returned labeled `[lesson]` hits with the backend named
+  (AMSMemoryBackend, fallback: false).
 
 ## T4 — jit-recall `lesson_ref` integration
 


### PR DESCRIPTION
First post-restart session on the 8.4.0 plugin — the live-receipt session the handoff called for.

## What this records

- **decisions.md D6**: the three T5-gate receipts — SessionStart health (warn-only silence + direct backend_status verification: AMSMemoryBackend, fallback false), lesson_recall live injection (Tag-mechanics on the squash-tag trap prompt; jit_recall fired organically in-session), and /recall two-store search with labeled [lesson] hits.
- **tasks.md T3**: in-CC-session receipt flipped from "gated on plugin update" to CAPTURED.
- **CLAUDE.md lesson**: the root-cause find — a parked main checkout darkens every plugin hook (stale-version variant of the hook-interpreter rule), plus the worktree-squatting-on-main recovery.

Outstanding for T5: the Stop-hook stash receipt at a real session end on fixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
