### PR TITLE
feat(lessons): jit-recall lesson_ref resolution via LessonsIndex (T4)

### DIFF
--- a/docs/specs/lessons-corpus-rag/tasks.md
+++ b/docs/specs/lessons-corpus-rag/tasks.md
@@ -62,11 +62,26 @@ Bounded PRs; each task names its receipt.
   `claude plugin update`** (same gating as the recall-loop fixes —
   live sessions run the cached plugin).
 
-## T4 — jit-recall `lesson_ref` integration
+## T4 — jit-recall `lesson_ref` integration — DONE 2026-06-12
 
 - `_recall_map.py` entries may reference a lesson slug; resolved
   through `LessonsIndex` at fire time. Convert one existing inline
   entry as the proof.
+- Shipped: optional `lesson_ref` field (documented in the map's
+  authoring rules); `jit_recall._resolve_lesson()` resolves it via
+  `LessonsIndex().get()` lazily at fire time — whitespace-normalized
+  excerpt capped at 600 chars, appended as a "Full lesson — …" line
+  below the inline one-liner. Best-effort: import failure (older
+  install / stale main checkout) or a dangling slug falls back to
+  the one-liner alone. Proof entry: `release-verify-merge-sha` →
+  the Tag-mechanics lesson.
+- **Receipt:** live fire with the `gh release create` payload
+  appended the real Tag-mechanics lesson body from the corpus
+  (resolve cost ~0.36 s, well inside the 3 s hook timeout). Tests
+  22 (5 new): resolved-excerpt append, excerpt bound, ImportError
+  fallback, unknown-slug fallback, and a drift guard asserting
+  every `lesson_ref` in the map resolves against the REAL corpus
+  (slugs derive from titles — a title edit dangles the ref).
 
 ## T5 — The cutover (gated on T1–T3 receipts)
 

--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -18,6 +18,15 @@ Authoring rules:
   serialized ``tool_input`` contains the substring — REQUIRED for
   broad tools like ``Bash`` so the rule fires only at the actual
   decision point, not on the session's first bash call.
+- Optional ``lesson_ref`` names a lessons-corpus slug (an
+  ``attune.lessons`` entry path like ``tag-mechanics-….md``); the
+  hook resolves it through ``LessonsIndex`` at fire time and appends
+  an excerpt of the CURRENT lesson body below the one-liner, so the
+  nudge never drifts from the corpus. Resolution is best-effort —
+  older installs without ``attune.lessons`` fall back to the
+  one-liner alone. Slugs derive from lesson titles: a title edit
+  changes the slug (the drift-guard test in
+  ``test_jit_recall.py`` catches a dangling ref).
 
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0
@@ -46,6 +55,9 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
         {
             "rule_id": "release-verify-merge-sha",
             "match_substring": "gh release create",
+            "lesson_ref": (
+                "tag-mechanics-push-protection-squash-timing-" "and-the-auto-release-body.md"
+            ),
             "text": (
                 "Before `gh release create`: verify the release content "
                 "is IN the target commit (`git show <sha>:pyproject.toml "

--- a/plugin/hooks/jit_recall.py
+++ b/plugin/hooks/jit_recall.py
@@ -56,6 +56,31 @@ except Exception:  # noqa: BLE001 — hook must never crash a tool call
 
 _SENTINEL_PREFIX = ".jit-recalled-"
 _SENTINEL_TTL_SECONDS = 7 * 24 * 3600  # match _state's compact-warned TTL
+_LESSON_EXCERPT_CHARS = 600  # keep the injected context bounded
+
+
+def _resolve_lesson(ref: str) -> str | None:
+    """Resolve a lessons-corpus slug to ``title: excerpt`` at fire time.
+
+    Best-effort by design: returns None when ``attune.lessons`` is
+    unavailable (older install, stale main checkout) or the slug no
+    longer exists — the caller falls back to the inline one-liner.
+    """
+    try:
+        from attune.lessons import LessonsIndex
+
+        entry = LessonsIndex().get(ref)
+        if entry is None or not entry.content:
+            return None
+        body = " ".join(entry.content.split())
+        if len(body) > _LESSON_EXCERPT_CHARS:
+            body = body[:_LESSON_EXCERPT_CHARS].rstrip() + "…"
+        title = (entry.summary or "").strip()
+        return f"{title}: {body}" if title else body
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: lesson enrichment is optional; the inline
+        # one-liner still surfaces (R4: never block the tool call).
+        return None
 
 
 def _enabled() -> bool:
@@ -131,7 +156,13 @@ def main() -> int:
             return 0
 
         lines = [f"Just-in-time recall — rule(s) governing {tool_name}:"]
-        lines.extend(f"- {rule['text']}" for rule in fresh)
+        for rule in fresh:
+            lines.append(f"- {rule['text']}")
+            ref = rule.get("lesson_ref")
+            if ref:
+                resolved = _resolve_lesson(ref)
+                if resolved:
+                    lines.append(f"  Full lesson — {resolved}")
         sys.stdout.write(
             json.dumps(
                 {

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -164,6 +164,107 @@ def test_non_matching_rule_writes_no_sentinel(jit_mod, monkeypatch, capsys, tmp_
 
 
 # ==========================================================================
+# lesson_ref resolution (lessons-corpus-rag T4)
+# ==========================================================================
+
+
+class _FakeEntry:
+    summary = "Tag mechanics — fake title"
+    content = "Don't tag before a squash-merge.   Extra   whitespace\ncollapses."
+
+
+def _install_fake_lessons(monkeypatch, entry):
+    """Inject a fake ``attune.lessons`` so the lazy import resolves to it."""
+    import types
+
+    fake = types.ModuleType("attune.lessons")
+
+    class LessonsIndex:
+        def get(self, ref):
+            return entry if ref else None
+
+    fake.LessonsIndex = LessonsIndex
+    monkeypatch.setitem(sys.modules, "attune.lessons", fake)
+
+
+def test_lesson_ref_appends_resolved_excerpt(jit_mod, monkeypatch, capsys):
+    _install_fake_lessons(monkeypatch, _FakeEntry())
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("gh release create v9.9.9 --target abc123"),
+    )
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "40-char merge SHA" in ctx  # inline one-liner still leads
+    assert "Full lesson — Tag mechanics — fake title:" in ctx
+    assert "whitespace collapses" in ctx  # body whitespace normalized
+
+
+def test_lesson_ref_excerpt_is_bounded(jit_mod, monkeypatch, capsys):
+    entry = _FakeEntry()
+    entry.content = "word " * 1000
+    _install_fake_lessons(monkeypatch, entry)
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("gh release create v9.9.9 --target abc123"),
+    )
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    lesson_line = next(line for line in ctx.splitlines() if "Full lesson" in line)
+    assert lesson_line.endswith("…")
+    assert len(lesson_line) < jit_mod._LESSON_EXCERPT_CHARS + 100
+
+
+def test_lesson_ref_import_failure_falls_back_to_inline(jit_mod, monkeypatch, capsys):
+    """Older install / stale checkout: the one-liner must still surface."""
+    monkeypatch.setitem(sys.modules, "attune.lessons", None)  # import -> ImportError
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("gh release create v9.9.9 --target abc123"),
+    )
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "40-char merge SHA" in ctx
+    assert "Full lesson" not in ctx
+
+
+def test_lesson_ref_unknown_slug_falls_back_to_inline(jit_mod, monkeypatch, capsys):
+    _install_fake_lessons(monkeypatch, None)  # get() returns None for any ref
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("gh release create v9.9.9 --target abc123"),
+    )
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "40-char merge SHA" in ctx
+    assert "Full lesson" not in ctx
+
+
+def test_all_lesson_refs_resolve_against_real_corpus(jit_mod):
+    """Drift guard: slugs derive from lesson TITLES, so a title edit in
+    the corpus silently dangles any ``lesson_ref`` pointing at it."""
+    lessons = pytest.importorskip("attune.lessons")
+    repo_root = Path(__file__).resolve().parents[3]
+    idx = lessons.LessonsIndex(lessons.find_lessons_file(repo_root))
+    for tool, rules in jit_mod.RECALL_MAP.items():
+        for rule in rules:
+            ref = rule.get("lesson_ref")
+            if not ref:
+                continue
+            assert idx.get(ref) is not None, (
+                f"{tool}/{rule['rule_id']}: lesson_ref {ref!r} does not "
+                "resolve — was the lesson's title edited?"
+            )
+
+
+# ==========================================================================
 # Surface-once gate (R3, D5)
 # ==========================================================================
 


### PR DESCRIPTION
lessons-corpus-rag T4 — the last task before the T5 cutover.

## What

- `RECALL_MAP` entries gain an optional `lesson_ref` slug (authoring rules documented in the map docstring).
- `jit_recall._resolve_lesson()` resolves it via `LessonsIndex().get()` lazily at fire time; a whitespace-normalized excerpt (600-char cap) is appended as a "Full lesson — …" line below the inline one-liner. The one-liner stays the distilled nudge; the excerpt tracks the CURRENT corpus, so the map never drifts.
- Best-effort by design: ImportError (older install / stale main checkout — see today's parked-checkout lesson) or a dangling slug falls back to the inline text. Never blocks the tool call.
- Proof conversion: `release-verify-merge-sha` → the Tag-mechanics lesson.

## Receipts

- Live fire with a `gh release create` payload appended the real Tag-mechanics body from the corpus; resolve cost ~0.36s inside the 3s hook timeout.
- 22 tests pass (5 new): resolved append, excerpt bound, ImportError fallback, unknown-slug fallback, and a drift guard asserting every `lesson_ref` resolves against the REAL corpus.

Note: touches the same tasks.md as #779 (different sections); whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
