### PR TITLE
docs(lessons): close lessons-corpus-rag — D6 fresh-session receipt + T6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Lessons corpus moved to `.claude/lessons.md`** (canonical, 386
+  lessons) — CLAUDE.md shrank 438,783 → 41,370 chars (**91%
+  smaller, ~99k tokens freed per session**). 22 core lessons stay
+  mirrored in CLAUDE.md, drift-guarded by
+  `tests/unit/lessons/test_core_mirror.py`. Retrieval is
+  unchanged: the prompt-time recall hook, `/recall`, and
+  `attune.lessons.LessonsIndex` all read lessons.md (benchmark on
+  the real file: P@1 84%, P@3 96%, high-severity 7/7). New
+  lessons append to lessons.md, not CLAUDE.md. (#782)
+
+### Added
+
+- `docs/how-to/lessons-workflow.md` — how the append → retrieve
+  lessons loop works (where lessons live, how they come back, the
+  core-mirror rule).
+
 ## [8.4.0] — 2026-06-11
 
 Cross-session memory grows a lessons brain: the repo's ~380-lesson

--- a/docs/how-to/lessons-workflow.md
+++ b/docs/how-to/lessons-workflow.md
@@ -1,0 +1,66 @@
+---
+description: How the lessons loop works — where lessons live, how they come back, and the rule for adding new ones.
+---
+
+# Lessons Workflow
+
+Attune AI keeps a corpus of engineering lessons and feeds them back
+to you at the moment they apply. This page covers the loop: where
+lessons live, how they're retrieved, and how to add one.
+
+## Where lessons live
+
+| File | Role |
+|------|------|
+| `.claude/lessons.md` | Canonical corpus — every lesson, full text |
+| `.claude/CLAUDE.md` ("Lessons — core") | A small set of core lessons mirrored verbatim for always-in-context availability |
+
+The split keeps session context lean (moving the corpus out of
+CLAUDE.md cut it by 91%, freeing ~99k tokens per session) without
+losing anything: the full corpus stays retrievable.
+
+A drift-guard test (`tests/unit/lessons/test_core_mirror.py`)
+asserts each core mirror byte-matches its canonical block in
+lessons.md, so the two files cannot silently diverge.
+
+## How lessons come back
+
+Three retrieval surfaces, all reading `.claude/lessons.md`:
+
+- **Prompt-time recall** — a `UserPromptSubmit` hook matches your
+  prompt against the corpus and injects the top-matching lessons
+  as context before the agent acts. Multi-part lessons are split
+  into atomic sub-lessons so the specific gotcha surfaces, not
+  just the umbrella title.
+- **`/recall <topic>`** — on-demand search across both stores:
+  past-session findings (file backend, or Redis Agent Memory
+  Server when connected) and the lessons corpus.
+- **Just-in-time rules** — a `PreToolUse` hook can attach a
+  `lesson_ref` to a governing rule, resolved through
+  `LessonsIndex` at fire time so the rule text stays current.
+
+Programmatic access:
+
+```python
+from attune.lessons import LessonsIndex, find_lessons_file
+
+index = LessonsIndex(find_lessons_file())
+hits = index.retrieve("stash pop silently skipped files", k=3)
+```
+
+Retrieval quality on the project's golden-query benchmark:
+P@1 84%, P@3 96%, with all high-severity queries hitting.
+
+## Adding a lesson
+
+1. Append the lesson to `.claude/lessons.md` under the
+   `## Lessons Learned` heading (the splitter anchors on that
+   literal heading). Use the existing format: a bold title bullet,
+   then the body.
+2. If the lesson is core-worthy (you want it in every session's
+   context, not just retrieved on match), also mirror it verbatim
+   into CLAUDE.md's `## Lessons — core` section. The drift guard
+   enforces that the two copies match.
+
+Do **not** append new lessons to CLAUDE.md alone — the canonical
+home is lessons.md, and retrieval only sees what's there.

--- a/docs/specs/lessons-corpus-rag/decisions.md
+++ b/docs/specs/lessons-corpus-rag/decisions.md
@@ -191,3 +191,41 @@ two-file edit.
 pair on the post-cutover file) is the one item left for the next
 session: confirm `/recall` + the prompt-time hook answer from
 lessons.md in a session that loaded the 41k CLAUDE.md.
+
+## D6 fresh-session receipt — captured 2026-06-12 (post-cutover)
+
+Captured in the first session after #782 merged (worktree
+`loving-sutherland-ac3a7b`, synced to merge commit `585d2aee`).
+All three recall surfaces verified live against the post-cutover
+tree:
+
+- **Prompt-time hook (`lesson_recall.py`, UserPromptSubmit)** —
+  fired from the 8.4.0 plugin cache with the prompt "git stash
+  pop silently skipped restoring my files after switching
+  branches, why?": exit 0, `additionalContext` returned with the
+  stash-pop silent-skip lesson as the TOP hit, retrieved from
+  `.claude/lessons.md` (the atomic-child match credited to its
+  parent title — the T1 parent-linkage design working as built).
+  `find_lessons_file()` in the hook interpreter resolves to the
+  post-cutover `.claude/lessons.md`.
+- **SessionStart recall (`session_recall.py`)** — fired at this
+  session's startup: 5 findings surfaced from AMS, including the
+  prior session's "All three receipts captured" note.
+- **`/recall` underlying path** — `recall_entries()` +
+  `backend_status()`: backend `AMSMemoryBackend`,
+  `fallback: False`; query returned relevant past-session
+  findings (recall-loop receipts, the parked-checkout incident,
+  the D7 searchable-write roundtrip).
+
+One honest caveat for the record: this session's worktree was
+created pre-#782, so its in-context CLAUDE.md was the pre-cutover
+copy; the worktree and the main `~/attune-ai` checkout were both
+synced to `585d2aee` at session start, and all hook receipts
+above ran against the post-cutover tree (41,370-char CLAUDE.md +
+435,257-char lessons.md on disk). Every session created from
+here on loads the 41k file — the load itself is deterministic
+file inclusion; the "registered ≠ working" risk lived in the
+retrieval surfaces, which are the parts verified live above.
+
+D6 is closed. With T6 (docs + CHANGELOG) shipped in the same PR
+as this receipt, the spec is complete.

--- a/docs/specs/lessons-corpus-rag/tasks.md
+++ b/docs/specs/lessons-corpus-rag/tasks.md
@@ -1,7 +1,7 @@
 # Lessons Corpus via RAG — Tasks
 
-**Status:** in progress (2026-06-12) — T1–T5 done; T6 (docs +
-release note) open.
+**Status:** complete (2026-06-12) — T1–T6 done; D6 fresh-session
+receipt captured post-cutover (decisions.md).
 Bounded PRs; each task names its receipt.
 
 ## T1 — `attune.lessons` module — DONE 2026-06-11
@@ -110,10 +110,20 @@ Bounded PRs; each task names its receipt.
   drift-guarded by tests/unit/lessons/test_core_mirror.py.
   Remaining for D6: the fresh-session live pair on the
   post-cutover file (next session).
+- **D6 fresh-session receipt — DONE 2026-06-12** (first
+  post-cutover session): lesson_recall hook answered from
+  lessons.md (correct top hit), SessionStart recall surfaced 5
+  AMS findings, `/recall` path live on `AMSMemoryBackend`. Full
+  record in decisions.md "D6 fresh-session receipt".
 
-## T6 — Docs + release note
+## T6 — Docs + release note — DONE 2026-06-12
 
 - CHANGELOG entry with the measured context reduction; a short
   `docs/` note on the lessons workflow (append → retrieve); the R6
   dogfood story ("attune-rag over our own engineering memory") in
   the README's RAG section if Patrick wants the marketing surface.
+- **Receipt:** CHANGELOG `[Unreleased]` entry (91% cut + benchmark
+  numbers); `docs/how-to/lessons-workflow.md` added and wired into
+  the mkdocs nav (Memory System group); README item shipped early
+  via #781 (the cross-session memory loop section IS the
+  marketing surface — R6 dogfood story covered there).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,7 @@ nav:
       - Memory System:
           - Unified Memory: how-to/unified-memory-system.md
           - Memory Graph: how-to/memory-graph.md
+          - Lessons Workflow: how-to/lessons-workflow.md
       - AI Agents:
           - Agent Factory: how-to/agent-factory.md
           - Smart Router: how-to/smart-router.md


### PR DESCRIPTION
Closes out the **lessons-corpus-rag** spec (T1–T6 all done).

## What's here

- **D6 fresh-session receipt** (decisions.md): captured in the first post-cutover session —
  - `lesson_recall.py` (UserPromptSubmit) fired live from the 8.4.0 plugin cache and answered from `.claude/lessons.md` with the correct top hit (atomic-child match credited to its parent)
  - SessionStart recall surfaced 5 AMS findings at startup
  - `/recall` underlying path verified: `AMSMemoryBackend`, `fallback: False`
- **T6 docs + release note**:
  - CHANGELOG `[Unreleased]` entry for the 91% CLAUDE.md cut (#782): 438,783 → 41,370 chars, ~99k tokens/session freed, retrieval unchanged (P@1 84% / P@3 96% / hs 7/7)
  - New `docs/how-to/lessons-workflow.md` (append → retrieve loop, core-mirror rule), wired into the mkdocs nav — `mkdocs build --strict` green locally
- **tasks.md status flipped to complete** (highest-phase file, so the reconciler sees it)

README item was shipped early via #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)