### PR TITLE
feat(scripts): bump_version generator + reach_snapshot (release-ritual tooling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/how-to/lessons-workflow.md` — how the append → retrieve
   lessons loop works (where lessons live, how they come back, the
   core-mirror rule).
+- `scripts/bump_version.py` — one command bumps the release version
+  across all 7 files / 9 sites (pyproject, plugin manifests,
+  `plugin/core/__init__.py`, CLAUDE.md and API_REFERENCE
+  headers/footers), count-validated before writing and verified
+  after. The `test_all_versions_match` drift guard stays as the
+  backstop and now names the command (drift-guards-to-generators
+  conversion 1).
+- `scripts/reach_snapshot.py` — records a dated reach snapshot
+  (pypistats for all five attune packages with rate-limit-safe
+  60s spacing, plus GitHub stars/traffic) to
+  `docs/specs/usage-signals/snapshots/`; the release ritual runs it
+  at tag time so every release gets a before/after install-count
+  pair (usage-signals R4).
 
 ## [8.4.0] — 2026-06-11
 

--- a/docs/specs/drift-guards-to-generators/requirements.md
+++ b/docs/specs/drift-guards-to-generators/requirements.md
@@ -1,6 +1,8 @@
 # Drift Guards → Generators — Requirements
 
-**Status:** approved (2026-06-11) · **Owner:** Patrick + agent
+**Status:** in progress (2026-06-12) — conversion 1 (version bump)
+shipped; registration-mirror conversions open.
+**Owner:** Patrick + agent
 **Born:** discipline-review chat, 2026-06-11 (improvement #4 of 6).
 
 ## Problem
@@ -86,6 +88,12 @@ Candidate conversions, by observed pain frequency:
   / attune-author; different failure modes).
 - Converting guards whose value IS the judgment prompt (e.g.
   deprecation-marker past-due checks).
+
+## Conversions shipped
+
+| Guard | Generator | Backstop test |
+|-------|-----------|---------------|
+| Version-site drift (the v7.2.0 class) | `scripts/bump_version.py <version>` — writes all 7 files / 9 sites, count-validates before writing, verifies after | `test_plugin_config_validation.py::TestVersionConsistency::test_all_versions_match` (failure message names the command); plus `tests/unit/scripts/test_bump_version.py::TestRealRepo` (site list vs the actual tree) |
 
 ## Done when
 

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -176,3 +176,29 @@ Reading: attune-rag's volume is ~85% non-mirror — i.e. REAL
 downloads, dominated by attune-ai CI dependency installs (it became
 a core dep in the 7.x line). attune-ai's own raw counts are ~75%
 mirror noise; the mirror-free ~2.9k/month is the number to track.
+
+## D3 — R4 snapshot script shipped (2026-06-12)
+
+`scripts/reach_snapshot.py` automates the D1 method: pypistats
+`/recent` for all five packages with 60-s spacing (the D1
+rate-limit lesson baked in — a 429 ABORTS with a "wait 15 minutes"
+message instead of retrying), plus best-effort GitHub signals
+(stars/forks always; traffic clones/views when the token allows).
+Writes `docs/specs/usage-signals/snapshots/<date>.json` and prints
+a paste-ready markdown table.
+
+Release-ritual hook (R4 proper): the release-execute skill's tag
+step now kicks the script off in the background at tag time and
+commits the snapshot in close-out, so every release gets its
+before/after pair without manual effort.
+
+Tests: `tests/unit/scripts/test_reach_snapshot.py` — network
+boundaries mocked; spacing (n-1 sleeps, none before the first),
+429-abort short-circuit, table rendering, CLI write/exit paths.
+One bug caught at authoring time: a def-time default argument
+(`fetcher=fetch_pypistats_recent`) bound the real fetcher and the
+first CLI test silently hit the live API — defaults now resolve at
+call time.
+
+Remaining in scope: R3 (dashboard Reach panel), R5 (telemetry
+watchdog), R6 (spend alarm), and the Phase 2 opt-in ping question.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Bump the release version across every release-artifact file.
+
+Source of truth: the version passed on the command line; the current
+version is read from ``pyproject.toml`` (the authoritative PyPI
+surface). Writes, in one validated pass:
+
+1. ``pyproject.toml`` — ``version = "X"``
+2. ``plugin/.claude-plugin/plugin.json`` — ``"version"``
+3. ``plugin/.claude-plugin/marketplace.json`` — ``metadata.version``
+   AND ``plugins[0].version``
+4. ``.claude-plugin/marketplace.json`` (root) — same two fields
+5. ``plugin/core/__init__.py`` — ``__version__``
+6. ``.claude/CLAUDE.md`` — header (``# Attune AI Framework vX``) and
+   footer (``**Version:** X``)
+7. ``docs/reference/API_REFERENCE.md`` — header and footer
+   (``**Version:** X``)
+
+Every replacement is count-checked against the expected number of
+occurrences BEFORE any file is written; a mismatch aborts with no
+partial state. After writing, all sites are re-read and verified.
+
+Backstop guard: ``tests/unit/plugins/test_plugin_config_validation.py
+::TestVersionConsistency::test_all_versions_match`` (asserts all
+sites equal — fails with a pointer to this script).
+
+Usage:
+    python scripts/bump_version.py 8.5.0
+    python scripts/bump_version.py 8.5.0 --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+@dataclass
+class Site:
+    """One file's version-replacement plan."""
+
+    path: Path
+    pattern: str  # template with {v} for the version
+    expected: int  # exact count, or minimum when min_count=True
+    min_count: bool = False
+
+    def render(self, version: str) -> str:
+        """Render the pattern with a version, escaping regex chars."""
+        return re.escape(self.pattern).replace(r"\{v\}", re.escape(version))
+
+
+def _sites(root: Path) -> list[Site]:
+    """The full release-artifact site list (R1 source of truth)."""
+    return [
+        Site(root / "pyproject.toml", 'version = "{v}"', 1),
+        Site(
+            root / "plugin" / ".claude-plugin" / "plugin.json",
+            '"version": "{v}"',
+            1,
+        ),
+        Site(
+            root / "plugin" / ".claude-plugin" / "marketplace.json",
+            '"version": "{v}"',
+            2,
+        ),
+        Site(
+            root / ".claude-plugin" / "marketplace.json",
+            '"version": "{v}"',
+            2,
+        ),
+        Site(
+            root / "plugin" / "core" / "__init__.py",
+            '__version__ = "{v}"',
+            1,
+        ),
+        Site(
+            root / ".claude" / "CLAUDE.md",
+            "# Attune AI Framework v{v}",
+            1,
+        ),
+        Site(
+            root / ".claude" / "CLAUDE.md",
+            "**Version:** {v}",
+            1,
+            min_count=True,
+        ),
+        Site(
+            root / "docs" / "reference" / "API_REFERENCE.md",
+            "**Version:** {v}",
+            2,
+            min_count=True,
+        ),
+    ]
+
+
+def read_current_version(root: Path) -> str:
+    """Read the authoritative current version from pyproject.toml."""
+    text = (root / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version = "(\d+\.\d+\.\d+)"', text, re.MULTILINE)
+    if not match:
+        raise ValueError('pyproject.toml: no semver `version = "X.Y.Z"` line found')
+    return match.group(1)
+
+
+def bump(root: Path, new_version: str, dry_run: bool = False) -> str:
+    """Bump all sites from the current pyproject version to new_version.
+
+    Returns the old version. Raises ValueError on any validation
+    failure BEFORE writing anything (no partial state).
+    """
+    if not SEMVER.match(new_version):
+        raise ValueError(f"not a semver version: {new_version!r}")
+    old = read_current_version(root)
+    if old == new_version:
+        raise ValueError(f"already at {new_version}")
+
+    # Validate every site first; collect planned writes.
+    planned: dict[Path, str] = {}
+    for site in _sites(root):
+        text = planned.get(site.path) or site.path.read_text(encoding="utf-8")
+        old_re = site.render(old)
+        count = len(re.findall(old_re, text))
+        ok = count >= site.expected if site.min_count else count == site.expected
+        if not ok:
+            want = f">= {site.expected}" if site.min_count else str(site.expected)
+            raise ValueError(
+                f"{site.path}: expected {want} occurrence(s) of "
+                f"{site.pattern.format(v=old)!r}, found {count} — "
+                "fix the file (or this script's site list) before bumping"
+            )
+        planned[site.path] = re.sub(old_re, site.pattern.format(v=new_version), text)
+
+    if not dry_run:
+        for path, text in planned.items():
+            path.write_text(text, encoding="utf-8")
+        # Post-write verification: every site reads back at new_version.
+        for site in _sites(root):
+            text = site.path.read_text(encoding="utf-8")
+            count = len(re.findall(site.render(new_version), text))
+            ok = count >= site.expected if site.min_count else count == site.expected
+            if not ok:
+                raise RuntimeError(f"{site.path}: post-write verification failed")
+    return old
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("version", help="new semver version, e.g. 8.5.0")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repo root (default: this script's parent repo)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate every site without writing",
+    )
+    args = parser.parse_args(argv)
+    try:
+        old = bump(args.root, args.version, dry_run=args.dry_run)
+    except (ValueError, RuntimeError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    verb = "would bump" if args.dry_run else "bumped"
+    files = sorted({str(s.path.relative_to(args.root)) for s in _sites(args.root)})
+    print(f"{verb} {old} -> {args.version} across {len(files)} files:")
+    for f in files:
+        print(f"  {f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reach_snapshot.py
+++ b/scripts/reach_snapshot.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Record a reach snapshot: PyPI downloads + GitHub traffic.
+
+usage-signals R4: the release ritual records a baseline snapshot at
+tag time so every release has a before/after pair. Reads public
+zero-instrumentation signals only:
+
+- pypistats.org ``/api/packages/<pkg>/recent`` for each attune
+  package (mirror-corrected per the Phase 0 finding).
+- GitHub repo signals via ``gh api`` (stars; traffic clones/views
+  when the token has push access). Degrades gracefully without gh.
+
+Writes ``<out>/<YYYY-MM-DD>.json`` and prints a markdown table.
+
+Rate-limit discipline (Phase 0 lesson): pypistats 429-penalizes
+bursts and the penalty outlasts minutes of retrying — this script
+spaces requests (default 60s) and ABORTS on the first 429 with a
+"wait 15 minutes" message instead of hammering.
+
+Usage:
+    python scripts/reach_snapshot.py
+    python scripts/reach_snapshot.py --spacing 60 --out docs/specs/usage-signals/snapshots
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PACKAGES = [
+    "attune-ai",
+    "attune-rag",
+    "attune-help",
+    "attune-author",
+    "attune-verify",
+]
+REPO = "Smart-AI-Memory/attune-ai"
+
+
+class RateLimitedError(RuntimeError):
+    """pypistats returned 429 — stop immediately, retrying makes it worse."""
+
+
+def fetch_pypistats_recent(package: str) -> dict[str, int]:
+    """Fetch last_day/last_week/last_month for one package.
+
+    Raises RateLimitedError on HTTP 429 (caller must abort, not
+    retry — see module docstring).
+    """
+    url = f"https://pypistats.org/api/packages/{package}/recent"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        if e.code == 429:
+            raise RateLimitedError(
+                f"pypistats rate-limited on {package}. Wait 15 minutes, "
+                "then rerun with --spacing 60 (the penalty outlasts "
+                "short retries)."
+            ) from e
+        raise
+    data = payload.get("data", {})
+    return {
+        "last_day": int(data.get("last_day", 0)),
+        "last_week": int(data.get("last_week", 0)),
+        "last_month": int(data.get("last_month", 0)),
+    }
+
+
+def fetch_github_signals(repo: str = REPO) -> dict[str, object]:
+    """Best-effort GitHub signals via gh CLI; {} when unavailable."""
+    signals: dict[str, object] = {}
+    try:
+        out = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}",
+                "--jq",
+                "{stars: .stargazers_count, forks: .forks_count}",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=True,
+        )
+        signals.update(json.loads(out.stdout))
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as e:
+        logger.warning("GitHub repo signals unavailable: %s", e)
+        return signals
+    # Traffic endpoints need push access; degrade per-endpoint.
+    for key, endpoint, jq in [
+        ("clones_14d", f"repos/{repo}/traffic/clones", ".count"),
+        ("views_14d", f"repos/{repo}/traffic/views", ".count"),
+    ]:
+        try:
+            out = subprocess.run(
+                ["gh", "api", endpoint, "--jq", jq],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=True,
+            )
+            signals[key] = int(out.stdout.strip())
+        except (OSError, subprocess.SubprocessError, ValueError) as e:
+            logger.warning("GitHub traffic %s unavailable: %s", key, e)
+    return signals
+
+
+def build_snapshot(
+    packages: list[str],
+    spacing_seconds: float,
+    fetcher=None,
+    sleeper=None,
+) -> dict[str, object]:
+    """Fetch all package stats with rate-limit spacing between calls.
+
+    fetcher/sleeper default to the module-level functions, resolved
+    at CALL time (not def time) so tests can monkeypatch the module
+    attributes — a def-time default would bind the original function
+    object and silently bypass patches.
+    """
+    fetcher = fetcher or fetch_pypistats_recent
+    sleeper = sleeper or time.sleep
+    pypi: dict[str, dict[str, int]] = {}
+    for i, pkg in enumerate(packages):
+        if i:
+            sleeper(spacing_seconds)
+        pypi[pkg] = fetcher(pkg)
+    return {
+        "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        "taken_at": datetime.now(timezone.utc).isoformat(),
+        "pypi_recent": pypi,
+        "github": fetch_github_signals(),
+    }
+
+
+def render_table(snapshot: dict[str, object]) -> str:
+    """Markdown table for the snapshot (paste-ready for decisions.md)."""
+    lines = [
+        f"Reach snapshot — {snapshot['date']}",
+        "",
+        "| Package | last_day | last_week | last_month |",
+        "|---|---|---|---|",
+    ]
+    pypi = snapshot.get("pypi_recent", {})
+    assert isinstance(pypi, dict)
+    for pkg, stats in pypi.items():
+        lines.append(
+            f"| {pkg} | {stats['last_day']} | {stats['last_week']} | {stats['last_month']} |"
+        )
+    gh = snapshot.get("github") or {}
+    assert isinstance(gh, dict)
+    if gh:
+        parts = ", ".join(f"{k}={v}" for k, v in gh.items())
+        lines += ["", f"GitHub: {parts}"]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("docs/specs/usage-signals/snapshots"),
+        help="directory for the dated snapshot JSON",
+    )
+    parser.add_argument(
+        "--spacing",
+        type=float,
+        default=60.0,
+        help="seconds between pypistats requests (default 60 — do not lower after a 429)",
+    )
+    parser.add_argument(
+        "--packages",
+        nargs="*",
+        default=PACKAGES,
+        help="packages to snapshot",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+
+    try:
+        snapshot = build_snapshot(args.packages, args.spacing)
+    except RateLimitedError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    except (urllib.error.URLError, OSError) as e:
+        print(f"error: network failure: {e}", file=sys.stderr)
+        return 1
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    out_path = args.out / f"{snapshot['date']}.json"
+    out_path.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(render_table(snapshot))
+    print(f"wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -437,8 +437,9 @@ class TestVersionConsistency:
         assert len(unique) == 1, (
             f"Version mismatch across release-artifact files: {versions}. "
             "Project policy requires pyproject.toml and every plugin "
-            "manifest to carry the same version. Bump all entries to "
-            "match the new release."
+            "manifest to carry the same version. Run "
+            "`python scripts/bump_version.py <version>` to regenerate "
+            "every site from one command."
         )
 
     def test_version_is_semver(self) -> None:

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -1,0 +1,149 @@
+"""Tests for scripts/bump_version.py (drift-guards-to-generators R4).
+
+Covers:
+- happy path: all 7 files / 9 sites rewritten, old version returned;
+- dry-run: validation runs, nothing written;
+- semver / same-version rejection;
+- count-mismatch aborts BEFORE any write (no partial state);
+- real-repo dry-run smoke: the site list matches the actual tree
+  (the generator drifting from reality fails here, not at release).
+
+Loads the script via importlib (matches the existing scripts-test
+pattern).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "bump_version.py"
+
+OLD = "1.0.0"
+NEW = "1.1.0"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_bump_version", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    # The script defines a @dataclass; dataclasses resolves
+    # cls.__module__ via sys.modules, so the module must be
+    # registered BEFORE exec_module or decoration crashes.
+    sys.modules["_bump_version"] = m
+    try:
+        spec.loader.exec_module(m)
+        yield m
+    finally:
+        sys.modules.pop("_bump_version", None)
+
+
+@pytest.fixture()
+def fixture_root(tmp_path: Path) -> Path:
+    """A minimal repo tree carrying every version site at OLD."""
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "x"\nversion = "{OLD}"\n', encoding="utf-8"
+    )
+    plugin_cp = tmp_path / "plugin" / ".claude-plugin"
+    plugin_cp.mkdir(parents=True)
+    (plugin_cp / "plugin.json").write_text(
+        f'{{\n  "name": "x",\n  "version": "{OLD}"\n}}\n', encoding="utf-8"
+    )
+    marketplace = (
+        f'{{\n  "metadata": {{"version": "{OLD}"}},\n'
+        f'  "plugins": [{{"version": "{OLD}"}}]\n}}\n'
+    )
+    (plugin_cp / "marketplace.json").write_text(marketplace, encoding="utf-8")
+    root_cp = tmp_path / ".claude-plugin"
+    root_cp.mkdir()
+    (root_cp / "marketplace.json").write_text(marketplace, encoding="utf-8")
+    core = tmp_path / "plugin" / "core"
+    core.mkdir()
+    (core / "__init__.py").write_text(f'__version__ = "{OLD}"\n', encoding="utf-8")
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / "CLAUDE.md").write_text(
+        f"# Attune AI Framework v{OLD}\n\nbody\n\n**Version:** {OLD} | tail\n",
+        encoding="utf-8",
+    )
+    ref = tmp_path / "docs" / "reference"
+    ref.mkdir(parents=True)
+    (ref / "API_REFERENCE.md").write_text(
+        f"# API\n\n**Version:** {OLD}\n\nbody\n\n**Version:** {OLD} | tail\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _all_texts(root: Path) -> str:
+    return "\n".join(
+        p.read_text(encoding="utf-8")
+        for p in [
+            root / "pyproject.toml",
+            root / "plugin" / ".claude-plugin" / "plugin.json",
+            root / "plugin" / ".claude-plugin" / "marketplace.json",
+            root / ".claude-plugin" / "marketplace.json",
+            root / "plugin" / "core" / "__init__.py",
+            root / ".claude" / "CLAUDE.md",
+            root / "docs" / "reference" / "API_REFERENCE.md",
+        ]
+    )
+
+
+class TestBump:
+    def test_happy_path_updates_every_site(self, mod, fixture_root: Path) -> None:
+        old = mod.bump(fixture_root, NEW)
+        assert old == OLD
+        combined = _all_texts(fixture_root)
+        assert OLD not in combined
+        # 1 pyproject + 1 plugin.json + 2+2 marketplace + 1 __init__
+        # + 2 CLAUDE.md + 2 API_REFERENCE = 11 occurrences
+        assert combined.count(NEW) == 11
+
+    def test_dry_run_writes_nothing(self, mod, fixture_root: Path) -> None:
+        before = _all_texts(fixture_root)
+        old = mod.bump(fixture_root, NEW, dry_run=True)
+        assert old == OLD
+        assert _all_texts(fixture_root) == before
+
+    def test_rejects_non_semver(self, mod, fixture_root: Path) -> None:
+        with pytest.raises(ValueError, match="not a semver"):
+            mod.bump(fixture_root, "1.1")
+
+    def test_rejects_same_version(self, mod, fixture_root: Path) -> None:
+        with pytest.raises(ValueError, match="already at"):
+            mod.bump(fixture_root, OLD)
+
+    def test_count_mismatch_aborts_with_no_partial_writes(self, mod, fixture_root: Path) -> None:
+        # Break a LATE site (CLAUDE.md header) so early sites would
+        # already have validated; nothing may be written.
+        claude_md = fixture_root / ".claude" / "CLAUDE.md"
+        claude_md.write_text(f"no header here\n\n**Version:** {OLD} | tail\n", encoding="utf-8")
+        before = _all_texts(fixture_root)
+        with pytest.raises(ValueError, match="expected 1 occurrence"):
+            mod.bump(fixture_root, NEW)
+        assert _all_texts(fixture_root) == before
+
+    def test_cli_main_happy_and_error(self, mod, fixture_root: Path, capsys) -> None:
+        rc = mod.main([NEW, "--root", str(fixture_root)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert f"bumped {OLD} -> {NEW}" in out
+        rc = mod.main(["nope", "--root", str(fixture_root)])
+        assert rc == 1
+        assert "not a semver" in capsys.readouterr().err
+
+
+class TestRealRepo:
+    def test_site_list_matches_actual_tree(self, mod) -> None:
+        """Dry-run against the REAL repo: every site resolves and the
+        occurrence counts hold. Catches the generator drifting from
+        the tree (renamed file, changed header format) before a
+        release does."""
+        old = mod.bump(REPO_ROOT, "999.999.999", dry_run=True)
+        assert old.count(".") == 2

--- a/tests/unit/scripts/test_reach_snapshot.py
+++ b/tests/unit/scripts/test_reach_snapshot.py
@@ -1,0 +1,109 @@
+"""Tests for scripts/reach_snapshot.py (usage-signals R4).
+
+Network boundaries (pypistats HTTP, gh subprocess) are mocked; the
+spacing/abort logic, snapshot shape, table rendering, and CLI exit
+codes run real.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "reach_snapshot.py"
+
+STATS = {"last_day": 1, "last_week": 7, "last_month": 30}
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_reach_snapshot", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["_reach_snapshot"] = m
+    try:
+        spec.loader.exec_module(m)
+        yield m
+    finally:
+        sys.modules.pop("_reach_snapshot", None)
+
+
+class TestBuildSnapshot:
+    def test_spacing_between_requests_not_before_first(self, mod, monkeypatch) -> None:
+        sleeps: list[float] = []
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {})
+        snap = mod.build_snapshot(
+            ["a", "b", "c"],
+            spacing_seconds=60,
+            fetcher=lambda pkg: dict(STATS),
+            sleeper=sleeps.append,
+        )
+        assert sleeps == [60, 60]  # n-1 sleeps, none before the first
+        assert set(snap["pypi_recent"]) == {"a", "b", "c"}
+        assert snap["pypi_recent"]["a"] == STATS
+
+    def test_rate_limit_aborts_without_further_fetches(self, mod, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {})
+        fetched: list[str] = []
+
+        def fetcher(pkg: str):
+            fetched.append(pkg)
+            if pkg == "b":
+                raise mod.RateLimitedError("wait 15 minutes")
+            return dict(STATS)
+
+        with pytest.raises(mod.RateLimitedError):
+            mod.build_snapshot(
+                ["a", "b", "c"], spacing_seconds=0, fetcher=fetcher, sleeper=lambda s: None
+            )
+        assert fetched == ["a", "b"]  # c never attempted
+
+
+class TestRenderTable:
+    def test_table_has_all_packages_and_github_line(self, mod) -> None:
+        snap = {
+            "date": "2026-06-12",
+            "pypi_recent": {"attune-ai": STATS},
+            "github": {"stars": 5},
+        }
+        out = mod.render_table(snap)
+        assert "| attune-ai | 1 | 7 | 30 |" in out
+        assert "stars=5" in out
+
+    def test_table_omits_github_line_when_empty(self, mod) -> None:
+        snap = {"date": "2026-06-12", "pypi_recent": {}, "github": {}}
+        assert "GitHub:" not in mod.render_table(snap)
+
+
+class TestCli:
+    def test_writes_dated_json_and_prints_table(
+        self, mod, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", lambda pkg: dict(STATS))
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {"stars": 9})
+        rc = mod.main(["--out", str(tmp_path), "--spacing", "0", "--packages", "attune-ai"])
+        assert rc == 0
+        files = list(tmp_path.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text(encoding="utf-8"))
+        assert data["pypi_recent"]["attune-ai"] == STATS
+        assert data["github"] == {"stars": 9}
+        out = capsys.readouterr().out
+        assert "| attune-ai | 1 | 7 | 30 |" in out
+
+    def test_rate_limited_exit_1_with_wait_message(
+        self, mod, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        def boom(pkg: str):
+            raise mod.RateLimitedError("pypistats rate-limited. Wait 15 minutes")
+
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", boom)
+        rc = mod.main(["--out", str(tmp_path), "--spacing", "0", "--packages", "attune-ai"])
+        assert rc == 1
+        assert "Wait 15 minutes" in capsys.readouterr().err
+        assert not list(tmp_path.glob("*.json"))


### PR DESCRIPTION
Two small release-ritual scripts, each closing a ratified spec item, with full unit coverage (13 tests).

## scripts/bump_version.py — drift-guards-to-generators conversion 1

- One command writes all **7 files / 9 version sites** (pyproject, plugin.json, both marketplace.json ×2 fields, `plugin/core/__init__.py`, CLAUDE.md header+footer, API_REFERENCE header+footer) — replacing the 7-file manual checklist that produced the v7.2.0 drift.
- **Validate-all-then-write-all**: every site's occurrence count is checked against expectations BEFORE any write (no partial state); all sites re-verified after writing. `--dry-run` supported.
- R2 (guards stay, inverted): `test_all_versions_match`'s failure message now names the command. A real-repo dry-run test pins the script's site list to the actual tree, so a renamed file or changed header fails in CI, not at release time.
- Spec: conversions table + status recorded in `docs/specs/drift-guards-to-generators/requirements.md`.

## scripts/reach_snapshot.py — usage-signals R4

- Dated reach snapshot: pypistats `/recent` for all five attune packages + best-effort GitHub stars/forks/traffic → `docs/specs/usage-signals/snapshots/<date>.json` + paste-ready markdown table.
- The Phase-0 rate-limit lesson is baked in: 60s spacing between requests, and a 429 **aborts** with wait-15-minutes guidance instead of retrying into a longer penalty.
- Release-execute skill (user-level, `~/.claude/skills`) now kicks it off at tag time so every release gets a before/after install-count pair.
- Spec: D3 recorded in `docs/specs/usage-signals/decisions.md`.
- Test-authoring catch worth noting: a def-time default arg (`fetcher=fetch_pypistats_recent`) bound the real fetcher and one test silently hit the live API — defaults now resolve at call time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)