### PR TITLE
fix(mcp): report-aware workflow responses — workflow-result-formatting T5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP workflow tools no longer return None scores / empty
+  findings for report-emitting workflows** (workflow-result-
+  formatting T5). After T8 made all 15 SDK-native workflows return
+  a serialized `WorkflowReport` as `final_output`, the MCP handlers
+  still field-picked from it as if it were the legacy flat dict.
+  A shared `_workflow_response()` helper now detects the report
+  payload and returns the rendered summary markdown verbatim
+  (`summary_markdown`), the `WorkflowReport` JSON (`report`), and
+  the back-compat `score`/`findings` fields restored from the
+  report; legacy flat-dict workflows keep their exact previous
+  response shape.
+
 ### Changed
 
 - **Lessons corpus moved to `.claude/lessons.md`** (canonical, 386

--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -5,9 +5,10 @@ data model, #649), T2 (the markdown renderer
 `attune.voice.report_renderer` — `render()` + crash-visible
 `render_safe()`, all 4 test layers, 98% branch, #741), T3 (voice
 wiring + safety net + `show_cost_metrics`/`resolve_show_cost()`),
-T4 (CLI terminal rendering), T7 (release-prep
+T4 (CLI terminal rendering), T5 (MCP handlers report-aware,
+2026-06-12), T7 (release-prep
 migration — the motivating case), and T8 (adapter-level migration of
-all 15 SDK-native workflows) shipped; T5/T6 pending.
+all 15 SDK-native workflows) shipped; T6 (dashboard panel) pending.
 
 > Bounded PRs; see [design.md](design.md) for the decisions each task
 > implements.
@@ -78,11 +79,31 @@ all 15 SDK-native workflows) shipped; T5/T6 pending.
   resolved: the wrapper suppresses both for rendered reports (the
   report's `**Score:**` and `NextStepsSection` own them).
 
-## T5 — MCP
+## T5 — MCP — DONE
 
 - `mcp/server.py:format_mcp_response`: return the summary markdown
   verbatim as human content; `WorkflowReport.to_dict()` JSON travels
   alongside. (Surface map.)
+- Shipped 2026-06-12: the fix landed in the HANDLERS, not
+  `format_mcp_response` (which wraps generically and needed no
+  change). Post-T8, every handler that field-picked from
+  `final_output` (`.get("health_score")`, `.get("findings")`, …)
+  silently returned None scores / empty findings because the report
+  dict only carries `_type`/`sections`. One helper —
+  `workflow_handlers._workflow_response(result, **field_picks)` —
+  now backs all 15 return sites in `mcp/server.py` +
+  `mcp/workflow_handlers.py`: report-dict `final_output` →
+  `summary_markdown` (render_safe, disclosure="summary",
+  show_cost=resolve_show_cost()) verbatim + `report` JSON alongside
+  + back-compat `score`/`findings` restored from the report's
+  `.findings` property (metadata `findings` dict as fallback for
+  string-bullet/ListSection reports); legacy flat dicts keep the
+  exact pre-T5 field-picked shape. Receipt:
+  `tests/unit/mcp/handlers/test_workflow_response.py` (13 tests —
+  verbatim-markdown + report-JSON + non-empty-findings through
+  `_run_security_audit`, raw-output handlers carry the markdown,
+  legacy shape asserted unchanged); full MCP + voice suites green
+  (497 passed).
 
 ## T6 — Dashboard panel
 

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -34,7 +34,7 @@ from attune.mcp.tool_schemas import (
     get_utility_tools,
     get_workflow_tools,
 )
-from attune.mcp.workflow_handlers import WorkflowHandlersMixin
+from attune.mcp.workflow_handlers import WorkflowHandlersMixin, _workflow_response
 
 logger = logging.getLogger(__name__)
 
@@ -381,13 +381,12 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         workflow = SecurityAuditWorkflow()
         result = await workflow.execute(path=validated_path)
 
-        return {
-            "success": result.success,
-            "score": result.final_output.get("health_score"),
-            "findings": result.final_output.get("findings", []),
-            "cost": result.cost_report.total_cost,
-            "provider": result.provider,
-        }
+        return _workflow_response(
+            result,
+            include_provider=True,
+            score="health_score",
+            findings=("findings", []),
+        )
 
     async def _run_bug_predict(self, args: dict[str, Any]) -> dict[str, Any]:
         """Run bug prediction workflow."""
@@ -400,11 +399,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         workflow = BugPredictionWorkflow()
         result = await workflow.execute(path=validated_path)
 
-        return {
-            "success": result.success,
-            "predictions": result.final_output.get("predictions", []),
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, predictions=("predictions", []))
 
     async def _run_code_review(self, args: dict[str, Any]) -> dict[str, Any]:
         """Run code review workflow."""
@@ -415,12 +410,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         workflow = CodeReviewWorkflow()
         result = await workflow.execute(path=validated_path)
 
-        return {
-            "success": result.success,
-            "feedback": result.final_output.get("feedback"),
-            "score": result.final_output.get("quality_score"),
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, feedback="feedback", score="quality_score")
 
     async def _run_test_generation(self, args: dict[str, Any]) -> dict[str, Any]:
         """Run test generation workflow."""
@@ -431,12 +421,11 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         workflow = TestGenerationWorkflow()
         result = await workflow.execute(module_path=validated_path)
 
-        return {
-            "success": result.success,
-            "tests_generated": result.final_output.get("tests_generated", 0),
-            "output_path": result.final_output.get("output_path"),
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(
+            result,
+            tests_generated=("tests_generated", 0),
+            output_path="output_path",
+        )
 
     async def _run_performance_audit(self, args: dict[str, Any]) -> dict[str, Any]:
         """Run performance audit workflow."""
@@ -447,12 +436,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         workflow = PerformanceAuditWorkflow()
         result = await workflow.execute(path=validated_path)
 
-        return {
-            "success": result.success,
-            "findings": result.final_output.get("findings", []),
-            "score": result.final_output.get("score"),
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, findings=("findings", []), score="score")
 
     async def _run_release_prep(self, args: dict[str, Any]) -> dict[str, Any]:
         """Run release preparation workflow."""
@@ -465,24 +449,21 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         workflow = ReleasePreparationWorkflow()
         result = await workflow.execute(path=validated_path)
 
-        # ``final_output`` is dict-shaped on the happy path but degrades to a
-        # plain string when the workflow short-circuits (e.g. with an error
-        # message). Coerce to a dict view so the response shape stays stable
-        # and ``.get()`` doesn't AttributeError.
-        final_output = result.final_output
-        if not isinstance(final_output, dict):
-            final_output = {"recommendation": str(final_output)}
-
-        return {
-            "success": result.success,
-            "approved": final_output.get("approved"),
-            "health_score": final_output.get("health_score"),
-            # Serialized WorkflowReport dicts carry no "recommendation"
-            # key — fall back to the result summary so the field stays
-            # populated now that SDK workflows emit report payloads.
-            "recommendation": final_output.get("recommendation") or result.summary,
-            "cost": result.cost_report.total_cost,
-        }
+        response = _workflow_response(
+            result,
+            approved="approved",
+            health_score="health_score",
+            recommendation="recommendation",
+        )
+        if not isinstance(result.final_output, dict):
+            # Short-circuited workflows degrade ``final_output`` to a
+            # plain string (e.g. an error message) — surface it.
+            response["recommendation"] = str(result.final_output)
+        elif not response["recommendation"]:
+            # Report payloads carry no "recommendation" key — fall back
+            # to the result summary so the field stays populated.
+            response["recommendation"] = result.summary
+        return response
 
     async def _get_auth_status(self) -> dict[str, Any]:
         """Get authentication strategy status."""

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -10,6 +10,116 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+#: pick names that mean "the workflow's findings" across handlers
+_FINDINGS_KEYS = frozenset({"findings", "predictions", "checks"})
+
+
+def _is_score_key(name: str) -> bool:
+    """True for pick names that mean "the workflow's score"."""
+    return name == "score" or name.endswith("_score")
+
+
+def _metadata_findings(result: Any) -> list[Any]:
+    """Findings from ``result.metadata`` when the report carries none.
+
+    The SDK adapter stores parsed findings as a category→items dict on
+    ``metadata["findings"]``; string-bullet findings become a ListSection
+    (not a FindingsSection), so the report's ``.findings`` property can
+    be empty while metadata still has the items. Flatten to one list.
+    """
+    metadata = getattr(result, "metadata", None)
+    if not isinstance(metadata, dict):
+        return []
+    raw = metadata.get("findings")
+    if isinstance(raw, dict):
+        flat: list[Any] = []
+        for items in raw.values():
+            if isinstance(items, list):
+                flat.extend(items)
+        return flat
+    if isinstance(raw, list):
+        return raw
+    return []
+
+
+def _workflow_response(
+    result: Any,
+    *,
+    include_provider: bool = False,
+    raw_output: bool = False,
+    **field_picks: Any,
+) -> dict[str, Any]:
+    """Build an MCP response dict from a WorkflowResult.
+
+    Two shapes, decided by what ``result.final_output`` carries
+    (workflow-result-formatting spec, T5):
+
+    - **Serialized WorkflowReport**: the response carries the rendered
+      summary markdown verbatim (``summary_markdown``), the report JSON
+      (``report``), and the back-compat ``score`` / ``findings`` fields
+      restored from the report (metadata findings as fallback).
+      Findings-like picks (``findings``/``predictions``/``checks``)
+      resolve to the report findings; score-like picks (``score``,
+      ``*_score`` — either side of the mapping) to the report score;
+      everything else to its default.
+    - **Legacy flat dict**: each pick is ``final_output.get(source)``,
+      exactly the field-picking the handlers did before.
+
+    Args:
+        result: WorkflowResult returned by a workflow ``execute()``.
+        include_provider: Include ``result.provider`` in the response.
+        raw_output: Include an ``output`` field — the legacy
+            ``final_output`` passthrough; on the report path it carries
+            the summary markdown instead of the raw report dict.
+        **field_picks: ``response_key=source`` mappings where ``source``
+            is a final_output key or a ``(key, default)`` tuple.
+
+    Returns:
+        JSON-safe response dict with ``success`` and ``cost`` always set.
+    """
+    from attune.workflows.output import WorkflowReport
+
+    response: dict[str, Any] = {"success": result.success}
+    fo = result.final_output
+
+    if WorkflowReport.is_report_dict(fo):
+        from attune.config import resolve_show_cost
+        from attune.voice.report_renderer import render_safe
+
+        report = WorkflowReport.from_dict(fo)
+        findings = [f.to_dict() for f in report.findings] or _metadata_findings(result)
+        response["summary_markdown"] = render_safe(
+            report,
+            disclosure="summary",
+            show_cost=resolve_show_cost(),
+        )
+        response["report"] = fo
+        response["score"] = report.score
+        response["findings"] = findings
+        if raw_output:
+            response["output"] = response["summary_markdown"]
+        for key, source in field_picks.items():
+            src_key, default = source if isinstance(source, tuple) else (source, None)
+            if key in _FINDINGS_KEYS or src_key in _FINDINGS_KEYS:
+                response[key] = findings
+            elif _is_score_key(key) or _is_score_key(src_key):
+                response[key] = report.score
+            else:
+                response[key] = default
+    else:
+        fo_dict = fo if isinstance(fo, dict) else {}
+        for key, source in field_picks.items():
+            src_key, default = source if isinstance(source, tuple) else (source, None)
+            response[key] = fo_dict.get(src_key, default)
+        if raw_output:
+            response["output"] = fo
+
+    cost_report = getattr(result, "cost_report", None)
+    response["cost"] = cost_report.total_cost if cost_report is not None else 0.0
+    if include_provider:
+        response["provider"] = result.provider
+    return response
+
 
 class WorkflowHandlersMixin:
     """Mixin providing workflow tool handlers for EmpathyMCPServer.
@@ -59,12 +169,7 @@ class WorkflowHandlersMixin:
         workflow = DocAuditWorkflow()
         result = await workflow.execute(project_root=self._validated_path(args))
 
-        return {
-            "success": result.success,
-            "score": result.final_output.get("score"),
-            "findings": result.final_output.get("checks", []),
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, score="score", findings=("checks", []))
 
     # ------------------------------------------------------------------
     # Doc Generation
@@ -101,12 +206,7 @@ class WorkflowHandlersMixin:
             audience=args.get("audience", "developers"),
         )
 
-        return {
-            "success": result.success,
-            "document": result.final_output.get("document"),
-            "sections": result.final_output.get("sections"),
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, document="document", sections="sections")
 
     # ------------------------------------------------------------------
     # Doc Orchestrator
@@ -159,11 +259,7 @@ class WorkflowHandlersMixin:
         workflow = TestAuditWorkflow()
         result = await workflow.execute(src_path=self._validated_path(args, default="src/"))
 
-        return {
-            "success": result.success,
-            "output": result.final_output,
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, raw_output=True)
 
     # ------------------------------------------------------------------
     # Parallel Test Generation
@@ -189,14 +285,13 @@ class WorkflowHandlersMixin:
             batch_size=args.get("batch_size", 10),
         )
 
-        return {
-            "success": result.success,
-            "total_modules": result.final_output.get("total_modules", 0),
-            "completed": result.final_output.get("completed", 0),
-            "errors": result.final_output.get("errors", 0),
-            "generated_files": result.final_output.get("generated_files", []),
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(
+            result,
+            total_modules=("total_modules", 0),
+            completed=("completed", 0),
+            errors=("errors", 0),
+            generated_files=("generated_files", []),
+        )
 
     # ------------------------------------------------------------------
     # Refactor Plan
@@ -217,11 +312,7 @@ class WorkflowHandlersMixin:
         workflow = RefactorPlanWorkflow()
         result = await workflow.execute(path=self._validated_path(args))
 
-        return {
-            "success": result.success,
-            "output": result.final_output,
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, raw_output=True)
 
     # ------------------------------------------------------------------
     # Dependency Check
@@ -242,11 +333,7 @@ class WorkflowHandlersMixin:
         workflow = DependencyCheckWorkflow()
         result = await workflow.execute(path=self._validated_path(args))
 
-        return {
-            "success": result.success,
-            "output": result.final_output,
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, raw_output=True)
 
     # ------------------------------------------------------------------
     # Deep Review
@@ -267,11 +354,7 @@ class WorkflowHandlersMixin:
         workflow = DeepReviewAgentSDKWorkflow()
         result = await workflow.execute(path=self._validated_path(args))
 
-        return {
-            "success": result.success,
-            "output": result.final_output,
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, raw_output=True)
 
     # ------------------------------------------------------------------
     # Simplify Code
@@ -292,11 +375,7 @@ class WorkflowHandlersMixin:
         workflow = SimplifyCodeWorkflow()
         result = await workflow.execute(path=self._validated_path(args))
 
-        return {
-            "success": result.success,
-            "output": result.final_output,
-            "cost": result.cost_report.total_cost,
-        }
+        return _workflow_response(result, raw_output=True)
 
     # ------------------------------------------------------------------
     # Secure Release
@@ -390,6 +469,20 @@ class WorkflowHandlersMixin:
         )
 
         final = result.final_output if hasattr(result, "final_output") else result
+
+        from attune.workflows.output import WorkflowReport
+
+        if WorkflowReport.is_report_dict(final):
+            response = _workflow_response(
+                result,
+                key_insights="key_insights",
+                confidence="confidence",
+            )
+            # "answer" is this tool's primary consumer field — the
+            # rendered summary IS the synthesized answer.
+            response["answer"] = response["summary_markdown"]
+            return response
+
         if isinstance(final, dict):
             return {
                 "success": True,

--- a/tests/unit/mcp/handlers/test_workflow_response.py
+++ b/tests/unit/mcp/handlers/test_workflow_response.py
@@ -1,0 +1,285 @@
+"""Unit tests for the report-aware MCP response helper (spec T5).
+
+Covers _workflow_response directly (legacy flat-dict picks vs the
+serialized-WorkflowReport path) and two handler-level round-trips:
+a report-dict final_output through _run_security_audit must carry
+the rendered summary markdown verbatim plus the report JSON and
+non-empty back-compat findings; a legacy flat-dict final_output
+must keep the exact pre-T5 response shape.
+
+Copyright 2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import PurePosixPath
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from attune.mcp.server import EmpathyMCPServer
+from attune.mcp.workflow_handlers import _workflow_response
+from attune.voice.report_renderer import render_safe
+from attune.workflows.output import Finding, WorkflowReport
+
+# ------------------------------------------------------------------
+# Shared helpers (same pattern as test_workflow_handlers.py)
+# ------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fixed_show_cost():
+    """Pin resolve_show_cost so rendered markdown is deterministic."""
+    with patch("attune.config.resolve_show_cost", return_value=False):
+        yield
+
+
+@pytest.fixture()
+def _bypass_path_validation():
+    """Stub path validation so handler tests work cross-platform."""
+
+    def _passthrough(path, **_kwargs):
+        return PurePosixPath(path)
+
+    with patch(
+        "attune.security.path_validation._validate_file_path",
+        side_effect=_passthrough,
+    ):
+        yield
+
+
+def _make_server(workspace_root: str = "/") -> EmpathyMCPServer:
+    with patch.object(EmpathyMCPServer, "_register_plugin_tools"):
+        with patch.dict(sys.modules, {"attune.mcp.version_check": MagicMock()}):
+            return EmpathyMCPServer(workspace_root=workspace_root)
+
+
+def _make_result(
+    success: bool = True,
+    final_output: object = None,
+    total_cost: float = 0.01,
+    metadata: dict | None = None,
+) -> MagicMock:
+    result = MagicMock()
+    result.success = success
+    result.final_output = final_output if final_output is not None else {}
+    result.cost_report = MagicMock()
+    result.cost_report.total_cost = total_cost
+    result.provider = "anthropic"
+    result.metadata = metadata if metadata is not None else {}
+    return result
+
+
+def _make_workflow_module(module_name: str, class_name: str, result: MagicMock) -> ModuleType:
+    mod = ModuleType(module_name)
+    workflow_cls = MagicMock()
+    workflow_instance = MagicMock()
+    workflow_instance.execute = AsyncMock(return_value=result)
+    workflow_cls.return_value = workflow_instance
+    setattr(mod, class_name, workflow_cls)
+    return mod
+
+
+def _make_report() -> WorkflowReport:
+    return WorkflowReport.from_findings(
+        "Security audit",
+        [
+            Finding(severity="high", file="src/app.py", line=10, message="eval() usage"),
+            Finding(severity="low", file="src/util.py", line=3, message="TODO left in"),
+        ],
+        summary="2 issues found.",
+        score=72,
+    )
+
+
+# ==================================================================
+# _workflow_response — legacy flat-dict path
+# ==================================================================
+
+
+class TestWorkflowResponseLegacy:
+    """Legacy flat-dict final_output keeps the exact pre-T5 shape."""
+
+    def test_field_picks_and_defaults(self):
+        result = _make_result(final_output={"health_score": 85}, total_cost=0.05)
+        out = _workflow_response(
+            result,
+            include_provider=True,
+            score="health_score",
+            findings=("findings", []),
+        )
+
+        assert out == {
+            "success": True,
+            "score": 85,
+            "findings": [],
+            "cost": 0.05,
+            "provider": "anthropic",
+        }
+
+    def test_missing_keys_default_to_none(self):
+        result = _make_result(final_output={})
+        out = _workflow_response(result, feedback="feedback", score="quality_score")
+
+        assert out["feedback"] is None
+        assert out["score"] is None
+        assert "report" not in out
+        assert "summary_markdown" not in out
+
+    def test_raw_output_passes_final_output_through(self):
+        result = _make_result(final_output={"coverage": 85})
+        out = _workflow_response(result, raw_output=True)
+
+        assert out["output"] == {"coverage": 85}
+
+    def test_string_final_output_yields_pick_defaults(self):
+        result = _make_result(success=False, final_output="boom", total_cost=0.0)
+        out = _workflow_response(result, approved="approved", recommendation="recommendation")
+
+        assert out["success"] is False
+        assert out["approved"] is None
+        assert out["recommendation"] is None
+
+
+# ==================================================================
+# _workflow_response — serialized WorkflowReport path
+# ==================================================================
+
+
+class TestWorkflowResponseReport:
+    """Report-dict final_output carries markdown + report + back-compat."""
+
+    def test_summary_markdown_verbatim_and_report_json(self):
+        report = _make_report()
+        report_dict = report.to_dict()
+        result = _make_result(final_output=report_dict)
+
+        out = _workflow_response(result, score="health_score", findings=("findings", []))
+
+        expected = render_safe(
+            WorkflowReport.from_dict(report_dict),
+            disclosure="summary",
+            show_cost=False,
+        )
+        assert out["summary_markdown"] == expected
+        assert out["report"] == report_dict
+        assert out["score"] == 72
+        assert len(out["findings"]) == 2
+        assert out["findings"][0]["message"] == "eval() usage"
+
+    def test_findings_like_picks_resolve_to_report_findings(self):
+        result = _make_result(final_output=_make_report().to_dict())
+        out = _workflow_response(result, predictions=("predictions", []))
+
+        assert out["predictions"] == out["findings"]
+        assert len(out["predictions"]) == 2
+
+    def test_score_like_picks_resolve_to_report_score(self):
+        result = _make_result(final_output=_make_report().to_dict())
+        out = _workflow_response(result, health_score="health_score")
+
+        assert out["health_score"] == 72
+
+    def test_other_picks_resolve_to_defaults(self):
+        result = _make_result(final_output=_make_report().to_dict())
+        out = _workflow_response(
+            result, tests_generated=("tests_generated", 0), document="document"
+        )
+
+        assert out["tests_generated"] == 0
+        assert out["document"] is None
+
+    def test_raw_output_carries_summary_markdown(self):
+        result = _make_result(final_output=_make_report().to_dict())
+        out = _workflow_response(result, raw_output=True)
+
+        assert out["output"] == out["summary_markdown"]
+
+    def test_metadata_findings_fallback_when_report_has_none(self):
+        """String-bullet findings live in metadata, not FindingsSection."""
+        report = WorkflowReport(title="Doc audit", summary="ok", score=90)
+        result = _make_result(
+            final_output=report.to_dict(),
+            metadata={"findings": {"stale": ["a.md outdated"], "broken": ["b.md 404"]}},
+        )
+
+        out = _workflow_response(result)
+
+        assert sorted(out["findings"]) == ["a.md outdated", "b.md 404"]
+
+
+# ==================================================================
+# Handler-level round-trips
+# ==================================================================
+
+
+class TestHandlerReportPath:
+    """A report-dict final_output flows through a real handler."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("_bypass_path_validation")
+    async def test_security_audit_report_response(self):
+        server = _make_server()
+        report_dict = _make_report().to_dict()
+        result = _make_result(final_output=report_dict, total_cost=0.05)
+        mod = _make_workflow_module(
+            "attune.workflows.security_audit", "SecurityAuditWorkflow", result
+        )
+
+        with patch.dict(sys.modules, {"attune.workflows.security_audit": mod}):
+            out = await server._run_security_audit({"path": "/src"})
+
+        expected = render_safe(
+            WorkflowReport.from_dict(report_dict),
+            disclosure="summary",
+            show_cost=False,
+        )
+        assert out["summary_markdown"] == expected
+        assert out["report"] == report_dict
+        assert out["score"] == 72
+        assert len(out["findings"]) == 2
+        assert out["cost"] == 0.05
+        assert out["provider"] == "anthropic"
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("_bypass_path_validation")
+    async def test_deep_review_output_is_summary_markdown(self):
+        server = _make_server()
+        report_dict = _make_report().to_dict()
+        result = _make_result(final_output=report_dict)
+        mod = _make_workflow_module(
+            "attune.workflows.deep_review", "DeepReviewAgentSDKWorkflow", result
+        )
+
+        with patch.dict(sys.modules, {"attune.workflows.deep_review": mod}):
+            out = await server._run_deep_review({"path": "/src"})
+
+        assert out["output"] == out["summary_markdown"]
+        assert out["report"] == report_dict
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("_bypass_path_validation")
+    async def test_legacy_flat_dict_shape_unchanged(self):
+        """Pre-report workflows keep the exact legacy response shape."""
+        server = _make_server()
+        result = _make_result(
+            final_output={"health_score": 85, "findings": ["issue-1"]},
+            total_cost=0.05,
+        )
+        mod = _make_workflow_module(
+            "attune.workflows.security_audit", "SecurityAuditWorkflow", result
+        )
+
+        with patch.dict(sys.modules, {"attune.workflows.security_audit": mod}):
+            out = await server._run_security_audit({"path": "/src"})
+
+        assert out == {
+            "success": True,
+            "score": 85,
+            "findings": ["issue-1"],
+            "cost": 0.05,
+            "provider": "anthropic",
+        }


### PR DESCRIPTION
## Summary

T5 of the `workflow-result-formatting` spec. After T8 (#782-era adapter migration) made all 15 SDK-native workflows return a serialized `WorkflowReport` dict as `WorkflowResult.final_output`, the MCP handlers in `src/attune/mcp/server.py` and `src/attune/mcp/workflow_handlers.py` still field-picked from it as if it were the legacy flat dict (`.get("health_score")`, `.get("findings")`, ...). The report dict only carries `_type`/`sections` keys, so every report-emitting MCP tool silently returned `None` scores and empty findings.

## Change

One shared helper, `workflow_handlers._workflow_response(result, **field_picks)`, now backs all 15 handler return sites:

- **Report-dict `final_output`** → response carries:
  - `summary_markdown` — the rendered summary verbatim (`render_safe(report, disclosure="summary", show_cost=resolve_show_cost())`)
  - `report` — the `WorkflowReport.to_dict()` JSON alongside
  - back-compat `score`/`findings` restored from the report's `.findings` property, with `result.metadata["findings"]` as fallback (string-bullet findings land in a `ListSection`, not a `FindingsSection`)
  - findings-like picks (`predictions`/`checks`) and score-like picks (`*_score`) resolve from the report; `output`-style handlers carry the markdown
- **Legacy flat dicts** → exact pre-T5 field-picked shape, unchanged.

`voice/formatter.py:format_mcp_response` needed no change (it wraps generically; the report path now feeds it a real `score`).

`_run_release_prep` keeps its string-degradation regression behavior; `_run_research_synthesis` maps `answer` to the rendered summary on the report path.

## Tests

- New: `tests/unit/mcp/handlers/test_workflow_response.py` (13 tests) — verbatim summary markdown + report JSON + non-empty findings through `_run_security_audit`; raw-output handlers carry the markdown; metadata-findings fallback; legacy flat-dict shape asserted byte-for-byte unchanged.
- Existing MCP handler tests (legacy shapes) pass untouched: MCP + voice suites 497 passed.

## Spec

T5 marked done with receipt in `docs/specs/workflow-result-formatting/tasks.md`; T6 (dashboard panel) is the remaining task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
