### PR TITLE
feat(ops): structured report panel on run view — workflow-result-formatting T6

### DIFF
--- a/docs/specs/workflow-result-formatting/tasks.md
+++ b/docs/specs/workflow-result-formatting/tasks.md
@@ -1,14 +1,14 @@
 # Tasks: Workflow result formatting
 
-**Status:** partial (2026-06-11) — T1 (the `WorkflowReport` / Section
+**Status:** complete (2026-06-12) — T1 (the `WorkflowReport` / Section
 data model, #649), T2 (the markdown renderer
 `attune.voice.report_renderer` — `render()` + crash-visible
 `render_safe()`, all 4 test layers, 98% branch, #741), T3 (voice
 wiring + safety net + `show_cost_metrics`/`resolve_show_cost()`),
 T4 (CLI terminal rendering), T5 (MCP handlers report-aware,
-2026-06-12), T7 (release-prep
+2026-06-12), T6 (dashboard report panel, 2026-06-12), T7 (release-prep
 migration — the motivating case), and T8 (adapter-level migration of
-all 15 SDK-native workflows) shipped; T6 (dashboard panel) pending.
+all 15 SDK-native workflows) all shipped.
 
 > Bounded PRs; see [design.md](design.md) for the decisions each task
 > implements.

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -350,9 +350,12 @@ def _emit_run_meta_for_daemon(result: object) -> None:
     Reads ``sdk_stderr`` / ``sdk_error_kind`` from
     ``result.metadata`` (set by ``BaseWorkflow._error_result()``
     during SDK subprocess failure) and writes them as base64-encoded
-    + plain-text stdout lines that the runner parses. Silent no-op
-    when the env var isn't set, when ``result`` doesn't carry
-    metadata, or when neither field is populated.
+    + plain-text stdout lines that the runner parses. When
+    ``result.final_output`` carries a serialized ``WorkflowReport``
+    (the ``_type`` discriminator), it is also emitted as a
+    ``report_b64`` line so the dashboard's run view can render a
+    structured report panel (workflow-result-formatting T6). Silent
+    no-op when the env var isn't set or when nothing is emittable.
 
     Part of the ``docs/specs/sdk-error-message-fidelity/`` Phase 3b
     flow. The side-channel design (rather than calling into runner
@@ -365,11 +368,17 @@ def _emit_run_meta_for_daemon(result: object) -> None:
     if not run_meta_stdout.is_emission_enabled():
         return
     metadata = getattr(result, "metadata", None)
-    if not isinstance(metadata, dict):
-        return
-    kind = metadata.get("sdk_error_kind")
-    stderr_text = metadata.get("sdk_stderr")
-    if not kind and not stderr_text:
+    kind = metadata.get("sdk_error_kind") if isinstance(metadata, dict) else None
+    stderr_text = metadata.get("sdk_stderr") if isinstance(metadata, dict) else None
+
+    from attune.workflows.output import WorkflowReport
+
+    final_output = getattr(result, "final_output", None)
+    report_encoded = ""
+    if WorkflowReport.is_report_dict(final_output):
+        report_encoded = run_meta_stdout.encode_report(final_output)  # type: ignore[arg-type]
+
+    if not kind and not stderr_text and not report_encoded:
         return
     # Emit version line first so the parser knows what grammar it's
     # reading. Cheap; downstream consumer ignores it after the version
@@ -381,3 +390,5 @@ def _emit_run_meta_for_daemon(result: object) -> None:
         encoded = run_meta_stdout.encode_stderr(str(stderr_text))
         if encoded:
             run_meta_stdout.emit_field_line("sdk_stderr_b64", encoded)
+    if report_encoded:
+        run_meta_stdout.emit_field_line("report_b64", report_encoded)

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -141,6 +141,40 @@ async def get_run(run_id: str, request: Request) -> JSONResponse:
     return JSONResponse(content=run.to_dict())
 
 
+@router.get("/runs/{run_id}/report")
+async def get_run_report(run_id: str, request: Request) -> JSONResponse:
+    """Structured ``WorkflowReport`` for a run, plus its summary markdown.
+
+    Returns ``{"report": <dict>, "markdown": <str>}`` when the run
+    carried a serialized report over the run-meta side-channel; 404
+    when the run is unknown or produced no structured report (the run
+    view treats that as "no panel", keeping unmigrated workflows
+    working unchanged). The markdown is rendered server-side by the
+    canonical renderer so the dashboard never reimplements report
+    formatting — it only converts the constrained markdown subset to
+    HTML. Workflow-result-formatting T6; disk-loaded runs are served
+    via ``get_or_load`` so the panel survives a daemon restart.
+    """
+    svc = _service(request)
+    run = svc.get_or_load(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    if run.report is None:
+        raise HTTPException(status_code=404, detail="run has no structured report")
+
+    from attune.config import resolve_show_cost
+    from attune.voice.report_renderer import render_safe
+    from attune.workflows.output import WorkflowReport
+
+    try:
+        report = WorkflowReport.from_dict(run.report)
+    except (TypeError, ValueError) as exc:
+        logger.warning("ops.report: malformed report for run %s: %s", run_id, exc)
+        raise HTTPException(status_code=404, detail="run report is malformed") from exc
+    markdown = render_safe(report, disclosure="summary", show_cost=resolve_show_cost())
+    return JSONResponse(content={"report": run.report, "markdown": markdown})
+
+
 @router.get("/runs/{run_id}/stream")
 async def stream_run(run_id: str, request: Request) -> StreamingResponse:
     svc = _service(request)

--- a/src/attune/ops/run_meta_stdout.py
+++ b/src/attune/ops/run_meta_stdout.py
@@ -26,6 +26,7 @@ Grammar (one event per line):
     ATTUNE_RUN_META_VERSION 1
     ATTUNE_RUN_META sdk_error_kind=<kind>
     ATTUNE_RUN_META sdk_stderr_b64=<base64>
+    ATTUNE_RUN_META report_b64=<base64-json>
 
 The ``sdk_stderr`` field is base64-encoded because raw stderr
 typically spans multiple lines and includes characters (quotes,
@@ -59,7 +60,10 @@ VERSION = 1
 # Allowed key names. Restricting to a known set keeps the grammar tight;
 # extending this requires updating both ``emit_field_line`` and
 # ``parse_line`` (and the consumer in ``RunnerService._execute``).
-_ALLOWED_KEYS = frozenset(("sdk_error_kind", "sdk_stderr_b64"))
+# ``report_b64`` carries the serialized ``WorkflowReport`` dict
+# (base64-encoded JSON) so the dashboard's run view can render a
+# structured report panel — workflow-result-formatting T6.
+_ALLOWED_KEYS = frozenset(("sdk_error_kind", "sdk_stderr_b64", "report_b64"))
 
 # Regex per line kind. Anchored at start; trailing content is the value.
 _RE_VERSION = re.compile(r"^ATTUNE_RUN_META_VERSION (\d+)$")
@@ -133,6 +137,41 @@ def decode_stderr(b64_text: str) -> str:
         return base64.b64decode(b64_text, validate=True).decode("utf-8", errors="replace")
     except (ValueError, UnicodeDecodeError):
         return ""
+
+
+def encode_report(report_dict: dict[str, Any]) -> str:
+    """Base64-encode a serialized ``WorkflowReport`` dict for wire transit.
+
+    JSON is compact-encoded (no whitespace) before base64 so the single
+    marker line stays as short as possible. Returns empty string when
+    the dict can't be JSON-encoded — the caller skips emission rather
+    than writing a malformed marker.
+    """
+    import json
+
+    try:
+        raw = json.dumps(report_dict, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return ""
+    return base64.b64encode(raw.encode("utf-8")).decode("ascii")
+
+
+def decode_report(b64_text: str) -> dict[str, Any] | None:
+    """Inverse of :func:`encode_report`. ``None`` on malformed input.
+
+    The consumer (``RunnerService.handle_stdout_line``) treats ``None``
+    as "drop the marker, keep any previously-stashed report".
+    """
+    import json
+
+    if not b64_text:
+        return None
+    try:
+        raw = base64.b64decode(b64_text, validate=True).decode("utf-8")
+        parsed = json.loads(raw)
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
 
 
 def parse_line(line: str) -> dict[str, Any] | None:

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -126,6 +126,11 @@ class Run:
     # ``auth``, ``rate_limit``, ``not_found``, ``schema_rejected``,
     # ``unknown``). ``None`` when no SDK failure was captured.
     sdk_error_kind: str | None = None
+    # Serialized ``WorkflowReport`` dict (``_type: WorkflowReport``)
+    # delivered via the ``report_b64`` run-meta side-channel when the
+    # workflow's ``final_output`` carried one. Drives the run view's
+    # structured report panel — workflow-result-formatting T6.
+    report: dict[str, object] | None = None
     lines: list[str] = field(default_factory=list)
     # Buffered recommendations replayed to late subscribers so a user
     # who opens /runs/<id>/view after the run finished still sees the
@@ -157,6 +162,7 @@ class Run:
             "command": list(self.command) if self.command else None,
             "sdk_stderr": self.sdk_stderr,
             "sdk_error_kind": self.sdk_error_kind,
+            "report": self.report,
         }
 
     def to_record(self) -> dict[str, object]:
@@ -195,6 +201,9 @@ class Run:
         sdk_stderr = str(sdk_stderr_raw) if isinstance(sdk_stderr_raw, str) else None
         sdk_kind_raw = data.get("sdk_error_kind")
         sdk_error_kind = str(sdk_kind_raw) if isinstance(sdk_kind_raw, str) else None
+        # Structured report (T6) — old records read back as None.
+        report_raw = data.get("report")
+        report = report_raw if isinstance(report_raw, dict) else None
         return cls(
             id=str(data.get("id", "")),
             workflow=str(data.get("workflow", "")),
@@ -206,6 +215,7 @@ class Run:
             command=command,
             sdk_stderr=sdk_stderr,
             sdk_error_kind=sdk_error_kind,
+            report=report,
             lines=lines,
         )
 
@@ -242,6 +252,10 @@ class Run:
                     "status": self.status,
                     "sdk_error_kind": self.sdk_error_kind,
                     "sdk_stderr": self.sdk_stderr,
+                    # Signals the run view to fetch /runs/<id>/report and
+                    # render the structured panel (T6). A boolean rather
+                    # than the report itself keeps the SSE frame small.
+                    "has_report": self.report is not None,
                 },
             )
         )
@@ -290,6 +304,7 @@ class Run:
                         "status": self.status,
                         "sdk_error_kind": self.sdk_error_kind,
                         "sdk_stderr": self.sdk_stderr,
+                        "has_report": self.report is not None,
                     },
                 )
             )
@@ -526,6 +541,10 @@ class RunnerService:
                     decoded = run_meta_stdout.decode_stderr(value)
                     if decoded:
                         run.sdk_stderr = decoded
+                elif key == "report_b64" and value:
+                    decoded_report = run_meta_stdout.decode_report(value)
+                    if decoded_report is not None:
+                        run.report = decoded_report
             return
         run.append_line(line)
 

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -1176,6 +1176,93 @@ a.kpi:hover {
   font-size: 12px;
 }
 
+/* ---------- Structured report panel (workflow-result-formatting T6) -- */
+/* Populated by run_view.js from GET /runs/<id>/report once the run is
+   terminal. The markdown subset (headings, tables, callouts, lists,
+   native <details>) is converted to HTML client-side. */
+.run-report-panel {
+  margin: 16px 0;
+  padding: 18px 20px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius);
+}
+.run-report-body h2 {
+  margin: 0 0 8px;
+  font-size: 18px;
+}
+.run-report-body h3 {
+  margin: 18px 0 6px;
+  font-size: 15px;
+}
+.run-report-body h4 {
+  margin: 14px 0 4px;
+  font-size: 13px;
+}
+.run-report-body p {
+  margin: 6px 0;
+  font-size: 13px;
+}
+.run-report-body table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  font-size: 13px;
+}
+.run-report-body th,
+.run-report-body td {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  text-align: left;
+}
+.run-report-body th {
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-weight: 600;
+}
+.run-report-body ul {
+  margin: 6px 0;
+  padding-left: 22px;
+  font-size: 13px;
+}
+.run-report-body blockquote {
+  margin: 8px 0;
+  padding: 6px 12px;
+  border-left: 3px solid var(--accent);
+  background: var(--bg);
+  border-radius: var(--radius);
+}
+.run-report-body pre {
+  margin: 6px 0;
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 12px;
+  overflow-x: auto;
+}
+.run-report-body details {
+  margin: 8px 0;
+}
+.run-report-body details > summary {
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+.run-report-actions {
+  margin-top: 12px;
+}
+
+/* Terminal pane wrapper — open while streaming; run_view.js collapses
+   it when the report panel renders so the raw output becomes a
+   click-to-expand process log. */
+.run-log-details > summary {
+  cursor: pointer;
+  color: var(--fg-muted);
+  font-size: 13px;
+  margin: 8px 0 4px;
+}
+
 /* ---------- Completion candidates section ("Ready to close?") ---------- */
 /* Server-rendered shell at the top of /specs, populated by
    completion_candidates.js. Hidden when there are no candidates so

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -21,9 +21,21 @@
 
   var STREAM_URL = DATA.stream_url || "";
   var INITIAL_STATUS = DATA.initial_status || "";
+  var RUN_ID = DATA.run_id || "";
   var SOURCE_WORKFLOW = DATA.workflow || "";
   var SOURCE_PATH = DATA.path == null ? null : DATA.path;
   var ALLOW_RUN = DATA.allow_run === true;
+
+  // Suggestion-chip parsing patterns. Declared up top (not in the
+  // suggestion-chips section below) because the disk-loaded branch
+  // calls renderSuggestionChipsFromLog SYNCHRONOUSLY during IIFE
+  // evaluation — with the assignments further down, the hoisted vars
+  // would still be undefined at that call and the page init would
+  // die on _NEXT_STEP_RE.exec. Lines look like:
+  //   I'd run `attune workflow run security-audit` next — Your spec ...
+  // The backtick-wrapped workflow name is the parsable signal.
+  var _NEXT_STEP_RE = /attune workflow run\s+([a-z][a-z0-9-]+)/i;
+  var _VALID_WORKFLOW_NAME_RE = /^[a-z][a-z0-9-]+$/;
 
   var pre = document.querySelector("[data-log]");
   var statusEl = document.querySelector("[data-status]");
@@ -208,6 +220,9 @@
       // The marker pattern is stable across all SDK-native workflows
       // (defined in attune.voice.personality.HEADER_NEXT_STEPS).
       renderSuggestionChipsFromLog(logBuffer);
+      // T6 — when the run carried a structured WorkflowReport, fetch
+      // it and render the report panel above the (now collapsing) log.
+      if (info.has_report) fetchAndRenderReport();
       es.close();
     });
 
@@ -248,6 +263,9 @@
     if (preEl) {
       renderSuggestionChipsFromLog(preEl.textContent || "");
     }
+    // T6 — disk-loaded runs may carry a persisted structured report;
+    // a 404 from the report route just means "no panel".
+    fetchAndRenderReport();
   }
 
   // ----------------------------------------------------------------
@@ -569,12 +587,9 @@
   // Suggestion chips parsed from "What I'd Do Next" log lines
   // ------------------------------------------------------------------
 
-  // Pattern: lines look like
-  //   I'd run `attune workflow run security-audit` next — Your spec ...
-  // The backtick-wrapped workflow name is the parsable signal. Free-form
+  // Pattern vars (_NEXT_STEP_RE / _VALID_WORKFLOW_NAME_RE) are declared
+  // at the top of the IIFE — see the comment there for why. Free-form
   // explanation after the em-dash is kept as the chip's tooltip text.
-  var _NEXT_STEP_RE = /attune workflow run\s+([a-z][a-z0-9-]+)/i;
-  var _VALID_WORKFLOW_NAME_RE = /^[a-z][a-z0-9-]+$/;
 
   function parseSuggestions(logText) {
     if (!logText || typeof logText !== "string") return [];
@@ -717,6 +732,261 @@
   }
 
   // ------------------------------------------------------------------
+  // T6 (workflow-result-formatting) — structured report panel
+  // ------------------------------------------------------------------
+  //
+  // The runner stashes the workflow's serialized WorkflowReport (sent
+  // over the ATTUNE_RUN_META report_b64 side-channel) and the server
+  // renders its summary markdown via the canonical Python renderer.
+  // This module fetches /runs/<id>/report once the run is terminal,
+  // converts that CONSTRAINED markdown subset to HTML (headings,
+  // tables, lists, blockquote callouts, fenced code, inline bold/code,
+  // and the renderer's literal <details> wrappers), and renders Run
+  // chips for next-step actions whose command is a runnable
+  // `attune workflow run <name>`. The terminal log collapses into a
+  // "Process log" <details> so the report is the primary content.
+
+  function escapeHtml(text) {
+    return String(text)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  // Inline transforms applied AFTER escaping: **bold**, `code`,
+  // *emphasis*. Escaping first means the regexes only ever see
+  // entity-encoded text, so no raw HTML can sneak through.
+  function mdInline(text) {
+    var s = escapeHtml(text);
+    s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    s = s.replace(/`([^`]+)`/g, "<code>$1</code>");
+    s = s.replace(/(^|[\s(])\*([^*\s][^*]*)\*/g, "$1<em>$2</em>");
+    return s;
+  }
+
+  // Convert the report renderer's markdown subset to HTML. This is NOT
+  // a general markdown parser — it handles exactly what
+  // attune.voice.report_renderer emits (see that module's docstring).
+  // Anything unrecognized renders as an escaped paragraph, so renderer
+  // drift degrades to ugly-but-safe text rather than broken markup.
+  function mdToHtml(md) {
+    var lines = String(md).split(/\r?\n/);
+    var out = [];
+    var para = [];
+    var i, line;
+
+    function flushPara() {
+      if (!para.length) return;
+      out.push("<p>" + mdInline(para.join(" ")) + "</p>");
+      para = [];
+    }
+
+    for (i = 0; i < lines.length; i++) {
+      line = lines[i];
+      var trimmed = line.trim();
+
+      if (!trimmed) { flushPara(); continue; }
+
+      // Renderer-emitted <details> wrappers pass through as real tags
+      // (title re-escaped). Everything else angle-bracketed is escaped.
+      var dm = /^<details><summary>(.*)<\/summary>$/.exec(trimmed);
+      if (dm) {
+        flushPara();
+        out.push("<details><summary>" + mdInline(dm[1]) + "</summary>");
+        continue;
+      }
+      if (trimmed === "</details>") {
+        flushPara();
+        out.push("</details>");
+        continue;
+      }
+
+      // Fenced code block — consume until the closing fence. The
+      // renderer indents command fences under their bullet; strip that
+      // shared indent so the <pre> doesn't render leading whitespace.
+      if (/^```/.test(trimmed)) {
+        flushPara();
+        var fenceIndent = line.length - line.replace(/^\s+/, "").length;
+        var code = [];
+        i++;
+        while (i < lines.length && !/^\s*```/.test(lines[i])) {
+          code.push(lines[i].slice(fenceIndent));
+          i++;
+        }
+        out.push("<pre><code>" + escapeHtml(code.join("\n")) + "</code></pre>");
+        continue;
+      }
+
+      // Headings — demoted one level (the page owns <h1>).
+      var hm = /^(#{1,3})\s+(.*)$/.exec(trimmed);
+      if (hm) {
+        flushPara();
+        var level = hm[1].length + 1;
+        out.push("<h" + level + ">" + mdInline(hm[2]) + "</h" + level + ">");
+        continue;
+      }
+
+      // Pipe table — consume contiguous | lines; row 2 is the ---
+      // separator the renderer always emits.
+      if (trimmed.charAt(0) === "|") {
+        flushPara();
+        var rows = [];
+        while (i < lines.length && lines[i].trim().charAt(0) === "|") {
+          rows.push(lines[i].trim());
+          i++;
+        }
+        i--;
+        out.push(mdTable(rows));
+        continue;
+      }
+
+      // Unordered list — consume contiguous "- " lines. Commands under
+      // a bullet arrive as indented fenced blocks and are handled by
+      // the fence branch above because the renderer separates them
+      // with blank lines.
+      if (/^- /.test(trimmed)) {
+        flushPara();
+        var items = [];
+        while (i < lines.length && /^- /.test(lines[i].trim())) {
+          items.push("<li>" + mdInline(lines[i].trim().slice(2)) + "</li>");
+          i++;
+        }
+        i--;
+        out.push("<ul>" + items.join("") + "</ul>");
+        continue;
+      }
+
+      // Blockquote callout — consume contiguous "> " lines.
+      if (trimmed.charAt(0) === ">") {
+        flushPara();
+        var quoted = [];
+        while (i < lines.length && lines[i].trim().charAt(0) === ">") {
+          quoted.push(lines[i].trim().replace(/^>\s?/, ""));
+          i++;
+        }
+        i--;
+        out.push(
+          "<blockquote>" +
+          quoted.filter(function (q) { return q !== ""; })
+            .map(function (q) { return "<p>" + mdInline(q) + "</p>"; })
+            .join("") +
+          "</blockquote>"
+        );
+        continue;
+      }
+
+      para.push(trimmed);
+    }
+    flushPara();
+    return out.join("\n");
+  }
+
+  function mdTable(rows) {
+    function cells(row) {
+      // "| a | b |" → ["a", "b"]. Manual scan (no regex lookbehind —
+      // it's a parse error on older Safari) honoring the renderer's
+      // escaped \| cells.
+      var inner = row.replace(/^\|/, "").replace(/\|$/, "");
+      var parts = [];
+      var cur = "";
+      for (var k = 0; k < inner.length; k++) {
+        var ch = inner.charAt(k);
+        if (ch === "\\" && inner.charAt(k + 1) === "|") { cur += "|"; k++; continue; }
+        if (ch === "|") { parts.push(cur.trim()); cur = ""; continue; }
+        cur += ch;
+      }
+      parts.push(cur.trim());
+      return parts;
+    }
+    var head = cells(rows[0]);
+    var html = ["<table><thead><tr>"];
+    head.forEach(function (c) { html.push("<th>" + mdInline(c) + "</th>"); });
+    html.push("</tr></thead><tbody>");
+    // rows[1] is the --- separator; body starts at 2.
+    for (var r = 2; r < rows.length; r++) {
+      html.push("<tr>");
+      cells(rows[r]).forEach(function (c) { html.push("<td>" + mdInline(c) + "</td>"); });
+      html.push("</tr>");
+    }
+    html.push("</tbody></table>");
+    return html.join("");
+  }
+
+  // Extract runnable next-step actions from the report dict: items in
+  // any kind === "next-steps" section whose command parses as
+  // `attune workflow run <name>` (same grammar the log-scrape chips
+  // use). Other commands stay as fenced code in the markdown.
+  function runnableNextActions(report) {
+    var out = [];
+    var sections = (report && report.sections) || [];
+    for (var i = 0; i < sections.length; i++) {
+      var s = sections[i];
+      if (!s || s.kind !== "next-steps" || !s.items) continue;
+      for (var j = 0; j < s.items.length; j++) {
+        var item = s.items[j];
+        if (!item || typeof item.command !== "string") continue;
+        var m = _NEXT_STEP_RE.exec(item.command);
+        if (!m || !_VALID_WORKFLOW_NAME_RE.test(m[1])) continue;
+        out.push({ name: m[1], tooltip: item.text || "" });
+      }
+    }
+    return out;
+  }
+
+  function renderReportPanel(data) {
+    var panel = document.querySelector("[data-report-panel]");
+    if (!panel || !data || typeof data.markdown !== "string") return;
+    while (panel.firstChild) panel.removeChild(panel.firstChild);
+
+    var body = document.createElement("div");
+    body.className = "run-report-body";
+    body.innerHTML = mdToHtml(data.markdown);
+    panel.appendChild(body);
+
+    // One-click Run chips for runnable next-step commands — reuses the
+    // suggestion-chip POST flow (and its busy/read-only handling).
+    var actions = runnableNextActions(data.report);
+    if (actions.length) {
+      var row = document.createElement("div");
+      row.className = "suggestion-row run-report-actions";
+      var label = document.createElement("span");
+      label.className = "suggestion-row-label";
+      label.textContent = "Run next:";
+      row.appendChild(label);
+      for (var i = 0; i < actions.length; i++) {
+        row.appendChild(buildSuggestionChip(actions[i]));
+      }
+      panel.appendChild(row);
+    }
+
+    panel.hidden = false;
+    // The report is now the page's primary content; tuck the raw
+    // terminal output away as a collapsed process log.
+    var logDetails = document.querySelector("[data-log-details]");
+    if (logDetails) logDetails.open = false;
+  }
+
+  function fetchAndRenderReport() {
+    if (!RUN_ID) return;
+    fetch("/runs/" + encodeURIComponent(RUN_ID) + "/report", {
+      headers: { Accept: "application/json" }
+    })
+      .then(function (resp) {
+        if (!resp.ok) return null; // 404 = no structured report; fine.
+        return resp.json();
+      })
+      .then(function (data) {
+        if (data) renderReportPanel(data);
+      })
+      .catch(function (err) {
+        // INTENTIONAL: the panel is progressive enhancement — a fetch
+        // failure leaves the classic log view fully usable.
+        console.warn("attune-ops: report fetch failed", err);
+      });
+  }
+
+  // ------------------------------------------------------------------
   // Copy report — clipboard handler for the [data-copy-report] button
   // ------------------------------------------------------------------
 
@@ -800,6 +1070,12 @@
       readReportText: readReportText,
       copyReportToClipboard: copyReportToClipboard,
       wireCopyReportButton: wireCopyReportButton,
+      escapeHtml: escapeHtml,
+      mdInline: mdInline,
+      mdToHtml: mdToHtml,
+      runnableNextActions: runnableNextActions,
+      renderReportPanel: renderReportPanel,
+      fetchAndRenderReport: fetchAndRenderReport,
       DATA: DATA
     };
   }

--- a/src/attune/ops/templates/run_view.html
+++ b/src/attune/ops/templates/run_view.html
@@ -65,12 +65,26 @@
   </section>
 {% endif %}
 
+{# T6 (workflow-result-formatting) — structured report panel. Hidden
+   until run_view.js fetches /runs/<id>/report (on page load for
+   terminal runs, on the SSE done event for live ones) and converts
+   the renderer's markdown subset to HTML. Runs without a structured
+   report never reveal this section. #}
+<section class="run-report-panel" data-report-panel hidden></section>
+
 {# When stream_url is empty, this run was loaded from disk (older than
    the runner's in-memory ring buffer). Server pre-fills the log here
    so the page renders without SSE — run_view.js detects the empty
-   stream_url and skips EventSource creation. #}
-<pre class="log-output run-view-log" data-log>{% for line in server_rendered_lines %}{{ line }}
+   stream_url and skips EventSource creation.
+   The <details> wrapper stays open while the run streams; once the
+   structured report panel renders, run_view.js collapses it so the
+   report is the page's primary content and the raw output becomes a
+   click-to-expand process log (T6). #}
+<details class="run-log-details" data-log-details open>
+  <summary>Process log</summary>
+  <pre class="log-output run-view-log" data-log>{% for line in server_rendered_lines %}{{ line }}
 {% endfor %}</pre>
+</details>
 
 {# Phase 3a — collapsible raw stderr from the underlying claude CLI
    subprocess when an SDK-backed workflow fails. Default-collapsed so
@@ -106,6 +120,7 @@
 {
   "stream_url": {{ stream_url|tojson }},
   "initial_status": {{ run.status|tojson }},
+  "run_id": {{ run.id|tojson }},
   "workflow": {{ run.workflow|tojson }},
   "path": {{ run.path|tojson }},
   "allow_run": {{ allow_run|tojson }}

--- a/tests/unit/ops/test_run_report_panel.py
+++ b/tests/unit/ops/test_run_report_panel.py
@@ -1,0 +1,318 @@
+"""Tests for the run-view structured report panel.
+
+Workflow-result-formatting T6: the CLI emits the serialized
+``WorkflowReport`` over the ``ATTUNE_RUN_META report_b64`` stdout
+side-channel; the runner stashes it on ``Run.report`` (persisted with
+the record and flagged via ``has_report`` in the SSE done payload);
+``GET /runs/{run_id}/report`` serves the dict plus server-rendered
+summary markdown; ``run_view.js`` converts that markdown subset to
+HTML in a panel above the (collapsing) process log.
+
+Spec: docs/specs/workflow-result-formatting/ T6.
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+pytest.importorskip("yaml")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.cli_commands.workflow_commands import _emit_run_meta_for_daemon  # noqa: E402
+from attune.ops import run_meta_stdout  # noqa: E402
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.runner import Run, RunnerService  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+from attune.workflows.output import (  # noqa: E402
+    FindingsSection,
+    NextAction,
+    NextStepsSection,
+    WorkflowReport,
+)
+
+_SRC = Path(__file__).resolve().parents[3] / "src" / "attune" / "ops"
+_TEMPLATE = _SRC / "templates" / "run_view.html"
+_JS = _SRC / "static" / "js" / "run_view.js"
+_CSS = _SRC / "static" / "css" / "main.css"
+
+
+def _report_dict() -> dict[str, Any]:
+    report = WorkflowReport(
+        title="Security audit",
+        summary="2 findings across 14 files.",
+        score=87,
+        sections=[
+            FindingsSection(title="Findings", tier="essential", findings=[]),
+            NextStepsSection(
+                title="Next steps",
+                tier="essential",
+                items=[
+                    NextAction(
+                        text="Re-run the audit on src/",
+                        command="attune workflow run security-audit",
+                    ),
+                    NextAction(
+                        text="Fix the flagged file",
+                        file="src/attune/config.py:42",
+                    ),
+                ],
+            ),
+        ],
+    )
+    return report.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# run_meta_stdout — report_b64 wire format
+# ---------------------------------------------------------------------------
+
+
+class TestReportWireFormat:
+    def test_encode_decode_round_trip(self):
+        encoded = run_meta_stdout.encode_report(_report_dict())
+        assert encoded
+        assert run_meta_stdout.decode_report(encoded) == _report_dict()
+
+    def test_decode_malformed_b64_returns_none(self):
+        assert run_meta_stdout.decode_report("!!notb64!!") is None
+
+    def test_decode_non_dict_json_returns_none(self):
+        import base64
+
+        encoded = base64.b64encode(b'["not", "a", "dict"]').decode("ascii")
+        assert run_meta_stdout.decode_report(encoded) is None
+
+    def test_encode_unserializable_returns_empty(self):
+        assert run_meta_stdout.encode_report({"bad": object()}) == ""
+
+    def test_parse_line_accepts_report_b64_key(self):
+        encoded = run_meta_stdout.encode_report(_report_dict())
+        parsed = run_meta_stdout.parse_line(f"ATTUNE_RUN_META report_b64={encoded}")
+        assert parsed == {"event": "field", "key": "report_b64", "value": encoded}
+
+
+# ---------------------------------------------------------------------------
+# CLI emitter — final_output report dict → report_b64 line
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResult:
+    metadata: dict[str, Any] = field(default_factory=dict)
+    final_output: Any = None
+
+
+def _capture(callback) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        callback()
+    return buf.getvalue()
+
+
+class TestCliEmitter:
+    def test_report_final_output_emits_report_b64(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_RUN_META_EMIT", "1")
+        result = _FakeResult(final_output=_report_dict())
+        out = _capture(lambda: _emit_run_meta_for_daemon(result))
+        lines = out.strip().split("\n")
+        assert lines[0].startswith("ATTUNE_RUN_META_VERSION ")
+        b64_lines = [ln for ln in lines if ln.startswith("ATTUNE_RUN_META report_b64=")]
+        assert len(b64_lines) == 1
+        encoded = b64_lines[0].split("=", 1)[1]
+        assert run_meta_stdout.decode_report(encoded) == _report_dict()
+
+    def test_non_report_final_output_emits_nothing(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_RUN_META_EMIT", "1")
+        result = _FakeResult(final_output={"formatted_report": "legacy text"})
+        assert _capture(lambda: _emit_run_meta_for_daemon(result)) == ""
+
+    def test_env_unset_emits_nothing_even_with_report(self, monkeypatch):
+        monkeypatch.delenv("ATTUNE_RUN_META_EMIT", raising=False)
+        result = _FakeResult(final_output=_report_dict())
+        assert _capture(lambda: _emit_run_meta_for_daemon(result)) == ""
+
+    def test_report_and_sdk_error_both_emit(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_RUN_META_EMIT", "1")
+        result = _FakeResult(
+            metadata={"sdk_error_kind": "auth"},
+            final_output=_report_dict(),
+        )
+        out = _capture(lambda: _emit_run_meta_for_daemon(result))
+        assert "ATTUNE_RUN_META sdk_error_kind=auth" in out
+        assert "ATTUNE_RUN_META report_b64=" in out
+
+
+# ---------------------------------------------------------------------------
+# Runner — stash, done payload, persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+def _make_runner() -> RunnerService:
+    return RunnerService(command_builder=lambda _name: ("true",))
+
+
+class TestRunnerStash:
+    def test_report_b64_marker_stashes_on_run(self):
+        runner = _make_runner()
+        run = Run(id="testrunid01", workflow="security-audit")
+        encoded = run_meta_stdout.encode_report(_report_dict())
+        runner.handle_stdout_line(run, f"ATTUNE_RUN_META report_b64={encoded}")
+        assert run.report == _report_dict()
+        assert "ATTUNE_RUN_META" not in "\n".join(run.lines)
+
+    def test_malformed_report_b64_does_not_clobber(self):
+        runner = _make_runner()
+        run = Run(id="testrunid01", workflow="security-audit")
+        encoded = run_meta_stdout.encode_report(_report_dict())
+        runner.handle_stdout_line(run, f"ATTUNE_RUN_META report_b64={encoded}")
+        runner.handle_stdout_line(run, "ATTUNE_RUN_META report_b64=!!notb64!!")
+        assert run.report == _report_dict()
+
+    def test_done_payload_flags_has_report(self):
+        run = Run(id="testrunid01", workflow="security-audit")
+        run.report = _report_dict()
+        captured: list[tuple[str, object]] = []
+        run._broadcast = captured.append  # type: ignore[method-assign]
+        run.mark_done(0)
+        ((kind, payload),) = captured
+        assert kind == "done"
+        assert payload["has_report"] is True  # type: ignore[index]
+
+    def test_done_payload_has_report_false_without_report(self):
+        run = Run(id="testrunid01", workflow="security-audit")
+        captured: list[tuple[str, object]] = []
+        run._broadcast = captured.append  # type: ignore[method-assign]
+        run.mark_done(0)
+        ((_, payload),) = captured
+        assert payload["has_report"] is False  # type: ignore[index]
+
+    def test_record_round_trip_preserves_report(self):
+        run = Run(id="abc12345", workflow="security-audit", status="completed")
+        run.report = _report_dict()
+        restored = Run.from_record(run.to_record())
+        assert restored.report == _report_dict()
+
+    def test_old_record_without_report_reads_back_none(self):
+        restored = Run.from_record(
+            {"id": "abc12345", "workflow": "security-audit", "status": "completed"}
+        )
+        assert restored.report is None
+
+
+# ---------------------------------------------------------------------------
+# GET /runs/{run_id}/report
+# ---------------------------------------------------------------------------
+
+
+def _make_app(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=True,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(command_builder=lambda _name: ("true",))
+    app = create_app(config, runner=runner)
+    return app, runner
+
+
+class TestReportRoute:
+    def test_unknown_run_404(self, tmp_path, monkeypatch):
+        app, _ = _make_app(tmp_path, monkeypatch)
+        with TestClient(app) as client:
+            resp = client.get("/runs/deadbeef0001/report")
+        assert resp.status_code == 404
+
+    def test_run_without_report_404(self, tmp_path, monkeypatch):
+        app, runner = _make_app(tmp_path, monkeypatch)
+        run = Run(id="deadbeef0001", workflow="security-audit", status="completed")
+        runner._runs[run.id] = run
+        with TestClient(app) as client:
+            resp = client.get("/runs/deadbeef0001/report")
+        assert resp.status_code == 404
+
+    def test_run_with_report_returns_dict_and_markdown(self, tmp_path, monkeypatch):
+        app, runner = _make_app(tmp_path, monkeypatch)
+        run = Run(id="deadbeef0001", workflow="security-audit", status="completed")
+        run.report = _report_dict()
+        runner._runs[run.id] = run
+        with TestClient(app) as client:
+            resp = client.get("/runs/deadbeef0001/report")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["report"] == _report_dict()
+        # Rendered by the canonical renderer — title heading + summary
+        # text + the next-steps command fence must all survive.
+        assert "# Security audit" in body["markdown"]
+        assert "2 findings across 14 files." in body["markdown"]
+        assert "attune workflow run security-audit" in body["markdown"]
+
+
+# ---------------------------------------------------------------------------
+# Template / JS surface (source-grep level, like the copy-report tests)
+# ---------------------------------------------------------------------------
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+class TestTemplateAndJs:
+    def test_template_has_report_panel_slot(self):
+        text = _read(_TEMPLATE)
+        assert "data-report-panel" in text
+
+    def test_template_wraps_log_in_collapsible(self):
+        text = _read(_TEMPLATE)
+        assert "data-log-details" in text
+        assert "Process log" in text
+        # The wrapper must still contain the canonical [data-log] pre so
+        # the copy-report button and SSE append path keep working.
+        details_idx = text.find("data-log-details")
+        log_idx = text.find("data-log>", details_idx)
+        assert details_idx >= 0 and log_idx > details_idx
+
+    def test_template_injects_run_id(self):
+        assert '"run_id"' in _read(_TEMPLATE)
+
+    def test_js_exports_report_panel_helpers(self):
+        text = _read(_JS)
+        for name in (
+            "function mdToHtml(",
+            "function renderReportPanel(",
+            "function fetchAndRenderReport(",
+            "function runnableNextActions(",
+            "mdToHtml: mdToHtml",
+            "renderReportPanel: renderReportPanel",
+            "fetchAndRenderReport: fetchAndRenderReport",
+        ):
+            assert name in text, f"missing {name!r} in run_view.js"
+
+    def test_js_fetches_report_on_done_and_disk_loaded(self):
+        text = _read(_JS)
+        assert "info.has_report" in text
+        assert text.count("fetchAndRenderReport()") >= 2
+
+    def test_js_escapes_before_inline_markup(self):
+        """The converter must escape HTML before applying inline
+        transforms — the escape call inside mdInline is the guard
+        against report text injecting markup."""
+        text = _read(_JS)
+        inline_idx = text.find("function mdInline(")
+        assert inline_idx >= 0
+        body = text[inline_idx : text.find("}", inline_idx)]
+        assert "escapeHtml(" in body
+
+    def test_css_styles_report_panel(self):
+        text = _read(_CSS)
+        assert ".run-report-panel" in text
+        assert ".run-log-details" in text


### PR DESCRIPTION
Closes the **last open task (T6)** of `docs/specs/workflow-result-formatting/` — the spec status flips to **complete**.

## What

The run view gets a structured report panel: when a workflow's `final_output` carries a serialized `WorkflowReport`, the dashboard renders it as real HTML (score, callouts, findings tables, native `<details>` collapsibles, one-click "Run next" chips) above the terminal stream, and the raw output collapses into a "Process log" disclosure.

## How it flows

1. **CLI → daemon**: `_emit_run_meta_for_daemon` emits a new `report_b64` key (base64 compact JSON) over the existing `ATTUNE_RUN_META` stdout side-channel — same env-gated design as `sdk_stderr_b64`, so piped CLI output stays clean.
2. **Runner**: stashes it on `Run.report`, includes it in `to_dict()`/persistence (old records read back as `None`), and flags `has_report` in the SSE `done` payload.
3. **API**: new `GET /runs/{run_id}/report` → `{"report": dict, "markdown": str}`, markdown rendered server-side by the canonical `attune.voice.report_renderer` (`disclosure="summary"`, `resolve_show_cost()`). Uses `get_or_load` so disk-loaded runs work after a daemon restart.
4. **UI**: `run_view.js` fetches on SSE `done` (live) or page init (disk-loaded), converts the renderer's *constrained* markdown subset to HTML — escape-first so report text can't inject markup — and builds Run chips for `NextAction.command`s matching `attune workflow run <name>` (reusing the suggestion-chip POST flow, including busy/read-only handling).

## Scope note

`NextAction.file` refs render as inline code, not links — the dashboard has no file-serving route and adding one is a security surface this task doesn't need. Noted in the commit message.

## Drive-by fix

Latent init-order bug: the disk-loaded branch called `renderSuggestionChipsFromLog` synchronously before the hoisted `_NEXT_STEP_RE` var was assigned — a "What I'd Do Next" header in a disk-loaded log would have thrown and killed the rest of page init. Pattern vars now live at the top of the IIFE.

## Verification

- 25 new tests in `tests/unit/ops/test_run_report_panel.py`: wire format round-trip, CLI emitter gates, runner stash + clobber-protection + persistence round-trip, report route (404/200), template/JS/CSS surface.
- Full ops suite: **1286 passed**; CLI + voice + output suites green.
- `mdToHtml` exercised in node against real Python-renderer output: XSS escaping, tables (incl. escaped `\|` cells), `<details>` passthrough, dedented command fences, `runnableNextActions` filtering — 14/14 checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
