### PR TITLE
chore(release): 8.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.4.0"
+    "version": "8.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.4.0
+# Attune AI Framework v8.5.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.4.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.5.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.5.0] — 2026-06-12
+
+Workflow results get a face, and the lessons brain gets sharper. The
+ops dashboard now renders structured workflow reports (scores,
+findings tables, collapsible detail, one-click next steps) instead of
+a raw log; the MCP surface returns the same report verbatim; and
+prompt-time lesson recall now resolves a live corpus excerpt so the
+nudge never drifts. Plus release-ritual tooling: a one-command
+version bumper and a reach-snapshot script.
+
 ### Fixed
 
 - **MCP workflow tools no longer return None scores / empty
@@ -35,6 +45,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Structured report panel on the ops dashboard run view**
+  (workflow-result-formatting T6 — completes the spec). When a
+  workflow emits a serialized `WorkflowReport`, the run view renders
+  it as a styled panel above the terminal stream (score, callouts,
+  findings tables, native `<details>` collapsibles) and the raw log
+  collapses into a "Process log" disclosure. The report crosses the
+  subprocess boundary over the existing `ATTUNE_RUN_META`
+  side-channel; a new `GET /runs/<id>/report` serves the dict plus
+  server-rendered summary markdown (canonical renderer, so the
+  dashboard never reimplements formatting); next-step actions whose
+  command is `attune workflow run <name>` become one-click Run chips.
+  Disk-loaded runs keep the panel after a daemon restart. (#786)
+- **Prompt-time lesson recall resolves a live corpus excerpt**
+  (lessons-corpus-rag T4). `RECALL_MAP` entries may carry a
+  `lesson_ref` slug; `jit_recall` resolves it through `LessonsIndex`
+  at fire time and appends a bounded excerpt of the *current* lesson
+  body below the inline one-liner, so the nudge never drifts from the
+  corpus. Best-effort: older installs or a dangling slug fall back to
+  the one-liner alone. (#780)
 - `docs/how-to/lessons-workflow.md` — how the append → retrieve
   lessons loop works (where lessons live, how they come back, the
   core-mirror rule).

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.4.0
+**Version:** 8.5.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.4.0 | **License:** Apache 2.0
+**Version:** 8.5.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.4.0"
+    "version": "8.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.4.0"
+__version__ = "8.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.4.0"
+version = "8.5.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.4.0"
+version = "8.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## 8.5.0 — workflow report panel + sharper lesson recall

Carries everything unreleased since 8.4.0.

### Highlights
- **Ops dashboard structured report panel** (workflow-result-formatting **T6**, #786) — *completes the spec*. Run view renders scores/findings/collapsibles + one-click Run chips; raw log collapses to a "Process log".
- **MCP report-aware responses** (T5, #785) — workflow tools return rendered summary markdown + report JSON + restored score/findings.
- **Prompt-time lesson recall corpus excerpts** (lessons-corpus-rag **T4**, #780) — `lesson_ref` resolves a live excerpt at fire time.
- **Lessons corpus → `.claude/lessons.md`** (T5 cutover, #782) — CLAUDE.md 91% smaller, ~99k tokens/session freed; retrieval unchanged (P@3 96%).
- **Release-ritual tooling** (#784) — `scripts/bump_version.py` (one-command 7-file bump) + `scripts/reach_snapshot.py`.

### Release prep
- Version bumped across all 7 sites via `scripts/bump_version.py` (count-validated; `test_all_versions_match` green).
- CHANGELOG `[Unreleased]` → `[8.5.0]`; added the missing T6/T4 feature entries.
- `uv.lock` refreshed (version-only diff).
- **Docs regen skipped** this release (polish lever, not CI-required, needs author preview) — follow-up for 8.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)