### PR TITLE
chore(usage-signals): reach snapshot 2026-06-12 (v8.5.0 baseline)

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-06-12.json
+++ b/docs/specs/usage-signals/snapshots/2026-06-12.json
@@ -1,0 +1,37 @@
+{
+  "date": "2026-06-12",
+  "github": {
+    "clones_14d": 57451,
+    "forks": 1,
+    "stars": 5,
+    "views_14d": 662
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 157,
+      "last_month": 2551,
+      "last_week": 652
+    },
+    "attune-author": {
+      "last_day": 166,
+      "last_month": 2826,
+      "last_week": 743
+    },
+    "attune-help": {
+      "last_day": 7,
+      "last_month": 721,
+      "last_week": 148
+    },
+    "attune-rag": {
+      "last_day": 2059,
+      "last_month": 31953,
+      "last_week": 6833
+    },
+    "attune-verify": {
+      "last_day": 1950,
+      "last_month": 3081,
+      "last_week": 3081
+    }
+  },
+  "taken_at": "2026-06-12T05:39:51.576109+00:00"
+}


### PR DESCRIPTION
R4 reach snapshot captured at the v8.5.0 tag — the release's before/after install-count baseline (usage-signals R4 ritual; `reach_snapshot.py` shipped in #784).

- attune-ai 2551/month · attune-rag 31953/month · attune-author 2826 · attune-help 721 · attune-verify 3081
- GitHub: 5 stars, 1 fork

Data-only (one JSON file under `docs/specs/usage-signals/snapshots/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)