### PR TITLE
fix(hooks): correct session_stash MIN_UTIL docstring default

### DIFF
--- a/plugin/hooks/session_stash.py
+++ b/plugin/hooks/session_stash.py
@@ -24,7 +24,7 @@ on disk for the next ``/recall``. On older Claude Code the JSON line is
 ignored (stdout was previously discarded), so this is purely additive.
 
 Tunables (env): ``ATTUNE_MEMORY_STASH`` (set ``0`` to disable),
-``ATTUNE_MEMORY_STASH_MIN_UTIL`` (gate, default 0.30),
+``ATTUNE_MEMORY_STASH_MIN_UTIL`` (gate, default 0.05),
 ``ATTUNE_MEMORY_OLLAMA_MODEL`` (default ``llama3.1:8b``),
 ``ATTUNE_MEMORY_OLLAMA_URL`` (default ``http://localhost:11434``),
 ``ATTUNE_MEMORY_STASH_TIMEOUT`` (LLM timeout secs, default 40 — a cold


### PR DESCRIPTION
## What

The `session_stash` Stop-hook module docstring listed
`ATTUNE_MEMORY_STASH_MIN_UTIL`'s default as **0.30**, but the actual
constant `_DEFAULT_MIN_UTIL` was recalibrated to **0.05** on 2026-06-11.
This aligns the docstring with the constant.

## Why

The utilization estimator counts only user/assistant message-body chars
(tool results excluded), so real tool-heavy sessions plateau well below
the old 0.30 gate (a 1.2 MB transcript measured 0.18 and never stashed).
0.05 is the calibrated value; the docstring was stale.

## Scope

One-line docstring change. No behavior change (the constant was already
0.05). Black + ruff pre-flighted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)