### PR TITLE
test: QA #1 boundary round-trip suite (AMS, git, Ollama, network)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8083,3 +8083,44 @@ files.
   import-then-use, `grep -n "import X"` before running. Pairs with the
   "interrupted/partial Edit" lessons — same family (the file on disk
   isn't what your sequence of edits implies).
+- **Mutation testing in this repo — use mutmut 2.x not 3.x, scope +
+  PYTHONPATH to the worktree, expect equivalent mutants, and ISOLATE
+  real user state (2026-06-12)**: a mutmut pass on
+  `security/path_validation.py` (17/51 survived despite 60 green tests)
+  and `models/auth_strategy.py` (129/270 survived) surfaced real gaps
+  line-coverage hid. Durable mechanics:
+  - **mutmut 3.x fights this repo's layout** — config isn't on the CLI
+    (only `--max-children`), it reads a config file whose keys are
+    non-obvious, and its `mutants/`-copy model collides with the
+    worktree editable-install (MAPPING points `attune` at MAIN's src).
+    Pin **`mutmut==2.4.4`**: CLI/`setup.cfg`-configurable, mutates
+    IN-PLACE, so `PYTHONPATH=<absolute-worktree>/src` makes the runner
+    import the mutated worktree file. Temp `setup.cfg`:
+    `[mutmut]\npaths_to_mutate=<one file>\nrunner=<MAIN venv python> -m
+    pytest <fast scoped tests> -x -o addopts= -p no:cacheprovider -q`.
+    Run via `uv run --with 'mutmut==2.4.4' mutmut run`; `mutmut
+    results` / `mutmut show <id>`; then `rm -f setup.cfg; rm -rf
+    .mutmut-cache` and verify `grep -c XX <file>` == 0 (mutmut reverts
+    in place, but confirm).
+  - **Equivalent mutants are expected — don't chase 100%.** Survivors
+    that can't be killed without changing code: blocklist entries
+    substring-subsumed by a broader entry (`\windows\system32` ⊂
+    `\windows\system`), and no-op string-arg mutations (`rstrip("\\")`
+    → `rstrip("XX\\XX")` strips the same chars). Document them, move on.
+  - **A low kill rate flags a coverage-padding suite.** auth_strategy's
+    `*_coverage_boost.py` hit lines for the coverage number but asserted
+    little → 52% survived. Mutation kill-rate is the test-QUALITY metric
+    line coverage can't be.
+  - **Mutating a module whose tests touch REAL user state can clobber
+    it.** The auth_strategy run reset `~/.attune/auth_strategy.json`
+    (Patrick's `default_mode`) even though a NORMAL run of those tests
+    is isolated — a *mutant* broke a test's `patch(AUTH_STRATEGY_FILE)`
+    and a real write leaked through, ×270. Before mutmut-ing any module
+    whose tests read/write real paths (`~/.attune/`, `~/.config`),
+    redirect `HOME`/the config path to a tmp dir for the run. Snapshot
+    the real file before and restore after.
+  - **Verify-first still applies under mutation pressure**: I twice
+    declared a "standing leak / production bug" from one observation,
+    and a 30-second repro (read the client source; run the tests
+    normally) refuted both. Reproduce before claiming, even when the
+    symptom looks damning.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8037,3 +8037,49 @@ files.
   having consumers — and expect the stragglers to self-identify at
   runtime, which is a reason to keep the old location working as a
   fallback during the transition.
+- **"This filter form is broken" needs a CONTROLLED repro before you
+  change production code — the AMS dict-vs-`Namespace` false alarm
+  (2026-06-12)**: while dogfooding an AMS example I saw
+  `search_long_term_memory(namespace={"eq": ns})` return
+  cross-namespace results, then `namespace=Namespace(eq=ns)` return
+  isolated results, and concluded the dict form was silently ignored —
+  AND that `attune_redis/memory.py`'s `search`/`recent` (which use the
+  dict form, lines 445/493) had a production isolation bug. Reading the
+  installed client source REFUTED it:
+  `agent_memory_client.client.search_long_term_memory` does
+  `if isinstance(namespace, dict): namespace = Namespace(**namespace)`
+  — the dict is coerced to the identical object, so the two forms are
+  equivalent and `memory.py` is fine. The real cause was almost
+  certainly **AMS async indexing latency** (newly-created long-term
+  memories aren't instantly searchable): the two runs differed in BOTH
+  the filter form AND elapsed-time-since-write, and I attributed the
+  difference to the variable I happened to be looking at. Rules:
+  (1) when two runs differ, change ONE variable at a time before
+  drawing a causal conclusion — immediate-search-after-write vs a later
+  search is an uncontrolled timing variable in any embed-then-index
+  store (AMS, vector DBs); (2) before claiming a client/SDK filter is
+  "ignored," read how the client serializes it (dict→model coercion is
+  common) rather than inferring from end-to-end behavior; (3) a no-op
+  "fix" (dict→object here) justified by a wrong diagnosis is worse than
+  no change — it encodes a false story in the code. Pairs with
+  "verify-first applies to infra/config diagnoses" and "research
+  subagents confabulate SDK signatures — introspect before coding."
+  Separately, the genuine gap that triggered this is real: the AMS
+  round-trip test asserts PRESENCE ("marker is findable"), not
+  ISOLATION ("other namespaces excluded") — a presence test passes even
+  if isolation is broken, so isolation needs its own assertion (stash
+  ns A + B, search A, assert B absent) with a wait-for-index.
+- **The PostToolUse autoflake/ruff formatter strips a just-added import
+  if it isn't used YET — add the import and its first use in the SAME
+  edit (or add the use first)**: 2026-06-12, editing a file in two
+  steps — first `Edit` added `from agent_memory_client.filters import
+  Namespace`, second `Edit` added the `Namespace(...)` usage. The
+  PostToolUse formatter ran after the FIRST edit, saw the import
+  unused, and removed it; the second edit added the usage but the
+  import was already gone → `NameError: name 'Namespace' is not
+  defined` at runtime. Fix: when adding an import for new code,
+  introduce the import and at least one use in a single Edit, or add
+  the usage before the import. Detection: after a two-step
+  import-then-use, `grep -n "import X"` before running. Pairs with the
+  "interrupted/partial Edit" lessons — same family (the file on disk
+  isn't what your sequence of edits implies).

--- a/tests/memory/test_ams_backend_integration.py
+++ b/tests/memory/test_ams_backend_integration.py
@@ -177,3 +177,62 @@ def test_session_stash_round_trip():
         assert hit is not None, f"stashed finding not recalled for {marker!r}"
     finally:
         be.close()
+
+
+def test_search_is_namespace_isolated():
+    """A namespace-scoped search must EXCLUDE other namespaces' records.
+
+    The round-trip tests above prove PRESENCE ("the marker I wrote is
+    findable"). They pass even if search leaks across namespaces, because a
+    leak only *adds* results. This proves ISOLATION: write the *same* semantic
+    content under two namespaces with distinct markers, then search from one
+    and assert the other's marker is absent. If namespace scoping were ignored
+    (search returning the whole store), the shared text would rank the other
+    namespace's record highly and this would fail.
+    """
+    from attune_redis.config import RedisPluginConfig
+    from attune_redis.memory import AMSMemoryBackend
+
+    shared = "shared finding about redis namespace isolation in attune"
+    marker_a = f"itest-{uuid.uuid4().hex[:10]}"
+    marker_b = f"itest-{uuid.uuid4().hex[:10]}"
+
+    be_a = AMSMemoryBackend(
+        RedisPluginConfig(
+            ams_base_url=_AMS_BASE_URL,
+            ams_namespace=f"itest-A-{uuid.uuid4().hex[:8]}",
+        )
+    )
+    be_b = AMSMemoryBackend(
+        RedisPluginConfig(
+            ams_base_url=_AMS_BASE_URL,
+            ams_namespace=f"itest-B-{uuid.uuid4().hex[:8]}",
+        )
+    )
+    try:
+        assert (
+            be_a.remember(f"{marker_a}: {shared}", memory_id=marker_a, topics=["type:note"]) is True
+        )
+        assert (
+            be_b.remember(f"{marker_b}: {shared}", memory_id=marker_b, topics=["type:note"]) is True
+        )
+
+        # Wait until A's own record is indexed/searchable from A's namespace.
+        hit_a = None
+        for _ in range(15):
+            results_a = be_a.search(shared, limit=20)
+            hit_a = next((r for r in results_a if marker_a in (r.get("text") or "")), None)
+            if hit_a is not None:
+                break
+            time.sleep(1)
+        assert hit_a is not None, f"A's own record not searchable from A for {marker_a!r}"
+
+        # Isolation: B's marker must NOT surface in A's search, even though the
+        # shared text would rank B's record highly if namespaces leaked.
+        texts_a = " ".join(r.get("text") or "" for r in be_a.search(shared, limit=20))
+        assert (
+            marker_b not in texts_a
+        ), "namespace leak: B's record surfaced in A's namespace-scoped search"
+    finally:
+        be_a.close()
+        be_b.close()

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import os
 import sys
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -170,6 +172,62 @@ def test_extract_via_ollama_returns_none_on_empty_findings(stash_mod, monkeypatc
 
     monkeypatch.setattr(stash_mod.urllib.request, "urlopen", lambda *a, **k: _Resp())
     assert stash_mod._extract_via_ollama("some transcript") is None
+
+
+# ==========================================================================
+# session_stash — Ollama extraction, NON-MOCKED round-trip (real boundary)
+# ==========================================================================
+
+
+def _ollama_available() -> bool:
+    """True when Ollama answers and the configured extraction model is pulled."""
+    base = os.environ.get("ATTUNE_MEMORY_OLLAMA_URL", "http://localhost:11434").rstrip("/")
+    model = os.environ.get("ATTUNE_MEMORY_OLLAMA_MODEL", "llama3.1:8b")
+    try:
+        with urllib.request.urlopen(f"{base}/api/tags", timeout=2) as resp:
+            tags = json.loads(resp.read().decode("utf-8"))
+    except Exception:  # noqa: BLE001 — any failure means "no Ollama" -> skip
+        return False
+    names = {m.get("name", "") for m in tags.get("models", [])}
+    family = model.split(":")[0]
+    return any(n == model or n.startswith(family) for n in names)
+
+
+@pytest.mark.skipif(not _ollama_available(), reason="Ollama + extraction model not available")
+def test_extract_via_ollama_real_round_trip(stash_mod):
+    """NON-MOCKED: a real Ollama call returns parseable typed findings.
+
+    The mocked test above proves parsing of a *canned* response; this proves
+    the real ``/api/generate`` request shape + real model output parse
+    end-to-end — the boundary a mock cannot exercise. Model output is
+    non-deterministic, so assert STRUCTURE, not content.
+    """
+    transcript = (
+        "user: We kept getting double charges on Stripe webhooks.\n"
+        "assistant: Root cause was the idempotency key being omitted on retries; "
+        "adding it fixed the double charge. We also decided to standardize on "
+        "Redis AMS for cross-session memory.\n"
+    )
+    findings = stash_mod._extract_via_ollama(transcript)
+    assert findings is not None, "real Ollama returned no parseable findings for a clear transcript"
+    assert isinstance(findings, list) and findings
+    for f in findings:
+        assert isinstance(f, dict)
+        assert isinstance(f.get("content"), str) and f["content"].strip()
+    # Normalized output honors the contract: well-typed and clamped.
+    norm = stash_mod._normalize(findings)
+    assert 1 <= len(norm) <= stash_mod._MAX_FINDINGS
+    assert all(n["type"] in stash_mod._VALID_TYPES for n in norm)
+
+
+def test_extract_via_ollama_real_unreachable_returns_none(stash_mod, monkeypatch):
+    """Real refused socket (dead port) -> None, so main() falls back to the
+    heuristic. Complements the mocked-exception test with urllib's actual
+    error path against a port where nothing listens.
+    """
+    monkeypatch.setenv("ATTUNE_MEMORY_OLLAMA_URL", "http://127.0.0.1:1")
+    monkeypatch.setenv("ATTUNE_MEMORY_STASH_TIMEOUT", "2")
+    assert stash_mod._extract_via_ollama("a session where we fixed a real bug") is None
 
 
 # ==========================================================================

--- a/tests/unit/mcp/test_version_check_resilience.py
+++ b/tests/unit/mcp/test_version_check_resilience.py
@@ -1,0 +1,135 @@
+"""Non-mocked network-resilience tests for the PyPI version check.
+
+``tests/unit/mcp/test_version_check.py`` mocks ``urlopen`` with canned
+objects, so it proves the parsing/compare logic but NOT that the real
+network path degrades gracefully on slow/error/garbage responses. These
+tests stand up a REAL local HTTP stub and drive ``check_for_updates``
+through the REAL ``urllib`` stack (real socket, real 2-second timeout) —
+only the destination URL is redirected to the stub, behavior is not mocked.
+
+This is the receipt that "network failures are silently ignored"
+(the module's promise) actually holds against real failure modes.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from attune.mcp import version_check
+
+_REAL_URLOPEN = urllib.request.urlopen
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Routes by path to a happy / error / garbage / slow response."""
+
+    def log_message(self, *args):  # noqa: D102 - silence stub access logs
+        pass
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path == "/good":
+            body = json.dumps({"info": {"version": "999.0.0"}}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/error":
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(b"server error")
+        elif self.path == "/garbage":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b"not valid json {{{")
+        elif self.path == "/slow":
+            time.sleep(3)  # exceeds the check's hardcoded 2s timeout
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"{}")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+@pytest.fixture
+def stub_server():
+    """A real localhost HTTP server; yields its base URL."""
+    server = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _redirect_to(stub_url: str):
+    """A urlopen replacement that hits the stub via the REAL urllib stack.
+
+    Not a mock: it constructs a real Request to the local stub and calls the
+    real ``urlopen`` (preserving the ``timeout`` kwarg), so the socket, HTTP
+    round-trip, and timeout behavior are all genuine.
+    """
+
+    def _open(req, *args, **kwargs):  # noqa: ANN001
+        new_req = urllib.request.Request(stub_url, headers={"Accept": "application/json"})
+        return _REAL_URLOPEN(new_req, *args, **kwargs)
+
+    return _open
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    """The module caches in a global; clear it before each case."""
+    monkeypatch.setattr(version_check, "_cached_status", None)
+
+
+def test_real_http_happy_path_parses_version(stub_server, monkeypatch):
+    """A real 200 + valid JSON yields the parsed update status."""
+    monkeypatch.setattr(
+        version_check.urllib.request, "urlopen", _redirect_to(f"{stub_server}/good")
+    )
+    result = version_check.check_for_updates()
+    assert result is not None
+    assert result["latest"] == "999.0.0"
+    assert result["update_available"] is True  # 999.0.0 > any real current version
+
+
+def test_real_http_500_degrades_to_none(stub_server, monkeypatch):
+    """A real 5xx response degrades to None, not a crash."""
+    monkeypatch.setattr(
+        version_check.urllib.request, "urlopen", _redirect_to(f"{stub_server}/error")
+    )
+    assert version_check.check_for_updates() is None
+
+
+def test_real_http_garbage_body_degrades_to_none(stub_server, monkeypatch):
+    """A real 200 with non-JSON body degrades to None."""
+    monkeypatch.setattr(
+        version_check.urllib.request, "urlopen", _redirect_to(f"{stub_server}/garbage")
+    )
+    assert version_check.check_for_updates() is None
+
+
+@pytest.mark.timeout(10)
+def test_real_http_timeout_degrades_to_none(stub_server, monkeypatch):
+    """A real slow response trips the hardcoded 2s socket timeout -> None.
+
+    Exercises the genuine timeout path (~2s), the one case a mock can't
+    faithfully reproduce.
+    """
+    monkeypatch.setattr(
+        version_check.urllib.request, "urlopen", _redirect_to(f"{stub_server}/slow")
+    )
+    start = time.monotonic()
+    assert version_check.check_for_updates() is None
+    assert time.monotonic() - start < 3, "should fail at the 2s timeout, not wait for the 3s body"

--- a/tests/unit/patterns/test_git_extractor_roundtrip.py
+++ b/tests/unit/patterns/test_git_extractor_roundtrip.py
@@ -1,0 +1,91 @@
+"""Non-mocked round-trip tests for the git subprocess seam in GitPatternExtractor.
+
+The existing ``test_git_extractor.py`` mocks ``subprocess`` heavily, so it
+proves the parsing logic but NOT that the real ``git log``/``git diff``
+invocations and their output parsing actually work end-to-end. These tests
+run the extractor against a REAL temporary git repo through the real
+subprocess seam — the receipt that the boundary works, not just the mock.
+
+Git is a hard dependency of the dev/test environment, so no skip gate is
+needed; the repo is created fresh in ``tmp_path`` for determinism.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from attune.patterns.git_extractor import GitPatternExtractor
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not on PATH")
+
+
+def _git(repo, *args: str) -> str:
+    """Run a git command in ``repo`` and return stdout (test setup helper)."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def real_repo(tmp_path):
+    """A real git repo with one fix commit (deterministic, isolated)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "tester@example.com")
+    _git(repo, "config", "user.name", "Round Trip Tester")
+    (repo / "app.py").write_text("def f(x):\n    return x\n", encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(repo, "commit", "-q", "-m", "fix: handle null input in f")
+    return repo
+
+
+def test_get_commit_info_reads_real_commit(real_repo, monkeypatch):
+    """_get_commit_info parses real `git log` output for the actual commit."""
+    monkeypatch.chdir(real_repo)
+    full_hash = _git(real_repo, "rev-parse", "HEAD")
+
+    extractor = GitPatternExtractor(patterns_dir=str(real_repo / "patterns"))
+    info = extractor._get_commit_info("HEAD")
+
+    assert info is not None, "real git commit not read through the subprocess seam"
+    assert info["hash"] == full_hash[:8]
+    assert info["message"] == "fix: handle null input in f"
+    assert info["author"] == "Round Trip Tester"
+    assert info["date"]  # ISO date string, non-empty
+
+
+def test_get_staged_diff_reads_real_staged_change(real_repo, monkeypatch):
+    """_get_staged_diff returns the real `git diff --cached` output."""
+    monkeypatch.chdir(real_repo)
+    (real_repo / "app.py").write_text("def f(x):\n    return x or 0\n", encoding="utf-8")
+    _git(real_repo, "add", "app.py")
+
+    extractor = GitPatternExtractor(patterns_dir=str(real_repo / "patterns"))
+    diff = extractor._get_staged_diff()
+
+    assert "return x or 0" in diff, "staged change not seen through the subprocess seam"
+    assert diff.startswith("diff --git"), "output is not a real unified git diff"
+
+
+def test_get_commit_info_returns_none_outside_repo(tmp_path, monkeypatch):
+    """Outside a git repo, the seam degrades to None (real failure path)."""
+    monkeypatch.chdir(tmp_path)  # tmp_path itself is not a git repo
+    extractor = GitPatternExtractor(patterns_dir=str(tmp_path / "patterns"))
+    assert extractor._get_commit_info("HEAD") is None
+
+
+def test_extract_from_recent_commits_runs_on_real_repo(real_repo, monkeypatch):
+    """End-to-end: the public extractor runs over a real repo without error."""
+    monkeypatch.chdir(real_repo)
+    extractor = GitPatternExtractor(patterns_dir=str(real_repo / "patterns"))
+    result = extractor.extract_from_recent_commits(num_commits=1)
+    assert isinstance(result, list)  # real round-trip completes; content is best-effort


### PR DESCRIPTION
Completes the **QA #1 boundary-verification track**: every external seam now has a non-mocked round-trip that exercises the real boundary — the receipts the mocked suites can't provide. Each verified against the real thing.

| # | Boundary | File | What it proves (mocks couldn't) |
|---|----------|------|----------------------------------|
| 1 | **AMS** | test_ams_backend_integration.py | namespace **isolation** (not just presence) — live; cleaned up by-id |
| 2 | **git subprocess** | test_git_extractor_roundtrip.py | real `git log`/`git diff` against a real tmp repo |
| 3 | **Ollama** | test_session_memory_hooks.py | real `/api/generate` round-trip + real refused-socket fallback |
| 4 | **network/HTTP** | test_version_check_resilience.py | real socket + real 2s timeout degrade gracefully (500/garbage/slow → None) |

All skipif-gated where they need a live service (AMS, Ollama); git + network use local fixtures, so they run everywhere. No production code changed — pure test additions. Plus two session lessons in `.claude/lessons.md`.

This is the durable answer to the recurring "registered ≠ working / passing tests don't prove integration" lesson: a non-mocked round-trip at every seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)