### PR TITLE
test(models)+docs(spec): auth_strategy spend-routing mutant + sequenced rewrite plan (QA #2 phase 2)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8124,3 +8124,48 @@ files.
     and a 30-second repro (read the client source; run the tests
     normally) refuted both. Reproduce before claiming, even when the
     symptom looks damning.
+
+- **mutmut 2.4.4 operational gotchas — `tests_dir` is mandatory,
+  scope the RUNNER to the FULL suite (not the slice), and prove a
+  kill by apply/revert not by the aggregate count (2026-06-12, QA #2
+  phase 2 on `auth_strategy.get_recommended_mode`)**: extends the
+  mutmut lesson above with the mechanics that bit this session.
+  - **`setup.cfg` needs `tests_dir=` or mutmut crashes** — the
+    template above (`paths_to_mutate`/`runner` only) errors `TypeError:
+    'NoneType' object is not iterable` at `split_paths(tests_dir)`. Add
+    `tests_dir=<dir containing the test file>` even though `runner`
+    already names the exact tests.
+  - **Scope the RUNNER to the whole module test file, NOT a subset.**
+    Pointing `runner` at just the target class (to go fast) makes every
+    mutant OUTSIDE those tests survive → 260/270 "survived", useless.
+    Run the FULL `test_<module>.py` as the runner so unrelated mutants
+    die by their own tests; THEN read `mutmut show <id>` and filter
+    survivors to the slice's line range. With the full suite,
+    auth_strategy dropped to 21/270 (the handoff's 129 was a
+    weaker-runner number), and only ONE killable survivor (mutant 42,
+    `auth_strategy.py:108` `<`→`<=`) actually lived in
+    `get_recommended_mode`.
+  - **Driving mutmut from this harness is flaky — `nohup` + poll the
+    log for `270/270`, don't `pgrep`.** macOS has no `timeout` (use
+    `gtimeout` or none — a bare `timeout …` errors out and kills the
+    whole command). `pgrep -f "mutmut/__main__"` misses the uv-spawned
+    subprocess name, so an `until ! pgrep` wait-loop exits PREMATURELY
+    while the run is still going (looked like it "stopped at mutant
+    18/42"; it hadn't). mutmut resumes from `.mutmut-cache` on re-run,
+    so a partial run isn't lost — but the reliable wait is
+    `until grep -q "270/270" run.log; do sleep 10; done`.
+  - **Prove a specific mutant is killed by apply/revert, not by the
+    survivor delta.** Hand-apply the exact mutation to the git-tracked
+    source (`python` string-replace), run ONLY the new tests (expect
+    FAIL), `git checkout -- <src>` to revert, confirm the new tests now
+    PASS. This is more direct and cheaper than a 3-min full re-run to
+    watch 21→20, and immune to the flakiness above.
+  - **The real gap behind a boundary mutant was an untested INPUT
+    DIMENSION, not a missing assertion.** `<`→`<=` on
+    `small_module_threshold` survived because no test set
+    `prefer_subscription=False` — with the `True` default the small and
+    medium branches both return SUBSCRIPTION, so the boundary is
+    unobservable and the `else AuthMode.API` arm is dead code under
+    test. Killing the mutant = adding the missing dimension, which also
+    lit up the dead branch. Look for the un-varied parameter, not just
+    a weak `assert`.

--- a/docs/specs/test-quality-program/auth-strategy-mutation-rewrite.md
+++ b/docs/specs/test-quality-program/auth-strategy-mutation-rewrite.md
@@ -1,0 +1,107 @@
+# auth_strategy behavioral-test rewrite (mutation-driven)
+
+**Status:** planned — sequenced across sessions
+**Parent program:** [test-quality-program](./tasks.md)
+**Module:** `src/attune/models/auth_strategy.py`
+**Opened:** 2026-06-12 (QA #2 phase 2)
+
+---
+
+## Why this is its own plan, not a single per-module cycle
+
+The standard per-module loop (`design.md` §Per-module loop) assumes
+one module → one PR. `auth_strategy.py` does not fit: a clean-cache
+`mutmut==2.4.4` pass over the module, using the existing
+`tests/unit/models/test_auth_strategy_coverage_boost.py` as the
+runner, leaves **128 / 270 mutants surviving (~53%)**.
+
+That is the signature of a coverage-padded suite — the tests hit
+lines for the coverage number but assert little. Killing 128 mutants
+is a behavioral-test **rewrite** spanning many functions, not a
+one-sitting hardening. It is therefore sequenced into per-function
+sub-slices, each shippable as its own focused PR under this program.
+
+This confirms the handoff hypothesis (the `*_coverage_boost.py`
+suites are coverage-padded) with a hard number.
+
+---
+
+## Already done — do not redo
+
+- **`get_recommended_mode`** (the subscription-vs-API spend routing):
+  hardened in **QA #2 phase 2**, [PR #793]. Clean-cache mutmut
+  confirms mutants 38–43 (the function's full range) are all killed,
+  including the `small_module_threshold` `<`→`<=` boundary (mutant 42,
+  verified by apply/revert). The gap was an un-varied input dimension
+  (`prefer_subscription=False`), not a weak assertion. Covered by
+  `TestAuthStrategyPreferSubscriptionRouting`.
+
+[PR #793]: https://github.com/Smart-AI-Memory/attune-ai/pull/793
+
+---
+
+## Sub-slices (each = one PR)
+
+Ordered by leverage. The live per-slice survivor list is regenerated
+at execution time (mutants drift as code/tests change) — see
+*Mechanics* below. Counts here are the function groupings of the
+2026-06-12 survivor set, not a frozen contract.
+
+| # | Slice | Functions | Survivor shape |
+|---|-------|-----------|----------------|
+| 1 | Serialization fidelity | enum `.value` defs, dataclass field defaults, `to_dict`, `from_dict` | enum value → `None`/`"XX..XX"`; `500`→`501`, `True`→`False`/`None`; dropped/renamed dict keys |
+| 2 | Cost estimation | `estimate_tokens`, `estimate_cost` | arithmetic operator swaps (`*`→`/`), per-tier cost constants, the `fits_in_context` thresholds (`200_000` / `1_000_000`), the `mode is None` default branch |
+| 3 | Pros/cons rendering | `get_pros_cons` | dict-key drops, f-string content, threshold-interpolation strings |
+| 4 | Persistence I/O | `save`, `load` | default-path branch, the corrupt-file fallback, the `validated_path.exists()` guard |
+| 5 | Interactive setup | `configure_auth_interactive` | the `tier_map`/`mode_map` defaults, the `default_mode == AUTO` branch, print strings (many will be **equivalent** — see below) |
+| 6 | Utilities | `count_lines_of_code`, `get_module_size_category` | the comment/blank-line skip logic, the `< 500` / `< 2000` category boundaries |
+
+---
+
+## Acceptance per slice
+
+1. Regenerate the live survivor list for the slice's functions
+   (full-suite runner — see *Mechanics*).
+2. For each **killable** survivor, add a behavioral test that fails
+   on the mutant and passes on the original. Prove at least the
+   load-bearing ones by apply/revert, not by the aggregate count.
+3. **Document equivalent / no-value mutants** in the PR body rather
+   than chasing 100%. Expected here: print-string `"XX..XX"` wraps
+   (output text not asserted by design), and any blocklist-style
+   substring-subsumed entries. Equivalent mutants are expected — do
+   not weaken production code to kill them.
+4. Tests are **behavioral** (assert observable outputs), not coverage
+   padding. The slice's kill-rate, not its line coverage, is the
+   quality bar.
+5. One PR per slice; test-only unless a real production bug surfaces
+   (then a sibling PR per `design.md` risk #5). Log any bug in
+   `docs/COVERAGE_BUG_LOG.md`.
+
+---
+
+## Mechanics
+
+Pinned recipe lives in `.claude/lessons.md` (the mutmut 2.4.4
+entries). Summary:
+
+- `uv run --with 'mutmut==2.4.4' mutmut run` from a scratch dir with a
+  temp `setup.cfg`: `paths_to_mutate=<this file>`, `tests_dir=<the
+  models test dir>`, and a `runner` that runs the **full**
+  `test_auth_strategy_coverage_boost.py` (not a subset — a scoped
+  runner makes everything else falsely "survive").
+- Isolate real user state: redirect `HOME` to a temp dir for the run
+  (`auth_strategy` tests touch `~/.attune/auth_strategy.json`; a
+  mutant can break a test's isolation and clobber the real file).
+  Snapshot before, restore after.
+- Drive via `nohup` + poll the log for `270/270`; `pgrep` misses the
+  uv subprocess and a wait-loop exits early. macOS has no `timeout`.
+- Use the MAIN venv python + absolute `PYTHONPATH=<worktree>/src`
+  (the worktree editable-install MAPPING points at main's src).
+
+---
+
+## Done-state
+
+Closes when slices 1–6 ship and a clean-cache mutmut refresh shows
+only documented-equivalent survivors remaining. Until then this is an
+open, sequenced sub-plan under the living `test-quality-program`.

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -575,3 +575,40 @@ Coverage 43.1% → **100.00%** line + branch (52/52 statements,
 **PR:** _(filled in after merge)_
 **Bug log entry:** `docs/COVERAGE_BUG_LOG.md` —
 "2026-05-16 — eighteenth module under test-quality-program"
+
+
+## models/auth_strategy.py
+
+**Date:** 2026-06-12
+**Rubric score at pick time:** n/a — picked via **mutation testing**,
+not the coverage rubric. The module already had high line coverage
+(the `*_coverage_boost.py` suite); mutation testing exposed that the
+coverage was padded.
+**Picked because:** QA #2 phase 2 mutation-hardened the
+`get_recommended_mode` spend-routing slice ([PR #793]), and a
+clean-cache `mutmut==2.4.4` pass over the whole module surfaced
+**128 / 270 survivors (~53%)** — a coverage-padded suite confirmed
+with a hard number, exactly the handoff hypothesis.
+**Outcome:** This module does **not** fit the one-module-one-PR loop.
+Designated as a **sequenced multi-session behavioral rewrite** with
+its own plan: [auth-strategy-mutation-rewrite.md]. `get_recommended_mode`
+is already done (mutants 38–43 all killed, verified by apply/revert);
+the remaining survivors are split into six per-function sub-slices
+(serialization, cost estimation, pros/cons, persistence I/O,
+interactive setup, utilities), each a future PR. No further code this
+session for this module — the decision is to spec, not execute.
+
+**Decision rationale (why spec, not slice-by-slice now):** carving the
+serialization sub-slice this session was on the table, but the "20
+remaining survivors" framing that motivated it was a **stale
+incremental-cache artifact** from interrupted mutmut runs. The honest
+clean-cache number (128) reframes the module as a rewrite, not a
+hardening — so sequencing it as a plan beats peeling one slice under a
+wrong premise.
+
+**PR:** _(plan only — no code PR this session)_
+**Bug log entry:** _(none yet — no production bug surfaced; mutation
+gaps are test-quality, logged in the plan not the bug log)_
+
+[PR #793]: https://github.com/Smart-AI-Memory/attune-ai/pull/793
+[auth-strategy-mutation-rewrite.md]: ./auth-strategy-mutation-rewrite.md

--- a/docs/specs/test-quality-program/tasks.md
+++ b/docs/specs/test-quality-program/tasks.md
@@ -53,6 +53,20 @@ healthy code but wrong for dead/skipped code. The program needs a
 Closes once tasks 10-12 ship and the next rubric refresh shows the
 flagged modules no longer in the top 20.
 
+### Phase 5 — Mutation-driven module rewrites
+
+Some modules pass the coverage rubric (high line coverage) yet fail
+**mutation** testing — the coverage is padded. These don't fit the
+one-module-one-PR loop and get their own sequenced sub-plans.
+
+| # | Module | Survival | Plan | Status |
+|---|--------|----------|------|--------|
+| 13 | `models/auth_strategy.py` | 128/270 (~53%) | [auth-strategy-mutation-rewrite.md](./auth-strategy-mutation-rewrite.md) | planned — `get_recommended_mode` done ([#793](https://github.com/Smart-AI-Memory/attune-ai/pull/793)); 6 sub-slices remain |
+
+When a future rubric/mutation cycle flags another padded module, add a
+row here and author a sibling plan rather than forcing it through the
+single-PR loop.
+
 ### Done-state for this spec
 
 This spec is a **standing program**, not a one-shot deliverable.

--- a/tests/unit/models/test_auth_strategy_coverage_boost.py
+++ b/tests/unit/models/test_auth_strategy_coverage_boost.py
@@ -703,3 +703,63 @@ class TestCountNonBlankLines:
         with patch("builtins.open", side_effect=OSError("no access")):
             result = count_lines_of_code(f)
         assert result == 0
+
+
+@pytest.mark.unit
+class TestAuthStrategyPreferSubscriptionRouting:
+    """prefer_subscription routing — the spend-routing dimension the existing
+    suite never exercised (every prior test left prefer_subscription at its
+    True default).
+
+    With prefer_subscription=False the small branch (SUBSCRIPTION) and the
+    medium branch (API) diverge, which is what makes the
+    small_module_threshold boundary observable: a value exactly at the
+    threshold pins the comparison as strict ``<`` rather than ``<=``. Without
+    these tests, ``module_lines < self.small_module_threshold`` could be
+    weakened to ``<=`` undetected (mutmut survivor on auth_strategy.py:108).
+    """
+
+    @staticmethod
+    def _max_auto(*, prefer: bool) -> AuthStrategy:
+        return AuthStrategy(
+            subscription_tier=SubscriptionTier.MAX,
+            default_mode=AuthMode.AUTO,
+            small_module_threshold=500,
+            medium_module_threshold=2000,
+            prefer_subscription=prefer,
+        )
+
+    def test_small_threshold_boundary_is_strict_less_than(self):
+        """module_lines == small_threshold must fall through to the medium
+        branch, not the small branch.
+
+        499 takes the small branch (always SUBSCRIPTION); 500 is NOT < 500 and
+        falls to the medium branch, which routes to API when
+        prefer_subscription is False. If ``<`` were ``<=``, 500 would route to
+        SUBSCRIPTION instead.
+        """
+        strategy = self._max_auto(prefer=False)
+        assert strategy.get_recommended_mode(499) == AuthMode.SUBSCRIPTION
+        assert strategy.get_recommended_mode(500) == AuthMode.API
+
+    def test_medium_range_routes_to_api_when_prefer_subscription_false(self):
+        """Medium modules route to API when the user does not prefer
+        subscription (exercises the previously-dead ``else AuthMode.API``
+        branch on line 114)."""
+        strategy = self._max_auto(prefer=False)
+        assert strategy.get_recommended_mode(1000) == AuthMode.API
+        assert strategy.get_recommended_mode(1999) == AuthMode.API
+
+    def test_medium_range_routes_to_subscription_when_prefer_subscription_true(self):
+        """Medium modules route to SUBSCRIPTION when prefer_subscription is
+        True (the True arm of the same ternary)."""
+        strategy = self._max_auto(prefer=True)
+        assert strategy.get_recommended_mode(1000) == AuthMode.SUBSCRIPTION
+        assert strategy.get_recommended_mode(1999) == AuthMode.SUBSCRIPTION
+
+    def test_prefer_subscription_only_gates_the_medium_range(self):
+        """prefer_subscription must not change small (always SUBSCRIPTION) or
+        large (always API) routing — only the medium range."""
+        strategy = self._max_auto(prefer=False)
+        assert strategy.get_recommended_mode(100) == AuthMode.SUBSCRIPTION
+        assert strategy.get_recommended_mode(3000) == AuthMode.API


### PR DESCRIPTION
## QA #2 phase 2 — auth_strategy spend-routing slice + mutation triage

Continues the QA track (#789–792). Three coherent pieces from one
mutation-testing pass on `models/auth_strategy.py`:

### 1. Killed the spend-routing boundary mutant (the shipped fix)

A `mutmut==2.4.4` pass left one killable survivor in
`get_recommended_mode`:

```
auth_strategy.py:108
-  if module_lines < self.small_module_threshold:
+  if module_lines <= self.small_module_threshold:
```

**Root cause:** the existing suite never exercised
`prefer_subscription=False`, so the small branch (SUBSCRIPTION) and the
medium branch never diverged — the threshold boundary was unobservable
and the `else AuthMode.API` arm was dead under test.

`TestAuthStrategyPreferSubscriptionRouting` (4 behavioral tests) pins
the comparison as strict `<`, covers the dead branch, and asserts
`prefer_subscription` only gates the medium range. **Mutant-kill
verified by apply/revert** (fails on the `<=` mutant, passes on the
original). `get_recommended_mode` is now fully clean (mutants 38–43 all
killed). 58 passed (+4), no regression.

### 2. mutmut operational lessons (`.claude/lessons.md`)

`tests_dir` is mandatory; scope the runner to the **full** module test
file (a scoped runner falsely "survives" everything else); drive via
`nohup` + poll for `270/270` (`pgrep` misses the uv subprocess; macOS
has no `timeout`); prove kills by apply/revert, not the aggregate count.

### 3. Deferred the rest as a sequenced spec (not this PR's code)

Clean-cache mutmut over the **whole module** shows **128/270 survivors
(~53%)** — a coverage-padded suite, confirming the handoff hypothesis.
That's a multi-session behavioral rewrite, not a one-sitting fix, so
it's designated as a sequenced sub-plan under `test-quality-program`:

- `docs/specs/test-quality-program/auth-strategy-mutation-rewrite.md` —
  6 per-function sub-slices, mechanics, per-slice acceptance.
- `decisions.md` — per-module designation (incl. the note that an
  earlier "20 survivors" read was a stale-cache artifact; honest number
  is 128).
- `tasks.md` — new Phase 5 (mutation-driven module rewrites).

### Verification / scope

- Test-only + docs — **no release cut** (nothing user-facing).
- Real `~/.attune/auth_strategy.json` isolated to a temp HOME during the
  mutmut run and confirmed unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
