### PR TITLE
test(security): pin secrets_detector entropy detection boundary + confidence (QA #2 phase 4)

### DIFF
--- a/tests/security/test_secrets_detector.py
+++ b/tests/security/test_secrets_detector.py
@@ -430,6 +430,67 @@ class TestSecretsDetectorIntegration:
         assert all("os.getenv" not in d.context_snippet for d in detections)
 
 
+class TestHighEntropyDetectionIntegrity:
+    """Pin the entropy detection boundary and confidence scoring for
+    `_detect_high_entropy`.
+
+    The existing suite checks that *some* high-entropy string is flagged but
+    never the boundary (a string whose entropy is exactly the threshold) nor
+    the confidence value. So ``entropy >= threshold`` could weaken to ``>``
+    (a secret sitting exactly at the threshold would be silently MISSED) and
+    the confidence formula could drift, both undetected.
+
+    These tests construct a string with an EXACT Shannon entropy (16 distinct
+    chars, each twice → entropy = log2(16) = 4.0) and set the threshold
+    relative to it, which makes the boundary observable and the confidence
+    formula `min(1.0, (entropy - threshold) / 2.0 + 0.5)` exactly computable.
+    """
+
+    # 16 distinct base64-class chars, each appearing twice: entropy is
+    # exactly 4.0, length 32 (>= the default min_entropy_length of 20).
+    EXACT_ENTROPY_SECRET = "ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP"
+
+    def _entropy(self) -> float:
+        return SecretsDetector()._calculate_entropy(self.EXACT_ENTROPY_SECRET)
+
+    def _entropy_hits(self, detector: SecretsDetector) -> list:
+        content = f'token = "{self.EXACT_ENTROPY_SECRET}"'
+        return [
+            d for d in detector.detect(content) if d.secret_type == SecretType.HIGH_ENTROPY_STRING
+        ]
+
+    def test_entropy_exactly_at_threshold_is_flagged(self):
+        """A string whose entropy equals the threshold MUST be detected —
+        the comparison is ``>=``, not ``>``. Threshold is set to the string's
+        own entropy so the boundary is exact regardless of float rounding."""
+        e = self._entropy()
+        detector = SecretsDetector(entropy_threshold=e, min_entropy_length=20)
+        hits = self._entropy_hits(detector)
+        assert len(hits) == 1
+        # confidence = min(1.0, (e - e) / 2 + 0.5) = 0.5
+        assert hits[0].confidence == 0.5
+
+    def test_confidence_below_cap_uses_exact_formula(self):
+        """With the threshold 0.5 below the string's entropy, the confidence
+        is min(1.0, 0.5/2 + 0.5) = 0.75 — pins the divisor and the additive
+        term (not capped, so the formula is fully exercised)."""
+        e = self._entropy()
+        detector = SecretsDetector(entropy_threshold=e - 0.5, min_entropy_length=20)
+        hits = self._entropy_hits(detector)
+        assert len(hits) == 1
+        assert hits[0].confidence == 0.75
+
+    def test_confidence_is_capped_at_one(self):
+        """With the threshold 2.0 below the string's entropy the raw formula
+        yields 1.5; confidence must be capped at 1.0 (``min(1.0, …)``, not a
+        looser bound)."""
+        e = self._entropy()
+        detector = SecretsDetector(entropy_threshold=e - 2.0, min_entropy_length=20)
+        hits = self._entropy_hits(detector)
+        assert len(hits) == 1
+        assert hits[0].confidence == 1.0
+
+
 # Run tests if executed directly
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## QA #2 phase 4 — secrets_detector entropy detection integrity

Continues the QA mutation-hardening track (#789–794). Bounded slice: the
high-entropy detection path in `memory/security/secrets_detector.py` — where
a surviving mutant means a **secret is missed** or mis-scored.

### What mutation testing found

`mutmut==2.4.4` over the module: **60/189 survived (~32%)** — notably less
padded than pii_scrubber (62%); the existing suite is decent. But it checks
that *some* high-entropy string is flagged, never the **boundary** or the
**confidence value**:

| Mutant | Line | Change | Effect |
|--------|------|--------|--------|
| 118 | 392 | `entropy >= threshold` → `>` | secret **exactly at threshold silently missed** |
| 122 | 404 | `min(1.0, …)` → `min(2.0, …)` | confidence can exceed 1.0 |
| 123–128 | 404 | `(entropy - threshold)/2.0 + 0.5` → `+threshold` / `*2.0` / `/3.0` / `-0.5` / `+1.5` / `None` | confidence scoring drifts |

### The fix

`TestHighEntropyDetectionIntegrity` (3 tests). Construct a string with an
**exact Shannon entropy** (16 distinct chars ×2 → `log2(16) = 4.0`) and set
the threshold relative to it — this makes the boundary FP-exact and the
confidence formula exactly computable:

- threshold = entropy → must flag (kills `>=`→`>`), confidence `0.5`
- threshold = entropy − 0.5 → confidence `0.75` (pins divisor + additive term)
- threshold = entropy − 2.0 → confidence `1.0` (pins the `min(1.0, …)` cap)

All 8 survivors killed, **verified by apply/revert**.

### Scope

- Test-only — **no release cut**. Pure-logic module, no isolation.
- 40 passed (+3), no regression.
- Remaining survivors (overlap-filter boundary, context-snippet, custom-pattern
  mgmt) are lower-severity / harder to construct — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
