### PR TITLE
fix(curator): graceful, non-leaky offline messages instead of raw API errors

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8201,3 +8201,39 @@ files.
     non-colliding PII types (IPv4, which phone can't match). Diagnostic:
     if a fresh exact-output test fails on unmutated source, suspect
     pattern cross-matching before suspecting a real bug.
+
+- **Ops-dashboard curator "is offline (401 invalid x-api-key)" → a STALE
+  repo-root `.env` shadows the live key; and even fixed, the curator needs
+  API CREDITS the Claude subscription doesn't grant (2026-06-12)**: the
+  Briefing page's curator makes a RAW `AsyncAnthropic()` call
+  (`curator/core.py`), so it reads `ANTHROPIC_API_KEY` from the process env.
+  Two layered causes, both worth the diagnostic discipline:
+  - **Dead `.env` shadows the live key.** `/Users/.../attune-ai/.env` held a
+    rotated-out (dead) key from an earlier date; `~/.attune/anthropic.env`
+    held the current live one. `load_dotenv` (default `override=False`)
+    loads `.env`'s dead key when the shell has none exported, so the server
+    sends the dead key → 401. Diagnostic that pinned it WITHOUT leaking
+    secrets: for each candidate key file, parse the value, print only
+    `len`+`prefix` (`sk-ant-…`), and `curl -s -o /dev/null -w "%{http_code}"
+    https://api.anthropic.com/v1/models -H "x-api-key: $K" -H
+    "anthropic-version: 2023-06-01"` — 200 = live, 401 = dead. Compare file
+    mtimes to spot which is stale. Fix without touching the secret value:
+    relaunch the server with the live key sourced
+    (`set -a; source ~/.attune/anthropic.env; set +a; exec …`) — it wins
+    over `.env` because `override=False`.
+  - **"Subscription mode" ≠ free API.** With the live key the curator then
+    got **400 "credit balance is too low"** — the key authenticates but its
+    org has no pay-as-you-go API credit. The Claude Pro/Max subscription
+    powers claude.ai / Claude Code, NOT raw API calls; any dashboard feature
+    using the raw `anthropic` SDK genuinely needs API billing. A
+    subscription-only user (Patrick: "no API-key polish") simply can't run
+    the curator without funding credits — it's an account choice, not a bug
+    to code around. A 400-credit error is ORG-level, so if credits were
+    added on a DIFFERENT account than the key's org, it still 400s.
+  - **The code half (shipped):** the curator interpolated the raw exception
+    (`f"… offline ({exc})"`) — leaking `request_id`/error internals to the
+    UI. Replaced with an `_offline_summary(exc)` classifier (401→key
+    guidance, 400+"credit balance"→billing guidance, 429→rate-limit, else
+    generic) that NEVER interpolates the raw exc; the full error still goes
+    to `logger.warning`. Anti-leak is a tested property (assert the
+    `request_id` is absent from the summary).

--- a/src/attune/curator/core.py
+++ b/src/attune/curator/core.py
@@ -256,6 +256,43 @@ async def _query_opus(
     )
 
 
+def _offline_summary(exc: Exception) -> str:
+    """Map an LLM/transport failure to a clean, actionable offline message.
+
+    Deliberately does NOT interpolate the raw exception into the
+    dashboard-facing summary: SDK errors carry a ``request_id`` and other
+    internals that shouldn't surface in the UI. The full exception is logged
+    separately for debugging.
+
+    Args:
+        exc: The exception raised while reaching Anthropic.
+
+    Returns:
+        A user-facing sentence beginning with "The curator is offline".
+    """
+    status = getattr(exc, "status_code", None)
+    text = str(exc).lower()
+
+    if status == 401 or "authentication" in text or "x-api-key" in text:
+        return (
+            "The curator is offline: the ANTHROPIC_API_KEY is missing or "
+            "invalid. Set a valid key (e.g. in ~/.attune/anthropic.env)."
+        )
+    if "credit balance" in text or "plans & billing" in text or "billing" in text:
+        return (
+            "The curator is offline: the Anthropic account has no API credit "
+            "balance. The curator makes a direct API call, which needs "
+            "pay-as-you-go credits — the Claude subscription does not include "
+            "raw API access. Add credits to enable AI briefings."
+        )
+    if status == 429 or "rate limit" in text:
+        return "The curator is offline: Anthropic rate limit reached. " "Try again shortly."
+    return (
+        "The curator is offline due to a temporary error reaching Anthropic. "
+        "See the server logs for details."
+    )
+
+
 async def run_curator(
     *,
     project_root: Path,
@@ -314,7 +351,7 @@ async def run_curator(
         # to an offline briefing rather than crashing the dashboard.
         logger.warning("curator: synthesis failed: %s", exc)
         return CuratorResult(
-            summary=f"The curator is offline ({exc}).",
+            summary=_offline_summary(exc),
             items=[],
             sources_consulted=sources_consulted,
             model=model,

--- a/tests/unit/curator/test_run_curator.py
+++ b/tests/unit/curator/test_run_curator.py
@@ -211,13 +211,51 @@ def test_zero_ttl_always_misses(isolate):
     assert len(client.messages.calls) == 2
 
 
+class _StatusError(Exception):
+    """Stand-in for an anthropic SDK status error (carries ``status_code``)."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
 def test_offline_on_sdk_failure(isolate):
     client = _FakeClient(exc=RuntimeError("api down"))
     result = asyncio.run(core.run_curator(project_root=isolate, client=client))
     assert result.items == []
     assert result.summary.startswith("The curator is offline")
-    assert "api down" in result.summary
+    # The raw exception text must NOT leak into the dashboard-facing summary.
+    assert "api down" not in result.summary
     assert set(result.sources_consulted) == {"bulletin", "specs"}
+
+
+def test_offline_auth_error_gives_key_guidance(isolate):
+    exc = _StatusError("Error code: 401 - invalid x-api-key", status_code=401)
+    result = asyncio.run(core.run_curator(project_root=isolate, client=_FakeClient(exc=exc)))
+    assert "ANTHROPIC_API_KEY" in result.summary
+    # No raw error / request_id leakage.
+    assert "401" not in result.summary
+    assert "x-api-key" not in result.summary
+
+
+def test_offline_no_credits_gives_billing_guidance(isolate):
+    exc = _StatusError(
+        "Error code: 400 - Your credit balance is too low to access the "
+        "Anthropic API. request_id: req_abc123",
+        status_code=400,
+    )
+    result = asyncio.run(core.run_curator(project_root=isolate, client=_FakeClient(exc=exc)))
+    assert "credit" in result.summary.lower()
+    assert "subscription does not include raw API access" in result.summary
+    # The request_id must never reach the UI.
+    assert "req_abc123" not in result.summary
+
+
+def test_offline_rate_limit_message(isolate):
+    exc = _StatusError("Error code: 429 - rate limit exceeded", status_code=429)
+    result = asyncio.run(core.run_curator(project_root=isolate, client=_FakeClient(exc=exc)))
+    assert "rate limit" in result.summary.lower()
+    assert "429" not in result.summary
 
 
 def test_budget_overage_logs_warning(isolate, caplog):


### PR DESCRIPTION
## Curator: graceful, non-leaky offline messages

Found while debugging the ops dashboard Briefing page, which showed:

> The curator is offline (Error code: 401 - {'type': 'error', 'error':
> {'type': 'authentication_error', 'message': 'invalid x-api-key'}, ...}).

### The bug

`curator/core.py` interpolated the **raw exception** into the
dashboard-facing summary — `f"The curator is offline ({exc})."` — so an
Anthropic 401/400 dumped the error type and `request_id` straight onto the
UI, with no actionable guidance for the user.

### The fix

`_offline_summary(exc)` classifies the failure and returns a clean sentence,
**never interpolating the raw exception** (the full error is still logged via
`logger.warning` for debugging):

| Condition | Message |
|-----------|---------|
| 401 / `authentication` / `x-api-key` | `ANTHROPIC_API_KEY` missing/invalid, where to set it |
| `credit balance` / `billing` | account has no API credit; the curator makes a direct API call, which the Claude subscription doesn't cover |
| 429 / `rate limit` | rate-limited, retry shortly |
| else | generic temporary error, see logs |

The no-credit case is the real one for a subscription-only setup: the Claude
Pro/Max subscription powers claude.ai / Claude Code, **not** raw API calls, so
a direct `AsyncAnthropic()` call needs pay-as-you-go credits.

### Tests

- `test_offline_on_sdk_failure` updated to assert the raw exc does **not** leak
- new auth / no-credit / rate-limit cases, each asserting the clean message
  **and the absence of the raw status code / `request_id`** (anti-leak property)
- 22 passed

### Verification

Live-verified on the running ops dashboard: the Briefing page now renders the
clean "no API credit balance" message with **zero `request_id`/raw-error
leakage** (confirmed by fetching `/curator` and grepping the response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
