### PR TITLE
ci(tests): right-size matrix — skip advisory lanes on test/docs-only diffs

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -5780,6 +5780,41 @@ files.
   CANCELLED noise (separate, low-priority) is quietable with
   `cancel-in-progress: false` in the scan workflow.
 
+- **Advisory CI lanes don't gate — for test/docs-only PRs, merge on
+  the required greens; don't WAIT on Windows/macOS (and right-size the
+  matrix so they don't even spawn)**: 2026-06-13, closing the
+  auth_strategy work I sat ~30 min watching #797/#798's Windows lanes
+  before merging — they were NEVER required. `gh api
+  .../branches/main/protection/required_status_checks` showed only 7
+  required contexts (`CodeQL, code-quality, coverage, lint,
+  platform-compat, pre-commit, test (ubuntu-latest, 3.12)`); the other
+  11 of the 12-lane `tests.yml` matrix (all Windows, all macOS, ubuntu
+  3.10/3.11/3.13) are ADVISORY. The repo is PUBLIC so minutes are free —
+  the cost was self-imposed latency + the temptation to treat a
+  non-gating lane as a gate. Two durable rules: (1) **behavioral** —
+  for a tests/docs-only diff merge on the required greens; the "wait
+  for all OS lanes before admin-merging" caution (its own lesson)
+  applies only to SOURCE changes touching paths/subprocess/encoding/the
+  filesystem, where a Windows regression is plausible; a test-only diff
+  can't introduce a cross-platform SOURCE bug. (2) **structural** —
+  right-size the matrix so advisory lanes don't even run on
+  non-source diffs: a `changes` job (git-diff paths filter, fail-safe
+  to FULL matrix on any ambiguity) → a `setup-matrix` job emitting
+  full/slim matrix JSON → `test` consuming
+  `${{ fromJSON(needs.setup-matrix.outputs.matrix) }}`. **The trap**:
+  GitHub matches a required check by job name INCLUDING matrix params
+  (`test (ubuntu-latest, 3.12)`); that exact lane must be in EVERY
+  matrix variant or a non-source PR leaves the required check "missing"
+  → blocked forever (same failure shape as the stacked-PR
+  base-retarget "required check stays MISSING" lesson). Keep both
+  variants cartesian-shaped (`{os:[…],python-version:[…]}`) so naming
+  is identical; slim = `{os:[ubuntu,windows],python-version:[3.12]}`
+  (required lane + one Windows smoke for test-portability bugs like
+  `/tmp` vs `C:\`). See `docs/specs/ci-matrix-right-sizing/`. Pairs
+  with the "Verify-first applies to infra/config" lesson above (read
+  required-vs-advisory before treating a red/pending check as
+  blocking).
+
 - **The worktree-path-guard hook hard-blocks Edit/Write to a
   *sibling* repo (a different repo root entirely) from the
   session worktree — route cross-repo edits through a Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,78 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decide whether this change needs the full cross-platform matrix.
+  # A diff that touches no source/packaging files (tests-only, docs-only)
+  # cannot introduce a cross-platform SOURCE regression, so it runs a slim
+  # matrix instead of all 12 lanes. Fail-safe: anything other than a clean
+  # PR diff that misses every trigger path falls back to the FULL matrix
+  # (run more, never fewer required signals).
+  # See docs/specs/ci-matrix-right-sizing/.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        fetch-depth: 0
+    - id: filter
+      shell: bash
+      env:
+        EVENT: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        set -euo pipefail
+        # Non-PR events (push to main/develop, manual dispatch) always get
+        # the full matrix — the slim path is a PR-iteration optimization.
+        if [ "$EVENT" != "pull_request" ] || [ -z "${BASE_REF:-}" ]; then
+          echo "event=$EVENT -> full matrix"
+          echo "src=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        git fetch --no-tags --quiet origin "$BASE_REF" || true
+        if ! CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD"); then
+          echo "diff failed -> full matrix (fail-safe)"
+          echo "src=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "changed files:"; printf '%s\n' "$CHANGED"
+        # Trigger paths (D2): any source/packaging change, or a change to
+        # THIS workflow, needs full cross-platform validation.
+        if printf '%s\n' "$CHANGED" | grep -qE '^(src/|pyproject\.toml|setup\.cfg|\.github/workflows/tests\.yml)'; then
+          echo "src=true (source/packaging touched) -> full matrix"
+          echo "src=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "src=false (tests/docs-only) -> slim matrix"
+          echo "src=false" >> "$GITHUB_OUTPUT"
+        fi
+
+  # Emit the test matrix JSON. CRITICAL: the slim matrix MUST keep the
+  # `test (ubuntu-latest, 3.12)` lane — that exact job name is a REQUIRED
+  # status check, and a required check that never runs reports as "missing"
+  # → the PR is blocked forever. Both variants are cartesian-shaped so the
+  # job name is identical (`test (<os>, <python-version>)`). If the required
+  # Python pin ever changes here, update branch protection in lockstep.
+  setup-matrix:
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+    - id: set
+      shell: bash
+      run: |
+        if [ "${{ needs.changes.outputs.src }}" = "true" ]; then
+          echo 'matrix={"os":["ubuntu-latest","macos-latest","windows-latest"],"python-version":["3.10","3.11","3.12","3.13"]}' >> "$GITHUB_OUTPUT"
+        else
+          # slim (D1): the required ubuntu-3.12 lane + one Windows smoke
+          echo 'matrix={"os":["ubuntu-latest","windows-latest"],"python-version":["3.12"]}' >> "$GITHUB_OUTPUT"
+        fi
+
   test:
+    needs: setup-matrix
     # TEMPORARY (2026-06-07): ubuntu matrix entries run on default
     # GitHub-hosted `ubuntu-latest` runners. The 8-core/32GB larger
     # runner (`ubuntu-8core-or-linux-32gb`) was de-provisioned, which left
@@ -28,9 +99,7 @@ jobs:
     timeout-minutes: 75
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
 
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/docs/specs/ci-matrix-right-sizing/decisions.md
+++ b/docs/specs/ci-matrix-right-sizing/decisions.md
@@ -1,0 +1,42 @@
+# Decisions — CI matrix right-sizing
+
+Append-only log.
+
+---
+
+## 2026-06-13 — D1–D3 decided (Patrick), implementation built
+
+- **D1 — slim matrix shape: `ubuntu-3.12 + windows-3.12`.** On a
+  tests/docs-only diff, run the required ubuntu-3.12 lane plus one
+  Windows smoke. Rationale: a test-only PR's one realistic platform
+  break is a new test baking in POSIX-only path assumptions; one
+  Windows lane catches it for ~13 min instead of dropping all
+  cross-platform signal.
+- **D2 — full-matrix trigger paths:** `src/**`, `pyproject.toml`,
+  `setup.cfg`, `.github/workflows/tests.yml`. Any change matching these
+  runs the full 12-lane matrix. Everything else (tests, docs, `.claude`,
+  markdown) runs slim.
+- **D3 — behavioral rule codified:** for tests/docs-only PRs, merge on
+  the 7 required green checks; do not wait on advisory Windows/macOS
+  lanes (they don't gate). For `src/`-touching PRs the advisory lanes
+  run but still don't gate — the "wait for Windows before merging"
+  caution applies only to source changes touching paths / subprocess /
+  encoding / the filesystem. Captured as a lesson in `.claude/lessons.md`.
+
+### Implementation note
+
+Built in `.github/workflows/tests.yml`: a `changes` job (git-diff
+paths filter, fail-safe to full matrix on any ambiguity) → a
+`setup-matrix` job (emits full/slim matrix JSON) → the `test` job
+consumes `fromJSON(...)`. No third-party action added (pure git diff)
+and no branch-protection edit — the required `test (ubuntu-latest,
+3.12)` lane is present in both matrix variants, so the required check
+name is always emitted.
+
+### Verification owed (post-merge)
+
+This PR touches `tests.yml`, a D2 trigger, so it runs the FULL matrix
+and validates the full path + that the required name still emits. The
+SLIM path must be proven by a follow-up **tests-only** PR: confirm
+`test (ubuntu-latest, 3.12)` reports, `test (windows-latest, 3.12)`
+runs, the PR is mergeable, and the other 10 lanes did NOT spawn.

--- a/docs/specs/ci-matrix-right-sizing/requirements.md
+++ b/docs/specs/ci-matrix-right-sizing/requirements.md
@@ -1,0 +1,149 @@
+# CI matrix right-sizing — skip advisory lanes on test/docs-only diffs
+
+**Status:** building — D1–D3 decided 2026-06-13 (see decisions.md);
+workflow implemented, slim-path proof owed post-merge
+**Opened:** 2026-06-13
+**Layer:** attune-ai (CI / `.github/workflows/tests.yml`)
+**Owner:** Patrick + agent
+
+---
+
+## Problem
+
+The `Tests` workflow runs a **12-lane matrix** (3 OS × 4 Python) on
+every push/PR. Only **one** lane gates the merge —
+`test (ubuntu-latest, 3.12)`. The other 11 (all 4 Windows, all 4 macOS,
+ubuntu 3.10/3.11/3.13) are **advisory**: they run but gate nothing.
+
+Because the repo is **public, Actions minutes are free** — so the cost
+is not dollars. It is:
+
+- **merge latency** — Windows lanes take ~13 min; waiting on them
+  delays low-risk merges;
+- **CI noise** — 12 check rows + a non-required `security` cancel make
+  "is it green?" harder to read at a glance;
+- **the temptation to wait** — advisory lanes look like gates, so an
+  operator (human or agent) waits on them when they don't block. This
+  literally happened on #797/#798: ~30+ min spent watching Windows
+  lanes that were never required.
+
+For a **test-only or docs-only** diff, the full cross-platform×Python
+matrix is especially low-value: a change that touches no `src/` cannot
+introduce a cross-platform *source* regression.
+
+---
+
+## Verified findings (grounded, 2026-06-13)
+
+| Fact | How verified |
+|------|--------------|
+| Required checks = `CodeQL, code-quality, coverage, lint, platform-compat, pre-commit, test (ubuntu-latest, 3.12)` | `gh api repos/.../branches/main/protection/required_status_checks` |
+| Matrix = `[ubuntu, macos, windows] × [3.10–3.13]`, only the one ubuntu-3.12 lane required | `.github/workflows/tests.yml:29-33` + the required list above |
+| Repo is public → free minutes | `gh repo view --json visibility` → PUBLIC |
+
+This corrects an earlier impression that "the 12-lane matrix is the
+merge gate." It is not — 11 of 12 lanes are advisory.
+
+---
+
+## Goals
+
+- On `tests/**`- or `docs/**`-only diffs (no `src/` change), **do not
+  spawn** the 11 advisory matrix lanes.
+- **Never** change which checks are *required* in a way that can leave
+  a required check "missing" (the merge-blocking trap — see Risks).
+- Keep the change to a single workflow file; no branch-protection edit
+  if avoidable.
+
+## Non-goals
+
+- Not changing required-check policy or branch protection (that's the
+  heavier "two-tier" alternative, deferred).
+- Not touching the separate `security`/CodeQL/pre-commit workflows.
+- Not addressing the `security` CANCELLED cosmetic-noise issue (a
+  separate, known item — `cancel-in-progress: false` on that scan).
+
+---
+
+## Design (recommended): dynamic matrix via paths-filter
+
+Keep one workflow, make the matrix breadth conditional:
+
+1. **`changes` job** — a paths-filter step (`dorny/paths-filter` or a
+   `git diff --name-only` against the merge base) sets
+   `outputs.src = true|false` (true if any `src/**` or packaging file
+   changed).
+2. **`setup-matrix` job** (`needs: changes`) — emits matrix JSON:
+   - `src == true` → full `{os:[ubuntu,macos,windows], py:[3.10–3.13]}`
+   - `src == false` → slim matrix (see **D1**).
+3. **`test` job** — `strategy.matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}`.
+
+**The trap this design must respect:** GitHub matches required checks
+by job name *including* matrix params — `test (ubuntu-latest, 3.12)`.
+That exact lane MUST be present in *every* variant of the matrix, or a
+test-only PR leaves the required check **missing → merge blocked
+forever** (this is the documented stacked-PR "required check stays
+MISSING" failure mode). The slim matrix therefore always includes
+`ubuntu-latest / 3.12`.
+
+`coverage`, `lint`, `platform-compat`, `code-quality`, `pre-commit`,
+`CodeQL` are single ubuntu jobs and keep running unconditionally — they
+are fast and required, so no change.
+
+### Alternative (deferred): two-tier required checks
+
+Demote the whole matrix to advisory, add one fast always-on required
+"gate" job, then path-filter the matrix freely. Cleaner long-term but
+needs a branch-protection change → larger blast radius. Revisit only if
+the dynamic-matrix approach proves fiddly.
+
+---
+
+## Decisions needed (Patrick)
+
+- **D1 — slim matrix shape.** On a test/docs-only diff, run:
+  - (a) `ubuntu-3.12` only, **or**
+  - (b) `ubuntu-3.12 + windows-3.12` (one Windows smoke).
+  *Recommendation: (b).* A test-only PR's one realistic platform break
+  is a new test using POSIX-only path assumptions (`/tmp`, separators);
+  one Windows lane catches it cheaply, and it keeps the merge-relevant
+  signal honest.
+- **D2 — what counts as "needs full matrix."** Proposed `src` trigger =
+  any change under `src/**`, `pyproject.toml`, `setup.cfg`,
+  `.github/workflows/tests.yml`. Everything else (`tests/**`,
+  `docs/**`, `.claude/**`, `*.md`) → slim. Confirm or adjust.
+- **D3 — behavioral note.** Independent of the workflow change: codify
+  that for test/docs-only PRs we merge on the 7 required greens without
+  waiting on advisory lanes. Record in this spec's decisions, and/or as
+  a lesson. (The structural change makes this moot for the *skipped*
+  lanes, but the rule still matters for src-touching PRs where the
+  advisory macOS/Windows lanes run but don't gate.)
+
+---
+
+## Build tasks (deferred — after D1–D3)
+
+1. Add `changes` + `setup-matrix` jobs to `tests.yml`; wire
+   `test.strategy.matrix` to the dynamic JSON. Preserve the
+   `test (ubuntu-latest, 3.12)` lane in both variants.
+2. Prove the required-check name is emitted on a `tests/**`-only PR
+   (open a throwaway test-only PR; confirm `test (ubuntu-latest, 3.12)`
+   reports and the PR is mergeable; confirm the 11 advisory lanes did
+   NOT spawn).
+3. Prove a `src/**` PR still spawns the full 12 lanes.
+4. Record D1–D3 outcomes in `decisions.md`; one-line `CHANGELOG`/note
+   if user-visible (it isn't — CI-internal).
+
+## Risks
+
+- **Required-check-missing → permanent block** (HIGH) — mitigated by
+  always including the `ubuntu-3.12` lane; verified by build task #2
+  before relying on it.
+- **paths-filter merge-base edge cases** — first push to a new branch,
+  or force-pushes, can confuse `git diff` base detection;
+  `dorny/paths-filter` handles PR vs push contexts but needs the PR
+  event (not just push). Default to **full matrix on ambiguity** (fail
+  safe = run more, never fewer required signals).
+- **Matrix-name drift** — if Python pin in the required lane ever
+  changes (3.12 → 3.13), branch protection's required context must be
+  updated in lockstep, or it goes missing. Note in the workflow comment.


### PR DESCRIPTION
## CI matrix right-sizing — skip advisory lanes on test/docs-only diffs

Spec: [docs/specs/ci-matrix-right-sizing/](docs/specs/ci-matrix-right-sizing/requirements.md) · decisions D1–D3 recorded.

### Problem

`tests.yml` runs a **12-lane matrix** (3 OS × 4 Python) on every push, but only **`test (ubuntu-latest, 3.12)` is required** — the other 11 (all Windows, all macOS, ubuntu 3.10/3.11/3.13) are **advisory**. Public repo → minutes are free, so the cost is **merge latency, CI noise, and the temptation to wait on lanes that don't gate** (verified: ~30 min spent watching non-required Windows lanes on #797/#798).

### Change

A `changes` job (git-diff paths filter) → a `setup-matrix` job (emits matrix JSON) → `test` consumes `fromJSON(...)`:

- **tests/docs-only diff** → slim matrix: `ubuntu-3.12` + one `windows-3.12` smoke (D1).
- **`src/**`, `pyproject.toml`, `setup.cfg`, or `tests.yml`** → full 12 (D2).
- **fail-safe:** non-PR events, diff failure, or any ambiguity → full matrix (run more, never fewer required signals).

No branch-protection change, no third-party action (pure git diff).

### The trap this is built around

GitHub matches a required check by job name **including matrix params** (`test (ubuntu-latest, 3.12)`). That exact lane is present in **both** matrix variants, so the required-check name is always emitted — a required check that never runs reports "missing" and blocks the PR forever. Both variants are cartesian-shaped so naming is identical. Validated locally: required lane present in full (12) and slim (2).

### Verification status

This PR touches `tests.yml` (a D2 trigger), so it runs the **full matrix** — validating the full path + that the required name still emits. The **slim path** must be proven by a follow-up **tests-only PR** (see `decisions.md` → "Verification owed"): confirm `test (ubuntu-latest, 3.12)` reports, `windows-3.12` runs, the PR is mergeable, and the other 10 lanes don't spawn.

### Also

- D3 behavioral rule (merge test/docs-only PRs on the required greens; don't wait on advisory lanes) recorded as a lesson in `.claude/lessons.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
