### PR TITLE
fix(test): make encryption key-file tests Windows-portable

### DIFF
--- a/tests/unit/memory/test_encryption_coverage_boost.py
+++ b/tests/unit/memory/test_encryption_coverage_boost.py
@@ -49,10 +49,15 @@ def isolated_key_env(monkeypatch, tmp_path):
     redirects ``Path.home()`` to an empty tmp dir (no ``master.key``),
     so ``_load_or_generate_key`` falls through to ephemeral generation
     unless a test explicitly sets one of these up.
+
+    Note: patch ``Path.home`` directly rather than ``$HOME`` — on Windows
+    ``Path.home()`` reads ``%USERPROFILE%``, not ``$HOME``, so a
+    ``setenv("HOME", ...)`` redirect is silently ignored there (it was —
+    see the key-file tests failing on the windows-3.12 lane).
     """
     monkeypatch.delenv("ATTUNE_MASTER_KEY", raising=False)
     monkeypatch.delenv("EMPATHY_MASTER_KEY", raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(enc_mod.Path, "home", lambda: tmp_path)
     return tmp_path
 
 


### PR DESCRIPTION
## Windows hotfix for #799's encryption suite

`test_encryption_coverage_boost.py`'s `isolated_key_env` fixture redirected key resolution with `monkeypatch.setenv("HOME", tmp_path)`, but the module calls `Path.home()` — which on **Windows reads `%USERPROFILE%`, not `$HOME`**. The redirect was silently ignored on the `windows-3.12` lane, so no `master.key` was found, key resolution fell through to ephemeral generation, and the key-file tests asserted a random key.

**Surfaced by #803's Windows lane:** `TestKeyResolution::test_key_file_is_read_when_present` — `AssertionError: assert b'\xd3...' == b'KKK...'`.

The required `ubuntu-3.12` lane was green (POSIX honors `$HOME`), which is why #799 merged with this latent Windows failure.

**Fix:** patch `Path.home` directly (OS-agnostic) instead of setting `$HOME`. All 28 tests pass locally; the slim matrix's `windows-3.12` lane validates the fix in CI.

Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)