### PR TITLE
chore(qa): authoritative coverage baseline + PR babysitter scripts

### DIFF
--- a/scripts/qa_coverage_baseline.sh
+++ b/scripts/qa_coverage_baseline.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# qa_coverage_baseline.sh — authoritative coverage baseline for a QA batch.
+#
+# The FIRST step of any test-quality batch. Runs the full unit suite (the
+# only reliable measure — a single-subdir run undercounts modules whose
+# tests live elsewhere; see .claude/lessons.md "subset coverage baseline
+# undercounts") scoped to one package, keyless (no API spend), and prints
+# the modules under a coverage threshold, ranked by missed lines.
+#
+# Worktree-safe: runs from the worktree root with the MAIN checkout's venv
+# python (which has all extras) + a PYTHONPATH override so the worktree's
+# code is measured, and --cov-config=/dev/null to bypass the rcfile
+# source-mapping that otherwise reports 0% from a worktree.
+#
+# Usage:
+#   bash scripts/qa_coverage_baseline.sh [package] [threshold] [out_file]
+#
+#   package    dotted package to scope coverage to   (default: attune.memory)
+#   threshold  report modules strictly below this %  (default: 80)
+#   out_file   where to write the full term-missing   (default: a temp file)
+#
+# Examples:
+#   bash scripts/qa_coverage_baseline.sh
+#   bash scripts/qa_coverage_baseline.sh attune.workflows 85
+#
+set -euo pipefail
+
+PACKAGE="${1:-attune.memory}"
+THRESHOLD="${2:-80}"
+
+WT_ROOT="$(git rev-parse --show-toplevel)"
+
+# Locate a python with all extras: prefer the MAIN checkout's venv (a
+# worktree venv is usually synced with only dev/developer extras).
+COMMON_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
+MAIN_ROOT="$(dirname "$COMMON_DIR")"
+if [ -x "$MAIN_ROOT/.venv/bin/python" ]; then
+  PY="$MAIN_ROOT/.venv/bin/python"
+elif [ -x "$WT_ROOT/.venv/bin/python" ]; then
+  PY="$WT_ROOT/.venv/bin/python"
+else
+  PY="python3"
+fi
+
+OUT_FILE="${3:-$(mktemp -t qa_baseline_XXXX).txt}"
+
+echo "package:   $PACKAGE"
+echo "python:    $PY"
+echo "threshold: <${THRESHOLD}%"
+echo "report:    $OUT_FILE"
+echo "running full unit suite (keyless, this takes ~1-2 min)…"
+
+# ANTHROPIC_API_KEY="" => CI-keyless: integration-gated SDK tests skip and
+# do NOT spend real money (an UNSET key lets dotenv inject the real one).
+# --ignore=tests/integration => those add ~no unit-module coverage anyway.
+set +e
+ANTHROPIC_API_KEY="" PYTHONPATH="$WT_ROOT/src" "$PY" -m pytest "$WT_ROOT/tests" \
+  --ignore="$WT_ROOT/tests/integration" \
+  -o addopts="" \
+  --cov="$PACKAGE" --cov-config=/dev/null \
+  --cov-report=term-missing \
+  -n auto -q -p no:cacheprovider >"$OUT_FILE" 2>&1
+RC=$?
+set -e
+
+if ! grep -q "TOTAL" "$OUT_FILE"; then
+  echo "ERROR: no coverage TOTAL in output — run failed. Tail:" >&2
+  tail -20 "$OUT_FILE" >&2
+  exit "${RC:-1}"
+fi
+
+echo
+echo "=== ${PACKAGE} TOTAL ==="
+grep -E "^TOTAL" "$OUT_FILE" || true
+
+echo
+echo "=== modules below ${THRESHOLD}% (ranked by missed lines, desc) ==="
+# Columns: Name Stmts Miss Cover[%] [Missing…]
+awk -v th="$THRESHOLD" '
+  $1 ~ /\.py$/ {
+    cov = $4; gsub("%", "", cov);
+    if (cov + 0 < th + 0) printf "%-6s %4s missed  %5s%%  %s\n", "", $3, cov, $1;
+  }
+' "$OUT_FILE" | sort -k2 -nr | sed 's|src/attune/||'
+
+echo
+echo "Full term-missing report: $OUT_FILE"
+echo "REMINDER: a module here is a HYPOTHESIS. Before writing tests, confirm"
+echo "its real coverage with its actual test files (find tests -name '*<mod>*')."

--- a/scripts/qa_pr_babysitter.sh
+++ b/scripts/qa_pr_babysitter.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# qa_pr_babysitter.sh — merge your own green QA PRs as their CI passes.
+#
+# A standing poller for a QA batch: every interval it lists YOUR open PRs
+# whose head branch matches a prefix, and squash-merges any whose REQUIRED
+# checks are all green. Exits when no matching PRs remain or the deadline
+# is hit.
+#
+# Safe by design:
+#   - Only touches PRs authored by you (gh pr list --author "@me").
+#   - Only merges when ALL required checks pass (the advisory Windows/macOS
+#     lanes and the non-required `security` scanner are ignored).
+#   - Plain `--squash --delete-branch` — NO --admin, NO branch-protection
+#     changes. Branch protection requires 0 reviews for these (verify with
+#     `gh api repos/<o>/<r>/branches/main/protection`).
+#
+# Usage:
+#   bash scripts/qa_pr_babysitter.sh [branch_prefix] [deadline_min] [interval_sec]
+#
+#   branch_prefix  head-branch prefix to match   (default: qa)
+#   deadline_min   stop after this many minutes  (default: 90)
+#   interval_sec   seconds between scans          (default: 60)
+#
+# Run it backgrounded, or via the /loop skill for a recurring babysitter.
+#
+set -euo pipefail
+
+PREFIX="${1:-qa}"
+DEADLINE_MIN="${2:-90}"
+INTERVAL="${3:-60}"
+
+# The 7 REQUIRED checks per main branch protection (2026-06-13). If branch
+# protection changes, update this list (gh pr checks shows all; required
+# ones are in repos/<o>/<r>/branches/main/protection.required_status_checks).
+REQUIRED='["pre-commit","lint","code-quality","coverage","platform-compat","CodeQL","test (ubuntu-latest, 3.12)"]'
+
+deadline=$(( $(date +%s) + DEADLINE_MIN * 60 ))
+echo "babysitter: prefix='${PREFIX}*'  deadline=${DEADLINE_MIN}m  interval=${INTERVAL}s"
+
+while true; do
+  # Open PRs by me whose head branch starts with the prefix.
+  mapfile -t prs < <(gh pr list --author "@me" --state open \
+    --json number,headRefName \
+    --jq ".[] | select(.headRefName | startswith(\"${PREFIX}\")) | .number")
+
+  if [ "${#prs[@]}" -eq 0 ]; then
+    echo "no open ${PREFIX}* PRs remain — done."
+    break
+  fi
+
+  for pr in "${prs[@]}"; do
+    notpass=$(gh pr checks "$pr" --json name,bucket \
+      --jq "[.[] | select(.name as \$x | ${REQUIRED} | index(\$x)) | select(.bucket != \"pass\")] | length" \
+      2>/dev/null || echo 1)
+    if [ "$notpass" -eq 0 ]; then
+      echo "#$pr: required-green -> merging"
+      gh pr merge "$pr" --squash --delete-branch 2>&1 | tail -1 || echo "#$pr merge errored (may already be merged)"
+    else
+      echo "#$pr: $notpass required check(s) pending"
+    fi
+  done
+
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "deadline reached — stopping (some PRs may still be pending)."
+    break
+  fi
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## What

Codifies two pieces of the QA-batch workflow proven in the 2026-06-13 `memory/` session (11 modules hardened, `attune.memory` → 94%).

### `scripts/qa_coverage_baseline.sh`
The reliable **first step** of a batch: runs the full unit suite (keyless — no API spend) scoped to a package and ranks modules under a threshold by missed lines.

- Worktree-safe: MAIN venv python + `PYTHONPATH` override + `--cov-config=/dev/null` (the rcfile otherwise reports 0% from a worktree).
- Exists because a single-subdir baseline **undercounts** modules tested elsewhere — this session it made `audit_logger`/`secrets_detector` look like 56–59% when really 92–94%. The script runs the authoritative whole-suite measure and reminds the caller a listed module is a *hypothesis* until its real test files confirm the gap.

```
bash scripts/qa_coverage_baseline.sh [package] [threshold] [out_file]
```

### `scripts/qa_pr_babysitter.sh`
Merges **your** green QA PRs (head-branch prefix match) as their **required** checks pass — ignores advisory Windows/macOS lanes and the non-required `security` scanner.

- Safe: only PRs authored by the runner; plain `--squash --delete-branch`, **no `--admin`**, no branch-protection changes (main requires 0 reviews for these).

```
bash scripts/qa_pr_babysitter.sh [branch_prefix] [deadline_min] [interval_sec]
```

Both validated: syntax-checked, babysitter smoke-tested (correctly finds no open `qa5*` PRs and exits), baseline run end-to-end against `attune.memory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)