### PR TITLE
fix(memory): pin cryptography once so serial --cov memory runs don't disable encryption

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8544,3 +8544,57 @@ files.
   with the attune-verify `find_spec`-top-level-only lessons (same API,
   the mirror-image surprise: there it under-checks submodules, here it
   over-raises on them).
+
+- **The serial `--cov` `HAS_ENCRYPTION=False` failure is NOT a
+  polluting test — it's cryptography's PyO3 "init once per process"
+  tripped by pytest-cov's startup source import (2026-06-13,
+  corrects the note directly above)**: serial
+  `pytest --cov=attune.memory.short_term.* tests/...` intermittently
+  fails ~13–32 tests with `RuntimeError: cryptography library required
+  when master_key is provided` because
+  `attune.memory.encryption.HAS_ENCRYPTION` is False. The prior
+  hypothesis (a test mutates the global / reloads encryption / removes
+  cryptography and a `monkeypatch`/fixture restore fixes it) is WRONG:
+  it reproduces with a SINGLE test file, from the MAIN checkout, and
+  `HAS_ENCRYPTION` is already False **before any test body runs**, so
+  nothing leaks between tests and no teardown fix applies. Real cause,
+  traced with a `sys.addaudithook` import tracer: `cryptography` ships
+  its core as a Rust/PyO3 extension
+  (`cryptography.hazmat.bindings._rust`) that may be **initialized only
+  once per interpreter process**. pytest-cov imports the `--cov` source
+  module at startup, BEFORE any conftest. For a memory target that
+  import transitively eager-loads
+  `redis`→`redis.auth.token`→`PyJWT`→`cryptography` (the
+  `import redis` availability guard at `short_term/base.py:51`),
+  initializing `_rust` once. That startup import then unwinds and
+  evicts the cryptography modules from `sys.modules` (C-level, so a
+  `dict.__delitem__` override on `sys.modules` never sees it) while
+  PyO3's **process-global** once-only counter stays incremented;
+  `tests/conftest.py` re-imports the chain → second `_rust` init →
+  `ImportError: PyO3 modules … may only be initialized once`, swallowed
+  by encryption.py's `except ImportError` → `HAS_ENCRYPTION = False`
+  for the WHOLE session. The test-file-local
+  `from cryptography.fernet import Fernet; HAS_ENCRYPTION=True` reads a
+  *cached* fernet so skipifs don't skip — the tests run and error
+  instead of skipping. **Why CI is fine:** xdist (`-n auto`) isolates
+  workers; green also without `--cov` or with a non-memory `--cov`
+  target (`--cov=attune.cli_minimal` → all pass). **Fix:** import
+  cryptography exactly once, cleanly, before pytest-cov's source
+  import. Shipped as a `pytest11` plugin
+  (`src/attune/_pytest_crypto_pin.py`, registered in pyproject) whose
+  top-level import runs during setuptools-entry-point loading —
+  VERIFIED to beat pytest-cov (bare repro 32 failed+13 errors → 2612
+  passed). **Conftest pins are too late** — both `tests/conftest.py`
+  and a repo-root `conftest.py` were verified still-failing because the
+  corruption predates conftest. In a worktree the entry point isn't in
+  editable metadata yet, so the fallback is `-p attune._pytest_crypto_pin`
+  (also verified green). Diagnostic recipe for any "library X
+  unavailable only under `--cov`/some import order" puzzle where X has a
+  compiled (PyO3/maturin/C) extension: (1) `sys.addaudithook` to log
+  every import of the compiled submodule with a stack — a SECOND import
+  of a once-only extension is the tell; (2) check who pre-loads it
+  (often a transitive eager dep like PyJWT-via-redis); (3) the fix is an
+  early one-time pin, not a teardown restore. Pairs with the
+  "editable install MAPPING points attune at MAIN" lesson (the same
+  worktree double-resolution made the entry-point verification fail
+  until the module was placed in main's src too).

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -25,6 +25,63 @@ and the endpoint detection/availability parsing — all with
 
 ---
 
+## 2026-06-13 — serial `--cov` memory-suite pollution (Opus 4.8)
+
+Classification: **test-infra / coverage-tooling interaction** (not
+crash / dead / mocked — the closest legacy bucket is "mocked" only in
+the sense that it corrupts test state, but nothing is actually mocked).
+Surfaced during QA #5 `memory/` coverage work.
+
+**Symptom.** Serial `pytest --cov=attune.memory.short_term.* tests/...`
+runs intermittently fail ~13–32 tests with
+`RuntimeError: cryptography library required when master_key is
+provided` from
+[encryption.py:54](../src/attune/memory/encryption.py) because
+`HAS_ENCRYPTION` is `False`. Green without `--cov`; green with a
+non-memory `--cov` target (e.g. `--cov=attune.cli_minimal` → 2612
+passed).
+
+**The hypothesis it disproves.** It is *not* a between-tests isolation
+leak and there is *no* polluting test. It reproduces with a single
+test file and from the main checkout, and `HAS_ENCRYPTION` is already
+`False` before any test body runs. So a `monkeypatch` / fixture
+"restore" fix does not apply.
+
+**Real root cause** (traced with a `sys.addaudithook` import tracer):
+`cryptography` ships its core as a Rust/PyO3 extension
+(`cryptography.hazmat.bindings._rust`) that may be **initialized only
+once per interpreter process**. With a `attune.memory.*` `--cov`
+target, pytest-cov imports the coverage source at startup — before any
+conftest. That import transitively eager-loads
+`redis` → `redis.auth.token` → `PyJWT` → `cryptography`
+(via [short_term/base.py:51](../src/attune/memory/short_term/base.py)),
+initializing `_rust` once. The startup import then unwinds and evicts
+the cryptography modules from `sys.modules` while PyO3's
+**process-global** once-only counter stays incremented. When
+`tests/conftest.py` re-imports the chain, `_rust` re-init raises
+`ImportError: PyO3 modules ... may only be initialized once`, which
+`encryption.py`'s `except ImportError` swallows → `HAS_ENCRYPTION =
+False` for the whole session. Tests whose `skipif(not HAS_ENCRYPTION)`
+read a *cached* `cryptography.fernet` (still `True`) don't skip — they
+run and error.
+
+CI is unaffected: coverage runs under xdist (`-n auto`), which
+isolates workers. This only bites serial `--cov` used for local QA
+coverage measurement.
+
+**Fix.** Import `cryptography` exactly once, cleanly, before
+pytest-cov's startup source import. Shipped as a `pytest11` plugin
+([_pytest_crypto_pin.py](../src/attune/_pytest_crypto_pin.py),
+registered in `pyproject.toml`) whose top-level import runs during
+setuptools-entry-point loading — verified to beat pytest-cov.
+Conftest-level pins were verified *too late* (the corruption predates
+conftest). Verification: full original repro **32 failed + 13 errors →
+2612 passed**. In a worktree (entry point not yet in editable
+metadata), use the manual fallback
+`-p attune._pytest_crypto_pin` (also verified green).
+
+---
+
 ## 2026-05-16 — eighteenth module under test-quality-program (Opus 4.7)
 
 First cycle after a two-day pause. Selected from the existing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -394,6 +394,13 @@ Issues = "https://github.com/Smart-AI-Memory/attune-ai/issues"
 Discussions = "https://github.com/Smart-AI-Memory/attune-ai/discussions"
 Changelog = "https://github.com/Smart-AI-Memory/attune-ai/blob/main/CHANGELOG.md"
 
+# pytest plugin: pin the cryptography PyO3 extension once at startup so
+# serial `pytest --cov=attune.memory.*` runs don't re-init `_rust` and
+# disable encryption. See src/attune/_pytest_crypto_pin.py for the full
+# root-cause writeup.
+[project.entry-points.pytest11]
+attune_crypto_pin = "attune._pytest_crypto_pin"
+
 # Plugin entry points for auto-discovery
 [project.entry-points."attune.plugins"]
 software = "attune_software.plugin:SoftwarePlugin"

--- a/src/attune/_pytest_crypto_pin.py
+++ b/src/attune/_pytest_crypto_pin.py
@@ -1,0 +1,51 @@
+"""Pin the ``cryptography`` PyO3 extension once, at pytest startup.
+
+Why this exists
+---------------
+``cryptography`` ships its core as a Rust/PyO3 extension
+(``cryptography.hazmat.bindings._rust``). PyO3 extensions built for
+CPython 3.8-or-older ABI may be **initialized only once per interpreter
+process**; a second initialization raises::
+
+    ImportError: PyO3 modules compiled for CPython 3.8 or older may only
+    be initialized once per interpreter process
+
+That second init is normally impossible, but it happens during *serial*
+``pytest --cov`` runs whose ``--cov`` target is an ``attune.memory.*``
+module. pytest-cov imports the coverage source at startup (before any
+conftest). For a memory target that import transitively eager-loads
+``redis`` -> ``redis.auth.token`` -> ``PyJWT`` -> ``cryptography``,
+initializing ``_rust`` once. That startup import then unwinds and evicts
+the cryptography modules from ``sys.modules`` while PyO3's *process-global*
+once-only counter stays incremented. When ``tests/conftest.py`` later
+re-imports the chain, ``cryptography`` is re-imported, ``_rust`` is
+initialized a second time, and the import fails. The failure is swallowed
+by ``attune.memory.encryption``'s ``except ImportError`` guard, leaving
+``HAS_ENCRYPTION = False`` for the whole session, so every test that builds
+``EncryptionManager(master_key=...)`` errors.
+
+CI is unaffected because it measures coverage under xdist (``-n auto``),
+which isolates workers; this only bites serial ``--cov`` runs used for
+local QA coverage measurement.
+
+The fix
+-------
+Import ``cryptography`` exactly once, cleanly, at pytest startup -- before
+pytest-cov imports the coverage source. This module is loaded as a
+``pytest11`` plugin, so its top-level import runs while pytest loads
+setuptools entry points, which is earlier than pytest-cov's source import.
+With ``_rust`` already cached, every later import (the unwinding startup
+import, conftest, the test bodies) is a cache hit and never re-initializes
+the extension.
+
+The import is best-effort: if ``cryptography`` is genuinely absent, the
+guard does nothing and ``HAS_ENCRYPTION`` is legitimately ``False``.
+"""
+
+try:  # noqa: SIM105 - explicit guard is clearer than contextlib.suppress here
+    import cryptography.exceptions  # noqa: F401
+    import cryptography.hazmat.primitives.ciphers.aead  # noqa: F401
+except ImportError:
+    # INTENTIONAL: cryptography is optional; if it is truly missing the
+    # encryption layer is correctly disabled and there is nothing to pin.
+    pass

--- a/tests/unit/test_pytest_crypto_pin.py
+++ b/tests/unit/test_pytest_crypto_pin.py
@@ -1,0 +1,44 @@
+"""Behavioral tests for the ``attune._pytest_crypto_pin`` pytest plugin.
+
+The plugin imports ``cryptography`` once at startup so serial
+``pytest --cov=attune.memory.*`` runs don't re-init the PyO3 ``_rust``
+extension and disable encryption (see the module for the full writeup).
+Its observable contract is a side effect at import time: cryptography is
+loaded (when available) and the import never raises.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.unit
+def test_pin_loads_cryptography() -> None:
+    """Importing the plugin leaves cryptography's PyO3 core loaded.
+
+    Reloading re-runs the module body; cryptography is already cached so
+    this is a no-op dict lookup (no PyO3 re-init). After it runs, the
+    ``_rust`` extension must be present in ``sys.modules``.
+    """
+    mod = importlib.import_module("attune._pytest_crypto_pin")
+    importlib.reload(mod)
+
+    assert "cryptography.hazmat.bindings._rust" in sys.modules
+
+
+@pytest.mark.unit
+def test_pin_is_best_effort_when_cryptography_unavailable(monkeypatch) -> None:
+    """The import guard swallows ImportError when cryptography is absent.
+
+    Simulate a missing dependency with the ``sys.modules[name] = None``
+    sentinel (which makes ``import name`` raise ImportError) and confirm
+    reloading the plugin does not propagate the error.
+    """
+    monkeypatch.setitem(sys.modules, "cryptography.exceptions", None)
+
+    mod = importlib.import_module("attune._pytest_crypto_pin")
+    # Must not raise even though `import cryptography.exceptions` fails.
+    importlib.reload(mod)


### PR DESCRIPTION
## Problem

Serial `pytest --cov=attune.memory.short_term.* tests/...` runs intermittently failed ~13–32 tests with:

```
RuntimeError: cryptography library required when master_key is provided
```

because `attune.memory.encryption.HAS_ENCRYPTION` was `False`. Green without `--cov`, and green with a non-memory `--cov` target. This made local serial coverage measurement unreliable for QA coverage work.

## Root cause (not a test-isolation leak)

The original hypothesis — a test mutates `HAS_ENCRYPTION` / reloads encryption and a `monkeypatch`/fixture restore fixes it — is **disproven**: it reproduces with a single test file, from the main checkout, and `HAS_ENCRYPTION` is already `False` *before any test body runs*.

Traced with a `sys.addaudithook` import tracer:

1. `cryptography` ships its core as a PyO3 Rust extension (`cryptography.hazmat.bindings._rust`) that may be **initialized only once per interpreter process**.
2. pytest-cov imports the `--cov` source at startup, **before any conftest**. For a memory target that import transitively eager-loads `redis` → `redis.auth.token` → `PyJWT` → `cryptography` (the `import redis` guard at `short_term/base.py:51`), initializing `_rust` once.
3. That startup import then unwinds and evicts cryptography from `sys.modules`, while PyO3's **process-global** once-only counter stays incremented.
4. `tests/conftest.py` re-imports the chain → second `_rust` init → `ImportError: PyO3 modules … may only be initialized once` → swallowed by `encryption.py`'s `except ImportError` → `HAS_ENCRYPTION = False` for the whole session.

**CI is unaffected** because coverage runs under xdist (`-n auto`), which isolates workers.

## Fix

A `pytest11` plugin (`src/attune/_pytest_crypto_pin.py`) that imports `cryptography` once, cleanly, at pytest startup — before pytest-cov's source import. Its top-level import runs during setuptools-entry-point loading, verified to beat pytest-cov.

Conftest-level pins (both `tests/conftest.py` and a repo-root `conftest.py`) were verified **too late** — the corruption predates conftest.

## Verification

| Scenario | Before | After |
|---|---|---|
| Full original repro (installed, auto-load) | 32 failed, 13 errors | **2612 passed**, 47 skipped |
| Single file (installed, auto-load) | 13 failed, 13 errors | **28 passed** |
| Worktree, `-p attune._pytest_crypto_pin` fallback | 13 failed, 13 errors | **28 passed** |

## Notes

- **Worktree caveat:** auto-load fires only once the entry point is in editable metadata (needs a reinstall). Until then, QA runs from a worktree should add `-p attune._pytest_crypto_pin` (verified green).
- **Global externality:** as a `pytest11` entry point this imports `cryptography` (~tens of ms) at pytest startup for any downstream project with attune-ai installed. Minor; can be made opt-in (drop the entry point, rely on `-p`) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
