### PR TITLE
fix(monitoring): OTELBackend construction no longer crashes without [otel] extra

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8518,3 +8518,29 @@ files.
   family. Generalizes beyond Windows: any OS/lane-specific failure on a
   long-lived branch should first be checked against "is this branch
   just behind a fix already on main?"
+
+- **`importlib.util.find_spec("pkg.submodule")` RAISES
+  `ModuleNotFoundError` when the PARENT package is absent — it does
+  NOT return None**: hit 2026-06-13 fixing `OTELBackend`
+  (`src/attune/monitoring/otel_backend.py`, PR #838). A "graceful
+  optional-dependency" check swept submodules through `find_spec`
+  bare — `all(find_spec(p) is not None for p in [...])` — on the
+  assumption that a missing module yields `None`. False for
+  *submodules*: `find_spec("opentelemetry.trace")` imports the parent
+  `opentelemetry` to read its `__path__`, so when the `[otel]` extra
+  isn't installed it raises `ModuleNotFoundError` rather than
+  returning `None`, and the unguarded call propagated out of
+  `__init__` — crashing construction in exactly the no-extra
+  environment the fallback was meant to serve. (Top-LEVEL names like
+  `find_spec("opentelemetry")` *do* return `None` cleanly; only the
+  dotted submodule form raises.) Fix: wrap the sweep in `try/except
+  (ModuleNotFoundError, ValueError): return False` (ValueError covers
+  malformed names). Regression-guard placement matters: the bug only
+  manifests when the dep is ABSENT, which is precisely where an
+  otel-gated test module is `pytest.skip(allow_module_level=True)`'d —
+  so the guard must live in a SEPARATE ungated file that simulates the
+  missing dep by `patch.object(importlib.util, "find_spec",
+  side_effect=ModuleNotFoundError)`, not in the skipped module. Pairs
+  with the attune-verify `find_spec`-top-level-only lessons (same API,
+  the mirror-image surprise: there it under-checks submodules, here it
+  over-raises on them).

--- a/src/attune/monitoring/otel_backend.py
+++ b/src/attune/monitoring/otel_backend.py
@@ -164,7 +164,14 @@ class OTELBackend:
             "opentelemetry.sdk.trace.export",
         ]
 
-        return all(importlib.util.find_spec(pkg) is not None for pkg in required_packages)
+        # find_spec raises ModuleNotFoundError (not returns None) when a
+        # submodule's PARENT package is absent — it imports the parent to read
+        # its __path__. Catch that so an uninstalled [otel] extra degrades
+        # gracefully to "not available" instead of crashing __init__.
+        try:
+            return all(importlib.util.find_spec(pkg) is not None for pkg in required_packages)
+        except (ModuleNotFoundError, ValueError):
+            return False
 
     def _init_otel(self) -> None:
         """Initialize OTEL tracer and exporter."""

--- a/tests/unit/monitoring/test_otel_backend_graceful.py
+++ b/tests/unit/monitoring/test_otel_backend_graceful.py
@@ -1,0 +1,65 @@
+"""Regression tests for OTELBackend graceful degradation without [otel] extra.
+
+These tests deliberately have NO module-level skip on opentelemetry — the bug
+they guard against (PR #837) manifests precisely in environments WITHOUT the
+optional opentelemetry packages installed, which is exactly where the rest of
+test_otel_backend.py is skipped. They simulate the missing dependency by making
+importlib.util.find_spec raise ModuleNotFoundError, the way it does when a
+submodule's parent package is absent.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+import importlib.util
+from unittest.mock import patch
+
+import pytest
+
+from attune.monitoring.otel_backend import OTELBackend
+
+
+@pytest.mark.unit
+class TestOTELBackendGracefulDegradation:
+    """OTELBackend must construct without crashing when [otel] is absent."""
+
+    def test_construct_does_not_raise_when_find_spec_raises_module_not_found(self):
+        """Constructor degrades gracefully when find_spec raises ModuleNotFoundError.
+
+        importlib.util.find_spec("opentelemetry.trace") raises (not returns None)
+        when the parent 'opentelemetry' package is not installed, because it
+        imports the parent to read its __path__. _check_otel_installed must
+        catch this and report False rather than letting __init__ crash.
+        """
+        with patch.object(
+            importlib.util,
+            "find_spec",
+            side_effect=ModuleNotFoundError("No module named 'opentelemetry'"),
+        ):
+            backend = OTELBackend(endpoint="http://x:4317")
+
+        assert backend.is_available() is False
+        assert backend._otel_available is False
+
+    def test_construct_does_not_raise_when_find_spec_raises_value_error(self):
+        """find_spec can also raise ValueError (e.g. for malformed module names)."""
+        with patch.object(
+            importlib.util,
+            "find_spec",
+            side_effect=ValueError("bad module spec"),
+        ):
+            backend = OTELBackend(endpoint="http://x:4317")
+
+        assert backend.is_available() is False
+        assert backend._otel_available is False
+
+    def test_check_otel_installed_returns_false_when_dependency_missing(self):
+        """_check_otel_installed returns False instead of propagating the error."""
+        backend = OTELBackend.__new__(OTELBackend)  # skip __init__
+
+        with patch.object(
+            importlib.util,
+            "find_spec",
+            side_effect=ModuleNotFoundError("No module named 'opentelemetry'"),
+        ):
+            assert backend._check_otel_installed() is False


### PR DESCRIPTION
## Problem

`OTELBackend()` crashed with `ModuleNotFoundError` in any environment without the optional `[otel]` extra installed — contradicting the module's documented graceful-fallback / optional-dependency design.

**Repro** (env without `opentelemetry`):

```
PYTHONPATH=src python -c "from attune.monitoring.otel_backend import OTELBackend; OTELBackend(endpoint='http://x:4317')"
# -> ModuleNotFoundError: No module named 'opentelemetry'
```

## Root cause

`_check_otel_installed()` swept otel submodules through `importlib.util.find_spec` bare:

```python
return all(importlib.util.find_spec(pkg) is not None for pkg in required_packages)
```

`find_spec("opentelemetry.trace")` **raises** `ModuleNotFoundError` (rather than returning `None`) when the parent `opentelemetry` package is absent — it imports the parent to read its `__path__`. `__init__` calls this unguarded (`self._otel_available = self._check_otel_installed()`), so construction raised.

## Fix

Wrap the `find_spec` sweep in `try/except (ModuleNotFoundError, ValueError)` returning `False`, so a missing extra degrades to "not available" instead of crashing.

## Tests

New `tests/unit/monitoring/test_otel_backend_graceful.py` — a regression guard with **no module-level otel skip**. The bug only manifests when otel is *absent*, which is exactly where the existing `test_otel_backend.py` is skipped, so the guard lives in a separate ungated file and simulates the missing dependency by patching `find_spec` to raise.

- New regression tests: 3 passed
- Existing `test_otel_backend.py`: 19 passed, 1 xfailed (unchanged)
- Keyless repro now prints `OK — no crash; is_available: False`

Closes the COVERAGE_BUG_LOG 2026-06-13 entry; relates to #837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
