### PR TITLE
fix(platform): use Proactor (not Selector) asyncio policy on Windows

### DIFF
--- a/scripts/check_platform_compat.py
+++ b/scripts/check_platform_compat.py
@@ -4,7 +4,6 @@
 Scans the codebase for common cross-platform issues:
 - Hardcoded Unix paths (/var/log, /tmp, etc.)
 - open() calls without encoding specified
-- asyncio.run() without setup_asyncio_policy()
 - os.path operations that should use pathlib
 
 Usage:
@@ -79,8 +78,6 @@ OPEN_WITHOUT_ENCODING = re.compile(
     re.MULTILINE,
 )
 
-ASYNCIO_RUN = re.compile(r"\basyncio\.run\s*\(")
-
 OS_PATH_OPERATIONS = [
     (r"\bos\.path\.join\s*\(", "Consider using pathlib.Path instead of os.path.join"),
     (r"\bos\.path\.exists\s*\(", "Consider using Path.exists() instead"),
@@ -137,24 +134,6 @@ def scan_file(filepath: Path, result: ScanResult) -> None:
                             message="open() without encoding specified",
                             severity="warning",
                             suggestion='Add encoding="utf-8" parameter',
-                        ),
-                    )
-
-        # Check for asyncio.run() usage
-        for line_num, line in enumerate(lines, 1):
-            if ASYNCIO_RUN.search(line):
-                # Check if setup_asyncio_policy is called nearby
-                start = max(0, line_num - 20)
-                context = "\n".join(lines[start:line_num])
-                if "setup_asyncio_policy" not in context:
-                    result.add_issue(
-                        Issue(
-                            file=relative_path,
-                            line=line_num,
-                            category="asyncio_policy",
-                            message="asyncio.run() without setup_asyncio_policy()",
-                            severity="info",
-                            suggestion="Call setup_asyncio_policy() before asyncio.run() for Windows compatibility",
                         ),
                     )
 

--- a/src/attune/platform_utils.py
+++ b/src/attune/platform_utils.py
@@ -121,19 +121,33 @@ def get_default_cache_dir() -> Path:
 
 
 def setup_asyncio_policy() -> None:
-    """Configure asyncio event loop policy for the current platform.
+    """Ensure a subprocess-capable asyncio event loop policy on Windows.
 
-    On Windows, this uses WindowsSelectorEventLoopPolicy to avoid issues
-    with the default ProactorEventLoop, particularly with subprocesses
-    and certain network operations.
+    On Windows, ``asyncio.create_subprocess_exec`` and
+    ``loop.connect_read_pipe`` require the ProactorEventLoop;
+    SelectorEventLoop raises ``NotImplementedError`` for both. Proactor
+    has been the Windows default since Python 3.8, so this is normally a
+    no-op -- we set it explicitly to self-heal in case an imported
+    library swapped in the Selector policy process-wide.
 
-    This should be called early in the application startup, before
-    any asyncio.run() calls.
+    attune spawns subprocesses (SDK runner, hook executor, help-regen)
+    and reads stdin over a pipe (the stdio MCP server), so Selector is
+    never correct here. (The previous code set Selector with a comment
+    claiming it helped "particularly with subprocesses" -- that is
+    backwards: Selector cannot spawn subprocesses on Windows at all.) If
+    a specific dependency ever needs Selector, the right fix is a
+    per-call loop, not a process-wide policy switch.
+
+    On non-Windows platforms this is a no-op.
+
+    This should be called early in application startup, before any
+    ``asyncio.run()`` calls.
     """
     if is_windows():
-        # Windows requires WindowsSelectorEventLoopPolicy for compatibility
-        # with many libraries and subprocess operations
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore[attr-defined]
+        # Proactor is the Windows default and the only loop that supports
+        # subprocesses and pipes; set it explicitly to undo any library
+        # that forced Selector process-wide.
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())  # type: ignore[attr-defined]
 
 
 def safe_run_async(coro: Any, debug: bool = False) -> Any:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,25 @@ def _reset_workflow_tier_maps():
         cls.tier_map.update(original)
 
 
+@pytest.fixture(autouse=True)
+def _restore_event_loop_policy():
+    """Restore the global asyncio event loop policy after each test.
+
+    ``asyncio.set_event_loop_policy`` mutates process-wide state. Under
+    xdist that leak crosses test *files* on the same worker: a test that
+    sets (e.g.) the Selector policy would leave it set for an unrelated
+    subprocess/pipe test that lands afterward, which then fails with
+    ``NotImplementedError`` on Windows (this poisoned the help-regen
+    tests on Windows CI). Snapshot before, restore after, so policy
+    mutation can never cross a test boundary.
+    """
+    import asyncio
+
+    original = asyncio.get_event_loop_policy()
+    yield
+    asyncio.set_event_loop_policy(original)
+
+
 # =============================================================================
 # File Test Tracking - Automatic per-file test result recording
 # Supports both single-process and xdist parallel execution

--- a/tests/core/test_platform_utils.py
+++ b/tests/core/test_platform_utils.py
@@ -211,11 +211,16 @@ class TestAsyncioPolicy:
 
     @patch("attune.platform_utils.is_windows", return_value=True)
     def test_setup_asyncio_policy_windows(self, mock_windows):
-        """Test setup_asyncio_policy sets policy on Windows."""
+        """Test setup_asyncio_policy sets the Proactor policy on Windows.
+
+        Proactor is the only Windows loop that supports subprocesses and
+        pipes; Selector raises NotImplementedError for both. ``set_event_loop_policy``
+        is mocked so this never mutates the real global policy.
+        """
         import asyncio
 
         with patch.object(asyncio, "set_event_loop_policy") as mock_set_policy:
-            with patch.object(asyncio, "WindowsSelectorEventLoopPolicy", create=True):
+            with patch.object(asyncio, "WindowsProactorEventLoopPolicy", create=True):
                 setup_asyncio_policy()
                 # On Windows, set_event_loop_policy should be called
                 mock_set_policy.assert_called_once()


### PR DESCRIPTION
## Problem

`platform_utils.setup_asyncio_policy()` set `WindowsSelectorEventLoopPolicy` on Windows, with a comment claiming it helped "particularly with subprocesses". That is **backwards**: on Windows, `SelectorEventLoop` does **not** support subprocesses or pipes — `create_subprocess_exec` and `connect_read_pipe` raise `NotImplementedError`. `ProactorEventLoop` (the Python 3.8+ default) is the one that supports both.

attune actively relies on both APIs:
- `create_subprocess_*` — `hooks/executor.py`, `ops/runner.py`, `ops/help_regen.py`
- `connect_read_pipe` — `socratic/mcp_server.py` (stdio MCP server)

A grep confirmed **nothing** in the tree needs Selector. The override has been cargo-culted since the original empathy→attune migration.

## Fixes

1. **Production:** switch to `WindowsProactorEventLoopPolicy` (subprocess/pipe-capable, the Windows default). Set explicitly so it self-heals if an imported library forces Selector process-wide. Docstring rewritten to be accurate.
2. **Test pollution:** `setup_asyncio_policy()` mutated the global event-loop policy and never restored it. Under xdist that leaked Selector to later subprocess/pipe tests on the same worker — this poisoned the help-regen tests on Windows CI (empty `[regen error]` / `NotImplementedError`). Added a global autouse conftest fixture that snapshots/restores `asyncio.get_event_loop_policy()` after every test, mirroring the existing `_reset_workflow_tier_maps` pattern.
3. Updated `test_setup_asyncio_policy_windows` to assert the Proactor policy.

4. **Linter cleanup** (commit f900ec9b): removed the `scripts/check_platform_compat.py` rule that flagged `asyncio.run() without setup_asyncio_policy()`. With the function now setting Proactor (the Windows default), that advice is a no-op nudge on ~12 sites; its original premise (the broken Selector override) is gone. The function itself stays as a documented self-heal util.

## Verification

- `tests/core/test_platform_utils.py`, `test_platform_compat_ci.py`, `test_coverage_batch13.py`, `tests/unit/ops/test_help_regen.py` — pass single-process and under `-n auto`.
- Broader slice (`tests/core/`, `tests/unit/socratic/`, `tests/unit/ops/`): 2979 passed.
- Watching Windows CI (windows-latest, 3.10–3.13) on this PR for the cross-worker case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

