### PR TITLE
test(hooks): fix order-dependent _sdk_gate import in worktree_path_guard tests

### DIFF
--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1,3 +1,32 @@
+## 2026-06-13 — test isolation: worktree_path_guard `_sdk_gate` import (Opus 4.8)
+
+`tests/unit/hooks/test_worktree_path_guard.py`, **test-infra / isolation
+bug** (not a production-code class — a test-harness defect). The 3
+`TestScriptMainEntry` tests
+(`test_script_with_empty_stdin_exits_0`,
+`test_script_with_skip_context_exits_0`,
+`test_script_catches_main_exception_and_exits_0`) fail with
+`ModuleNotFoundError: No module named '_sdk_gate'` when the file is run in
+isolation, but pass in the full suite.
+
+- **Bug — order-dependent green via `sys.path` pollution.** The tests use
+  `runpy.run_path(SCRIPT_PATH, run_name="__main__")`, which executes the
+  `if __name__ == "__main__"` block of
+  `src/attune/hooks/scripts/worktree_path_guard.py:170`
+  (`from _sdk_gate import exit_if_sdk_subprocess`). `runpy.run_path` on a
+  *file path* does NOT add the script's directory to `sys.path`, so that
+  sibling-relative import only resolves when an earlier test in the run
+  already inserted `src/attune/hooks/scripts` into `sys.path`. Run alone,
+  that pollution is absent and the import fails. CI was green only by
+  accident of ordering. Latent since PR #521 (commit c1b4cf33), not
+  introduced by QA work. **Fix:** added `tests/unit/hooks/conftest.py`
+  that inserts the absolute `src/attune/hooks/scripts` dir at the front of
+  `sys.path`, so `_sdk_gate` resolves regardless of test order. Verified
+  the file passes in isolation and the full `tests/unit/hooks/` dir stays
+  green (312 passed, 1 skipped).
+
+---
+
 ## 2026-06-13 — monitoring/otel_backend.py (QA, Opus 4.8)
 
 `monitoring/otel_backend.py` (`OTELBackend`), **~import-only → 100%**.

--- a/tests/unit/hooks/conftest.py
+++ b/tests/unit/hooks/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures/config for hook-script tests.
+
+The hook scripts under ``src/attune/hooks/scripts/`` use sibling-relative
+imports (``from _sdk_gate import ...``) inside their ``__main__`` block.
+Tests that execute a script via ``runpy.run_path(..., run_name="__main__")``
+trigger that import, but ``runpy.run_path`` on a file path does NOT add the
+script's directory to ``sys.path`` — so ``_sdk_gate`` only resolves if some
+earlier test happened to insert that directory. Inserting it here makes the
+sibling import resolve regardless of test order (or running a single file in
+isolation).
+"""
+
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "src" / "attune" / "hooks" / "scripts"
+
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))


### PR DESCRIPTION
## Problem

`tests/unit/hooks/test_worktree_path_guard.py` has 3 order-dependent tests in `TestScriptMainEntry` that **fail when the file is run in isolation** but pass in the full suite:

```
ANTHROPIC_API_KEY="" PYTHONPATH=src .venv/bin/python -m pytest \
  tests/unit/hooks/test_worktree_path_guard.py -o addopts= -p no:xdist -q
```

→ `ModuleNotFoundError: No module named '_sdk_gate'` at `worktree_path_guard.py:170`.

## Root cause

Those tests use `runpy.run_path(SCRIPT_PATH, run_name="__main__")`, which executes the script's `__main__` block containing the sibling-relative `from _sdk_gate import exit_if_sdk_subprocess`. `runpy.run_path` on a *file path* does **not** add the script's directory to `sys.path`, so `_sdk_gate` only resolves when an *earlier* test in the run has already inserted `src/attune/hooks/scripts` into `sys.path`. Run alone, that pollution is absent and the import fails.

Latent since PR #521 (commit c1b4cf33) — CI is green only by accident of test ordering, not by design.

## Fix

Add `tests/unit/hooks/conftest.py` that inserts the absolute `src/attune/hooks/scripts` directory at the front of `sys.path`, so `_sdk_gate` is importable regardless of test order.

## Verification

- File **passes in isolation** with the repro command: `16 passed`.
- Full `tests/unit/hooks/` dir stays green: `312 passed, 1 skipped`.
- Logged in `docs/COVERAGE_BUG_LOG.md` as a test-infra / isolation bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)