### PR TITLE
test(monitoring): deflake test_force_flush_invoked under xdist

### DIFF
--- a/tests/unit/monitoring/test_otel_backend_export.py
+++ b/tests/unit/monitoring/test_otel_backend_export.py
@@ -12,8 +12,11 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import gc
 import sys
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from attune.monitoring.otel_backend import OTELBackend
 
@@ -192,6 +195,25 @@ class TestInitHop:
 
 
 class TestFlush:
+    @pytest.fixture(autouse=True)
+    def _freeze_finalizers(self):
+        """Stop stray ``OTELBackend.__del__`` -> ``flush()`` polluting counts.
+
+        These tests patch the process-global ``sys.modules['opentelemetry']``.
+        Other tests leave "available" backends alive in reference cycles; if the
+        cyclic collector fires *inside* the patched window it finalizes one, and
+        its ``__del__`` -> ``flush()`` reaches the SAME mock tracer provider,
+        making ``force_flush`` look "called 2 times" (the xdist-ordering-only
+        flake). Drain pending finalizers, then freeze the cyclic collector for
+        the test body so exactly one flush (ours) runs against the mock.
+        """
+        gc.collect()
+        gc.disable()
+        try:
+            yield
+        finally:
+            gc.enable()
+
     def test_unavailable_is_noop(self):
         b = _ready()
         b._available = False


### PR DESCRIPTION
## Problem

`tests/unit/monitoring/test_otel_backend_export.py::TestFlush::test_force_flush_invoked` is intermittently flaky on CI under xdist:

```
AssertionError: Expected 'force_flush' to have been called once. Called 2 times.
```

(observed on `ubuntu-latest` 3.12, 2026-06-13). Passes in isolation and on most runs.

## Root cause (reproduced, not theorized)

`test_force_flush_invoked` patches the **process-global** `sys.modules['opentelemetry']` for the duration of `b.flush()`. Other tests in the file create *available* `OTELBackend` instances that, when left alive in a reference cycle (as exception tracebacks / pytest frames do across tests), are only reclaimable by the **cyclic** collector.

If the cyclic collector fires *inside* the patched window, it finalizes one of those stray backends — and `OTELBackend.__del__` -> `flush()` reaches the **same** mock tracer provider, calling `force_flush` a second time. Because it's GC-timing-dependent, it only surfaces under certain xdist worker packings.

A standalone repro reproduced the exact symptom (`force_flush call_count == 2` with a cycle-held backend; `== 1` with the fix).

## Fix

Autouse `_freeze_finalizers` fixture on `TestFlush`: `gc.collect()` to drain pending finalizers, then `gc.disable()` for the test body (re-enabled in `finally`). With the cyclic collector frozen, no stray `__del__` can fire inside the patch window, so `force_flush` is invoked **exactly once, deterministically**.

This is a test-isolation fix, not a production change: `__del__` -> `flush()` is correct shutdown behavior; the corruption is purely an artifact of global `sys.modules` patching + GC-timed finalizers.

## Verification

- Mechanism reproduced directly (count 2 → 1 with the freeze).
- `test_otel_backend_export.py`: 23/23 pass.
- `tests/unit/monitoring/ -n auto`: 6× consecutive green (154 passed, 1 xfailed each).
- Pinned black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)