### PR TITLE
fix(tests): Windows-portable HOME isolation in suggest_compact suite

### DIFF
--- a/tests/unit/hooks/test_suggest_compact.py
+++ b/tests/unit/hooks/test_suggest_compact.py
@@ -36,8 +36,15 @@ SCRIPT_PATH = (
 
 @pytest.fixture(autouse=True)
 def isolated_home(tmp_path, monkeypatch):
-    """Redirect HOME to a tmp dir and clear env threshold overrides."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    """Point Path.home() at a tmp dir and clear env threshold overrides.
+
+    Patching ``Path.home`` directly (rather than ``setenv("HOME", ...)``)
+    is cross-platform: on Windows ``Path.home()`` resolves via
+    ``%USERPROFILE%``, not ``$HOME``, so a HOME override there is a no-op
+    and the hook would read/write the real shared state file — leaking
+    state across tests/xdist workers.
+    """
+    monkeypatch.setattr(hook.Path, "home", lambda: tmp_path)
     monkeypatch.delenv("COMPACT_THRESHOLD", raising=False)
     monkeypatch.delenv("COMPACT_INTERVAL", raising=False)
     return tmp_path


### PR DESCRIPTION
## Problem

The `test_suggest_compact` suite (added in #856) isolated the compaction
state file via `monkeypatch.setenv("HOME", tmp_path)`. On **Windows**,
`Path.home()` resolves through `%USERPROFILE%`, not `$HOME`, so the
override was a no-op — the hook read/wrote the real, shared
`~/.attune/compaction_state.json`, leaking state across tests and xdist
workers. This broke main's Windows CI lanes (caught via #847's matrix):

```
test_state_file_path_under_home  - C:/Users/runneradmin/.attune/... != tmp
test_main_increments_count...    - assert 43 == 1   (polluted count)
test_main_persists_across_calls  - assert 45 == 2
test_main_respects_env_threshold - assert 51 == 1
```

## Fix

Patch `Path.home()` directly instead of `$HOME` — cross-platform and
per-test isolated (each test gets its own `tmp_path`). Since the module's
`Path` is `pathlib.Path`, this also covers the `runpy` `__main__` demo.

Coverage unchanged (80 stmts, **100%**); 20 pass, clean under `-n auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)