### PR TITLE
fix(platform): remove dead setup_asyncio_policy that set the wrong Windows loop policy

### DIFF
--- a/scripts/check_platform_compat.py
+++ b/scripts/check_platform_compat.py
@@ -4,7 +4,6 @@
 Scans the codebase for common cross-platform issues:
 - Hardcoded Unix paths (/var/log, /tmp, etc.)
 - open() calls without encoding specified
-- asyncio.run() without setup_asyncio_policy()
 - os.path operations that should use pathlib
 
 Usage:
@@ -79,8 +78,6 @@ OPEN_WITHOUT_ENCODING = re.compile(
     re.MULTILINE,
 )
 
-ASYNCIO_RUN = re.compile(r"\basyncio\.run\s*\(")
-
 OS_PATH_OPERATIONS = [
     (r"\bos\.path\.join\s*\(", "Consider using pathlib.Path instead of os.path.join"),
     (r"\bos\.path\.exists\s*\(", "Consider using Path.exists() instead"),
@@ -137,24 +134,6 @@ def scan_file(filepath: Path, result: ScanResult) -> None:
                             message="open() without encoding specified",
                             severity="warning",
                             suggestion='Add encoding="utf-8" parameter',
-                        ),
-                    )
-
-        # Check for asyncio.run() usage
-        for line_num, line in enumerate(lines, 1):
-            if ASYNCIO_RUN.search(line):
-                # Check if setup_asyncio_policy is called nearby
-                start = max(0, line_num - 20)
-                context = "\n".join(lines[start:line_num])
-                if "setup_asyncio_policy" not in context:
-                    result.add_issue(
-                        Issue(
-                            file=relative_path,
-                            line=line_num,
-                            category="asyncio_policy",
-                            message="asyncio.run() without setup_asyncio_policy()",
-                            severity="info",
-                            suggestion="Call setup_asyncio_policy() before asyncio.run() for Windows compatibility",
                         ),
                     )
 

--- a/src/attune/platform_utils.py
+++ b/src/attune/platform_utils.py
@@ -10,7 +10,6 @@ Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
 
-import asyncio
 import os
 import platform
 from pathlib import Path
@@ -118,40 +117,6 @@ def get_default_cache_dir() -> Path:
     # Linux and other Unix
     xdg_cache = os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
     return Path(xdg_cache) / "empathy"
-
-
-def setup_asyncio_policy() -> None:
-    """Configure asyncio event loop policy for the current platform.
-
-    On Windows, this uses WindowsSelectorEventLoopPolicy to avoid issues
-    with the default ProactorEventLoop, particularly with subprocesses
-    and certain network operations.
-
-    This should be called early in the application startup, before
-    any asyncio.run() calls.
-    """
-    if is_windows():
-        # Windows requires WindowsSelectorEventLoopPolicy for compatibility
-        # with many libraries and subprocess operations
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore[attr-defined]
-
-
-def safe_run_async(coro: Any, debug: bool = False) -> Any:
-    """Run an async coroutine with platform-appropriate event loop handling.
-
-    This is a cross-platform wrapper for asyncio.run() that handles
-    Windows-specific event loop requirements.
-
-    Args:
-        coro: Coroutine to run
-        debug: Enable asyncio debug mode
-
-    Returns:
-        Result of the coroutine
-
-    """
-    setup_asyncio_policy()
-    return asyncio.run(coro, debug=debug)
 
 
 def open_text_file(path: str | Path, mode: str = "r", **kwargs: Any):

--- a/tests/core/test_platform_compat_ci.py
+++ b/tests/core/test_platform_compat_ci.py
@@ -58,7 +58,6 @@ class TestPlatformCompatibility:
                 is_linux,
                 is_macos,
                 is_windows,
-                setup_asyncio_policy,
             )
 
             # Verify functions are callable
@@ -67,7 +66,6 @@ class TestPlatformCompatibility:
             assert callable(is_linux)
             assert callable(get_default_log_dir)
             assert callable(get_default_data_dir)
-            assert callable(setup_asyncio_policy)
         except ImportError as e:
             pytest.fail(f"platform_utils module not importable: {e}")
 
@@ -94,10 +92,3 @@ class TestPlatformCompatibility:
         assert isinstance(get_default_data_dir(), Path)
         assert isinstance(get_default_config_dir(), Path)
         assert isinstance(get_default_cache_dir(), Path)
-
-    def test_asyncio_policy_runs_without_error(self):
-        """Ensure asyncio policy setup doesn't raise."""
-        from attune.platform_utils import setup_asyncio_policy
-
-        # Should not raise on any platform
-        setup_asyncio_policy()

--- a/tests/core/test_platform_utils.py
+++ b/tests/core/test_platform_utils.py
@@ -11,8 +11,6 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from attune.platform_utils import (
     PLATFORM_INFO,
     ensure_dir,
@@ -28,8 +26,6 @@ from attune.platform_utils import (
     normalize_path,
     open_text_file,
     read_text_file,
-    safe_run_async,
-    setup_asyncio_policy,
     write_text_file,
 )
 
@@ -199,37 +195,6 @@ class TestDefaultDirectoriesLinux:
         """Test cache directory on Linux uses XDG_CACHE_HOME."""
         cache_dir = get_default_cache_dir()
         assert "empathy" in str(cache_dir)
-
-
-class TestAsyncioPolicy:
-    """Tests for asyncio event loop policy functions."""
-
-    def test_setup_asyncio_policy_runs(self):
-        """Test setup_asyncio_policy executes without error."""
-        # Should not raise on any platform
-        setup_asyncio_policy()
-
-    @patch("attune.platform_utils.is_windows", return_value=True)
-    def test_setup_asyncio_policy_windows(self, mock_windows):
-        """Test setup_asyncio_policy sets policy on Windows."""
-        import asyncio
-
-        with patch.object(asyncio, "set_event_loop_policy") as mock_set_policy:
-            with patch.object(asyncio, "WindowsSelectorEventLoopPolicy", create=True):
-                setup_asyncio_policy()
-                # On Windows, set_event_loop_policy should be called
-                mock_set_policy.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_safe_run_async_executes(self):
-        """Test safe_run_async can execute a coroutine."""
-
-        async def sample_coro():
-            return 42
-
-        # We can't easily test safe_run_async from within an async test
-        # since we're already in an event loop, but we can verify import works
-        assert callable(safe_run_async)
 
 
 class TestFileUtilities:

--- a/tests/unit/ops/test_help_regen.py
+++ b/tests/unit/ops/test_help_regen.py
@@ -26,21 +26,17 @@ from attune.ops.help_regen import (
 )
 from attune.ops.server import create_app
 
-# Tests that actually spawn the fake binary are skipped on Windows. They
-# need a ProactorEventLoop (SelectorEventLoop raises NotImplementedError on
-# create_subprocess_exec), but a sibling test in the same xdist worker can
-# flip the *global* policy to WindowsSelectorEventLoopPolicy via
-# attune.platform_utils.setup_asyncio_policy() and never restore it,
-# poisoning these tests non-deterministically. The runner's logic
-# (stream capture, exit-code handling, ANSI stripping, output cap) is
-# OS-agnostic and fully covered on the POSIX lanes; production is
-# unaffected (uvicorn runs Proactor, real attune-author is a .exe). The
-# global-policy pollution is tracked as a separate fix.
+# Tests that actually spawn the fake binary are skipped on Windows. The
+# fixture's fake binary is a .bat wrapper, and asyncio.create_subprocess_exec
+# cannot launch a .bat directly on Windows (CreateProcess only runs real
+# executables — error 193), so the launch fails. The runner's logic (stream
+# capture, exit-code handling, ANSI stripping, output cap) is OS-agnostic and
+# fully covered on the POSIX lanes; production is unaffected (uvicorn runs a
+# ProactorEventLoop, and the real attune-author is a .exe).
 _skip_subprocess_on_windows = pytest.mark.skipif(
     sys.platform == "win32",
-    reason="needs ProactorEventLoop; global asyncio-policy pollution on "
-    "Windows xdist workers makes subprocess launch non-deterministic "
-    "(covered on POSIX lanes)",
+    reason="fake .bat binary is not directly launchable via "
+    "create_subprocess_exec on Windows (covered on POSIX lanes)",
 )
 
 

--- a/tests/unit/test_coverage_batch13.py
+++ b/tests/unit/test_coverage_batch13.py
@@ -97,22 +97,6 @@ class TestPlatformUtils:
                 result = get_default_data_dir()
         assert "empathy" in str(result)
 
-    def test_setup_asyncio_policy_noop_on_non_windows(self):
-        from attune.platform_utils import setup_asyncio_policy
-
-        with patch("platform.system", return_value="Darwin"):
-            setup_asyncio_policy()  # Should not raise
-
-    def test_safe_run_async_runs_coroutine(self):
-
-        from attune.platform_utils import safe_run_async
-
-        async def echo(x):
-            return x
-
-        result = safe_run_async(echo(42))
-        assert result == 42
-
     def test_open_text_file_defaults_utf8(self, tmp_path):
         from attune.platform_utils import open_text_file
 


### PR DESCRIPTION
## Problem

`platform_utils.setup_asyncio_policy()` set `asyncio.WindowsSelectorEventLoopPolicy()` on Windows, with a docstring claiming it helps "particularly with subprocesses." That's **backwards** — on Windows, `SelectorEventLoop` *cannot* spawn subprocesses (`create_subprocess_exec` raises `NotImplementedError`); only `ProactorEventLoop` can, and Proactor is already the Windows default. The function installed a broken, non-default policy **process-wide**.

It was also **dead code** with **harmful side effects**:
- `setup_asyncio_policy()` was called only by `safe_run_async()`, which has **zero production callers** (neither is in `__all__`/`__init__`; no sibling/external use).
- `scripts/check_platform_compat.py` emitted an `info` advisory on *every* `asyncio.run()` recommending this broken function (~12 hits) — spreading the wrong pattern.
- Tests that called it directly **polluted the global event-loop policy**, which non-deterministically poisoned the help-regen subprocess tests on Windows CI (the root cause behind [#840](https://github.com/Smart-AI-Memory/attune-ai/pull/840)'s skips).

## Change

- Remove `setup_asyncio_policy()` and `safe_run_async()` from `platform_utils.py`.
- Drop the `asyncio_policy` rule from `check_platform_compat.py` (+ its `ASYNCIO_RUN` pattern and docstring bullet).
- Delete the tests that exercised them.
- Update the #840 help-regen skip comment to its now-accurate reason (the fixture's `.bat` wrapper isn't directly launchable via `create_subprocess_exec` on Windows — the policy-pollution explanation no longer applies).

**Net −120 lines. No production behavior change** — the removed code was unreachable.

## Note

This removes two undocumented, non-`__all__` module-level functions. Any external code importing `attune.platform_utils.{setup_asyncio_policy,safe_run_async}` would break — but both were unused internally and one installed a broken policy, so keeping them is worse. Worth a "Removed" CHANGELOG line in the next release.

## Verification

- 129 passed / 1 skipped across the 4 affected test files (solo + xdist)
- `platform-compat` CI command exits 0 (0 errors); no more asyncio advisories
- ruff + black clean on all 6 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
