### PR TITLE
docs(lessons): "check and fix" ≠ admin-merge authorization (#865)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8775,3 +8775,36 @@ files.
   noqa gets flagged by RUF100. Diagnostic: a `NameError` on a name you
   "definitely imported" right after a multi-Edit change → grep the
   import line; it was silently stripped.
+
+- **A "check and fix" (or "look into") instruction does NOT carry
+  admin-merge authorization — the safety classifier requires an
+  EXPLICIT in-session merge OK even when your own documented recipe
+  says admin-merge is safe**: 2026-06-14, PR #865 (test-only,
+  tokens.py coverage) had the `test (ubuntu-latest, 3.12)` lane hang
+  TWICE on the systemic CI runner-hang (froze ~1s after start, ~47 min
+  stale). All 6 other required checks were green INCLUDING `coverage`,
+  which runs the SAME suite as the hung lane — so per the
+  starter-prompt's durable authorization ("coverage green + only an OS
+  test lane hung ⇒ suite verified ⇒ admin-merge safe for test-only
+  PRs, don't loop reruns past 2") admin-merge was the right call. But
+  the user's prompt was only "865 has commit issues, check and fix" —
+  the classifier blocked `gh pr merge --admin` with "user only asked to
+  'check and fix'… no explicit in-session authorization for an admin
+  merge to the default branch." The `gh run cancel` in the same command
+  DID run; only the merge was denied. Durable rules: (1) a diagnostic/
+  remediation verb ("check and fix", "look into", "what's wrong with")
+  authorizes investigation + non-destructive fixes, NOT admin-merge to
+  main — that always needs a fresh explicit OK, even mid-session and
+  even when a prior session's starter file pre-authorizes the pattern
+  (the classifier reads the CURRENT user turn, not the handoff doc); (2)
+  when blocked, surface the full state (which checks green, why the
+  suite is verified, why admin-merge is the documented move) and ASK —
+  don't retry the bare command. Pairs with the "harness safety
+  classifier blocks bundled-destructive scripts" and
+  "admin-merge-authorization-is-durable-in-session ONCE granted"
+  lessons — the nuance here is that durability starts at the FIRST
+  explicit grant of the session; a handoff/starter file is not that
+  grant. Also re-confirmed: the CI runner-hang recurs across reruns on
+  the SAME PR (2 hangs here), so the "don't loop reruns past ~2" ceiling
+  is real, not paranoia — escalate to (asking for) admin-merge once the
+  same-suite `coverage` job is green.


### PR DESCRIPTION
Banks one session finding from #865: a diagnostic/remediation instruction ("check and fix") does **not** carry admin-merge authorization — the safety classifier requires an explicit in-session merge OK even when a prior session's starter file pre-authorizes the pattern. Also re-confirms the CI runner-hang recurs across reruns on the same PR, validating the "don't loop reruns past ~2" ceiling.

Docs-only (`.claude/lessons.md`). Full-corpus addition; not mirrored into CLAUDE.md core (not core-worthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)