### PR TITLE
fix(bulletin): rotate against UTC date, not local date

### DIFF
--- a/src/attune/bulletin/file_backend.py
+++ b/src/attune/bulletin/file_backend.py
@@ -214,12 +214,17 @@ class FileBulletinBackend:
         """Move yesterday's active.jsonl into archive/ if needed.
 
         Triggered lazily on append. Checks the file's mtime against
-        today's date — if mtime is on an earlier day, rotate.
+        today's date — if mtime is on an earlier day, rotate. Both
+        sides are compared in UTC: the mtime is read as a UTC date and
+        "today" is ``datetime.now(timezone.utc).date()``. Using the
+        local ``date.today()`` here would mix clocks and cause rotation
+        to skip or fire on the wrong day depending on the runner's
+        timezone and time of day.
         """
         if not self.active_path.exists():
             return
         mtime = datetime.fromtimestamp(self.active_path.stat().st_mtime, tz=timezone.utc)
-        if mtime.date() >= date.today():
+        if mtime.date() >= datetime.now(timezone.utc).date():
             return
         self.archive_dir.mkdir(parents=True, exist_ok=True)
         archive_name = f"{mtime.date().isoformat()}.jsonl"


### PR DESCRIPTION
## Problem

`tests/unit/bulletin/test_file_backend.py::TestRotation::test_yesterdays_log_moved_to_archive` fails on main (caught by the full-suite QA baseline, 2026-06-13). It's a **real product bug**, not a test bug — and a date-dependent one that flakes based on the runner's timezone and time of day.

## Root cause

`FileBulletinBackend._maybe_rotate` reads the active log's mtime as a **UTC** date but compared it against `date.today()` (**local** time):

```python
mtime = datetime.fromtimestamp(self.active_path.stat().st_mtime, tz=timezone.utc)
if mtime.date() >= date.today():   # UTC date vs local date — mixed clocks
    return
```

When the two clocks straddle a day boundary, rotation skips (or fires) on the wrong day. The rest of the module is UTC-consistent — `read_active` uses `datetime.now(timezone.utc)`, and archive filenames are written from the UTC `mtime.date()`.

## Fix

Compare against `datetime.now(timezone.utc).date()` so both sides use one clock authority. One-line change plus a docstring note.

## Verification

- `tests/unit/bulletin/test_file_backend.py` — 32 passed (was 1 failing). The existing rotation test is the regression guard.
- black / ruff / pre-commit clean.
- Keyless (`ANTHROPIC_API_KEY=""`), zero API spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)