### PR TITLE
fix(datetime): use UTC consistently in two clock-mix sites

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -774,7 +774,12 @@ def home_kpis(summary: TelemetrySummary, *, today: date | None = None) -> HomeKp
     Always returns a 7-entry sparkline (zero-fills missing days) so the SVG
     layout is stable even on a fresh install.
     """
-    today = today or date.today()
+    # Default to the UTC date, not local ``date.today()``: ``by_day``
+    # buckets are keyed by the UTC date of each event (see ``_to_day``),
+    # so a local "today" would read the wrong bucket in the evening for
+    # non-UTC users (e.g. US Eastern after ~20:00, UTC is already
+    # tomorrow). Mixing clocks is the same bug class as #867.
+    today = today or datetime.now(timezone.utc).date()
     by_day_lookup = {row[0]: (row[1], row[2]) for row in summary.by_day}
 
     sparkline: list[DailyCost] = []
@@ -823,7 +828,8 @@ def read_telemetry_summary(
     """Aggregate ``usage.jsonl`` into a UI-friendly summary.
 
     ``today`` is a test injection point — production callers leave it
-    ``None`` so the rolling-window cutoff uses ``date.today()``. Tests
+    ``None`` so the rolling-window cutoff uses the UTC date
+    (``datetime.now(timezone.utc).date()``). Tests
     pass an explicit date so fixed-date fixtures (e.g. events dated
     ``2026-05-14``) stay inside the recent-days window regardless of
     when the test actually runs. Mirrors the existing ``now=None``
@@ -909,7 +915,9 @@ def read_telemetry_summary(
     by_workflow = heapq.nlargest(20, filtered, key=lambda row: row[2])
 
     if today is None:
-        today = date.today()
+        # UTC, not local: ``by_day_count`` keys are UTC dates (``_to_day``),
+        # so the rolling-window cutoff must use the same clock authority.
+        today = datetime.now(timezone.utc).date()
     cutoff = today.toordinal() - recent_days
     recent_days_data = sorted(
         (

--- a/src/attune/workflows/test_runner.py
+++ b/src/attune/workflows/test_runner.py
@@ -293,12 +293,16 @@ def track_file_tests(
     tests_modified_at = None
 
     if source_path.exists():
-        source_modified_at = datetime.fromtimestamp(source_path.stat().st_mtime).isoformat() + "Z"
+        source_modified_at = datetime.fromtimestamp(
+            source_path.stat().st_mtime, tz=timezone.utc
+        ).isoformat()
 
     if test_file:
         test_path = Path(test_file)
         if test_path.exists():
-            tests_modified_at = datetime.fromtimestamp(test_path.stat().st_mtime).isoformat() + "Z"
+            tests_modified_at = datetime.fromtimestamp(
+                test_path.stat().st_mtime, tz=timezone.utc
+            ).isoformat()
 
     # Check if we have tests to run
     if test_file is None or not Path(test_file).exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -326,14 +326,14 @@ def pytest_sessionfinish(session, exitstatus):
             tests_modified_at = None
 
             if source_path.exists():
-                source_modified_at = (
-                    datetime.fromtimestamp(source_path.stat().st_mtime).isoformat() + "Z"
-                )
+                source_modified_at = datetime.fromtimestamp(
+                    source_path.stat().st_mtime, tz=timezone.utc
+                ).isoformat()
 
             if test_path.exists():
-                tests_modified_at = (
-                    datetime.fromtimestamp(test_path.stat().st_mtime).isoformat() + "Z"
-                )
+                tests_modified_at = datetime.fromtimestamp(
+                    test_path.stat().st_mtime, tz=timezone.utc
+                ).isoformat()
 
             # Check staleness
             is_stale = False

--- a/tests/unit/ops/test_home.py
+++ b/tests/unit/ops/test_home.py
@@ -32,6 +32,42 @@ def test_home_kpis_with_empty_summary_returns_seven_zero_days():
     assert all(d.cost == 0.0 for d in kpis.sparkline)
 
 
+def test_home_kpis_default_today_uses_utc_not_local(monkeypatch):
+    """Regression: when ``today`` is omitted, the default reference date is
+    the UTC date — matching ``by_day``'s UTC keying (``_to_day``) — not local
+    ``date.today()``.
+
+    Bug class of #867: a local "today" reads the wrong bucket in the evening
+    for non-UTC users (after ~20:00 US-Pacific, UTC is already tomorrow). We
+    freeze ``datetime`` to 2026-06-14 06:30 UTC, which is still 2026-06-13
+    local in any TZ behind UTC; the UTC bucket (06-14) must win.
+    """
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
+
+    fixed = _dt(2026, 6, 14, 6, 30, tzinfo=_tz.utc)
+
+    class _FrozenDateTime(_dt):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed.astimezone(tz) if tz else fixed.replace(tzinfo=None)
+
+    monkeypatch.setattr(data, "datetime", _FrozenDateTime)
+
+    summary = data.TelemetrySummary(
+        total_requests=3,
+        total_cost=0.30,
+        total_savings=0.0,
+        by_workflow=[],
+        by_day=[("2026-06-14", 3, 0.30)],  # UTC-keyed bucket
+        last_event_at=None,
+    )
+    kpis = data.home_kpis(summary)  # today=None -> exercises the default
+    assert kpis.today_events == 3
+    assert kpis.today_cost == 0.30
+    assert kpis.sparkline[-1].day == "2026-06-14"
+
+
 def test_home_kpis_zero_fills_missing_days():
     """Days without telemetry rows must still appear at zero."""
     summary = data.TelemetrySummary(

--- a/tests/unit/workflows/test_test_runner.py
+++ b/tests/unit/workflows/test_test_runner.py
@@ -387,6 +387,37 @@ class TestTrackFileTests:
         record = track_file_tests(source_file=str(source), test_file=str(tf))
         assert record.is_stale is True
 
+    @patch("attune.workflows.test_runner.subprocess.run")
+    @patch("attune.workflows.test_runner._log_file_test")
+    def test_modified_at_labels_are_true_utc(self, mock_log, mock_run, tmp_path):
+        """Regression: mtime labels are TRUE UTC, not local time + 'Z'.
+
+        Previously the code did ``fromtimestamp(mtime).isoformat() + "Z"``,
+        which stamps a naive LOCAL time with a UTC ('Z') marker — off by the
+        local UTC offset (a full-day error near midnight). Deterministic via a
+        fixed epoch set with ``os.utime``; never reads the wall clock.
+        """
+        import os
+
+        source = tmp_path / "src.py"
+        source.write_text("x = 1")
+        tf = tmp_path / "test_src.py"
+        tf.write_text("def test_x(): pass")
+
+        fixed_epoch = 1_749_000_000  # 2025-06-04T01:20:00+00:00
+        os.utime(str(source), (fixed_epoch, fixed_epoch))
+        os.utime(str(tf), (fixed_epoch, fixed_epoch))
+
+        mock_run.return_value = _make_completed_process(0, _PYTEST_PASSING_OUTPUT)
+        record = track_file_tests(source_file=str(source), test_file=str(tf))
+
+        expected = datetime.fromtimestamp(fixed_epoch, tz=timezone.utc).isoformat()
+        assert record.source_modified_at == expected
+        assert record.tests_modified_at == expected
+        # Parsing back yields a UTC-aware datetime (no naked 'Z' mislabel).
+        parsed = datetime.fromisoformat(record.source_modified_at)
+        assert parsed.utcoffset() == timezone.utc.utcoffset(None)
+
 
 # ---------------------------------------------------------------------------
 # get_file_test_status() / get_files_needing_tests() — thin wrappers


### PR DESCRIPTION
## Summary

Date/TZ bug-family sweep — the autonomous follow-up to #867 (bulletin
rotation comparing a UTC mtime against local `date.today()`). A
clock-mixing bug is a **class, not an instance**; this sweep grepped the
whole `src/attune/` tree for the smell and triaged every hit.

**Two genuine clock-mix bugs found and fixed:**

1. **`workflows/test_runner.py`** — `source_modified_at` /
   `tests_modified_at` were built as `fromtimestamp(mtime).isoformat() + "Z"`:
   a naive **local** time stamped with a UTC (`Z`) marker, off by the local
   UTC offset (a full-day error near midnight). Inconsistent with the same
   function's `datetime.now(timezone.utc)`. Now uses
   `fromtimestamp(mtime, tz=timezone.utc).isoformat()`. The `is_stale`
   string compare (two identically-built values) is unaffected.

2. **`ops/data.py`** — `home_kpis()` and `read_telemetry_summary()`
   defaulted their `today` reference to local `date.today()`, but `by_day`
   buckets are keyed by the **UTC** date of each event (`_to_day`). For
   non-UTC users in the evening (UTC already tomorrow) the "today" KPI tile
   read the wrong bucket and undercounted. Defaults now use
   `datetime.now(timezone.utc).date()`.

## Sweep result (the rest)

- **Benign (majority):** naive `datetime.now().isoformat()` record
  timestamps and naive `now − now` duration math — internally consistent,
  no cross-clock comparison.
- **Already correct:** every `fromtimestamp(..., tz=timezone.utc)`
  (`ops/data.py:608`, `ops/routes/specs.py:186`, `usage_tracker.py:463`,
  `bulletin/file_backend.py:226` — the #867 fix). `usage_tracker._utcnow`
  is properly aware (the `utcnow()` grep was a false match on the method
  name).
- **Consistent-but-naive, left alone:** `project_index/scanner.py`
  (`last_modified` staleness is local-vs-local), `cost_tracker`,
  `trust/circuit_breaker`, `agent_monitoring` — all compare now-vs-stored
  in the same naive-local clock; a naive/aware mix would raise `TypeError`
  loudly, not silently corrupt.

## Verification

- Both bugs **confirmed in a REPL** with backdated/frozen inputs before
  fixing (Anchorage TZ evening → `date.today()` 06-13 vs UTC 06-14;
  mislabel `…17:20:00Z` vs true `…01:20:00+00:00`).
- **Deterministic regression guards** added (`os.utime` fixed epoch /
  frozen `datetime`, never the wall clock). Both verified to **fail on
  pre-fix code** and pass on the fix.
- `conftest`'s fake `track_file_tests` mirror aligned to the UTC form.
- 37/37 in both affected suites; black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
