### PR TITLE
ci(tests): add hostile-clock TZ lane to catch date/TZ bugs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,6 +159,50 @@ jobs:
     - name: Run security and workflow tests
       run: pytest tests/unit/memory/test_long_term_security.py tests/unit/scanner/test_file_traversal.py tests/unit/workflows/test_workflow_execution.py -v --tb=short
 
+  clock-tz:
+    # Hostile-clock lane: runs the unit suite under extreme NON-UTC
+    # timezones so date/TZ bugs (the #867 / #868 clock-mix class) fail in
+    # CI instead of in production. GitHub-hosted runners default to UTC, so
+    # the 12-lane `test` matrix only ever exercises the UTC path — this is
+    # the one place a "local date.today() vs UTC-keyed bucket" mix gets
+    # caught. Two TZs bracket the bug in both directions:
+    #   Pacific/Kiritimati  UTC+14  (local AHEAD of UTC — evening rolls over)
+    #   America/Anchorage   UTC-9   (local BEHIND UTC — morning lags)
+    #
+    # Runs ALWAYS (no slim/full gate): a tests-only PR adding a
+    # wall-clock-dependent test is exactly what this guards. Keyless by
+    # design. NOT a required check yet — promote in branch protection once
+    # it has a few green runs (needs the GitHub-Actions app_id; tracked
+    # separately, deliberately out of scope for this PR).
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        tz: ["Pacific/Kiritimati", "America/Anchorage"]
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Run unit suite under ${{ matrix.tz }}
+      shell: bash
+      run: |
+        python -c "import time, datetime; print('TZ=', time.tzname, 'utcoffset=', datetime.datetime.now().astimezone().utcoffset())"
+        pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
+      env:
+        TZ: ${{ matrix.tz }}
+        ANTHROPIC_API_KEY: ""  # keyless by design — see the `test` job note
+
   coverage:
     # Dedicated coverage job — runs once on Linux 3.11 with branch
     # coverage on. Split out of the matrix to keep branch-coverage


### PR DESCRIPTION
## Summary

Item #2 of the date/TZ QA track (follows #868). GitHub-hosted runners
default to **UTC**, so the existing 12-lane `test` matrix only ever
exercises the UTC path — a "local `date.today()` vs UTC-keyed bucket"
clock-mix (the #867/#868 bug class) **cannot fail in CI today**.

Adds a dedicated `clock-tz` job that runs the unit suite under two
extreme non-UTC timezones, bracketing the bug in both directions:

| TZ | Offset | Catches |
|----|--------|---------|
| `Pacific/Kiritimati` | UTC+14 | local **ahead** — evening rollover |
| `America/Anchorage` | UTC-9 | local **behind** — morning lag |

## Design

- **Cheap:** 2 ubuntu/3.12 lanes, keyless, ~30s suite each — not a
  re-matrix.
- **Runs always** (no slim/full gate): a tests-only PR adding a
  wall-clock-dependent test is exactly what this guards.
- **Not required yet:** wiring it as a required check needs a
  branch-protection change with the GitHub-Actions `app_id` — deliberately
  out of scope here. Promote after a few green runs.

## Verification

Smoke-verified green locally under **both** TZs on the date-sensitive
suites (bulletin / telemetry / ops / test_runner): 1670 passed under
Kiritimati, 1694 under Anchorage. A test like #867's (UTC mtime vs local
`date.today()`) would have failed here under the wrong TZ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
