### PR TITLE
fix(tests): pre-import pydantic.root_model to lift the --cov SDK wall

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,24 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
+# =============================================================================
+# Coverage Import Guard - pre-import pydantic.root_model
+# =============================================================================
+# Under the pytest-cov plugin (``pytest --cov=...``), importing any module
+# whose chain transitively builds a pydantic ``RootModel[...]`` generic
+# (e.g. ``attune.workflows`` -> ``claude_agent_sdk`` -> ``mcp.types``) raises
+# ``KeyError: 'pydantic.root_model'`` deep in
+# ``pydantic._internal._generics.create_generic_submodel`` — it does
+# ``sys.modules[created_model.__module__]`` (the module is ``pydantic.root_model``)
+# and the submodule isn't registered yet under pytest-cov's startup ordering.
+# Plain ``pytest`` and ``coverage run -m pytest`` are unaffected; only the
+# pytest-cov plugin trips it, which walls LOCAL ``--cov`` measurement of
+# workflows / meta_workflows / orchestration (anything importing the SDK).
+# Warming ``pydantic.root_model`` into sys.modules first is the minimal,
+# deterministic fix (verified: importing ``pydantic._internal._generics``
+# alone is NOT sufficient). Harmless everywhere else — it's a core dep
+# already imported transitively.
+import pydantic.root_model  # noqa: F401  (import for side effect: sys.modules warm-up)
 import pytest
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Item #3 of the date/TZ QA track — knocks down the `--cov` SDK import
wall that blocked **local** coverage measurement of an entire tier.

Under the **pytest-cov plugin** (`pytest --cov=...`), importing any
module whose chain transitively builds a pydantic `RootModel[...]`
generic — `attune.workflows` → `claude_agent_sdk` → `mcp.types` — raised:

```
KeyError: 'pydantic.root_model'
  pydantic/_internal/_generics.py:144 in create_generic_submodel
    reference_module_globals = sys.modules[created_model.__module__].__dict__
```

`created_model.__module__` is `'pydantic.root_model'` (inherited from
`RootModel`), and that submodule isn't yet registered in `sys.modules`
under pytest-cov's startup ordering. The result: QA's "pre-verify
wall-free" step had to **skip** workflows / meta_workflows /
orchestration, and two finished suites were parked.

## Root cause (isolated empirically)

| Invocation | Result |
|------------|--------|
| `pytest` (no `--cov`) | ✅ passes |
| `coverage run -m pytest -p no:cov` | ✅ passes |
| `pytest --cov` (pytest-cov plugin) | ❌ KeyError |

So coverage **measurement** isn't the trigger — the **pytest-cov plugin's
import ordering** is. Warming `pydantic.root_model` into `sys.modules`
*before* the SDK's `RootModel` builds is the minimal, deterministic fix.
Verified that importing `pydantic._internal._generics` alone is **not**
sufficient — only `pydantic.root_model` is.

## Why this is safe

`pydantic` is a core dependency already imported transitively by the
whole suite; the pre-import is a pure `sys.modules` warm-up. Full tier
still collects clean: **3707 passed** across workflows + meta_workflows +
orchestration.

## Verification

`--cov` now measures, both single-process and `-n auto`:

- `attune.workflows.code_review` → 84%
- `attune.meta_workflows.models` → 98%
- `attune.orchestration` → measures (19 passed)

One conftest fix unblocks the whole tier. (CI's `coverage` job was
already green — this is a local-measurement unblock; the `--cov=src/attune`
path-source + editable install evidently ordered imports differently.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
