### PR TITLE
ci(coverage): ratchet --cov-fail-under 85 -> 94 (one-way valve)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,12 +190,21 @@ jobs:
       run: python scripts/check_badge_freshness.py
 
     - name: Run tests with coverage
+      # Coverage RATCHET: --cov-fail-under is a one-way valve, not a static
+      # floor. Main has measured 94.69–94.71% across recent runs (stable to
+      # ~0.02%); the gate sits at 94 (≈0.7pt headroom for normal churn). The
+      # old 85 left a ~9.7pt silent-erosion slack — coverage could fall from
+      # ~94.7 to 85 without CI noticing. RATCHET POLICY: only ever raise this
+      # number (when main climbs and holds above floor+~1), never lower it to
+      # make a red PR pass — a drop is a signal to add tests, not slacken the
+      # gate. (pyproject's fail_under stays 85 as the absolute floor for
+      # ad-hoc/partial local runs whose --cov scope differs from CI's.)
       run: |
         echo "[mem-baseline $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "total="$2"MB used="$3"MB avail="$7"MB"}')"
         (while sleep 30; do echo "[mem-tick $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"; done) &
         MEM_MONITOR_PID=$!
         trap 'kill $MEM_MONITOR_PID 2>/dev/null || true' EXIT
-        pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=85 --timeout=60 --timeout-method=thread -m "not network and not integration"
+        pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
         echo "[mem-final $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"
       env:
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY


### PR DESCRIPTION
## Summary

Item #4 (final) of the date/TZ QA track — a cheap, durable coverage
backstop. The `coverage` job's `--cov-fail-under` was a static **85**
while main has measured **94.69–94.71%** across the last 4 runs (stable
to ~0.02%). That left a **~9.7-point silent-erosion slack**: coverage
could fall from ~94.7% all the way to 85% without CI ever failing.

Raises the gate to **94** (≈0.7pt headroom for normal churn), turning
the coverage push into a one-way valve.

## Ratchet policy (documented in the step comment)

- **Only ever raise** the number — when main climbs and holds above
  `floor + ~1`.
- **Never lower it** to make a red PR pass; a drop is a signal to add
  tests, not to slacken the gate.
- `pyproject`'s `fail_under = 85` stays as the absolute floor for
  ad-hoc/partial local runs whose `--cov` scope differs from CI's.

## Why 94 and not higher

| Recent main run | coverage.py TOTAL |
|---|---|
| 27448665097 | 94.71% |
| 27434474309 | 94.71% |
| 27433105339 | 94.70% |
| 27430919384 | 94.69% |

Variance is ~0.02pt, so 94 won't false-fail on churn. This PR adds no
source, so its own `coverage` job stays at 94.71% and passes the new
gate — the change self-validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
