### PR TITLE
docs(spec): CI runner-hang root cause + fix plan

### DIFF
--- a/docs/specs/ci-runner-hang/decisions.md
+++ b/docs/specs/ci-runner-hang/decisions.md
@@ -35,23 +35,37 @@ runtimes.
 
 ---
 
-## Open decisions (need Patrick or probe data)
+## Resolved decisions (Patrick, 2026-06-14)
 
-- **OD1 — Is this its own spec or a phase of `windows-xdist-flakes`?**
-  Recommendation: **own spec** (different OS, different manifestation —
-  hang vs crash), cross-linked. If P3/P5 prove a *shared* polluter,
-  fix once and reference both. Confirm.
-- **OD2 — Acceptable normal-runtime ceiling for the timeout guard.**
-  Need a week of `coverage`/`test` durations to set `timeout-minutes`
-  without false-failing healthy slow runs. Proposed interim: 25 min.
-- **OD3 — Appetite for the P5 autouse I/O guard now vs after a
-  confirmed H2.** It is the durable G4 regression guard but touches the
-  whole unit-test tree (some legitimate loopback tests must be
-  allow-listed). Recommend deferring until P1/P3 implicate H2, to avoid
-  a large speculative change.
-- **OD4 — `--timeout-method=signal` on POSIX lanes (P4).** Only pursue
-  if P1's stack shows a C-call wedge the thread method missed; do not
-  blind-switch (xdist interaction risk).
+- **OD1 → own spec.** This stays a standalone spec, cross-linked to
+  `windows-xdist-flakes`. If P3/P5 prove a *shared* polluter, fix once
+  and reference both.
+- **OD2 → 25 min interim.** `timeout-minutes` tightened from the
+  current 75. Implementation: coverage job → 25; matrix `test` job →
+  20 on ubuntu (where the hang lives, normal ~4 min) / 40 on
+  Windows+macOS (normal ~13–15 min, must not false-fail). Re-tune after
+  a week of observed durations.
+- **OD3 → defer.** The broad P5 autouse I/O guard waits until P1/P3
+  implicate H2 — no large speculative change now.
+- **OD4 → approved, gated.** Pursue `--timeout-method=signal` on the
+  POSIX lanes *only after* Phase 1's stack shows a C-call wedge the
+  thread method missed. Not a blind switch (the existing tests.yml
+  comment notes thread-method is deliberate for Windows; signal is
+  POSIX-only and has xdist-interaction risk).
+
+## Implementation note (Phase 1)
+
+faulthandler is armed in `tests/conftest.py` gated on the auto-set `CI`
+env var (so local runs are unaffected) with an OS-tuned threshold
+(`RUNNER_OS == "Linux"` → 600s, else 1200s), via
+`faulthandler.dump_traceback_later(secs, repeat=False, all_threads=True)`
+at conftest import time so it covers the xdist controller AND every
+worker subprocess, including collection-time hangs. The threshold sits
+below the job `timeout-minutes` so the all-thread stack lands in the log
+*before* the fast-fail kills the job. Threshold overridable for local
+smoke-testing via `PYTEST_HANG_DUMP_SECONDS`. This keeps the `tests.yml`
+diff to the two `timeout-minutes` lines (no `env:` edits → no conflict
+with the open `--cov-fail-under` change in #871).
 
 ---
 

--- a/docs/specs/ci-runner-hang/decisions.md
+++ b/docs/specs/ci-runner-hang/decisions.md
@@ -1,0 +1,68 @@
+# Decisions: CI Runner-Hang Root Cause and Fix
+
+**Status:** draft
+**Created:** 2026-06-14
+**Requirements:** [requirements.md](requirements.md) ·
+**Design:** [design.md](design.md)
+
+---
+
+## Decision log
+
+### D1 — Diagnostics-first, not fix-first (decided 2026-06-14)
+
+The hang is intermittent and opaque. Prior CI specs in this repo went
+stale by hypothesizing a root cause and building probes around it
+before the failure mode was confirmed (see the "re-validate a spec's
+premise" lesson). So the first PR ships only diagnostics + a fast-fail
+guard (P1 faulthandler dump + P2 `timeout-minutes`); the root fix waits
+for a named stack trace from a real or injected hang.
+
+**Why:** without a stack trace the root fix is guesswork; with one it is
+mechanical.
+
+### D2 — Job `timeout-minutes` ships regardless of root cause
+(decided 2026-06-14)
+
+Even before the cause is known, a bounded job timeout converts a silent
+multi-minute (worst case 6h) wedge into a fast, visible, auto-rerunnable
+failure. This alone removes most of the human-intervention tax the
+"CI runner-hang recipe" lesson describes.
+
+**Open:** exact `timeout-minutes` value — start at 25 (test p99 ~4 min,
+coverage ~8 min; 2–3× headroom). Tune after observing a week of normal
+runtimes.
+
+---
+
+## Open decisions (need Patrick or probe data)
+
+- **OD1 — Is this its own spec or a phase of `windows-xdist-flakes`?**
+  Recommendation: **own spec** (different OS, different manifestation —
+  hang vs crash), cross-linked. If P3/P5 prove a *shared* polluter,
+  fix once and reference both. Confirm.
+- **OD2 — Acceptable normal-runtime ceiling for the timeout guard.**
+  Need a week of `coverage`/`test` durations to set `timeout-minutes`
+  without false-failing healthy slow runs. Proposed interim: 25 min.
+- **OD3 — Appetite for the P5 autouse I/O guard now vs after a
+  confirmed H2.** It is the durable G4 regression guard but touches the
+  whole unit-test tree (some legitimate loopback tests must be
+  allow-listed). Recommend deferring until P1/P3 implicate H2, to avoid
+  a large speculative change.
+- **OD4 — `--timeout-method=signal` on POSIX lanes (P4).** Only pursue
+  if P1's stack shows a C-call wedge the thread method missed; do not
+  blind-switch (xdist interaction risk).
+
+---
+
+## Phase plan (proposed)
+
+| Phase | Scope | PR shape |
+|-------|-------|----------|
+| 1 | P1 faulthandler all-thread dump + P2 job `timeout-minutes` | one `ci(tests)` PR; validate G1/G2 with an injected hang on a throwaway branch |
+| 2 | Wait for a named stack (real hang or injected); P3 serial bisect if needed | investigation note in this spec dir |
+| 3 | Root fix per confirmed hypothesis (H2 polluter fix / H3 coverage isolation) + G4 guard | `fix(...)` PR with a rerun-count verification |
+| 4 | Promote `clock-tz`-style: if a diagnostic lane was added, fold it back or remove | cleanup PR |
+
+Phase 1 is self-contained and worth shipping immediately; Phases 2–4
+are gated on Phase 1's diagnostics producing a stack.

--- a/docs/specs/ci-runner-hang/decisions.md
+++ b/docs/specs/ci-runner-hang/decisions.md
@@ -40,11 +40,16 @@ runtimes.
 - **OD1 → own spec.** This stays a standalone spec, cross-linked to
   `windows-xdist-flakes`. If P3/P5 prove a *shared* polluter, fix once
   and reference both.
-- **OD2 → 25 min interim.** `timeout-minutes` tightened from the
-  current 75. Implementation: coverage job → 25; matrix `test` job →
-  20 on ubuntu (where the hang lives, normal ~4 min) / 40 on
-  Windows+macOS (normal ~13–15 min, must not false-fail). Re-tune after
-  a week of observed durations.
+- **OD2 → tightened from 75.** `coverage` job → **25**; matrix `test`
+  job → **35** (flat). *Implementation correction:* the first attempt
+  used a per-OS `${{ matrix.os ... && 20 || 40 }}` expression, but that
+  broke the existing `test_timeout_values_are_reasonable` guard (it
+  expects an integer, got the expression string). A flat 35 passes the
+  guard, stays generous for Windows/macOS (~13–15 min normal) to avoid
+  false-fails, and still fails a wedged ubuntu step far faster than 75.
+  Per-OS tightness is unnecessary anyway: the **early faulthandler dump
+  (~10 min) is the diagnostic**; the job timeout is only the kill
+  backstop. Re-tune after a week of observed durations.
 - **OD3 → defer.** The broad P5 autouse I/O guard waits until P1/P3
   implicate H2 — no large speculative change now.
 - **OD4 → approved, gated.** Pursue `--timeout-method=signal` on the
@@ -84,3 +89,51 @@ with the open `--cov-fail-under` change in #871).
 
 Phase 1 is self-contained and worth shipping immediately; Phases 2–4
 are gated on Phase 1's diagnostics producing a stack.
+
+---
+
+## Phase 1 status + Phase 2 handoff (2026-06-14)
+
+**Phase 1 DONE — PR #874** (`ci/runner-hang-phase1`): faulthandler
+watchdog in `tests/conftest.py` (CI-gated, Linux 600s / else 1200s) +
+`timeout-minutes` 75→ test 35 / coverage 25. Local smoke-verified
+(watchdog dumps at threshold, test still passes; unset = not armed).
+The guard-test break was fixed in the same PR (flat int, not a per-OS
+expression). At handoff #874 is open with auto-merge — **confirm it
+merged** (`gh pr view 874 --json state,mergedAt`).
+
+### Phase 2 — start here, in a FRESH session
+
+Phase 2 is **gated on a real hang stack**. Do NOT attempt a root fix
+without one — guessing failed prior CI specs (see the "re-validate a
+spec's premise" lesson). Concretely:
+
+1. **Confirm Phase 1 merged** and the watchdog is live on `main`.
+2. **Wait for the next hang.** With #874 live, a wedged ubuntu lane now
+   (a) prints an all-thread faulthandler dump at ~10 min and (b) fails
+   the job at 25–35 min instead of stalling. When CI shows a `test`/
+   `coverage` job failing at/near its `timeout-minutes` (not a normal
+   assertion failure), pull its log:
+   `gh api repos/Smart-AI-Memory/attune-ai/actions/jobs/<job_id>/logs`
+   (works once the JOB is complete even if the RUN is in progress) and
+   find the `Timeout (0:..)!` section — it names the wedged frame(s) in
+   the controller and each worker.
+   - #874's OWN run is a full-matrix run (touches tests.yml), so it may
+     itself capture a stack — check its run first.
+3. **Classify with the stack:** a worker wedged in a C-level
+   socket/subprocess/lock call ⇒ H1/H2 (the I/O-polluter family shared
+   with `windows-xdist-flakes`); a coverage-combine frame ⇒ H3.
+4. **Fix narrowly** (per design.md "Proposed fix shape"): mock/loopback
+   the polluting I/O with an explicit socket timeout (proven Windows-
+   spec pattern), and only then consider OD4 (`--timeout-method=signal`
+   on POSIX) if the stack shows a C-call the thread method couldn't
+   break. Land the P5 autouse I/O guard (G4) once H2 is confirmed (OD3
+   says defer until then).
+5. **Verify with a rerun count**, not a single green — intermittent bug
+   ⇒ require ≥10 clean reruns under `-n auto` (design.md G3).
+
+**If no hang reproduces within a reasonable window:** that's a fine
+outcome — Phase 1's diagnostics + fast-fail already retire most of the
+intervention tax. Mark the spec `monitoring` and let the next captured
+stack reopen Phase 2. Tar-pit guard: do not chase an unreproducible
+hang past two investigation attempts.

--- a/docs/specs/ci-runner-hang/decisions.md
+++ b/docs/specs/ci-runner-hang/decisions.md
@@ -58,11 +58,15 @@ runtimes.
 faulthandler is armed in `tests/conftest.py` gated on the auto-set `CI`
 env var (so local runs are unaffected) with an OS-tuned threshold
 (`RUNNER_OS == "Linux"` → 600s, else 1200s), via
-`faulthandler.dump_traceback_later(secs, repeat=False, all_threads=True)`
-at conftest import time so it covers the xdist controller AND every
-worker subprocess, including collection-time hangs. The threshold sits
-below the job `timeout-minutes` so the all-thread stack lands in the log
-*before* the fast-fail kills the job. Threshold overridable for local
+`faulthandler.dump_traceback_later(secs, repeat=False)` at conftest
+import time so it covers the xdist controller AND every worker
+subprocess, including collection-time hangs.
+(`dump_traceback_later` always dumps ALL threads — there is no
+`all_threads` kwarg on it; that exists only on `register()` /
+`dump_traceback()`. Passing it raises `TypeError` at import and breaks
+collection — caught by the Phase 1 local smoke test before ship.) The
+threshold sits below the job `timeout-minutes` so the all-thread stack
+lands in the log *before* the fast-fail kills the job. Shipped in #874. Threshold overridable for local
 smoke-testing via `PYTEST_HANG_DUMP_SECONDS`. This keeps the `tests.yml`
 diff to the two `timeout-minutes` lines (no `env:` edits → no conflict
 with the open `--cov-fail-under` change in #871).

--- a/docs/specs/ci-runner-hang/design.md
+++ b/docs/specs/ci-runner-hang/design.md
@@ -1,0 +1,128 @@
+# Design: CI Runner-Hang Root Cause and Fix
+
+**Status:** draft
+**Created:** 2026-06-14
+**Requirements:** [requirements.md](requirements.md)
+
+---
+
+## Approach
+
+Diagnostics-first. The hang is intermittent and currently opaque, so
+the highest-leverage move is to make the *next* occurrence
+self-documenting and bounded, then let the named stack drive the root
+fix. Ship G1 (hang dump) and G2 (job timeout) before attempting G3
+(root fix), because without a stack trace the root fix is guesswork —
+and guessing failed the "re-validate the premise" test in prior CI
+specs.
+
+## Ranked hypotheses
+
+**H1 — xdist worker/controller wedge the thread-timeout can't break
+(most likely).** A worker blocks in an uninterruptible C call (socket
+recv, subprocess wait, lock acquire) while holding the GIL, so
+`--timeout-method=thread` (which raises in the worker's main thread)
+can never run. The controller then waits on that worker indefinitely.
+Fits all five constraints: in-test-step, timeout doesn't fire,
+intermittent, both lanes, `-n auto`. Shared polluter class with the
+Windows worker-crash spec.
+
+**H2 — A specific test doing real network/subprocess I/O without its
+own timeout** (subset of H1's mechanism). The Windows spec already
+found three such sites in the memory/agents test trees (real Redis
+subprocess starts, non-loopback socket probes). On Ubuntu the same code
+may *hang* (connect to a black-hole host that neither refuses nor
+resolves quickly) rather than crash. Strong prior.
+
+**H3 — pytest-cov × xdist data-collection deadlock at the
+worker/process boundary.** Coverage combines per-worker data at
+teardown; a worker wedged mid-collection could stall combine. Weakened
+by the plain `test` lane also hanging, but `--cov` may widen the race
+window — keep as an aggravator to rule out, not a primary.
+
+**H4 — Runner resource exhaustion (memory → swap thrash).** A test
+allocating unbounded objects (the handoff notes a historical "~100k
+MagicMocks zombie thread") could make the runner thrash and appear
+hung. Less likely (pre-test steps fine, rerun fine), but `faulthandler`
++ a memory probe will show it if real.
+
+## Probes (cheap-first; STOP when a named stack appears)
+
+**P1 — faulthandler all-thread dump (the keystone diagnostic).**
+Enable a watchdog that dumps *every* thread's stack to stderr after N
+seconds, so a hang prints where it is wedged — in the worker AND the
+controller. Two complementary mechanisms:
+
+- pytest `faulthandler_timeout` in config (dumps the main process), and
+- `PYTHONFAULTHANDLER=1` plus an explicit
+  `faulthandler.dump_traceback_later(<sec>, all_threads=True)` armed in
+  a session-scoped conftest fixture so worker subprocesses are covered.
+
+Set the dump threshold below the job timeout (e.g. 300s) so the trace
+lands *before* the fast-fail kills the job. Validate by injecting a
+deliberate `time.sleep(9999)` test on a throwaway branch and confirming
+the CI log names it.
+
+**P2 — job-level `timeout-minutes` (the mitigation, ships regardless).**
+Add `timeout-minutes:` to the `test` and `coverage` jobs in
+`tests.yml`, sized at ~2–3× p99 normal runtime (normal: test ~4 min,
+coverage ~8 min → start at 25 min). A wedge then fails that job in
+bounded time; `gh run rerun --failed` recovers it, and the failure is
+visible instead of silent. Combined with P1, the failed job carries the
+stack.
+
+**P3 — serial bisect lane (confirm xdist involvement).** On a
+diagnostic branch, run one lane with `-p no:xdist` (serial). If the
+hang vanishes serially across several runs, xdist is implicated (H1).
+If it still hangs serially, the wedge is in a test's own blocking I/O
+(H2) independent of xdist.
+
+**P4 — switch `--timeout-method` on POSIX.** Try `--timeout-method=
+signal` on the Ubuntu lanes (signal-based SIGALRM can interrupt some C
+calls the thread method cannot). If the per-test timeout then *fires*
+and names the test, that both diagnoses and partially mitigates. Caveat:
+signal method interacts poorly with some xdist setups — gate behind P1's
+findings, do not blind-switch.
+
+**P5 — I/O polluter inventory (if P1/P3 point at H2).** Extend the
+Windows spec's proposed `autouse` guard to the whole unit tree: a
+session fixture that fails fast on (a) real `ensure_redis`/subprocess
+starts and (b) socket connects to non-loopback hosts. This both finds
+the current polluter and becomes G4's regression guard.
+
+## Proposed fix shape (driven by probe results)
+
+1. **Always ship (diagnostics + mitigation):** P1 faulthandler dump +
+   P2 job `timeout-minutes`. Low risk, high value, independent of root
+   cause. This alone retires most of the human-intervention tax.
+2. **If H2/H1 confirmed:** fix the polluting test (mock the I/O / use
+   loopback + closed port + an explicit socket timeout, per the Windows
+   spec's proven pattern) and land P5's autouse guard (G4).
+3. **If H3 confirmed:** isolate coverage combine (e.g. `--cov-context`
+   off, or `COVERAGE_CORE=sysmon` on 3.12+) — narrowest change first.
+4. **If unreproducible after 2 attempts:** ship 1+2, mark the spec
+   `monitoring`, and let the next named stack reopen G3. (Tar-pit
+   guard.)
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `timeout-minutes` set too low fails healthy slow runs | medium | size at 2–3× p99; the badge/dep steps are outside the test step so only test time counts |
+| faulthandler dump noise on every run | low | only dumps on the timer; threshold > normal runtime so healthy runs never trigger |
+| signal timeout-method breaks xdist | medium | P4 is gated behind P1, not blind |
+| Fixing one polluter while another lurks (cf. Windows spec needing 3 fixes) | medium | land the P5 autouse guard so the *class* is caught, not just instances |
+| Changing `tests.yml` triggers the full matrix (D2 path) | low | expected; validates the change on all lanes |
+
+## Verification
+
+- **G1:** inject a deliberate hang on a throwaway branch → confirm the
+  CI log prints the all-thread stack naming the injected frame.
+- **G2:** same injected hang → confirm the job fails at
+  `timeout-minutes`, not at manual cancel, and `rerun --failed`
+  recovers.
+- **G3:** after the fix, the named polluter's test passes serially and
+  under `-n auto` across ≥10 reruns (intermittent bug → require a run
+  count, not a single green).
+- **G4:** add a test that performs the wedge condition and assert the
+  autouse guard fails it fast.

--- a/docs/specs/ci-runner-hang/requirements.md
+++ b/docs/specs/ci-runner-hang/requirements.md
@@ -1,0 +1,126 @@
+# Spec: CI Runner-Hang Root Cause and Fix
+
+> The Ubuntu `coverage` and `test (ubuntu-latest, 3.12)` lanes
+> intermittently freeze *inside the pytest execution step* and never
+> progress until manually cancelled. The configured per-test timeout
+> (`--timeout=60 --timeout-method=thread`) does not fire. Every QA
+> session pays a cancel→rerun (and sometimes admin-merge) tax. This
+> spec root-causes the hang and ships a fix plus a fast-fail guard so a
+> future hang is self-documenting and auto-recoverable instead of a
+> silent multi-minute stall.
+
+**Status:** draft
+**Created:** 2026-06-14
+**Owner:** Patrick + agent
+**Related:**
+
+- `docs/specs/windows-xdist-flakes/` — Windows xdist *worker-crash*
+  family (opaque "worker 'gwN' crashed", passes on rerun). Same
+  suspected polluter class (real socket/subprocess I/O in fixtures) but
+  a different manifestation (crash on Windows vs hang on Ubuntu).
+- `docs/specs/ci-matrix-right-sizing/` — which lanes run (matrix
+  sizing). Orthogonal: the hang is about a lane freezing, not about how
+  many lanes spawn.
+- `.claude/lessons.md` — "CI runner-hang recipe" (cancel→rerun, don't
+  loop past ~2, escalate to admin-merge once the same-suite `coverage`
+  job is green). This spec aims to retire the *need* for that recipe.
+
+---
+
+## Phase 1: Requirements
+
+**Status:** draft
+
+### Problem statement
+
+On `tests.yml`, the `coverage` and `test (ubuntu-latest, 3.12)` jobs
+sometimes wedge: the test step starts, runs for 13+ minutes with zero
+progress, and only ends when a human cancels it. Because two of the
+seven required checks are affected, the PR sits `BLOCKED` and cannot
+merge. The documented workaround (cancel the run, wait `completed`,
+`gh run rerun --failed`) usually clears it, but it:
+
+- requires a human to notice the stale `updatedAt` and intervene,
+- recurs across reruns on the same PR (observed 2 hangs/PR this
+  session), and
+- breaks the unattended-QA model — the predictable infra failure lands
+  exactly where autonomy needs a human (admin-merge authorization).
+
+### Evidence (this session, 2026-06-14)
+
+Captured from the cancelled first attempt of run `27485708268` (PR
+#867) via `gh api .../attempts/1/jobs`:
+
+| Step | Result | Duration |
+|------|--------|----------|
+| Set up job | success | ~2s |
+| Checkout | success | ~2s |
+| Set up Python 3.11 | success | ~7s |
+| Install dependencies | success | ~20s |
+| Check README badge freshness | success | ~68s |
+| **Run tests with coverage** | **cancelled** | **13m32s, no progress** |
+
+The `test (ubuntu-latest, 3.12)` job hung identically in its
+**"Run tests"** step. Both runs in this session (#866, #867) hung;
+each rerun of the *same* step then completed normally (coverage ~8 min,
+test ~4 min). Prior session handoffs report the hang recurring "all
+day" on 2026-06-13.
+
+### Key facts that constrain the root cause
+
+1. **The hang is in pytest execution, not infra/provisioning** — all
+   pre-test steps complete in seconds; only the test step wedges.
+2. **`pytest-timeout` is configured and did NOT fire.** Both lanes run
+   `pytest -n auto --timeout=60 --timeout-method=thread`
+   (`tests.yml:152` test, `tests.yml:198` coverage). A 60s per-test
+   thread-timeout that never triggers during a 13-min hang means the
+   wedge is **not a single test the thread method can interrupt** —
+   consistent with a thread blocked in an uninterruptible C call while
+   holding the GIL, or a wedge in the xdist controller↔worker channel
+   that lives *outside* any single test's timeout window.
+3. **Intermittent.** The identical step succeeds on rerun → a race /
+   resource / I/O-dependent deadlock, not a deterministic bug.
+4. **Not coverage-specific.** Both the `coverage` lane (pytest-cov) and
+   the plain `test` lane hang, so `--cov` is at most an aggravator, not
+   the cause.
+5. **`-n auto` (xdist) is in play on both lanes**, and the sibling
+   Windows spec already traced *worker crashes* to real
+   socket/subprocess I/O in fixtures — a strong prior for the polluter
+   class.
+
+### Goals
+
+- **G1 — Diagnose:** turn the next hang from opaque into a named stack
+  trace (all-thread dump at the hang site).
+- **G2 — Fast-fail guard:** a job-level hard timeout so a hang fails in
+  ~bounded time and is auto-rerunnable, instead of running until manual
+  cancel (or the GitHub 6h ceiling).
+- **G3 — Root fix:** identify and fix the polluter (test/fixture) or
+  the xdist/timeout configuration that allows an un-killable wedge.
+- **G4 — Regression guard:** a guard that fails fast at authoring time
+  if a test re-introduces the wedge condition (real I/O / un-timed
+  blocking), so the class cannot silently return.
+
+### Non-goals
+
+- Matrix right-sizing (covered by `ci-matrix-right-sizing`).
+- The Windows worker-crash inventory (covered by
+  `windows-xdist-flakes`), except where a shared polluter is found —
+  then fix once and cross-reference both specs.
+- Eliminating `-n auto` / coverage outright (performance regression);
+  only change them if proven causal and no narrower fix exists.
+
+### Acceptance criteria (Done when)
+
+- The next observed hang produces a full all-thread traceback in the CI
+  log naming the wedged frame (G1 verified by a deliberately-injected
+  hang in a throwaway branch, or by the first real hang post-merge).
+- A job-level `timeout-minutes` guard is live on the `test` and
+  `coverage` jobs, sized above the p99 normal runtime, so a wedge fails
+  the job (not the whole run silently) and `rerun --failed` recovers it.
+- Root cause is identified and fixed, OR — if not reproducible after a
+  bounded investigation — the diagnostics (G1/G2) are shipped and the
+  spec is left `monitoring` with the probe wired to catch the next
+  occurrence. (Tar-pit guard: do not chase an unreproducible hang past
+  two failed investigation attempts; ship the diagnostics and wait for
+  a named stack.)


### PR DESCRIPTION
Creates `docs/specs/ci-runner-hang/` — root-cause spec for the
intermittent Ubuntu `coverage` / `test (ubuntu-latest, 3.12)` lane
freeze that's been taxing every QA run (cancel→rerun, sometimes
admin-merge).

## What the evidence shows

From this session's hung runs (`gh api .../attempts/1/jobs` on #866/#867):

- The hang is **inside the pytest execution step** — all pre-test steps
  (setup, checkout, Python, deps, badge check) finish in seconds; the
  test step runs 13+ min with zero progress until manually cancelled.
- **`--timeout=60 --timeout-method=thread` is configured but never
  fires** → not a single interruptible test. It's a worker/xdist-level
  wedge (a thread blocked in uninterruptible C code holding the GIL, or
  a controller↔worker channel deadlock).
- **Intermittent** (rerun of the same step succeeds) and **not
  coverage-specific** (the plain `test` lane hangs too).
- Same suspected polluter class as `windows-xdist-flakes` (real
  socket/subprocess I/O in fixtures), but a hang on Ubuntu vs a crash
  on Windows.

## Plan (diagnostics-first)

- **Phase 1 (ship now):** faulthandler all-thread dump + job
  `timeout-minutes` → the next hang is self-documenting and fails fast
  instead of stalling silently.
- **Phase 2+:** let the named stack drive the root fix (polluter fix /
  coverage isolation) + an autouse I/O regression guard. Tar-pit guard:
  don't chase an unreproducible hang past two attempts — ship the
  diagnostics and wait for a stack.

Three files: `requirements.md`, `design.md`, `decisions.md` (with open
decisions OD1–OD4 flagged for Patrick). Docs-only. Keyless, zero API spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)