### PR TITLE
feat(ci): pre-authorized auto-merge class for tests/docs-only PRs

### DIFF
--- a/.github/scripts/auto_merge_guard.py
+++ b/.github/scripts/auto_merge_guard.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Path-class guard for the ``auto-merge-safe`` workflow.
+
+Decides whether a PR's changed-file set is wholly within the
+pre-authorized auto-merge class (test/docs only). The whole point
+is to be **tight and fail-closed**: anything that isn't provably
+test/docs keeps the PR out of the class, and an empty file set is
+treated as unsafe.
+
+In-class paths (every changed path must match one):
+
+- under ``tests/``
+- under ``docs/``
+- under ``.help/``
+- a root-level markdown file (``*.md`` with no ``/`` in the path)
+
+Everything else — ``src/``, ``.github/``, ``pyproject.toml``,
+lockfiles, ``mkdocs.yml`` — is out-of-class by construction. The
+guard itself lives under ``.github/`` so a PR that edits it is
+out-of-class and can never self-auto-merge.
+
+CLI:
+    python .github/scripts/auto_merge_guard.py PATH [PATH ...]
+    printf '%s\\n' tests/a.py docs/b.md | python .github/scripts/auto_merge_guard.py
+
+Exit 0 = safe (all in-class); exit 1 = unsafe (prints offenders).
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Directory prefixes that are in-class. Trailing slash is required
+# so ``.help`` cannot be matched by a sibling like ``.helpers/``.
+SAFE_DIR_PREFIXES: tuple[str, ...] = ("tests/", "docs/", ".help/")
+
+
+def is_in_class(path: str) -> bool:
+    """Return True if a single changed path is within the class.
+
+    Args:
+        path: A repo-relative POSIX path (no leading slash), as
+            returned by the GitHub PR "files" API.
+
+    Returns:
+        True iff the path is under an in-class directory or is a
+        root-level ``*.md`` file. Empty paths and paths containing
+        a ``..`` segment are rejected (fail-closed / traversal
+        defense).
+    """
+    if not path:
+        return False
+    if ".." in path.split("/"):
+        return False
+    if path.startswith(SAFE_DIR_PREFIXES):
+        return True
+    # Root-level markdown: README.md, CHANGELOG.md, etc.
+    return "/" not in path and path.endswith(".md")
+
+
+def is_safe_change(paths: list[str]) -> tuple[bool, list[str]]:
+    """Classify a full changed-file set.
+
+    Args:
+        paths: All changed paths for the PR. The caller should
+            include each rename's previous path as well, so a move
+            out of ``src/`` is caught.
+
+    Returns:
+        ``(safe, offending)`` where ``safe`` is True only if every
+        path is in-class and the set is non-empty. ``offending``
+        lists the out-of-class paths.
+    """
+    # Fail-closed: an empty set is not a provable test/docs PR.
+    if not paths:
+        return False, []
+    offending = [p for p in paths if not is_in_class(p)]
+    return (not offending), offending
+
+
+def main(argv: list[str]) -> int:
+    """CLI entry point. Paths from argv or, if none, stdin lines."""
+    if len(argv) > 1:
+        paths = [p.strip() for p in argv[1:] if p.strip()]
+    else:
+        paths = [line.strip() for line in sys.stdin if line.strip()]
+
+    safe, offending = is_safe_change(paths)
+    if safe:
+        print(f"SAFE: all {len(paths)} path(s) within the auto-merge class")
+        return 0
+
+    if not paths:
+        print("UNSAFE: empty changed-file set (fail-closed)")
+    else:
+        print("UNSAFE: out-of-class path(s):")
+        for p in offending:
+            print(f"  {p}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/auto-merge-safe.yml
+++ b/.github/workflows/auto-merge-safe.yml
@@ -1,0 +1,173 @@
+name: Auto-merge safe (tests/docs only)
+
+# Pre-authorized auto-merge for a TIGHT class of PRs: every changed
+# file is under tests/, docs/, .help/, or is a root-level *.md, the
+# author is the repo owner, and the `coverage` required check is
+# green. The merge is performed DETERMINISTICALLY by GitHub Actions
+# (no agent, no safety classifier) and admin-bypasses only the
+# REDUNDANT hung lane (e.g. `test (ubuntu-latest, 3.12)`) — never the
+# `coverage` gate, which re-runs the full suite.
+#
+# See docs/specs/auto-merge-safe-class/ for the class definition and
+# the rejected alternatives.
+#
+# Credential: the merge job authenticates with ADMIN_MERGE_TOKEN, a
+# fine-grained PAT owned by an admin (silversurfer562), repo-scoped,
+# Contents + Pull-requests read/write only. GITHUB_TOKEN cannot
+# bypass branch protection (the bot is not an admin). Until the
+# secret exists the merge job is inert (fails closed).
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  check_run:
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: >-
+    auto-merge-safe-${{ github.event.pull_request.head.sha ||
+    github.event.check_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------
+  # Apply/remove the `auto-merge-safe` label based on the path class.
+  # Automation owns the label so it is never hand-applied; the merge
+  # job re-verifies the path class anyway (label = necessary, not
+  # sufficient).
+  # ---------------------------------------------------------------
+  label:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.login == 'silversurfer562'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # Default ref on pull_request_target is the BASE branch (main),
+      # so we always run the trusted base copy of the guard, never
+      # the PR's version.
+      - name: Checkout base repo (trusted guard)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Compute path class and (un)label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mapfile -t paths < <(
+            gh api --paginate "repos/$REPO/pulls/$PR/files" \
+              --jq '.[] | .filename, (.previous_filename // empty)'
+          )
+          if [ "${#paths[@]}" -gt 0 ] && \
+             printf '%s\n' "${paths[@]}" | \
+             python3 .github/scripts/auto_merge_guard.py; then
+            echo "In-class -> adding auto-merge-safe label"
+            gh pr edit "$PR" --add-label auto-merge-safe
+          else
+            echo "Out-of-class -> removing label if present"
+            gh pr edit "$PR" --remove-label auto-merge-safe || true
+          fi
+
+  # ---------------------------------------------------------------
+  # When the `coverage` check goes green, re-evaluate ALL gates and
+  # admin-merge. Reacts the instant coverage succeeds, regardless of
+  # a still-hung redundant sibling lane (the whole point).
+  # ---------------------------------------------------------------
+  merge:
+    if: >-
+      github.event_name == 'check_run' &&
+      github.event.check_run.name == 'coverage' &&
+      github.event.check_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout base repo (trusted guard)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Evaluate gates and admin-merge
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_MERGE_TOKEN }}
+          SHA: ${{ github.event.check_run.head_sha }}
+          REPO: ${{ github.repository }}
+          OWNER_LOGIN: silversurfer562
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "ADMIN_MERGE_TOKEN not set; merge job inert (fail-closed)."
+            exit 0
+          fi
+
+          mapfile -t prs < <(
+            gh api "repos/$REPO/commits/$SHA/pulls" \
+              --jq '.[] | select(.state=="open" and .base.ref=="main") | .number'
+          )
+          if [ "${#prs[@]}" -eq 0 ]; then
+            echo "No open PR against main for $SHA."
+            exit 0
+          fi
+
+          for pr in "${prs[@]}"; do
+            echo "::group::PR #$pr"
+            meta=$(gh api "repos/$REPO/pulls/$pr" --jq '{
+              author: .user.login,
+              draft: .draft,
+              head_repo: .head.repo.full_name,
+              base_repo: .base.repo.full_name,
+              head_sha: .head.sha,
+              has_label: ([.labels[].name] | index("auto-merge-safe") != null)
+            }')
+            author=$(echo "$meta" | jq -r .author)
+            draft=$(echo "$meta" | jq -r .draft)
+            head_repo=$(echo "$meta" | jq -r .head_repo)
+            base_repo=$(echo "$meta" | jq -r .base_repo)
+            head_sha=$(echo "$meta" | jq -r .head_sha)
+            has_label=$(echo "$meta" | jq -r .has_label)
+
+            if [ "$author" != "$OWNER_LOGIN" ]; then
+              echo "skip: author $author != $OWNER_LOGIN"; echo "::endgroup::"; continue
+            fi
+            if [ "$draft" != "false" ]; then
+              echo "skip: draft PR"; echo "::endgroup::"; continue
+            fi
+            if [ "$head_repo" != "$base_repo" ]; then
+              echo "skip: fork PR ($head_repo)"; echo "::endgroup::"; continue
+            fi
+            if [ "$has_label" != "true" ]; then
+              echo "skip: no auto-merge-safe label"; echo "::endgroup::"; continue
+            fi
+
+            # Re-verify the path class INDEPENDENT of the label, so a
+            # hand-applied label on an out-of-class PR cannot merge.
+            mapfile -t paths < <(
+              gh api --paginate "repos/$REPO/pulls/$pr/files" \
+                --jq '.[] | .filename, (.previous_filename // empty)'
+            )
+            if [ "${#paths[@]}" -eq 0 ] || \
+               ! printf '%s\n' "${paths[@]}" | \
+               python3 .github/scripts/auto_merge_guard.py; then
+              echo "skip: path-class re-check failed"; echo "::endgroup::"; continue
+            fi
+
+            # Coverage must be green on the PR's CURRENT head (the
+            # check_run that triggered us may be for an older SHA).
+            cov=$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
+              --jq '[.check_runs[] | select(.name=="coverage")] |
+                    sort_by(.started_at) | last | .conclusion // "none"')
+            if [ "$cov" != "success" ]; then
+              echo "skip: coverage=$cov on $head_sha"; echo "::endgroup::"; continue
+            fi
+
+            echo "All gates pass -> admin squash-merge PR #$pr"
+            gh pr merge "$pr" --squash --admin --delete-branch || \
+              echo "merge call failed (possibly already merged)"
+            echo "::endgroup::"
+          done

--- a/docs/specs/auto-merge-safe-class/decisions.md
+++ b/docs/specs/auto-merge-safe-class/decisions.md
@@ -1,0 +1,112 @@
+# Auto-Merge-Safe Class — Decisions
+
+**Status:** approved (2026-06-14)
+
+---
+
+## D1 — Class definition (the pre-authorized set)
+
+A PR is **auto-merge-safe** iff ALL of these hold (fail-closed on
+any failure or ambiguity):
+
+| # | Gate | Detail |
+|---|------|--------|
+| 1 | Label | `auto-merge-safe` present |
+| 2 | Path class | every changed path (incl. rename's previous path) under `tests/`, `docs/`, `.help/`, or a root-level `*.md` |
+| 3 | Coverage | `coverage` required check == `success` on PR head |
+| 4 | Author | login == `silversurfer562` (repo owner) |
+| 5 | Provenance | head repo == base repo (no forks); not a draft |
+
+The merge bypasses only the **redundant hung lane** (e.g.
+`test (ubuntu-latest, 3.12)`). The `coverage` job re-runs the
+**full** suite, so for a test/docs-only PR coverage-green ⇒ the
+suite is verified ⇒ the redundant matrix lane is safe to skip
+(established lesson, 2026-06-13/14).
+
+**Why these paths:** `tests/` + `docs/` is the literal scope.
+`.help/` and root `*.md` were added (D-path) because docs
+auto-runs routinely touch `.help/` templates and root markdown
+(README/CHANGELOG); excluding them would make the class "so tight
+it never fires." Everything else — `src/`, `.github/`,
+`pyproject.toml`, lockfiles, `mkdocs.yml` — stays out by
+construction.
+
+---
+
+## D2 — The classifier is the wrong layer; move the merge into CI
+
+The harness safety classifier requires conversational
+authorization for admin-merge and does not honor any
+settings/label/starter-file grant. Rather than fight that, the
+**agent is removed from the merge loop entirely**: a GitHub
+Actions workflow performs the merge deterministically. No
+agent, no classifier.
+
+---
+
+## D3 — Merge credential: fine-grained admin PAT (not GITHUB_TOKEN)
+
+`GITHUB_TOKEN` runs as `github-actions[bot]`, which is **not** a
+repo admin, and there is **no ruleset bypass** configured
+(`rulesets == []`, classic protection with `restrictions: null`).
+Verified: with `enforce_admins: false`, only an **admin actor**
+bypasses required checks. So:
+
+- The merge job authenticates with a **fine-grained PAT** owned
+  by `silversurfer562` (an admin), stored as the Actions secret
+  `ADMIN_MERGE_TOKEN`.
+- Scope: **this repo only**; permissions **Contents: Read/Write**
+  + **Pull requests: Read/Write**; **NOT** Administration.
+- Tradeoff: a long-lived admin-capable secret. Mitigated by the
+  five gates in D1 (label + ALL-in-class path filter + coverage +
+  author + no-fork), the merge job re-verifying the path class
+  independent of the label, and the guard living under `.github/`
+  (out-of-class, so it can't self-merge). Rotate per normal PAT
+  hygiene.
+
+Rejected for now: a GitHub App (auto-expiring tokens, more
+secure) — materially more setup; revisit if PAT hygiene becomes a
+burden.
+
+---
+
+## D4 — Label is applied by automation, re-verified at merge
+
+The `auto-merge-safe` label is applied/removed by the workflow's
+label job (computed from the path class + author) on every PR
+update, so it tracks reality (a later push that adds a `src/`
+file removes the label). The **merge job re-runs the path-class
+guard** before merging, so even a hand-applied label on an
+out-of-class PR will not merge. Label = necessary, not
+sufficient.
+
+---
+
+## Rejected alternatives
+
+### A — Drop the redundant `test (ubuntu-latest, 3.12)` from required checks
+
+**Rejected: too broad.** It weakens the gate for **all** PRs
+(including `src/` changes), not just the test/docs class. The
+hung lane is redundant *only for test/docs-only PRs where
+coverage re-runs the suite*; for code PRs the matrix lane carries
+real per-platform signal. Removing it from branch protection
+throws away that signal globally to fix a narrow case.
+
+### B — Any starter-file or settings "authorization" note
+
+**Rejected: not durable.** The harness safety classifier ignores
+it and demands conversational authorization every session (proven
+2026-06-14, PR #865). A note cannot close an unattended-run gap.
+
+### C — `gh pr merge --auto --squash` (the dependabot pattern)
+
+**Rejected: does not close the gap.** `--auto` **waits** for the
+required checks; the whole problem is that a required check
+**hangs and never completes**. Auto-merge would wait forever.
+
+### D — Merge via `GITHUB_TOKEN` with `--admin`
+
+**Rejected: cannot work here.** The bot is not an admin and there
+is no ruleset bypass, so `--admin` fails on exactly the
+hung-check case. (See D3.)

--- a/docs/specs/auto-merge-safe-class/design.md
+++ b/docs/specs/auto-merge-safe-class/design.md
@@ -1,0 +1,102 @@
+# Auto-Merge-Safe Class — Design
+
+**Status:** approved (2026-06-14)
+
+---
+
+## Components
+
+| File | Role |
+|------|------|
+| `.github/scripts/auto_merge_guard.py` | Path-class guard. Pure function + CLI. Fail-closed. |
+| `.github/workflows/auto-merge-safe.yml` | Label job (PR events) + merge job (check_run events). |
+| `tests/unit/github_scripts/test_auto_merge_guard.py` | Unit tests for the guard (importlib-loaded, repo convention). |
+
+The guard lives under `.github/` on purpose: `.github/` is
+out-of-class, so a PR that edits the guard or workflow can never
+satisfy the path filter and can never self-auto-merge.
+
+---
+
+## Path-class guard
+
+`is_in_class(path)` is True iff:
+
+- `path` startswith one of `tests/`, `docs/`, `.help/`, **or**
+- `path` is a root-level markdown file (`.md`, no `/` in path).
+
+`is_safe_change(paths)` returns `(safe, offending)`:
+
+- empty `paths` => `(False, [])` (fail-closed; nothing to merge
+  is suspicious).
+- any path with a `..` segment => unsafe (traversal defense).
+- safe iff every path `is_in_class`.
+
+CLI: paths via argv or stdin (one per line); exit 0 = safe,
+exit 1 = unsafe (prints offending paths).
+
+The workflow feeds the guard the union of each changed file's
+`filename` **and** `previous_filename` (so a rename out of `src/`
+is caught).
+
+---
+
+## Workflow triggers and jobs
+
+```yaml
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  check_run:
+    types: [completed]
+```
+
+### Job `label` (if event == pull_request_target)
+
+- Permissions: `pull-requests: write`, `contents: read`.
+- Token: `GITHUB_TOKEN` (no PAT — labels only).
+- Steps: author == `silversurfer562`? fetch PR files (paginated);
+  run guard over filename+previous_filename; if safe add
+  `auto-merge-safe`, else remove it if present.
+
+### Job `merge` (if event == check_run, name == coverage, conclusion == success)
+
+- Permissions: `contents: write`, `pull-requests: write`.
+- Token: `ADMIN_MERGE_TOKEN` (fine-grained admin PAT) for the
+  merge; reads can use the same.
+- Steps, per open PR for the check_run head SHA (base == main):
+  1. author == `silversurfer562`, not draft, head repo == base
+     repo — else skip.
+  2. labels contain `auto-merge-safe` — else skip.
+  3. fetch PR files; run guard — else skip (defense in depth vs a
+     hand-applied label).
+  4. re-confirm `coverage` == `success` on PR head — else skip.
+  5. `gh pr merge <n> --squash --admin --delete-branch`
+     (idempotent: skip if not open).
+
+Concurrency keyed per head SHA prevents double-merge races. The
+merge job never checks out PR code — pure API calls — so
+`pull_request_target` / `check_run` running with base secrets is
+safe.
+
+---
+
+## Why `check_run` (not `workflow_run`) for the merge trigger
+
+`coverage` is a job in the **Tests** workflow. Triggering on
+`check_run: completed` filtered to `name == 'coverage'` reacts
+the instant coverage goes green, regardless of whether the
+redundant `test (ubuntu-latest, 3.12)` sibling lane is still hung
+— which is precisely the gap. `workflow_run` would wait for the
+entire Tests run (including the hung lane's timeout) to complete.
+
+---
+
+## One-time setup (human)
+
+- Patrick creates the fine-grained PAT and stores it as
+  `ADMIN_MERGE_TOKEN`. Until then the merge job is inert (it has
+  no credential and will no-op/fail-closed).
+
+The `auto-merge-safe` label is pre-created (one-time) so the
+label job can add it without `issues: write`.

--- a/docs/specs/auto-merge-safe-class/requirements.md
+++ b/docs/specs/auto-merge-safe-class/requirements.md
@@ -1,0 +1,106 @@
+# Auto-Merge-Safe Class — Requirements
+
+**Status:** approved (2026-06-14)
+**Owner:** Patrick + agent
+
+---
+
+## Problem
+
+Autonomous QA/docs "auto-run" sessions open test-only or
+docs-only PRs and enable non-admin `gh pr merge --auto --squash`,
+which self-completes on green. The gap: when a **required check
+hangs** (the systemic ci-runner-hang — partly mitigated by #874's
+faulthandler watchdog + tightened timeouts), the happy path never
+lands, and admin-merge is the only recovery.
+
+Admin-merge requires an **explicit in-session human OK** every
+time (the harness safety classifier; a starter-file note is
+correctly not honored — see the "check-and-fix does NOT carry
+admin-merge authorization" lesson). So an unattended run cannot
+finish a hung-but-otherwise-green test PR.
+
+---
+
+## Goal
+
+A durable mechanism that lets a **tight** class of PRs
+(test/docs only) self-complete on the meaningful green signal
+**without** a per-session human admin-merge OK — while keeping
+code-touching PRs firmly out of the class.
+
+---
+
+## Key insight — the classifier is the wrong layer
+
+There is no evidence the harness safety classifier honors any
+settings/label grant for admin-merge; it wants conversational
+authorization. So we do **not** try to configure the classifier.
+Instead we take the agent **out of the merge loop**: a GitHub
+Actions workflow performs the merge deterministically. GitHub
+does the merge; no agent/classifier is involved.
+
+---
+
+## Functional requirements
+
+- **R1** — A workflow admin-merges (squash) a PR only when ALL
+  hold:
+  1. PR carries the `auto-merge-safe` label.
+  2. Every changed file is within the path class (see R2);
+     fail-closed on any out-of-class path or empty file set.
+  3. The `coverage` required check is `success` on the PR head.
+  4. PR author login is `silversurfer562` (the repo owner).
+  5. PR head repo == base repo (no forks) and PR is not a draft.
+- **R2** — Path class: every changed file (including a rename's
+  previous path) is under `tests/`, `docs/`, `.help/`, or is a
+  root-level `*.md`. Anything else (notably `src/`, `.github/`,
+  `pyproject.toml`, lockfiles, `mkdocs.yml`) makes the PR
+  out-of-class.
+- **R3** — The `auto-merge-safe` label is applied by the workflow
+  itself (computed from the path class + author), not by hand, so
+  humans/agents don't mis-apply it. The merge job **re-verifies**
+  the path class independently, so a hand-applied label on an
+  out-of-class PR still will not merge (label is necessary, not
+  sufficient).
+- **R4** — The merge uses a credential that bypasses the hung
+  required check (a fine-grained admin PAT; `GITHUB_TOKEN`
+  provably cannot — the bot is not a repo admin and there is no
+  ruleset bypass).
+- **R5** — The path-class guard is unit-tested and lives under
+  `.github/` so changes to the guard itself are out-of-class and
+  can never self-auto-merge.
+
+---
+
+## Exclusions (the whole ballgame)
+
+- Any `src/` or production-code change => excluded, no
+  exceptions.
+- Any change to CI workflows, branch protection, or the
+  auto-merge workflow itself => excluded (`.github/` is
+  out-of-class).
+- Fail closed: if the path filter cannot prove the PR is wholly
+  test/docs, do nothing.
+
+---
+
+## Non-goals
+
+- Bypassing the `coverage` gate. We bypass only the **redundant**
+  hung lane; `coverage` (which re-runs the full suite) must be
+  green.
+- Widening the class to any code path.
+- Solving the runner-hang itself (that is the ci-runner-hang
+  spec; this rides on top of its mitigations).
+
+---
+
+## Acceptance criteria
+
+- Spec recorded with `decisions.md` (class definition + rejected
+  alternatives).
+- `.github/workflows/auto-merge-safe.yml` + path-class guard with
+  passing unit tests landed via PR with CI green.
+- Verified on a throwaway test-only PR that it auto-merges, and
+  on a deliberately `src/`-touching PR that it is **not** merged.

--- a/docs/specs/auto-merge-safe-class/tasks.md
+++ b/docs/specs/auto-merge-safe-class/tasks.md
@@ -1,0 +1,32 @@
+# Auto-Merge-Safe Class — Tasks
+
+**Status:** in progress (2026-06-14)
+
+---
+
+## Phase 1 — Guard + tests (verifiable without the PAT)
+
+- [x] T1 — `.github/scripts/auto_merge_guard.py` (pure function +
+  CLI, fail-closed).
+- [x] T2 — `tests/unit/github_scripts/test_auto_merge_guard.py`
+  (importlib-loaded; covers in-class dirs, root `*.md`, `src/`
+  rejection, `.github/` rejection, rename previous-path, `..`
+  traversal, empty set).
+- [x] T3 — Guard tests pass locally (33 passed).
+
+## Phase 2 — Workflow
+
+- [x] T4 — `.github/workflows/auto-merge-safe.yml` (label job +
+  merge job per design).
+- [x] T5 — Pre-create the `auto-merge-safe` label.
+
+## Phase 3 — Land
+
+- [ ] T6 — PR; CI green; merge.
+
+## Phase 4 — Verify end-to-end (needs `ADMIN_MERGE_TOKEN`)
+
+- [ ] T7 — Patrick creates the fine-grained PAT secret.
+- [ ] T8 — Throwaway test-only PR auto-merges on coverage-green.
+- [ ] T9 — Deliberately `src/`-touching PR is NOT merged (label
+  withheld / merge job skips).

--- a/tests/unit/github_scripts/test_auto_merge_guard.py
+++ b/tests/unit/github_scripts/test_auto_merge_guard.py
@@ -1,0 +1,152 @@
+"""Tests for .github/scripts/auto_merge_guard.py.
+
+Loaded via importlib.util because .github/scripts/ is not a Python
+package — matches the repo convention used in
+tests/unit/github_scripts/test_analyze_security_results.py.
+
+The guard decides whether a PR's changed-file set is wholly within
+the pre-authorized auto-merge class (test/docs only). These tests
+are the regression guard for the class definition: any drift that
+lets a src/ or CI change slip into the class must fail here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / ".github" / "scripts" / "auto_merge_guard.py"
+
+
+@pytest.fixture
+def guard():
+    spec = importlib.util.spec_from_file_location("_auto_merge_guard", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_auto_merge_guard"] = mod
+    spec.loader.exec_module(mod)
+    yield mod
+    sys.modules.pop("_auto_merge_guard", None)
+
+
+# ---------------------------------------------------------------------------
+# is_in_class — single path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/unit/test_foo.py",
+        "tests/conftest.py",
+        "docs/guide.md",
+        "docs/specs/x/decisions.md",
+        ".help/templates/memory/concept.md",
+        "README.md",
+        "CHANGELOG.md",
+        "SECURITY.md",
+    ],
+)
+def test_in_class_paths_accepted(guard, path):
+    assert guard.is_in_class(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/attune/config.py",
+        "src/attune/workflows/base.py",
+        ".github/workflows/tests.yml",
+        ".github/scripts/auto_merge_guard.py",  # the guard cannot self-merge
+        ".github/workflows/auto-merge-safe.yml",
+        "pyproject.toml",
+        "uv.lock",
+        "requirements.txt",
+        "mkdocs.yml",  # not *.md, not under docs/ -> excluded
+        "attune_redis/foo.py",
+        "scripts/release.py",
+        "docs",  # bare dir name, no trailing slash -> not under docs/
+        ".helpers/x.md",  # sibling of .help must not match the prefix
+    ],
+)
+def test_out_of_class_paths_rejected(guard, path):
+    assert guard.is_in_class(path) is False
+
+
+def test_traversal_segment_rejected(guard):
+    assert guard.is_in_class("tests/../src/evil.py") is False
+    assert guard.is_in_class("docs/../../etc/passwd") is False
+
+
+def test_empty_path_rejected(guard):
+    assert guard.is_in_class("") is False
+
+
+def test_nested_markdown_under_src_rejected(guard):
+    # A markdown file NOT at root and not under an in-class dir.
+    assert guard.is_in_class("src/attune/NOTES.md") is False
+
+
+# ---------------------------------------------------------------------------
+# is_safe_change — full set
+# ---------------------------------------------------------------------------
+
+
+def test_all_in_class_is_safe(guard):
+    safe, offending = guard.is_safe_change(
+        ["tests/unit/test_a.py", "docs/b.md", "README.md", ".help/x.md"]
+    )
+    assert safe is True
+    assert offending == []
+
+
+def test_any_out_of_class_is_unsafe(guard):
+    safe, offending = guard.is_safe_change(["tests/unit/test_a.py", "src/attune/config.py"])
+    assert safe is False
+    assert offending == ["src/attune/config.py"]
+
+
+def test_empty_set_is_unsafe_failclosed(guard):
+    safe, offending = guard.is_safe_change([])
+    assert safe is False
+    assert offending == []
+
+
+def test_rename_previous_path_out_of_class_is_unsafe(guard):
+    # Workflow feeds filename + previous_filename; a rename out of
+    # src/ into tests/ must be caught via the previous path.
+    safe, offending = guard.is_safe_change(["tests/moved.py", "src/old.py"])
+    assert safe is False
+    assert "src/old.py" in offending
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_argv_safe_exits_zero(guard):
+    assert guard.main(["prog", "tests/a.py", "docs/b.md"]) == 0
+
+
+def test_cli_argv_unsafe_exits_one(guard):
+    assert guard.main(["prog", "tests/a.py", "src/x.py"]) == 1
+
+
+def test_cli_empty_argv_reads_stdin(guard, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("tests/a.py\ndocs/b.md\n"))
+    assert guard.main(["prog"]) == 0
+
+
+def test_cli_stdin_unsafe_exits_one(guard, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("src/x.py\n"))
+    assert guard.main(["prog"]) == 1
+
+
+def test_cli_empty_stdin_is_unsafe(guard, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+    assert guard.main(["prog"]) == 1


### PR DESCRIPTION
## What

A pre-authorized **auto-merge class** so autonomous QA/docs auto-runs
can self-complete a hung-but-green **tests/docs-only** PR without a
per-session human admin-merge OK — while keeping code-touching PRs
firmly out of the class.

Takes the agent **out of the merge loop**: `.github/workflows/auto-merge-safe.yml`
performs the merge deterministically (GitHub does it, no agent/classifier).

## The class (all must hold — fail-closed)

1. PR carries `auto-merge-safe` (applied by the workflow's label job,
   **re-verified** at merge — label is necessary, not sufficient).
2. Every changed path (incl. a rename's previous path) is under
   `tests/`, `docs/`, `.help/`, or is a root-level `*.md`.
3. `coverage` required check is `success` (it re-runs the **full**
   suite, so the redundant hung `test (ubuntu-latest, 3.12)` lane is
   safe to bypass — established lesson).
4. Author is the repo owner (`silversurfer562`); head repo == base
   repo (no forks); not a draft.

The merge admin-bypasses **only the redundant hung lane**, never the
`coverage` gate. `src/`, `.github/`, `pyproject.toml`, lockfiles,
`mkdocs.yml` are out-of-class by construction. The guard lives under
`.github/`, so it can never self-auto-merge.

## Why a workflow, not classifier config

`GITHUB_TOKEN` runs as `github-actions[bot]`, which is **not** a repo
admin, and there is **no ruleset bypass** — verified it cannot bypass
required checks. The merge job uses **`ADMIN_MERGE_TOKEN`** (a
fine-grained admin PAT). Until that secret exists the merge job is
**inert** (fail-closed).

## Rejected alternatives (see decisions.md)

- Drop the redundant lane from branch protection — too broad (weakens
  the gate for ALL PRs).
- Starter-file / settings authorization — the classifier ignores it.
- `gh pr merge --auto` — waits on the hung check forever.
- `GITHUB_TOKEN --admin` — bot isn't an admin; fails on the hung case.

## Tests

- `tests/unit/github_scripts/test_auto_merge_guard.py` — 33 tests
  (in-class dirs, root `*.md`, `src/`/`.github/` rejection, rename
  previous-path, `..` traversal, empty-set fail-closed, CLI). All green.

## Follow-up to fully arm (Phase 4)

- [ ] Create fine-grained PAT (owner, repo-scoped, Contents +
  Pull-requests write) → secret `ADMIN_MERGE_TOKEN`.
- [ ] Verify on a throwaway test-only PR (auto-merges) and a
  deliberately `src/`-touching PR (NOT merged).

Spec: `docs/specs/auto-merge-safe-class/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
