### PR TITLE
ci(tests): persist xdist worker hang dump as CI artifact (ci-runner-hang Phase 2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,6 +167,43 @@ jobs:
     - name: Run security and workflow tests
       run: pytest tests/unit/memory/test_long_term_security.py tests/unit/scanner/test_file_traversal.py tests/unit/workflows/test_workflow_execution.py -v --tb=short
 
+    # ci-runner-hang Phase 2: the conftest watchdog writes each process's
+    # all-thread stack to hang-dumps/hang-<worker>.txt. Surface + upload it
+    # with `if: always()` so a worker dump SURVIVES a `timeout-minutes` kill
+    # (the Phase 1 gap: a worker's raw stderr dump is lost when execnet
+    # never forwards it on a hang). Empty (armed-but-never-fired) dumps are
+    # pruned so a healthy run produces no artifact.
+    - name: Surface hang-watchdog dumps
+      if: always()
+      shell: bash
+      run: |
+        shopt -s nullglob
+        found=0
+        for f in hang-dumps/*.txt; do
+          if [ -s "$f" ]; then
+            found=1
+            echo "::group::HANG DUMP — $f"
+            cat "$f"
+            echo "::endgroup::"
+          else
+            rm -f "$f"
+          fi
+        done
+        if [ "$found" -eq 0 ]; then
+          echo "hang-watchdog: no dump fired (healthy run)."
+        else
+          echo "::warning::hang-watchdog captured a stack — a worker/controller wedged. See the hang-dumps artifact."
+        fi
+
+    - name: Upload hang-watchdog dumps
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: hang-dumps-test-${{ matrix.os }}-${{ matrix.python-version }}
+        path: hang-dumps/
+        if-no-files-found: ignore
+      continue-on-error: true
+
   clock-tz:
     # Hostile-clock lane: runs the unit suite under extreme NON-UTC
     # timezones so date/TZ bugs (the #867 / #868 clock-mix class) fail in
@@ -283,6 +320,40 @@ jobs:
         verbose: true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+    # ci-runner-hang Phase 2: surface + upload the worker/controller hang
+    # dumps so a `timeout-minutes` kill on this lane (the lane that wedged
+    # in run 27488685349) carries a named stack. See the `test` job note.
+    - name: Surface hang-watchdog dumps
+      if: always()
+      shell: bash
+      run: |
+        shopt -s nullglob
+        found=0
+        for f in hang-dumps/*.txt; do
+          if [ -s "$f" ]; then
+            found=1
+            echo "::group::HANG DUMP — $f"
+            cat "$f"
+            echo "::endgroup::"
+          else
+            rm -f "$f"
+          fi
+        done
+        if [ "$found" -eq 0 ]; then
+          echo "hang-watchdog: no dump fired (healthy run)."
+        else
+          echo "::warning::hang-watchdog captured a stack — a worker/controller wedged. See the hang-dumps artifact."
+        fi
+
+    - name: Upload hang-watchdog dumps
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: hang-dumps-coverage
+        path: hang-dumps/
+        if-no-files-found: ignore
+      continue-on-error: true
 
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ MagicMock/
 
 # Personal IDE launch configs (per-dev-machine; not portable)
 .claude/launch.json
+
+# ci-runner-hang watchdog: per-worker faulthandler dumps (CI artifact only)
+hang-dumps/

--- a/docs/specs/ci-runner-hang/phase2-findings.md
+++ b/docs/specs/ci-runner-hang/phase2-findings.md
@@ -1,0 +1,154 @@
+# Phase 2 Findings: CI Runner-Hang
+
+**Status:** in progress (diagnostics hardened; root fix gated on a
+captured frame)
+**Created:** 2026-06-14
+**Requirements:** [requirements.md](requirements.md) ·
+**Design:** [design.md](design.md) ·
+**Decisions:** [decisions.md](decisions.md)
+
+---
+
+## Summary
+
+Phase 1 (#874) armed a `faulthandler` watchdog but a fresh forensic
+capture on 2026-06-14 showed it had a gap: under xdist the dump fired
+inside the wedged *worker* and was lost when the job was killed, so we
+still had no frame. Phase 2 (this PR) closes that gap — the watchdog
+now writes each process's all-thread stack to a per-worker FILE that an
+`if: always()` CI step cats and uploads as an artifact, so a worker
+dump survives the `timeout-minutes` kill. The root fix (the polluting
+fixture/test) stays gated on a real captured frame per D1.
+
+---
+
+## Forensic capture — the hang's SHAPE
+
+From the `coverage` job of run `27488685349` (PR #876,
+`qa/analytics-commands`), killed at its 25-min timeout 05:14:34Z:
+
+- The full suite (`-n auto`, workers gw0–gw3, Linux) reached **99% at
+  04:54:29Z — only ~3.5 min in** — then froze for ~20 minutes (only
+  30-second `[mem-tick]` heartbeats, no test output) until the kill. A
+  real deadlock, not slowness.
+- Memory was **flat at ~3.2 GB** the entire freeze (`avail ~12.8 GB`) —
+  rules out OOM / memory leak (H4). A pure lock / uninterruptible-I/O
+  deadlock.
+- **Worker gw0 went silent FIRST**: its last output was
+  `[gw0] [ 89%] PASSED .../test_base_dataclasses.py::TestCostReport::
+  test_cost_report_default_cache_stats` at **04:53:56Z**. Workers
+  gw1/gw2/gw3 then drained their queues to 99% (last `[gw2]` at
+  04:54:29Z) and the session hung.
+
+This is a classic **xdist controller deadlock**: gw0 wedged mid-test,
+the other workers emptied their queues, and the controller waits
+forever for gw0 to report → the session never completes. Confirms
+hypothesis **H1** (design.md). The wedged test is the one gw0 picked up
+*after* its last PASSED (in/after
+`tests/unit/workflows/test_base_dataclasses.py`); the plain CI log only
+tags *completions* with `[gwN]`, never the in-flight test, so the exact
+gw0 test is not in the log — it must be reproduced.
+
+---
+
+## The Phase 1 watchdog GAP (root cause of "still no frame")
+
+Phase 1 armed
+`faulthandler.dump_traceback_later(secs, repeat=False)`, which defaults
+to `file=sys.stderr`. No dump appeared in the captured log even though
+the process was frozen 04:54→05:14 — well past the 600 s Linux trigger
+(which would fire ~05:01).
+
+**Why:** with pytest-xdist, `conftest.py` is imported in *each* worker
+subprocess, so the timer that matters fires inside the wedged worker
+(gw0). execnet does **not** forward a worker's raw fd-2 dump to the
+controller's stdout on a hang — worker output is surfaced via its own
+channel, typically flushed only at a test boundary/failure. So the
+dump was written to gw0's local stderr and discarded when the job was
+killed. The controller's own dump (had it fired) would have shown only
+the queue-wait, not the wedged frame.
+
+---
+
+## The fix (this PR) — make the worker dump survive
+
+Chose **option (a)** from the handoff (the robust one):
+
+1. **`tests/conftest.py`** — the watchdog now opens
+   `hang-dumps/hang-<worker>.txt` (keyed by `PYTEST_XDIST_WORKER`;
+   controller → `hang-controller`) and passes it as `file=` to
+   `dump_traceback_later`. The dir is workspace-relative (portable
+   across Linux/macOS/Windows lanes), the file ref is kept in a module
+   global so the fd stays alive, and the whole block is wrapped so an
+   un-writable workspace falls back to the Phase 1 stderr behavior
+   rather than breaking conftest import (which would fail *every*
+   test). faulthandler writes via the raw fd (async-signal-safe), so
+   the bytes hit the OS immediately — no buffer-flush concern; an
+   `[hang-watchdog] armed: …` line is printed at arm time for
+   correlation.
+
+2. **`.github/workflows/tests.yml`** — the `test` and `coverage` jobs
+   (the two `-n auto` lanes where the hang was observed) gained two
+   `if: always()` steps: "Surface hang-watchdog dumps" (cats every
+   non-empty dump into a `::group::`, prunes empty armed-but-never-
+   fired files) and "Upload hang-watchdog dumps" (uploads `hang-dumps/`
+   as a uniquely-named artifact, `if-no-files-found: ignore`). Because
+   the dump fires at ~10 min and the job is killed at 25/35 min, the
+   file is on disk before the kill and `if: always()` runs the capture
+   after the test step is cancelled.
+
+3. **Regression guard** — `tests/unit/ci/test_workflow_yaml.py::
+   TestHangDumpCapture` fails if either lane loses its
+   `if: always()` hang-dumps upload, so the gap can't silently reopen.
+
+4. **`.gitignore`** — `hang-dumps/` (CI artifact only; never committed).
+
+### Verification (G1, local)
+
+Injected hang reproduced the mechanism end-to-end:
+`CI=1 PYTEST_HANG_DUMP_SECONDS=3 pytest <hanging tests> -n 2`. Result:
+`hang-dumps/hang-gw0.txt` named the **exact wedged frame**
+(`test_hang.py line 3 in test_hangs`); `hang-controller.txt` showed the
+xdist `dsession.loop_once` queue-wait — the same deadlock shape as the
+forensic capture; non-hanging / respawned workers left empty files
+(pruned before upload). This is the frame Phase 1 lost.
+
+---
+
+## Follow-up (deliverable #2 — gated, NOT in this PR)
+
+Per D1 (diagnostics-first) and the tar-pit guard, the root fix waits
+for a real captured frame. Once the next ubuntu hang uploads a
+`hang-dumps-*` artifact (or `py-spy dump --pid <hung worker>` names it):
+
+1. Reproduce locally under load to re-wedge gw0:
+   `pytest tests/unit/workflows/test_base_dataclasses.py tests/workflows/
+   -n 4 -p no:cacheprovider` in a loop (or the whole suite `-n 4`),
+   watching for the 99%-freeze.
+2. Classify the frame: a worker blocked in uninterruptible I/O
+   (`socket.recv`, `subprocess.wait/communicate`, a lock `.acquire()`
+   inside a fixture) ⇒ H1/H2 — the same polluter family as
+   `windows-xdist-flakes` (real socket/subprocess I/O in a fixture,
+   hang-on-Linux vs crash-on-Windows).
+3. Fix the polluting fixture/test: make the I/O hermetic / properly
+   torn down (close sockets, terminate subprocesses, timeout on
+   `.wait()`), per the proven Windows-spec pattern.
+4. Land the P5 autouse guard (G4) that fails fast if a test opens a
+   real socket or spawns a real subprocess (OD3 says defer until H2 is
+   confirmed — now unblocked once a frame lands).
+5. Verify with a **rerun count** (≥10 clean `-n auto` reruns), not a
+   single green — the hang is nondeterministic / worker-distribution-
+   dependent (the same PR's required `test (ubuntu-latest, 3.12)` lane
+   PASSED while `coverage` wedged).
+
+### Watch-outs
+
+- `pytest-timeout`'s `--timeout=60 --timeout-method=thread` does NOT
+  fire on this GIL-blocked / uninterruptible wedge — do not expect it.
+- A clean run does not mean it's fixed; reproduce deliberately.
+- Keep the watchdog threshold (Linux 600 s) below every lane's normal
+  full-suite runtime so a slow-but-fine run never trips a false dump;
+  tune via `PYTEST_HANG_DUMP_SECONDS` if normal runtimes climb.
+- `clock-tz` also runs `-n auto` on ubuntu and could wedge; it was left
+  out of the capture steps to keep this PR scoped to the two
+  required-check lanes. Add the same two steps there if it ever hangs.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import faulthandler
 import json
 import os
+import sys
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,21 +38,61 @@ import pytest
 # deadlock) — invisible to a per-test thread timeout.
 #
 # Arm a process-level faulthandler watchdog so the NEXT hang dumps every
-# thread's stack to stderr (captured by CI) BEFORE the job `timeout-minutes`
-# kills it — turning an opaque stall into a named frame. Because this runs
-# at conftest import time, it arms in the xdist controller AND every worker
-# subprocess, and covers collection-time hangs too.
+# thread's stack BEFORE the job `timeout-minutes` kills it — turning an
+# opaque stall into a named frame. Because this runs at conftest import
+# time, it arms in the xdist controller AND every worker subprocess, and
+# covers collection-time hangs too.
+#
+# Phase 2 fix (the watchdog GAP): the dump MUST go to a per-process FILE,
+# not stderr. Under pytest-xdist the timer that matters fires inside the
+# wedged WORKER (e.g. gw0); execnet does NOT forward a worker's raw fd-2
+# dump to the controller's stdout on a HANG (worker output is surfaced via
+# its own channel, typically flushed only at a test boundary), so a
+# stderr dump is written to the worker's local stderr and LOST when the
+# job is killed at `timeout-minutes`. Forensic capture 2026-06-14 (run
+# 27488685349, coverage job): gw0 went silent first, the dump fired
+# ~05:01 but never reached the CI log. Writing to hang-dumps/hang-<worker>
+# .txt (workspace-relative, so a CI `if: always()` step can cat + upload
+# it as an artifact) makes the worker dump survive the kill. faulthandler
+# writes via the raw fd (async-signal-safe), so the bytes hit the OS
+# immediately — no Python-buffer flush needed; repeat=False writes once.
 #
 # Gated on the auto-set CI env var so local runs are unaffected. Threshold
 # is OS-tuned (Linux lanes are fast, ~4-8 min normal; Windows/macOS ~13-15)
 # and sits below the job timeout. Overridable via PYTEST_HANG_DUMP_SECONDS
-# for local smoke-testing.
+# for local smoke-testing (set CI=1 too, since the watchdog is CI-gated).
+_HANG_DUMP_FILE = None  # module-level ref keeps the fd alive for faulthandler
 if os.environ.get("CI"):
     _hang_default = 600.0 if os.environ.get("RUNNER_OS") == "Linux" else 1200.0
     _hang_secs = float(os.environ.get("PYTEST_HANG_DUMP_SECONDS", _hang_default))
-    # dump_traceback_later always dumps ALL threads (no all_threads kwarg —
-    # that exists only on register()/dump_traceback()).
-    faulthandler.dump_traceback_later(_hang_secs, repeat=False)
+    # Key the dump file by xdist worker (controller sees no worker env var).
+    # PYTEST_XDIST_WORKER is set in each worker subprocess's environment
+    # before its Python starts, so it is already present at conftest import.
+    _hang_worker = os.environ.get("PYTEST_XDIST_WORKER", "controller")
+    _hang_dir = Path(__file__).resolve().parent.parent / "hang-dumps"
+    try:
+        _hang_dir.mkdir(exist_ok=True)
+        # Line-buffered (buffering=1) is belt-and-suspenders; faulthandler
+        # writes via the fd directly regardless. Keep the ref in a module
+        # global so the file (and its fd) is not GC'd out from under the
+        # armed timer.
+        _HANG_DUMP_FILE = open(  # noqa: SIM115 (kept open for the watchdog's lifetime)
+            _hang_dir / f"hang-{_hang_worker}.txt", "w", buffering=1
+        )
+        # dump_traceback_later always dumps ALL threads (no all_threads
+        # kwarg — that exists only on register()/dump_traceback()).
+        faulthandler.dump_traceback_later(_hang_secs, repeat=False, file=_HANG_DUMP_FILE)
+        print(
+            f"[hang-watchdog] armed: {_hang_secs:.0f}s -> {_hang_dir.name}/"
+            f"hang-{_hang_worker}.txt",
+            file=sys.stderr,
+        )
+    except OSError:
+        # Never let an un-writable workspace break conftest import (which
+        # would fail collection on EVERY test). Fall back to the Phase 1
+        # stderr behavior — degraded (worker dumps still lost on a hang)
+        # but safe.
+        faulthandler.dump_traceback_later(_hang_secs, repeat=False)
 
 # =============================================================================
 # Import Guard - Ensure workflows package is properly initialized

--- a/tests/unit/ci/test_workflow_yaml.py
+++ b/tests/unit/ci/test_workflow_yaml.py
@@ -395,3 +395,45 @@ class TestPytestConfig:
             f"use an anchored pattern (/name), or add it to "
             f"TestPytestConfig._INTENTIONAL_EXCLUSIONS with a reason comment."
         )
+
+
+# ===========================================================================
+# 9. Hang-watchdog dump capture (ci-runner-hang Phase 2)
+# ===========================================================================
+
+
+class TestHangDumpCapture:
+    """The pytest lanes that wedge must upload the watchdog's hang dumps.
+
+    The conftest watchdog (Phase 1) writes each process's all-thread stack
+    to ``hang-dumps/hang-<worker>.txt``. Phase 2's whole point is that a
+    worker dump SURVIVES a ``timeout-minutes`` kill — which only works if
+    the job has an ``if: always()`` step that uploads ``hang-dumps/``.
+    Without this guard the capture step can be silently dropped in a future
+    ``tests.yml`` edit, re-opening the gap that lost the run-27488685349
+    stack. Guards the two `-n auto` lanes where the hang was observed.
+    """
+
+    LANES = ("test", "coverage")
+
+    @pytest.mark.parametrize("job_id", LANES)
+    def test_lane_uploads_hang_dumps_always(self, job_id):
+        """The test/coverage job must upload hang-dumps/ with if: always()."""
+        job = ALL_WORKFLOWS["tests.yml"]["jobs"][job_id]
+        upload = None
+        for step in job.get("steps", []):
+            uses = step.get("uses", "")
+            path = step.get("with", {}).get("path", "") or ""
+            if "upload-artifact" in uses and "hang-dumps" in path:
+                upload = step
+                break
+        assert upload is not None, (
+            f"tests.yml:{job_id} has no step uploading hang-dumps/ — a wedged "
+            f"worker's faulthandler dump would be lost on the timeout kill "
+            f"(ci-runner-hang Phase 2 regression)."
+        )
+        # `always()` is what makes the dump survive a timeout-minutes cancel.
+        assert "always()" in str(upload.get("if", "")), (
+            f"tests.yml:{job_id} hang-dumps upload must run with "
+            f"`if: always()` (else it is skipped when the job times out)."
+        )


### PR DESCRIPTION
## ci-runner-hang Phase 2 — make the worker hang-dump survive as a CI artifact

Advances [`docs/specs/ci-runner-hang`](https://github.com/Smart-AI-Memory/attune-ai/pull/873) to Phase 2. Phase 1 (#874) armed a faulthandler watchdog; a fresh forensic capture on 2026-06-14 pinned the hang's **shape** and exposed a **gap** in that watchdog. This PR closes the gap. The root fix stays gated on a captured frame (D1, diagnostics-first).

### The hang's shape (run `27488685349`, `coverage` job, killed at its 25-min timeout)
- Suite hit **99% at ~3.5 min in**, then froze ~20 min (only `[mem-tick]` heartbeats) until the kill — a real deadlock, not slowness.
- Memory **flat at ~3.2 GB** the whole freeze → not OOM.
- **gw0 went silent first** (last PASSED `test_base_dataclasses.py::TestCostReport::test_cost_report_default_cache_stats`); gw1/gw2/gw3 drained to 99% and the session hung → classic **xdist controller deadlock** (hypothesis H1).

### The Phase 1 gap
The watchdog dumped to `sys.stderr`. Under xdist the timer fires inside the wedged **worker** (gw0); execnet does **not** forward a worker's raw fd-2 dump to the controller on a hang, so the dump was written to gw0's local stderr and **lost** when the job was killed — we still had no frame.

### The fix
- **`tests/conftest.py`** — watchdog now writes each process's all-thread stack to `hang-dumps/hang-<worker>.txt` (keyed by `PYTEST_XDIST_WORKER`; controller → `hang-controller`). Workspace-relative (portable across all lanes), fd kept alive in a module global, fallback-safe so an un-writable workspace can't break conftest import.
- **`.github/workflows/tests.yml`** — `test` + `coverage` jobs gained two `if: always()` steps: cat each non-empty dump into a `::group::` (prune empty armed-but-never-fired files) and upload `hang-dumps/` as a uniquely-named artifact. The dump fires ~10 min; the job is killed at 25/35 min; `if: always()` runs the capture after the cancel.
- **Regression guard** — `tests/unit/ci/test_workflow_yaml.py::TestHangDumpCapture` fails if either lane drops its `always()` hang-dumps upload.
- **`.gitignore`** — `hang-dumps/` (artifact only).
- **`docs/specs/ci-runner-hang/phase2-findings.md`** — records the shape, gap, fix, and gated follow-up. (New file; no overlap with the spec PR #873.)

### Verification
- **G1 (local):** injected hang under `-n 2` → `hang-dumps/hang-gw0.txt` named the **exact wedged frame**; `hang-controller.txt` showed the `dsession.loop_once` queue-wait (same shape as the forensic capture). Empty/respawned-worker files pruned before upload.
- Workflow-yaml guard suite: **231 passed, 1 skipped** (incl. 2 new). Pinned `pre-commit` (black/ruff/bandit/detect-secrets/check-yaml) green on all changed files.
- Touches `tests.yml` → full matrix runs, validating the new steps on every lane.

### Follow-up (deliverable #2, NOT in this PR — gated on a captured frame)
Once the next ubuntu hang uploads a `hang-dumps-*` artifact (or `py-spy dump` names it): reproduce under `-n 4` load, classify the frame (expect socket/subprocess/lock in a fixture — the `windows-xdist-flakes` polluter family), fix the fixture hermetically, land the P5 autouse socket/subprocess guard (G4), and verify with ≥10 clean reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
