### PR TITLE
test(ci): Phase 4 out-of-class verification (src edit, must NOT auto-merge)

### DIFF
--- a/src/attune/__init__.py
+++ b/src/attune/__init__.py
@@ -340,3 +340,6 @@ __all__ = [
     "get_redis_memory",
     "load_config",
 ]
+
+# Phase 4 out-of-class auto-merge verification marker — this src/ edit
+# must NOT auto-merge. Safe to revert; PR will be closed after the test.


### PR DESCRIPTION
Phase 4 verification of the auto-merge-safe class — **out-of-class** case (comment-only `src/` edit; coverage stays green). Expected: NO `auto-merge-safe` label, and the `merge` job skips on its path-class re-check even when coverage is green. **This PR must NOT auto-merge** — it will be closed after verification.