### PR TITLE
fix(ci): auto-merge fires on workflow_run, not the dead check_run trigger

### DIFF
--- a/.github/workflows/auto-merge-safe.yml
+++ b/.github/workflows/auto-merge-safe.yml
@@ -20,7 +20,15 @@ name: Auto-merge safe (tests/docs only)
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
-  check_run:
+  # NOT check_run: a check_run produced by the `Tests` workflow runs
+  # under GITHUB_TOKEN, and GitHub does NOT start a new workflow run
+  # from a GITHUB_TOKEN-triggered event (anti-recursion). So the
+  # coverage check_run completing never reached this workflow. Use
+  # workflow_run instead — it fires when `Tests` finishes regardless
+  # of conclusion (so a hung/failed redundant lane doesn't block us),
+  # and the merge job re-checks the `coverage` check independently.
+  workflow_run:
+    workflows: ["Tests"]
     types: [completed]
 
 permissions: {}
@@ -28,7 +36,7 @@ permissions: {}
 concurrency:
   group: >-
     auto-merge-safe-${{ github.event.pull_request.head.sha ||
-    github.event.check_run.head_sha }}
+    github.event.workflow_run.head_sha }}
   cancel-in-progress: false
 
 jobs:
@@ -76,15 +84,14 @@ jobs:
           fi
 
   # ---------------------------------------------------------------
-  # When the `coverage` check goes green, re-evaluate ALL gates and
-  # admin-merge. Reacts the instant coverage succeeds, regardless of
-  # a still-hung redundant sibling lane (the whole point).
+  # When the `Tests` workflow completes (any conclusion), re-evaluate
+  # ALL gates and admin-merge. The job independently re-checks that
+  # the `coverage` check is green on the PR head, so a still-hung /
+  # failed redundant sibling lane (which makes the overall Tests run
+  # non-success) does not block the merge — that is the whole point.
   # ---------------------------------------------------------------
   merge:
-    if: >-
-      github.event_name == 'check_run' &&
-      github.event.check_run.name == 'coverage' &&
-      github.event.check_run.conclusion == 'success'
+    if: github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -96,7 +103,7 @@ jobs:
       - name: Evaluate gates and admin-merge
         env:
           GH_TOKEN: ${{ secrets.ADMIN_MERGE_TOKEN }}
-          SHA: ${{ github.event.check_run.head_sha }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
           REPO: ${{ github.repository }}
           OWNER_LOGIN: silversurfer562
         run: |


### PR DESCRIPTION
## Problem

The `auto-merge-safe` merge job (added in #878) **never fired**. It listened on `check_run: completed` for the `coverage` check — but that check run is produced by the `Tests` workflow under `GITHUB_TOKEN`, and GitHub does not start a new workflow run from a `GITHUB_TOKEN`-triggered event (anti-recursion rule).

**Verified live during Phase 4 testing:** on #881 (in-class docs PR), `coverage` went green but the PR never merged; the merge job skipped on every invocation and never executed once.

## Fix

Switch the merge trigger to `workflow_run` (`workflows: ["Tests"], types: [completed]`), which is not subject to the `GITHUB_TOKEN` limitation. The job already re-checks the `coverage` check conclusion on the PR head independently, so firing on `Tests` completion (any conclusion) still merges only when coverage is green — a hung/failed redundant lane no longer blocks the merge.

The `label` job (`pull_request_target`) is unchanged — it already works correctly (verified: #881 labeled in-class, #882 correctly not labeled).

## Follow-up

Re-test end-to-end once this lands — this will also finally exercise `ADMIN_MERGE_TOKEN` (the merge step it guards has never run). Relates to #878.