### PR TITLE
test(ops): align home-page TZ fixtures to UTC date (clock-tz UTC+14)

### DIFF
--- a/tests/unit/ops/test_home.py
+++ b/tests/unit/ops/test_home.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timezone
 
 import pytest
 
@@ -128,7 +128,6 @@ def test_home_renders_with_runner_recent_runs(tmp_path, monkeypatch):
     seeded = Run(id="abc123", workflow="code-review")
     seeded.status = "completed"
     seeded.exit_code = 0
-    from datetime import datetime, timezone
 
     seeded.started_at = datetime(2026, 5, 6, 12, 0, 0, tzinfo=timezone.utc)
     seeded.completed_at = datetime(2026, 5, 6, 12, 0, 5, tzinfo=timezone.utc)
@@ -169,7 +168,6 @@ def test_home_recent_runs_each_cell_links_to_run_view(tmp_path, monkeypatch):
     seeded = Run(id="abc12345", workflow="code-review")
     seeded.status = "completed"
     seeded.exit_code = 0
-    from datetime import datetime, timezone
 
     seeded.started_at = datetime(2026, 5, 6, 12, 0, 0, tzinfo=timezone.utc)
     seeded.completed_at = datetime(2026, 5, 6, 12, 0, 5, tzinfo=timezone.utc)
@@ -269,7 +267,14 @@ def test_home_renders_sparkline_svg_when_costs_present(tmp_path, monkeypatch):
     home = tmp_path / "attune-home"
     (home / "telemetry").mkdir(parents=True)
     log = home / "telemetry" / "usage.jsonl"
-    today = date.today().isoformat()
+    # UTC date, not local ``date.today()``: the event ts is UTC
+    # (``+00:00``) and the server windows the sparkline by UTC
+    # (``read_telemetry_summary``/``home_kpis`` anchor on
+    # ``datetime.now(timezone.utc).date()``). Stamping with local
+    # ``date.today()`` puts the event a UTC day in the future for any
+    # TZ ahead of UTC (e.g. UTC+14 Kiritimati), so it falls outside the
+    # 7-day window and the polyline vanishes. Same bug class as #868.
+    today = datetime.now(timezone.utc).date().isoformat()
     log.write_text(
         f'{{"workflow": "x", "total_cost": 0.42, "timestamp": "{today}T10:00:00+00:00"}}\n',
         encoding="utf-8",
@@ -298,7 +303,10 @@ def test_home_kpis_nonzero_when_telemetry_uses_ts_field(tmp_path, monkeypatch):
     home = tmp_path / "attune-home"
     (home / "telemetry").mkdir(parents=True)
     log = home / "telemetry" / "usage.jsonl"
-    today = date.today().isoformat()
+    # UTC date, not local ``date.today()`` — see the sparkline test
+    # above: local stamping puts the event a UTC day ahead under TZs
+    # east of UTC (UTC+14), dropping it from the UTC-anchored window.
+    today = datetime.now(timezone.utc).date().isoformat()
     # Write with ``ts`` (the real v1.0 schema key), NOT ``timestamp``.
     log.write_text(
         f'{{"workflow": "x", "total_cost": 0.42, "ts": "{today}T10:00:00+00:00"}}\n',

--- a/tests/unit/ops/test_telemetry_summary.py
+++ b/tests/unit/ops/test_telemetry_summary.py
@@ -21,8 +21,9 @@ from attune.ops.config import Config
 # Frozen "today" for the by-day-window assertions below. Events in the
 # fixtures are dated 2026-05-14; this anchors the rolling window to the
 # same day so the assertions don't age out as wall-clock time advances.
-# The production code path keeps using date.today() — the parameter
-# only affects tests that pass it.
+# The production code path defaults to the UTC date
+# (``datetime.now(timezone.utc).date()``) — the ``today`` parameter only
+# affects tests that pass it.
 _FIXED_TODAY = date(2026, 5, 14)
 
 


### PR DESCRIPTION
## What

Fixes the two `clock-tz (Pacific/Kiritimati)` (UTC+14) failures on `main`:

- `tests/unit/ops/test_home.py::test_home_renders_sparkline_svg_when_costs_present`
- `tests/unit/ops/test_home.py::test_home_kpis_nonzero_when_telemetry_uses_ts_field`

## Root cause — not where it looked

`src/attune/ops/data.py` is **already fully UTC-aligned**: `home_kpis`,
`read_telemetry_summary`, and `_to_day` all anchor on
`datetime.now(timezone.utc).date()`, and real telemetry events are
UTC-stamped via `_utcnow_iso()`. PR #868 fixed every production path.

The residual local-vs-UTC mismatch was in the **test fixtures**. Both
stamped their seeded event with local `date.today()`:

```python
today = date.today().isoformat()   # 2026-06-15 under UTC+14
log.write(... "ts": "{today}T10:00:00+00:00" ...)
```

Under `TZ=Pacific/Kiritimati`, local `date.today()` is **2026-06-15**
while the server's UTC window anchor is **2026-06-14**. The event lands
a UTC day in the *future*, outside the 7-day sparkline window → no
`<polyline>`, zero KPI tiles. Under TZs behind UTC, local never runs
ahead, so the tests passed there.

## Fix

Stamp both fixtures with `datetime.now(timezone.utc).date()` so the
event's UTC date matches the UTC window anchor under any TZ. Each
carries a comment naming the #868 bug class as a regression guard.
Also refreshed a stale comment in `test_telemetry_summary.py` that
still claimed the production path uses `date.today()`.

## Verification

- `tests/unit/ops/test_home.py` 12/12 and full `tests/unit/ops/`
  1277/1277 pass under `TZ=Pacific/Kiritimati`, `TZ=America/Anchorage`,
  and `TZ=UTC`.
- `black` + `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
