### PR TITLE
fix(ci): harden auto-merge-safe sha→PR lookup (prefer event payload) [D6]

### DIFF
--- a/.github/workflows/auto-merge-safe.yml
+++ b/.github/workflows/auto-merge-safe.yml
@@ -93,7 +93,7 @@ jobs:
   merge:
     if: github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -104,6 +104,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ADMIN_MERGE_TOKEN }}
           SHA: ${{ github.event.workflow_run.head_sha }}
+          # PRIMARY sha->PR source: the workflow_run event payload's
+          # pull_requests[] (synchronous, no indexing lag, populated for
+          # same-repo PRs — and our class requires head repo == base repo).
+          WORKFLOW_RUN_PRS: ${{ toJSON(github.event.workflow_run.pull_requests) }}
           REPO: ${{ github.repository }}
           OWNER_LOGIN: silversurfer562
         run: |
@@ -113,18 +117,58 @@ jobs:
             exit 0
           fi
 
+          # ---------------------------------------------------------------
+          # Resolve the triggering SHA -> PR number(s).
+          #
+          # PRIMARY: github.event.workflow_run.pull_requests[] — delivered
+          # in the event payload, so it has NO eventual-consistency lag and
+          # is populated for same-repo (non-fork) PRs, which is exactly our
+          # class. The diagnostic echo below records, per Phase-4 run,
+          # whether this repo actually populates the field.
+          #
+          # FALLBACK: repos/{repo}/commits/{sha}/pulls — an asynchronously
+          # INDEXED association endpoint that returns EMPTY for seconds-to-
+          # minutes after a push (root cause of the #884 bug, verified
+          # 2026-06-14: identical SHAs returned empty during the run and
+          # populated hours later while the PRs stayed open). Retried with
+          # backoff for the rare case the payload is empty too.
+          #
+          # Open/base re-checks live in the per-PR loop below, so resolution
+          # source doesn't matter to correctness — both feed the same gates.
+          # ---------------------------------------------------------------
+          echo "workflow_run.pull_requests payload: $WORKFLOW_RUN_PRS"
           mapfile -t prs < <(
-            gh api "repos/$REPO/commits/$SHA/pulls" \
-              --jq '.[] | select(.state=="open" and .base.ref=="main") | .number'
+            printf '%s' "${WORKFLOW_RUN_PRS:-[]}" | jq -r '.[].number' 2>/dev/null || true
           )
+
+          if [ "${#prs[@]}" -gt 0 ]; then
+            echo "Resolved ${#prs[@]} PR(s) from workflow_run.pull_requests: ${prs[*]}"
+          else
+            echo "workflow_run.pull_requests empty; falling back to commits/$SHA/pulls (with retry)."
+            for attempt in 1 2 3 4 5 6; do
+              mapfile -t prs < <(
+                gh api "repos/$REPO/commits/$SHA/pulls" \
+                  --jq '.[] | select(.base.ref=="main") | .number' 2>/dev/null || true
+              )
+              if [ "${#prs[@]}" -gt 0 ]; then
+                echo "commits/$SHA/pulls returned ${#prs[@]} PR(s) on attempt $attempt: ${prs[*]}"
+                break
+              fi
+              echo "attempt $attempt/6: commits/$SHA/pulls empty; sleeping 30s (indexing lag)."
+              sleep 30
+            done
+          fi
+
           if [ "${#prs[@]}" -eq 0 ]; then
-            echo "No open PR against main for $SHA."
+            echo "No PR resolved for $SHA (payload empty and commits/$SHA/pulls empty after retries)."
             exit 0
           fi
 
           for pr in "${prs[@]}"; do
             echo "::group::PR #$pr"
             meta=$(gh api "repos/$REPO/pulls/$pr" --jq '{
+              state: .state,
+              base_ref: .base.ref,
               author: .user.login,
               draft: .draft,
               head_repo: .head.repo.full_name,
@@ -132,6 +176,8 @@ jobs:
               head_sha: .head.sha,
               has_label: ([.labels[].name] | index("auto-merge-safe") != null)
             }')
+            state=$(echo "$meta" | jq -r .state)
+            base_ref=$(echo "$meta" | jq -r .base_ref)
             author=$(echo "$meta" | jq -r .author)
             draft=$(echo "$meta" | jq -r .draft)
             head_repo=$(echo "$meta" | jq -r .head_repo)
@@ -139,6 +185,12 @@ jobs:
             head_sha=$(echo "$meta" | jq -r .head_sha)
             has_label=$(echo "$meta" | jq -r .has_label)
 
+            if [ "$state" != "open" ]; then
+              echo "skip: PR state=$state (not open)"; echo "::endgroup::"; continue
+            fi
+            if [ "$base_ref" != "main" ]; then
+              echo "skip: base $base_ref != main"; echo "::endgroup::"; continue
+            fi
             if [ "$author" != "$OWNER_LOGIN" ]; then
               echo "skip: author $author != $OWNER_LOGIN"; echo "::endgroup::"; continue
             fi
@@ -165,7 +217,7 @@ jobs:
             fi
 
             # Coverage must be green on the PR's CURRENT head (the
-            # check_run that triggered us may be for an older SHA).
+            # workflow_run that triggered us may be for an older SHA).
             cov=$(gh api "repos/$REPO/commits/$head_sha/check-runs" \
               --jq '[.check_runs[] | select(.name=="coverage")] |
                     sort_by(.started_at) | last | .conclusion // "none"')

--- a/docs/specs/auto-merge-safe-class/decisions.md
+++ b/docs/specs/auto-merge-safe-class/decisions.md
@@ -1,6 +1,6 @@
 # Auto-Merge-Safe Class — Decisions
 
-**Status:** approved (2026-06-14)
+**Status:** approved (2026-06-14, amended with D5–D6 2026-06-14)
 
 ---
 
@@ -79,6 +79,74 @@ file removes the label). The **merge job re-runs the path-class
 guard** before merging, so even a hand-applied label on an
 out-of-class PR will not merge. Label = necessary, not
 sufficient.
+
+---
+
+## D5 — Merge trigger: `workflow_run`, not `check_run`
+
+**Shipped in [PR #883](https://github.com/Smart-AI-Memory/attune-ai/pull/883)
+(`0bc16edf9`, 2026-06-14); recorded here for completeness.**
+
+The merge job was originally triggered by `check_run: completed`
+for the `coverage` check. That trigger is **dead**: GitHub does
+not start a new workflow run from an event produced by the repo's
+own `GITHUB_TOKEN` (anti-recursion). The `coverage` check_run is
+produced by the `Tests` workflow under `GITHUB_TOKEN`, so its
+completion never reached this workflow (verified empirically:
+coverage went `success`, and >4 min later zero new runs existed,
+the PR stayed open).
+
+Fix: trigger on `workflow_run: workflows: ["Tests"], types:
+[completed]`. It fires when the whole `Tests` workflow finishes
+regardless of conclusion, so a hung/failed redundant lane does not
+suppress it, and the merge job re-checks `coverage` independently.
+
+**Caveat (out of scope):** `workflow_run` fires only when the
+ENTIRE `Tests` matrix completes, so a genuinely hung lane still
+delays the merge. Right-sizing the matrix is tracked separately.
+
+---
+
+## D6 — sha→PR resolution: event payload first, REST fallback with retry
+
+**Bug (found on [PR #884](https://github.com/Smart-AI-Memory/attune-ai/pull/884),
+2026-06-14):** with the D5 trigger live, #884's `Tests` completion
+DID invoke the merge job, but it logged `No open PR against main
+for <sha>` and bailed. The lookup
+`gh api repos/$REPO/commits/$SHA/pulls` returned EMPTY despite #884
+being open against `main` with exactly that head.
+
+**Root cause — verified, eventual-consistency lag (not a PAT
+quirk).** `commits/{sha}/pulls` is an asynchronously-INDEXED
+association endpoint; queried seconds-to-minutes after a push it
+can return empty, then populate later. Confirmed by a natural
+experiment: SHAs `2d9493ae` (#881) and `f904844d` (#873) each
+logged "No open PR" inside the merge run, yet the identical query
+returned those PRs as `open` hours later while the PRs were open
+the whole time. The fine-grained-PAT hypothesis is ruled out on
+mechanism — a repo-scoped PAT with Pull-requests:read has no
+per-PR visibility restriction for own-repo PRs, and the same
+empty→populated transition shows under a normal token.
+
+**Fix:**
+
+- **Primary** sha→PR source is
+  `github.event.workflow_run.pull_requests[]` — delivered in the
+  event payload, so it has no indexing lag and is populated for
+  same-repo PRs. Our class already requires head repo == base repo
+  (no forks), so this is exactly the population condition.
+- **Fallback** to `commits/{sha}/pulls`, retried with backoff
+  (6 × 30 s within a 10-min job timeout), for the rare case the
+  payload is empty.
+- **Open/base re-checks moved into the per-PR loop** (`state ==
+  open`, `base.ref == main`) so correctness no longer depends on
+  which source resolved the PR — both feed the same gate set
+  (author, draft, fork, label, path-class re-check, coverage on
+  head). The merge step logs the raw payload and which source
+  resolved, so Phase 4 records empirically whether
+  `workflow_run.pull_requests[]` populates on this repo.
+
+All D1 gates are preserved unchanged.
 
 ---
 


### PR DESCRIPTION
## What

Harden the `auto-merge-safe` merge job's SHA→PR resolution. Owning
spec: `docs/specs/auto-merge-safe-class/` (built #878, trigger fixed
#883). This is D6.

## Bug (PR #884, 2026-06-14)

With the #883 `workflow_run` trigger live, #884's `Tests` completion
DID invoke the merge job, but it logged `No open PR against main for
<sha>` and bailed — `gh api commits/$SHA/pulls` returned EMPTY while
#884 was plainly open against `main` with that exact head. The class
had **never merged a real PR end-to-end**.

## Root cause — verified

Eventual-consistency lag in the `commits/{sha}/pulls` association
index (NOT a PAT-visibility quirk). Natural experiment: SHAs
`2d9493ae` (#881) and `f904844d` (#873) each logged "No open PR"
inside the merge run, yet the identical query returns them as `open`
hours later while the PRs were open the whole time. A repo-scoped
fine-grained PAT has no per-PR visibility restriction for own-repo
PRs, so (b) is ruled out on mechanism.

## Fix

- **Primary** SHA→PR source: `github.event.workflow_run.pull_requests[]`
  — in the event payload, no indexing lag, populated for same-repo
  PRs (the class already requires head repo == base repo).
- **Fallback**: `commits/{sha}/pulls` retried with backoff (6×30s,
  10-min job timeout) for the rare empty-payload case.
- **Open + base==main re-checks moved into the per-PR loop**, so
  correctness is independent of which source resolved the PR. All D1
  gates (author, draft, fork, label, path-class re-check, coverage on
  head) preserved.
- Diagnostic logging of the raw payload + resolution source, so the
  Phase-4 run records empirically whether `workflow_run.pull_requests[]`
  populates on this repo.

Out of scope (noted in D5): `workflow_run` fires only when the WHOLE
`Tests` matrix completes, so a genuinely hung lane still delays merge.

## Decisions

`decisions.md` gains **D6** (this change) and **D5** (the
already-shipped #883 `check_run`→`workflow_run` trigger fix, recorded
for a gap-free history). @silversurfer562 / #883 owner: flagging the
D5 addition in case you intended to record it separately.

## Test plan

- [x] 33 path-guard unit tests pass (`auto_merge_guard.py` unchanged)
- [x] YAML validates; pre-commit clean
- [ ] **Phase 4 receipt (after this lands on main):** a tests/docs-only
      PR auto-merges; a `src/`-touching PR does NOT. (The merge job
      runs the workflow def from the default branch, so the fix must be
      on `main` before re-testing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
