### PR TITLE
fix(ci): strip whitespace from ADMIN_MERGE_TOKEN; correct D6 root cause

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8897,3 +8897,47 @@ files.
   wedged, controller-wait) but naming the culprit still needs the dying
   worker's own frame — an ABSENT worker dump is itself the signal
   (that worker died before the watchdog could fire).
+
+- **A trailing newline in a token SECRET makes EVERY `gh api` call
+  fail with `net/http: invalid header field value for "Authorization"`
+  — and inside `mapfile < <(gh api …)` that hard auth failure is
+  SILENTLY SWALLOWED under `set -e`, looking identical to "no data"**:
+  2026-06-14, the auto-merge-safe merge job (`auto-merge-safe.yml`)
+  logged `No open PR against main for <sha>` and bailed on every run.
+  Misdiagnosed for a full cycle as **eventual-consistency lag** in the
+  `commits/{sha}/pulls` association endpoint — even wrote a plausible
+  D6 decision blaming it, "confirmed" by a natural experiment that
+  queried the same SHAs hours later and got the PRs back. The
+  experiment was FLAWED: it used my own valid `gho_` token, never the
+  broken PAT. The real cause: `ADMIN_MERGE_TOKEN` was stored with a
+  trailing newline, so the `Authorization: Bearer <token>\n` header was
+  invalid and every `gh api` call 401'd/errored. Under `set -e`,
+  `mapfile -t prs < <(gh api … --jq …)` does NOT propagate the inner
+  command's failure (process-substitution exit status is unchecked), so
+  the error went to stderr and `prs` came back empty → "No open PR".
+  The bug only became visible when a LATER `gh api` call OUTSIDE a
+  process substitution (a bare `meta=$(gh api pulls/$pr …)`) finally
+  surfaced `invalid header field value` and exited non-zero. Durable
+  rules: (1) **a trailing newline in a secret is a top-suspect whenever
+  `gh`/curl auth "mysteriously" fails** — `gh secret set` from a file
+  or a UI paste easily includes one; defend by trimming in-workflow
+  (`TOKEN="$(printf '%s' "$TOKEN" | tr -d '[:space:]')"` — PATs never
+  contain whitespace) AND set cleanly (`printf %s 'tok' | gh secret
+  set`, never `echo`). (2) **`mapfile < <(cmd)` / `$(cmd)` in a
+  pipeline swallow failures under `set -e`** — a command whose failure
+  you must NOT ignore should run on its own line, or check `${PIPESTATUS
+  [@]}` / capture-then-test, so an auth/permission error fails LOUD
+  instead of masquerading as an empty result. (3) **when a lookup
+  returns empty, grep the run log for `error`/`invalid`/`401` BEFORE
+  theorizing about data/timing** — the `invalid header field value`
+  line was in run 27500989084's log the whole time; a too-narrow grep
+  for only the expected success/skip strings missed it, and a
+  verify-first read of the raw log would have skipped the entire
+  wrong-diagnosis detour. (4) **fine-grained PATs against an ORG repo
+  401 until the org approves them** (and expire fast); a classic PAT
+  with `repo` scope sidesteps the org fine-grained-approval dance when
+  you just need it working. Pairs with the "Verify-first applies to
+  infra/config diagnoses" and "research subagents confabulate — verify
+  before trusting" lessons — same discipline (read the authoritative
+  signal before asserting a cause), here applied to a CI auth failure
+  that two layers of swallowing kept invisible.

--- a/.github/workflows/auto-merge-safe.yml
+++ b/.github/workflows/auto-merge-safe.yml
@@ -117,6 +117,17 @@ jobs:
             exit 0
           fi
 
+          # Defensive: a trailing newline / whitespace in the secret value
+          # makes the HTTP Authorization header invalid ("net/http: invalid
+          # header field value for \"Authorization\""), so EVERY gh api call
+          # fails. A PAT never contains whitespace, so strip it. This was the
+          # true root cause of the #884/#881 merge failures — the secret was
+          # stored with a trailing newline (see D6); the empty sha->PR lookup
+          # was that auth error swallowed by a process substitution, NOT
+          # eventual-consistency lag.
+          GH_TOKEN="$(printf '%s' "$GH_TOKEN" | tr -d '[:space:]')"
+          export GH_TOKEN
+
           # ---------------------------------------------------------------
           # Resolve the triggering SHA -> PR number(s).
           #

--- a/docs/specs/auto-merge-safe-class/decisions.md
+++ b/docs/specs/auto-merge-safe-class/decisions.md
@@ -107,44 +107,64 @@ delays the merge. Right-sizing the matrix is tracked separately.
 
 ---
 
-## D6 — sha→PR resolution: event payload first, REST fallback with retry
+## D6 — true root cause: malformed `ADMIN_MERGE_TOKEN` (+ resolution hardening)
 
 **Bug (found on [PR #884](https://github.com/Smart-AI-Memory/attune-ai/pull/884),
 2026-06-14):** with the D5 trigger live, #884's `Tests` completion
 DID invoke the merge job, but it logged `No open PR against main
 for <sha>` and bailed. The lookup
-`gh api repos/$REPO/commits/$SHA/pulls` returned EMPTY despite #884
-being open against `main` with exactly that head.
+`gh api repos/$REPO/commits/$SHA/pulls` appeared to return EMPTY
+despite #884 being open against `main` with exactly that head.
 
-**Root cause — verified, eventual-consistency lag (not a PAT
-quirk).** `commits/{sha}/pulls` is an asynchronously-INDEXED
-association endpoint; queried seconds-to-minutes after a push it
-can return empty, then populate later. Confirmed by a natural
-experiment: SHAs `2d9493ae` (#881) and `f904844d` (#873) each
-logged "No open PR" inside the merge run, yet the identical query
-returned those PRs as `open` hours later while the PRs were open
-the whole time. The fine-grained-PAT hypothesis is ruled out on
-mechanism — a repo-scoped PAT with Pull-requests:read has no
-per-PR visibility restriction for own-repo PRs, and the same
-empty→populated transition shows under a normal token.
+**Root cause — VERIFIED, malformed token secret (NOT
+eventual-consistency lag).** An initial hypothesis blamed
+eventual-consistency lag in the `commits/{sha}/pulls` association
+index. That was **wrong** — corrected once the merge job finally
+failed loudly. The `ADMIN_MERGE_TOKEN` secret (created
+2026-06-14 12:38:34Z, never updated) was stored with a **trailing
+newline**, which makes the HTTP `Authorization` header invalid, so
+EVERY `gh api` call in the merge job fails with:
 
-**Fix:**
+```
+net/http: invalid header field value for "Authorization"
+```
 
-- **Primary** sha→PR source is
-  `github.event.workflow_run.pull_requests[]` — delivered in the
-  event payload, so it has no indexing lag and is populated for
-  same-repo PRs. Our class already requires head repo == base repo
-  (no forks), so this is exactly the population condition.
-- **Fallback** to `commits/{sha}/pulls`, retried with backoff
-  (6 × 30 s within a 10-min job timeout), for the rare case the
-  payload is empty.
-- **Open/base re-checks moved into the per-PR loop** (`state ==
-  open`, `base.ref == main`) so correctness no longer depends on
-  which source resolved the PR — both feed the same gate set
-  (author, draft, fork, label, path-class re-check, coverage on
-  head). The merge step logs the raw payload and which source
-  resolved, so Phase 4 records empirically whether
-  `workflow_run.pull_requests[]` populates on this repo.
+The original code ran `gh api commits/$SHA/pulls` inside a
+`mapfile < <(…)` process substitution; under `set -e` the
+process-substitution exit status is not checked, so the auth error
+was **swallowed** and surfaced as an empty array → "No open PR".
+The earlier "natural experiment" (querying the same SHAs hours
+later) was flawed: it used a *different, valid* token, so it never
+exercised the broken PAT. Direct evidence — run `27500989084`'s log
+contains the `invalid header field value` line immediately above
+its "No open PR" line; the error was present the whole time and was
+missed by a too-narrow log grep.
+
+**Fix (two parts):**
+
+1. **Strip whitespace from the token (the actual fix).**
+   `GH_TOKEN="$(printf '%s' "$GH_TOKEN" | tr -d '[:space:]')"` at
+   the top of the merge step. A PAT never contains whitespace, so
+   this is safe and makes the job robust to a secret stored with a
+   stray newline. Companion hygiene action: re-enter the secret
+   cleanly (`printf %s "$PAT" | gh secret set ADMIN_MERGE_TOKEN`,
+   no trailing newline).
+2. **sha→PR resolution hardening (robustness, independent of the
+   token bug).** Prefer `github.event.workflow_run.pull_requests[]`
+   (event payload — synchronous, populated for same-repo PRs, which
+   our no-fork class guarantees); fall back to `commits/{sha}/pulls`
+   with retry/backoff. Open/base re-checks moved into the per-PR
+   loop (`state == open`, `base.ref == main`) so correctness is
+   independent of which source resolved the PR. This both reduces
+   API calls and guards against *genuine* indexing lag — confirmed
+   working: it resolved #881 from the payload instantly.
+
+**Lesson:** a hard auth failure inside a `mapfile < <(gh api …)`
+process substitution is silently swallowed under `set -e` and looks
+identical to "no data." Prefer surfacing such errors (the per-PR
+loop's bare `gh api` call, which is NOT in a process substitution,
+is what finally exposed it). And grep logs for `error`/`invalid`,
+not just the expected success/skip strings.
 
 All D1 gates are preserved unchanged.
 


### PR DESCRIPTION
## What

Follow-up to #885. Fixes the **actual** root cause of the
auto-merge-safe merge-job failures and corrects the D6 record.

## True root cause (corrected)

#885's D6 blamed eventual-consistency lag in `commits/{sha}/pulls`.
**That was wrong.** Once the merge job finally failed loudly (after
#885's payload-resolution landed), the real cause was visible:

```
net/http: invalid header field value for "Authorization"
```

The `ADMIN_MERGE_TOKEN` secret was stored with a **trailing newline**,
which is invalid in an HTTP Authorization header — so *every* `gh api`
call in the merge job failed. The old `mapfile < <(gh api ...)`
process substitution swallowed that error under `set -e` and surfaced
it as a benign-looking empty "No open PR". Direct evidence: run
[27500989084](https://github.com/Smart-AI-Memory/attune-ai/actions/runs/27500989084)'s
log contains the `invalid header field value` line immediately above
its "No open PR" line — present the whole time, missed by a too-narrow
log grep.

## Fix

- **Strip whitespace from the token** at the top of the merge step
  (`tr -d '[:space:]'`). A PAT never contains whitespace, so this makes
  the job robust to a secret stored with a stray newline.
- **Correct D6** in `decisions.md`: real root cause = malformed token,
  plus the swallowed-error lesson. The payload-first sha→PR resolution
  from #885 is retained as genuine robustness (it resolved #881 from
  the event payload instantly, no lag).

Companion hygiene action (done by owner): the secret was also re-entered
cleanly.

## Receipt

Phase-4 end-to-end verification (#881 in-class auto-merges, #882
out-of-class does not) is being captured against main; result appended
below once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
