### PR TITLE
fix(ci): retry admin merge on concurrent-merge race (auto-merge-safe)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -8971,3 +8971,39 @@ files.
   and "xfail-as-test-bug" lessons (verify actual behavior against a
   controlled input) and the Windows-portability lessons (same family:
   environment-dependent test outcomes that pass locally, fail elsewhere).
+
+- **The auto-merge-safe merge job races itself when ≥2 in-class PRs
+  go green together — the first squash advances `main`, the sibling's
+  merge fails "Base branch was modified," and the old `|| echo` ate
+  it with no retry**: hit live 2026-06-14 (QA #6). Three in-class PRs
+  (#892/#893/#894) turned green within seconds; their independent
+  `workflow_run` merge jobs fired at 21:05:49 / :50 / :52. #892 and
+  #893 admin-squashed into `main` first; #894's merge job (which had
+  resolved the PR and passed EVERY gate — path-class ✓,
+  coverage=success ✓, label ✓) then hit
+  `GraphQL: Base branch was modified. Review and try the merge again.
+  (mergePullRequest)`. The line
+  `gh pr merge … --admin || echo "merge call failed (possibly already
+  merged)"` swallowed the GraphQL error and exited 0, leaving #894
+  **OPEN with all gates green and no retry**. Diagnosis: read the
+  merge job's OWN log for the failing PR's SHA
+  (`gh run view <auto-merge-safe-run> --log | grep -A2 "admin
+  squash-merge PR #<n>"`) — the gate-skip echoes (`skip: coverage=…`,
+  `skip: path-class…`) are just the script source unless followed by
+  a real "skip:" line; the actual failure was the GraphQL message
+  AFTER "All gates pass". Two durable points: (1) **fix** — wrap the
+  admin merge in a bounded retry (re-fetch + retry on "Base branch was
+  modified"; treat `.merged==true` as success; `::warning::` + leave
+  open on exhaustion) — shipped as D7 / PR #895. (2) **recover an
+  already-stalled PR via the existing system, not a manual admin
+  merge** — main is stable once the racing siblings land, so any
+  re-fire of that PR's merge job merges it: `gh run rerun <its-Tests-
+  run> --failed`, then once `coverage` is green again `gh run cancel
+  <that-run>` to force run COMPLETION → `workflow_run` fires → merge
+  job re-evaluates against now-stable main → admin-merges. Verified:
+  #894 merged on the re-fire within ~40s of the cancel. Pairs with D6
+  (token-newline auth swallowed by process substitution) — same shape
+  ("merge job resolved the PR but the merge CALL failed, silently"),
+  different cause (race vs auth); and with the cancel-to-bypass
+  runner-hang technique (same `gh run cancel → workflow_run fires`
+  mechanism, here used to RE-fire rather than first-fire).

--- a/.github/workflows/auto-merge-safe.yml
+++ b/.github/workflows/auto-merge-safe.yml
@@ -237,7 +237,26 @@ jobs:
             fi
 
             echo "All gates pass -> admin squash-merge PR #$pr"
-            gh pr merge "$pr" --squash --admin --delete-branch || \
-              echo "merge call failed (possibly already merged)"
+            # Retry the admin merge to survive the concurrent-merge race:
+            # when several in-class PRs go green together, their merge jobs
+            # fire within seconds. The first squash advances main, so a
+            # sibling's merge a moment later fails with
+            #   "Base branch was modified. Review and try the merge again."
+            # That is transient — main is stable once the siblings land —
+            # so re-fetch and retry with backoff. "already merged" (a
+            # concurrent job won the race) is success, not failure.
+            merged=false
+            for attempt in 1 2 3 4 5; do
+              if out=$(gh pr merge "$pr" --squash --admin --delete-branch 2>&1); then
+                echo "merged PR #$pr on attempt $attempt"; merged=true; break
+              fi
+              echo "merge attempt $attempt/5 failed: $out"
+              if [ "$(gh api "repos/$REPO/pulls/$pr" --jq .merged 2>/dev/null)" = "true" ]; then
+                echo "PR #$pr already merged (concurrent job won)"; merged=true; break
+              fi
+              sleep 6
+            done
+            [ "$merged" = "true" ] || \
+              echo "::warning::PR #$pr unresolved after 5 merge attempts (left open)"
             echo "::endgroup::"
           done

--- a/docs/specs/auto-merge-safe-class/decisions.md
+++ b/docs/specs/auto-merge-safe-class/decisions.md
@@ -198,3 +198,41 @@ required checks; the whole problem is that a required check
 **Rejected: cannot work here.** The bot is not an admin and there
 is no ruleset bypass, so `--admin` fails on exactly the
 hung-check case. (See D3.)
+
+---
+
+## D7 — Retry the admin merge on the concurrent-merge race
+
+**Date:** 2026-06-14
+**Status:** adopted
+
+**Symptom.** Three in-class PRs (#892, #893, #894) went green
+together and their merge jobs fired within ~3 seconds. #892 and
+#893 squash-merged first, advancing `main`. #894's merge fired ~2s
+later and GitHub rejected it:
+
+```text
+GraphQL: Base branch was modified. Review and try the merge again.
+(mergePullRequest)
+```
+
+The old code swallowed this with `|| echo "merge call failed
+(possibly already merged)"` and exited 0 — so #894 sat OPEN with
+**every gate green** (path-class ✓, coverage=success ✓, label ✓)
+and no retry. Any batch of ≥2 simultaneously-green in-class PRs can
+hit this; it is not specific to the cancel-to-bypass flow.
+
+**Fix.** Wrap the `gh pr merge --squash --admin --delete-branch`
+call in a 5-attempt loop with a 6s backoff. "Base branch was
+modified" is transient — `main` is stable once the racing siblings
+land — so a re-fetch + retry succeeds. A concurrent job that already
+merged the PR (`pulls/$pr .merged == true`) is treated as success,
+not failure. Exhausting all attempts emits a `::warning::` and
+leaves the PR open (fail-open, visible).
+
+**Scope.** This is a `.github/workflows/` change, so the fix PR is
+**out-of-class** and merges via human review (CI files cannot
+self-merge — correct). Pairs with D6 (the token-newline auth fix):
+both are "the merge job resolved the PR but the merge call failed"
+shapes — D6 was an auth error swallowed by process substitution,
+D7 is a race swallowed by `|| echo`.


### PR DESCRIPTION
## Problem

Three in-class PRs ([#892](https://github.com/Smart-AI-Memory/attune-ai/pull/892), [#893](https://github.com/Smart-AI-Memory/attune-ai/pull/893), [#894](https://github.com/Smart-AI-Memory/attune-ai/pull/894)) went green
together and their merge jobs fired within ~3 seconds. #892 and #893
squash-merged first, advancing `main`. #894's merge fired ~2s later
and GitHub rejected it:

\`\`\`
GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)
\`\`\`

The old code swallowed this with \`|| echo "merge call failed
(possibly already merged)"\` and exited 0 — so #894 sat **OPEN with
every gate green** (path-class ✓, coverage=success ✓, label ✓) and
no retry. Any batch of ≥2 simultaneously-green in-class PRs can hit
this.

## Fix

Wrap \`gh pr merge --squash --admin --delete-branch\` in a 5-attempt
loop with 6s backoff:

- "Base branch was modified" is transient (main is stable once the
  racing siblings land) → re-fetch + retry succeeds.
- A concurrent job that already merged the PR (\`.merged == true\`)
  is treated as success.
- Exhausting all attempts emits a \`::warning::\` and leaves the PR
  open (fail-open, visible — never a silent drop).

Diagnosis recorded as **D7** in
\`docs/specs/auto-merge-safe-class/decisions.md\`. Pairs with D6
(token-newline auth fix) — both are "merge job resolved the PR but
the merge call failed" shapes.

## Note

This touches \`.github/workflows/\`, so it is **out-of-class** and
needs human review/merge (CI files cannot self-merge — by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)