### PR TITLE
docs(test-quality): coverage omit-list audit [QA #6]

### DIFF
--- a/docs/specs/test-quality-program/omit-audit.md
+++ b/docs/specs/test-quality-program/omit-audit.md
@@ -1,0 +1,99 @@
+# Coverage `omit` list audit (QA #6, 2026-06-14)
+
+**Question:** are the modules in `pyproject.toml`'s
+`[tool.coverage.run] omit` genuinely untestable, or just untested?
+
+**Method:** for each entry whose comment claims a testability-blocking
+reason ("Requires LLM API calls", "Interactive", "Requires Redis",
+server), probe (a) does it import cleanly **keyless**
+(`ANTHROPIC_API_KEY=""`) — i.e. is the external dep needed at import or
+only at call time? and (b) its nature (dataclass / parsing / CLI /
+server / shim). Obvious excludes (`__init__.py`, `__main__.py`,
+`*_example.py`, deprecated `agent_factory` adapters, the `config.py`
+shadow) were not re-litigated.
+
+**Headline:** nearly every "untestable" module imports fine keyless —
+the external dependency is used at **call** time, so it is mockable.
+The omit comments describe *why a naive test would hit the network*,
+not an actual testability barrier. Several entries are mislabeled
+(dataclasses/shims tagged "Requires LLM API calls") and two are stale.
+
+---
+
+## Tier 1 — Stale / ineffective omits (remove; no testing needed)
+
+| Entry | Finding |
+|-------|---------|
+| `*/cache/hybrid.py` | `src/attune/cache/` does not exist — file deleted. Dead entry. |
+| `*/memory/cross_session.py` | Real file is `memory/short_term/cross_session.py`; the glob `*/memory/cross_session.py` does **not** match it, so the omit is a no-op (the file is measured normally or not at all). Fix the path or drop it. |
+
+---
+
+## Tier 2 — Mislabeled / wrongly omitted, high-ROI (convert)
+
+All import keyless; the "LLM/Redis" reason is an optional `try/except`
+import or a call-time dependency, not an import barrier.
+
+| Entry | loc | Real nature | Note |
+|-------|-----|-------------|------|
+| `agents/release/release_models.py` | 206 | Enums + `@dataclass` + config constants | "Requires LLM API calls" is wrong — pure data types. Trivially testable. |
+| `agents/release/release_parsing.py` | 60 | Pure parsing functions | Testable with literal inputs; no LLM. |
+| `agents/release/release_agents.py` | 27 | Re-export shim | One import test ≈ 100%. |
+| `agents/release/release_prep_team.py` | 420 | Orchestration (redis + llm at call time) | Mockable like `base_agent` (#896) — larger effort. |
+| `memory/claude_memory.py` | 309 | dataclasses + Claude at call time | Mock the client (cf. research_synthesis #892). |
+| `monitoring/otel_backend.py` | 268 | plain logic | Mock the otel SDK. |
+| `orchestration/_strategies/base.py` | 203 | plain logic / abstract base | Testable directly. |
+| `orchestration/execution_strategies.py` | 109 | plain logic | "Requires live agents" → inject mock agents. |
+| `core_modules/short_term_memory.py` | 222 | redis at call time | Mock redis. |
+| `meta_workflows/cli_commands/memory_commands.py` | 137 | plain logic | cf. existing `cli_commands` tests. |
+| `meta_workflows/cli_commands/analytics_commands.py` | 323 | plain logic | "" |
+| `meta_workflows/cli_commands/agent_commands.py` | 248 | plain logic | "" |
+| `meta_workflows/cli_commands/template_commands.py` | 268 | logic | "" |
+| `meta_workflows/cli_commands/config_commands.py` | 170 | logic | "" |
+
+---
+
+## Tier 3 — Testable, lower ROI (more harness effort)
+
+| Entry | loc | Why harder |
+|-------|-----|-----------|
+| `models/auth_cli.py` | 343 | `input()`-driven; mock stdin/Prompt. |
+| `monitoring/alerts_cli.py` | 344 | interactive CLI. |
+| `core_modules/interaction.py` | 164 | interactive prompts. |
+| `memory/control_panel_api.py` | 328 | FastAPI — coverable via `TestClient`. |
+| `memory/short_term/sessions.py` | 191 | redis-mockable (partly addressed in QA #5). |
+| `socratic/collaboration*.py` | ~500 | external collab service; verify not deprecated before investing. |
+
+---
+
+## Tier 4 — Keep omitted (genuinely not unit-testable)
+
+`mcp/server.py`, `workflows/progress_server.py` (live protocol
+servers), `project_index/scanner_parallel.py` (multiprocessing),
+`project_index/index.py` (integration-tested), all `__init__.py` /
+`__main__.py` package/entry stubs, `*_example.py`, deprecated
+`agent_factory/*` adapters, and `config.py` (import-shadowed). Hook
+scripts (`hooks/scripts/*.py`) are tagged "standalone / not importable
+via pytest" — **needs a second pass** to confirm (some may import and
+be partially coverable).
+
+---
+
+## Recommendations
+
+1. **Quick win:** delete the two Tier-1 stale entries.
+2. **Backlog:** convert Tier-2 one module per PR, cheapest first —
+   `release_models.py`, `release_parsing.py`, `release_agents.py` are
+   near-free. Each conversion = remove its `omit` line **and** add a
+   net-new test (the `omit`-line removal makes the PR out-of-class →
+   needs human merge; pure test additions without removing `omit`
+   would not count toward measured coverage).
+3. **Hygiene:** the `omit` comments should state the *real* reason.
+   "Requires LLM API calls" on a dataclasses file is how this debt
+   accumulated — a module gets parked in `omit` once and the label is
+   never revisited. Consider a periodic re-audit (this doc) and/or a
+   check that flags `omit` entries whose files import cleanly keyless.
+
+**Caveat:** this audit covers the "claims-untestable" entries, not the
+hook scripts or every `__init__`. Tier-2 alone is ~2,000 statements of
+currently-unmeasured, testable code.


### PR DESCRIPTION
## Summary

Audit of `pyproject.toml` `[tool.coverage.run] omit` — are the omitted
modules genuinely untestable, or just untested?

**Finding:** nearly every "untestable" module imports cleanly
**keyless** — the LLM/Redis/server dependency is used at *call* time
(mockable), not import time. The `omit` comments describe why a naive
test would hit the network, not a real barrier. Two entries are stale,
several are mislabeled (e.g. `release_models.py` tagged "Requires LLM
API calls" is actually Enums + dataclasses + config).

## Tiers

- **T1 stale (delete):** `cache/hybrid.py` (file deleted),
  `memory/cross_session.py` (glob mismatches real path).
- **T2 wrongly-omitted, high-ROI (~2,000 stmts):** release
  models/parsing/shim, `claude_memory`, `otel_backend`,
  orchestration strategies, the meta_workflows `cli_commands/*`.
- **T3 testable, more effort:** interactive CLIs, FastAPI control
  panel, socratic collab.
- **T4 keep omitted:** live servers, multiprocessing scanner,
  package `__init__`/`__main__`, examples, deprecated adapters.

Full doc: `docs/specs/test-quality-program/omit-audit.md`.

Docs-only, in-class for the auto-merge-safe class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)