### PR TITLE
test(agents): un-omit release_parsing + release_agents; drop dead cache omit [QA #6]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -688,11 +688,7 @@ omit = [
     "*/memory/short_term/sessions.py",  # Requires Redis server
     "*/memory/claude_memory.py",  # Requires Claude API
     # Agent modules requiring live LLM
-    "*/agents/release/release_agents.py",  # Requires LLM API calls
     "*/agents/release/release_prep_team.py",  # Requires LLM API calls
-    "*/agents/release/release_parsing.py",  # Requires LLM API calls
-    # Cache requiring Redis
-    "*/cache/hybrid.py",  # Requires Redis for hybrid caching
     # OpenTelemetry backend (requires otel infrastructure)
     "*/monitoring/otel_backend.py",  # Requires OpenTelemetry SDK
     # Orchestration execution (requires external services)

--- a/tests/unit/agents/release/test_release_agents_shim.py
+++ b/tests/unit/agents/release/test_release_agents_shim.py
@@ -1,0 +1,45 @@
+"""Tests for the release_agents re-export shim.
+
+release_agents.py re-exports the agent classes that were refactored into
+focused submodules, so existing
+``from attune.agents.release.release_agents import ReleaseAgent`` imports
+keep working. Previously omitted "Requires LLM API calls" — it is a pure
+import shim with no LLM. Un-omitted alongside this file per the
+omit-audit.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.agents.release import release_agents
+
+
+class TestReExportShim:
+    def test_all_names_exported(self):
+        for name in (
+            "CodeQualityAgent",
+            "DocumentationAgent",
+            "ReleaseAgent",
+            "SecurityAuditorAgent",
+            "TestCoverageAgent",
+        ):
+            assert name in release_agents.__all__
+            assert hasattr(release_agents, name)
+
+    def test_reexports_are_the_canonical_classes(self):
+        from attune.agents.release.base_agent import ReleaseAgent as BaseReleaseAgent
+
+        assert release_agents.ReleaseAgent is BaseReleaseAgent
+
+    def test_run_command_helper_reexported(self):
+        from attune.agents.release.base_agent import _run_command as canonical
+
+        assert release_agents._run_command is canonical
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/agents/release/test_release_parsing.py
+++ b/tests/unit/agents/release/test_release_parsing.py
@@ -1,0 +1,95 @@
+"""Tests for release_parsing._parse_response.
+
+Covers all four parse strategies (XML, markdown-fenced, raw JSON, regex
+extraction) plus their failure fallthroughs. Pure function, no external
+deps — previously omitted from coverage as "Requires LLM API calls"
+(mislabeled; un-omitted alongside this file per the omit-audit).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.agents.release.release_parsing import _parse_response
+
+
+class TestEmpty:
+    def test_empty_string(self):
+        assert _parse_response("") == {"parse_error": "empty response"}
+
+    def test_whitespace_only(self):
+        assert _parse_response("   \n\t ") == {"parse_error": "empty response"}
+
+
+class TestXmlStrategy:
+    def test_valid_xml_json(self):
+        out = _parse_response('<analysis>{"score": 9.0}</analysis>')
+        assert out == {"score": 9.0}
+
+    def test_invalid_xml_json_falls_through(self):
+        # XML block present but bad JSON → falls through to later strategies,
+        # ultimately the no-content error (no score/coverage tokens).
+        out = _parse_response("<analysis>not json</analysis>")
+        assert out["parse_error"] == "no parseable content"
+
+
+class TestMarkdownStrategy:
+    def test_valid_fenced_json(self):
+        out = _parse_response('```json\n{"coverage_percent": 85}\n```')
+        assert out == {"coverage_percent": 85}
+
+    def test_fenced_without_lang(self):
+        out = _parse_response('```\n{"score": 7}\n```')
+        assert out == {"score": 7}
+
+    def test_invalid_fenced_falls_through(self):
+        out = _parse_response("```\nnope\n```")
+        assert out["parse_error"] == "no parseable content"
+
+
+class TestRawJsonStrategy:
+    def test_valid_raw_json(self):
+        out = _parse_response('{"approved": true, "score": 8.5}')
+        assert out["approved"] is True
+        assert out["score"] == 8.5
+
+    def test_invalid_raw_json_falls_through(self):
+        # Starts with { but isn't valid JSON → regex last resort, then error.
+        out = _parse_response("{ broken")
+        assert out["parse_error"] == "no parseable content"
+
+
+class TestRegexStrategy:
+    def test_extracts_score(self):
+        out = _parse_response("Overall score: 7.5 looks good")
+        assert out["score"] == 7.5
+        assert out["parse_method"] == "regex"
+
+    def test_extracts_coverage(self):
+        out = _parse_response("Coverage: 92% of lines")
+        assert out["coverage_percent"] == 92.0
+        assert out["parse_method"] == "regex"
+
+    def test_extracts_critical_issues(self):
+        out = _parse_response("Found 3 critical issues in the scan")
+        assert out["critical_issues"] == 3
+        assert out["parse_method"] == "regex"
+
+    def test_extracts_multiple_metrics(self):
+        out = _parse_response("score: 6, coverage: 80%, 2 high findings")
+        assert out["score"] == 6.0
+        assert out["coverage_percent"] == 80.0
+        assert out["critical_issues"] == 2
+
+    def test_no_parseable_content_truncates_raw(self):
+        long_text = "x" * 1000
+        out = _parse_response(long_text)
+        assert out["parse_error"] == "no parseable content"
+        assert len(out["raw_text"]) == 500
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Omit-audit conversions round 2 (after release_models
[#901](https://github.com/Smart-AI-Memory/attune-ai/pull/901)), from
`docs/specs/test-quality-program/omit-audit.md`.

| Module | Was | Now | Note |
|--------|-----|-----|------|
| `release_parsing.py` | omit "Requires LLM API calls" | **100%** | pure multi-strategy parser, no LLM; net-new test |
| `release_agents.py` | omit "Requires LLM API calls" | **100%** | re-export shim, no LLM; import test |
| `cache/hybrid.py` | omit "Requires Redis" | removed | **stale** — `src/attune/cache/` was deleted |

Both modules measured alone at 100%. `cache/hybrid.py` is a dead
pattern (file no longer exists).

## Deferred

`cross_session.py`'s stale-glob removal is **not** in this PR — the
audit flagged the glob `*/memory/cross_session.py` as mismatching the
real path `memory/short_term/cross_session.py`, but multiple
`cross_session` test files target a different module, so removing it
needs a careful full-suite coverage check. Handled separately to keep
this PR low-risk.

## Note

Touches `pyproject.toml` → **out-of-class**, needs human review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)