### PR TITLE
docs(ci): gating-lane isolation spec + omit conversion backlog [QA #6]

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -9045,3 +9045,48 @@ files.
   lessons (per-module measurement) — this is the *discovery* half:
   whole-tree sweep to find the gap, omit cross-check to confirm it's
   real, then measure the one module alone.
+
+- **Cancelling a Tests run to bypass a hung lane KILLS the in-flight
+  `coverage` job if coverage hasn't concluded yet — the merge job then
+  skips with `coverage=cancelled`; never cancel before coverage is
+  green, and recover a killed coverage with `rerun --failed`**: the
+  cancel-to-fire trick (cancel the run → `workflow_run` fires → merge
+  job re-checks coverage independently) ONLY works when `coverage` has
+  ALREADY concluded `success`. Hit twice on #896/#904 (2026-06-14):
+  acted on "all that's left is clock-tz" without reading the coverage
+  check-run's own state, cancelled, and killed a still-running
+  coverage → the merge job correctly refused (`skip: coverage=cancelled
+  on <sha>`). Two rules: (1) **before any `gh run cancel` of a gating
+  Tests run, read the coverage check-run conclusion directly** —
+  `gh api repos/<o>/<r>/commits/<head_sha>/check-runs --jq
+  '[.check_runs[]|select(.name=="coverage")]|sort_by(.started_at)|last|
+  .conclusion // .status'` — and only cancel if it is `success`; (2)
+  to recover a coverage killed this way, `gh run rerun <run> --failed`
+  (cancelled counts as failed → coverage re-runs), wait for it to go
+  `success`, THEN cancel the still-hung redundant lanes. The
+  starter-prompt already says "a hung/cancelled coverage lane is NOT
+  bypassable" — this is the self-inflicted version of that: don't
+  CREATE a cancelled-coverage by cancelling too early. Pairs with the
+  "cancel-to-bypass / cancel-to-RE-fire" runner-hang techniques (same
+  mechanism, this is the precondition they omit).
+
+- **Admin-merging on a HUNG `coverage` lane is defensible when the
+  full suite is independently green AND the diff can only RAISE
+  coverage — but state that reasoning explicitly**: #904 (2026-06-14)
+  un-omitted two 100%-covered modules + dropped a dead omit; `coverage`
+  hung twice (~25 min, runner-hang) but `test (ubuntu-latest, 3.12)`
+  (which runs the SAME suite) was green and every other required check
+  passed. With explicit in-session user authorization, admin-merged on
+  the reasoning: (a) the suite is verified (3.12 green = coverage's own
+  test run), and (b) the change is **coverage-additive by
+  construction** — un-omits add 100% modules, the cache removal targets
+  a deleted file — so the `--cov-fail-under` threshold *cannot* be the
+  thing failing; only the runner is stuck. This is the INVERSE of the
+  documented "coverage green + OS lane hung ⇒ admin-merge safe" rule
+  (here coverage is the stuck lane, an OS lane is the green proof), and
+  it only holds when the diff is provably non-coverage-lowering — a
+  src-change that could drop coverage does NOT qualify (wait for a real
+  coverage pass). Requires explicit merge authorization (the safety
+  classifier needs it regardless of how sound the reasoning is). Pairs
+  with the "advisory CI lanes don't gate" and "coverage re-runs the
+  full suite, so a hung OS lane is safe to admin-merge" lessons.

--- a/docs/specs/ci-gating-lane-isolation/decisions.md
+++ b/docs/specs/ci-gating-lane-isolation/decisions.md
@@ -1,0 +1,33 @@
+# Decisions — CI gating-lane isolation
+
+**Status:** draft
+
+Append-only log. See `requirements.md` for the problem framing.
+
+---
+
+## Context that motivated the spec (2026-06-15)
+
+Opened after QA #6 (the omit-audit conversion run) where the
+runner-hang on the `coverage` and `clock-tz`/Windows lanes blocked
+auto-merge on nearly every PR (#892–#894, #901, #904), each needing
+manual `gh run cancel` / `gh run rerun --failed` and, on #904, an
+admin-merge on a hung `coverage` (justified by `test (ubuntu 3.12)`
+being green — same suite — and the diff being coverage-only-additive).
+
+The pre-existing `auto-merge-safe.yml` D7 retry fix (this session)
+handles the *concurrent-merge race* but NOT the *hang-blocks-trigger*
+problem — that needs the topology change proposed here.
+
+## Open decisions (to resolve in design)
+
+- **D1 — layering order.** Proposed: A (timeouts+retry) → B (gate/matrix
+  split) → C (coverage shard) only if needed. _Pending ratification._
+- **D2 — retry mechanism.** `nick-fields/retry` action vs a pure-shell
+  re-invoke (no third-party action, consistent with
+  ci-matrix-right-sizing's "no third-party action" preference).
+  _Pending._
+- **D3 — branch-protection migration.** How to flip required contexts
+  to the `Gate` workflow's job names without a "missing required check"
+  window. Likely: add new contexts as non-required, prove they emit,
+  then swap. _Pending._

--- a/docs/specs/ci-gating-lane-isolation/requirements.md
+++ b/docs/specs/ci-gating-lane-isolation/requirements.md
@@ -1,0 +1,150 @@
+# Spec: CI gating-lane isolation
+
+**Status:** draft
+**Opened:** 2026-06-15
+**Layer:** attune-ai (CI / `.github/workflows/`)
+**Owner:** Patrick + agent
+
+---
+
+## Problem
+
+The merge gate and the slow/flaky lanes live in the **same** `Tests`
+workflow, and the auto-merge trigger fires on `workflow_run` only when
+the **whole** workflow completes. So when *any* lane in `Tests` hangs —
+including a non-gating one — the merge is blocked even though every
+gate that matters is green.
+
+This is the recurring tax observed across QA #6 (2026-06-13 →
+2026-06-14): the systemic runner-hang freezes a lane ~1s after it
+starts, leaving it `in_progress` for 25–47 min until the job timeout
+cancels it. Two distinct failure shapes both trace to this topology:
+
+1. **Non-gating lane hangs, blocks the merge trigger.** `clock-tz
+   (Pacific/Kiritimati)`, the Windows lane, etc. hang; `coverage` is
+   already green but `workflow_run` never fires because the run hasn't
+   completed. Recovery today: `gh run cancel` to force completion so
+   `workflow_run` fires and the merge job (which re-checks `coverage`
+   independently) admin-merges. Manual, per-PR.
+
+2. **The gating lane itself hangs.** `coverage` (required) freezes.
+   This is *not* bypassable — coverage is the gate — and matrix
+   right-sizing does not help because `coverage` is required, not
+   advisory. Recovery today: `gh run rerun --failed`, wait for
+   coverage to conclude, and if it re-hangs, either re-run again
+   (fleet-wedge risk) or admin-merge on the reasoning that
+   `test (ubuntu-latest, 3.12)` (same suite) is green and the diff
+   can only raise coverage. Both are manual judgment calls.
+
+Across this session the hang cost ~15–25 min per affected PR and
+multiple cancel/re-run cycles on #901, #904, #892–#894. It is the
+single largest source of merge friction and the reason the
+auto-merge-safe class still needs babysitting.
+
+## Verified context (grounded)
+
+| Fact | Source |
+|------|--------|
+| Required checks = `CodeQL, code-quality, coverage, lint, platform-compat, pre-commit, test (ubuntu-latest, 3.12)` | `gh api .../branches/main/protection/required_status_checks` |
+| Auto-merge fires on `workflow_run: ["Tests"] types:[completed]` and re-checks `coverage` independently | `.github/workflows/auto-merge-safe.yml` |
+| `coverage` re-runs the FULL suite (so the ubuntu-3.12 lane is redundant with it) | `tests.yml` coverage job |
+| The hang is environment/runner-side, not a test failure (tests pass to ~99% then the lane freezes and is timeout-cancelled) | coverage logs on #901/#904 (last test ~22:27, cancel ~22:47) |
+
+## Relationship to existing CI specs (complementary, not duplicate)
+
+- **`ci-runner-hang`** — attacks the *root cause* (why the runner
+  freezes). This spec assumes the hang persists and makes the merge
+  path *resilient to it*. If ci-runner-hang lands a real fix, this
+  spec's value drops but its topology cleanup still stands.
+- **`ci-matrix-right-sizing`** — *reduces lane count* on test/docs-only
+  diffs (skips advisory lanes). It does **not** isolate the gate or
+  help when a *required* lane (`coverage`) hangs. This spec is the
+  structural complement: separate gate from non-gate.
+- **`windows-xdist-flakes`** — a specific flaky-lane investigation;
+  orthogonal.
+
+---
+
+## Goals
+
+- A hung **non-gating** lane must NEVER block the merge trigger or the
+  required-check set.
+- A hung **gating** lane (`coverage`) must self-recover without manual
+  `cancel`/`rerun` — bounded auto-retry, then fail loud (never silently
+  block forever).
+- No reduction in actual signal: every check that gates today still
+  gates; the full matrix still runs (just not in the gating path).
+- Minimal branch-protection churn; never leave a required check
+  "missing" (the merge-blocking trap from ci-matrix-right-sizing D2).
+
+## Non-goals
+
+- Not fixing the runner-hang root cause (that's `ci-runner-hang`).
+- Not changing *which* checks are required (policy stays; only their
+  workflow *home* and *robustness* change).
+- Not removing platform coverage — Windows/macOS lanes keep running.
+
+---
+
+## Proposed approach (to be refined in design.md)
+
+Three independently-shippable layers, cheapest first:
+
+### A. Per-job timeouts + auto-retry on the gating lanes (cheapest)
+
+Add `timeout-minutes` to the gating jobs (esp. `coverage`) well below
+the current implicit ceiling, and wrap the test step in a bounded
+retry (e.g. `nick-fields/retry` or a shell re-invoke) so a single
+frozen attempt is auto-killed and retried in-run instead of hanging
+25 min and needing a human `rerun`. Converts the #1/#2 manual recovery
+into automatic behavior. Smallest diff, highest immediate relief.
+
+### B. Topology split — gate workflow vs matrix workflow
+
+Move the 7 required checks (incl. `coverage`) into a lean `Gate`
+workflow and the full OS×Python matrix + clock-tz into a separate
+`Matrix` (advisory) workflow. Point the auto-merge `workflow_run`
+trigger at `Gate` only. Then a hung Windows/clock-tz lane lives in
+`Matrix` and cannot delay the merge trigger — failure shape #1
+disappears structurally. Requires updating branch protection to the
+same required names emitted by `Gate` (careful: name parity to avoid
+"missing required check").
+
+### C. Coverage sharding / fail-fast (optional, if B insufficient)
+
+If `coverage` itself remains hang-prone, shard it (pytest-xdist groups
+across N jobs) so one frozen shard is a small bounded loss and retried
+independently, or run coverage with a strict step timeout that fails
+fast into B's retry.
+
+**Recommended sequence:** A first (immediate, low-risk, self-contained),
+then B (the structural fix), then C only if measurements still show
+coverage hangs after A+B.
+
+---
+
+## Done when
+
+- A non-gating lane can hang and a tests/docs-only PR still
+  auto-merges with no manual `cancel` (proven on a real PR).
+- A coverage hang auto-retries within the run and concludes without a
+  human `rerun` (proven, or documented as moved to layer C).
+- Branch protection's required set is intact and emits with the new
+  workflow topology (no "missing required check").
+- `decisions.md` records the layering decisions and any
+  branch-protection edits.
+
+## Risks
+
+- **Branch-protection name parity (high).** Splitting workflows renames
+  the check *context*; if the required names don't match exactly, every
+  PR blocks on a "missing" required check (ci-matrix-right-sizing D2,
+  and the `required_check_app_ids` memory). Stage with a non-required
+  dry run first.
+- **Retry masking real failures (medium).** Auto-retry must
+  distinguish a hang (no progress) from a deterministic failure; cap
+  attempts and surface the retry in logs so a real failure isn't
+  silently re-run green.
+- **Two workflows double the matrix minutes (low).** Repo is public →
+  free; acceptable. Mitigate by composing with ci-matrix-right-sizing
+  (slim matrix on test/docs diffs).

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -715,3 +715,57 @@ exception fallback). All externals mocked (anthropic SDK patched —
 keyless-safe). Module measured alone: **100%**. No production bug found.
 **PR:** https://github.com/Smart-AI-Memory/attune-ai/pull/896
 **Bug log entry:** none
+
+---
+
+## Omit-list audit + conversions (QA #6, 2026-06-14)
+
+**Audit:** `docs/specs/test-quality-program/omit-audit.md` (PR #900).
+Probed every `omit` entry whose comment claimed a testability barrier:
+nearly all import cleanly **keyless** — the LLM/Redis/server dep is
+call-time (mockable), not import-time. The `omit` comments described
+"why a naive test would hit the network," not a real barrier; several
+were mislabeled and two were stale.
+
+**Conversions shipped (each: remove `omit` line + net-new test, all
+out-of-class so human/admin-merged):**
+
+- `agents/release/release_models.py` — was "Requires LLM API calls",
+  actually Enums + dataclasses + console formatting. **77→96%**
+  (#901, merged). Remaining 4 lines = redis/anthropic import guards.
+- `agents/release/release_parsing.py` — pure multi-strategy parser.
+  **→100%** (#904, admin-merged).
+- `agents/release/release_agents.py` — re-export shim. **→100%**
+  (#904).
+- `cache/hybrid.py` — **stale** omit (src/attune/cache/ deleted);
+  pattern removed (#904).
+
+**Deferred — `cross_session.py` stale-glob:** the audit flagged
+`*/memory/cross_session.py` as mismatching the real path
+`memory/short_term/cross_session.py`. Verification was inconclusive
+(multiple cross_session test files target a different module), so the
+removal was held out of #904 — needs a full-suite coverage check
+before touching, not a blind removal.
+
+**Tier-2 backlog (mislabeled/wrongly-omitted, real mocking effort —
+ranked, each its own out-of-class PR):**
+
+1. `memory/claude_memory.py` (309) — dataclasses + Claude at call time;
+   mock the client (cf. research_synthesis scaffold).
+2. `monitoring/otel_backend.py` (268) — mock the otel SDK.
+3. `orchestration/_strategies/base.py` (203) + `execution_strategies.py`
+   (109) — inject mock agents.
+4. `core_modules/short_term_memory.py` (222) — mock redis.
+5. `meta_workflows/cli_commands/{memory,analytics,agent,template,config}_commands.py`
+   — cf. existing `tests/unit/cli_commands` patterns (mock stdin/Prompt).
+
+**Tier-3 (more harness effort):** `models/auth_cli.py`,
+`monitoring/alerts_cli.py`, `core_modules/interaction.py` (interactive
+`input()`), `memory/control_panel_api.py` (FastAPI `TestClient`),
+`memory/short_term/sessions.py`, `socratic/collaboration*.py` (verify
+not deprecated first).
+
+**Hygiene follow-up:** `omit` comments should state the *real* reason;
+consider a check that flags `omit` entries whose files import cleanly
+keyless (the mislabel that let this debt accumulate). Tracked in
+omit-audit.md §Recommendations.


### PR DESCRIPTION
## Summary

Two docs deliverables:

1. **`test-quality-program/decisions.md`** — logs the omit-audit
   conversions ([#901](https://github.com/Smart-AI-Memory/attune-ai/pull/901)
   release_models, [#904](https://github.com/Smart-AI-Memory/attune-ai/pull/904)
   release_parsing/release_agents/cache), the deferred `cross_session`
   glob, and the ranked Tier-2/Tier-3 conversion backlog.

2. **New spec `docs/specs/ci-gating-lane-isolation/`** — the durable
   fix for the recurring runner-hang merge tax hit all through QA #6.
   The merge gate and the slow/flaky lanes share one `Tests` workflow,
   and auto-merge fires on `workflow_run` only when the *whole* run
   completes — so any hung lane (even non-gating) blocks the merge.
   Proposed layers: (A) per-job timeouts + auto-retry on gating lanes,
   (B) split a lean `Gate` workflow from the advisory `Matrix`
   workflow and point auto-merge at `Gate`, (C) coverage sharding if
   needed. Complementary to `ci-runner-hang` (root cause) and
   `ci-matrix-right-sizing` (advisory skip).

Docs-only, in-class for the auto-merge-safe class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)