### PR TITLE
ci(tests): auto-retry the gating lanes on a runner-hang [Layer A]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,10 +156,31 @@ jobs:
           (while sleep 30; do echo "[mem-tick $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"; done) &
           MEM_MONITOR_PID=$!
           trap 'kill $MEM_MONITOR_PID 2>/dev/null || true' EXIT
-        fi
-        pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
-        if [ "${{ runner.os }}" = "Linux" ]; then
+          # ci-gating-lane-isolation Layer A: auto-retry the REQUIRED
+          # `test (ubuntu-latest, 3.12)` lane ONLY on a step-timeout
+          # (rc=124 = runner-hang); any other non-zero is a real failure and
+          # returned immediately (never masked). Linux only — `timeout` here
+          # is coreutils; on Windows `shell: bash` it resolves to the
+          # unrelated timeout.exe, and the macOS/Windows lanes are advisory
+          # (non-gating) so they keep the plain invocation. 14m step timeout
+          # is above the 600s hang-watchdog dump and below the 35m job
+          # timeout. 2×14m fits the 35m backstop with install overhead.
+          rc=0
+          for attempt in 1 2; do
+            set +e
+            timeout -k 30s 14m pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
+            rc=$?
+            set -e
+            if [ "$rc" -ne 124 ]; then break; fi
+            echo "::warning::test pytest attempt ${attempt} hit the 14m step timeout (runner-hang signature) — retrying in-run; see the hang-dumps artifact for the captured stack"
+          done
           echo "[mem-final $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"
+          if [ "$rc" -eq 124 ]; then
+            echo "::error::test pytest hung on every attempt (runner-hang) — failing the job after bounded auto-retry"
+          fi
+          exit "$rc"
+        else
+          pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
         fi
       env:
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
@@ -257,9 +278,13 @@ jobs:
     # and `-n auto` restored, this job runs in parallel like the
     # matrix tests.
     runs-on: ubuntu-latest
-    # ci-runner-hang spec: tightened from 75 (normal coverage run ~8 min) so
-    # a wedged pytest step fails fast and is rerun-recoverable.
-    timeout-minutes: 25
+    # ci-gating-lane-isolation Layer A: the job timeout is now the FINAL
+    # backstop (both auto-retry attempts hung), not the first line of
+    # defence — the 14m step-level `timeout` below kills a single wedged
+    # attempt fast and retries in-run. Sized to fit 2×14m attempts plus
+    # pip-install/badge/codecov overhead (was 25, pre-retry). Stays well
+    # under the guard's 75-min ceiling.
+    timeout-minutes: 40
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -295,8 +320,27 @@ jobs:
         (while sleep 30; do echo "[mem-tick $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"; done) &
         MEM_MONITOR_PID=$!
         trap 'kill $MEM_MONITOR_PID 2>/dev/null || true' EXIT
-        pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
+        # ci-gating-lane-isolation Layer A: auto-retry ONLY on a step-timeout
+        # (rc=124 is the runner-hang signature — pytest freezes ~1s in and
+        # never progresses). A real coverage/test failure exits non-124 and
+        # is returned immediately, so a genuine red is NEVER masked green by
+        # the retry. The 14m step `timeout` sits ABOVE the 600s conftest
+        # hang-watchdog (so the wedged-stack dump still lands in hang-dumps/)
+        # and BELOW the 40m job timeout (the all-attempts-hung backstop).
+        rc=0
+        for attempt in 1 2; do
+          set +e
+          timeout -k 30s 14m pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
+          rc=$?
+          set -e
+          if [ "$rc" -ne 124 ]; then break; fi
+          echo "::warning::coverage pytest attempt ${attempt} hit the 14m step timeout (runner-hang signature) — retrying in-run; see the hang-dumps-coverage artifact for the captured stack"
+        done
         echo "[mem-final $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"
+        if [ "$rc" -eq 124 ]; then
+          echo "::error::coverage pytest hung on every attempt (runner-hang) — failing the job after bounded auto-retry"
+        fi
+        exit "$rc"
       env:
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 

--- a/docs/specs/ci-gating-lane-isolation/decisions.md
+++ b/docs/specs/ci-gating-lane-isolation/decisions.md
@@ -19,15 +19,59 @@ The pre-existing `auto-merge-safe.yml` D7 retry fix (this session)
 handles the *concurrent-merge race* but NOT the *hang-blocks-trigger*
 problem — that needs the topology change proposed here.
 
-## Open decisions (to resolve in design)
+## Resolved decisions
 
-- **D1 — layering order.** Proposed: A (timeouts+retry) → B (gate/matrix
-  split) → C (coverage shard) only if needed. _Pending ratification._
-- **D2 — retry mechanism.** `nick-fields/retry` action vs a pure-shell
-  re-invoke (no third-party action, consistent with
-  ci-matrix-right-sizing's "no third-party action" preference).
-  _Pending._
-- **D3 — branch-protection migration.** How to flip required contexts
-  to the `Gate` workflow's job names without a "missing required check"
-  window. Likely: add new contexts as non-required, prove they emit,
-  then swap. _Pending._
+- **D1 — layering order. RATIFIED (2026-06-15): A → B → C.** Layer A
+  (step-level timeout + bounded in-run retry on the gating lanes)
+  shipped first as the cheapest, self-contained relief. B (gate/matrix
+  topology split) and C (coverage shard) remain deferred and only get
+  built if measurements after A still show merge friction.
+- **D2 — retry mechanism. RESOLVED (2026-06-15): pure-shell re-invoke.**
+  Chose a `timeout`-wrapped bash retry loop over `nick-fields/retry`.
+  Rationale: (a) no new third-party action / SHA-pin / supply-chain
+  surface (consistent with ci-matrix-right-sizing's "no third-party
+  action" preference and this repo's SHA-pin + scorecard posture);
+  (b) full control over the retry predicate — we retry **only** on the
+  step `timeout`'s rc=124 (the runner-hang signature) and return any
+  other non-zero immediately, so a genuine red is never masked green
+  (`nick-fields/retry` retries on any non-zero by default). Verified
+  the five exit paths (clean / real-fail / hang→pass / hang→hang /
+  hang→real-fail) behave correctly before shipping.
+
+## Layer A — as-built (2026-06-15, PR pending)
+
+- **Scope:** the two REQUIRED ubuntu gating lanes in `tests.yml` —
+  `coverage` and `test (ubuntu-latest, 3.12)`. The `test` retry is
+  Linux-gated (`runner.os == Linux`): `timeout` there is coreutils;
+  on Windows `shell: bash` it resolves to the unrelated `timeout.exe`,
+  and the macOS/Windows lanes are advisory, so they keep the plain
+  invocation. `clock-tz` (advisory) was deliberately left out — a hung
+  advisory lane blocking the *trigger* is failure-shape #1, which is
+  Layer B's (topology) job, not A's.
+- **Step timeout = 14m.** Sits ABOVE the 600s conftest hang-watchdog
+  (so a wedged attempt still dumps its all-thread stack to
+  `hang-dumps/` before the kill) and BELOW the job timeout (the
+  all-attempts-hung backstop).
+- **Job-timeout change:** `coverage` 25 → 40 to fit 2×14m attempts +
+  pip-install/badge/codecov overhead (still ≤ the guard's 75 ceiling).
+  `test` stays 35 (2×14m + overhead ≈ 31 fits). The job timeout is now
+  the *final* backstop, not the first kill — the step `timeout` is the
+  fast-kill. This re-loosening of `coverage` is consistent with, not a
+  reversal of, the ci-runner-hang 75→25 tighten: that tighten existed
+  to bound a *single* wedged attempt; Layer A now bounds the attempt at
+  the step level (14m) and the job timeout only bounds the worst case
+  of *both* attempts hanging.
+- **Known limitation (accepted for v1):** `timeout` signals the pytest
+  controller; on SIGKILL, orphaned xdist workers could in principle
+  linger into the retry attempt. The observed hang freezes ~1s after
+  start (before workers do real work), so this is low-risk; if
+  measurements show retry-interference, escalate to a process-group
+  kill (`setsid`) or Layer C. Recorded so a future hang isn't
+  misdiagnosed.
+
+## Still open
+
+- **D3 — branch-protection migration.** Only relevant to Layer B (the
+  topology split renames check contexts). Untouched by Layer A, which
+  keeps every check in `Tests` under its existing name. _Deferred with
+  Layer B._

--- a/docs/specs/ci-gating-lane-isolation/requirements.md
+++ b/docs/specs/ci-gating-lane-isolation/requirements.md
@@ -1,6 +1,6 @@
 # Spec: CI gating-lane isolation
 
-**Status:** draft
+**Status:** Layer A shipping (2026-06-15) — see `decisions.md`; B/C deferred
 **Opened:** 2026-06-15
 **Layer:** attune-ai (CI / `.github/workflows/`)
 **Owner:** Patrick + agent


### PR DESCRIPTION
## What

Implements **Layer A** of [`docs/specs/ci-gating-lane-isolation`](docs/specs/ci-gating-lane-isolation/requirements.md): a step-level `timeout` + bounded in-run **auto-retry** on the two REQUIRED ubuntu gating lanes (`coverage`, `test (ubuntu-latest, 3.12)`).

## Why

The systemic runner-hang freezes a gating lane ~1s after it starts; it then sits `in_progress` for 25–47 min until the job `timeout-minutes` cancels it, requiring a manual `gh run rerun --failed`. This taxed nearly every PR across QA #6 (#892–#894, #901, #904). The job timeout killed a hang but never **retried** — that's the gap this closes.

## How

- Wrap pytest in a `timeout -k 30s 14m … ; retry` loop, **retrying ONLY on rc=124** (the step-timeout = runner-hang signature). Any other non-zero is a real failure and returns immediately → **a genuine red is never masked green**.
- 14m step timeout sits **above** the 600s conftest hang-watchdog (the wedged-stack dump still lands in `hang-dumps/`) and **below** the job timeout (the all-attempts-hung backstop).
- `coverage` job timeout **25 → 40** to fit 2×14m attempts + install/badge/codecov overhead (≤ the guard's 75 ceiling). `test` stays **35** (2×14m + overhead ≈ 31 fits).
- The `test` retry is **Linux-gated**: `timeout` is coreutils there; on Windows `shell: bash` it's the unrelated `timeout.exe`, and the macOS/Windows lanes are advisory, so they keep the plain invocation.

## Verification

- Simulated all five exit paths (clean / real-fail / hang→pass / hang→hang / hang→real-fail) under `bash -eo pipefail` — real failures fail fast, only hangs retry.
- Workflow-yaml guard suite green: **240 passed, 1 skipped**.
- Decisions **D1** (layering A→B→C) and **D2** (shell re-invoke over `nick-fields/retry`) ratified in [`decisions.md`](docs/specs/ci-gating-lane-isolation/decisions.md).

## Scope notes

- Out-of-class PR (touches `.github/`) → won't auto-merge; needs manual merge.
- No branch-protection change — every check keeps its existing name in `Tests`. The topology split (Layer B) and its branch-protection migration (D3) are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
