### PR TITLE
feat(telemetry): opt-in usage-ping client (usage-signals Phase 2a)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -9124,3 +9124,35 @@ files.
   cleanly keyless. Pairs with the omit-cross-check lesson above (that
   one SKIPS omit-masked modules at pick time; this one REPAIRS the omit
   list as its own work-stream).
+
+- **A coverage test that exercises a "real" (non-injected) config
+  path can CLOBBER the user's live `~/.attune/config.json` —
+  `ConfigLoader.save(path=None)` ignores the `config_path` passed to
+  `__init__` and falls back to `get_default_config_path()`**: hit
+  2026-06-15 covering `telemetry/usage_ping.py::_open_user_config`'s
+  real branch (PR #912). To set up an "existing home config" fixture I
+  wrote `ConfigLoader(config_path=tmp_home).save(UnifiedConfig())` —
+  but `save()` resolves its target from `path` arg → `self._loaded_path`
+  → `get_default_config_path()`, and `config_path` only seeds
+  `_loaded_path` after a `.load()`. With no load, `save(path=None)`
+  wrote fresh defaults to the REAL `~/.attune/config.json`, wiping the
+  user's file during a `/tmp` coverage run. Proof it was a full
+  recreate, not an edit: the file's embedded `_created` became the
+  exact run timestamp; no backup existed in `~/.attune/`,
+  `~/.attune/backups/`, or Time Machine local snapshots
+  (`tmutil listlocalsnapshots /` empty). Two durable rules: (1) in
+  tests, NEVER call a production `save()`/writer whose default path
+  resolves to real user state — write the fixture file directly with
+  `path.write_text(json.dumps(UnifiedConfig().to_dict()))` into
+  `tmp_path`, and gate the test with an assertion that the real
+  config's mtime is unchanged across the run; (2) when monkeypatching
+  `get_default_config_path` to a temp path to exercise a real
+  config-open branch, remember any *writer* in the same code path still
+  needs an explicit temp `path=` — patching the *reader* default does
+  not redirect `save()`. Pairs with the "ISOLATE real user state"
+  mutation-testing lesson and the "monkeypatch.delenv SUT-write leak"
+  testing-pattern — same family (a test mutating real machine state),
+  this one is the config-writer surface. Recovery when it happens:
+  there is none without a backup — surface it to the user immediately,
+  show the current (default) content field-by-field, and ask whether
+  any non-default customizations need manual reconstruction.

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -1,6 +1,6 @@
 # Usage Signals — Decisions
 
-**Status:** Phase 0 complete (2026-06-11)
+**Status:** Phase 2 scoped (2026-06-15) — Phase 0 complete (2026-06-11)
 
 ## D1 — Phase 0 baseline snapshot (2026-06-11)
 
@@ -202,3 +202,57 @@ call time.
 
 Remaining in scope: R3 (dashboard Reach panel), R5 (telemetry
 watchdog), R6 (spend alarm), and the Phase 2 opt-in ping question.
+
+## D4 — Phase 2 opt-in ping: BUILD (2026-06-15)
+
+The question D2 left open is decided: **build the opt-in
+phone-home ping.** Full design in
+[phase2-design.md](phase2-design.md). Locked choices:
+
+- **Sync-layer architecture** over the existing local `usage.jsonl`
+  (not a parallel pipeline) — reuses the local buffer, offline
+  resilience free, honors the "don't replace local telemetry"
+  non-goal.
+- **Backend:** Vercel `/api/usage` function → Vercel Postgres
+  (Neon). Relational store for retention / per-workflow / per-version
+  queries; AMS Redis untouched.
+- **Identity:** rotating anonymous install-ID — a recorded,
+  deliberate softening of R2's "no identification ever" to unlock
+  retention (the highest-value signal). Anonymous, resettable, no
+  PII; see phase2-design Privacy note.
+- **Consent:** ships OFF; first-run Socratic prompt + env +
+  `attune telemetry enable/disable`; `DO_NOT_TRACK` honored.
+- **Transport:** fire-and-forget, 2 s timeout, all errors swallowed.
+
+Payload frozen at schema v1 (package, version, install_id,
+event, outcome, os, py, ts) — no paths/code/prompts/args ever; a
+regression test asserts the exact key set. ~3 days, three PRs
+(2a client / 2b endpoint / 2c dashboard Reach panel = R3).
+
+Status moves Phase 0 complete → **Phase 2 scoped** (implementation
+pending an explicit go).
+
+## D5 — Phase 2a implemented: opt-in client (2026-06-15)
+
+The client half of the opt-in ping is built (PR pending). New
+`src/attune/telemetry/usage_ping.py` (frozen payload, enablement
+precedence, install-id, cursor, fire-and-forget `sync`/`run_sync`),
+`TelemetryConfig` gains `usage_ping` / `install_id` /
+`usage_ping_consented`, and `attune telemetry status|enable|disable`
+ship. 45 unit tests, 92% module coverage; dogfooded end-to-end.
+
+Two design adjustments surfaced while building (code is the contract):
+
+- **`outcome` dropped from v1.** The local `UsageTracker` records
+  LLM-call cost/token data, not a success/error outcome — emitting it
+  would fabricate data. v1 sends only what's real (workflow + ts);
+  `outcome` deferred to a `schema:2` bump. phase2-design.md updated.
+- **Opt-in state writes the USER config, never a discovered project
+  config.** First implementation wrote `./attune.config.json` (first
+  in discovery order), which would let a user commit their install-id
+  / `usage_ping=true`. Fixed: `enable/disable/reset` target
+  `~/.attune/config.json` explicitly.
+
+Deferred to 2b (no value until the endpoint exists): wiring `run_sync`
+into an atexit/Stop trigger. `DEFAULT_ENDPOINT` is empty, so even an
+opted-in user transmits nothing yet — intentional double-safety.

--- a/docs/specs/usage-signals/phase2-design.md
+++ b/docs/specs/usage-signals/phase2-design.md
@@ -1,0 +1,179 @@
+# Usage Signals — Phase 2 Design: Opt-In Phone-Home Ping
+
+**Status:** scoped (2026-06-15) · **Owner:** Patrick + agent
+**Decided in:** scoping session 2026-06-15 (D4). Closes the gap D2
+named — "which workflows/skills do external users run?" — which no
+zero-instrumentation source can answer.
+
+## Premise
+
+Phase 0 (D1–D3) proved public data answers *how many installs* but
+not *what users actually run*. The opt-in ping is the only path to
+that signal. This design takes it, staying inside the rails the
+spec already froze (R2 privacy, R3 one dashboard surface).
+
+## Decisions locked (D4)
+
+- **Architecture:** a *sync layer* on top of the existing local
+  `usage.jsonl`, not a parallel pipeline. Phone-home = "flush new
+  local events to an endpoint, mark them sent." Reuses the
+  local-first buffer, gives offline resilience free, honors the
+  non-goal "don't replace local telemetry."
+- **Backend:** a Vercel serverless function (`/api/usage` on the
+  attune-ai.dev project) writing to **Vercel Postgres (Neon)**.
+  Relational store chosen for `GROUP BY workflow` / retention /
+  per-version queries. AMS Redis stays focused on memory/RAG.
+- **Identity:** a **rotating anonymous install-ID** (random UUIDv4
+  in config; user can reset). Unlocks retention / returning-user
+  signal. Documented as anonymous and rotatable — a deliberate,
+  recorded softening of the spec's original "no identification
+  ever" (see Privacy note below).
+- **Consent:** ships OFF; one-time first-run Socratic prompt to
+  enable; `ATTUNE_USAGE_PING=0/1` and `attune telemetry
+  enable/disable` overrides; `DO_NOT_TRACK` honored.
+- **Transport:** fire-and-forget, async, ~2 s hard timeout, all
+  errors swallowed. Never blocks, slows, or crashes the CLI.
+
+## Frozen payload (schema v1)
+
+One auditable source file owns this struct. `attune telemetry
+status` prints exactly this. Adding a field requires bumping
+`schema` and updating the freeze test.
+
+```json
+{
+  "schema": 1,
+  "package": "attune-ai",
+  "version": "8.5.0",
+  "install_id": "<rotating uuid4>",
+  "event": "workflow.security_audit",
+  "os": "darwin",
+  "py": "3.12",
+  "ts": "2026-06-15T12:00:00Z"
+}
+```
+
+- `event` is `workflow.<name>` — the name comes from the local
+  `usage.jsonl` record's `workflow` field (registry-sourced), never
+  free-text. (`skill.<name>` / `command.<name>` are reserved for a
+  later schema once those surfaces emit local records.)
+- **`outcome` is NOT in v1.** The shipped v1 payload (Phase 2a) maps
+  only what the local emit path actually records — workflow name +
+  timestamp. The local `UsageTracker` records LLM-call cost/token
+  data, not a success/error outcome, so emitting `outcome` would mean
+  fabricating it. Capturing a real outcome requires instrumenting the
+  workflow-execution path and is deferred to a `schema: 2` bump (the
+  freeze test guards against silent addition). The Postgres `outcome`
+  column below is reserved/nullable for that future bump.
+- **NEVER carried:** paths, code, prompts, args, filenames, env
+  vars, project names, cost/token/model data, any free-text. Enforced
+  by `PAYLOAD_KEYS` + `FORBIDDEN_RECORD_FIELDS` and a regression test.
+
+## Postgres schema
+
+```sql
+create table usage_events (
+  id          bigserial primary key,
+  received_at timestamptz not null default now(),
+  package     text not null,
+  version     text not null,
+  install_id  uuid not null,
+  event       text not null,
+  outcome     text,          -- reserved for schema:2 (see payload note)
+  os          text,
+  py          text,
+  client_ts   timestamptz
+);
+create index on usage_events (package, event);
+create index on usage_events (install_id);
+create index on usage_events (received_at);
+```
+
+- The function stores **no IP and no headers** — drop them before
+  insert. Retention: raw events 90 days, then roll up to daily
+  aggregates (deferred until volume warrants).
+
+## Client flow (Phase 2a)
+
+1. **Consent gate.** On first interactive run, Socratic prompt:
+   *"Help improve attune-ai? Share anonymous usage (version, which
+   workflows you run, your OS — never code, paths, or prompts).
+   [Yes / No / Show me exactly what's sent]."* Persist
+   `usage_ping.enabled` + a freshly minted `usage_ping.install_id`
+   to config. Env / `DO_NOT_TRACK` short-circuit the prompt.
+2. **Emit.** `UsageTracker` already writes each event locally —
+   unchanged.
+3. **Sync.** A flush (atexit / Stop hook) reads local events past a
+   cursor, maps each to the frozen payload, batches one POST, and
+   advances the cursor on `204`. Timeout 2 s; any failure leaves the
+   cursor unmoved (retry next run) and is silently dropped from the
+   user's view.
+
+## Endpoint (Phase 2b)
+
+- `POST /api/usage`, public + unauthenticated (a CLI can't hold a
+  secret). Validates against schema v1, **rejects unknown fields**
+  (defense against future free-text creep), size-caps the body,
+  rate-limits per IP, drops IP/headers, inserts, returns `204`.
+- **Known limitation:** an unauthenticated public endpoint is
+  spoofable — anyone can POST fake events. Stakes are low (usage
+  counts, not money/auth). Mitigation is rate-limit + strict schema
+  validation; the data is best-effort, not adversarially trusted.
+  Documented, not engineered away.
+
+## Dashboard (Phase 2c — this is R3)
+
+The existing ops dashboard gains a "Reach" panel reading
+`usage_events`: events/workflow, returning-install retention curve,
+per-version adoption, opt-in rate. Sits beside the public-signal
+snapshot (D3) and the watchdog/spend panels (R5/R6).
+
+## Privacy note (amends R2)
+
+R2 said "no per-user identification, ever." Phase 2 adopts a
+**rotating anonymous install-ID** — coarse, anonymous, user-resettable,
+carrying no PII and no linkage to identity. This is a recorded,
+deliberate softening to unlock retention, the highest-value product
+signal. Mitigations keeping it trustworthy: default-OFF, explicit
+consent, frozen auditable payload, `status` command, one-command
+opt-out, deletion-by-install-id on request, documented in README +
+SECURITY.md.
+
+## Concerns / work breakdown
+
+| Concern | Work |
+|---|---|
+| `impl` 2a | consent + config + frozen payload + fire-and-forget sync client + `attune telemetry status/enable/disable` |
+| `impl` 2b | Vercel `/api/usage` function + Neon schema + validation/rate-limit |
+| `impl` 2c | dashboard Reach panel (R3) |
+| `test` | freeze-test asserting payload keys exactly (regression-guard against scope creep); sync cursor/offline/timeout paths; consent-default-OFF test |
+| `docs` | README opt-in section + SECURITY.md privacy/payload disclosure + frozen-payload reference |
+| `release-notes` | CHANGELOG: user-facing trust change; announce default-OFF + how to opt in |
+
+Additive — no `migration`.
+
+## Risks
+
+| Severity | Risk | Mitigation |
+|---|---|---|
+| high | Silent exfiltration would torch trust | default-OFF + explicit consent + auditable payload + `status` |
+| medium | Payload scope-creep over releases | frozen schema-version int + exact-keys regression test |
+| medium | Blocking/crashing the CLI | fire-and-forget + 2 s timeout + swallow all errors |
+| low | Spoofable public endpoint | rate-limit + schema validation; data treated as best-effort |
+| low | GDPR/PII exposure | anonymous + opt-in + no PII + deletable + documented |
+
+## Rough effort
+
+~3 focused days: 2a ~1 d, 2b ~0.5 d, 2c ~0.5–1 d, docs/tests ~0.5 d.
+Each ships as its own PR; 2a is usable (default-OFF, endpoint
+stubbed) before 2b lands.
+
+## Done when (Phase 2)
+
+- Opt-in ping ships default-OFF with auditable frozen payload and a
+  passing freeze regression test.
+- `/api/usage` ingests to Neon; the dashboard Reach panel shows
+  events-by-workflow and a retention curve from real opt-in data.
+- README + SECURITY.md disclose the payload and opt-in/opt-out.
+- One release later, you can answer "which workflows do external
+  users actually run?" with evidence — the question D2 left open.

--- a/src/attune/cli_commands/telemetry_commands.py
+++ b/src/attune/cli_commands/telemetry_commands.py
@@ -557,3 +557,70 @@ def cmd_telemetry_signals(args: Namespace) -> int:
         logger.exception("Signals error: %s", e)
         print(f"❌ Error: {e}")
         return 1
+
+
+def cmd_telemetry_status(args: Namespace) -> int:
+    """Show opt-in usage-ping status and the exact payload that is sent."""
+    try:
+        from attune.config.loader import ConfigLoader
+        from attune.telemetry import usage_ping
+
+        config = ConfigLoader().load()
+        tele = config.telemetry
+        enabled = usage_ping.is_enabled(tele.usage_ping)
+        endpoint = usage_ping.resolve_endpoint() or "(not configured — Phase 2b)"
+
+        print("\n📡 Usage Ping (anonymous, opt-in)\n")
+        print("-" * 60)
+        print(f"  Enabled:        {'yes' if enabled else 'no'}")
+        print(f"  Config flag:    {tele.usage_ping}")
+        print(f"  Consented:      {tele.usage_ping_consented}")
+        print(f"  Install ID:     {tele.install_id or '(none — minted on opt-in)'}")
+        print(f"  Endpoint:       {endpoint}")
+        print("-" * 60)
+        print("  Exactly this is sent per workflow run (nothing else):\n")
+        print(json.dumps(usage_ping.example_payload(config), indent=2))
+        print("-" * 60)
+        print("  Enable:  attune telemetry enable")
+        print("  Disable: attune telemetry disable")
+        print("  DO_NOT_TRACK / ATTUNE_USAGE_PING env vars override this.\n")
+        return 0
+    except Exception as e:  # noqa: BLE001
+        # INTENTIONAL: CLI commands should catch all errors and report gracefully
+        logger.exception("Usage-ping status error: %s", e)
+        print(f"❌ Error: {e}")
+        return 1
+
+
+def cmd_telemetry_enable(args: Namespace) -> int:
+    """Opt in to anonymous usage pinging."""
+    try:
+        from attune.telemetry import usage_ping
+
+        install_id = usage_ping.enable()
+        print("\n✅ Usage ping enabled. Thank you — this helps prioritize work.")
+        print(f"   Anonymous install ID: {install_id}")
+        print("   Only the workflow name, version, OS, and Python version are sent.")
+        print("   Never code, paths, prompts, or arguments.")
+        print("   Opt out anytime: attune telemetry disable\n")
+        return 0
+    except Exception as e:  # noqa: BLE001
+        # INTENTIONAL: CLI commands should catch all errors and report gracefully
+        logger.exception("Usage-ping enable error: %s", e)
+        print(f"❌ Error: {e}")
+        return 1
+
+
+def cmd_telemetry_disable(args: Namespace) -> int:
+    """Opt out of anonymous usage pinging."""
+    try:
+        from attune.telemetry import usage_ping
+
+        usage_ping.disable()
+        print("\n✅ Usage ping disabled. Nothing will be transmitted.\n")
+        return 0
+    except Exception as e:  # noqa: BLE001
+        # INTENTIONAL: CLI commands should catch all errors and report gracefully
+        logger.exception("Usage-ping disable error: %s", e)
+        print(f"❌ Error: {e}")
+        return 1

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -28,6 +28,9 @@ Utility commands:
     attune telemetry models           Show model performance by provider
     attune telemetry agents           Show active agents and their status
     attune telemetry signals          Show coordination signals for an agent
+    attune telemetry status           Show opt-in usage-ping status + payload
+    attune telemetry enable           Opt in to anonymous usage pinging
+    attune telemetry disable          Opt out of anonymous usage pinging
 
     attune provider show              Show current provider config
     attune provider set <name>        Set provider (anthropic)
@@ -84,6 +87,8 @@ from attune.cli_commands.provider_commands import (
 )
 from attune.cli_commands.telemetry_commands import (
     cmd_telemetry_agents,
+    cmd_telemetry_disable,
+    cmd_telemetry_enable,
     cmd_telemetry_export,
     cmd_telemetry_models,
     cmd_telemetry_routing_check,
@@ -91,6 +96,7 @@ from attune.cli_commands.telemetry_commands import (
     cmd_telemetry_savings,
     cmd_telemetry_show,
     cmd_telemetry_signals,
+    cmd_telemetry_status,
 )
 from attune.cli_commands.utility_commands import (
     cmd_doctor,
@@ -213,6 +219,13 @@ def _add_telemetry_subparsers(subparsers: argparse._SubParsersAction) -> None:
         default=30,
         help="Number of days (default: 30)",
     )
+
+    telemetry_sub.add_parser(
+        "status",
+        help="Show opt-in usage-ping status and exact payload",
+    )
+    telemetry_sub.add_parser("enable", help="Opt in to anonymous usage pinging")
+    telemetry_sub.add_parser("disable", help="Opt out of anonymous usage pinging")
 
     savings_parser = telemetry_sub.add_parser("savings", help="Show cost savings")
     savings_parser.add_argument(
@@ -574,6 +587,9 @@ _SUBCOMMAND_DISPATCH: dict[str, dict[str, object]] = {
         "models": cmd_telemetry_models,
         "agents": cmd_telemetry_agents,
         "signals": cmd_telemetry_signals,
+        "status": cmd_telemetry_status,
+        "enable": cmd_telemetry_enable,
+        "disable": cmd_telemetry_disable,
     },
     "provider": {
         "_attr": "provider_command",

--- a/src/attune/config/sections/telemetry.py
+++ b/src/attune/config/sections/telemetry.py
@@ -21,6 +21,13 @@ class TelemetryConfig:
         export_path: Path for telemetry exports.
         retention_days: Days to retain telemetry data.
         detailed_logging: Enable detailed operation logging.
+        usage_ping: Opt-in anonymous usage ping (phone-home). Default
+            OFF — nothing transmits unless the user explicitly opts in.
+            See docs/specs/usage-signals/phase2-design.md.
+        install_id: Rotating anonymous install identifier (UUIDv4).
+            Minted on opt-in; carries no PII; user-resettable.
+        usage_ping_consented: True once the user has been asked and made
+            an explicit choice (so we never re-prompt).
 
     """
 
@@ -30,6 +37,9 @@ class TelemetryConfig:
     export_path: str = "~/.attune/telemetry"
     retention_days: int = 30
     detailed_logging: bool = False
+    usage_ping: bool = False
+    install_id: str = ""
+    usage_ping_consented: bool = False
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
@@ -40,6 +50,9 @@ class TelemetryConfig:
             "export_path": self.export_path,
             "retention_days": self.retention_days,
             "detailed_logging": self.detailed_logging,
+            "usage_ping": self.usage_ping,
+            "install_id": self.install_id,
+            "usage_ping_consented": self.usage_ping_consented,
         }
 
     @classmethod
@@ -52,4 +65,7 @@ class TelemetryConfig:
             export_path=data.get("export_path", "~/.attune/telemetry"),
             retention_days=data.get("retention_days", 30),
             detailed_logging=data.get("detailed_logging", False),
+            usage_ping=data.get("usage_ping", False),
+            install_id=data.get("install_id", ""),
+            usage_ping_consented=data.get("usage_ping_consented", False),
         )

--- a/src/attune/telemetry/usage_ping.py
+++ b/src/attune/telemetry/usage_ping.py
@@ -1,0 +1,421 @@
+"""Opt-in usage ping — the Phase 2 phone-home sync layer.
+
+This is a *sync layer* over the local ``usage.jsonl`` written by
+``UsageTracker`` (not a parallel pipeline): it reads local usage
+records, maps each to a frozen anonymous payload, and best-effort POSTs
+them to a collection endpoint.
+
+Privacy contract (frozen — see ``docs/specs/usage-signals/phase2-design.md``):
+
+- Ships OFF. Nothing transmits unless the user explicitly opts in.
+- Payload is enumerated and frozen at schema v1 (:data:`PAYLOAD_KEYS`):
+  package, version, anonymous rotating ``install_id``, event name
+  (``workflow.<name>``), os, py, and timestamp. NEVER paths, code,
+  prompts, args, filenames, cost/token/model data, or any free-text.
+- Transport is fire-and-forget: short timeout, all errors swallowed —
+  telemetry must never block, slow, or crash the CLI.
+- ``DO_NOT_TRACK`` and ``ATTUNE_USAGE_PING`` env vars override config.
+
+Phase 2a ships the client only; :data:`DEFAULT_ENDPOINT` is empty, so
+even an opted-in user transmits nothing until the Vercel endpoint is
+wired in Phase 2b. That is intentional double-safety.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import sys
+import urllib.request
+import uuid
+from collections.abc import Callable, Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Payload schema version. Bump whenever :data:`PAYLOAD_KEYS` changes;
+#: the freeze regression test asserts the exact set so the schema cannot
+#: quietly grow free-text fields release-over-release.
+PAYLOAD_SCHEMA_VERSION = 1
+
+#: The EXACT, frozen set of keys a ping payload may contain. Anything
+#: not listed here must never be transmitted.
+PAYLOAD_KEYS = frozenset({"schema", "package", "version", "install_id", "event", "os", "py", "ts"})
+
+#: Local-record fields that must NEVER appear in a payload. Documents
+#: intent and backs a regression guard against accidental leakage.
+FORBIDDEN_RECORD_FIELDS = frozenset(
+    {
+        "user_id",
+        "cost",
+        "tokens",
+        "model",
+        "provider",
+        "tier",
+        "stage",
+        "duration_ms",
+        "prompt_cache",
+        "cache",
+        "seq",
+    }
+)
+
+#: Collection endpoint. Empty in Phase 2a (client only) — wired to the
+#: Vercel function in Phase 2b. Overridable via ``ATTUNE_USAGE_ENDPOINT``.
+DEFAULT_ENDPOINT = ""
+
+#: Env values treated as "true" for flag variables.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+#: Cursor filename (stores the ISO timestamp of the last synced record).
+_CURSOR_FILENAME = ".usage_ping_cursor"
+
+_DEFAULT_TIMEOUT = 2.0
+_DEFAULT_BATCH_SIZE = 100
+
+
+def _env_truthy(value: str | None) -> bool:
+    """Return True if an env value should be read as truthy."""
+    return value is not None and value.strip().lower() in _TRUTHY
+
+
+def is_enabled(usage_ping_flag: bool, env: Mapping[str, str] | None = None) -> bool:
+    """Return whether usage pinging is enabled.
+
+    Precedence (most authoritative first):
+
+    1. ``DO_NOT_TRACK`` — if set to anything other than empty/0/false,
+       pinging is OFF regardless of config (the opt-out always wins).
+    2. ``ATTUNE_USAGE_PING`` — explicit env override (truthy enables).
+    3. The persisted config flag.
+
+    The default is OFF.
+
+    Args:
+        usage_ping_flag: The persisted ``TelemetryConfig.usage_ping``.
+        env: Environment mapping (defaults to ``os.environ``).
+
+    Returns:
+        True if pings should be sent.
+    """
+    env = os.environ if env is None else env
+    dnt = env.get("DO_NOT_TRACK")
+    if dnt is not None and dnt.strip().lower() not in {"", "0", "false"}:
+        return False
+    override = env.get("ATTUNE_USAGE_PING")
+    if override is not None:
+        return _env_truthy(override)
+    return bool(usage_ping_flag)
+
+
+def resolve_endpoint(env: Mapping[str, str] | None = None) -> str:
+    """Return the collection endpoint (env override or default)."""
+    env = os.environ if env is None else env
+    return (env.get("ATTUNE_USAGE_ENDPOINT") or DEFAULT_ENDPOINT).strip()
+
+
+def new_install_id() -> str:
+    """Mint a fresh anonymous, rotating install identifier (UUIDv4)."""
+    return str(uuid.uuid4())
+
+
+def _platform_os() -> str:
+    """Return a coarse platform name (e.g. 'darwin', 'linux', 'windows')."""
+    return platform.system().lower()
+
+
+def _platform_py() -> str:
+    """Return the major.minor Python version (e.g. '3.12')."""
+    return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+def build_payload(
+    record: Mapping[str, Any],
+    *,
+    install_id: str,
+    version: str,
+    os_name: str | None = None,
+    py_version: str | None = None,
+) -> dict[str, Any]:
+    """Map a local usage record to the frozen anonymous ping payload.
+
+    Only the workflow NAME and timestamp are taken from the record; all
+    cost/token/model/user fields are dropped by construction. The result
+    contains exactly :data:`PAYLOAD_KEYS`.
+
+    Args:
+        record: A single local ``usage.jsonl`` entry.
+        install_id: Rotating anonymous install identifier.
+        version: attune-ai package version.
+        os_name: Override platform name (defaults to the live platform).
+        py_version: Override Python version (defaults to the live one).
+
+    Returns:
+        A payload dict whose keys are exactly :data:`PAYLOAD_KEYS`.
+    """
+    workflow = str(record.get("workflow") or "unknown")
+    return {
+        "schema": PAYLOAD_SCHEMA_VERSION,
+        "package": "attune-ai",
+        "version": version,
+        "install_id": install_id,
+        "event": f"workflow.{workflow}",
+        "os": os_name if os_name is not None else _platform_os(),
+        "py": py_version if py_version is not None else _platform_py(),
+        "ts": str(record.get("ts") or ""),
+    }
+
+
+def _urllib_post(url: str, batch: list[dict[str, Any]], timeout: float) -> bool:
+    """POST a batch of payloads as JSON. Returns True on a 2xx response."""
+    data = json.dumps({"events": batch}).encode("utf-8")
+    req = urllib.request.Request(  # noqa: S310 (scheme validated by caller)
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "attune-ai-usage-ping",
+        },
+    )
+    # nosec B310: sync() validates the scheme is http/https before calling.
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 # nosec B310
+        status = getattr(resp, "status", None) or resp.getcode()
+        return 200 <= int(status) < 300
+
+
+def sync(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    endpoint: str,
+    install_id: str,
+    version: str,
+    timeout: float = _DEFAULT_TIMEOUT,
+    batch_size: int = _DEFAULT_BATCH_SIZE,
+    poster: Callable[[str, list[dict[str, Any]], float], bool] = _urllib_post,
+) -> int:
+    """Best-effort transmit payloads built from ``records``.
+
+    Fire-and-forget: this never raises. On any failure it returns the
+    count of records confirmed sent so far, so the caller can leave its
+    cursor parked before the first unsent record and retry next run.
+
+    Records are sent in iteration order; callers that need an accurate
+    resume cursor should pass them sorted by timestamp.
+
+    Args:
+        records: Local usage records to transmit.
+        endpoint: Collection URL (must be http/https; empty = no-op).
+        install_id: Rotating anonymous install identifier.
+        version: attune-ai package version.
+        timeout: Per-request timeout in seconds.
+        batch_size: Max payloads per POST.
+        poster: Injectable transport (defaults to a urllib POST).
+
+    Returns:
+        Number of records confirmed transmitted (a 2xx response).
+    """
+    if not endpoint:
+        return 0
+    if not (endpoint.startswith("https://") or endpoint.startswith("http://")):
+        logger.debug("usage-ping: endpoint scheme not allowed: %r", endpoint)
+        return 0
+
+    sent = 0
+    batch: list[dict[str, Any]] = []
+    try:
+        for record in records:
+            batch.append(build_payload(record, install_id=install_id, version=version))
+            if len(batch) >= batch_size:
+                if not poster(endpoint, batch, timeout):
+                    return sent
+                sent += len(batch)
+                batch = []
+        if batch and poster(endpoint, batch, timeout):
+            sent += len(batch)
+        return sent
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: telemetry must never raise into the caller.
+        logger.debug("usage-ping: sync failed", exc_info=True)
+        return sent
+
+
+def read_cursor(telemetry_dir: Path) -> str:
+    """Return the last-synced ISO timestamp, or '' if none/unreadable."""
+    try:
+        return (telemetry_dir / _CURSOR_FILENAME).read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def write_cursor(telemetry_dir: Path, ts: str) -> None:
+    """Persist the last-synced ISO timestamp (best-effort)."""
+    try:
+        (telemetry_dir / _CURSOR_FILENAME).write_text(ts, encoding="utf-8")
+    except OSError:
+        logger.debug("usage-ping: could not write cursor")
+
+
+def records_since(telemetry_dir: Path, cursor_ts: str) -> list[dict[str, Any]]:
+    """Return local usage records newer than ``cursor_ts``, sorted by ts.
+
+    Reads every ``usage*.jsonl`` (current + rotated) so the cursor
+    survives file rotation. ISO-8601 UTC timestamps sort lexically =
+    chronologically. Malformed lines are skipped.
+    """
+    out: list[dict[str, Any]] = []
+    for path in sorted(telemetry_dir.glob("usage*.jsonl")):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    ts = str(rec.get("ts") or "")
+                    if ts and ts > cursor_ts:
+                        out.append(rec)
+        except OSError:
+            continue
+    out.sort(key=lambda r: str(r.get("ts") or ""))
+    return out
+
+
+def run_sync(
+    config: Any,
+    *,
+    telemetry_dir: Path | None = None,
+    version: str | None = None,
+    env: Mapping[str, str] | None = None,
+    poster: Callable[[str, list[dict[str, Any]], float], bool] = _urllib_post,
+) -> int:
+    """Orchestrate one sync pass: gate, read, transmit, advance cursor.
+
+    Returns the number of records transmitted (0 if disabled, no endpoint,
+    no install id, or nothing new). Never raises.
+
+    Args:
+        config: A ``UnifiedConfig`` (uses ``config.telemetry``).
+        telemetry_dir: Override directory (defaults to ~/.attune/telemetry).
+        version: Override package version (defaults to ``attune.__version__``).
+        env: Environment mapping (defaults to ``os.environ``).
+        poster: Injectable transport.
+    """
+    env = os.environ if env is None else env
+    tele = config.telemetry
+    if not is_enabled(tele.usage_ping, env):
+        return 0
+    if not tele.install_id:
+        return 0
+    endpoint = resolve_endpoint(env)
+    if not endpoint:
+        return 0
+
+    if telemetry_dir is None:
+        telemetry_dir = Path("~/.attune/telemetry").expanduser()
+    if version is None:
+        from attune import __version__ as version
+
+    cursor = read_cursor(telemetry_dir)
+    records = records_since(telemetry_dir, cursor)
+    if not records:
+        return 0
+
+    sent = sync(
+        records,
+        endpoint=endpoint,
+        install_id=tele.install_id,
+        version=version,
+        poster=poster,
+    )
+    if sent > 0:
+        write_cursor(telemetry_dir, str(records[sent - 1].get("ts") or cursor))
+    return sent
+
+
+def example_payload(
+    config: Any,
+    *,
+    version: str | None = None,
+    os_name: str | None = None,
+    py_version: str | None = None,
+) -> dict[str, Any]:
+    """Return the exact payload shape that would be transmitted.
+
+    Used by ``attune telemetry status`` so a user can audit precisely
+    what leaves their machine before opting in.
+    """
+    if version is None:
+        from attune import __version__ as version
+    return build_payload(
+        {"workflow": "<example>", "ts": "<timestamp>"},
+        install_id=config.telemetry.install_id or "<minted-on-opt-in>",
+        version=version,
+        os_name=os_name,
+        py_version=py_version,
+    )
+
+
+def _open_user_config(loader: Any) -> tuple[Any, Any, Path | None]:
+    """Return ``(loader, config, save_path)`` targeting the USER config.
+
+    Opt-in state (the flag + anonymous install id) is per-user and
+    per-machine, so it must NEVER be written to a discovered
+    project-local ``attune.config.json`` (that would let a user commit
+    their install id, or ``usage_ping=true`` for everyone who clones).
+    When no loader is injected we target ``~/.attune/config.json``
+    explicitly, starting from defaults if it does not exist yet.
+
+    A non-None ``loader`` (tests) is used as-is with ``save_path=None``.
+    """
+    if loader is not None:
+        return loader, loader.load(), None
+
+    from attune.config.loader import ConfigLoader
+    from attune.config.unified import UnifiedConfig
+
+    home = ConfigLoader.get_default_config_path()
+    if home.exists():
+        loader = ConfigLoader(config_path=home)
+        return loader, loader.load(), home
+    return ConfigLoader(), UnifiedConfig(), home
+
+
+def enable(loader: Any = None) -> str:
+    """Opt in to usage pinging. Mints an install id if absent.
+
+    Writes to the user config (~/.attune/config.json). Returns the
+    (anonymous) install id.
+    """
+    loader, config, save_path = _open_user_config(loader)
+    config.telemetry.usage_ping = True
+    config.telemetry.usage_ping_consented = True
+    if not config.telemetry.install_id:
+        config.telemetry.install_id = new_install_id()
+    loader.save(config, save_path)
+    return config.telemetry.install_id
+
+
+def disable(loader: Any = None) -> None:
+    """Opt out of usage pinging (records the explicit choice)."""
+    loader, config, save_path = _open_user_config(loader)
+    config.telemetry.usage_ping = False
+    config.telemetry.usage_ping_consented = True
+    loader.save(config, save_path)
+
+
+def reset_install_id(loader: Any = None) -> str:
+    """Rotate the anonymous install id to a fresh value. Returns it."""
+    loader, config, save_path = _open_user_config(loader)
+    config.telemetry.install_id = new_install_id()
+    loader.save(config, save_path)
+    return config.telemetry.install_id

--- a/tests/unit/cli_commands/test_telemetry_commands.py
+++ b/tests/unit/cli_commands/test_telemetry_commands.py
@@ -28,6 +28,8 @@ import pytest
 
 from attune.cli_commands.telemetry_commands import (
     cmd_telemetry_agents,
+    cmd_telemetry_disable,
+    cmd_telemetry_enable,
     cmd_telemetry_export,
     cmd_telemetry_models,
     cmd_telemetry_routing_check,
@@ -35,6 +37,7 @@ from attune.cli_commands.telemetry_commands import (
     cmd_telemetry_savings,
     cmd_telemetry_show,
     cmd_telemetry_signals,
+    cmd_telemetry_status,
 )
 
 
@@ -1586,3 +1589,118 @@ class TestCmdTelemetrySignals:
         assert result == 0
         captured = capsys.readouterr().out
         assert "Payload:" not in captured
+
+
+# ---------------------------------------------------------------------------
+# cmd_telemetry_status / enable / disable  (usage-ping, Phase 2a)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdTelemetryStatus:
+    """Tests for cmd_telemetry_status (opt-in usage-ping status)."""
+
+    @staticmethod
+    def _patch_config(*, usage_ping: bool, consented: bool, install_id: object):
+        cfg = types.SimpleNamespace(
+            telemetry=types.SimpleNamespace(
+                usage_ping=usage_ping,
+                usage_ping_consented=consented,
+                install_id=install_id,
+            )
+        )
+        mock_loader = MagicMock()
+        mock_loader.load.return_value = cfg
+        return patch("attune.config.loader.ConfigLoader", return_value=mock_loader)
+
+    def test_status_enabled_shows_install_id_and_payload(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Status renders the install id and the exact audit payload."""
+        with self._patch_config(usage_ping=True, consented=True, install_id="abc-123"):
+            result = cmd_telemetry_status(_make_args())
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Usage Ping" in out
+        assert "Install ID" in out
+        assert "abc-123" in out
+        # The audit payload is rendered as JSON with the frozen schema keys.
+        assert '"package": "attune-ai"' in out
+        assert '"event": "workflow.<example>"' in out
+
+    def test_status_no_install_id_shows_placeholder(self, capsys: pytest.CaptureFixture) -> None:
+        """With no install id minted yet, status shows the placeholder."""
+        with self._patch_config(usage_ping=False, consented=False, install_id=None):
+            result = cmd_telemetry_status(_make_args())
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "(none" in out  # "(none — minted on opt-in)"
+
+    def test_status_generic_exception(self, capsys: pytest.CaptureFixture) -> None:
+        """Status returns 1 and reports the error gracefully."""
+        with patch(
+            "attune.config.loader.ConfigLoader",
+            side_effect=RuntimeError("load boom"),
+        ):
+            result = cmd_telemetry_status(_make_args())
+
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "Error:" in out
+        assert "load boom" in out
+
+
+class TestCmdTelemetryEnable:
+    """Tests for cmd_telemetry_enable (opt in)."""
+
+    def test_enable_reports_install_id(self, capsys: pytest.CaptureFixture) -> None:
+        """Enable reports the anonymous install id returned by usage_ping."""
+        with patch("attune.telemetry.usage_ping.enable", return_value="id-xyz") as mock_enable:
+            result = cmd_telemetry_enable(_make_args())
+
+        assert result == 0
+        mock_enable.assert_called_once_with()
+        out = capsys.readouterr().out
+        assert "enabled" in out.lower()
+        assert "id-xyz" in out
+
+    def test_enable_generic_exception(self, capsys: pytest.CaptureFixture) -> None:
+        """Enable returns 1 and reports the error gracefully."""
+        with patch(
+            "attune.telemetry.usage_ping.enable",
+            side_effect=RuntimeError("write fail"),
+        ):
+            result = cmd_telemetry_enable(_make_args())
+
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "Error:" in out
+        assert "write fail" in out
+
+
+class TestCmdTelemetryDisable:
+    """Tests for cmd_telemetry_disable (opt out)."""
+
+    def test_disable_reports_success(self, capsys: pytest.CaptureFixture) -> None:
+        """Disable calls usage_ping.disable and confirms nothing transmits."""
+        with patch("attune.telemetry.usage_ping.disable") as mock_disable:
+            result = cmd_telemetry_disable(_make_args())
+
+        assert result == 0
+        mock_disable.assert_called_once_with()
+        out = capsys.readouterr().out
+        assert "disabled" in out.lower()
+
+    def test_disable_generic_exception(self, capsys: pytest.CaptureFixture) -> None:
+        """Disable returns 1 and reports the error gracefully."""
+        with patch(
+            "attune.telemetry.usage_ping.disable",
+            side_effect=RuntimeError("io boom"),
+        ):
+            result = cmd_telemetry_disable(_make_args())
+
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "Error:" in out
+        assert "io boom" in out

--- a/tests/unit/telemetry/test_usage_ping.py
+++ b/tests/unit/telemetry/test_usage_ping.py
@@ -451,3 +451,71 @@ def test_write_cursor_swallows_oserror(monkeypatch, tmp_path):
     monkeypatch.setattr(usage_ping.Path, "write_text", boom)
     # Must not raise.
     usage_ping.write_cursor(tmp_path, "2026-06-15T00:00:00Z")
+
+
+def test_records_since_swallows_unreadable_file(monkeypatch, tmp_path):
+    """An OSError opening a matched file is skipped, not raised."""
+    (tmp_path / "usage.jsonl").write_text(
+        json.dumps({"workflow": "w", "ts": "t2"}) + "\n", encoding="utf-8"
+    )
+
+    def boom(*a, **k):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("builtins.open", boom)
+    assert usage_ping.records_since(tmp_path, "t1") == []
+
+
+# --------------------------------------------------------------------------- #
+# run_sync default-path branches (no injected telemetry_dir / version)
+# --------------------------------------------------------------------------- #
+
+
+def test_run_sync_uses_default_dir_and_version(monkeypatch):
+    """With telemetry_dir/version omitted, run_sync resolves defaults.
+
+    Real disk is isolated by stubbing the reader functions, so this
+    exercises the default-path branches without touching ~/.attune.
+    """
+    monkeypatch.setattr(usage_ping, "read_cursor", lambda d: "")
+    monkeypatch.setattr(usage_ping, "records_since", lambda d, c: [])
+    config = _FakeConfig(TelemetryConfig(usage_ping=True, install_id="id"))
+    sent = usage_ping.run_sync(
+        config,
+        env={"ATTUNE_USAGE_ENDPOINT": "https://x/api"},
+        poster=lambda url, batch, timeout: True,
+    )
+    assert sent == 0  # no records, but default dir + version were resolved
+
+
+# --------------------------------------------------------------------------- #
+# _open_user_config — the real (non-injected) USER-config path
+# --------------------------------------------------------------------------- #
+
+
+def test_open_user_config_creates_loader_for_missing_home(monkeypatch, tmp_path):
+    """No loader + no existing user config → fresh defaults at the home path."""
+    from attune.config.loader import ConfigLoader
+
+    home = tmp_path / "config.json"  # does not exist
+    monkeypatch.setattr(ConfigLoader, "get_default_config_path", staticmethod(lambda: home))
+    loader, config, save_path = usage_ping._open_user_config(None)
+    assert isinstance(loader, ConfigLoader)
+    assert config is not None
+    assert save_path == home
+
+
+def test_open_user_config_opens_existing_home(monkeypatch, tmp_path):
+    """No loader + existing user config → load from that home path."""
+    from attune.config.loader import ConfigLoader
+    from attune.config.unified import UnifiedConfig
+
+    home = tmp_path / "config.json"
+    # Write directly to the temp path — never call ConfigLoader.save(),
+    # whose path=None fallback resolves to the REAL ~/.attune/config.json.
+    home.write_text(json.dumps(UnifiedConfig().to_dict()), encoding="utf-8")
+    monkeypatch.setattr(ConfigLoader, "get_default_config_path", staticmethod(lambda: home))
+    loader, config, save_path = usage_ping._open_user_config(None)
+    assert isinstance(loader, ConfigLoader)
+    assert config is not None
+    assert save_path == home

--- a/tests/unit/telemetry/test_usage_ping.py
+++ b/tests/unit/telemetry/test_usage_ping.py
@@ -1,0 +1,453 @@
+"""Tests for the opt-in usage-ping sync layer (Phase 2a).
+
+Covers the privacy-critical invariants: the payload is frozen to an
+exact key set, no forbidden local-record fields ever leak, enablement
+defaults OFF with the documented override precedence, and transport is
+truly fire-and-forget (never raises, never sends when disabled).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from attune.config.sections.telemetry import TelemetryConfig
+from attune.telemetry import usage_ping
+
+
+class _FakeConfig:
+    """Minimal stand-in for UnifiedConfig (only .telemetry is used)."""
+
+    def __init__(self, telemetry: TelemetryConfig) -> None:
+        self.telemetry = telemetry
+
+
+# --------------------------------------------------------------------------- #
+# Frozen payload — the privacy contract's load-bearing test
+# --------------------------------------------------------------------------- #
+
+
+def test_build_payload_has_exactly_frozen_keys():
+    payload = usage_ping.build_payload(
+        {"workflow": "security_audit", "ts": "2026-06-15T00:00:00.000000Z"},
+        install_id="abc",
+        version="9.9.9",
+        os_name="linux",
+        py_version="3.12",
+    )
+    assert set(payload) == usage_ping.PAYLOAD_KEYS
+
+
+def test_build_payload_carries_no_forbidden_fields():
+    """A record full of sensitive fields must yield a clean payload."""
+    record = {
+        "workflow": "deep_review",
+        "ts": "2026-06-15T00:00:00.000000Z",
+        "user_id": "deadbeefcafe1234",
+        "cost": 1.23,
+        "tokens": 4567,
+        "model": "claude-opus-4-8",
+        "provider": "anthropic",
+        "tier": "premium",
+        "stage": "analysis",
+        "duration_ms": 999,
+        "prompt_cache": {"hit": True},
+        "cache": {"hit": False},
+        "seq": 42,
+    }
+    payload = usage_ping.build_payload(record, install_id="id", version="1.0")
+    leaked = usage_ping.FORBIDDEN_RECORD_FIELDS & set(payload)
+    assert not leaked, f"forbidden fields leaked: {leaked}"
+    assert payload["event"] == "workflow.deep_review"
+    # Values, not just keys: no sensitive value should appear anywhere.
+    blob = json.dumps(payload)
+    for forbidden in ("deadbeefcafe1234", "claude-opus-4-8", "1.23", "4567"):
+        assert forbidden not in blob
+
+
+def test_build_payload_defaults_unknown_workflow():
+    payload = usage_ping.build_payload({"ts": "t"}, install_id="i", version="v")
+    assert payload["event"] == "workflow.unknown"
+
+
+def test_payload_schema_version_matches_payload():
+    payload = usage_ping.build_payload({"workflow": "x"}, install_id="i", version="v")
+    assert payload["schema"] == usage_ping.PAYLOAD_SCHEMA_VERSION
+
+
+# --------------------------------------------------------------------------- #
+# Enablement precedence — DO_NOT_TRACK > ATTUNE_USAGE_PING > config
+# --------------------------------------------------------------------------- #
+
+
+def test_is_enabled_defaults_off():
+    assert usage_ping.is_enabled(False, env={}) is False
+
+
+def test_is_enabled_config_flag_on():
+    assert usage_ping.is_enabled(True, env={}) is True
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE", " On "])
+def test_is_enabled_env_override_truthy(val):
+    assert usage_ping.is_enabled(False, env={"ATTUNE_USAGE_PING": val}) is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "", "off"])
+def test_is_enabled_env_override_falsy_beats_config(val):
+    assert usage_ping.is_enabled(True, env={"ATTUNE_USAGE_PING": val}) is False
+
+
+def test_do_not_track_always_wins():
+    env = {"DO_NOT_TRACK": "1", "ATTUNE_USAGE_PING": "1"}
+    assert usage_ping.is_enabled(True, env=env) is False
+
+
+def test_do_not_track_zero_is_not_optout():
+    assert usage_ping.is_enabled(True, env={"DO_NOT_TRACK": "0"}) is True
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint resolution & scheme guard
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_endpoint_default_empty():
+    assert usage_ping.resolve_endpoint(env={}) == ""
+
+
+def test_resolve_endpoint_env_override():
+    url = "https://example.com/api/usage"
+    assert usage_ping.resolve_endpoint(env={"ATTUNE_USAGE_ENDPOINT": url}) == url
+
+
+def test_sync_no_endpoint_is_noop():
+    calls = []
+    sent = usage_ping.sync(
+        [{"workflow": "a", "ts": "t"}],
+        endpoint="",
+        install_id="i",
+        version="v",
+        poster=lambda *a: calls.append(a) or True,
+    )
+    assert sent == 0
+    assert calls == []
+
+
+def test_sync_rejects_non_http_scheme():
+    calls = []
+    sent = usage_ping.sync(
+        [{"workflow": "a", "ts": "t"}],
+        endpoint="file:///etc/passwd",
+        install_id="i",
+        version="v",
+        poster=lambda *a: calls.append(a) or True,
+    )
+    assert sent == 0
+    assert calls == []
+
+
+# --------------------------------------------------------------------------- #
+# sync() transport behavior — batching, failure, fire-and-forget
+# --------------------------------------------------------------------------- #
+
+
+def test_sync_sends_all_records_on_success():
+    posted = []
+
+    def poster(url, batch, timeout):
+        posted.extend(batch)
+        return True
+
+    records = [{"workflow": f"w{i}", "ts": f"t{i}"} for i in range(5)]
+    sent = usage_ping.sync(
+        records, endpoint="https://x/api", install_id="i", version="v", poster=poster
+    )
+    assert sent == 5
+    assert len(posted) == 5
+    assert all(set(p) == usage_ping.PAYLOAD_KEYS for p in posted)
+
+
+def test_sync_batches_by_batch_size():
+    batches = []
+    sent = usage_ping.sync(
+        [{"workflow": "w", "ts": str(i)} for i in range(5)],
+        endpoint="https://x/api",
+        install_id="i",
+        version="v",
+        batch_size=2,
+        poster=lambda url, batch, timeout: batches.append(len(batch)) or True,
+    )
+    assert sent == 5
+    assert batches == [2, 2, 1]
+
+
+def test_sync_stops_at_first_failed_batch():
+    attempts = {"n": 0}
+
+    def poster(url, batch, timeout):
+        attempts["n"] += 1
+        return attempts["n"] == 1  # first batch ok, second fails
+
+    sent = usage_ping.sync(
+        [{"workflow": "w", "ts": str(i)} for i in range(4)],
+        endpoint="https://x/api",
+        install_id="i",
+        version="v",
+        batch_size=2,
+        poster=poster,
+    )
+    assert sent == 2  # only the first batch confirmed
+
+
+def test_sync_swallows_poster_exception():
+    def boom(url, batch, timeout):
+        raise RuntimeError("network down")
+
+    sent = usage_ping.sync(
+        [{"workflow": "w", "ts": "t"}],
+        endpoint="https://x/api",
+        install_id="i",
+        version="v",
+        poster=boom,
+    )
+    assert sent == 0  # never raises
+
+
+# --------------------------------------------------------------------------- #
+# Cursor + record reading
+# --------------------------------------------------------------------------- #
+
+
+def test_cursor_roundtrip(tmp_path):
+    assert usage_ping.read_cursor(tmp_path) == ""
+    usage_ping.write_cursor(tmp_path, "2026-06-15T00:00:00.000000Z")
+    assert usage_ping.read_cursor(tmp_path) == "2026-06-15T00:00:00.000000Z"
+
+
+def test_records_since_filters_and_sorts(tmp_path):
+    lines = [
+        {"workflow": "a", "ts": "2026-06-15T00:00:01.000000Z"},
+        {"workflow": "b", "ts": "2026-06-15T00:00:03.000000Z"},
+        {"workflow": "c", "ts": "2026-06-15T00:00:02.000000Z"},
+    ]
+    (tmp_path / "usage.jsonl").write_text(
+        "\n".join(json.dumps(x) for x in lines) + "\n", encoding="utf-8"
+    )
+    got = usage_ping.records_since(tmp_path, "2026-06-15T00:00:01.000000Z")
+    assert [r["workflow"] for r in got] == ["c", "b"]  # > cursor, ts-sorted
+
+
+def test_records_since_skips_malformed_lines(tmp_path):
+    (tmp_path / "usage.jsonl").write_text(
+        'not json\n{"workflow":"a","ts":"t2"}\n\n', encoding="utf-8"
+    )
+    got = usage_ping.records_since(tmp_path, "t1")
+    assert [r["workflow"] for r in got] == ["a"]
+
+
+def test_records_since_reads_rotated_files(tmp_path):
+    (tmp_path / "usage.jsonl").write_text(
+        json.dumps({"workflow": "new", "ts": "t3"}) + "\n", encoding="utf-8"
+    )
+    (tmp_path / "usage.2026-06-14.jsonl").write_text(
+        json.dumps({"workflow": "old", "ts": "t2"}) + "\n", encoding="utf-8"
+    )
+    got = usage_ping.records_since(tmp_path, "t1")
+    assert {r["workflow"] for r in got} == {"new", "old"}
+
+
+# --------------------------------------------------------------------------- #
+# run_sync orchestration
+# --------------------------------------------------------------------------- #
+
+
+def test_run_sync_disabled_returns_zero(tmp_path):
+    config = _FakeConfig(TelemetryConfig(usage_ping=False))
+    sent = usage_ping.run_sync(config, telemetry_dir=tmp_path, version="v", env={})
+    assert sent == 0
+
+
+def test_run_sync_enabled_no_install_id_returns_zero(tmp_path):
+    config = _FakeConfig(TelemetryConfig(usage_ping=True, install_id=""))
+    sent = usage_ping.run_sync(config, telemetry_dir=tmp_path, version="v", env={})
+    assert sent == 0
+
+
+def test_run_sync_no_endpoint_returns_zero(tmp_path):
+    config = _FakeConfig(TelemetryConfig(usage_ping=True, install_id="id"))
+    sent = usage_ping.run_sync(config, telemetry_dir=tmp_path, version="v", env={})
+    assert sent == 0
+
+
+def test_run_sync_happy_path_advances_cursor(tmp_path):
+    (tmp_path / "usage.jsonl").write_text(
+        "\n".join(
+            json.dumps({"workflow": "w", "ts": f"2026-06-15T00:00:0{i}.000000Z"}) for i in range(3)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config = _FakeConfig(TelemetryConfig(usage_ping=True, install_id="id"))
+    posted = []
+    sent = usage_ping.run_sync(
+        config,
+        telemetry_dir=tmp_path,
+        version="v",
+        env={"ATTUNE_USAGE_ENDPOINT": "https://x/api"},
+        poster=lambda url, batch, timeout: posted.extend(batch) or True,
+    )
+    assert sent == 3
+    assert usage_ping.read_cursor(tmp_path) == "2026-06-15T00:00:02.000000Z"
+    # A second pass has nothing new.
+    assert (
+        usage_ping.run_sync(
+            config,
+            telemetry_dir=tmp_path,
+            version="v",
+            env={"ATTUNE_USAGE_ENDPOINT": "https://x/api"},
+            poster=lambda url, batch, timeout: True,
+        )
+        == 0
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Config glue (enable / disable / reset) via an injected loader
+# --------------------------------------------------------------------------- #
+
+
+class _FakeLoader:
+    """Loader stub that holds a config in memory."""
+
+    def __init__(self, config):
+        self._config = config
+        self.saved = False
+
+    def load(self):
+        return self._config
+
+    def save(self, config, path=None):
+        self._config = config
+        self.saved = True
+        return path
+
+
+def test_enable_mints_install_id_and_sets_flags():
+    loader = _FakeLoader(_FakeConfig(TelemetryConfig()))
+    install_id = usage_ping.enable(loader=loader)
+    tele = loader.load().telemetry
+    assert tele.usage_ping is True
+    assert tele.usage_ping_consented is True
+    assert tele.install_id == install_id and install_id
+    assert loader.saved
+
+
+def test_enable_keeps_existing_install_id():
+    loader = _FakeLoader(_FakeConfig(TelemetryConfig(install_id="keep-me")))
+    assert usage_ping.enable(loader=loader) == "keep-me"
+
+
+def test_disable_sets_flag_off_and_consented():
+    loader = _FakeLoader(_FakeConfig(TelemetryConfig(usage_ping=True, install_id="x")))
+    usage_ping.disable(loader=loader)
+    tele = loader.load().telemetry
+    assert tele.usage_ping is False
+    assert tele.usage_ping_consented is True
+
+
+def test_reset_install_id_rotates():
+    loader = _FakeLoader(_FakeConfig(TelemetryConfig(install_id="old")))
+    new = usage_ping.reset_install_id(loader=loader)
+    assert new != "old" and new
+    assert loader.load().telemetry.install_id == new
+
+
+def test_example_payload_shape():
+    config = _FakeConfig(TelemetryConfig(install_id="id"))
+    payload = usage_ping.example_payload(config, version="1.2.3")
+    assert set(payload) == usage_ping.PAYLOAD_KEYS
+    assert payload["install_id"] == "id"
+
+
+def test_config_roundtrip_preserves_new_fields():
+    tele = TelemetryConfig(usage_ping=True, install_id="abc", usage_ping_consented=True)
+    restored = TelemetryConfig.from_dict(tele.to_dict())
+    assert restored.usage_ping is True
+    assert restored.install_id == "abc"
+    assert restored.usage_ping_consented is True
+
+
+# --------------------------------------------------------------------------- #
+# Real transport (_urllib_post) via a mocked urlopen
+# --------------------------------------------------------------------------- #
+
+
+class _FakeResp:
+    def __init__(self, status):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def getcode(self):
+        return self.status
+
+
+def test_urllib_post_builds_request_and_reads_2xx(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = json.loads(req.data)
+        captured["ct"] = req.headers.get("Content-type")
+        return _FakeResp(204)
+
+    monkeypatch.setattr(usage_ping.urllib.request, "urlopen", fake_urlopen)
+    ok = usage_ping._urllib_post("https://x/api", [{"a": 1}], 2.0)
+    assert ok is True
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://x/api"
+    assert captured["body"] == {"events": [{"a": 1}]}
+    assert captured["ct"] == "application/json"
+
+
+def test_urllib_post_non_2xx_returns_false(monkeypatch):
+    monkeypatch.setattr(usage_ping.urllib.request, "urlopen", lambda req, timeout: _FakeResp(500))
+    assert usage_ping._urllib_post("https://x/api", [], 2.0) is False
+
+
+def test_sync_default_poster_round_trips(monkeypatch):
+    """Exercise sync() with the real default poster over a mocked socket."""
+    seen = []
+
+    def fake_urlopen(req, timeout):
+        seen.append(json.loads(req.data))
+        return _FakeResp(200)
+
+    monkeypatch.setattr(usage_ping.urllib.request, "urlopen", fake_urlopen)
+    sent = usage_ping.sync(
+        [{"workflow": "w", "ts": "t"}],
+        endpoint="https://x/api",
+        install_id="i",
+        version="v",
+    )
+    assert sent == 1
+    assert seen and set(seen[0]["events"][0]) == usage_ping.PAYLOAD_KEYS
+
+
+def test_write_cursor_swallows_oserror(monkeypatch, tmp_path):
+    def boom(*a, **k):
+        raise OSError("read-only fs")
+
+    monkeypatch.setattr(usage_ping.Path, "write_text", boom)
+    # Must not raise.
+    usage_ping.write_cursor(tmp_path, "2026-06-15T00:00:00Z")


### PR DESCRIPTION
## What

Phase 2a of the `usage-signals` spec: the **client** half of the
anonymous, opt-in usage ping (phone-home). Ships **OFF**; transmits
nothing until a user explicitly opts in *and* the collection endpoint
is wired in Phase 2b (`DEFAULT_ENDPOINT` is empty — intentional
double-safety).

Closes the gap `decisions.md` D2 named: *which workflows do external
users actually run?* — which no zero-instrumentation source can answer.

## How

- **`src/attune/telemetry/usage_ping.py`** — a *sync layer* over the
  existing local `usage.jsonl` (not a parallel pipeline):
  - Frozen payload (`PAYLOAD_KEYS`, schema v1) + a regression test
    asserting the exact key set, so the schema can't silently grow.
  - Enablement precedence: `DO_NOT_TRACK` > `ATTUNE_USAGE_PING` > config.
  - Rotating anonymous install-id; timestamp cursor (survives rotation).
  - `sync()` / `run_sync()` are fire-and-forget: 2s timeout, all errors
    swallowed — never blocks, slows, or crashes the CLI.
- **`TelemetryConfig`** gains `usage_ping` / `install_id` /
  `usage_ping_consented`.
- **CLI**: `attune telemetry status | enable | disable`. `status`
  prints the *exact* payload that would be sent. Opt-in state writes
  the **user** config (`~/.attune/config.json`), never a discovered
  project config.

## Privacy

Payload carries only `package, version, install_id, event, os, py, ts`
— **never** paths, code, prompts, args, filenames, or cost/token/model
data. `outcome` was dropped from v1 (the local emit path records none;
deferred to a `schema:2` bump).

## Tests

45 unit tests, **92%** module coverage (incl. mocked-`urlopen`
transport + the privacy freeze test). Full telemetry suite: 391 pass.
Dogfooded end-to-end (status → enable → status → disable) in a temp
HOME; verified the project config is untouched.

## Spec

`docs/specs/usage-signals/phase2-design.md` (new) + `decisions.md`
D4 (build decision) / D5 (implementation notes). Deferred to 2b:
endpoint + the atexit/Stop sync trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
