### PR TITLE
docs(ci-runner-hang): first captured frame — finalize-wedge (H4), not I/O-polluter

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -9159,3 +9159,40 @@ files.
     hang→hang / hang→real-fail) — `-e` interacts with `cmd; rc=$?`
     (wrap the timed command in `set +e`/`set -e`, and use an explicit
     `if … then break` not `[ … ] && break`, which `-e` mishandles).
+
+- **Reading a hang-dump + its job log: per-JOB `gh api …/jobs/<id>/logs`
+  works mid-run, and the wedged worker is the one with a non-execnet
+  frame**: decoding the first captured runner-hang stack (2026-06-15,
+  run 27541609728, the live test of ci-gating-lane-isolation Layer A).
+  Durable mechanics:
+  - **`gh run view <run> --log` / `--log-failed` return nothing while
+    the OVERALL run is in_progress** (other lanes still running) — but a
+    single COMPLETED job's log is readable immediately via
+    `gh api repos/<o>/<r>/actions/jobs/<job_id>/logs` (get the job id
+    from `gh run view <run> --json jobs --jq '.jobs[]|select(.name==
+    "<job>")|.databaseId'`). This is how you read a failed lane's tail
+    before the slow advisory lanes finish. Extends the existing "gh run
+    view --log-failed returns nothing in-flight" lesson with the
+    per-job escape hatch.
+  - **`gh run download` errors `fatal: not a git repository`** when the
+    cwd isn't inside the repo checkout — pass `-R <owner/repo>` and
+    `-D <outdir>` explicitly (e.g. downloading a `hang-dumps-*`
+    artifact to /tmp).
+  - **Decoding the xdist hang stack:** the worker carrying an
+    APP-LEVEL thread frame (not just `execnet gateway_base`) is the
+    suspect. Controller wedged in `xdist/dsession.py loop_once →
+    queue.get → wait` + ALL workers cleanly idle in `execnet serve →
+    integrate_as_primary_thread → wait` = an **end-of-session finalize
+    deadlock** (tests pass to ~99%, then the session can't conclude) —
+    NOT a worker blocked in uninterruptible I/O. Distinguish the two:
+    an I/O-polluter hang shows a worker stuck in `socket.recv` /
+    `subprocess.wait` / `lock.acquire`; a finalize deadlock shows
+    everyone cleanly idle. `--timeout=60 --timeout-method=thread` does
+    NOT fire on either (GIL/uninterruptible or clean-idle).
+  - **A leaked non-daemon thread blocks worker exit; a leaked DAEMON
+    thread does not** — so before blaming a leaked app thread for a
+    finalize wedge, check `daemon=` AND whether its loop is a no-op in
+    the test env (e.g. `cross_session` coordinator's `_heartbeat_loop`
+    is `daemon=True` and no-ops when `client is None`, i.e. keyless CI).
+    A no-op daemon is a CORRELATION/suspect, not a proven cause — get
+    N>1 dumps before shipping a fix (tar-pit guard).

--- a/docs/specs/ci-gating-lane-isolation/requirements.md
+++ b/docs/specs/ci-gating-lane-isolation/requirements.md
@@ -16,9 +16,14 @@ including a non-gating one — the merge is blocked even though every
 gate that matters is green.
 
 This is the recurring tax observed across QA #6 (2026-06-13 →
-2026-06-14): the systemic runner-hang freezes a lane ~1s after it
-starts, leaving it `in_progress` for 25–47 min until the job timeout
-cancels it. Two distinct failure shapes both trace to this topology:
+2026-06-14): the systemic runner-hang lets the suite run to ~99%
+(tests passing) and then freezes at session finalize, leaving the
+lane `in_progress` for 25–47 min until the job timeout cancels it.
+(Corrected 2026-06-15 from an earlier "~1s after start" guess — the
+first captured stack disproves it; see
+[`ci-runner-hang/phase2-findings.md`](../ci-runner-hang/phase2-findings.md)
+"Phase 3", run 27541609728.) Two distinct failure shapes both trace
+to this topology:
 
 1. **Non-gating lane hangs, blocks the merge trigger.** `clock-tz
    (Pacific/Kiritimati)`, the Windows lane, etc. hang; `coverage` is

--- a/docs/specs/ci-runner-hang/evidence/run-27541609728/hang-controller.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-27541609728/hang-controller.txt
@@ -1,0 +1,46 @@
+Timeout (0:10:00)!
+Thread 0x00007f427ffff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f428dffd6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f428effe6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f428ffff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f429ce0fb80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 331 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/queue.py", line 180 in get
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/xdist/dsession.py", line 154 in loop_once
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/xdist/dsession.py", line 138 in pytest_runtestloop
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 384 in _main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 330 in wrap_session
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 377 in pytest_cmdline_main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 229 in _main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 253 in _console_main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/bin/pytest", line 6 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-27541609728/hang-gw1.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-27541609728/hang-gw1.txt
@@ -1,0 +1,16 @@
+Timeout (0:10:00)!
+Thread 0x00007fa7903ff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007fa791c0eb80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-27541609728/hang-gw2.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-27541609728/hang-gw2.txt
@@ -1,0 +1,16 @@
+Timeout (0:10:00)!
+Thread 0x00007f4ff6bff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f4ff83adb80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-27541609728/hang-gw3.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-27541609728/hang-gw3.txt
@@ -1,0 +1,24 @@
+Timeout (0:10:00)!
+Thread 0x00007fce2eafe6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 331 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/home/runner/work/attune-ai/attune-ai/src/attune/memory/cross_session/coordinator.py", line 289 in _heartbeat_loop
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 982 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 1045 in _bootstrap_inner
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 1002 in _bootstrap
+
+Thread 0x00007fce4dbff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007fce4f454b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/phase2-findings.md
+++ b/docs/specs/ci-runner-hang/phase2-findings.md
@@ -152,3 +152,82 @@ for a real captured frame. Once the next ubuntu hang uploads a
 - `clock-tz` also runs `-n auto` on ubuntu and could wedge; it was left
   out of the capture steps to keep this PR scoped to the two
   required-check lanes. Add the same two steps there if it ever hangs.
+
+---
+
+## Phase 3 — FIRST captured production frame (2026-06-15)
+
+The Phase 2 dump-survival mechanism paid off: PR #911's `coverage`
+lane wedged at ~99% and the `if: always()` upload preserved all four
+process stacks. Raw dumps:
+[evidence/run-27541609728/](evidence/run-27541609728/) (coverage job
+`81404541787`, run `27541609728`). This is the first real frame — D1's
+gate is now satisfied.
+
+### What the stacks show
+
+| Process | Main-thread frame | Reading |
+|---------|-------------------|---------|
+| controller | `xdist/dsession.py:154 loop_once → queue.get → threading wait` | waiting for a worker event that never arrives |
+| gw1 | `execnet gateway_base serve → integrate_as_primary_thread → wait` | idle, done, awaiting shutdown |
+| gw2 | same as gw1 | idle |
+| gw3 | same as gw1 — **plus** a 3rd thread: `attune/memory/cross_session/coordinator.py:289 _heartbeat_loop → threading wait` | idle **+ a leaked heartbeat thread** |
+
+### Classification — does NOT match H1/H2
+
+Crucially, **no process is blocked in uninterruptible I/O** (no
+`socket.recv`, no `subprocess.wait`, no `lock.acquire`). Every worker is
+cleanly idle in execnet `serve`; the controller is cleanly idle in
+`queue.get`. So this frame does **not** fit H1/H2 (the real-socket /
+real-subprocess fixture-polluter family shared with
+`windows-xdist-flakes`). It looks instead like an **execnet/xdist
+end-of-session control-channel deadlock** (lost-wakeup at finalize):
+all tests passed, but the session never concludes. Call it **H4**.
+
+### The one differentiator — and why it's a LEAD, not a proven cause
+
+The only thing distinguishing the wedged-fleet's `gw3` from gw1/gw2 is
+a leaked `_heartbeat_loop` thread — a test called
+`coordinator.start_heartbeat()` and never `stop_heartbeat()`, so the
+thread persists for the worker's life. Candidates that start a
+heartbeat: `tests/unit/memory/test_cross_session_coordinator.py`,
+`tests/unit/workflows/test_execution_mixin_branches.py`,
+`tests/unit/telemetry/test_agent_tracking.py`.
+
+**But the causal chain is NOT closed.** The thread is `daemon=True`
+(coordinator.py:271) and `_send_heartbeat` no-ops when there is no
+Redis client (`client is None`) — which is exactly keyless CI. So in CI
+it is a no-op daemon, and a no-op daemon thread should not deadlock
+execnet. It is a strong **correlation / prime suspect**, not a
+demonstrated cause. Do not ship a "fix" on one dump.
+
+### Next actions (confirm-then-fix — tar-pit guarded)
+
+1. **Gather 2–3 more captured frames** before committing to a fix.
+   The key question: is the leaked-heartbeat thread present on the
+   wedged worker **every** time, or was run-27541609728 a coincidence?
+   The same PR's required `test (ubuntu-latest, 3.12)` lane PASSED
+   while `coverage` wedged — confirming the hang is intermittent /
+   worker-distribution-dependent, so N>1 dumps are needed to establish
+   the pattern.
+2. **Cheap defensive move (do regardless):** an autouse teardown
+   fixture that stops any leaked coordinator heartbeat thread after
+   each test. It removes the one variable that differs on the wedged
+   worker, so the *next* dump is cleaner — and it is good hygiene
+   even if H4 (execnet finalize race) turns out to be the real cause.
+   Low-risk; its own scoped PR.
+3. **If the leak is ruled out**, pivot to H4: investigate the
+   execnet/xdist finalize handshake directly (the controller's
+   `loop_once` waiting on `queue.get` while all workers idle in
+   `serve` is the signature to research upstream).
+4. **Verify with a rerun count** (≥10 clean `-n auto` reruns), never a
+   single green — per the existing Phase 2 watch-out.
+
+### Note for the sibling spec
+
+`ci-gating-lane-isolation/requirements.md` described the hang as
+freezing "~1s after start." This frame **disproves** that: the freeze
+is a ~99% **finalize-wedge** (all tests pass, then the session can't
+conclude). That spec's premise table is corrected in the same PR as
+this finding. (This `ci-runner-hang` spec already had the "99%-freeze"
+shape right.)


### PR DESCRIPTION
Banks the root-cause lead surfaced while validating Layer A ([#910](https://github.com/Smart-AI-Memory/attune-ai/pull/910)). **Docs-only**; no code change.

## The win

Phase 2's dump-survival mechanism worked: [#911](https://github.com/Smart-AI-Memory/attune-ai/pull/911)'s `coverage` lane wedged at ~99% and the `if: always()` upload preserved all four process stacks (run `27541609728`). **First real captured frame — D1's gate is satisfied.**

## What the frame says

| Process | Frame | Reading |
|---|---|---|
| controller | `dsession.loop_once → queue.get → wait` | waiting for a worker event that never comes |
| gw1, gw2 | `execnet serve → integrate_as_primary_thread → wait` | cleanly idle |
| gw3 | same idle serve **+** leaked `cross_session/coordinator._heartbeat_loop` | idle + a leaked heartbeat thread |

**Does NOT match H1/H2** — no worker blocked in uninterruptible I/O. Everyone is cleanly idle → an **end-of-session finalize deadlock (new H4)**, not the I/O-polluter family shared with `windows-xdist-flakes`.

## Honest confidence

The leaked heartbeat thread is the only differentiator on the wedged worker — but it's `daemon=True` and no-ops keyless (no Redis client in CI). A no-op daemon shouldn't deadlock execnet, so it's a **prime suspect, not a proven cause**. **Confirm-then-fix:** gather N>1 dumps before shipping; a cheap defensive teardown fixture (stop leaked heartbeats) is proposed as its own scoped PR. Tar-pit-guarded.

## Contents

- `ci-runner-hang/phase2-findings.md` — Phase 3 section + classification + next actions.
- `ci-runner-hang/evidence/run-27541609728/` — the four raw stacks.
- `ci-gating-lane-isolation/requirements.md` — premise corrected (~99% finalize-wedge, not "~1s after start").
- `.claude/lessons.md` — hang-dump diagnostic technique (per-job `gh api` log mid-run, `gh run download -R`, decode the non-execnet frame, daemon-vs-non-daemon).

Out-of-class (`.claude/` + docs) → needs manual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)