### PR TITLE
test(ci-hang): stop leaked CrossSessionCoordinator heartbeat threads

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -534,6 +534,50 @@ def _disable_help_telemetry(monkeypatch):
     monkeypatch.setenv("ATTUNE_HELP_TELEMETRY", "0")
 
 
+@pytest.fixture(autouse=True, scope="function")
+def _stop_leaked_heartbeat_threads():
+    """Stop any CrossSessionCoordinator heartbeat thread a test leaks.
+
+    ``CrossSessionCoordinator(auto_announce=True)`` — the default — spawns
+    a daemon ``heartbeat-<agent_id>`` thread on construction. A test that
+    builds one without ``auto_announce=False`` and never calls ``close()``
+    /``stop_heartbeat()`` leaks that thread into the (xdist) worker
+    process, where it lingers for the rest of the session. Leaked daemon
+    threads are a confounding variable in the xdist end-of-session
+    finalize deadlock under investigation, so this teardown stops and
+    joins any survivor — keeping each worker (and any captured hang-dump)
+    clean. See docs/specs/ci-runner-hang/.
+    """
+    yield
+
+    import logging
+    import threading
+
+    leaked = [
+        thread
+        for thread in threading.enumerate()
+        if thread.is_alive() and thread.name.startswith("heartbeat-")
+    ]
+    for thread in leaked:
+        # The thread target is the coordinator's bound ``_heartbeat_loop``;
+        # signalling its stop event wakes the loop out of its interval wait
+        # so the join returns promptly.
+        coordinator = getattr(getattr(thread, "_target", None), "__self__", None)
+        stop_event = getattr(coordinator, "_heartbeat_stop", None)
+        if stop_event is not None:
+            stop_event.set()
+        thread.join(timeout=5)
+
+    if leaked:
+        logging.getLogger(__name__).warning(
+            "stopped %d leaked heartbeat thread(s): %s — a "
+            "CrossSessionCoordinator was constructed without "
+            "auto_announce=False and never closed",
+            len(leaked),
+            [thread.name for thread in leaked],
+        )
+
+
 # =============================================================================
 # Additional Shared Fixtures for Testing Improvements
 # =============================================================================

--- a/tests/integration/test_graceful_degradation.py
+++ b/tests/integration/test_graceful_degradation.py
@@ -55,7 +55,10 @@ class TestGracefulDegradationMemory:
         from attune.memory.types import RedisConfig
 
         memory = RedisShortTermMemory(config=RedisConfig(use_mock=True))
-        coordinator = CrossSessionCoordinator(memory)
+        # auto_announce=False: ``_degraded`` is set before the announce
+        # block, so the assertion still holds without leaking a heartbeat
+        # daemon thread (see docs/specs/ci-runner-hang/).
+        coordinator = CrossSessionCoordinator(memory, auto_announce=False)
 
         assert coordinator._degraded is True
 

--- a/tests/unit/memory/test_cross_session.py
+++ b/tests/unit/memory/test_cross_session.py
@@ -107,5 +107,8 @@ class TestCrossSessionCoordinatorMockMode:
 
         # Phase 2.5: CrossSessionCoordinator no longer raises on mock mode,
         # it enters degraded mode instead with a warning.
-        coordinator = CrossSessionCoordinator(memory=memory)
+        # auto_announce=False: ``_degraded`` is set before the announce
+        # block, so the assertion still holds, and we avoid leaking a
+        # heartbeat daemon thread (see docs/specs/ci-runner-hang/).
+        coordinator = CrossSessionCoordinator(memory=memory, auto_announce=False)
         assert coordinator._degraded is True

--- a/tests/unit/memory/test_cross_session_coordinator.py
+++ b/tests/unit/memory/test_cross_session_coordinator.py
@@ -245,6 +245,26 @@ class TestCrossSessionCoordinatorHeartbeat:
         coord.close()
         assert coord._heartbeat_thread is None
 
+    def test_default_construction_heartbeat_is_stopped_by_close(self):
+        """Default auto_announce spawns a heartbeat thread that close() stops.
+
+        Regression guard for the xdist end-of-session finalize deadlock
+        (docs/specs/ci-runner-hang/): the default ``auto_announce=True``
+        path starts a daemon ``heartbeat-<agent_id>`` thread, and a test
+        or caller that never closes the coordinator leaks it into the
+        worker process. This pins that close() terminates the OS thread,
+        not merely the attribute.
+        """
+        memory = RedisShortTermMemory(use_mock=True)
+        coord = CrossSessionCoordinator(memory=memory)  # auto_announce=True
+        thread_name = f"heartbeat-{coord._agent_id}"
+        try:
+            assert any(t.name == thread_name for t in threading.enumerate())
+        finally:
+            coord.close()
+        assert coord._heartbeat_thread is None
+        assert not any(t.is_alive() and t.name == thread_name for t in threading.enumerate())
+
 
 # ---------------------------------------------------------------------------
 # Event handler registration


### PR DESCRIPTION
## What

Confirm-then-fix **Step 2** for the recurring CI runner-hang
(`docs/specs/ci-runner-hang/`). Stops tests from leaking a
`CrossSessionCoordinator` heartbeat daemon thread into the xdist worker
process, removing the one confounding variable from the next captured
hang-dump.

## Why

The first captured hang-dump (run `27541609728`, banked in #913) showed
the wedged worker uniquely carried a leaked
`heartbeat-<agent_id>` daemon thread. Root cause found:

- `CrossSessionCoordinator.__init__` defaults to `auto_announce=True`,
  which calls `self.start_heartbeat()` on construction.
- `tests/unit/memory/test_cross_session.py::test_degrades_on_mock_mode`
  built `CrossSessionCoordinator(memory=memory)` (default) and never
  closed it → leaked the daemon thread **on green** (the test still
  passes), exactly matching the dump. An integration twin had the same
  bug.

This is **not** a root deadlock fix shipped on a single dump (that stays
gated per the tar-pit guard). It's the cheap, do-regardless cleanup so
the next dump is uncontaminated.

## Changes

- **`tests/conftest.py`** — autouse teardown reaps any leaked
  `heartbeat-*` thread after every test (catch-all that also covers the
  service-start and integration paths).
- **`test_cross_session.py` / `test_graceful_degradation.py`** — fix the
  confirmed leak: pass `auto_announce=False`. `_degraded` is set before
  the announce block, so the assertions are unchanged.
- **`test_cross_session_coordinator.py`** — regression guard pinning that
  the default-construction heartbeat thread is actually terminated by
  `close()` (not just the attribute cleared).

No production behavior change — the `auto_announce=True` default stays.

## Verification

- Targeted suite green keyless: `51 passed in 0.19s`, no hang.
- A deliberate-leak probe confirmed the autouse guard reaps the thread
  before the next test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
