### PR TITLE
chore: weekly report 2026-06-15

### DIFF
--- a/weekly-reports/2026-06-15.md
+++ b/weekly-reports/2026-06-15.md
@@ -1,0 +1,160 @@
+# Anthropic Ecosystem Weekly — 2026-06-15
+
+## Summary
+
+**Claude Fable 5 launched June 9** (`claude-fable-5`, $10/$50/MTok), a new tier
+above Opus 4.8 with always-on adaptive thinking and safety classifiers that return
+`stop_reason: "refusal"` on HTTP 200 — a new response shape not currently handled
+by attune-ai's executor or SDK adapter. The **Agent SDK credit pool went live today**
+(June 15). Several carry-overs are confirmed resolved in code: the Opus 4.8 upgrade,
+the SDK ceiling, the CLAUDE_PROJECT_DIR MCP fix, and the June-8 cost_tracker alarm
+(a false read — the code correctly keeps the legacy key for historical lookups).
+
+---
+
+## Recommendations
+
+**1. Handle `stop_reason: "refusal"` before adding Fable 5 to the stack**
+
+Fable 5 declines requests by returning HTTP 200 with `stop_reason: "refusal"` — not
+an exception. `src/attune/llm/providers/anthropic.py:235` captures `stop_reason` but
+doesn't check for `"refusal"`. `agent_sdk_adapter.py:1249` records it in metadata but
+doesn't surface it as an error or trigger fallback.
+
+If Fable 5 is ever passed as a model, refused calls would silently return
+empty/truncated content — `FallbackStrategy.CHEAPER_TIER_SAME_PROVIDER` won't
+trigger because no exception was raised.
+
+Two-step prep (not urgent while Fable 5 isn't in the registry):
+
+- In `anthropic.py`: after capturing `stop_reason`, raise or flag when
+  `stop_reason == "refusal"` so the resilient executor can trigger fallback.
+- Add `claude-fable-5` entry to `src/attune/models/registry.py` at $10/$50/MTok.
+
+The API also now ships a `fallbacks: [model_id, ...]` beta parameter for server-side
+retry on refusals, with a "fallback credit" to avoid paying cache costs twice. Could
+simplify the client-side fallback logic for Fable 5.
+
+- **Applies to:** `src/attune/llm/providers/anthropic.py:235`,
+  `src/attune/models/registry.py`, `src/attune/models/resilient_executor.py`
+- **Urgency:** Low while `claude-fable-5` is not in the registry. High before adding it.
+- **Alternatives:** Don't add Fable 5 to the stack (Opus 4.8 is adequate for most
+  tasks); use the server-side `fallbacks` parameter instead of client-side logic.
+
+---
+
+**2. Agent SDK credit pool is live today — confirm per-run caps are set**
+
+The $200/month credit pool for Agent SDK calls and `claude -p` activated June 15.
+Deep-review at Opus 4.8 rates runs ~$5–10/run; 20–40 runs drains the pool. There is
+no interactive fallback and no built-in Anthropic alert — just failures mid-session.
+
+Confirm `ATTUNE_MAX_BUDGET_USD` is set in every config that invokes SDK workflows
+(`deep_review`, `release_prep`, `research_synthesis`). The pool cap is
+per-calendar-month and hard.
+
+- **Applies to:** `src/attune/workflows/agent_sdk_adapter.py`, user config
+- **Urgency:** High — live today.
+- **Alternatives:** None; this is a billing architecture change, not a code change.
+
+---
+
+**3. Document `--safe-mode` and `disableBundledSkills` in attune-ai plugin docs**
+
+Claude Code v2.1.169 added `--safe-mode` (and `CLAUDE_CODE_SAFE_MODE=1`), which
+disables all CLAUDE.md, plugins, skills, hooks, and MCP servers. This is the
+canonical first isolation step when debugging whether a problem is in attune-ai's
+plugin or in Claude Code itself — and saves users from filing bugs against the wrong
+thing.
+
+Also new: `disableBundledSkills` setting hides built-in slash commands from the model
+while leaving custom MCP servers active. Useful for a "clean" attune-ai-only
+environment where bundled skills don't compete with attune-ai's.
+
+Both belong in a troubleshooting section of the attune-ai plugin docs.
+
+- **Applies to:** attune-ai plugin docs / README
+- **Urgency:** Low — additive doc update.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| June-8 Rec #1 | 2026-06-08 | Fix `cost_tracker.py` snapshot key before June 15 | **Closed — false alarm.** Code comment explicitly says keep the legacy key for historical cost lookups on pre-retirement records. Not a live API-call path. Correct as-is. |
+| June-8 Rec #2 | 2026-06-08 | Pre-flight before Opus 4.8 upgrade | **Closed.** `adaptive_routing.py:150` already has `"premium": "claude-opus-4-8"` — upgrade was done before the June-8 report. |
+| June-8 Rec #3 | 2026-06-08 | Confirm Agent SDK billing exposure | **Active → Rec #2 above.** Pool is live today. |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` | Open. |
+| June-1 Rec #1 | 2026-06-01 | Upgrade PREMIUM tier to Opus 4.8 | **Closed ✅** — `adaptive_routing.py:150` confirmed. |
+| June-1 #4 | 2026-06-01 | Add SDK ceiling `<0.2.82` to pyproject.toml | **Closed ✅** — `pyproject.toml` confirmed at `>=0.1.60,<0.2.82` with rationale comment. |
+| May-25 #2 | 2026-05-25 | attune-ops: switch to `claude agents --json` | Open. v2.1.169 added new `id`/`state` fields and `--all` flag — schema is richer now. |
+| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish pipeline | Open (5 weeks). |
+| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open (5 weeks — minor doc edit). |
+| May-18 #1 | 2026-05-18 | Cap Agent SDK below v0.2.82 | **Closed ✅** — same as June-1 #4; `pyproject.toml` confirmed. |
+| May-18 #3 | 2026-05-18 | `CLAUDE_PROJECT_DIR` in MCP `workspace_root` | **Closed ✅** — `server.py:117-120` already reads `os.environ.get("CLAUDE_PROJECT_DIR")`. |
+| May-11 #6 | 2026-05-11 | `ENABLE_PROMPT_CACHING_1H` for attune-author polish | Open (6 weeks). |
+| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | Open (6 weeks). |
+
+May-11 items #6 and #7 have been open 6 weeks. If they're genuinely blocked, say so
+and close them; if still relevant, a one-line code change each.
+
+---
+
+## Watch list
+
+- **Fable 5 server-side `fallbacks` parameter (beta)**: `fallbacks: [model_id, ...]`
+  on the Messages API retries a refused request on another model and issues a
+  "fallback credit" so prompt-cache costs aren't paid twice. Currently beta on the
+  Claude API only (not Bedrock/Vertex). Could replace parts of attune-ai's client-side
+  fallback chain for Fable 5 calls. Watch for GA.
+
+- **Nested sub-agents up to 5 levels (v2.1.172)**: Claude Code now allows sub-agents
+  to spawn their own sub-agents. attune-ai's CrewAI teams have a flatter topology; this
+  opens architectural options for deeper orchestration. No action yet — worth an
+  experiment when a concrete use case appears.
+
+- **`post-session` lifecycle hook for self-hosted runner (v2.1.169)**: Runs after
+  session ends, before workspace deletion — useful for snapshotting uncommitted work or
+  exporting logs. Relevant if attune-ops ever ships a self-hosted runner config.
+
+- **`enforceAvailableModels` managed setting (v2.1.175)**: Constrains the Default model
+  to a declared allowlist. Relevant for enterprise deployments of attune-ai where model
+  choice must be locked down.
+
+- **Fable 5 30-day data retention / no ZDR**: Fable 5 is a "Covered Model" with 30-day
+  retention. Enterprise customers with zero-data-retention contracts cannot use it. If
+  enterprise users ask why Fable 5 is unavailable, this is the reason.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Claude Mythos 5 | Invite-only (Project Glasswing); not accessible to the stack |
+| Self-hosted sandbox `GET /v1/environments/{id}/work` on AWS (June 10) | Stack uses direct SDK, not self-hosted Managed Agents sandbox |
+| Dynamic Workflows research preview | API surface still unstable; not in stack |
+| `wheelScrollAccelerationEnabled` (v2.1.174) | UI setting; no stack impact |
+| Session titles in conversation language (v2.1.176) | UI feature; no stack impact |
+| `footerLinksRegexes` setting (v2.1.176) | UI configuration; no stack impact |
+| Bedrock GovCloud region fix (v2.1.174) | Not using Bedrock GovCloud |
+| Fable 5 `[1m]` suffix normalization (v2.1.173) | No stack impact until `claude-fable-5` is in registry |
+| Plugin marketplace search bar (v2.1.172) | UI feature |
+| AWS Bedrock region from `~/.aws` (v2.1.172) | Not using Bedrock directly |
+| `/cd` command (v2.1.169) | No stack code impact |
+| `taskCreate` reliability improvements (v2.1.169) | Used by Claude Code internally; no attune-ai code impact |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` (through June 10, 2026)
+- `platform.claude.com/docs/en/about-claude/models/overview` (June 2026)
+- `platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5`
+- Claude Code CHANGELOG v2.1.169–v2.1.176 (June 8–12, 2026)
+- Repo audit: `src/attune/cost_tracker.py`, `src/attune/models/adaptive_routing.py`,
+  `src/attune/models/registry.py`, `src/attune/llm/providers/anthropic.py`,
+  `src/attune/workflows/agent_sdk_adapter.py`, `src/attune/mcp/server.py`,
+  `pyproject.toml`
+- Prior report: `weekly-reports/2026-06-08.md`


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-06-15

## Summary

**Claude Fable 5 launched June 9** (`claude-fable-5`, $10/$50/MTok), a new tier
above Opus 4.8 with always-on adaptive thinking and safety classifiers that return
`stop_reason: "refusal"` on HTTP 200 — a new response shape not currently handled
by attune-ai's executor or SDK adapter. The **Agent SDK credit pool went live today**
(June 15). Several carry-overs are confirmed resolved in code: the Opus 4.8 upgrade,
the SDK ceiling, the CLAUDE_PROJECT_DIR MCP fix, and the June-8 cost_tracker alarm
(a false read — the code correctly keeps the legacy key for historical lookups).

---

## Recommendations

**1. Handle `stop_reason: "refusal"` before adding Fable 5 to the stack**

Fable 5 declines requests by returning HTTP 200 with `stop_reason: "refusal"` — not
an exception. `src/attune/llm/providers/anthropic.py:235` captures `stop_reason` but
doesn't check for `"refusal"`. `agent_sdk_adapter.py:1249` records it in metadata but
doesn't surface it as an error or trigger fallback.

If Fable 5 is ever passed as a model, refused calls would silently return
empty/truncated content — `FallbackStrategy.CHEAPER_TIER_SAME_PROVIDER` won't
trigger because no exception was raised.

Two-step prep (not urgent while Fable 5 isn't in the registry):

- In `anthropic.py`: after capturing `stop_reason`, raise or flag when
  `stop_reason == "refusal"` so the resilient executor can trigger fallback.
- Add `claude-fable-5` entry to `src/attune/models/registry.py` at $10/$50/MTok.

The API also now ships a `fallbacks: [model_id, ...]` beta parameter for server-side
retry on refusals, with a "fallback credit" to avoid paying cache costs twice. Could
simplify the client-side fallback logic for Fable 5.

- **Applies to:** `src/attune/llm/providers/anthropic.py:235`,
  `src/attune/models/registry.py`, `src/attune/models/resilient_executor.py`
- **Urgency:** Low while `claude-fable-5` is not in the registry. High before adding it.
- **Alternatives:** Don't add Fable 5 yet (Opus 4.8 is adequate for most tasks); use
  server-side `fallbacks` parameter instead of client-side logic when ready.

---

**2. Agent SDK credit pool is live today — confirm per-run caps are set**

The $200/month credit pool for Agent SDK calls and `claude -p` activated June 15.
Deep-review at Opus 4.8 rates runs ~$5–10/run; 20–40 runs drains the pool. There is
no interactive fallback and no built-in Anthropic alert — just failures mid-session.

Confirm `ATTUNE_MAX_BUDGET_USD` is set in every config that invokes SDK workflows
(`deep_review`, `release_prep`, `research_synthesis`).

- **Applies to:** `src/attune/workflows/agent_sdk_adapter.py`, user config
- **Urgency:** High — live today.

---

**3. Document `--safe-mode` and `disableBundledSkills` in attune-ai plugin docs**

Claude Code v2.1.169 added `--safe-mode` / `CLAUDE_CODE_SAFE_MODE=1`, which disables
all CLAUDE.md, plugins, skills, hooks, and MCP servers. First isolation step for
debugging whether a problem is in attune-ai's plugin or in Claude Code itself.

Also new: `disableBundledSkills` setting hides built-in slash commands while leaving
custom MCP servers active — useful for a "clean" attune-ai-only environment.

- **Applies to:** attune-ai plugin docs
- **Urgency:** Low — additive doc update.

---

## Carry-overs

| # | First raised | Recommendation | Status |
|---|---|---|---|
| June-8 Rec #1 | 2026-06-08 | Fix `cost_tracker.py` snapshot key before June 15 | **Closed — false alarm.** Code comment explicitly says keep the legacy key for historical cost lookups on pre-retirement records. Correct as-is. |
| June-8 Rec #2 | 2026-06-08 | Pre-flight before Opus 4.8 upgrade | **Closed.** `adaptive_routing.py:150` already has `"premium": "claude-opus-4-8"` — upgrade done before last report. |
| June-8 Rec #3 | 2026-06-08 | Confirm Agent SDK billing exposure | **Active → Rec #2 above.** Pool is live today. |
| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` | Open. |
| June-1 Rec #1 | 2026-06-01 | Upgrade PREMIUM tier to Opus 4.8 | **Closed ✅** — `adaptive_routing.py:150` confirmed. |
| June-1 #4 | 2026-06-01 | Add SDK ceiling `<0.2.82` to pyproject.toml | **Closed ✅** — `pyproject.toml` confirmed at `>=0.1.60,<0.2.82`. |
| May-25 #2 | 2026-05-25 | attune-ops: switch to `claude agents --json` | Open. v2.1.169 added `id`/`state` fields and `--all` flag. |
| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish | Open (5 weeks). |
| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open (5 weeks — minor doc edit). |
| May-18 #1 | 2026-05-18 | Cap Agent SDK below v0.2.82 | **Closed ✅** — same as June-1 #4; `pyproject.toml` confirmed. |
| May-18 #3 | 2026-05-18 | `CLAUDE_PROJECT_DIR` in MCP `workspace_root` | **Closed ✅** — `server.py:117-120` already reads `os.environ.get("CLAUDE_PROJECT_DIR")`. |
| May-11 #6 | 2026-05-11 | `ENABLE_PROMPT_CACHING_1H` for attune-author polish | Open (6 weeks). |
| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | Open (6 weeks). |

May-11 items #6 and #7 have been open 6 weeks. If blocked, close them; if still relevant, each is a one-line code change.

---

## Watch list

- **Fable 5 server-side `fallbacks` parameter (beta)**: `fallbacks: [model_id, ...]` retries refused requests on another model with a "fallback credit" so cache costs aren't paid twice. Beta on Claude API only (not Bedrock/Vertex). Watch for GA — could simplify attune-ai's fallback chain.

- **Nested sub-agents up to 5 levels (v2.1.172)**: Claude Code now allows sub-agents to spawn sub-agents. attune-ai's CrewAI teams are flatter — deeper nesting opens architectural options. No action yet.

- **`post-session` lifecycle hook for self-hosted runner (v2.1.169)**: Runs after session ends, before workspace deletion. Relevant if attune-ops ever ships a self-hosted runner config.

- **`enforceAvailableModels` managed setting (v2.1.175)**: Constrains the Default model to an allowlist. Relevant for enterprise attune-ai deployments.

- **Fable 5 30-day data retention / no ZDR**: Fable 5 is a "Covered Model" with 30-day retention. Enterprise users with zero-data-retention contracts cannot use it.

---

## No-ops

| Item | Why skipped |
|---|---|
| Claude Mythos 5 | Invite-only (Project Glasswing); not accessible to the stack |
| Self-hosted sandbox `GET /v1/environments/{id}/work` on AWS (June 10) | Stack uses direct SDK, not Managed Agents sandbox |
| Dynamic Workflows research preview | API surface still unstable; not in stack |
| `wheelScrollAccelerationEnabled` (v2.1.174) | UI setting; no stack impact |
| Session titles in conversation language (v2.1.176) | UI feature; no stack impact |
| `footerLinksRegexes` setting (v2.1.176) | UI configuration; no stack impact |
| Bedrock GovCloud region fix (v2.1.174) | Not using Bedrock GovCloud |
| Fable 5 `[1m]` suffix normalization (v2.1.173) | No stack impact until `claude-fable-5` is in registry |
| Plugin marketplace search bar (v2.1.172) | UI feature |
| AWS Bedrock region from `~/.aws` (v2.1.172) | Not using Bedrock directly |
| `/cd` command (v2.1.169) | No stack code impact |
| `TaskCreate` reliability improvements (v2.1.169) | Used by Claude Code internally; no attune-ai code impact |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/api` (through June 10, 2026)
- `platform.claude.com/docs/en/about-claude/models/overview` (June 2026)
- `platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5`
- Claude Code CHANGELOG v2.1.169–v2.1.176 (June 8–12, 2026)
- Repo audit: `src/attune/cost_tracker.py`, `src/attune/models/adaptive_routing.py`, `src/attune/models/registry.py`, `src/attune/llm/providers/anthropic.py`, `src/attune/workflows/agent_sdk_adapter.py`, `src/attune/mcp/server.py`, `pyproject.toml`
- Prior report: `weekly-reports/2026-06-08.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1TejYVFqidKJhaa8hLCC8)_