### PR TITLE
feat(website): reposition site as spec-driven development platform

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -9196,3 +9196,49 @@ files.
     is `daemon=True` and no-ops when `client is None`, i.e. keyless CI).
     A no-op daemon is a CORRELATION/suspect, not a proven cause — get
     N>1 dumps before shipping a fix (tar-pit guard).
+
+- **The marketing site lives in `website/` (Next.js 15) and the
+  `website-content-accuracy` rule's verification snippets drift too**:
+  2026-06-15 repositioning smartaimemory.com as a "spec-driven
+  development platform." (1) Canonical counts are `website/lib/
+  features.ts` `CAPABILITIES`; verify against the LIVE registry, not the
+  rule's snippet. The rule's wizards command is STALE — `from
+  attune.wizards import WizardRegistry` no longer exists; current API is
+  `from attune.wizards import list_wizards; len(list_wizards())` (=5).
+  Working introspection for all five: workflows `len([w for w in
+  list_workflows() if w.get('stages')])` (=17 multi-stage vs 20 listed
+  total — README said 20, site said 17; both right, different framing);
+  mcpTools = `sum(len(getattr(ts,n)()) for n in dir(ts) if
+  n.startswith('get_') and n.endswith('_tools'))` from
+  `attune.mcp.tool_schemas` (=41); templateKinds `len(
+  attune_author.generator._ALL_TEMPLATE_NAMES)` (=15, SEPARATE package —
+  may be absent); skills = `plugin/skills/` dir count (=17, no Python
+  needed). Landed a Vitest guard (`website/test/
+  capabilities-accuracy.test.ts`, `npm test` in website/) that asserts
+  CAPABILITIES against these — shells to Python, skips if attune
+  unimportable (force with `ATTUNE_PYTHON=<venv> npm test`). (2)
+  `attune_redis` is PART of attune-ai (the `[redis]` extra / bundled
+  plugin), NOT a separate sibling package like attune-help/author/rag/
+  gui — its README already attributes "for Attune AI." (3) `plugin/
+  README.md` carried silently-rotted facts (skills 13→17, MCP 31→41,
+  version 5.4.0→8.5.0); no CI gate catches README drift — only the new
+  Vitest guard covers features.ts, not prose READMEs.
+
+- **`worktree_path_guard.py` PreToolUse hook misfires when the Bash
+  cwd has drifted into a subdir** — it resolves its script via the
+  RELATIVE path `src/attune/hooks/scripts/worktree_path_guard.py` from
+  cwd, so after a `cd website && npm …` the NEXT Edit/Write fails with
+  `can't open file '.../website/src/attune/hooks/scripts/…'` (a hook
+  ERROR, not a deliberate block). The Bash tool's cwd persists between
+  calls; `cd <subdir> && …` leaves it there. Fix: `cd` back to the
+  worktree root before any Edit/Write. Fired ~3× in one session. Pairs
+  with the worktree-PYTHONPATH / Write-absolute-path cwd-hygiene
+  lessons.
+
+- **Tailwind JIT never emits dynamically-built class names** — `bg-[var(
+  --${p.color})]` (template-literal class) is silently absent and the
+  element renders unstyled; the scanner only sees COMPLETE literal
+  strings. Use a lookup map of full literals (`{primary:
+  'bg-[var(--primary)]/10', secondary: …, accent: …}`) keyed by the
+  dynamic value. Used in `website/app/page.tsx` (`PILLAR_COLOR`) and the
+  how-it-works rewrite.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- mcp-name: io.github.Smart-AI-Memory/attune-ai -->
 
-**Multi-agent developer workflows for Claude Code.**
+**Spec-driven development for Claude Code — turn requirements into reliable software.**
 
 🌐 **Docs & guides: [attune-ai.dev](https://attune-ai.dev)**
 
@@ -23,11 +23,14 @@
 
 ---
 
-20 multi-agent workflows, 17 auto-triggering Claude Code skills, and
-41 MCP tools — specialist teams of 2–6 Claude subagents that review
-your code, surface vulnerabilities, generate tests, and plan refactors.
-The same system doubles as the authoring and assistance toolkit for
-building and maintaining knowledge bases at scale.
+A spec-driven development platform for Claude Code. Four pillars — AI
+workflows, project memory, retrieval grounding, and verification — turn
+requirements into reliable software. 20 workflows (17 multi-stage),
+17 auto-triggering skills, and 41 MCP tools run specialist teams of 2–6
+Claude subagents that review your code, surface vulnerabilities, generate
+tests, and plan refactors — grounded in your real source, with findings
+remembered across sessions. The same system doubles as the authoring and
+assistance toolkit for building and maintaining knowledge bases at scale.
 
 **Managing and creating help content and docs?**
 That's [`attune-gui`](https://github.com/Smart-AI-Memory/attune-gui)

--- a/attune-ai-dev/index.html
+++ b/attune-ai-dev/index.html
@@ -181,14 +181,15 @@
 <body>
   <main>
     <span class="eyebrow">
-      <span>v7.4.0</span>
+      <span>v8.5.0</span>
       <span class="dot"></span>
-      <span>AI Workflow OS for Claude Code</span>
+      <span>Spec-driven development platform</span>
     </span>
 
     <h1>attune-ai</h1>
     <p class="tagline">
-      The discipline behind productive collaboration with AI coding agents.
+      Turn requirements into reliable software — with AI workflows, project
+      memory, retrieval grounding, and verification, built for Claude Code.
     </p>
 
     <div class="install" aria-label="Install command">

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,10 +1,10 @@
 # attune-ai
 
-Developer workflow tools for Claude Code. 13
-auto-triggering skills — zero commands. Say what you
-need and Claude picks the right skill.
+Spec-driven development for Claude Code — turn requirements
+into reliable software. 17 auto-triggering skills, zero
+commands: say what you need and Claude picks the right skill.
 
-**Version:** 5.4.0 | **License:** Apache 2.0
+**Version:** 8.5.0 | **License:** Apache 2.0
 
 ## Install
 
@@ -66,7 +66,7 @@ The plugin ships two security hooks:
 ## Python Package (optional — unlocks CLI + MCP)
 
 The plugin works standalone. Add the Python package
-for CLI automation, 31 MCP tools, multi-agent
+for CLI automation, 41 MCP tools, multi-agent
 workflows, and cost tracking:
 
 ```bash
@@ -75,9 +75,9 @@ pip install 'attune-ai[developer]'
 
 | Capability | Plugin only | + pip |
 | ---------- | ----------- | ----- |
-| 13 auto-triggering skills | Yes | Yes |
+| 17 auto-triggering skills | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| 31 MCP tools | -- | Yes |
+| 41 MCP tools | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Cost tracking | -- | Yes |

--- a/website/app/contact/page.tsx
+++ b/website/app/contact/page.tsx
@@ -157,7 +157,7 @@ export default function ContactPage() {
               Contact Us
             </h1>
             <p className="text-2xl mb-8 opacity-90">
-              Questions about the framework? Looking to partner? We&apos;d love to hear from you.
+              Questions about the platform? Looking to partner? We&apos;d love to hear from you.
             </p>
           </div>
         </div>

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -7,15 +7,20 @@ import { generateMetadata as genMeta, generateStructuredData } from '@/lib/metad
 export const metadata: Metadata = genMeta({
   title: 'Documentation',
   description:
-    'Getting started with attune-ai, attune-help, and the Claude Code plugin.',
+    'Get started with Attune-AI — the spec-driven development platform. Install in one command, then turn requirements into reliable software with AI workflows, project memory, retrieval grounding, and verification.',
   url: 'https://smartaimemory.com/docs',
 });
 
 const faqItems = [
   {
-    question: 'How is this different from a wiki?',
+    question: 'What is attune-ai?',
     answer:
-      'Wiki pages drift the moment code changes. Attune templates are generated from your source code and include file hashes. When the code changes, staleness detection flags the affected templates so they can be regenerated automatically.',
+      'A spec-driven development platform that turns requirements into reliable software. It combines four pillars — AI workflows, project memory, retrieval grounding, and verification — into one reliability loop: specify with /spec, ground every change in your real code, build with multi-stage workflows, remember what worked across sessions, and verify the output before it ships.',
+  },
+  {
+    question: 'How does it keep generated content from drifting?',
+    answer:
+      'Retrieval grounding (powered by attune-rag, a built-in dependency) keeps generated content anchored to your actual source — mean faithfulness is at least 0.97 and CI-gated, so drift fails the build. For docs specifically, templates carry source file hashes; when code changes, staleness detection flags the affected templates so they can be regenerated automatically.',
   },
   {
     question: 'Do I need attune-ai to read templates?',
@@ -33,9 +38,9 @@ const faqItems = [
       'Each template stores SHA-256 hashes of the source files it was generated from. The maintenance workflow re-hashes those files and compares. If the hash changed, the template is flagged stale and queued for regeneration.',
   },
   {
-    question: 'Is it free?',
+    question: 'Is it free? What do I need to run it?',
     answer:
-      'Fully open source under Apache 2.0. Free for personal, commercial, and enterprise use. No license keys, no usage limits.',
+      'Fully open source under Apache 2.0 — free for personal, commercial, and enterprise use, with no license keys and no usage limits. It works on a Claude subscription or an API key, so you can run it with whichever access you already have.',
   },
   {
     question: 'What Claude Code skills are included?',
@@ -101,8 +106,9 @@ export default function DocsPage() {
             <div className="max-w-3xl mx-auto text-center">
               <h1 className="text-5xl font-bold mb-6">Documentation</h1>
               <p className="text-xl opacity-90 mb-8">
-                Everything you need to generate, serve, and maintain help
-                content from your codebase.
+                Everything you need to turn requirements into reliable
+                software — install in one command, then run the reliability
+                loop: specify, ground, build, remember, verify.
               </p>
               <nav className="flex flex-wrap justify-center gap-3">
                 <a href="#quickstart" className="px-5 py-2 text-sm rounded-lg font-medium !text-white border-2 border-white/60 hover:bg-white/15 transition-colors">
@@ -137,7 +143,8 @@ export default function DocsPage() {
             <div className="max-w-5xl mx-auto">
               <h2 className="text-4xl font-bold text-center mb-4">Quick Start</h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                Choose the package that fits your needs. All four are
+                Install the platform, or pick the piece that fits the job.
+                Works on a Claude subscription or an API key. Everything is
                 open source under Apache 2.0.
               </p>
 
@@ -163,12 +170,13 @@ export default function DocsPage() {
                 {/* attune-ai */}
                 <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-6 flex flex-col">
                   <div className="text-xs font-bold text-[var(--primary)] uppercase tracking-wider mb-2">
-                    Full Framework
+                    Full Platform
                   </div>
                   <h3 className="text-lg font-bold mb-2">attune-ai</h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
-                    Generate, maintain, and serve help from your codebase.
-                    17 workflows, 17 skills, MCP server.
+                    The whole platform: spec engine, AI workflows, project
+                    memory, retrieval grounding, and verification.
+                    17 multi-stage workflows, 17 skills, 41 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -241,10 +249,11 @@ export default function DocsPage() {
           <div className="container">
             <div className="max-w-4xl mx-auto">
               <h2 className="text-4xl font-bold text-center mb-4">
-                Attune AI Framework
+                Attune AI Platform
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                The full pipeline: scan your codebase, generate help templates,
+                Beyond AI workflows and verification, the platform keeps your
+                docs grounded too: scan your codebase, generate templates,
                 detect when code drifts, and regenerate stale content.
               </p>
 
@@ -561,9 +570,10 @@ export default function DocsPage() {
                 Workflows &amp; Skills
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                attune-ai includes 17 multi-stage workflows, 17
-                auto-invoking Claude Code skills, and an MCP server
-                with 41 registered tools.
+                The build half of the loop: 17 multi-stage workflows
+                (20 workflows total), 17 auto-triggering Claude Code skills,
+                and an MCP server with 41 registered tools — review, tests,
+                bug prediction, refactor, and release prep.
               </p>
 
               <div className="grid md:grid-cols-2 gap-8 mb-12">
@@ -665,7 +675,8 @@ export default function DocsPage() {
             <div className="max-w-3xl mx-auto text-center">
               <h2 className="text-4xl font-bold mb-6">Ready to Get Started?</h2>
               <p className="text-xl mb-8 opacity-90">
-                Generate help content from your codebase in under 5 minutes.
+                Install in one command, then run /spec on your next feature
+                and turn requirements into reliable software.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <a

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -22,19 +22,19 @@ const faqData: FAQCategory[] = [
     questions: [
       {
         question: 'What is Attune AI?',
-        answer: 'Attune AI is a production-ready framework for AI-powered developer workflows with cost optimization and multi-agent orchestration. It includes 13 agent templates, dynamic team composition, persistent agent state, 10+ integrated workflows, and a tier-based LLM routing system that saves 34-86% on API costs.',
+        answer: 'Attune AI is a spec-driven development platform that combines AI workflows, project memory, retrieval grounding, and verification tools to help teams turn requirements into reliable software. It runs on a Claude subscription or an API key, and is open source under Apache 2.0.',
       },
       {
-        question: 'What is multi-agent orchestration?',
-        answer: 'Multi-agent orchestration lets you compose teams of specialized AI agents that collaborate on complex tasks. Attune AI supports parallel, sequential, two-phase, and delegation strategies with quality gates to ensure results meet your standards. The MetaOrchestrator analyzes tasks and automatically selects optimal agent teams.',
+        question: 'What is the reliability loop?',
+        answer: 'The reliability loop is the arc Attune AI takes a requirement through on its way to shipped software: Specify, Ground, Build, Remember, Verify. You write a spec, ground every change in your real code, build with multi-stage workflows, carry what worked into the next session, and verify the output before it ships.',
       },
       {
-        question: 'What is Agent State Persistence?',
-        answer: 'Agent State Persistence stores execution history, checkpoints, and accumulated metrics for each agent across sessions. This enables recovery from interruptions, performance tracking over time, and pattern learning. State is stored locally in JSON files under .attune/agents/state/.',
+        question: 'What are the four pillars?',
+        answer: 'Attune AI is built on four pillars, each a real, shipped capability: AI workflows (17 multi-stage workflows for review, tests, bug prediction, and refactors), Project memory (cross-session findings and a retrievable lessons corpus), Retrieval grounding (citations back to your source via attune-rag), and Verification (fact-checking generated content before it reaches main).',
       },
       {
-        question: 'What is Dynamic Team Composition?',
-        answer: 'Dynamic Team Composition allows you to build agent teams at runtime from 13 pre-built templates or custom configurations. Teams can execute with different strategies (parallel, sequential, two-phase, delegation) and enforce quality gates. You can also compose entire workflows into teams using the WorkflowComposer.',
+        question: 'What can Attune AI do, in numbers?',
+        answer: 'Attune AI ships 20 workflows (17 multi-stage), 41 MCP tools, 17 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",
@@ -85,28 +85,28 @@ const faqData: FAQCategory[] = [
     category: 'Technical',
     questions: [
       {
-        question: 'Which LLM providers are supported?',
-        answer: "Attune AI is built exclusively for Anthropic Claude with a Claude-native architecture. This leverages Anthropic's automatic prompt caching, extended thinking, and optimized tool use. Agent and team creation features (dynamic composition, SDK integration) work with the Anthropic Agent SDK for enhanced capabilities.",
+        question: 'How does retrieval grounding keep answers accurate?',
+        answer: 'Retrieval grounding is powered by attune-rag, a core (built-in) dependency. Keyword and semantic retrieval keep generated content anchored to your actual source, with citations back to where each claim came from. Mean faithfulness is measured at ≥ 0.97 and CI-gated — drift fails the build rather than slipping through.',
       },
       {
-        question: 'What are agent templates?',
-        answer: 'Agent templates are pre-built agent archetypes with defined roles, capabilities, tier preferences, and quality gates. Attune AI includes 13 templates: security auditor, code reviewer, test coverage analyzer, documentation writer, performance optimizer, architecture analyst, refactoring specialist, dependency checker, bug predictor, release coordinator, integration tester, API designer, and DevOps engineer.',
+        question: 'How does verification catch hallucinations?',
+        answer: 'Verification fact-checks LLM output against your source-of-truth before a change reaches main: it confirms imports actually import, CLI flags are real, links resolve, and counts match. It closes the loop the spec opened, so generated docs and code stay honest.',
       },
       {
-        question: 'How is the framework tested?',
-        answer: 'Attune AI has 14,800+ comprehensive tests covering unit tests, integration tests, and cross-platform compatibility. Core modules are rigorously tested for security, agent state persistence, dynamic team orchestration, workflow coordination, and meta-workflow functionality.',
+        question: 'Is my code sent anywhere?',
+        answer: 'Memory is local-first — nothing is sent to a cloud by default. Findings and the lessons corpus live on your machine. An optional Redis semantic tier is available for richer recall, and it uses local Ollama embeddings, so you stay in control of where your data goes.',
       },
       {
-        question: 'How does prompt caching save money?',
-        answer: 'Attune AI leverages Anthropic\'s automatic prompt caching out of the box — no configuration required. Cached input tokens cost just 10% of the standard price, delivering up to 90% cost savings and up to 85% faster responses. The framework\'s Claude-native architecture is designed around caching: system prompts, tool definitions, and conversation history are automatically cached and reused across requests.',
+        question: 'Do I need an API key?',
+        answer: 'No. Attune AI works on a Claude subscription or an API key — use whichever you have. The platform is open source under Apache 2.0 with no license keys or hidden fees.',
       },
       {
-        question: 'What is semantic caching?',
-        answer: 'On top of Anthropic\'s API-level caching, Attune AI includes an optional HybridCache powered by sentence-transformers. It detects semantically similar prompts (95%+ cosine similarity) and reuses cached responses, avoiding redundant API calls entirely. Hash-only caching achieves ~30% hit rate; with semantic matching enabled, measured hit rates reach ~57% on workflows like security audits. Install with pip install attune-ai[developer] to enable it automatically.',
+        question: 'Which LLM provider is supported?',
+        answer: "Attune AI is built for Anthropic Claude with a Claude-native architecture, so it leverages Anthropic's automatic prompt caching, extended thinking, and optimized tool use.",
       },
       {
         question: 'What platforms are supported?',
-        answer: 'The framework is cross-platform and runs on macOS, Linux, and Windows. It requires Python 3.10+ and works with all major development environments including VS Code, JetBrains IDEs, and terminal-based workflows.',
+        answer: 'The platform is cross-platform and runs on macOS, Linux, and Windows. It requires Python 3.10+ and works with all major development environments including VS Code, JetBrains IDEs, and terminal-based workflows.',
       },
     ],
   },
@@ -115,7 +115,7 @@ const faqData: FAQCategory[] = [
     questions: [
       {
         question: 'What are wizards?',
-        answer: 'Wizards are guided, multi-step AI workflows that walk you through complex tasks like debugging, security audits, refactoring, and test generation. Each wizard collects context via questions, runs AI analysis, decomposes work into tasks, and previews results before acting. Attune AI ships with 10 built-in wizards: security-audit, code-review, bug-predict, perf-audit, refactor-plan, test-gen, doc-gen, dependency-check, release-prep, and research.',
+        answer: 'Wizards are guided, multi-step AI workflows that walk you through complex tasks. Each wizard collects context via questions, runs AI analysis, decomposes work into tasks, and previews results before acting. Attune AI ships with 5 built-in wizards.',
       },
       {
         question: 'How do I run a wizard?',
@@ -132,15 +132,15 @@ const faqData: FAQCategory[] = [
     questions: [
       {
         question: 'What can I build with Attune AI?',
-        answer: 'You can build AI-powered developer workflows for software development (bug prediction, security scanning, test generation, code review), orchestrate multi-agent teams for complex analysis tasks, and compose workflows into coordinated pipelines. The framework also supports healthcare use cases with clinical decision support.',
+        answer: 'You take requirements through to reliable software: write a spec with /spec, ground changes in your real code, run multi-stage workflows for code review, security scanning, test generation, bug prediction, and refactor planning, then verify the output before it ships. The lessons corpus and cross-session memory carry what worked into the next session.',
+      },
+      {
+        question: 'How does the spec engine work?',
+        answer: 'The spec engine runs via /spec. It guides you Socratically through requirements, design, and tasks with an approval gate, so a feature starts from an agreed spec rather than an open-ended prompt — the first stage of the reliability loop.',
       },
       {
         question: 'What happened to the Fair Source License?',
-        answer: 'As of January 28, 2026, we switched from Fair Source 0.9 to Apache 2.0. We realized the licensing restrictions were limiting adoption without generating revenue. Going fully open source lets us focus on building the best framework and growing a community.',
-      },
-      {
-        question: 'Is the framework production-ready?',
-        answer: 'Yes! The framework is v3.6.x Production/Stable with comprehensive tests, extensive documentation, persistent agent state, dynamic team composition, and is being used in production software development tools and AI workflows.',
+        answer: 'As of January 28, 2026, we switched from Fair Source 0.9 to Apache 2.0. We realized the licensing restrictions were limiting adoption without generating revenue. Going fully open source lets us focus on building the best platform and growing a community.',
       },
     ],
   },
@@ -173,16 +173,17 @@ const faqData: FAQCategory[] = [
 ];
 
 export const metadata: Metadata = generateMetadata({
-  title: 'Attune AI FAQ — Open Source Agent Framework for Claude Code',
+  title: 'Attune AI FAQ — Spec-Driven Development Platform for Claude Code',
   description:
-    'Answers to common questions about Attune AI: installation, Claude Code integration, multi-agent orchestration, licensing, and cost optimization.',
+    'Answers to common questions about Attune AI: the reliability loop, AI workflows, project memory, retrieval grounding, verification, licensing, and how it turns requirements into reliable software.',
   url: 'https://smartaimemory.com/faq',
   keywords: [
     'Attune AI FAQ',
-    'Claude Code agent framework',
-    'open source AI framework',
-    'AI workflow questions',
-    'multi-agent orchestration FAQ',
+    'spec-driven development platform',
+    'Claude Code workflows',
+    'retrieval grounding',
+    'AI verification',
+    'project memory',
   ],
 });
 
@@ -224,7 +225,7 @@ export default function FAQPage() {
                 Frequently Asked Questions
               </h1>
               <p className="text-2xl mb-8 opacity-90">
-                Everything you need to know about Attune AI
+                How Attune AI turns requirements into reliable software
               </p>
             </div>
           </div>

--- a/website/app/how-it-works/page.tsx
+++ b/website/app/how-it-works/page.tsx
@@ -3,71 +3,22 @@ import Link from 'next/link';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import { generateMetadata as genMeta, generateStructuredData } from '@/lib/metadata';
+import { RELIABILITY_LOOP, PILLARS } from '@/lib/features';
 
 export const metadata: Metadata = genMeta({
   title: 'How It Works',
   description:
-    'From source code to living documentation. Learn how Attune AI generates, serves, and maintains help content.',
+    'How Attune AI turns requirements into reliable software: specify, ground, build, remember, and verify — the loop your AI coding agent runs every time.',
   url: 'https://smartaimemory.com/how-it-works',
 });
 
-const steps = [
-  {
-    number: 1,
-    name: 'Bootstrap',
-    summary: 'Scan your codebase and discover features',
-    detail:
-      'The scanner reads your project structure, finds modules, classes, and functions, then proposes features with source-glob patterns and tags. Everything lands in .help/features.yaml as the single source of truth.',
-  },
-  {
-    number: 2,
-    name: 'Generate',
-    summary: 'AI creates templates from your source code',
-    detail:
-      'For each feature, three Jinja-based templates are generated from actual source code: concept (what is it?), task (how to use it), and reference (full API detail). Each template includes a source hash in its frontmatter for staleness tracking.',
-  },
-  {
-    number: 3,
-    name: 'Serve',
-    summary: 'Progressive help via attune-help or /coach',
-    detail:
-      'Ask about a topic and get the concept overview first. Ask again and you auto-advance to the task walkthrough. A third ask delivers the full reference. New topics always reset to concept depth.',
-  },
-  {
-    number: 4,
-    name: 'Maintain',
-    summary: 'Detect drift and regenerate stale templates',
-    detail:
-      'Source hashes in each template\'s frontmatter are compared against the current codebase. Only stale templates are regenerated. Hand-written templates marked status: manual are always preserved.',
-  },
-];
-
-const depthLevels = [
-  {
-    name: 'Concept',
-    color: 'var(--primary)',
-    bgClass: 'border-[var(--primary)]',
-    tagClass: 'bg-[var(--primary)]',
-    description: 'What is it? When to use it?',
-    detail: 'A high-level overview that orients you. Explains purpose, context, and when to reach for this feature.',
-  },
-  {
-    name: 'Task',
-    color: 'var(--secondary)',
-    bgClass: 'border-[var(--secondary)]',
-    tagClass: 'bg-[var(--secondary)]',
-    description: 'Step-by-step: how to do it',
-    detail: 'A practical walkthrough with commands, code snippets, and expected output. Gets you from zero to working.',
-  },
-  {
-    name: 'Reference',
-    color: 'var(--accent)',
-    bgClass: 'border-[var(--accent)]',
-    tagClass: 'bg-[var(--accent)]',
-    description: 'Full detail, edge cases, API',
-    detail: 'Complete API surface, configuration options, edge cases, and caveats. The exhaustive resource.',
-  },
-];
+// Literal Tailwind class strings per pillar color so the JIT
+// scanner emits them (dynamic `bg-[var(--${color})]` is not emitted).
+const PILLAR_COLOR: Record<string, { bg: string; text: string }> = {
+  primary: { bg: 'bg-[var(--primary)]/10', text: 'text-[var(--primary)]' },
+  secondary: { bg: 'bg-[var(--secondary)]/10', text: 'text-[var(--secondary)]' },
+  accent: { bg: 'bg-[var(--accent)]/10', text: 'text-[var(--accent)]' },
+};
 
 export default function HowItWorksPage() {
   const breadcrumbSchema = generateStructuredData('breadcrumb', {
@@ -92,32 +43,38 @@ export default function HowItWorksPage() {
             <div className="max-w-3xl mx-auto text-center">
               <h1 className="text-5xl font-bold mb-4">How It Works</h1>
               <p className="text-xl opacity-90">
-                From source code to living documentation in four steps.
+                From a requirement to reliable software — the loop your
+                AI coding agent runs every time.
               </p>
             </div>
           </div>
         </section>
 
-        {/* Four-Step Lifecycle */}
+        {/* The reliability loop */}
         <section className="py-20">
           <div className="container">
             <div className="max-w-5xl mx-auto">
-              <h2 className="text-3xl font-bold text-center mb-16">
-                The Lifecycle
-              </h2>
+              <div className="text-center mb-16">
+                <h2 className="text-3xl font-bold mb-4">The reliability loop</h2>
+                <p className="text-xl text-[var(--text-secondary)] max-w-2xl mx-auto">
+                  Five stages keep the work honest from idea to merge.
+                  Nothing gets generated without a spec, grounded without
+                  your code, or shipped without verification.
+                </p>
+              </div>
 
               <div className="relative">
                 {/* Vertical timeline line (desktop only) */}
                 <div className="hidden md:block absolute left-1/2 top-0 bottom-0 w-px bg-[var(--border)] -translate-x-1/2" />
 
                 <div className="space-y-12 md:space-y-20">
-                  {steps.map((step, index) => {
+                  {RELIABILITY_LOOP.map((stage, index) => {
                     const isLeft = index % 2 === 0;
                     return (
-                      <div key={step.number} className="relative">
+                      <div key={stage.name} className="relative">
                         {/* Timeline dot (desktop only) */}
-                        <div className="hidden md:flex absolute left-1/2 top-8 -translate-x-1/2 -translate-y-1/2 z-10 w-12 h-12 rounded-full bg-[var(--primary)] text-white items-center justify-center font-bold text-lg shadow-lg">
-                          {step.number}
+                        <div className="hidden md:flex absolute left-1/2 top-8 -translate-x-1/2 -translate-y-1/2 z-10 w-12 h-12 rounded-full bg-[var(--primary)] text-white items-center justify-center font-bold text-sm shadow-lg">
+                          {stage.n}
                         </div>
 
                         {/* Card */}
@@ -127,24 +84,14 @@ export default function HowItWorksPage() {
                           }`}
                         >
                           <div className="glass-panel rounded-xl p-8">
-                            {/* Step number (mobile only) */}
-                            <div className="md:hidden flex items-center gap-3 mb-4">
-                              <div className="w-10 h-10 rounded-full bg-[var(--primary)] text-white flex items-center justify-center font-bold text-sm shrink-0">
-                                {step.number}
+                            <div className="flex items-center gap-3 mb-3">
+                              <div className="md:hidden w-10 h-10 rounded-full bg-[var(--primary)] text-white flex items-center justify-center font-bold text-sm shrink-0">
+                                {stage.n}
                               </div>
-                              <h3 className="text-2xl font-bold">
-                                {step.name}
-                              </h3>
+                              <h3 className="text-2xl font-bold">{stage.name}</h3>
                             </div>
-                            {/* Step name (desktop only) */}
-                            <h3 className="hidden md:block text-2xl font-bold mb-2">
-                              {step.name}
-                            </h3>
-                            <p className="text-lg font-medium text-[var(--primary)] mb-3">
-                              {step.summary}
-                            </p>
                             <p className="text-[var(--text-secondary)] leading-relaxed">
-                              {step.detail}
+                              {stage.description}
                             </p>
                           </div>
                         </div>
@@ -157,120 +104,118 @@ export default function HowItWorksPage() {
           </div>
         </section>
 
-        {/* Progressive Depth */}
+        {/* Four pillars underneath */}
         <section className="py-20 bg-[var(--surface-container-low)]">
           <div className="container">
             <div className="max-w-5xl mx-auto">
               <div className="text-center mb-12">
-                <h2 className="text-3xl font-bold mb-4">
-                  Progressive Depth
-                </h2>
+                <h2 className="text-3xl font-bold mb-4">What&apos;s working underneath</h2>
                 <p className="text-xl text-[var(--text-secondary)] max-w-2xl mx-auto">
-                  Each topic has three layers. Ask once for the overview,
-                  again for the walkthrough, a third time for the full
-                  reference.
+                  Four pillars power every stage of the loop — each a real,
+                  shipped capability.
                 </p>
               </div>
 
-              <div className="grid md:grid-cols-3 gap-8">
-                {depthLevels.map((level) => (
-                  <div
-                    key={level.name}
-                    className={`bg-[var(--background)] rounded-xl p-8 border-t-4 ${level.bgClass} border-b border-l border-r border-b-[var(--border)] border-l-[var(--border)] border-r-[var(--border)]`}
-                  >
-                    <span
-                      className={`inline-block px-3 py-1 rounded-full text-xs font-semibold text-white mb-4 ${level.tagClass}`}
+              <div className="grid md:grid-cols-2 gap-6">
+                {PILLARS.map((p) => {
+                  const c = PILLAR_COLOR[p.color];
+                  return (
+                    <div
+                      key={p.id}
+                      className="bg-[var(--background)] rounded-xl p-8 border border-[var(--border)]"
                     >
-                      {level.name}
-                    </span>
-                    <h3 className="text-xl font-bold mb-2">
-                      {level.description}
-                    </h3>
-                    <p className="text-[var(--text-secondary)] text-sm leading-relaxed">
-                      {level.detail}
-                    </p>
-                  </div>
-                ))}
+                      <div className={`w-14 h-14 rounded-xl ${c.bg} flex items-center justify-center mb-5`}>
+                        <span className="text-3xl" aria-hidden="true">{p.icon}</span>
+                      </div>
+                      <span className={`text-xs font-bold uppercase tracking-[0.12em] ${c.text}`}>
+                        {p.tag}
+                      </span>
+                      <h3 className="text-xl font-bold mt-1 mb-3">{p.title}</h3>
+                      <p className="text-[var(--text-secondary)] leading-relaxed text-sm mb-4">
+                        {p.description}
+                      </p>
+                      <ul className="space-y-1.5">
+                        {p.points.map((pt) => (
+                          <li key={pt} className="flex items-start gap-2 text-sm text-[var(--text-secondary)]">
+                            <span className={`${c.text} mt-0.5`} aria-hidden="true">&#10003;</span>
+                            <span>{pt}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  );
+                })}
               </div>
-
-              <p className="text-center text-sm text-[var(--text-secondary)] mt-8">
-                Repeat calls auto-advance. New topic resets to concept.
-              </p>
             </div>
           </div>
         </section>
 
-        {/* Human Enhancement */}
+        {/* You stay in control */}
         <section className="py-20">
           <div className="container">
             <div className="max-w-4xl mx-auto">
               <div className="text-center mb-12">
                 <h2 className="text-3xl font-bold mb-4">
-                  AI Writes the First Draft. You Make It Yours.
+                  The Agent Drafts. You Approve. The Platform Verifies.
                 </h2>
                 <p className="text-xl text-[var(--text-secondary)] max-w-2xl mx-auto">
-                  Templates are generated from your source code, but
-                  you always have the final say.
+                  Reliability isn&apos;t a vibe — it&apos;s a gate at each end of
+                  the work.
                 </p>
               </div>
 
               <div className="grid md:grid-cols-2 gap-8">
                 <div className="glass-panel rounded-xl p-8">
-                  <div className="text-3xl mb-4">&#x1f916;</div>
-                  <h3 className="text-xl font-bold mb-3">
-                    Generated Templates
-                  </h3>
+                  <div className="text-3xl mb-4">&#x1f4dd;</div>
+                  <h3 className="text-xl font-bold mb-3">The spec gate</h3>
                   <ul className="space-y-3 text-[var(--text-secondary)]">
                     <li className="flex items-start gap-2">
                       <span className="text-[var(--primary)] mt-1 shrink-0">&#x2022;</span>
                       <span>
-                        Created automatically from source code using
-                        Jinja templates
+                        Requirements, design, and tasks are written and
+                        approved before a line of code
                       </span>
                     </li>
                     <li className="flex items-start gap-2">
                       <span className="text-[var(--primary)] mt-1 shrink-0">&#x2022;</span>
                       <span>
-                        Frontmatter tracks source hash, status, and
-                        generation timestamp
+                        Socratic discovery scopes the work with you, not
+                        around you
                       </span>
                     </li>
                     <li className="flex items-start gap-2">
                       <span className="text-[var(--primary)] mt-1 shrink-0">&#x2022;</span>
                       <span>
-                        Regenerated when source code changes and the
-                        hash drifts
+                        The spec is the contract the build is measured
+                        against
                       </span>
                     </li>
                   </ul>
                 </div>
 
                 <div className="glass-panel rounded-xl p-8">
-                  <div className="text-3xl mb-4">&#x270d;&#xfe0f;</div>
-                  <h3 className="text-xl font-bold mb-3">
-                    Hand-Written Content
-                  </h3>
+                  <div className="text-3xl mb-4">&#x2705;</div>
+                  <h3 className="text-xl font-bold mb-3">The verification gate</h3>
                   <ul className="space-y-3 text-[var(--text-secondary)]">
                     <li className="flex items-start gap-2">
                       <span className="text-[var(--secondary)] mt-1 shrink-0">&#x2022;</span>
                       <span>
-                        Edit any generated template or create new ones
-                        from scratch
+                        Generated claims are fact-checked against your real
+                        source
                       </span>
                     </li>
                     <li className="flex items-start gap-2">
                       <span className="text-[var(--secondary)] mt-1 shrink-0">&#x2022;</span>
                       <span>
-                        Mark with{' '}
-                        <code className="text-sm">status: manual</code>{' '}
-                        to protect from regeneration
+                        Imports import, CLI flags are real, links resolve,
+                        counts match
                       </span>
                     </li>
                     <li className="flex items-start gap-2">
                       <span className="text-[var(--secondary)] mt-1 shrink-0">&#x2022;</span>
                       <span>
-                        The maintenance pass always preserves
-                        hand-written templates
+                        Hallucinations are caught before the change reaches
+                        main
                       </span>
                     </li>
                   </ul>
@@ -285,11 +230,11 @@ export default function HowItWorksPage() {
           <div className="container">
             <div className="max-w-3xl mx-auto text-center">
               <h2 className="text-3xl font-bold mb-4">
-                Ready to bootstrap your help system?
+                Ready to turn requirements into reliable software?
               </h2>
               <p className="text-xl text-[var(--text-secondary)] mb-8">
-                One command scans your codebase and generates living
-                documentation.
+                Install from PyPI and run <code className="text-base">/spec</code>{' '}
+                on your next feature.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Link

--- a/website/app/migrate/page.tsx
+++ b/website/app/migrate/page.tsx
@@ -8,7 +8,7 @@ import { CANONICAL_INSTALL, POST_FOLD_INSTALL } from '@/lib/install-command';
 export const metadata: Metadata = generateMetadata({
   title: 'Migrating from attune-gui — Attune AI',
   description:
-    'Heads-up for current attune-gui users: the dashboard is folding back into attune-ai as an install extra. What changes, what doesn’t, and when.',
+    'Heads-up for current attune-gui users: the dashboard is folding into the attune-ai spec-driven development platform as an install extra. What changes, what doesn’t, and when.',
   url: 'https://smartaimemory.com/migrate',
   keywords: ['attune-gui migration', 'attune-ai dashboard', 'pip install attune-ai[gui]'],
 });
@@ -25,7 +25,9 @@ export default function MigratePage() {
                 Heads up: <code className="font-mono">attune-gui</code> is folding into <code className="font-mono">attune-ai</code>
               </h1>
               <p className="text-xl !text-white opacity-90">
-                Pre-fold notice. Nothing breaks today.
+                The dashboard is moving inside the platform that turns
+                requirements into reliable software. Pre-fold notice &mdash;
+                nothing breaks today.
               </p>
             </div>
           </div>
@@ -36,7 +38,11 @@ export default function MigratePage() {
             <div className="max-w-3xl mx-auto prose prose-lg">
               <h2>What&rsquo;s changing</h2>
               <p>
-                Today the dashboard ships as a standalone PyPI package:
+                Attune AI is one platform for spec-driven development &mdash;
+                AI workflows, project memory, retrieval grounding, and
+                verification, working together. The dashboard belongs with it,
+                so it&rsquo;s moving in. Today it ships as a standalone PyPI
+                package:
               </p>
               <pre><code>{CANONICAL_INSTALL}</code></pre>
               <p>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -5,6 +5,7 @@ import GitHubStarsBadge from '@/components/GitHubStarsBadge';
 import TestsBadge from '@/components/TestsBadge';
 import { generateStructuredData } from '@/lib/metadata';
 import { installCommand } from '@/lib/install-command';
+import { CAPABILITIES, PILLARS, RELIABILITY_LOOP } from '@/lib/features';
 
 // Doc-toolchain code sample. attune-ai is the parent
 // framework (headlined in the hero); the four packages
@@ -27,6 +28,16 @@ print(engine.lookup("security-audit"))
 # 4. attune-gui — local dashboard tying it all together.
 #    ${installCommand()} && attune-gui --open`;
 
+// Literal Tailwind class strings per pillar color. Built as full
+// literals (not `bg-[var(--${color})]`) so the JIT scanner can see
+// and generate them — dynamically-constructed class names are not
+// emitted.
+const PILLAR_COLOR: Record<string, { bg: string; text: string }> = {
+  primary: { bg: 'bg-[var(--primary)]/10', text: 'text-[var(--primary)]' },
+  secondary: { bg: 'bg-[var(--secondary)]/10', text: 'text-[var(--secondary)]' },
+  accent: { bg: 'bg-[var(--accent)]/10', text: 'text-[var(--accent)]' },
+};
+
 export default function Home() {
   const softwareSchema = generateStructuredData('product');
 
@@ -47,18 +58,20 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v8.4.0</span>
+                  <span>v8.5.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
-                  <span className="opacity-80">AI Workflow OS for Claude Code</span>
+                  <span className="opacity-80">Spec-driven development platform</span>
                 </div>
                 <h1 className="text-5xl md:text-7xl font-extrabold tracking-tighter mb-8 leading-[1.1]">
-                  AI Workflows for{' '}
-                  <span className="text-gradient">Claude Code</span>
+                  Turn requirements into{' '}
+                  <span className="text-gradient">reliable software</span>.
                 </h1>
                 <p className="text-lg md:text-xl text-[var(--text-secondary)] mb-10 max-w-xl leading-relaxed">
-                  17 workflows, 17 auto-triggering skills, MCP server with 41 tools.
-                  Plus the documentation toolchain we built along the way &mdash;
-                  now four standalone packages.
+                  Attune-AI gives your AI coding agent a spine: write a spec,
+                  ground every change in your real code, carry what worked into
+                  the next session, and verify the output before it ships.
+                  Workflows, memory, retrieval grounding, and verification
+                  &mdash; one platform for Claude Code.
                 </p>
                 <div className="flex flex-col sm:flex-row gap-4">
                   <a
@@ -94,51 +107,32 @@ export default function Home() {
                 </div>
               </div>
 
-              {/* Depth cards visual */}
+              {/* Reliability-loop spine visual */}
               <div className="relative">
                 <div className="relative z-10 rounded-2xl overflow-hidden bg-[var(--surface-container-low)] p-8 border border-[var(--border)]/40 shadow-2xl">
                   <div className="flex items-center gap-2 mb-6">
                     <div className="w-3 h-3 rounded-full bg-red-500/40"></div>
                     <div className="w-3 h-3 rounded-full bg-yellow-500/40"></div>
                     <div className="w-3 h-3 rounded-full bg-green-500/40"></div>
-                    <span className="ml-auto text-[10px] font-bold text-[var(--text-muted)] uppercase tracking-widest">Progressive Depth</span>
+                    <span className="ml-auto text-[10px] font-bold text-[var(--text-muted)] uppercase tracking-widest">One requirement, end to end</span>
                   </div>
 
-                  {/* Code icon connecting to depth cards */}
-                  <div className="flex items-center justify-center mb-6">
-                    <div className="w-12 h-12 rounded-lg bg-[var(--surface-container-high)] border border-[var(--border)]/30 flex items-center justify-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--primary)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                        <polyline points="16 18 22 12 16 6" />
-                        <polyline points="8 6 2 12 8 18" />
-                      </svg>
+                  {RELIABILITY_LOOP.map((s, i) => (
+                    <div key={s.name}>
+                      <div className="flex items-start gap-3 py-2.5">
+                        <span className="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--primary)]/10 text-[var(--primary)] font-bold text-xs shrink-0">
+                          {s.n}
+                        </span>
+                        <div>
+                          <div className="font-bold text-sm leading-tight">{s.name}</div>
+                          <p className="text-xs text-[var(--text-muted)] leading-snug mt-0.5">{s.description}</p>
+                        </div>
+                      </div>
+                      {i < RELIABILITY_LOOP.length - 1 && (
+                        <div className="ml-4 h-3 w-px bg-[var(--border)]"></div>
+                      )}
                     </div>
-                  </div>
-
-                  {/* Connection lines */}
-                  <div className="flex justify-center mb-4">
-                    <div className="w-px h-4 bg-[var(--border)]"></div>
-                  </div>
-                  <div className="flex justify-between px-8 mb-2">
-                    <div className="flex-1 flex justify-center">
-                      <div className="w-full h-px bg-[var(--border)]"></div>
-                    </div>
-                  </div>
-
-                  {/* Three depth cards */}
-                  <div className="grid grid-cols-3 gap-4">
-                    <div className="rounded-lg p-4 bg-[var(--primary)]/10 border border-[var(--primary)]/20 flex flex-col items-center justify-center text-center min-h-[100px]">
-                      <span className="text-xs font-bold text-[var(--primary)] tracking-wider uppercase mb-2">Concept</span>
-                      <p className="text-[10px] text-[var(--text-secondary)] leading-tight">What is it?</p>
-                    </div>
-                    <div className="rounded-lg p-4 bg-[var(--secondary)]/10 border border-[var(--secondary)]/20 flex flex-col items-center justify-center text-center min-h-[100px]">
-                      <span className="text-xs font-bold text-[var(--secondary)] tracking-wider uppercase mb-2">Task</span>
-                      <p className="text-[10px] text-[var(--text-secondary)] leading-tight">How to do it?</p>
-                    </div>
-                    <div className="rounded-lg p-4 bg-[var(--accent)]/10 border border-[var(--accent)]/20 flex flex-col items-center justify-center text-center min-h-[100px]">
-                      <span className="text-xs font-bold text-[var(--accent)] tracking-wider uppercase mb-2">Reference</span>
-                      <p className="text-[10px] text-[var(--text-secondary)] leading-tight">Full API detail</p>
-                    </div>
-                  </div>
+                  ))}
                 </div>
                 {/* Background blur */}
                 <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[140%] h-[140%] bg-gradient-to-tr from-[var(--surface-container-high)]/50 to-transparent rounded-full blur-3xl -z-10"></div>
@@ -147,56 +141,73 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Platform overview — one code sample, three packages */}
-        {/* OS layer: workflows + memory */}
-        <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="The OS layer">
+        {/* Four platform pillars */}
+        <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="Platform pillars">
           <div className="text-center mb-20">
-            <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">The OS Layer</span>
-            <h2 className="text-4xl md:text-5xl font-extrabold">Workflows That Remember</h2>
+            <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">The Platform</span>
+            <h2 className="text-4xl md:text-5xl font-extrabold">Four pillars, one outcome</h2>
             <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
-              What makes it an OS, not a toolbox: orchestrated workflows
-              on top, persistent memory underneath. Your AI collaborator
-              stops starting from zero.
+              Each pillar is a real, shipped capability &mdash; not a
+              roadmap promise. Together they keep your AI agent&apos;s work
+              grounded, remembered, and verified.
             </p>
           </div>
-          <div className="grid md:grid-cols-3 gap-6">
-            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
-                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#9881;&#65039;</span>
+          <div className="grid md:grid-cols-2 gap-6">
+            {PILLARS.map((p) => {
+              const c = PILLAR_COLOR[p.color];
+              return (
+                <div
+                  key={p.id}
+                  className="bg-[var(--surface)] rounded-2xl p-8 border border-[var(--border)]/40 hover:bg-[var(--surface-container-low)] transition-all duration-300"
+                >
+                  <div className={`w-14 h-14 rounded-xl ${c.bg} flex items-center justify-center mb-5`}>
+                    <span className="text-3xl" aria-hidden="true">{p.icon}</span>
+                  </div>
+                  <span className={`text-xs font-bold uppercase tracking-[0.12em] ${c.text}`}>
+                    {p.tag}
+                  </span>
+                  <h3 className="text-2xl font-bold mt-1 mb-3">{p.title}</h3>
+                  <p className="text-[var(--text-secondary)] leading-relaxed text-sm mb-4">
+                    {p.description}
+                  </p>
+                  <ul className="space-y-1.5">
+                    {p.points.map((pt) => (
+                      <li key={pt} className="flex items-start gap-2 text-xs text-[var(--text-muted)]">
+                        <span className={`${c.text} mt-0.5`} aria-hidden="true">&#10003;</span>
+                        <span>{pt}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* Capabilities stat band */}
+        <section className="py-20 bg-[var(--surface-container-low)]" aria-label="Capabilities at a glance">
+          <div className="max-w-7xl mx-auto px-6">
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-8 text-center">
+              <div>
+                <div className="text-4xl font-extrabold text-[var(--primary)]">{CAPABILITIES.workflows}</div>
+                <div className="text-sm text-[var(--text-muted)] mt-1">multi-stage workflows</div>
               </div>
-              <h3 className="text-xl font-bold mb-3">Orchestrated Workflows</h3>
-              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                17 multi-stage workflows — security audit, code review,
-                bug prediction, release prep — with cost-tiered model
-                routing and structured, readable reports. Works on a
-                Claude subscription or an API key.
-              </p>
-            </div>
-            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--secondary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--secondary)] transition-colors">
-                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#129504;</span>
+              <div>
+                <div className="text-4xl font-extrabold text-[var(--primary)]">{CAPABILITIES.mcpTools}</div>
+                <div className="text-sm text-[var(--text-muted)] mt-1">MCP tools</div>
               </div>
-              <h3 className="text-xl font-bold mb-3">Cross-Session Memory</h3>
-              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Findings from each session are stashed and recalled in
-                the next. A retrievable lessons corpus surfaces the
-                right engineering lesson at the moment a prompt needs
-                it — automatically, or on demand with /recall.
-              </p>
-            </div>
-            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--accent)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--accent)] transition-colors">
-                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#128190;</span>
+              <div>
+                <div className="text-4xl font-extrabold text-[var(--primary)]">{CAPABILITIES.skills}</div>
+                <div className="text-sm text-[var(--text-muted)] mt-1">auto-triggering skills</div>
               </div>
-              <h3 className="text-xl font-bold mb-3">Redis Semantic Tier</h3>
-              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Local-first by default; plug in Redis Agent Memory
-                Server for semantic search over your memory — local
-                Ollama embeddings, no cloud required. Enable it with{' '}
-                <code className="text-xs">pip install &apos;attune-ai[redis]&apos;</code>{' '}
-                plus a local AMS service. Our int8 vector quantization
-                work is an open upstream PR to Redis.
-              </p>
+              <div>
+                <div className="text-4xl font-extrabold text-[var(--primary)]">&ge;0.97</div>
+                <div className="text-sm text-[var(--text-muted)] mt-1">RAG faithfulness (CI-gated)</div>
+              </div>
+              <div>
+                <div className="text-4xl font-extrabold text-[var(--primary)]">100%</div>
+                <div className="text-sm text-[var(--text-muted)] mt-1">open source &middot; Apache 2.0</div>
+              </div>
             </div>
           </div>
         </section>
@@ -367,9 +378,10 @@ export default function Home() {
           <div className="grid lg:grid-cols-5 gap-8 items-center">
             <div className="lg:col-span-3 hero-gradient rounded-3xl p-12 text-white relative overflow-hidden">
               <div className="relative z-10">
-                <h3 className="text-3xl font-extrabold mb-6">Ready to make your docs live?</h3>
+                <h3 className="text-3xl font-extrabold mb-6">Ship software you can trust your agent built</h3>
                 <p className="text-white/80 text-lg mb-8 max-w-lg">
-                  Install from PyPI. Generate templates from your code. Ship help that never goes stale.
+                  Install from PyPI, run /spec on your next feature, and let the
+                  platform keep the work grounded, remembered, and verified.
                 </p>
                 <div className="flex flex-col sm:flex-row gap-4">
                   <Link

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -212,6 +212,38 @@ export default function Home() {
           </div>
         </section>
 
+        {/* Semantic memory — powered by Redis */}
+        <section className="py-24 px-6 max-w-7xl mx-auto" aria-label="Semantic memory powered by Redis">
+          <div className="rounded-3xl border border-[var(--border)]/60 bg-[var(--surface-container-low)] p-10 md:p-14">
+            <div className="grid md:grid-cols-2 gap-12 items-center">
+              <div>
+                <span className="text-xs font-bold text-[var(--secondary)] tracking-[0.2em] uppercase mb-4 block">Semantic memory</span>
+                <h2 className="text-3xl md:text-4xl font-extrabold mb-4">Powered by Redis when you want it</h2>
+                <p className="text-[var(--text-secondary)] leading-relaxed mb-6">
+                  Memory is local-first by default &mdash; nothing leaves your
+                  machine. Plug in Redis Agent Memory Server for semantic search
+                  over your project memory: local Ollama embeddings, int8 vector
+                  quantization, no cloud required.
+                </p>
+                <code className="inline-block bg-[var(--surface-container-high)] px-4 py-2 rounded-lg text-sm font-mono">pip install &apos;attune-ai[redis]&apos;</code>
+              </div>
+              <div className="grid sm:grid-cols-2 gap-3">
+                {[
+                  ['Local-first', 'Default backend is on-disk — no service required'],
+                  ['Redis AMS tier', 'Opt in for semantic recall across sessions'],
+                  ['Ollama embeddings', 'Runs locally — no API key, no cloud'],
+                  ['int8 quantization', 'Compact vectors, shipped in attune-ai 7.4'],
+                ].map(([title, desc]) => (
+                  <div key={title} className="bg-[var(--background)] rounded-xl p-4 border border-[var(--border)]/40">
+                    <div className="font-bold text-sm text-[var(--secondary)] mb-1">{title}</div>
+                    <p className="text-xs text-[var(--text-muted)] leading-snug">{desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
         <section className="py-24 bg-[var(--surface-container-low)]" aria-label="Platform overview">
           <div className="max-w-7xl mx-auto px-6">
             <div className="flex flex-col md:flex-row gap-16 items-start">

--- a/website/app/pricing/page.tsx
+++ b/website/app/pricing/page.tsx
@@ -3,20 +3,36 @@ import Link from 'next/link';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import { generateMetadata as genMeta, generateStructuredData } from '@/lib/metadata';
+import { CAPABILITIES, PILLARS, getPricingSummary } from '@/lib/features';
 
 export const metadata: Metadata = genMeta({
-  title: 'Free & Open Source',
+  title: 'Pricing — Free & Open Source',
   description:
-    'Attune AI is fully open source under Apache 2.0. Help content generation, progressive depth, and staleness detection — free for everyone.',
+    'Attune-AI is the spec-driven development platform — AI workflows, ' +
+    'project memory, retrieval grounding, and verification — fully open ' +
+    'source under Apache 2.0. No paid tiers, no usage limits, no license keys.',
   url: 'https://smartaimemory.com/pricing',
 });
 
+// Literal Tailwind class strings per pillar color. Built as full
+// literals (not `bg-[var(--${color})]`) so the JIT scanner can see
+// and generate them — dynamically-constructed class names are not
+// emitted.
+const PILLAR_COLOR: Record<string, { bg: string; text: string }> = {
+  primary: { bg: 'bg-[var(--primary)]/10', text: 'text-[var(--primary)]' },
+  secondary: { bg: 'bg-[var(--secondary)]/10', text: 'text-[var(--secondary)]' },
+  accent: { bg: 'bg-[var(--accent)]/10', text: 'text-[var(--accent)]' },
+};
+
 const includedItems = [
-  'Help content generation from source code',
-  'Progressive depth templates (concept / task / reference)',
-  'Staleness detection and auto-regeneration',
-  'Claude Code plugin with 17 skills',
-  'Standalone reader (attune-help)',
+  `${CAPABILITIES.workflows} multi-stage AI workflows`,
+  `MCP server with ${CAPABILITIES.mcpTools} registered tools`,
+  `${CAPABILITIES.skills} auto-triggering Claude Code skills`,
+  'Spec-driven workflow with an approval gate (/spec)',
+  'Retrieval grounding — attune-rag is built in',
+  'Local-first project memory and lessons corpus',
+  'Verification: fact-check generated content before it ships',
+  'Works on a Claude subscription or an API key',
   'Full source code access',
   'Community support on GitHub',
   'Commercial use rights (Apache 2.0)',
@@ -26,7 +42,7 @@ export default function PricingPage() {
   const breadcrumbSchema = generateStructuredData('breadcrumb', {
     items: [
       { name: 'Home', url: 'https://smartaimemory.com' },
-      { name: 'Open Source', url: 'https://smartaimemory.com/pricing' },
+      { name: 'Pricing', url: 'https://smartaimemory.com/pricing' },
     ],
   });
 
@@ -42,12 +58,17 @@ export default function PricingPage() {
         <section className="py-20 gradient-primary text-white">
           <div className="container">
             <div className="max-w-3xl mx-auto text-center">
+              <span className="inline-block text-xs font-bold tracking-[0.2em] uppercase mb-4 opacity-80">
+                Pricing
+              </span>
               <h1 className="text-5xl font-bold mb-6">
-                Free &amp; Open Source
+                The whole platform, free &amp; open source
               </h1>
               <p className="text-xl opacity-90 mb-8">
-                Apache License 2.0 — free for everyone. No hidden fees,
-                no usage limits, no license keys.
+                Turn requirements into reliable software with no paywall in
+                the way. Apache License 2.0 — no paid tiers, no usage limits,
+                no license keys. Run it on a Claude subscription or your own
+                API key.
               </p>
               <a
                 href="https://github.com/Smart-AI-Memory/attune-ai"
@@ -61,7 +82,7 @@ export default function PricingPage() {
           </div>
         </section>
 
-        {/* Everything Included */}
+        {/* What's in the platform */}
         <section className="py-24 px-6">
           <div className="max-w-4xl mx-auto">
             <div className="text-center mb-16">
@@ -69,8 +90,12 @@ export default function PricingPage() {
                 What You Get
               </span>
               <h2 className="text-4xl font-extrabold">
-                Everything Included
+                The full platform — nothing held back
               </h2>
+              <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
+                Every pillar, every workflow, every tool. There&apos;s no
+                upgrade tier to unlock — {getPricingSummary().toLowerCase()}.
+              </p>
             </div>
 
             <div className="grid md:grid-cols-2 gap-6 mb-16">
@@ -98,67 +123,48 @@ export default function PricingPage() {
           </div>
         </section>
 
-        {/* Open Source Benefits */}
+        {/* Four pillars — all free */}
         <section className="py-24 px-6 bg-[var(--surface-container-low)]">
           <div className="max-w-7xl mx-auto">
             <div className="text-center mb-16">
               <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">
-                Open Source
+                The Platform
               </span>
               <h2 className="text-4xl font-extrabold">
-                Why It&apos;s Free
+                Four pillars, zero cost
               </h2>
+              <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
+                Each pillar is a real, shipped capability — and every one is
+                included in the free, open source release.
+              </p>
             </div>
 
             <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
-              <div className="group bg-[var(--surface)] rounded-2xl p-8 hover:bg-[var(--background)] transition-all duration-300 hover:scale-[1.02]">
-                <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
-                  <span className="text-2xl group-hover:brightness-0 group-hover:invert transition-all">&#127881;</span>
-                </div>
-                <h3 className="text-lg font-bold mb-3">No Cost, Ever</h3>
-                <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
-                  Personal projects, startups, or enterprises.
-                  No fees, no limits.
-                </p>
-              </div>
-
-              <div className="group bg-[var(--surface)] rounded-2xl p-8 hover:bg-[var(--background)] transition-all duration-300 hover:scale-[1.02]">
-                <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
-                  <span className="text-2xl group-hover:brightness-0 group-hover:invert transition-all">&#128275;</span>
-                </div>
-                <h3 className="text-lg font-bold mb-3">Commercial Friendly</h3>
-                <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
-                  Build and sell commercial products. Apache 2.0
-                  includes patent protection.
-                </p>
-              </div>
-
-              <div className="group bg-[var(--surface)] rounded-2xl p-8 hover:bg-[var(--background)] transition-all duration-300 hover:scale-[1.02]">
-                <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
-                  <span className="text-2xl group-hover:brightness-0 group-hover:invert transition-all">&#128736;&#65039;</span>
-                </div>
-                <h3 className="text-lg font-bold mb-3">Fork &amp; Modify</h3>
-                <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
-                  Customize for your needs. Create private forks
-                  or contribute back.
-                </p>
-              </div>
-
-              <div className="group bg-[var(--surface)] rounded-2xl p-8 hover:bg-[var(--background)] transition-all duration-300 hover:scale-[1.02]">
-                <div className="w-14 h-14 rounded-xl bg-[var(--primary)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--primary)] transition-colors">
-                  <span className="text-2xl group-hover:brightness-0 group-hover:invert transition-all">&#129309;</span>
-                </div>
-                <h3 className="text-lg font-bold mb-3">Community Driven</h3>
-                <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
-                  Contribute features, fix bugs, or star the repo.
-                  We welcome everyone.
-                </p>
-              </div>
+              {PILLARS.map((p) => {
+                const c = PILLAR_COLOR[p.color];
+                return (
+                  <div
+                    key={p.id}
+                    className="group bg-[var(--surface)] rounded-2xl p-8 hover:bg-[var(--background)] transition-all duration-300 hover:scale-[1.02]"
+                  >
+                    <div className={`w-14 h-14 rounded-xl ${c.bg} flex items-center justify-center mb-6`}>
+                      <span className="text-2xl" aria-hidden="true">{p.icon}</span>
+                    </div>
+                    <span className={`text-xs font-bold uppercase tracking-[0.12em] ${c.text}`}>
+                      {p.tag}
+                    </span>
+                    <h3 className="text-lg font-bold mt-1 mb-3">{p.title}</h3>
+                    <p className="text-sm text-[var(--text-secondary)] leading-relaxed">
+                      {p.description}
+                    </p>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </section>
 
-        {/* Why Open Source */}
+        {/* Why open source */}
         <section className="py-24 px-6">
           <div className="max-w-3xl mx-auto">
             <div className="text-center mb-16">
@@ -166,29 +172,30 @@ export default function PricingPage() {
                 Our Philosophy
               </span>
               <h2 className="text-4xl font-extrabold">
-                Why We Went Open Source
+                Why the platform is free
               </h2>
             </div>
 
             <div className="space-y-8">
               <div className="p-8 rounded-2xl bg-[var(--surface)] border-l-4 border-[var(--primary)]">
                 <h3 className="text-xl font-bold mb-3">
-                  Adoption Over Revenue
+                  Reliability shouldn&apos;t be a premium tier
                 </h3>
                 <p className="text-[var(--text-secondary)] leading-relaxed">
-                  Developers want proven, open source tools — especially
-                  in the AI space. Going Apache 2.0 lets us focus on
-                  building the best help content generation framework
-                  and growing a community of contributors.
+                  Specifying, grounding, remembering, and verifying are how
+                  teams turn requirements into software they can trust. Those
+                  aren&apos;t add-ons to charge for — they&apos;re the whole
+                  point. Apache 2.0 keeps the reliability loop open to everyone.
                 </p>
               </div>
 
               <div className="p-8 rounded-2xl bg-[var(--surface)] border-l-4 border-[var(--secondary)]">
-                <h3 className="text-xl font-bold mb-3">Community First</h3>
+                <h3 className="text-xl font-bold mb-3">Built for teams</h3>
                 <p className="text-[var(--text-secondary)] leading-relaxed">
-                  The best developer tools are built by communities,
-                  not companies. Your feedback, contributions, and
-                  support are what will make this project successful.
+                  The best developer tools are built by communities, not locked
+                  behind seats. Memory is local-first with an optional Redis
+                  semantic tier, so a team can adopt the platform on its own
+                  terms. Your feedback and contributions are what make it better.
                 </p>
               </div>
             </div>
@@ -200,11 +207,12 @@ export default function PricingPage() {
           <div className="container">
             <div className="max-w-3xl mx-auto text-center">
               <h2 className="text-4xl font-bold mb-6">
-                Ready to Get Started?
+                Ready to ship reliable software?
               </h2>
               <p className="text-xl mb-8 opacity-90">
-                Free and open source forever. Generate help content
-                from your codebase today.
+                Free and open source forever. Install from PyPI, run /spec on
+                your next feature, and let the platform keep the work grounded,
+                remembered, and verified.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <a

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -19,7 +19,7 @@ export default function Footer() {
               Attune AI
             </Link>
             <p className="mt-4 text-sm text-[var(--text-secondary)]">
-              Living docs, rooted in code. Help content that stays fresh automatically.
+              Spec-driven development for Claude Code. Turn requirements into reliable software.
             </p>
             <div className="flex gap-4 mt-4">
               <a

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -274,6 +274,134 @@ export const CAPABILITIES = {
  */
 export const LEGACY_CAPABILITIES = CAPABILITIES;
 
+// --- Platform positioning (spec-driven dev) ---
+
+/**
+ * The five-stage reliability loop — the narrative spine of the
+ * homepage. Maps requirement → shipped without losing the thread.
+ */
+export interface LoopStage {
+  n: string;
+  name: string;
+  description: string;
+}
+
+export const RELIABILITY_LOOP: LoopStage[] = [
+  {
+    n: "01",
+    name: "Specify",
+    description:
+      "Socratic spec engine: requirements, design, and tasks with an approval gate.",
+  },
+  {
+    n: "02",
+    name: "Ground",
+    description:
+      "RAG retrieval cites your code so the agent doesn't invent APIs.",
+  },
+  {
+    n: "03",
+    name: "Build",
+    description:
+      "17 multi-stage workflows: review, tests, bug prediction, refactor.",
+  },
+  {
+    n: "04",
+    name: "Remember",
+    description:
+      "Cross-session memory and a lessons corpus surface what worked before.",
+  },
+  {
+    n: "05",
+    name: "Verify",
+    description:
+      "Fact-check generated content: imports, flags, links, counts — all real.",
+  },
+];
+
+/**
+ * The four platform pillars. Each maps to a real, shipped
+ * capability — verified against the live registry, no roadmap
+ * fiction (see website-content-accuracy rule). `color` selects a
+ * brand token: primary (action), secondary (knowledge), accent (AI).
+ */
+export interface Pillar {
+  id: string;
+  tag: string;
+  title: string;
+  description: string;
+  points: string[];
+  icon: string;
+  color: "primary" | "secondary" | "accent";
+}
+
+export const PILLARS: Pillar[] = [
+  {
+    id: "workflows",
+    tag: "AI workflows",
+    title: "Specialist teams, not one prompt",
+    description:
+      "17 multi-stage workflows run teams of 2–6 Claude subagents to " +
+      "review code, surface vulnerabilities, generate tests, and plan " +
+      "refactors — with cost-tiered model routing.",
+    points: [
+      "Security audit, code review, bug prediction, release prep",
+      "Cheap / capable / premium model routing",
+      "Structured, readable reports",
+    ],
+    icon: "⚙️",
+    color: "primary",
+  },
+  {
+    id: "memory",
+    tag: "Project memory",
+    title: "Your agent stops starting from zero",
+    description:
+      "Findings from each session are stashed and recalled in the next. " +
+      "A retrievable lessons corpus surfaces the right engineering lesson " +
+      "at the moment a prompt needs it.",
+    points: [
+      "Local-first by default — no cloud required",
+      "Optional Redis semantic tier (local Ollama embeddings)",
+      "Automatic recall, or on demand with /recall",
+    ],
+    icon: "🧠",
+    color: "secondary",
+  },
+  {
+    id: "grounding",
+    tag: "Retrieval grounding",
+    title: "Answers anchored to your code",
+    description:
+      "Keyword + semantic retrieval keeps generated content grounded in " +
+      "your actual source. Mean faithfulness ≥ 0.97, CI-gated — drift " +
+      "fails the build.",
+    points: [
+      "Powered by attune-rag — built in, no extra install",
+      "Citations back to source",
+      "Faithfulness measured, not assumed",
+    ],
+    icon: "🔎",
+    color: "secondary",
+  },
+  {
+    id: "verification",
+    tag: "Verification",
+    title: "Catch hallucinations before they ship",
+    description:
+      "Fact-check LLM output against source-of-truth: confirm imports " +
+      "import, CLI flags are real, links resolve, and counts match — " +
+      "before the change reaches main.",
+    points: [
+      "Verifies docs, code, and generated content",
+      "Closes the loop the spec opened",
+      "Built from the discipline that runs this project",
+    ],
+    icon: "✅",
+    color: "accent",
+  },
+];
+
 // --- Helpers ---
 
 export function getPricingSummary(): string {

--- a/website/lib/metadata.ts
+++ b/website/lib/metadata.ts
@@ -15,9 +15,9 @@ export interface SEOConfig {
 
 const defaultMetadata = {
   siteName: 'Attune AI',
-  title: 'Living Docs, Rooted in Code — Attune AI',
+  title: 'Turn requirements into reliable software — Attune AI',
   description:
-    'Help content generated from your codebase that stays fresh automatically. Progressive depth: concept, task, reference. Open source.',
+    'Spec-driven development platform for Claude Code: AI workflows, project memory, retrieval grounding, and verification. Turn requirements into reliable software — open source.',
   url: 'https://smartaimemory.com',
   image: '/og-image.png',
   twitterHandle: '@smartaimemory',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -44,7 +44,8 @@
         "eslint-config-next": "15.5.9",
         "tailwindcss": "^4",
         "tsx": "^4.19.2",
-        "typescript": "5.9.3"
+        "typescript": "5.9.3",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -61,21 +62,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -83,9 +84,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1530,6 +1531,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -1565,6 +1576,289 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1982,9 +2276,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1998,6 +2292,17 @@
       "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -2070,6 +2375,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2791,6 +3103,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3022,6 +3447,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3240,6 +3675,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3387,6 +3832,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3960,6 +4412,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4655,6 +5114,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6093,6 +6562,27 @@
         "lightningcss-win32-x64-msvc": "1.30.1"
       }
     },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
@@ -6377,9 +6867,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7531,9 +8021,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -7783,6 +8273,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7922,6 +8426,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.16.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
@@ -8041,9 +8552,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -8060,7 +8571,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8663,6 +9174,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8979,6 +9524,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -9029,10 +9581,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -9355,15 +9921,32 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9391,9 +9974,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9401,6 +9984,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9859,6 +10452,440 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9962,6 +10989,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,9 @@
     "build:docs": "cd .. && mkdocs build --clean && rm -rf website/public/framework-docs && cp -r site website/public/framework-docs",
     "check:migration-banner": "tsx scripts/check-migration-banner.ts",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "overrides": {
     "tar": "^7.5.7"
@@ -52,6 +54,7 @@
     "eslint-config-next": "15.5.9",
     "tailwindcss": "^4",
     "tsx": "^4.19.2",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^4.1.9"
   }
 }

--- a/website/test/capabilities-accuracy.test.ts
+++ b/website/test/capabilities-accuracy.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CAPABILITIES } from '../lib/features';
+
+// Accuracy guard for the homepage stat band / pillar copy.
+//
+// The website-content-accuracy rule requires every count shown on the
+// site to match the live Python registry. This test is the automated
+// enforcement of that rule for `CAPABILITIES` in lib/features.ts —
+// it catches the "14 workflows / 10 wizards / 13 templates"-style drift
+// that previously slipped onto the site.
+//
+// - The `skills` count is checked against the filesystem (plugin/skills),
+//   so it runs in any environment with no Python required.
+// - The remaining counts are checked against the live registry by
+//   shelling out to Python. If attune isn't importable (e.g. a bare
+//   node-only checkout), that assertion is skipped with a clear note
+//   rather than failing. Point ATTUNE_PYTHON at a venv to force it
+//   (e.g. ATTUNE_PYTHON=../.venv/bin/python npm test).
+
+const repoRoot = resolve(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
+const pythonpath = resolve(repoRoot, 'src');
+
+/** Find a python that can import attune, or null if none can. */
+function resolvePython(): string | null {
+  const candidates = [
+    process.env.ATTUNE_PYTHON,
+    'python3',
+    'python',
+    resolve(repoRoot, '.venv', 'bin', 'python'),
+  ].filter(Boolean) as string[];
+
+  for (const py of candidates) {
+    try {
+      execFileSync(py, ['-c', 'import attune'], {
+        env: { ...process.env, PYTHONPATH: pythonpath },
+        stdio: 'ignore',
+      });
+      return py;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
+}
+
+const INTROSPECT = [
+  'import json',
+  'd = {}',
+  'from attune.workflows import list_workflows',
+  "d['workflows'] = len([w for w in list_workflows() if w.get('stages')])",
+  'from attune.wizards import list_wizards',
+  "d['wizards'] = len(list_wizards())",
+  'from attune.mcp import tool_schemas as ts',
+  "d['mcpTools'] = sum(len(getattr(ts, n)()) for n in dir(ts) if n.startswith('get_') and n.endswith('_tools'))",
+  'try:',
+  '    from attune_author.generator import _ALL_TEMPLATE_NAMES',
+  "    d['templateKinds'] = len(_ALL_TEMPLATE_NAMES)",
+  'except Exception:',
+  '    pass',
+  'print(json.dumps(d))',
+].join('\n');
+
+describe('website CAPABILITIES accuracy', () => {
+  it('skills count matches the plugin/skills directory count', () => {
+    const skillsDir = resolve(repoRoot, 'plugin', 'skills');
+    const dirCount = readdirSync(skillsDir, { withFileTypes: true }).filter(
+      (d) => d.isDirectory(),
+    ).length;
+    expect(CAPABILITIES.skills).toBe(dirCount);
+  });
+
+  const python = resolvePython();
+
+  it.skipIf(!python)(
+    'workflow / wizard / MCP-tool / template counts match the live registry',
+    () => {
+      const raw = execFileSync(python as string, ['-c', INTROSPECT], {
+        env: { ...process.env, PYTHONPATH: pythonpath },
+        encoding: 'utf8',
+      });
+      const real = JSON.parse(raw) as Record<string, number>;
+
+      // Sanity: the registry calls we depend on must have resolved.
+      expect(real.workflows).toBeTypeOf('number');
+      expect(real.wizards).toBeTypeOf('number');
+      expect(real.mcpTools).toBeTypeOf('number');
+
+      expect(CAPABILITIES.workflows).toBe(real.workflows);
+      expect(CAPABILITIES.wizards).toBe(real.wizards);
+      expect(CAPABILITIES.mcpTools).toBe(real.mcpTools);
+
+      // attune_author is a separate package; only assert when present.
+      if (typeof real.templateKinds === 'number') {
+        expect(CAPABILITIES.templateKinds).toBe(real.templateKinds);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What

Repositions **smartaimemory.com** (plus the README and the attune-ai.dev
landing) around the spec-driven development platform theme:

> Attune-AI is a spec-driven development platform that combines AI
> workflows, project memory, retrieval-based grounding, and verification
> tools to help teams turn requirements into reliable software.

The site previously led with feature counts and a "living docs" frame.
It now leads with the outcome — **turn requirements into reliable
software** — structured around four pillars and the reliability loop
(specify → ground → build → remember → verify).

## Changes

- **Homepage** — new hero, reliability-loop spine visual, 4-pillar
  section, capabilities stat band, reframed CTA.
- **SSOT** — new `PILLARS` and `RELIABILITY_LOOP` exports in
  `lib/features.ts`; homepage and how-it-works consume them, and all
  displayed counts read from `CAPABILITIES`.
- **how-it-works** — rewritten from the help-system lifecycle to the
  reliability loop, the four pillars, and the spec/verification gates.
- **pricing / faq / docs / migrate / contact** — repositioned (copy
  only). Functional code, install commands, the `#quickstart` anchor,
  and the FAQ JSON-LD schema are preserved.
- **Footer** tagline + default SEO **metadata** updated.
- **README** tagline + intro reframed; workflow count reconciled to
  "20 workflows (17 multi-stage)".
- **attune-ai.dev** landing: tagline reframed; stale `v7.4.0` → `v8.5.0`.

## Accuracy

Per the website-content-accuracy rule, every claim was verified against
attune-ai 8.5.0: **17 multi-stage workflows** (20 total), **41 MCP
tools**, **17 skills**, **5 wizards**, **15 template kinds**, RAG
faithfulness **≥0.97** (CI-gated), attune-rag as a built-in core
dependency. The FAQ rewrite dropped stale/unverifiable claims
(14,800+ tests, "13 templates", "10 wizards") rather than carrying them
forward.

## Verification

- `npx tsc --noEmit` clean across the project.
- Dev server renders homepage, how-it-works, pricing, faq, docs with no
  console errors.

## Out of scope (intentionally untouched)

Blog posts, changelog, framework-docs embed, and legal pages
(privacy/terms/success) — dated/embedded content. The pitch deck
(`docs/pitch/EXECUTIVE_SUMMARY.md`) realignment is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
