### PR TITLE
feat(telemetry): opt-in usage-ping endpoint + go-live (usage-signals 2b)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -9303,3 +9303,42 @@ files.
   command, so second-worktree work needs compound `cd <abs> && ...` and
   Edit/Write tooling there is unreliable (path-guard runs from home
   cwd); drive second-worktree edits via bash (python in-place / heredoc).
+
+- **`claude-agent-sdk` bundles its OWN Claude Code CLI binary at
+  `<pkg>/_bundled/claude` — a version-pin bump silently swaps that
+  binary too, and CI (no system `claude`) runs THAT, not your local
+  one.** Diagnosing the 0.2.x migration break (PR #917,
+  `integration-auth`: `Exception: Claude Code returned an error result:
+  success` at `query.py:852 receive_messages`) was ROOT-CAUSED with
+  ZERO key spend by (a) diffing the SDK result-handling between the
+  working 0.1.63 and broken 0.2.102, and (b) reading each SDK's BUNDLED
+  CLI version (`<pkg>/_bundled/claude -v`). Findings: 0.1.63 bundles CLI
+  2.1.114, 0.2.102 bundles 2.1.178; 0.2.x added is_error handling
+  (`_last_error_result_text = "; ".join(errors) or str(subtype)`) that
+  rewrites a trailing `ProcessError` into `"Claude Code returned an
+  error result: <subtype>"` — with empty `errors` + `subtype="success"`
+  that yields the literal "...result: success". 0.1.63 never inspected
+  is_error. Generalizable rules: (1) when an SDK VENDORS a runtime/
+  binary, a Python-package pin change ALSO swaps the vendored binary —
+  check the bundled binary's version, not just the package's; CI with no
+  system binary uses the bundle. (2) A "registered ≠ working" live-loop
+  break can often be root-caused KEYLESS by diffing the vendored
+  library's old-vs-new code + bundled-binary version BEFORE a paid live
+  repro — reserve the spend for confirming the single remaining unknown
+  (here: why CLI 2.1.178 sets is_error on a success subtype). (3) Red
+  herring: `--task-budget`/`--max-turns` flag rejection looked plausible
+  but the break was systemic across workflows that never set those
+  (guarded by `_cli_supports_task_budget()`), so a per-flag cause can't
+  explain a whole-suite failure — a SYSTEMIC break points at the common
+  result path, not a per-workflow option.
+
+- **Vitest `@/` path alias needs a SCOPED regex, not a bare `'@'`
+  string alias.** To let Next API-route tests resolve the `@/lib/*`
+  tsconfig path (`"@/*": ["./*"]`), add `website/vitest.config.ts` with
+  `resolve.alias: [{ find: /^@\//, replacement: `${root}/` }]` where
+  `root = path.dirname(fileURLToPath(import.meta.url))`. A bare `'@'`
+  string-alias key ALSO rewrites `@scope/pkg` package imports (e.g.
+  `@anthropic-ai/sdk`) and breaks them; the leading-`@/` regex matches
+  only the project alias. Context that hid this: no vitest config existed
+  and the lone pre-existing test used relative imports, so `@/` had never
+  been exercised under vitest until an API-route test imported `@/lib/db`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in anonymous usage telemetry goes live (usage-signals Phase
+  2b).** A default-OFF usage ping that, once you opt in, reports only
+  which workflows you run — plus the package version, your OS, and
+  Python version — so the project can finally see what's actually
+  used. Privacy by construction: ships OFF, requires explicit
+  consent, transmits an auditable payload frozen at schema v1 (never
+  paths, code, prompts, args, filenames, cost, tokens, or model
+  data), honors `DO_NOT_TRACK`, and is fire-and-forget so it can
+  never block, slow, or crash the CLI. The collection endpoint stores
+  no IP and no request headers. Manage it with `attune telemetry
+  status|enable|disable`; override per-run with `ATTUNE_USAGE_PING=0`
+  or `=1`; rotate your anonymous install id any time. See the
+  **Privacy & Telemetry** section of the README and SECURITY.md for
+  the full payload disclosure.
+
 ## [8.5.0] — 2026-06-12
 
 Workflow results get a face, and the lessons brain gets sharper. The

--- a/README.md
+++ b/README.md
@@ -406,6 +406,41 @@ reporting and full security details.
 
 ---
 
+## Privacy & Telemetry
+
+Attune AI keeps usage data local-first. An **opt-in, anonymous usage
+ping** is available to help the project understand which workflows
+people actually use — it is **OFF by default** and sends nothing
+unless you explicitly turn it on.
+
+When enabled, each ping carries exactly this, and nothing more:
+
+- the package (`attune-ai`) and its version
+- the workflow name you ran (e.g. `workflow.security_audit`)
+- your OS (`darwin` / `linux` / `windows`) and Python version
+  (e.g. `3.12`)
+- a rotating, anonymous install id (a random UUID you can reset)
+- a timestamp
+
+It **never** sends paths, code, prompts, arguments, filenames,
+project names, cost, tokens, or model data — the payload is frozen in
+source and guarded by a regression test. Transport is fire-and-forget
+with a short timeout, so it can never block, slow, or crash the CLI,
+and the collection endpoint stores no IP address and no request
+headers.
+
+```bash
+attune telemetry status     # show exactly what would be sent
+attune telemetry enable     # opt in (mints an anonymous install id)
+attune telemetry disable    # opt out
+```
+
+`DO_NOT_TRACK=1` and `ATTUNE_USAGE_PING=0` force it off regardless of
+config; `ATTUNE_USAGE_PING=1` forces it on. Full payload disclosure is
+in [SECURITY.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/SECURITY.md).
+
+---
+
 ## Session continuity & cross-session memory
 
 Lightweight hook surfaces keep long Claude Code sessions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -264,6 +264,57 @@ When adding new file write operations:
 4. **Test attack scenarios**: path traversal, null bytes, system dirs
 5. See [test_config_path_security.py](tests/unit/test_config_path_security.py) for examples
 
+## Telemetry & Data Collection
+
+Attune AI is local-first. Workflow telemetry (cost, tokens, timing)
+is written only to your own machine under `~/.attune/`. The single
+exception is an **opt-in, anonymous usage ping**, and it is the only
+thing the package ever transmits off your machine.
+
+### Opt-in usage ping
+
+- **Default OFF.** Nothing is transmitted unless you explicitly run
+  `attune telemetry enable` (or set `ATTUNE_USAGE_PING=1`).
+- **Frozen payload (schema v1).** A ping contains *exactly* these
+  fields and no others:
+  - `schema` — payload version integer
+  - `package` — always `attune-ai`
+  - `version` — the installed package version
+  - `install_id` — a rotating, anonymous UUID you can reset at any
+    time (`attune telemetry reset` mints a fresh one); it carries no
+    PII and no linkage to your identity
+  - `event` — the workflow name as `workflow.<name>`, sourced from
+    the registry (never free text)
+  - `os` — `darwin` / `linux` / `windows`
+  - `py` — your `major.minor` Python version
+  - `ts` — an ISO-8601 timestamp
+- **Never transmitted:** file paths, source code, prompts, command
+  arguments, filenames, project names, cost, tokens, model names, or
+  any free-text field. The allowed key set is frozen in
+  `src/attune/telemetry/usage_ping.py` (`PAYLOAD_KEYS`) and enforced
+  by a regression test, and the ingest endpoint rejects any unknown
+  field.
+- **Endpoint stores no network envelope.** The collector
+  (`POST /api/usage`) drops the client IP and all request headers
+  before insert; it persists only the frozen payload above.
+- **Fire-and-forget.** Transport has a short hard timeout and
+  swallows every error, so telemetry can never block, slow, or crash
+  the CLI.
+- **Controls:** `attune telemetry status` prints the exact payload
+  that would be sent; `attune telemetry disable` opts out;
+  `DO_NOT_TRACK=1` and `ATTUNE_USAGE_PING=0` force it off regardless
+  of saved config.
+- **Deletion:** because events are keyed by your anonymous
+  `install_id`, you can request deletion of all data for that id (or
+  simply rotate it, after which prior events are no longer
+  associated with your install).
+
+The endpoint is public and unauthenticated (a CLI cannot hold a
+secret), so the data is treated as best-effort, not adversarially
+trusted; rate limiting and strict schema validation are the
+mitigations. See `docs/specs/usage-signals/phase2-design.md` for the
+full design and privacy rationale.
+
 ## Known Security Considerations
 
 ### AI Model Risks

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -1,6 +1,7 @@
 # Usage Signals — Decisions
 
-**Status:** Phase 2 scoped (2026-06-15) — Phase 0 complete (2026-06-11)
+**Status:** Phase 2b implemented (2026-06-16) — pending deploy/migration ·
+Phase 2 scoped (2026-06-15) · Phase 0 complete (2026-06-11)
 
 ## D1 — Phase 0 baseline snapshot (2026-06-11)
 
@@ -256,3 +257,59 @@ Two design adjustments surfaced while building (code is the contract):
 Deferred to 2b (no value until the endpoint exists): wiring `run_sync`
 into an atexit/Stop trigger. `DEFAULT_ENDPOINT` is empty, so even an
 opted-in user transmits nothing yet — intentional double-safety.
+
+## D6 — Phase 2b implemented: endpoint + client go-live (2026-06-16)
+
+The collection endpoint and the client's go-live wiring are built
+(branch `claude/usage-signals-phase2b`). What landed:
+
+**Endpoint (website / Next.js):**
+
+- `website/app/api/usage/route.ts` — `POST`, public/unauth, returns
+  204. Validates against frozen schema v1, **rejects unknown fields**,
+  size-caps the body (256 KB), best-effort per-IP rate-limits, and
+  **drops IP + all headers** (read only transiently for the rate-limit
+  key, never stored).
+- Validation + rate-limit extracted to testable libs
+  (`website/lib/usage/{validate,rate-limit}.ts`).
+- `usage_events` table + indexes added to `website/lib/db.ts`
+  `initializeDatabase()`, plus a `recordUsageEvents()` bulk insert.
+- 28 vitest tests green (added `website/vitest.config.ts` with a
+  scoped `@/` alias so API-route tests resolve `@/lib/*`).
+
+**Client (attune-ai):**
+
+- `DEFAULT_ENDPOINT` set to `https://smartaimemory.com/api/usage`.
+- `usage_ping.run_sync_at_exit()` added — cheap env/endpoint/no-config
+  short-circuits before any disk load, then defers to `run_sync`.
+- Registered in `UsageTracker.get_instance` BEFORE the local flush so
+  it runs AFTER it (atexit is LIFO) and sees freshly-flushed events.
+- 138 telemetry unit tests green (2 existing endpoint-default tests
+  updated for the now-non-empty default).
+
+**Two implementation decisions worth recording:**
+
+- **DB reuse, not a fresh Neon project.** D4 assumed a new Vercel
+  Postgres. In fact the website already has a provisioned Postgres
+  (`DATABASE_URL`, the Stripe/license store) behind `lib/db.ts`. 2b
+  reuses it — `usage_events` is a new, isolated, PII-free table in
+  that DB. This removed the "provision Neon" blocker entirely.
+  Trade-off to weigh at deploy: anonymous usage data co-locates in
+  the same database as customer-PII tables (separate tables, but one
+  DB). Acceptable given the data is anonymous; a separate DB is the
+  alternative if clean isolation is preferred — the route code is
+  identical either way.
+- **Domain = `smartaimemory.com`** (current canonical Next deployment;
+  `attune-ai-dev/` is static, no API routes). Overridable via
+  `ATTUNE_USAGE_ENDPOINT`. Revisit if the attune-ai.dev consolidation
+  moves the Next app; add a redirect or update `DEFAULT_ENDPOINT`.
+
+**Remaining before this is end-to-end live (deploy-time, owner: Patrick):**
+
+1. Apply the `usage_events` DDL to the prod DB (re-run the
+   admin-protected `POST /api/db/init`, or apply the table directly).
+2. Deploy the website so `/api/usage` is live, THEN ship the attune-ai
+   release carrying `DEFAULT_ENDPOINT` (client swallows errors if the
+   order slips, but endpoint-first is cleanest).
+3. Phase 2c — dashboard "Reach" panel (R3) reading `usage_events`.
+4. R5 telemetry watchdog + R6 spend alarm (separate PRs).

--- a/src/attune/telemetry/usage_ping.py
+++ b/src/attune/telemetry/usage_ping.py
@@ -66,9 +66,11 @@ FORBIDDEN_RECORD_FIELDS = frozenset(
     }
 )
 
-#: Collection endpoint. Empty in Phase 2a (client only) — wired to the
-#: Vercel function in Phase 2b. Overridable via ``ATTUNE_USAGE_ENDPOINT``.
-DEFAULT_ENDPOINT = ""
+#: Collection endpoint (Phase 2b). The ingest function is served by the
+#: Next.js app at smartaimemory.com (``website/app/api/usage/route.ts``).
+#: Overridable via ``ATTUNE_USAGE_ENDPOINT`` (and the whole ping is
+#: default-OFF, so this URL is only ever contacted by an opted-in user).
+DEFAULT_ENDPOINT = "https://smartaimemory.com/api/usage"
 
 #: Env values treated as "true" for flag variables.
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
@@ -340,6 +342,53 @@ def run_sync(
     if sent > 0:
         write_cursor(telemetry_dir, str(records[sent - 1].get("ts") or cursor))
     return sent
+
+
+def run_sync_at_exit(
+    *,
+    env: Mapping[str, str] | None = None,
+    poster: Callable[[str, list[dict[str, Any]], float], bool] = _urllib_post,
+) -> int:
+    """Best-effort sync entry point for the atexit / Stop trigger.
+
+    Self-gating and never raises. Applies the cheap short-circuits (hard
+    env opt-out, no endpoint, no user config on disk) BEFORE loading any
+    config, so an opted-out user pays nothing at process exit beyond a
+    couple of dict lookups. When it does proceed it defers entirely to
+    :func:`run_sync`, which re-checks enablement / install id / endpoint.
+
+    Opt-in state lives ONLY in the user config (``~/.attune/config.json``),
+    never a discovered project config — see :func:`_open_user_config`.
+
+    Returns:
+        Number of records transmitted (0 when disabled or nothing new).
+    """
+    try:
+        env = os.environ if env is None else env
+        # Hard opt-outs short-circuit before touching disk.
+        dnt = env.get("DO_NOT_TRACK")
+        if dnt is not None and dnt.strip().lower() not in {"", "0", "false"}:
+            return 0
+        override = env.get("ATTUNE_USAGE_PING")
+        if override is not None and not _env_truthy(override):
+            return 0
+        # No endpoint wired -> nothing to do (avoids a config load).
+        if not resolve_endpoint(env):
+            return 0
+
+        from attune.config.loader import ConfigLoader
+
+        path = ConfigLoader.get_default_config_path()
+        # A user who never created a config never opted in — don't create
+        # one (or even load defaults) at exit.
+        if not path.exists():
+            return 0
+        config = ConfigLoader(config_path=path).load()
+        return run_sync(config, env=env, poster=poster)
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: telemetry must never raise into process teardown.
+        logger.debug("usage-ping: run_sync_at_exit failed", exc_info=True)
+        return 0
 
 
 def example_payload(

--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -103,6 +103,13 @@ class UsageTracker:
         with cls._lock:
             if cls._instance is None:
                 cls._instance = cls(**kwargs)
+                # Register the opt-in usage-ping sync FIRST so it runs
+                # AFTER the local flush (atexit is LIFO). Ordering matters:
+                # the flush persists this run's buffered events to
+                # ``usage.jsonl`` and the ping must see them. The ping is
+                # default-OFF and fully self-gating — a no-op for users
+                # who haven't opted in.
+                atexit.register(cls._atexit_usage_ping)
                 # Register atexit flush so short-lived CLI runs (which
                 # typically produce 1-2 buffered entries — well below
                 # ``buffer_size``) still persist to disk before the
@@ -124,6 +131,24 @@ class UsageTracker:
             instance.flush()
         except Exception:  # noqa: BLE001
             # INTENTIONAL: best-effort flush at shutdown
+            pass
+
+    @staticmethod
+    def _atexit_usage_ping() -> None:
+        """atexit handler: best-effort opt-in usage-ping sync.
+
+        Runs after :meth:`_atexit_flush` (registered earlier; atexit is
+        LIFO) so it sees this run's freshly-flushed events. Default-OFF
+        and self-gating — does nothing unless the user opted in and an
+        endpoint is configured. Never raises; never blocks beyond the
+        ping's own short timeout.
+        """
+        try:
+            from attune.telemetry.usage_ping import run_sync_at_exit
+
+            run_sync_at_exit()
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: telemetry must never affect process exit.
             pass
 
     # =========================================================================

--- a/tests/unit/telemetry/test_usage_ping.py
+++ b/tests/unit/telemetry/test_usage_ping.py
@@ -116,8 +116,9 @@ def test_do_not_track_zero_is_not_optout():
 # --------------------------------------------------------------------------- #
 
 
-def test_resolve_endpoint_default_empty():
-    assert usage_ping.resolve_endpoint(env={}) == ""
+def test_resolve_endpoint_default_is_production():
+    # Phase 2b wired the production ingest endpoint as the default.
+    assert usage_ping.resolve_endpoint(env={}) == "https://smartaimemory.com/api/usage"
 
 
 def test_resolve_endpoint_env_override():
@@ -278,7 +279,10 @@ def test_run_sync_enabled_no_install_id_returns_zero(tmp_path):
     assert sent == 0
 
 
-def test_run_sync_no_endpoint_returns_zero(tmp_path):
+def test_run_sync_no_endpoint_returns_zero(tmp_path, monkeypatch):
+    # With the default endpoint blanked (and no env override), run_sync
+    # must short-circuit to a no-op.
+    monkeypatch.setattr(usage_ping, "DEFAULT_ENDPOINT", "")
     config = _FakeConfig(TelemetryConfig(usage_ping=True, install_id="id"))
     sent = usage_ping.run_sync(config, telemetry_dir=tmp_path, version="v", env={})
     assert sent == 0
@@ -519,3 +523,80 @@ def test_open_user_config_opens_existing_home(monkeypatch, tmp_path):
     assert isinstance(loader, ConfigLoader)
     assert config is not None
     assert save_path == home
+
+
+# --------------------------------------------------------------------------- #
+# run_sync_at_exit — the atexit/Stop entry point gating (Phase 2b)
+# --------------------------------------------------------------------------- #
+
+
+def test_run_sync_at_exit_respects_do_not_track(monkeypatch):
+    """DO_NOT_TRACK short-circuits before any config load or delegation."""
+    called = []
+    monkeypatch.setattr(usage_ping, "run_sync", lambda *a, **k: called.append(1) or 5)
+    assert usage_ping.run_sync_at_exit(env={"DO_NOT_TRACK": "1"}) == 0
+    assert called == []
+
+
+def test_run_sync_at_exit_respects_explicit_disable(monkeypatch):
+    """ATTUNE_USAGE_PING=0 short-circuits regardless of config."""
+    called = []
+    monkeypatch.setattr(usage_ping, "run_sync", lambda *a, **k: called.append(1) or 5)
+    assert usage_ping.run_sync_at_exit(env={"ATTUNE_USAGE_PING": "0"}) == 0
+    assert called == []
+
+
+def test_run_sync_at_exit_no_endpoint_is_noop(monkeypatch):
+    """With the endpoint blanked and no override, it never delegates."""
+    monkeypatch.setattr(usage_ping, "DEFAULT_ENDPOINT", "")
+    called = []
+    monkeypatch.setattr(usage_ping, "run_sync", lambda *a, **k: called.append(1) or 5)
+    assert usage_ping.run_sync_at_exit(env={}) == 0
+    assert called == []
+
+
+def test_run_sync_at_exit_no_user_config_is_noop(monkeypatch, tmp_path):
+    """A user who never created a config never opted in -> no-op."""
+    from attune.config.loader import ConfigLoader
+
+    missing = tmp_path / "nope.json"
+    monkeypatch.setattr(ConfigLoader, "get_default_config_path", staticmethod(lambda: missing))
+    called = []
+    monkeypatch.setattr(usage_ping, "run_sync", lambda *a, **k: called.append(1) or 5)
+    assert usage_ping.run_sync_at_exit(env={"ATTUNE_USAGE_ENDPOINT": "https://x/api"}) == 0
+    assert called == []
+
+
+def test_run_sync_at_exit_delegates_when_gates_pass(monkeypatch, tmp_path):
+    """Gates clear (no opt-out, endpoint set, config exists) -> run_sync."""
+    from attune.config.loader import ConfigLoader
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{}", encoding="utf-8")
+    fake_config = _FakeConfig(TelemetryConfig(usage_ping=True, install_id="id"))
+    monkeypatch.setattr(ConfigLoader, "get_default_config_path", staticmethod(lambda: cfg))
+    monkeypatch.setattr(ConfigLoader, "load", lambda self: fake_config)
+    captured: dict = {}
+    monkeypatch.setattr(
+        usage_ping,
+        "run_sync",
+        lambda config, **kw: captured.update(config=config, kw=kw) or 7,
+    )
+    sent = usage_ping.run_sync_at_exit(env={"ATTUNE_USAGE_ENDPOINT": "https://x/api"})
+    assert sent == 7
+    assert captured["config"] is fake_config
+
+
+def test_run_sync_at_exit_swallows_all_errors(monkeypatch, tmp_path):
+    """Any failure in the chain returns 0, never raises into teardown."""
+    from attune.config.loader import ConfigLoader
+
+    cfg = tmp_path / "config.json"
+    cfg.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(ConfigLoader, "get_default_config_path", staticmethod(lambda: cfg))
+
+    def _boom(self):
+        raise RuntimeError("config blew up")
+
+    monkeypatch.setattr(ConfigLoader, "load", _boom)
+    assert usage_ping.run_sync_at_exit(env={"ATTUNE_USAGE_ENDPOINT": "https://x/api"}) == 0

--- a/tests/unit/telemetry/test_usage_tracker.py
+++ b/tests/unit/telemetry/test_usage_tracker.py
@@ -1764,3 +1764,44 @@ class TestCacheStatsBranches:
         stats = tracker.get_cache_stats(days=7)
         assert stats["by_workflow"]["wf_no_hit"]["hits"] == 0
         assert stats["by_workflow"]["wf_no_hit"]["requests"] == 1
+
+
+class TestUsagePingAtExitWiring:
+    """The opt-in usage-ping sync is kicked from the atexit chain and
+    must run AFTER the local flush so it sees freshly-persisted events."""
+
+    def test_get_instance_registers_ping_before_flush(self, monkeypatch, temp_dir):
+        """atexit is LIFO, so ping (runs last) must be REGISTERED first."""
+        import atexit as _atexit
+
+        registered = []
+        monkeypatch.setattr(_atexit, "register", lambda fn, *a, **k: registered.append(fn))
+        UsageTracker._instance = None
+        try:
+            UsageTracker.get_instance(telemetry_dir=temp_dir)
+            assert UsageTracker._atexit_usage_ping in registered
+            assert UsageTracker._atexit_flush in registered
+            # ping registered first => ping runs AFTER flush at exit
+            assert registered.index(UsageTracker._atexit_usage_ping) < registered.index(
+                UsageTracker._atexit_flush
+            )
+        finally:
+            UsageTracker._instance = None
+
+    def test_atexit_usage_ping_delegates_to_run_sync_at_exit(self, monkeypatch):
+        from attune.telemetry import usage_ping
+
+        called = []
+        monkeypatch.setattr(usage_ping, "run_sync_at_exit", lambda: called.append(1) or 0)
+        UsageTracker._atexit_usage_ping()
+        assert called == [1]
+
+    def test_atexit_usage_ping_never_raises(self, monkeypatch):
+        from attune.telemetry import usage_ping
+
+        def _boom():
+            raise RuntimeError("ping blew up")
+
+        monkeypatch.setattr(usage_ping, "run_sync_at_exit", _boom)
+        # Must not propagate — telemetry can't affect process exit.
+        UsageTracker._atexit_usage_ping()

--- a/website/app/api/usage/route.ts
+++ b/website/app/api/usage/route.ts
@@ -1,0 +1,82 @@
+/**
+ * Usage Ingest API Route (Phase 2b).
+ *
+ * `POST /api/usage` — public, unauthenticated collection endpoint for the
+ * opt-in anonymous usage ping (a CLI can't hold a secret). Validates
+ * against frozen schema v1, rejects unknown fields, size-caps the body,
+ * best-effort rate-limits per IP, **drops the network envelope (IP +
+ * headers)**, inserts, and returns 204.
+ *
+ * Privacy: nothing here stores IP, headers, or any field outside the
+ * frozen schema. The client ships OFF by default and only an opted-in
+ * user transmits. See docs/specs/usage-signals/phase2-design.md.
+ *
+ * Copyright 2026 Smart-AI-Memory
+ * Licensed under Apache 2.0
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { recordUsageEvents } from '@/lib/db';
+import { validateBatch, MAX_BODY_BYTES } from '@/lib/usage/validate';
+import { rateLimit } from '@/lib/usage/rate-limit';
+
+// pg requires the Node.js runtime; never cache an ingest endpoint.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Read the client IP for rate-limiting ONLY. It is never stored,
+ * logged, or inserted — it leaves this function as a Map key and
+ * nothing more.
+ */
+function clientIp(req: NextRequest): string {
+  const xff = req.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0].trim();
+  return req.headers.get('x-real-ip') ?? 'unknown';
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  // Best-effort per-IP rate limit (IP read transiently, never persisted).
+  if (!rateLimit(clientIp(req))) {
+    return new NextResponse(null, { status: 429 });
+  }
+
+  // Size-cap the body BEFORE parsing.
+  let rawText: string;
+  try {
+    rawText = await req.text();
+  } catch {
+    return NextResponse.json({ error: 'unreadable body' }, { status: 400 });
+  }
+  if (Buffer.byteLength(rawText, 'utf8') > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: 'payload too large' }, { status: 413 });
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(rawText);
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON' }, { status: 400 });
+  }
+
+  const result = validateBatch(body);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  try {
+    await recordUsageEvents(result.events);
+  } catch (error) {
+    console.error('usage ingest failed:', error);
+    // 5xx → the client leaves its cursor parked and retries next run.
+    return NextResponse.json({ error: 'ingest failed' }, { status: 500 });
+  }
+
+  // 204: accepted, no body. The client advances its cursor on any 2xx.
+  return new NextResponse(null, { status: 204 });
+}
+
+/** Only POST is supported. */
+export async function GET(): Promise<NextResponse> {
+  return new NextResponse(null, { status: 405 });
+}

--- a/website/lib/db.ts
+++ b/website/lib/db.ts
@@ -122,7 +122,27 @@ export async function initializeDatabase(): Promise<void> {
       metadata JSONB
     );
 
+    -- Usage events table (Phase 2b opt-in anonymous telemetry).
+    -- Schema frozen in docs/specs/usage-signals/phase2-design.md.
+    -- Anonymous by construction: no IP, no headers, no PII. install_id
+    -- is a rotating, user-resettable UUID. NEVER paths/code/prompts/args.
+    CREATE TABLE IF NOT EXISTS usage_events (
+      id          BIGSERIAL PRIMARY KEY,
+      received_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+      package     TEXT NOT NULL,
+      version     TEXT NOT NULL,
+      install_id  UUID NOT NULL,
+      event       TEXT NOT NULL,
+      outcome     TEXT,          -- reserved for schema:2 (see payload note)
+      os          TEXT,
+      py          TEXT,
+      client_ts   TIMESTAMP WITH TIME ZONE
+    );
+
     -- Create indexes for common queries
+    CREATE INDEX IF NOT EXISTS idx_usage_events_pkg_event ON usage_events(package, event);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_install ON usage_events(install_id);
+    CREATE INDEX IF NOT EXISTS idx_usage_events_received ON usage_events(received_at);
     CREATE INDEX IF NOT EXISTS idx_customers_email ON customers(email);
     CREATE INDEX IF NOT EXISTS idx_customers_stripe_id ON customers(stripe_customer_id);
     CREATE INDEX IF NOT EXISTS idx_purchases_customer ON purchases(customer_id);
@@ -542,4 +562,54 @@ export async function updateContactStatus(id: number, status: string, notes?: st
     [status, notes, id]
   );
   return result.rows[0] || null;
+}
+
+// Usage events (Phase 2b opt-in anonymous telemetry)
+
+/**
+ * A single validated usage event ready for insert. Mirrors the frozen
+ * client payload (schema v1) — see docs/specs/usage-signals/phase2-design.md.
+ * No IP, no headers, no PII: the route drops the network envelope before
+ * calling this.
+ */
+export interface UsageEventInsert {
+  package: string;
+  version: string;
+  install_id: string;
+  event: string;
+  os: string | null;
+  py: string | null;
+  client_ts: string | null;
+}
+
+/**
+ * Bulk-insert validated usage events in a single statement.
+ *
+ * Uses a multi-row VALUES insert so a batched client POST is one round
+ * trip. Returns the number of rows written. The caller is responsible
+ * for validating each event against schema v1 first.
+ */
+export async function recordUsageEvents(events: UsageEventInsert[]): Promise<number> {
+  if (events.length === 0) return 0;
+
+  const cols = 7;
+  const valuesSql = events
+    .map((_, i) => {
+      const b = i * cols;
+      return `($${b + 1}, $${b + 2}, $${b + 3}, $${b + 4}, $${b + 5}, $${b + 6}, $${b + 7})`;
+    })
+    .join(', ');
+
+  const params: unknown[] = [];
+  for (const e of events) {
+    params.push(e.package, e.version, e.install_id, e.event, e.os, e.py, e.client_ts);
+  }
+
+  const result = await query(
+    `INSERT INTO usage_events
+       (package, version, install_id, event, os, py, client_ts)
+     VALUES ${valuesSql}`,
+    params
+  );
+  return result.rowCount ?? 0;
 }

--- a/website/lib/usage/rate-limit.ts
+++ b/website/lib/usage/rate-limit.ts
@@ -1,0 +1,54 @@
+/**
+ * Best-effort per-IP rate limiter for the public usage endpoint.
+ *
+ * In-memory + per serverless instance, so it resets on cold start and
+ * does NOT coordinate across instances. That is deliberate: the usage
+ * data is best-effort and the endpoint is spoofable by design (see
+ * phase2-design.md). This limiter exists to blunt accidental floods and
+ * trivial abuse, not to be an adversarial control.
+ *
+ * Copyright 2026 Smart-AI-Memory
+ * Licensed under Apache 2.0
+ */
+
+const WINDOW_MS = 60_000;
+const MAX_PER_WINDOW = 120;
+/** Bound the map so a spray of unique IPs can't grow it without limit. */
+const MAX_KEYS = 10_000;
+
+const hits = new Map<string, number[]>();
+
+export interface RateLimitOptions {
+  windowMs?: number;
+  max?: number;
+  now?: number;
+}
+
+/**
+ * Record a hit for `key` and return whether it is within the limit.
+ *
+ * @returns true if allowed, false if the key has exceeded `max` hits in
+ *   the trailing `windowMs`.
+ */
+export function rateLimit(key: string, opts: RateLimitOptions = {}): boolean {
+  const windowMs = opts.windowMs ?? WINDOW_MS;
+  const max = opts.max ?? MAX_PER_WINDOW;
+  const now = opts.now ?? Date.now();
+  const cutoff = now - windowMs;
+
+  if (hits.size > MAX_KEYS) hits.clear();
+
+  const recent = (hits.get(key) ?? []).filter((t) => t > cutoff);
+  if (recent.length >= max) {
+    hits.set(key, recent);
+    return false;
+  }
+  recent.push(now);
+  hits.set(key, recent);
+  return true;
+}
+
+/** Test seam: drop all recorded hits. */
+export function _resetRateLimit(): void {
+  hits.clear();
+}

--- a/website/lib/usage/validate.ts
+++ b/website/lib/usage/validate.ts
@@ -1,0 +1,175 @@
+/**
+ * Usage-event validation (Phase 2b).
+ *
+ * The collection endpoint is public and unauthenticated (a CLI can't
+ * hold a secret), so validation is the primary defense. Two jobs:
+ *
+ *  1. Reject anything that isn't exactly the frozen schema-v1 payload —
+ *     **including unknown fields** — so the payload can never quietly
+ *     grow free-text columns release-over-release (the spec's R2 frozen
+ *     payload). This mirrors the Python client's PAYLOAD_KEYS freeze.
+ *  2. Bound every field length so a spoofer can't bloat the table.
+ *
+ * The data is treated as best-effort, not adversarially trusted (an
+ * unauthenticated endpoint is spoofable by design — see phase2-design.md).
+ *
+ * Copyright 2026 Smart-AI-Memory
+ * Licensed under Apache 2.0
+ */
+
+import type { UsageEventInsert } from '@/lib/db';
+
+/** Frozen schema version. Bump in lockstep with the Python client. */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * The EXACT set of keys a client payload may carry (schema v1). Mirrors
+ * the Python client's PAYLOAD_KEYS. Any other key rejects the event.
+ */
+export const ALLOWED_KEYS = new Set([
+  'schema',
+  'package',
+  'version',
+  'install_id',
+  'event',
+  'os',
+  'py',
+  'ts',
+]);
+
+/** Per-request caps (defense against a spoofer bloating the table). */
+export const MAX_EVENTS_PER_REQUEST = 200;
+export const MAX_BODY_BYTES = 256 * 1024; // 256 KB
+
+/** Field length caps. */
+const LIMITS = {
+  package: 64,
+  version: 32,
+  event: 96,
+  os: 32,
+  py: 16,
+} as const;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// event is registry-sourced on the client: "workflow.<name>". Keep the
+// grammar tight so it can never carry free-text.
+const EVENT_RE = /^workflow\.[a-z0-9._-]{1,80}$/i;
+
+export type ValidationResult =
+  | { ok: true; value: UsageEventInsert }
+  | { ok: false; error: string };
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function cappedString(v: unknown, max: number): string | null {
+  if (typeof v !== 'string') return null;
+  const s = v.trim();
+  if (s.length === 0 || s.length > max) return null;
+  return s;
+}
+
+/** Normalize a client `ts` to an ISO string for `client_ts`, or null. */
+function normalizeTs(v: unknown): string | null {
+  if (typeof v !== 'string' || v.trim() === '') return null;
+  const d = new Date(v);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+/**
+ * Validate one raw client event against schema v1.
+ *
+ * Strict: unknown keys reject; every field is type- and length-checked.
+ * Maps the client's `ts` to `client_ts` and drops `schema` (it's a
+ * version gate, not stored).
+ */
+export function validateEvent(raw: unknown): ValidationResult {
+  if (!isPlainObject(raw)) {
+    return { ok: false, error: 'event is not an object' };
+  }
+
+  // Reject unknown fields outright — frozen-payload defense.
+  for (const key of Object.keys(raw)) {
+    if (!ALLOWED_KEYS.has(key)) {
+      return { ok: false, error: `unknown field: ${key}` };
+    }
+  }
+
+  if (raw.schema !== SCHEMA_VERSION) {
+    return { ok: false, error: `unsupported schema: ${String(raw.schema)}` };
+  }
+
+  const pkg = cappedString(raw.package, LIMITS.package);
+  if (!pkg) return { ok: false, error: 'invalid package' };
+
+  const version = cappedString(raw.version, LIMITS.version);
+  if (!version) return { ok: false, error: 'invalid version' };
+
+  const install_id = typeof raw.install_id === 'string' ? raw.install_id.trim() : '';
+  if (!UUID_RE.test(install_id)) {
+    return { ok: false, error: 'invalid install_id' };
+  }
+
+  const event = cappedString(raw.event, LIMITS.event);
+  if (!event || !EVENT_RE.test(event)) {
+    return { ok: false, error: 'invalid event' };
+  }
+
+  // os / py are optional but, when present, must be sane short strings.
+  const os = raw.os === undefined || raw.os === null ? null : cappedString(raw.os, LIMITS.os);
+  if (raw.os !== undefined && raw.os !== null && os === null) {
+    return { ok: false, error: 'invalid os' };
+  }
+  const py = raw.py === undefined || raw.py === null ? null : cappedString(raw.py, LIMITS.py);
+  if (raw.py !== undefined && raw.py !== null && py === null) {
+    return { ok: false, error: 'invalid py' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      package: pkg,
+      version,
+      install_id,
+      event,
+      os,
+      py,
+      client_ts: normalizeTs(raw.ts),
+    },
+  };
+}
+
+export type BatchResult =
+  | { ok: true; events: UsageEventInsert[] }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Validate a parsed request body of shape `{ events: [...] }`.
+ *
+ * Returns the HTTP status to use on failure so the route stays thin:
+ * 413 for too many events, 400 for anything malformed.
+ */
+export function validateBatch(body: unknown): BatchResult {
+  if (!isPlainObject(body) || !Array.isArray(body.events)) {
+    return { ok: false, status: 400, error: 'body must be { events: [...] }' };
+  }
+  const events = body.events;
+  if (events.length === 0) {
+    return { ok: false, status: 400, error: 'events is empty' };
+  }
+  if (events.length > MAX_EVENTS_PER_REQUEST) {
+    return { ok: false, status: 413, error: 'too many events' };
+  }
+
+  const out: UsageEventInsert[] = [];
+  for (let i = 0; i < events.length; i++) {
+    const res = validateEvent(events[i]);
+    if (!res.ok) {
+      return { ok: false, status: 400, error: `event[${i}]: ${res.error}` };
+    }
+    out.push(res.value);
+  }
+  return { ok: true, events: out };
+}

--- a/website/test/usage-rate-limit.test.ts
+++ b/website/test/usage-rate-limit.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { rateLimit, _resetRateLimit } from '../lib/usage/rate-limit';
+
+beforeEach(() => _resetRateLimit());
+
+describe('rateLimit', () => {
+  it('allows up to max within the window, then blocks', () => {
+    const opts = { max: 3, windowMs: 1000, now: 1000 };
+    expect(rateLimit('ip-a', opts)).toBe(true);
+    expect(rateLimit('ip-a', opts)).toBe(true);
+    expect(rateLimit('ip-a', opts)).toBe(true);
+    expect(rateLimit('ip-a', opts)).toBe(false); // 4th exceeds max=3
+  });
+
+  it('tracks each key independently', () => {
+    const opts = { max: 1, windowMs: 1000, now: 1000 };
+    expect(rateLimit('ip-a', opts)).toBe(true);
+    expect(rateLimit('ip-b', opts)).toBe(true); // different key, fresh budget
+    expect(rateLimit('ip-a', opts)).toBe(false);
+  });
+
+  it('forgets hits older than the window', () => {
+    expect(rateLimit('ip-a', { max: 1, windowMs: 1000, now: 1000 })).toBe(true);
+    expect(rateLimit('ip-a', { max: 1, windowMs: 1000, now: 1500 })).toBe(false); // still in window
+    expect(rateLimit('ip-a', { max: 1, windowMs: 1000, now: 2500 })).toBe(true); // window passed
+  });
+});

--- a/website/test/usage-route.test.ts
+++ b/website/test/usage-route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the DB layer so the route never touches Postgres.
+vi.mock('@/lib/db', () => ({
+  recordUsageEvents: vi.fn(async (events: unknown[]) => events.length),
+}));
+
+import { POST, GET } from '@/app/api/usage/route';
+import { recordUsageEvents } from '@/lib/db';
+import { _resetRateLimit } from '@/lib/usage/rate-limit';
+import { MAX_BODY_BYTES } from '@/lib/usage/validate';
+import { NextRequest } from 'next/server';
+
+const mockedRecord = vi.mocked(recordUsageEvents);
+
+function validEvent(over: Record<string, unknown> = {}) {
+  return {
+    schema: 1,
+    package: 'attune-ai',
+    version: '8.5.0',
+    install_id: '11111111-2222-4333-8444-555555555555',
+    event: 'workflow.security_audit',
+    os: 'linux',
+    py: '3.12',
+    ts: '2026-06-16T12:00:00Z',
+    ...over,
+  };
+}
+
+function postReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest('https://smartaimemory.com/api/usage', {
+    method: 'POST',
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+beforeEach(() => {
+  _resetRateLimit();
+  mockedRecord.mockClear();
+});
+
+describe('POST /api/usage', () => {
+  it('returns 204 and inserts validated events on a good batch', async () => {
+    const res = await POST(postReq({ events: [validEvent()] }));
+    expect(res.status).toBe(204);
+    expect(mockedRecord).toHaveBeenCalledOnce();
+  });
+
+  it('drops the network envelope — no IP/headers reach the DB', async () => {
+    await POST(postReq({ events: [validEvent()] }, { 'x-forwarded-for': '203.0.113.7' }));
+    const inserted = mockedRecord.mock.calls[0][0];
+    expect(inserted).toHaveLength(1);
+    // Only frozen-schema columns; nothing carrying the IP or headers.
+    expect(Object.keys(inserted[0]).sort()).toEqual(
+      ['client_ts', 'event', 'install_id', 'os', 'package', 'py', 'version'].sort()
+    );
+    expect(JSON.stringify(inserted)).not.toContain('203.0.113.7');
+  });
+
+  it('rejects an unknown field with 400 and does not insert', async () => {
+    const res = await POST(postReq({ events: [validEvent({ prompt: 'leak' })] }));
+    expect(res.status).toBe(400);
+    expect(mockedRecord).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid JSON with 400', async () => {
+    const res = await POST(postReq('{not json', {}));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an oversized body with 413 before parsing', async () => {
+    const huge = 'x'.repeat(MAX_BODY_BYTES + 1);
+    const res = await POST(postReq(huge));
+    expect(res.status).toBe(413);
+    expect(mockedRecord).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 (cursor parks) when the DB insert throws', async () => {
+    mockedRecord.mockRejectedValueOnce(new Error('db down'));
+    const res = await POST(postReq({ events: [validEvent()] }));
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('GET /api/usage', () => {
+  it('is not supported (405)', async () => {
+    expect((await GET()).status).toBe(405);
+  });
+});

--- a/website/test/usage-validate.test.ts
+++ b/website/test/usage-validate.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateEvent,
+  validateBatch,
+  ALLOWED_KEYS,
+  MAX_EVENTS_PER_REQUEST,
+} from '../lib/usage/validate';
+
+// A minimal valid schema-v1 client payload.
+function validEvent(over: Record<string, unknown> = {}) {
+  return {
+    schema: 1,
+    package: 'attune-ai',
+    version: '8.5.0',
+    install_id: '11111111-2222-4333-8444-555555555555',
+    event: 'workflow.security_audit',
+    os: 'darwin',
+    py: '3.12',
+    ts: '2026-06-16T12:00:00Z',
+    ...over,
+  };
+}
+
+describe('validateEvent — happy path', () => {
+  it('accepts a well-formed event and maps ts -> client_ts', () => {
+    const res = validateEvent(validEvent());
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value).toEqual({
+        package: 'attune-ai',
+        version: '8.5.0',
+        install_id: '11111111-2222-4333-8444-555555555555',
+        event: 'workflow.security_audit',
+        os: 'darwin',
+        py: '3.12',
+        client_ts: '2026-06-16T12:00:00.000Z',
+      });
+      // schema is a version gate, never stored.
+      expect('schema' in res.value).toBe(false);
+      expect('ts' in res.value).toBe(false);
+    }
+  });
+
+  it('allows os/py to be null', () => {
+    const res = validateEvent(validEvent({ os: null, py: null }));
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value.os).toBeNull();
+      expect(res.value.py).toBeNull();
+    }
+  });
+
+  it('null/empty ts becomes null client_ts', () => {
+    expect((validateEvent(validEvent({ ts: '' })) as { value: { client_ts: unknown } }).value.client_ts).toBeNull();
+  });
+});
+
+describe('validateEvent — frozen-payload defense', () => {
+  it('rejects an unknown field (free-text creep)', () => {
+    const res = validateEvent(validEvent({ prompt: 'rm -rf /' }));
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/unknown field: prompt/);
+  });
+
+  it('rejects forbidden telemetry fields that must never leave the client', () => {
+    for (const field of ['cost', 'tokens', 'model', 'user_id', 'path']) {
+      const res = validateEvent(validEvent({ [field]: 'x' }));
+      expect(res.ok).toBe(false);
+    }
+  });
+
+  it('ALLOWED_KEYS is exactly the schema-v1 set', () => {
+    expect([...ALLOWED_KEYS].sort()).toEqual(
+      ['event', 'install_id', 'os', 'package', 'py', 'schema', 'ts', 'version'].sort()
+    );
+  });
+});
+
+describe('validateEvent — field validation', () => {
+  it('rejects a wrong schema version', () => {
+    expect(validateEvent(validEvent({ schema: 2 })).ok).toBe(false);
+    expect(validateEvent(validEvent({ schema: undefined })).ok).toBe(false);
+  });
+
+  it('rejects a non-UUID install_id', () => {
+    expect(validateEvent(validEvent({ install_id: 'not-a-uuid' })).ok).toBe(false);
+    expect(validateEvent(validEvent({ install_id: 123 })).ok).toBe(false);
+  });
+
+  it('rejects an event outside the workflow.<name> grammar', () => {
+    expect(validateEvent(validEvent({ event: 'security_audit' })).ok).toBe(false); // no prefix
+    expect(validateEvent(validEvent({ event: 'workflow.has space' })).ok).toBe(false);
+    expect(validateEvent(validEvent({ event: 'skill.foo' })).ok).toBe(false); // reserved, not v1
+  });
+
+  it('rejects empty/oversized package and version', () => {
+    expect(validateEvent(validEvent({ package: '' })).ok).toBe(false);
+    expect(validateEvent(validEvent({ version: 'v'.repeat(64) })).ok).toBe(false);
+  });
+
+  it('rejects a non-object', () => {
+    expect(validateEvent(null).ok).toBe(false);
+    expect(validateEvent('nope').ok).toBe(false);
+    expect(validateEvent([validEvent()]).ok).toBe(false);
+  });
+});
+
+describe('validateBatch', () => {
+  it('accepts a {events:[...]} batch', () => {
+    const res = validateBatch({ events: [validEvent(), validEvent({ event: 'workflow.bug_predict' })] });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.events).toHaveLength(2);
+  });
+
+  it('rejects a non-batch body with 400', () => {
+    expect(validateBatch({}).ok).toBe(false);
+    expect((validateBatch({ events: 'x' } as unknown) as { status: number }).status).toBe(400);
+  });
+
+  it('rejects an empty events array with 400', () => {
+    const res = validateBatch({ events: [] });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.status).toBe(400);
+  });
+
+  it('rejects too many events with 413', () => {
+    const events = Array.from({ length: MAX_EVENTS_PER_REQUEST + 1 }, () => validEvent());
+    const res = validateBatch({ events });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.status).toBe(413);
+  });
+
+  it('reports the index of the first bad event', () => {
+    const res = validateBatch({ events: [validEvent(), validEvent({ install_id: 'bad' })] });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.status).toBe(400);
+      expect(res.error).toMatch(/event\[1\]/);
+    }
+  });
+});

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+
+// Mirror Next's `@/*` -> `./*` tsconfig path so API-route tests can
+// import `@/lib/...` the same way the routes do. Scoped to a leading
+// `@/` via regex so it never rewrites `@scope/pkg` package imports.
+export default defineConfig({
+  resolve: {
+    alias: [{ find: /^@\//, replacement: `${root}/` }],
+  },
+});


### PR DESCRIPTION
## Summary

Phase 2b of `usage-signals`: stand up the opt-in usage-ping **collection
endpoint** and take the **client live** (still default-OFF, explicit
consent required). This makes the question Phase 0 couldn't answer —
*which workflows do external users actually run?* — answerable once a
user opts in.

Opens **DRAFT**: applying the DDL to prod and deploying the endpoint are
deploy-time account actions (see Deploy checklist).

## Endpoint (website)

- `POST /api/usage` — public/unauth, returns **204**. Schema-v1
  validation, **rejects unknown fields**, 256 KB body cap, best-effort
  per-IP rate-limit, and **drops the client IP + all request headers**
  (IP read transiently as the rate-limit key only, never stored).
- Validation + rate-limit in testable libs `lib/usage/{validate,rate-limit}.ts`.
- `usage_events` table + indexes + `recordUsageEvents()` in `lib/db.ts`.
  Reuses the website's **already-provisioned Postgres** as a new,
  isolated, PII-free table (removed the Neon-provisioning blocker).
- `vitest.config.ts` adds a scoped `@/` alias so API-route tests resolve
  `@/lib/*` the way Next does.

## Client (attune-ai)

- `DEFAULT_ENDPOINT` → `https://smartaimemory.com/api/usage`.
- `run_sync_at_exit()` — cheap opt-out / no-endpoint / no-config
  short-circuits before any disk load, then defers to `run_sync`.
- Registered in `UsageTracker.get_instance` **before** the local flush so
  it runs **after** it (atexit is LIFO) and sees freshly-flushed events.

## Privacy

Default-OFF; explicit consent; payload frozen at schema v1 (package,
version, anonymous rotating install_id, `workflow.<name>`, os, py, ts) —
**never** paths/code/prompts/args/cost/tokens/model. Endpoint stores no
IP/headers. Fire-and-forget with a short timeout. Documented in README
(Privacy & Telemetry) + SECURITY.md (full payload disclosure).

## Tests / checks

- **28 vitest** (validate / rate-limit / route + existing suite intact)
- **138 telemetry pytest** (2 existing default-endpoint tests updated)
- `tsc --noEmit` clean · `ruff` + `black` clean

## Deploy checklist (owner: Patrick)

1. Apply the `usage_events` DDL to the prod DB (re-run the
   admin-protected `POST /api/db/init`, or apply the table directly).
2. Deploy the website so `/api/usage` is live.
3. Ship the attune-ai release carrying `DEFAULT_ENDPOINT` (endpoint-first
   is cleanest; the client swallows errors if order slips).

## Decisions to confirm

- **DB co-location** — anonymous `usage_events` shares the DB with
  customer-PII tables (separate table). A dedicated DB is the alternative
  for hard isolation; route code is identical either way.
- **Domain** = `smartaimemory.com` (current canonical Next deployment).
  Overridable via `ATTUNE_USAGE_ENDPOINT`; revisit on attune-ai.dev
  consolidation.

## Follow-ons (separate PRs)

Phase 2c dashboard "Reach" panel (R3); R5 telemetry watchdog; R6 spend
alarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
