### PR TITLE
fix(telemetry): usage-ping canonical /api/usage/ trailing slash

### DIFF
--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -304,6 +304,19 @@ The collection endpoint and the client's go-live wiring are built
   `ATTUNE_USAGE_ENDPOINT`. Revisit if the attune-ai.dev consolidation
   moves the Next app; add a redirect or update `DEFAULT_ENDPOINT`.
 
+## D7 — post-merge fix: endpoint trailing slash (2026-06-16)
+
+Probing the live endpoint after #920 merged surfaced a bug `DEFAULT_
+ENDPOINT` shipped with: the site runs `trailingSlash: true`, so
+`POST /api/usage` returns a 308 redirect to `/api/usage/` and `urllib`
+does not reliably re-issue a redirected POST. Verified live:
+`GET /api/usage/` → 405, malformed `POST /api/usage/` → 400 (route
+deployed + validating), but `/api/usage` (no slash) → 308. Fix:
+`DEFAULT_ENDPOINT` now points at the canonical `…/api/usage/`. Only
+local tests with arbitrary URLs ran pre-merge, so the mismatch was
+invisible until the live probe — a verify-against-the-real-surface
+catch. (Follow-up PR off main.)
+
 **Remaining before this is end-to-end live (deploy-time, owner: Patrick):**
 
 1. Apply the `usage_events` DDL to the prod DB (re-run the

--- a/src/attune/telemetry/usage_ping.py
+++ b/src/attune/telemetry/usage_ping.py
@@ -68,9 +68,13 @@ FORBIDDEN_RECORD_FIELDS = frozenset(
 
 #: Collection endpoint (Phase 2b). The ingest function is served by the
 #: Next.js app at smartaimemory.com (``website/app/api/usage/route.ts``).
-#: Overridable via ``ATTUNE_USAGE_ENDPOINT`` (and the whole ping is
-#: default-OFF, so this URL is only ever contacted by an opted-in user).
-DEFAULT_ENDPOINT = "https://smartaimemory.com/api/usage"
+#: The TRAILING SLASH is required: the site runs ``trailingSlash: true``,
+#: so ``/api/usage`` 308-redirects to ``/api/usage/`` and a redirected
+#: POST is not reliably followed by ``urllib`` — point straight at the
+#: canonical URL. Overridable via ``ATTUNE_USAGE_ENDPOINT`` (and the
+#: whole ping is default-OFF, so this is only ever contacted by an
+#: opted-in user).
+DEFAULT_ENDPOINT = "https://smartaimemory.com/api/usage/"
 
 #: Env values treated as "true" for flag variables.
 _TRUTHY = frozenset({"1", "true", "yes", "on"})

--- a/tests/unit/telemetry/test_usage_ping.py
+++ b/tests/unit/telemetry/test_usage_ping.py
@@ -117,8 +117,10 @@ def test_do_not_track_zero_is_not_optout():
 
 
 def test_resolve_endpoint_default_is_production():
-    # Phase 2b wired the production ingest endpoint as the default.
-    assert usage_ping.resolve_endpoint(env={}) == "https://smartaimemory.com/api/usage"
+    # Phase 2b wired the production ingest endpoint as the default. The
+    # trailing slash is required (site runs trailingSlash: true) so a
+    # POST lands directly instead of via a 308 redirect.
+    assert usage_ping.resolve_endpoint(env={}) == "https://smartaimemory.com/api/usage/"
 
 
 def test_resolve_endpoint_env_override():


### PR DESCRIPTION
## Summary

Follow-up correctness fix to #920. The opt-in usage-ping client's
`DEFAULT_ENDPOINT` shipped without a trailing slash, but the website
runs `trailingSlash: true` — so `POST /api/usage` 308-redirects to
`/api/usage/`, and `urllib` does not reliably re-issue a redirected
POST. Result: opted-in pings would waste a round trip or silently
never land.

## Verified against the live endpoint (post-#920 deploy)

- `GET  /api/usage/`            → **405** (route deployed)
- `POST /api/usage/` (bad body) → **400** (validation works)
- `GET  /api/usage`  (no slash) → **308** redirect

Local pre-merge tests used arbitrary URLs, so this was invisible until
the live probe — a verify-against-the-real-surface catch.

## Change

- `DEFAULT_ENDPOINT` → `https://smartaimemory.com/api/usage/` (canonical).
- Updated the default-endpoint unit test (55 usage-ping tests green).
- Recorded as decision D7 in the usage-signals spec.

No user impact yet: the ping is default-OFF and only reaches users on
the next attune-ai release — so this lands before anyone pings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
