### PR TITLE
chore(deps): adopt attune-rag 0.7.0 (lock bump + re-validation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "langsmith>=0.7.31,<2.0.0",  # GHSA-rr7j-v2q5-chgv (transitive via langchain-core)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "python-frontmatter>=1.0.0,<2.0.0",  # YAML frontmatter parsing for help templates — required by attune.help.engine which backs the help_lookup MCP tool (progressive/workflow_help/precursor/search_tag modes all parse template files). Vanilla pip install attune-ai without this breaks every help_lookup mode except `preamble`.
-    "attune-rag>=0.1.5,<0.8",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap raised to <0.7 in 8.1.0 after re-validating against attune-rag 0.6.0 (purely additive: CLI flags + measure(retriever=...); all 0.5.x public symbols unchanged per its POLICY §2); next minor still requires explicit re-validation.
+    "attune-rag>=0.1.5,<0.8",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap is <0.8: re-validated against attune-rag 0.7.0 (lock bumped 0.6.0->0.7.0; purely additive — subscription-first FaithfulnessJudge auth + new attune_rag.auth module; only removal is the internal Phase-4 freeze CI gate, "no library change"; all 0.6.x public symbols unchanged per its POLICY §2, confirmed by importing every attune-ai-consumed symbol); next minor (0.8.0) still requires explicit re-validation before lifting the cap.
     "attune-verify>=0.1.0,<0.3",  # Generation fact-checker backing the /verify skill (deterministic entity checks: imports/flags/links/counts). Core dep — stdlib-only (zero transitive deps), so promoting to core is cheap and lets /verify work out of the box without an extra. Semantic layer is opt-in (the skill acts as the ambient judge). Cap raised to <0.3 to admit 0.2.0 (full dotted-path import resolution — catches private-submodule hallucinations the 0.1.0 top-level-only checker missed; purely additive, no API break).
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib fallback for Python 3.10. Used by attune.utils.coverage (loaded transitively from release-prep + orchestrated-health-check workflows). Without this, those workflows fail to load on 3.10.
     # NOTE: attune-author is a workspace-only dev dep for authoring/
@@ -766,10 +766,10 @@ exclude_lines = [
 ]
 
 # Sibling repos — all published to PyPI:
-#   attune-rag     — core dep (>=0.1.5,<0.7) — promoted from optional; required for accuracy
+#   attune-rag     — core dep (>=0.1.5,<0.8) — promoted from optional; required for accuracy
 #   attune-verify  — core dep (>=0.1.0,<0.3) — backs /verify; stdlib-only, zero transitive deps
-#   attune-author  — [author] optional extra (>=0.6.2,<0.16)
-#   attune-rag     — [rag] optional extra (>=0.1.5,<0.7) — no-op alias since rag is core
+#   attune-author  — [author] optional extra (>=0.6.2,<0.19)
+#   attune-rag     — [rag] optional extra (>=0.1.5,<0.8) — no-op alias since rag is core
 #
 # No [tool.uv.sources] overrides needed: CI resolves all three
 # from PyPI (https://pypi.org/simple). For local iteration against

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "attune-rag"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -619,9 +619,9 @@ dependencies = [
     { name = "rich" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/c3/c4c2c8803f96b0c27475cc39f06e591b4862dbde8373c6059389f73f70f3/attune_rag-0.6.0.tar.gz", hash = "sha256:ae49e19ece883a22d9cc554700e217021fb6c1b6d02d6844b642253cc0e4166b", size = 119936, upload-time = "2026-06-10T06:17:26.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/49/84efe9c087dd36f7a4faf8c7c4cb3d481ab3040cb69f40a6e02a0422e66f/attune_rag-0.7.0.tar.gz", hash = "sha256:df5d6b93475a0729a551250bba8ac48c73908a3c6a272eca66e46cbd9f58798c", size = 124432, upload-time = "2026-06-11T12:44:13.323Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/8d/8445e31360592995a3e7346ea52bec64d3c75abaa9781d95b1c9aee2fb22/attune_rag-0.6.0-py3-none-any.whl", hash = "sha256:f1550d2bf99996063deab957be7409354315e653eb8114bfd6a8c0d516eeab51", size = 130064, upload-time = "2026-06-10T06:17:25.065Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/30/f369f5bad8baea6c1fcff2fe7fae4c8f2849108d674142087229b070f6b8/attune_rag-0.7.0-py3-none-any.whl", hash = "sha256:a8d30a11bc8fec65fd60f81f689bc1a01f6cc9bc875fe931c2caa1e41908c053", size = 134556, upload-time = "2026-06-11T12:44:11.977Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adopt **attune-rag 0.7.0** properly — bump the lock and record the
re-validation the deliberate cap demands.

## Why

PR #906 widened the cap from `<0.7` to `<0.8` but **never moved the
lock** (it stayed at `attune-rag==0.6.0`), so CI validated nothing and
0.7.0 could land silently on any future `uv lock --upgrade` — the exact
ceiling-bump trap documented in #918. The pyproject comment also still
said `<0.7` and "next minor requires explicit re-validation", which
hadn't been done.

## Changes

- `uv lock --upgrade-package attune-rag`: **0.6.0 → 0.7.0**. Minimal
  diff — attune-rag's own dependency list is unchanged, no transitive
  cascade.
- Updated the `pyproject.toml` cap comment to record the 0.7.0
  re-validation; fixed the stale sibling-repo comment block
  (`<0.7` → `<0.8`, and the adjacent attune-author `<0.16` → `<0.19`
  left stale by #908).

## Re-validation (POLICY §2 — additive minor)

attune-rag 0.7.0 changelog:
- **Added:** subscription-first `FaithfulnessJudge` auth + new
  `attune_rag.auth` module (purely additive; new optional params).
- **Removed:** only the internal Phase-4 feature-freeze CI gate —
  explicitly *"Internal CI only; no library change."*

Verified every attune-ai-consumed symbol imports under 0.7.0
(`RagPipeline`, `KeywordRetriever`, `RetrievalEntry`, `RetrievalHit`,
`DirectoryCorpus`, `format_citations_markdown`) and the new
`attune_rag.auth` module is present.

## Tests

54 rag-path tests green: `tests/unit/rag/`,
`tests/unit/workflows/test_rag_code_gen_security.py`,
`tests/unit/workflows/test_task_budget_wiring.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
