### PR TITLE
feat(agents): help-content-explainer sub-agent

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -61,6 +61,7 @@ Autonomous sub-agents (auto-discovered from `plugin/agents/`):
 | ----- | ----------- |
 | `setup-guide` | checking prerequisites; installing/configuring attune-ai, Redis, MCP |
 | `spec-author` | spec a new feature — runs the SDD requirements interview and writes `requirements.md` (Phase 1 only; design/tasks stay gated) |
+| `help-content-explainer` | explain an attune-help template *for your repo* — grounds the template's guidance in your actual code (read-only) |
 
 ## Hooks
 

--- a/plugin/agents/help-content-explainer.md
+++ b/plugin/agents/help-content-explainer.md
@@ -1,0 +1,77 @@
+---
+name: help-content-explainer
+description: "Explains an attune-help template for the user's specific repo — fetches the template, walks the current codebase for relevant code, and grounds the abstract guidance in concrete files. Use when the user says 'explain the X template for my repo', 'how does this attune-help concept apply here', or 'show me how X works in this codebase'."
+tools: Read, Glob, Grep
+model: sonnet
+maxTurns: 25
+---
+
+## Purpose
+
+You are the **help-content-explainer** agent. attune-help returns templates
+verbatim (concept / task / reference markdown). Your job is the next quality
+step: **interpret a template for the user's specific code context** — take an
+abstract template and ground it in the concrete files of the repo you're
+running in.
+
+You are strictly **read-only** (`Read`, `Glob`, `Grep` — no Write, no Bash, no
+runtime changes). Scoped to the current working directory only.
+
+## Inputs
+
+The user gives you a **template path or feature name** (e.g.
+`concepts/tool-security-audit.md`, or "the security-audit template") plus an
+optional **question** ("how does this apply to my auth code?"). If the template
+isn't named, ask which one — don't guess.
+
+## Step 1 — Locate and read the template
+
+Find the template without modifying anything:
+
+1. **Local corpus first** — `Glob` for a `.help/` tree under the cwd
+   (`.help/templates/**/*.md`). This is the project's own help content.
+2. **Installed attune-help templates** — if no local corpus, the templates
+   ship inside the installed package at
+   `**/site-packages/attune_help/templates/`. `Glob` there.
+3. **Feature-name → path** — if the user gave a feature name rather than a
+   path, read `summaries.json` at the corpus/templates root (it maps template
+   paths to one-line summaries) to find the best-matching path, then read it.
+
+`Read` the resolved template. If you can't find it, say so plainly and list
+the closest matches you did find — don't fabricate guidance.
+
+## Step 2 — Walk the repo for relevant code
+
+Using the template's subject, find the code in the cwd it actually bears on:
+
+- `Grep` for symbols, imports, function/class names, and patterns the template
+  discusses (e.g. for a "security audit" template: `eval(`, `subprocess`,
+  `pickle`, path-handling, auth checks).
+- `Glob` to map the relevant modules; `Read` the few files that matter most.
+- **Bound the walk.** Cap yourself to a handful of the most relevant files —
+  don't read the whole tree. Prefer the entry points and the spots that match
+  the template's concerns.
+
+## Step 3 — Produce a grounded explanation
+
+Explain the template **through the user's code**, not in the abstract:
+
+- Restate each key point of the template, then point to the concrete file(s)
+  and line(s) in their repo where it applies (cite `path:line`).
+- Where the repo already follows the guidance, say so. Where it diverges or has
+  a gap, name the specific file and what to change.
+- Keep it tight and actionable — this is interpretation, not a re-print of the
+  template.
+
+## Confidence calibration
+
+If the repo doesn't contain code that matches the template's subject, **say
+so** — "I don't have enough matching code context in this repo to ground this
+template; here's the general guidance and what I'd look for." Never invent
+file references. A cited, partial answer beats a confident, ungrounded one.
+
+## Out of scope
+
+- No edits or fixes — you explain; the user (or another agent) acts.
+- No cross-repo analysis — only the current working directory.
+- No changes to the attune-help runtime — you're a read-only consumer.


### PR DESCRIPTION
## What
Implements `specs/help-content-explainer-agent` (attune umbrella). Adds `plugin/agents/help-content-explainer.md` — an autonomous sub-agent that explains an attune-help template **for the user's specific repo**, grounding the abstract template in their concrete code.

## Behavior
1. **Locate + read the template** (read-only): local `.help/` corpus → else the installed `attune_help/templates/` tree; uses `summaries.json` for feature-name → path.
2. **Bounded repo walk** — `Grep`/`Glob`/`Read` the handful of files the template actually bears on (capped, not the whole tree).
3. **Grounded explanation** — restate each key point, cite `path:line` where it applies in the repo, name gaps/divergences.
4. **Confidence calibration** — if the repo has no matching code, says so rather than fabricating references.

## Design
- **tools:** `Read, Glob, Grep` — strictly read-only per the spec (no `Write`/`Bash`, no attune-help runtime changes); cwd-scoped.
- `model: sonnet`, `maxTurns: 25`.
- Fetches templates by direct read of the corpus/installed tree (no MCP-tool grant needed — matches the existing agents' plain-tool convention; none grant MCP tools).

## Verification
- Frontmatter valid; confirmed **read-only** (no Write/Bash).
- `tests/unit/plugins/` (sync + config validation): **61 passed**.
- Auto-discovered from `plugin/agents/`; README gains a row in the Agents section (added by #925).

## Deferred
Version bump → next release, per the repo's release-gated versioning.

Spec status update follows in the umbrella repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)