### PR TITLE
ci(tests): retry hung required lanes with fewer xdist workers (-n 2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,12 +167,20 @@ jobs:
           # timeout. 2×14m fits the 35m backstop with install overhead.
           rc=0
           for attempt in 1 2; do
+            # ci-runner-hang: retry with FEWER xdist workers. The hang is an
+            # xdist shutdown-handshake deadlock (a worker goes silent at
+            # session end → controller waits forever; per-test --timeout can't
+            # catch it since no test is running). Fewer workers = simpler/faster
+            # shutdown + less per-worker memory pressure (the OOM-worker-death
+            # history), sharply cutting the odds of a second hang. -n 2 stays
+            # parallel enough to fit the 14m budget; serial -n 0 would not.
+            if [ "$attempt" -eq 1 ]; then NPROC=auto; else NPROC=2; fi
             set +e
-            timeout -k 30s 14m pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
+            timeout -k 30s 14m pytest -n "$NPROC" --timeout=60 --timeout-method=thread -m "not network and not integration"
             rc=$?
             set -e
             if [ "$rc" -ne 124 ]; then break; fi
-            echo "::warning::test pytest attempt ${attempt} hit the 14m step timeout (runner-hang signature) — retrying in-run; see the hang-dumps artifact for the captured stack"
+            echo "::warning::test pytest attempt ${attempt} (-n ${NPROC}) hit the 14m step timeout (runner-hang signature) — retrying with fewer workers; see the hang-dumps artifact for the captured stack"
           done
           echo "[mem-final $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"
           if [ "$rc" -eq 124 ]; then
@@ -329,12 +337,15 @@ jobs:
         # and BELOW the 40m job timeout (the all-attempts-hung backstop).
         rc=0
         for attempt in 1 2; do
+          # ci-runner-hang: retry with FEWER xdist workers (rationale in the
+          # test lane above — xdist shutdown-handshake deadlock + OOM pressure).
+          if [ "$attempt" -eq 1 ]; then NPROC=auto; else NPROC=2; fi
           set +e
-          timeout -k 30s 14m pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
+          timeout -k 30s 14m pytest -n "$NPROC" --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
           rc=$?
           set -e
           if [ "$rc" -ne 124 ]; then break; fi
-          echo "::warning::coverage pytest attempt ${attempt} hit the 14m step timeout (runner-hang signature) — retrying in-run; see the hang-dumps-coverage artifact for the captured stack"
+          echo "::warning::coverage pytest attempt ${attempt} (-n ${NPROC}) hit the 14m step timeout (runner-hang signature) — retrying with fewer workers; see the hang-dumps-coverage artifact for the captured stack"
         done
         echo "[mem-final $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"
         if [ "$rc" -eq 124 ]; then


### PR DESCRIPTION
## Problem
The recurring `runner-hang` that fails the required `test (ubuntu-latest, 3.12)` / coverage lanes is an **xdist shutdown-handshake deadlock**, diagnosed from the hang-dumps artifact of the #927 failure:

- Every thread is in `execnet`/`xdist` plumbing — **no attune-ai frame** on any stack.
- Controller: 4 receiver threads blocked in `execnet ...read`; main thread in `xdist/dsession.py:154 loop_once → queue.get`.
- Workers gw1–gw3 idle in `execnet serve`; **`gw0` produced no dump** → it went silent at session end, and the controller deadlocks waiting on it (the "~98% finalize" signature).
- `--timeout-method=thread` can't catch it (no test is running at shutdown), so it falls to the 14m wall-clock wrapper.
- **execnet 2.1.2 / pytest-xdist 3.8.0 are already the latest** → no version-bump fix.

## Fix (bounded resilience, not a root-cause fix)
Make the existing auto-retry *resilient* instead of a verbatim repeat: attempt 1 stays `-n auto`; **the retry drops to `-n 2`**. Fewer workers → simpler/faster shutdown handshake + far less per-worker memory pressure (the prior OOM-worker-death history), which sharply cuts the chance of a *second* hang. `-n 2` stays parallel enough to fit the 14m budget; a serial `-n 0` full suite would not.

Applied to both required retry lanes (test + coverage). One-line escalation guarded by `attempt`.

## Verification
- YAML parses; retry bash logic syntax-checked.
- No behavior change on the happy path (attempt 1 is unchanged `-n auto`); only the rare rc=124 retry differs.

## Honest scope
This reduces the failure frequency of an **intermittent upstream xdist hang**; it does not eliminate the underlying worker-death. Deeper root-cause hunting was deprioritized as a tar-pit (intermittent, doesn't reproduce locally, deps already latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)