### PR TITLE
test(conftest): finalize leaked asyncio transports at sessionfinish (runner-hang)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,6 +345,21 @@ def _aggregate_xdist_results() -> dict:
 
 def pytest_sessionfinish(session, exitstatus):
     """Store file test records at end of test session."""
+    # ci-runner-hang: deterministically finalize any leaked asyncio subprocess
+    # transport NOW, while the worker process is still healthy. A transport left
+    # dangling from a per-test ``asyncio.run()`` otherwise finalizes during
+    # interpreter shutdown (``BaseSubprocessTransport.__del__`` → "Event loop is
+    # closed"); on Linux/py3.12 that wedges the xdist worker, so the controller
+    # deadlocks at ~99% waiting on a worker that never exits (the recurring
+    # runner-hang). Forcing GC here moves that finalization out of the fragile
+    # interpreter-exit phase, where it can no longer block worker teardown.
+    # Two passes: the first frees the transport, the second collects any cycle
+    # it was part of. Harmless on platforms where this was already benign.
+    import gc as _gc
+
+    _gc.collect()
+    _gc.collect()
+
     # Check if this is an xdist worker
     if hasattr(session.config, "workerinput"):
         # This is a worker - write results to file for main node to collect


### PR DESCRIPTION
## Root cause
The recurring CI **runner-hang** (rc=124; the required `test (ubuntu-latest, 3.12)` + coverage lanes have been taking ~30m, i.e. hanging on attempt 1 and limping through the retry) is an **xdist worker that won't exit at interpreter shutdown** — not OOM (memory was fine, run reached 99%), not a fixture assertion.

A per-test `asyncio.run()` that spawns a subprocess can leave a `BaseSubprocessTransport` dangling; its `__del__` then runs during **interpreter shutdown** (`RuntimeError: Event loop is closed`). On **Linux/py3.12** — which reworked asyncio child-process/loop finalization — that dangling transport wedges the worker, so the controller deadlocks at ~99% waiting on a worker (gw0, no faulthandler dump) that never exits.

**Evidence:** running the full suite locally (macOS/py3.10) reproduces the *fingerprint* — `Exception ignored in: <function BaseSubprocessTransport.__del__> ... Event loop is closed` at teardown — but benignly there; the actual wedge is Linux/py3.12-specific (which is why it only fails that lane).

## Fix
Force `gc.collect()` (×2, for reference cycles) at the top of the existing `pytest_sessionfinish` hook. This **deterministically finalizes the dangling transport while the worker is still healthy**, moving it out of the fragile interpreter-exit phase where it blocks teardown. Runs on every xdist worker + the controller; a no-op cost where it was already benign.

## Validation
- ruff clean; xdist subset green locally.
- **The real test is CI:** the ubuntu-3.12 lanes hang ~100% right now, so a clean, fast (<10m) run here confirms the fix.

Supersedes the closed #928 (the `-n 2` retry didn't help — both attempts still hung). If this doesn't clear it, the next step is a Linux/py3.12 Docker repro to pin the exact leaking `asyncio.run()` site (prime suspect: `src/attune/hooks/executor.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)