### PR TITLE
fix(project-index): skip multiprocessing Pool for tiny scans (CI runner-hang)

### DIFF
--- a/src/attune/project_index/scanner_parallel.py
+++ b/src/attune/project_index/scanner_parallel.py
@@ -23,6 +23,17 @@ from typing import Any
 from .models import FileRecord, IndexConfig, ProjectSummary
 from .scanner import ProjectScanner
 
+# Minimum number of files before the multiprocessing path is worth it.
+# Forking a Pool of `cpu_count` processes costs more than analysing a
+# handful of files sequentially — and, crucially, forking a process pool
+# inside an already-multi-threaded process (e.g. a pytest-xdist worker)
+# is a deadlock hazard: a child can inherit a parent FD (an open socket,
+# a held lock) and never release it. On Linux (default start method
+# `fork`) that leaked FD kept the xdist *controller* from ever seeing the
+# worker exit, wedging CI at ~99% (see scanner-pool-fork-hang). Below this
+# threshold we stay sequential, which is both faster and fork-free.
+_PARALLEL_MIN_FILES = 50
+
 
 def _analyze_file_worker(
     file_path_str: str,
@@ -139,10 +150,14 @@ class ParallelProjectScanner(ProjectScanner):
         self._build_test_mapping(all_files)
 
         # Second pass: analyze each file (PARALLEL - slow)
-        if use_parallel and self.workers > 1:
+        # Only spin up a process Pool when there are enough files to amortise
+        # the fork cost. For tiny scans the Pool is pure overhead and a fork
+        # hazard inside multi-threaded hosts (see _PARALLEL_MIN_FILES).
+        if use_parallel and self.workers > 1 and len(all_files) >= _PARALLEL_MIN_FILES:
             records = self._analyze_files_parallel(all_files)
         else:
-            # Fall back to sequential for debugging or single worker
+            # Fall back to sequential for debugging, single worker, or a
+            # file count too small to be worth a process pool.
             for file_path in all_files:
                 record = self._analyze_file(file_path)
                 if record:

--- a/tests/unit/project_index/test_scanner_parallel.py
+++ b/tests/unit/project_index/test_scanner_parallel.py
@@ -1,0 +1,72 @@
+"""Regression tests for ParallelProjectScanner's multiprocessing guard.
+
+The parallel scanner must NOT spin up a multiprocessing.Pool for tiny
+scans. Forking a Pool of ``cpu_count`` processes inside an already
+multi-threaded host (e.g. a pytest-xdist worker) is a deadlock hazard: a
+fork child can inherit a parent FD (an open socket, a held lock) and never
+release it. On Linux (default start method ``fork``) a leaked execnet
+socket FD kept the xdist *controller* from ever seeing the worker exit,
+wedging CI at ~99% (see scanner-pool-fork-hang). Below the threshold the
+scanner stays sequential — both faster and fork-free.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from attune.project_index.scanner_parallel import (
+    _PARALLEL_MIN_FILES,
+    ParallelProjectScanner,
+)
+
+POOL = "attune.project_index.scanner_parallel.mp.Pool"
+
+
+def _make_py_files(tmp_path, count: int) -> None:
+    """Create ``count`` trivial top-level .py source files."""
+    for i in range(count):
+        (tmp_path / f"mod_{i}.py").write_text("x = 1\n")
+
+
+class TestParallelMinFilesGuard:
+    """The Pool is created only when the file count justifies the fork cost."""
+
+    def test_empty_scan_does_not_fork_a_pool(self, tmp_path):
+        """0 files (the CI hang scenario) must stay sequential — no Pool."""
+        scanner = ParallelProjectScanner(str(tmp_path), workers=4)
+        with patch(POOL) as pool_ctor:
+            scanner.scan(analyze_dependencies=False)
+        pool_ctor.assert_not_called()
+
+    def test_small_scan_does_not_fork_a_pool(self, tmp_path):
+        """A handful of files (< threshold) must stay sequential — no Pool."""
+        _make_py_files(tmp_path, 3)
+        scanner = ParallelProjectScanner(str(tmp_path), workers=4)
+        with patch(POOL) as pool_ctor:
+            records, summary = scanner.scan(analyze_dependencies=False)
+        pool_ctor.assert_not_called()
+        # The sequential fallback still produces records.
+        assert summary.total_files == 3
+        assert len(records) == 3
+
+    def test_large_scan_uses_a_pool(self, tmp_path):
+        """At/above the threshold the parallel path is taken (Pool created)."""
+        _make_py_files(tmp_path, _PARALLEL_MIN_FILES + 5)
+        scanner = ParallelProjectScanner(str(tmp_path), workers=2)
+        with patch(POOL) as pool_ctor:
+            # Keep the test itself fork-free: the patched Pool's context
+            # manager returns no records.
+            pool_ctor.return_value.__enter__.return_value.map.return_value = []
+            scanner.scan(analyze_dependencies=False)
+        pool_ctor.assert_called_once()
+
+    def test_single_worker_never_forks(self, tmp_path):
+        """workers=1 is sequential regardless of file count."""
+        _make_py_files(tmp_path, _PARALLEL_MIN_FILES + 5)
+        scanner = ParallelProjectScanner(str(tmp_path), workers=1)
+        with patch(POOL) as pool_ctor:
+            scanner.scan(analyze_dependencies=False)
+        pool_ctor.assert_not_called()


### PR DESCRIPTION
## The CI runner-hang, root-caused and fixed

The required **`test (ubuntu-latest, 3.12)`** lane has been wedging ~100% on attempt 1 (saved only by the in-run auto-retry). Three prior CI-side fixes (#928 `-n 2`, #929 gc-at-sessionfinish, etc.) treated symptoms. This PR fixes the **root cause**, reproduced deterministically in a local Linux/py3.12 Docker container.

### Root cause

`ParallelProjectScanner.scan()` unconditionally created an `mp.cpu_count()`-sized **fork**-based `multiprocessing.Pool` — even for a near-empty file list. The concrete trigger is the `orchestrator` fixture in `tests/unit/workflows/test_documentation_orchestrator.py`, which builds a `DocumentationOrchestrator(project_root=tmp_path)` whose `__init__` runs a real project-index `refresh()` → `scanner.scan()` → `mp.Pool(...)` **inside a pytest-xdist worker**.

The deadlock chain (Linux-specific):

1. The xdist worker is multi-threaded (execnet receiver threads). It `fork`s a Pool of ~`cpu_count` children.
2. Each fork child **inherits the worker's execnet socket FD** to the controller.
3. The worker is later killed (60s per-test `--timeout-method=thread` → `os._exit()`), but the orphaned Pool children (reparented to init) **keep that socket's write-end open**.
4. The controller's execnet receiver `read()` therefore **never sees EOF**, so it never reports "worker crashed" — the controller blocks forever in `xdist/dsession.py:loop_once → queue.get()` at **~99%**. The per-test timeout already fired but can't save the controller.

This is **Linux-only** because macOS/py3.12 defaults `multiprocessing` to `spawn` (children don't inherit the FD → controller gets EOF → no hang) — exactly why earlier attempts saw the fingerprint on macOS but never the hang.

### Reproduction

Linux `python:3.12` container pinned to 2 cores (`--cpuset-cpus=0,1`), exact CI invocation (`pytest -n 2 --timeout=60 --timeout-method=thread -m "not network and not integration"`):

- **Before:** wedges at 97% indefinitely. `py-spy` of the live processes shows the controller in `queue.get()`, a zombie worker child, and ~8 orphaned `multiprocessing.Pool` children (reparented to init) with the inherited FD.
- **After:** full suite completes in **~4:50** (`22018 passed`; the only failures are root-in-container permission artifacts, absent on the non-root GitHub runner).

### Fix

Guard the parallel path behind a minimum file count (`_PARALLEL_MIN_FILES = 50`). Tiny scans stay sequential — both faster (forking `cpu_count` processes to analyze a handful of files is pure overhead) and fork-free. Adds `tests/unit/project_index/test_scanner_parallel.py` locking in the behavior (empty / small → no Pool; large → Pool; `workers=1` → no Pool).

### Validation

- Local Linux/py3.12 full-suite run: hang gone, completes in ~4:50.
- `tests/unit/project_index/test_scanner_parallel.py` + `tests/unit/workflows/test_documentation_orchestrator.py`: **99 passed in 6.66s**.

CI validates by the required lane running fast (no 14m attempt-1 hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)