### PR TITLE
chore(ci): retire the runner-hang retry wrapper on the coverage lane too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -286,31 +286,14 @@ jobs:
       # gate. (pyproject's fail_under stays 85 as the absolute floor for
       # ad-hoc/partial local runs whose --cov scope differs from CI's.)
       run: |
-        echo "[mem-baseline $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "total="$2"MB used="$3"MB avail="$7"MB"}')"
-        (while sleep 30; do echo "[mem-tick $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"; done) &
-        MEM_MONITOR_PID=$!
-        trap 'kill $MEM_MONITOR_PID 2>/dev/null || true' EXIT
-        # ci-gating-lane-isolation Layer A: auto-retry ONLY on a step-timeout
-        # (rc=124 is the runner-hang signature — pytest freezes ~1s in and
-        # never progresses). A real coverage/test failure exits non-124 and
-        # is returned immediately, so a genuine red is NEVER masked green by
-        # the retry. The 14m step `timeout` sits ABOVE the 600s conftest
-        # hang-watchdog (so the wedged-stack dump still lands in hang-dumps/)
-        # and BELOW the 40m job timeout (the all-attempts-hung backstop).
-        rc=0
-        for attempt in 1 2; do
-          set +e
-          timeout -k 30s 14m pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
-          rc=$?
-          set -e
-          if [ "$rc" -ne 124 ]; then break; fi
-          echo "::warning::coverage pytest attempt ${attempt} hit the 14m step timeout (runner-hang signature) — retrying in-run; see the hang-dumps-coverage artifact for the captured stack"
-        done
-        echo "[mem-final $(date +%H:%M:%S)] $(free -m | awk '/Mem:/ {print "used="$3"MB avail="$7"MB"}')"
-        if [ "$rc" -eq 124 ]; then
-          echo "::error::coverage pytest hung on every attempt (runner-hang) — failing the job after bounded auto-retry"
-        fi
-        exit "$rc"
+        # The runner-hang that once required a 14m-timeout + 2× auto-retry
+        # wrapper on this lane was root-caused and fixed in #930 (a fork-based
+        # multiprocessing.Pool inside an xdist worker leaked the execnet socket
+        # FD, deadlocking the controller at ~99%; Linux-only because macOS uses
+        # `spawn`). With the cause gone, run coverage plainly — the job
+        # `timeout-minutes` plus the conftest hang-watchdog (which still
+        # uploads hang-dumps/) remain as the backstop.
+        pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
       env:
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 


### PR DESCRIPTION
Companion to #931. That PR removed the `14m-timeout` + 2× `rc=124` auto-retry + `[mem-tick]` scaffolding from the **test** lane; the **coverage** lane carried a byte-for-byte copy (it was the other `-n auto` lane where the hang surfaced — see the conftest Phase-2 forensic note).

Same root cause, same fix (#930 — fork-based `multiprocessing.Pool` inside an xdist worker leaked the execnet socket FD, deadlocking the controller at ~99%; Linux-only because macOS uses `spawn`). So collapse the coverage step to its plain invocation as well.

### Retained
40m job `timeout-minutes`, per-test `--timeout=60 --timeout-method=thread`, the `--cov-fail-under=94` ratchet, and the conftest hang-watchdog with its `if: always()` hang-dumps upload (guarded by `tests/unit/ci/test_workflow_yaml.py`).

### Validation
`tests/unit/ci/test_workflow_yaml.py`: **240 passed, 1 skipped**. YAML parses; coverage `timeout-minutes` unchanged at 40. Zero retry/mem-tick references remain anywhere in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)