### PR TITLE
feat(hooks): spec-status-integrity — flag stale specs whose deliverables shipped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: help spec-audit
+
+help:  ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+spec-audit:  ## Flag specs whose deliverables shipped but status didn't
+	python plugin/hooks/spec_audit.py

--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -103,9 +103,78 @@ def _leading_verdict(status: str) -> str:
     return m.group(0).lower() if m else ""
 
 
+# ── Deliverables block (spec-status-integrity, DECIDE-3) ──────
+#
+# A machine-readable "## Deliverables" section names the paths/globs
+# (and optional symbols) a spec ships. The staleness classifier checks
+# them for existence on disk so a spec whose work shipped but whose
+# Status line still says draft/approved can be flagged. Grammar lives
+# in the spec's design.md §"Data contract".
+_DELIVERABLES_HEADING = re.compile(
+    r"^##\s+Deliverables\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+# One deliverable: ``- <path-or-glob>`` with an optional
+# `` — symbol: <name>`` (em-dash or ``--``) suffix; the path may be
+# backtick-wrapped. The pattern is non-greedy so the symbol suffix is
+# split off rather than swallowed.
+_DELIVERABLE_ITEM = re.compile(
+    r"^\s*-\s+"
+    r"`?(?P<pattern>[^`\s][^`]*?)`?"
+    r"(?:\s+(?:—|--)\s*symbol:\s*(?P<symbol>\S+))?"
+    r"\s*$",
+)
+# A lone ``- N/A`` / ``- None`` item ⇒ docs-only sentinel. Tolerant of
+# italic/backtick wrappers (``_None_``) and a trailing period/ellipsis.
+_DELIVERABLE_NA = re.compile(
+    r"^\s*-\s+[_*`]*\s*(?:N/?A|None)\s*(?:\.{1,3})?\s*[_*`]*\s*$",
+    re.IGNORECASE,
+)
+# Opt-out line, matched anywhere in the file (mirrors the terminal-line
+# anywhere-scan): a deliberate long-lived draft suppresses the check.
+_DRIFT_OPT_OUT = re.compile(
+    r"^\s*drift-check:\s*ignore\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+# Glob metacharacters — a deliverable pattern containing any of these is
+# resolved by splitting off the literal-prefix dir and globbing the tail
+# inside it (pathlib ``**`` does not recurse into symlinked dirs
+# reliably, so we glob from the already-symlink-followed prefix).
+_GLOB_CHARS = re.compile(r"[*?\[]")
+
+
 # Sentinel TTL: anything older than this on a SessionStart prune
 # sweep is considered orphaned from an ungraceful exit.
 _SENTINEL_TTL_SECONDS = 7 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class DeliverableEntry:
+    """One declared deliverable from a spec's ``## Deliverables`` block.
+
+    ``pattern`` is a repo-prefixed path or glob (e.g.
+    ``attune-ai/plugin/hooks/spec_audit.py`` or
+    ``attune-gui/tests/**/test_bar.py``). ``symbol`` is an optional
+    grep target (function / class name) that must also be present in a
+    matched file before the entry counts as resolved.
+    """
+
+    pattern: str
+    symbol: str = ""
+
+
+@dataclass(frozen=True)
+class DeliverableSpec:
+    """Parsed ``## Deliverables`` contract for one spec.
+
+    ``is_na`` marks the docs-only sentinel (a lone ``- N/A`` item);
+    ``opt_out`` marks a deliberate ``drift-check: ignore`` suppression.
+    Both keep a spec out of ``suspected-stale`` without silent magic.
+    """
+
+    entries: tuple[DeliverableEntry, ...] = ()
+    is_na: bool = False
+    opt_out: bool = False
 
 
 @dataclass(frozen=True)
@@ -153,6 +222,18 @@ class SpecInfo:
     """True when ``effective_status`` overrode a non-terminal
     ``status`` (i.e. header drifted away from completion state).
     spec_orient renders a one-line hint when True."""
+
+    # spec-status-integrity additions (2026-06-17). Optional with safe
+    # defaults so existing positional/keyword constructors don't break
+    # (same discipline as the 2026-06-02 self-truthing fields above).
+    deliverables: tuple[DeliverableEntry, ...] = ()
+    """Deliverables parsed from the chosen phase file's
+    ``## Deliverables`` block; empty when none are declared."""
+
+    staleness: str = "unknown"
+    """Staleness verdict from ``classify_staleness`` — one of
+    ``ok`` / ``suspected-stale`` / ``unknown`` / ``partial`` /
+    ``docs-only`` / ``opted-out``. See DECIDE-3..5."""
 
 
 @dataclass(frozen=True)
@@ -247,6 +328,50 @@ def _completion_signal(text: str) -> tuple[str | None, str]:
     return None, "header"
 
 
+def deliverables_for_spec(text: str) -> DeliverableSpec:
+    """Parse a spec's ``## Deliverables`` block into a contract.
+
+    Same regex-driven style as ``_completion_signal``. The section is
+    bounded by the ``## Deliverables`` heading and the next ``## `` (via
+    ``_NEXT_H2``). Each list item becomes a ``DeliverableEntry``; a lone
+    ``- N/A`` item sets ``is_na``; a ``drift-check: ignore`` line found
+    anywhere in the file sets ``opt_out``.
+
+    A malformed or empty block yields zero entries (so the classifier
+    reports ``unknown``, never a false ``suspected-stale``). The opt-out
+    scan is independent of the section, mirroring the terminal-line scan.
+    """
+    opt_out = bool(_DRIFT_OPT_OUT.search(text))
+
+    heading = _DELIVERABLES_HEADING.search(text)
+    if heading is None:
+        return DeliverableSpec(opt_out=opt_out)
+
+    section_start = heading.end()
+    next_heading = _NEXT_H2.search(text, section_start)
+    section_end = next_heading.start() if next_heading else len(text)
+    section = text[section_start:section_end]
+
+    entries: list[DeliverableEntry] = []
+    is_na = False
+    for line in section.splitlines():
+        if not line.lstrip().startswith("-"):
+            continue
+        if _DELIVERABLE_NA.match(line):
+            is_na = True
+            continue
+        match = _DELIVERABLE_ITEM.match(line)
+        if match is None:
+            continue
+        pattern = match.group("pattern").strip()
+        if not pattern:
+            continue
+        symbol = (match.group("symbol") or "").strip()
+        entries.append(DeliverableEntry(pattern=pattern, symbol=symbol))
+
+    return DeliverableSpec(entries=tuple(entries), is_na=is_na, opt_out=opt_out)
+
+
 def _reconcile_status(header_status: str, phase_text: str) -> tuple[str, str, bool]:
     """Reconcile header status against completion signals.
 
@@ -269,13 +394,140 @@ def _reconcile_status(header_status: str, phase_text: str) -> tuple[str, str, bo
     return verdict, source, not header_is_terminal
 
 
+def _split_glob(pattern: str) -> tuple[str, str]:
+    """Split a path-glob into ``(literal_prefix, glob_tail)``.
+
+    The literal prefix is the leading run of ``/``-separated segments
+    that contain no glob metacharacters; the tail is the remainder
+    (which begins at the first segment that does). A plain path with no
+    glob yields an empty tail. Splitting lets the caller resolve the
+    prefix directory (following any symlink) and then glob the tail
+    *inside* the real directory — avoiding pathlib's unreliable
+    ``**``-across-symlink recursion (D-4).
+    """
+    parts = pattern.split("/")
+    literal: list[str] = []
+    for i, part in enumerate(parts):
+        if _GLOB_CHARS.search(part):
+            return "/".join(literal), "/".join(parts[i:])
+        literal.append(part)
+    return "/".join(literal), ""
+
+
+def _symbol_present(files: list[Path], symbol: str) -> bool:
+    """True if ``symbol`` appears as a substring in any of ``files``.
+
+    v1 uses plain substring matching (decisions.md "Open" — AST-accurate
+    detection is out of scope). Unreadable files are skipped.
+    """
+    for fpath in files:
+        try:
+            content = fpath.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if symbol in content:
+            return True
+    return False
+
+
+def _resolve_entry(entry: DeliverableEntry, roots: list[Path]) -> bool:
+    """True if a deliverable resolves to an on-disk file under any root.
+
+    Resolution semantics (D-4):
+
+    - The pattern is repo-prefixed (``attune-rag/src/...``) and every
+      layer is a symlink under the workspace root, so ``root / pattern``
+      follows the symlink without ``.resolve()`` (which would escape the
+      root — see ``reference_sibling_editable_venvs``).
+    - Globs are split into a literal prefix + tail; the prefix dir is
+      resolved first, then the tail is globbed inside it.
+    - When ``entry.symbol`` is set, at least one matched file must also
+      contain the symbol (substring grep) for the entry to resolve.
+    """
+    prefix, tail = _split_glob(entry.pattern)
+    for root in roots:
+        matched: list[Path] = []
+        if tail:
+            base = root / prefix if prefix else root
+            try:
+                if not base.is_dir():
+                    continue
+                matched = [p for p in base.glob(tail) if p.is_file()]
+            except OSError:
+                continue
+        else:
+            candidate = root / entry.pattern
+            try:
+                if not candidate.exists():
+                    continue
+                if candidate.is_file():
+                    matched = [candidate]
+                else:
+                    # Directory deliverable — existence is the signal; a
+                    # symbol grep over a directory is meaningless.
+                    if not entry.symbol:
+                        return True
+                    continue
+            except OSError:
+                continue
+        if not matched:
+            continue
+        if entry.symbol:
+            if _symbol_present(matched, entry.symbol):
+                return True
+            continue
+        return True
+    return False
+
+
+def classify_staleness(spec_text: str, header_status: str, roots: list[Path]) -> str:
+    """Classify a spec's staleness from its declared deliverables.
+
+    Returns one of (design.md §"Classifier", D-5 — require ALL):
+
+    - ``opted-out``       — a ``drift-check: ignore`` line is present.
+    - ``docs-only``       — the ``- N/A`` docs-only sentinel.
+    - ``unknown``         — no Deliverables block, zero parseable
+      entries, or entries declared but none present yet (genuinely
+      pre-implementation — no actionable signal).
+    - ``partial``         — at least one entry resolves, but not all
+      (mid-implementation; never flagged, to keep the warning quiet).
+    - ``suspected-stale`` — ALL entries resolve AND the (reconciled)
+      status is still non-terminal: work shipped, status didn't.
+    - ``ok``              — all entries resolve AND the status is
+      already terminal/ongoing.
+    """
+    spec = deliverables_for_spec(spec_text)
+    if spec.opt_out:
+        return "opted-out"
+    if spec.is_na:
+        return "docs-only"
+    if not spec.entries:
+        return "unknown"
+
+    resolved = sum(1 for entry in spec.entries if _resolve_entry(entry, roots))
+    if resolved == 0:
+        return "unknown"
+    if resolved < len(spec.entries):
+        return "partial"
+
+    # Every declared deliverable resolves. Reconcile the header against
+    # any in-body terminal signal (DECIDE-1) so a spec already marked
+    # done deeper in the file is not falsely flagged.
+    effective, _source, _conflict = _reconcile_status(header_status, spec_text)
+    lead = _leading_verdict(effective)
+    if lead in _TERMINAL_VERDICTS or lead in _ONGOING_VERDICTS:
+        return "ok"
+    return "suspected-stale"
+
+
 def _phase_for_dir(
     spec_dir: Path,
-) -> tuple[str, str, str, str, bool, float] | None:
+) -> tuple[str, str, str, str, bool, str, float] | None:
     """Pick the highest-priority phase file present in a spec dir.
 
     Returns ``(phase, raw_status, effective_status, status_source,
-    status_conflict, mtime)``:
+    status_conflict, phase_text, mtime)``:
 
     - ``phase`` — ``requirements`` / ``design`` / ``tasks``
     - ``raw_status`` — verbatim header status, lowercased
@@ -285,12 +537,15 @@ def _phase_for_dir(
       ``"terminal-line"``
     - ``status_conflict`` — True when ``effective_status`` overrode
       a non-terminal ``raw_status``
+    - ``phase_text`` — full text of the chosen phase file, so the
+      caller can parse the Deliverables block and classify staleness
+      without re-reading from disk
     - ``mtime`` — most recent across all phase files (fresh-file
       bumps the spec to the top of the list)
 
     Returns ``None`` when no phase file is readable.
     """
-    chosen: tuple[str, str, str, str, bool] | None = None
+    chosen: tuple[str, str, str, str, bool, str] | None = None
     latest_mtime = 0.0
     for phase, fname in _PHASE_FILES:
         fpath = spec_dir / fname
@@ -305,10 +560,10 @@ def _phase_for_dir(
         if chosen is None:
             raw_status, phase_text = _read_phase(fpath)
             effective, source, conflict = _reconcile_status(raw_status, phase_text)
-            chosen = (phase, raw_status, effective, source, conflict)
+            chosen = (phase, raw_status, effective, source, conflict, phase_text)
     if chosen is None:
         return None
-    return chosen[0], chosen[1], chosen[2], chosen[3], chosen[4], latest_mtime
+    return (*chosen, latest_mtime)
 
 
 def _is_in_flight(phase: str, effective_status: str) -> bool:
@@ -360,17 +615,22 @@ def _layer_for(roots: list[Path], base: Path) -> str:
 _SPEC_SUBDIRS: tuple[str, ...] = ("specs", "docs/specs")
 
 
-def discover_specs(roots: list[Path]) -> list[SpecInfo]:
+def discover_specs(roots: list[Path], include_terminal: bool = False) -> list[SpecInfo]:
     """Walk ``specs/`` directories under each root for in-flight specs.
 
     Args:
         roots: Workspace roots to scan. Each root is checked for a
             top-level ``specs/`` and for ``<root>/<layer>/specs/``
             directories (one nested level only — no recursive walk).
+        include_terminal: When False (default), terminal/ongoing specs
+            are excluded — the in-flight-only view ``spec_orient`` wants.
+            When True, every spec is returned with its staleness verdict
+            populated — the full table ``spec_audit`` prints.
 
     Returns:
         ``SpecInfo`` list, most-recently modified first. Tolerates
-        missing dirs and malformed status lines.
+        missing dirs and malformed status lines. Each result carries its
+        parsed ``deliverables`` and ``staleness`` verdict.
     """
     found: list[SpecInfo] = []
     seen: set[Path] = set()
@@ -401,9 +661,19 @@ def discover_specs(roots: list[Path]) -> list[SpecInfo]:
                 phase_info = _phase_for_dir(spec_dir)
                 if phase_info is None:
                     continue
-                phase, raw_status, effective, source, conflict, mtime = phase_info
-                if not _is_in_flight(phase, effective):
+                (
+                    phase,
+                    raw_status,
+                    effective,
+                    source,
+                    conflict,
+                    phase_text,
+                    mtime,
+                ) = phase_info
+                if not include_terminal and not _is_in_flight(phase, effective):
                     continue
+                deliverable_spec = deliverables_for_spec(phase_text)
+                staleness = classify_staleness(phase_text, raw_status, roots)
                 found.append(
                     SpecInfo(
                         slug=spec_dir.name,
@@ -415,6 +685,8 @@ def discover_specs(roots: list[Path]) -> list[SpecInfo]:
                         effective_status=effective,
                         status_source=source,
                         status_conflict=conflict,
+                        deliverables=deliverable_spec.entries,
+                        staleness=staleness,
                     )
                 )
     found.sort(key=lambda s: s.mtime, reverse=True)

--- a/plugin/hooks/spec_audit.py
+++ b/plugin/hooks/spec_audit.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Spec status audit — flag specs whose deliverables shipped but status didn't.
+
+On-demand / CI companion to the always-on ``spec_orient`` SessionStart
+hint. Discovers every spec (including terminal ones), classifies each
+against its declared ``## Deliverables`` block, and prints a matrix:
+
+    Spec | Layer | Status | Staleness | Unresolved
+
+D-7 — **warn by default, gate opt-in.** Exits ``0`` even when stale
+specs exist; ``--strict`` exits ``1`` on any ``suspected-stale`` so a
+repo can wire a hard CI gate. Crash-proof: any unexpected error prints
+what we have and still exits ``0`` (warn-by-default never hard-fails).
+
+Run via ``make spec-audit`` or ``python plugin/hooks/spec_audit.py``.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+
+# Force utf-8 on stdout/stderr — the table uses ⚠ and an em-dash rule
+# that Windows cp1252 can't encode (matches spec_orient.py).
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+# Hooks are invoked as standalone scripts; ensure sibling helpers resolve.
+_HOOKS_DIR = str(Path(__file__).resolve().parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+from _state import (  # noqa: E402 — sys.path bootstrap above
+    _resolve_entry,
+    discover_specs,
+    workspace_roots,
+)
+
+# Display order — suspected-stale rows surface first; ``ok`` sinks last.
+_STALENESS_ORDER = {
+    "suspected-stale": 0,
+    "partial": 1,
+    "unknown": 2,
+    "docs-only": 3,
+    "opted-out": 4,
+    "ok": 5,
+}
+# Only suspected-stale gets a glyph; the rest render verbatim.
+_STALENESS_LABEL = {"suspected-stale": "⚠ suspected-stale"}
+
+_HEADERS = ("Spec", "Layer", "Status", "Staleness", "Unresolved")
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """One spec's audit row."""
+
+    slug: str
+    layer: str
+    status: str
+    staleness: str
+    resolved: int  # entries that resolve on disk
+    total: int  # entries declared
+
+
+def audit_specs(roots: list[Path] | None = None) -> list[AuditResult]:
+    """Classify every discovered spec (terminal included) into a row.
+
+    Resolution counts are recomputed per spec so the report can show how
+    many declared deliverables are present. Per-spec failures degrade to
+    a zero-count row rather than aborting the whole audit.
+    """
+    if roots is None:
+        roots = workspace_roots()
+    results: list[AuditResult] = []
+    for spec in discover_specs(roots, include_terminal=True):
+        total = len(spec.deliverables)
+        resolved = 0
+        # Counts only matter where resolution actually ran (partial shows
+        # "N of M"; suspected-stale/ok are all-resolve by definition).
+        if total and spec.staleness in ("partial", "suspected-stale", "ok"):
+            try:
+                resolved = sum(1 for e in spec.deliverables if _resolve_entry(e, roots))
+            except Exception:  # noqa: BLE001 — one bad spec must not abort the audit
+                resolved = 0
+        results.append(
+            AuditResult(
+                slug=spec.slug,
+                layer=spec.layer,
+                status=spec.status or "—",
+                staleness=spec.staleness,
+                resolved=resolved,
+                total=total,
+            )
+        )
+    return results
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Clip ``text`` to ``limit`` chars, ellipsizing the overflow."""
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _detail(result: AuditResult) -> str:
+    """Render the ``Unresolved`` column for one row."""
+    if result.staleness == "opted-out":
+        return "(opt-out)"
+    if result.staleness == "docs-only":
+        return "(N/A)"
+    if result.staleness == "unknown":
+        return "(no block)" if result.total == 0 else f"0 of {result.total}"
+    if result.staleness == "partial":
+        return f"{result.total - result.resolved} of {result.total}"
+    # suspected-stale / ok — every declared deliverable resolves.
+    return "—"
+
+
+def format_report(results: list[AuditResult]) -> str:
+    """Render the full audit matrix as a string."""
+    stale = [r for r in results if r.staleness == "suspected-stale"]
+    noun = "spec" if len(results) == 1 else "specs"
+    title = f"SPEC STATUS AUDIT — {len(results)} {noun} ({len(stale)} suspected-stale)"
+    if not results:
+        return f"{title}\n\n(no specs found)"
+
+    ordered = sorted(results, key=lambda r: (_STALENESS_ORDER.get(r.staleness, 9), r.slug))
+    rows = [
+        (
+            _truncate(r.slug, 44),
+            _truncate(r.layer, 14),
+            # Status lines are written informatively and can run to a
+            # whole paragraph — truncate so one long status doesn't blow
+            # the column out (e.g. integration-coverage's 1k-char line).
+            _truncate(r.status, 32),
+            _STALENESS_LABEL.get(r.staleness, r.staleness),
+            _detail(r),
+        )
+        for r in ordered
+    ]
+    widths = [max(len(_HEADERS[i]), *(len(row[i]) for row in rows)) for i in range(len(_HEADERS))]
+
+    def _line(cells: tuple[str, ...]) -> str:
+        return "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(cells)).rstrip()
+
+    out = [title, "", _line(_HEADERS), "─" * len(_line(_HEADERS))]
+    out.extend(_line(row) for row in rows)
+    out.append("")
+    if stale:
+        out.append(
+            f"⚠ {len(stale)} spec(s) have shipped deliverables but a "
+            "non-terminal status — verify & update."
+        )
+    else:
+        out.append("✓ No suspected-stale specs.")
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the audit matrix; exit per ``--strict``. Never hard-crashes."""
+    try:
+        args = sys.argv[1:] if argv is None else argv
+        strict = "--strict" in args
+        results = audit_specs()
+        print(format_report(results))
+        if strict and any(r.staleness == "suspected-stale" for r in results):
+            return 1
+        return 0
+    except Exception:  # noqa: BLE001 — warn-by-default: report and exit 0
+        traceback.print_exc(file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugin/hooks/spec_orient.py
+++ b/plugin/hooks/spec_orient.py
@@ -68,6 +68,14 @@ def _format_phase(spec: SpecInfo) -> str:
     When ``status_conflict`` is True (header drifted from the
     completion state), append a one-line hint so the source drift
     surfaces and can be fixed.
+
+    When ``staleness`` is ``"suspected-stale"`` (every declared
+    deliverable resolves on disk but the status is still non-terminal),
+    append a parallel hint so a session doesn't rebuild shipped work.
+    The two hints don't collide: an in-body terminal signal would have
+    set ``status_conflict`` and excluded the spec from the in-flight
+    list, so a still-listed spec that is ``suspected-stale`` has no
+    terminal signal — but ``status_conflict`` is checked first anyway.
     """
     phase_label = {
         "requirements": "requirements",
@@ -83,6 +91,9 @@ def _format_phase(spec: SpecInfo) -> str:
         }.get(spec.status_source, spec.status_source)
         raw = spec.status or "no header"
         return f'{base} — {source_label}; header says "{raw}", worth fixing'
+    if spec.staleness == "suspected-stale":
+        raw = spec.status or "no status"
+        return f'{base} — ⚠ deliverables present, status still "{raw}"; ' "verify before building"
     return base
 
 

--- a/tests/unit/hooks/test_session_continuity_state.py
+++ b/tests/unit/hooks/test_session_continuity_state.py
@@ -357,6 +357,94 @@ class TestStatusReconciliation:
         rendered = mod._format_phase(spec_info)
         assert rendered == "design approved"
 
+    @staticmethod
+    def _load_spec_orient(name: str):
+        """Load spec_orient.py fresh (matches the conflict-hint tests)."""
+        import importlib.util
+        from pathlib import Path as _P
+
+        plugin_hooks = _P(__file__).resolve().parents[3] / "plugin" / "hooks"
+        spec = importlib.util.spec_from_file_location(name, plugin_hooks / "spec_orient.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_format_phase_renders_suspected_stale_hint(self, state_mod) -> None:
+        """A suspected-stale spec appends the deliverables-present hint."""
+        mod = self._load_spec_orient("_test_spec_orient_stale")
+        spec_info = state_mod.SpecInfo(
+            slug="shipped",
+            path=Path("/tmp/x"),
+            layer="workspace",
+            phase="tasks",
+            status="approved",
+            mtime=0.0,
+            effective_status="approved",
+            status_source="header",
+            status_conflict=False,
+            staleness="suspected-stale",
+        )
+        rendered = mod._format_phase(spec_info)
+        assert rendered.startswith("tasks approved")
+        assert "deliverables present" in rendered
+        assert '"approved"' in rendered
+        assert "verify before building" in rendered
+
+    def test_format_phase_no_stale_hint_for_ok_or_unknown(self, state_mod) -> None:
+        """ok / unknown staleness render nothing beyond the base blurb."""
+        mod = self._load_spec_orient("_test_spec_orient_ok")
+        for verdict in ("ok", "unknown", "partial", "docs-only", "opted-out"):
+            spec_info = state_mod.SpecInfo(
+                slug="normal",
+                path=Path("/tmp/x"),
+                layer="workspace",
+                phase="design",
+                status="approved",
+                mtime=0.0,
+                effective_status="approved",
+                status_source="header",
+                status_conflict=False,
+                staleness=verdict,
+            )
+            assert mod._format_phase(spec_info) == "design approved"
+
+    def test_format_phase_conflict_wins_over_stale(self, state_mod) -> None:
+        """status_conflict takes precedence when both signals are set."""
+        mod = self._load_spec_orient("_test_spec_orient_precedence")
+        spec_info = state_mod.SpecInfo(
+            slug="both",
+            path=Path("/tmp/x"),
+            layer="workspace",
+            phase="tasks",
+            status="draft",
+            mtime=0.0,
+            effective_status="complete",
+            status_source="terminal-line",
+            status_conflict=True,
+            staleness="suspected-stale",
+        )
+        rendered = mod._format_phase(spec_info)
+        assert "worth fixing" in rendered
+        assert "deliverables present" not in rendered
+
+    def test_format_phase_suspected_stale_empty_status(self, state_mod) -> None:
+        """A suspected-stale spec with no header status never raises."""
+        mod = self._load_spec_orient("_test_spec_orient_empty")
+        spec_info = state_mod.SpecInfo(
+            slug="nostatus",
+            path=Path("/tmp/x"),
+            layer="workspace",
+            phase="tasks",
+            status="",
+            mtime=0.0,
+            effective_status="",
+            status_source="header",
+            status_conflict=False,
+            staleness="suspected-stale",
+        )
+        rendered = mod._format_phase(spec_info)
+        assert '"no status"' in rendered
+
 
 # ── git_state ────────────────────────────────────────────────
 

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -1,0 +1,506 @@
+"""Tests for the spec-status-integrity Deliverables parser in _state.py.
+
+Covers ``deliverables_for_spec`` — the machine-readable
+``## Deliverables`` contract a spec declares so the staleness
+classifier can check whether its work has shipped. Mock-free /
+filesystem-only per testing-conventions.md (no ``live`` marker, no
+API key).
+
+The hook module is loaded via ``spec_from_file_location`` to match the
+existing plugin-hook test convention (see
+``test_session_continuity_state.py``).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
+
+
+def _load_state_module():
+    """Load _state.py fresh — avoids cross-test sys.path leakage."""
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    if "_state" in sys.modules:
+        return sys.modules["_state"]
+    spec = importlib.util.spec_from_file_location("_state", _HOOKS_DIR / "_state.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_state"] = module  # dataclasses-friendly registration
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_spec_audit_module():
+    """Load spec_audit.py fresh (its sibling _state import resolves via
+    the sys.path bootstrap in the hook header)."""
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    spec = importlib.util.spec_from_file_location("spec_audit", _HOOKS_DIR / "spec_audit.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["spec_audit"] = module  # dataclasses-friendly registration
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def state_mod():
+    return _load_state_module()
+
+
+@pytest.fixture
+def audit_mod():
+    return _load_spec_audit_module()
+
+
+def _block(*items: str, heading: str = "## Deliverables") -> str:
+    """Wrap deliverable list items in a minimal spec document."""
+    body = "\n".join(items)
+    return f"# Some Spec\n\n**Status**: approved\n\n{heading}\n\n{body}\n"
+
+
+# ── path-only items ──────────────────────────────────────────
+
+
+class TestPathOnly:
+    def test_single_path(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(_block("- attune-rag/src/attune_rag/foo.py"))
+        assert result.entries == (
+            state_mod.DeliverableEntry(pattern="attune-rag/src/attune_rag/foo.py"),
+        )
+        assert result.is_na is False
+        assert result.opt_out is False
+
+    def test_multiple_paths(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(
+            _block(
+                "- attune-ai/plugin/hooks/spec_audit.py",
+                "- attune-rag/src/attune_rag/foo.py",
+            )
+        )
+        assert [e.pattern for e in result.entries] == [
+            "attune-ai/plugin/hooks/spec_audit.py",
+            "attune-rag/src/attune_rag/foo.py",
+        ]
+        assert all(e.symbol == "" for e in result.entries)
+
+    def test_glob_pattern_preserved(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(_block("- attune-gui/tests/**/test_bar.py"))
+        assert result.entries[0].pattern == "attune-gui/tests/**/test_bar.py"
+
+
+# ── symbol suffix ────────────────────────────────────────────
+
+
+class TestSymbolSuffix:
+    def test_em_dash_symbol(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(
+            _block("- attune-ai/plugin/hooks/spec_audit.py — symbol: audit_specs")
+        )
+        entry = result.entries[0]
+        assert entry.pattern == "attune-ai/plugin/hooks/spec_audit.py"
+        assert entry.symbol == "audit_specs"
+
+    def test_double_hyphen_symbol(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(
+            _block("- attune-ai/plugin/hooks/spec_audit.py -- symbol: audit_specs")
+        )
+        entry = result.entries[0]
+        assert entry.pattern == "attune-ai/plugin/hooks/spec_audit.py"
+        assert entry.symbol == "audit_specs"
+
+
+# ── backtick tolerance ───────────────────────────────────────
+
+
+class TestBacktickVariants:
+    def test_backtick_wrapped_path(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(_block("- `attune-ai/plugin/hooks/spec_audit.py`"))
+        assert result.entries[0].pattern == "attune-ai/plugin/hooks/spec_audit.py"
+        assert result.entries[0].symbol == ""
+
+    def test_backtick_wrapped_with_symbol(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(
+            _block("- `attune-ai/plugin/hooks/spec_audit.py` — symbol: audit_specs")
+        )
+        entry = result.entries[0]
+        assert entry.pattern == "attune-ai/plugin/hooks/spec_audit.py"
+        assert entry.symbol == "audit_specs"
+
+
+# ── N/A sentinel ─────────────────────────────────────────────
+
+
+class TestNaSentinel:
+    def test_lone_na_sets_is_na(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(_block("- N/A"))
+        assert result.is_na is True
+        assert result.entries == ()
+
+    def test_na_without_slash(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(_block("- NA"))
+        assert result.is_na is True
+
+    def test_italic_none_sets_is_na(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(_block("- _None_"))
+        assert result.is_na is True
+        assert result.entries == ()
+
+    def test_na_does_not_become_an_entry(self, state_mod) -> None:
+        # N/A must be caught by the sentinel branch, not parsed as a path.
+        result = state_mod.deliverables_for_spec(_block("- N/A"))
+        assert all(e.pattern != "N/A" for e in result.entries)
+
+
+# ── opt-out ──────────────────────────────────────────────────
+
+
+class TestOptOut:
+    def test_drift_check_ignore_sets_opt_out(self, state_mod) -> None:
+        text = _block("- attune-rag/src/foo.py") + "\ndrift-check: ignore\n"
+        result = state_mod.deliverables_for_spec(text)
+        assert result.opt_out is True
+        # Entries still parse — opt_out is an independent signal.
+        assert len(result.entries) == 1
+
+    def test_opt_out_anywhere_without_block(self, state_mod) -> None:
+        text = "# Draft\n\n**Status**: draft\n\ndrift-check: ignore\n"
+        result = state_mod.deliverables_for_spec(text)
+        assert result.opt_out is True
+        assert result.entries == ()
+
+    def test_no_opt_out_by_default(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(_block("- attune-rag/src/foo.py"))
+        assert result.opt_out is False
+
+
+# ── absent / malformed blocks ────────────────────────────────
+
+
+class TestAbsentOrMalformed:
+    def test_no_deliverables_section(self, state_mod) -> None:
+        text = "# Spec\n\n**Status**: approved\n\n## Overview\n\nSome prose.\n"
+        result = state_mod.deliverables_for_spec(text)
+        assert result.entries == ()
+        assert result.is_na is False
+        assert result.opt_out is False
+
+    def test_empty_block_zero_entries(self, state_mod) -> None:
+        text = "# Spec\n\n## Deliverables\n\n## Next Section\n\n- not a deliverable\n"
+        result = state_mod.deliverables_for_spec(text)
+        assert result.entries == ()
+
+    def test_malformed_items_skipped(self, state_mod) -> None:
+        # A bare list bullet with no content, and prose lines, are ignored.
+        text = _block("-", "just prose, not a bullet", "- attune-rag/src/ok.py")
+        result = state_mod.deliverables_for_spec(text)
+        assert [e.pattern for e in result.entries] == ["attune-rag/src/ok.py"]
+
+    def test_section_bounded_by_next_h2(self, state_mod) -> None:
+        # Items after the next ## heading must NOT be collected.
+        text = (
+            "# Spec\n\n## Deliverables\n\n"
+            "- attune-rag/src/in_section.py\n\n"
+            "## Testing strategy\n\n"
+            "- attune-rag/src/out_of_section.py\n"
+        )
+        result = state_mod.deliverables_for_spec(text)
+        assert [e.pattern for e in result.entries] == ["attune-rag/src/in_section.py"]
+
+    def test_case_insensitive_heading(self, state_mod) -> None:
+        result = state_mod.deliverables_for_spec(
+            _block("- attune-rag/src/foo.py", heading="## deliverables")
+        )
+        assert len(result.entries) == 1
+
+
+# ── resolution + classifier (task 2) ─────────────────────────
+
+
+@pytest.fixture
+def workspace(tmp_path: Path):
+    """A workspace root whose layer dir is reached through a symlink.
+
+    Mirrors the on-disk layout: ``~/attune/attune-rag`` is a symlink to
+    the real ``~/attune-rag`` checkout. Returns the workspace root used
+    as the resolution base. Skips when symlinks aren't available.
+    """
+    layer = tmp_path / "attune-rag"
+    (layer / "src" / "attune_rag").mkdir(parents=True)
+    (layer / "src" / "attune_rag" / "foo.py").write_text(
+        "def foo():\n    return 1\n", encoding="utf-8"
+    )
+    (layer / "tests" / "unit").mkdir(parents=True)
+    (layer / "tests" / "unit" / "test_bar.py").write_text(
+        "def test_bar():\n    assert True\n", encoding="utf-8"
+    )
+    root = tmp_path / "attune"
+    root.mkdir()
+    try:
+        (root / "attune-rag").symlink_to(layer, target_is_directory=True)
+    except (OSError, NotImplementedError):  # pragma: no cover - platform guard
+        pytest.skip("symlinks not supported in this environment")
+    return root
+
+
+class TestResolveEntry:
+    def test_existing_path_resolves(self, state_mod, workspace) -> None:
+        entry = state_mod.DeliverableEntry(pattern="attune-rag/src/attune_rag/foo.py")
+        assert state_mod._resolve_entry(entry, [workspace]) is True
+
+    def test_missing_path_does_not_resolve(self, state_mod, workspace) -> None:
+        entry = state_mod.DeliverableEntry(pattern="attune-rag/src/nope.py")
+        assert state_mod._resolve_entry(entry, [workspace]) is False
+
+    def test_glob_resolves_across_symlink(self, state_mod, workspace) -> None:
+        # ** must recurse inside the real dir reached through the symlink.
+        entry = state_mod.DeliverableEntry(pattern="attune-rag/tests/**/test_bar.py")
+        assert state_mod._resolve_entry(entry, [workspace]) is True
+
+    def test_symbol_present_resolves(self, state_mod, workspace) -> None:
+        entry = state_mod.DeliverableEntry(
+            pattern="attune-rag/src/attune_rag/foo.py", symbol="def foo"
+        )
+        assert state_mod._resolve_entry(entry, [workspace]) is True
+
+    def test_symbol_absent_does_not_resolve(self, state_mod, workspace) -> None:
+        # File exists, but the named symbol is not in it.
+        entry = state_mod.DeliverableEntry(
+            pattern="attune-rag/src/attune_rag/foo.py", symbol="def missing_symbol"
+        )
+        assert state_mod._resolve_entry(entry, [workspace]) is False
+
+    def test_directory_deliverable_resolves_on_existence(self, state_mod, workspace) -> None:
+        entry = state_mod.DeliverableEntry(pattern="attune-rag/src/attune_rag")
+        assert state_mod._resolve_entry(entry, [workspace]) is True
+
+
+class TestClassifyStaleness:
+    def _spec(self, *items: str, status: str = "approved") -> str:
+        body = "\n".join(items)
+        return f"# Spec\n\n**Status**: {status}\n\n## Deliverables\n\n{body}\n"
+
+    def test_all_resolve_non_terminal_is_suspected_stale(self, state_mod, workspace) -> None:
+        text = self._spec(
+            "- attune-rag/src/attune_rag/foo.py",
+            "- attune-rag/tests/**/test_bar.py",
+            status="approved",
+        )
+        assert state_mod.classify_staleness(text, "approved", [workspace]) == "suspected-stale"
+
+    def test_all_resolve_terminal_status_is_ok(self, state_mod, workspace) -> None:
+        text = self._spec("- attune-rag/src/attune_rag/foo.py", status="complete (2026-06-17)")
+        assert state_mod.classify_staleness(text, "complete (2026-06-17)", [workspace]) == "ok"
+
+    def test_body_terminal_signal_clears_stale(self, state_mod, workspace) -> None:
+        # Header says approved, but a terminal line deeper in the doc wins.
+        text = (
+            "# Spec\n\n**Status**: approved\n\n"
+            "## Deliverables\n\n- attune-rag/src/attune_rag/foo.py\n\n"
+            "Status: shipped #99\n"
+        )
+        assert state_mod.classify_staleness(text, "approved", [workspace]) == "ok"
+
+    def test_partial_when_one_of_two_resolves(self, state_mod, workspace) -> None:
+        text = self._spec(
+            "- attune-rag/src/attune_rag/foo.py",  # exists
+            "- attune-rag/src/attune_rag/missing.py",  # absent
+            status="approved",
+        )
+        assert state_mod.classify_staleness(text, "approved", [workspace]) == "partial"
+
+    def test_bad_symbol_makes_it_partial(self, state_mod, workspace) -> None:
+        text = self._spec(
+            "- attune-rag/src/attune_rag/foo.py",  # resolves
+            "- attune-rag/src/attune_rag/foo.py — symbol: def nope",  # symbol absent
+            status="approved",
+        )
+        assert state_mod.classify_staleness(text, "approved", [workspace]) == "partial"
+
+    def test_opt_out_is_opted_out(self, state_mod, workspace) -> None:
+        text = (
+            self._spec("- attune-rag/src/attune_rag/foo.py", status="approved")
+            + "\ndrift-check: ignore\n"
+        )
+        assert state_mod.classify_staleness(text, "approved", [workspace]) == "opted-out"
+
+    def test_na_is_docs_only(self, state_mod, workspace) -> None:
+        text = self._spec("- N/A", status="approved")
+        assert state_mod.classify_staleness(text, "approved", [workspace]) == "docs-only"
+
+    def test_no_block_is_unknown(self, state_mod, workspace) -> None:
+        text = "# Spec\n\n**Status**: approved\n\n## Overview\n\nProse.\n"
+        assert state_mod.classify_staleness(text, "approved", [workspace]) == "unknown"
+
+    def test_entries_none_present_is_unknown(self, state_mod, workspace) -> None:
+        # Declared deliverables, none shipped yet — pre-implementation.
+        text = self._spec("- attune-rag/src/attune_rag/not_yet.py", status="approved")
+        assert state_mod.classify_staleness(text, "approved", [workspace]) == "unknown"
+
+
+# ── discover_specs wiring (task 3) ───────────────────────────
+
+
+def _spec_file(spec_dir: Path, *, status: str, deliverable: str) -> None:
+    """Write a one-file spec with a Deliverables block."""
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / "tasks.md").write_text(
+        f"# Tasks\n\n**Status**: {status}\n\n## Deliverables\n\n- {deliverable}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def spec_tree(tmp_path: Path):
+    """A workspace root with three specs and one shipped source file.
+
+    - ``shipped-spec``  — approved, deliverable present  → suspected-stale
+    - ``pending-spec``  — approved, deliverable absent   → unknown
+    - ``done-spec``     — complete, deliverable present  → ok (terminal)
+    """
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "shipped.py").write_text("x = 1\n", encoding="utf-8")
+    specs = tmp_path / "specs"
+    _spec_file(specs / "shipped-spec", status="approved", deliverable="src/shipped.py")
+    _spec_file(specs / "pending-spec", status="approved", deliverable="src/not_yet.py")
+    _spec_file(specs / "done-spec", status="complete (2026-06-17)", deliverable="src/shipped.py")
+    return tmp_path
+
+
+class TestDiscoverSpecsStaleness:
+    def test_default_excludes_terminal_and_populates_staleness(self, state_mod, spec_tree) -> None:
+        result = state_mod.discover_specs([spec_tree])
+        by_slug = {s.slug: s for s in result}
+        # Terminal spec excluded by default.
+        assert set(by_slug) == {"shipped-spec", "pending-spec"}
+        assert by_slug["shipped-spec"].staleness == "suspected-stale"
+        assert by_slug["pending-spec"].staleness == "unknown"
+
+    def test_deliverables_field_populated(self, state_mod, spec_tree) -> None:
+        result = state_mod.discover_specs([spec_tree])
+        shipped = next(s for s in result if s.slug == "shipped-spec")
+        assert [e.pattern for e in shipped.deliverables] == ["src/shipped.py"]
+
+    def test_include_terminal_returns_all_with_ok(self, state_mod, spec_tree) -> None:
+        result = state_mod.discover_specs([spec_tree], include_terminal=True)
+        by_slug = {s.slug: s for s in result}
+        assert set(by_slug) == {"shipped-spec", "pending-spec", "done-spec"}
+        assert by_slug["done-spec"].staleness == "ok"
+
+    def test_spec_without_block_is_unknown(self, state_mod, tmp_path) -> None:
+        spec = tmp_path / "specs" / "no-block"
+        spec.mkdir(parents=True)
+        (spec / "tasks.md").write_text(
+            "# Tasks\n\n**Status**: approved\n\n## Overview\n\nProse.\n",
+            encoding="utf-8",
+        )
+        result = state_mod.discover_specs([tmp_path])
+        assert len(result) == 1
+        assert result[0].staleness == "unknown"
+        assert result[0].deliverables == ()
+
+
+# ── spec_audit CLI (task 5) ──────────────────────────────────
+
+
+def _audit_spec_file(spec_dir: Path, *, status: str, deliverables: list[str]) -> None:
+    """Write a one-file spec with one or more Deliverables items."""
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    items = "\n".join(f"- {d}" for d in deliverables)
+    (spec_dir / "tasks.md").write_text(
+        f"# Tasks\n\n**Status**: {status}\n\n## Deliverables\n\n{items}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def audit_tree(tmp_path: Path):
+    """A workspace with one of each staleness verdict for the matrix.
+
+    - ``shipped-spec`` approved, present            → suspected-stale
+    - ``partial-spec`` approved, 1 present / 1 not  → partial
+    - ``pending-spec`` approved, absent             → unknown (0 of 1)
+    - ``done-spec``    complete, present            → ok
+    """
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "shipped.py").write_text("x = 1\n", encoding="utf-8")
+    specs = tmp_path / "specs"
+    _audit_spec_file(specs / "shipped-spec", status="approved", deliverables=["src/shipped.py"])
+    _audit_spec_file(
+        specs / "partial-spec",
+        status="approved",
+        deliverables=["src/shipped.py", "src/missing.py"],
+    )
+    _audit_spec_file(specs / "pending-spec", status="approved", deliverables=["src/not_yet.py"])
+    _audit_spec_file(
+        specs / "done-spec", status="complete (2026-06-17)", deliverables=["src/shipped.py"]
+    )
+    return tmp_path
+
+
+class TestAuditSpecs:
+    def test_rows_classify_each_spec(self, audit_mod, audit_tree) -> None:
+        by_slug = {r.slug: r for r in audit_mod.audit_specs([audit_tree])}
+        assert by_slug["shipped-spec"].staleness == "suspected-stale"
+        assert by_slug["shipped-spec"].resolved == 1
+        assert by_slug["shipped-spec"].total == 1
+        assert by_slug["partial-spec"].staleness == "partial"
+        assert by_slug["partial-spec"].resolved == 1
+        assert by_slug["partial-spec"].total == 2
+        assert by_slug["pending-spec"].staleness == "unknown"
+        assert by_slug["done-spec"].staleness == "ok"  # terminal, included
+
+    def test_empty_workspace_returns_no_rows(self, audit_mod, tmp_path) -> None:
+        assert audit_mod.audit_specs([tmp_path]) == []
+
+
+class TestFormatReport:
+    def test_matrix_headers_and_stale_footer(self, audit_mod, audit_tree) -> None:
+        report = audit_mod.format_report(audit_mod.audit_specs([audit_tree]))
+        for header in ("Spec", "Layer", "Status", "Staleness", "Unresolved"):
+            assert header in report
+        assert "⚠ suspected-stale" in report
+        assert "shipped-spec" in report
+        assert "1 of 2" in report  # partial detail (unresolved of total)
+        assert "verify & update" in report
+
+    def test_empty_report(self, audit_mod) -> None:
+        report = audit_mod.format_report([])
+        assert "(no specs found)" in report
+
+
+class TestMainExitCodes:
+    def test_default_exit_zero_with_stale(self, audit_mod, audit_tree, monkeypatch, capsys) -> None:
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(audit_tree))
+        assert audit_mod.main([]) == 0
+        out = capsys.readouterr().out
+        assert "SPEC STATUS AUDIT" in out
+
+    def test_strict_exit_one_with_stale(self, audit_mod, audit_tree, monkeypatch) -> None:
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(audit_tree))
+        assert audit_mod.main(["--strict"]) == 1
+
+    def test_strict_exit_zero_without_stale(self, audit_mod, tmp_path, monkeypatch) -> None:
+        # Only a pending (unknown) spec — nothing suspected-stale.
+        _audit_spec_file(
+            tmp_path / "specs" / "pending",
+            status="approved",
+            deliverables=["src/not_yet.py"],
+        )
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(tmp_path))
+        assert audit_mod.main(["--strict"]) == 0
+
+    def test_main_is_crash_proof(self, audit_mod, monkeypatch) -> None:
+        def _boom(*_a, **_k):
+            raise RuntimeError("disk on fire")
+
+        monkeypatch.setattr(audit_mod, "audit_specs", _boom)
+        # Warn-by-default: a thrown audit still exits 0.
+        assert audit_mod.main([]) == 0


### PR DESCRIPTION
## Summary

Implements tasks 1–5 of **spec-status-integrity** — an automated check
that flags attune specs whose deliverables already shipped but whose
`Status:` line still says draft/approved, so stale statuses stop
misleading future sessions.

Extends the existing `_state.py` spec reconciler (which read only in-doc
signals) to also check the codebase: a spec whose declared
`## Deliverables` all resolve on disk while its status is non-terminal is
flagged `suspected-stale`.

## What's in this PR

- **`plugin/hooks/_state.py`** — `deliverables_for_spec` parser +
  `DeliverableEntry`/`DeliverableSpec` dataclasses; `_resolve_entry`
  (symlink-safe `.exists()`, split-prefix glob, optional symbol grep) +
  `classify_staleness` (require-ALL, D-5); `SpecInfo` gains back-compat
  `deliverables`/`staleness` fields; `discover_specs(include_terminal=)`.
- **`plugin/hooks/spec_orient.py`** — inline `suspected-stale` hint in
  `_format_phase` (status-conflict still wins on a tie).
- **`plugin/hooks/spec_audit.py`** (new) + **`Makefile`** `spec-audit`
  target — warn-by-default matrix, `--strict` gate (D-7), crash-proof.
- **Tests** — `tests/unit/hooks/test_spec_audit.py` (46, mock-free) plus
  `_format_phase` stale-hint cases in `test_session_continuity_state.py`.

## Verification

- `tests/unit/hooks/` — 436 passed, 1 skipped (symlink platform guard)
- pinned black + ruff (24.10.0 / 0.8.4) clean
- `make spec-audit` renders the live 126-spec matrix; exit 0 default,
  `--strict` exit 0 (0 suspected-stale pre-backfill)

## Follow-ups (not in this PR)

- **Task 6** — `## Deliverables` section added to the workspace
  `specs/TEMPLATE.md` + `TEMPLATE-AI.md` (separate repo).
- **Task 7** — re-vendor the three hooks into the 4 layer repos'
  `.claude/hooks/` (deferred until this merges, per the spec).
- **Task 8** — backfill `## Deliverables` blocks into ~21 workspace
  specs; the four known-shipped specs then light up `suspected-stale`.

Spec: `specs/spec-status-integrity/` (attune workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
