### PR TITLE
docs(ci-runner-hang): second captured hang frame (#924) — H4 confirmed, heartbeat lead weakened

### DIFF
--- a/docs/specs/ci-runner-hang/evidence/run-27615182285/hang-controller.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-27615182285/hang-controller.txt
@@ -1,0 +1,46 @@
+Timeout (0:10:00)!
+Thread 0x00007f8abeffe6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f8abffff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f8ac59fe6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f8ac69ff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f8ad2a83b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 331 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/queue.py", line 180 in get
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/xdist/dsession.py", line 154 in loop_once
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/xdist/dsession.py", line 138 in pytest_runtestloop
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 384 in _main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 330 in wrap_session
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 377 in pytest_cmdline_main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 229 in _main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 253 in _console_main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/bin/pytest", line 6 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-27615182285/hang-gw1.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-27615182285/hang-gw1.txt
@@ -1,0 +1,16 @@
+Timeout (0:10:00)!
+Thread 0x00007f1f955ff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f1f96e03b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-27615182285/hang-gw2.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-27615182285/hang-gw2.txt
@@ -1,0 +1,16 @@
+Timeout (0:10:00)!
+Thread 0x00007f90801ff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f9081a12b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-27615182285/hang-gw3.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-27615182285/hang-gw3.txt
@@ -1,0 +1,16 @@
+Timeout (0:10:00)!
+Thread 0x00007f6ebd9ff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f6ebf1f5b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/phase2-findings.md
+++ b/docs/specs/ci-runner-hang/phase2-findings.md
@@ -231,3 +231,44 @@ is a ~99% **finalize-wedge** (all tests pass, then the session can't
 conclude). That spec's premise table is corrected in the same PR as
 this finding. (This `ci-runner-hang` spec already had the "99%-freeze"
 shape right.)
+
+## Phase 3 — SECOND captured frame (2026-06-16, #924)
+
+The N>1 dump the first frame called for. PR #924
+(`chore(deps): adopt attune-rag 0.7.0`) wedged its
+`test (ubuntu-latest, 3.11)` lane: every test passed, then the session
+hung, the 14m step-timeout fired, the bounded auto-retry hung again, and
+the job died with **exit code 124**. The `if: always()` upload preserved
+all four stacks. Raw dumps:
+[evidence/run-27615182285/](evidence/run-27615182285/) (job
+`81649261853`, run `27615182285`).
+
+### What the stacks show
+
+| Process | Main-thread frame | Reading |
+|---------|-------------------|---------|
+| controller | `xdist/dsession.py:154 loop_once → queue.get → threading wait` | waiting for a worker event that never arrives |
+| gw1 | `execnet gateway_base serve → integrate_as_primary_thread → wait` | idle, done, awaiting shutdown |
+| gw2 | same as gw1 | idle |
+| gw3 | same as gw1 | idle |
+
+Identical **H4** controller signature to the first frame — clean idle
+on every process, no uninterruptible I/O (no `socket.recv`,
+`subprocess.wait`, or `lock.acquire`), so still **not** H1/H2.
+
+### The discriminating result — heartbeat-leak lead WEAKENED
+
+The first frame's only differentiator was a leaked
+`coordinator.py _heartbeat_loop` thread on the wedged `gw3`, which
+became the prime LEAD. **This frame reproduces the exact same
+finalize-wedge with NO leaked heartbeat thread on any worker** (each
+worker carries only its 2 execnet threads; `grep -ri heartbeat` over the
+dumps is empty). Two consecutive H4 wedges, only one of which had the
+leaked thread, argues the heartbeat thread was **incidental, not
+causal** — the deadlock is in the execnet/xdist end-of-session control
+channel itself.
+
+This satisfies "Next actions" item 3 above (*if the leak is ruled out,
+pivot to H4*): the cheap heartbeat-teardown fixture (item 2) is still
+worth doing as hygiene, but the root-cause hunt should now target the
+execnet/xdist finalize handshake directly, not the heartbeat leak.


### PR DESCRIPTION
## Summary

Adds the **second captured production frame** of the CI runner-hang
(from PR #924's hung `test (ubuntu-latest, 3.11)` lane) as evidence for
the `ci-runner-hang` investigation. Docs/evidence only — no code.

#924's lane did not assert-fail; it **hung** (exit 124, 14m step
timeout + bounded auto-retry), the known runner-hang. The
dump-survival mechanism preserved all four process stacks.

## What it shows

- **Same H4 finalize-wedge** as the first frame (run `27541609728`):
  controller idle in `xdist/dsession.py loop_once → queue.get`, all
  workers idle in `execnet serve`. No uninterruptible I/O → not H1/H2.
- **Discriminating result:** this frame has **no leaked
  `_heartbeat_loop` thread** on any worker — the very thing that was
  the first frame's prime lead. Two consecutive H4 wedges, only one
  with the leaked thread ⇒ the heartbeat leak looks **incidental, not
  causal**. Recommends pivoting the root-cause hunt to the
  execnet/xdist finalize handshake (the spec's "if the leak is ruled
  out" next-action).

## Contents

- `evidence/run-27615182285/{hang-controller,hang-gw1,hang-gw2,hang-gw3}.txt`
- `phase2-findings.md` — new "Phase 3 — SECOND captured frame" section

No bearing on #924 itself (a clean dep lock-bump merged green except
for this flaky hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
