### PR TITLE
ci(tests): skip Python suite on website-only PRs

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -9355,6 +9355,35 @@ files.
   and the lone pre-existing test used relative imports, so `@/` had never
   been exercised under vitest until an API-route test imported `@/lib/db`.
 
+- **`mergeStateStatus=CLEAN` + all per-PR checks green ≠ safe to
+  merge when the validating job is KEYLESS and the real validation
+  is a separate scheduled/dispatched job.** Reviewing PR #917
+  (claude-agent-sdk 0.2.x bump, 2026-06-18): the PR showed
+  `draft=false`, `merge=CLEAN`, and 35 green checks — yet its OWN
+  `decisions.md` ended "**PR #917 is DRAFT — do not merge**" because
+  live-key `integration-auth` had failed systemically (every
+  real-API workflow raised `Claude Code returned an error result:
+  success`). The green rollup was structurally blind to it: every
+  per-PR check runs `ANTHROPIC_API_KEY: ""` (keyless-by-design — the
+  $1200-burn lesson), INCLUDING `integration (no-auth)`; the
+  live-key `integration-auth` job is NOT a per-PR/required check
+  (scheduled + budget-capped) so its failure never enters the
+  `mergeStateStatus` rollup. A pure dependency bump (6 files, no
+  code/adapter fix) that flips the resolved SDK is exactly the diff
+  whose risk lives entirely in the keyless-CI blind spot. Review
+  rules before merging any dep bump that touches the live-SDK/
+  real-key path: (1) don't read green per-PR CI or `CLEAN` as
+  merge-readiness — confirm a live-key validation EXISTS and read
+  its ACTUAL result (`gh run list --workflow=integration-auth.yml
+  --branch=<b>`), since it won't appear in `gh pr checks`; (2) read
+  the PR's spec `decisions.md` resume-gate before trusting the PR's
+  draft/ready state — the doc is the contract, the green checkmarks
+  are not; (3) re-draft a parked PR (`gh pr ready --undo`) so a
+  CLEAN state can't be auto-merged while it waits. Pairs with the
+  bundled-CLI is_error root-cause lesson above (same PR — the
+  mechanism) and "registered ≠ working / dogfood the live loop"
+  (mocked/keyless green is necessary-not-sufficient).
+
 - **Path-filtering a workflow that produces a REQUIRED status check —
   gate the JOB's heavy STEPS, never skip the job**: to make
   irrelevant-path PRs (e.g. `website/`-only) cheap without blocking the

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -9354,3 +9354,30 @@ files.
   only the project alias. Context that hid this: no vitest config existed
   and the lone pre-existing test used relative imports, so `@/` had never
   been exercised under vitest until an API-route test imported `@/lib/db`.
+
+- **Path-filtering a workflow that produces a REQUIRED status check —
+  gate the JOB's heavy STEPS, never skip the job**: to make
+  irrelevant-path PRs (e.g. `website/`-only) cheap without blocking the
+  merge, do NOT add `paths-ignore` to the trigger and do NOT job-level
+  `if:`-skip the job — a required check that never runs reports as
+  "missing" and blocks the PR forever (and skipped-required-check
+  semantics vary by GitHub version, so don't bet the merge gate on
+  them). Instead keep the job RUNNING and put `if: <signal> != 'true'`
+  on each expensive step (pip-install, pytest), plus a cheap
+  skip-notice step — the job completes green under its exact required
+  name so branch protection stays satisfied. This is the same
+  discipline `tests.yml`'s slim-matrix already uses (it keeps the
+  required `test (ubuntu-latest, 3.12)` lane running even when it drops
+  the rest). Implemented 2026-06-18 (#935): a `website_only` output on
+  the existing `changes` gate (`! grep -qvE '^website/'` over the PR
+  diff = every file under website/), consumed by the three full-suite
+  jobs (`test`, `clock-tz`, `coverage`) via step-level `if:`. Two gotchas:
+  (1) a downstream job only sees `needs.<job>.outputs.*` if that job is
+  in its OWN `needs:` list — `test` needed `[changes, setup-matrix]`,
+  not just `setup-matrix`, to read `needs.changes.outputs.website_only`;
+  (2) a PR that edits the workflow file itself can't exercise its own
+  new path-filter (the workflow-file change flips the signal to
+  full-run) — validating the cheap path needs a follow-up
+  trivial-website-only PR. Pairs with the existing "required Tests
+  checks stay MISSING after `gh pr edit --base`" lesson (same
+  missing-required-check failure mode, different trigger).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       src: ${{ steps.filter.outputs.src }}
+      website_only: ${{ steps.filter.outputs.website_only }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -43,12 +44,14 @@ jobs:
         if [ "$EVENT" != "pull_request" ] || [ -z "${BASE_REF:-}" ]; then
           echo "event=$EVENT -> full matrix"
           echo "src=true" >> "$GITHUB_OUTPUT"
+          echo "website_only=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
         git fetch --no-tags --quiet origin "$BASE_REF" || true
         if ! CHANGED=$(git diff --name-only "origin/$BASE_REF...HEAD"); then
           echo "diff failed -> full matrix (fail-safe)"
           echo "src=true" >> "$GITHUB_OUTPUT"
+          echo "website_only=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
         echo "changed files:"; printf '%s\n' "$CHANGED"
@@ -60,6 +63,18 @@ jobs:
         else
           echo "src=false (tests/docs-only) -> slim matrix"
           echo "src=false" >> "$GITHUB_OUTPUT"
+        fi
+        # website_only (D-website): if EVERY changed file is under website/,
+        # the Python suite cannot be affected — the full-suite jobs (test,
+        # clock-tz, coverage) no-op their pip-install + pytest steps. The
+        # jobs still RUN and report green, so the required checks
+        # (test (ubuntu-latest, 3.12), coverage) are never "missing" and the
+        # PR is not blocked — same discipline as the slim matrix above.
+        if [ -n "$CHANGED" ] && ! printf '%s\n' "$CHANGED" | grep -qvE '^website/'; then
+          echo "website_only=true (only website/ touched) -> skip Python suite"
+          echo "website_only=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "website_only=false" >> "$GITHUB_OUTPUT"
         fi
 
   # Emit the test matrix JSON. CRITICAL: the slim matrix MUST keep the
@@ -86,7 +101,7 @@ jobs:
         fi
 
   test:
-    needs: setup-matrix
+    needs: [changes, setup-matrix]
     # TEMPORARY (2026-06-07): ubuntu matrix entries run on default
     # GitHub-hosted `ubuntu-latest` runners. The 8-core/32GB larger
     # runner (`ubuntu-8core-or-linux-32gb`) was de-provisioned, which left
@@ -118,12 +133,18 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
+    - name: Skip notice (website-only PR)
+      if: needs.changes.outputs.website_only == 'true'
+      run: echo "website-only change — Python suite skipped; reporting green for the required check."
+
     - name: Install dependencies
+      if: needs.changes.outputs.website_only != 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
     - name: Run tests
+      if: needs.changes.outputs.website_only != 'true'
       # --timeout=60 + --timeout-method=thread: names a hanging test (with a
       # stack trace) instead of letting it silently kill the xdist worker.
       # The `thread` method is required cross-platform (`signal`/SIGALRM is
@@ -156,6 +177,7 @@ jobs:
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 
     - name: Run security and workflow tests
+      if: needs.changes.outputs.website_only != 'true'
       run: pytest tests/unit/memory/test_long_term_security.py tests/unit/scanner/test_file_traversal.py tests/unit/workflows/test_workflow_execution.py -v --tb=short
 
     # ci-runner-hang Phase 2: the conftest watchdog writes each process's
@@ -210,6 +232,7 @@ jobs:
     # design. NOT a required check yet — promote in branch protection once
     # it has a few green runs (needs the GitHub-Actions app_id; tracked
     # separately, deliberately out of scope for this PR).
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -219,18 +242,25 @@ jobs:
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+    - name: Skip notice (website-only PR)
+      if: needs.changes.outputs.website_only == 'true'
+      run: echo "website-only change — hostile-clock suite skipped."
+
     - name: Set up Python 3.12
+      if: needs.changes.outputs.website_only != 'true'
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
         cache: 'pip'
 
     - name: Install dependencies
+      if: needs.changes.outputs.website_only != 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
     - name: Run unit suite under ${{ matrix.tz }}
+      if: needs.changes.outputs.website_only != 'true'
       shell: bash
       run: |
         python -c "import time, datetime; print('TZ=', time.tzname, 'utcoffset=', datetime.datetime.now().astimezone().utcoffset())"
@@ -255,16 +285,23 @@ jobs:
     # pip-install/badge/codecov overhead (was 25, pre-retry). Stays well
     # under the guard's 75-min ceiling.
     timeout-minutes: 40
+    needs: changes
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+    - name: Skip notice (website-only PR)
+      if: needs.changes.outputs.website_only == 'true'
+      run: echo "website-only change — coverage suite skipped; reporting green for the required check."
+
     - name: Set up Python 3.11
+      if: needs.changes.outputs.website_only != 'true'
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
         cache: 'pip'
 
     - name: Install dependencies
+      if: needs.changes.outputs.website_only != 'true'
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
@@ -273,6 +310,7 @@ jobs:
     # drifts far below the real collected count, or if coverage regressed to a
     # hardcoded value instead of the dynamic Codecov badge. Cheap (collect-only).
     - name: Check README badge freshness
+      if: needs.changes.outputs.website_only != 'true'
       run: python scripts/check_badge_freshness.py
 
     - name: Run tests with coverage
@@ -285,6 +323,7 @@ jobs:
       # make a red PR pass — a drop is a signal to add tests, not slacken the
       # gate. (pyproject's fail_under stays 85 as the absolute floor for
       # ad-hoc/partial local runs whose --cov scope differs from CI's.)
+      if: needs.changes.outputs.website_only != 'true'
       run: |
         # The runner-hang that once required a 14m-timeout + 2× auto-retry
         # wrapper on this lane was root-caused and fixed in #930 (a fork-based
@@ -298,11 +337,13 @@ jobs:
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 
     - name: Track per-file test results
+      if: needs.changes.outputs.website_only != 'true'
       run: |
         python scripts/track_file_tests.py --coverage coverage.xml --limit 50
       continue-on-error: true
 
     - name: Upload file test tracking data
+      if: needs.changes.outputs.website_only != 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: file-test-tracking
@@ -310,6 +351,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload coverage to Codecov
+      if: needs.changes.outputs.website_only != 'true'
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         files: ./coverage.xml

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -1,0 +1,30 @@
+# Website — working notes
+
+The marketing/docs/telemetry site for attune-ai (`smartaimemory.com`).
+Next.js, deployed by Vercel's git integration on push to `main`. It is
+**not** the application and is not versioned.
+
+## Changelog policy
+
+The website is continuously deployed and has no changelog of its own.
+
+- **Website-only change** (CSS, copy, a new page, Vercel config — touches
+  only `website/`): **no changelog entry anywhere.** Git history is the
+  record.
+- **Change that affects the PyPI package** (even if it also touches the
+  site — e.g. a telemetry feature whose client ships in the package):
+  entry goes in the **root `CHANGELOG.md`**, as normal.
+
+Why the package CHANGELOG still matters here: the public page
+`smartaimemory.com/changelog` renders the root `CHANGELOG.md` verbatim
+(`app/changelog/page.tsx` reads `../CHANGELOG.md`). Keeping website-only
+churn out of it keeps that page release-focused and avoids
+website↔package merge conflicts in a shared changelog.
+
+## CI
+
+Website-only PRs (nothing changed outside `website/`) no-op the Python
+test suite — the `changes` job in `.github/workflows/tests.yml` emits
+`website_only=true`, and the full-suite jobs (`test`, `clock-tz`,
+`coverage`) skip their pip-install + pytest steps while still reporting
+green so branch protection stays satisfied.


### PR DESCRIPTION
## What

Website-only PRs (every changed file under `website/`) no longer run
the Python test suite. The `website/` surface is continuously deployed
by Vercel and has no version or changelog of its own — a CSS/copy/page
change cannot affect a Python test outcome.

## How

Extends the existing `changes` gate in `tests.yml` with a
`website_only` output (true when no file outside `website/` changed).
The three full-suite jobs guard their pip-install + pytest steps:

- `test` (slim matrix)
- `clock-tz` (hostile-clock lanes)
- `coverage`

## Required-check safety

The required checks `test (ubuntu-latest, 3.12)` and `coverage` are
**not skipped** — the jobs still run and report green, with only their
heavy steps gated off. This avoids the "required check never runs →
MISSING → PR blocked forever" trap, exactly as the slim-matrix logic
already does for the required lane. All 240 `tests/unit/ci/test_workflow_yaml.py`
guard tests pass.

## Scope notes

- Cheap jobs (`lint`, `platform-compat`, `code-quality`, `build`) are
  left running — low value to gate, less surface to break a required
  check. Easy follow-up if desired.
- This PR edits `tests.yml`, so its **own** run takes the full-matrix
  path (`website_only=false`). Exercising the website-only path live
  needs a follow-up website-only PR.

## Also

- `website/CLAUDE.md` documents the no-changelog policy (website-only →
  no changelog; package-affecting → root `CHANGELOG.md`, which the
  public `/changelog` page renders) and this CI behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
