### PR TITLE
docs: plugin-first quickstart for Claude Code

### DIFF
--- a/docs/getting-started/quickstart-plugin.md
+++ b/docs/getting-started/quickstart-plugin.md
@@ -1,0 +1,131 @@
+---
+description: Get started with the Attune AI plugin for Claude Code in 5 minutes — install it, then drive code review, security audits, and spec-driven development with plain English. No CLI, no API key.
+---
+
+# Quickstart: The Plugin (Claude Code)
+
+The fastest way to use Attune AI is as a **Claude Code plugin**. Install it
+once, then drive everything — code review, security audits, test generation,
+spec-driven development — with plain English in your normal Claude Code
+session.
+
+No CLI to learn. No Python package. No separate API key — the plugin runs
+inside the Claude Code session you already have.
+
+!!! tip "Prefer the CLI or Python?"
+    This page is the plugin-first path. If you'd rather run workflows from a
+    terminal or from code, start with [First Steps](first-steps.md) instead —
+    it covers the `attune` CLI and the Python API.
+
+---
+
+## What you get
+
+The plugin ships **17 auto-triggering skills**. You don't memorize commands —
+you describe what you want, and the right skill activates.
+
+| Say something like… | Skill that activates | What it does |
+|---------------------|----------------------|--------------|
+| "review this file for quality issues" | `code-quality` | Code review + bug prediction |
+| "scan src/ for vulnerabilities" | `security-audit` | eval/exec, secrets, injection, path traversal |
+| "what tests am I missing?" | `smart-test` | Finds coverage gaps, generates tests |
+| "this test keeps failing" | `fix-test` | Diagnoses and fixes, up to 3 attempts |
+| "help me plan this feature" | `planning` | Architecture + TDD planning |
+| "let's build X from a spec" | `spec` | Brainstorm → plan → execute with quality gates |
+| "what can attune do?" | `attune-hub` | Routes you to the right skill |
+
+---
+
+## Step 1 — Install the plugin (1 min)
+
+In Claude Code:
+
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-ai@attune-ai
+```
+
+That's it. The skills are now available in every Claude Code session — no API
+key, no config file.
+
+---
+
+## Step 2 — Orient yourself (30 sec)
+
+Ask the hub what's available:
+
+```
+what can attune do?
+```
+
+The `attune-hub` skill activates and routes you to the workflow that fits your
+goal. Use this whenever you're not sure which capability you want.
+
+---
+
+## Step 3 — Run your first real workflow (3 min)
+
+Point it at code you actually care about. Two good first runs:
+
+**Code review** — open a file (or just name it) and ask:
+
+```
+review src/payments.py for quality issues and likely bugs
+```
+
+The `code-quality` skill spins up a small team of specialist subagents, reads
+your real source, and returns prioritized findings with file/line references
+and suggested fixes.
+
+**Security audit** — for a vulnerability-focused pass:
+
+```
+do a security audit on the src/ directory
+```
+
+The `security-audit` skill scans for `eval`/`exec` misuse, hardcoded secrets,
+path traversal, and injection risks, then reports each finding with severity
+and a fix.
+
+Either one shows you the core pattern in a couple of minutes: **describe the
+goal → specialist agents review your real code → you get actionable,
+cited findings.**
+
+---
+
+## Step 4 — Go deeper (optional)
+
+Once the basics click, the highest-leverage skill is **spec-driven
+development**:
+
+```
+/spec
+```
+
+This walks you from a rough idea through requirements, design, and an ordered
+task list — with human approval gates between phases — then executes the tasks.
+It's the recommended path for anything non-trivial.
+
+Other skills worth trying by name or description:
+
+- `smart-test` — "find untested code in this module and write tests for it"
+- `refactor-plan` — "this file has too much going on, plan a refactor"
+- `release-prep` — "get me ready to cut a release"
+- `recall` — "did I hit this problem in a past session?"
+
+---
+
+## What's next
+
+| If you want to… | Go to |
+|-----------------|-------|
+| Run workflows from a terminal or Python | [First Steps](first-steps.md) |
+| Add the full MCP toolset (41 tools) + CLI | [MCP Integration](mcp-integration.md) |
+| Pick a longer learning path | [Choose Your Path](choose-your-path.md) |
+| See every workflow | [First Steps → Try More Workflows](first-steps.md#try-more-workflows) |
+
+!!! note "Plugin vs. package"
+    The **plugin** gives you the 17 natural-language skills with zero setup.
+    Installing the **Python package** (`pip install attune-ai`) adds the
+    `attune` CLI, the MCP server, and 41 MCP tools on top. You can start with
+    the plugin today and add the package later — they layer cleanly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,6 +175,7 @@ nav:
       - getting-started/index.md
       - Installation: getting-started/installation.md
       - First Steps: getting-started/first-steps.md
+      - Quickstart (Plugin): getting-started/quickstart-plugin.md
       - Choose Your Path: getting-started/choose-your-path.md
       - Redis Setup: getting-started/redis-setup.md
       - MCP Integration: getting-started/mcp-integration.md


### PR DESCRIPTION
## What

Adds a **plugin-first** Getting Started page for new users: install the attune-ai plugin in Claude Code, then drive code review, security audits, and spec-driven development with plain English — no CLI, no API key.

Fills the gap the existing `first-steps.md` doesn't cover (that page is CLI/Python-first).

## Changes
- `docs/getting-started/quickstart-plugin.md` — new page (install → `attune-hub` → first code-review/security workflow → `/spec`)
- `mkdocs.yml` — wired into the Getting Started nav after *First Steps* as "Quickstart (Plugin)"

## Verified
- `mkdocs build` runs clean; nav reference resolves, no warnings on the new page
- Install commands match `plugin/README.md`

Companion PR in attune-help adds a matching RAG-retrievable quickstart template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)