### PR TITLE
feat(drift-guards): generate runner.js WORKFLOW_NAMES (conversion 2)

### DIFF
--- a/docs/specs/drift-guards-to-generators/requirements.md
+++ b/docs/specs/drift-guards-to-generators/requirements.md
@@ -1,7 +1,10 @@
 # Drift Guards → Generators — Requirements
 
-**Status:** in progress (2026-06-12) — conversion 1 (version bump)
-shipped; registration-mirror conversions open.
+**Status:** complete (2026-06-19) — "Done when" met: conversion 1
+(version bump) + conversion 2 (workflow-names mirror) shipped, each with
+an inverted backstop and a row in the table below. Conversions 3
+(skills table) and 4 (count assertions) remain as optional future
+candidates, not blockers.
 **Owner:** Patrick + agent
 **Born:** discipline-review chat, 2026-06-11 (improvement #4 of 6).
 
@@ -94,6 +97,7 @@ Candidate conversions, by observed pain frequency:
 | Guard | Generator | Backstop test |
 |-------|-----------|---------------|
 | Version-site drift (the v7.2.0 class) | `scripts/bump_version.py <version>` — writes all 7 files / 9 sites, count-validates before writing, verifies after | `test_plugin_config_validation.py::TestVersionConsistency::test_all_versions_match` (failure message names the command); plus `tests/unit/scripts/test_bump_version.py::TestRealRepo` (site list vs the actual tree) |
+| Dashboard `WORKFLOW_NAMES` JS-array drift | `scripts/sync_runner_workflow_names.py` — rewrites the marker-delimited array in `runner.js` from `attune.ops.data.list_workflows()`; `--check` verifies and names the command | `test_runner_js_parsing.py::test_workflow_names_array_is_generated_and_in_sync` (runs the generator in `--check`); plus `tests/unit/scripts/test_sync_runner_workflow_names.py` (generator logic) |
 
 ## Done when
 

--- a/scripts/sync_runner_workflow_names.py
+++ b/scripts/sync_runner_workflow_names.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Generate the ops dashboard's ``WORKFLOW_NAMES`` JS array.
+
+Single source of truth: ``attune.ops.data.list_workflows()`` (the same
+canonical list the dashboard serves). The derived artifact is the
+``WORKFLOW_NAMES`` array in ``src/attune/ops/static/js/runner.js`` —
+used to render workflow-name mentions as clickable pills.
+
+This replaces the old hand-edit-and-hope-a-test-catches-it loop
+(``test_runner_js_parsing.py::test_workflow_names_match_canonical_list``)
+with a generator + an inverted backstop: the test now runs ``--check``
+and tells you the command to run when the array is stale. See
+docs/specs/drift-guards-to-generators/.
+
+Usage:
+    python scripts/sync_runner_workflow_names.py          # Regenerate
+    python scripts/sync_runner_workflow_names.py --check   # Verify in sync
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Sentinel markers delimiting the generated block in runner.js. The
+# generator only ever rewrites text between these (inclusive), so the
+# surrounding hand-written JS is never touched.
+BEGIN = "  // >>> AUTO-GENERATED: WORKFLOW_NAMES — do not hand-edit."
+END = "  // <<< AUTO-GENERATED: WORKFLOW_NAMES"
+
+# Names per rendered line (cosmetic; keeps the array readable).
+_PER_LINE = 4
+
+_BLOCK_RE = re.compile(
+    re.escape(BEGIN) + r".*?" + re.escape(END),
+    re.DOTALL,
+)
+
+
+def _canonical_names() -> list[str]:
+    """Return the sorted canonical workflow names (source of truth)."""
+    from attune.ops import data
+
+    return sorted(w.name for w in data.list_workflows())
+
+
+def render_block(names: list[str]) -> str:
+    """Render the full generated block (markers + array) for runner.js."""
+    rows: list[str] = []
+    for i in range(0, len(names), _PER_LINE):
+        chunk = names[i : i + _PER_LINE]
+        rows.append("    " + ", ".join(f'"{n}"' for n in chunk) + ",")
+    # Drop the trailing comma on the final entry for clean JS.
+    if rows:
+        rows[-1] = rows[-1].rstrip(",")
+    body = "\n".join(rows)
+    return (
+        f"{BEGIN}\n"
+        "  // Source of truth: attune.ops.data.list_workflows().\n"
+        "  // Regenerate: python scripts/sync_runner_workflow_names.py\n"
+        "  var WORKFLOW_NAMES = [\n"
+        f"{body}\n"
+        "  ];\n"
+        f"{END}"
+    )
+
+
+def apply(runner_js: Path, *, check: bool) -> int:
+    """Generate or verify the WORKFLOW_NAMES block. Returns an exit code."""
+    text = runner_js.read_text(encoding="utf-8")
+    if not _BLOCK_RE.search(text):
+        print(
+            f"FAIL: generated markers not found in {runner_js.name}.\n"
+            f"      Expected a block delimited by:\n"
+            f"        {BEGIN}\n"
+            f"        {END}"
+        )
+        return 1
+
+    new_block = render_block(_canonical_names())
+    new_text = _BLOCK_RE.sub(lambda _: new_block, text)
+
+    if new_text == text:
+        print(f"OK: {runner_js.name} WORKFLOW_NAMES is in sync.")
+        return 0
+
+    if check:
+        print(
+            f"FAIL: {runner_js.name} WORKFLOW_NAMES is out of sync with "
+            "attune.ops.data.list_workflows().\n"
+            "      Run: python scripts/sync_runner_workflow_names.py"
+        )
+        return 1
+
+    runner_js.write_text(new_text, encoding="utf-8")
+    print(f"Regenerated WORKFLOW_NAMES in {runner_js.name}.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    if argv is None:
+        argv = sys.argv[1:]
+    check = "--check" in argv
+    repo_root = Path(__file__).resolve().parent.parent
+    runner_js = repo_root / "src" / "attune" / "ops" / "static" / "js" / "runner.js"
+    return apply(runner_js, check=check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -10,18 +10,21 @@
 (function () {
   "use strict";
 
-  // Canonical workflow names — kept in sync with `attune.ops.data
-  // .list_workflows()` output. When this drifts, runner.js still works
-  // (mentions of unknown names just render as text), so no hard sync
-  // dependency, but worth a periodic glance.
+  // Canonical workflow names — generated from `attune.ops.data
+  // .list_workflows()`. When this drifts, runner.js still works (mentions
+  // of unknown names just render as text), so no hard runtime dependency,
+  // but the backstop test fails so the array stays honest.
+  // >>> AUTO-GENERATED: WORKFLOW_NAMES — do not hand-edit.
+  // Source of truth: attune.ops.data.list_workflows().
+  // Regenerate: python scripts/sync_runner_workflow_names.py
   var WORKFLOW_NAMES = [
     "bug-predict", "code-review", "deep-review", "dependency-check",
     "discovery-sweep", "doc-audit", "doc-gen", "doc-orchestrator",
-    "health-check", "orchestrated-health-check", "perf-audit",
-    "rag-code-gen", "refactor-plan", "release-prep",
-    "research-synthesis", "secure-release", "security-audit",
-    "simplify-code", "test-audit", "test-gen"
+    "health-check", "orchestrated-health-check", "perf-audit", "rag-code-gen",
+    "refactor-plan", "release-prep", "research-synthesis", "secure-release",
+    "security-audit", "simplify-code", "test-audit", "test-gen"
   ];
+  // <<< AUTO-GENERATED: WORKFLOW_NAMES
 
   // Section headers (line-leader text) that get bolded/colored so users
   // can scan workflow output quickly. Matched case-insensitively against

--- a/tests/unit/ops/test_runner_js_parsing.py
+++ b/tests/unit/ops/test_runner_js_parsing.py
@@ -35,23 +35,31 @@ def test_runner_js_exists():
     assert _RUNNER_JS.is_file(), f"missing {_RUNNER_JS}"
 
 
-def test_workflow_names_match_canonical_list(runner_js_text):
-    """JS WORKFLOW_NAMES array must include every workflow exposed by
-    `attune.ops.data.list_workflows()` — otherwise mentions in workflow
-    output wouldn't get the pill treatment.
-    """
-    pytest.importorskip("fastapi")  # ops imports need this
-    from attune.ops import data
+def test_workflow_names_array_is_generated_and_in_sync():
+    """runner.js WORKFLOW_NAMES must equal a fresh generation from
+    `attune.ops.data.list_workflows()`.
 
-    canonical = {w.name for w in data.list_workflows()}
-    # Extract the JS array literal
-    m = re.search(r"WORKFLOW_NAMES\s*=\s*\[(.*?)\]", runner_js_text, re.DOTALL)
-    assert m, "WORKFLOW_NAMES array not found in runner.js"
-    js_names = set(re.findall(r'"([a-z][a-z0-9-]+)"', m.group(1)))
-    missing = canonical - js_names
-    assert not missing, (
-        f"Canonical workflow names missing from runner.js WORKFLOW_NAMES: {sorted(missing)}. "
-        "Update the array in runner.js so mentions of these workflows render as pills."
+    The array is a GENERATED artifact (drift-guards-to-generators
+    Conversion 2): `scripts/sync_runner_workflow_names.py` writes it from
+    the canonical list. This inverts the old drift guard — instead of
+    asserting "no canonical name is missing" and leaving a human to
+    hand-edit, it asserts the whole artifact matches what the generator
+    would produce and the failure message names the command to run.
+    """
+    pytest.importorskip("fastapi")  # generator imports attune.ops.data
+    import importlib.util
+
+    script = Path(__file__).resolve().parents[3] / "scripts" / "sync_runner_workflow_names.py"
+    spec = importlib.util.spec_from_file_location("_sync_runner_wf", script)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    rc = mod.apply(_RUNNER_JS, check=True)
+    assert rc == 0, (
+        "runner.js WORKFLOW_NAMES is out of sync with "
+        "attune.ops.data.list_workflows(). "
+        "Run: python scripts/sync_runner_workflow_names.py"
     )
 
 

--- a/tests/unit/scripts/test_sync_runner_workflow_names.py
+++ b/tests/unit/scripts/test_sync_runner_workflow_names.py
@@ -1,0 +1,100 @@
+"""Tests for scripts/sync_runner_workflow_names.py.
+
+Conversion 2 of drift-guards-to-generators: the ops dashboard's
+``WORKFLOW_NAMES`` JS array is generated from
+``attune.ops.data.list_workflows()`` rather than hand-edited.
+
+Covers the generator logic in isolation (monkeypatching the canonical
+source so these stay fast and free of the [ops] extra):
+- ``render_block`` shape — markers, 4-per-line, no trailing comma;
+- ``apply`` idempotency — a freshly generated file checks clean;
+- ``apply`` drift detection — an out-of-sync array fails ``--check``
+  and is rewritten in write mode;
+- missing markers abort with exit 1.
+
+Loads the script via importlib (matches the existing scripts-test
+pattern).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "sync_runner_workflow_names.py"
+
+NAMES = ["alpha", "bravo", "charlie", "delta", "echo"]
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_sync_runner_wf", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["_sync_runner_wf"] = m
+    try:
+        spec.loader.exec_module(m)
+        yield m
+    finally:
+        sys.modules.pop("_sync_runner_wf", None)
+
+
+def _runner_stub(block: str) -> str:
+    """Wrap a generated block in minimal surrounding JS."""
+    return f"(function () {{\n{block}\n  var OTHER = 1;\n}})();\n"
+
+
+def test_render_block_shape(mod):
+    block = mod.render_block(NAMES)
+    assert block.startswith(mod.BEGIN)
+    assert block.rstrip().endswith(mod.END)
+    assert "var WORKFLOW_NAMES = [" in block
+    # All names present, quoted.
+    for n in NAMES:
+        assert f'"{n}"' in block
+    # No trailing comma on the final entry (clean JS).
+    assert '"echo",' not in block
+    assert '"echo"' in block
+
+
+def test_render_block_four_per_line(mod):
+    block = mod.render_block(NAMES)
+    array_lines = [ln for ln in block.splitlines() if ln.strip().startswith('"')]
+    # 5 names at 4 per line → first row has 4, second has 1.
+    assert array_lines[0].count('"') == 8  # 4 names × 2 quotes
+    assert array_lines[1].count('"') == 2  # 1 name × 2 quotes
+
+
+def test_apply_idempotent_when_in_sync(mod, tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "_canonical_names", lambda: NAMES)
+    runner = tmp_path / "runner.js"
+    runner.write_text(_runner_stub(mod.render_block(NAMES)), encoding="utf-8")
+    assert mod.apply(runner, check=True) == 0
+    assert mod.apply(runner, check=False) == 0  # nothing to rewrite
+
+
+def test_apply_detects_and_rewrites_drift(mod, tmp_path, monkeypatch):
+    monkeypatch.setattr(mod, "_canonical_names", lambda: NAMES)
+    runner = tmp_path / "runner.js"
+    # Seed with a stale block (missing "echo").
+    stale = mod.render_block(NAMES[:-1])
+    runner.write_text(_runner_stub(stale), encoding="utf-8")
+
+    # --check fails on drift.
+    assert mod.apply(runner, check=True) == 1
+    # Write mode repairs it.
+    assert mod.apply(runner, check=False) == 0
+    # Now in sync.
+    assert mod.apply(runner, check=True) == 0
+    assert '"echo"' in runner.read_text(encoding="utf-8")
+
+
+def test_apply_missing_markers_aborts(mod, tmp_path):
+    runner = tmp_path / "runner.js"
+    runner.write_text("(function () {\n  var WORKFLOW_NAMES = [];\n})();\n", encoding="utf-8")
+    assert mod.apply(runner, check=True) == 1
+    assert mod.apply(runner, check=False) == 1


### PR DESCRIPTION
## What

Conversion 2 of **drift-guards-to-generators**: the ops dashboard's
`WORKFLOW_NAMES` JS array becomes a **generated** artifact instead of a
hand-edited mirror.

- `scripts/sync_runner_workflow_names.py` rewrites the marker-delimited
  array in `runner.js` from `attune.ops.data.list_workflows()` (the
  canonical source). `--check` verifies in sync and names the regen
  command on failure.
- `runner.js` gains `AUTO-GENERATED` markers around the array (one-time
  hand edit; the generator owns the block thereafter). Same 20 names,
  reformatted deterministically — **no runtime change**.
- **Inverts the drift guard** (R2): `test_workflow_names_array_is_
  generated_and_in_sync` runs the generator in `--check` mode instead of
  the old one-directional "a canonical name is missing" assertion that
  left a human to hand-edit.
- Adds `tests/unit/scripts/test_sync_runner_workflow_names.py` for the
  generator logic (render shape, idempotency, drift repair, missing
  markers).

## Why

Closes the spec's "Done when": version-bump (conversion 1) **plus** one
registration-mirror conversion now ship, each with an inverted backstop
and a row in the spec's shipped-conversions table. Per-change friction
for adding a workflow drops from "hand-edit runner.js and hope the test
catches it" to "one command regenerates it." Status flipped to
**complete**; conversions 3 (skills table) / 4 (count assertions) remain
optional future candidates.

## Verification

- `python scripts/sync_runner_workflow_names.py --check` → in sync.
- `pytest tests/unit/ops/test_runner_js_parsing.py` → 11 passed.
- `pytest tests/unit/scripts/test_sync_runner_workflow_names.py` → 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
