### PR TITLE
docs(sibling-precommit): per-repo session starter prompts

### DIFF
--- a/docs/specs/sibling-package-pre-commit/starters/README.md
+++ b/docs/specs/sibling-package-pre-commit/starters/README.md
@@ -1,0 +1,19 @@
+# Sibling Pre-commit — session starter prompts
+
+One self-contained starter prompt per sibling repo. Open a fresh
+Claude Code session **in that repo's directory**, then paste the
+matching prompt. Each is independent and produces one mergeable PR.
+
+| Phase | Repo | Starter | Notes |
+|-------|------|---------|-------|
+| 1 | attune-rag | [attune-rag.md](attune-rag.md) | First — golden fixtures are the load-bearing exclusion |
+| 2 | attune-author | [attune-author.md](attune-author.md) | Watch long prompt-string ruff trips (`# noqa`) |
+| 3 | attune-help | [attune-help.md](attune-help.md) | Template `.md`/`.json` exclusion is critical |
+| 4 | attune-gui | [attune-gui.md](attune-gui.md) | Hybrid repo; `editor-frontend/` out of scope |
+
+Source of truth for the baseline + exclusions:
+[../decisions.md](../decisions.md) (D1, D2, D3). If a starter and
+decisions.md disagree, decisions.md wins — update the starter.
+
+Each prompt is keyless (zero API cost). After all four land, mark the
+spec status complete in [../tasks.md](../tasks.md) Phase 5.

--- a/docs/specs/sibling-package-pre-commit/starters/attune-author.md
+++ b/docs/specs/sibling-package-pre-commit/starters/attune-author.md
@@ -1,0 +1,148 @@
+# Starter: pre-commit parity for attune-author
+
+Paste this into a fresh Claude Code session opened in the
+**attune-author** repo. Self-contained. Phase 2 of
+`sibling-package-pre-commit` (keyless). Produce ONE mergeable PR.
+
+**Before starting:** confirm you are in attune-author, then branch off
+`origin/main` (the repo may be in detached HEAD — branch explicitly):
+
+```bash
+git fetch origin main
+git checkout -b chore/pre-commit-parity origin/main
+```
+
+## Step 1 — write `.pre-commit-config.yaml`
+
+Pinned versions match attune-ai exactly (never run a newer formatter
+than the umbrella). Repo-specific excludes are the hallucination eval
+baselines/artifacts and the Jinja templates:
+
+```yaml
+exclude: |
+  (?x)^(
+    \.venv/|
+    build/|
+    dist/|
+    .*\.egg-info/|
+    .*__pycache__/|
+    node_modules/|
+    benchmarks/hallucination-v.*/|
+    benchmarks/.*\.yaml|
+    src/attune_author/meta_templates/.*\.j2
+  )
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: ['--line-length=100']
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: ['--fix', '--exit-non-zero-on-fix']
+      - id: ruff
+        name: ruff-bare-exception-check
+        args: ['--select=BLE', '--no-fix']
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1200']
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+```
+
+Do NOT add bandit or mypy (out of baseline).
+
+**Repo-specific watch-for:** the polish pipeline's `_anthropic.py` and
+regeneration scripts have long LLM-prompt string literals that ruff may
+flag (E501 / line length). attune-author's `pyproject.toml` already has
+`[tool.ruff] line-length = 100` and `select = ["E","F","W","I","UP","BLE"]`,
+so this is pure dev-loop gain. Resolve any prompt-string trips with a
+per-line `# noqa: E501` (or the specific code) — do NOT exclude the whole
+files. Capture which lines needed it in the PR body.
+
+## Step 2 — `.secrets.baseline`
+
+```bash
+uv run --with detect-secrets detect-secrets scan > .secrets.baseline
+```
+
+Verify every entry is a false positive before committing; if anything
+real appears, STOP and report.
+
+## Step 3 — run hooks, fix in this PR
+
+```bash
+uv run --with pre-commit pre-commit install
+uv run --with pre-commit pre-commit run --all-files --show-diff-on-failure
+```
+
+Fix in-PR. If >~50 files reformat, split into "config" + "fix" PRs.
+Report the count.
+
+## Step 4 — CI gate
+
+Add a `pre-commit` job running on PRs. Inspect existing
+`.github/workflows/` first and match conventions (runner, SHA-pin vs
+tag, uv vs pip):
+
+```yaml
+name: Lint
+on:
+  pull_request:
+  push:
+    branches: [main]
+concurrency:
+  group: lint-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@<match-repo-convention>
+      - uses: actions/setup-python@<match-repo-convention>
+        with:
+          python-version: '3.12'
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files --show-diff-on-failure
+```
+
+## Step 5 — contributor docs
+
+Add to `CONTRIBUTING.md` (or README dev section):
+
+```bash
+uv sync --extra dev && uv run pre-commit install
+```
+
+## Step 6 — open the PR
+
+Title: `chore(dev): add pre-commit parity with attune-ai`. No CHANGELOG.
+Note in the body which prompt-string lines needed `# noqa`, for the next
+sibling's session.
+
+## Done when
+
+- `.pre-commit-config.yaml` + `.secrets.baseline` committed.
+- `pre-commit run --all-files` passes on the branch.
+- CI runs pre-commit on PRs and fails on violations.
+- Contributor docs point at `pre-commit install`.
+- PR open and green. Report back for spec Phase 2 tick + lesson.

--- a/docs/specs/sibling-package-pre-commit/starters/attune-gui.md
+++ b/docs/specs/sibling-package-pre-commit/starters/attune-gui.md
@@ -1,0 +1,150 @@
+# Starter: pre-commit parity for attune-gui
+
+Paste this into a fresh Claude Code session opened in the **attune-gui**
+repo. Self-contained. Phase 4 (last) of `sibling-package-pre-commit`
+(keyless). Produce ONE mergeable PR.
+
+**Before starting:** confirm you are in attune-gui, then branch off
+`origin/main` (the repo may be in detached HEAD — branch explicitly):
+
+```bash
+git fetch origin main
+git checkout -b chore/pre-commit-parity origin/main
+```
+
+This is a **hybrid repo**: Python sidecar + a TypeScript/React frontend
+under `editor-frontend/` with its own toolchain (eslint/prettier/vite).
+Pre-commit here only meaningfully applies to the Python surface
+(`sidecar/`, `scripts/`, `specs/`). `editor-frontend/` is OUT OF SCOPE —
+a prettier hook is a possible follow-up, not this PR.
+
+## Step 1 — write `.pre-commit-config.yaml`
+
+Exclude the frontend and build/cache artifacts that live at repo root:
+
+```yaml
+exclude: |
+  (?x)^(
+    \.venv/|
+    build/|
+    dist/|
+    .*\.egg-info/|
+    .*__pycache__/|
+    node_modules/|
+    editor-frontend/
+  )
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: ['--line-length=100']
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: ['--fix', '--exit-non-zero-on-fix']
+      - id: ruff
+        name: ruff-bare-exception-check
+        args: ['--select=BLE', '--no-fix']
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1200']
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+```
+
+Do NOT add bandit, mypy, or any frontend hook (prettier/eslint) — all
+out of scope for this baseline parity PR.
+
+**Repo-specific watch-for:** any committed frontend assets OUTSIDE
+`editor-frontend/` (stray HTML/CSS/JS at root or under `sidecar/static`)
+— black/ruff don't apply, but `trailing-whitespace`/`end-of-file-fixer`
+will rewrite them. If that's noisy, narrow with an added exclude rather
+than dropping the hook. There's no `[tool.setuptools.package-data]`, so
+the exclusion surface is simpler than the other three siblings.
+
+## Step 2 — `.secrets.baseline`
+
+```bash
+uv run --with detect-secrets detect-secrets scan > .secrets.baseline
+```
+
+Verify every entry is a false positive before committing; if anything
+real appears, STOP and report.
+
+## Step 3 — run hooks, fix in this PR
+
+```bash
+uv run --with pre-commit pre-commit install
+uv run --with pre-commit pre-commit run --all-files --show-diff-on-failure
+```
+
+Fix in-PR. If >~50 files reformat, split into "config" + "fix" PRs.
+Confirm `editor-frontend/` was untouched. Report the count.
+
+## Step 4 — CI gate
+
+Add a `pre-commit` job on PRs. Inspect existing `.github/workflows/`
+first and match conventions:
+
+```yaml
+name: Lint
+on:
+  pull_request:
+  push:
+    branches: [main]
+concurrency:
+  group: lint-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@<match-repo-convention>
+      - uses: actions/setup-python@<match-repo-convention>
+        with:
+          python-version: '3.12'
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files --show-diff-on-failure
+```
+
+## Step 5 — contributor docs
+
+Add to `CONTRIBUTING.md` (or README dev section):
+
+```bash
+uv sync --extra dev && uv run pre-commit install
+```
+
+## Step 6 — open the PR
+
+Title: `chore(dev): add pre-commit parity with attune-ai`. No CHANGELOG.
+Note in the body whether a prettier/eslint follow-up is worth a separate
+spec for the frontend.
+
+## Done when
+
+- `.pre-commit-config.yaml` + `.secrets.baseline` committed.
+- `pre-commit run --all-files` passes; `editor-frontend/` untouched.
+- CI runs pre-commit on PRs and fails on violations.
+- Contributor docs point at `pre-commit install`.
+- PR open and green. This is the last sibling — once merged, report back
+  so the attune-ai spec flips to **complete** (Phase 5).

--- a/docs/specs/sibling-package-pre-commit/starters/attune-help.md
+++ b/docs/specs/sibling-package-pre-commit/starters/attune-help.md
@@ -1,0 +1,147 @@
+# Starter: pre-commit parity for attune-help
+
+Paste this into a fresh Claude Code session opened in the **attune-help**
+repo. Self-contained. Phase 3 of `sibling-package-pre-commit` (keyless).
+Produce ONE mergeable PR.
+
+**Before starting:** confirm you are in attune-help, then branch off
+`origin/main` (the repo may be on a `docs/...` branch — branch off main
+explicitly, don't pile onto it):
+
+```bash
+git fetch origin main
+git checkout -b chore/pre-commit-parity origin/main
+```
+
+## Step 1 — write `.pre-commit-config.yaml`
+
+The **load-bearing** exclusion here is the LLM-polished template content:
+without it, `trailing-whitespace` + `end-of-file-fixer` silently rewrite
+hundreds of generated `.md` files and `check-json` rejects schema
+variants — corrupting polished content. Exclude templates + demos:
+
+```yaml
+exclude: |
+  (?x)^(
+    \.venv/|
+    build/|
+    dist/|
+    .*\.egg-info/|
+    .*__pycache__/|
+    node_modules/|
+    src/attune_help/templates/.*\.(md|json)|
+    src/attune_help/demos/.*\.md
+  )
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: ['--line-length=100']
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: ['--fix', '--exit-non-zero-on-fix']
+      - id: ruff
+        name: ruff-bare-exception-check
+        args: ['--select=BLE', '--no-fix']
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1200']
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+```
+
+Do NOT add bandit or mypy (out of baseline).
+
+**Repo-specific watch-for:** the manifest YAML files have stable schemas
+— `check-yaml` should validate them fine (that's desired). The
+`templates/`/`demos/` markdown exclusion above is the critical move;
+verify after Step 3 that no generated `.md` got rewritten (`git diff
+--stat` should show none under those paths).
+
+## Step 2 — `.secrets.baseline`
+
+```bash
+uv run --with detect-secrets detect-secrets scan > .secrets.baseline
+```
+
+Verify every entry is a false positive before committing; if anything
+real appears, STOP and report.
+
+## Step 3 — run hooks, fix in this PR
+
+```bash
+uv run --with pre-commit pre-commit install
+uv run --with pre-commit pre-commit run --all-files --show-diff-on-failure
+```
+
+Fix in-PR. If >~50 files reformat (excluding the templates, which must
+stay untouched), split into "config" + "fix" PRs. Confirm the template
+exclusion held. Report the count.
+
+## Step 4 — CI gate
+
+Add a `pre-commit` job on PRs. Inspect existing `.github/workflows/`
+first and match conventions:
+
+```yaml
+name: Lint
+on:
+  pull_request:
+  push:
+    branches: [main]
+concurrency:
+  group: lint-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@<match-repo-convention>
+      - uses: actions/setup-python@<match-repo-convention>
+        with:
+          python-version: '3.12'
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files --show-diff-on-failure
+```
+
+## Step 5 — contributor docs
+
+Add to `CONTRIBUTING.md` (or README dev section):
+
+```bash
+uv sync --extra dev && uv run pre-commit install
+```
+
+## Step 6 — open the PR
+
+Title: `chore(dev): add pre-commit parity with attune-ai`. No CHANGELOG.
+Note in the body whether the template exclusion fully protected the
+generated content.
+
+## Done when
+
+- `.pre-commit-config.yaml` + `.secrets.baseline` committed.
+- `pre-commit run --all-files` passes; generated templates untouched.
+- CI runs pre-commit on PRs and fails on violations.
+- Contributor docs point at `pre-commit install`.
+- PR open and green. Report back for spec Phase 3 tick + lesson.

--- a/docs/specs/sibling-package-pre-commit/starters/attune-rag.md
+++ b/docs/specs/sibling-package-pre-commit/starters/attune-rag.md
@@ -1,0 +1,173 @@
+# Starter: pre-commit parity for attune-rag
+
+Paste this into a fresh Claude Code session opened in the **attune-rag**
+repo. It is self-contained — the session does not need the attune-ai
+spec loaded.
+
+---
+
+You are adding pre-commit parity to **attune-rag**, matching the mature
+config in the sibling `attune-ai` repo. This is Phase 1 of the
+`sibling-package-pre-commit` spec (keyless; zero API cost). Produce ONE
+mergeable PR.
+
+**Before starting:** confirm you are in the attune-rag repo, then branch
+off the current `origin/main` (do not pile onto any in-progress feature
+branch). There may be an untracked `site/.gitignore` — leave it alone,
+don't stage it.
+
+```bash
+git fetch origin main
+git checkout -b chore/pre-commit-parity origin/main
+```
+
+## Step 1 — write `.pre-commit-config.yaml`
+
+Use exactly these pinned versions (they match attune-ai; never run a
+newer formatter than the umbrella, or every merged PR churns):
+
+```yaml
+exclude: |
+  (?x)^(
+    \.venv/|
+    build/|
+    dist/|
+    .*\.egg-info/|
+    .*__pycache__/|
+    node_modules/|
+    tests/golden/|
+    src/attune_rag/dashboard/templates/.*\.html|
+    src/attune_rag/editor/template_schema\.json
+  )
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        args: ['--line-length=100']
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: ['--fix', '--exit-non-zero-on-fix']
+      - id: ruff
+        name: ruff-bare-exception-check
+        args: ['--select=BLE', '--no-fix']
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=1200']
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: ['--fix=lf']
+```
+
+**Repo-specific exclusions (already in the regex above):**
+`tests/golden/` (retrieval-regression fixtures — exact-byte stability
+is the whole point; nothing may rewrite them), the shipped dashboard
+HTML templates, and `editor/template_schema.json` (package data).
+
+If a `mkdocs.yml` with custom `!!python/...` tags exists and
+`check-yaml` chokes on it, add `exclude: ^mkdocs.*\.yml$` to the
+`check-yaml` hook only.
+
+Do NOT add bandit or mypy — they're deliberately out of the baseline.
+
+## Step 2 — generate `.secrets.baseline`
+
+Fresh scan (not seeded from attune-ai):
+
+```bash
+uv run --with detect-secrets detect-secrets scan > .secrets.baseline
+```
+
+Open `.secrets.baseline` and confirm every entry is a false positive /
+test fixture before committing. If anything real appears, STOP and
+report it — do not commit.
+
+## Step 3 — run the hooks, fix violations in this PR
+
+```bash
+uv run --with pre-commit pre-commit install
+uv run --with pre-commit pre-commit run --all-files --show-diff-on-failure
+```
+
+Fix everything in this same PR. **If more than ~50 files need
+reformatting, split** into "config + clean slate" and "fix remaining
+violations" PRs — don't ship one noisy 500-file diff. Report the count
+either way.
+
+## Step 4 — add a CI gate
+
+Add a `pre-commit` job that runs on PRs. **First inspect this repo's
+existing `.github/workflows/` and match its conventions** (runner,
+action SHA-pinning vs tags, uv-vs-pip). If actions are SHA-pinned
+elsewhere, pin yours too. A minimal shape:
+
+```yaml
+name: Lint
+on:
+  pull_request:
+  push:
+    branches: [main]
+concurrency:
+  group: lint-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@<match-repo-convention>
+      - uses: actions/setup-python@<match-repo-convention>
+        with:
+          python-version: '3.12'
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files --show-diff-on-failure
+```
+
+Put it in a new `lint.yml` (preferred) or the existing `tests.yml` if
+that's the repo's pattern.
+
+## Step 5 — contributor docs
+
+Add to `CONTRIBUTING.md` (or the `README.md` dev section if there's no
+CONTRIBUTING) a dev-setup line:
+
+```bash
+uv sync --extra dev && uv run pre-commit install
+```
+
+## Step 6 — open the PR
+
+Title: `chore(dev): add pre-commit parity with attune-ai`. No CHANGELOG
+entry (dev-loop change, not user-facing). In the PR body, note any
+per-repo surprises (an exclusion you had to add, a hook that was too
+noisy) so the next sibling's session benefits.
+
+## Done when
+
+- `.pre-commit-config.yaml` + `.secrets.baseline` committed.
+- `pre-commit run --all-files` passes on the branch (violations fixed
+  in-PR).
+- CI runs `pre-commit run --all-files` on PRs and fails on violations.
+- Contributor docs point at `pre-commit install`.
+- PR open and green.
+
+After it merges, report back so the attune-ai
+`sibling-package-pre-commit` spec can tick Phase 1 and capture the
+lesson.


### PR DESCRIPTION
## What

Adds `docs/specs/sibling-package-pre-commit/starters/` — one
self-contained, copy-pasteable session starter prompt per sibling repo
(attune-rag, attune-author, attune-help, attune-gui) plus a README index.

## Why

The `sibling-package-pre-commit` spec (approved) does its work in four
*separate* repos. Rather than mutate those checkouts from an attune-ai
session, each starter lets you open a fresh session **in the sibling
repo** and paste a prompt that already encodes:

- the locked baseline (D1: pinned black 24.10.0 / ruff v0.8.4 /
  detect-secrets v1.5.0 / pre-commit-hooks v5.0.0),
- that repo's specific exclusions (D2/D3),
- the full step sequence (config → secrets baseline → run+fix → CI gate
  → contributor docs → PR) and done-when.

Keyless; one mergeable PR per repo. Suggested order: attune-rag →
attune-author → attune-help → attune-gui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
