### PR TITLE
docs(spec): mark sibling-package-pre-commit complete (Phase 5)

### DIFF
--- a/docs/specs/sibling-package-pre-commit/requirements.md
+++ b/docs/specs/sibling-package-pre-commit/requirements.md
@@ -1,8 +1,10 @@
 # Spec: Sibling-Package Pre-commit Parity
 
-**Status**: approved
+**Status**: ✓ complete 2026-06-20
 **Created**: 2026-05-12
 **Approved**: 2026-05-12
+**Completed**: 2026-06-20 — all four siblings shipped (attune-rag #187,
+attune-author #74 + #75, attune-help #19, attune-gui #78)
 **Origin**: Daily briefing carryover item — attune-ai ships a
 mature `.pre-commit-config.yaml` (black, ruff, bandit, detect-
 secrets, custom freshness checks). Its four sibling packages

--- a/docs/specs/sibling-package-pre-commit/tasks.md
+++ b/docs/specs/sibling-package-pre-commit/tasks.md
@@ -1,6 +1,8 @@
 # Tasks: Sibling-Package Pre-commit Parity
 
-**Status**: approved — Phase 0 complete, Phase 1+ pending
+**Status**: ✓ **complete 2026-06-20** — all 5 phases done; all four
+siblings shipped (attune-rag #187, attune-author #74 + #75,
+attune-help #19, attune-gui #78). See "Outcomes & lessons" below.
 
 ---
 
@@ -24,7 +26,16 @@ versions) and D2 (per-repo exclusion table).
    - `attune-help`: `templates/**/*.{md,json}`, demos
    - `attune-gui`: `editor-frontend/` (separate toolchain)
 
-## Phase 1 — attune-rag (first; API contract source of truth)
+## Phase 1 — attune-rag ✓ complete 2026-06-20 ([#187](https://github.com/Smart-AI-Memory/attune-rag/pull/187))
+
+> **Landed.** New `lint.yml` gate (not folded into tests.yml).
+> **Surprise:** CI only lints `src/ tests/`, so whole-tree ruff
+> surfaced 21 pre-existing issues in `scripts/`/`docs/` — including a
+> real latent **F821** (`measure_reranker.py` used `QueryScore` in
+> annotations without importing it, masked by `from __future__ import
+> annotations`). Fixed the real ones (F821, UP038, BLE bare-except);
+> used the repo's per-file-ignore idiom for legitimately-exceptional
+> E402 (sys.path-hack diagnostic runners) and E501 (embedded CSS/HTML).
 
 3. **Author `attune-rag/.pre-commit-config.yaml`** with the
    baseline + the exclusions decided in Phase 0.
@@ -53,7 +64,19 @@ versions) and D2 (per-repo exclusion table).
    that was too noisy and got removed) in a session lesson
    for future repos.
 
-## Phase 2 — attune-author
+## Phase 2 — attune-author ✓ complete 2026-06-20 ([#74](https://github.com/Smart-AI-Memory/attune-author/pull/74), [#75](https://github.com/Smart-AI-Memory/attune-author/pull/75))
+
+> **Landed.** The predicted prompt-string E501 noqas **did not
+> occur** — the polish-pipeline literals were already within
+> line-length. The real surprise: the `trailing-whitespace` hook
+> silently corrupted a **syrupy `.ambr` snapshot** (generated output
+> legitimately carries trailing whitespace on blank lines), breaking 3
+> tests — so `tests/__snapshots__/` is now excluded (byte-exact
+> fixtures, same class as attune-rag's `tests/golden/`). Also: this
+> repo sets `core.hooksPath = .githooks`, so `pre-commit install`
+> doesn't wire into local commits (CI enforces it regardless). The
+> UP038 reformat dragged a pre-existing partial branch into codecov's
+> patch report → follow-up coverage PR #75.
 
 9. Repeat Phase 1 for `attune-author`. Watch for: the polish
    pipeline's `_anthropic.py` and the regeneration scripts —
@@ -61,7 +84,22 @@ versions) and D2 (per-repo exclusion table).
    may complain about. Likely needs `noqa` or
    per-file-ignores.
 
-## Phase 3 — attune-help
+## Phase 3 — attune-help ✓ complete 2026-06-20 ([#19](https://github.com/Smart-AI-Memory/attune-help/pull/19))
+
+> **Landed.** The predicted template trailing-whitespace risk was real
+> and **load-bearing** (634 generated `.md` files) — the
+> `templates/**/*.{md,json}` + `demos/` exclusion held perfectly
+> (`git diff --stat` showed zero changes under those paths). This repo
+> has **no `[tool.ruff]` config**, so ruff ran with defaults
+> (`E4/E7/E9/F` only) — far fewer findings; ruff auto-fixed one unused
+> import, the rest was black. 4 E402s from the deliberate
+> `pytest.importorskip("attune_author")`-before-import shim pattern →
+> per-line `# noqa: E402`.
+> **Bonus:** surfaced a separate, pre-existing failure — the RAG P@1
+> regression gate had been red on `main` since inception (overall P@1
+> 71.4% < 0.73). Fixed honestly in **[#20](https://github.com/Smart-AI-Memory/attune-help/pull/20)**
+> (strengthened 4 owner summaries → 73.5%, zero regressions), not by
+> lowering the threshold.
 
 10. Repeat Phase 1 for `attune-help`. Watch for: the manifest
     YAML files have stable schemas; check-yaml should
@@ -69,7 +107,19 @@ versions) and D2 (per-repo exclusion table).
     — trailing-whitespace fires on every multi-line LLM-
     generated paragraph. Exclude or tune.
 
-## Phase 4 — attune-gui
+## Phase 4 — attune-gui ✓ complete 2026-06-20 ([#78](https://github.com/Smart-AI-Memory/attune-gui/pull/78))
+
+> **Landed.** The predicted committed-frontend-asset risk was real:
+> `end-of-file-fixer` rewrote the generated **Vite bundle**
+> (`sidecar/attune_gui/static/`) — excluded alongside `editor-frontend/`.
+> This repo has the **strictest** ruff `select` of the four
+> (`["E","F","I","N","W","UP","B","S","BLE001"]` — adds `N` naming + `S`
+> bandit); whole-tree ruff surfaced 10 `S` findings, all in dev tooling
+> (`.claude/hooks/`, `scripts/`) → per-file-ignores (`"S"` for those
+> dirs), matching the repo's existing test S-ignore idiom. No shipped
+> `sidecar/` code changed. Matched this repo's `@v4`/`@v5` **tag**
+> convention for the lint workflow (the other three SHA-pin). Frontend
+> prettier/eslint left out of scope (its own `npm` toolchain runs in CI).
 
 11. Repeat Phase 1 for `attune-gui`. Watch for: any committed
     frontend assets (HTML, CSS, JS) — pre-commit's
@@ -77,14 +127,49 @@ versions) and D2 (per-repo exclusion table).
     don't. May want a follow-up to add prettier; out of
     scope here.
 
-## Phase 5 — close
+## Phase 5 — close ✓ complete 2026-06-20
 
-12. **Daily briefing carryover update** — once all four land,
-    explicitly mark the carryover item ✓ in the next briefing.
+12. ☐ **Daily briefing carryover update** — mark the carryover item ✓
+    in the next briefing. (Pending the next briefing cycle; all four
+    PRs have landed, so it's ready to tick.)
 
-13. **Spec status → complete.** No CHANGELOG entry needed —
-    pre-commit additions are dev-loop changes, not user-
-    facing.
+13. ✓ **Spec status → complete.** Done in this PR. No CHANGELOG entry —
+    pre-commit additions are dev-loop changes, not user-facing.
+
+---
+
+## Outcomes & lessons
+
+All four siblings shipped one mergeable PR each (plus two follow-ups in
+attune-help). Cross-cutting lessons for the next time we replicate a
+config across sibling repos:
+
+- **CI lint scope is narrower than pre-commit's.** Every sibling lints
+  only its shipped surface in CI (`src/ tests/`, or `sidecar/`), so
+  turning the hooks loose on the whole tree reliably surfaces
+  pre-existing debt in `scripts/`, `docs/`, `.claude/hooks/`. Budget
+  for it — attune-rag alone had 21 latent issues (one a real F821).
+  Fix the genuine ones; use each repo's own per-file-ignore idiom for
+  legitimately-exceptional code rather than excluding whole files.
+- **Byte-exact generated content must be excluded, and it's repo-
+  specific.** Each sibling had a different flavor: attune-rag
+  `tests/golden/`, attune-author syrupy `tests/__snapshots__/`,
+  attune-help's 634 `templates/**/*.md`, attune-gui's committed Vite
+  bundle. The hygiene hooks (trailing-whitespace / EOF / check-json)
+  will silently rewrite these and break things if not excluded.
+- **Match each repo's existing conventions, don't impose attune-ai's.**
+  Action-pin style differed (three SHA-pin, attune-gui tags); ruff
+  `select` ranged from defaults-only (attune-help) to the strict
+  `N`+`S` set (attune-gui). The lint workflow and any ignores should
+  look native to the repo.
+- **The starters paid off but weren't exhaustive.** Per-repo predicted
+  watch-fors were mostly right; the misses were the snapshot-exclusion
+  (attune-author) and `core.hooksPath` (attune-author). Fold those
+  back into the playbook for any future sibling.
+- **Reformatting can dent codecov.** A pure formatting/UP038 reformat
+  pulled a pre-existing partial branch into codecov's patch report
+  (attune-author) — expect a possible coverage follow-up after a
+  whole-tree reformat.
 
 ---
 


### PR DESCRIPTION
## What

Closes out the **sibling-package-pre-commit** spec (Phase 5). All four siblings now have pre-commit parity, shipped one mergeable PR each:

| sibling | PR(s) |
|---|---|
| attune-rag | [#187](https://github.com/Smart-AI-Memory/attune-rag/pull/187) |
| attune-author | [#74](https://github.com/Smart-AI-Memory/attune-author/pull/74) + [#75](https://github.com/Smart-AI-Memory/attune-author/pull/75) (coverage follow-up) |
| attune-help | [#19](https://github.com/Smart-AI-Memory/attune-help/pull/19) + [#20](https://github.com/Smart-AI-Memory/attune-help/pull/20) (unrelated pre-existing RAG-gate fix) |
| attune-gui | [#78](https://github.com/Smart-AI-Memory/attune-gui/pull/78) |

## Changes

- `requirements.md` + `tasks.md` status → **✓ complete 2026-06-20**.
- Each phase annotated with its landing PR and the **actual** surprise (vs the predicted watch-for) — e.g. the predicted attune-author prompt-string E501 noqas never happened; the real surprise was syrupy snapshot corruption.
- New **Outcomes & lessons** section with the cross-cutting takeaways for future sibling-config replications.

## Lessons captured

- **CI lint scope < pre-commit scope** — whole-tree hooks surface pre-existing debt in `scripts/`/`docs/`/`.claude/` (attune-rag alone: 21 issues, incl. a real latent F821). Fix the genuine ones; use each repo's per-file-ignore idiom for the rest.
- **Byte-exact generated content must be excluded, repo-specifically** — `tests/golden/` (rag), syrupy `tests/__snapshots__/` (author), 634 `templates/**/*.md` (help), committed Vite bundle (gui).
- **Match each repo's conventions** — action-pin style (SHA vs tag) and ruff `select` (defaults-only → strict `N`+`S`) varied; the lint workflow should look native.
- **Reformatting can dent codecov** — a UP038 reformat pulled a pre-existing partial branch into the patch report (author → #75).

No CHANGELOG entry — dev-loop/docs only.

**Remaining:** Phase 5 task 12 (tick the daily-briefing carryover item) is ready for the next briefing cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)