### PR TITLE
release: prep 8.6.0

### DIFF
--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -319,10 +319,42 @@ catch. (Follow-up PR off main.)
 
 **Remaining before this is end-to-end live (deploy-time, owner: Patrick):**
 
-1. Apply the `usage_events` DDL to the prod DB (re-run the
-   admin-protected `POST /api/db/init`, or apply the table directly).
-2. Deploy the website so `/api/usage` is live, THEN ship the attune-ai
-   release carrying `DEFAULT_ENDPOINT` (client swallows errors if the
-   order slips, but endpoint-first is cleanest).
+1. ~~Apply the `usage_events` DDL to the prod DB~~ — DONE (table live).
+2. ~~Deploy the website so `/api/usage` is live~~ — DONE (see D8). THEN
+   ship the attune-ai release carrying `DEFAULT_ENDPOINT` (client
+   swallows errors if the order slips, but endpoint-first is cleanest)
+   — still pending the next PyPI release.
 3. Phase 2c — dashboard "Reach" panel (R3) reading `usage_events`.
 4. R5 telemetry watchdog + R6 spend alarm (separate PRs).
+
+## D8 — Phase 2b end-to-end live, verified (2026-06-20)
+
+The deploy-time blocker (D7 item 1+2) is cleared: `DATABASE_URL` is set
+in the **website** project's Production env and a redeploy since the
+06-16 pause picked it up. Verified directly against the live surface:
+
+- `POST https://smartaimemory.com/api/usage/` with a valid schema-v1
+  batch → **HTTP 204** (a missing/broken `DATABASE_URL` would 500 in
+  the `recordUsageEvents()` catch). Confirmed in Vercel runtime logs:
+  `POST /api/usage/ 204` on production deploy
+  `dpl_AT9f3wQbdhTZSgyDRUnoPRdjaZ9s` (commit `ff9472e4`, current `main`).
+
+So the ingest chain — client → validate → rate-limit → drop envelope →
+insert → 204 — is proven live end-to-end. The ONLY thing gating real
+signal now is the next attune-ai PyPI release shipping the
+`DEFAULT_ENDPOINT` client (item 2, above).
+
+**Verification test row left in place.** The probe inserted one sentinel
+row (`install_id = '00000000-0000-4000-8000-000000000000'`,
+`version = '0.0.0-verify'`, `event = 'workflow.verification_test'`).
+Deleting it now would require pulling the full production env (Stripe
+keys, `ADMIN_SECRET`, the PII-DB connection string) to local disk to
+reach the DB for one harmless, trivially-filterable row — not worth the
+secret exposure. It is excluded by any real query
+(`WHERE version <> '0.0.0-verify'`). Drop it from the Neon console when
+convenient:
+
+```sql
+DELETE FROM usage_events
+WHERE install_id = '00000000-0000-4000-8000-000000000000';
+```


### PR DESCRIPTION
## 8.6.0 release prep

Cuts the **8.6.0** release. Headline feature is the opt-in usage
telemetry going live end-to-end (usage-signals Phase 2b), so this PR
bundles the go-live receipt, the version bump, and the changelog.

### Contents

- **CHANGELOG** — opened `## [8.6.0]`: usage telemetry live, five new
  specialist sub-agents, and UTC / Windows / graceful-degradation
  fixes. Internal CI/test/website/dev-hook commits excluded per the
  website-changelog policy.
- **Version bump** 8.5.0 → 8.6.0 across the 7 canonical sites via
  `bump_version.py`; `test_all_versions_match` passes. `uv.lock` synced.
- **usage-signals D8** — Phase 2b verified live on prod (`POST /api/usage/` → 204 on `dpl_AT9f3wQbdhTZSgyDRUnoPRdjaZ9s`).
- **usage-signals D9** — decision to keep the ping default-OFF; first-run consent prompt is the future opt-in lever.
- **README** — fix the `[developer]` extra row (LangChain/LangGraph are optional interop adapters, not the agent-team engine — teams are dynamic + SDK-native).

### Notes

- `Integration Tests (auth)` failures on main are environmental (`401 invalid x-api-key`, keyless CI), **not** a code regression — not a release blocker.
- Real telemetry signal only begins once this release ships the `DEFAULT_ENDPOINT` client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)