### PR TITLE
release: prep 8.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.5.0"
+    "version": "8.6.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.5.0
+# Attune AI Framework v8.6.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.5.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.6.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.6.0] — 2026-06-20
+
+Usage signals come online, and the agent roster grows. The headline:
+the opt-in anonymous usage ping is live end-to-end, so the project can
+finally see which workflows external users actually run — strictly by
+consent, default-OFF. Plus five new specialist sub-agents and a batch
+of correctness fixes (UTC consistency, Windows stability, graceful
+degradation without optional extras).
+
 ### Added
 
 - **Opt-in anonymous usage telemetry goes live (usage-signals Phase
@@ -22,7 +31,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status|enable|disable`; override per-run with `ATTUNE_USAGE_PING=0`
   or `=1`; rotate your anonymous install id any time. See the
   **Privacy & Telemetry** section of the README and SECURITY.md for
-  the full payload disclosure.
+  the full payload disclosure. (#912, #920, #923)
+- **Five new specialist sub-agents.** `release-prep-auditor`,
+  `security-reviewer`, and `refactor-planner` for release and review
+  workflows; `help-content-explainer` for documentation; and
+  `spec-author`, which runs the spec-driven requirements interview.
+  (#925, #926, #927)
+
+### Fixed
+
+- **Consistent UTC time handling.** Two clock-mix sites and
+  bulletin-board rotation now use UTC instead of local time, fixing
+  off-by-a-day behavior across time zones. (#867, #868)
+- **Windows stability.** The asyncio event loop now uses the Proactor
+  policy on Windows, fixing subprocess and IO failures. (#847)
+- **Graceful degradation without optional extras.** OTEL monitoring no
+  longer crashes when the `[otel]` extra isn't installed, and the
+  curator shows clean offline messages instead of raw API errors.
+  (#796, #838)
+- **Encryption is no longer silently disabled** during certain serial
+  memory runs (cryptography pinned once at import). (#835)
+- **Faster small project scans.** The project index skips
+  multiprocessing overhead for tiny scans. (#930)
 
 ## [8.5.0] — 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ dependencies. Add extras only for the surfaces you use:
 | You want | Install |
 | -------- | ------- |
 | Everything most users need | `pip install attune-ai` |
-| Claude API mode + LangChain/LangGraph agent teams | `pip install 'attune-ai[developer]'` |
+| Claude API mode + optional LangChain/LangGraph interop adapters | `pip install 'attune-ai[developer]'` |
 | The ops dashboard (`attune ops`) | `pip install 'attune-ai[ops]'` |
 | Redis / Agent Memory Server memory backend | `pip install 'attune-ai[redis]'` |
 | Help authoring (generate / maintain `.help/` templates) | `pip install 'attune-ai[author]'` |

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.5.0
+**Version:** 8.6.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.5.0 | **License:** Apache 2.0
+**Version:** 8.6.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -359,6 +359,22 @@ DELETE FROM usage_events
 WHERE install_id = '00000000-0000-4000-8000-000000000000';
 ```
 
+**Second sentinel row (2026-06-20 release dogfood, D10).** Pre-release
+readiness dogfood transmitted through the *shipped 8.6.0 wheel* (built,
+installed in a clean venv) to confirm the real client network path works
+end-to-end against the live endpoint — server logged `204`. It inserted
+one more sentinel row (`install_id =
+'11111111-1111-4111-8111-111111111111'`, `event =
+'workflow.release_dogfood_860'`). Drop both together:
+
+```sql
+DELETE FROM usage_events
+WHERE install_id IN (
+  '00000000-0000-4000-8000-000000000000',
+  '11111111-1111-4111-8111-111111111111'
+);
+```
+
 ## D9 — default stays OFF; first-run consent prompt is the opt-in lever (2026-06-20)
 
 Question raised at release time: to maximize signal, should the usage

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -358,3 +358,25 @@ convenient:
 DELETE FROM usage_events
 WHERE install_id = '00000000-0000-4000-8000-000000000000';
 ```
+
+## D9 — default stays OFF; first-run consent prompt is the opt-in lever (2026-06-20)
+
+Question raised at release time: to maximize signal, should the usage
+ping default to ON (`ATTUNE_USAGE_PING=1` / config-enabled by default)?
+
+**Decision: No. The ping stays default-OFF.** Silently defaulting it ON
+would contradict the stance already shipped in the README, SECURITY.md,
+CHANGELOG, and R2 ("ships OFF, requires explicit consent, privacy by
+construction"), and developers are the audience most hostile to surprise
+telemetry — the reputational downside of default-ON dwarfs the signal
+upside, and it is a one-way door. It also wouldn't yield much: the
+privacy-conscious slice opts out immediately, leaving a noisy
+self-selected sample.
+
+**The lever instead:** a first-run consent prompt (ask once, explicitly,
+default No) — the Homebrew / .NET CLI / Next.js-notice pattern. An
+explicit friendly ask converts far better than passive opt-in (~0) while
+keeping consent intact. Tracked as a Phase 2c follow-up, NOT bundled
+into the 8.6.0 release; the client ships default-OFF as already built.
+
+No copy changes needed — existing telemetry text remains accurate.

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.5.0"
+    "version": "8.6.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.5.0"
+__version__ = "8.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.5.0"
+version = "8.6.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/src/attune/telemetry/usage_ping.py
+++ b/src/attune/telemetry/usage_ping.py
@@ -16,9 +16,9 @@ Privacy contract (frozen — see ``docs/specs/usage-signals/phase2-design.md``):
   telemetry must never block, slow, or crash the CLI.
 - ``DO_NOT_TRACK`` and ``ATTUNE_USAGE_PING`` env vars override config.
 
-Phase 2a ships the client only; :data:`DEFAULT_ENDPOINT` is empty, so
-even an opted-in user transmits nothing until the Vercel endpoint is
-wired in Phase 2b. That is intentional double-safety.
+As of Phase 2b, :data:`DEFAULT_ENDPOINT` points at the live collection
+endpoint, so an opted-in user transmits there by default. The default
+remains OFF — opting in is still an explicit, deliberate choice.
 
 Copyright 2026 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.5.0"
+version = "8.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## 8.6.0 release prep

Cuts **8.6.0**. (The usage-signals go-live receipt, D8, already landed on
`main` via #942 — auto-merged as a docs-only change — so this PR carries
only the release prep.)

### Contents

- **CHANGELOG** — opens `## [8.6.0]`: opt-in usage telemetry live, five
  new specialist sub-agents, and UTC / Windows / graceful-degradation
  fixes. Internal CI/test/website/dev-hook commits excluded per the
  website-changelog policy.
- **Version bump** 8.5.0 → 8.6.0 across the 7 canonical sites via
  `bump_version.py`; `test_all_versions_match` passes. `uv.lock` synced.
- **README** — `[developer]` row fix (LangChain/LangGraph are optional
  interop adapters, not the agent-team engine — teams are dynamic +
  SDK-native).
- **usage-signals D9/D10** — keep the ping default-OFF (first-run consent
  prompt is the future lever); record the pre-release dogfood.

### Readiness receipts

- **Dogfooded the shipped 8.6.0 wheel** (built, installed in a clean venv,
  real client `sync()`) against the live endpoint → server logged **204**.
  Closes the #923-class silent-failure risk.
- **Privacy enforced**: unknown fields reject on both client + server;
  only 7 anonymous columns stored (no IP/headers/PII); event grammar
  blocks free-text; fire-and-forget guarded. Both sides tested.
- `Integration Tests (auth)` failures on main are environmental (`401`,
  keyless CI), not a regression.

Touches packaging + `src/`, so the auto-merge-safe class does NOT apply —
merge is gated on review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)