### PR TITLE
fix(cli): base CLI crashed on default install without [ops] extra (fastapi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ degradation without optional extras).
 
 ### Fixed
 
+- **The `attune` CLI no longer crashes on a default install.** Without
+  the `[ops]` extra (the common `pip install attune-ai`), the base CLI
+  imported FastAPI transitively — the curator's spec source pulled
+  `SpecRecord` / `_list_specs_in_root` from the web-route module — so
+  `attune --help` (and every command) died with
+  `ModuleNotFoundError: No module named 'fastapi'`. The pure
+  spec-listing data layer moved to a framework-free
+  `attune.ops.specs_data` module; a regression guard now imports the
+  base CLI with FastAPI blocked so this can't silently return.
 - **Consistent UTC time handling.** Two clock-mix sites and
   bulletin-board rotation now use UTC instead of local time, fixing
   off-by-a-day behavior across time zones. (#867, #868)

--- a/src/attune/curator/sources/specs.py
+++ b/src/attune/curator/sources/specs.py
@@ -22,7 +22,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from attune.ops.config import build_config
-from attune.ops.routes.specs import SpecRecord, _list_specs_in_root
+
+# Import from the framework-free data module, NOT attune.ops.routes.specs —
+# the route module imports FastAPI at load time, which is absent in a default
+# `pip install attune-ai` (no `[ops]` extra) and would crash the base CLI.
+from attune.ops.specs_data import SpecRecord, _list_specs_in_root
 
 from ..result import SourceItem, SourceSummary
 

--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -24,7 +24,7 @@ import logging
 import os
 import re
 import tempfile
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +32,22 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Request
 
 from attune.ops import dismiss_store, pending_writes
 from attune.ops.security import require_client_token
+
+# The pure data layer lives in attune.ops.specs_data (framework-free) so
+# the base CLI / curator can list specs without importing FastAPI. Re-export
+# here for backward compatibility — existing callers (dashboard route, tests)
+# still do `from attune.ops.routes.specs import SpecRecord, ...`.
+from attune.ops.specs_data import (  # noqa: F401
+    _PHASE_FILES,
+    _STATUS_RE,
+    SpecPhase,
+    SpecRecord,
+    _extract_status,
+    _list_specs_in_root,
+    _newest_md_mtime,
+    _resolved_roots,
+    _scan_spec_dir,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,25 +65,8 @@ _COMPLETE_LIKE_STATUSES: frozenset[str] = frozenset({"complete", "completed", "d
 _SNAPSHOT_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
-# Phase files we recognize. Match attune-gui's convention; decisions.md is
-# attune-ai's additional convention and is included for parity with current
-# specs (probe-c, ops-specs-features, etc. all use decisions.md as the
-# primary doc).
-_PHASE_FILES: tuple[str, ...] = (
-    "decisions.md",
-    "requirements.md",
-    "design.md",
-    "tasks.md",
-)
-
-# Status line pattern — accepts both Markdown bolding conventions:
-#   **Status:** value   (colon inside the bolding — attune-ai convention)
-#   **Status**: value   (colon outside — attune-gui convention)
-# Captures the value, stripping trailing whitespace.
-_STATUS_RE = re.compile(
-    r"^\s*\*\*Status(?::\*\*|\*\*:)\s*(.+?)\s*$",
-    re.MULTILINE,
-)
+# `_PHASE_FILES` and `_STATUS_RE` are imported from attune.ops.specs_data
+# (see the re-export import above).
 
 # Phase file names (without `.md`) accepted by the status-flip endpoint.
 # Derived from `_PHASE_FILES` so the two stay in lockstep.
@@ -88,136 +87,6 @@ _VALID_STATUSES: tuple[str, ...] = (
 # Slug rule: lowercase letters/digits/dashes, must start with letter/digit,
 # max 63 chars. Matches attune-gui's `_SLUG_RE` so the two endpoints agree.
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
-
-
-@dataclass(frozen=True)
-class SpecPhase:
-    """One phase file's status snapshot."""
-
-    name: str  # "decisions" / "requirements" / "design" / "tasks"
-    file: str  # e.g. "decisions.md"
-    exists: bool
-    status: str | None  # parsed from `**Status**:` line, or None if absent
-
-
-@dataclass(frozen=True)
-class SpecRecord:
-    """One spec's summary — directory + status of each phase file present."""
-
-    slug: str  # directory name
-    root: str  # absolute path of the containing root
-    path: str  # absolute path of the spec directory
-    phases: list[SpecPhase]
-    # ISO-8601 timestamp of the most recently modified *.md file in the
-    # spec directory (any kind — `decisions.md`, `_sequencing.md`,
-    # `audit.md`, etc.). None if the directory has no .md files at all
-    # (which shouldn't happen since _list_specs_in_root requires at
-    # least one canonical phase file, but handled defensively).
-    last_modified: str | None = None
-    # Lifecycle bucket derived from `phases` + `last_modified` via
-    # `attune.ops.spec_lifecycle.derive_lifecycle`. Computed in
-    # `__post_init__` so callers don't need to coordinate. `init=False`
-    # keeps the constructor signature backward-compatible with the many
-    # `SpecRecord(slug=..., phases=..., last_modified=...)` test fixtures.
-    # One of: "paused", "complete", "stale", "draft",
-    # "approved-not-shipped", "active". See
-    # [docs/specs/ops-specs-page-refinement/decisions.md](../../../docs/specs/ops-specs-page-refinement/decisions.md).
-    lifecycle: str = field(init=False, default="")
-
-    def __post_init__(self) -> None:
-        # Lazy import to avoid any chance of an import cycle between
-        # routes/specs.py and spec_lifecycle.py (defensive; no cycle
-        # exists today since spec_lifecycle uses a structural Protocol).
-        from attune.ops.spec_lifecycle import derive_lifecycle
-
-        # Frozen dataclass — use object.__setattr__ to set the field.
-        object.__setattr__(self, "lifecycle", derive_lifecycle(self))
-
-
-def _extract_status(text: str) -> str | None:
-    """Pull the value after `**Status**:` from a markdown file."""
-    match = _STATUS_RE.search(text)
-    if not match:
-        return None
-    return match.group(1).strip()
-
-
-def _scan_spec_dir(spec_dir: Path) -> list[SpecPhase]:
-    """List the phase files in one spec directory with their statuses."""
-    phases: list[SpecPhase] = []
-    for phase_file in _PHASE_FILES:
-        file_path = spec_dir / phase_file
-        name = phase_file.removesuffix(".md")
-        if not file_path.is_file():
-            phases.append(SpecPhase(name=name, file=phase_file, exists=False, status=None))
-            continue
-        try:
-            text = file_path.read_text(encoding="utf-8")
-        except OSError:
-            # INTENTIONAL: an unreadable phase file is reported as
-            # existing-but-statusless rather than failing the whole listing.
-            phases.append(SpecPhase(name=name, file=phase_file, exists=True, status=None))
-            continue
-        phases.append(
-            SpecPhase(name=name, file=phase_file, exists=True, status=_extract_status(text))
-        )
-    return phases
-
-
-def _newest_md_mtime(spec_dir: Path) -> str | None:
-    """Return the newest mtime across all `.md` files in the spec dir,
-    formatted as a UTC ISO-8601 string. Catches edits to canonical phase
-    files AND auxiliary content (`_sequencing.md`, `audit.md`, etc.)."""
-    from datetime import datetime, timezone
-
-    newest: float | None = None
-    try:
-        for md in spec_dir.glob("*.md"):
-            try:
-                mt = md.stat().st_mtime
-            except OSError:
-                continue
-            if newest is None or mt > newest:
-                newest = mt
-    except OSError:
-        return None
-    if newest is None:
-        return None
-    return datetime.fromtimestamp(newest, tz=timezone.utc).isoformat()
-
-
-def _list_specs_in_root(root: Path) -> list[SpecRecord]:
-    """Find all spec directories under one root, with phase statuses."""
-    if not root.is_dir():
-        return []
-    records: list[SpecRecord] = []
-    for child in sorted(root.iterdir()):
-        if not child.is_dir():
-            continue
-        # A spec dir must contain at least ONE of the recognized phase files;
-        # otherwise it's just an unrelated subdirectory.
-        has_phase = any((child / phase).is_file() for phase in _PHASE_FILES)
-        if not has_phase:
-            continue
-        records.append(
-            SpecRecord(
-                slug=child.name,
-                root=str(root),
-                path=str(child),
-                phases=_scan_spec_dir(child),
-                last_modified=_newest_md_mtime(child),
-            )
-        )
-    return records
-
-
-def _resolved_roots(config) -> list[Path]:
-    """Resolve the spec roots from config, defaulting to
-    `<project-root>/docs/specs/` if none are configured."""
-    roots = getattr(config, "specs_roots", ()) or ()
-    if not roots:
-        roots = (config.project_root / "docs" / "specs",)
-    return [Path(r).expanduser().resolve() for r in roots]
 
 
 @router.get("")

--- a/src/attune/ops/specs_data.py
+++ b/src/attune/ops/specs_data.py
@@ -1,0 +1,170 @@
+"""Spec listing — framework-free data layer.
+
+The pure spec-discovery logic (dataclasses + filesystem readers) used by
+BOTH the ops web route (``attune.ops.routes.specs``) and the base-CLI
+curator (``attune.curator.sources.specs``). It lives here, free of any
+web-framework import, so importing the spec model never drags FastAPI
+into a default ``pip install attune-ai`` (where ``[ops]`` extras —
+fastapi/uvicorn — are absent). The route module re-exports these names
+for backward compatibility.
+
+See docs/specs/ops-specs-features/ for the endpoint design; this module
+is just the data half, split out so the CLI can use it without the web
+stack.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Phase files we recognize. Match attune-gui's convention; decisions.md is
+# attune-ai's additional convention and is included for parity with current
+# specs (probe-c, ops-specs-features, etc. all use decisions.md as the
+# primary doc).
+_PHASE_FILES: tuple[str, ...] = (
+    "decisions.md",
+    "requirements.md",
+    "design.md",
+    "tasks.md",
+)
+
+# Status line pattern — accepts both Markdown bolding conventions:
+#   **Status:** value   (colon inside the bolding — attune-ai convention)
+#   **Status**: value   (colon outside — attune-gui convention)
+# Captures the value, stripping trailing whitespace.
+_STATUS_RE = re.compile(
+    r"^\s*\*\*Status(?::\*\*|\*\*:)\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class SpecPhase:
+    """One phase file's status snapshot."""
+
+    name: str  # "decisions" / "requirements" / "design" / "tasks"
+    file: str  # e.g. "decisions.md"
+    exists: bool
+    status: str | None  # parsed from `**Status**:` line, or None if absent
+
+
+@dataclass(frozen=True)
+class SpecRecord:
+    """One spec's summary — directory + status of each phase file present."""
+
+    slug: str  # directory name
+    root: str  # absolute path of the containing root
+    path: str  # absolute path of the spec directory
+    phases: list[SpecPhase]
+    # ISO-8601 timestamp of the most recently modified *.md file in the
+    # spec directory (any kind — `decisions.md`, `_sequencing.md`,
+    # `audit.md`, etc.). None if the directory has no .md files at all
+    # (which shouldn't happen since _list_specs_in_root requires at
+    # least one canonical phase file, but handled defensively).
+    last_modified: str | None = None
+    # Lifecycle bucket derived from `phases` + `last_modified` via
+    # `attune.ops.spec_lifecycle.derive_lifecycle`. Computed in
+    # `__post_init__` so callers don't need to coordinate. `init=False`
+    # keeps the constructor signature backward-compatible with the many
+    # `SpecRecord(slug=..., phases=..., last_modified=...)` test fixtures.
+    # One of: "paused", "complete", "stale", "draft",
+    # "approved-not-shipped", "active". See
+    # [docs/specs/ops-specs-page-refinement/decisions.md](../../../docs/specs/ops-specs-page-refinement/decisions.md).
+    lifecycle: str = field(init=False, default="")
+
+    def __post_init__(self) -> None:
+        # Lazy import to avoid any chance of an import cycle between
+        # routes/specs.py and spec_lifecycle.py (defensive; no cycle
+        # exists today since spec_lifecycle uses a structural Protocol).
+        from attune.ops.spec_lifecycle import derive_lifecycle
+
+        # Frozen dataclass — use object.__setattr__ to set the field.
+        object.__setattr__(self, "lifecycle", derive_lifecycle(self))
+
+
+def _extract_status(text: str) -> str | None:
+    """Pull the value after `**Status**:` from a markdown file."""
+    match = _STATUS_RE.search(text)
+    if not match:
+        return None
+    return match.group(1).strip()
+
+
+def _scan_spec_dir(spec_dir: Path) -> list[SpecPhase]:
+    """List the phase files in one spec directory with their statuses."""
+    phases: list[SpecPhase] = []
+    for phase_file in _PHASE_FILES:
+        file_path = spec_dir / phase_file
+        name = phase_file.removesuffix(".md")
+        if not file_path.is_file():
+            phases.append(SpecPhase(name=name, file=phase_file, exists=False, status=None))
+            continue
+        try:
+            text = file_path.read_text(encoding="utf-8")
+        except OSError:
+            # INTENTIONAL: an unreadable phase file is reported as
+            # existing-but-statusless rather than failing the whole listing.
+            phases.append(SpecPhase(name=name, file=phase_file, exists=True, status=None))
+            continue
+        phases.append(
+            SpecPhase(name=name, file=phase_file, exists=True, status=_extract_status(text))
+        )
+    return phases
+
+
+def _newest_md_mtime(spec_dir: Path) -> str | None:
+    """Return the newest mtime across all `.md` files in the spec dir,
+    formatted as a UTC ISO-8601 string. Catches edits to canonical phase
+    files AND auxiliary content (`_sequencing.md`, `audit.md`, etc.)."""
+    from datetime import datetime, timezone
+
+    newest: float | None = None
+    try:
+        for md in spec_dir.glob("*.md"):
+            try:
+                mt = md.stat().st_mtime
+            except OSError:
+                continue
+            if newest is None or mt > newest:
+                newest = mt
+    except OSError:
+        return None
+    if newest is None:
+        return None
+    return datetime.fromtimestamp(newest, tz=timezone.utc).isoformat()
+
+
+def _list_specs_in_root(root: Path) -> list[SpecRecord]:
+    """Find all spec directories under one root, with phase statuses."""
+    if not root.is_dir():
+        return []
+    records: list[SpecRecord] = []
+    for child in sorted(root.iterdir()):
+        if not child.is_dir():
+            continue
+        # A spec dir must contain at least ONE of the recognized phase files;
+        # otherwise it's just an unrelated subdirectory.
+        has_phase = any((child / phase).is_file() for phase in _PHASE_FILES)
+        if not has_phase:
+            continue
+        records.append(
+            SpecRecord(
+                slug=child.name,
+                root=str(root),
+                path=str(child),
+                phases=_scan_spec_dir(child),
+                last_modified=_newest_md_mtime(child),
+            )
+        )
+    return records
+
+
+def _resolved_roots(config) -> list[Path]:
+    """Resolve the spec roots from config, defaulting to
+    `<project-root>/docs/specs/` if none are configured."""
+    roots = getattr(config, "specs_roots", ()) or ()
+    if not roots:
+        roots = (config.project_root / "docs" / "specs",)
+    return [Path(r).expanduser().resolve() for r in roots]

--- a/tests/unit/ops/test_specs_data.py
+++ b/tests/unit/ops/test_specs_data.py
@@ -1,0 +1,171 @@
+"""Unit tests for attune.ops.specs_data — the framework-free spec data layer.
+
+Exercises the defensive branches (unreadable files, stat/glob OSErrors,
+missing roots) that the route/curator integration tests don't hit, plus
+the happy paths, root resolution, and the SpecRecord lifecycle
+computation. Lives here (not in test_specs_routes) precisely because this
+module must be importable and testable without FastAPI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.ops.specs_data import (
+    SpecPhase,
+    SpecRecord,
+    _extract_status,
+    _list_specs_in_root,
+    _newest_md_mtime,
+    _resolved_roots,
+    _scan_spec_dir,
+)
+
+
+def _make_spec(root: Path, slug: str, *, status: str | None = "draft") -> Path:
+    d = root / slug
+    d.mkdir(parents=True)
+    body = f"**Status:** {status}\n" if status else "no status here\n"
+    (d / "decisions.md").write_text(body, encoding="utf-8")
+    return d
+
+
+# --- _extract_status -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("**Status:** approved", "approved"),  # colon inside the bolding
+        ("**Status**: in-review", "in-review"),  # colon outside the bolding
+        ("  **Status:**   complete  ", "complete"),  # surrounding whitespace
+        ("no status line here", None),
+        ("", None),
+    ],
+)
+def test_extract_status(text: str, expected: str | None) -> None:
+    assert _extract_status(text) == expected
+
+
+# --- _scan_spec_dir --------------------------------------------------------
+
+
+def test_scan_spec_dir_reports_existing_and_missing(tmp_path: Path) -> None:
+    (tmp_path / "decisions.md").write_text("**Status:** draft\n", encoding="utf-8")
+    phases = {p.name: p for p in _scan_spec_dir(tmp_path)}
+    assert phases["decisions"].exists and phases["decisions"].status == "draft"
+    assert phases["requirements"].exists is False
+    assert phases["requirements"].status is None
+
+
+def test_scan_spec_dir_unreadable_file_is_statusless(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An existing-but-unreadable phase file is reported exists=True, status=None."""
+    (tmp_path / "decisions.md").write_text("**Status:** draft\n", encoding="utf-8")
+
+    def boom(self: Path, *a: object, **k: object) -> str:
+        raise OSError("simulated unreadable file")
+
+    monkeypatch.setattr(Path, "read_text", boom)
+    decisions = next(p for p in _scan_spec_dir(tmp_path) if p.name == "decisions")
+    assert decisions.exists is True
+    assert decisions.status is None
+
+
+# --- _newest_md_mtime ------------------------------------------------------
+
+
+def test_newest_md_mtime_returns_iso(tmp_path: Path) -> None:
+    (tmp_path / "a.md").write_text("x", encoding="utf-8")
+    out = _newest_md_mtime(tmp_path)
+    assert out is not None and "T" in out  # ISO-8601
+
+
+def test_newest_md_mtime_no_md_files_returns_none(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("x", encoding="utf-8")
+    assert _newest_md_mtime(tmp_path) is None
+
+
+def test_newest_md_mtime_per_file_stat_oserror_is_skipped(tmp_path: Path) -> None:
+    """A single .md whose stat() raises (broken symlink) is skipped, not fatal.
+
+    glob yields the entry by name, then `md.stat()` follows the dangling
+    link and raises FileNotFoundError (an OSError) — the loop must `continue`
+    past it and still return the good file's mtime.
+    """
+    (tmp_path / "good.md").write_text("x", encoding="utf-8")
+    broken = tmp_path / "broken.md"
+    try:
+        broken.symlink_to(tmp_path / "nonexistent-target")
+    except (OSError, NotImplementedError):  # pragma: no cover - platform-dependent
+        pytest.skip("symlinks not supported on this platform")
+    # broken.md is skipped; good.md still yields a timestamp (no crash).
+    assert _newest_md_mtime(tmp_path) is not None
+
+
+def test_newest_md_mtime_glob_oserror_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(self: Path, *a: object, **k: object) -> object:
+        raise OSError("simulated glob failure")
+
+    monkeypatch.setattr(Path, "glob", boom)
+    assert _newest_md_mtime(tmp_path) is None
+
+
+# --- _list_specs_in_root ---------------------------------------------------
+
+
+def test_list_specs_in_root_missing_root_returns_empty(tmp_path: Path) -> None:
+    assert _list_specs_in_root(tmp_path / "does-not-exist") == []
+
+
+def test_list_specs_in_root_skips_nonspec_dirs_and_files(tmp_path: Path) -> None:
+    _make_spec(tmp_path, "real-spec")
+    (tmp_path / "loose-file.md").write_text("x", encoding="utf-8")  # a file, not a dir
+    nonspec = tmp_path / "not-a-spec"  # a dir with no recognized phase file
+    nonspec.mkdir()
+    (nonspec / "readme.txt").write_text("x", encoding="utf-8")
+    records = _list_specs_in_root(tmp_path)
+    assert [r.slug for r in records] == ["real-spec"]
+
+
+def test_list_specs_in_root_populates_record(tmp_path: Path) -> None:
+    _make_spec(tmp_path, "alpha", status="complete")
+    (rec,) = _list_specs_in_root(tmp_path)
+    assert rec.slug == "alpha"
+    assert rec.root == str(tmp_path)
+    assert rec.last_modified is not None
+    assert rec.lifecycle  # computed in __post_init__
+
+
+# --- _resolved_roots -------------------------------------------------------
+
+
+def test_resolved_roots_defaults_to_docs_specs(tmp_path: Path) -> None:
+    cfg = type("C", (), {"project_root": tmp_path, "specs_roots": ()})()
+    assert _resolved_roots(cfg) == [(tmp_path / "docs" / "specs").resolve()]
+
+
+def test_resolved_roots_uses_configured(tmp_path: Path) -> None:
+    cfg = type(
+        "C", (), {"project_root": tmp_path, "specs_roots": (tmp_path / "a", tmp_path / "b")}
+    )()
+    assert _resolved_roots(cfg) == [(tmp_path / "a").resolve(), (tmp_path / "b").resolve()]
+
+
+# --- SpecRecord lifecycle --------------------------------------------------
+
+
+def test_spec_record_computes_lifecycle() -> None:
+    rec = SpecRecord(
+        slug="x",
+        root="/r",
+        path="/r/x",
+        phases=[SpecPhase(name="tasks", file="tasks.md", exists=True, status="complete")],
+        last_modified=None,
+    )
+    assert isinstance(rec.lifecycle, str) and rec.lifecycle

--- a/tests/unit/test_base_cli_imports_without_ops_extra.py
+++ b/tests/unit/test_base_cli_imports_without_ops_extra.py
@@ -1,0 +1,83 @@
+"""Regression guard: the base CLI must import without the `[ops]` extra.
+
+A default ``pip install attune-ai`` does NOT install the `[ops]` extra
+(fastapi / uvicorn / jinja2). The base ``attune`` CLI must therefore
+import and run without fastapi present.
+
+This regressed silently before 8.6.0: ``attune.cli_minimal`` ->
+``attune.cli_commands.curator`` -> ``attune.curator.sources.specs``
+imported ``SpecRecord`` / ``_list_specs_in_root`` from the FastAPI web
+route module ``attune.ops.routes.specs``, so ``attune --help`` crashed
+with ``ModuleNotFoundError: No module named 'fastapi'`` on every default
+install. CI never caught it because CI always installs the dev/ops
+extras (fastapi is present), so the pure unit suite imported fine.
+
+The fix moved the pure spec-listing data layer to the framework-free
+``attune.ops.specs_data`` module. These tests simulate the
+no-``[ops]``-extra environment by blocking ``fastapi`` at import time in
+a subprocess (a subprocess so the block can't leak into the rest of the
+suite, where fastapi is legitimately installed).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+# Imports that MUST succeed in a default (no-[ops]) install.
+_BASE_IMPORTS = (
+    "import attune.cli_minimal",
+    "import attune.curator.sources.specs",
+    "from attune.ops.specs_data import SpecRecord, _list_specs_in_root",
+)
+
+_BLOCK_FASTAPI = """
+import sys, importlib.abc
+
+class _FastapiBlocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path, target=None):
+        if name == "fastapi" or name.startswith("fastapi."):
+            raise ModuleNotFoundError("No module named 'fastapi' (simulated no-[ops] install)")
+        return None
+
+sys.meta_path.insert(0, _FastapiBlocker())
+"""
+
+
+def _run_with_fastapi_blocked(body: str) -> subprocess.CompletedProcess:
+    code = textwrap.dedent(_BLOCK_FASTAPI) + body + '\nprint("IMPORT_OK")\n'
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_fastapi_is_actually_blocked() -> None:
+    """Sanity-check the blocker: `import fastapi` must fail under it."""
+    result = _run_with_fastapi_blocked("import fastapi")
+    assert result.returncode != 0
+    assert "fastapi" in result.stderr
+
+
+def test_base_cli_imports_without_fastapi() -> None:
+    """`attune.cli_minimal` and the curator spec source import with no fastapi."""
+    result = _run_with_fastapi_blocked("\n".join(_BASE_IMPORTS))
+    assert result.returncode == 0, (
+        "The base CLI failed to import without the [ops] extra (fastapi). "
+        "A base-CLI import path is pulling in fastapi again.\n\n"
+        f"STDERR:\n{result.stderr}"
+    )
+    assert "IMPORT_OK" in result.stdout
+
+
+def test_specs_data_is_framework_free() -> None:
+    """attune.ops.specs_data must not transitively import fastapi."""
+    result = _run_with_fastapi_blocked(
+        "from attune.ops import specs_data\n"
+        "r = specs_data._resolved_roots(type('C', (), {'specs_roots': (), 'project_root': __import__('pathlib').Path('.')})())\n"
+        "assert isinstance(r, list)"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "IMPORT_OK" in result.stdout


### PR DESCRIPTION
## The bug (release-blocking for 8.6.0)

`pip install attune-ai` **without** the `[ops]` extra installs no
fastapi, yet the base `attune` CLI imported it transitively and
**crashed on startup**:

```
$ attune --help
ModuleNotFoundError: No module named 'fastapi'
```

Import chain: `cli_minimal` → `cli_commands.curator` →
`curator.sources.specs` imported `SpecRecord` / `_list_specs_in_root`
from the FastAPI web-route module `attune.ops.routes.specs`.

**Pre-existing since #485** — published **8.5.0 has the identical
crash**. CI never caught it because CI always installs dev/ops extras
(fastapi present). Caught by a clean-venv `attune --help` smoke of the
shipped wheel during 8.6.0 release QA — the "dogfood the artifact"
discipline.

## Fix

Extract the pure, framework-free spec-listing data layer (`SpecPhase`,
`SpecRecord`, `_list_specs_in_root`, helpers) into a new
**`attune.ops.specs_data`** module. `routes/specs.py` re-exports the
names (dashboard route + all existing tests unchanged); the curator
imports from `specs_data`, so the base CLI no longer touches fastapi.

## Regression guard

`tests/unit/test_base_cli_imports_without_ops_extra.py` imports
`cli_minimal` + the curator spec source in a **subprocess with fastapi
blocked** — reproducing the no-`[ops]` environment CI's
extras-installed suite cannot.

## Verification

- Shipped **8.6.0 wheel** installed in a clean **fastapi-free** venv →
  `attune --help` exits 0; `attune version` → `attune-ai 8.6.0`.
- Route re-exports still import with fastapi present (no web-layer
  regression).
- **163** affected tests pass (regression guard + route + completion-
  candidates + curator specs source).

Must land on `main` **before** tagging `v8.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)