### PR TITLE
feat(telemetry): first-run consent prompt for the usage ping (8.6.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.6.0"
+    "version": "8.6.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.6.0
+# Attune AI Framework v8.6.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.6.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.6.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.6.1] — 2026-06-20
+
+### Added
+
+- **First-run consent prompt for anonymous usage sharing.** 8.6.0
+  shipped the opt-in usage ping but never *asked*, so realistically no
+  one turned it on. The CLI now asks once, on first interactive use:
+  whether to share anonymous usage (workflow names + version + OS +
+  Python). It is **default-No** and asks **only in an interactive
+  terminal** — it silently no-ops in CI, pipes, and scripts, and never
+  prompts when `DO_NOT_TRACK` or `ATTUNE_USAGE_PING` is set, or for the
+  `telemetry`/`setup`/`version`/`doctor`/`auth` commands. Either answer
+  is remembered, so it asks at most once. You can still manage it
+  anytime with `attune telemetry enable` / `disable`.
+
 ## [8.6.0] — 2026-06-20
 
 Usage signals come online, and the agent roster grows. The headline:

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.6.0
+**Version:** 8.6.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.6.0 | **License:** Apache 2.0
+**Version:** 8.6.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -396,3 +396,33 @@ keeping consent intact. Tracked as a Phase 2c follow-up, NOT bundled
 into the 8.6.0 release; the client ships default-OFF as already built.
 
 No copy changes needed — existing telemetry text remains accurate.
+
+## D11 — first-run consent prompt shipped (the D9 opt-in lever) (2026-06-20, 8.6.1)
+
+D9 kept the ping default-OFF and named a first-run consent prompt as the
+opt-in lever, deferred to a follow-up. After 8.6.0 shipped the client,
+the gap was concrete: nothing *asked*, so opt-in ≈ 0 (users won't run
+`attune telemetry enable` for a feature they were never told about).
+
+**Shipped in 8.6.1:** `usage_ping.maybe_prompt_consent()`, called from
+`cli_minimal.main()` before dispatch. It asks once, default-No. Design:
+
+- **Interactive only.** Gated on `sys.stdin.isatty() AND sys.stdout.isatty()`
+  (`_is_interactive`) — never hangs or nags CI / pipes / scripts.
+- **Asks at most once.** Gated on `TelemetryConfig.usage_ping_consented`
+  (the field already existed). "Yes" → `enable()`; anything else →
+  `disable()`. Both set `consented=True`, so it never re-appears.
+- **Respects prior signals.** Skips entirely (and does NOT record
+  consent) when `DO_NOT_TRACK` or `ATTUNE_USAGE_PING` is set — those are
+  already an explicit choice.
+- **Skips meta commands** (`telemetry`/`setup`/`version`/`doctor`/`auth`)
+  so the prompt fires on real first use, not while managing telemetry.
+- **Transient skips don't burn the one-shot.** Non-interactive runs and
+  an aborted prompt (EOF/Ctrl-C) leave `consented=False`, so a later
+  interactive run can still ask.
+- **Best-effort.** Never raises into the CLI (config-load and persist
+  failures are swallowed) — and it's pure stdlib, so it stays out of the
+  [ops]/fastapi base-CLI crash class (#945).
+
+Default stays OFF; this only adds the *ask*. Wording reviewed and
+approved by Patrick. Remaining: Phase 2c Reach dashboard, R5/R6.

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.6.0"
+    "version": "8.6.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.6.0"
+__version__ = "8.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.6.0"
+version = "8.6.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -633,6 +633,13 @@ _SIMPLE_DISPATCH: dict[str, object] = {
     "memory-agent": cmd_memory_agent,
 }
 
+# Commands that should NOT trigger the first-run usage-ping consent prompt:
+# telemetry (the user is already managing it), plus meta/info/onboarding
+# commands where an unsolicited prompt would be intrusive.
+_CONSENT_SKIP_COMMANDS: frozenset[str] = frozenset(
+    {"telemetry", "setup", "version", "doctor", "auth"}
+)
+
 
 def _dispatch_subcommand(args, command: str) -> int:
     """Dispatch a command that has subcommands."""
@@ -688,6 +695,20 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.WARNING)
 
     command = args.command
+
+    # First-run, interactive-only consent prompt for the anonymous usage
+    # ping — the opt-in lever for usage-signals. Asks at most once; silently
+    # no-ops in CI/pipes and for meta commands (telemetry/setup/version/etc.).
+    # Best-effort: it must NEVER block or break the CLI.
+    if command not in _CONSENT_SKIP_COMMANDS:
+        try:
+            from attune.telemetry.usage_ping import maybe_prompt_consent
+
+            maybe_prompt_consent()
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: a telemetry prompt failure can't be allowed to
+            # take down a normal command.
+            logging.getLogger(__name__).debug("usage-ping consent prompt failed", exc_info=True)
 
     # Subcommand dispatch (workflow, telemetry, provider, auth, costs)
     if command in _SUBCOMMAND_DISPATCH:

--- a/src/attune/telemetry/usage_ping.py
+++ b/src/attune/telemetry/usage_ping.py
@@ -472,3 +472,105 @@ def reset_install_id(loader: Any = None) -> str:
     config.telemetry.install_id = new_install_id()
     loader.save(config, save_path)
     return config.telemetry.install_id
+
+
+# The one-time, interactive first-run consent notice. Kept verbatim so the
+# wording is reviewable in one place; printed only in an interactive
+# terminal (see :func:`maybe_prompt_consent`).
+_CONSENT_NOTICE = (
+    "\nattune-ai can share anonymous usage to help improve it — only which\n"
+    "workflows you run, plus the version, your OS, and Python version.\n"
+    "Never code, paths, prompts, or personal data. Off by default.\n\n"
+    "Enable anonymous usage sharing? [y/N]: "
+)
+
+
+def _is_interactive() -> bool:
+    """True only when BOTH stdin and stdout are real terminals.
+
+    Guards the consent prompt so it never hangs or nags a non-interactive
+    run (CI, pipes, scripts, redirected output).
+    """
+    try:
+        return bool(sys.stdin.isatty() and sys.stdout.isatty())
+    except (OSError, ValueError):  # closed/!detached streams
+        return False
+
+
+def maybe_prompt_consent(
+    loader: Any = None,
+    env: Mapping[str, str] | None = None,
+    *,
+    input_fn: Callable[[str], str] = input,
+) -> bool | None:
+    """Ask once, interactively, whether to enable the anonymous usage ping.
+
+    The opt-in lever for usage-signals: fires at most once per user
+    (gated on :attr:`TelemetryConfig.usage_ping_consented`), and only in
+    an interactive terminal where the user has not already expressed a
+    preference via ``DO_NOT_TRACK`` or ``ATTUNE_USAGE_PING``. "Yes" opts
+    in (minting an install id); anything else records an explicit opt-out.
+    Either answer sets ``usage_ping_consented`` so the prompt never
+    re-appears.
+
+    Best-effort and silent: it never raises into the caller and never
+    blocks a non-interactive run. When it skips for a *transient* reason
+    (non-interactive, ``DO_NOT_TRACK`` set, an aborted prompt) it does
+    NOT record consent, so a later interactive run can still ask.
+
+    Args:
+        loader: Optional config loader (tests inject one); defaults to the
+            user config at ``~/.attune/config.json``.
+        env: Environment mapping (defaults to ``os.environ``).
+        input_fn: Injectable input function (tests).
+
+    Returns:
+        True if the user opted in, False if they opted out, or None if no
+        prompt was shown (skipped).
+    """
+    env = os.environ if env is None else env
+
+    # An explicit env signal already settles it — never prompt over one.
+    dnt = env.get("DO_NOT_TRACK")
+    if dnt is not None and dnt.strip().lower() not in {"", "0", "false"}:
+        return None
+    if env.get("ATTUNE_USAGE_PING") is not None:
+        return None
+
+    if not _is_interactive():
+        return None
+
+    try:
+        cfg_loader, config, _ = _open_user_config(loader)
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: telemetry consent must never break the CLI. If the
+        # config can't be read, skip quietly (no consent recorded).
+        logger.debug("usage-ping: consent prompt skipped (config load failed)", exc_info=True)
+        return None
+
+    if config.telemetry.usage_ping_consented:
+        return None
+
+    try:
+        answer = input_fn(_CONSENT_NOTICE).strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        # Aborted prompt = "not now": do NOT record consent so a future
+        # interactive run can ask again.
+        print()
+        return None
+
+    try:
+        if answer in {"y", "yes"}:
+            enable(cfg_loader)
+            print(
+                "Thanks! Anonymous usage sharing is on. "
+                "Disable anytime with `attune telemetry disable`.\n"
+            )
+            return True
+        disable(cfg_loader)
+        print("No problem — staying off. " "Enable anytime with `attune telemetry enable`.\n")
+        return False
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: a persist failure must not crash the CLI.
+        logger.debug("usage-ping: consent prompt persist failed", exc_info=True)
+        return None

--- a/tests/unit/telemetry/test_usage_ping_consent.py
+++ b/tests/unit/telemetry/test_usage_ping_consent.py
@@ -1,0 +1,194 @@
+"""Tests for the first-run usage-ping consent prompt.
+
+`maybe_prompt_consent` is the opt-in lever for usage-signals: it asks
+once, interactively, default-No, and must never block or break the CLI
+in a non-interactive context.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.config.sections.telemetry import TelemetryConfig
+from attune.telemetry import usage_ping
+
+
+class _FakeConfig:
+    def __init__(self, telemetry: TelemetryConfig) -> None:
+        self.telemetry = telemetry
+
+
+class _FakeLoader:
+    def __init__(self, config: _FakeConfig) -> None:
+        self._config = config
+        self.saved = False
+
+    def load(self) -> _FakeConfig:
+        return self._config
+
+    def save(self, config: _FakeConfig, path: object = None) -> object:
+        self._config = config
+        self.saved = True
+        return path
+
+
+def _loader(**tele: object) -> _FakeLoader:
+    return _FakeLoader(_FakeConfig(TelemetryConfig(**tele)))
+
+
+class _FakeStream:
+    def __init__(self, tty: bool) -> None:
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+@pytest.fixture
+def tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force an interactive terminal for the prompt path."""
+    monkeypatch.setattr(usage_ping, "_is_interactive", lambda: True)
+
+
+# --- the prompt outcomes ---------------------------------------------------
+
+
+def test_yes_opts_in(tty: None) -> None:
+    loader = _loader()
+    result = usage_ping.maybe_prompt_consent(loader=loader, env={}, input_fn=lambda _p: "y")
+    tele = loader.load().telemetry
+    assert result is True
+    assert tele.usage_ping is True
+    assert tele.usage_ping_consented is True
+    assert tele.install_id  # an anonymous id was minted
+
+
+@pytest.mark.parametrize("answer", ["n", "no", "", "   ", "nope", "maybe"])
+def test_non_yes_opts_out_but_records_consent(tty: None, answer: str) -> None:
+    loader = _loader()
+    result = usage_ping.maybe_prompt_consent(loader=loader, env={}, input_fn=lambda _p: answer)
+    tele = loader.load().telemetry
+    assert result is False
+    assert tele.usage_ping is False
+    assert tele.usage_ping_consented is True  # so we never ask again
+
+
+def test_yes_is_case_insensitive(tty: None) -> None:
+    loader = _loader()
+    assert usage_ping.maybe_prompt_consent(loader=loader, env={}, input_fn=lambda _p: "  YES  ")
+
+
+# --- when it must NOT prompt ----------------------------------------------
+
+
+def test_already_consented_does_not_prompt(tty: None) -> None:
+    loader = _loader(usage_ping_consented=True)
+    calls: list[str] = []
+    result = usage_ping.maybe_prompt_consent(
+        loader=loader, env={}, input_fn=lambda p: calls.append(p) or "y"
+    )
+    assert result is None
+    assert calls == []  # input never called
+    assert loader.saved is False
+
+
+def test_non_interactive_does_not_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(usage_ping, "_is_interactive", lambda: False)
+    loader = _loader()
+    calls: list[str] = []
+    result = usage_ping.maybe_prompt_consent(
+        loader=loader, env={}, input_fn=lambda p: calls.append(p) or "y"
+    )
+    assert result is None
+    assert calls == []
+    # The one-shot is NOT burned — a later interactive run can still ask.
+    assert loader.load().telemetry.usage_ping_consented is False
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"DO_NOT_TRACK": "1"},
+        {"DO_NOT_TRACK": "true"},
+        {"ATTUNE_USAGE_PING": "0"},
+        {"ATTUNE_USAGE_PING": "1"},
+    ],
+)
+def test_env_signal_skips_prompt(tty: None, env: dict[str, str]) -> None:
+    loader = _loader()
+    calls: list[str] = []
+    result = usage_ping.maybe_prompt_consent(
+        loader=loader, env=env, input_fn=lambda p: calls.append(p) or "y"
+    )
+    assert result is None
+    assert calls == []
+    assert loader.load().telemetry.usage_ping_consented is False  # not recorded
+
+
+def test_do_not_track_falsey_still_prompts(tty: None) -> None:
+    """DO_NOT_TRACK=0 is treated as 'not set' — the prompt still fires."""
+    loader = _loader()
+    assert usage_ping.maybe_prompt_consent(
+        loader=loader, env={"DO_NOT_TRACK": "0"}, input_fn=lambda _p: "y"
+    )
+
+
+def test_aborted_prompt_records_no_consent(tty: None) -> None:
+    loader = _loader()
+
+    def abort(_p: str) -> str:
+        raise EOFError
+
+    result = usage_ping.maybe_prompt_consent(loader=loader, env={}, input_fn=abort)
+    assert result is None
+    # Aborting ("not now") must NOT burn the one-shot.
+    assert loader.load().telemetry.usage_ping_consented is False
+
+
+# --- _is_interactive -------------------------------------------------------
+
+
+def test_is_interactive_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin", _FakeStream(True))
+    monkeypatch.setattr("sys.stdout", _FakeStream(True))
+    assert usage_ping._is_interactive() is True
+
+
+def test_is_interactive_false_when_not_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdin", _FakeStream(True))
+    monkeypatch.setattr("sys.stdout", _FakeStream(False))
+    assert usage_ping._is_interactive() is False
+
+
+def test_is_interactive_false_on_closed_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Boom:
+        def isatty(self) -> bool:
+            raise ValueError("I/O operation on closed file")
+
+    monkeypatch.setattr("sys.stdin", _Boom())
+    monkeypatch.setattr("sys.stdout", _Boom())
+    assert usage_ping._is_interactive() is False
+
+
+# --- best-effort: never crashes the CLI -----------------------------------
+
+
+def test_config_load_failure_is_swallowed(tty: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the config can't be read, the prompt skips quietly (no raise)."""
+
+    def boom(_loader: object) -> object:
+        raise OSError("config unreadable")
+
+    monkeypatch.setattr(usage_ping, "_open_user_config", boom)
+    assert usage_ping.maybe_prompt_consent(env={}, input_fn=lambda _p: "y") is None
+
+
+def test_persist_failure_is_swallowed(tty: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failure while saving the choice must not crash the CLI."""
+
+    def boom(_loader: object = None) -> str:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(usage_ping, "enable", boom)
+    loader = _loader()
+    assert usage_ping.maybe_prompt_consent(loader=loader, env={}, input_fn=lambda _p: "y") is None

--- a/tests/unit/test_cli_minimal.py
+++ b/tests/unit/test_cli_minimal.py
@@ -363,3 +363,34 @@ class TestMainAuthRouting:
         with ctx:
             assert main(["auth", "setup"]) == 0
         mock_fn.assert_called_once()
+
+
+class TestMainConsentPrompt:
+    """main() fires the first-run usage-ping consent prompt (best-effort)."""
+
+    def test_prompt_invoked_for_non_meta_command(self) -> None:
+        ctx, mock_fn = _mock_simple("validate")
+        with ctx, patch("attune.telemetry.usage_ping.maybe_prompt_consent") as prompt:
+            assert main(["validate"]) == 0
+        prompt.assert_called_once()
+        mock_fn.assert_called_once()
+
+    def test_prompt_skipped_for_meta_command(self) -> None:
+        # "version" is in _CONSENT_SKIP_COMMANDS — no prompt.
+        ctx, mock_fn = _mock_simple("version")
+        with ctx, patch("attune.telemetry.usage_ping.maybe_prompt_consent") as prompt:
+            assert main(["version"]) == 0
+        prompt.assert_not_called()
+
+    def test_prompt_failure_never_breaks_the_cli(self) -> None:
+        # A raising consent prompt must be swallowed; the command still runs.
+        ctx, mock_fn = _mock_simple("validate")
+        with (
+            ctx,
+            patch(
+                "attune.telemetry.usage_ping.maybe_prompt_consent",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            assert main(["validate"]) == 0
+        mock_fn.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.6.0"
+version = "8.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Why

8.6.0 shipped the opt-in usage ping but **never asked** — so opt-in is
effectively 0 (nobody runs `attune telemetry enable` for a feature they
were never told about). This adds the **D9 lever**: a first-run consent
prompt. Default stays **OFF** — this only adds the *ask*.

## What

`usage_ping.maybe_prompt_consent()`, called from `cli_minimal.main()`
before dispatch. Asks once, **default-No**:

```
attune-ai can share anonymous usage to help improve it — only which
workflows you run, plus the version, your OS, and Python version.
Never code, paths, prompts, or personal data. Off by default.

Enable anonymous usage sharing? [y/N]:
```

Safety-critical behavior:
- **Interactive terminals only** (stdin AND stdout `isatty`) — never
  hangs or nags CI / pipes / scripts.
- **Asks at most once** (gated on the existing `usage_ping_consented`);
  either answer is remembered.
- **Skips** when `DO_NOT_TRACK` / `ATTUNE_USAGE_PING` is set, and for
  `telemetry`/`setup`/`version`/`doctor`/`auth`.
- **Transient skips don't burn the one-shot** (non-interactive, aborted
  prompt → can still ask later).
- **Best-effort**: never raises into the CLI; pure stdlib, so it stays
  out of the `[ops]`/fastapi base-CLI crash class (#945).

## Tests

`test_usage_ping_consent.py` — yes/no/Enter, case-insensitivity,
already-consented, non-interactive, `DO_NOT_TRACK`/env-override, abort,
`_is_interactive`, and the best-effort config-load/persist failure
paths. New code 100% covered. The no-`[ops]` import guard still passes.

Ships as **8.6.1** (version bump + CHANGELOG + uv.lock + usage-signals D11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)