### PR TITLE
ci: default-install smoke gate (base CLI must boot without extras)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -528,3 +528,29 @@ jobs:
       with:
         name: dist-packages
         path: dist/
+
+  default-install-smoke:
+    # REQUIRED gate. A default install (`pip install attune-ai`, no extras)
+    # must boot the base CLI. Catches the class of bug where the base CLI
+    # transitively imports an extras-only dependency (e.g. fastapi from the
+    # [ops] extra) and crashes on startup — invisible to the rest of the
+    # suite, which always installs the extras. 8.5.0 shipped exactly this
+    # (attune --help -> ModuleNotFoundError: fastapi). Self-contained (it
+    # builds its own wheel) so it never skips on an upstream failure — a
+    # skipped required check would block every merge.
+    name: default-install-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.11'
+
+    - name: Install build tooling
+      run: python -m pip install --upgrade pip build
+
+    - name: Smoke the default install (no extras)
+      run: bash scripts/smoke_default_install.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -548,6 +548,7 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install build tooling
       run: python -m pip install --upgrade pip build

--- a/scripts/smoke_default_install.sh
+++ b/scripts/smoke_default_install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Default-install smoke gate.
+#
+# The base `attune` CLI must boot under a DEFAULT install
+# (`pip install attune-ai`, with NO extras). This catches the class of
+# bug where the base CLI transitively imports an extras-only dependency
+# (e.g. fastapi from `[ops]`) and crashes on startup — invisible to the
+# normal test suite, which always installs the dev/ops extras.
+#
+# Concretely: 8.5.0 shipped with `attune --help` crashing with
+# `ModuleNotFoundError: No module named 'fastapi'` on every default
+# install, because a base-CLI import path pulled a symbol from the
+# FastAPI web-route module. CI never saw it (fastapi was always present).
+# This gate reproduces the real default-install environment and boots the
+# CLI, so that class can never ship again.
+#
+# Usage:
+#   scripts/smoke_default_install.sh [path/to/attune_ai-*.whl]
+#
+# With no argument it builds a wheel from the repo (requires `build`).
+# In CI, pass the wheel already produced by the `build` job.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+WHEEL="${1:-}"
+if [[ -z "$WHEEL" ]]; then
+  echo "== no wheel given — building one from the repo =="
+  python -m build --wheel --outdir "$WORK/dist" "$ROOT"
+  WHEEL="$(ls "$WORK"/dist/*.whl | head -n1)"
+fi
+echo "== wheel under test: $WHEEL =="
+
+echo "== creating a fresh venv and BARE-installing (no extras) =="
+python -m venv "$WORK/venv"
+VPY="$WORK/venv/bin/python"
+"$VPY" -m pip install --quiet --upgrade pip
+"$VPY" -m pip install --quiet "$WHEEL"
+
+echo "== sanity: confirm this is a true default install (extras absent) =="
+"$VPY" - <<'PY'
+import importlib.util
+import sys
+
+# fastapi belongs to the [ops] extra and is the marker for the web stack —
+# it is exactly what the base CLI must NOT need. If a CORE dependency ever
+# pulls it in transitively, this smoke would be testing the wrong thing
+# (the original bug would pass), so fail loudly. (uvicorn is intentionally
+# NOT checked: it is a core transitive dependency, present in every install.)
+if importlib.util.find_spec("fastapi") is not None:
+    sys.exit("ERROR: fastapi present in a bare install — not a clean default env (the [ops] gate is meaningless)")
+print("confirmed: fastapi (the [ops] web stack) is absent — true default install")
+PY
+
+echo "== smoke: the base CLI must boot without extras =="
+ATTUNE="$WORK/venv/bin/attune"
+"$ATTUNE" --help >/dev/null
+"$ATTUNE" version
+
+echo "PASS: default-install CLI boots without extras"


### PR DESCRIPTION
## Why

The systemic fix behind the 8.5.0/8.6.0 base-CLI crash. CI always
installs the dev/ops extras, so `fastapi` (an `[ops]` dep) imported
transitively by the base CLI was **invisible** — `pip install attune-ai
&& attune --help` crashed for every default user since #485, across
multiple releases, with the whole suite green. #945 fixed the bug; this
prevents the *class*.

## What

A `default-install-smoke` job that:
1. Builds the wheel
2. Installs it **bare** in a fresh venv (no extras)
3. Asserts `fastapi` is absent (true default env)
4. Boots `attune --help` + `attune version`

**Self-contained** (builds its own wheel, no `needs`) so it never
*skips* on an upstream failure — required because a skipped required
check blocks merges.

`scripts/smoke_default_install.sh` is also runnable locally during
release prep (it's what caught the 8.6.0 crash by hand).

## Follow-up (after merge)

Add `default-install-smoke` to branch-protection `required_status_checks`
so the class can never ship again — not just advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)