### PR TITLE
release: 8.6.2 — plugin/MCP consent-notice hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.6.1"
+    "version": "8.6.2"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.6.1",
+      "version": "8.6.2",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.6.1
+# Attune AI Framework v8.6.2
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.6.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.6.2 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Consent ask now reaches the plugin/MCP channel.** The 8.6.1
+  first-run prompt fired only from the interactive `attune` CLI — but
+  most users reach attune through the Claude Code plugin and MCP tools,
+  which never hit that path while still recording local usage. A new
+  SessionStart hook (`usage_consent_notice.py`) closes that gap: it
+  surfaces a one-time notice asking Claude to put the choice to you via
+  the normal `AskUserQuestion` flow, then persists your answer with the
+  existing `attune telemetry enable` / `disable`. Still default-OFF,
+  silent once you've chosen, suppressed by `DO_NOT_TRACK` /
+  `ATTUNE_USAGE_PING`, disablable with `ATTUNE_CONSENT_NOTICE=0`, and
+  capped at 3 sessions so it never nags.
+
 ## [8.6.1] — 2026-06-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.6.2] — 2026-06-20
+
+Completes the consent story 8.6.1 started. 8.6.1 added the first-run
+ask but wired it only to the interactive CLI — the channel most users
+never touch. This patch extends the ask to the Claude Code plugin / MCP
+path, so the people actually generating usage data are the ones offered
+the choice. Default stays OFF.
+
 ### Added
 
 - **Consent ask now reaches the plugin/MCP channel.** The 8.6.1

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.6.1
+**Version:** 8.6.2
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.6.1 | **License:** Apache 2.0
+**Version:** 8.6.2 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -426,3 +426,39 @@ the gap was concrete: nothing *asked*, so opt-in ≈ 0 (users won't run
 
 Default stays OFF; this only adds the *ask*. Wording reviewed and
 approved by Patrick. Remaining: Phase 2c Reach dashboard, R5/R6.
+
+## D12 — consent ask also reaches the plugin/MCP channel (2026-06-20)
+
+D11's prompt fires only from `cli_minimal.main()` in an interactive
+terminal. But the dominant channel is the **Claude Code plugin + MCP
+tools**, which never call `main()` — yet their workflows still write
+local `usage.jsonl` records. So plugin users generate the data but were
+never offered the choice: the exact "nobody was ever told" gap D11 closed
+for the CLI persisted verbatim for the larger audience.
+
+**Constraint:** hooks run as piped subprocesses (no TTY) and the MCP
+server is a JSON-RPC stdio server, so neither can reuse D11's
+`input()`-based prompt — `_is_interactive()` would always skip.
+
+**Shipped:** a SessionStart hook `plugin/hooks/usage_consent_notice.py`
+that surfaces a short `## Anonymous usage sharing` block to context,
+asking **Claude** to put the choice to the user via `AskUserQuestion`
+(the Socratic surface D9 always intended). The user's answer is persisted
+by the existing `attune telemetry enable` / `disable` commands — no new
+persistence path. Design:
+
+- **Delegated ask, not a prompt.** The hook can't prompt; it instructs
+  Claude to ask. `AskUserQuestion` is the native conversational surface
+  and matches the project's core Socratic rule.
+- **Quiet by default.** Emits nothing once `usage_ping_consented` is set
+  (opt-in OR opt-out), when `DO_NOT_TRACK`/`ATTUNE_USAGE_PING` is set,
+  on the `compact` source, or when `ATTUNE_CONSENT_NOTICE` is falsey.
+- **Anti-nag cap.** A `~/.attune/telemetry/.consent_notice_count` marker
+  caps the notice at 3 sessions, so an ignored ask stops nagging instead
+  of reappearing forever. Consent itself still lives only in the config.
+- **Best-effort, pure stdlib.** Reads `~/.attune/config.json` directly;
+  never raises into the session; carries the `_sdk_gate` so it never
+  poisons SDK-subprocess streams.
+
+Default stays OFF; this only widens *where the ask reaches*. Remaining:
+Phase 2c Reach dashboard, R5/R6.

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.6.1"
+    "version": "8.6.2"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.6.1",
+      "version": "8.6.2",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.6.1",
+  "version": "8.6.2",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.6.1"
+__version__ = "8.6.2"

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -14,6 +14,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/usage_consent_notice.py",
+            "timeout": 2000
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/help_freshness_check.py",
             "timeout": 2000
           }

--- a/plugin/hooks/usage_consent_notice.py
+++ b/plugin/hooks/usage_consent_notice.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""SessionStart hook — surface the anonymous-usage consent ask once.
+
+The CLI consent prompt (``usage_ping.maybe_prompt_consent``) fires only
+from ``cli_minimal.main()`` in an interactive terminal. Plugin / MCP
+users — the dominant channel — never hit that path, yet their workflows
+still write local ``usage.jsonl`` records. So they generate the data but
+are never offered the choice to share it (the exact gap D11 closed for
+the CLI; see ``docs/specs/usage-signals/decisions.md`` D11/D12).
+
+Hooks run as piped subprocesses with no TTY, so this hook CANNOT prompt
+interactively. Instead it emits a short ``## Anonymous usage sharing``
+block to stdout (which Claude Code splices into the model's context)
+asking Claude to put the choice to the user via ``AskUserQuestion`` — the
+Socratic surface D9 always intended. The user's answer is persisted by
+the existing ``attune telemetry enable`` / ``disable`` commands.
+
+Quiet by design — emits nothing when:
+
+- the user has already chosen (``telemetry.usage_ping_consented`` True),
+- ``DO_NOT_TRACK`` or ``ATTUNE_USAGE_PING`` is set (an explicit signal),
+- the notice has already been shown ``_MAX_SHOWS`` times (anti-nag cap),
+- ``ATTUNE_CONSENT_NOTICE`` is ``0``/``false``/``no`` (hook opt-out), or
+- the SessionStart source is ``compact``.
+
+Never raises — a crash here must not break the session.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+for _stream in (sys.stdout, sys.stderr):
+    if _stream.encoding and _stream.encoding.lower() != "utf-8":
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+#: User config (opt-in state lives here, never a project-local config).
+CONFIG_PATH = Path("~/.attune/config.json").expanduser()
+
+#: Tracks how many times the notice has been surfaced, so an ignored ask
+#: stops nagging after a few sessions instead of every session forever.
+COUNT_PATH = Path("~/.attune/telemetry/.consent_notice_count").expanduser()
+
+#: Stop surfacing the notice after this many sessions without a choice.
+_MAX_SHOWS = 3
+
+_FALSEY = {"", "0", "false", "no"}
+
+_NOTICE = """\
+## Anonymous usage sharing (one-time setup)
+
+attune-ai can share **anonymous** usage to help improve it — only which
+workflows you run, plus the package version, your OS, and Python version.
+Never code, paths, prompts, filenames, or any personal data. It ships
+**OFF** and you have not chosen yet.
+
+ACTION FOR CLAUDE: At a natural break in this session, ask the user once
+via `AskUserQuestion` whether to enable anonymous usage sharing
+(recommend "No" as the safe default). Then persist their choice by
+running exactly one of:
+
+- Yes → `attune telemetry enable`
+- No  → `attune telemetry disable`
+
+Either command records the choice so this notice stops appearing. The
+user can also run `attune telemetry status` to audit the exact payload
+before deciding. Do not enable anything without an explicit "yes"."""
+
+
+def _enabled() -> bool:
+    """False when the hook is explicitly disabled via env."""
+    return os.environ.get("ATTUNE_CONSENT_NOTICE", "1").strip().lower() not in _FALSEY
+
+
+def _env_opt_out() -> bool:
+    """True when an env signal already settles consent — never ask over it."""
+    dnt = os.environ.get("DO_NOT_TRACK")
+    if dnt is not None and dnt.strip().lower() not in _FALSEY:
+        return True
+    return os.environ.get("ATTUNE_USAGE_PING") is not None
+
+
+def _already_consented() -> bool:
+    """True when the user has recorded a choice (opt-in OR opt-out).
+
+    A missing/unreadable config means no choice yet → eligible to ask.
+    """
+    try:
+        data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    tele = data.get("telemetry") if isinstance(data, dict) else None
+    return bool(isinstance(tele, dict) and tele.get("usage_ping_consented"))
+
+
+def _show_count() -> int:
+    """How many times the notice has been surfaced (0 if unknown)."""
+    try:
+        return int(COUNT_PATH.read_text(encoding="utf-8").strip() or "0")
+    except (OSError, ValueError):
+        return 0
+
+
+def _bump_count(current: int) -> None:
+    """Persist the incremented show count (best-effort)."""
+    try:
+        COUNT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        COUNT_PATH.write_text(str(current + 1), encoding="utf-8")
+    except OSError:
+        pass  # anti-nag is best-effort; a missed bump just shows once more
+
+
+def main() -> int:
+    try:
+        if not _enabled() or _env_opt_out():
+            return 0
+
+        try:
+            payload = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            payload = {}
+        if str(payload.get("source") or "startup").lower() == "compact":
+            return 0  # don't pile onto post-compact context
+
+        if _already_consented():
+            return 0
+
+        count = _show_count()
+        if count >= _MAX_SHOWS:
+            return 0
+
+        print(_NOTICE)
+        _bump_count(count)
+        return 0
+    except Exception:  # noqa: BLE001 — SessionStart hook must never crash a session
+        traceback.print_exc(file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.6.1"
+version = "8.6.2"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/tests/unit/hooks/test_usage_consent_notice.py
+++ b/tests/unit/hooks/test_usage_consent_notice.py
@@ -1,0 +1,152 @@
+"""Tests for usage_consent_notice.py SessionStart hook.
+
+Covers:
+
+- Emits the notice when no choice recorded and no env opt-out
+- No-op when the user has already consented (opt-in OR opt-out)
+- No-op when DO_NOT_TRACK / ATTUNE_USAGE_PING is set
+- No-op when the hook is disabled via ATTUNE_CONSENT_NOTICE=0
+- No-op on the post-compact SessionStart source
+- Anti-nag cap: stops after _MAX_SHOWS and bumps the count each emit
+- Missing/unreadable config counts as "no choice yet" (eligible)
+- Hook never raises (script-level catch-all)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
+
+
+def _load_module(name: str):
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    if name in sys.modules:
+        del sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _HOOKS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook(tmp_path, monkeypatch):
+    """Load the hook with config + count paths isolated to tmp_path and a
+    clean env (no opt-out/disable signals)."""
+    mod = _load_module("usage_consent_notice")
+    monkeypatch.setattr(mod, "CONFIG_PATH", tmp_path / "config.json")
+    monkeypatch.setattr(mod, "COUNT_PATH", tmp_path / "telemetry" / ".consent_notice_count")
+    for var in ("DO_NOT_TRACK", "ATTUNE_USAGE_PING", "ATTUNE_CONSENT_NOTICE"):
+        monkeypatch.delenv(var, raising=False)
+    return mod
+
+
+def _write_config(mod, *, consented: bool) -> None:
+    mod.CONFIG_PATH.write_text(
+        json.dumps({"telemetry": {"usage_ping_consented": consented}}), encoding="utf-8"
+    )
+
+
+def _run(mod, monkeypatch, capsys, payload: dict | None = None) -> tuple[int, str]:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload or {})))
+    rc = mod.main()
+    return rc, capsys.readouterr().out
+
+
+class TestEmits:
+    def test_emits_when_no_choice_and_no_optout(self, hook, monkeypatch, capsys):
+        # No config file at all = no choice yet.
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert "Anonymous usage sharing" in out
+        assert "AskUserQuestion" in out
+        assert "attune telemetry enable" in out
+
+    def test_emits_when_consented_false(self, hook, monkeypatch, capsys):
+        _write_config(hook, consented=False)
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert "Anonymous usage sharing" in out
+
+    def test_emit_bumps_the_show_count(self, hook, monkeypatch, capsys):
+        _run(hook, monkeypatch, capsys)
+        assert hook.COUNT_PATH.read_text(encoding="utf-8").strip() == "1"
+
+
+class TestNoOp:
+    def test_silent_when_already_consented(self, hook, monkeypatch, capsys):
+        _write_config(hook, consented=True)
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert out == ""
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes"])
+    def test_silent_on_do_not_track(self, hook, monkeypatch, capsys, value):
+        monkeypatch.setenv("DO_NOT_TRACK", value)
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert out == ""
+
+    def test_silent_when_usage_ping_env_set(self, hook, monkeypatch, capsys):
+        # Any explicit value (even "0") is a choice — don't ask over it.
+        monkeypatch.setenv("ATTUNE_USAGE_PING", "0")
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert out == ""
+
+    @pytest.mark.parametrize("value", ["0", "false", "no"])
+    def test_silent_when_hook_disabled(self, hook, monkeypatch, capsys, value):
+        monkeypatch.setenv("ATTUNE_CONSENT_NOTICE", value)
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert out == ""
+
+    def test_silent_on_compact_source(self, hook, monkeypatch, capsys):
+        rc, out = _run(hook, monkeypatch, capsys, {"source": "compact"})
+        assert rc == 0
+        assert out == ""
+
+    def test_do_not_track_falsey_still_asks(self, hook, monkeypatch, capsys):
+        # DO_NOT_TRACK="0" is not an opt-out — the notice should still show.
+        monkeypatch.setenv("DO_NOT_TRACK", "0")
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert "Anonymous usage sharing" in out
+
+
+class TestAntiNagCap:
+    def test_silent_once_cap_reached(self, hook, monkeypatch, capsys):
+        hook.COUNT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        hook.COUNT_PATH.write_text(str(hook._MAX_SHOWS), encoding="utf-8")
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert out == ""
+
+    def test_shows_exactly_max_times(self, hook, monkeypatch, capsys):
+        shows = 0
+        for _ in range(hook._MAX_SHOWS + 2):
+            _, out = _run(hook, monkeypatch, capsys)
+            if "Anonymous usage sharing" in out:
+                shows += 1
+        assert shows == hook._MAX_SHOWS
+
+
+class TestRobustness:
+    def test_unreadable_config_is_eligible(self, hook, monkeypatch, capsys):
+        hook.CONFIG_PATH.write_text("{ not valid json", encoding="utf-8")
+        rc, out = _run(hook, monkeypatch, capsys)
+        assert rc == 0
+        assert "Anonymous usage sharing" in out
+
+    def test_never_raises_on_bad_stdin(self, hook, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("not json at all"))
+        rc = hook.main()
+        assert rc == 0

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.6.1"
+version = "8.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 8.6.2 (patch)

Bundles the plugin/MCP consent-notice hook **and** the version bump in
one PR. Bumps all version sites `8.6.1 -> 8.6.2`, promotes the changelog.

### Why this ships as a patch

8.6.1 added the first-run consent prompt but wired it only to the
interactive `attune` CLI — the channel most users never touch. This
patch extends the ask to the Claude Code plugin / MCP path, so the
people actually generating usage data are the ones offered the choice.
Same 8.6.x consent-UX line; default stays OFF.

## What's in it

A SessionStart hook, `plugin/hooks/usage_consent_notice.py`. Hooks have
no TTY, so it can't reuse the CLI's `input()` prompt. Instead it injects
a short `## Anonymous usage sharing` block into context asking Claude to
put the choice to the user via `AskUserQuestion`. The answer is persisted
by the existing `attune telemetry enable` / `disable` — no new
persistence path.

Quiet by default — emits nothing when already chosen, on
`DO_NOT_TRACK` / `ATTUNE_USAGE_PING`, on the `compact` source, when
`ATTUNE_CONSENT_NOTICE` is falsey, or after a 3-session anti-nag cap.
Pure stdlib, never raises, carries `_sdk_gate`.

## Caveat

The hook can't prompt — it asks Claude to ask. The ask therefore depends
on the model acting on injected context, softer than the CLI's direct
prompt. The cap assumes it usually fires on session 1.

## Verification

- 17 new unit tests; full hooks suite **461 passed**
- SDK-gate enforcement + plugin-config validation: **58 passed**
- Version-drift backstop (`test_all_versions_match`): **passed**
- Live subprocess dogfood: SDK-gate / `DO_NOT_TRACK` / disabled all
  exit 0 silent
- ruff + black + bandit + detect-secrets clean (pre-commit)

Decision recorded as **D12** in `docs/specs/usage-signals/decisions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
