### PR TITLE
feat(ops): R6 spend alarm — daily anomaly + ceiling gauge (usage-signals)

### DIFF
--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -1,6 +1,6 @@
 # Usage Signals — Decisions
 
-**Status:** Phase 2b implemented (2026-06-16) — pending deploy/migration ·
+**Status:** R6 spend alarm shipped (2026-06-20) · Phase 2b live (D8) ·
 Phase 2 scoped (2026-06-15) · Phase 0 complete (2026-06-11)
 
 ## D1 — Phase 0 baseline snapshot (2026-06-11)
@@ -462,3 +462,48 @@ persistence path. Design:
 
 Default stays OFF; this only widens *where the ask reaches*. Remaining:
 Phase 2c Reach dashboard, R5/R6.
+
+## D13 — R6 spend alarm shipped (2026-06-20)
+
+R6 ("the $1,200-night class of event must be visible within a day") is
+implemented and surfacing on the ops dashboard home page. New code in
+`src/attune/ops/data.py`: a pure `spend_alarm()` verdict, a
+`read_daily_spend()` local reader, and a `build_spend_alarm()` source
+selector; an "API spend watch" panel in `home.html` (CSS in `main.css`);
+wired into the home route. Tests: `tests/unit/ops/test_spend_alarm.py`
+(18 tests, full ops suite green).
+
+**Two triggers, either raises the alarm:**
+
+1. **Daily anomaly** vs a trailing baseline of prior *active* (non-zero)
+   days — comparing today against a typical *active* day, not against
+   quiet days whose zeros would make any normal day look anomalous.
+   - `stddev > 0` → z-score; flag at `z >= 3.0`.
+   - **`stddev == 0` (flat history) → the spec's explicit multiplier
+     fallback:** flag when `today > baseline_mean * 3`. A variance-free
+     baseline yields no z-score, so the multiplier stands in. Below
+     3 active prior days → `insufficient_data` (anomaly judgment skipped;
+     the panel still shows today + the ceiling gauge).
+2. **Ceiling approach** — month-to-date `>= 80%` of the `$350` monthly
+   API ceiling (org 7edead08; see the `user_monthly_spend_budget`
+   memory). Fires independently of baseline history, so it makes
+   "approach to the cap" visible even on a fresh install.
+
+**Source precedence — a deliberate refinement of the task's named
+source.** The session brief pointed at local `usage.jsonl` (the
+`scripts/ci_report_api_cost.py` cost field, bucketed by `ts`). But the
+$1,200 burn lived on **CI**, whose spend never reaches Patrick's local
+`usage.jsonl` (confirmed: local telemetry showed only ~$126/mo that
+month). Building R6 *only* on local telemetry would be structurally blind
+to the exact event class R6 exists to catch. So `build_spend_alarm()`
+**prefers the account-level admin cost-report** (`anthropic_cost.py`'s
+`by_day` + `month_to_date_usd`, already fetched on the home route — no
+extra API call), which captures everything billed to the org including
+CI, and falls back to local `usage.jsonl` (the named source) when no
+admin key is configured. The verdict carries `source` ("account" /
+"local") and the panel says so; the local path appends a "CI spend not
+counted" note so the blind spot is explicit, not silent.
+
+The `ts`-not-`timestamp` field discipline (the #867 bug that made Home
+read zero) is honored in `read_daily_spend()` with a `timestamp` legacy
+fallback. Remaining: Phase 2c Reach dashboard, R5 telemetry watchdog.

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -10,6 +10,7 @@ import contextlib
 import heapq
 import json
 import logging
+import statistics
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -936,6 +937,273 @@ def read_telemetry_summary(
         by_day=recent_days_data,
         last_event_at=last_event_at,
     )
+
+
+# ---------------------------------------------------------------------------
+# Spend anomaly alarm — R6 of docs/specs/usage-signals/. Surfaces the
+# "$1,200-night" class of event within a day. See decisions.md D13.
+# ---------------------------------------------------------------------------
+
+# The z-score bar (3.0) is the textbook outlier threshold. The flat-history
+# multiplier (3x) is the spec's explicit fallback for the stddev == 0 case:
+# a baseline with no variance can't yield a z-score, so "today is >= 3x the
+# flat baseline" stands in. The monthly ceiling + 80% alert fraction mirror
+# the Anthropic Console spend limit Patrick set on org 7edead08 ($350/mo
+# hard cap, alert at $280) — see the user_monthly_spend_budget memory.
+SPEND_Z_THRESHOLD = 3.0
+SPEND_FLAT_MULTIPLIER = 3.0
+SPEND_MIN_BASELINE_DAYS = 3
+MONTHLY_API_CEILING_USD = 350.0
+CEILING_ALERT_FRACTION = 0.8
+
+
+@dataclass(frozen=True)
+class SpendAlarm:
+    """Daily API-spend anomaly verdict for the dashboard (R6)."""
+
+    level: str  # "ok" | "alarm" | "insufficient_data"
+    triggered_by: tuple[str, ...]  # subset of {"daily_anomaly", "ceiling"}
+    today_cost: float
+    baseline_mean: float
+    baseline_days: int
+    method: str  # "zscore" | "multiplier" | "none"
+    z_score: float | None
+    month_to_date: float
+    monthly_ceiling: float
+    ceiling_pct: float
+    source: str  # "account" | "local"
+    detail: str  # one-line human explanation
+
+
+def spend_alarm(
+    daily: dict[str, float],
+    *,
+    today: date | None = None,
+    monthly_ceiling: float = MONTHLY_API_CEILING_USD,
+    ceiling_fraction: float = CEILING_ALERT_FRACTION,
+    z_threshold: float = SPEND_Z_THRESHOLD,
+    flat_multiplier: float = SPEND_FLAT_MULTIPLIER,
+    min_baseline_days: int = SPEND_MIN_BASELINE_DAYS,
+    source: str = "local",
+    month_to_date: float | None = None,
+) -> SpendAlarm:
+    """Flag anomalous daily API spend and approach to the monthly ceiling.
+
+    ``daily`` maps ``YYYY-MM-DD`` -> total USD cost for that day. The
+    function is source-agnostic: pass account-level buckets (preferred —
+    they see CI spend) or local ``usage.jsonl`` buckets.
+
+    Two independent triggers raise ``level == "alarm"``:
+
+    1. **Daily anomaly.** Today's spend is an outlier versus the trailing
+       baseline of prior *active* (non-zero) days:
+
+       - ``stddev > 0`` -> z-score; flag when ``z >= z_threshold``.
+       - **``stddev == 0`` (flat history)** -> the spec's explicit
+         fallback: flag when ``today > baseline_mean * flat_multiplier``.
+         A variance-free baseline yields no z-score, so the multiplier
+         stands in. This is the branch the $1,200-night needs when the
+         prior days are all-equal (or there is a single repeated value).
+
+    2. **Ceiling approach.** Month-to-date spend ``>= ceiling_fraction``
+       of the monthly ceiling (default 80% of $350). Fires independently
+       of the baseline, so even a fresh install with no history alarms
+       when month-to-date is already near the cap.
+
+    The baseline excludes today and zero-cost days, so a normal active
+    day isn't flagged against a baseline diluted by quiet (zero) days.
+    Fewer than ``min_baseline_days`` active prior days -> the daily-anomaly
+    check is skipped (``level == "insufficient_data"`` unless the ceiling
+    trigger fires); the panel still shows today's number and the gauge.
+
+    Args:
+        daily: Day (``YYYY-MM-DD``) -> total USD cost.
+        today: Reference date (UTC). Defaults to the current UTC date;
+            a test injection point mirroring ``read_telemetry_summary``.
+        monthly_ceiling: Monthly API spend cap in USD.
+        ceiling_fraction: Fraction of the ceiling that trips the alarm.
+        z_threshold: Z-score at/above which today is anomalous.
+        flat_multiplier: Multiple of the flat baseline that trips the
+            stddev == 0 fallback.
+        min_baseline_days: Minimum prior active days to judge anomalies.
+        source: ``"account"`` (admin cost-report) or ``"local"``
+            (usage.jsonl). Annotates the verdict; ``"local"`` appends a
+            CI-blindness note to ``detail``.
+        month_to_date: Optional explicit month-to-date total. When given
+            (the admin cost-report computes the true full-month figure),
+            it overrides summing in-window days — the day window may not
+            reach the 1st of the month.
+
+    Returns:
+        A :class:`SpendAlarm`.
+    """
+    today = today or datetime.now(timezone.utc).date()
+    today_key = today.isoformat()
+    today_cost = round(float(daily.get(today_key, 0.0)), 4)
+
+    month_prefix = today_key[:7]
+    if month_to_date is None:
+        mtd = round(sum(c for d, c in daily.items() if d[:7] == month_prefix), 4)
+    else:
+        mtd = round(float(month_to_date), 4)
+    ceiling_pct = round(mtd / monthly_ceiling * 100, 1) if monthly_ceiling > 0 else 0.0
+    ceiling_hit = monthly_ceiling > 0 and mtd >= monthly_ceiling * ceiling_fraction
+
+    baseline = [c for d, c in daily.items() if d != today_key and c > 0]
+    baseline_days = len(baseline)
+    baseline_mean = round(statistics.fmean(baseline), 4) if baseline else 0.0
+
+    triggers: list[str] = []
+    method = "none"
+    z_score: float | None = None
+    detail_parts: list[str] = []
+
+    if baseline_days >= min_baseline_days:
+        stdev = statistics.stdev(baseline) if baseline_days >= 2 else 0.0
+        if stdev > 0:
+            method = "zscore"
+            z_score = round((today_cost - baseline_mean) / stdev, 2)
+            if z_score >= z_threshold:
+                triggers.append("daily_anomaly")
+                detail_parts.append(
+                    f"today ${today_cost:.2f} is {z_score:.1f}σ above the "
+                    f"${baseline_mean:.2f}/day baseline"
+                )
+        else:
+            # Flat history: no variance -> multiplier fallback (the
+            # explicit spec rule). baseline_mean > 0 here (non-zero days).
+            method = "multiplier"
+            if today_cost > baseline_mean * flat_multiplier:
+                triggers.append("daily_anomaly")
+                ratio = today_cost / baseline_mean if baseline_mean else float("inf")
+                detail_parts.append(
+                    f"today ${today_cost:.2f} is {ratio:.1f}x the flat "
+                    f"${baseline_mean:.2f}/day baseline (no variance)"
+                )
+
+    if ceiling_hit:
+        triggers.append("ceiling")
+        detail_parts.append(
+            f"month-to-date ${mtd:.0f} is {ceiling_pct:.0f}% of the "
+            f"${monthly_ceiling:.0f} ceiling"
+        )
+
+    if triggers:
+        level = "alarm"
+    elif baseline_days < min_baseline_days:
+        level = "insufficient_data"
+    else:
+        level = "ok"
+
+    if detail_parts:
+        detail = "; ".join(detail_parts)
+    elif level == "insufficient_data":
+        detail = (
+            f"only {baseline_days} prior active day(s) — need "
+            f"{min_baseline_days} to judge anomalies"
+        )
+    else:
+        detail = f"today ${today_cost:.2f} within normal range"
+    if source == "local":
+        detail += " (local telemetry only — CI spend not counted)"
+
+    return SpendAlarm(
+        level=level,
+        triggered_by=tuple(triggers),
+        today_cost=today_cost,
+        baseline_mean=baseline_mean,
+        baseline_days=baseline_days,
+        method=method,
+        z_score=z_score,
+        month_to_date=mtd,
+        monthly_ceiling=monthly_ceiling,
+        ceiling_pct=ceiling_pct,
+        source=source,
+        detail=detail,
+    )
+
+
+def read_daily_spend(
+    config: Config, *, days: int = 35, today: date | None = None
+) -> dict[str, float]:
+    """Daily API spend (USD) bucketed by ``ts`` from ``usage.jsonl``.
+
+    Returns ``{YYYY-MM-DD: total_cost}`` over the trailing ``days`` days
+    (UTC). The window defaults to 35 so the current calendar month is
+    always fully covered for the month-to-date gauge even at month-end.
+
+    Buckets by the ``ts`` key (v1.0 schema from
+    ``UsageTracker._format_entry``), with ``timestamp`` as a legacy
+    fallback — the same field discipline as :func:`read_telemetry_summary`.
+    Reading the wrong key is the #867 bug class that made Home read zero.
+
+    Never raises; a missing or unreadable file yields an empty dict.
+    """
+    path = config.telemetry_path
+    if not path.exists():
+        return {}
+    if today is None:
+        today = datetime.now(timezone.utc).date()
+    cutoff = today.toordinal() - days
+    out: dict[str, float] = defaultdict(float)
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event: dict[str, Any] = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts = str(event.get("ts") or event.get("timestamp") or "")
+                day = _to_day(ts)
+                if day is None:
+                    continue
+                ordinal = _ordinal(day)
+                if ordinal is None or ordinal < cutoff:
+                    continue
+                out[day] += float(event.get("total_cost", event.get("cost", 0.0)) or 0.0)
+    except OSError:
+        return {}
+    return {d: round(c, 4) for d, c in out.items()}
+
+
+def build_spend_alarm(
+    config: Config,
+    cost_summary: Any | None = None,
+    *,
+    today: date | None = None,
+) -> SpendAlarm:
+    """Assemble the spend alarm, preferring account-level spend.
+
+    Source precedence:
+
+    1. **Account-level** (Anthropic admin cost-report ``CostSummary``):
+       captures *everything billed to the org* — including CI, the surface
+       the 2026-06-10 ~$1,200 burn actually lived on. This is the source
+       R6's "$1,200-night must be visible within a day" requires; local
+       telemetry structurally can't see CI spend.
+    2. **Local fallback** (``usage.jsonl`` via :func:`read_daily_spend`)
+       when no admin key is configured or the fetch failed. Honest about
+       the blind spot via ``SpendAlarm.source == "local"``.
+
+    ``cost_summary`` is typed ``Any`` to avoid importing the optional
+    ``anthropic_cost`` module (which needs ``httpx``) at import time; the
+    caller passes the already-fetched summary from the home route, so no
+    extra API call is made.
+    """
+    by_day = getattr(cost_summary, "by_day", None)
+    if cost_summary is not None and by_day:
+        daily = {d.isoformat(): float(c) for d, c in by_day}
+        return spend_alarm(
+            daily,
+            today=today,
+            source="account",
+            month_to_date=cost_summary.month_to_date_usd,
+        )
+    daily = read_daily_spend(config, today=today)
+    return spend_alarm(daily, today=today, source="local")
 
 
 @dataclass(frozen=True)

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -74,6 +74,17 @@ async def home(request: Request) -> HTMLResponse:
         # never block the home page render on a billing-fetch surprise.
         logger.debug("anthropic_cost.fetch_summary raised", exc_info=True)
         cost_summary, cost_error = None, None
+    # Spend anomaly alarm (R6 of usage-signals). Prefers the account-level
+    # cost summary already fetched above (it sees CI spend, the surface the
+    # $1,200-night lived on); falls back to local usage.jsonl when no admin
+    # key is configured. Never raises — degrade to no panel on a surprise.
+    try:
+        spend = data.build_spend_alarm(cfg, cost_summary)
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: the alarm is a best-effort signal; never block the
+        # home render on an aggregation surprise.
+        logger.debug("data.build_spend_alarm raised", exc_info=True)
+        spend = None
     return _render(
         request,
         "home.html",
@@ -87,6 +98,7 @@ async def home(request: Request) -> HTMLResponse:
         attune_ai=attune_ai,
         cost_summary=cost_summary,
         cost_error=cost_error,
+        spend=spend,
     )
 
 

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -291,6 +291,64 @@ a.kpi:hover {
   border-left-color: var(--warn, #c87a00);
 }
 
+/* Spend alarm (R6 of usage-signals). A panel that flags anomalous daily
+   API spend + approach to the monthly ceiling. The left-edge accent
+   tracks the alarm level: ok (green) / alarm (red) / building baseline
+   (muted). */
+.spend-alarm {
+  border-left: 3px solid var(--border-strong);
+}
+.spend-alarm-ok {
+  border-left-color: var(--ok);
+}
+.spend-alarm-alarm {
+  border-left-color: var(--danger);
+  background: var(--danger-soft);
+}
+.spend-alarm-insufficient_data {
+  border-left-color: var(--fg-subtle);
+}
+.spend-alarm-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.spend-alarm-head h2 {
+  margin: 0;
+}
+.spend-alarm-detail {
+  margin: 8px 0 14px;
+  color: var(--fg-muted);
+}
+.spend-gauge-track {
+  height: 8px;
+  border-radius: 99px;
+  background: var(--bg-soft);
+  overflow: hidden;
+}
+.spend-gauge-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 99px;
+  transition: width 0.3s ease;
+}
+.spend-gauge-fill-hot {
+  background: var(--danger);
+}
+.spend-gauge-foot {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.spend-alarm-source {
+  margin: 12px 0 0;
+  font-size: 12px;
+  color: var(--fg-subtle);
+}
+
 /* ---------- Panels ---------- */
 
 .panel {

--- a/src/attune/ops/templates/home.html
+++ b/src/attune/ops/templates/home.html
@@ -83,6 +83,42 @@
   </section>
 {% endif %}
 
+{# Spend alarm (R6 of usage-signals). Daily API-spend anomaly + approach
+   to the monthly ceiling. ``spend.source`` is "account" (admin
+   cost-report — sees CI) or "local" (usage.jsonl, CI-blind). The panel's
+   accent follows ``spend.level``: ok / alarm / insufficient_data. #}
+{% if spend is not none %}
+  <section class="panel spend-alarm spend-alarm-{{ spend.level }}">
+    <div class="spend-alarm-head">
+      <h2>API spend watch</h2>
+      {% if spend.level == "alarm" %}
+        <span class="chip chip-danger">⚠ anomaly</span>
+      {% elif spend.level == "insufficient_data" %}
+        <span class="chip chip-muted">building baseline</span>
+      {% else %}
+        <span class="chip chip-ok">normal</span>
+      {% endif %}
+    </div>
+    <p class="spend-alarm-detail">{{ spend.detail }}</p>
+    <div class="spend-gauge" role="img"
+         aria-label="Month-to-date ${{ '%.0f'|format(spend.month_to_date) }} of ${{ '%.0f'|format(spend.monthly_ceiling) }} monthly ceiling ({{ '%.0f'|format(spend.ceiling_pct) }}%)">
+      <div class="spend-gauge-track">
+        {# Cap the visual fill at 100% so an over-ceiling month doesn't
+           overflow the bar; the numeric % below still shows the truth. #}
+        <div class="spend-gauge-fill{% if 'ceiling' in spend.triggered_by %} spend-gauge-fill-hot{% endif %}"
+             style="width: {{ [spend.ceiling_pct, 100]|min }}%;"></div>
+      </div>
+      <div class="spend-gauge-foot">
+        <span>${{ '%.2f'|format(spend.month_to_date) }} MTD</span>
+        <span>{{ '%.0f'|format(spend.ceiling_pct) }}% of ${{ '%.0f'|format(spend.monthly_ceiling) }}</span>
+      </div>
+    </div>
+    <p class="spend-alarm-source">
+      Source: {{ "Anthropic account billing (includes CI)" if spend.source == "account" else "local telemetry only — CI spend not counted" }}
+    </p>
+  </section>
+{% endif %}
+
 <section class="panel">
   <h2>Recent runs</h2>
   {% if recent_runs %}

--- a/tests/unit/ops/test_spend_alarm.py
+++ b/tests/unit/ops/test_spend_alarm.py
@@ -1,0 +1,310 @@
+"""Tests for the spend anomaly alarm — R6 of docs/specs/usage-signals/.
+
+Covers the pure :func:`spend_alarm` verdict (z-score path, the explicit
+flat-history/stddev==0 multiplier fallback, ceiling approach, insufficient
+data), the local :func:`read_daily_spend` ts-bucketing reader, the
+:func:`build_spend_alarm` source-precedence builder, and the home-page
+panel render.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+import pytest
+
+from attune.ops import data
+
+# --------------------------------------------------------------------------
+# spend_alarm — pure verdict
+# --------------------------------------------------------------------------
+
+TODAY = date(2026, 6, 20)
+
+
+def test_spend_alarm_zscore_flags_outlier():
+    """A spike many sigma above a varied baseline flags via z-score."""
+    daily = {
+        "2026-06-15": 4.0,
+        "2026-06-16": 6.0,
+        "2026-06-17": 5.0,
+        "2026-06-18": 7.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 1200.0,  # the $1,200-night
+    }
+    alarm = data.spend_alarm(daily, today=TODAY)
+    assert alarm.level == "alarm"
+    assert "daily_anomaly" in alarm.triggered_by
+    assert alarm.method == "zscore"
+    assert alarm.z_score is not None and alarm.z_score >= 3.0
+    assert alarm.today_cost == 1200.0
+
+
+def test_spend_alarm_zscore_normal_day_is_ok():
+    """A typical day within the varied baseline is ``ok``."""
+    daily = {
+        "2026-06-15": 4.0,
+        "2026-06-16": 6.0,
+        "2026-06-17": 5.0,
+        "2026-06-18": 7.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 6.0,
+    }
+    alarm = data.spend_alarm(daily, today=TODAY)
+    assert alarm.level == "ok"
+    assert alarm.triggered_by == ()
+    assert alarm.method == "zscore"
+
+
+def test_spend_alarm_flat_history_multiplier_flags():
+    """REQUIRED branch: stddev == 0 (all baseline days equal) falls back to
+    the multiplier rule. A z-score is undefined with zero variance, so
+    ``today > baseline_mean * flat_multiplier`` stands in."""
+    daily = {
+        "2026-06-17": 5.0,
+        "2026-06-18": 5.0,
+        "2026-06-19": 5.0,  # flat baseline, zero variance
+        "2026-06-20": 20.0,  # 4x the flat $5/day baseline (> 3x)
+    }
+    alarm = data.spend_alarm(daily, today=TODAY)
+    assert alarm.method == "multiplier"
+    assert alarm.level == "alarm"
+    assert "daily_anomaly" in alarm.triggered_by
+    assert alarm.z_score is None  # no z-score in the flat-history branch
+    assert "x the flat" in alarm.detail
+
+
+def test_spend_alarm_flat_history_within_multiplier_is_ok():
+    """Flat baseline, today below the multiplier threshold → ``ok``."""
+    daily = {
+        "2026-06-17": 5.0,
+        "2026-06-18": 5.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 10.0,  # 2x — under the 3x flat multiplier
+    }
+    alarm = data.spend_alarm(daily, today=TODAY)
+    assert alarm.method == "multiplier"
+    assert alarm.level == "ok"
+    assert alarm.triggered_by == ()
+
+
+def test_spend_alarm_insufficient_baseline():
+    """Fewer than min_baseline_days active prior days → no anomaly judgment."""
+    daily = {
+        "2026-06-19": 5.0,  # only one prior active day (< min 3)
+        "2026-06-20": 50.0,  # a spike, but kept under the ceiling
+    }
+    alarm = data.spend_alarm(daily, today=TODAY)
+    assert alarm.level == "insufficient_data"
+    assert alarm.method == "none"
+    assert "need 3" in alarm.detail
+
+
+def test_spend_alarm_ceiling_fires_without_baseline():
+    """The ceiling trigger is independent of baseline history: a fresh
+    install whose month-to-date already exceeds 80% of the ceiling alarms
+    even with insufficient daily history."""
+    daily = {"2026-06-20": 50.0}
+    alarm = data.spend_alarm(daily, today=TODAY, monthly_ceiling=350.0, month_to_date=300.0)
+    assert alarm.level == "alarm"
+    assert "ceiling" in alarm.triggered_by
+    assert "daily_anomaly" not in alarm.triggered_by
+    assert alarm.month_to_date == 300.0
+    assert alarm.ceiling_pct == pytest.approx(300.0 / 350.0 * 100, abs=0.1)
+
+
+def test_spend_alarm_ceiling_just_under_threshold_is_ok():
+    """Month-to-date below 80% of the ceiling does not trip the gauge."""
+    daily = {"2026-06-20": 10.0}
+    alarm = data.spend_alarm(daily, today=TODAY, monthly_ceiling=350.0, month_to_date=200.0)
+    # 200/350 ≈ 57% < 80% → no ceiling trigger (and no baseline → insufficient)
+    assert "ceiling" not in alarm.triggered_by
+    assert alarm.level == "insufficient_data"
+
+
+def test_spend_alarm_month_to_date_summed_from_window_when_not_given():
+    """Without an explicit month_to_date, MTD sums the current-month days
+    present in ``daily`` (the local-source path)."""
+    daily = {
+        "2026-05-31": 100.0,  # prior month — excluded from MTD
+        "2026-06-01": 10.0,
+        "2026-06-20": 5.0,
+    }
+    alarm = data.spend_alarm(daily, today=TODAY)
+    assert alarm.month_to_date == pytest.approx(15.0)
+
+
+def test_spend_alarm_local_source_notes_ci_blindness():
+    daily = {"2026-06-20": 1.0}
+    alarm = data.spend_alarm(daily, today=TODAY, source="local")
+    assert alarm.source == "local"
+    assert "CI spend not counted" in alarm.detail
+
+
+def test_spend_alarm_account_source_no_blindness_note():
+    daily = {"2026-06-20": 1.0}
+    alarm = data.spend_alarm(daily, today=TODAY, source="account")
+    assert alarm.source == "account"
+    assert "CI spend not counted" not in alarm.detail
+
+
+# --------------------------------------------------------------------------
+# read_daily_spend — local usage.jsonl reader
+# --------------------------------------------------------------------------
+
+
+def test_read_daily_spend_buckets_by_ts(tmp_path, monkeypatch):
+    """Events keyed by ``ts`` (v1.0 schema) bucket correctly — the field
+    discipline that keeps Home from reading zero (#867 class)."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "h"))
+    from attune.ops.config import build_config
+
+    home = tmp_path / "h"
+    (home / "telemetry").mkdir(parents=True)
+    (home / "telemetry" / "usage.jsonl").write_text(
+        '{"workflow": "x", "total_cost": 0.40, "ts": "2026-06-20T10:00:00+00:00"}\n'
+        '{"workflow": "y", "total_cost": 0.10, "ts": "2026-06-20T12:00:00+00:00"}\n'
+        '{"workflow": "z", "total_cost": 1.00, "ts": "2026-06-19T09:00:00+00:00"}\n',
+        encoding="utf-8",
+    )
+    cfg = build_config(project_root=tmp_path, trusted_hosts=("test",))
+    daily = data.read_daily_spend(cfg, today=TODAY)
+    assert daily["2026-06-20"] == pytest.approx(0.50)
+    assert daily["2026-06-19"] == pytest.approx(1.00)
+
+
+def test_read_daily_spend_legacy_timestamp_fallback(tmp_path, monkeypatch):
+    """Archived events using the legacy ``timestamp`` key still bucket."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "h"))
+    from attune.ops.config import build_config
+
+    home = tmp_path / "h"
+    (home / "telemetry").mkdir(parents=True)
+    (home / "telemetry" / "usage.jsonl").write_text(
+        '{"workflow": "x", "cost": 0.25, "timestamp": "2026-06-20T10:00:00+00:00"}\n',
+        encoding="utf-8",
+    )
+    cfg = build_config(project_root=tmp_path, trusted_hosts=("test",))
+    daily = data.read_daily_spend(cfg, today=TODAY)
+    assert daily["2026-06-20"] == pytest.approx(0.25)
+
+
+def test_read_daily_spend_window_excludes_old_events(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "h"))
+    from attune.ops.config import build_config
+
+    home = tmp_path / "h"
+    (home / "telemetry").mkdir(parents=True)
+    (home / "telemetry" / "usage.jsonl").write_text(
+        '{"total_cost": 1.0, "ts": "2026-06-20T10:00:00+00:00"}\n'
+        '{"total_cost": 9.0, "ts": "2026-01-01T10:00:00+00:00"}\n',  # far outside 35d
+        encoding="utf-8",
+    )
+    cfg = build_config(project_root=tmp_path, trusted_hosts=("test",))
+    daily = data.read_daily_spend(cfg, days=35, today=TODAY)
+    assert "2026-06-20" in daily
+    assert "2026-01-01" not in daily
+
+
+def test_read_daily_spend_missing_file_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "h"))
+    from attune.ops.config import build_config
+
+    cfg = build_config(project_root=tmp_path, trusted_hosts=("test",))
+    assert data.read_daily_spend(cfg, today=TODAY) == {}
+
+
+# --------------------------------------------------------------------------
+# build_spend_alarm — source precedence
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCostSummary:
+    by_day: list
+    month_to_date_usd: float
+
+
+def test_build_spend_alarm_prefers_account_source(tmp_path, monkeypatch):
+    """When a cost summary with by_day is present, the alarm uses the
+    account-level series (which sees CI) and reports source=account."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "h"))
+    from attune.ops.config import build_config
+
+    cfg = build_config(project_root=tmp_path, trusted_hosts=("test",))
+    summary = _FakeCostSummary(
+        by_day=[
+            (date(2026, 6, 17), 5.0),
+            (date(2026, 6, 18), 5.0),
+            (date(2026, 6, 19), 5.0),
+            (date(2026, 6, 20), 1200.0),
+        ],
+        month_to_date_usd=1300.0,
+    )
+    alarm = data.build_spend_alarm(cfg, summary, today=TODAY)
+    assert alarm.source == "account"
+    assert alarm.level == "alarm"
+    assert alarm.month_to_date == 1300.0  # from the summary, not summed window
+
+
+def test_build_spend_alarm_falls_back_to_local(tmp_path, monkeypatch):
+    """No cost summary → read local usage.jsonl, source=local."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "h"))
+    from attune.ops.config import build_config
+
+    home = tmp_path / "h"
+    (home / "telemetry").mkdir(parents=True)
+    (home / "telemetry" / "usage.jsonl").write_text(
+        '{"total_cost": 2.0, "ts": "2026-06-20T10:00:00+00:00"}\n',
+        encoding="utf-8",
+    )
+    cfg = build_config(project_root=tmp_path, trusted_hosts=("test",))
+    alarm = data.build_spend_alarm(cfg, None, today=TODAY)
+    assert alarm.source == "local"
+    assert alarm.today_cost == pytest.approx(2.0)
+
+
+def test_build_spend_alarm_empty_summary_falls_back_to_local(tmp_path, monkeypatch):
+    """A cost summary with an empty by_day still falls back to local."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "h"))
+    from attune.ops.config import build_config
+
+    cfg = build_config(project_root=tmp_path, trusted_hosts=("test",))
+    summary = _FakeCostSummary(by_day=[], month_to_date_usd=0.0)
+    alarm = data.build_spend_alarm(cfg, summary, today=TODAY)
+    assert alarm.source == "local"
+
+
+# --------------------------------------------------------------------------
+# Home page render
+# --------------------------------------------------------------------------
+
+
+def test_home_renders_spend_alarm_panel(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi")
+    pytest.importorskip("jinja2")
+    from fastapi.testclient import TestClient
+
+    from attune.ops.config import build_config
+    from attune.ops.server import create_app
+
+    home = tmp_path / "attune-home"
+    (home / "telemetry").mkdir(parents=True)
+    # A populated local log so the panel renders with real numbers (no
+    # admin key in the test env → local source).
+    from datetime import datetime, timezone
+
+    today = datetime.now(timezone.utc).date().isoformat()
+    (home / "telemetry" / "usage.jsonl").write_text(
+        f'{{"workflow": "x", "total_cost": 1.5, "ts": "{today}T10:00:00+00:00"}}\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ATTUNE_HOME", str(home))
+    config = build_config(project_root=tmp_path, trusted_hosts=("testserver", "test"))
+    app = create_app(config)
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert "API spend watch" in resp.text
+    assert "spend-alarm" in resp.text


### PR DESCRIPTION
## What

Implements **R6 (spend alarm)** of `docs/specs/usage-signals/` — a daily
API-spend anomaly check on the ops dashboard home page, so the
"$1,200-night" class of event is visible within a day, not a billing
cycle.

## How

- **`spend_alarm()`** (pure, in `ops/data.py`) — verdict over a
  `day -> cost` dict. Two independent triggers raise the alarm:
  1. **Daily anomaly** vs a trailing baseline of prior *active* (non-zero)
     days. `stddev > 0` → z-score (flag at `z >= 3.0`). **`stddev == 0`
     (flat history) → the spec's explicit multiplier fallback**: flag when
     `today > baseline_mean * 3`. < 3 active prior days → `insufficient_data`.
  2. **Ceiling approach** — month-to-date `>= 80%` of the `$350/mo` API
     ceiling (org `7edead08`), independent of baseline so it's visible
     even on a fresh install.
- **Source precedence** (`build_spend_alarm()`): prefers the account-level
  admin cost-report (`anthropic_cost.by_day` + `month_to_date_usd`,
  already fetched on the home route — **no extra API call**), which sees
  **CI spend** — the surface the $1,200 burn actually lived on. Falls back
  to local `usage.jsonl` (`read_daily_spend()`, bucketed by `ts` with a
  `timestamp` legacy fallback) when no admin key is configured. The local
  path is explicit about its CI blind spot.
- **"API spend watch" panel** in `home.html` + CSS; wired into the home
  route (best-effort — never blocks the render).

## Why account-first (refinement of the named source)

The session brief pointed at local `usage.jsonl`. But the $1,200 burn was
**CI spend**, which never reaches the local file (that month local
telemetry showed only ~$126). Building R6 only on local telemetry would be
structurally blind to the exact event class R6 exists to catch — so the
account-level cost-report is the primary source, local is the fallback.
Recorded as **D13** in `decisions.md`.

## Tests

- `tests/unit/ops/test_spend_alarm.py` — 18 tests incl. the required
  **`stddev == 0` flat-history branch**, z-score path, ceiling trigger,
  insufficient-data, `ts` bucketing + legacy fallback, source precedence,
  and home-page panel render.
- Full ops suite green: **1312 passed**.

Remaining in the spec: Phase 2c Reach dashboard, R5 telemetry watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
