### PR TITLE
chore: jit-recall T2.1 + spec housekeeping (website retire, usage-signals cleanup status)

### DIFF
--- a/docs/specs/just-in-time-recall/tasks.md
+++ b/docs/specs/just-in-time-recall/tasks.md
@@ -50,11 +50,14 @@ implementation past it until the injection mechanism is logged in
 
 ## Phase 2 — grow the map + tune cadence (deferred)
 
-- [ ] **T2.1** Add the next 2–3 highest-value slip-points (e.g. git push
+- [x] **T2.1** Add the next 2–3 highest-value slip-points (e.g. git push
   to a shared branch → fetch-first rule) once the proof case holds.
-  *(1 of 2-3 added 2026-06-10: `release-verify-merge-sha` on
-  `Bash`+`gh release create`, via the new `match_substring` filter —
-  broad tools MUST scope rules this way, drift-guarded in tests.)*
+  *(Done 2026-06-20: 3 corpus-backed `Bash` slip-points added —
+  `git-commit-verify-landed` (`git commit`), `admin-merge-verify-remote`
+  (`pr merge`), `rebase-resigns-gpg` (`rebase`) — each `match_substring`-
+  scoped and text-only (no dangling `lesson_ref`); +5 tests, live
+  round-trip dogfood confirmed. Earlier: `release-verify-merge-sha` on
+  `gh release create`, 2026-06-10.)*
 - [ ] **T2.2** Decide the surface-once vs decay question (D5) from proof-
   case evidence; implement decay only if once-per-session proves too
   sparse.

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -375,6 +375,18 @@ WHERE install_id IN (
 );
 ```
 
+**Cleanup status: PENDING (deferred 2026-06-20).** Attempted the
+console-only `DELETE` but the Neon SQL editor was not readily
+reachable — the store does not appear under the Vercel
+`empathy-framework` team's Storage tab, and console.neon.tech showed
+no projects (wrong Neon account). Since both rows are harmless and
+already excluded from every real query (`version <> '0.0.0-verify'`),
+chasing the right account was not worth the time. Cleanup deferred
+until console access is sorted. To finish: read the `DATABASE_URL`
+host in the website project's Vercel env (the `ep-*.neon.tech`
+endpoint identifies the project), sign into the Neon account that
+owns it, and run the two-row `DELETE` above.
+
 ## D9 — default stays OFF; first-run consent prompt is the opt-in lever (2026-06-20)
 
 Question raised at release time: to maximize signal, should the usage

--- a/docs/specs/website-update-dashboard-and-fold/decisions.md
+++ b/docs/specs/website-update-dashboard-and-fold/decisions.md
@@ -1,10 +1,39 @@
 # Decisions — Website update: dashboard maturity + fold-back
-**Status:** approved
+**Status:** RETIRED / superseded (2026-06-20)
 **Owner:** Patrick
 **Opened:** 2026-05-10
 **Companion specs:**
 - `~/attune-gui/specs/dashboard-quality-pass/` — engineering polish (sentence case, humanised timestamps, generic command result renderer, profile chip cleanup, sidecar reload-dir fix)
 - `~/attune-gui/specs/fold-attune-gui-into-attune-ai/` — packaging consolidation (`pip install attune-gui` → `pip install attune-ai[gui]`)
+
+---
+
+## RETIRED — 2026-06-20
+
+Retired by Patrick. The spec's framing went stale and parts already
+shipped; executing the task list would re-create existing files and
+chase a fold trigger that is now history.
+
+**Why retired:**
+
+- **Trigger is past.** Phase 2 was gated on "the day v7.0 lands."
+  attune-ai is now at **8.6.2** — that trigger is long gone, so the
+  two-phase pre-fold / post-fold structure no longer maps to reality.
+- **Foundation already exists.** `website/lib/install-command.ts`
+  (1.1.1), `website/lib/migration-banner.ts` (1.1.2), and
+  `website/app/migrate/page.tsx` (1.6.1) are already in the tree; the
+  FAQ already references `attune-gui`. The task list describes
+  creating files that are present.
+- **Web-surface ownership moved.** The spec targets
+  `smartaimemory.com`, but the web/docs surface is being consolidated
+  onto **attune-ai.dev** (see the attune-ai.dev consolidation plan).
+  Any remaining website work should be re-specced against that target,
+  not this one.
+
+**Not done, intentionally dropped:** the dedicated dashboard feature
+page (`website/app/dashboard/page.tsx`, tasks 1.2.x) was never built.
+If a dashboard marketing surface is still wanted, open a fresh, small
+spec scoped to attune-ai.dev rather than reviving this one.
 
 ---
 

--- a/docs/specs/website-update-dashboard-and-fold/design.md
+++ b/docs/specs/website-update-dashboard-and-fold/design.md
@@ -1,5 +1,5 @@
 # Design — Website update: dashboard maturity + fold-back
-**Status:** approved
+**Status:** RETIRED / superseded (2026-06-20) — see `decisions.md`.
 Technical shape, mitigations, and durable fixes. See `decisions.md` for context, `requirements.md` for user stories, `tasks.md` for the phase plan.
 
 ---

--- a/docs/specs/website-update-dashboard-and-fold/requirements.md
+++ b/docs/specs/website-update-dashboard-and-fold/requirements.md
@@ -1,5 +1,5 @@
 # Requirements — Website update: dashboard maturity + fold-back
-**Status:** approved
+**Status:** RETIRED / superseded (2026-06-20) — see `decisions.md`.
 User-facing stories and contracts. See `decisions.md` for context, `design.md` for mitigations, `tasks.md` for the phase plan.
 
 ---

--- a/docs/specs/website-update-dashboard-and-fold/tasks.md
+++ b/docs/specs/website-update-dashboard-and-fold/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Website update: dashboard maturity + fold-back
 
-**Status:** approved — pre-Phase-1 audit done 2026-05-12 ([phase0-audit.md](phase0-audit.md))
+**Status:** RETIRED / superseded (2026-06-20) — see `decisions.md`. Do not execute this task list; its premises are stale.
 
 Two-phase plan. Phase 1 ships everything that doesn't depend on the fold-back; Phase 2 swaps install commands + adds redirects + automated screenshots once the fold lands. See `decisions.md`, `requirements.md`, `design.md` for context, and `phase0-audit.md` for the current-state inventory + three implementation nuances the spec didn't flag (narrow `pip install` replacement scope, dashboard-mention reuse on homepage, changelog lives in root `CHANGELOG.md`).
 

--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -65,5 +65,44 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
                 "FULL 40-char merge SHA via --target, never a branch name."
             ),
         },
+        # Commit-didn't-land dance (T2.1, added 2026-06-20): pre-commit
+        # auto-fixers re-stage files and `commit -q` can exit 0 yet skip
+        # the commit — a repeated, silent slip across release sessions.
+        {
+            "rule_id": "git-commit-verify-landed",
+            "match_substring": "git commit",
+            "text": (
+                "After `git commit`, verify it LANDED (`git log --oneline "
+                "-1` / `git status --short`) — pre-commit auto-fixers can "
+                "leave files re-staged and `git commit -q` can exit 0 yet "
+                "SKIP the commit. Pre-flight the PINNED black/ruff before "
+                "`git add` so the hooks see already-clean files."
+            ),
+        },
+        # Admin-merge already-merged trap (T2.1, added 2026-06-20): the
+        # local post-merge step errors even when the remote merge
+        # succeeded; a blind retry 404s because the PR is already merged.
+        {
+            "rule_id": "admin-merge-verify-remote",
+            "match_substring": "pr merge",
+            "text": (
+                "`gh pr merge --admin` can error from the LOCAL post-merge "
+                "step even when the REMOTE merge SUCCEEDED — verify `gh pr "
+                "view <n> --json state,mergedAt,mergeCommit` before "
+                "retrying; a retry 404s because it is already merged."
+            ),
+        },
+        # Rebase drops GPG signatures (T2.1, added 2026-06-20): replayed
+        # commits come back unsigned; pushing them loses the signature.
+        {
+            "rule_id": "rebase-resigns-gpg",
+            "match_substring": "rebase",
+            "text": (
+                "Rebase (and `git pull --rebase`) REPLAYS commits "
+                "UNSIGNED — re-sign with `git commit --amend -S "
+                "--no-edit` (or re-sign the replayed range) before "
+                "pushing, or the pushed commits lose their GPG signature."
+            ),
+        },
     ],
 }

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -164,6 +164,50 @@ def test_non_matching_rule_writes_no_sentinel(jit_mod, monkeypatch, capsys, tmp_
 
 
 # ==========================================================================
+# T2.1 slip-points (git-commit / admin-merge / rebase)
+# ==========================================================================
+
+
+def test_git_commit_rule_fires_on_commit(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("git commit -m 'x'"))
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "LANDED" in ctx
+
+
+def test_admin_merge_rule_fires_on_pr_merge(jit_mod, monkeypatch, capsys):
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("gh pr merge 952 --admin --squash"),
+    )
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "already merged" in ctx
+
+
+def test_rebase_rule_fires_on_rebase(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("git rebase main"))
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "UNSIGNED" in ctx
+
+
+def test_t21_rules_silent_on_unrelated_bash(jit_mod, monkeypatch, capsys):
+    """None of the T2.1 substrings appear in an ordinary `ls`, so silent."""
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("ls -la"))
+    assert rc == 0
+    assert out == ""
+
+
+def test_all_rule_ids_are_unique(jit_mod):
+    """rule_id keys the per-session sentinel — a dup would cross-silence."""
+    ids = [r["rule_id"] for rules in jit_mod.RECALL_MAP.values() for r in rules]
+    assert len(ids) == len(set(ids)), f"duplicate rule_id in RECALL_MAP: {ids}"
+
+
+# ==========================================================================
 # lesson_ref resolution (lessons-corpus-rag T4)
 # ==========================================================================
 


### PR DESCRIPTION
Three small, independent changes bundled from a triage/cleanup session.

## 1. `feat(jit-recall)` — T2.1: 3 Bash slip-points (`a06f86ab5`)

Grows the just-in-time recall map (`plugin/hooks/_recall_map.py`) with
three corpus-backed, `match_substring`-scoped Bash rules that fire at
their decision points:

| rule_id | fires on | guards |
|---------|----------|--------|
| `git-commit-verify-landed` | `git commit` | commit silently not landing / auto-fixer re-stage |
| `admin-merge-verify-remote` | `pr merge` | retrying an admin-merge that already succeeded remotely |
| `rebase-resigns-gpg` | `rebase` | pushing unsigned replayed commits |

All text-only (no dangling `lesson_ref`), under the existing `Bash` key
(`hooks.json` already covers it). **+5 tests, 27 pass.** Live non-mocked
round-trip confirmed the `git commit` rule surfaces through the real
hook. Completes T2.1 of `docs/specs/just-in-time-recall`.

## 2. `docs(spec)` — retire website-update-dashboard-and-fold (`c28e764df`)

Spec approved 2026-05-12 is stale: Phase 2 was gated on v7.0 landing
(now at 8.6.2), foundation files already exist, and the web surface is
consolidating onto attune-ai.dev. All four spec files marked RETIRED
with the reasons recorded in its `decisions.md`.

## 3. `docs(usage-signals)` — sentinel cleanup marked pending (`b6d79326f`)

The two PII-free sentinel rows in Neon `usage_events` couldn't be
deleted this session (console-only `DELETE`; the Neon SQL editor wasn't
reachable). Records the truthful **pending** status + the steps to
finish. Rows are harmless and already filtered (`version <> '0.0.0-verify'`).

---

Only #1 is code; #2 and #3 are docs/spec status. No version bump, no
release artifact.