### PR TITLE
spec(help-docs-single-source): one master file per feature, rendered to both

### DIFF
--- a/docs/specs/help-docs-single-source/decisions.md
+++ b/docs/specs/help-docs-single-source/decisions.md
@@ -1,0 +1,77 @@
+# Decisions: Single-Source Help + Docs
+
+Decisions recorded during the 2026-06-21 requirements
+interview. Each is the agreed answer to a fork; rationale is
+captured so later phases don't relitigate it.
+
+---
+
+## D1 — Direction: single-source, render to both
+
+**Decided:** Author content once; render to BOTH the in-tool
+`.help` corpus and the mkdocs site.
+
+**Why:** The two corpora serve different consumers (in-CLI
+help vs published site) but document the same features.
+Single-sourcing ends the duplication while keeping both
+consumers. Rejected: docs-canonical-only (loses the 11-kind
+in-tool structure), keep-both-raise-quality (duplication
+remains), one-off merges (doesn't fix the architecture).
+
+---
+
+## D2 — Source format: hand-authored structured markdown
+
+**Decided:** One "master file" per feature — YAML frontmatter
+plus a fixed set of named markdown sections.
+
+**Why:** Patrick's bar is the hand-authored feel of today's
+`docs/` (which the agent authored over time, not via
+attune-author). Markdown keeps authoring ergonomic and
+git-diffable; the "structure" is a convention over markdown,
+not a new serialization. Rejected: YAML/TOML data files
+(awkward for long-form prose).
+
+---
+
+## D3 — attune-author repurposed as projector + validator
+
+**Decided:** attune-author's role shifts from *LLM
+content-generator* to *deterministic projector + validator*.
+It renders the master file into outputs and runs
+fact-check/grounding; it does not author or rewrite
+canonical prose.
+
+**Why:** LLM authoring of canon is exactly what produced the
+fiction (bare-module imports, hallucinated cross-refs).
+Removing the LLM from the canonical path preserves the
+hand-authored feel and kills the fiction at its root. The LLM
+remains an optional drafting assist (D-linked to R9).
+
+---
+
+## D4 — Pilot-first
+
+**Decided:** Prove the full chain on two features before
+rollout: `spec-engine` and `models`.
+
+**Why:** ~270 files + a repurposed engine + a new projector +
+a help read-path change is too large to land blind.
+`spec-engine` (Python-API shape, just worked this session)
+and `models` (CLI-reference/tabular shape) give contrasting
+content to stress the projector. The rollout playbook (R7) is
+written from what the pilot teaches.
+
+---
+
+## D5 — RAG-grounding is a quality mechanism, not a pilot feature
+
+**Decided:** "RAG grounding" means master-file claims are
+RAG-grounded/cited against the codebase (via
+`rag_knowledge_query`) and fact-checked — so hand-authored
+content stays verifiably true to the code. It is NOT a
+synonym for picking the `rag-grounding` feature as a pilot.
+
+**Why:** Patrick clarified the intent is verifiable content
+quality. This becomes R3; the second pilot feature is chosen
+independently for content-shape coverage (`models`).

--- a/docs/specs/help-docs-single-source/design.md
+++ b/docs/specs/help-docs-single-source/design.md
@@ -1,0 +1,182 @@
+# Design: Single-Source Help + Docs
+
+**Status:** design (awaiting approval)
+**Created:** 2026-06-21
+**Builds on:** [requirements.md](requirements.md),
+[decisions.md](decisions.md)
+
+---
+
+## Key insight (grounded in spec-engine)
+
+The 11 `.help` kinds and the 4 `docs/` feature pages are not 11+4
+independent documents — they are **projections of one smaller
+canonical content set**. Evidence from the live spec-engine corpus:
+
+| `.help` kind | Section headings (actual) | Canonical source |
+|---|---|---|
+| concept | Mental model, Core data structures, Execution entry points, State lifecycle, Presentation layer | Overview + Concepts |
+| reference | Classes, Functions, Source files, Tags | Reference (code-derived) |
+| task | Prerequisites, <procedures>, Verify success | Tasks |
+| quickstart | Step 1–4 | Quickstart |
+| comparison | Context, Feature comparison, Tradeoffs, Decision guide | Comparison |
+| error | Error signatures, Origins, Diagnose | Failure modes |
+| troubleshooting | Symptom table, Diagnosis, Common fixes | Failure modes |
+| warning | What to watch, Risk areas, How to avoid | Failure modes |
+| faq | Q&A pairs | FAQ |
+| note | How packages fit, API boundaries | Notes + Concepts |
+| tip | (sparse) | Notes & tips |
+
+| `docs/` page | Section headings (actual) | Canonical source |
+|---|---|---|
+| how-to/spec-engine | Quick start, Core API, Integration patterns, See also | Quickstart + Tasks + Reference |
+| tutorials/spec-engine | Prerequisites, Step 1–6, Complete script, What you learned | Tutorial (a guided path over Tasks) |
+| architecture/spec-engine | Purpose, Key classes, Data flow, Design decisions, Extension points | Overview + Concepts + Design & extension |
+| reference/spec-engine | Description, Usage, Options, Subcommands, Exit codes | CLI reference (code-derived) |
+
+So the master file needs ~10 canonical sections; everything else is a
+**slice + format** of those.
+
+---
+
+## Master-file schema
+
+One file per feature. YAML frontmatter + a fixed set of named H2
+sections. The "structure" is a convention over markdown (D2).
+
+```markdown
+---
+feature: spec-engine
+summary: Spec-driven development with approval loops
+tags: [spec, planning]
+source_globs: [src/attune/spec/**, src/attune/pipeline/**]
+cli: { command: spec }        # present only for CLI-backed features
+nav:
+  help: spec-engine
+  mkdocs:
+    how-to: how-to/spec-engine
+    tutorial: tutorials/spec-engine
+    architecture: architecture/spec-engine
+    reference: reference/spec-engine
+---
+
+## Overview            # mental model; when this feature matters
+## Concepts            # data model, lifecycle, package boundaries
+## Quickstart          # minimal end-to-end path (numbered steps)
+## Tasks               # procedures — each: goal / steps / verify
+## Reference           # API (code-derived) + CLI options for cli features
+## Comparison          # vs alternatives / layer tradeoffs
+## Failure modes       # each: symptom / cause / fix / severity
+## FAQ                 # Q&A pairs
+## Notes & tips        # supplementary callouts
+## Design & extension  # design decisions, extension points
+```
+
+A feature may omit sections it doesn't need (e.g. no `cli:` block →
+no CLI reference). The projector treats a missing section as "skip the
+outputs that depend on it," never as an error.
+
+---
+
+## Projection map (section → outputs)
+
+| Canonical section | → `.help` kinds | → `docs/` pages |
+|---|---|---|
+| Overview | concept, note | architecture#purpose, how-to intro |
+| Concepts | concept, note | architecture#key-classes, #data-flow |
+| Quickstart | quickstart | how-to#quick-start, tutorial seed |
+| Tasks | task | how-to#core-api, tutorial steps |
+| Reference | reference | reference/* (CLI), architecture#key-classes |
+| Comparison | comparison | (optional guide) |
+| Failure modes | error, troubleshooting, warning | how-to#integration callouts |
+| FAQ | faq | (optional guide) |
+| Notes & tips | note, tip | inline callouts |
+| Design & extension | note | architecture#design-decisions, #extension-points |
+
+Each output target declares the sections it consumes; the projector
+renders only those. This table is the contract the projector
+implements.
+
+---
+
+## Open design decisions — recommendations
+
+### DD1 — Projector technology
+
+**Recommend: a new dedicated projector module inside attune-author**,
+reusing the existing pieces rather than extending the LLM generator.
+Reuse: `_extract_source_info` (AST → classes/functions/signatures) for
+the Reference section; the frontmatter/staleness machinery; the
+`fact_check` package (incl. this session's `import_repair`). The
+generator's LLM polish path is NOT reused for canon (D3). A clean
+module keeps the deterministic projector free of the LLM-generation
+code that produced the fiction.
+
+### DD2 — Help read-path
+
+**Recommend: project to `.help` files (no consumer change) for the
+pilot.** The help system (`help_lookup`, `coach`, MCP) keeps reading
+`.help/templates/<feature>/*.md` exactly as today — the projector just
+becomes their producer instead of the LLM generator. Satisfies R4 with
+zero consumer risk. Reading the master file directly is a possible
+later optimization, out of pilot scope.
+
+### DD3 — Master-file location
+
+**Recommend: a new source tree `content/features/<feature>.md`**,
+separate from both render targets. Rationale: `docs/` is now an
+*output* (feature pages are generated), so the source can't live
+there without a source/output collision. Cross-cutting hand-authored
+docs (getting-started, philosophy, guides) stay in `docs/` untouched —
+only the per-feature pages (how-to/tutorial/architecture/reference)
+become projected.
+
+### DD4 — Grounding + fact-check (R3)
+
+Run on the master file before projection:
+
+- **Static fact-check** — `python_refs` (imports/signatures),
+  `cli_refs` (flags), `md_links` (cross-refs), reusing
+  `import_repair` to auto-correct mis-pathed imports.
+- **RAG grounding** — for prose claims about behavior, query
+  `rag_knowledge_query` against the codebase and surface
+  unsupported claims as a verification report (warn for the pilot;
+  promote to a CI gate post-pilot).
+
+### DD5 — Defuse the regen-overwrite trap (R8)
+
+A migrated feature must be **removed from the LLM generator's
+feature manifest** (or flagged `source: projected`) so the weekly
+regen neither generates nor overwrites it. The projector owns it
+instead. This is checked per-feature at migration time.
+
+---
+
+## Pilot plan (spec-engine, then models)
+
+1. Author `content/features/spec-engine.md` by **consolidating the
+   existing hand-authored `docs/` pages** (how-to, tutorial,
+   architecture, reference) + the good parts of the `.help` corpus
+   into the canonical sections. No new prose invented — this is a
+   merge, preserving the hand-authored feel.
+2. Build the projector module + the projection map (above).
+3. Render → `.help/templates/spec-engine/*` + the 4 `docs/` pages.
+4. Run fact-check + RAG grounding; resolve findings.
+5. Verify the help system serves the projected `.help` unchanged;
+   verify `mkdocs build` is clean.
+6. Remove spec-engine from the LLM generator manifest (DD5).
+7. Repeat for `models` (exercises the `cli:` block + `cli_refs`).
+8. Write the rollout playbook (R7) from what steps 1–7 taught.
+
+---
+
+## Still to prototype (resolve during pilot, not before)
+
+- Exact slicing rules where one section feeds differently-formatted
+  outputs (e.g. a `Tasks` section → terse `.help/task` vs narrative
+  `how-to#core-api`). Likely a light per-output template.
+- Whether `Quickstart` is authored or derived from the first Task.
+- Whether `tutorial` (a guided narrative) can be projected at all, or
+  must stay hand-authored per-feature (it may be the one kind that
+  resists pure projection).
+- mkdocs nav wiring for projected pages.

--- a/docs/specs/help-docs-single-source/requirements.md
+++ b/docs/specs/help-docs-single-source/requirements.md
@@ -1,0 +1,165 @@
+# Requirements: Single-Source Help + Docs
+
+**Status:** requirements (awaiting approval)
+**Created:** 2026-06-21
+**Owner:** Patrick + agent
+
+---
+
+## Context
+
+Two documentation corpora exist today, fed by the same
+attune-author generator with different templates:
+
+- **`.help/templates/<feature>/`** — 25 features × 11 kinds
+  (concept, task, reference, quickstart, comparison, error,
+  faq, note, tip, troubleshooting, warning) ≈ 270 files,
+  LLM-generated. Consumed in-tool by the help system
+  (`help_lookup`, `coach`, MCP help tools). One orphan:
+  `resilience` (3-kind leftover from the deprecated 3-depth
+  generator).
+- **`docs/`** — the mkdocs site. Mostly hand-authored
+  (getting-started, guides, philosophy, reference, redis,
+  rag, …) PLUS attune-author "project-doc kinds"
+  (`docs/how-to/`, `docs/tutorials/`, `docs/architecture/`).
+
+The hand-authored `docs/` content was written by the agent
+over time (not via attune-author) and has a markedly superior
+"hand-authored feel." The LLM-generated `.help` corpus is
+lower quality and prone to systematic fiction — e.g. the
+bare-module import bug fixed on 2026-06-21
+([attune-author#76], [attune-ai#956]).
+
+---
+
+## Problem
+
+- **Duplication.** The same feature is documented twice, in
+  two trees, in two formats — double the maintenance.
+- **Quality gap.** The generated `.help` corpus lacks the
+  hand-authored quality of `docs/`.
+- **Fiction risk.** LLM generation of canonical content
+  invents imports, signatures, and cross-refs that ship to
+  users until a fact-check catches them.
+
+---
+
+## Goals
+
+1. **One canonical source per feature** — a hand-authored
+   "master file" — from which both the in-tool `.help` corpus
+   and the mkdocs site are produced.
+2. **Preserve the hand-authored feel.** The master file is
+   hand-authored; the render step never rewrites prose.
+3. **Eliminate duplication.** Author once; render to both.
+4. **Keep content verifiably true to the code** via fact-check
+   plus RAG-grounding against the codebase.
+5. **No consumer regression** — the help system keeps working.
+
+---
+
+## Non-Goals
+
+- Re-authoring all 25 features in one pass (pilot-first).
+- Changing the mkdocs theme or the in-tool help UX.
+- Removing the LLM entirely — it stays as an optional
+  drafting assist, never the source of canon.
+
+---
+
+## Requirements
+
+- **R1 — Canonical source.** Each feature has one
+  hand-authored "master file": structured markdown (YAML
+  frontmatter + a fixed set of named sections). Quality bar =
+  today's `docs/`. Where good `docs/` content already exists,
+  it becomes the source rather than being regenerated.
+- **R2 — Deterministic projector.** A render step (repurposed
+  attune-author) projects the master file into the 11 `.help`
+  kinds and the mkdocs page(s). It slices/renders only — it
+  does not author or rewrite prose. No LLM in the canonical
+  path.
+- **R3 — Grounding + fact-check.** Code-derived claims
+  (imports, signatures, CLI flags, cross-refs) are verified
+  against source — reusing `import_repair` / `python_refs` /
+  `cli_refs` — AND RAG-grounded/cited against the codebase via
+  `rag_knowledge_query`, so the hand-authored content stays
+  verifiably true.
+- **R4 — No consumer regression.** The help system
+  (`help_lookup`, `coach`, MCP) keeps serving. Design decides
+  whether it reads the projected `.help` output or the master
+  source directly.
+- **R5 — Section schema + projection map.** A defined set of
+  named sections and an explicit map of which output target
+  consumes each section.
+- **R6 — Pilot.** Two features end-to-end before rollout:
+  `spec-engine` and `models` (chosen for contrasting content
+  shapes — Python-API vs CLI-reference/tabular). Acceptance:
+  both targets render, the help system serves the result, the
+  fact-check/grounding is green, and the hand-authored feel is
+  preserved.
+- **R7 — Rollout plan.** A documented, repeatable migration
+  path for the remaining 23 features, including how existing
+  `.help`/`docs` content is folded into each master file.
+- **R8 — Defuse the regen-overwrite trap.** The weekly
+  attune-author LLM regen must not clobber a migrated feature's
+  hand-authored master file. Per-feature opt-out / generator
+  repurposing is part of the design.
+- **R9 — LLM as optional assist.** The LLM may *draft* a
+  section for a human to accept/edit, but never writes
+  canonical content directly.
+
+---
+
+## Pilot scope
+
+- **Pilot features:** `spec-engine`, `models`.
+- **End-to-end chain proven:** master file → projector →
+  `.help` kinds + mkdocs page → help system serves →
+  fact-check/grounding green.
+- **Exit criterion:** the chain is repeatable and the rollout
+  playbook (R7) is written from what the pilot taught.
+
+---
+
+## Open design questions (deferred to design phase)
+
+- Exact section schema and the section→output projection map
+  (how 11 `.help` kinds + mkdocs sections derive from one
+  file).
+- Projector technology: extend attune-author's existing
+  generator vs a new dedicated projector module.
+- Help read-path: does the help system read projected `.help`
+  files (no consumer change) or the master source directly?
+- mkdocs nav integration for projected pages.
+- How RAG-grounding surfaces (inline citations, a
+  verification report, or a CI gate).
+- Master-file storage location (under `docs/`, a new
+  `content/` tree, or alongside `.help/`).
+
+---
+
+## Risks
+
+- **Regen-overwrite (lesson-driven).** Adding/keeping features
+  in the existing generator's manifest triggers a regen that
+  overwrites hand-authored content. R8 must be designed before
+  any feature is migrated.
+- **Scope drift (lesson-driven).** The 11-kind ↔ mkdocs
+  mapping may not be 1:1 in practice; grep/verify the real
+  content shapes per feature before committing the schema.
+- **Two consumers.** Any read-path change must be validated
+  against the in-tool help system, not just the mkdocs build.
+
+---
+
+## References
+
+- [attune-author#76] — generator import-repair (merged)
+- [attune-ai#956] — spec-engine doc cleanup + drift guard
+- `docs/specs/doc-fiction-cleanup/` — prior, distinct surface
+- `.claude/lessons.md` — orphan `.help` dirs / regen-overwrite;
+  spec-scope-drifts-from-code
+
+[attune-author#76]: https://github.com/Smart-AI-Memory/attune-author/pull/76
+[attune-ai#956]: https://github.com/Smart-AI-Memory/attune-ai/pull/956


### PR DESCRIPTION
Requirements + decisions for consolidating the `.help/templates/` generated corpus and the `docs/` site into a single **hand-authored master file per feature**, rendered to both the in-tool `.help` corpus and the mkdocs site.

## Decisions
- **D1** single-source → render to both
- **D2** hand-authored structured markdown (master file = frontmatter + named sections)
- **D3** attune-author repurposed as a *deterministic projector + validator* — no LLM authoring of canon (kills the fiction at its root); LLM stays as optional drafting assist
- **D4** pilot-first: `spec-engine` + `models` (contrasting content shapes)
- **D5** RAG-grounding = quality mechanism (claims cited/verified against the codebase), not a pilot feature

## Requirements
R1 canonical source · R2 deterministic projector · R3 grounding+fact-check · R4 no consumer regression · R5 section schema + projection map · R6 pilot · R7 rollout · R8 defuse regen-overwrite trap · R9 LLM-as-assist.

**Requirements phase only — no code.** Design phase (section schema, projector tech, help read-path) is deferred and listed as open questions. Awaiting approval before design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)