### PR TITLE
chore(deps): admit attune-author 0.19.0 in [author] extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Adopted `claude-agent-sdk` 0.2.x** (pin `>=0.2.101,<0.3.0`, lock at 0.2.105). Lifts the deliberate `<0.2.82` cap to a new `<0.3.0` guard. The 0.1->0.2 behavioral breaks (MCP background-connection default, TodoWrite->Task tools, system-prompt default) do not affect attune: workflows pass no `mcp_servers`, never use `TodoWrite`, and isolate with `setting_sources=[]`. Full keyless unit suite green (17857). Locked at 0.2.105 rather than 0.2.102 because 0.2.102's bundled Claude Code CLI (2.1.178) emitted `is_error:true` on a `success` result and broke the auth integration loop; 0.2.105 bundles CLI 2.1.183 which returns `is_error:false`. See `docs/specs/claude-agent-sdk-0-2-migration/`.
+- **`[author]` extra: `attune-author>=0.6.2,<0.19` → `>=0.19.0,<0.20`.** Admits attune-author 0.19.0, which ships the deterministic help-docs projector (`attune_author.projector`). Unblocks the `scripts/project_features.py` driver for the help-docs-single-source pilot. The floor jump is safe — 0.19.0 is a strict superset (projector added, nothing removed) — and `[author]` is an optional authoring extra, so vanilla `pip install attune-ai` is unaffected.
 
 ## [8.6.2] — 2026-06-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ rag = []
 # to the sibling path for workspace dev; PyPI is the
 # fallback.
 author = [
-    "attune-author>=0.6.2,<0.19",
+    "attune-author>=0.19.0,<0.20",
     # attune-author 0.15.0 moved attune-help from its core deps to its
     # dev extra — attune-ai had been receiving it TRANSITIVELY. The
     # rag_knowledge_query MCP tool and help-corpus tests need it, so
@@ -768,7 +768,7 @@ exclude_lines = [
 # Sibling repos — all published to PyPI:
 #   attune-rag     — core dep (>=0.1.5,<0.8) — promoted from optional; required for accuracy
 #   attune-verify  — core dep (>=0.1.0,<0.3) — backs /verify; stdlib-only, zero transitive deps
-#   attune-author  — [author] optional extra (>=0.6.2,<0.19)
+#   attune-author  — [author] optional extra (>=0.19.0,<0.20)
 #   attune-rag     — [rag] optional extra (>=0.1.5,<0.8) — no-op alias since rag is core
 #
 # No [tool.uv.sources] overrides needed: CI resolves all three

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'enterprise'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
-    { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.6.2,<0.19" },
+    { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.19.0,<0.20" },
     { name = "attune-help", marker = "extra == 'author'", specifier = ">=0.10.0" },
     { name = "attune-rag", specifier = ">=0.1.5,<0.8" },
     { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.8" },
@@ -584,16 +584,16 @@ provides-extras = ["rag", "author", "memory", "redis", "anthropic", "llm", "memd
 
 [[package]]
 name = "attune-author"
-version = "0.18.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "python-frontmatter" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/c9/57c6508231118b6f0db3b3f7b1b119ab97aadcd7107de535e994d06d0790/attune_author-0.18.0.tar.gz", hash = "sha256:60c939827d4e82e223e8bbe4fa53bf475d615e60fcb45c924a44c4132e53358d", size = 266759, upload-time = "2026-06-15T02:19:49.099Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/3b/98d2e42a791a76886708256ca8f02f185cc7017d220594befc081b12a8a9/attune_author-0.19.0.tar.gz", hash = "sha256:4a0c236d980b78a64280047a17db5ec3aae05f0bafa512d6ffdfe3714917b571", size = 274619, upload-time = "2026-06-21T14:53:49.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/03/1601768d38a2a810fe0d1f462b38db9fd38a0dda0c342d3b3f44a0b84877/attune_author-0.18.0-py3-none-any.whl", hash = "sha256:9e26920bc8701c63e94cc6b02e36a4cd3347ada20a1a934802e8ceed6e242bbf", size = 199690, upload-time = "2026-06-15T02:19:47.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/eb/a3f7fdaf0f3783f6db03b444ab68ac75b88ecb34eef2bfb17558ce10ec5f/attune_author-0.19.0-py3-none-any.whl", hash = "sha256:cca47abb2e26b9494ecc55353c5d49d5f670d89cbe9782df6d296f1b6fa2c859", size = 208277, upload-time = "2026-06-21T14:53:47.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Widen the optional **`[author]`** extra pin so attune-ai can install the attune-author release that ships the deterministic help-docs projector.

## Change
- `pyproject.toml` — `attune-author>=0.6.2,<0.19` → **`>=0.19.0,<0.20`** (+ the doc-comment mirror)
- `uv.lock` — `attune-author 0.18.0 → 0.19.0` (specifier + hashes; no cascade)
- `CHANGELOG.md` — `[Unreleased] → Changed` entry

## Why
attune-author 0.19.0 adds `attune_author.projector` (the single-source help-docs projector, [attune-author#78](https://github.com/Smart-AI-Memory/attune-author/pull/78)). This unblocks `scripts/project_features.py` (the pilot driver, currently parked on `spec/t2-design-lock`) — its `attune_author.projector` import resolves once CI installs attune-author per this pin.

## Safety
- `[author]` is an **optional authoring extra** — vanilla `pip install attune-ai` is unaffected.
- Floor jump 0.6.2 → 0.19.0 is safe: 0.19.0 is a strict superset (projector *added*, nothing removed); `uv lock` resolved cleanly (187 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)