### PR TITLE
chore(help): bump attune-author to >=0.20.0 + re-project spec-engine/models

### DIFF
--- a/.help/templates/models/comparison.md
+++ b/.help/templates/models/comparison.md
@@ -3,10 +3,12 @@ type: comparison
 name: models-comparison
 feature: models
 depth: comparison
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Comparison
 

--- a/.help/templates/models/concept.md
+++ b/.help/templates/models/concept.md
@@ -3,10 +3,12 @@ type: concept
 name: models-concept
 feature: models
 depth: concept
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Overview
 

--- a/.help/templates/models/error.md
+++ b/.help/templates/models/error.md
@@ -3,10 +3,12 @@ type: error
 name: models-error
 feature: models
 depth: error
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Failure modes
 

--- a/.help/templates/models/note.md
+++ b/.help/templates/models/note.md
@@ -3,10 +3,12 @@ type: note
 name: models-note
 feature: models
 depth: note
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Overview
 

--- a/.help/templates/models/quickstart.md
+++ b/.help/templates/models/quickstart.md
@@ -3,10 +3,12 @@ type: quickstart
 name: models-quickstart
 feature: models
 depth: quickstart
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Quickstart
 

--- a/.help/templates/models/reference.md
+++ b/.help/templates/models/reference.md
@@ -3,10 +3,12 @@ type: reference
 name: models-reference
 feature: models
 depth: reference
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Reference
 

--- a/.help/templates/models/task.md
+++ b/.help/templates/models/task.md
@@ -3,10 +3,12 @@ type: task
 name: models-task
 feature: models
 depth: task
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Tasks
 

--- a/.help/templates/models/tip.md
+++ b/.help/templates/models/tip.md
@@ -3,10 +3,12 @@ type: tip
 name: models-tip
 feature: models
 depth: tip
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Notes & tips
 

--- a/.help/templates/models/troubleshooting.md
+++ b/.help/templates/models/troubleshooting.md
@@ -3,10 +3,12 @@ type: troubleshooting
 name: models-troubleshooting
 feature: models
 depth: troubleshooting
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Failure modes
 

--- a/.help/templates/models/warning.md
+++ b/.help/templates/models/warning.md
@@ -3,10 +3,12 @@ type: warning
 name: models-warning
 feature: models
 depth: warning
-generated_at: 2026-06-21T17:12:30.780290+00:00
+generated_at: 2026-06-21T18:43:46.304112+00:00
 source_hash: 234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459
 status: generated
 ---
+
+# LLM authentication, provider routing, and tier management
 
 ## Failure modes
 

--- a/.help/templates/spec-engine/comparison.md
+++ b/.help/templates/spec-engine/comparison.md
@@ -3,10 +3,12 @@ type: comparison
 name: spec-engine-comparison
 feature: spec-engine
 depth: comparison
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Comparison
 

--- a/.help/templates/spec-engine/concept.md
+++ b/.help/templates/spec-engine/concept.md
@@ -3,10 +3,12 @@ type: concept
 name: spec-engine-concept
 feature: spec-engine
 depth: concept
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Overview
 

--- a/.help/templates/spec-engine/error.md
+++ b/.help/templates/spec-engine/error.md
@@ -3,10 +3,12 @@ type: error
 name: spec-engine-error
 feature: spec-engine
 depth: error
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Failure modes
 

--- a/.help/templates/spec-engine/note.md
+++ b/.help/templates/spec-engine/note.md
@@ -3,10 +3,12 @@ type: note
 name: spec-engine-note
 feature: spec-engine
 depth: note
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Overview
 

--- a/.help/templates/spec-engine/quickstart.md
+++ b/.help/templates/spec-engine/quickstart.md
@@ -3,10 +3,12 @@ type: quickstart
 name: spec-engine-quickstart
 feature: spec-engine
 depth: quickstart
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Quickstart
 

--- a/.help/templates/spec-engine/reference.md
+++ b/.help/templates/spec-engine/reference.md
@@ -3,10 +3,12 @@ type: reference
 name: spec-engine-reference
 feature: spec-engine
 depth: reference
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Reference
 

--- a/.help/templates/spec-engine/task.md
+++ b/.help/templates/spec-engine/task.md
@@ -3,10 +3,12 @@ type: task
 name: spec-engine-task
 feature: spec-engine
 depth: task
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Tasks
 

--- a/.help/templates/spec-engine/tip.md
+++ b/.help/templates/spec-engine/tip.md
@@ -3,10 +3,12 @@ type: tip
 name: spec-engine-tip
 feature: spec-engine
 depth: tip
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Notes & tips
 

--- a/.help/templates/spec-engine/troubleshooting.md
+++ b/.help/templates/spec-engine/troubleshooting.md
@@ -3,10 +3,12 @@ type: troubleshooting
 name: spec-engine-troubleshooting
 feature: spec-engine
 depth: troubleshooting
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Failure modes
 

--- a/.help/templates/spec-engine/warning.md
+++ b/.help/templates/spec-engine/warning.md
@@ -3,10 +3,12 @@ type: warning
 name: spec-engine-warning
 feature: spec-engine
 depth: warning
-generated_at: 2026-06-21T17:12:30.161122+00:00
+generated_at: 2026-06-21T18:43:45.172614+00:00
 source_hash: 2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1
 status: generated
 ---
+
+# Spec-driven development with approval loops
 
 ## Failure modes
 

--- a/docs/specs/help-docs-single-source/follow-ups.md
+++ b/docs/specs/help-docs-single-source/follow-ups.md
@@ -240,7 +240,8 @@ per-feature.
 
 ## P5 — Code examples need EXECUTION-based verification
 
-**Status:** open · **Raised:** 2026-06-21 (pilot review) · **Lands
+**Status:** check landed (2026-06-21, attune-author 0.20.0); R7 process
+rule still open · **Raised:** 2026-06-21 (pilot review) · **Lands
 in:** attune-author fact_check + R7 process
 
 The pilot review proved that neither the static fact-checker nor
@@ -271,8 +272,50 @@ Concrete follow-ups:
   as a first-class check (`check_doc_examples`) so it runs in the same
   warn/gate pass as `python_refs`/`cli_refs`, for every consumer — not
   just this repo's driver. The prototype is the spec.
+  **DONE (attune-author 0.20.0):** landed as `fact_check.check_doc_examples`,
+  wired into `check_polished_file`. The promoted version derives
+  async-ness generically from each block's own imports (no hardcoded
+  package list) to stay consumer-agnostic; the repo driver keeps the
+  prototype (`scripts/check_doc_examples.py`) as an attune-specific
+  second layer that also catches async misuse when an example omits the
+  import.
 - **R7 process rule:** the per-feature checklist's adversarial review
   step must explicitly verify, for every public callable used in an
   example, whether it is `async` (grep `async def`) and whether the
   example awaits it correctly. Treat "is this example runnable as
   written?" as a distinct check from "do these symbols exist?".
+
+---
+
+## P6 — Tutorial-as-landing / per-feature hub page
+
+**Status:** open · **Raised:** 2026-06-21 (pilot review — Patrick wants
+tutorials front-and-center) · **Lands in:** attune-ai (mkdocs nav +
+landing convention), pairs with P4
+
+Patrick wants a feature's **tutorial** to be the first thing a user of
+that feature sees — the rich, narrative `docs/tutorials/<feature>.md`
+(e.g. spec-engine's "Build a Spec Engine Pipeline Runner"), not the
+concept/reference. This is a placement/nav decision and is fully
+compatible with D10 (tutorials stay hand-authored/LLM-generated, never
+projected — see [keep-rich-tutorials feedback]).
+
+**Constraint that shapes the design — coverage.** Tutorials are the one
+channel the projector cannot generate. Today only **11 of 25** manifest
+features have a tutorial (`models`, a pilot feature, does NOT); the
+~270-feature rollout will have a tutorial for a small minority. So a
+literal "tutorial is the first/only page" rule gives most features a
+dead front door, and it taxes the frequent quick-answer lookup to serve
+the first-visit case (Diátaxis puts tutorials as a deliberate detour,
+not the hub).
+
+**Proposed design (decide at rollout, with P4):** a thin per-feature
+**landing/hub page** that **leads with a prominent "Start here →
+Tutorial" CTA when a tutorial exists**, then routes to how-to /
+reference / concept; degrades gracefully to concept/how-to-first when
+no tutorial exists. The projector/driver can emit the hub (it knows the
+feature's available kinds) and the nav fragment P4 needs. Open
+questions: in-tool surface (does the ops dashboard / `help_lookup`
+also lead with the tutorial?), and whether to invest in generating more
+tutorials (LLM channel, rich) to widen coverage before making them the
+marquee entry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ rag = []
 # to the sibling path for workspace dev; PyPI is the
 # fallback.
 author = [
-    "attune-author>=0.19.0,<0.20",
+    "attune-author>=0.20.0,<0.21",
     # attune-author 0.15.0 moved attune-help from its core deps to its
     # dev extra — attune-ai had been receiving it TRANSITIVELY. The
     # rag_knowledge_query MCP tool and help-corpus tests need it, so
@@ -768,7 +768,7 @@ exclude_lines = [
 # Sibling repos — all published to PyPI:
 #   attune-rag     — core dep (>=0.1.5,<0.8) — promoted from optional; required for accuracy
 #   attune-verify  — core dep (>=0.1.0,<0.3) — backs /verify; stdlib-only, zero transitive deps
-#   attune-author  — [author] optional extra (>=0.19.0,<0.20)
+#   attune-author  — [author] optional extra (>=0.20.0,<0.21)
 #   attune-rag     — [rag] optional extra (>=0.1.5,<0.8) — no-op alias since rag is core
 #
 # No [tool.uv.sources] overrides needed: CI resolves all three

--- a/scripts/project_features.py
+++ b/scripts/project_features.py
@@ -83,17 +83,17 @@ def main(argv: list[str] | None = None) -> int:
         example_problems = []
         print(f"warning: example check skipped: {exc}", file=sys.stderr)
 
-    # ``tutorial`` is skipped: a guided tutorial (single progressive
-    # "what you'll build" arc) resists pure section projection — the
-    # projected version is just the Tasks list verbatim, which reads
-    # thin and duplicates the how-to. Tutorials stay hand-authored per
-    # feature. See docs/specs/help-docs-single-source/decisions.md D10.
-    # ``faq`` is skipped per D7 (FAQ Generator unbuilt).
+    # ``faq`` is skipped per D7 (FAQ Generator unbuilt). ``tutorial`` no
+    # longer needs an explicit skip: attune-author >=0.20.0 drops it from
+    # DOCS_PAGE_SECTIONS by default (a guided tutorial resists pure
+    # section projection — the projected version is just the Tasks list
+    # verbatim, duplicating the how-to; tutorials stay hand-authored per
+    # decision D10).
     result = project_feature(
         master_path,
         repo_root,
         help_dir,
-        skip_kinds=("faq", "tutorial"),
+        skip_kinds=("faq",),
         dry_run=args.dry_run,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -438,7 +438,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'enterprise'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
-    { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.19.0,<0.20" },
+    { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.20.0,<0.21" },
     { name = "attune-help", marker = "extra == 'author'", specifier = ">=0.10.0" },
     { name = "attune-rag", specifier = ">=0.1.5,<0.8" },
     { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.8" },
@@ -584,16 +584,16 @@ provides-extras = ["rag", "author", "memory", "redis", "anthropic", "llm", "memd
 
 [[package]]
 name = "attune-author"
-version = "0.19.0"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
     { name = "python-frontmatter" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/3b/98d2e42a791a76886708256ca8f02f185cc7017d220594befc081b12a8a9/attune_author-0.19.0.tar.gz", hash = "sha256:4a0c236d980b78a64280047a17db5ec3aae05f0bafa512d6ffdfe3714917b571", size = 274619, upload-time = "2026-06-21T14:53:49.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/9d/ec9d4febe1b6d569d209a95ebbf88be55a146c369cf61b7bdd570336febf/attune_author-0.20.0.tar.gz", hash = "sha256:033638096d9d9678468751d6008710d9ba556808700e6777115550ca162a189e", size = 277436, upload-time = "2026-06-21T18:39:40.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/eb/a3f7fdaf0f3783f6db03b444ab68ac75b88ecb34eef2bfb17558ce10ec5f/attune_author-0.19.0-py3-none-any.whl", hash = "sha256:cca47abb2e26b9494ecc55353c5d49d5f670d89cbe9782df6d296f1b6fa2c859", size = 208277, upload-time = "2026-06-21T14:53:47.41Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/9e547d30f0bc225d8839a73654ed60ba4f6a42b2459ed0fd4b985ed7e7cf/attune_author-0.20.0-py3-none-any.whl", hash = "sha256:1784e8539a1a830acfd86b93e017a2b16e08dcdd816e43a5a1c0d87103893f39", size = 211833, upload-time = "2026-06-21T18:39:39.135Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to the single-source projector pilot ([#964](https://github.com/Smart-AI-Memory/attune-ai/pull/964)). attune-author **0.20.0** ([release](https://github.com/Smart-AI-Memory/attune-author/releases/tag/v0.20.0)) changed projector output, so re-project the two pilot features to pick it up before the bulk rollout.

## Changes
- **Pin bump:** `[author]` extra `attune-author>=0.19.0,<0.20` → `>=0.20.0,<0.21`.
- **Re-projected `spec-engine` + `models`:** every `.help` body now opens with an `# H1` (the feature summary). The ops dashboard's `_title_from_content` now recovers a real card title instead of degrading to `<feature> / <kind>`:
  ```
  spec-engine/concept.md -> 'Spec-driven development with approval loops'
  models/task.md         -> 'LLM authentication, provider routing, and tier management'
  ```
- **Driver:** dropped the `tutorial` entry from `skip_kinds` in `scripts/project_features.py` — 0.20.0 excludes it from `DOCS_PAGE_SECTIONS` by default (D10), so the workaround is redundant. `faq` stays skipped (D7).
- **Follow-ups doc:** marked P5's `check_doc_examples` as landed; recorded **P6 — tutorial-as-landing** (a per-feature hub page that leads with the tutorial when one exists), to settle at rollout alongside P4.

## Notes
- `docs/` pages (how-to / architecture / reference) are **byte-identical** — only `_wrap_help` changed in 0.20.0, and `_wrap_docs` already emitted an H1. The diff is the 20 `.help` templates (+H1, +`generated_at` bump) plus the pin, the driver, and the follow-ups doc.
- **Tutorials are untouched.** The rich hand-authored/LLM tutorials under `docs/tutorials/` stay exactly as-is; the projector never owns that path (D10). P6 is about putting them *first*, not projecting them.

## Verification
- Re-projection clean: **0 fact-check findings**, example gate clean, `mkdocs build` no errors.
- `tests/unit/ops/ + tests/unit/help/` title/help/golden subset: 201 passed, 3 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)