### PR TITLE
release: 8.7.0 — single-source help/docs pilot + claude-agent-sdk 0.2.x

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.6.2"
+    "version": "8.7.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
       "source": "./plugin",
-      "version": "8.6.2",
+      "version": "8.7.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.6.2
+# Attune AI Framework v8.7.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.6.2 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.7.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.7.0] — 2026-06-22
+
+Ships two strands of work that landed after 8.6.2: the
+single-source help/docs pilot (one authored master file per feature,
+deterministically projected to both the in-tool `.help` corpus and
+the published docs site) and the `claude-agent-sdk` 0.2.x adoption.
+Plus the ops spend-alarm dashboard widget. No breaking changes for
+`pip install attune-ai`.
+
+### Added
+
+- **Single-source help + docs (pilot).** A feature's documentation is
+  now authored once in `content/features/<feature>.md` and projected
+  deterministically (no LLM in the canonical path) to both the in-tool
+  `.help` corpus and the mkdocs `docs/` pages — including a per-feature
+  "Start here" hub and an auto-wired top-level **Features** nav.
+  Pilot covers `spec-engine` and `models` via the new
+  `scripts/project_features.py` driver (backed by attune-author's
+  `projector`). See `docs/specs/help-docs-single-source/`.
+- **Ops spend alarm.** The ops dashboard gains a daily spend-anomaly
+  detector and a budget-ceiling gauge (usage-signals R6).
+
 ### Changed
 
 - **Adopted `claude-agent-sdk` 0.2.x** (pin `>=0.2.101,<0.3.0`, lock at 0.2.105). Lifts the deliberate `<0.2.82` cap to a new `<0.3.0` guard. The 0.1->0.2 behavioral breaks (MCP background-connection default, TodoWrite->Task tools, system-prompt default) do not affect attune: workflows pass no `mcp_servers`, never use `TodoWrite`, and isolate with `setting_sources=[]`. Full keyless unit suite green (17857). Locked at 0.2.105 rather than 0.2.102 because 0.2.102's bundled Claude Code CLI (2.1.178) emitted `is_error:true` on a `success` result and broke the auth integration loop; 0.2.105 bundles CLI 2.1.183 which returns `is_error:false`. See `docs/specs/claude-agent-sdk-0-2-migration/`.
-- **`[author]` extra: `attune-author>=0.6.2,<0.19` → `>=0.19.0,<0.20`.** Admits attune-author 0.19.0, which ships the deterministic help-docs projector (`attune_author.projector`). Unblocks the `scripts/project_features.py` driver for the help-docs-single-source pilot. The floor jump is safe — 0.19.0 is a strict superset (projector added, nothing removed) — and `[author]` is an optional authoring extra, so vanilla `pip install attune-ai` is unaffected.
+- **`[author]` extra: `attune-author>=0.6.2,<0.19` → `>=0.21.0,<0.22`.** Admits attune-author 0.21.0, which ships the deterministic help-docs projector (`attune_author.projector`) plus the Variant-1 per-feature hub emitter that powers the single-source pilot above. The floor jump is safe — each release is a strict superset (projector + hub added, nothing removed) — and `[author]` is an optional authoring extra, so vanilla `pip install attune-ai` is unaffected.
 
 ## [8.6.2] — 2026-06-20
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.6.2
+**Version:** 8.7.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.6.2 | **License:** Apache 2.0
+**Version:** 8.7.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.6.2"
+    "version": "8.7.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.6.2",
+      "version": "8.7.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.6.2",
+  "version": "8.7.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.6.2"
+__version__ = "8.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.6.2"
+version = "8.7.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.6.2"
+version = "8.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## 8.7.0 — minor release

Ships the work that landed after 8.6.2 (18 commits):

### Added
- **Single-source help + docs (pilot)** — features authored once in `content/features/<F>.md`, projected deterministically to both the in-tool `.help` corpus and the docs site, with a per-feature "Start here" hub + auto-wired **Features** nav. Pilot: `spec-engine`, `models` (#963/#964/#966).
- **Ops spend alarm** — daily spend-anomaly detector + budget-ceiling gauge (usage-signals R6) (#953).

### Changed
- **`claude-agent-sdk` 0.2.x adoption** (lock 0.2.105) (#917). Migration spec `claude-agent-sdk-0-2-migration` is T0–T4 complete; the earlier `integration-auth` red was a stale CI secret, not a regression.
- **`[author]` extra → `>=0.21.0,<0.22`** (projector + Variant-1 hub emitter). Optional extra; vanilla install unaffected.

## Release mechanics
- All version sites bumped 8.6.2 → 8.7.0 via `scripts/bump_version.py`.
- Changelog reconciled (corrected stale `[author]` pin entry; added the two missing features) and promoted.
- `uv.lock` relocked (attune-ai version line only).

Minor bump: feat commits in range. No breaking changes for `pip install attune-ai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)