### PR TITLE
ci(help-site): make help-page auto-commit push race-safe

### DIFF
--- a/.github/workflows/build-help-site.yml
+++ b/.github/workflows/build-help-site.yml
@@ -60,5 +60,21 @@ jobs:
             echo "help pages already up to date"
           else
             git commit -m "chore(help-site): rebuild help pages [skip ci]"
-            git push
+            # Another commit (e.g. a release PR merge) can land on main
+            # while this run is mid-rebuild, making a plain push lose a
+            # non-fast-forward race (! [rejected] main -> main). Rebase
+            # onto the latest main and retry so the auto-commit survives
+            # a concurrent merge.
+            for attempt in 1 2 3; do
+              git pull --rebase --autostash origin main
+              if git push; then
+                echo "pushed on attempt $attempt"
+                break
+              fi
+              echo "push attempt $attempt failed (main moved); retrying"
+              if [ "$attempt" -eq 3 ]; then
+                echo "push failed after 3 attempts" >&2
+                exit 1
+              fi
+            done
           fi


### PR DESCRIPTION
## Problem

`build-help-site.yml` regenerates the public help pages and auto-commits
them to protected `main`. PR #967 fixed the push **auth** (checkout with
`ADMIN_MERGE_TOKEN` so it can bypass the PR requirement), but the
push step still did a plain `git push` with **no rebase/retry**.

That loses a non-fast-forward race whenever another commit lands on
`main` while the workflow is mid-rebuild. Observed 2026-06-22: a
dispatched run failed with `! [rejected] main -> main (fetch first)`
because a release PR merged during the rebuild; a re-dispatch only
succeeded because `main` happened to be quiet.

## Fix

Wrap the push in a 3-attempt loop that rebases onto the latest `main`
before each push:

```sh
for attempt in 1 2 3; do
  git pull --rebase --autostash origin main
  if git push; then ... break; fi
  ...
done
```

- `[skip ci]` commit message: **unchanged**
- "already up to date" no-op branch: **unchanged**
- Fails the run only after 3 genuine attempts

## Verification

- `yaml.safe_load` parses the workflow cleanly (5 steps)
- `bash -n` on the extracted `run:` script passes
- No-op (no content delta) path preserved verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)
