### PR TITLE
chore(website): bump smartaimemory.com version labels to 8.7.0

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v8.5.0</span>
+                  <span>v8.7.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -30,7 +30,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "8.4.0",
+    version: "8.7.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -99,7 +99,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "8.4.0",
+    version: "8.7.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",
@@ -246,8 +246,8 @@ export const DIFFERENTIATORS: Differentiator[] = [
 /**
  * Counts that appear in prose and stat callouts across the
  * site. Verified against the live Python code per the
- * website-content-accuracy rule (last verified 2026-06-11,
- * attune-ai 8.4.0):
+ * website-content-accuracy rule (last verified 2026-06-22,
+ * attune-ai 8.7.0):
  *
  *   workflows: attune.workflows.list_workflows() with stages
  *   skills: plugin/skills/ directory count (test_skill_count)


### PR DESCRIPTION
After shipping attune-ai 8.7.0, smartaimemory.com still showed **v8.5.0** (homepage hero) and **8.4.0** (`features.ts` PRODUCTS). This bumps both to 8.7.0.

### Verified, not guessed
Re-ran the capability counts against the **live Python registry** per the website-content-accuracy rule — all unchanged at 8.7.0:

| count | value | source |
|-------|-------|--------|
| workflows | 17 | `list_workflows()` with stages |
| skills | 17 | `plugin/skills/` |
| mcpTools | 41 | `tool_schemas.get_*_tools()` |
| templateKinds | 15 | `_ALL_TEMPLATE_NAMES` |
| wizards | 5 | `list_wizards()` |

So only the version labels + the verification stamp move (8.7.0's features were internal — no new registry entries).

### Changelog
`/changelog` renders root `CHANGELOG.md` verbatim, so it picks up the 8.7.0 entry automatically on the next Vercel deploy — no edit needed.

Website-only change (touches only `website/`) → no changelog entry per `website/CLAUDE.md`; Python suite no-ops green. Vercel will build a preview URL on this PR for visual confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)