### PR TITLE
docs+web: Apache 2.0 license + purge the old ≤5/6+ pricing model

### DIFF
--- a/docs/blog/social/reddit_claude_costs.md
+++ b/docs/blog/social/reddit_claude_costs.md
@@ -565,7 +565,7 @@ PRs welcome! Things I'd love help with:
 
 ## License
 
-Apache License 2.0 0.9 (free for up to 3 users, paid beyond that)
+Apache License 2.0 — free and open source, no user or seat limits.
 
 ---
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -209,9 +209,7 @@ As the community grows, we may add:
 
 ### Code License
 
-All contributions to the Attune AI are licensed under **Apache License 2.0**:
-- **Free**: For individuals, students, educators, and organizations with ≤5 employees
-- **Commercial**: $99/developer/year for organizations with 6+ employees
+All contributions to Attune AI are licensed under the **Apache License 2.0** — free and open source for any use, including commercial, with no team-size, seat, or revenue restrictions.
 
 ### Documentation License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -199,12 +199,13 @@ Organized using the [Diátaxis framework](https://diataxis.fr/) for better disco
 
 ## License
 
-**Apache License 2.0 0.9**
-- ✅ Free for students, educators, teams ≤5 employees
-- 💰 contact us for pricing for teams 6+ employees
-- 🔄 Auto-converts to Apache 2.0 on January 1, 2029
+**Apache License 2.0** — free and open source.
 
-[Read full license](https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE)
+- ✅ Free for everyone, including commercial use
+- ✅ No team-size, seat, or revenue restrictions
+- ✅ Modify, distribute, and build on it freely
+
+[Read the full license](https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE)
 
 ---
 

--- a/docs/pitch/CASE_STUDIES.md
+++ b/docs/pitch/CASE_STUDIES.md
@@ -41,7 +41,7 @@ Deployed Attune AI with:
 - API cost savings: $50,400/year = **$50,400**
 - **Total: $320,400/year**
 
-**Investment:** Commercial license + setup
+**Investment:** Setup and integration time (the software is free, Apache 2.0)
 **Payback period:** < 2 months
 
 ---
@@ -165,18 +165,18 @@ Bug prevention: (bugs × 0.67) × fix_hours × hourly_rate × 12 months
 
 **Total Annual ROI:**
 ```
-Time savings + AI savings - License cost
+Time savings + AI savings
 ```
 
 ### Quick Estimates by Team Size
 
-| Team Size | Est. Annual Savings | License Cost | Net ROI |
-|-----------|---------------------|--------------|---------|
-| 1-5 devs | $15,000-$40,000 | $0 (Free) | $15,000-$40,000 |
-| 10 devs | $80,000-$120,000 | Contact us | High |
-| 25 devs | $180,000-$250,000 | Contact us | High |
-| 50 devs | $300,000-$450,000 | Contact us | High |
-| 100 devs | $600,000-$900,000 | Contact us | High |
+| Team Size | Est. Annual Savings | Net ROI |
+|-----------|---------------------|---------|
+| 1-5 devs | $15,000-$40,000 | $15,000-$40,000 |
+| 10 devs | $80,000-$120,000 | High |
+| 25 devs | $180,000-$250,000 | High |
+| 50 devs | $300,000-$450,000 | High |
+| 100 devs | $600,000-$900,000 | High |
 
 ---
 
@@ -232,7 +232,7 @@ attune init
 attune workflow run security-scan
 ```
 
-### Commercial Evaluation
+### Rollout Support
 Contact us for:
 - Proof of concept support
 - ROI assessment for your team

--- a/docs/pitch/CASE_STUDIES.md
+++ b/docs/pitch/CASE_STUDIES.md
@@ -89,7 +89,7 @@ A freelance developer handling multiple client projects needs:
 - Minimal AI costs on tight budgets
 
 ### Implementation
-Deployed Attune AI (Free tier) with:
+Deployed Attune AI with:
 - Smart model routing (Haiku for simple tasks)
 - SecurityWizard for pre-delivery scans
 - DocGenWizard for README and API docs
@@ -105,7 +105,7 @@ Deployed Attune AI (Free tier) with:
 | Client satisfaction | Good | Excellent | Faster delivery |
 
 ### Value for Small Teams
-- Free tier covers full functionality
+- Free and open source — full functionality at no cost
 - Professional-grade security scanning
 - Consistent quality without enterprise overhead
 
@@ -225,7 +225,7 @@ Built-in audit trails and security scanning reduce compliance burden.
 
 ## Getting Started
 
-### Free Tier (Teams ≤5)
+### Quick Start
 ```bash
 pip install attune-ai
 attune init

--- a/docs/pitch/TECHNICAL_BRIEF.md
+++ b/docs/pitch/TECHNICAL_BRIEF.md
@@ -302,10 +302,10 @@ print(tracker.summary())
 
 **Repository:** [github.com/Smart-AI-Memory/attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
-**License:** Apache License 2.0 0.9
-- Free for teams ≤5 employees
-- Commercial license required for 6+
-- Full source access for modification
+**License:** Apache License 2.0
+- Free and open source for any use, including commercial
+- No team-size, seat, or revenue restrictions
+- Full source access to use, modify, and redistribute
 
 ---
 

--- a/docs/pitch/VC_PITCH_DECK.md
+++ b/docs/pitch/VC_PITCH_DECK.md
@@ -80,13 +80,18 @@ A 5-level maturity model that progresses AI from reactive responses to predictin
 
 ### Business Model
 
-| Tier | Price | Target |
-|------|-------|--------|
-| **Free** | $0 | Students, educators, teams ≤5 |
-| **Commercial** | Contact us | Teams 6+ employees |
-| **Enterprise** | Custom | Volume licensing, SLA, on-prem |
+Attune AI is **free and open source (Apache 2.0)** — no seat or
+team-size licensing. Revenue comes from services layered on the open
+core:
 
-**Apache License 2.0 0.9:** Sustainable model balancing adoption with revenue.
+| Offering | Target |
+|----------|--------|
+| **Open source** | Everyone — free, including commercial use |
+| **Commercial support** | Teams wanting priority support and SLAs |
+| **Enterprise services** | On-prem deployment, integration, training |
+
+Open distribution drives adoption; support and services monetize the
+teams that come to depend on it.
 
 ---
 

--- a/website/ENHANCEMENTS_SUMMARY.md
+++ b/website/ENHANCEMENTS_SUMMARY.md
@@ -185,7 +185,6 @@ All pages now have proper Open Graph tags including:
 
 #### Terms of Service Covers:
 - Apache License 2.0 explanation
-- Free vs. Commercial tiers
 - Acceptable use policy
 - User accounts and responsibilities
 - Intellectual property rights

--- a/website/app/terms/page.tsx
+++ b/website/app/terms/page.tsx
@@ -54,13 +54,6 @@ export default function TermsPage() {
                 Full license terms available at: <a href="https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE">LICENSE</a>
               </p>
 
-              <h3>2.2 Commercial License</h3>
-              <p>
-                Commercial licenses are required for organizations with 6 or more employees.
-                One license covers all developer environments (workstation, staging, production, CI/CD).
-                See <a href="https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE-COMMERCIAL.md">LICENSE-COMMERCIAL.md</a> for full terms.
-              </p>
-
               <h2>3. Acceptable Use</h2>
               <p>You agree NOT to use our Services to:</p>
               <ul>
@@ -177,7 +170,6 @@ export default function TermsPage() {
               <ul>
                 <li>Violation of these Terms</li>
                 <li>Fraudulent or illegal activity</li>
-                <li>Non-payment of commercial license fees</li>
                 <li>At our sole discretion for any reason</li>
               </ul>
               <p>Upon termination, your right to use our Services ceases immediately.</p>

--- a/website/app/terms/page.tsx
+++ b/website/app/terms/page.tsx
@@ -46,10 +46,9 @@ export default function TermsPage() {
                 Attune AI is licensed under the Apache 2.0 License. Key terms:
               </p>
               <ul>
-                <li><strong>Free Tier:</strong> Free for students, educators, and organizations with ≤5 employees</li>
-                <li><strong>Commercial Tier:</strong> Contact us for pricing (organizations with 6+ employees)</li>
-                <li><strong>Source Available:</strong> You may read and modify the source code</li>
-                <li><strong>Redistribution:</strong> Subject to license terms</li>
+                <li><strong>Free &amp; open source:</strong> Free for everyone, including commercial use, with no team-size, seat, or revenue restrictions</li>
+                <li><strong>Modify &amp; distribute:</strong> You may use, modify, and redistribute the source code under the Apache 2.0 terms</li>
+                <li><strong>Patent grant:</strong> Apache 2.0 includes an express grant of patent rights from contributors</li>
               </ul>
               <p>
                 Full license terms available at: <a href="https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE">LICENSE</a>

--- a/website/lib/email.ts
+++ b/website/lib/email.ts
@@ -177,7 +177,6 @@ export async function sendBookEmail(data: {
       <h3>What's Included</h3>
       <ul>
         <li>Complete book in PDF, ePub, and Mobi formats</li>
-        <li>1-year commercial developer license ($49.99 value)</li>
         <li>Access to Software Development Plugin</li>
         <li>Access to Healthcare Plugin</li>
         <li>All future updates to this edition</li>


### PR DESCRIPTION
The docs and website misstated the license and carried a retired Business-Source-style pricing model (free for teams ≤5 / commercial for 6+, "\$99/dev/year", "auto-converts to Apache 2.0 in 2029", garbled "Apache License 2.0 0.9"). The actual `LICENSE` is **Apache 2.0** — free, open source, no restrictions. Per owner, the old pricing is removed everywhere.

### License statements corrected
- `docs/index.md`, `docs/governance.md` — plain Apache 2.0, no seat/team terms; dropped the 2029 auto-conversion.
- **`website/app/terms/page.tsx`** — the public Terms of Service license section (legally binding) corrected to Apache 2.0.

### Old pricing purged
- `docs/pitch/VC_PITCH_DECK.md` — Business Model reframed to open-source + support/services (no ≤5/6+ tiers, no invented prices).
- `docs/pitch/TECHNICAL_BRIEF.md`, `docs/pitch/CASE_STUDIES.md` — license/"Free tier" language → Apache 2.0 / open source.
- `docs/blog/social/reddit_claude_costs.md` — license line corrected.
- `website/lib/email.ts` — dropped the "1-year commercial developer license (\$49.99 value)" book-bundle perk.

### Left as-is (flagged)
- `docs/reference/TROUBLESHOOTING.md` "Commercial Support: contact us" — paid *support* is Apache-2.0-compatible and a current offering, not the retired license tier. Say the word if you want it gone too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)