### PR TITLE
docs(.help): full help-freshness sweep — 0 stale, + fix-test deleted-subsystem bug fix

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -10062,3 +10062,73 @@ files.
   pitch decks (the owner's call) and *paid-support* offerings (Apache-
   2.0-compatible, keep). When in doubt on commerce code, check for an
   existing `@deprecated` marker before ripping it out.
+
+- **`.help` content-hash staleness flags THAT source changed, not
+  WHETHER templates reference DELETED symbols — add a symbol-existence +
+  manifest-glob-existence pass to catch the dead-doc / broken-glob class
+  the hash is blind to**: 2026-06-22 help-freshness sweep.
+  `attune.help.staleness.compute_source_hash` / `check_staleness` only
+  compare a SHA of concatenated source against a stored hash (read from
+  `concept.md` frontmatter only), so a feature reads "stale" the moment
+  any byte under its glob changes — but the checker CANNOT see (a)
+  templates documenting symbols that were deleted, or (b)
+  `features.yaml` globs pointing at files that no longer exist. The
+  `fix-test` feature exposed both: `src/attune/workflows/test_lifecycle.py`
+  was deleted in #887 (TestLifecycleManager, TestTask, the task queue,
+  git-hook processing), yet all 11 fix-test templates still documented
+  those symbols AND the manifest still globbed the deleted file. Caught
+  only by a deliberate check: extract backticked `ClassName` / `func()`
+  refs from each feature's templates and assert each appears in that
+  feature's *resolved* source text (ignore-list builtins/stdlib like
+  `compile`, `ValueError`, `FileNotFoundError`). Durable rule: the
+  staleness flag is necessary-not-sufficient — to find docs that are
+  WRONG (reference removed code) vs merely STALE (accurate but old), run
+  a symbol/glob-existence pass. Regression-guard test queued (manifest
+  globs must resolve to real files; template symbols must exist in
+  source). Pairs with "research subagents confabulate SDK signatures —
+  introspect before coding" (verify against source, don't trust text).
+
+- **Most "stale" `.help` features are false positives from cross-cutting
+  refactors — rank by per-feature source-diff since each feature's OWN
+  gen date, and treat verified-accurate features with a hash-refresh,
+  not a regen**: same sweep. 23/23 features showed "stale," but ranking
+  by `git log --numstat --since=<that feature's generated_at>` over its
+  resolved globs showed wildly uneven drift: ~3,500 of ~4,100 changed
+  lines lived in 5 features; ~12 had ≤34 lines (lessons/formatting churn
+  or repo-wide refactors like "WorkflowReport output for all SDK
+  workflows" / "SDK subprocess isolation" that touched function bodies
+  without changing documented behavior); memory + agents had ZERO
+  content drift (stale only because a file was added/removed under the
+  glob). For the false-positive tier the correct action is a *verified*
+  hash-refresh — confirm every documented symbol still exists (above
+  lesson), then rewrite ONLY `generated_at` + `source_hash` frontmatter,
+  NOT a regen. `check_staleness` reads the stored hash from `concept.md`
+  only, so a concept-hash refresh clears the flag; refresh sibling
+  templates for consistency (harmless, not checked).
+
+- **The keyless `.help` regen is a content-STRIPPING regression and
+  "polish without the key" is a no-op — the driving Claude session is a
+  SUPERIOR polish layer to the API polish pass, and the only one that
+  catches correctness bugs; "best results" ≠ "wire up the API"**:
+  extends the "whole-feature re-polish" lesson with the quality
+  hierarchy. `run_maintenance` / `generate_feature_templates` WITHOUT
+  `ANTHROPIC_API_KEY` emit bare AST-scaffold (saw −582 lines across 5
+  features: lost hand-organized command/field tables, code examples,
+  polished prose; garbled preambles like "Use plugin when you need to
+  claude code plugin"). `_maybe_polish` just returns the bare content
+  when no key is set — there is NO keyless-polish mode. The polish pass
+  that exists (`attune.help.polish.polish_template`, raw
+  `anthropic.Anthropic`, `claude-sonnet-4-6`) (a) needs real API credits
+  the Claude subscription does NOT grant (400 "credit balance too low"),
+  and (b) only rewrites PROSE from a source *summary* — it trusts the
+  generator's structure and will NOT catch deleted-symbol / broken-glob
+  drift. The highest-quality, $0 path proven this session: keyless
+  generator for current structure → the driving Claude session
+  hand-polishes (verifying every fact against live source) →
+  symbol-existence check for correctness. So a curated agent session
+  beats automated API polish on BOTH prose and correctness; the API
+  path is the right tool ONLY for the unattended weekly CI regen (no
+  human in the loop), where it beats keyless-bare. Process win: parallel
+  read-only subagents produced per-feature surgical edit plans (exact
+  old→new strings); the driver verified every proposed signature/class
+  against source before applying (zero confabulation found).

--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -97,7 +97,6 @@ features:
     files:
       - src/attune/workflows/test_runner.py
       - src/attune/workflows/test_maintenance.py
-      - src/attune/workflows/test_lifecycle.py
     tags: [tests, debugging, fixes]
 
   mcp-server:

--- a/.help/templates/agents/comparison.md
+++ b/.help/templates/agents/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: agents-comparison
 feature: agents
 depth: comparison
-generated_at: 2026-06-04T23:45:26.769779+00:00
-source_hash: 1e0485a1d4d99146ba7b61c353f12a4e84f199551b1b95660a8148e047f01d2f
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 ---
 

--- a/.help/templates/agents/concept.md
+++ b/.help/templates/agents/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: agents-concept
 feature: agents
 depth: concept
-generated_at: 2026-06-11T04:43:25.146451+00:00
-source_hash: 7ddd0fc96a1f5315731bff455997f261001e41fc40732100eff70032b8dc0689
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 scaffold_hash: eed16125044825f51edb6ed518640ee3d6695302a7e9bb31e8311c530b6ab8fe
 ---

--- a/.help/templates/agents/error.md
+++ b/.help/templates/agents/error.md
@@ -3,8 +3,8 @@ type: error
 name: agents-error
 feature: agents
 depth: error
-generated_at: 2026-06-04T23:45:26.749017+00:00
-source_hash: 1e0485a1d4d99146ba7b61c353f12a4e84f199551b1b95660a8148e047f01d2f
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 ---
 

--- a/.help/templates/agents/faq.md
+++ b/.help/templates/agents/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: agents-faq
 feature: agents
 depth: faq
-generated_at: 2026-06-04T23:45:26.759983+00:00
-source_hash: 1e0485a1d4d99146ba7b61c353f12a4e84f199551b1b95660a8148e047f01d2f
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 ---
 

--- a/.help/templates/agents/note.md
+++ b/.help/templates/agents/note.md
@@ -3,8 +3,8 @@ type: note
 name: agents-note
 feature: agents
 depth: note
-generated_at: 2026-06-04T23:45:26.767017+00:00
-source_hash: 1e0485a1d4d99146ba7b61c353f12a4e84f199551b1b95660a8148e047f01d2f
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 ---
 

--- a/.help/templates/agents/quickstart.md
+++ b/.help/templates/agents/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: agents-quickstart
 feature: agents
 depth: quickstart
-generated_at: 2026-06-04T23:45:26.762514+00:00
-source_hash: 1e0485a1d4d99146ba7b61c353f12a4e84f199551b1b95660a8148e047f01d2f
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 ---
 

--- a/.help/templates/agents/reference.md
+++ b/.help/templates/agents/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: agents-reference
 feature: agents
 depth: reference
-generated_at: 2026-06-11T04:43:25.152927+00:00
-source_hash: 7ddd0fc96a1f5315731bff455997f261001e41fc40732100eff70032b8dc0689
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 scaffold_hash: 4784cd713b49011cc685b0c641b8519c53bcfa436aa96ec99e0886eef0ff9158
 ---

--- a/.help/templates/agents/task.md
+++ b/.help/templates/agents/task.md
@@ -3,8 +3,8 @@ type: task
 name: agents-task
 feature: agents
 depth: task
-generated_at: 2026-06-11T04:43:25.149762+00:00
-source_hash: 7ddd0fc96a1f5315731bff455997f261001e41fc40732100eff70032b8dc0689
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 scaffold_hash: 7421c22965ec3807961fe28de1b2907cf8908cc785869e21935dddbcab0b5191
 ---

--- a/.help/templates/agents/tip.md
+++ b/.help/templates/agents/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: agents-tip
 feature: agents
 depth: tip
-generated_at: 2026-06-04T23:45:26.764952+00:00
-source_hash: 1e0485a1d4d99146ba7b61c353f12a4e84f199551b1b95660a8148e047f01d2f
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 ---
 

--- a/.help/templates/agents/troubleshooting.md
+++ b/.help/templates/agents/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: agents-troubleshooting
 feature: agents
 depth: troubleshooting
-generated_at: 2026-06-04T23:45:26.757291+00:00
-source_hash: 1e0485a1d4d99146ba7b61c353f12a4e84f199551b1b95660a8148e047f01d2f
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 ---
 

--- a/.help/templates/agents/warning.md
+++ b/.help/templates/agents/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: agents-warning
 feature: agents
 depth: warning
-generated_at: 2026-06-04T23:45:26.754933+00:00
-source_hash: 1e0485a1d4d99146ba7b61c353f12a4e84f199551b1b95660a8148e047f01d2f
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f67c2f70bbc6d8bdf391e3cbf1ac1e57c554913aa2b3b355f736347e5526634
 status: generated
 ---
 

--- a/.help/templates/bug-predict/comparison.md
+++ b/.help/templates/bug-predict/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: bug-predict-comparison
 feature: bug-predict
 depth: comparison
-generated_at: 2026-06-02T10:56:02.703254+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/concept.md
+++ b/.help/templates/bug-predict/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: bug-predict-concept
 feature: bug-predict
 depth: concept
-generated_at: 2026-06-02T10:56:02.655473+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/error.md
+++ b/.help/templates/bug-predict/error.md
@@ -3,8 +3,8 @@ type: error
 name: bug-predict-error
 feature: bug-predict
 depth: error
-generated_at: 2026-06-02T10:56:02.674663+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/faq.md
+++ b/.help/templates/bug-predict/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: bug-predict-faq
 feature: bug-predict
 depth: faq
-generated_at: 2026-06-02T10:56:02.690028+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/note.md
+++ b/.help/templates/bug-predict/note.md
@@ -3,8 +3,8 @@ type: note
 name: bug-predict-note
 feature: bug-predict
 depth: note
-generated_at: 2026-06-02T10:56:02.700196+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/quickstart.md
+++ b/.help/templates/bug-predict/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: bug-predict-quickstart
 feature: bug-predict
 depth: quickstart
-generated_at: 2026-06-02T10:56:02.693845+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/reference.md
+++ b/.help/templates/bug-predict/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: bug-predict-reference
 feature: bug-predict
 depth: reference
-generated_at: 2026-06-02T10:56:02.668568+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/task.md
+++ b/.help/templates/bug-predict/task.md
@@ -3,8 +3,8 @@ type: task
 name: bug-predict-task
 feature: bug-predict
 depth: task
-generated_at: 2026-06-02T10:56:02.663294+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/tip.md
+++ b/.help/templates/bug-predict/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: bug-predict-tip
 feature: bug-predict
 depth: tip
-generated_at: 2026-06-02T10:56:02.697411+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/troubleshooting.md
+++ b/.help/templates/bug-predict/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: bug-predict-troubleshooting
 feature: bug-predict
 depth: troubleshooting
-generated_at: 2026-06-02T10:56:02.687232+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/bug-predict/warning.md
+++ b/.help/templates/bug-predict/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: bug-predict-warning
 feature: bug-predict
 depth: warning
-generated_at: 2026-06-02T10:56:02.684528+00:00
-source_hash: c4c1270dc9f702965624a9648b2eb72a439ab5e8009c5bf4c13f0018002eecde
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 750014addbbc0825c7da37de3ee7d765c2c29f9e0e9db47dbc9d3df3542340a0
 status: generated
 ---
 

--- a/.help/templates/cli/concept.md
+++ b/.help/templates/cli/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: cli-concept
 feature: cli
 depth: concept
-generated_at: 2026-06-10T07:07:04.638186+00:00
-source_hash: 5b5c949846a62732ae6954c6682e1c7a924430b6ac1efcd58027d681df89d386
+generated_at: 2026-06-22T09:48:39.757537+00:00
+source_hash: 164b677043cfbe05cdc85850c811ec14af92dabac3c48dced21fedf0c3c58146
 status: generated
 ---
 
@@ -29,7 +29,7 @@ The handler functions are organized into focused modules:
 | **Workflows** | `cmd_workflow_run`, `cmd_workflow_list`, `cmd_workflow_info` | Run and inspect registered workflows |
 | **Memory** | `cmd_remember`, `cmd_forget`, `cmd_memory_recall`, `cmd_memory_topics`, `cmd_memory_capture`, `cmd_memory_forget_topic`, `cmd_lessons` | Read and write the Redis-backed lesson store |
 | **Costs** | `cmd_costs`, `cmd_costs_today`, `cmd_costs_export`, `cmd_costs_reset` | Report, export, and clear cost-tracking data |
-| **Telemetry** | `cmd_telemetry_show`, `cmd_telemetry_savings`, `cmd_telemetry_routing_stats`, `cmd_telemetry_models`, `cmd_telemetry_agents`, `cmd_telemetry_signals` | Inspect routing and model-usage telemetry |
+| **Telemetry** | `cmd_telemetry_show`, `cmd_telemetry_savings`, `cmd_telemetry_routing_stats`, `cmd_telemetry_models`, `cmd_telemetry_agents`, `cmd_telemetry_signals`, `cmd_telemetry_status`, `cmd_telemetry_enable`, `cmd_telemetry_disable` | Inspect routing and model-usage telemetry, and control the opt-in usage ping |
 | **Providers** | `cmd_provider_show`, `cmd_provider_set` | View and change the active model provider |
 | **Patterns** | `cmd_patterns_review`, `cmd_patterns_promote`, `cmd_patterns_reject` | Curate promoted code patterns |
 | **Utility** | `cmd_setup`, `cmd_validate`, `cmd_version`, `cmd_doctor`, `cmd_features` | Diagnose, configure, and inspect the installation |

--- a/.help/templates/cli/reference.md
+++ b/.help/templates/cli/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: cli-reference
 feature: cli
 depth: reference
-generated_at: 2026-06-10T07:07:04.648409+00:00
-source_hash: 5b5c949846a62732ae6954c6682e1c7a924430b6ac1efcd58027d681df89d386
+generated_at: 2026-06-22T09:48:39.757537+00:00
+source_hash: 164b677043cfbe05cdc85850c811ec14af92dabac3c48dced21fedf0c3c58146
 status: generated
 ---
 

--- a/.help/templates/cli/task.md
+++ b/.help/templates/cli/task.md
@@ -3,8 +3,8 @@ type: task
 name: cli-task
 feature: cli
 depth: task
-generated_at: 2026-06-10T07:07:04.644047+00:00
-source_hash: 5b5c949846a62732ae6954c6682e1c7a924430b6ac1efcd58027d681df89d386
+generated_at: 2026-06-22T09:48:39.757537+00:00
+source_hash: 164b677043cfbe05cdc85850c811ec14af92dabac3c48dced21fedf0c3c58146
 status: generated
 ---
 

--- a/.help/templates/code-quality/comparison.md
+++ b/.help/templates/code-quality/comparison.md
@@ -2,8 +2,8 @@
 type: comparison
 feature: code-quality
 depth: comparison
-generated_at: 2026-04-19T18:47:17.035116+00:00
-source_hash: 44a3613be3cabe60572ba20a4d4a482a2b2727856106c44e43c6eafd7e2cc42e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/concept.md
+++ b/.help/templates/code-quality/concept.md
@@ -2,8 +2,8 @@
 type: concept
 feature: code-quality
 depth: concept
-generated_at: 2026-05-04T02:24:10.692732+00:00
-source_hash: 0d2aa6913a2dae27ec39d314c14f1f9a65365582fb2ba40d7060f571d73ca77e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/error.md
+++ b/.help/templates/code-quality/error.md
@@ -2,8 +2,8 @@
 type: error
 feature: code-quality
 depth: error
-generated_at: 2026-04-19T18:45:54.256615+00:00
-source_hash: 44a3613be3cabe60572ba20a4d4a482a2b2727856106c44e43c6eafd7e2cc42e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/faq.md
+++ b/.help/templates/code-quality/faq.md
@@ -2,8 +2,8 @@
 type: faq
 feature: code-quality
 depth: faq
-generated_at: 2026-04-19T18:46:40.477789+00:00
-source_hash: 44a3613be3cabe60572ba20a4d4a482a2b2727856106c44e43c6eafd7e2cc42e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/note.md
+++ b/.help/templates/code-quality/note.md
@@ -2,8 +2,8 @@
 type: note
 feature: code-quality
 depth: note
-generated_at: 2026-04-19T18:47:09.607556+00:00
-source_hash: 44a3613be3cabe60572ba20a4d4a482a2b2727856106c44e43c6eafd7e2cc42e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/quickstart.md
+++ b/.help/templates/code-quality/quickstart.md
@@ -2,8 +2,8 @@
 type: quickstart
 feature: code-quality
 depth: quickstart
-generated_at: 2026-04-19T18:46:52.819410+00:00
-source_hash: 44a3613be3cabe60572ba20a4d4a482a2b2727856106c44e43c6eafd7e2cc42e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/reference.md
+++ b/.help/templates/code-quality/reference.md
@@ -2,8 +2,8 @@
 type: reference
 feature: code-quality
 depth: reference
-generated_at: 2026-05-04T02:24:34.493990+00:00
-source_hash: 0d2aa6913a2dae27ec39d314c14f1f9a65365582fb2ba40d7060f571d73ca77e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/task.md
+++ b/.help/templates/code-quality/task.md
@@ -2,8 +2,8 @@
 type: task
 feature: code-quality
 depth: task
-generated_at: 2026-05-14T00:00:00+00:00
-source_hash: 0d2aa6913a2dae27ec39d314c14f1f9a65365582fb2ba40d7060f571d73ca77e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: hand_authored
 ---
 

--- a/.help/templates/code-quality/tip.md
+++ b/.help/templates/code-quality/tip.md
@@ -2,8 +2,8 @@
 type: tip
 feature: code-quality
 depth: tip
-generated_at: 2026-04-19T18:47:03.313407+00:00
-source_hash: 44a3613be3cabe60572ba20a4d4a482a2b2727856106c44e43c6eafd7e2cc42e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/troubleshooting.md
+++ b/.help/templates/code-quality/troubleshooting.md
@@ -2,8 +2,8 @@
 type: troubleshooting
 feature: code-quality
 depth: troubleshooting
-generated_at: 2026-04-19T18:46:23.112847+00:00
-source_hash: 44a3613be3cabe60572ba20a4d4a482a2b2727856106c44e43c6eafd7e2cc42e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/code-quality/warning.md
+++ b/.help/templates/code-quality/warning.md
@@ -2,8 +2,8 @@
 type: warning
 feature: code-quality
 depth: warning
-generated_at: 2026-04-19T18:46:09.104935+00:00
-source_hash: 44a3613be3cabe60572ba20a4d4a482a2b2727856106c44e43c6eafd7e2cc42e
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 4f0f1e5876a5f83b83316fb690fa9aa652fd8f63b15844a89c384083fbac424f
 status: generated
 ---
 

--- a/.help/templates/configuration/comparison.md
+++ b/.help/templates/configuration/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: configuration-comparison
 feature: configuration
 depth: comparison
-generated_at: 2026-06-04T23:45:26.726411+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/concept.md
+++ b/.help/templates/configuration/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: configuration-concept
 feature: configuration
 depth: concept
-generated_at: 2026-06-04T23:45:26.690316+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/error.md
+++ b/.help/templates/configuration/error.md
@@ -3,8 +3,8 @@ type: error
 name: configuration-error
 feature: configuration
 depth: error
-generated_at: 2026-06-04T23:45:26.705556+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/faq.md
+++ b/.help/templates/configuration/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: configuration-faq
 feature: configuration
 depth: faq
-generated_at: 2026-06-04T23:45:26.716548+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/note.md
+++ b/.help/templates/configuration/note.md
@@ -3,8 +3,8 @@ type: note
 name: configuration-note
 feature: configuration
 depth: note
-generated_at: 2026-06-04T23:45:26.723581+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/quickstart.md
+++ b/.help/templates/configuration/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: configuration-quickstart
 feature: configuration
 depth: quickstart
-generated_at: 2026-06-04T23:45:26.718993+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/reference.md
+++ b/.help/templates/configuration/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: configuration-reference
 feature: configuration
 depth: reference
-generated_at: 2026-06-04T23:45:26.701239+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/task.md
+++ b/.help/templates/configuration/task.md
@@ -3,8 +3,8 @@ type: task
 name: configuration-task
 feature: configuration
 depth: task
-generated_at: 2026-06-04T23:45:26.696710+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/tip.md
+++ b/.help/templates/configuration/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: configuration-tip
 feature: configuration
 depth: tip
-generated_at: 2026-06-04T23:45:26.721393+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/troubleshooting.md
+++ b/.help/templates/configuration/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: configuration-troubleshooting
 feature: configuration
 depth: troubleshooting
-generated_at: 2026-06-04T23:45:26.714110+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/configuration/warning.md
+++ b/.help/templates/configuration/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: configuration-warning
 feature: configuration
 depth: warning
-generated_at: 2026-06-04T23:45:26.711774+00:00
-source_hash: b67c4428689dde6c18aca17808e3037eded03448162cc3406741340bbe33b804
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
 status: generated
 ---
 

--- a/.help/templates/deep-review/comparison.md
+++ b/.help/templates/deep-review/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: deep-review-comparison
 feature: deep-review
 depth: comparison
-generated_at: 2026-06-02T10:54:11.468921+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/concept.md
+++ b/.help/templates/deep-review/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: deep-review-concept
 feature: deep-review
 depth: concept
-generated_at: 2026-06-02T10:54:11.428956+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/error.md
+++ b/.help/templates/deep-review/error.md
@@ -3,8 +3,8 @@ type: error
 name: deep-review-error
 feature: deep-review
 depth: error
-generated_at: 2026-06-02T10:54:11.446251+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/faq.md
+++ b/.help/templates/deep-review/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: deep-review-faq
 feature: deep-review
 depth: faq
-generated_at: 2026-06-02T10:54:11.458134+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/note.md
+++ b/.help/templates/deep-review/note.md
@@ -3,8 +3,8 @@ type: note
 name: deep-review-note
 feature: deep-review
 depth: note
-generated_at: 2026-06-02T10:54:11.466157+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/quickstart.md
+++ b/.help/templates/deep-review/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: deep-review-quickstart
 feature: deep-review
 depth: quickstart
-generated_at: 2026-06-02T10:54:11.460701+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/reference.md
+++ b/.help/templates/deep-review/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: deep-review-reference
 feature: deep-review
 depth: reference
-generated_at: 2026-06-02T10:54:11.441297+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/task.md
+++ b/.help/templates/deep-review/task.md
@@ -3,8 +3,8 @@ type: task
 name: deep-review-task
 feature: deep-review
 depth: task
-generated_at: 2026-06-02T10:54:11.436381+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/tip.md
+++ b/.help/templates/deep-review/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: deep-review-tip
 feature: deep-review
 depth: tip
-generated_at: 2026-06-02T10:54:11.463750+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/troubleshooting.md
+++ b/.help/templates/deep-review/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: deep-review-troubleshooting
 feature: deep-review
 depth: troubleshooting
-generated_at: 2026-06-02T10:54:11.455541+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/deep-review/warning.md
+++ b/.help/templates/deep-review/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: deep-review-warning
 feature: deep-review
 depth: warning
-generated_at: 2026-06-02T10:54:11.453016+00:00
-source_hash: e32648187b67c25e74699fc7a341857694ff7edd49f5c3d2fd4b545c1bdf65e4
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 0166eb83fb8436c203cdd073439a7339645f40e53cdfe39db4fbed0559eac81d
 status: generated
 ---
 

--- a/.help/templates/doc-gen/comparison.md
+++ b/.help/templates/doc-gen/comparison.md
@@ -2,8 +2,8 @@
 type: comparison
 feature: doc-gen
 depth: comparison
-generated_at: 2026-04-14T14:47:03.109926+00:00
-source_hash: 67aadd029bbf773d9f478a4d4c750e25344dc6b0bd9e1edadbcf5151d83f3bff
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/concept.md
+++ b/.help/templates/doc-gen/concept.md
@@ -2,8 +2,8 @@
 type: concept
 feature: doc-gen
 depth: concept
-generated_at: 2026-05-04T02:25:44.871332+00:00
-source_hash: 40c128b66a197e8117c6093f1f637e47e612fceae7fd2f94851a5a1d91120296
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/error.md
+++ b/.help/templates/doc-gen/error.md
@@ -2,8 +2,8 @@
 type: error
 feature: doc-gen
 depth: error
-generated_at: 2026-04-14T14:45:43.510233+00:00
-source_hash: 67aadd029bbf773d9f478a4d4c750e25344dc6b0bd9e1edadbcf5151d83f3bff
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/faq.md
+++ b/.help/templates/doc-gen/faq.md
@@ -2,8 +2,8 @@
 type: faq
 feature: doc-gen
 depth: faq
-generated_at: 2026-04-14T14:46:32.519288+00:00
-source_hash: 67aadd029bbf773d9f478a4d4c750e25344dc6b0bd9e1edadbcf5151d83f3bff
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/note.md
+++ b/.help/templates/doc-gen/note.md
@@ -2,8 +2,8 @@
 type: note
 feature: doc-gen
 depth: note
-generated_at: 2026-04-14T14:46:53.718269+00:00
-source_hash: 67aadd029bbf773d9f478a4d4c750e25344dc6b0bd9e1edadbcf5151d83f3bff
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/quickstart.md
+++ b/.help/templates/doc-gen/quickstart.md
@@ -2,8 +2,8 @@
 type: quickstart
 feature: doc-gen
 depth: quickstart
-generated_at: 2026-04-14T14:46:41.158188+00:00
-source_hash: 67aadd029bbf773d9f478a4d4c750e25344dc6b0bd9e1edadbcf5151d83f3bff
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/reference.md
+++ b/.help/templates/doc-gen/reference.md
@@ -2,8 +2,8 @@
 type: reference
 feature: doc-gen
 depth: reference
-generated_at: 2026-05-04T02:26:09.249962+00:00
-source_hash: 40c128b66a197e8117c6093f1f637e47e612fceae7fd2f94851a5a1d91120296
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/task.md
+++ b/.help/templates/doc-gen/task.md
@@ -2,8 +2,8 @@
 type: task
 feature: doc-gen
 depth: task
-generated_at: 2026-05-04T02:25:57.849088+00:00
-source_hash: 40c128b66a197e8117c6093f1f637e47e612fceae7fd2f94851a5a1d91120296
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/tip.md
+++ b/.help/templates/doc-gen/tip.md
@@ -2,8 +2,8 @@
 type: tip
 feature: doc-gen
 depth: tip
-generated_at: 2026-04-14T14:46:49.006874+00:00
-source_hash: 67aadd029bbf773d9f478a4d4c750e25344dc6b0bd9e1edadbcf5151d83f3bff
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/troubleshooting.md
+++ b/.help/templates/doc-gen/troubleshooting.md
@@ -2,8 +2,8 @@
 type: troubleshooting
 feature: doc-gen
 depth: troubleshooting
-generated_at: 2026-04-14T14:46:13.308363+00:00
-source_hash: 67aadd029bbf773d9f478a4d4c750e25344dc6b0bd9e1edadbcf5151d83f3bff
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/doc-gen/warning.md
+++ b/.help/templates/doc-gen/warning.md
@@ -2,8 +2,8 @@
 type: warning
 feature: doc-gen
 depth: warning
-generated_at: 2026-04-14T14:45:57.643752+00:00
-source_hash: 67aadd029bbf773d9f478a4d4c750e25344dc6b0bd9e1edadbcf5151d83f3bff
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: e72f8c7df1bc5e57a104c92b8ea7ec8a43b33084d7d1ab2add257441af45c122
 status: generated
 ---
 

--- a/.help/templates/fix-test/comparison.md
+++ b/.help/templates/fix-test/comparison.md
@@ -2,62 +2,50 @@
 type: comparison
 feature: fix-test
 depth: comparison
-generated_at: 2026-04-14T14:58:21.402719+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
-# TestLifecycleManager vs TestMaintenanceWorkflow vs manual test tracking
+# TestMaintenanceWorkflow vs manual tracking functions
 
-The test automation system provides three approaches for managing test lifecycle and maintenance. Each targets different automation levels and integration patterns.
+The fix-test feature offers two approaches for keeping tests in step with source changes. Each targets a different level of automation.
 
 ## Feature comparison
 
-| Feature | TestLifecycleManager | TestMaintenanceWorkflow | Manual tracking functions |
-|---------|---------------------|------------------------|---------------------------|
-| **Automation level** | Full event-driven automation | Workflow orchestration | Manual execution |
-| **File change detection** | Automatic via file events | Manual trigger | No detection |
-| **Queue management** | Built-in task queue with priorities | Plan-based execution | No queuing |
-| **Execution model** | Real-time or batch processing | On-demand workflow runs | Immediate execution |
-| **Git integration** | Pre/post-commit hooks | No git integration | No git integration |
-| **Scheduling** | Configurable maintenance intervals | Manual scheduling | No scheduling |
-| **Configuration complexity** | Medium (auto_execute, queue settings) | Low (project root only) | Minimal (optional params) |
+| Feature | TestMaintenanceWorkflow | Manual tracking functions |
+|---------|------------------------|---------------------------|
+| **Automation level** | Workflow orchestration | Manual execution |
+| **File change handling** | Event handlers map a change to a `TestPlanItem` | No detection |
+| **Planning** | Builds a `TestMaintenancePlan` you can filter and review | No planning |
+| **Execution model** | On-demand `run()`; you choose which items to act on | Immediate execution |
+| **Configuration complexity** | Low (project root only) | Minimal (optional params) |
 
 ## Detailed tradeoffs
 
-**TestLifecycleManager** provides the most comprehensive automation but requires setup overhead. It monitors file changes in real-time and can automatically execute test actions, making it ~10x faster for continuous integration scenarios. However, the event-driven nature means debugging issues requires understanding the queue state and callback system.
+**TestMaintenanceWorkflow** gives you structured control. You trigger it with `run()` (or per-file via `on_file_created/modified/deleted`), and it returns a `TestMaintenancePlan` of `TestPlanItem` entries — each with an `action`, `priority`, and `auto_executable` flag. You can review planned work before acting and run only the safe subset via `get_auto_executable_items()`. Best when you want visibility into what will happen before it does.
 
-**TestMaintenanceWorkflow** offers a middle ground with explicit control flow. You trigger workflows manually but get structured planning via TestMaintenancePlan objects. This approach is ~3x slower than lifecycle automation for frequent changes but provides better visibility into what actions will be taken before execution.
-
-**Manual tracking functions** give you precise control over individual operations with zero setup cost. Each function (`run_tests_with_tracking`, `track_coverage`, etc.) executes immediately and returns specific results. This is fastest for one-off debugging but becomes inefficient when managing more than a handful of test files.
-
-## Use TestLifecycleManager when...
-
-- You need continuous test maintenance during active development
-- Your project has frequent file changes that affect test validity
-- You want automated responses to git operations (pre-commit, post-commit)
-- You can tolerate some debugging complexity for maximum automation
+**Manual tracking functions** give you precise control over individual operations with zero setup cost. Each function (`run_tests_with_tracking`, `track_coverage`, `get_file_test_status`, …) executes immediately and returns specific results. Fastest for one-off debugging, but you coordinate the work yourself.
 
 ## Use TestMaintenanceWorkflow when...
 
-- You prefer explicit control over when test maintenance runs
+- You want changes mapped to prioritized test work automatically
 - You want to review planned actions before execution
-- Your test maintenance happens in scheduled batches rather than continuously
-- You need structured reporting via TestMaintenancePlan objects
+- You need structured reporting via `TestMaintenancePlan` objects
+- You want to auto-run the safe items and defer `REVIEW`/`MANUAL` ones
 
 ## Use manual tracking functions when...
 
 - You're debugging specific test failures interactively
 - You need to integrate test tracking into existing scripts or tools
-- You want immediate results without queue delays
-- You're working with a small number of files that don't change frequently
+- You want immediate results for a specific file or suite
+- You're working with a small number of files
 
-**Winner:** TestLifecycleManager for active development environments where test maintenance overhead is a bottleneck. The automation benefits outweigh the complexity cost once you have more than 10-15 test files to manage.
+**Rule of thumb:** reach for `TestMaintenanceWorkflow` when you want a reviewable plan across many files; drop to the tracking functions for targeted, one-off operations.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/concept.md
+++ b/.help/templates/fix-test/concept.md
@@ -1,47 +1,41 @@
 ---
-type: concept
 feature: fix-test
 depth: concept
-generated_at: 2026-05-04T02:28:39.831715+00:00
-source_hash: bff04fe2ad91cb5eb72a0a1c91eccca5bb1b81eba3549bb3ac7e694b3e7a98b8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Fix Test
 
-Fix-test automatically manages test lifecycles by responding to code changes and scheduling test maintenance tasks based on file events throughout your project.
+The fix-test feature keeps a project's tests healthy by reacting to source-file changes, diagnosing what test work each change implies, and producing a prioritized, partly auto-executable maintenance plan.
 
-## Event-driven test management
+## How it works
 
-When you modify source files, fix-test watches for these changes and queues appropriate test actions:
+`TestMaintenanceWorkflow` is the central coordinator. It turns file-system events into a `TestMaintenancePlan` — an ordered set of `TestPlanItem` entries, each describing one piece of test work: which file it concerns, what `TestAction` to take, and at what `TestPriority`.
 
-- **File creation** — Schedules test generation for new modules through `on_file_created()`
-- **File modification** — Queues test updates when existing code changes via `on_file_modified()`
-- **File deletion** — Removes orphaned tests when source files are deleted using `on_file_deleted()`
+The building blocks:
 
-The `TestLifecycleManager` acts as the central coordinator, transforming file system events into prioritized `TestTask` items that specify what test action to take and when.
+- **`TestMaintenanceWorkflow`** — coordinates everything. `run(context)` produces a maintenance plan; the event handlers `on_file_created()`, `on_file_modified()`, and `on_file_deleted()` translate a single file change into the test work it implies.
+- **`TestPlanItem`** — one unit of test work. Carries `file_path`, `action`, `priority`, `reason`, `test_file_path`, `estimated_effort`, and `auto_executable`.
+- **`TestMaintenancePlan`** — the assembled plan. Filter it with `get_items_by_action()`, `get_items_by_priority()`, or `get_auto_executable_items()`.
+- **`TestAction`** — what to do with a test: `CREATE`, `UPDATE`, `REVIEW`, `DELETE`, `SKIP`, or `MANUAL`.
+- **`TestPriority`** — how urgent: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `DEFERRED`.
 
-## Task prioritization and execution
+## How a change becomes a plan
 
-Each test task gets assigned a priority level through `TestPriority` (high, medium, low) and an action type via `TestAction` (create, update, delete, validate). The system maintains a persistent queue where you can:
+1. A source file changes. The matching handler — `on_file_created()`, `on_file_modified()`, or `on_file_deleted()` — inspects it and decides which `TestAction` applies (a new module needs a `CREATE`; a deleted one may imply a `DELETE` or `REVIEW`).
+2. The workflow assigns a `TestPriority` based on impact and rolls the resulting `TestPlanItem` entries into a `TestMaintenancePlan`.
+3. Callers act on the plan: `get_auto_executable_items()` returns the items safe to run automatically, while higher-touch items (`REVIEW`, `MANUAL`) are surfaced for a human.
 
-- Process tasks by priority using `get_queue_by_priority()`
-- Execute batches of work with `process_queue()` up to a specified limit
-- Schedule recurring maintenance through `schedule_maintenance()`
+## Tracking what actually ran
 
-For example, a critical bug fix that breaks existing tests gets high priority, while adding tests for edge cases in stable code gets low priority.
+The companion module `test_runner.py` records outcomes so the workflow can reason about staleness and gaps:
 
-## Git workflow integration
+- `run_tests_with_tracking()` runs a suite and records the result for Tier 1 monitoring.
+- `track_coverage()` and `track_file_tests()` persist coverage and per-file test status.
+- `get_file_test_status()` and `get_files_needing_tests()` answer "is this file covered?" and "what still needs tests?" — the same signals `TestMaintenanceWorkflow.get_stale_tests()` and `get_test_health_summary()` build on.
 
-Fix-test hooks into your Git workflow at two key points:
+## When this matters
 
-- **Pre-commit** — Validates that staged files have corresponding tests via `process_git_pre_commit()`
-- **Post-commit** — Schedules test updates for all changed files through `process_git_post_commit()`
-
-This ensures your test suite stays synchronized with code changes without manual intervention.
-
-## Test maintenance planning
-
-The `TestMaintenanceWorkflow` analyzes your entire project to create comprehensive maintenance plans. It identifies files that need tests through `get_files_needing_tests()`, finds outdated tests via `get_stale_tests()`, and generates a `TestMaintenancePlan` with concrete action items.
-
-Each `TestPlanItem` includes the target file, required action, priority level, effort estimate, and whether the task can be automated — giving you a clear roadmap for improving test coverage and keeping tests current.
+You work with fix-test when you want to keep test coverage in step with source changes automatically — surfacing the tests a change demands, prioritizing them by impact, and auto-running the safe ones — rather than discovering gaps after a regression lands.

--- a/.help/templates/fix-test/error.md
+++ b/.help/templates/fix-test/error.md
@@ -2,22 +2,22 @@
 type: error
 feature: fix-test
 depth: error
-generated_at: 2026-04-14T14:56:45.083008+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Fix Test errors
 
-Failures in automated test lifecycle management, test execution tracking, and test maintenance workflows.
+Failures in test maintenance planning, test execution tracking, and source-file event handling.
 
 ## Common error signatures
 
 - `FileNotFoundError: Coverage file not found: {path}` — The coverage.xml file specified in `track_coverage()` doesn't exist
 - `ValueError: Invalid coverage.xml format: {details}` — Coverage file exists but contains malformed XML or missing required elements
-- Test task queue corruption causing `TestTask` processing failures
+- Unexpected `TestPlanItem` entries when an event maps a file to the wrong `TestAction`
 - File path resolution errors when mapping source files to their corresponding test files
-- Priority filtering failures in `TestLifecycleManager.process_queue()`
+- Priority filtering returning nothing from `TestMaintenancePlan.get_items_by_priority()` when an invalid `TestPriority` is passed
 
 ## Where errors originate
 
@@ -25,26 +25,25 @@ Most failures occur during:
 
 - **Test execution tracking** — `run_tests_with_tracking()` fails when test commands exit with non-zero codes or produce unparseable output
 - **Coverage analysis** — `track_coverage()` raises exceptions when coverage files are missing, corrupted, or in unexpected formats
-- **File monitoring** — Event handlers (`on_file_created()`, `on_file_modified()`, `on_file_deleted()`) fail when file paths are invalid or inaccessible
-- **Queue processing** — `TestLifecycleManager.process_queue()` encounters errors when tasks reference deleted files or have malformed metadata
-- **Test maintenance planning** — `TestMaintenanceWorkflow.run()` fails when project structure analysis produces inconsistent results
+- **File event handling** — the handlers (`on_file_created()`, `on_file_modified()`, `on_file_deleted()`) fail when file paths are invalid or inaccessible
+- **Plan generation** — `TestMaintenanceWorkflow.run()` fails when project structure analysis produces inconsistent results
+- **Plan filtering** — `get_items_by_action()` / `get_items_by_priority()` return empty results when passed a value that isn't a `TestAction` / `TestPriority`
 
 ## How to diagnose
 
-1. **Check file paths first.** Many errors stem from missing test files, moved source files, or incorrect project root configuration. Verify that `project_root` in `TestMaintenanceWorkflow` and `TestLifecycleManager` points to the correct directory.
+1. **Check file paths first.** Many errors stem from missing test files, moved source files, or incorrect project root configuration. Verify that the project root used by `TestMaintenanceWorkflow` points to the correct directory.
 
-2. **Examine the task queue.** If `TestLifecycleManager` operations fail, call `get_queue()` to inspect pending tasks. Look for tasks with invalid `file_path` values or corrupted `metadata` fields.
+2. **Examine the plan.** If `TestMaintenanceWorkflow.run()` produces unexpected results, inspect `plan.items` and each item's `file_path`, `action`, and `metadata` for invalid or corrupted values.
 
 3. **Validate coverage files.** When `track_coverage()` fails, check that the coverage.xml file exists and contains valid XML. The file must include `<coverage>` root elements with measurable line and branch data.
 
-4. **Test file mapping issues.** If test lifecycle events fail, verify that the `ProjectIndex` can correctly map source files to test files. Missing or outdated index data causes most file-based operations to fail.
+4. **Test file mapping issues.** If event handlers fail, verify that the `ProjectIndex` can correctly map source files to test files. Missing or outdated index data causes most file-based operations to fail.
 
-5. **Check priority and action values.** `TestPlanItem` and `TestTask` objects require valid `TestAction` and `TestPriority` enum values. Invalid enums cause filtering and processing methods to raise `AttributeError` or `KeyError`.
+5. **Check priority and action values.** `TestPlanItem` objects require valid `TestAction` and `TestPriority` enum values. Invalid enums cause filtering methods to return nothing or raise `AttributeError`.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/faq.md
+++ b/.help/templates/fix-test/faq.md
@@ -2,8 +2,8 @@
 type: faq
 feature: fix-test
 depth: faq
-generated_at: 2026-04-14T14:57:37.506391+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
@@ -20,7 +20,7 @@ Use fix-test when you need to:
 - Monitor test coverage and execution
 - Get maintenance plans for stale or missing tests
 - Respond to file changes with appropriate test actions
-- Schedule regular test health checks
+- Get a quick test-health summary for your project
 
 ## What are the main functions I should know about?
 
@@ -37,7 +37,7 @@ Use the `TestMaintenanceWorkflow` class. It analyzes your project and generates 
 
 ## How do I respond to file changes automatically?
 
-The `TestLifecycleManager` handles file events for you. It creates `TestTask` objects when files are created, modified, or deleted, then queues them for processing based on priority.
+`TestMaintenanceWorkflow` handles file events for you. Its `on_file_created()`, `on_file_modified()`, and `on_file_deleted()` handlers each return a `TestPlanItem` describing the test action that change implies, with an assigned `TestAction` and `TestPriority`.
 
 ## What happens when I run `track_coverage()`?
 
@@ -49,9 +49,8 @@ First, run `pytest -k "fix-test" -v` to check if the feature's own tests pass. I
 
 ## Where are the source files?
 
-The fix-test feature spans three files:
+The fix-test feature spans two files:
 - `src/attune/workflows/test_runner.py` — Test execution and coverage tracking
-- `src/attune/workflows/test_maintenance.py` — Maintenance workflow and planning
-- `src/attune/workflows/test_lifecycle.py` — Event-driven test lifecycle management
+- `src/attune/workflows/test_maintenance.py` — Maintenance workflow, planning, and source-file event handlers
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/note.md
+++ b/.help/templates/fix-test/note.md
@@ -2,8 +2,8 @@
 type: note
 feature: fix-test
 depth: note
-generated_at: 2026-04-14T14:58:08.551287+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
@@ -11,26 +11,23 @@ status: generated
 
 ## Context
 
-The fix-test feature provides automated test lifecycle management through event-driven workflows. It tracks test coverage, identifies files needing test attention, and manages test maintenance plans with priority-based execution.
+The fix-test feature provides test maintenance through event-driven planning. It tracks test coverage, identifies files needing test attention, and turns source-file changes into prioritized maintenance plans.
 
 ## Architecture
 
-The feature combines three complementary modules:
+The feature combines two complementary modules:
 
 **Test execution tracking** (`test_runner.py`) provides opt-in monitoring functions that record test results and coverage data for Tier 1 automation. Key functions include `run_tests_with_tracking()` for explicit test execution tracking and `track_coverage()` for parsing coverage.xml files.
 
-**Test maintenance planning** (`test_maintenance.py`) defines the data structures for organizing test work. `TestMaintenancePlan` contains prioritized `TestPlanItem` instances that specify actions like creating new tests or updating existing ones. Each item includes metadata like estimated effort and auto-execution flags.
-
-**Event-driven lifecycle management** (`test_lifecycle.py`) responds to file system changes through `TestLifecycleManager`. When source files are created, modified, or deleted, the manager queues appropriate `TestTask` instances. The workflow supports Git hooks for pre-commit and post-commit processing.
+**Test maintenance planning and event handling** (`test_maintenance.py`) defines both the plan model and the coordinator. `TestMaintenancePlan` contains prioritized `TestPlanItem` instances that specify actions like creating or updating tests, each with metadata like estimated effort and an auto-executable flag. `TestMaintenanceWorkflow` responds to file-system changes through its `on_file_created()`, `on_file_modified()`, and `on_file_deleted()` handlers and assembles the plan via `run()`.
 
 ## Integration pattern
 
-The modules work together through shared data types. Test execution functions accept workflow IDs that link results to specific maintenance plans. The lifecycle manager generates tasks that reference the same action and priority enums used in maintenance plans. This allows the system to automatically queue test work when files change and execute it according to configured priorities.
+The modules work together through shared data types. Test execution functions accept workflow IDs that link results to specific maintenance plans. The event handlers produce `TestPlanItem` entries that reference the same `TestAction` and `TestPriority` enums used throughout the plan. This lets the system map a file change to prioritized test work and surface the auto-executable subset for execution.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/quickstart.md
+++ b/.help/templates/fix-test/quickstart.md
@@ -2,14 +2,14 @@
 type: quickstart
 feature: fix-test
 depth: quickstart
-generated_at: 2026-04-14T14:57:50.585458+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Quickstart: fix-test
 
-Track and manage failing tests across your project. The fix-test feature automatically identifies files that need test attention and queues maintenance tasks.
+Track and manage failing tests across your project. The fix-test feature identifies files that need test attention and turns changes into a prioritized maintenance plan.
 
 ```python
 from attune.workflows.test_runner import get_files_needing_tests
@@ -29,30 +29,31 @@ File: src/another_module.py
 Status: no_tests
 ```
 
-## Set up automated test lifecycle management
+## Build a test maintenance plan
 
-1. **Initialize the test lifecycle manager**
+1. **Create the workflow**
    ```python
-   from attune.workflows.test_lifecycle import TestLifecycleManager
+   from attune.workflows.test_maintenance import TestMaintenanceWorkflow
 
-   manager = TestLifecycleManager(project_root=".", auto_execute=True)
+   workflow = TestMaintenanceWorkflow()
    ```
 
-2. **Process file changes to queue test tasks**
+2. **React to a change, or build a full plan**
    ```python
-   # When files change, automatically queue maintenance tasks
-   tasks = manager.on_files_changed(["src/updated_file.py", "src/new_file.py"])
-   print(f"Queued {len(tasks)} test maintenance tasks")
+   # Per-file: returns a TestPlanItem | None
+   item = workflow.on_file_modified("src/updated_file.py")
+
+   # Or a full plan for the project
+   plan = workflow.run({})
+   print(f"Planned {len(plan.items)} test maintenance items")
    ```
 
-3. **Execute queued maintenance**
+3. **Act on the safe subset**
    ```python
-   # Process pending test maintenance tasks
-   results = manager.process_queue(max_tasks=5)
-   print(f"Completed: {results['completed_count']}")
-   print(f"Failed: {results['failed_count']}")
+   safe = plan.get_auto_executable_items()
+   print(f"{len(safe)} items can run automatically")
    ```
 
 ## Next steps
 
-Run `manager.get_test_health_summary()` to see an overview of your project's test coverage and identify the highest-priority areas for improvement.
+Run `workflow.get_test_health_summary()` to see an overview of your project's test coverage and identify the highest-priority areas for improvement.

--- a/.help/templates/fix-test/reference.md
+++ b/.help/templates/fix-test/reference.md
@@ -1,126 +1,76 @@
 ---
-type: reference
 feature: fix-test
 depth: reference
-generated_at: 2026-05-04T02:29:09.486519+00:00
-source_hash: bff04fe2ad91cb5eb72a0a1c91eccca5bb1b81eba3549bb3ac7e694b3e7a98b8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Fix Test reference
 
-Event-driven test management with automatic lifecycle control, maintenance workflows, and execution tracking for automated test repair and monitoring.
-
 ## Classes
 
-| Class | Description |
-|-------|-------------|
-| `TestTask` | A queued test management task |
-| `TestLifecycleManager` | Manages test lifecycle based on source file events |
-| `TestAction` | Actions available for test management |
-| `TestPriority` | Priority levels for test actions |
-| `TestPlanItem` | Single item in a test maintenance plan |
-| `TestMaintenancePlan` | Complete test maintenance plan for a project |
-| `TestMaintenanceWorkflow` | Workflow for automatic test lifecycle management |
+| Class | Description | File |
+|-------|-------------|------|
+| `TestAction` | Action to take for a test: `CREATE`, `UPDATE`, `REVIEW`, `DELETE`, `SKIP`, `MANUAL`. | `src/attune/workflows/test_maintenance.py` |
+| `TestPriority` | Priority for a test action: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `DEFERRED`. | `src/attune/workflows/test_maintenance.py` |
+| `TestPlanItem` | A single item in a test maintenance plan. | `src/attune/workflows/test_maintenance.py` |
+| `TestMaintenancePlan` | Complete test maintenance plan for a project. | `src/attune/workflows/test_maintenance.py` |
+| `TestMaintenanceWorkflow` | Coordinates test maintenance from source-file events. | `src/attune/workflows/test_maintenance.py` |
 
-### TestTask
+### `TestPlanItem` fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `id` | `str` | | Task identifier |
-| `file_path` | `str` | | Path to the file being tested |
-| `action` | `TestAction` | | Action to perform |
-| `priority` | `TestPriority` | | Task priority level |
-| `created_at` | `datetime` | `field(default_factory=datetime.now)` | Task creation timestamp |
-| `scheduled_for` | `datetime | None` | `None` | Scheduled execution time |
-| `status` | `str` | `'pending'` | Current task status |
-| `result` | `dict[str, Any] | None` | `None` | Task execution results |
+| Field | Type | Role |
+|-------|------|------|
+| `file_path` | `str` | The source file the work concerns |
+| `action` | `TestAction` | What to do with the test |
+| `priority` | `TestPriority` | How urgent the work is |
+| `reason` | `str` | Why this item was generated |
+| `test_file_path` | `str \| None` | The associated test file, if known |
+| `estimated_effort` | `str` | Rough effort estimate |
+| `auto_executable` | `bool` | Whether the item can be run without review |
+| `metadata` | `dict` | Free-form extra context |
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Convert task to dictionary format |
+`to_dict()` serializes the item.
 
-### TestLifecycleManager
+### `TestMaintenancePlan` methods
 
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|
-| `__init__(self, project_root, index, auto_execute, queue_file)` | `project_root: str, index: ProjectIndex | None = None, auto_execute: bool = False, queue_file: str | None = None` | | Initialize test lifecycle manager |
-| `on_file_created(self, file_path)` | `file_path: str` | `TestTask | None` | Handle file creation event |
-| `on_file_modified(self, file_path)` | `file_path: str` | `TestTask | None` | Handle file modification event |
-| `on_file_deleted(self, file_path)` | `file_path: str` | `TestTask | None` | Handle file deletion event |
-| `on_files_changed(self, changed_files)` | `changed_files: list[str]` | `list[TestTask]` | Handle multiple file changes |
-| `get_queue(self)` | | `list[dict[str, Any]]` | Get current task queue |
-| `get_pending_count(self)` | | `int` | Get count of pending tasks |
-| `get_queue_by_priority(self, priority)` | `priority: TestPriority` | `list[TestTask]` | Get tasks filtered by priority |
-| `clear_queue(self)` | | `int` | Clear all queued tasks |
-| `process_queue(self, max_tasks, priority_filter)` | `max_tasks: int = 10, priority_filter: TestPriority | None = None` | `dict[str, Any]` | Process queued tasks |
-| `schedule_maintenance(self, interval_hours, auto_execute)` | `interval_hours: int = 24, auto_execute: bool = False` | `dict[str, Any]` | Schedule maintenance tasks |
-| `run_maintenance(self, auto_execute)` | `auto_execute: bool = False` | `dict[str, Any]` | Run maintenance workflow |
-| `process_git_pre_commit(self, staged_files)` | `staged_files: list[str]` | `dict[str, Any]` | Process pre-commit file changes |
-| `process_git_post_commit(self, changed_files)` | `changed_files: list[str]` | `dict[str, Any]` | Process post-commit file changes |
-| `on_task_queued(self, callback)` | `callback: Callable[[TestTask], None]` | `None` | Register task queued callback |
-| `on_task_completed(self, callback)` | `callback: Callable[[TestTask], None]` | `None` | Register task completed callback |
-| `get_status(self)` | | `dict[str, Any]` | Get manager status |
+| `to_dict()` | — | `dict` | Serialize the plan. |
+| `get_items_by_action(action)` | `action: TestAction` | `list[TestPlanItem]` | Items with the given action. |
+| `get_items_by_priority(priority)` | `priority: TestPriority` | `list[TestPlanItem]` | Items at the given priority. |
+| `get_auto_executable_items()` | — | `list[TestPlanItem]` | Items safe to run automatically. |
 
-### TestPlanItem
+Fields: `generated_at`, `items`, `summary`, `options`.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `file_path` | `str` | | Path to source file |
-| `action` | `TestAction` | | Required action |
-| `priority` | `TestPriority` | | Action priority |
-| `reason` | `str` | | Reason for action |
-| `test_file_path` | `str | None` | `None` | Associated test file |
-| `estimated_effort` | `str` | `'unknown'` | Effort estimate |
-| `auto_executable` | `bool` | `True` | Whether action can be automated |
-| `metadata` | `dict[str, Any]` | `field(default_factory=dict)` | Additional metadata |
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Convert item to dictionary format |
-
-### TestMaintenancePlan
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `generated_at` | `datetime` | `field(default_factory=datetime.now)` | Plan generation timestamp |
-| `items` | `list[TestPlanItem]` | `field(default_factory=list)` | Plan items |
-| `summary` | `dict[str, Any]` | `field(default_factory=dict)` | Plan summary |
-| `options` | `list[dict[str, Any]]` | `field(default_factory=list)` | Available options |
+### `TestMaintenanceWorkflow` methods
 
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|
-| `to_dict(self)` | | `dict[str, Any]` | Convert plan to dictionary format |
-| `get_items_by_action(self, action)` | `action: TestAction` | `list[TestPlanItem]` | Filter items by action type |
-| `get_items_by_priority(self, priority)` | `priority: TestPriority` | `list[TestPlanItem]` | Filter items by priority |
-| `get_auto_executable_items(self)` | | `list[TestPlanItem]` | Get items that can be automated |
-
-### TestMaintenanceWorkflow
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__(self, project_root, index)` | `project_root: str, index: ProjectIndex | None = None` | | Initialize maintenance workflow |
-| `run(self, context)` | `context: dict[str, Any]` | `dict[str, Any]` | Run maintenance workflow |
-| `on_file_created(self, file_path)` | `file_path: str` | `dict[str, Any]` | Handle file creation |
-| `on_file_modified(self, file_path)` | `file_path: str` | `dict[str, Any]` | Handle file modification |
-| `on_file_deleted(self, file_path)` | `file_path: str` | `dict[str, Any]` | Handle file deletion |
-| `get_files_needing_tests(self, limit)` | `limit: int = 20` | `list[dict[str, Any]]` | Get files requiring test coverage |
-| `get_stale_tests(self, limit)` | `limit: int = 20` | `list[dict[str, Any]]` | Get outdated test files |
-| `get_test_health_summary(self)` | | `dict[str, Any]` | Get overall test health status |
+| `run(context)` | `context: dict` | `TestMaintenancePlan` | Build a maintenance plan for the project. |
+| `on_file_created(file_path)` | `file_path: str` | `TestPlanItem \| None` | Test work implied by a new file. |
+| `on_file_modified(file_path)` | `file_path: str` | `TestPlanItem \| None` | Test work implied by a changed file. |
+| `on_file_deleted(file_path)` | `file_path: str` | `TestPlanItem \| None` | Test work implied by a deleted file. |
+| `get_files_needing_tests(limit)` | `limit: int` | `list` | Files needing tests, prioritized by impact. |
+| `get_stale_tests(limit)` | `limit: int` | `list` | Files with stale tests. |
+| `get_test_health_summary()` | — | `dict` | Quick test-health summary. |
 
 ## Functions
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `run_tests_with_tracking(test_suite, test_files, command, workflow_id, triggered_by)` | `test_suite: str = 'unit', test_files: list[str] | None = None, command: str | None = None, workflow_id: str | None = None, triggered_by: str = 'manual'` | `TestExecutionRecord` | Run tests with explicit tracking for Tier 1 monitoring |
-| `track_coverage(coverage_file, workflow_id)` | `coverage_file: str = 'coverage.xml', workflow_id: str | None = None` | `CoverageRecord` | Track test coverage from coverage.xml file |
-| `track_file_tests(source_file, test_file, workflow_id)` | `source_file: str, test_file: str | None = None, workflow_id: str | None = None` | `FileTestRecord` | Track test execution for a specific source file |
-| `get_file_test_status(file_path)` | `file_path: str` | `FileTestRecord | None` | Get latest test status for a file |
-| `get_files_needing_tests(stale_only, failed_only)` | `stale_only: bool = False, failed_only: bool = False` | `list[FileTestRecord]` | Get files that need test attention |
+| Function | Parameters | Returns | Description | File |
+|----------|------------|---------|-------------|------|
+| `run_tests_with_tracking()` | `test_suite, test_files, command, workflow_id, triggered_by` | `dict` | Run tests with explicit tracking (opt-in Tier 1 monitoring). | `test_runner.py` |
+| `track_coverage()` | `coverage_file, workflow_id` | `dict` | Track coverage from a `coverage.xml` file. | `test_runner.py` |
+| `track_file_tests()` | `source_file, test_file, workflow_id` | `dict` | Track test execution for a specific source file. | `test_runner.py` |
+| `get_file_test_status()` | `file_path` | `FileTestRecord \| None` | Latest test status for a file. | `test_runner.py` |
+| `get_files_needing_tests()` | `stale_only, failed_only` | `list` | Files that need test attention. | `test_runner.py` |
 
-### Raises
+## Source files
 
-| Function | Exception | Message |
-|----------|-----------|---------|
-| `track_coverage()` | `FileNotFoundError` | `'Coverage file not found: {...}'` |
-| `track_coverage()` | `ValueError` | `'Invalid coverage.xml format: {...}'` |
+- `src/attune/workflows/test_runner.py`
+- `src/attune/workflows/test_maintenance.py`
+
+## Tags
+
+`tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/task.md
+++ b/.help/templates/fix-test/task.md
@@ -1,82 +1,95 @@
 ---
-type: task
 feature: fix-test
 depth: task
-generated_at: 2026-05-04T02:28:54.250565+00:00
-source_hash: bff04fe2ad91cb5eb72a0a1c91eccca5bb1b81eba3549bb3ac7e694b3e7a98b8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Work with fix test
 
-Use the fix-test system when you need to implement or modify automatic test diagnosis and repair capabilities in your project.
+Use fix test when you want to extend how source-file changes are
+turned into prioritized test work, or change how test outcomes are
+tracked.
 
 ## Prerequisites
 
 - Access to the project source code
-- Understanding of test execution workflows
-- Familiarity with the test lifecycle management system
+- Familiarity with `src/attune/workflows/test_maintenance.py` (the
+  workflow and plan model) and `src/attune/workflows/test_runner.py`
+  (outcome tracking)
 
-## Understand the test lifecycle architecture
+## Understand the two modules
 
-Start by examining how the test lifecycle system works:
+| Module | Owns |
+|--------|------|
+| `test_maintenance.py` | `TestMaintenanceWorkflow` and the plan model — `TestPlanItem`, `TestMaintenancePlan`, `TestAction`, `TestPriority` |
+| `test_runner.py` | Outcome tracking — `run_tests_with_tracking()`, `track_coverage()`, `track_file_tests()`, and the status queries |
 
-1. Open `src/attune/workflows/test_lifecycle.py` to see the `TestLifecycleManager` class
-2. Review the `TestTask` and `TestAction` dataclasses to understand the task queue structure
-3. Check `src/attune/workflows/test_maintenance.py` for the `TestMaintenanceWorkflow` that handles automatic test management
+## Generate a maintenance plan
 
-The system uses event-driven test management where file changes trigger test tasks that get queued and processed automatically.
+1. **Instantiate the workflow** and call `run()` with a context dict:
 
-## Identify the target component
+   ```python
+   from attune.workflows.test_maintenance import TestMaintenanceWorkflow
 
-Determine which component needs modification based on your goal:
+   workflow = TestMaintenanceWorkflow()
+   plan = workflow.run({})
+   ```
 
-- **Test execution tracking**: Modify functions in `src/attune/workflows/test_runner.py`
-- **Test lifecycle events**: Update `TestLifecycleManager` methods in `test_lifecycle.py`
-- **Maintenance workflows**: Change `TestMaintenanceWorkflow` in `test_maintenance.py`
+2. **Filter the plan** by what you need:
 
-## Modify test execution functions
+   ```python
+   from attune.workflows.test_maintenance import TestAction, TestPriority
 
-For changes to test running and tracking:
+   to_create = plan.get_items_by_action(TestAction.CREATE)
+   urgent = plan.get_items_by_priority(TestPriority.CRITICAL)
+   safe = plan.get_auto_executable_items()
+   ```
 
-1. Locate the specific function in `test_runner.py`:
-   - `run_tests_with_tracking()` for test execution with monitoring
-   - `track_coverage()` for coverage analysis
-   - `track_file_tests()` for file-specific test tracking
-   - `get_file_test_status()` for retrieving test status
-   - `get_files_needing_tests()` for identifying test gaps
+3. **Inspect a `TestPlanItem`** — each carries `file_path`, `action`,
+   `priority`, `reason`, `test_file_path`, `estimated_effort`, and
+   `auto_executable`.
 
-2. Read the function's docstring and examine its parameters and return type
-3. Study the existing error handling patterns and logging style
-4. Implement your changes following the established conventions
+## React to a single file change
 
-## Update lifecycle management
+Use the event handlers when you want per-file behavior rather than a
+full plan:
 
-For changes to the test lifecycle system:
-
-1. Modify the appropriate method in `TestLifecycleManager`:
-   - `on_file_created()`, `on_file_modified()`, or `on_file_deleted()` for file event handling
-   - `process_queue()` for task execution
-   - `schedule_maintenance()` or `run_maintenance()` for automated maintenance
-
-2. Update the corresponding `TestTask` or `TestPlanItem` properties if needed
-3. Ensure the task priority and action enums are used correctly
-
-## Test your changes
-
-Run the test suite to verify your modifications work correctly:
-
-```bash
-pytest -k "test_lifecycle" tests/
-pytest -k "test_runner" tests/
+```python
+item = workflow.on_file_modified("src/attune/foo.py")
+if item and item.auto_executable:
+    ...
 ```
 
-Your changes should pass all existing tests without breaking the test lifecycle workflow.
+`on_file_created()`, `on_file_modified()`, and `on_file_deleted()`
+each return a `TestPlanItem | None`.
 
-## Success criteria
+## Track test outcomes
 
-Your fix-test modifications are complete when:
-- All targeted tests pass
-- The test lifecycle manager processes tasks correctly
-- Test execution tracking records data as expected
-- No regressions appear in the existing test suite
+Use `test_runner.py` to persist what actually ran:
+
+1. `run_tests_with_tracking(test_suite, test_files, command, workflow_id, triggered_by)` runs a suite and records the result.
+2. `track_coverage(coverage_file, workflow_id)` ingests a `coverage.xml`.
+3. `get_file_test_status(file_path)` and `get_files_needing_tests(stale_only, failed_only)` answer coverage questions for a file or the whole project.
+
+## Modify behavior
+
+- **Plan generation / prioritization** — edit `TestMaintenanceWorkflow`
+  methods in `test_maintenance.py`. Adjust how an event maps to a
+  `TestAction`, or how `TestPriority` is assigned.
+- **New plan-item field** — add it to the `TestPlanItem` dataclass and
+  update `to_dict()`.
+- **Outcome tracking** — edit the tracking functions in
+  `test_runner.py`.
+
+## Verify your changes
+
+Run the related tests:
+
+```
+pytest -k "maintenance or test_runner" tests/
+```
+
+A passing suite with no new failures confirms the plan model and
+outcome tracking still behave correctly.

--- a/.help/templates/fix-test/tip.md
+++ b/.help/templates/fix-test/tip.md
@@ -2,35 +2,38 @@
 type: tip
 feature: fix-test
 depth: tip
-generated_at: 2026-04-14T14:58:00.827179+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
-# Use TestLifecycleManager for event-driven test maintenance
+# Use TestMaintenanceWorkflow for event-driven test maintenance
 
-Start with `TestLifecycleManager` when files change in your project—it automatically queues appropriate test actions based on what happened to each file.
+Reach for `TestMaintenanceWorkflow` when files change in your project — its event handlers turn each change into a `TestPlanItem` describing the test action that change implies.
 
 ## Why this matters
 
-Setting up event handlers once is faster than manually tracking which tests need updates every time you modify source code.
+Letting the workflow map changes to test actions is faster than manually tracking which tests need updates every time you modify source code.
 
 ## How to use it
 
-Initialize the manager with your project root and call the appropriate handler:
+Call the handler that matches the change, then act on the returned item:
 
 ```python
-manager = TestLifecycleManager(project_root="/path/to/project")
+from attune.workflows.test_maintenance import TestMaintenanceWorkflow
+
+workflow = TestMaintenanceWorkflow()
 
 # When a file is created, modified, or deleted
-task = manager.on_file_created("src/new_module.py")
-task = manager.on_file_modified("src/existing_module.py")
-task = manager.on_file_deleted("src/old_module.py")
+item = workflow.on_file_created("src/new_module.py")
+item = workflow.on_file_modified("src/existing_module.py")
+item = workflow.on_file_deleted("src/old_module.py")
 
-# Process queued tasks
-result = manager.process_queue(max_tasks=5)
+# Or build a full plan and run only the safe items
+plan = workflow.run({})
+safe = plan.get_auto_executable_items()
 ```
 
 ## The tradeoff
 
-The manager queues tasks instead of running them immediately—you get control over when test maintenance happens, but you must remember to process the queue.
+`run()` produces a plan rather than executing everything — you get control over what runs, but you decide which items to act on. Use `get_auto_executable_items()` for the safe subset and leave `REVIEW`/`MANUAL` items for a human.

--- a/.help/templates/fix-test/troubleshooting.md
+++ b/.help/templates/fix-test/troubleshooting.md
@@ -2,8 +2,8 @@
 type: troubleshooting
 feature: fix-test
 depth: troubleshooting
-generated_at: 2026-04-14T14:57:17.002317+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
@@ -11,16 +11,16 @@ status: generated
 
 ## Before you start
 
-The fix-test feature provides automated test execution, coverage tracking, and lifecycle management. When tests fail unexpectedly or the system doesn't respond correctly to file changes, use this guide to diagnose and fix the issues.
+The fix-test feature provides test maintenance planning, coverage tracking, and source-file event handling. When tests fail unexpectedly or the system doesn't respond correctly to file changes, use this guide to diagnose and fix the issues.
 
 ## Symptom table
 
 | If you observe | Check |
 |----------------|-------|
-| Tests not running automatically | Verify `TestLifecycleManager` initialization and file event handlers in your project |
+| No plan items generated for a change | Verify the file event handler (`on_file_created/modified/deleted`) is being called with a valid path |
 | Coverage tracking fails | Check that `coverage.xml` exists and is valid XML format at the expected path |
 | Stale test warnings persist | Run `get_stale_tests()` to see if the detection logic matches your actual test files |
-| Queue processing hangs | Check `get_pending_count()` and verify no tasks are stuck with invalid status values |
+| Plan is empty or missing expected items | Inspect `plan.items` after `TestMaintenanceWorkflow.run()`; confirm the project root is correct |
 | File change events ignored | Confirm the `ProjectIndex` is properly initialized and file paths are relative to project root |
 
 ## Step-by-step diagnosis
@@ -28,8 +28,8 @@ The fix-test feature provides automated test execution, coverage tracking, and l
 1. **Reproduce with minimal setup.**
    Create a simple test case that isolates the failing behavior. For test execution issues, try calling `run_tests_with_tracking()` directly with just the required parameters.
 
-2. **Check the task queue status.**
-   Run `TestLifecycleManager.get_status()` to see pending tasks and queue health. Look for tasks stuck in 'pending' status or unexpected error states in the results.
+2. **Inspect the generated plan.**
+   Call `TestMaintenanceWorkflow.run({})` and examine the returned `TestMaintenancePlan`. Look at `plan.items` for entries with unexpected `action` or `priority`, and use `get_auto_executable_items()` to see what would run automatically.
 
 3. **Verify file path resolution.**
    Many issues stem from incorrect file paths. Ensure all paths are relative to the project root and that the `ProjectIndex` can find your test files.
@@ -38,29 +38,26 @@ The fix-test feature provides automated test execution, coverage tracking, and l
    - `run_tests_with_tracking()` — Verify test command execution and result capture
    - `track_coverage()` — Confirm coverage.xml parsing (check file exists and has valid XML)
    - `get_file_test_status()` — Test file-to-test mapping logic
-   - `TestLifecycleManager.on_file_modified()` — Verify event handling creates appropriate tasks
+   - `TestMaintenanceWorkflow.on_file_modified()` — Verify event handling returns an appropriate `TestPlanItem`
 
 5. **Enable debug logging.**
-   Set logging level to `DEBUG` for the `attune.workflows` modules before running operations. The logs will show task creation, queue processing, and file event handling details.
+   Set logging level to `DEBUG` for the `attune.workflows` modules before running operations. The logs will show plan generation, file event handling, and tracking details.
 
 ## Common fixes
 
 - **Missing coverage.xml file:** Run your test suite with coverage first: `python -m pytest --cov=src --cov-report=xml`. The `track_coverage()` function requires this file to exist.
 
-- **Incorrect project root:** Initialize `TestLifecycleManager` and `TestMaintenanceWorkflow` with the absolute path to your project root, not a relative path or subdirectory.
+- **Incorrect project root:** Make sure `TestMaintenanceWorkflow` resolves the absolute path to your project root, not a relative path or subdirectory.
 
-- **Auto-execution disabled:** Set `auto_execute=True` when initializing `TestLifecycleManager` if you want immediate task processing. Without this flag, tasks queue but don't run automatically.
+- **Acting on the wrong items:** To run only the safe work, filter with `plan.get_auto_executable_items()` rather than executing every item — `REVIEW` and `MANUAL` actions are meant for a human.
 
 - **Invalid test file patterns:** The system looks for files matching your project's test patterns. If using custom test discovery, ensure your test files are detectable by the `ProjectIndex`.
 
-- **Stale queue file:** If the task queue behaves strangely, clear it with `TestLifecycleManager.clear_queue()` and restart task processing.
-
-- **Git hook integration:** For automatic execution on commits, use `process_git_pre_commit()` and `process_git_post_commit()` with the actual changed file lists from your Git hooks.
+- **Unexpected action for a change:** If an event produces the wrong `TestAction`, review the mapping logic in the corresponding `on_file_*` handler in `test_maintenance.py`.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/warning.md
+++ b/.help/templates/fix-test/warning.md
@@ -2,8 +2,8 @@
 type: warning
 feature: fix-test
 depth: warning
-generated_at: 2026-04-14T14:57:01.164017+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
@@ -11,44 +11,43 @@ status: generated
 
 ## What to watch for
 
-Auto-diagnose and fix failing tests — identifies root causes and applies fixes.
+Test maintenance turns file changes into test work — review what it plans before you act on it.
 
 ## Risk areas
 
-### Automatic test execution can modify your codebase
+### Auto-executable items still modify your codebase
 
-The `TestLifecycleManager` with `auto_execute=True` will automatically run test fixes without user confirmation. This can modify test files, create new tests, or delete obsolete ones based on file change events. Set `auto_execute=False` during development to review changes before they're applied.
+`TestMaintenancePlan.get_auto_executable_items()` returns the items the workflow considers safe to run without review — but running them can still create, update, or delete test files. Inspect `plan.items` and confirm each `action` before executing, especially `DELETE`.
 
 ### Coverage tracking requires specific file formats
 
 The `track_coverage()` function expects a valid `coverage.xml` file in the correct format. If your coverage tool generates a different format or the file is corrupted, tracking will fail with a `ValueError`. Always verify your coverage configuration produces compatible XML before enabling tracking.
 
-### Test lifecycle events fire on every file change
+### Event handlers fire for any file path you pass
 
-File watchers trigger `on_file_created()`, `on_file_modified()`, and `on_file_deleted()` for any project file change, not just source files. This can flood your test task queue with irrelevant maintenance tasks. Use appropriate file filtering in your project configuration to limit events to meaningful changes.
+`on_file_created()`, `on_file_modified()`, and `on_file_deleted()` act on whatever path they're given — including non-source files. If you wire them to a broad file watcher, filter to meaningful source changes first so the plan doesn't fill with irrelevant items.
 
-### Queue processing can overwhelm your system
+### A plan is only as good as the action mapping
 
-`process_queue()` with a high `max_tasks` value can spawn many concurrent test processes. Each test task may consume significant CPU and memory. Monitor system resources when processing large queues, especially in CI environments with limited capacity.
+Each `TestPlanItem` gets its `TestAction` and `TestPriority` from the workflow's mapping logic. If items come back with the wrong action, review the `on_file_*` handlers rather than acting on the bad items.
 
 ### Stale test detection depends on file timestamps
 
-The system identifies stale tests by comparing file modification times between source files and their corresponding test files. If your build system or version control modifies timestamps unexpectedly, you may get false positives for stale tests. Verify timestamp accuracy before trusting stale test reports.
+The system identifies stale tests by comparing modification times between source files and their corresponding test files. If your build system or version control modifies timestamps unexpectedly, you may get false positives. Verify timestamp accuracy before trusting `get_stale_tests()` reports.
 
 ## How to avoid problems
 
-1. **Start with manual execution.** Initialize `TestLifecycleManager` with `auto_execute=False` and review the task queue before enabling automatic processing. Use `get_queue()` to inspect pending tasks.
+1. **Review before executing.** Call `run()` and read `plan.items` first. Filter with `get_auto_executable_items()` and leave `REVIEW`/`MANUAL` items for a human.
 
-2. **Configure appropriate file filters.** Set up your project to only monitor relevant file types and directories. Exclude build artifacts, temporary files, and vendor directories from test lifecycle events.
+2. **Filter the paths you feed in.** When driving the event handlers from a watcher, exclude build artifacts, temporary files, and vendor directories.
 
-3. **Process queues incrementally.** Use smaller `max_tasks` values (5-10) when processing test queues, especially on shared systems. Monitor `get_pending_count()` to avoid overwhelming your environment.
+3. **Check priorities.** Use `get_items_by_priority(TestPriority.CRITICAL)` to focus on the highest-impact work first instead of running everything at once.
 
-4. **Validate coverage setup early.** Test your coverage configuration with `track_coverage()` on a known good coverage file before integrating it into automated workflows.
+4. **Validate coverage setup early.** Test your coverage configuration with `track_coverage()` on a known-good coverage file before integrating it into automated workflows.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/help-system/comparison.md
+++ b/.help/templates/help-system/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: help-system-comparison
 feature: help-system
 depth: comparison
-generated_at: 2026-06-02T10:56:02.717021+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/concept.md
+++ b/.help/templates/help-system/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: help-system-concept
 feature: help-system
 depth: concept
-generated_at: 2026-06-02T10:56:02.667333+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/error.md
+++ b/.help/templates/help-system/error.md
@@ -3,8 +3,8 @@ type: error
 name: help-system-error
 feature: help-system
 depth: error
-generated_at: 2026-06-02T10:56:02.687547+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/faq.md
+++ b/.help/templates/help-system/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: help-system-faq
 feature: help-system
 depth: faq
-generated_at: 2026-06-02T10:56:02.703427+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/note.md
+++ b/.help/templates/help-system/note.md
@@ -3,8 +3,8 @@ type: note
 name: help-system-note
 feature: help-system
 depth: note
-generated_at: 2026-06-02T10:56:02.713979+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/quickstart.md
+++ b/.help/templates/help-system/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: help-system-quickstart
 feature: help-system
 depth: quickstart
-generated_at: 2026-06-02T10:56:02.706335+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/reference.md
+++ b/.help/templates/help-system/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: help-system-reference
 feature: help-system
 depth: reference
-generated_at: 2026-06-02T10:56:02.681968+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/task.md
+++ b/.help/templates/help-system/task.md
@@ -3,8 +3,8 @@ type: task
 name: help-system-task
 feature: help-system
 depth: task
-generated_at: 2026-06-02T10:56:02.674680+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/tip.md
+++ b/.help/templates/help-system/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: help-system-tip
 feature: help-system
 depth: tip
-generated_at: 2026-06-02T10:56:02.709091+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/troubleshooting.md
+++ b/.help/templates/help-system/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: help-system-troubleshooting
 feature: help-system
 depth: troubleshooting
-generated_at: 2026-06-02T10:56:02.699217+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/help-system/warning.md
+++ b/.help/templates/help-system/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: help-system-warning
 feature: help-system
 depth: warning
-generated_at: 2026-06-02T10:56:02.696305+00:00
-source_hash: f28fa9280df8c251aa5a61ebcded32895a7b6d42c1aefca8dc7171d220e0ebc4
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 15713124af0cd76c022a741b771c19b44c22f9a2907b20d728e874c8b91b68f5
 status: generated
 ---
 

--- a/.help/templates/hooks/comparison.md
+++ b/.help/templates/hooks/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: hooks-comparison
 feature: hooks
 depth: comparison
-generated_at: 2026-06-02T10:56:02.727042+00:00
-source_hash: 4690cd16c282bccaee1ffc3de0ea189b194fa0d71b87cec08e2f3675e136bbb9
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 ---
 

--- a/.help/templates/hooks/concept.md
+++ b/.help/templates/hooks/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: hooks-concept
 feature: hooks
 depth: concept
-generated_at: 2026-06-11T04:49:42.136978+00:00
-source_hash: c616d1d3b693f3ea1e8811ca9fcf005cdcb50eb831d6a67ee7f5dd74236f44dd
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 scaffold_hash: 5f756279fb78a65834c6236804bbd23166bbbb2aec951ee6f6347f0419c40255
 ---

--- a/.help/templates/hooks/error.md
+++ b/.help/templates/hooks/error.md
@@ -3,8 +3,8 @@ type: error
 name: hooks-error
 feature: hooks
 depth: error
-generated_at: 2026-06-02T10:56:02.704265+00:00
-source_hash: 4690cd16c282bccaee1ffc3de0ea189b194fa0d71b87cec08e2f3675e136bbb9
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 ---
 

--- a/.help/templates/hooks/faq.md
+++ b/.help/templates/hooks/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: hooks-faq
 feature: hooks
 depth: faq
-generated_at: 2026-06-02T10:56:02.716571+00:00
-source_hash: 4690cd16c282bccaee1ffc3de0ea189b194fa0d71b87cec08e2f3675e136bbb9
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 ---
 

--- a/.help/templates/hooks/note.md
+++ b/.help/templates/hooks/note.md
@@ -3,8 +3,8 @@ type: note
 name: hooks-note
 feature: hooks
 depth: note
-generated_at: 2026-06-02T10:56:02.723366+00:00
-source_hash: 4690cd16c282bccaee1ffc3de0ea189b194fa0d71b87cec08e2f3675e136bbb9
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 ---
 

--- a/.help/templates/hooks/quickstart.md
+++ b/.help/templates/hooks/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: hooks-quickstart
 feature: hooks
 depth: quickstart
-generated_at: 2026-06-02T10:56:02.718986+00:00
-source_hash: 4690cd16c282bccaee1ffc3de0ea189b194fa0d71b87cec08e2f3675e136bbb9
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 ---
 

--- a/.help/templates/hooks/reference.md
+++ b/.help/templates/hooks/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: hooks-reference
 feature: hooks
 depth: reference
-generated_at: 2026-06-11T04:49:42.143344+00:00
-source_hash: c616d1d3b693f3ea1e8811ca9fcf005cdcb50eb831d6a67ee7f5dd74236f44dd
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 scaffold_hash: ecf92cd0a9d28d4a09669183241ef08059389f8bc15e663ad79a0e6b7e8362fa
 ---

--- a/.help/templates/hooks/task.md
+++ b/.help/templates/hooks/task.md
@@ -3,8 +3,8 @@ type: task
 name: hooks-task
 feature: hooks
 depth: task
-generated_at: 2026-06-11T04:49:42.140418+00:00
-source_hash: c616d1d3b693f3ea1e8811ca9fcf005cdcb50eb831d6a67ee7f5dd74236f44dd
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 scaffold_hash: 842971e6c4af90b51b8762d9aedd9bd8e6a08156f8087b238d4c3045acb8d52c
 ---

--- a/.help/templates/hooks/tip.md
+++ b/.help/templates/hooks/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: hooks-tip
 feature: hooks
 depth: tip
-generated_at: 2026-06-02T10:56:02.721343+00:00
-source_hash: 4690cd16c282bccaee1ffc3de0ea189b194fa0d71b87cec08e2f3675e136bbb9
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 ---
 

--- a/.help/templates/hooks/troubleshooting.md
+++ b/.help/templates/hooks/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: hooks-troubleshooting
 feature: hooks
 depth: troubleshooting
-generated_at: 2026-06-02T10:56:02.714159+00:00
-source_hash: 4690cd16c282bccaee1ffc3de0ea189b194fa0d71b87cec08e2f3675e136bbb9
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 ---
 

--- a/.help/templates/hooks/warning.md
+++ b/.help/templates/hooks/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: hooks-warning
 feature: hooks
 depth: warning
-generated_at: 2026-06-02T10:56:02.710836+00:00
-source_hash: 4690cd16c282bccaee1ffc3de0ea189b194fa0d71b87cec08e2f3675e136bbb9
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 92f76c4d4d77b21e59b9a6aed8e65dd221371f5ce10f2941171a5c0310c232c1
 status: generated
 ---
 

--- a/.help/templates/mcp-server/concept.md
+++ b/.help/templates/mcp-server/concept.md
@@ -2,8 +2,8 @@
 type: concept
 feature: mcp-server
 depth: concept
-generated_at: 2026-05-04T02:29:38.826492+00:00
-source_hash: f7f2360f6ad84733ba187b2e644d9b01ac30e15d2ae8fe8567af6dfb064ee44b
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: 9e36c58165bf28d2d017a183ce57a5f54f8bf32c3d68cd05d5d762a3eb741ae4
 status: generated
 ---
 

--- a/.help/templates/mcp-server/reference.md
+++ b/.help/templates/mcp-server/reference.md
@@ -2,8 +2,8 @@
 type: reference
 feature: mcp-server
 depth: reference
-generated_at: 2026-05-04T02:30:02.079856+00:00
-source_hash: f7f2360f6ad84733ba187b2e644d9b01ac30e15d2ae8fe8567af6dfb064ee44b
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: 9e36c58165bf28d2d017a183ce57a5f54f8bf32c3d68cd05d5d762a3eb741ae4
 status: generated
 ---
 
@@ -31,7 +31,7 @@ Build MCP-compatible servers that expose Attune AI workflows, help system, memor
 
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|
-| `__init__` | `workspace_root: str \| None = None, user_id: str \| None = None` | - | Initialize MCP server with workspace and user context |
+| `__init__` | `workspace_root: str \| None = None, user_id: str \| None = None` | - | Initialize MCP server with workspace and user context. Workspace root resolves in order: explicit argument → `ATTUNE_MCP_WORKSPACE_ROOT` → `CLAUDE_PROJECT_DIR` → cwd |
 | `get_prompt_list` | - | `list[dict[str, Any]]` | Get list of available prompts |
 | `get_prompt_messages` | `prompt_name: str, arguments: dict[str, str]` | `list[dict[str, Any]]` | Get messages for a specific prompt |
 | `call_tool` | `tool_name: str, arguments: dict[str, Any]` | `dict[str, Any]` | Execute a tool with provided arguments |

--- a/.help/templates/mcp-server/task.md
+++ b/.help/templates/mcp-server/task.md
@@ -2,8 +2,8 @@
 type: task
 feature: mcp-server
 depth: task
-generated_at: 2026-05-04T02:29:51.286450+00:00
-source_hash: f7f2360f6ad84733ba187b2e644d9b01ac30e15d2ae8fe8567af6dfb064ee44b
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: 9e36c58165bf28d2d017a183ce57a5f54f8bf32c3d68cd05d5d762a3eb741ae4
 status: generated
 ---
 

--- a/.help/templates/memory/comparison.md
+++ b/.help/templates/memory/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: memory-comparison
 feature: memory
 depth: comparison
-generated_at: 2026-06-10T07:07:04.805059+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 ---
 

--- a/.help/templates/memory/concept.md
+++ b/.help/templates/memory/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: memory-concept
 feature: memory
 depth: concept
-generated_at: 2026-06-12T00:20:52.581029+00:00
-source_hash: 439162c85525d4aff627199f05d3f52d259589b86b947c5b2f62b832a0d15fae
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 scaffold_hash: fc0d9984517f8c22ce4ac76cb18edf9fd2a3bcc4d42b5edbc949332d6846906e
 ---

--- a/.help/templates/memory/error.md
+++ b/.help/templates/memory/error.md
@@ -3,8 +3,8 @@ type: error
 name: memory-error
 feature: memory
 depth: error
-generated_at: 2026-06-10T07:07:04.783678+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 ---
 

--- a/.help/templates/memory/faq.md
+++ b/.help/templates/memory/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: memory-faq
 feature: memory
 depth: faq
-generated_at: 2026-06-10T07:07:04.794691+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 ---
 

--- a/.help/templates/memory/note.md
+++ b/.help/templates/memory/note.md
@@ -3,8 +3,8 @@ type: note
 name: memory-note
 feature: memory
 depth: note
-generated_at: 2026-06-10T07:07:04.802206+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 ---
 

--- a/.help/templates/memory/quickstart.md
+++ b/.help/templates/memory/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: memory-quickstart
 feature: memory
 depth: quickstart
-generated_at: 2026-06-10T07:07:04.797304+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 ---
 

--- a/.help/templates/memory/reference.md
+++ b/.help/templates/memory/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: memory-reference
 feature: memory
 depth: reference
-generated_at: 2026-06-12T00:20:52.589323+00:00
-source_hash: 439162c85525d4aff627199f05d3f52d259589b86b947c5b2f62b832a0d15fae
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 scaffold_hash: 8c6258d4a61cd8f4917baaa8a00c3f4054394b40ba97c4386f7c2f7279eb584f
 ---

--- a/.help/templates/memory/task.md
+++ b/.help/templates/memory/task.md
@@ -3,8 +3,8 @@ type: task
 name: memory-task
 feature: memory
 depth: task
-generated_at: 2026-06-12T00:20:52.586192+00:00
-source_hash: 439162c85525d4aff627199f05d3f52d259589b86b947c5b2f62b832a0d15fae
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 scaffold_hash: de9d8b9e160093b1f9e12b058655c619120213c3afb90087452e3c0a307ae0a9
 ---

--- a/.help/templates/memory/tip.md
+++ b/.help/templates/memory/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: memory-tip
 feature: memory
 depth: tip
-generated_at: 2026-06-10T07:07:04.799881+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 ---
 

--- a/.help/templates/memory/troubleshooting.md
+++ b/.help/templates/memory/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: memory-troubleshooting
 feature: memory
 depth: troubleshooting
-generated_at: 2026-06-10T07:07:04.792122+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 ---
 

--- a/.help/templates/memory/warning.md
+++ b/.help/templates/memory/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: memory-warning
 feature: memory
 depth: warning
-generated_at: 2026-06-10T07:07:04.789830+00:00
-source_hash: 570dd4977cd655a0cf44a47b917577fd70f4cf08eb5d256d4da2915dbea871f0
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
 status: generated
 ---
 

--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: ops-dashboard-concept
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-06-10T07:07:04.642397+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: dd650b4658efc1f6876bf6f2701d846e9091228187573660cdcfc10ab83fa6c2
 status: generated
 ---
 
@@ -18,7 +18,7 @@ You start it with `attune ops` (or `python -m attune.ops`). It binds to `127.0.0
 
 ## How the pieces fit together
 
-The dashboard is built from four cooperating concerns: configuration, cost reporting, telemetry, and spec-completion detection.
+The dashboard is built from five cooperating concerns: configuration, cost reporting, telemetry, spend-anomaly detection, and spec-completion detection.
 
 **Configuration** is the root. `Config` tells every other part of the dashboard where to look for project state and attune state:
 
@@ -30,6 +30,8 @@ The dashboard is built from four cooperating concerns: configuration, cost repor
 - `runs_retention_days` (default `30`) controls how long run history is kept on disk.
 
 **Cost reporting** calls the Anthropic admin cost-report endpoint at `https://api.anthropic.com/v1/organizations/cost_report`. `fetch_summary(refresh=False)` returns either a `CostSummary` or a `CostFetchError`. `CostSummary` breaks spending down along three axes — `by_day`, `by_model`, and `by_cost_type` — plus rolled-up totals (`today_usd`, `seven_day_usd`, `month_to_date_usd`, `thirty_day_usd`). The `source` field tells you whether the data came from a live API call or an in-memory cache. When the fetch fails, `CostFetchError` carries a `kind` (a `CostFetchErrorKind` enum) and a human-readable `message` so the UI can display a precise error rather than a generic one.
+
+**Spend-anomaly detection** (R6) raises alerts when daily API spend becomes anomalous or approaches the monthly ceiling. `SpendAlarm` independently flags two triggers: (1) today's spend is a statistical outlier versus the trailing baseline (z-score, with a flat-multiplier fallback when variance is zero), and (2) month-to-date spend reaches 80% of the monthly cap (default $350). The alarm prefers account-level spend (the admin cost-report, which also sees CI spend) and falls back to local `usage.jsonl` when no admin key is configured. Its `detail` field carries a one-line explanation for display.
 
 **Telemetry** is recorded locally. `TelemetrySummary` aggregates the requests the dashboard has processed: `total_requests`, `total_cost`, `total_savings`, and breakdowns `by_workflow` and `by_day`. The UI uses this data to show you which workflows you run most and what they cost.
 
@@ -45,6 +47,7 @@ Sessions — individual Claude Code conversations — surface on the `/sessions`
 
 You need the ops dashboard when you want to:
 
+- Monitor daily API-spend anomalies and month-to-date spending against an automated ceiling gauge.
 - Track Anthropic API spend across models and days without leaving your project.
 - Run attune workflows from a browser UI rather than typing CLI commands, especially when you want to chain multiple workflows in sequence.
 - Review persisted run history beyond the `runs_retention_days` window to audit what ran and when.

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: ops-dashboard-reference
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-06-10T07:07:04.653081+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: dd650b4658efc1f6876bf6f2701d846e9091228187573660cdcfc10ab83fa6c2
 status: generated
 ---
 
@@ -28,6 +28,7 @@ Run and monitor the attune workflow OS from a local web dashboard. The dashboard
 | `FamilyVersion` | Package name, version, and resolution source for one attune family member. |
 | `DailyCost` | One day's cost for the home-page sparkline. |
 | `HomeKpis` | Summary numbers shown above the fold on the home page. |
+| `SpendAlarm` | Daily API-spend anomaly verdict with ceiling-approach gauge for the dashboard (R6). |
 | `SweepChipCounts` | Per-bucket counts loaded from a persisted discovery-sweep result. |
 | `DismissEntry` | One dismissed candidate's persisted state. |
 | `TemplateRecord` | One template file in the help corpus. |
@@ -183,6 +184,25 @@ Run and monitor the attune workflow OS from a local web dashboard. The dashboard
 | `version` | `str | None` |
 | `source` | `str` |
 
+---
+
+### `SpendAlarm` fields
+
+| Field | Type |
+|-------|------|
+| `level` | `str` — `"ok"` \| `"alarm"` \| `"insufficient_data"` |
+| `triggered_by` | `tuple[str, ...]` — subset of `{"daily_anomaly", "ceiling"}` |
+| `today_cost` | `float` |
+| `baseline_mean` | `float` |
+| `baseline_days` | `int` |
+| `method` | `str` — `"zscore"` \| `"multiplier"` \| `"none"` |
+| `z_score` | `float \| None` |
+| `month_to_date` | `float` |
+| `monthly_ceiling` | `float` |
+| `ceiling_pct` | `float` |
+| `source` | `str` — `"account"` \| `"local"` |
+| `detail` | `str` — one-line human explanation |
+
 ## Functions
 
 The tables below are organized by source module.
@@ -250,6 +270,9 @@ The tables below are organized by source module.
 | `sparkline_points` | `values: list[float], *, width: int = 240, height: int = 40` | `str` | Render values as an SVG `polyline` `points` string. |
 | `read_telemetry_summary` | `config: Config, *, recent_days: int = 7, today: date | None = None` | `TelemetrySummary` | Aggregate `usage.jsonl` into a UI-friendly summary. |
 | `read_sweep_chip_counts` | `scope_path: str, config: Config` | `SweepChipCounts` | Read the latest persisted sweep result for `scope_path` and tally chips. |
+| `read_daily_spend` | `config: Config, *, days: int = 35, today: date \| None = None` | `dict[str, float]` | Daily API spend (USD) bucketed by timestamp from `usage.jsonl`. |
+| `spend_alarm` | `daily: dict[str, float], *, today: date \| None = None, monthly_ceiling: float = 350.0, ceiling_fraction: float = 0.8, z_threshold: float = 3.0, flat_multiplier: float = 3.0, min_baseline_days: int = 3, ...` | `SpendAlarm` | Flag anomalous daily API spend and approach to the monthly ceiling. |
+| `build_spend_alarm` | `config: Config, cost_summary: Any \| None = None, *, today: date \| None = None` | `SpendAlarm` | Assemble the spend alarm, preferring account-level spend from the cost summary. |
 | `list_workflows` | — | `list[WorkflowEntry]` | Return the registered workflow catalog. Empty if the registry is unavailable. |
 | `family_versions` | — | `list[FamilyVersion]` | Resolve installed versions for every related attune package. |
 | `env_health` | `config: Config` | `dict[str, Any]` | Lightweight environment snapshot for the Health page. |

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -3,8 +3,8 @@ type: task
 name: ops-dashboard-task
 feature: ops-dashboard
 depth: task
-generated_at: 2026-06-10T07:07:04.648249+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: dd650b4658efc1f6876bf6f2701d846e9091228187573660cdcfc10ab83fa6c2
 status: generated
 ---
 
@@ -70,6 +70,34 @@ Use the ops dashboard when you need to run workflows, browse per-feature scopes,
    ```
 
 4. **Clear the in-memory cache** during testing by calling `clear_cache()` from `src/attune/ops/anthropic_cost.py`.
+
+## Monitor spend anomalies and ceiling approach
+
+1. **Assemble the alarm** with `build_spend_alarm()` from `src/attune/ops/data.py`:
+
+   ```python
+   from attune.ops import data, anthropic_cost
+
+   cost_summary, _ = anthropic_cost.fetch_summary()
+   alarm = data.build_spend_alarm(config, cost_summary)
+   ```
+
+   - `alarm.level` is `"ok"`, `"alarm"`, or `"insufficient_data"`.
+   - `alarm.triggered_by` lists which condition(s) fired: `"daily_anomaly"` and/or `"ceiling"`.
+   - `alarm.source` is `"account"` (admin cost-report) or `"local"` (`usage.jsonl`).
+
+2. **Daily-anomaly trigger:** today's spend is flagged when it exceeds the
+   z-score threshold (default `3.0`) versus the trailing baseline, or — when
+   the baseline has zero variance — when it exceeds `baseline_mean * 3.0`.
+   Fewer than 3 prior active (non-zero) days skips the check.
+
+3. **Ceiling trigger:** month-to-date spend is flagged once it reaches
+   `ceiling_fraction` (default `0.8`) of `monthly_ceiling` (default `$350`).
+   Pass `monthly_ceiling=` to override for your org.
+
+4. **Access raw data** with `read_daily_spend()` (local only) for a
+   `{YYYY-MM-DD: total_cost}` dict, then pass it to `spend_alarm()` with
+   custom thresholds when you need fine-grained control.
 
 ## Detect spec completion candidates
 

--- a/.help/templates/orchestration/comparison.md
+++ b/.help/templates/orchestration/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: orchestration-comparison
 feature: orchestration
 depth: comparison
-generated_at: 2026-05-16T06:14:24.039272+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/concept.md
+++ b/.help/templates/orchestration/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: orchestration-concept
 feature: orchestration
 depth: concept
-generated_at: 2026-05-16T06:14:24.004585+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/error.md
+++ b/.help/templates/orchestration/error.md
@@ -3,8 +3,8 @@ type: error
 name: orchestration-error
 feature: orchestration
 depth: error
-generated_at: 2026-05-16T06:14:24.018957+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/faq.md
+++ b/.help/templates/orchestration/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: orchestration-faq
 feature: orchestration
 depth: faq
-generated_at: 2026-05-16T06:14:24.029814+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/note.md
+++ b/.help/templates/orchestration/note.md
@@ -3,8 +3,8 @@ type: note
 name: orchestration-note
 feature: orchestration
 depth: note
-generated_at: 2026-05-16T06:14:24.036834+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/quickstart.md
+++ b/.help/templates/orchestration/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: orchestration-quickstart
 feature: orchestration
 depth: quickstart
-generated_at: 2026-05-16T06:14:24.032517+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/reference.md
+++ b/.help/templates/orchestration/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: orchestration-reference
 feature: orchestration
 depth: reference
-generated_at: 2026-05-16T06:14:24.014903+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/task.md
+++ b/.help/templates/orchestration/task.md
@@ -3,8 +3,8 @@ type: task
 name: orchestration-task
 feature: orchestration
 depth: task
-generated_at: 2026-05-16T06:14:24.010384+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/tip.md
+++ b/.help/templates/orchestration/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: orchestration-tip
 feature: orchestration
 depth: tip
-generated_at: 2026-05-16T06:14:24.034848+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/troubleshooting.md
+++ b/.help/templates/orchestration/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: orchestration-troubleshooting
 feature: orchestration
 depth: troubleshooting
-generated_at: 2026-05-16T06:14:24.027236+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/orchestration/warning.md
+++ b/.help/templates/orchestration/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: orchestration-warning
 feature: orchestration
 depth: warning
-generated_at: 2026-05-16T06:14:24.025029+00:00
-source_hash: ea07a9fe2c597e0620947bda28929f02936ea17148cbff01940256571429e078
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 1d31bb00ab6284a8ff06a91f07123af0d56d15af02f09b6311f660814398d142
 status: generated
 ---
 

--- a/.help/templates/plugin/concept.md
+++ b/.help/templates/plugin/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: plugin-concept
 feature: plugin
 depth: concept
-generated_at: 2026-06-12T00:37:02.517564+00:00
-source_hash: e7e856d3cca09a12fdc753f3691d81dfaa025bb8ad4c1459e92ca254b38a9438
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: 843f895eed3fa2d3d0b8021830c8c31e3c292c176a967396a76c27deb5a60deb
 status: generated
 scaffold_hash: 41c8ef7e7320fa5ba02ff6bb2c51cab36592879c3e7ac3505bbb510d6b91be64
 ---
@@ -25,7 +25,7 @@ The plugin's hooks fire at specific Claude Code lifecycle moments. They fall int
 
 **Safety** — `security_guard` validates bash commands against `SEARCH_COMMAND_PREFIXES` and file paths against `SYSTEM_DIRECTORIES` before Claude executes them.
 
-**Help and formatting** — `help_on_error`, `help_post_commit`, and `help_freshness_check` surface relevant help at key moments. `format_on_save` formats files when Claude writes them.
+**Help and formatting** — `help_on_error`, `help_post_commit`, and `help_freshness_check` surface relevant help at key moments. `usage_consent_notice` asks once per workspace about anonymous usage sharing when running under MCP / Claude Code. `format_on_save` formats files when Claude writes them.
 
 Every hook that must not run inside an SDK-spawned subprocess calls `exit_if_sdk_subprocess()` at startup. You can inspect the gate condition directly with `is_sdk_subprocess()`.
 

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: plugin-reference
 feature: plugin
 depth: reference
-generated_at: 2026-06-12T00:37:02.524584+00:00
-source_hash: e7e856d3cca09a12fdc753f3691d81dfaa025bb8ad4c1459e92ca254b38a9438
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: 843f895eed3fa2d3d0b8021830c8c31e3c292c176a967396a76c27deb5a60deb
 status: generated
 scaffold_hash: 6f4dd2b63d52d539274f6852ceaf44e9ec2a4b35ec27f4d69ffcdcd7d8193d4f
 ---
@@ -69,6 +69,7 @@ Both are dataclasses defined in `plugin/hooks/_state.py`.
 | `main` | — | `None` | Check for stale help after git commit. | `plugin/hooks/help_post_commit.py` |
 | `main` | — | `int` | Surface matching rules once per session; never raises. | `plugin/hooks/jit_recall.py` |
 | `main` | — | `int` | Surface top-scoring lessons for this prompt, once per session each. | `plugin/hooks/lesson_recall.py` |
+| `main` | — | `int` | Surface the anonymous-usage consent ask once per workspace (MCP / Claude Code). | `plugin/hooks/usage_consent_notice.py` |
 | `validate_bash_command` | `command: str` | `tuple[bool, str]` | Validate a Bash command against security policies. | `plugin/hooks/security_guard.py` |
 | `validate_file_path` | `file_path: str` | `tuple[bool, str]` | Validate a file path against security policies. | `plugin/hooks/security_guard.py` |
 | `main` | `context: dict[str, Any]` | `dict[str, Any]` | Validate a tool call against security policies. | `plugin/hooks/security_guard.py` |

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -3,8 +3,8 @@ type: task
 name: plugin-task
 feature: plugin
 depth: task
-generated_at: 2026-06-12T00:37:02.521196+00:00
-source_hash: e7e856d3cca09a12fdc753f3691d81dfaa025bb8ad4c1459e92ca254b38a9438
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: 843f895eed3fa2d3d0b8021830c8c31e3c292c176a967396a76c27deb5a60deb
 status: generated
 scaffold_hash: 50c1caa20aa764e3b2db2159a2560e5480f7bfc5f82efed9516912df86eebf1d
 ---
@@ -32,6 +32,7 @@ Each module in `hooks/` owns a single responsibility. Match your goal to the cor
 | Manage compact-warning sentinels | `hooks/_state.py` | `session_sentinel_path()`, `prune_stale_sentinels()` |
 | Estimate context utilization from a transcript | `hooks/_transcript_size.py` | `estimate_utilization()` |
 | Validate bash commands or file paths | `hooks/security_guard.py` | `validate_bash_command()`, `validate_file_path()` |
+| Show the usage-consent notice to MCP users (SessionStart) | `hooks/usage_consent_notice.py` | `main()` |
 | Orient the session around active specs | `hooks/spec_orient.py` | `main()` |
 
 ## Modify the hook

--- a/.help/templates/rag-grounding/comparison.md
+++ b/.help/templates/rag-grounding/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: rag-grounding-comparison
 feature: rag-grounding
 depth: comparison
-generated_at: 2026-06-02T10:56:02.722830+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/concept.md
+++ b/.help/templates/rag-grounding/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: rag-grounding-concept
 feature: rag-grounding
 depth: concept
-generated_at: 2026-06-02T10:56:02.667913+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/error.md
+++ b/.help/templates/rag-grounding/error.md
@@ -3,8 +3,8 @@ type: error
 name: rag-grounding-error
 feature: rag-grounding
 depth: error
-generated_at: 2026-06-02T10:56:02.693151+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/faq.md
+++ b/.help/templates/rag-grounding/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: rag-grounding-faq
 feature: rag-grounding
 depth: faq
-generated_at: 2026-06-02T10:56:02.708476+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/note.md
+++ b/.help/templates/rag-grounding/note.md
@@ -3,8 +3,8 @@ type: note
 name: rag-grounding-note
 feature: rag-grounding
 depth: note
-generated_at: 2026-06-02T10:56:02.720104+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/quickstart.md
+++ b/.help/templates/rag-grounding/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: rag-grounding-quickstart
 feature: rag-grounding
 depth: quickstart
-generated_at: 2026-06-02T10:56:02.711969+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/reference.md
+++ b/.help/templates/rag-grounding/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: rag-grounding-reference
 feature: rag-grounding
 depth: reference
-generated_at: 2026-06-02T10:56:02.685870+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/task.md
+++ b/.help/templates/rag-grounding/task.md
@@ -3,8 +3,8 @@ type: task
 name: rag-grounding-task
 feature: rag-grounding
 depth: task
-generated_at: 2026-06-02T10:56:02.679193+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/tip.md
+++ b/.help/templates/rag-grounding/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: rag-grounding-tip
 feature: rag-grounding
 depth: tip
-generated_at: 2026-06-02T10:56:02.717692+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/troubleshooting.md
+++ b/.help/templates/rag-grounding/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: rag-grounding-troubleshooting
 feature: rag-grounding
 depth: troubleshooting
-generated_at: 2026-06-02T10:56:02.703714+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/rag-grounding/warning.md
+++ b/.help/templates/rag-grounding/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: rag-grounding-warning
 feature: rag-grounding
 depth: warning
-generated_at: 2026-06-02T10:56:02.700632+00:00
-source_hash: 0c56c05d50048a3426da1a4782fa4bdecd9fc2a19dcd7d2d0957aa7b55b42550
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 88333793edaf078345820f76455b27a1c759145c2e48dd64da93abf6f2d61450
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/comparison.md
+++ b/.help/templates/refactor-plan/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: refactor-plan-comparison
 feature: refactor-plan
 depth: comparison
-generated_at: 2026-06-02T10:56:02.712315+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/concept.md
+++ b/.help/templates/refactor-plan/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: refactor-plan-concept
 feature: refactor-plan
 depth: concept
-generated_at: 2026-06-02T10:56:02.665660+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/error.md
+++ b/.help/templates/refactor-plan/error.md
@@ -3,8 +3,8 @@ type: error
 name: refactor-plan-error
 feature: refactor-plan
 depth: error
-generated_at: 2026-06-02T10:56:02.685786+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/faq.md
+++ b/.help/templates/refactor-plan/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: refactor-plan-faq
 feature: refactor-plan
 depth: faq
-generated_at: 2026-06-02T10:56:02.698550+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/note.md
+++ b/.help/templates/refactor-plan/note.md
@@ -3,8 +3,8 @@ type: note
 name: refactor-plan-note
 feature: refactor-plan
 depth: note
-generated_at: 2026-06-02T10:56:02.707953+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/quickstart.md
+++ b/.help/templates/refactor-plan/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: refactor-plan-quickstart
 feature: refactor-plan
 depth: quickstart
-generated_at: 2026-06-02T10:56:02.702837+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/reference.md
+++ b/.help/templates/refactor-plan/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: refactor-plan-reference
 feature: refactor-plan
 depth: reference
-generated_at: 2026-06-02T10:56:02.680417+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/task.md
+++ b/.help/templates/refactor-plan/task.md
@@ -3,8 +3,8 @@ type: task
 name: refactor-plan-task
 feature: refactor-plan
 depth: task
-generated_at: 2026-06-02T10:56:02.674933+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/tip.md
+++ b/.help/templates/refactor-plan/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: refactor-plan-tip
 feature: refactor-plan
 depth: tip
-generated_at: 2026-06-02T10:56:02.705686+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/troubleshooting.md
+++ b/.help/templates/refactor-plan/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: refactor-plan-troubleshooting
 feature: refactor-plan
 depth: troubleshooting
-generated_at: 2026-06-02T10:56:02.695166+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/refactor-plan/warning.md
+++ b/.help/templates/refactor-plan/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: refactor-plan-warning
 feature: refactor-plan
 depth: warning
-generated_at: 2026-06-02T10:56:02.692746+00:00
-source_hash: 048ea0ef75e8eaeda7382792e46947bba2ddef4a450bb9395be4c8ba0c1d1f38
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: a8b5dc570639e8d2770577c7a57611f86fbf596d547e3e6299cd6a5dd1281ea0
 status: generated
 ---
 

--- a/.help/templates/release-prep/comparison.md
+++ b/.help/templates/release-prep/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: release-prep-comparison
 feature: release-prep
 depth: comparison
-generated_at: 2026-06-04T23:45:26.721514+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 ---
 

--- a/.help/templates/release-prep/concept.md
+++ b/.help/templates/release-prep/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: release-prep-concept
 feature: release-prep
 depth: concept
-generated_at: 2026-06-11T04:39:32.868111+00:00
-source_hash: b484e3b8f8e27e1e37d71dd39e93de2e14c056d5969f51d404e9b11858bd81b7
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 scaffold_hash: 358b98c551538d98776b2cdd99b8b946240628c170cf8b124e5c5918e6e3e960
 ---

--- a/.help/templates/release-prep/error.md
+++ b/.help/templates/release-prep/error.md
@@ -3,8 +3,8 @@ type: error
 name: release-prep-error
 feature: release-prep
 depth: error
-generated_at: 2026-06-04T23:45:26.701314+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 ---
 

--- a/.help/templates/release-prep/faq.md
+++ b/.help/templates/release-prep/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: release-prep-faq
 feature: release-prep
 depth: faq
-generated_at: 2026-06-04T23:45:26.712031+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 ---
 

--- a/.help/templates/release-prep/note.md
+++ b/.help/templates/release-prep/note.md
@@ -3,8 +3,8 @@ type: note
 name: release-prep-note
 feature: release-prep
 depth: note
-generated_at: 2026-06-04T23:45:26.718942+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 ---
 

--- a/.help/templates/release-prep/quickstart.md
+++ b/.help/templates/release-prep/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: release-prep-quickstart
 feature: release-prep
 depth: quickstart
-generated_at: 2026-06-04T23:45:26.714392+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 ---
 

--- a/.help/templates/release-prep/reference.md
+++ b/.help/templates/release-prep/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: release-prep-reference
 feature: release-prep
 depth: reference
-generated_at: 2026-06-11T04:39:32.875454+00:00
-source_hash: b484e3b8f8e27e1e37d71dd39e93de2e14c056d5969f51d404e9b11858bd81b7
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 scaffold_hash: 83c37b9fadf0a212df19cec4c730dd92b02d065a4544f6352bc1521bf8fc20e5
 ---

--- a/.help/templates/release-prep/task.md
+++ b/.help/templates/release-prep/task.md
@@ -3,8 +3,8 @@ type: task
 name: release-prep-task
 feature: release-prep
 depth: task
-generated_at: 2026-06-11T04:39:32.872298+00:00
-source_hash: b484e3b8f8e27e1e37d71dd39e93de2e14c056d5969f51d404e9b11858bd81b7
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 scaffold_hash: 27a90574d75339f2fab8f7a1a95121920a49e38a867a7c39451f9987629e9532
 ---

--- a/.help/templates/release-prep/tip.md
+++ b/.help/templates/release-prep/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: release-prep-tip
 feature: release-prep
 depth: tip
-generated_at: 2026-06-04T23:45:26.716688+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 ---
 

--- a/.help/templates/release-prep/troubleshooting.md
+++ b/.help/templates/release-prep/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: release-prep-troubleshooting
 feature: release-prep
 depth: troubleshooting
-generated_at: 2026-06-04T23:45:26.709590+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 ---
 

--- a/.help/templates/release-prep/warning.md
+++ b/.help/templates/release-prep/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: release-prep-warning
 feature: release-prep
 depth: warning
-generated_at: 2026-06-04T23:45:26.707118+00:00
-source_hash: 154aea0206f2809204a60d671b6411b36f1e98b1dd2cd5158175147523b39cc2
+generated_at: 2026-06-22T10:13:38.223145+00:00
+source_hash: 2e9628fb196173f4048d6aab29c024a2318abaeea4420bd4865253bdc1d46702
 status: generated
 ---
 

--- a/.help/templates/resilience/concept.md
+++ b/.help/templates/resilience/concept.md
@@ -2,8 +2,8 @@
 type: concept
 feature: resilience
 depth: concept
-generated_at: 2026-05-04T02:41:54.401524+00:00
-source_hash: ac7fa86c6fc160b49ba191ab5eb87d2a363ce5215faf5399776e3d9bd9112df7
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: fc9bb0156f639a552b0e370a4a654fbc4e2ed99680ac269383522a95975a9464
 status: generated
 ---
 

--- a/.help/templates/resilience/reference.md
+++ b/.help/templates/resilience/reference.md
@@ -2,8 +2,8 @@
 type: reference
 feature: resilience
 depth: reference
-generated_at: 2026-05-04T02:42:31.244227+00:00
-source_hash: ac7fa86c6fc160b49ba191ab5eb87d2a363ce5215faf5399776e3d9bd9112df7
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: fc9bb0156f639a552b0e370a4a654fbc4e2ed99680ac269383522a95975a9464
 status: generated
 ---
 

--- a/.help/templates/resilience/task.md
+++ b/.help/templates/resilience/task.md
@@ -2,8 +2,8 @@
 type: task
 feature: resilience
 depth: task
-generated_at: 2026-05-04T02:42:08.720688+00:00
-source_hash: ac7fa86c6fc160b49ba191ab5eb87d2a363ce5215faf5399776e3d9bd9112df7
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: fc9bb0156f639a552b0e370a4a654fbc4e2ed99680ac269383522a95975a9464
 status: generated
 ---
 

--- a/.help/templates/security-audit/comparison.md
+++ b/.help/templates/security-audit/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: security-audit-comparison
 feature: security-audit
 depth: comparison
-generated_at: 2026-06-02T10:56:02.715269+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/concept.md
+++ b/.help/templates/security-audit/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: security-audit-concept
 feature: security-audit
 depth: concept
-generated_at: 2026-06-02T10:56:02.673454+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/error.md
+++ b/.help/templates/security-audit/error.md
@@ -3,8 +3,8 @@ type: error
 name: security-audit-error
 feature: security-audit
 depth: error
-generated_at: 2026-06-02T10:56:02.690217+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/faq.md
+++ b/.help/templates/security-audit/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: security-audit-faq
 feature: security-audit
 depth: faq
-generated_at: 2026-06-02T10:56:02.703460+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/note.md
+++ b/.help/templates/security-audit/note.md
@@ -3,8 +3,8 @@ type: note
 name: security-audit-note
 feature: security-audit
 depth: note
-generated_at: 2026-06-02T10:56:02.712135+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/quickstart.md
+++ b/.help/templates/security-audit/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: security-audit-quickstart
 feature: security-audit
 depth: quickstart
-generated_at: 2026-06-02T10:56:02.706438+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/reference.md
+++ b/.help/templates/security-audit/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: security-audit-reference
 feature: security-audit
 depth: reference
-generated_at: 2026-06-02T10:56:02.685158+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/task.md
+++ b/.help/templates/security-audit/task.md
@@ -3,8 +3,8 @@ type: task
 name: security-audit-task
 feature: security-audit
 depth: task
-generated_at: 2026-06-02T10:56:02.680360+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/tip.md
+++ b/.help/templates/security-audit/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: security-audit-tip
 feature: security-audit
 depth: tip
-generated_at: 2026-06-02T10:56:02.709415+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/troubleshooting.md
+++ b/.help/templates/security-audit/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: security-audit-troubleshooting
 feature: security-audit
 depth: troubleshooting
-generated_at: 2026-06-02T10:56:02.700253+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/security-audit/warning.md
+++ b/.help/templates/security-audit/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: security-audit-warning
 feature: security-audit
 depth: warning
-generated_at: 2026-06-02T10:56:02.697450+00:00
-source_hash: b5ac92e21712579189bcbb6c5f4ee162ee999a19b070da3f645661ffa7e81668
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: eae54371f777d7daaf221262e83161689f726496eaa58090e4ea0460f613d131
 status: generated
 ---
 

--- a/.help/templates/smart-test/comparison.md
+++ b/.help/templates/smart-test/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: smart-test-comparison
 feature: smart-test
 depth: comparison
-generated_at: 2026-05-16T06:19:45.819669+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/concept.md
+++ b/.help/templates/smart-test/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: smart-test-concept
 feature: smart-test
 depth: concept
-generated_at: 2026-05-16T06:19:45.785002+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/error.md
+++ b/.help/templates/smart-test/error.md
@@ -3,8 +3,8 @@ type: error
 name: smart-test-error
 feature: smart-test
 depth: error
-generated_at: 2026-05-16T06:19:45.799447+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/faq.md
+++ b/.help/templates/smart-test/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: smart-test-faq
 feature: smart-test
 depth: faq
-generated_at: 2026-05-16T06:19:45.810099+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/note.md
+++ b/.help/templates/smart-test/note.md
@@ -3,8 +3,8 @@ type: note
 name: smart-test-note
 feature: smart-test
 depth: note
-generated_at: 2026-05-16T06:19:45.817118+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/quickstart.md
+++ b/.help/templates/smart-test/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: smart-test-quickstart
 feature: smart-test
 depth: quickstart
-generated_at: 2026-05-16T06:19:45.812538+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/reference.md
+++ b/.help/templates/smart-test/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: smart-test-reference
 feature: smart-test
 depth: reference
-generated_at: 2026-05-16T06:19:45.795322+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/task.md
+++ b/.help/templates/smart-test/task.md
@@ -3,8 +3,8 @@ type: task
 name: smart-test-task
 feature: smart-test
 depth: task
-generated_at: 2026-05-16T06:19:45.790819+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/tip.md
+++ b/.help/templates/smart-test/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: smart-test-tip
 feature: smart-test
 depth: tip
-generated_at: 2026-05-16T06:19:45.814975+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74367cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/troubleshooting.md
+++ b/.help/templates/smart-test/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: smart-test-troubleshooting
 feature: smart-test
 depth: troubleshooting
-generated_at: 2026-05-16T06:19:45.807645+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/smart-test/warning.md
+++ b/.help/templates/smart-test/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: smart-test-warning
 feature: smart-test
 depth: warning
-generated_at: 2026-05-16T06:19:45.805234+00:00
-source_hash: 2ed25e274258323117a16cf96fcb5bf0a40e45a9bb8c246d4abfdc74365cfabc
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: b1325f36412cbd67b36481e0f150de834b91392f8fa17c843f8aecd357d18b07
 status: generated
 ---
 

--- a/.help/templates/telemetry/concept.md
+++ b/.help/templates/telemetry/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: telemetry-concept
 feature: telemetry
 depth: concept
-generated_at: 2026-05-16T06:19:45.821122+00:00
-source_hash: ed8485991002cc1c218f67b4f33f230bcbdc4325599a2e03f2bbe584d94a5e90
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: dba935dbb81bdeff572ce1339760a554a2afb6a7b99583b95b2a4ce078fd6abc
 status: generated
 ---
 
@@ -14,16 +14,17 @@ Attune's telemetry layer is an observability system that tracks agent activity, 
 
 ## What telemetry covers
 
-Telemetry spans four distinct concerns that work together to keep multi-agent workflows visible and controllable:
+Telemetry spans five distinct concerns that work together to keep multi-agent workflows visible and controllable:
 
 | Concern | What it does | Key types |
 |---|---|---|
 | **Usage tracking** | Records help queries and calculates cost savings from prompt caching and model-tier routing | `UsageTracker`, `FeedbackLoop` |
+| **Anonymous usage ping** | Opt-in (default OFF) phone-home of a frozen, anonymized payload to help prioritize development | `usage_ping` |
 | **Agent heartbeats** | Publishes liveness signals to Redis TTL keys so you can detect stale or crashed agents | `HeartbeatCoordinator`, `AgentHeartbeat` |
 | **Inter-agent coordination** | Routes typed signals between agents with configurable TTLs; expired signals are discarded automatically | `CoordinationSignals`, `CoordinationSignal` |
 | **Human approval gates** | Pauses a workflow until a human responds to an `ApprovalRequest`; times out if no response arrives within `timeout_seconds` | `ApprovalGate`, `ApprovalRequest`, `ApprovalResponse` |
 
-A fifth concern — real-time event streaming — cuts across all four: `EventStreamer` publishes `StreamEvent` records to Redis Streams so external consumers can observe what is happening without polling.
+A sixth concern — real-time event streaming — cuts across the others: `EventStreamer` publishes `StreamEvent` records to Redis Streams so external consumers can observe what is happening without polling.
 
 ## How the pieces fit together
 
@@ -36,6 +37,8 @@ Think of telemetry as three concentric layers:
 3. **Control.** `ApprovalGate.request_approval()` blocks until a human calls `respond_to_approval()` or the request times out. The `ApprovalResponse` carries `approved: bool` and an optional `reason`, giving the workflow a typed branch point rather than an ambiguous string.
 
 Usage data recorded by `UsageTracker` and quality scores from `FeedbackLoop` sit alongside these runtime signals. The CLI commands (`cmd_telemetry_show`, `cmd_telemetry_savings`, `cmd_telemetry_cache_stats`, `cmd_agent_performance`) surface that data without requiring direct access to the underlying storage.
+
+Separately, an **opt-in usage ping** lets you share an anonymized signal with the maintainers. It is **OFF by default**; `cmd_telemetry_enable`, `cmd_telemetry_disable`, and `cmd_telemetry_status` (under `attune telemetry`) turn it on or off and show the exact payload that would be sent. The payload is frozen — workflow name, an anonymous install ID, package version, OS, and Python version only. No paths, prompts, costs, tokens, or free text are ever included, and `DO_NOT_TRACK` overrides everything.
 
 ## When telemetry matters
 

--- a/.help/templates/telemetry/reference.md
+++ b/.help/templates/telemetry/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: telemetry-reference
 feature: telemetry
 depth: reference
-generated_at: 2026-05-16T06:19:45.831550+00:00
-source_hash: ed8485991002cc1c218f69b4f33f230bcbdc4325599a2e03f2bbe584d94a5e90
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: dba935dbb81bdeff572ce1339760a554a2afb6a7b99583b95b2a4ce078fd6abc
 status: generated
 ---
 
@@ -35,6 +35,7 @@ Track usage, coordinate agents, manage approval gates, and collect quality feedb
 | `TierRecommendation` | Tier recommendation based on quality feedback. | `src/attune/telemetry/feedback_models.py` |
 | `HelpTracker` | Append-only JSONL tracker for help-system queries. | `src/attune/telemetry/help_tracker.py` |
 | `UsageTracker` | Privacy-first local telemetry tracker. | `src/attune/telemetry/usage_tracker.py` |
+| `usage_ping` | Opt-in anonymous usage sync (frozen payload, default OFF). | `src/attune/telemetry/usage_ping.py` |
 
 ### CoordinationSignal
 
@@ -240,4 +241,30 @@ Real-time event streaming using Redis Streams.
 | `cmd_telemetry_cache_stats` | `args: Any` | `int` | Show prompt caching performance statistics. | `src/attune/telemetry/cli_core.py` |
 | `cmd_telemetry_compare` | `args: Any` | `int` | Compare telemetry across two time periods. | `src/attune/telemetry/cli_core.py` |
 | `cmd_telemetry_reset` | `args: Any` | `int` | Reset/clear all telemetry data. | `src/attune/telemetry/cli_core.py` |
-| `cmd_telemetry_export` | `args: Any` | `int` | Export
+| `cmd_telemetry_export` | `args: Any` | `int` | Export telemetry data to a file. | `src/attune/telemetry/cli_core.py` |
+| `cmd_telemetry_status` | `args: Namespace` | `int` | Show opt-in usage-ping status and the exact payload that would be sent. | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_enable` | `args: Namespace` | `int` | Opt in to anonymous usage pinging (returns the anonymous install ID). | `src/attune/cli_commands/telemetry_commands.py` |
+| `cmd_telemetry_disable` | `args: Namespace` | `int` | Opt out of anonymous usage pinging. | `src/attune/cli_commands/telemetry_commands.py` |
+
+## `usage_ping` module
+
+Opt-in, anonymous usage sync (`src/attune/telemetry/usage_ping.py`). **Default OFF** — nothing is transmitted unless the user opts in via `attune telemetry enable`.
+
+### Functions
+
+| Function | Parameters | Returns | Description |
+|----------|------------|---------|-------------|
+| `is_enabled` | `usage_ping_flag: bool, env: Mapping[str, str] \| None = None` | `bool` | Whether pinging is on, honoring `DO_NOT_TRACK` and `ATTUNE_USAGE_PING`. |
+| `resolve_endpoint` | `env: Mapping[str, str] \| None = None` | `str` | The collection endpoint from env or the default. |
+| `enable` | `loader: Any = None` | `str` | Opt in; returns the anonymous install ID. |
+| `disable` | `loader: Any = None` | `None` | Opt out. |
+| `build_payload` | `record, *, install_id, version, os_name=None, py_version=None` | `dict` | Map a local record to the frozen payload (schema v1). |
+| `example_payload` | `config, *, version=None, os_name=None, py_version=None` | `dict` | The exact payload shape that would be sent (for user audit). |
+| `sync` | `records, *, endpoint, install_id, version, timeout=2.0, batch_size=100, ...` | `int` | Fire-and-forget transmit; returns count confirmed sent. |
+| `run_sync` | `config, *, telemetry_dir=None, version=None, env=None, ...` | `int` | Orchestrate one sync pass (gate → read → transmit → advance cursor). |
+
+### Frozen payload (schema v1)
+
+Exactly these keys, nothing else: `schema`, `package` (`"attune-ai"`), `version`, `install_id` (rotating anonymous UUID), `event` (`"workflow.<name>"`), `os`, `py`, `ts`. **Never** included: `user_id`, cost, tokens, model, provider, tier, stage, duration, paths, prompts, or any free text.
+
+**Opt-in precedence:** `DO_NOT_TRACK` (set → always off) → `ATTUNE_USAGE_PING` env override → persisted `config.telemetry.usage_ping`. Default is OFF.

--- a/.help/templates/telemetry/task.md
+++ b/.help/templates/telemetry/task.md
@@ -3,8 +3,8 @@ type: task
 name: telemetry-task
 feature: telemetry
 depth: task
-generated_at: 2026-05-16T06:19:45.827036+00:00
-source_hash: ed8485991002cc1c218f67b4f33f230bcbdc4325599a2e03f2bbe584d94a5e90
+generated_at: 2026-06-22T10:00:48.764701+00:00
+source_hash: dba935dbb81bdeff572ce1339760a554a2afb6a7b99583b95b2a4ce078fd6abc
 status: generated
 ---
 
@@ -32,6 +32,9 @@ Use the telemetry module when you need to query usage data, review cost savings,
    | View Tier 1 automation status | `cmd_tier1_status()` | `cli_automation.py` |
    | View task routing report | `cmd_task_routing_report()` | `cli_automation.py` |
    | View agent performance metrics | `cmd_agent_performance()` | `cli_automation.py` |
+   | Check usage-ping opt-in status and payload | `cmd_telemetry_status()` | `cli_commands/telemetry_commands.py` |
+   | Opt in to anonymous usage pinging | `cmd_telemetry_enable()` | `cli_commands/telemetry_commands.py` |
+   | Opt out of anonymous usage pinging | `cmd_telemetry_disable()` | `cli_commands/telemetry_commands.py` |
 
 2. **Read the function's docstring, parameters, and return type.**
    Confirm that the function owns the exact behavior you need before proceeding. All CLI command functions return `int` (exit code `0` on success).
@@ -46,7 +49,7 @@ Use the telemetry module when you need to query usage data, review cost savings,
    Apply your change — new logic, additional output fields, or updated filtering. Match the naming conventions, error-handling style, and logging patterns already present in that file.
 
 5. **Register any new subcommand in the CLI entry point.**
-   If you added a new `cmd_*` function, wire it up in `src/attune/telemetry/__main__.py` via `main()` so the CLI can dispatch to it.
+   If you added a new `cmd_*` function for the telemetry module, wire it up in `src/attune/telemetry/__main__.py` via `main()`. For user-facing commands like the usage-ping opt-in controls, add them to `src/attune/cli_commands/telemetry_commands.py` instead (registered through `cli_minimal.py`).
 
 6. **Run the tests again.**
    ```
@@ -61,6 +64,8 @@ Use the telemetry module when you need to query usage data, review cost savings,
 | `src/attune/telemetry/cli_core.py` | Core telemetry display and savings commands |
 | `src/attune/telemetry/cli_analysis.py` | Cost and test-status analysis commands |
 | `src/attune/telemetry/cli_automation.py` | Tier 1, task routing, and agent performance commands |
+| `src/attune/telemetry/usage_ping.py` | Opt-in anonymous usage sync — enable/disable, payload building, endpoint resolution |
+| `src/attune/cli_commands/telemetry_commands.py` | User-facing usage-ping commands: `cmd_telemetry_enable`, `cmd_telemetry_disable`, `cmd_telemetry_status` |
 
 ## Verify your changes
 

--- a/.help/templates/wizards/comparison.md
+++ b/.help/templates/wizards/comparison.md
@@ -2,8 +2,8 @@
 type: comparison
 feature: wizards
 depth: comparison
-generated_at: 2026-04-14T15:29:13.364553+00:00
-source_hash: 655cede9671032e7ccc7f39a9f47afbc96ce8855aa0b1bbe2c6567c1a091bf8b
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/concept.md
+++ b/.help/templates/wizards/concept.md
@@ -2,8 +2,8 @@
 type: concept
 feature: wizards
 depth: concept
-generated_at: 2026-05-04T02:39:47.054190+00:00
-source_hash: 76c270cd6e9ba25a7ffd711122874b94ee586d10897f8210e8c4844f8ecd9f81
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/error.md
+++ b/.help/templates/wizards/error.md
@@ -2,8 +2,8 @@
 type: error
 feature: wizards
 depth: error
-generated_at: 2026-04-14T15:27:42.839594+00:00
-source_hash: 655cede9671032e7ccc7f39a9f47afbc96ce8855aa0b1bbe2c6567c1a091bf8b
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/faq.md
+++ b/.help/templates/wizards/faq.md
@@ -2,8 +2,8 @@
 type: faq
 feature: wizards
 depth: faq
-generated_at: 2026-04-14T15:28:39.160037+00:00
-source_hash: 655cede9671032e7ccc7f39a9f47afbc96ce8855aa0b1bbe2c6567c1a091bf8b
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/note.md
+++ b/.help/templates/wizards/note.md
@@ -2,8 +2,8 @@
 type: note
 feature: wizards
 depth: note
-generated_at: 2026-04-14T15:29:02.454692+00:00
-source_hash: 655cede9671032e7ccc7f39a9f47afbc96ce8855aa0b1bbe2c6567c1a091bf8b
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/quickstart.md
+++ b/.help/templates/wizards/quickstart.md
@@ -2,8 +2,8 @@
 type: quickstart
 feature: wizards
 depth: quickstart
-generated_at: 2026-04-14T15:28:49.322267+00:00
-source_hash: 655cede9671032e7ccc7f39a9f47afbc96ce8855aa0b1bbe2c6567c1a091bf8b
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/reference.md
+++ b/.help/templates/wizards/reference.md
@@ -2,8 +2,8 @@
 type: reference
 feature: wizards
 depth: reference
-generated_at: 2026-05-04T02:40:16.892185+00:00
-source_hash: 76c270cd6e9ba25a7ffd711122874b94ee586d10897f8210e8c4844f8ecd9f81
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/task.md
+++ b/.help/templates/wizards/task.md
@@ -2,8 +2,8 @@
 type: task
 feature: wizards
 depth: task
-generated_at: 2026-05-04T02:40:00.202293+00:00
-source_hash: 76c270cd6e9ba25a7ffd711122874b94ee586d10897f8210e8c4844f8ecd9f81
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/tip.md
+++ b/.help/templates/wizards/tip.md
@@ -2,8 +2,8 @@
 type: tip
 feature: wizards
 depth: tip
-generated_at: 2026-04-14T15:28:57.267201+00:00
-source_hash: 655cede9671032e7ccc7f39a9f47afbc96ce8855aa0b1bbe2c6567c1a091bf8b
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/troubleshooting.md
+++ b/.help/templates/wizards/troubleshooting.md
@@ -2,8 +2,8 @@
 type: troubleshooting
 feature: wizards
 depth: troubleshooting
-generated_at: 2026-04-14T15:28:16.638086+00:00
-source_hash: 655cede9671032e7ccc7f39a9f47afbc96ce8855aa0b1bbe2c6567c1a091bf8b
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 

--- a/.help/templates/wizards/warning.md
+++ b/.help/templates/wizards/warning.md
@@ -2,8 +2,8 @@
 type: warning
 feature: wizards
 depth: warning
-generated_at: 2026-04-14T15:27:57.892257+00:00
-source_hash: 655cede9671032e7ccc7f39a9f47afbc96ce8855aa0b1bbe2c6567c1a091bf8b
+generated_at: 2026-06-22T10:11:35.814147+00:00
+source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
 status: generated
 ---
 


### PR DESCRIPTION
Brings the entire project-local help corpus from **23 stale / 0 current → 0 stale / 25 current**, with no API spend (keyless throughout). Three commits, each a distinct class of work.

## 1. Hand-polish 5 high-drift features (`478a52341`)

Features with genuine source drift since their last generation. Surgically updated only what changed, preserving polished prose/tables/examples. Every proposed signature verified against source first (no confabulation).

| Feature | Added |
|---------|-------|
| cli | usage-ping commands in Telemetry group |
| mcp-server | workspace_root resolution order (`CLAUDE_PROJECT_DIR`) |
| telemetry | opt-in `usage_ping` subsystem — CLI cmds, frozen-payload schema, env precedence (+ fixed a truncated row) |
| ops-dashboard | R6 spend alarm — `SpendAlarm` class/fields, 3 data fns, concept + task guide |
| plugin | `usage_consent_notice` SessionStart hook |

## 2. fix-test bug fix — documented a deleted subsystem (`b50af7e0f`)

`test_lifecycle.py` (`TestLifecycleManager`, `TestTask`, the task queue, git-hook processing) was deleted in #887, but **all 11 fix-test templates still referenced those symbols** and `features.yaml` still globbed the deleted file. Found via symbol-existence verification during the sweep.

- Dropped the deleted file from the fix-test manifest glob
- Rewrote all 11 templates around the surviving API (`TestMaintenanceWorkflow`, `TestPlanItem`, `TestMaintenancePlan`, `TestAction`/`TestPriority`, test_runner tracking fns)

## 3. Verified hash-refresh for 17 false-positive-stale features (`737c168cb`)

These were flagged stale only by cross-cutting refactors (WorkflowReport output, SDK subprocess isolation, cwd resolution) or file-set changes — documented behavior unchanged; memory/agents had zero drift. Verified every documented symbol still exists, then refreshed `generated_at` + `source_hash`. No content changes.

## Verification

- Full corpus: **0 stale / 25** (`check_staleness`)
- fix-test: 0 unresolved symbols
- Markdown mechanical lint: clean (no trailing ws / tabs / heading-spacing issues)
- A follow-up regression-guard task is queued to catch manifest globs pointing at deleted files + templates referencing deleted symbols (the gap content-hash staleness can't see)

🤖 Generated with [Claude Code](https://claude.com/claude-code)