### PR TITLE
test(help): regression guard for manifest globs + template symbols

### DIFF
--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -42,7 +42,6 @@ features:
     description: Review code for style issues, likely bugs, and structural problems
     files:
       - src/attune/workflows/code_review.py
-      - src/attune/workflows/code_review_*.py
     tags: [review, quality, bugs, lint]
 
   smart-test:
@@ -109,7 +108,6 @@ features:
     description: Progressive-depth help engine and template management
     files:
       - src/attune/help/**
-      - packages/attune-help/src/attune_help/**
     tags: [help, templates, docs]
     doc_paths:
       - docs/how-to/help-system-maintenance.md
@@ -170,7 +168,6 @@ features:
     description: Dynamic teams, workflow composition, and agent models
     files:
       - src/attune/orchestration/**
-      - src/attune/coordination/**
     tags: [orchestration, teams]
     doc_paths:
       - docs/how-to/multi-agent-coordination.md

--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -97,7 +97,6 @@ features:
     files:
       - src/attune/workflows/test_runner.py
       - src/attune/workflows/test_maintenance.py
-      - src/attune/workflows/test_lifecycle.py
     tags: [tests, debugging, fixes]
 
   mcp-server:

--- a/.help/templates/code-quality/error.md
+++ b/.help/templates/code-quality/error.md
@@ -15,7 +15,7 @@ Code quality failures occur when the review workflow can't analyze your code or 
 
 - `FileNotFoundError: [Errno 2] No such file or directory` — The specified path doesn't exist or isn't accessible
 - `PermissionError: [Errno 13] Permission denied` — Can't read the target files or directory
-- `WorkflowExecutionError` — One or more subagents (security-reviewer, quality-reviewer, perf-reviewer, architect-reviewer) failed to complete
+- `SdkSubprocessError` — One or more subagent subprocesses (security-reviewer, quality-reviewer, perf-reviewer, architect-reviewer) failed to complete
 - `ValueError: Invalid path format` — The path argument is malformed or points to an unsupported file type
 - `TimeoutError` — Review took longer than expected, often on large codebases
 

--- a/.help/templates/fix-test/comparison.md
+++ b/.help/templates/fix-test/comparison.md
@@ -2,62 +2,50 @@
 type: comparison
 feature: fix-test
 depth: comparison
-generated_at: 2026-04-14T14:58:21.402719+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
-# TestLifecycleManager vs TestMaintenanceWorkflow vs manual test tracking
+# TestMaintenanceWorkflow vs manual tracking functions
 
-The test automation system provides three approaches for managing test lifecycle and maintenance. Each targets different automation levels and integration patterns.
+The fix-test feature offers two approaches for keeping tests in step with source changes. Each targets a different level of automation.
 
 ## Feature comparison
 
-| Feature | TestLifecycleManager | TestMaintenanceWorkflow | Manual tracking functions |
-|---------|---------------------|------------------------|---------------------------|
-| **Automation level** | Full event-driven automation | Workflow orchestration | Manual execution |
-| **File change detection** | Automatic via file events | Manual trigger | No detection |
-| **Queue management** | Built-in task queue with priorities | Plan-based execution | No queuing |
-| **Execution model** | Real-time or batch processing | On-demand workflow runs | Immediate execution |
-| **Git integration** | Pre/post-commit hooks | No git integration | No git integration |
-| **Scheduling** | Configurable maintenance intervals | Manual scheduling | No scheduling |
-| **Configuration complexity** | Medium (auto_execute, queue settings) | Low (project root only) | Minimal (optional params) |
+| Feature | TestMaintenanceWorkflow | Manual tracking functions |
+|---------|------------------------|---------------------------|
+| **Automation level** | Workflow orchestration | Manual execution |
+| **File change handling** | Event handlers map a change to a `TestPlanItem` | No detection |
+| **Planning** | Builds a `TestMaintenancePlan` you can filter and review | No planning |
+| **Execution model** | On-demand `run()`; you choose which items to act on | Immediate execution |
+| **Configuration complexity** | Low (project root only) | Minimal (optional params) |
 
 ## Detailed tradeoffs
 
-**TestLifecycleManager** provides the most comprehensive automation but requires setup overhead. It monitors file changes in real-time and can automatically execute test actions, making it ~10x faster for continuous integration scenarios. However, the event-driven nature means debugging issues requires understanding the queue state and callback system.
+**TestMaintenanceWorkflow** gives you structured control. You trigger it with `run()` (or per-file via `on_file_created/modified/deleted`), and it returns a `TestMaintenancePlan` of `TestPlanItem` entries — each with an `action`, `priority`, and `auto_executable` flag. You can review planned work before acting and run only the safe subset via `get_auto_executable_items()`. Best when you want visibility into what will happen before it does.
 
-**TestMaintenanceWorkflow** offers a middle ground with explicit control flow. You trigger workflows manually but get structured planning via TestMaintenancePlan objects. This approach is ~3x slower than lifecycle automation for frequent changes but provides better visibility into what actions will be taken before execution.
-
-**Manual tracking functions** give you precise control over individual operations with zero setup cost. Each function (`run_tests_with_tracking`, `track_coverage`, etc.) executes immediately and returns specific results. This is fastest for one-off debugging but becomes inefficient when managing more than a handful of test files.
-
-## Use TestLifecycleManager when...
-
-- You need continuous test maintenance during active development
-- Your project has frequent file changes that affect test validity
-- You want automated responses to git operations (pre-commit, post-commit)
-- You can tolerate some debugging complexity for maximum automation
+**Manual tracking functions** give you precise control over individual operations with zero setup cost. Each function (`run_tests_with_tracking`, `track_coverage`, `get_file_test_status`, …) executes immediately and returns specific results. Fastest for one-off debugging, but you coordinate the work yourself.
 
 ## Use TestMaintenanceWorkflow when...
 
-- You prefer explicit control over when test maintenance runs
+- You want changes mapped to prioritized test work automatically
 - You want to review planned actions before execution
-- Your test maintenance happens in scheduled batches rather than continuously
-- You need structured reporting via TestMaintenancePlan objects
+- You need structured reporting via `TestMaintenancePlan` objects
+- You want to auto-run the safe items and defer `REVIEW`/`MANUAL` ones
 
 ## Use manual tracking functions when...
 
 - You're debugging specific test failures interactively
 - You need to integrate test tracking into existing scripts or tools
-- You want immediate results without queue delays
-- You're working with a small number of files that don't change frequently
+- You want immediate results for a specific file or suite
+- You're working with a small number of files
 
-**Winner:** TestLifecycleManager for active development environments where test maintenance overhead is a bottleneck. The automation benefits outweigh the complexity cost once you have more than 10-15 test files to manage.
+**Rule of thumb:** reach for `TestMaintenanceWorkflow` when you want a reviewable plan across many files; drop to the tracking functions for targeted, one-off operations.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/concept.md
+++ b/.help/templates/fix-test/concept.md
@@ -1,47 +1,41 @@
 ---
-type: concept
 feature: fix-test
 depth: concept
-generated_at: 2026-05-04T02:28:39.831715+00:00
-source_hash: bff04fe2ad91cb5eb72a0a1c91eccca5bb1b81eba3549bb3ac7e694b3e7a98b8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Fix Test
 
-Fix-test automatically manages test lifecycles by responding to code changes and scheduling test maintenance tasks based on file events throughout your project.
+The fix-test feature keeps a project's tests healthy by reacting to source-file changes, diagnosing what test work each change implies, and producing a prioritized, partly auto-executable maintenance plan.
 
-## Event-driven test management
+## How it works
 
-When you modify source files, fix-test watches for these changes and queues appropriate test actions:
+`TestMaintenanceWorkflow` is the central coordinator. It turns file-system events into a `TestMaintenancePlan` — an ordered set of `TestPlanItem` entries, each describing one piece of test work: which file it concerns, what `TestAction` to take, and at what `TestPriority`.
 
-- **File creation** — Schedules test generation for new modules through `on_file_created()`
-- **File modification** — Queues test updates when existing code changes via `on_file_modified()`
-- **File deletion** — Removes orphaned tests when source files are deleted using `on_file_deleted()`
+The building blocks:
 
-The `TestLifecycleManager` acts as the central coordinator, transforming file system events into prioritized `TestTask` items that specify what test action to take and when.
+- **`TestMaintenanceWorkflow`** — coordinates everything. `run(context)` produces a maintenance plan; the event handlers `on_file_created()`, `on_file_modified()`, and `on_file_deleted()` translate a single file change into the test work it implies.
+- **`TestPlanItem`** — one unit of test work. Carries `file_path`, `action`, `priority`, `reason`, `test_file_path`, `estimated_effort`, and `auto_executable`.
+- **`TestMaintenancePlan`** — the assembled plan. Filter it with `get_items_by_action()`, `get_items_by_priority()`, or `get_auto_executable_items()`.
+- **`TestAction`** — what to do with a test: `CREATE`, `UPDATE`, `REVIEW`, `DELETE`, `SKIP`, or `MANUAL`.
+- **`TestPriority`** — how urgent: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, or `DEFERRED`.
 
-## Task prioritization and execution
+## How a change becomes a plan
 
-Each test task gets assigned a priority level through `TestPriority` (high, medium, low) and an action type via `TestAction` (create, update, delete, validate). The system maintains a persistent queue where you can:
+1. A source file changes. The matching handler — `on_file_created()`, `on_file_modified()`, or `on_file_deleted()` — inspects it and decides which `TestAction` applies (a new module needs a `CREATE`; a deleted one may imply a `DELETE` or `REVIEW`).
+2. The workflow assigns a `TestPriority` based on impact and rolls the resulting `TestPlanItem` entries into a `TestMaintenancePlan`.
+3. Callers act on the plan: `get_auto_executable_items()` returns the items safe to run automatically, while higher-touch items (`REVIEW`, `MANUAL`) are surfaced for a human.
 
-- Process tasks by priority using `get_queue_by_priority()`
-- Execute batches of work with `process_queue()` up to a specified limit
-- Schedule recurring maintenance through `schedule_maintenance()`
+## Tracking what actually ran
 
-For example, a critical bug fix that breaks existing tests gets high priority, while adding tests for edge cases in stable code gets low priority.
+The companion module `test_runner.py` records outcomes so the workflow can reason about staleness and gaps:
 
-## Git workflow integration
+- `run_tests_with_tracking()` runs a suite and records the result for Tier 1 monitoring.
+- `track_coverage()` and `track_file_tests()` persist coverage and per-file test status.
+- `get_file_test_status()` and `get_files_needing_tests()` answer "is this file covered?" and "what still needs tests?" — the same signals `TestMaintenanceWorkflow.get_stale_tests()` and `get_test_health_summary()` build on.
 
-Fix-test hooks into your Git workflow at two key points:
+## When this matters
 
-- **Pre-commit** — Validates that staged files have corresponding tests via `process_git_pre_commit()`
-- **Post-commit** — Schedules test updates for all changed files through `process_git_post_commit()`
-
-This ensures your test suite stays synchronized with code changes without manual intervention.
-
-## Test maintenance planning
-
-The `TestMaintenanceWorkflow` analyzes your entire project to create comprehensive maintenance plans. It identifies files that need tests through `get_files_needing_tests()`, finds outdated tests via `get_stale_tests()`, and generates a `TestMaintenancePlan` with concrete action items.
-
-Each `TestPlanItem` includes the target file, required action, priority level, effort estimate, and whether the task can be automated — giving you a clear roadmap for improving test coverage and keeping tests current.
+You work with fix-test when you want to keep test coverage in step with source changes automatically — surfacing the tests a change demands, prioritizing them by impact, and auto-running the safe ones — rather than discovering gaps after a regression lands.

--- a/.help/templates/fix-test/error.md
+++ b/.help/templates/fix-test/error.md
@@ -2,22 +2,22 @@
 type: error
 feature: fix-test
 depth: error
-generated_at: 2026-04-14T14:56:45.083008+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Fix Test errors
 
-Failures in automated test lifecycle management, test execution tracking, and test maintenance workflows.
+Failures in test maintenance planning, test execution tracking, and source-file event handling.
 
 ## Common error signatures
 
 - `FileNotFoundError: Coverage file not found: {path}` — The coverage.xml file specified in `track_coverage()` doesn't exist
 - `ValueError: Invalid coverage.xml format: {details}` — Coverage file exists but contains malformed XML or missing required elements
-- Test task queue corruption causing `TestTask` processing failures
+- Unexpected `TestPlanItem` entries when an event maps a file to the wrong `TestAction`
 - File path resolution errors when mapping source files to their corresponding test files
-- Priority filtering failures in `TestLifecycleManager.process_queue()`
+- Priority filtering returning nothing from `TestMaintenancePlan.get_items_by_priority()` when an invalid `TestPriority` is passed
 
 ## Where errors originate
 
@@ -25,26 +25,25 @@ Most failures occur during:
 
 - **Test execution tracking** — `run_tests_with_tracking()` fails when test commands exit with non-zero codes or produce unparseable output
 - **Coverage analysis** — `track_coverage()` raises exceptions when coverage files are missing, corrupted, or in unexpected formats
-- **File monitoring** — Event handlers (`on_file_created()`, `on_file_modified()`, `on_file_deleted()`) fail when file paths are invalid or inaccessible
-- **Queue processing** — `TestLifecycleManager.process_queue()` encounters errors when tasks reference deleted files or have malformed metadata
-- **Test maintenance planning** — `TestMaintenanceWorkflow.run()` fails when project structure analysis produces inconsistent results
+- **File event handling** — the handlers (`on_file_created()`, `on_file_modified()`, `on_file_deleted()`) fail when file paths are invalid or inaccessible
+- **Plan generation** — `TestMaintenanceWorkflow.run()` fails when project structure analysis produces inconsistent results
+- **Plan filtering** — `get_items_by_action()` / `get_items_by_priority()` return empty results when passed a value that isn't a `TestAction` / `TestPriority`
 
 ## How to diagnose
 
-1. **Check file paths first.** Many errors stem from missing test files, moved source files, or incorrect project root configuration. Verify that `project_root` in `TestMaintenanceWorkflow` and `TestLifecycleManager` points to the correct directory.
+1. **Check file paths first.** Many errors stem from missing test files, moved source files, or incorrect project root configuration. Verify that the project root used by `TestMaintenanceWorkflow` points to the correct directory.
 
-2. **Examine the task queue.** If `TestLifecycleManager` operations fail, call `get_queue()` to inspect pending tasks. Look for tasks with invalid `file_path` values or corrupted `metadata` fields.
+2. **Examine the plan.** If `TestMaintenanceWorkflow.run()` produces unexpected results, inspect `plan.items` and each item's `file_path`, `action`, and `metadata` for invalid or corrupted values.
 
 3. **Validate coverage files.** When `track_coverage()` fails, check that the coverage.xml file exists and contains valid XML. The file must include `<coverage>` root elements with measurable line and branch data.
 
-4. **Test file mapping issues.** If test lifecycle events fail, verify that the `ProjectIndex` can correctly map source files to test files. Missing or outdated index data causes most file-based operations to fail.
+4. **Test file mapping issues.** If event handlers fail, verify that the `ProjectIndex` can correctly map source files to test files. Missing or outdated index data causes most file-based operations to fail.
 
-5. **Check priority and action values.** `TestPlanItem` and `TestTask` objects require valid `TestAction` and `TestPriority` enum values. Invalid enums cause filtering and processing methods to raise `AttributeError` or `KeyError`.
+5. **Check priority and action values.** `TestPlanItem` objects require valid `TestAction` and `TestPriority` enum values. Invalid enums cause filtering methods to return nothing or raise `AttributeError`.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/faq.md
+++ b/.help/templates/fix-test/faq.md
@@ -2,8 +2,8 @@
 type: faq
 feature: fix-test
 depth: faq
-generated_at: 2026-04-14T14:57:37.506391+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
@@ -20,7 +20,7 @@ Use fix-test when you need to:
 - Monitor test coverage and execution
 - Get maintenance plans for stale or missing tests
 - Respond to file changes with appropriate test actions
-- Schedule regular test health checks
+- Get a quick test-health summary for your project
 
 ## What are the main functions I should know about?
 
@@ -37,7 +37,7 @@ Use the `TestMaintenanceWorkflow` class. It analyzes your project and generates 
 
 ## How do I respond to file changes automatically?
 
-The `TestLifecycleManager` handles file events for you. It creates `TestTask` objects when files are created, modified, or deleted, then queues them for processing based on priority.
+`TestMaintenanceWorkflow` handles file events for you. Its `on_file_created()`, `on_file_modified()`, and `on_file_deleted()` handlers each return a `TestPlanItem` describing the test action that change implies, with an assigned `TestAction` and `TestPriority`.
 
 ## What happens when I run `track_coverage()`?
 
@@ -49,9 +49,8 @@ First, run `pytest -k "fix-test" -v` to check if the feature's own tests pass. I
 
 ## Where are the source files?
 
-The fix-test feature spans three files:
+The fix-test feature spans two files:
 - `src/attune/workflows/test_runner.py` — Test execution and coverage tracking
-- `src/attune/workflows/test_maintenance.py` — Maintenance workflow and planning
-- `src/attune/workflows/test_lifecycle.py` — Event-driven test lifecycle management
+- `src/attune/workflows/test_maintenance.py` — Maintenance workflow, planning, and source-file event handlers
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/note.md
+++ b/.help/templates/fix-test/note.md
@@ -2,8 +2,8 @@
 type: note
 feature: fix-test
 depth: note
-generated_at: 2026-04-14T14:58:08.551287+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
@@ -11,26 +11,23 @@ status: generated
 
 ## Context
 
-The fix-test feature provides automated test lifecycle management through event-driven workflows. It tracks test coverage, identifies files needing test attention, and manages test maintenance plans with priority-based execution.
+The fix-test feature provides test maintenance through event-driven planning. It tracks test coverage, identifies files needing test attention, and turns source-file changes into prioritized maintenance plans.
 
 ## Architecture
 
-The feature combines three complementary modules:
+The feature combines two complementary modules:
 
 **Test execution tracking** (`test_runner.py`) provides opt-in monitoring functions that record test results and coverage data for Tier 1 automation. Key functions include `run_tests_with_tracking()` for explicit test execution tracking and `track_coverage()` for parsing coverage.xml files.
 
-**Test maintenance planning** (`test_maintenance.py`) defines the data structures for organizing test work. `TestMaintenancePlan` contains prioritized `TestPlanItem` instances that specify actions like creating new tests or updating existing ones. Each item includes metadata like estimated effort and auto-execution flags.
-
-**Event-driven lifecycle management** (`test_lifecycle.py`) responds to file system changes through `TestLifecycleManager`. When source files are created, modified, or deleted, the manager queues appropriate `TestTask` instances. The workflow supports Git hooks for pre-commit and post-commit processing.
+**Test maintenance planning and event handling** (`test_maintenance.py`) defines both the plan model and the coordinator. `TestMaintenancePlan` contains prioritized `TestPlanItem` instances that specify actions like creating or updating tests, each with metadata like estimated effort and an auto-executable flag. `TestMaintenanceWorkflow` responds to file-system changes through its `on_file_created()`, `on_file_modified()`, and `on_file_deleted()` handlers and assembles the plan via `run()`.
 
 ## Integration pattern
 
-The modules work together through shared data types. Test execution functions accept workflow IDs that link results to specific maintenance plans. The lifecycle manager generates tasks that reference the same action and priority enums used in maintenance plans. This allows the system to automatically queue test work when files change and execute it according to configured priorities.
+The modules work together through shared data types. Test execution functions accept workflow IDs that link results to specific maintenance plans. The event handlers produce `TestPlanItem` entries that reference the same `TestAction` and `TestPriority` enums used throughout the plan. This lets the system map a file change to prioritized test work and surface the auto-executable subset for execution.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/quickstart.md
+++ b/.help/templates/fix-test/quickstart.md
@@ -2,14 +2,14 @@
 type: quickstart
 feature: fix-test
 depth: quickstart
-generated_at: 2026-04-14T14:57:50.585458+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Quickstart: fix-test
 
-Track and manage failing tests across your project. The fix-test feature automatically identifies files that need test attention and queues maintenance tasks.
+Track and manage failing tests across your project. The fix-test feature identifies files that need test attention and turns changes into a prioritized maintenance plan.
 
 ```python
 from attune.workflows.test_runner import get_files_needing_tests
@@ -29,30 +29,31 @@ File: src/another_module.py
 Status: no_tests
 ```
 
-## Set up automated test lifecycle management
+## Build a test maintenance plan
 
-1. **Initialize the test lifecycle manager**
+1. **Create the workflow**
    ```python
-   from attune.workflows.test_lifecycle import TestLifecycleManager
+   from attune.workflows.test_maintenance import TestMaintenanceWorkflow
 
-   manager = TestLifecycleManager(project_root=".", auto_execute=True)
+   workflow = TestMaintenanceWorkflow()
    ```
 
-2. **Process file changes to queue test tasks**
+2. **React to a change, or build a full plan**
    ```python
-   # When files change, automatically queue maintenance tasks
-   tasks = manager.on_files_changed(["src/updated_file.py", "src/new_file.py"])
-   print(f"Queued {len(tasks)} test maintenance tasks")
+   # Per-file: returns a TestPlanItem | None
+   item = workflow.on_file_modified("src/updated_file.py")
+
+   # Or a full plan for the project
+   plan = workflow.run({})
+   print(f"Planned {len(plan.items)} test maintenance items")
    ```
 
-3. **Execute queued maintenance**
+3. **Act on the safe subset**
    ```python
-   # Process pending test maintenance tasks
-   results = manager.process_queue(max_tasks=5)
-   print(f"Completed: {results['completed_count']}")
-   print(f"Failed: {results['failed_count']}")
+   safe = plan.get_auto_executable_items()
+   print(f"{len(safe)} items can run automatically")
    ```
 
 ## Next steps
 
-Run `manager.get_test_health_summary()` to see an overview of your project's test coverage and identify the highest-priority areas for improvement.
+Run `workflow.get_test_health_summary()` to see an overview of your project's test coverage and identify the highest-priority areas for improvement.

--- a/.help/templates/fix-test/reference.md
+++ b/.help/templates/fix-test/reference.md
@@ -1,126 +1,76 @@
 ---
-type: reference
 feature: fix-test
 depth: reference
-generated_at: 2026-05-04T02:29:09.486519+00:00
-source_hash: bff04fe2ad91cb5eb72a0a1c91eccca5bb1b81eba3549bb3ac7e694b3e7a98b8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Fix Test reference
 
-Event-driven test management with automatic lifecycle control, maintenance workflows, and execution tracking for automated test repair and monitoring.
-
 ## Classes
 
-| Class | Description |
-|-------|-------------|
-| `TestTask` | A queued test management task |
-| `TestLifecycleManager` | Manages test lifecycle based on source file events |
-| `TestAction` | Actions available for test management |
-| `TestPriority` | Priority levels for test actions |
-| `TestPlanItem` | Single item in a test maintenance plan |
-| `TestMaintenancePlan` | Complete test maintenance plan for a project |
-| `TestMaintenanceWorkflow` | Workflow for automatic test lifecycle management |
+| Class | Description | File |
+|-------|-------------|------|
+| `TestAction` | Action to take for a test: `CREATE`, `UPDATE`, `REVIEW`, `DELETE`, `SKIP`, `MANUAL`. | `src/attune/workflows/test_maintenance.py` |
+| `TestPriority` | Priority for a test action: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`, `DEFERRED`. | `src/attune/workflows/test_maintenance.py` |
+| `TestPlanItem` | A single item in a test maintenance plan. | `src/attune/workflows/test_maintenance.py` |
+| `TestMaintenancePlan` | Complete test maintenance plan for a project. | `src/attune/workflows/test_maintenance.py` |
+| `TestMaintenanceWorkflow` | Coordinates test maintenance from source-file events. | `src/attune/workflows/test_maintenance.py` |
 
-### TestTask
+### `TestPlanItem` fields
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `id` | `str` | | Task identifier |
-| `file_path` | `str` | | Path to the file being tested |
-| `action` | `TestAction` | | Action to perform |
-| `priority` | `TestPriority` | | Task priority level |
-| `created_at` | `datetime` | `field(default_factory=datetime.now)` | Task creation timestamp |
-| `scheduled_for` | `datetime | None` | `None` | Scheduled execution time |
-| `status` | `str` | `'pending'` | Current task status |
-| `result` | `dict[str, Any] | None` | `None` | Task execution results |
+| Field | Type | Role |
+|-------|------|------|
+| `file_path` | `str` | The source file the work concerns |
+| `action` | `TestAction` | What to do with the test |
+| `priority` | `TestPriority` | How urgent the work is |
+| `reason` | `str` | Why this item was generated |
+| `test_file_path` | `str \| None` | The associated test file, if known |
+| `estimated_effort` | `str` | Rough effort estimate |
+| `auto_executable` | `bool` | Whether the item can be run without review |
+| `metadata` | `dict` | Free-form extra context |
 
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Convert task to dictionary format |
+`to_dict()` serializes the item.
 
-### TestLifecycleManager
+### `TestMaintenancePlan` methods
 
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|
-| `__init__(self, project_root, index, auto_execute, queue_file)` | `project_root: str, index: ProjectIndex | None = None, auto_execute: bool = False, queue_file: str | None = None` | | Initialize test lifecycle manager |
-| `on_file_created(self, file_path)` | `file_path: str` | `TestTask | None` | Handle file creation event |
-| `on_file_modified(self, file_path)` | `file_path: str` | `TestTask | None` | Handle file modification event |
-| `on_file_deleted(self, file_path)` | `file_path: str` | `TestTask | None` | Handle file deletion event |
-| `on_files_changed(self, changed_files)` | `changed_files: list[str]` | `list[TestTask]` | Handle multiple file changes |
-| `get_queue(self)` | | `list[dict[str, Any]]` | Get current task queue |
-| `get_pending_count(self)` | | `int` | Get count of pending tasks |
-| `get_queue_by_priority(self, priority)` | `priority: TestPriority` | `list[TestTask]` | Get tasks filtered by priority |
-| `clear_queue(self)` | | `int` | Clear all queued tasks |
-| `process_queue(self, max_tasks, priority_filter)` | `max_tasks: int = 10, priority_filter: TestPriority | None = None` | `dict[str, Any]` | Process queued tasks |
-| `schedule_maintenance(self, interval_hours, auto_execute)` | `interval_hours: int = 24, auto_execute: bool = False` | `dict[str, Any]` | Schedule maintenance tasks |
-| `run_maintenance(self, auto_execute)` | `auto_execute: bool = False` | `dict[str, Any]` | Run maintenance workflow |
-| `process_git_pre_commit(self, staged_files)` | `staged_files: list[str]` | `dict[str, Any]` | Process pre-commit file changes |
-| `process_git_post_commit(self, changed_files)` | `changed_files: list[str]` | `dict[str, Any]` | Process post-commit file changes |
-| `on_task_queued(self, callback)` | `callback: Callable[[TestTask], None]` | `None` | Register task queued callback |
-| `on_task_completed(self, callback)` | `callback: Callable[[TestTask], None]` | `None` | Register task completed callback |
-| `get_status(self)` | | `dict[str, Any]` | Get manager status |
+| `to_dict()` | — | `dict` | Serialize the plan. |
+| `get_items_by_action(action)` | `action: TestAction` | `list[TestPlanItem]` | Items with the given action. |
+| `get_items_by_priority(priority)` | `priority: TestPriority` | `list[TestPlanItem]` | Items at the given priority. |
+| `get_auto_executable_items()` | — | `list[TestPlanItem]` | Items safe to run automatically. |
 
-### TestPlanItem
+Fields: `generated_at`, `items`, `summary`, `options`.
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `file_path` | `str` | | Path to source file |
-| `action` | `TestAction` | | Required action |
-| `priority` | `TestPriority` | | Action priority |
-| `reason` | `str` | | Reason for action |
-| `test_file_path` | `str | None` | `None` | Associated test file |
-| `estimated_effort` | `str` | `'unknown'` | Effort estimate |
-| `auto_executable` | `bool` | `True` | Whether action can be automated |
-| `metadata` | `dict[str, Any]` | `field(default_factory=dict)` | Additional metadata |
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `to_dict(self)` | `dict[str, Any]` | Convert item to dictionary format |
-
-### TestMaintenancePlan
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `generated_at` | `datetime` | `field(default_factory=datetime.now)` | Plan generation timestamp |
-| `items` | `list[TestPlanItem]` | `field(default_factory=list)` | Plan items |
-| `summary` | `dict[str, Any]` | `field(default_factory=dict)` | Plan summary |
-| `options` | `list[dict[str, Any]]` | `field(default_factory=list)` | Available options |
+### `TestMaintenanceWorkflow` methods
 
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|
-| `to_dict(self)` | | `dict[str, Any]` | Convert plan to dictionary format |
-| `get_items_by_action(self, action)` | `action: TestAction` | `list[TestPlanItem]` | Filter items by action type |
-| `get_items_by_priority(self, priority)` | `priority: TestPriority` | `list[TestPlanItem]` | Filter items by priority |
-| `get_auto_executable_items(self)` | | `list[TestPlanItem]` | Get items that can be automated |
-
-### TestMaintenanceWorkflow
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__(self, project_root, index)` | `project_root: str, index: ProjectIndex | None = None` | | Initialize maintenance workflow |
-| `run(self, context)` | `context: dict[str, Any]` | `dict[str, Any]` | Run maintenance workflow |
-| `on_file_created(self, file_path)` | `file_path: str` | `dict[str, Any]` | Handle file creation |
-| `on_file_modified(self, file_path)` | `file_path: str` | `dict[str, Any]` | Handle file modification |
-| `on_file_deleted(self, file_path)` | `file_path: str` | `dict[str, Any]` | Handle file deletion |
-| `get_files_needing_tests(self, limit)` | `limit: int = 20` | `list[dict[str, Any]]` | Get files requiring test coverage |
-| `get_stale_tests(self, limit)` | `limit: int = 20` | `list[dict[str, Any]]` | Get outdated test files |
-| `get_test_health_summary(self)` | | `dict[str, Any]` | Get overall test health status |
+| `run(context)` | `context: dict` | `TestMaintenancePlan` | Build a maintenance plan for the project. |
+| `on_file_created(file_path)` | `file_path: str` | `TestPlanItem \| None` | Test work implied by a new file. |
+| `on_file_modified(file_path)` | `file_path: str` | `TestPlanItem \| None` | Test work implied by a changed file. |
+| `on_file_deleted(file_path)` | `file_path: str` | `TestPlanItem \| None` | Test work implied by a deleted file. |
+| `get_files_needing_tests(limit)` | `limit: int` | `list` | Files needing tests, prioritized by impact. |
+| `get_stale_tests(limit)` | `limit: int` | `list` | Files with stale tests. |
+| `get_test_health_summary()` | — | `dict` | Quick test-health summary. |
 
 ## Functions
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `run_tests_with_tracking(test_suite, test_files, command, workflow_id, triggered_by)` | `test_suite: str = 'unit', test_files: list[str] | None = None, command: str | None = None, workflow_id: str | None = None, triggered_by: str = 'manual'` | `TestExecutionRecord` | Run tests with explicit tracking for Tier 1 monitoring |
-| `track_coverage(coverage_file, workflow_id)` | `coverage_file: str = 'coverage.xml', workflow_id: str | None = None` | `CoverageRecord` | Track test coverage from coverage.xml file |
-| `track_file_tests(source_file, test_file, workflow_id)` | `source_file: str, test_file: str | None = None, workflow_id: str | None = None` | `FileTestRecord` | Track test execution for a specific source file |
-| `get_file_test_status(file_path)` | `file_path: str` | `FileTestRecord | None` | Get latest test status for a file |
-| `get_files_needing_tests(stale_only, failed_only)` | `stale_only: bool = False, failed_only: bool = False` | `list[FileTestRecord]` | Get files that need test attention |
+| Function | Parameters | Returns | Description | File |
+|----------|------------|---------|-------------|------|
+| `run_tests_with_tracking()` | `test_suite, test_files, command, workflow_id, triggered_by` | `dict` | Run tests with explicit tracking (opt-in Tier 1 monitoring). | `test_runner.py` |
+| `track_coverage()` | `coverage_file, workflow_id` | `dict` | Track coverage from a `coverage.xml` file. | `test_runner.py` |
+| `track_file_tests()` | `source_file, test_file, workflow_id` | `dict` | Track test execution for a specific source file. | `test_runner.py` |
+| `get_file_test_status()` | `file_path` | `FileTestRecord \| None` | Latest test status for a file. | `test_runner.py` |
+| `get_files_needing_tests()` | `stale_only, failed_only` | `list` | Files that need test attention. | `test_runner.py` |
 
-### Raises
+## Source files
 
-| Function | Exception | Message |
-|----------|-----------|---------|
-| `track_coverage()` | `FileNotFoundError` | `'Coverage file not found: {...}'` |
-| `track_coverage()` | `ValueError` | `'Invalid coverage.xml format: {...}'` |
+- `src/attune/workflows/test_runner.py`
+- `src/attune/workflows/test_maintenance.py`
+
+## Tags
+
+`tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/task.md
+++ b/.help/templates/fix-test/task.md
@@ -1,82 +1,95 @@
 ---
-type: task
 feature: fix-test
 depth: task
-generated_at: 2026-05-04T02:28:54.250565+00:00
-source_hash: bff04fe2ad91cb5eb72a0a1c91eccca5bb1b81eba3549bb3ac7e694b3e7a98b8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
 # Work with fix test
 
-Use the fix-test system when you need to implement or modify automatic test diagnosis and repair capabilities in your project.
+Use fix test when you want to extend how source-file changes are
+turned into prioritized test work, or change how test outcomes are
+tracked.
 
 ## Prerequisites
 
 - Access to the project source code
-- Understanding of test execution workflows
-- Familiarity with the test lifecycle management system
+- Familiarity with `src/attune/workflows/test_maintenance.py` (the
+  workflow and plan model) and `src/attune/workflows/test_runner.py`
+  (outcome tracking)
 
-## Understand the test lifecycle architecture
+## Understand the two modules
 
-Start by examining how the test lifecycle system works:
+| Module | Owns |
+|--------|------|
+| `test_maintenance.py` | `TestMaintenanceWorkflow` and the plan model — `TestPlanItem`, `TestMaintenancePlan`, `TestAction`, `TestPriority` |
+| `test_runner.py` | Outcome tracking — `run_tests_with_tracking()`, `track_coverage()`, `track_file_tests()`, and the status queries |
 
-1. Open `src/attune/workflows/test_lifecycle.py` to see the `TestLifecycleManager` class
-2. Review the `TestTask` and `TestAction` dataclasses to understand the task queue structure
-3. Check `src/attune/workflows/test_maintenance.py` for the `TestMaintenanceWorkflow` that handles automatic test management
+## Generate a maintenance plan
 
-The system uses event-driven test management where file changes trigger test tasks that get queued and processed automatically.
+1. **Instantiate the workflow** and call `run()` with a context dict:
 
-## Identify the target component
+   ```python
+   from attune.workflows.test_maintenance import TestMaintenanceWorkflow
 
-Determine which component needs modification based on your goal:
+   workflow = TestMaintenanceWorkflow()
+   plan = workflow.run({})
+   ```
 
-- **Test execution tracking**: Modify functions in `src/attune/workflows/test_runner.py`
-- **Test lifecycle events**: Update `TestLifecycleManager` methods in `test_lifecycle.py`
-- **Maintenance workflows**: Change `TestMaintenanceWorkflow` in `test_maintenance.py`
+2. **Filter the plan** by what you need:
 
-## Modify test execution functions
+   ```python
+   from attune.workflows.test_maintenance import TestAction, TestPriority
 
-For changes to test running and tracking:
+   to_create = plan.get_items_by_action(TestAction.CREATE)
+   urgent = plan.get_items_by_priority(TestPriority.CRITICAL)
+   safe = plan.get_auto_executable_items()
+   ```
 
-1. Locate the specific function in `test_runner.py`:
-   - `run_tests_with_tracking()` for test execution with monitoring
-   - `track_coverage()` for coverage analysis
-   - `track_file_tests()` for file-specific test tracking
-   - `get_file_test_status()` for retrieving test status
-   - `get_files_needing_tests()` for identifying test gaps
+3. **Inspect a `TestPlanItem`** — each carries `file_path`, `action`,
+   `priority`, `reason`, `test_file_path`, `estimated_effort`, and
+   `auto_executable`.
 
-2. Read the function's docstring and examine its parameters and return type
-3. Study the existing error handling patterns and logging style
-4. Implement your changes following the established conventions
+## React to a single file change
 
-## Update lifecycle management
+Use the event handlers when you want per-file behavior rather than a
+full plan:
 
-For changes to the test lifecycle system:
-
-1. Modify the appropriate method in `TestLifecycleManager`:
-   - `on_file_created()`, `on_file_modified()`, or `on_file_deleted()` for file event handling
-   - `process_queue()` for task execution
-   - `schedule_maintenance()` or `run_maintenance()` for automated maintenance
-
-2. Update the corresponding `TestTask` or `TestPlanItem` properties if needed
-3. Ensure the task priority and action enums are used correctly
-
-## Test your changes
-
-Run the test suite to verify your modifications work correctly:
-
-```bash
-pytest -k "test_lifecycle" tests/
-pytest -k "test_runner" tests/
+```python
+item = workflow.on_file_modified("src/attune/foo.py")
+if item and item.auto_executable:
+    ...
 ```
 
-Your changes should pass all existing tests without breaking the test lifecycle workflow.
+`on_file_created()`, `on_file_modified()`, and `on_file_deleted()`
+each return a `TestPlanItem | None`.
 
-## Success criteria
+## Track test outcomes
 
-Your fix-test modifications are complete when:
-- All targeted tests pass
-- The test lifecycle manager processes tasks correctly
-- Test execution tracking records data as expected
-- No regressions appear in the existing test suite
+Use `test_runner.py` to persist what actually ran:
+
+1. `run_tests_with_tracking(test_suite, test_files, command, workflow_id, triggered_by)` runs a suite and records the result.
+2. `track_coverage(coverage_file, workflow_id)` ingests a `coverage.xml`.
+3. `get_file_test_status(file_path)` and `get_files_needing_tests(stale_only, failed_only)` answer coverage questions for a file or the whole project.
+
+## Modify behavior
+
+- **Plan generation / prioritization** — edit `TestMaintenanceWorkflow`
+  methods in `test_maintenance.py`. Adjust how an event maps to a
+  `TestAction`, or how `TestPriority` is assigned.
+- **New plan-item field** — add it to the `TestPlanItem` dataclass and
+  update `to_dict()`.
+- **Outcome tracking** — edit the tracking functions in
+  `test_runner.py`.
+
+## Verify your changes
+
+Run the related tests:
+
+```
+pytest -k "maintenance or test_runner" tests/
+```
+
+A passing suite with no new failures confirms the plan model and
+outcome tracking still behave correctly.

--- a/.help/templates/fix-test/tip.md
+++ b/.help/templates/fix-test/tip.md
@@ -2,35 +2,38 @@
 type: tip
 feature: fix-test
 depth: tip
-generated_at: 2026-04-14T14:58:00.827179+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
-# Use TestLifecycleManager for event-driven test maintenance
+# Use TestMaintenanceWorkflow for event-driven test maintenance
 
-Start with `TestLifecycleManager` when files change in your project—it automatically queues appropriate test actions based on what happened to each file.
+Reach for `TestMaintenanceWorkflow` when files change in your project — its event handlers turn each change into a `TestPlanItem` describing the test action that change implies.
 
 ## Why this matters
 
-Setting up event handlers once is faster than manually tracking which tests need updates every time you modify source code.
+Letting the workflow map changes to test actions is faster than manually tracking which tests need updates every time you modify source code.
 
 ## How to use it
 
-Initialize the manager with your project root and call the appropriate handler:
+Call the handler that matches the change, then act on the returned item:
 
 ```python
-manager = TestLifecycleManager(project_root="/path/to/project")
+from attune.workflows.test_maintenance import TestMaintenanceWorkflow
+
+workflow = TestMaintenanceWorkflow()
 
 # When a file is created, modified, or deleted
-task = manager.on_file_created("src/new_module.py")
-task = manager.on_file_modified("src/existing_module.py")
-task = manager.on_file_deleted("src/old_module.py")
+item = workflow.on_file_created("src/new_module.py")
+item = workflow.on_file_modified("src/existing_module.py")
+item = workflow.on_file_deleted("src/old_module.py")
 
-# Process queued tasks
-result = manager.process_queue(max_tasks=5)
+# Or build a full plan and run only the safe items
+plan = workflow.run({})
+safe = plan.get_auto_executable_items()
 ```
 
 ## The tradeoff
 
-The manager queues tasks instead of running them immediately—you get control over when test maintenance happens, but you must remember to process the queue.
+`run()` produces a plan rather than executing everything — you get control over what runs, but you decide which items to act on. Use `get_auto_executable_items()` for the safe subset and leave `REVIEW`/`MANUAL` items for a human.

--- a/.help/templates/fix-test/troubleshooting.md
+++ b/.help/templates/fix-test/troubleshooting.md
@@ -2,8 +2,8 @@
 type: troubleshooting
 feature: fix-test
 depth: troubleshooting
-generated_at: 2026-04-14T14:57:17.002317+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
@@ -11,16 +11,16 @@ status: generated
 
 ## Before you start
 
-The fix-test feature provides automated test execution, coverage tracking, and lifecycle management. When tests fail unexpectedly or the system doesn't respond correctly to file changes, use this guide to diagnose and fix the issues.
+The fix-test feature provides test maintenance planning, coverage tracking, and source-file event handling. When tests fail unexpectedly or the system doesn't respond correctly to file changes, use this guide to diagnose and fix the issues.
 
 ## Symptom table
 
 | If you observe | Check |
 |----------------|-------|
-| Tests not running automatically | Verify `TestLifecycleManager` initialization and file event handlers in your project |
+| No plan items generated for a change | Verify the file event handler (`on_file_created/modified/deleted`) is being called with a valid path |
 | Coverage tracking fails | Check that `coverage.xml` exists and is valid XML format at the expected path |
 | Stale test warnings persist | Run `get_stale_tests()` to see if the detection logic matches your actual test files |
-| Queue processing hangs | Check `get_pending_count()` and verify no tasks are stuck with invalid status values |
+| Plan is empty or missing expected items | Inspect `plan.items` after `TestMaintenanceWorkflow.run()`; confirm the project root is correct |
 | File change events ignored | Confirm the `ProjectIndex` is properly initialized and file paths are relative to project root |
 
 ## Step-by-step diagnosis
@@ -28,8 +28,8 @@ The fix-test feature provides automated test execution, coverage tracking, and l
 1. **Reproduce with minimal setup.**
    Create a simple test case that isolates the failing behavior. For test execution issues, try calling `run_tests_with_tracking()` directly with just the required parameters.
 
-2. **Check the task queue status.**
-   Run `TestLifecycleManager.get_status()` to see pending tasks and queue health. Look for tasks stuck in 'pending' status or unexpected error states in the results.
+2. **Inspect the generated plan.**
+   Call `TestMaintenanceWorkflow.run({})` and examine the returned `TestMaintenancePlan`. Look at `plan.items` for entries with unexpected `action` or `priority`, and use `get_auto_executable_items()` to see what would run automatically.
 
 3. **Verify file path resolution.**
    Many issues stem from incorrect file paths. Ensure all paths are relative to the project root and that the `ProjectIndex` can find your test files.
@@ -38,29 +38,26 @@ The fix-test feature provides automated test execution, coverage tracking, and l
    - `run_tests_with_tracking()` — Verify test command execution and result capture
    - `track_coverage()` — Confirm coverage.xml parsing (check file exists and has valid XML)
    - `get_file_test_status()` — Test file-to-test mapping logic
-   - `TestLifecycleManager.on_file_modified()` — Verify event handling creates appropriate tasks
+   - `TestMaintenanceWorkflow.on_file_modified()` — Verify event handling returns an appropriate `TestPlanItem`
 
 5. **Enable debug logging.**
-   Set logging level to `DEBUG` for the `attune.workflows` modules before running operations. The logs will show task creation, queue processing, and file event handling details.
+   Set logging level to `DEBUG` for the `attune.workflows` modules before running operations. The logs will show plan generation, file event handling, and tracking details.
 
 ## Common fixes
 
 - **Missing coverage.xml file:** Run your test suite with coverage first: `python -m pytest --cov=src --cov-report=xml`. The `track_coverage()` function requires this file to exist.
 
-- **Incorrect project root:** Initialize `TestLifecycleManager` and `TestMaintenanceWorkflow` with the absolute path to your project root, not a relative path or subdirectory.
+- **Incorrect project root:** Make sure `TestMaintenanceWorkflow` resolves the absolute path to your project root, not a relative path or subdirectory.
 
-- **Auto-execution disabled:** Set `auto_execute=True` when initializing `TestLifecycleManager` if you want immediate task processing. Without this flag, tasks queue but don't run automatically.
+- **Acting on the wrong items:** To run only the safe work, filter with `plan.get_auto_executable_items()` rather than executing every item — `REVIEW` and `MANUAL` actions are meant for a human.
 
 - **Invalid test file patterns:** The system looks for files matching your project's test patterns. If using custom test discovery, ensure your test files are detectable by the `ProjectIndex`.
 
-- **Stale queue file:** If the task queue behaves strangely, clear it with `TestLifecycleManager.clear_queue()` and restart task processing.
-
-- **Git hook integration:** For automatic execution on commits, use `process_git_pre_commit()` and `process_git_post_commit()` with the actual changed file lists from your Git hooks.
+- **Unexpected action for a change:** If an event produces the wrong `TestAction`, review the mapping logic in the corresponding `on_file_*` handler in `test_maintenance.py`.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/.help/templates/fix-test/warning.md
+++ b/.help/templates/fix-test/warning.md
@@ -2,8 +2,8 @@
 type: warning
 feature: fix-test
 depth: warning
-generated_at: 2026-04-14T14:57:01.164017+00:00
-source_hash: add950818a88e621df7bd12cd03ded18fe60e40bac9a1bae6eb24fe1ff69abc8
+generated_at: 2026-06-22T10:21:37.523920+00:00
+source_hash: 26d8af3fe4cef200ee3e0528559c0e39b2bd3756956371d1e78427e02cb6385b
 status: generated
 ---
 
@@ -11,44 +11,43 @@ status: generated
 
 ## What to watch for
 
-Auto-diagnose and fix failing tests — identifies root causes and applies fixes.
+Test maintenance turns file changes into test work — review what it plans before you act on it.
 
 ## Risk areas
 
-### Automatic test execution can modify your codebase
+### Auto-executable items still modify your codebase
 
-The `TestLifecycleManager` with `auto_execute=True` will automatically run test fixes without user confirmation. This can modify test files, create new tests, or delete obsolete ones based on file change events. Set `auto_execute=False` during development to review changes before they're applied.
+`TestMaintenancePlan.get_auto_executable_items()` returns the items the workflow considers safe to run without review — but running them can still create, update, or delete test files. Inspect `plan.items` and confirm each `action` before executing, especially `DELETE`.
 
 ### Coverage tracking requires specific file formats
 
 The `track_coverage()` function expects a valid `coverage.xml` file in the correct format. If your coverage tool generates a different format or the file is corrupted, tracking will fail with a `ValueError`. Always verify your coverage configuration produces compatible XML before enabling tracking.
 
-### Test lifecycle events fire on every file change
+### Event handlers fire for any file path you pass
 
-File watchers trigger `on_file_created()`, `on_file_modified()`, and `on_file_deleted()` for any project file change, not just source files. This can flood your test task queue with irrelevant maintenance tasks. Use appropriate file filtering in your project configuration to limit events to meaningful changes.
+`on_file_created()`, `on_file_modified()`, and `on_file_deleted()` act on whatever path they're given — including non-source files. If you wire them to a broad file watcher, filter to meaningful source changes first so the plan doesn't fill with irrelevant items.
 
-### Queue processing can overwhelm your system
+### A plan is only as good as the action mapping
 
-`process_queue()` with a high `max_tasks` value can spawn many concurrent test processes. Each test task may consume significant CPU and memory. Monitor system resources when processing large queues, especially in CI environments with limited capacity.
+Each `TestPlanItem` gets its `TestAction` and `TestPriority` from the workflow's mapping logic. If items come back with the wrong action, review the `on_file_*` handlers rather than acting on the bad items.
 
 ### Stale test detection depends on file timestamps
 
-The system identifies stale tests by comparing file modification times between source files and their corresponding test files. If your build system or version control modifies timestamps unexpectedly, you may get false positives for stale tests. Verify timestamp accuracy before trusting stale test reports.
+The system identifies stale tests by comparing modification times between source files and their corresponding test files. If your build system or version control modifies timestamps unexpectedly, you may get false positives. Verify timestamp accuracy before trusting `get_stale_tests()` reports.
 
 ## How to avoid problems
 
-1. **Start with manual execution.** Initialize `TestLifecycleManager` with `auto_execute=False` and review the task queue before enabling automatic processing. Use `get_queue()` to inspect pending tasks.
+1. **Review before executing.** Call `run()` and read `plan.items` first. Filter with `get_auto_executable_items()` and leave `REVIEW`/`MANUAL` items for a human.
 
-2. **Configure appropriate file filters.** Set up your project to only monitor relevant file types and directories. Exclude build artifacts, temporary files, and vendor directories from test lifecycle events.
+2. **Filter the paths you feed in.** When driving the event handlers from a watcher, exclude build artifacts, temporary files, and vendor directories.
 
-3. **Process queues incrementally.** Use smaller `max_tasks` values (5-10) when processing test queues, especially on shared systems. Monitor `get_pending_count()` to avoid overwhelming your environment.
+3. **Check priorities.** Use `get_items_by_priority(TestPriority.CRITICAL)` to focus on the highest-impact work first instead of running everything at once.
 
-4. **Validate coverage setup early.** Test your coverage configuration with `track_coverage()` on a known good coverage file before integrating it into automated workflows.
+4. **Validate coverage setup early.** Test your coverage configuration with `track_coverage()` on a known-good coverage file before integrating it into automated workflows.
 
 ## Source files
 
 - `src/attune/workflows/test_runner.py`
 - `src/attune/workflows/test_maintenance.py`
-- `src/attune/workflows/test_lifecycle.py`
 
 **Tags:** `tests`, `debugging`, `fixes`

--- a/tests/unit/help/test_help_manifest_integrity.py
+++ b/tests/unit/help/test_help_manifest_integrity.py
@@ -1,0 +1,210 @@
+"""Regression guard for the ``.help/`` help system against two
+classes of drift the content-hash staleness system cannot see.
+
+The staleness system (``attune.help.staleness.compute_source_hash`` /
+``check_staleness``) compares a SHA-256 of a feature's *current* source
+files to the hash stored in template frontmatter. It catches edits to
+files that still exist, but it is blind to:
+
+1. **Manifest globs that reference deleted files.** ``features.yaml``
+   can keep globbing ``src/.../deleted.py`` indefinitely — the hash of
+   the surviving files simply changes once, and after a refresh the
+   manifest looks "current" even though it points at a path that no
+   longer exists. (Concretely: the ``fix-test`` feature globbed
+   ``src/attune/workflows/test_lifecycle.py`` after that module was
+   deleted in #887 — see PR #980 / commit b50af7e0f.)
+
+2. **Templates that document deleted symbols.** All 11 ``fix-test``
+   templates described ``TestLifecycleManager``, ``TestTask``,
+   ``process_queue()`` and friends — symbols from the deleted module.
+   The content hash is computed over *source*, not over the
+   *templates*, so a template can name a class that no longer exists
+   anywhere and staleness stays green.
+
+These tests close that gap. ``test_manifest_file_references_resolve``
+is the hard guard (every manifest ``files`` entry must resolve to real
+files on disk). ``test_template_symbols_exist_in_source`` checks that
+every backticked ``ClassName`` / ``function()`` a feature's templates
+document still appears somewhere in that feature's resolved source.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from attune.help.manifest import Feature, load_manifest
+from attune.help.staleness import _is_excluded, compute_source_hash
+
+# tests/unit/help/ -> tests/unit -> tests -> repo root
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELP_DIR = REPO_ROOT / ".help"
+TEMPLATES_DIR = HELP_DIR / "templates"
+
+_MANIFEST = load_manifest(HELP_DIR)
+
+# Features that carry source globs (manual/single-sourced features are
+# authored or projected and intentionally carry no globs to resolve).
+_GENERATED_FEATURES = sorted(
+    name for name, feat in _MANIFEST.features.items() if not feat.is_manual
+)
+
+# Features that additionally ship a templates/<feature>/ directory.
+_FEATURES_WITH_TEMPLATES = sorted(
+    name for name in _GENERATED_FEATURES if (TEMPLATES_DIR / name).is_dir()
+)
+
+# Backticked `ClassName` (CapWords) and `function()` references.
+_CLASS_RE = re.compile(r"`([A-Z][A-Za-z0-9_]+)`")
+_FUNC_RE = re.compile(r"`([a-z_][A-Za-z0-9_]*)\(\)`")
+
+# Symbols a template may legitimately reference that do NOT live in the
+# feature's own source globs: Python stdlib/typing names plus genuine
+# cross-feature symbols (verified to exist elsewhere in the codebase).
+_IGNORED_SYMBOLS: frozenset[str] = frozenset(
+    {
+        # stdlib / typing referenced in prose
+        "Path",
+        "datetime",
+        # cross-feature: help feedback API (src/attune/help/feedback.py)
+        "get_template_confidence",
+        "record_template_feedback",
+        # cross-feature: MCP tool / handler (src/attune/mcp/*)
+        "doc_orchestrator",
+        # cross-feature: project index (src/attune/project_index/*)
+        "ProjectIndex",
+    }
+)
+
+# Pre-existing dead-symbol drift that is OUT OF SCOPE for this guard's
+# originating fix (#980, fix-test only). Each entry is real drift to be
+# cleaned up separately — the guard stays strict for everything else so
+# NEW drift in any feature fails immediately. Remove entries here as the
+# corresponding templates are fixed.
+_KNOWN_DEAD_SYMBOL_DRIFT: dict[str, frozenset[str]] = {
+    # `WorkflowExecutionError` is not defined anywhere in the codebase;
+    # code-quality/error.md hallucinated it. Tracked for a follow-up
+    # template rewrite.
+    "code-quality": frozenset({"WorkflowExecutionError"}),
+}
+
+
+def _is_glob(pattern: str) -> bool:
+    """True if a manifest ``files`` entry is a glob, not a literal path."""
+    return any(ch in pattern for ch in "*?[")
+
+
+def _resolve_glob(pattern: str) -> list[Path]:
+    """Resolve a glob pattern against the repo root.
+
+    Mirrors ``compute_source_hash``'s normalization: a trailing ``**``
+    is expanded to ``**/*`` so it matches files, not just directories.
+    Cache/build directories are excluded the same way staleness does.
+    """
+    glob_pattern = pattern + "/*" if pattern.endswith("**") else pattern
+    return [p for p in REPO_ROOT.glob(glob_pattern) if p.is_file() and not _is_excluded(p)]
+
+
+def _resolved_source_text(feature: Feature) -> str:
+    """Concatenated text of every source file a feature's globs match."""
+    _, matched = compute_source_hash(feature, REPO_ROOT)
+    parts: list[str] = []
+    for rel in matched:
+        try:
+            parts.append((REPO_ROOT / rel).read_text(encoding="utf-8", errors="ignore"))
+        except OSError:
+            continue
+    return "\n".join(parts)
+
+
+def _documented_symbols(feature_name: str) -> set[str]:
+    """Extract backticked ClassName / function() symbols from a feature's
+    templates, dropping builtins and ALL-CAPS constants/env-vars."""
+    import builtins
+
+    builtin_names = set(dir(builtins))
+    symbols: set[str] = set()
+    for md in sorted((TEMPLATES_DIR / feature_name).glob("*.md")):
+        text = md.read_text(encoding="utf-8", errors="ignore")
+        symbols |= set(_CLASS_RE.findall(text))
+        symbols |= set(_FUNC_RE.findall(text))
+    # `DEBUG`, `ERROR`, `PATH`, `ATTUNE_*` etc. are constants / env-vars /
+    # log levels, not class references — drop anything fully uppercase.
+    return {s for s in symbols if s not in builtin_names and not s.isupper()}
+
+
+@pytest.mark.unit
+class TestManifestFileReferences:
+    """Hard guard: manifest globs/paths must resolve to real files."""
+
+    def test_manifest_loads(self) -> None:
+        """Sanity: the real manifest parses and has features."""
+        assert _MANIFEST.features, "features.yaml has no features"
+
+    @pytest.mark.parametrize("feature_name", _GENERATED_FEATURES)
+    def test_manifest_file_references_resolve(self, feature_name: str) -> None:
+        """Every ``files`` entry resolves: literal paths exist on disk,
+        glob patterns match at least one file.
+
+        This is the hard regression guard for manifest drift — it would
+        have failed when ``fix-test`` still globbed the deleted
+        ``test_lifecycle.py`` (PR #980).
+        """
+        feature = _MANIFEST.features[feature_name]
+        missing_literals: list[str] = []
+        empty_globs: list[str] = []
+
+        for entry in feature.files:
+            if _is_glob(entry):
+                if not _resolve_glob(entry):
+                    empty_globs.append(entry)
+            elif not (REPO_ROOT / entry).exists():
+                missing_literals.append(entry)
+
+        problems: list[str] = []
+        if missing_literals:
+            problems.append(f"deleted/missing files: {missing_literals}")
+        if empty_globs:
+            problems.append(f"globs matching nothing: {empty_globs}")
+
+        assert not problems, (
+            f"Feature '{feature_name}' references source that no longer "
+            f"exists ({'; '.join(problems)}). Update .help/features.yaml "
+            f"to drop the dead reference."
+        )
+
+
+@pytest.mark.unit
+class TestTemplateSymbolReferences:
+    """Hard guard: documented symbols must still exist in source."""
+
+    @pytest.mark.parametrize("feature_name", _FEATURES_WITH_TEMPLATES)
+    def test_template_symbols_exist_in_source(self, feature_name: str) -> None:
+        """Every backticked ``ClassName`` / ``function()`` a feature's
+        templates document must appear somewhere in that feature's
+        resolved source files.
+
+        Catches the deleted-symbol class of drift (e.g. fix-test
+        templates documenting ``TestLifecycleManager`` after the module
+        was deleted) that content-hash staleness cannot see. A small
+        ignore-list covers stdlib + genuine cross-feature symbols; one
+        documented allow-list (``_KNOWN_DEAD_SYMBOL_DRIFT``) carries
+        pre-existing drift out of scope for this guard's originating fix.
+        """
+        source_text = _resolved_source_text(_MANIFEST.features[feature_name])
+        allowed = _IGNORED_SYMBOLS | _KNOWN_DEAD_SYMBOL_DRIFT.get(feature_name, frozenset())
+
+        unresolved = sorted(
+            sym
+            for sym in _documented_symbols(feature_name)
+            if sym not in allowed and not re.search(rf"\b{re.escape(sym)}\b", source_text)
+        )
+
+        assert not unresolved, (
+            f"Feature '{feature_name}' templates document symbols not "
+            f"found in its source files: {unresolved}. Either the source "
+            f"was renamed/deleted (update the templates) or these are "
+            f"cross-feature references (add to _IGNORED_SYMBOLS)."
+        )

--- a/tests/unit/help/test_help_manifest_integrity.py
+++ b/tests/unit/help/test_help_manifest_integrity.py
@@ -79,16 +79,13 @@ _IGNORED_SYMBOLS: frozenset[str] = frozenset(
 )
 
 # Pre-existing dead-symbol drift that is OUT OF SCOPE for this guard's
-# originating fix (#980, fix-test only). Each entry is real drift to be
-# cleaned up separately — the guard stays strict for everything else so
-# NEW drift in any feature fails immediately. Remove entries here as the
-# corresponding templates are fixed.
-_KNOWN_DEAD_SYMBOL_DRIFT: dict[str, frozenset[str]] = {
-    # `WorkflowExecutionError` is not defined anywhere in the codebase;
-    # code-quality/error.md hallucinated it. Tracked for a follow-up
-    # template rewrite.
-    "code-quality": frozenset({"WorkflowExecutionError"}),
-}
+# originating fix. Each entry is real drift to be cleaned up separately
+# — the guard stays strict for everything else so NEW drift in any
+# feature fails immediately. Remove entries here as the corresponding
+# templates are fixed. (Currently empty: the one known case,
+# `WorkflowExecutionError` in code-quality/error.md, was corrected to the
+# real `SdkSubprocessError` in this change.)
+_KNOWN_DEAD_SYMBOL_DRIFT: dict[str, frozenset[str]] = {}
 
 
 def _is_glob(pattern: str) -> bool:


### PR DESCRIPTION
## What

Adds a regression guard for the `.help/` help system that catches two
drift classes the content-hash staleness system is structurally blind
to — the two the help-freshness sweep (#980) exposed.

`attune.help.staleness.compute_source_hash` / `check_staleness` hashes a
feature's **source** files. That flags edits to surviving files but
cannot see:

1. **Manifest globs referencing deleted files** — `features.yaml` can
   keep globbing a deleted path; the survivors' hash changes once, then
   looks "current" forever.
2. **Templates documenting deleted symbols** — the hash is over source,
   not templates, so a template can name a class that exists nowhere and
   staleness stays green.

## The guard

`tests/unit/help/test_help_manifest_integrity.py` — two hard assertions:

| Test | Scope | Check |
|------|-------|-------|
| `test_manifest_file_references_resolve` | all generated features | every `files` entry resolves — literal paths exist on disk, globs match ≥1 file (mirrors staleness's `**`→`**/*` + cache-dir exclusion) |
| `test_template_symbols_exist_in_source` | features with templates | every backticked `` `ClassName` `` / `` `func()` `` a feature's templates document appears in that feature's resolved source |

Symbol filtering: drops Python builtins + ALL-CAPS constants/env-vars,
plus a small `_IGNORED_SYMBOLS` (stdlib + verified cross-feature refs)
and a documented `_KNOWN_DEAD_SYMBOL_DRIFT` allow-list for pre-existing
out-of-scope drift.

## Drift the guard surfaced (and this PR fixes)

Three more dead manifest globs — same bug class as #980 — removed from
`features.yaml`. All hash-neutral (they matched zero files, so the
source hash and staleness are unchanged):

| Feature | Dead glob | Cause |
|---------|-----------|-------|
| `orchestration` | `src/attune/coordination/**` | module deleted in #279 |
| `code-quality` | `src/attune/workflows/code_review_*.py` | consolidated to `code_review.py` |
| `help-system` | `packages/attune-help/src/attune_help/**` | path not in this repo |

It also surfaced one dead symbol — `WorkflowExecutionError` in
`code-quality/error.md` (hallucinated, exists nowhere). Out of scope for
this fix-test-focused PR, so it's allow-listed with a comment and
tracked for a follow-up template rewrite.

## Coordination note — #980

PR #980's fix (`b50af7e0f`) is **not yet on main**. The template-symbol
check can only pass against the corrected fix-test templates, so this
branch **cherry-picks `b50af7e0f`** to stay self-consistent. Git handles
the duplicate cleanly when both merge — **sequence #980 first if
possible**, after which the cherry-pick here becomes a no-op on rebase.

## Verification

- `test_help_manifest_integrity.py`: **47 passed** (CI-faithful, `filterwarnings = error`)
- Full `tests/unit/help/`: **438 passed, 3 xfailed**
- ruff + pinned black: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
