### PR TITLE
build(deps): mirror [ops] dashboard deps into [dev] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,13 @@ dev = [
     "pre-commit>=3.0,<5.0",  # Updated for pre-commit 4.x
     # Test dependencies for API and integration tests
     "httpx>=0.27.0,<1.0.0",  # For API testing
-    "fastapi>=0.109.1,<1.0.0",  # For wizard API tests
+    "fastapi>=0.110.0,<1.0.0",  # For wizard API tests + attune.ops dashboard
+    # attune.ops dashboard runtime ([ops] extra) — mirrored into [dev]
+    # so worktree/dev syncs can run and test `python -m attune.ops`
+    # without a separate `--extra ops`. Keep pins in lock-step with the
+    # [ops] extra above.
+    "uvicorn[standard]>=0.27.0,<1.0",
+    "jinja2>=3.1.0,<4.0",
     "requests>=2.28.0,<3.0.0",  # For notification tests
     # RAG integration test coverage — attune-rag is an
     # optional runtime dep but required for the rag_code_gen

--- a/uv.lock
+++ b/uv.lock
@@ -331,6 +331,7 @@ dev = [
     { name = "coverage" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "jinja2" },
     { name = "langchain-anthropic" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -347,6 +348,7 @@ dev = [
     { name = "ruff" },
     { name = "tiktoken" },
     { name = "types-pyyaml" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 developer = [
     { name = "anthropic" },
@@ -459,13 +461,14 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.0,<1.0.0" },
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.109.1,<1.0.0" },
     { name = "fastapi", marker = "extra == 'backend'", specifier = ">=0.109.1,<1.0.0" },
-    { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.109.1,<1.0.0" },
+    { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.110.0,<1.0.0" },
     { name = "fastapi", marker = "extra == 'enterprise'", specifier = ">=0.109.1,<1.0.0" },
     { name = "fastapi", marker = "extra == 'ops'", specifier = ">=0.110.0,<1.0" },
     { name = "filelock", marker = "extra == 'all'", specifier = ">=3.16.0,<4.0.0" },
     { name = "httpx", marker = "extra == 'all'", specifier = ">=0.27.0,<1.0.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0,<1.0.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0.0" },
+    { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.1.0,<4.0" },
     { name = "jinja2", marker = "extra == 'ops'", specifier = ">=3.1.0,<4.0" },
     { name = "langchain", marker = "extra == 'agents'", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain", marker = "extra == 'all'", specifier = ">=1.0.0,<2.0.0" },
@@ -578,6 +581,7 @@ requires-dist = [
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.20.0,<1.0.0" },
     { name = "uvicorn", marker = "extra == 'backend'", specifier = ">=0.20.0,<1.0.0" },
     { name = "uvicorn", marker = "extra == 'enterprise'", specifier = ">=0.20.0,<1.0.0" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'dev'", specifier = ">=0.27.0,<1.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'ops'", specifier = ">=0.27.0,<1.0" },
 ]
 provides-extras = ["rag", "author", "memory", "redis", "anthropic", "llm", "memdocs", "agents", "cache", "agent-sdk", "software", "socratic", "backend", "lsp", "windows", "ops", "otel", "docs", "dev", "developer", "enterprise", "full", "all"]


### PR DESCRIPTION
## Summary

Mirror the `[ops]` dashboard runtime deps into the `[dev]` extra so
worktree/dev syncs can run and test the `attune.ops` dashboard.

`python -m attune.ops` crashed with `ModuleNotFoundError: fastapi`
in worktree/dev environments because dev syncs pull `[dev]` +
`[developer]` but not the `[ops]` extra. Added `uvicorn[standard]`
and `jinja2` to `[dev]` (fastapi was already there for wizard API
tests), bumped the dev fastapi floor `0.109.1 → 0.110.0` to
lock-step with `[ops]`, and regenerated `uv.lock`. A plain
`uv sync --extra dev --extra developer` now resolves all three.

## Notes
- **Originally a two-part PR.** The first commit fixed a hallucinated
  `WorkflowExecutionError` in `.help/templates/code-quality/error.md`.
  A parallel session landed the identical fix on main (#980/#981,
  which also added the template-symbol regression guard), so that
  commit was dropped during rebase — main's version wins. This PR is
  now deps-only.
- The masking risk from the 8.5.0 lesson (base CLI importing an
  extras-only module) is **unchanged** — fastapi was already in
  `[dev]`; `uvicorn`/`jinja2` aren't imported by the base CLI.

## Test plan
- [x] `uv lock --check` passes (lock consistent with pyproject, 187 pkgs)
- [x] Clean `uv sync --extra dev --extra developer` then import-check:
  `fastapi`/`uvicorn`/`jinja2` all import
- [x] `attune.ops` dashboard boots and serves 200 OK on :8765

🤖 Generated with [Claude Code](https://claude.com/claude-code)
