### PR TITLE
docs(spec): attune-docs marketplace — keep, automate, or retire

### DIFF
--- a/docs/specs/attune-docs-marketplace/decisions.md
+++ b/docs/specs/attune-docs-marketplace/decisions.md
@@ -1,0 +1,42 @@
+# attune-docs Marketplace — Decisions
+
+**Status:** draft — awaiting ratification
+
+---
+
+## D1 — Direction: keep, automate, or retire
+
+**Decision:** _pending_
+
+**Options:** A (retire + consolidate, recommended) · B (keep + automate)
+· C (status quo, rejected).
+
+**Context:** see `requirements.md`. The marketplace is frozen since
+2026-05-06, has no CI, and ships plugins ~15 minor versions stale; the
+project is consolidating onto attune-ai.dev.
+
+---
+
+## D2 — If A: target home for the plugins
+
+**Decision:** _pending_
+
+`attune-ai` marketplace vs `attune-ai.dev`.
+
+---
+
+## D3 — If A: migration path for existing marketplace users
+
+**Decision:** _pending_
+
+Archive note + README/redirect on attune-docs so users who already ran
+`claude plugin marketplace add Smart-AI-Memory/attune-docs` are pointed
+to the new home.
+
+---
+
+## D4 — If B: sync mechanism
+
+**Decision:** _pending_
+
+Release webhook vs scheduled job; owning repo.

--- a/docs/specs/attune-docs-marketplace/decisions.md
+++ b/docs/specs/attune-docs-marketplace/decisions.md
@@ -1,42 +1,52 @@
 # attune-docs Marketplace — Decisions
 
-**Status:** draft — awaiting ratification
+**Status:** D1 ratified 2026-06-22 — Option A (retire + consolidate)
 
 ---
 
 ## D1 — Direction: keep, automate, or retire
 
-**Decision:** _pending_
+**Decision:** **A — retire + consolidate** (ratified by Patrick,
+2026-06-22).
 
 **Options:** A (retire + consolidate, recommended) · B (keep + automate)
 · C (status quo, rejected).
 
 **Context:** see `requirements.md`. The marketplace is frozen since
 2026-05-06, has no CI, and ships plugins ~15 minor versions stale; the
-project is consolidating onto attune-ai.dev.
+project is consolidating onto attune-ai.dev. The April split's promised
+independent release cadence was never realized, so the maintenance
+liability is not buying anything.
 
 ---
 
-## D2 — If A: target home for the plugins
+## D2 — Target home for the plugins
 
-**Decision:** _pending_
+**Decision:** **proposed — `attune-ai` marketplace** (confirm before
+execution).
 
-`attune-ai` marketplace vs `attune-ai.dev`.
+`attune-ai.dev` is a website, not a `claude plugin marketplace add`
+target, so the Claude Code plugins must live in a marketplace repo. The
+natural home is the existing `Smart-AI-Memory/attune-ai` marketplace
+(already clean, already the canonical dev-tool front door). Install
+becomes `claude plugin install attune-help@attune-ai` /
+`attune-author@attune-ai`. attune-ai.dev remains the web/docs home, not
+a plugin source.
 
 ---
 
-## D3 — If A: migration path for existing marketplace users
+## D3 — Migration path for existing marketplace users
 
-**Decision:** _pending_
+**Decision:** **proposed** (confirm before execution).
 
-Archive note + README/redirect on attune-docs so users who already ran
-`claude plugin marketplace add Smart-AI-Memory/attune-docs` are pointed
-to the new home.
+Before archiving `attune-docs`: replace its README with a migration
+note pointing to the attune-ai marketplace, and keep the repo public
+(archived, read-only) so `claude plugin marketplace add
+Smart-AI-Memory/attune-docs` adders find the redirect rather than a
+404. Do NOT delete the repo.
 
 ---
 
 ## D4 — If B: sync mechanism
 
-**Decision:** _pending_
-
-Release webhook vs scheduled job; owning repo.
+**Decision:** N/A — Option B not chosen.

--- a/docs/specs/attune-docs-marketplace/requirements.md
+++ b/docs/specs/attune-docs-marketplace/requirements.md
@@ -1,6 +1,6 @@
 # attune-docs Marketplace — Keep, Automate, or Retire
 
-**Status:** draft — awaiting ratification
+**Status:** D1 ratified 2026-06-22 — Option A (retire + consolidate)
 **Owner:** Patrick + agent
 **Created:** 2026-06-22
 

--- a/docs/specs/attune-docs-marketplace/requirements.md
+++ b/docs/specs/attune-docs-marketplace/requirements.md
@@ -1,0 +1,152 @@
+# attune-docs Marketplace — Keep, Automate, or Retire
+
+**Status:** draft — awaiting ratification
+**Owner:** Patrick + agent
+**Created:** 2026-06-22
+
+---
+
+## Problem
+
+The `Smart-AI-Memory/attune-docs` Claude Code plugin marketplace was
+created in the 2026-04-08 two-marketplace split to give attune-help and
+attune-author an independent release cadence and a distinct "help
+platform" marketing story, separate from attune-ai the developer tool.
+
+In practice the split's core promise was never delivered. The
+marketplace is hand-synced, has no CI, and has drifted badly — new
+users following the documented quickstart installed plugins roughly 15
+minor versions behind the current release.
+
+This spec decides what to do with it: **keep and automate**, or
+**retire and consolidate**.
+
+---
+
+## Evidence (gathered 2026-06-22)
+
+- **Frozen:** last commit `2026-05-06`; ~9 commits total, all from
+  April–early May.
+- **No automation:** the repo has no `.github/workflows` — every
+  version bump is a manual copy step.
+- **Stale plugin versions in the marketplace manifest:**
+
+  | Plugin | attune-docs marketplace | PyPI latest | attune-ai pin |
+  |--------|-------------------------|-------------|---------------|
+  | attune-author | 0.6.2 | 0.21.0 | `>=0.21.0,<0.22` |
+  | attune-help | 0.10.2 | 0.11.1 | `>=0.10.0` |
+  | attune-gui | 1.1.1 | — | — |
+
+- **Architecture:** attune-help and attune-author are Python packages
+  on PyPI; the attune-docs plugins are thin Claude Code wrappers
+  (plugin.json + skills/commands) around those packages. PyPI is the
+  primary artifact; the marketplace adds the Claude-Code-native UX.
+- **attune-ai's own marketplace is clean** — it lists only `attune-ai`
+  (the extraction worked).
+- **Strategic drift:** the stated direction since 2026-06-04 is to
+  consolidate the whole docs/web surface onto `attune-ai.dev`. The
+  April "two distinct product lines" framing has softened.
+- **Weak usage signal:** overall project telemetry is ~0 real users;
+  no open issues or PRs on attune-docs.
+
+---
+
+## What the split was meant to buy (and whether it did)
+
+| Must-have from the April plan | Delivered? |
+|-------------------------------|------------|
+| Independent release cadence for all three plugins | No — attune-docs is frozen, not cadenced |
+| Frictionless help-builder install (one marketplace) | Partially — works, but installs stale versions |
+| Clean two-product marketing story | Undercut by the attune-ai.dev consolidation direction |
+| All funnels work without cross-contamination | Yes (attune-ai marketplace is clean) |
+
+---
+
+## Goal
+
+A single ratified decision, recorded in `decisions.md`, on the future
+of the attune-docs marketplace — with a small, scoped execution plan
+for whichever option is chosen. No code change ships until the decision
+is ratified.
+
+---
+
+## Non-goals
+
+- The website quickstart mitigation (lead with PyPI, flag the stale
+  marketplace) is already handled in a separate website-only PR. This
+  spec does not re-litigate that.
+- Re-designing the PyPI packaging of attune-help / attune-author.
+
+---
+
+## Options
+
+### Option A — Retire attune-docs, consolidate (recommended)
+
+Fold the attune-help / attune-author Claude Code plugins back into the
+`attune-ai` marketplace (or under `attune-ai.dev`), archive the
+`attune-docs` repo, and update all references.
+
+- **Pros:** matches the attune-ai.dev consolidation direction; removes
+  a CI-less manual-sync liability permanently; one front door.
+- **Cons:** reverses a deliberate April decision; reopens the
+  "one suite vs two product lines" framing; one-time migration +
+  reference cleanup; users who added the attune-docs marketplace need a
+  migration note.
+
+### Option B — Keep the split, automate it
+
+Add a release-triggered CI job to attune-docs that bumps each plugin's
+version on every attune-help / attune-author release, and bump the
+three plugins to current now.
+
+- **Pros:** preserves the independent-product story; least conceptual
+  change.
+- **Cons:** real release-engineering work in a second repo; runs
+  against the consolidation grain; keeps two marketplaces to reason
+  about.
+
+### Option C — Status quo
+
+Leave it stale.
+
+- **Rejected:** it is the documented front door and actively ships
+  ~15-version-stale plugins. Not acceptable even with the website
+  mitigation in place.
+
+---
+
+## Recommendation
+
+**Option A (retire + consolidate).** The split is a maintenance
+liability whose stated benefit (independent cadence) is unrealized, and
+the project is already consolidating onto attune-ai.dev. Retiring
+attune-docs removes a structurally drift-prone surface rather than
+investing release-engineering effort to prop up a direction that has
+since changed.
+
+Pick Option B only if the "two distinct product lines" marketing story
+is something you still actively want.
+
+---
+
+## Open decisions (to ratify in decisions.md)
+
+- **D1 — Direction:** A (retire/consolidate), B (keep + automate), or C.
+- **D2 — If A:** target home for the help/author plugins —
+  `attune-ai` marketplace vs `attune-ai.dev`.
+- **D3 — If A:** migration note + redirect/README on the archived
+  attune-docs repo so existing marketplace-adders aren't stranded.
+- **D4 — If B:** sync trigger shape (release webhook vs scheduled job)
+  and which repo owns it.
+
+---
+
+## Acceptance criteria
+
+- D1 ratified in `decisions.md`.
+- A scoped tasks.md exists for the chosen option.
+- All in-repo references to the attune-docs marketplace are consistent
+  with the decision (website already mitigated; docs/README updated to
+  match the final direction).

--- a/docs/specs/attune-docs-marketplace/tasks.md
+++ b/docs/specs/attune-docs-marketplace/tasks.md
@@ -1,0 +1,70 @@
+# attune-docs Marketplace — Tasks (Option A: retire + consolidate)
+
+**Status:** planned — D1 ratified; execution awaiting go-ahead on the
+multi-repo / destructive steps (T4, T5).
+
+D2 proposed home: `Smart-AI-Memory/attune-ai` marketplace.
+D3: archive attune-docs read-only with a migration README (do not
+delete).
+
+---
+
+## T1 — Add help/author plugins to the attune-ai marketplace
+
+**Repo:** attune-ai (this repo). **Reversible.**
+
+- Copy the `attune-help` and `attune-author` plugin dirs into this
+  repo's marketplace layout (mirror how `attune-docs` packaged them:
+  physical plugin dirs + relative-path `source`).
+- Register both in `.claude-plugin/marketplace.json` alongside
+  `attune-ai`.
+- Pin to current versions: attune-help 0.11.1, attune-author 0.21.0
+  (also bring attune-gui forward if it moves with them — TBD).
+- Validate the manifest (`marketplace.json` parses; sources resolve).
+
+## T2 — Point docs/site at the new home
+
+**Repo:** attune-ai. **Reversible.**
+
+- Update `website/app/docs/page.tsx` and `website/lib/features.ts`
+  install commands to `…@attune-ai` (supersedes the #985 interim
+  "lead with PyPI + stale-marketplace caveat" once the plugins are
+  actually live in attune-ai).
+- Update `website/components/Footer.tsx` attune-docs link.
+- Update README references to the attune-docs marketplace.
+- Refresh the `features.ts` header comment (the "2026-04-10 split"
+  mapping) to reflect consolidation.
+
+## T3 — End-to-end install verification
+
+**Reversible.**
+
+- `claude plugin marketplace add Smart-AI-Memory/attune-ai` then
+  `claude plugin install attune-help@attune-ai` /
+  `attune-author@attune-ai` — confirm they install at current versions
+  and the skills/commands surface.
+
+## T4 — Migration note on attune-docs  ⚠️ separate repo
+
+**Repo:** Smart-AI-Memory/attune-docs. **Needs go-ahead.**
+
+- Replace the attune-docs README with a migration note pointing to the
+  attune-ai marketplace; keep the marketplace.json or a stub so an
+  existing `marketplace add` resolves with a clear "moved" signal.
+
+## T5 — Archive attune-docs  ⚠️ destructive / outward-facing
+
+**Repo:** Smart-AI-Memory/attune-docs. **Needs explicit go-ahead.**
+
+- After T4 lands, set the repo to **archived (read-only)**. Do NOT
+  delete it — existing `marketplace add` users must still reach the
+  redirect, and archive is reversible where delete is not.
+
+---
+
+## Sequencing
+
+T1 → T2 → T3 (all in attune-ai, one PR) prove the new home works before
+touching attune-docs. Only then T4 → T5. Each of T4/T5 is confirmed
+with Patrick at execution time (separate-repo + archive are not covered
+by spec ratification alone).


### PR DESCRIPTION
## Summary

Decision spec for the future of the `attune-docs` Claude Code plugin
marketplace. It's frozen (last commit 2026-05-06), has no CI, and ships
plugins ~15 minor versions behind PyPI (attune-author 0.6.2 vs 0.21.0).

The spec lays out the evidence, what the April two-marketplace split was
meant to buy vs what it actually delivered, three options, and a
recommendation.

## Recommendation

**Retire attune-docs and consolidate** the help/author plugins back into
the attune-ai marketplace / attune-ai.dev — the split's core promise
(independent release cadence) was never realized, and the project is
already consolidating onto attune-ai.dev. Keep + automate (Option B) is
the alternative if the two-product marketing story is still wanted.

## Decisions to ratify (`decisions.md`)
- **D1** — direction: retire (A, recommended) / automate (B) / status quo (C)
- **D2/D3** — if A: target home + migration note for existing users
- **D4** — if B: sync mechanism

## Scope
- **Decision-only.** No marketplace or code change ships until D1 is
  ratified. The website quickstart mitigation is the separate #985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
