### PR TITLE
feat(marketplace): consolidate attune-help + attune-author into attune-ai marketplace (T1-T3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "attune-ai",
-      "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. Looking for help content tools? See Smart-AI-Memory/attune-docs.",
+      "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
       "version": "8.7.0",
       "author": {
@@ -31,6 +31,36 @@
         "release-prep",
         "cost-optimization"
       ]
+    },
+    {
+      "name": "attune-help",
+      "source": "./plugins/attune-help",
+      "description": "Lightweight runtime reader for .help/ templates. Progressive depth (concept -> task -> reference). No AI keys required. Install alone to consume help content, or pair with attune-author to build it.",
+      "version": "0.11.1",
+      "author": {
+        "name": "Smart AI Memory",
+        "email": "patrick.roebuck@smartaimemory.com"
+      },
+      "homepage": "https://smartaimemory.com",
+      "repository": "https://github.com/Smart-AI-Memory/attune-ai",
+      "license": "Apache-2.0",
+      "category": "developer-tools",
+      "tags": ["help", "documentation", "lookup", "progressive-depth", "runtime"]
+    },
+    {
+      "name": "attune-author",
+      "source": "./plugins/attune-author",
+      "description": "AI-powered authoring companion for attune-help. Generates, maintains, and validates .help/ templates through a 3-stage pipeline with staleness detection. Pairs with attune-help to build and ship context-sensitive help content.",
+      "version": "0.21.0",
+      "author": {
+        "name": "Smart AI Memory",
+        "email": "patrick.roebuck@smartaimemory.com"
+      },
+      "homepage": "https://smartaimemory.com",
+      "repository": "https://github.com/Smart-AI-Memory/attune-ai",
+      "license": "Apache-2.0",
+      "category": "developer-tools",
+      "tags": ["documentation", "authoring", "help-system", "templates", "doc-generation"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Consolidated the help/author Claude Code plugins into the
+  `Smart-AI-Memory/attune-ai` marketplace.** `attune-help` (pinned
+  0.11.1) and `attune-author` (pinned 0.21.0) now ship as plugins from
+  this repo's marketplace alongside `attune-ai`, retiring the separate
+  frozen `Smart-AI-Memory/attune-docs` marketplace (which lagged ~15
+  minor versions behind PyPI). Install becomes
+  `claude plugin install attune-help@attune-ai` /
+  `attune-author@attune-ai`. No effect on `pip install attune-ai`. See
+  `docs/specs/attune-docs-marketplace/`.
+
 ## [8.7.0] — 2026-06-22
 
 Ships two strands of work that landed after 8.6.2: the

--- a/README.md
+++ b/README.md
@@ -479,26 +479,30 @@ or raise it to `0.75`.
 
 ## Migration
 
-`attune-help` and `attune-author` have moved to their own
-marketplace at
-[Smart-AI-Memory/attune-docs](https://github.com/Smart-AI-Memory/attune-docs).
-If you previously installed either from the `attune-ai` marketplace:
+`attune-help` and `attune-author` now ship from the
+`Smart-AI-Memory/attune-ai` marketplace alongside `attune-ai` itself.
+The separate `Smart-AI-Memory/attune-docs` marketplace is retired.
+
+New users:
+
+```text
+/plugin marketplace add Smart-AI-Memory/attune-ai
+/plugin install attune-help@attune-ai
+/plugin install attune-author@attune-ai
+```
+
+If you previously installed either from `attune-docs`:
 
 1. ```text
-   /plugin marketplace add Smart-AI-Memory/attune-docs
+   /plugin uninstall attune-help@attune-docs
+   /plugin uninstall attune-author@attune-docs
    ```
 
 2. ```text
-   /plugin uninstall attune-help@attune-ai
-   /plugin uninstall attune-author@attune-ai
+   /plugin marketplace add Smart-AI-Memory/attune-ai
+   /plugin install attune-help@attune-ai
+   /plugin install attune-author@attune-ai
    ```
-
-3. ```text
-   /plugin install attune-help@attune-docs
-   /plugin install attune-author@attune-docs
-   ```
-
-New users: add `Smart-AI-Memory/attune-docs` directly.
 
 ---
 

--- a/packages/attune-author/README.md
+++ b/packages/attune-author/README.md
@@ -4,7 +4,9 @@ The `attune-author` Python package has its own dedicated repo now:
 
 - **GitHub:** https://github.com/Smart-AI-Memory/attune-author
 - **PyPI:** https://pypi.org/project/attune-author/
-- **Claude Code plugin wrapper:** https://github.com/Smart-AI-Memory/attune-docs
+- **Claude Code plugin:** `claude plugin install attune-author@attune-ai`
+  (from the [Smart-AI-Memory/attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+  marketplace)
 
 Install from PyPI:
 

--- a/packages/attune-help/README.md
+++ b/packages/attune-help/README.md
@@ -4,7 +4,9 @@ The `attune-help` Python package has its own dedicated repo now:
 
 - **GitHub:** https://github.com/Smart-AI-Memory/attune-help
 - **PyPI:** https://pypi.org/project/attune-help/
-- **Claude Code plugin wrapper:** https://github.com/Smart-AI-Memory/attune-docs
+- **Claude Code plugin:** `claude plugin install attune-help@attune-ai`
+  (from the [Smart-AI-Memory/attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+  marketplace)
 
 Install from PyPI:
 

--- a/plugins/attune-author/.claude-plugin/plugin.json
+++ b/plugins/attune-author/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "attune-author",
+  "version": "0.21.0",
+  "description": "Documentation authoring for Claude Code — generate, maintain, and validate help content with the attune-author library",
+  "author": {
+    "name": "Smart AI Memory",
+    "email": "patrick.roebuck@smartaimemory.com"
+  },
+  "homepage": "https://smartaimemory.com",
+  "repository": "https://github.com/Smart-AI-Memory/attune-ai",
+  "license": "Apache-2.0",
+  "keywords": ["documentation", "authoring", "help-system", "templates", "doc-generation", "claude-code"]
+}

--- a/plugins/attune-author/.mcp.json
+++ b/plugins/attune-author/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "attune-author": {
+      "command": "uvx",
+      "args": ["--from", "attune-author[plugin]", "python", "-m", "attune_author.mcp.server"],
+      "env": {
+        "ANTHROPIC_API_KEY": "${ANTHROPIC_API_KEY}"
+      }
+    }
+  }
+}

--- a/plugins/attune-author/README.md
+++ b/plugins/attune-author/README.md
@@ -1,0 +1,97 @@
+# attune-author plugin
+
+Documentation authoring tools for Claude Code. Generate,
+maintain, and validate help content through natural
+language.
+
+```text
+attune-help (reader) -> attune-author (authoring) -> attune-ai (full workflows)
+```
+
+## Install
+
+```bash
+# 1. Install the underlying Python package
+pip install 'attune-author[plugin]'
+
+# 2. Add the marketplace and install the plugin
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-author@attune-author-plugin
+```
+
+## Quick Start
+
+Just describe what you want — the `author` skill routes
+you to the right tool:
+
+| You say | What happens |
+| ------- | ------------ |
+| "set up help in this project" | Scans for features and creates `.help/features.yaml` |
+| "what's stale?" | Reports outdated templates |
+| "regenerate the auth feature" | Generates concept/task/reference for `auth` |
+| "refresh all stale templates" | Bulk regeneration in one pass |
+| "write API docs for src/utils.py" | 3-stage AI doc generation |
+| "look up the security feature" | Returns the concept template |
+
+## Skills
+
+| Skill | Purpose |
+| ----- | ------- |
+| `author` | Hub — Socratic discovery, routes to sub-skills |
+| `author-init` | Bootstrap `.help/features.yaml` |
+| `author-status` | Report stale features |
+| `author-generate` | Generate templates for one feature |
+| `author-maintain` | Regenerate all stale features |
+| `author-docs` | Generate full docs from source via AI |
+
+## MCP Tools
+
+The plugin starts an MCP server (`attune-author`) that
+exposes 6 tools:
+
+| Tool | Wraps |
+| ---- | ----- |
+| `author_init` | `bootstrap.scan_project` + `manifest.save_manifest` |
+| `author_status` | `staleness.check_staleness` |
+| `author_generate` | `generator.generate_feature_templates` |
+| `author_maintain` | `maintenance.run_maintenance` |
+| `author_docs` | `doc_gen.generate_docs` (requires `[ai]`) |
+| `author_lookup` | `manifest.resolve_topic` + reads template |
+
+## Hooks
+
+A non-blocking PostToolUse hook detects `git commit`
+commands and surfaces stale-template suggestions via
+stderr. You can ignore the suggestion or run
+`/author maintain` to act on it.
+
+## Agents
+
+`doc-writer` — subagent for larger doc jobs that need
+multiple turns or multiple output files. Used by the
+`author-docs` skill when the target is a directory or
+multi-file module.
+
+## Requirements
+
+- Python 3.10+
+- `attune-author` Python package (installed automatically
+  with the plugin)
+- `ANTHROPIC_API_KEY` for the `author_docs` tool only —
+  all other tools work without an API key
+
+## Ecosystem
+
+| Package | Role |
+| ------- | ---- |
+| `attune-help` | Lightweight reader (1 dep) |
+| `attune-author` | Author, generate, maintain (4 deps) |
+| `attune-ai` | Full developer workflow OS |
+
+`attune-author` is the right choice if you want
+documentation tooling without the full attune-ai
+workflow stack.
+
+## License
+
+Apache 2.0

--- a/plugins/attune-author/agents/doc-writer.md
+++ b/plugins/attune-author/agents/doc-writer.md
@@ -1,0 +1,84 @@
+---
+name: doc-writer
+description: "Generate comprehensive documentation through outline -> write -> review pipeline. Use for multi-file modules or large doc jobs."
+tools: Read, Write, Bash
+model: sonnet
+maxTurns: 15
+---
+
+## Purpose
+
+Subagent for larger documentation jobs that exceed the
+budget of a single MCP tool call. Runs the same 3-stage
+pipeline (`outline` → `write` → `review`) as the
+`author_docs` MCP tool, but with the freedom to:
+
+- Read multiple source files into context
+- Write multiple output files (one per module)
+- Iterate when the polish stage finds gaps
+- Pause and ask the user for clarification mid-task
+
+When the `author-docs` skill is invoked on a single file
+or short snippet, it should call the `author_docs` MCP
+tool directly. Delegate to this agent only when:
+
+- The target is a directory or multi-file module
+- The documentation needs to be split across multiple
+  output files
+- The user wants to iterate on tone or audience after
+  the first draft
+
+## Pipeline
+
+### Stage 1: Outline
+
+Read the source files and produce a structured outline:
+
+1. List the source files in scope (use `Read` or `Bash`
+   with `find`)
+2. For each file, extract public API surface
+3. Group related items into sections
+4. Decide section ordering: overview → quick start → API
+   reference → usage examples → reference
+
+### Stage 2: Write
+
+For each outline section:
+
+1. Read the relevant source code
+2. Write the section content with real, executable code
+   examples (no placeholders)
+3. Include parameter types, return types, exceptions
+4. Use the user's specified `audience` to tune tone
+
+### Stage 3: Review
+
+After the draft is complete:
+
+1. Re-read the source to verify accuracy
+2. Check that every public symbol is documented
+3. Verify code examples compile (run them with `python -c`
+   if possible)
+4. Fix tone, clarity, formatting issues
+
+## Output
+
+Write the final documentation to the user-specified
+output path(s) using the `Write` tool. Confirm each file
+written before exiting.
+
+## Error Handling
+
+- **Source file unreadable**: Report which file and ask
+  the user how to proceed (skip, fix, or abort).
+- **Examples don't compile**: Note them as TODOs in the
+  output and surface them to the user; do not silently
+  drop broken examples.
+- **Out of turns**: Save partial output to
+  `<output>.partial.md` and tell the user what's missing.
+
+## Key Principle
+
+Documentation accuracy beats documentation completeness.
+Better to ship a small, correct API reference than a
+comprehensive but inaccurate one.

--- a/plugins/attune-author/commands/author.md
+++ b/plugins/attune-author/commands/author.md
@@ -1,0 +1,21 @@
+---
+name: author
+description: Documentation authoring hub — generate, maintain, and validate help content
+argument-hint: "[init | status | generate <feature> | maintain | docs <path>]"
+---
+
+Invoke the `author` skill from the attune-author plugin to handle this request.
+
+User arguments: $ARGUMENTS
+
+The `author` skill is the routing hub that dispatches to the
+appropriate sub-skill based on the user's intent:
+
+- `init` — bootstrap `.help/features.yaml` (author-init skill)
+- `status` — report stale templates (author-status skill)
+- `generate <feature>` — regenerate one feature (author-generate skill)
+- `maintain` — regenerate all stale features (author-maintain skill)
+- `docs <path>` — 3-stage AI doc pipeline (author-docs skill)
+
+If no arguments are provided, the skill will use
+`AskUserQuestion` to scope the request before executing.

--- a/plugins/attune-author/core/__init__.py
+++ b/plugins/attune-author/core/__init__.py
@@ -1,0 +1,3 @@
+"""Plugin version constant — keep in sync with plugin.json."""
+
+__version__ = "0.21.0"

--- a/plugins/attune-author/hooks/help_post_commit.py
+++ b/plugins/attune-author/hooks/help_post_commit.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: surface stale-template suggestions after commits.
+
+Triggered after every Bash tool call. Filters for `git commit`
+commands, then calls attune_author.maintenance.run_hook() to
+detect features touched by the commit and report stale templates.
+
+Always exits 0 (non-blocking). Suggestions go to stderr so
+Claude Code surfaces them; stdout is silently discarded by the
+hook protocol.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _read_payload() -> dict:
+    """Read the JSON payload from stdin.
+
+    Returns:
+        Parsed payload dict, or empty dict on parse failure.
+    """
+    try:
+        return json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _is_git_commit(tool_input: dict) -> bool:
+    """Return True if the bash command is a git commit."""
+    command = tool_input.get("command", "")
+    if not isinstance(command, str):
+        return False
+    return "git commit" in command
+
+
+def main() -> int:
+    """Hook entry point. Always returns 0 (non-blocking)."""
+    payload = _read_payload()
+
+    tool_name = payload.get("tool_name", "")
+    if tool_name != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    if not _is_git_commit(tool_input):
+        return 0
+
+    # Lazy import — keeps the hook fast for non-commit calls
+    try:
+        from attune_author.maintenance import run_hook
+    except ImportError:
+        # attune-author not installed in this environment
+        return 0
+
+    try:
+        from pathlib import Path
+
+        cwd = Path.cwd()
+        help_dir = cwd / ".help"
+        if not (help_dir / "features.yaml").exists():
+            return 0
+
+        result = run_hook(help_dir=help_dir, project_root=cwd)
+        if result is None or result.stale_count == 0:
+            return 0
+
+        print(
+            f"\n[attune-author] {result.stale_count} feature(s) "
+            f"may have stale documentation after this commit:",
+            file=sys.stderr,
+        )
+        for name in result.staleness.stale_features[:5]:
+            print(f"  - {name}", file=sys.stderr)
+        print(
+            "  Run /author maintain to refresh templates.",
+            file=sys.stderr,
+        )
+    except Exception as e:  # noqa: BLE001
+        # INTENTIONAL: hook is non-blocking — never raise
+        print(
+            f"[attune-author] hook error (non-fatal): {e}",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/attune-author/hooks/hooks.json
+++ b/plugins/attune-author/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/help_post_commit.py",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/attune-author/skills/author-docs/SKILL.md
+++ b/plugins/attune-author/skills/author-docs/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: author-docs
+description: "Generate full documentation from source code with the 3-stage AI pipeline (outline, write, review). Triggers on: write docs, generate API reference, create README, AI doc generation."
+argument-hint: "<source-path>"
+---
+
+# Author Docs
+
+Generate full documentation from a source file using the
+3-stage AI pipeline: outline → write → review. Output is
+production-ready API references, guides, or READMEs.
+
+## When to use
+
+- New module needs an API reference
+- Library needs a fresh README
+- Internal docs need to be rewritten for external audiences
+
+## Requirements
+
+- `ANTHROPIC_API_KEY` must be set in the environment
+- The `[ai]` extra must be installed:
+  `pip install 'attune-author[ai]'`
+
+## Scoping
+
+Use `AskUserQuestion` to gather inputs:
+
+```yaml
+question: "What kind of documentation do you need?"
+header: "Doc Type"
+options:
+  - label: "API reference"
+    description: "Function/class signatures, args, returns, examples"
+  - label: "User guide"
+    description: "How-to walkthrough for end users"
+  - label: "README"
+    description: "Project overview, install, quick start"
+  - label: "Module overview"
+    description: "Architecture and component descriptions"
+```
+
+Then ask for `audience` (developers, beginners, ops) and
+the target source path.
+
+## Execution
+
+1. Call the MCP tool `author_docs` with `target`,
+   `doc_type`, `audience`, and optional `output_path`.
+2. The pipeline runs three stages — show progress to the
+   user as each stage completes.
+3. If `output_path` is set, confirm the file was written.
+   Otherwise show the content inline.
+
+## Delegating to the doc-writer agent
+
+For larger jobs (multi-file modules, full directories),
+delegate to the `doc-writer` subagent instead of calling
+the tool directly. The agent has more turns to work with
+and can iterate on multiple files.
+
+## Output
+
+```text
+Stages: outline → write → review
+Output: docs/api/auth.md (4827 chars)
+```

--- a/plugins/attune-author/skills/author-generate/SKILL.md
+++ b/plugins/attune-author/skills/author-generate/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: author-generate
+description: "Generate concept, task, and reference templates for one feature using Jinja2 meta templates. Triggers on: generate template, regenerate feature, write help for, create docs for one feature."
+argument-hint: "<feature-name>"
+---
+
+# Author Generate
+
+Generate concept, task, and reference templates for a
+single feature using Jinja2 meta templates and an optional
+LLM polish pass (when `ANTHROPIC_API_KEY` is set).
+
+## When to use
+
+- After adding a new feature to `.help/features.yaml`
+- After a feature's source code changes substantially
+- When you want to overwrite a manual template
+  (`overwrite=true`)
+
+## Scoping
+
+If no feature name is provided, use `AskUserQuestion` to
+list features from `features.yaml`:
+
+1. Read `.help/features.yaml` to enumerate features
+2. Present them as options (max 4, with "Other" for
+   manual entry if more)
+3. Confirm the choice before calling the tool
+
+## Execution
+
+1. Call the MCP tool `author_generate` with `feature`,
+   `help_dir`, `project_root`, and `overwrite` (default
+   `false`).
+2. List the generated template paths.
+3. Suggest reading the templates with the user's editor
+   or running `author-status` to confirm they're current.
+
+## Output
+
+```text
+Generated 3 templates for 'auth':
+  - .help/templates/auth/concept.md
+  - .help/templates/auth/task.md
+  - .help/templates/auth/reference.md
+```
+
+If a template has `status: manual` in frontmatter, it is
+skipped unless `overwrite=true` is set.

--- a/plugins/attune-author/skills/author-init/SKILL.md
+++ b/plugins/attune-author/skills/author-init/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: author-init
+description: "Initialize a .help/ documentation system in a project. Scans source directories for features and creates features.yaml. Triggers on: init help, set up help, bootstrap docs, scan project for features."
+argument-hint: "[project-root]"
+---
+
+# Author Init
+
+Bootstrap a `.help/` documentation system in a project by
+scanning source directories and creating an initial
+`features.yaml` manifest.
+
+## When to use
+
+- Setting up documentation for the first time
+- Adding `.help/` to an existing project
+- Re-scanning after a major restructure (manual review
+  required)
+
+## Scoping
+
+Use `AskUserQuestion` to confirm:
+
+```yaml
+question: "Which directory should I scan and initialize?"
+header: "Init"
+options:
+  - label: "Current directory"
+    description: "Scan and create .help/ here"
+  - label: "Specific path"
+    description: "I'll provide a project root path"
+```
+
+## Execution
+
+1. Call the MCP tool `author_init` with the chosen
+   `project_root`.
+2. Show the discovered features (name, description,
+   confidence, files).
+3. Ask the user to review `.help/features.yaml` and edit
+   it before generating templates.
+4. Suggest the next step: `author-generate` for one
+   feature, or `author-maintain` to generate all.
+
+## Output
+
+```text
+Initialized .help/features.yaml with N features:
+  + auth — Authentication module (3 files)
+  ~ utils — Utility helpers (5 files)
+  ? scripts — Build scripts (1 file)
+
+Edit .help/features.yaml to refine, then run:
+  author-generate <feature>
+```
+
+Confidence markers: `+` high, `~` medium, `?` low.

--- a/plugins/attune-author/skills/author-maintain/SKILL.md
+++ b/plugins/attune-author/skills/author-maintain/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: author-maintain
+description: "Detect and regenerate all stale feature templates in one pass. Use after refactors or before releases. Triggers on: regenerate all, update stale, maintain help, refresh templates."
+argument-hint: "[--dry-run]"
+---
+
+# Author Maintain
+
+Detect and regenerate every stale feature template in one
+pass. Useful after large refactors or as a release-prep
+step.
+
+## When to use
+
+- Before a release — get all docs back in sync
+- After a large refactor that touched many features
+- Scheduled maintenance (weekly, monthly)
+
+## Scoping
+
+Use `AskUserQuestion` to confirm scope:
+
+```yaml
+question: "How should I run maintenance?"
+header: "Maintain"
+options:
+  - label: "Dry run (preview only)"
+    description: "Show what's stale without writing files"
+  - label: "Regenerate all stale"
+    description: "Refresh every stale feature"
+  - label: "Filter by feature"
+    description: "Only regenerate specific features"
+```
+
+## Execution
+
+1. Call the MCP tool `author_maintain` with the chosen
+   options.
+2. For dry runs, show the stale list without acting.
+3. For real runs, show the regenerated count and any
+   failures.
+4. If failures occurred, suggest investigating with
+   `author-generate <feature>` to see the error in
+   isolation.
+
+## Output
+
+Dry run:
+```text
+Stale features (3):
+  - auth
+  - cli
+  - utils
+```
+
+Real run:
+```text
+Regenerated: 3
+Failed: (none)
+```

--- a/plugins/attune-author/skills/author-status/SKILL.md
+++ b/plugins/attune-author/skills/author-status/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: author-status
+description: "Report which feature templates are stale by comparing source file hashes. Triggers on: stale templates, what's outdated, doc status, check help freshness, what changed."
+argument-hint: "[help-dir]"
+---
+
+# Author Status
+
+Report which feature templates are stale by comparing the
+SHA-256 hash of source files against the hash stored in
+each template's frontmatter.
+
+## When to use
+
+- Before publishing a release — make sure docs match code
+- After a refactor — see which features need attention
+- Periodic maintenance — keep `.help/` in sync
+
+## Scoping
+
+If no `help_dir` is provided, default to `.help/` in the
+current project. Use `AskUserQuestion` only if the path is
+ambiguous (multiple `.help/` directories visible).
+
+## Execution
+
+1. Call the MCP tool `author_status` with `help_dir` and
+   `project_root`.
+2. Render the markdown report returned in the `report`
+   field.
+3. If stale features exist, suggest the next step:
+   `author-maintain` to regenerate all, or
+   `author-generate <feature>` for a single feature.
+
+## Output
+
+The MCP tool returns markdown like:
+
+```markdown
+## Help Status
+
+**12** current, **3** stale
+
+### Stale Features
+
+| Feature | Description | Files Changed |
+|---------|-------------|---------------|
+| auth | Authentication and authorization | 5 source files |
+| cli | Command-line interface | 2 source files |
+```
+
+Render this as-is — no further formatting needed.

--- a/plugins/attune-author/skills/author/SKILL.md
+++ b/plugins/attune-author/skills/author/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: author
+description: "Documentation authoring hub — generate, maintain, and validate help content for your project. Triggers on: author, write docs, generate documentation, help system, stale templates, doc-gen, README, .help."
+argument-hint: "<what you need>"
+---
+
+# Author Hub
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Author Hub** — Your starting point for documentation
+> authoring — generates, maintains, and validates help
+> content.
+
+## Scoping
+
+If no argument is provided, use `AskUserQuestion`:
+
+```yaml
+question: "What would you like to do with documentation?"
+header: "attune-author"
+options:
+  - label: "Set up help system"
+    description: "Bootstrap .help/features.yaml in this project"
+  - label: "Check what's stale"
+    description: "Find features with outdated templates"
+  - label: "Generate or update templates"
+    description: "Generate concept/task/reference templates for one or more features"
+  - label: "Generate full docs from source"
+    description: "Use AI to write API references, guides, or READMEs"
+```
+
+## Execution
+
+Map the user's intent to the right sub-skill:
+
+| Input | Route to |
+| ----- | -------- |
+| "Set up help system" or `init` | author-init skill |
+| "Check what's stale" or `status` | author-status skill |
+| "Generate templates" or `generate <feature>` | author-generate skill |
+| "Update everything" or `maintain` | author-maintain skill |
+| "Generate full docs" or `docs <path>` | author-docs skill |
+| "Look up help on X" or `lookup <topic>` | call `author_lookup` MCP tool directly |
+
+## Natural Language Routing
+
+| Pattern | Route to |
+| ------- | -------- |
+| "init", "set up", "bootstrap", "scan project" | author-init skill |
+| "stale", "status", "what changed", "outdated" | author-status skill |
+| "generate template", "regenerate one feature" | author-generate skill |
+| "regenerate all", "update all stale", "maintain" | author-maintain skill |
+| "write docs", "API reference", "README", "guide" | author-docs skill |
+
+## MCP Tools
+
+The plugin exposes these tools via the `attune-author` MCP server:
+
+| Tool | Purpose |
+| ---- | ------- |
+| `author_init` | Bootstrap `.help/features.yaml` from a project scan |
+| `author_status` | Report stale and current features as markdown |
+| `author_generate` | Generate templates for one feature |
+| `author_maintain` | Regenerate all stale features in one pass |
+| `author_docs` | 3-stage AI doc generation (outline → write → review) |
+| `author_lookup` | Look up help for a topic by name or tag |
+
+## MCP Server Not Running
+
+If the MCP server is not responding, install the package
+and verify it's reachable:
+
+```bash
+pip install 'attune-author[plugin]'
+python -m attune_author.mcp.server  # should start without errors
+```

--- a/plugins/attune-help/.claude-plugin/plugin.json
+++ b/plugins/attune-help/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "attune-help",
+  "version": "0.11.1",
+  "description": "Read and explore .help/ documentation with progressive depth. Lightweight runtime companion to attune-author — no AI keys required.",
+  "author": {
+    "name": "Smart AI Memory",
+    "email": "patrick.roebuck@smartaimemory.com"
+  },
+  "homepage": "https://smartaimemory.com",
+  "repository": "https://github.com/Smart-AI-Memory/attune-ai",
+  "license": "Apache-2.0",
+  "keywords": ["help", "documentation", "progressive-depth", "lookup", "runtime", "claude-code"]
+}

--- a/plugins/attune-help/.mcp.json
+++ b/plugins/attune-help/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "attune-help": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "attune-help[plugin]",
+        "python",
+        "-m",
+        "attune_help.mcp.server"
+      ]
+    }
+  }
+}

--- a/plugins/attune-help/README.md
+++ b/plugins/attune-help/README.md
@@ -1,0 +1,127 @@
+# attune-help plugin
+
+Lightweight help runtime for Claude Code. Reads `.help/`
+templates with progressive depth, audience adaptation, and
+renderer choices. No AI API keys required.
+
+Pairs with [attune-author](../attune-author/plugin/) to give
+you a complete author-and-read workflow without the full
+[attune-ai](../../../plugin/) plugin.
+
+## Install
+
+From the monorepo marketplace:
+
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-help@attune-ai
+```
+
+Or for local testing:
+
+```bash
+claude --plugin-dir packages/attune-help/plugin
+```
+
+The plugin requires the `[plugin]` extra of the
+`attune-help` library so the MCP server can start:
+
+```bash
+pip install 'attune-help[plugin]'
+```
+
+## Quick Start
+
+Say any of these in Claude Code after installing:
+
+- `look up progressive depth` — fetch the concept view
+- `tell me more` — advance to the next depth level
+- `list topics` — browse everything available
+- `what should I watch out for in src/app.py` — file-context warnings
+- `look up security` — start a new topic
+
+## Skills
+
+| Skill | What it does |
+| ----- | ------------ |
+| `lookup` | Hub — Socratic routing to the other skills |
+| `lookup-topic` | Progressive depth lookup for one topic |
+| `lookup-warn` | File-context warnings by extension and name |
+| `lookup-list` | Enumerate available topics, grouped by category |
+
+## MCP Tools
+
+The plugin's MCP server exposes six tools prefixed with
+`lookup_` to avoid colliding with attune-ai's `help_*` tools:
+
+| Tool | Purpose |
+| ---- | ------- |
+| `lookup_topic` | Progressive depth lookup |
+| `lookup_list` | Enumerate topics with optional tag filter |
+| `lookup_warn` | Relevant warnings for a file path |
+| `lookup_preamble` | One-line "Use X when..." tooltip |
+| `lookup_reset` | Clear session so next lookup starts at concept |
+| `lookup_status` | Read current depth level (read-only, no advance) |
+
+## Ecosystem
+
+Three plugins, one monorepo:
+
+| Plugin | Role | Requires |
+| ------ | ---- | -------- |
+| `attune-ai` | Full workflow OS — 14 skills, security, tests, release prep | — |
+| `attune-author` | Author .help/ templates — scan, generate, maintain, AI doc gen | Anthropic API key for `author_docs` |
+| `attune-help` | Read .help/ templates with progressive depth | — |
+
+You can install any combination. Common pairings:
+
+- `attune-author` + `attune-help` — author-and-read without the workflow layer
+- `attune-ai` only — the full experience including `/coach`, which plays a similar role to `/lookup`
+- All three — `/lookup` and `/coach` coexist, each matches different natural-language triggers
+
+## How it Works
+
+`attune-help` ships 557 bundled templates (43 concepts, 40
+tasks, 64 references, plus warnings, tips, comparisons, and
+more). It also reads project-local templates from
+`.help/templates/` when they exist, falling back to bundled
+content when a topic is missing from the project.
+
+Progressive depth is the core UX: the first call on a topic
+returns the concept view (what is it, when to use it).
+Repeat calls on the same topic escalate to the task view
+(step-by-step), then the reference view (full detail). Say
+"reset" or "start over" to go back to the concept view.
+
+## Configuration
+
+The plugin writes session state to
+`~/.attune-help/sessions/` by default. To use a different
+storage backend, configure your own `HelpEngine` in Python
+and pass a custom `SessionStorage` implementation. The MCP
+server always uses `LocalFileStorage` with default paths.
+
+## Troubleshooting
+
+If `/mcp` doesn't show the `attune-help` server after
+installing, the MCP process logs to a file — nothing goes
+to stdout so the JSON-RPC stream over stdio stays clean.
+Check:
+
+```text
+$TMPDIR/attune-help/attune-help-mcp.log
+```
+
+On macOS that typically resolves to
+`/var/folders/.../T/attune-help/attune-help-mcp.log`. On
+Linux, `/tmp/attune-help/attune-help-mcp.log`. The file is
+created on first start; if it's missing entirely, the
+server process itself never launched — check that
+`uv run --from 'attune-help[plugin]' python -m
+attune_help.mcp.server` runs cleanly from a real shell.
+
+## Related
+
+- [attune-help library docs](../README.md)
+- [attune-author plugin](../../attune-author/plugin/) — the authoring side
+- [attune-ai plugin](../../../plugin/) — the full workflow suite

--- a/plugins/attune-help/core/__init__.py
+++ b/plugins/attune-help/core/__init__.py
@@ -1,0 +1,7 @@
+"""Plugin version constant.
+
+Mirrors the pinned attune-help PyPI version advertised in this
+plugin's plugin.json and the marketplace.json entry.
+"""
+
+__version__ = "0.11.1"

--- a/plugins/attune-help/skills/lookup-list/SKILL.md
+++ b/plugins/attune-help/skills/lookup-list/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: lookup-list
+description: "List all available help topics, optionally filtered by tag. Use to browse what's in the bundled templates or the project's .help/ directory. Triggers on: list topics, what's available, browse help, show topics."
+argument-hint: "[tag]"
+---
+
+# Lookup List
+
+Enumerate available help topics as a grouped markdown table.
+Uses the `lookup_list` MCP tool, which reads the
+`cross_links.json` index for the active template directory.
+
+## When to use
+
+- User asks "what topics are available"
+- User is exploring and doesn't know exact slug names
+- User wants to filter by a specific tag (e.g. "show me all security topics")
+
+## Scoping
+
+Always ask about scope first — the unfiltered list is long:
+
+```yaml
+question: "How should I narrow the list?"
+header: "lookup-list"
+options:
+  - label: "All topics"
+    description: "Show everything, grouped by category (concepts, tasks, references, etc.)"
+  - label: "Filter by tag"
+    description: "Pick a tag like python, security, ci, testing"
+  - label: "Just one category"
+    description: "concepts, tasks, references, warnings, or another category"
+```
+
+If the user picks "filter by tag", ask for the tag name via
+a second `AskUserQuestion`.
+
+## Execution
+
+1. Call the MCP tool `lookup_list` with:
+   - `tag` — optional tag filter from scoping
+   - `limit` — default 100, or what the user asked for
+   - `template_dir` — `.help/templates` if the project has one
+2. Render the response as a grouped markdown table (one
+   section per category).
+3. After the list, mention how to drill in: "Say 'look up X'
+   for any topic you want to read."
+
+## Output Format
+
+```markdown
+## Available Topics
+
+**Total:** 557 (showing 100)
+**Filter:** tag=python
+
+### Concepts (43)
+
+- con-audience-adaptation
+- con-progressive-depth
+- ...
+
+### Tasks (40)
+
+- tas-task-api-endpoint-design
+- ...
+
+### References (64)
+
+- ref-claude-code-hooks
+- ...
+```
+
+Sort entries alphabetically within each group. Don't show
+categories that have no entries.

--- a/plugins/attune-help/skills/lookup-topic/SKILL.md
+++ b/plugins/attune-help/skills/lookup-topic/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: lookup-topic
+description: "Look up a help topic with progressive depth. First call returns concept, repeat calls escalate to task then reference. Triggers on: look up topic, open template, tell me more, go deeper, start over."
+argument-hint: "<topic slug>"
+---
+
+# Lookup Topic
+
+Progressive depth lookup for a single topic. Uses the
+`lookup_topic` MCP tool. Each repeat call on the same topic
+escalates from concept (what is it, when to use) to task
+(step-by-step) to reference (full detail).
+
+## When to use
+
+- User asks "what is X" or "look up X"
+- User says "tell me more" after a previous lookup — advances depth
+- User says "start over" or "reset X" — resets session then looks up
+- User wants to explore a specific topic without browsing a full list
+
+## Scoping
+
+If no topic is provided, use `AskUserQuestion`:
+
+```yaml
+question: "Which topic do you want to look up?"
+header: "lookup-topic"
+options:
+  - label: "I know the topic slug"
+    description: "I'll provide it directly (e.g. progressive-depth, security)"
+  - label: "Show me what's available"
+    description: "Route to lookup-list first, then pick"
+```
+
+If the user picks the second option, route to `lookup-list`.
+
+## Execution
+
+1. Call the MCP tool `lookup_topic` with:
+   - `topic` — the slug from the user
+   - `template_dir` — `.help/templates` if the project has one,
+     otherwise omit (uses bundled templates)
+   - `user_id` — default `mcp-session`
+2. If the result's `success` is `false`, surface the error
+   and suggest `lookup-list` to find valid slugs.
+3. Print the `rendered` field as-is.
+4. Append a hint based on `depth_level`:
+   - `0` (concept): "Say 'tell me more' for step-by-step instructions"
+   - `1` (task): "Say 'tell me more' for the full reference"
+   - `2` (reference): "That's the full reference — say 'reset' to start over"
+
+## Reset behavior
+
+If the user says "start over" or "reset":
+
+1. Call `lookup_reset` with the same `user_id`
+2. Then call `lookup_topic` with the topic — will return concept again
+
+## Output Format
+
+```markdown
+## <topic>
+
+<rendered content from the MCP tool>
+
+*(concept view — say 'tell me more' for next depth level)*
+
+**Tags:** help-system, ux
+```
+
+Keep it minimal. The rendered content usually includes its
+own heading and structure.

--- a/plugins/attune-help/skills/lookup-warn/SKILL.md
+++ b/plugins/attune-help/skills/lookup-warn/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: lookup-warn
+description: "Get context warnings for a file based on its extension and name. Surfaces known gotchas before the user hits them. Triggers on: warn me, gotchas, pitfalls, what should I watch out for, check this file."
+argument-hint: "<file-path>"
+---
+
+# Lookup Warn
+
+File-context warnings for the file the user is editing or
+about to edit. Uses the `lookup_warn` MCP tool, which maps
+the file extension and name to relevant tags and returns
+the top N matching warning and task templates.
+
+## When to use
+
+- User is about to edit a file and wants to know the pitfalls
+- User asks "what should I watch out for" on a specific file
+- IDE selection changed — proactively surface warnings
+
+## Scoping
+
+If no file path is provided, use `AskUserQuestion`:
+
+```yaml
+question: "Which file should I check?"
+header: "lookup-warn"
+options:
+  - label: "The file I'm currently viewing"
+    description: "Use the IDE selection (if one is active)"
+  - label: "A different file"
+    description: "Provide a path relative to the project root"
+```
+
+If an IDE selection is available, prefer it without asking.
+
+## Execution
+
+1. Call the MCP tool `lookup_warn` with:
+   - `file_path` — the user's file
+   - `max_results` — 3 by default, or what the user asked for
+   - `template_dir` — `.help/templates` if the project has one,
+     otherwise omit
+2. If `count` is 0, tell the user there are no known warnings
+   for this file type and suggest running `lookup-list` to
+   browse topics manually.
+3. Print each entry in the `warnings` array as a list item.
+
+## Output Format
+
+```markdown
+## Warnings for `<file-path>`
+
+3 relevant topics:
+
+1. <first warning content>
+
+2. <second warning content>
+
+3. <third warning content>
+
+*To look up any of these topics in more detail, say 'look up X'.*
+```
+
+Keep entries compact — the templates are already rendered.
+Don't paraphrase the tool output.

--- a/plugins/attune-help/skills/lookup/SKILL.md
+++ b/plugins/attune-help/skills/lookup/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: lookup
+description: "Look up help topics with progressive depth. Pair with attune-author for full author-and-read workflow. Triggers on: lookup, look up, depth, topic, help topic, tell me more."
+argument-hint: "[topic or intent]"
+---
+
+# Lookup Hub
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Lookup Hub** — Read `.help/` templates with progressive
+> depth. Companion to `/author` for author-and-read workflows.
+
+## Scoping
+
+If no argument is provided, use `AskUserQuestion`:
+
+```yaml
+question: "What would you like to do?"
+header: "attune-help"
+options:
+  - label: "Look up a topic"
+    description: "Progressive depth — concept, then task, then reference on repeat calls"
+  - label: "List available topics"
+    description: "Show all bundled or project-specific topics, optionally filtered by tag"
+  - label: "Warn me about this file"
+    description: "Show context warnings relevant to the file I'm editing"
+```
+
+## Execution
+
+Map the user's intent to the right sub-skill:
+
+| Input | Route to |
+| ----- | -------- |
+| "Look up X" or `<topic>` | lookup-topic skill |
+| "Tell me more" or "deeper" | lookup-topic skill (repeat call advances depth) |
+| "Start over" or "reset" | lookup-topic skill (calls `lookup_reset` first) |
+| "List topics" or `list` | lookup-list skill |
+| "What about this file" or `warn <path>` | lookup-warn skill |
+
+## Natural Language Routing
+
+| Pattern | Route to |
+| ------- | -------- |
+| "look up", "find topic", "open template" | lookup-topic skill |
+| "list topics", "what's available", "browse help" | lookup-list skill |
+| "warn me", "check this file", "gotchas for" | lookup-warn skill |
+
+## MCP Tools
+
+The plugin exposes these tools via the `attune-help` MCP server:
+
+| Tool | Purpose |
+| ---- | ------- |
+| `lookup_topic` | Progressive depth lookup (concept -> task -> reference) |
+| `lookup_list` | Enumerate available topics as a markdown table |
+| `lookup_warn` | File-context warnings by extension and name |
+| `lookup_preamble` | One-line "Use X when..." tooltip for a feature |
+| `lookup_reset` | Clear session so next lookup starts at concept |
+
+## MCP Server Not Running
+
+If the MCP server is not responding, install the package
+with the plugin extra and verify it's reachable:
+
+```bash
+pip install 'attune-help[plugin]'
+python -m attune_help.mcp.server  # should start without errors
+```
+
+## Relationship to attune-ai and attune-author
+
+- `/coach` (attune-ai) — full workflow coach with team memory
+- `/lookup` (attune-help) — lightweight read-only topic lookup
+- `/author` (attune-author) — writes templates that `/lookup` reads
+
+`/lookup` is designed to coexist with `/coach`. Both can be
+installed; Claude picks the right one based on trigger phrases.

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -50,7 +50,7 @@ const faqItems = [
   {
     question: 'Where do I install attune-help and attune-author from?',
     answer:
-      'Both ship on PyPI, which is the current and recommended source: `pip install attune-help` (the reader, no API key required) and `pip install \'attune-author[plugin]\'` (the AI authoring companion). The Claude Code plugin versions live in the separate Smart-AI-Memory/attune-docs marketplace (`claude plugin marketplace add Smart-AI-Memory/attune-docs`, then `attune-help@attune-docs` / `attune-author@attune-docs`), but that marketplace can lag the latest PyPI release.',
+      'Both ship on PyPI: `pip install attune-help` (the reader, no API key required) and `pip install \'attune-author[plugin]\'` (the AI authoring companion). Their Claude Code plugin versions now live in the same Smart-AI-Memory/attune-ai marketplace as attune-ai itself: `claude plugin marketplace add Smart-AI-Memory/attune-ai`, then `claude plugin install attune-help@attune-ai` / `attune-author@attune-ai`. (The old Smart-AI-Memory/attune-docs marketplace is retired.)',
   },
 ];
 
@@ -223,23 +223,22 @@ export default function DocsPage() {
                   Installing attune-help and attune-author
                 </h3>
                 <p className="text-sm text-[var(--text-secondary)] mb-4">
-                  Both ship as Python packages on PyPI — the current,
-                  recommended way to install them. The Claude Code
-                  plugin versions live in the separate{" "}
+                  Both ship as Python packages on PyPI, and their Claude
+                  Code plugin versions now live in the same{" "}
                   <code className="text-xs bg-[var(--surface-container-high)] px-1 rounded">
-                    Smart-AI-Memory/attune-docs
+                    Smart-AI-Memory/attune-ai
                   </code>{" "}
-                  marketplace, which can lag the latest PyPI release.
+                  marketplace as attune-ai itself.
                 </p>
                 <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-4 leading-relaxed">
-                  <div className="text-white/50"># Recommended: install from PyPI (always current)</div>
+                  <div className="text-white/50"># Install from PyPI</div>
                   <div>pip install attune-help</div>
                   <div>pip install &apos;attune-author[plugin]&apos;</div>
                   <br />
-                  <div className="text-white/50"># Claude Code plugins (may lag the PyPI release)</div>
-                  <div>claude plugin marketplace add Smart-AI-Memory/attune-docs</div>
-                  <div>claude plugin install attune-help@attune-docs</div>
-                  <div>claude plugin install attune-author@attune-docs</div>
+                  <div className="text-white/50"># Or as Claude Code plugins from the attune-ai marketplace</div>
+                  <div>claude plugin marketplace add Smart-AI-Memory/attune-ai</div>
+                  <div>claude plugin install attune-help@attune-ai</div>
+                  <div>claude plugin install attune-author@attune-ai</div>
                 </div>
               </div>
             </div>
@@ -482,8 +481,8 @@ export default function DocsPage() {
                   <div className="text-white/50"># PyPI install (includes the polish runtime)</div>
                   <div>pip install &apos;attune-author[plugin]&apos;</div>
                   <br />
-                  <div className="text-white/50"># Or the Claude Code plugin (may lag the PyPI release)</div>
-                  <div>claude plugin install attune-author@attune-docs</div>
+                  <div className="text-white/50"># Or the Claude Code plugin from the attune-ai marketplace</div>
+                  <div>claude plugin install attune-author@attune-ai</div>
                 </div>
                 <p className="text-sm text-[var(--text-secondary)]">
                   Requires <code className="text-xs bg-[var(--surface-container-high)] px-1 rounded">ANTHROPIC_API_KEY</code> for

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -148,12 +148,12 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  href="https://github.com/Smart-AI-Memory/attune-docs"
+                  href="https://github.com/Smart-AI-Memory/attune-ai"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-[var(--text-secondary)] hover:text-[var(--primary)] transition-colors"
                 >
-                  attune-docs marketplace
+                  Claude Code marketplace
                 </a>
               </li>
               <li>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -4,10 +4,12 @@
  * All pages should import from here to ensure consistency.
  * Update counts and descriptions here when features change.
  *
- * Marketplace mapping after the 2026-04-10 attune-docs split:
+ * Marketplace mapping (consolidated 2026-06-22, retiring the
+ * 2026-04-10 attune-docs split): all three plugins now live in the
+ * single Smart-AI-Memory/attune-ai marketplace.
  *   attune-ai     → Smart-AI-Memory/attune-ai marketplace
- *   attune-help   → Smart-AI-Memory/attune-docs marketplace
- *   attune-author → Smart-AI-Memory/attune-docs marketplace
+ *   attune-help   → Smart-AI-Memory/attune-ai marketplace
+ *   attune-author → Smart-AI-Memory/attune-ai marketplace
  */
 
 // --- Products ---
@@ -56,7 +58,7 @@ export const PRODUCTS: Product[] = [
     tagline: "Lightweight reader for help templates",
     installCommand: "pip install attune-help",
     marketplaceInstall:
-      "claude plugin install attune-help@attune-docs",
+      "claude plugin install attune-help@attune-ai",
     description:
       "Standalone reader with just 1 dependency. Loads templates, " +
       "provides progressive depth (concept → task → reference), " +
@@ -78,7 +80,7 @@ export const PRODUCTS: Product[] = [
     tagline: "Author and polish help content with AI",
     installCommand: "pip install 'attune-author[plugin]'",
     marketplaceInstall:
-      "claude plugin install attune-author@attune-docs",
+      "claude plugin install attune-author@attune-ai",
     description:
       "The AI authoring companion for attune-help. Generates 15 kinds " +
       "of source-grounded templates — concept, task, reference, " +


### PR DESCRIPTION
## What

Executes **T1–T3** of `docs/specs/attune-docs-marketplace/` (D1=A — retire + consolidate, ratified 2026-06-22). Brings the `attune-help` and `attune-author` Claude Code plugins home into the **`Smart-AI-Memory/attune-ai` marketplace** at current PyPI versions, retiring the frozen `attune-docs` marketplace (which lagged ~15 minor versions: author 0.6.2 vs PyPI 0.21.0; help 0.10.2 vs 0.11.1).

All changes are in this repo and reversible. **T4/T5** (migration README + archiving the separate `attune-docs` repo) are intentionally **not** included — they're outward-facing/destructive and await explicit per-step go-ahead.

## T1 — add plugins
- Vendored `plugins/attune-help/` and `plugins/attune-author/` (physical dirs + relative-path `source`, mirroring how attune-docs packaged them).
- Pinned to current versions: **attune-help 0.11.1**, **attune-author 0.21.0** — consistent across `plugin.json`, `core/__init__.py`, and the marketplace entry.
- Repointed each `plugin.json` `repository` at attune-ai.
- Registered both in `.claude-plugin/marketplace.json`; dropped the stale "see Smart-AI-Memory/attune-docs" pointer from the attune-ai plugin description.

These are thin MCP-backed wrappers (`.mcp.json` runs `uvx --from <pkg>[plugin]`, which always resolves the latest PyPI) — no canonical newer source or generator exists, so a verified copy + metadata refresh is the correct reversible move.

## T2 — rewire docs
- `website/lib/features.ts` — `marketplaceInstall` → `@attune-ai`; refreshed the "2026-04-10 split" header comment.
- `website/app/docs/page.tsx` — FAQ + both install blocks → `@attune-ai`.
- `website/components/Footer.tsx` — marketplace link → attune-ai.
- `README.md` — Migration section rewritten for the consolidation.
- `packages/{attune-help,attune-author}/README.md` — plugin links.
- `CHANGELOG.md` — `[Unreleased]` entry.

## T3 — end-to-end install verification
Built a throwaway local marketplace pointing at the exact vendored dirs and installed both through the real `claude plugin install` path:
- **attune-help@0.11.1** → 4 lookup skills surfaced.
- **attune-author@0.21.0** → 6 skills + `author` command + `doc-writer` agent surfaced.

Cleaned up afterward (uninstalled, marketplace removed). The only difference from `@attune-ai` is the cosmetic marketplace name.

## Notes
- `attune-gui` (the third attune-docs plugin) is out of scope this session — flagged as follow-up before attune-docs is archived (else it'd be stranded).
- Manifest validated (parses + all sources resolve + versions match). Existing plugin validation tests (`tests/unit/plugins/`) pass; they're scoped to `plugin/` and don't scan the new dirs. All pre-commit hooks green.

Spec PR (decisions/tasks): #986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
