### PR TITLE
feat(marketplace): consolidate attune-gui into attune-ai marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -61,6 +61,21 @@
       "license": "Apache-2.0",
       "category": "developer-tools",
       "tags": ["documentation", "authoring", "help-system", "templates", "doc-generation"]
+    },
+    {
+      "name": "attune-gui",
+      "source": "./plugins/attune-gui",
+      "description": "Launch the attune-gui dashboard (Cowork sidebar — Health · Templates · Specs · Summaries · Living Docs · Commands · Jobs) in the Cowork preview pane. Use /attune-gui or just ask to open the dashboard.",
+      "version": "1.1.1",
+      "author": {
+        "name": "Smart AI Memory",
+        "email": "patrick.roebuck@smartaimemory.com"
+      },
+      "homepage": "https://smartaimemory.com",
+      "repository": "https://github.com/Smart-AI-Memory/attune-ai",
+      "license": "Apache-2.0",
+      "category": "developer-tools",
+      "tags": ["attune", "dashboard", "gui", "templates", "developer-tools", "living-docs"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Consolidated the help/author Claude Code plugins into the
+- **Consolidated the help/author/gui Claude Code plugins into the
   `Smart-AI-Memory/attune-ai` marketplace.** `attune-help` (pinned
-  0.11.1) and `attune-author` (pinned 0.21.0) now ship as plugins from
-  this repo's marketplace alongside `attune-ai`, retiring the separate
-  frozen `Smart-AI-Memory/attune-docs` marketplace (which lagged ~15
-  minor versions behind PyPI). Install becomes
+  0.11.1), `attune-author` (pinned 0.21.0), and `attune-gui` (pinned
+  plugin 1.1.1) now ship as plugins from this repo's marketplace
+  alongside `attune-ai`, retiring the separate frozen
+  `Smart-AI-Memory/attune-docs` marketplace (which lagged ~15 minor
+  versions behind PyPI) and the already-deprecated
+  `attune-gui-plugin` repo. Install becomes
   `claude plugin install attune-help@attune-ai` /
-  `attune-author@attune-ai`. No effect on `pip install attune-ai`. See
-  `docs/specs/attune-docs-marketplace/`.
+  `attune-author@attune-ai` / `attune-gui@attune-ai`. No effect on
+  `pip install attune-ai`. See `docs/specs/attune-docs-marketplace/`.
 
 ## [8.7.0] — 2026-06-22
 

--- a/plugins/attune-gui/.claude-plugin/plugin.json
+++ b/plugins/attune-gui/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "attune-gui",
+  "version": "1.1.1",
+  "description": "Launch the attune-gui dashboard (Cowork sidebar — Health · Templates · Specs · Summaries · Living Docs · Commands · Jobs) in the Cowork preview pane. Use /attune-gui or just ask to open the dashboard.",
+  "author": {
+    "name": "Smart AI Memory",
+    "email": "patrick.roebuck@smartaimemory.com"
+  },
+  "homepage": "https://smartaimemory.com",
+  "repository": "https://github.com/Smart-AI-Memory/attune-ai",
+  "license": "Apache-2.0",
+  "keywords": ["attune", "dashboard", "gui", "templates", "developer-tools"]
+}

--- a/plugins/attune-gui/README.md
+++ b/plugins/attune-gui/README.md
@@ -1,0 +1,84 @@
+# attune-gui Plugin
+
+A Claude Code plugin that launches the
+[attune-gui](https://github.com/Smart-AI-Memory/attune-gui) dashboard in
+the Cowork preview pane with a single command — or hands-free when you
+ask the model to "open the dashboard".
+
+## What you get
+
+The dashboard's Cowork sidebar (server-rendered Jinja2, ships with the PyPI
+package — no `npm` step):
+
+- **Health** — cross-layer version + import probe of `attune-rag`,
+  `attune-help`, `attune-author`, `attune-gui`, plus a corpus snapshot
+- **Templates** — markdown templates with mtime staleness, tags,
+  AI-generated vs. manually-pinned filter, and a per-row pin toggle
+- **Specs** — feature specs in `specs/<feature>/` with phase + status
+  badges and direct links to each phase file
+- **Summaries** — inline-editable `summaries.json` with regen-overwrite warning
+- **Living Docs** — workspace editor, scan trigger, document health,
+  review queue, and RAG quality bars
+- **Commands** — run any registered attune command from a card grid
+- **Jobs** — history with per-feature progress, last-output column,
+  Cancel button, and auto-refresh
+
+## Requirements
+
+- Claude Code with Cowork (preview pane support)
+- [uv](https://docs.astral.sh/uv/) on your `PATH`
+- `attune-gui >= 0.5.0` installed (`pip install attune-gui`) **or** the
+  repo cloned locally
+
+## Install
+
+This plugin lives in the
+[attune-ai](https://github.com/Smart-AI-Memory/attune-ai) marketplace
+alongside `attune-ai`, `attune-help`, and `attune-author`. From inside
+Claude Code:
+
+```
+/plugin marketplace add Smart-AI-Memory/attune-ai
+/plugin install attune-gui@attune-ai
+```
+
+## Usage
+
+Two ways to launch:
+
+**Slash command** — explicit:
+
+```
+/attune-gui
+```
+
+**Natural language** — the skill's trigger description picks up phrases like:
+
+```
+open the dashboard
+show me living docs
+launch the attune-gui dashboard
+```
+
+Either path runs the same logic:
+
+1. Detects your attune-gui project path (current directory or `./attune-gui/`)
+2. Writes `.claude/launch.json` with the correct `uv run` configuration (idempotent)
+3. Calls `mcp__Claude_Preview__preview_start` — Cowork starts the sidecar and
+   opens the dashboard in the preview pane
+
+## Optional environment
+
+For `Commands` page actions that need an Anthropic key (e.g. `author.regen`,
+`author.maintain`), the sidecar auto-loads `.env` from `./`, the
+attune-gui repo root, `~/.attune-gui/`, or `~/.attune/`. Common keys:
+
+```
+ANTHROPIC_API_KEY=sk-ant-…
+ATTUNE_SPECS_ROOT=/path/to/your/repo/specs
+ATTUNE_WORKSPACE=/path/to/your/project
+```
+
+## License
+
+Apache-2.0

--- a/plugins/attune-gui/commands/attune-gui.md
+++ b/plugins/attune-gui/commands/attune-gui.md
@@ -1,0 +1,39 @@
+---
+name: attune-gui
+description: "Launch the attune-gui dashboard in the Cowork preview pane. Starts the FastAPI sidecar if not already running."
+argument-hint: ""
+---
+
+# attune-gui Dashboard
+
+Launch the attune-gui living-docs dashboard.
+
+## Steps
+
+1. Use the Bash tool to determine the attune-gui project path:
+   - Run: `grep -s 'name = "attune-gui"' pyproject.toml`
+   - If the grep returns a match, the resolved path is `.`
+   - Else if `./attune-gui/` is a directory, the resolved path is `./attune-gui`
+   - Else report: "attune-gui not found. Install with: pip install attune-gui then open Claude Code from the attune-gui project directory." and stop.
+
+2. Check `.claude/launch.json`:
+   - If it does not exist, or does not contain an `"attune-gui"` entry, write `.claude/launch.json`:
+     ```json
+     {
+       "version": "0.0.1",
+       "configurations": [
+         {
+           "name": "attune-gui",
+           "runtimeExecutable": "uv",
+           "runtimeArgs": ["run", "--directory", "<resolved-path>", "attune-gui", "--port", "8000"],
+           "port": 8000
+         }
+       ]
+     }
+     ```
+     Replace `<resolved-path>` with the path resolved in step 1.
+   - If `.claude/launch.json` already contains an `"attune-gui"` entry, skip writing it.
+
+3. Call `mcp__Claude_Preview__preview_start` with `name: "attune-gui"`.
+
+4. Tell the user: "attune-gui is running at http://localhost:8000 — dashboard is open in the preview pane."

--- a/plugins/attune-gui/skills/attune-gui/SKILL.md
+++ b/plugins/attune-gui/skills/attune-gui/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: attune-gui
+description: >
+  Use this skill when the user wants to open, launch, or view the attune-gui
+  dashboard, living docs, or template browser — without typing /attune-gui.
+  Trigger on phrases like "open the dashboard", "show living docs", "launch the GUI",
+  "show me the templates", "open attune-gui", or "I want to see the template dashboard".
+  Do NOT trigger for general questions about attune-gui or requests to install it.
+argument-hint: ""
+---
+
+# Launch attune-gui Dashboard
+
+The user wants the dashboard open. Run the /attune-gui command steps:
+
+1. Determine the attune-gui project path:
+   - Run: `grep -s 'name = "attune-gui"' pyproject.toml`
+   - Match → resolved path is `.`
+   - No match but `./attune-gui/` exists → resolved path is `./attune-gui`
+   - Neither → tell the user: "attune-gui not found. Install with: `pip install attune-gui` then open Claude Code from the attune-gui project directory." and stop.
+
+2. Check `.claude/launch.json` — if it does not exist or has no `"attune-gui"` entry, write it:
+   ```json
+   {
+     "version": "0.0.1",
+     "configurations": [
+       {
+         "name": "attune-gui",
+         "runtimeExecutable": "uv",
+         "runtimeArgs": ["run", "--directory", "<resolved-path>", "attune-gui", "--port", "8000"],
+         "port": 8000
+       }
+     ]
+   }
+   ```
+   Replace `<resolved-path>` with the path from step 1. If the entry already exists, skip.
+
+3. Call `mcp__Claude_Preview__preview_start` with `name: "attune-gui"`.
+
+4. Tell the user: "attune-gui is running at http://localhost:8000 — dashboard is open in the preview pane."


### PR DESCRIPTION
## What

Follow-up to #988. Consolidates the **third and last** attune-docs plugin — `attune-gui` — into the `Smart-AI-Memory/attune-ai` marketplace as a separate opt-in plugin.

## Why now

attune-gui lived only in the frozen `attune-docs` marketplace, and its former dedicated repo `Smart-AI-Memory/attune-gui-plugin` was already **deprecated 2026-05-04 with a redirect *to* attune-docs**. Archiving attune-docs (spec T5) would therefore strand it. Bringing it home now unblocks T5.

## Shape decision

Kept as a **separate plugin** (`attune-gui@attune-ai`), not folded into the core attune-ai plugin — it depends on the Cowork preview pane, so it stays honestly opt-in rather than auto-triggering for every (mostly non-Cowork) attune-ai user.

## Changes

- Vendored `plugins/attune-gui/` (command + skill launcher; no MCP server).
- Pinned to **plugin version 1.1.1** — the `plugin.json` value, fixing the stale `1.1.0` the attune-docs marketplace entry carried. (Plugin version is independent of the attune-gui PyPI package, currently 0.8.0; the launcher resolves the package at runtime via `uv`.)
- Repointed `plugin.json` `repository` + README install at attune-ai.
- Registered in `.claude-plugin/marketplace.json`.
- Folded into the existing `CHANGELOG [Unreleased]` consolidation entry.

## Verification

Manifest validated (parses, all four sources resolve, versions match). Installed end-to-end via a throwaway local marketplace: **attune-gui@1.1.1** installs through the real `claude plugin install` path with its `/attune-gui` command and skill surfacing. Pre-commit hooks green.

## After this

All three attune-docs plugins now live in the attune-ai marketplace. **T4/T5** (migration README on attune-docs + archiving the attune-docs repo, and a matching redirect note on the already-deprecated attune-gui-plugin repo) remain deferred pending your explicit per-step go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
