### PR TITLE
docs(spec): close out attune-docs-marketplace — T1-T5 complete

### DIFF
--- a/docs/specs/attune-docs-marketplace/decisions.md
+++ b/docs/specs/attune-docs-marketplace/decisions.md
@@ -1,6 +1,7 @@
 # attune-docs Marketplace — Decisions
 
-**Status:** D1 ratified 2026-06-22 — Option A (retire + consolidate)
+**Status:** complete 2026-06-22 — Option A (retire + consolidate)
+ratified and shipped; see `tasks.md` for the PR trail.
 
 ---
 

--- a/docs/specs/attune-docs-marketplace/requirements.md
+++ b/docs/specs/attune-docs-marketplace/requirements.md
@@ -1,6 +1,7 @@
 # attune-docs Marketplace — Keep, Automate, or Retire
 
-**Status:** D1 ratified 2026-06-22 — Option A (retire + consolidate)
+**Status:** complete 2026-06-22 — Option A (retire + consolidate)
+shipped end-to-end; see `tasks.md` for the PR trail.
 **Owner:** Patrick + agent
 **Created:** 2026-06-22
 

--- a/docs/specs/attune-docs-marketplace/tasks.md
+++ b/docs/specs/attune-docs-marketplace/tasks.md
@@ -1,7 +1,10 @@
 # attune-docs Marketplace — Tasks (Option A: retire + consolidate)
 
-**Status:** planned — D1 ratified; execution awaiting go-ahead on the
-multi-repo / destructive steps (T4, T5).
+**Status:** complete — all tasks shipped 2026-06-22. T1-T3 +
+attune-gui: attune-ai #988 / #989 (+ lessons #990). T4: attune-docs #6
+(migration README + moved-signal). T5: attune-docs archived read-only;
+attune-gui-plugin was already archived (redirect chains via attune-docs
+→ attune-ai), left as-is.
 
 D2 proposed home: `Smart-AI-Memory/attune-ai` marketplace.
 D3: archive attune-docs read-only with a migration README (do not


### PR DESCRIPTION
Status-only closeout of `docs/specs/attune-docs-marketplace/` now that the consolidation has fully shipped.

- **tasks.md** — Status `planned` → `complete`, with the PR trail (attune-ai #988/#989/#990, attune-docs #6, attune-docs archived read-only; attune-gui-plugin was already archived).
- **requirements.md / decisions.md** — Status bumped from `ratified` to `complete` so no file in the dir reads in-progress (cross-file spec-status-drift hygiene).

No code or marketplace changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)