### PR TITLE
release: 8.7.1 — docs/distribution patch (refresh PyPI README)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.7.0"
+    "version": "8.7.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.7.0
+# Attune AI Framework v8.7.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.7.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.7.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.7.1] — 2026-06-22
+
+Docs/distribution patch — **no runtime changes** (`src/attune` is
+identical to 8.7.0). Released to refresh the PyPI project page, whose
+README still pointed new users at the now-retired `attune-docs`
+marketplace.
+
 ### Changed
 
 - **Consolidated the help/author/gui Claude Code plugins into the

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.7.0
+**Version:** 8.7.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.7.0 | **License:** Apache 2.0
+**Version:** 8.7.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.7.0"
+    "version": "8.7.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.7.0"
+__version__ = "8.7.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.7.0"
+version = "8.7.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.7.0"
+version = "8.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What

`8.7.1` — **docs/distribution patch, no runtime changes** (`src/attune` is byte-identical to 8.7.0).

## Why release with no code change

The PyPI project page renders `README.md` as its long_description, and the v8.7.0 README still tells new users *"add Smart-AI-Memory/attune-docs directly"* — a marketplace that's now archived. The only way to refresh that page is to publish. This release does that and ships the marketplace-consolidation note as the 8.7.1 changelog entry.

## Changes

- Version 8.7.0 → 8.7.1 across the 7 standard sites (help/author/gui plugin entries left at pinned 0.11.1/0.21.0/1.1.1).
- CHANGELOG `[Unreleased]` → `[8.7.1]`, labeled docs/distribution patch.
- `uv.lock` refreshed (attune-ai self-version only — tight 1-line diff).
- Docs regen deliberately skipped (no source changes → no `.help` staleness; freshness hook passes).

Version-drift backstop (`test_bump_version`, `test_all_versions_match`) green; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)