### PR TITLE
feat(hooks): surface project-local .attune/next_session_starter.md

### DIFF
--- a/src/attune/hooks/scripts/starter_prompt_nudge.py
+++ b/src/attune/hooks/scripts/starter_prompt_nudge.py
@@ -1,12 +1,21 @@
 #!/usr/bin/env python3
-"""SessionStart hook: surface ~/.attune/next_session_starter.md when present.
+"""SessionStart hook: surface next_session_starter.md handoffs when present.
 
 Eliminates the cross-session handoff friction documented in the
 ``feedback_cross_account_handoff`` memory: previously, the starter
 prompt had to be pasted manually at the start of each new session.
-This hook reads ``~/.attune/next_session_starter.md`` (if it
-exists) and prints a short notice with the file path, last-modified
-date, and a one-line hint to read it.
+
+Two locations are surfaced, most-specific first:
+
+1. **Project-local** ``<repo-root>/.attune/next_session_starter.md`` —
+   the handoff for THIS repo. Lets a session that hands off to a
+   *different* repo (e.g. attune-ai → attune-gui) leave the starter
+   where the next session in that repo will actually find it, instead
+   of clobbering the single global file. ``<repo-root>`` is the git
+   toplevel discovered by walking up from the cwd.
+2. **Global** ``~/.attune/next_session_starter.md`` — the
+   cross-cutting / cwd-agnostic handoff (back-compat with the original
+   single-file behavior).
 
 The file content itself is NOT printed inline — keeps the
 SessionStart noise floor low. Users / the agent open it
@@ -33,6 +42,27 @@ from pathlib import Path
 
 STARTER_PATH = Path.home() / ".attune" / "next_session_starter.md"
 
+#: Relative location of a per-repo handoff, under the git toplevel.
+PROJECT_STARTER_RELPATH = Path(".attune") / "next_session_starter.md"
+
+
+def _find_project_starter(start: Path | None = None) -> Path | None:
+    """Return ``<git-toplevel>/.attune/next_session_starter.md`` or None.
+
+    Walks up from ``start`` (default: cwd) looking for a ``.git``
+    entry (dir for a normal checkout, file for a worktree/submodule).
+    Returns the project-local starter path if that file exists; None
+    if no repo root is found or the file is absent. ``start`` is a
+    parameter so tests can pin the search root.
+    """
+    if start is None:
+        start = Path.cwd()
+    for parent in [start, *start.parents]:
+        if (parent / ".git").exists():
+            candidate = parent / PROJECT_STARTER_RELPATH
+            return candidate if candidate.is_file() else None
+    return None
+
 
 def _format_age(mtime_ts: float, now: float | None = None) -> str:
     """Return a short human-readable age like '2h ago', '3d ago'.
@@ -55,28 +85,44 @@ def _format_age(mtime_ts: float, now: float | None = None) -> str:
     return f"{int(delta / 86400)}d ago"
 
 
-def main() -> int:
-    """Print the starter-prompt notice if the file exists."""
-    if not STARTER_PATH.is_file():
-        return 0
+def _emit_notice(path: Path, scope: str) -> bool:
+    """Print the starter-prompt notice for ``path`` if it has content.
 
+    ``scope`` is a short label ("project" / "global") shown in the
+    notice. Returns True if a notice was printed, False on any no-op
+    (missing / empty / vanished file).
+    """
+    if not path.is_file():
+        return False
     try:
-        stat = STARTER_PATH.stat()
+        stat = path.stat()
     except OSError:
         # File disappeared between is_file() and stat(); just no-op.
-        return 0
-
+        return False
     if stat.st_size == 0:
         # Empty file — nothing to surface.
-        return 0
+        return False
 
     age = _format_age(stat.st_mtime)
     size_kb = stat.st_size / 1024
-
     print(
-        f"[starter-prompt] {STARTER_PATH} ({size_kb:.1f} KB, modified {age}) — "
+        f"[starter-prompt:{scope}] {path} ({size_kb:.1f} KB, modified {age}) — "
         "read this for cross-session handoff context."
     )
+    return True
+
+
+def main() -> int:
+    """Surface project-local then global starter notices, if present."""
+    project_path = _find_project_starter()
+    if project_path is not None:
+        _emit_notice(project_path, "project")
+
+    # Always also surface the global handoff (it serves a different,
+    # cwd-agnostic purpose) — unless it IS the project-local file we
+    # already emitted (a repo rooted at ~ would alias the two).
+    if project_path is None or STARTER_PATH.resolve() != project_path.resolve():
+        _emit_notice(STARTER_PATH, "global")
     return 0
 
 

--- a/tests/unit/hooks/test_starter_prompt_nudge.py
+++ b/tests/unit/hooks/test_starter_prompt_nudge.py
@@ -41,9 +41,14 @@ def hook_module():
 @pytest.fixture
 def isolated_starter(tmp_path, hook_module, monkeypatch):
     """Redirect STARTER_PATH to a tmp path so tests don't depend on
-    the user's real ~/.attune/next_session_starter.md."""
+    the user's real ~/.attune/next_session_starter.md.
+
+    Also stubs ``_find_project_starter`` to None so the global-focused
+    tests don't pick up a project-local file from the real cwd.
+    """
     path = tmp_path / "next_session_starter.md"
     monkeypatch.setattr(hook_module, "STARTER_PATH", path)
+    monkeypatch.setattr(hook_module, "_find_project_starter", lambda *a, **k: None)
     return path
 
 
@@ -81,6 +86,57 @@ class TestSurfacing:
         hook_module.main()
         captured = capsys.readouterr()
         assert "just now" in captured.out or "m ago" in captured.out
+
+
+class TestProjectLocalStarter:
+    """Project-local <repo>/.attune/next_session_starter.md surfacing."""
+
+    def _make_repo(self, tmp_path: Path, with_starter: str | None) -> Path:
+        (tmp_path / ".git").mkdir()
+        if with_starter is not None:
+            d = tmp_path / ".attune"
+            d.mkdir()
+            (d / "next_session_starter.md").write_text(with_starter, encoding="utf-8")
+        return tmp_path
+
+    def test_finds_starter_at_git_toplevel(self, hook_module, tmp_path):
+        repo = self._make_repo(tmp_path, "handoff")
+        nested = repo / "src" / "deep"
+        nested.mkdir(parents=True)
+        found = hook_module._find_project_starter(start=nested)
+        assert found == repo / ".attune" / "next_session_starter.md"
+
+    def test_none_when_no_repo(self, hook_module, tmp_path):
+        # No .git anywhere up the tree.
+        assert hook_module._find_project_starter(start=tmp_path) is None
+
+    def test_none_when_repo_but_no_starter(self, hook_module, tmp_path):
+        repo = self._make_repo(tmp_path, None)
+        assert hook_module._find_project_starter(start=repo) is None
+
+    def test_project_notice_emitted(self, hook_module, tmp_path, monkeypatch, capsys):
+        repo = self._make_repo(tmp_path, "# repo handoff\n")
+        starter = repo / ".attune" / "next_session_starter.md"
+        monkeypatch.setattr(hook_module, "_find_project_starter", lambda *a, **k: starter)
+        # No global file.
+        monkeypatch.setattr(hook_module, "STARTER_PATH", tmp_path / "nope.md")
+        code = hook_module.main()
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "[starter-prompt:project]" in out
+        assert str(starter) in out
+
+    def test_both_project_and_global_emitted(self, hook_module, tmp_path, monkeypatch, capsys):
+        repo = self._make_repo(tmp_path, "# repo\n")
+        starter = repo / ".attune" / "next_session_starter.md"
+        global_path = tmp_path / "global_starter.md"
+        global_path.write_text("# global\n", encoding="utf-8")
+        monkeypatch.setattr(hook_module, "_find_project_starter", lambda *a, **k: starter)
+        monkeypatch.setattr(hook_module, "STARTER_PATH", global_path)
+        hook_module.main()
+        out = capsys.readouterr().out
+        assert "[starter-prompt:project]" in out
+        assert "[starter-prompt:global]" in out
 
 
 class TestAgeFormatter:


### PR DESCRIPTION
## What (bullet 1 — starter-prompt findability)

The SessionStart starter-prompt hook only read the single global `~/.attune/next_session_starter.md`. So when a session hands off to a **different** repo (this session: attune-ai → attune-gui), there was nowhere to leave a repo-specific starter the next session would find — and the global file gets clobbered by whichever repo last wrote it. (That's exactly what bit us today.)

## Change

`starter_prompt_nudge.py` now also discovers `<git-toplevel>/.attune/next_session_starter.md` (walking up from cwd) and surfaces it **first** as `[starter-prompt:project]`, with the global one (now `[starter-prompt:global]`) still emitted for the cwd-agnostic case. Both informational; exit 0 always; never blocks session start.

## Companion convention (not code)

When handing a session off to another repo, write the starter to **that repo's** `.attune/next_session_starter.md` so this hook surfaces it on arrival. (Captured as a memory too.)

## Tests

Project-local discovery at the git toplevel, no-repo / no-file no-ops, project+global both-emitted, plus the existing global-path + age-formatter coverage. **15 passed**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)