### PR TITLE
docs(spec): post-release hardening specs for review (reach-snapshot + post-commit-help)

### DIFF
--- a/docs/specs/post-commit-help-check-only/requirements.md
+++ b/docs/specs/post-commit-help-check-only/requirements.md
@@ -1,0 +1,101 @@
+# Post-Commit Help Maintenance → Check-Only
+
+**Status:** draft — awaiting review
+**Owner:** Patrick + agent
+**Created:** 2026-06-22
+
+---
+
+## Premise correction (verify-first)
+
+A standing lesson said *"the `.help` regen pre-commit hook does a full
+LLM re-polish of a feature's whole help corpus on any source touch,
+leaving stash-and-reappear files."* That is now **stale**: the
+**pre-commit** path was fixed by the polish-cost-reduction spec (lever
+1, ratified 2026-06-10) —
+
+- `scripts/regenerate_help_templates.py` is **check-only** (warns which
+  features lag; never regenerates, never spends LLM).
+- `scripts/check_docs_freshness.py` is **warn-only** unless
+  `ATTUNE_DOCS_AUTOREGEN=1`.
+
+But the problem still *exists* on a different path, which is why
+`.help/templates/plugin/{concept,reference,task}.md` got rewritten in
+the working tree during the 8.7.1 ship (the release commit touched
+`plugin/core/__init__.py`):
+
+- **`plugin/hooks/help_post_commit.py`** (a PostToolUse hook on `git
+  commit`) calls `attune.help.maintenance.run_hook(...)`, which calls
+  `run_maintenance(...)` **in regenerate mode** — LLM-re-polishing every
+  affected feature's templates and dropping them in the working tree.
+
+So the per-commit whole-feature re-polish — the exact repeat-API-spend
++ hallucination-risk + stash-and-reappear churn lever 1 eliminated for
+the pre-commit path — is **still live on the post-commit path**, and
+inconsistent with the ratified policy ("polish-bearing regen happens at
+release-prep cadence, not per-commit").
+
+---
+
+## Goals
+
+1. The post-commit hook becomes **check-only**: detect + warn which
+   features are stale after a commit; **never** auto-regenerate, spend
+   LLM budget, or write to the working tree.
+2. Behavior matches the pre-commit hooks and the polish-cost-reduction
+   policy — polish-bearing regen happens only at release-prep
+   (`attune-author regenerate` / `/coach maintain`).
+3. Retire/correct the stale lesson so it names the real (now-fixed)
+   surface.
+
+## Non-goals
+
+- Removing the post-commit hook entirely (the *warning* is useful).
+- Changing release-prep regeneration.
+
+---
+
+## Design sketch
+
+The check-only capability **already exists** — `run_maintenance(...)`
+takes `dry_run: bool` ("If True, report staleness without
+regenerating"). `run_hook()` currently calls it **without** `dry_run`.
+
+Two clean options:
+
+**A — Flip the hook to dry-run (recommended, smallest).** Have
+`help_post_commit.py` (or `run_hook`) pass `dry_run=True`, so the
+post-commit path only reports staleness. The hook's existing
+`stale_count > 0` / `regenerated_count == 0` branch already prints the
+right "N feature(s) are stale — run /coach maintain" warning; the
+regenerated-count branch becomes dead and is removed.
+
+**B — Add a `regenerate: bool = False` param to `run_hook`.** Same
+effect, explicit at the entry point; lets a deliberate caller still
+regenerate. Slightly more surface.
+
+**Recommendation: A** — matches lever 1's "hooks never spend LLM"
+stance and removes a now-misleading code path. Reserve B if there's a
+real non-release caller that wants regen (none known).
+
+## Validation
+
+- Unit: `run_hook` with affected features + a stubbed generator →
+  assert `regenerated_count == 0` and no template files written
+  (dry-run), warning emitted.
+- Regression guard: a test asserting the post-commit hook path does not
+  call the regenerating branch (drift guard, so this can't silently
+  come back).
+- Manual: commit a change touching a feature's source glob → confirm
+  only a stderr warning, no `.help/templates/<feature>/` diff.
+
+## Close-out
+
+- Update `.claude/lessons.md`: correct the stale pre-commit-hook lesson
+  to point at the post-commit hook + record the fix.
+
+## Open questions
+
+- **D1**: approve A (dry-run flip) vs B (param)?
+- Is there any caller of `run_hook`/`run_maintenance` that *wants*
+  per-commit regen? (Grep found only the post-commit hook.)

--- a/docs/specs/reach-snapshot-resilience/requirements.md
+++ b/docs/specs/reach-snapshot-resilience/requirements.md
@@ -1,0 +1,107 @@
+# Reach Snapshot Resilience
+
+**Status:** draft — awaiting review
+**Owner:** Patrick + agent
+**Created:** 2026-06-22
+
+---
+
+## Problem
+
+`scripts/reach_snapshot.py` (usage-signals R4) is kicked off at tag
+time by the release ritual to capture a PyPI-downloads + GitHub-traffic
+baseline. It reliably fails there:
+
+- pypistats 429-penalizes bursts, and (per the script's own Phase 0
+  docstring) the penalty *outlasts* short retries.
+- The script's defense is correct-but-blunt: it **aborts the entire
+  run on the first 429**, discarding any packages already fetched. So
+  a run that gets 3 of 5 packages then 429s writes **nothing** — the
+  next run starts from zero and is likely to 429 again.
+- Hit twice in one day (2026-06-22, the 8.7.0 and 8.7.1 ships). The
+  net effect: the "before/after pair" R4 promises is frequently never
+  captured, so the data the release ritual exists to collect is
+  silently missing.
+
+This is a resilience gap, not a correctness bug — the rate-limit
+discipline (don't hammer) is right; the all-or-nothing failure mode is
+what wastes the partial progress.
+
+---
+
+## Goals
+
+1. A snapshot run **preserves partial progress** — packages already
+   fetched in a run/day are not lost to a later 429.
+2. A 429 degrades to "**rerun later to finish the remainder**," not
+   "start over."
+3. No change to the rate-limit discipline: still space requests, still
+   never hammer on a 429.
+4. The release ritual stays unblocked — the snapshot remains
+   best-effort and never gates a release.
+
+## Non-goals
+
+- Authenticated/private pypistats access or a different data source.
+- In-run aggressive retry/backoff against pypistats (the penalty
+  outlasts it — explicitly rejected, see D-Options B).
+
+---
+
+## Options (D1 — approach)
+
+**A — Resumable partial write (recommended).** Persist per-package
+results to the day's `<date>.json` *as each succeeds*. On rerun, load
+the existing day file and **skip packages already captured today**;
+only fetch the remainder. A 429 still aborts the current run, but the
+captured packages are durable and a rerun completes the set. Lowest
+risk; respects the existing discipline; smallest change.
+
+**B — In-run exponential backoff.** Retry the 429'd package with
+growing waits inside the same run. **Rejected** — the module docstring
+documents that the penalty outlasts minutes of retrying, so this fights
+reality and lengthens a run that's already best-effort.
+
+**C — Move off the release critical path to a scheduled cadence.**
+Run the snapshot from a cron/scheduled job (e.g. daily) decoupled from
+tag time, so release-time 429s never matter. Complementary to A, not a
+substitute (A still needed for the scheduled run to be robust). Could
+be a follow-up.
+
+**D — Skip on docs-only releases.** Don't even attempt at tag time for
+a `src`-identical release. Narrow; doesn't fix the underlying
+fragility. Could pair with C.
+
+**Recommendation:** **A** now (durable partial progress — directly
+fixes the wasted-work failure), with **C** as a fast follow if Patrick
+wants the snapshot off the release path entirely.
+
+---
+
+## Design sketch (Option A)
+
+- `main()` loads `<out>/<YYYY-MM-DD>.json` if it exists and seeds the
+  results dict from it.
+- Iterate `PACKAGES`; for each not already present, fetch + **write
+  the day file after each success** (atomic write: temp + rename).
+- On `RateLimitedError`: log "captured N/total today; rerun after the
+  cooldown to finish the rest," write what we have, exit non-zero
+  *only* in standalone use — but the release ritual already runs it in
+  the background and ignores exit code, so no ritual change needed.
+- GitHub signals (already best-effort/degrading) unchanged.
+
+## Validation
+
+- Unit: seed a day file with 2 packages, stub `fetch_pypistats_recent`
+  to raise `RateLimitedError` on the 3rd → assert the 2 seeded + any
+  newly-fetched persist and the run doesn't lose them.
+- Unit: full success path writes all packages and is idempotent on
+  rerun (no duplicate fetches — already-present packages skipped).
+
+## Open questions
+
+- **D1**: approve A (and is C a wanted follow-up, or leave tag-time
+  best-effort)?
+- Retention: is one file per day (current) fine, or should a rerun the
+  same day overwrite vs merge? (Design assumes **merge/skip** within a
+  day.)


### PR DESCRIPTION
Two **review-only** spec drafts from the post-8.7.1 feedback. Each is self-contained in its own `docs/specs/` dir and can be approved/executed independently — no code changes here.

### 1. `reach-snapshot-resilience`
`scripts/reach_snapshot.py` aborts the **whole** snapshot on the first pypistats 429, discarding packages already fetched (hit twice on 2026-06-22). Recommends **durable partial-progress writes** so a 429 means "rerun to finish the remainder," not "start over" — keeping the existing don't-hammer discipline. Optional follow-up: move the snapshot off the release critical path to a scheduled cadence.

### 2. `post-commit-help-check-only`
**Corrects a stale lesson.** The pre-commit help hooks are *already* check-only (polish-cost-reduction lever 1) — but the PostToolUse hook `plugin/hooks/help_post_commit.py` still LLM-re-polishes whole features on `git commit` via `run_hook → run_maintenance` (no `dry_run`). That's what rewrote `.help/templates/plugin/` during the 8.7.1 ship. Recommends flipping it to `dry_run=True` (the capability already exists) so per-commit regen stops, matching the ratified "polish at release-prep cadence" policy. Includes a regression guard + a lesson correction in close-out.

Review asks are the **D1** option-picks at the bottom of each spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)