### PR TITLE
chore: weekly report 2026-06-22

### DIFF
--- a/weekly-reports/2026-06-22.md
+++ b/weekly-reports/2026-06-22.md
@@ -1,0 +1,193 @@
+# Anthropic Ecosystem Weekly — 2026-06-22
+
+## Summary
+
+**Agent SDK credit pool billing was reversed on June 15** — the same day it
+was supposed to go live. SDK usage is back on subscription, walking back last
+week's Rec #2. Five Claude Code releases shipped this week (v2.1.178–
+v2.1.185); two that directly affect the stack: auto mode now blocks destructive
+git commands by default, and a prompt caching bug on custom
+`ANTHROPIC_BASE_URL`/Foundry was fixed (reinforcing the 7-week-old
+attune-author cache recommendation).
+
+---
+
+## Recommendations
+
+**1. Adjust release workflows for auto mode destructive git blocking (v2.1.183)**
+
+Claude Code's auto mode now blocks these commands unless you explicitly
+requested discarding local work this session:
+
+- `git reset --hard`
+- `git checkout -- .`
+- `git clean -fd`
+- `git stash drop`
+- `git commit --amend` (when the prior commit wasn't made by the agent this
+  session)
+- `terraform destroy` / `pulumi destroy` / `cdk destroy`
+
+attune-ai's release workflow and any workflow that issues these as intermediate
+steps will stall in unattended auto mode. The most likely hit: `git stash drop`
+after a pre-flight clean. `git commit --amend` is also used in some session
+recovery flows.
+
+Two options: (a) switch release runs to `--dangerously-skip-permissions`
+explicitly, which the harness allows for pre-authorized runs, or (b) audit the
+release workflow steps and replace `--hard`/`--amend` variants with safer
+equivalents where possible (preferred — those are also the commands that bite
+you when Claude gets confused about branch state).
+
+- **Applies to:** `.claude/` hooks, `src/attune/agents/release/`, release
+  scripts that invoke git destructive ops through Claude Code auto mode
+- **Urgency:** Medium — affects next unattended release run.
+- **Alternative:** Confirm which steps stall in practice; the classifier only
+  blocks when it infers the request didn't come from the user. Explicit
+  "discard uncommitted changes and reset" in the session prompt should still
+  pass.
+
+---
+
+**2. Investigate prompt caching on custom base URL — and unblock May-11 #6
+now**
+
+v2.1.181 (June 17) fixed prompt caching issues on custom `ANTHROPIC_BASE_URL`
+endpoints and Foundry. `src/attune/workflows/rag_code_gen.py:310` passes a
+custom `base_url` (`_CITATION_BASE_URL`) to an Anthropic client — if that URL
+proxies to Anthropic, caching was silently broken until v2.1.181.
+
+More importantly: this fix means the 7-week-open May-11 #6 (1-hour cache TTL
+for attune-author polish pipeline) is no longer blocked by a latent caching
+bug. If the attune-author polish pipeline runs through Claude Code or uses
+`ANTHROPIC_BASE_URL`, cache misses you've been seeing may have been from this
+bug, not from the TTL setting. Upgrade Claude Code to ≥v2.1.181 first, then
+implement the 1-hour TTL.
+
+The fix for the `_CITATION_BASE_URL` case: confirm whether that endpoint
+proxies Anthropic requests. If yes, check whether prompt caching is expected
+and was broken pre-v2.1.181.
+
+- **Applies to:** `src/attune/workflows/rag_code_gen.py:310`,
+  attune-author polish pipeline
+- **Urgency:** Medium — both items unblocked by the same fix.
+
+---
+
+**3. Use `Tool(param:value)` permission rules for cost control in auto mode
+(v2.1.178)**
+
+New `Tool(param:value)` syntax lets you match permission rules against tool
+input parameters. The motivating case for attune-ai: `Agent(model:opus)` as a
+deny rule blocks auto-spawned Opus sub-agents without blocking the Agent tool
+entirely. Given that deep-review and research workflows at Opus 4.8 rates are
+~$5–10/run, and auto mode's classifier now evaluates subagent spawns before
+launch (also v2.1.178), this is a practical cost guard.
+
+Example rule for `.claude/settings.json`:
+
+```json
+{
+  "permissions": {
+    "deny": ["Agent(model:claude-opus-4-8)"]
+  }
+}
+```
+
+Pairs with `ATTUNE_MAX_BUDGET_USD` as a belt-and-suspenders safeguard.
+
+- **Applies to:** `.claude/settings.json` (project or user level), attune-ai
+  plugin docs
+- **Urgency:** Low — additive config option.
+
+---
+
+**4. Set `CLAUDE_CLIENT_PRESENCE_FILE` for scheduled runs (v2.1.181)**
+
+New env var suppresses mobile push notifications when Claude Code runs in a
+background/scheduled context. This routine runs on a schedule; without this
+set, every model query during the run can trigger a phone notification. Set
+`CLAUDE_CLIENT_PRESENCE_FILE=/tmp/.claude_scheduled_run` (or any writable
+path) in the environment that runs scheduled attune-ai workflows to silence the
+noise.
+
+- **Applies to:** Scheduled CI/cron environments running Claude Code
+- **Urgency:** Low — quality of life.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| June-15 Rec #1 | 2026-06-15 | Handle `stop_reason: "refusal"` before adding Fable 5 | Open. Still low urgency — `claude-fable-5` not in registry. |
+| June-15 Rec #2 | 2026-06-15 | Confirm per-run caps for Agent SDK credit pool | **Revised — billing paused.** SDK usage is back on subscription (see Watch list). Keep `ATTUNE_MAX_BUDGET_USD` as a safeguard but remove hard-stop urgency. |
+| June-15 Rec #3 | 2026-06-15 | Document `--safe-mode` and `disableBundledSkills` in plugin docs | Open. Still minor. |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` | Open (3 weeks). |
+| May-25 #2 | 2026-05-25 | attune-ops: switch to `claude agents --json` | Open (4 weeks). v2.1.183 adds deprecation warnings for outdated models — if attune-ops reads agent output, you'll start seeing warning noise. |
+| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish pipeline | Open (7 weeks). **Escalating.** v2.1.181 fixed a cache bug on custom base URLs — run a before/after comparison now. |
+| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open (7 weeks — one-liner edit, just do it). |
+| May-11 #6 | 2026-05-11 | 1-hour cache TTL for attune-author polish | Open (7 weeks). Unblocked by v2.1.181 per Rec #2 above. |
+| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | Open (7 weeks). No new info. If you haven't hit this in practice, consider closing. |
+
+The May-11 items are 7 weeks old. If they're genuinely not causing pain, close
+them explicitly rather than carrying them indefinitely — they're creating noise
+in the carry-overs table.
+
+---
+
+## Watch list
+
+- **Agent SDK credit pool billing — paused, not cancelled.** Anthropic said
+  "for now, nothing has changed." Developer pushback (notably from Zed) caused
+  the June 15 reversal. A revised structure will come; watch the support site
+  for the next announcement. The $200/month credit pool plan showed ~$5/run
+  for deep-review at Opus 4.8 rates — that math doesn't change when they retry.
+
+- **Fable 5 `stop_reason: "refusal"` handling (June-15 Rec #1)**: still
+  pre-launch for attune-ai, but the server-side `fallbacks` beta parameter
+  (retry refused request on another model) remains worth watching. No GA date.
+
+- **`attribution.sessionUrl` setting (v2.1.183)**: omits the claude.ai session
+  link from commits and PR bodies. Relevant for attune-ai's commit/PR
+  workflows if you want cleaner attribution in enterprise contexts. No action
+  needed but check if clients ask.
+
+- **Auto mode classifier evaluating subagent spawns before launch (v2.1.178)**:
+  CrewAI-based teams are orchestrated through the Python SDK, not Claude Code's
+  native Agent tool, so this doesn't affect attune-ai's existing crews. But if
+  the attune-ai MCP server ever exposes an agent-spawn tool, this classifier
+  gate becomes relevant.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Stream-stall hint wording/timeout change (v2.1.185) | UI-only change; no stack impact |
+| `sandbox.allowAppleEvents` (v2.1.181) | macOS sandboxed commands only; no attune-ai code impact |
+| Bun runtime upgrade to 1.4 (v2.1.181) | Claude Code internal runtime; no attune-ai code impact |
+| Write/Edit 0-byte file fix on network drives (v2.1.181) | Not on network drives |
+| WSL2 mouse-wheel scrolling fix (v2.1.179) | UI fix; no stack impact |
+| `terraform destroy` blocking in auto mode (v2.1.183) | No terraform/pulumi/CDK in stack |
+| `/config --help` and toggle Enter/Space fix (v2.1.183) | UI UX only |
+| `Ctrl+O` subagent transcript fix (v2.1.179) | UI fix only |
+| Fullscreen TUI corruption fix (v2.1.183) | UI fix only |
+| `GET /v1/environments/{id}/work` on AWS (June 10, pre-period) | Stack uses direct SDK, not self-hosted Managed Agents sandbox |
+| API: no charge on pre-output refusals (June 2) | Stack doesn't use Fable 5 yet; zero impact |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` (through June 15, 2026)
+- `github.com/anthropics/claude-code/releases` (v2.1.178–v2.1.185, June
+  15–20, 2026)
+- `letsdatascience.com` — Agent SDK billing pause announcement (June 15, 2026)
+- `releasebot.io/updates/anthropic/claude-code` (June 16–21, 2026)
+- `github.com/anthropics/claude-agent-sdk-python/blob/main/CHANGELOG.md`
+  (v0.2.106 — only change: bundled CLI updated to v2.1.185)
+- Prior report: `weekly-reports/2026-06-15.md`
+- Repo audit: `src/attune/workflows/rag_code_gen.py`,
+  `src/attune/help/polish.py`, `src/attune/models/adaptive_routing.py`,
+  `src/attune/ops/` (no `claude agents` usage found)


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-06-22

## Summary

**Agent SDK credit pool billing was reversed on June 15** — the same day it
was supposed to go live. SDK usage is back on subscription, walking back last
week's Rec #2. Five Claude Code releases shipped this week (v2.1.178–
v2.1.185); two that directly affect the stack: auto mode now blocks destructive
git commands by default, and a prompt caching bug on custom
`ANTHROPIC_BASE_URL`/Foundry was fixed (reinforcing the 7-week-old
attune-author cache recommendation).

---

## Recommendations

**1. Adjust release workflows for auto mode destructive git blocking (v2.1.183)**

Claude Code's auto mode now blocks these commands unless you explicitly
requested discarding local work this session:

- `git reset --hard`
- `git checkout -- .`
- `git clean -fd`
- `git stash drop`
- `git commit --amend` (when the prior commit wasn't made by the agent this
  session)
- `terraform destroy` / `pulumi destroy` / `cdk destroy`

attune-ai's release workflow and any workflow that issues these as intermediate
steps will stall in unattended auto mode. The most likely hit: `git stash drop`
after a pre-flight clean. `git commit --amend` is also used in some session
recovery flows.

Two options: (a) switch release runs to `--dangerously-skip-permissions`
explicitly, which the harness allows for pre-authorized runs, or (b) audit the
release workflow steps and replace `--hard`/`--amend` variants with safer
equivalents where possible (preferred — those are also the commands that bite
you when Claude gets confused about branch state).

- **Applies to:** `.claude/` hooks, `src/attune/agents/release/`, release
  scripts that invoke git destructive ops through Claude Code auto mode
- **Urgency:** Medium — affects next unattended release run.

---

**2. Investigate prompt caching on custom base URL — and unblock May-11 #6 now**

v2.1.181 (June 17) fixed prompt caching issues on custom `ANTHROPIC_BASE_URL`
endpoints and Foundry. `src/attune/workflows/rag_code_gen.py:310` passes a
custom `base_url` (`_CITATION_BASE_URL`) to an Anthropic client — if that URL
proxies Anthropic, caching was silently broken until v2.1.181.

More importantly: the 7-week-open May-11 #6 (1-hour cache TTL for attune-author
polish pipeline) is no longer blocked by a latent caching bug. Upgrade Claude
Code to ≥v2.1.181 first, then implement the 1-hour TTL.

- **Applies to:** `src/attune/workflows/rag_code_gen.py:310`, attune-author
  polish pipeline
- **Urgency:** Medium.

---

**3. Use `Tool(param:value)` permission rules for cost control in auto mode (v2.1.178)**

New syntax lets you match permission rules against tool input parameters. For
attune-ai: `Agent(model:claude-opus-4-8)` as a deny rule blocks auto-spawned
Opus sub-agents without blocking the Agent tool entirely.

```json
{ "permissions": { "deny": ["Agent(model:claude-opus-4-8)"] } }
```

- **Applies to:** `.claude/settings.json`, attune-ai plugin docs
- **Urgency:** Low — additive config option.

---

**4. Set `CLAUDE_CLIENT_PRESENCE_FILE` for scheduled runs (v2.1.181)**

New env var suppresses mobile push notifications in background/scheduled
contexts. Set to any writable path in environments running scheduled attune-ai
workflows.

- **Applies to:** Scheduled CI/cron environments running Claude Code
- **Urgency:** Low.

---

## Carry-overs

| # | First raised | Recommendation | Status |
|---|---|---|---|
| June-15 Rec #1 | 2026-06-15 | Handle `stop_reason: "refusal"` before adding Fable 5 | Open. Still low urgency. |
| June-15 Rec #2 | 2026-06-15 | Confirm per-run caps for Agent SDK credit pool | **Revised — billing paused.** Back on subscription. Keep `ATTUNE_MAX_BUDGET_USD` as a safeguard but remove hard-stop urgency. |
| June-15 Rec #3 | 2026-06-15 | Document `--safe-mode` and `disableBundledSkills` | Open. |
| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` | Open (3 weeks). |
| May-25 #2 | 2026-05-25 | attune-ops: switch to `claude agents --json` | Open (4 weeks). v2.1.183 adds deprecation warnings — if attune-ops reads agent output, expect noise. |
| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish pipeline | Open (7 weeks). **Escalating.** v2.1.181 fixed cache on custom base URLs — run before/after now. |
| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open (7 weeks). One-liner edit. |
| May-11 #6 | 2026-05-11 | 1-hour cache TTL for attune-author polish | Open (7 weeks). Unblocked by v2.1.181. |
| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | Open (7 weeks). Consider closing if not hitting this in practice. |

---

## Watch list

- **Agent SDK credit pool — paused, not cancelled.** Anthropic said "for now, nothing has changed." Developer pushback caused the reversal; revised structure will come. Watch support site.
- **Fable 5 server-side `fallbacks` parameter**: still beta; no GA date.
- **`attribution.sessionUrl` setting (v2.1.183)**: omits claude.ai session link from commits/PRs — relevant for enterprise clients.
- **Auto mode subagent classifier (v2.1.178)**: evaluates spawns before launch. Not relevant for attune-ai's CrewAI crews (Python SDK), but relevant if MCP server ever exposes an agent-spawn tool.

---

## No-ops

| Item | Why skipped |
|---|---|
| Stream-stall hint wording/timeout (v2.1.185) | UI-only |
| `sandbox.allowAppleEvents` (v2.1.181) | macOS sandboxed commands only |
| Bun runtime upgrade to 1.4 (v2.1.181) | Claude Code internal |
| Write/Edit 0-byte fix on network drives (v2.1.181) | Not on network drives |
| WSL2 mouse-wheel scrolling fix (v2.1.179) | UI fix |
| `terraform destroy` blocking in auto mode (v2.1.183) | No terraform/pulumi/CDK in stack |
| `/config --help` and toggle UX fix (v2.1.183) | UI UX only |
| `Ctrl+O` subagent transcript fix (v2.1.179) | UI fix |
| `GET /v1/environments/{id}/work` on AWS | Stack uses direct SDK, not Managed Agents sandbox |
| API: no charge on pre-output refusals (June 2) | No Fable 5 in registry yet |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/api` (through June 15, 2026)
- `github.com/anthropics/claude-code/releases` (v2.1.178–v2.1.185)
- Agent SDK billing pause: letsdatascience.com + thenewstack.io (June 15, 2026)
- `releasebot.io/updates/anthropic/claude-code` (June 16–21, 2026)
- `github.com/anthropics/claude-agent-sdk-python` CHANGELOG (v0.2.106)
- Prior report: `weekly-reports/2026-06-15.md`
- Repo audit: `src/attune/workflows/rag_code_gen.py`, `src/attune/help/polish.py`, `src/attune/models/adaptive_routing.py`, `src/attune/ops/`

---
_Generated by [Claude Code](https://claude.ai/code/session_0134PraULHNv52p7zjNv3tPY)_