### PR TITLE
feat(llm): env-driven extended cache TTL in AnthropicProvider

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -10290,3 +10290,27 @@ files.
   response body. Recurs at every gated release; pairs with the existing
   "publish job awaits env approval, self-approve via gh api" lesson —
   this is the exact-flag correction.
+
+- **A long `pytest` run that shows ZERO output for 20+ min is usually
+  OUTPUT BUFFERING, not a deadlock — confirm with `ps` (CPU time
+  climbing = alive) before killing, and avoid the two buffer traps**:
+  ran the full `-m "not live"` suite from a worktree and saw 0 bytes of
+  output for 20 min — looked like the known xdist finalize-hang. It
+  wasn't: `ps aux | grep '[p]ytest'` showed the process at ~22% CPU
+  with cumulative CPU time *climbing*, i.e. genuinely running. Two
+  independent buffering traps had hidden all progress: (1) piping
+  through `| tail -N` buffers the ENTIRE stream until the process exits
+  (tail only prints the last N lines at EOF) — never pipe a
+  long-running test command through `tail` if you want progress; redirect
+  to a file with `> out.txt 2>&1` instead; (2) passing `-o addopts=`
+  STRIPS the repo's default `-n auto`, so the suite runs single-process
+  and is ~Nx slower (here 22320 tests single-process vs 2:54 with
+  `-n auto`). The fix that gave both speed AND streaming progress:
+  `PYTHONPATH=<worktree>/src ANTHROPIC_API_KEY="" <main-venv>/python -m
+  pytest -m "not live" -n auto -q > /tmp/run.txt 2>&1` (xdist flushes
+  the `....` progress line to the file as workers complete chunks).
+  Result: 22320 passed / 218 skipped / 6 xfailed in 2:54. Distinct from
+  the real CI-runner-hang lesson (that's an actual finalize-deadlock at
+  ~100%); the `ps` CPU-climbing check is what tells them apart before
+  you waste a kill+rerun cycle. Pairs with the worktree-PYTHONPATH
+  lesson (run worktree code, not main's via the editable MAPPING).

--- a/.claude/plans/extended-cache-ttl-siblings.md
+++ b/.claude/plans/extended-cache-ttl-siblings.md
@@ -1,0 +1,36 @@
+# Plan: Extended Cache TTL — Sibling Packages
+
+**Spec**: [specs/extended-cache-ttl-siblings/](../../specs/extended-cache-ttl-siblings/)
+**Created**: 2026-06-22
+
+---
+
+## Summary
+
+`attune-rag` shipped an env-driven extended prompt-cache TTL
+(`ATTUNE_RAG_CACHE_TTL=1h` → 1-hour `cache_control` window via
+`_cache_control()` in `attune_rag/providers/claude.py`). This plan
+mirrors that helper into the sibling packages so the longer window
+is reachable there too, byte-identical when the env var is unset.
+
+---
+
+## Tasks
+
+- **Task A — attune-ai** (this repo): add `_cache_control()` to
+  `src/attune/llm/providers/anthropic.py` (env var
+  `ATTUNE_CACHE_TTL`) and route all three `cache_control` emit
+  sites through it. Tests + `-m "not live"` suite. One PR.
+- **Task B — attune-author** (separate repo, separate PR):
+  same mirror. **Do not start in the attune-ai session.**
+
+See [the spec](../../specs/extended-cache-ttl-siblings/tasks.md)
+for per-task status.
+
+---
+
+## Reference
+
+- Source helper: `attune-rag/src/attune_rag/providers/claude.py`
+  (`_cache_control`).
+- Mirror tests: `attune-rag/tests/unit/providers/test_claude_cache_ttl.py`.

--- a/specs/extended-cache-ttl-siblings/design.md
+++ b/specs/extended-cache-ttl-siblings/design.md
@@ -1,0 +1,61 @@
+# Design: Extended Cache TTL — Sibling Packages
+
+**Status**: approved (2026-06-22)
+
+---
+
+## Source of truth
+
+`attune_rag/providers/claude.py`:
+
+```python
+def _cache_control() -> dict[str, str]:
+    if os.getenv("ATTUNE_RAG_CACHE_TTL", "5m").strip().lower() == "1h":
+        return {"type": "ephemeral", "ttl": "1h"}
+    return {"type": "ephemeral"}
+```
+
+Read per-call (not memoized) so tests can flip the value with
+`monkeypatch.setenv`; the cost is one `os.getenv` on an
+already-networked path.
+
+---
+
+## Task A — attune-ai
+
+**File**: `src/attune/llm/providers/anthropic.py`
+
+Add a module-level `_cache_control()` identical to the rag helper
+except the env var is `ATTUNE_CACHE_TTL` (no `_RAG_` infix — this
+is the general-purpose provider).
+
+**Emit sites routed through the helper** (three today):
+
+| Method | What it caches |
+|--------|----------------|
+| `generate()` | system-prompt prefix block |
+| `analyze_large_codebase()` | codebase-files block |
+| `generate_stream()` | system-prompt prefix block |
+
+Each previously held a literal `{"type": "ephemeral"}`; all three
+now call `_cache_control()`.
+
+---
+
+## Why per-package copies, not a shared module
+
+The helper is ~16 lines and the env var name differs per package
+by design (a rag dashboard sweep and an attune-ai workflow run are
+independently tunable). A shared module would couple the release
+cadence of otherwise-independent PyPI packages for no real saving.
+This matches the existing rag precedent; see requirements
+Non-goals.
+
+---
+
+## Testing
+
+Mock the `anthropic` client; assert the `cache_control` dict at
+each emit site for both the default (env unset) and `1h`. Mirrors
+`attune-rag/tests/unit/providers/test_claude_cache_ttl.py`. No live
+API — runs under `-m "not live"`.

--- a/specs/extended-cache-ttl-siblings/requirements.md
+++ b/specs/extended-cache-ttl-siblings/requirements.md
@@ -1,0 +1,66 @@
+# Requirements: Extended Cache TTL — Sibling Packages
+
+**Status**: approved (2026-06-22)
+**Owner**: patrick + agent
+
+---
+
+## Problem
+
+`attune-rag` shipped an env-driven extended prompt-cache TTL:
+`ATTUNE_RAG_CACHE_TTL=1h` flips the Anthropic `cache_control`
+marker from the default 5-minute ephemeral window to a 1-hour
+window at the same per-token rate
+(`attune_rag/providers/claude.py:26` `_cache_control()`).
+
+The sibling packages that also attach `cache_control` markers to
+Claude requests hardcode `{"type": "ephemeral"}` and cannot opt
+into the longer window. Dashboards and benchmark sweeps that issue
+clusters of related queries within an hour pay repeated cache-write
+cost they could avoid.
+
+---
+
+## Goal
+
+Mirror the shipped `attune-rag` `_cache_control()` helper into the
+sibling packages so the 1-hour window is reachable via an
+environment variable, with behavior byte-identical to today when
+the variable is unset.
+
+---
+
+## Scope
+
+- **Task A — attune-ai** (this repo): add `_cache_control()` to
+  `src/attune/llm/providers/anthropic.py` and route every
+  `cache_control` emit site through it. Env var `ATTUNE_CACHE_TTL`.
+- **Task B — attune-author** (separate repo, separate PR): same
+  mirror in its Claude provider path. Deferred — not in this
+  session.
+
+Out of scope: changing the default window; any non-Anthropic
+provider; any caller-facing API change.
+
+---
+
+## Acceptance criteria
+
+1. `_cache_control()` returns `{"type": "ephemeral", "ttl": "1h"}`
+   when the package env var is `1h` (case/whitespace insensitive),
+   and `{"type": "ephemeral"}` for unset / `5m` / any other value.
+2. Every existing `cache_control` emit site in the target provider
+   routes through the helper — no remaining hardcoded marker.
+3. Default behavior (env unset) is byte-identical to the prior
+   wire shape; existing tests stay green.
+4. Wire-shape tests lock both the default and the `1h` marker at
+   every emit site, mocked — no live API.
+
+---
+
+## Non-goals
+
+- A shared cross-package helper module. Each package keeps its own
+  small copy with its own env var name (`ATTUNE_RAG_CACHE_TTL`,
+  `ATTUNE_CACHE_TTL`), matching the existing rag precedent. The
+  duplication is ~16 lines and deliberate.

--- a/specs/extended-cache-ttl-siblings/tasks.md
+++ b/specs/extended-cache-ttl-siblings/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: Extended Cache TTL — Sibling Packages
+
+**Status**: in progress (2026-06-22) — Task A (attune-ai) done;
+Task B (attune-author) deferred to a separate session + PR.
+
+---
+
+## Task A — attune-ai ✓ complete 2026-06-22
+
+Mirror `attune-rag`'s `_cache_control()` into attune-ai's Claude
+provider.
+
+1. ✓ **Add `_cache_control()` helper** to
+   `src/attune/llm/providers/anthropic.py` reading
+   `ATTUNE_CACHE_TTL` (`1h` → extended marker; unset/`5m`/other →
+   default).
+2. ✓ **Route all three emit sites** through the helper
+   (`generate`, `analyze_large_codebase`, `generate_stream`) —
+   no remaining hardcoded `{"type": "ephemeral"}`.
+3. ✓ **Wire-shape tests** —
+   `tests/llm/test_anthropic_cache_ttl.py`: parametrized helper
+   test plus default + `1h` assertions at each emit site (mocked,
+   `-m "not live"`).
+4. ✓ **Suite green** — `tests/llm/` 283 passed; full `-m "not
+   live"` run clean.
+
+PR: _(linked on open)_
+
+## Task B — attune-author ⬜ pending
+
+Same mirror in attune-author's Claude provider path. **Separate
+repo, separate PR — not started in the attune-ai session.** Pick
+the package-local env var name (`ATTUNE_AUTHOR_CACHE_TTL` or reuse
+`ATTUNE_CACHE_TTL` — decide at task time) and route its emit
+site(s) through a local `_cache_control()` copy.

--- a/specs/extended-cache-ttl-siblings/tasks.md
+++ b/specs/extended-cache-ttl-siblings/tasks.md
@@ -24,7 +24,7 @@ provider.
 4. ✓ **Suite green** — `tests/llm/` 283 passed; full `-m "not
    live"` run clean.
 
-PR: _(linked on open)_
+PR: [attune-ai#998](https://github.com/Smart-AI-Memory/attune-ai/pull/998)
 
 ## Task B — attune-author ⬜ pending
 

--- a/src/attune/llm/providers/anthropic.py
+++ b/src/attune/llm/providers/anthropic.py
@@ -5,6 +5,7 @@ Licensed under the Apache License, Version 2.0
 """
 
 import logging
+import os
 import re
 from collections.abc import AsyncGenerator
 from typing import Any
@@ -18,6 +19,27 @@ logger = logging.getLogger(__name__)
 # future opus-4-9 / opus-4-1x. Older models (Opus 4.6-, Sonnet, Haiku)
 # still accept these params, so they're left untouched.
 _OPUS_NO_SAMPLING_RE = re.compile(r"opus-4-(?:[7-9]|\d{2,})")
+
+
+def _cache_control() -> dict[str, str]:
+    """Resolve the ephemeral ``cache_control`` marker from the environment.
+
+    ``ATTUNE_CACHE_TTL=1h`` extends the prompt-cache window from the
+    5-minute default to 1 hour at the same per-token rate — useful for
+    dashboards and benchmark sweeps that issue clusters of related queries
+    within an hour. Any other value (including unset or ``5m``) yields the
+    default 5-minute ephemeral marker, byte-identical to the prior behavior.
+
+    Read per-call (not cached in a module global) so tests can flip it via
+    ``monkeypatch.setenv``; the cost is one ``os.getenv`` on an
+    already-networked path.
+
+    Mirrors ``attune_rag.providers.claude._cache_control`` (env var
+    ``ATTUNE_RAG_CACHE_TTL``); see specs/extended-cache-ttl-siblings/.
+    """
+    if os.getenv("ATTUNE_CACHE_TTL", "5m").strip().lower() == "1h":
+        return {"type": "ephemeral", "ttl": "1h"}
+    return {"type": "ephemeral"}
 
 
 def _normalize_api_kwargs_for_model(api_kwargs: dict[str, Any]) -> None:
@@ -156,7 +178,7 @@ class AnthropicProvider(BaseLLMProvider):
                 {
                     "type": "text",
                     "text": system_prompt,
-                    "cache_control": {"type": "ephemeral"},
+                    "cache_control": _cache_control(),
                 },
             ]
         elif system_prompt:
@@ -305,7 +327,7 @@ class AnthropicProvider(BaseLLMProvider):
             {
                 "type": "text",
                 "text": f"Codebase files:\n\n{file_context}",
-                "cache_control": {"type": "ephemeral"},  # Cache the codebase
+                "cache_control": _cache_control(),  # Cache the codebase
             },
         ]
 
@@ -356,7 +378,7 @@ class AnthropicProvider(BaseLLMProvider):
                 {
                     "type": "text",
                     "text": system_prompt,
-                    "cache_control": {"type": "ephemeral"},
+                    "cache_control": _cache_control(),
                 },
             ]
         elif system_prompt:

--- a/tests/llm/test_anthropic_cache_ttl.py
+++ b/tests/llm/test_anthropic_cache_ttl.py
@@ -1,0 +1,218 @@
+"""Cache-TTL wire-shape tests for AnthropicProvider.
+
+``ATTUNE_CACHE_TTL=1h`` extends the prompt-cache window from the
+5-minute default to 1 hour by adding ``"ttl": "1h"`` to the
+``cache_control`` marker. These tests lock the wire shape at all three
+emit sites (``generate`` system prefix, ``analyze_large_codebase``
+codebase block, ``generate_stream`` system prefix) for the default and
+the 1h value, mocking the client — no live API.
+
+Mirrors attune-rag's ``tests/unit/providers/test_claude_cache_ttl.py``;
+see specs/extended-cache-ttl-siblings/ for the cross-package rollout.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from attune.llm.providers import AnthropicProvider
+from attune.llm.providers.anthropic import _cache_control
+
+_EPHEMERAL = {"type": "ephemeral"}
+_EPHEMERAL_1H = {"type": "ephemeral", "ttl": "1h"}
+
+
+def _make_mock_anthropic(client: MagicMock) -> MagicMock:
+    """Build a mock ``anthropic`` module exposing the async client."""
+    mock_anthropic = MagicMock()
+    mock_anthropic.AsyncAnthropic.return_value = client
+    return mock_anthropic
+
+
+class _FakeStream:
+    """Async context manager mimicking ``client.messages.stream(...)``."""
+
+    def __init__(self, texts):
+        self._texts = texts
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    @property
+    def text_stream(self):
+        texts = self._texts
+
+        async def _gen():
+            for text in texts:
+                yield text
+
+        return _gen()
+
+
+# --- _cache_control() helper ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, _EPHEMERAL),  # unset → default
+        ("5m", _EPHEMERAL),  # explicit default
+        ("1h", _EPHEMERAL_1H),  # extended
+        (" 1H ", _EPHEMERAL_1H),  # case + whitespace insensitive
+        ("30m", _EPHEMERAL),  # unsupported value → safe default
+        ("", _EPHEMERAL),  # empty → default
+    ],
+)
+def test_cache_control_resolves_from_env(monkeypatch: pytest.MonkeyPatch, value, expected) -> None:
+    if value is None:
+        monkeypatch.delenv("ATTUNE_CACHE_TTL", raising=False)
+    else:
+        monkeypatch.setenv("ATTUNE_CACHE_TTL", value)
+    assert _cache_control() == expected
+
+
+# --- generate() system prefix site ------------------------------------------
+
+
+def _make_response(text: str = "ok") -> MagicMock:
+    block = MagicMock()
+    block.text = text
+    response = MagicMock()
+    response.content = [block]
+    response.usage = MagicMock(input_tokens=1, output_tokens=1)
+    response.stop_reason = "end_turn"
+    return response
+
+
+@pytest.mark.asyncio
+async def test_generate_system_prefix_carries_1h_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ATTUNE_CACHE_TTL=1h the cached system block carries the
+    extended marker."""
+    monkeypatch.setenv("ATTUNE_CACHE_TTL", "1h")
+    client = MagicMock()
+    client.messages.create = AsyncMock(return_value=_make_response())
+    mock_anthropic = _make_mock_anthropic(client)
+
+    with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+        provider = AnthropicProvider(api_key="test-key", use_prompt_caching=True)
+        await provider.generate([{"role": "user", "content": "hi"}], system_prompt="be helpful")
+
+    system = client.messages.create.await_args.kwargs["system"]
+    assert system[0]["cache_control"] == _EPHEMERAL_1H
+
+
+@pytest.mark.asyncio
+async def test_generate_system_prefix_defaults_to_5m(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset env → the system marker is byte-identical to the prior default."""
+    monkeypatch.delenv("ATTUNE_CACHE_TTL", raising=False)
+    client = MagicMock()
+    client.messages.create = AsyncMock(return_value=_make_response())
+    mock_anthropic = _make_mock_anthropic(client)
+
+    with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+        provider = AnthropicProvider(api_key="test-key", use_prompt_caching=True)
+        await provider.generate([{"role": "user", "content": "hi"}], system_prompt="be helpful")
+
+    system = client.messages.create.await_args.kwargs["system"]
+    assert system[0]["cache_control"] == _EPHEMERAL
+
+
+# --- analyze_large_codebase() codebase block site ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_analyze_codebase_block_carries_1h_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With 1h set, the cached codebase block carries the extended marker."""
+    monkeypatch.setenv("ATTUNE_CACHE_TTL", "1h")
+    client = MagicMock()
+    client.messages.create = AsyncMock(return_value=_make_response())
+    mock_anthropic = _make_mock_anthropic(client)
+
+    with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+        provider = AnthropicProvider(api_key="test-key")
+        await provider.analyze_large_codebase(
+            codebase_files=[{"path": "a.py", "content": "x = 1"}],
+            analysis_prompt="summarize",
+        )
+
+    system = client.messages.create.await_args.kwargs["system"]
+    assert system[1]["cache_control"] == _EPHEMERAL_1H
+
+
+@pytest.mark.asyncio
+async def test_analyze_codebase_block_defaults_to_5m(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset env → codebase-block marker is byte-identical to prior default."""
+    monkeypatch.delenv("ATTUNE_CACHE_TTL", raising=False)
+    client = MagicMock()
+    client.messages.create = AsyncMock(return_value=_make_response())
+    mock_anthropic = _make_mock_anthropic(client)
+
+    with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+        provider = AnthropicProvider(api_key="test-key")
+        await provider.analyze_large_codebase(
+            codebase_files=[{"path": "a.py", "content": "x = 1"}],
+            analysis_prompt="summarize",
+        )
+
+    system = client.messages.create.await_args.kwargs["system"]
+    assert system[1]["cache_control"] == _EPHEMERAL
+
+
+# --- generate_stream() system prefix site -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_system_prefix_carries_1h_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With 1h set, the streamed system block carries the extended marker."""
+    monkeypatch.setenv("ATTUNE_CACHE_TTL", "1h")
+    client = MagicMock()
+    client.messages.stream = MagicMock(return_value=_FakeStream(["x"]))
+    mock_anthropic = _make_mock_anthropic(client)
+
+    with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+        provider = AnthropicProvider(api_key="test-key", use_prompt_caching=True)
+        _ = [
+            c
+            async for c in provider.generate_stream(
+                [{"role": "user", "content": "hi"}], system_prompt="be helpful"
+            )
+        ]
+
+    system = client.messages.stream.call_args.kwargs["system"]
+    assert system[0]["cache_control"] == _EPHEMERAL_1H
+
+
+@pytest.mark.asyncio
+async def test_stream_system_prefix_defaults_to_5m(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset env → streamed system marker is byte-identical to prior default."""
+    monkeypatch.delenv("ATTUNE_CACHE_TTL", raising=False)
+    client = MagicMock()
+    client.messages.stream = MagicMock(return_value=_FakeStream(["x"]))
+    mock_anthropic = _make_mock_anthropic(client)
+
+    with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+        provider = AnthropicProvider(api_key="test-key", use_prompt_caching=True)
+        _ = [
+            c
+            async for c in provider.generate_stream(
+                [{"role": "user", "content": "hi"}], system_prompt="be helpful"
+            )
+        ]
+
+    system = client.messages.stream.call_args.kwargs["system"]
+    assert system[0]["cache_control"] == _EPHEMERAL


### PR DESCRIPTION
## What

Task A of **specs/extended-cache-ttl-siblings/** — mirror
attune-rag's shipped `_cache_control()` helper into attune-ai's
Claude provider so the extended 1-hour prompt-cache window is
reachable via an environment variable.

`ATTUNE_CACHE_TTL=1h` flips the Anthropic `cache_control` marker
from the default 5-minute ephemeral window to a 1-hour window at
the same per-token rate — useful for dashboards and benchmark
sweeps that issue clusters of related queries within an hour. Unset
/ `5m` / any other value yields the prior default marker,
byte-identical to before.

## Changes

- `src/attune/llm/providers/anthropic.py`: add module-level
  `_cache_control()` (reads `ATTUNE_CACHE_TTL`, per-call so tests
  can `monkeypatch.setenv`).
- Route all three `cache_control` emit sites through it —
  `generate()`, `analyze_large_codebase()`, `generate_stream()`.
  No remaining hardcoded `{"type": "ephemeral"}`.
- `tests/llm/test_anthropic_cache_ttl.py`: parametrized helper test
  plus default + `1h` assertions at every emit site (mocked, no
  live API).

## Mirrors

- Source: `attune-rag/src/attune_rag/providers/claude.py`
  (`_cache_control`, env `ATTUNE_RAG_CACHE_TTL`).
- Tests: `attune-rag/tests/unit/providers/test_claude_cache_ttl.py`.

## Verification

- `tests/llm/` — 283 passed.
- Full `-m "not live"` suite — **22320 passed, 218 skipped,
  6 xfailed, 0 failures**.
- black + ruff pre-flight clean.

## Out of scope

Task B (attune-author) is a **separate repo and a separate PR** —
not started here. See
[specs/extended-cache-ttl-siblings/tasks.md](specs/extended-cache-ttl-siblings/tasks.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
