### PR TITLE
release: 8.8.0 — opt-in extended cache TTL + project-local starters

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.7.1"
+    "version": "8.8.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "8.7.1",
+      "version": "8.8.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.7.1
+# Attune AI Framework v8.8.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.7.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.8.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.8.0] — 2026-06-22
+
+Two opt-in features — an extended prompt-cache window for the
+Anthropic provider, and project-local session-handoff starters.
+
+### Added
+
+- **Extended prompt-cache TTL (opt-in).** Setting
+  `ATTUNE_CACHE_TTL=1h` extends the Anthropic prompt-cache window from
+  the 5-minute default to 1 hour at the same per-token rate — useful
+  for dashboards and benchmark sweeps that issue clusters of related
+  queries within an hour. A new module-level `_cache_control()` helper
+  in `attune.llm.providers.anthropic` resolves the marker from the
+  environment (read per call) and is routed through all three
+  `cache_control` emit sites (`generate`, `analyze_large_codebase`,
+  `generate_stream`). Unset / `5m` / any other value is byte-identical
+  to prior behavior. Sibling of attune-author's
+  `ATTUNE_AUTHOR_CACHE_TTL` and attune-rag's `ATTUNE_RAG_CACHE_TTL`.
+  (#998)
+- **Project-local session-handoff starters.** The `SessionStart`
+  starter-prompt hook now also surfaces a repo-local
+  `.attune/next_session_starter.md`, so a session handing off to a
+  different repo can leave a repo-specific starter without clobbering
+  the global `~/.attune/next_session_starter.md`. (#994)
+
 ## [8.7.1] — 2026-06-22
 
 Docs/distribution patch — **no runtime changes** (`src/attune` is

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.7.1
+**Version:** 8.8.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.7.1 | **License:** Apache 2.0
+**Version:** 8.8.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.7.1"
+    "version": "8.8.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.7.1",
+      "version": "8.8.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.7.1",
+  "version": "8.8.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.7.1"
+__version__ = "8.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.7.1"
+version = "8.8.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.7.1"
+version = "8.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What

Minor release bundling the two opt-in features merged since 8.7.1.

### Added

- **Extended prompt-cache TTL** — `ATTUNE_CACHE_TTL=1h` extends the
  Anthropic prompt-cache window from 5min to 1h via `_cache_control()`
  in `attune.llm.providers.anthropic`, routed through all three emit
  sites. Byte-identical when unset.
  ([#998](https://github.com/Smart-AI-Memory/attune-ai/pull/998))
- **Project-local session-handoff starters** — `SessionStart` hook
  surfaces repo-local `.attune/next_session_starter.md` for cross-repo
  handoffs.
  ([#994](https://github.com/Smart-AI-Memory/attune-ai/pull/994))

## Release mechanics

- `bump_version.py 8.8.0` → 7 files / 9 sites
- CHANGELOG `[Unreleased]` → `[8.8.0] — 2026-06-22`
- `uv.lock`; `test_all_versions_match` + version tests green locally

Sibling release: **attune-author 0.22.0** (already published) ships the
matching `ATTUNE_AUTHOR_CACHE_TTL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)