### PR TITLE
test(orchestration): fix xdist KeyError flake in test_real_tools

### DIFF
--- a/tests/unit/orchestration/test_real_tools.py
+++ b/tests/unit/orchestration/test_real_tools.py
@@ -507,17 +507,13 @@ class TestRealTestGenerator:
         """Test that missing API key disables LLM mode."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-        # Mock anthropic module and prevent load_dotenv from restoring
-        # the key from .env files. Use sys.modules patch to avoid
-        # __import__ mock issues with Python 3.13 ExceptionGroup.
-        with (
-            patch.dict("sys.modules", {"anthropic": Mock()}),
-            patch(
-                "os.environ.get",
-                side_effect=lambda k, *a: (
-                    None if k == "ANTHROPIC_API_KEY" else os.environ.get(k, *a)
-                ),
-            ),
+        # With no key, _initialize_llm bails before constructing the client,
+        # so the real anthropic import is harmless and left intact. Patch
+        # os.environ.get so load_dotenv can't restore a key from a .env file.
+        # (No global sys.modules swap — that races under xdist.)
+        with patch(
+            "os.environ.get",
+            side_effect=lambda k, *a: (None if k == "ANTHROPIC_API_KEY" else os.environ.get(k, *a)),
         ):
             generator = RealTestGenerator(
                 project_root=str(tmp_path),
@@ -527,15 +523,17 @@ class TestRealTestGenerator:
 
         assert generator.use_llm is False  # Should fallback to template mode
 
-    def test_init_with_api_key_enables_llm(self, tmp_path, monkeypatch):
+    def test_init_with_api_key_enables_llm(self, tmp_path):
         """Test that API key enables LLM mode."""
-        # Mock the Anthropic import
-        mock_anthropic_module = Mock()
+        # Patch the import target directly. anthropic is installed, so
+        # patch("anthropic.Anthropic", ...) swaps a single attribute and
+        # restores it. Swapping the whole sys.modules entry instead
+        # (patch.dict) clears+rebuilds the global dict on teardown, which
+        # races under xdist and surfaces as a transient KeyError.
         mock_client = Mock()
         mock_anthropic_class = Mock(return_value=mock_client)
-        mock_anthropic_module.Anthropic = mock_anthropic_class
 
-        with patch.dict("sys.modules", {"anthropic": mock_anthropic_module}):
+        with patch("anthropic.Anthropic", mock_anthropic_class):
             generator = RealTestGenerator(
                 project_root=str(tmp_path),
                 api_key="test-key-123",
@@ -546,18 +544,21 @@ class TestRealTestGenerator:
             assert generator._llm == mock_client
             mock_anthropic_class.assert_called_once_with(api_key="test-key-123")
 
-    def test_init_with_missing_anthropic_package_disables_llm(self, tmp_path):
-        """Test that missing anthropic package disables LLM.
+    def test_init_with_missing_anthropic_package_disables_llm(self, tmp_path, monkeypatch):
+        """Test that a missing anthropic symbol disables LLM.
 
-        Uses sys.modules patch (setting to None triggers ImportError)
-        instead of __import__ mock to avoid Python 3.13 ExceptionGroup.
+        Deletes the Anthropic attribute so ``from anthropic import Anthropic``
+        raises ImportError. Surgical (monkeypatch restores the attribute) and
+        avoids swapping the whole sys.modules, which races under xdist.
         """
-        with patch.dict("sys.modules", {"anthropic": None}):
-            generator = RealTestGenerator(
-                project_root=str(tmp_path),
-                api_key="test-key",
-                use_llm=True,
-            )
+        import anthropic
+
+        monkeypatch.delattr(anthropic, "Anthropic", raising=False)
+        generator = RealTestGenerator(
+            project_root=str(tmp_path),
+            api_key="test-key",
+            use_llm=True,
+        )
 
         assert generator.use_llm is False  # Should fallback
 
@@ -630,10 +631,10 @@ def test_example():
         ]
         mock_client.messages.create.return_value = mock_response
 
-        # Mock the Anthropic import
-        mock_anthropic_module = Mock()
+        # Patch the import target directly (see note in
+        # test_init_with_api_key_enables_llm — avoids the xdist-racy
+        # whole-sys.modules swap).
         mock_anthropic_class = Mock(return_value=mock_client)
-        mock_anthropic_module.Anthropic = mock_anthropic_class
 
         # Create source file
         src_dir = tmp_path / "src"
@@ -641,7 +642,7 @@ def test_example():
         source_file = src_dir / "example.py"
         source_file.write_text("def foo(): pass")
 
-        with patch.dict("sys.modules", {"anthropic": mock_anthropic_module}):
+        with patch("anthropic.Anthropic", mock_anthropic_class):
             generator = RealTestGenerator(
                 project_root=str(tmp_path),
                 api_key="test-key",
@@ -674,17 +675,17 @@ def test_example():
         ]
         mock_client.messages.create.return_value = mock_response
 
-        # Mock the Anthropic import
-        mock_anthropic_module = Mock()
+        # Patch the import target directly (see note in
+        # test_init_with_api_key_enables_llm — avoids the xdist-racy
+        # whole-sys.modules swap).
         mock_anthropic_class = Mock(return_value=mock_client)
-        mock_anthropic_module.Anthropic = mock_anthropic_class
 
         src_dir = tmp_path / "src"
         src_dir.mkdir()
         source_file = src_dir / "example.py"
         source_file.write_text("def foo(): pass")
 
-        with patch.dict("sys.modules", {"anthropic": mock_anthropic_module}):
+        with patch("anthropic.Anthropic", mock_anthropic_class):
             generator = RealTestGenerator(
                 project_root=str(tmp_path),
                 api_key="test-key",
@@ -707,17 +708,17 @@ def test_example():
         # All models fail
         mock_client.messages.create.side_effect = Exception("API Error")
 
-        # Mock the Anthropic import
-        mock_anthropic_module = Mock()
+        # Patch the import target directly (see note in
+        # test_init_with_api_key_enables_llm — avoids the xdist-racy
+        # whole-sys.modules swap).
         mock_anthropic_class = Mock(return_value=mock_client)
-        mock_anthropic_module.Anthropic = mock_anthropic_class
 
         src_dir = tmp_path / "src"
         src_dir.mkdir()
         source_file = src_dir / "example.py"
         source_file.write_text("def foo(): pass")
 
-        with patch.dict("sys.modules", {"anthropic": mock_anthropic_module}):
+        with patch("anthropic.Anthropic", mock_anthropic_class):
             generator = RealTestGenerator(
                 project_root=str(tmp_path),
                 api_key="test-key",


### PR DESCRIPTION
## Problem

`tests/unit/orchestration/test_real_tools.py::TestRealTestGenerator::test_init_with_api_key_enables_llm`
flaked on CI (#1001's `test (ubuntu-latest, 3.11)` lane) with
`KeyError: <object-id>` — while passing on every other OS/Python lane,
the full-suite `coverage` job, and in local isolation.

## Root cause

The `RealTestGenerator` init tests mocked the anthropic import via
`patch.dict("sys.modules", {"anthropic": ...})`. `patch.dict`'s teardown
does `sys.modules.clear()` then rebuilds it from a snapshot — a
**non-atomic global clear+rebuild**. Under xdist, with GC finalizers
firing (or a background thread) touching `sys.modules` during that
window, it races and surfaces as a transient `KeyError` keyed by an
object id. It's the only `sys.modules`-wide mutation in the file, and
`KeyError: <id>` is the signature of concurrent dict mutation.

## Fix

`anthropic` is an installed dependency, so patch the **single import
target** instead of swapping all of `sys.modules`:

- "enabled" tests → `patch("anthropic.Anthropic", mock_class)` (restores
  one attribute; no global swap)
- "no api key" test → drop the mock entirely (init bails before
  constructing the client); keep the `os.environ.get` patch
- "missing package" test → `monkeypatch.delattr(anthropic, "Anthropic")`
  so `from anthropic import Anthropic` raises `ImportError` surgically

Behavior assertions unchanged. No `patch.dict("sys.modules")` remains in
the file.

## Verification

- 6 affected tests pass in isolation
- full file green across 3 consecutive xdist rounds (`-n 4`)
- whole `tests/unit/orchestration/` dir: 752 passed
- black + ruff clean

## Follow-up (not in this PR)

~60 other test files use the same `patch.dict("sys.modules")` pattern —
a latent flake source. Worth a sweep if this class recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)