### PR TITLE
test(ci): guard against new patch.dict("sys.modules") + fake_module fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -665,3 +665,36 @@ def mock_workflow_config():
         "telemetry_enabled": False,
         "user_id": "test-user",
     }
+
+
+@pytest.fixture
+def fake_module(monkeypatch):
+    """Surgically register a fake/absent module in ``sys.modules``.
+
+    Use this INSTEAD of ``patch.dict`` on ``sys.modules``. That helper's
+    teardown does ``sys.modules.clear()`` then rebuilds from a snapshot — a
+    non-atomic global clear+rebuild that races under xdist (a background
+    thread or GC finalizer touching ``sys.modules`` mid-clear surfaces as a
+    transient ``KeyError: <object-id>``). ``monkeypatch.setitem`` restores
+    only the single key on teardown, so there is no global clear and no race.
+
+    Returns a factory ``register(name, module=None) -> module``:
+
+    - ``register("somepkg", mock)`` makes ``import somepkg`` return ``mock``.
+    - ``register("somepkg")`` (module=None) simulates an ABSENT package —
+      ``import somepkg`` / ``from somepkg import X`` raises ``ImportError``.
+
+    For an INSTALLED package where you only need to stub one symbol, prefer
+    patching that attribute directly, e.g. ``patch("anthropic.Anthropic", m)``
+    — it is even narrower than faking the whole module.
+
+    Example:
+        >>> def test_optional_dep_missing(fake_module):
+        ...     fake_module("some_optional_pkg")  # import now raises
+    """
+
+    def register(name: str, module=None):
+        monkeypatch.setitem(sys.modules, name, module)
+        return module
+
+    return register

--- a/tests/unit/ci/test_no_new_sys_modules_patch.py
+++ b/tests/unit/ci/test_no_new_sys_modules_patch.py
@@ -1,0 +1,149 @@
+"""Guard: no NEW ``patch.dict("sys.modules", ...)`` in the test suite.
+
+``patch.dict("sys.modules", {...})`` is convenient for mocking an import,
+but its teardown does ``sys.modules.clear()`` followed by a rebuild from a
+snapshot — a non-atomic global clear+rebuild. Under xdist, a background
+thread or a GC finalizer touching ``sys.modules`` during that window races
+and surfaces as a transient ``KeyError: <object-id>`` (the signature of a
+concurrent dict mutation). This bit ``test_real_tools.py`` on CI; see the
+fix in that file and the ``.claude/lessons.md`` entry.
+
+Safer alternatives (both surgical — they restore only the touched key):
+
+- Installed package, one symbol → ``patch("pkg.Attr", mock)``.
+- Fake or absent whole module → the ``fake_module`` fixture in
+  ``tests/conftest.py`` (wraps ``monkeypatch.setitem(sys.modules, ...)``).
+
+This guard does NOT force the existing 219 sites to be converted — it
+freezes them as a per-file baseline so the debt cannot GROW. As files are
+converted (opportunistically, when they flake), ratchet their entry DOWN
+(or delete it). A new/raised usage anywhere fails this test.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TESTS_DIR = REPO_ROOT / "tests"
+
+# Matches ``patch.dict("sys.modules"`` / ``patch.dict('sys.modules'`` with
+# any whitespace (including newlines) after the opening paren.
+_PATTERN = re.compile(r"""patch\.dict\(\s*["']sys\.modules["']""")
+
+# Per-file frozen baseline (relative to tests/). Ratchet DOWN as files are
+# converted; never add an entry. Captured 2026-06-22.
+_BASELINE: dict[str, int] = {
+    "agent_factory/test_llm_toolkit_langgraph_adapter.py": 4,
+    "agent_factory/test_native_adapter.py": 2,
+    "llm/test_anthropic_cache_ttl.py": 6,
+    "llm/test_anthropic_provider_coverage.py": 9,
+    "llm/test_llm_toolkit_providers.py": 1,
+    "llm/test_providers.py": 17,
+    "memory/test_claude_memory.py": 1,
+    "models/test_token_estimator.py": 1,
+    "unit/agent_factory/test_langgraph_adapter.py": 8,
+    "unit/cli_commands/test_provider_commands.py": 33,
+    "unit/cli_commands/test_telemetry_commands.py": 19,
+    "unit/cli_commands/test_utility_commands.py": 24,
+    "unit/commands/test_context.py": 2,
+    "unit/help/test_polish.py": 4,
+    "unit/help/test_usage_weights.py": 7,
+    "unit/hooks/test_help_hooks.py": 1,
+    "unit/mcp/handlers/test_telemetry_handlers.py": 2,
+    "unit/mcp/test_version_check.py": 5,
+    "unit/memory/test_control_panel_display.py": 3,
+    "unit/meta_workflows/test_llm_execution.py": 3,
+    "unit/meta_workflows/test_plan_generator.py": 1,
+    "unit/models/test_empathy_executor_new.py": 6,
+    "unit/orchestration/test_tools_test_generation.py": 4,
+    "unit/routing/test_classifier.py": 1,
+    "unit/socratic/test_llm_analyzer.py": 3,
+    "unit/socratic/test_llm_explainer.py": 3,
+    "unit/telemetry/test_cli_automation.py": 1,
+    "unit/test_batch_provider.py": 3,
+    "unit/test_coverage_batch1.py": 10,
+    "unit/test_coverage_batch10.py": 1,
+    "unit/test_coverage_batch17.py": 2,
+    "unit/test_coverage_batch9.py": 2,
+    "unit/test_event_streaming.py": 3,
+    "unit/test_main_entries.py": 9,
+    "unit/wizards/test_builtin_refactor_wizard.py": 1,
+    "unit/wizards/test_builtin_security_wizard.py": 1,
+    "unit/wizards/test_wizard_coverage_boost.py": 2,
+    "unit/workflows/test_coordination_mixin_coverage.py": 3,
+    "unit/workflows/test_document_gen_outline_stage.py": 1,
+    "unit/workflows/test_execution_mixin_branches.py": 1,
+    "unit/workflows/test_workflow_coordination.py": 6,
+    "unit/workflows/test_workflow_services.py": 3,
+}
+
+_HINT = (
+    "Use the `fake_module` fixture (tests/conftest.py) for a fake/absent "
+    "module, or `patch('pkg.Attr', mock)` for an installed package. "
+    'patch.dict("sys.modules", ...) clears+rebuilds all of sys.modules on '
+    "teardown and races under xdist (KeyError: <id>)."
+)
+
+
+# Files that legitimately contain the literal pattern in prose/regex (this
+# guard documents it; conftest documents the safe alternative) — never code.
+_SELF_EXCLUDE: frozenset[str] = frozenset(
+    {
+        "unit/ci/test_no_new_sys_modules_patch.py",
+    }
+)
+
+
+def _current_counts() -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for path in TESTS_DIR.rglob("*.py"):
+        rel = path.relative_to(TESTS_DIR).as_posix()
+        if rel in _SELF_EXCLUDE:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        n = len(_PATTERN.findall(text))
+        if n:
+            counts[rel] = n
+    return counts
+
+
+def test_no_new_sys_modules_patch_dict():
+    """Fail if any test file introduces or increases sys.modules patching."""
+    current = _current_counts()
+
+    new_files = sorted(set(current) - set(_BASELINE))
+    assert not new_files, (
+        'New file(s) use patch.dict("sys.modules", ...):\n  '
+        + "\n  ".join(new_files)
+        + f"\n\n{_HINT}"
+    )
+
+    grew = sorted(
+        f"{f}: {current[f]} > baseline {_BASELINE[f]}"
+        for f in current
+        if f in _BASELINE and current[f] > _BASELINE[f]
+    )
+    assert not grew, (
+        'patch.dict("sys.modules", ...) usage increased:\n  ' + "\n  ".join(grew) + f"\n\n{_HINT}"
+    )
+
+
+def test_sys_modules_patch_baseline_is_not_stale():
+    """If a baseline file was converted, ratchet its entry DOWN.
+
+    Keeps the baseline honest: an entry whose real count dropped (or which
+    no longer matches) must be lowered/removed so the guard stays tight.
+    """
+    current = _current_counts()
+    stale = sorted(
+        f"{f}: baseline {count} but now {current.get(f, 0)} — lower it"
+        for f, count in _BASELINE.items()
+        if current.get(f, 0) < count
+    )
+    assert (
+        not stale
+    ), "Baseline is looser than reality; ratchet these DOWN in " "_BASELINE:\n  " + "\n  ".join(
+        stale
+    )


### PR DESCRIPTION
## Why

`patch.dict` on `sys.modules` clears+rebuilds the entire global dict on
teardown — a non-atomic operation that races under xdist (a background
thread / GC finalizer touching `sys.modules` mid-clear surfaces as a
transient `KeyError: <object-id>`). That was the root cause of the
`test_real_tools` flake fixed in #1003.

Rather than rewrite all ~219 existing call sites (negative ROI — see
the analysis: ~25h to save ~minutes per 100 PRs), this **freezes the
debt and prevents growth**, and gives new tests a safe primitive.

## What

**`tests/conftest.py` — `fake_module` fixture.** Wraps
`monkeypatch.setitem(sys.modules, name, module)` (surgical — restores one
key, no global clear). Covers both cases the old pattern was used for:

- `fake_module("pkg", mock)` → `import pkg` returns the mock
- `fake_module("pkg")` → simulates an ABSENT package (import raises `ImportError`)

(For an installed package needing one symbol stubbed, prefer
`patch("pkg.Attr", m)` — even narrower.)

**`tests/unit/ci/test_no_new_sys_modules_patch.py` — ratchet guard.**
Per-file frozen baseline (42 files / 219 sites, captured today). Fails if
any test file **introduces** the pattern or **grows** its count. Existing
debt is frozen, not forced — convert files opportunistically (when they
flake) and ratchet their baseline entry DOWN.

## Verification

- Guard passes on current `main` (post-#1003); planted a new violation →
  guard fails naming the file; removed → passes.
- `fake_module` validated under xdist (absent + fake + no-leak), 3 passed.
- black + ruff clean.

This is the **B** half of the flake-class plan; **C** (opportunistic
per-file conversion) already started with #1003. Optional future **A**
(neutralize the concurrent `sys.modules` toucher — the leaked heartbeat
thread) would let all 219 sites stop racing without edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)