### PR TITLE
docs(lessons): patch.dict(sys.modules) xdist race + ratchet-guard pattern

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -10371,3 +10371,58 @@ files.
   "'Is the published version current?' is upload-time vs merge-time"
   lesson — both are about not trusting a convenient-but-stale version
   signal.
+
+- **A test that flakes ONLY under xdist with `KeyError: <big-int>`
+  (an object id) is the signature of `patch.dict("sys.modules", {...})`
+  — its teardown clears+rebuilds ALL of `sys.modules`, which races a
+  concurrent toucher**: hit 2026-06-22 on
+  `test_real_tools.py::...::test_init_with_api_key_enables_llm` — failed
+  on ONE CI lane (`test (ubuntu-latest, 3.11)`) with
+  `KeyError: 139878600014720`, while passing on every other OS/Python
+  lane, the full-suite `coverage` job, and local isolation. Diagnostic
+  chain: (1) the failing assertion would have been `AssertionError`, but
+  it was `KeyError` → the error escapes the SUT's own try/except, i.e.
+  it's in test setup/teardown, not the code under test; (2) the key is
+  `id()`-shaped (≈1.4e14) → a dict keyed by object identity mutated
+  concurrently; (3) in-file xdist repro PASSES → the leak is CROSS-FILE
+  (a co-tenant test in the same worker, not concurrency within the
+  file). Root cause confirmed by reading CPython
+  `unittest.mock._patch_dict._unpatch_dict`: it does `sys.modules.clear()`
+  then `update(snapshot)` — a non-atomic global clear+rebuild. Any
+  background thread or GC finalizer touching `sys.modules` during that
+  window (e.g. a leaked heartbeat thread) hits a half-cleared dict →
+  transient KeyError, blamed on whichever test was running. **Fix —
+  never swap the whole `sys.modules`; touch one key:** for an installed
+  package needing one symbol stubbed, `patch("anthropic.Anthropic", m)`
+  (restores one attribute). For a fake/absent whole module,
+  `monkeypatch.setitem(sys.modules, name, mock_or_None)` — surgical,
+  restores only that key (verified: `len(sys.modules)` unchanged after
+  teardown), and `=None` makes `import name` raise ImportError. A
+  `fake_module` conftest fixture wraps the setitem form. Also 3.13-safe
+  (no `__import__` mock → no ExceptionGroup). Pairs with the
+  windows-xdist-flakes crash inventory — same family (a test's teardown
+  racing the harness), different surface.
+
+- **Freeze a latent test-debt pattern with a per-file RATCHET GUARD
+  instead of a blanket rewrite — when fixing every instance is
+  negative-ROI**: 2026-06-22, after the patch.dict-sys.modules flake, a
+  blanket conversion of all 219 sites / 42 files measured at ~25h of
+  work to save ~minutes per 100 PRs (the flake fires on a low-single-%
+  of runs; most sites never race). The durable cheap move: a structural
+  test (`tests/unit/ci/test_no_new_*.py`, modeled on
+  `test_zsh_readonly_assignments.py`) that regex-counts the bad pattern
+  per file against a FROZEN baseline dict and fails if any file
+  INTRODUCES it or GROWS its count. Existing debt is frozen, not forced;
+  entries ratchet DOWN as files convert opportunistically ("guard now,
+  fix-on-flake later"). Gotchas baked in from doing it: (a) the guard
+  file and any doc that NAMES the pattern in prose/regex must
+  self-exclude, or word it so the matcher can't flag its own
+  documentation (write ```patch.dict``` on ```sys.modules``` rather than
+  the literal); (b) generate the baseline from the SAME regex the guard
+  runs — don't eyeball-count (a loose line-grep over-counted 267 vs the
+  precise 219); (c) base the guard PR on the state where any
+  already-fixed file is at its post-fix count (merge the fix PR first,
+  then regenerate the baseline / rebase), else the guard flags the
+  not-yet-merged file as "new". Higher-leverage alternative if the
+  pattern keeps biting: fix the single CONCURRENT TOUCHER (the leaked
+  thread) rather than the N sites — one fix neutralizes them all.

--- a/docs/specs/ci-runner-hang/phase2-findings.md
+++ b/docs/specs/ci-runner-hang/phase2-findings.md
@@ -272,3 +272,31 @@ This satisfies "Next actions" item 3 above (*if the leak is ruled out,
 pivot to H4*): the cheap heartbeat-teardown fixture (item 2) is still
 worth doing as hygiene, but the root-cause hunt should now target the
 execnet/xdist finalize handshake directly, not the heartbeat leak.
+
+## Phase 4 — heartbeat thread ruled out for the SEPARATE sys.modules flake (2026-06-22)
+
+A different xdist symptom surfaced this session and could be mistaken
+for this hang: `test_real_tools.py` flaked on one lane with
+`KeyError: <object-id>` (fixed in #1003, guarded in #1004). It is
+tempting to re-blame the leaked heartbeat thread as a "concurrent
+`sys.modules` toucher" — **don't.** Evidence gathered while fixing it:
+
+- `threading.enumerate()` in a clean keyless worker returns `[]` (no
+  non-main threads) — verified in both xdist and single-process.
+- The heartbeat loop **no-ops keyless** and is killed per-test by the
+  autouse `_stop_leaked_heartbeat_threads` fixture, so it is not alive
+  during an unrelated test's body.
+- A concurrent importing thread does **not** reproduce the KeyError
+  (20k `patch.dict("sys.modules")` teardowns, GIL-serialized, clean).
+- Decisive: the failing key is an **int** (`id()`-shaped), but
+  `sys.modules` keys are **strings** — so the KeyError is **not** from
+  `sys.modules` at all. It is a re-entrant GC/finalizer touch of some
+  `id()`-keyed cache triggered when `patch.dict`'s teardown runs
+  `sys.modules.clear()`. Single-threaded re-entrancy, **no toucher to
+  kill.**
+
+Bottom line: killing the heartbeat thread would not have fixed the
+sys.modules flake (the right fix was removing the `clear()`). The
+heartbeat thread remains only a (weakened) suspect for the H4
+finalize-wedge above, still gated on N>1 dumps — do not let the
+sys.modules symptom revive it.


### PR DESCRIPTION
## What

Two net-new lessons captured from the test_real_tools flake work
(8.8.0 session), appended to the tail of `.claude/lessons.md` (core
section untouched; `test_core_mirror.py` green):

1. **`patch.dict("sys.modules")` xdist race.** A test flaking *only*
   under xdist with `KeyError: <object-id>` is the signature of
   `patch.dict("sys.modules", ...)` — its teardown does
   `sys.modules.clear()` + rebuild, racing any concurrent toucher.
   Captures the full diagnostic chain (KeyError-not-AssertionError →
   error is in setup/teardown; `id()`-shaped key → concurrent dict
   mutation; in-file repro passes → cross-file leak) and the surgical
   fixes (`patch("pkg.Attr")` / `monkeypatch.setitem` / `fake_module`).

2. **Per-file ratchet guard for latent test-debt.** When fixing every
   instance is negative-ROI (measured: ~25h to save ~minutes/100 PRs),
   freeze the pattern with a baseline-counted structural test instead.
   Includes the self-exclusion / same-regex / merge-order gotchas hit
   while building #1004.

Closes out the lessons side of #1003 / #1004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Added (2026-06-22):** `docs/specs/ci-runner-hang/phase2-findings.md` Phase 4 note — rules out the leaked heartbeat thread as the `sys.modules` KeyError toucher (Option A investigation), so a future session doesn't re-chase it for that symptom. Evidence: no live threads in a keyless worker; concurrent-importer doesn't repro; the failing key is an int while `sys.modules` keys are strings → re-entrant GC during `clear()`, no toucher to kill.