### PR TITLE
test(telemetry): stop the test suite polluting real ~/.attune telemetry

### DIFF
--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -237,18 +237,28 @@ class UsageTracker:
         If no summary file exists (e.g. first run after upgrade), rebuilds
         it from existing JSONL files. This is a one-time O(entries) cost;
         subsequent loads are O(days).
-        """
-        if self._summary_file.exists():
-            try:
-                with open(self._summary_file, encoding="utf-8") as f:
-                    data = json.load(f)
-                self._daily_summary = data.get("days", {})
-                return
-            except (OSError, json.JSONDecodeError):
-                self._daily_summary = {}
 
-        # No summary file — build from existing disk data (migration path)
-        self._rebuild_summary_from_disk()
+        Telemetry is best-effort: a read-only or otherwise unreadable
+        telemetry dir (the ``.exists()`` stat and the rebuild glob both
+        touch the filesystem) must degrade to an empty summary, never
+        raise — the same contract as the guarded ``mkdir`` in __init__.
+        """
+        try:
+            if self._summary_file.exists():
+                try:
+                    with open(self._summary_file, encoding="utf-8") as f:
+                        data = json.load(f)
+                    self._daily_summary = data.get("days", {})
+                    return
+                except (OSError, json.JSONDecodeError):
+                    self._daily_summary = {}
+
+            # No summary file — build from existing disk data (migration path)
+            self._rebuild_summary_from_disk()
+        except OSError:
+            # Telemetry dir unreadable (e.g. read-only) — disable gracefully.
+            logger.debug("Failed to load telemetry summary: %s", self.telemetry_dir)
+            self._daily_summary = {}
 
     def _rebuild_summary_from_disk(self) -> None:
         """Scan all JSONL files to build the daily summary.

--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -12,6 +12,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import threading
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
@@ -67,7 +68,14 @@ class UsageTracker:
                         on unexpected process termination.
 
         """
-        self.telemetry_dir = telemetry_dir or Path.home() / ".attune" / "telemetry"
+        # Resolve the default under ATTUNE_HOME (env override -> ~/.attune),
+        # matching attune.ops.config.attune_home(). Read inline rather than
+        # importing that module to keep this base-telemetry module free of any
+        # attune.ops dependency. Lets ops/tests relocate telemetry off real
+        # ~/.attune (tests isolate it per-test; see tests/conftest.py).
+        _home = os.environ.get("ATTUNE_HOME")
+        _attune_dir = Path(_home).expanduser() if _home else Path.home() / ".attune"
+        self.telemetry_dir = telemetry_dir or _attune_dir / "telemetry"
         self.retention_days = retention_days
         self.max_file_size_mb = max_file_size_mb
         self.buffer_size = buffer_size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -535,6 +535,38 @@ def _disable_help_telemetry(monkeypatch):
 
 
 @pytest.fixture(autouse=True, scope="function")
+def _isolate_attune_home(tmp_path, monkeypatch):
+    """Route ~/.attune writes to a per-test tmp dir.
+
+    Without this, anything that resolves the default attune home writes
+    into the developer's real ``~/.attune`` during the test run. The worst
+    offender is the workflow telemetry singleton
+    (``UsageTracker.get_instance()``): every test that executes a stub
+    workflow appended ``stub-workflow`` / ``test-tier-fallback`` rows to the
+    real ``~/.attune/telemetry/usage.jsonl``, polluting it (and drowning any
+    genuine dogfood signal). Setting ``ATTUNE_HOME`` per test (auto-undone by
+    monkeypatch, and honored by both ``attune.ops.config.attune_home`` and
+    ``UsageTracker``) redirects those writes; resetting the singleton forces
+    it to re-resolve under the tmp dir on next use and prevents a
+    tmp-pointed instance from leaking into the next test.
+    """
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+
+    def _reset_usage_singleton():
+        try:
+            from attune.telemetry.usage_tracker import UsageTracker
+
+            UsageTracker._instance = None
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: telemetry is optional; env isolation still applies.
+            pass
+
+    _reset_usage_singleton()
+    yield
+    _reset_usage_singleton()
+
+
+@pytest.fixture(autouse=True, scope="function")
 def _stop_leaked_heartbeat_threads():
     """Stop any CrossSessionCoordinator heartbeat thread a test leaks.
 

--- a/tests/unit/telemetry/test_usage_tracker.py
+++ b/tests/unit/telemetry/test_usage_tracker.py
@@ -506,6 +506,26 @@ class TestSingletonPattern:
         UsageTracker._instance = None
 
 
+class TestDefaultTelemetryDir:
+    """The default telemetry dir must honor ATTUNE_HOME.
+
+    Regression guard for the test-pollution leak: the default used
+    ``Path.home() / ".attune"`` directly, so the workflow telemetry
+    singleton wrote stub/test events into the developer's real
+    ``~/.attune/telemetry/usage.jsonl`` during the suite. The default now
+    reads ``ATTUNE_HOME`` (matching ``attune.ops.config.attune_home``),
+    which ``tests/conftest.py`` isolates to a tmp dir per test.
+    """
+
+    def test_default_dir_respects_attune_home(self, tmp_path, monkeypatch):
+        """With no explicit telemetry_dir, the default lands under ATTUNE_HOME."""
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        UsageTracker._instance = None
+        tracker = UsageTracker()  # no telemetry_dir -> resolve default
+        assert tracker.telemetry_dir == tmp_path / "home" / "telemetry"
+        UsageTracker._instance = None
+
+
 class TestPermissionErrors:
     """Test handling of permission errors."""
 


### PR DESCRIPTION
## Problem

Surfaced while answering "do we have user telemetry for QA?" — the local
`~/.attune/telemetry/usage.jsonl` (24,173 events) was **mostly test
noise**: `stub-workflow` (5.6k), `test-workflow` (4.6k),
`test-tier-fallback` (4.1k), `failing-stub`… ~16k of 24k. The workflow
telemetry singleton (`UsageTracker.get_instance()`) resolved its dir as
`Path.home()/".attune"/"telemetry"` **directly** — bypassing the central
`attune_home()` resolver — so every test that executed a stub workflow
wrote into the developer's *real* telemetry file, drowning any genuine
dogfood signal. (Sibling of the known `monkeypatch` SUT-write-leak class.)

## Fix

- **`usage_tracker.py`**: the default dir now honors `ATTUNE_HOME`
  (env override → `~/.attune`), matching
  `attune.ops.config.attune_home()`. Read **inline** (not imported) to
  keep this base-telemetry module free of any `attune.ops` dependency
  (avoids the #945 default-install-crash class).
- **`conftest.py`**: autouse `_isolate_attune_home` fixture points
  `ATTUNE_HOME` at a per-test tmp dir (auto-undone by monkeypatch) and
  resets the `UsageTracker` singleton — the analog of the existing
  `_disable_help_telemetry` fixture.
- **Regression guard**: `TestDefaultTelemetryDir` asserts the default
  honors `ATTUNE_HOME`.

## Verification

- **Leak closed:** real `usage.jsonl` delta = **0** across a **7,874-test**
  slice (curator/ops/telemetry/memory/workflows/cli/mcp) — it was growing
  on every prior run.
- 84 `usage_tracker` tests pass; black + ruff clean.
- The 8 `test_redis_integration` failures under `-n auto` are
  **pre-existing** (shared-Redis parallel collisions — fail identically on
  `origin/main`, pass in isolation), not from this change.

## Follow-up (not in this PR)

The existing 24k-line local `usage.jsonl` is still historically polluted;
a clean slate would make it a usable N=1 dogfood QA signal going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)