### PR TITLE
test(agent_factory): make missing-key contract hermetic

### DIFF
--- a/tests/unit/agent_factory/test_langchain_adapter_runtime.py
+++ b/tests/unit/agent_factory/test_langchain_adapter_runtime.py
@@ -244,6 +244,10 @@ class TestGetLLM:
 
     def test_anthropic_missing_key_raises(self, monkeypatch):
         monkeypatch.setattr(mod, "_langchain_available", True)
+        # Make the missing-key contract hermetic: LangChainAdapter falls back
+        # to os.getenv("ANTHROPIC_API_KEY"), so a developer with the key set in
+        # their shell would otherwise take the happy path and DID NOT RAISE.
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         adapter = LangChainAdapter(provider="anthropic", api_key=None)
         with patch("langchain_anthropic.ChatAnthropic"), pytest.raises(ValueError):
             adapter._get_llm(_cfg(model_override="claude-sonnet-4-6"))


### PR DESCRIPTION
## Problem

`tests/unit` is green on keyless CI but a developer who has `ANTHROPIC_API_KEY`
set in their shell sees three failures. These are **environment-coupled tests**,
not product bugs.

## Investigation

The authoritative pytest config is **`pytest.ini`** (pytest ignores
`pyproject.toml`'s `[tool.pytest.ini_options]` when `pytest.ini` exists).
`pytest.ini`'s default `addopts` already contains `-m "not integration and not
network"`, so under the real default config only one of the three tests
actually fails:

| Test | Marker(s) | Default-config status |
|------|-----------|-----------------------|
| `TestRunAnalyzeImageLive::test_analyze_png_returns_analysis` | `network` | already **deselected** (0 items) — verified |
| `TestIntegrationWithRealAgents::test_sequential_with_real_agents` | `integration`, `slow` | already **deselected** (0 items) — verified |
| `TestGetLLM::test_anthropic_missing_key_raises` | none | **fails** — env key leaks in |

The two `network`/`integration` tests are already correctly marked and gated;
they only "fail" if you clear `addopts`. The genuine failure is the missing-key
test: `LangChainAdapter.__init__` falls back to `os.getenv("ANTHROPIC_API_KEY")`,
so a real key in the shell takes the happy path → `DID NOT RAISE ValueError`.

## Fix

Make the missing-key contract hermetic — `monkeypatch.delenv("ANTHROPIC_API_KEY",
raising=False)` at the top of the test (the source reads only that var for the
Anthropic provider). One file, +4 lines.

## CI is unchanged

No config touched. The change is strictly an improvement to one test — it passes
both keyless (CI) and with a key present.

## Verification

- `test_anthropic_missing_key_raises` → passes with `ANTHROPIC_API_KEY=""`
  (CI-faithful) **and** with a dummy key present.
- `network` / `integration` tests → confirmed deselected (0 items) under the
  default `pytest.ini` config with a dummy key exported (no live call).
- Full `tests/unit/agent_factory/` → 175 passed (no collection breakage).

Independent of #1006 (telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)