### PR TITLE
fix(mcp): repair handler kwargs dropped by the v4.2.0 SDK execute migration

### DIFF
--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -419,7 +419,10 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
 
         validated_path = str(_validate_file_path(args["module"], allowed_dir=self._workspace_root))
         workflow = TestGenerationWorkflow()
-        result = await workflow.execute(module_path=validated_path)
+        # execute reads `path` — the legacy `module_path` kwarg was dropped
+        # in the v4.2.0 SDK migration, so passing it left `path` empty and
+        # every call failed with "path argument is required".
+        result = await workflow.execute(path=validated_path)
 
         return _workflow_response(
             result,

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -167,7 +167,9 @@ class WorkflowHandlersMixin:
         from attune.workflows.doc_audit import DocAuditWorkflow
 
         workflow = DocAuditWorkflow()
-        result = await workflow.execute(project_root=self._validated_path(args))
+        # execute reads `path` (not the legacy `project_root`); passing the
+        # stale kwarg left `path` empty → "path argument is required".
+        result = await workflow.execute(path=self._validated_path(args))
 
         return _workflow_response(result, score="score", findings=("checks", []))
 
@@ -188,23 +190,12 @@ class WorkflowHandlersMixin:
         """
         from attune.workflows.document_gen import DocumentGenerationWorkflow
 
-        source_code = ""
-        raw_source_path = args.get("source_path", "")
-        if raw_source_path:
-            source_path = self._validated_path(args, key="source_path", default="")
-            try:
-                from pathlib import Path
-
-                source_code = Path(source_path).read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError) as e:
-                logger.warning("Could not read source file %s: %s", source_path, e)
-
+        # execute reads `path` (and `depth`); the SDK subagents read the
+        # source themselves. The legacy `source_code`/`doc_type`/`audience`
+        # kwargs were dropped in the v4.2.0 SDK migration, so passing them
+        # left `path` empty → "path argument is required".
         workflow = DocumentGenerationWorkflow()
-        result = await workflow.execute(
-            source_code=source_code,
-            doc_type=args.get("doc_type", "api_reference"),
-            audience=args.get("audience", "developers"),
-        )
+        result = await workflow.execute(path=self._validated_path(args, key="source_path"))
 
         return _workflow_response(result, document="document", sections="sections")
 
@@ -227,9 +218,10 @@ class WorkflowHandlersMixin:
         )
 
         workflow = DocumentationOrchestrator()
-        result = await workflow.execute(
-            context={"project_root": self._validated_path(args)},
-        )
+        # execute scopes off the `path` kwarg; the project root was
+        # previously buried inside the `context` dict, where execute never
+        # read it — so the ops scope-picker could not re-scope the run.
+        result = await workflow.execute(path=self._validated_path(args))
 
         return {
             "success": getattr(result, "phase", "") == "complete",
@@ -257,7 +249,9 @@ class WorkflowHandlersMixin:
         from attune.workflows.test_audit import TestAuditWorkflow
 
         workflow = TestAuditWorkflow()
-        result = await workflow.execute(src_path=self._validated_path(args, default="src/"))
+        # Use the canonical `path` kwarg; `src_path` still works but is a
+        # deprecated alias that emits a DeprecationWarning.
+        result = await workflow.execute(path=self._validated_path(args, default="src/"))
 
         return _workflow_response(result, raw_output=True)
 
@@ -424,8 +418,10 @@ class WorkflowHandlersMixin:
         )
 
         workflow = OrchestratedHealthCheckWorkflow()
+        # Use the canonical `path` kwarg; `project_root` still works but is a
+        # deprecated alias that emits a DeprecationWarning.
         result = await workflow.execute(
-            project_root=self._validated_path(args, key="project_root"),
+            path=self._validated_path(args, key="project_root"),
         )
 
         return {

--- a/tests/unit/mcp/handlers/test_handler_execute_contract.py
+++ b/tests/unit/mcp/handlers/test_handler_execute_contract.py
@@ -1,0 +1,86 @@
+"""Non-mocked guard for the MCP-handler → workflow ``execute`` contract.
+
+The handler unit tests mock ``execute`` (AsyncMock), which means they
+verify *which kwargs the handler passes* but never that the workflow's
+real ``execute`` actually *reads* those kwargs. That gap let a whole
+class of bug ship: the v4.2.0 SDK migration changed several workflow
+``execute`` signatures to ``(path, depth)``, but the MCP handlers kept
+passing the pre-migration kwargs (``module_path``, ``source_code`` /
+``doc_type`` / ``audience``, ``project_root``). The stale kwargs were
+silently dropped, ``path`` was empty, and every call failed with
+"path argument is required" — yet the mocked tests stayed green.
+
+These tests call the REAL ``execute`` (no mocking) with the legacy
+kwargs and assert it still fails fast on the missing ``path``. That
+proves ``path`` is the required scope kwarg, so a handler that passes
+anything else is broken. The path gate returns before any Agent SDK /
+LLM call, so these tests are cheap and make no network calls.
+
+Copyright 2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.workflows.doc_audit import DocAuditWorkflow
+from attune.workflows.document_gen import DocumentGenerationWorkflow
+from attune.workflows.test_gen import TestGenerationWorkflow
+
+
+@pytest.mark.parametrize(
+    "workflow_cls",
+    [TestGenerationWorkflow, DocumentGenerationWorkflow, DocAuditWorkflow],
+)
+@pytest.mark.asyncio
+async def test_execute_reads_path_not_legacy_kwargs(workflow_cls):
+    """Real ``execute`` requires ``path`` and ignores the legacy kwargs.
+
+    Passing every pre-migration kwarg the broken handlers used to send
+    must STILL fail with "path argument is required" — that is exactly
+    the failure users hit, and the receipt that those kwargs are dead.
+    """
+    result = await workflow_cls().execute(
+        module_path="/x",
+        source_code="def f(): pass",
+        doc_type="api_reference",
+        audience="developers",
+        project_root="/x",
+    )
+
+    assert result.success is False
+    assert "path argument is required" in (result.error or "")
+
+
+@pytest.mark.parametrize(
+    "workflow_cls",
+    [TestGenerationWorkflow, DocumentGenerationWorkflow, DocAuditWorkflow],
+)
+@pytest.mark.asyncio
+async def test_execute_path_gate_passes_with_path(workflow_cls):
+    """A non-empty ``path`` clears the gate (no 'path argument is required').
+
+    We do not run the workflow to completion (that needs the Agent SDK);
+    we only assert that *with* ``path`` the early required-arg gate no
+    longer fires — i.e. the kwarg the handlers now pass is the right one.
+    The SDK call is stubbed so no network/LLM work happens.
+    """
+    workflow = workflow_cls()
+
+    async def _stub(*_args, **_kwargs):
+        # Minimal AgentRunResult-shaped stub so execute can build a result.
+        from attune.workflows.agent_sdk_adapter import AgentRunResult
+
+        return AgentRunResult(result_text="stub")
+
+    # Each workflow's SDK call lives in a private _run_agent_* method that
+    # runs AFTER the path gate. Stub whichever this workflow has.
+    for attr in ("_run_agent_gen", "_run_agent_audit"):
+        if hasattr(workflow, attr):
+            setattr(workflow, attr, _stub)
+
+    result = await workflow.execute(path="src/")
+
+    # The point is only that the required-arg gate did not fire.
+    assert "path argument is required" not in (result.error or "")

--- a/tests/unit/mcp/handlers/test_workflow_handlers.py
+++ b/tests/unit/mcp/handlers/test_workflow_handlers.py
@@ -247,8 +247,13 @@ class TestRunTestGeneration:
         assert out["cost"] == 0.04
 
     @pytest.mark.asyncio
-    async def test_run_test_generation_passes_module_path(self):
-        """execute() is called with module_path kwarg."""
+    async def test_run_test_generation_passes_path(self):
+        """execute() is called with the canonical `path` kwarg.
+
+        The TOOL input key stays `module`; only the execute kwarg is
+        fixed from the legacy `module_path` (which execute ignored, so
+        every call failed with "path argument is required").
+        """
         server = _make_server()
         result = _make_result()
         mod = _make_workflow_module("attune.workflows.test_gen", "TestGenerationWorkflow", result)
@@ -256,9 +261,7 @@ class TestRunTestGeneration:
         with patch.dict(sys.modules, {"attune.workflows.test_gen": mod}):
             await server._run_test_generation({"module": "src/foo.py"})
 
-        mod.TestGenerationWorkflow.return_value.execute.assert_awaited_once_with(
-            module_path="src/foo.py"
-        )
+        mod.TestGenerationWorkflow.return_value.execute.assert_awaited_once_with(path="src/foo.py")
 
     @pytest.mark.asyncio
     async def test_run_test_generation_zero_tests_default(self):

--- a/tests/unit/mcp/handlers/test_workflow_handlers_mixin.py
+++ b/tests/unit/mcp/handlers/test_workflow_handlers_mixin.py
@@ -180,8 +180,10 @@ class TestMixinPathValidation:
             await server._run_doc_audit({"path": "../../etc/passwd"})
 
     @pytest.mark.asyncio
-    async def test_doc_gen_skips_validation_when_no_source_path(self):
-        """_run_doc_gen skips validation when source_path is empty."""
+    async def test_doc_gen_validates_default_path_when_no_source_path(self):
+        """_run_doc_gen validates the default path ('.') when source_path
+        is absent — execute now takes a validated `path`, so the default
+        is validated against the workspace root too."""
         server = _make_server(workspace_root="/workspace")
         result = _make_result()
         mod = _make_workflow_module(
@@ -198,7 +200,7 @@ class TestMixinPathValidation:
         ):
             await server._run_doc_gen({})
 
-        mock_validate.assert_not_called()
+        mock_validate.assert_called_once_with(".", allowed_dir="/workspace")
 
 
 # ==================================================================
@@ -239,7 +241,7 @@ class TestRunDocAudit:
         with patch.dict(sys.modules, {"attune.workflows.doc_audit": mod}):
             await server._run_doc_audit({})
 
-        mod.DocAuditWorkflow.return_value.execute.assert_awaited_once_with(project_root=".")
+        mod.DocAuditWorkflow.return_value.execute.assert_awaited_once_with(path=".")
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("_bypass_path_validation")
@@ -285,8 +287,8 @@ class TestRunDocGen:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("_bypass_path_validation")
-    async def test_empty_source_path_skips_read(self):
-        """Empty source_path passes empty string to workflow."""
+    async def test_defaults_path_to_dot(self):
+        """Absent source_path defaults the `path` kwarg to '.'."""
         server = _make_server()
         result = _make_result()
         mod = _make_workflow_module(
@@ -299,12 +301,15 @@ class TestRunDocGen:
             await server._run_doc_gen({})
 
         call_kwargs = mod.DocumentGenerationWorkflow.return_value.execute.call_args
-        assert call_kwargs.kwargs["source_code"] == ""
+        # execute reads `path` — NOT the legacy source_code/doc_type/audience
+        # kwargs, which the SDK migration dropped. Guard against the drift
+        # reappearing.
+        assert call_kwargs.kwargs == {"path": "."}
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("_bypass_path_validation")
-    async def test_passes_doc_type_and_audience(self):
-        """doc_type and audience are forwarded to execute()."""
+    async def test_passes_source_path_as_path(self):
+        """The source_path arg is forwarded to execute() as `path`."""
         server = _make_server()
         result = _make_result()
         mod = _make_workflow_module(
@@ -314,11 +319,12 @@ class TestRunDocGen:
         )
 
         with patch.dict(sys.modules, {"attune.workflows.document_gen": mod}):
-            await server._run_doc_gen({"doc_type": "tutorial", "audience": "beginners"})
+            await server._run_doc_gen({"source_path": "src/mod.py"})
 
         call_kwargs = mod.DocumentGenerationWorkflow.return_value.execute.call_args
-        assert call_kwargs.kwargs["doc_type"] == "tutorial"
-        assert call_kwargs.kwargs["audience"] == "beginners"
+        assert call_kwargs.kwargs == {"path": "src/mod.py"}
+        assert "source_code" not in call_kwargs.kwargs
+        assert "doc_type" not in call_kwargs.kwargs
 
 
 class TestRunDocOrchestrator:
@@ -353,8 +359,8 @@ class TestRunDocOrchestrator:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("_bypass_path_validation")
-    async def test_passes_path_in_context(self):
-        """Path is passed inside context dict."""
+    async def test_passes_path(self):
+        """Path is passed as the `path` kwarg (execute scopes off it)."""
         server = _make_server()
         result = MagicMock()
         result.phase = "complete"
@@ -371,7 +377,10 @@ class TestRunDocOrchestrator:
             await server._run_doc_orchestrator({"path": "/myproject"})
 
         call_kwargs = mod.DocumentationOrchestrator.return_value.execute.call_args
-        assert call_kwargs.kwargs["context"]["project_root"] == "/myproject"
+        # execute reads `path` (or the deprecated top-level `project_root`),
+        # never a `context["project_root"]` — passing it inside context
+        # silently dropped the scope.
+        assert call_kwargs.kwargs == {"path": "/myproject"}
 
 
 class TestRunTestAudit:
@@ -406,8 +415,10 @@ class TestRunTestAudit:
             await server._run_test_audit({})
 
         call_kwargs = mod.TestAuditWorkflow.return_value.execute.call_args
-        # PurePosixPath strips trailing slash: "src/" → "src"
-        assert call_kwargs.kwargs["src_path"] in ("src/", "src")
+        # execute takes the canonical `path` kwarg now (`src_path` is a
+        # deprecated alias). PurePosixPath strips trailing slash: "src/" → "src"
+        assert call_kwargs.kwargs["path"] in ("src/", "src")
+        assert "src_path" not in call_kwargs.kwargs
 
 
 class TestRunTestGenParallel:
@@ -661,8 +672,8 @@ class TestRunHealthCheck:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("_bypass_path_validation")
-    async def test_passes_project_root(self):
-        """execute() receives project_root kwarg."""
+    async def test_passes_path(self):
+        """execute() receives the canonical `path` kwarg."""
         server = _make_server()
         result = MagicMock()
         mod = _make_workflow_module(
@@ -675,10 +686,12 @@ class TestRunHealthCheck:
             sys.modules,
             {"attune.workflows.orchestrated_health_check": mod},
         ):
+            # The TOOL input key stays `project_root`; only the execute kwarg
+            # is modernized to `path` (`project_root` is a deprecated alias).
             await server._run_health_check({"project_root": "/proj"})
 
         mod.OrchestratedHealthCheckWorkflow.return_value.execute.assert_awaited_once_with(
-            project_root="/proj"
+            path="/proj"
         )
 
 


### PR DESCRIPTION
## Summary

Repairs a class of silently-broken MCP tools found during the help-docs
single-source rollout. The v4.2.0 SDK migration changed several workflow
`execute()` signatures to `(path, depth)`, but the MCP handlers kept
passing the pre-migration kwargs — which `execute` drops, leaving `path`
empty so **every call failed with "path argument is required."** The
handler unit tests mocked `execute` and asserted the *stale* kwargs, so
the breakage shipped green ("registered ≠ working" at the MCP boundary).

I audited **every** `_run_*` handler and fixed the mismatches:

| Handler | Was | Now | State |
|---|---|---|---|
| `test_generation` | `execute(module_path=)` | `execute(path=)` | was fully broken |
| `doc_gen` | `execute(source_code=/doc_type=/audience=)` | `execute(path=)` | was fully broken |
| `doc_audit` | `execute(project_root=)` | `execute(path=)` | was fully broken |
| `doc_orchestrator` | `execute(context={"project_root":…})` | `execute(path=)` | scope silently ignored |
| `test_audit` | `execute(src_path=)` | `execute(path=)` | worked via deprecated alias |
| `health_check` | `execute(project_root=)` | `execute(path=)` | worked via deprecated alias |

Tool **input** keys are unchanged (`module`, `source_path`, `project_root`)
— only the internal `execute()` kwarg is corrected, so no tool contract
changes. (For `doc_gen` I also dropped the pointless source-file read — the
SDK subagents read files themselves.)

## Tests

- Corrected the handler tests that **asserted the old kwargs** (they
  codified the bug) to assert `path=`.
- Added `tests/unit/mcp/handlers/test_handler_execute_contract.py` —
  **non-mocked** guards that call the real `execute()` with the legacy
  kwargs and assert it still fails on the missing `path`, and that a real
  `path` clears the gate (SDK call stubbed, no network). This closes the
  gap the mocked tests left open.
- Full `tests/unit/mcp/handlers/` suite: **158 passed** (the one failure is
  the pre-existing `TestRunAnalyzeImageLive` live-API test, which needs a
  valid key and is skipped in keyless CI — unrelated to this change).

## Not fixed — flagged for a decision

`research_synthesis`'s handler passes `sources=/question=`, but
`ResearchSynthesisWorkflow.execute` is now **path-based** — a *semantic*
mismatch, not a kwarg rename. Left untouched and flagged rather than
guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
