### PR TITLE
refactor(workflows): disambiguate release-prep — SDK workflow becomes release-notes

### DIFF
--- a/scripts/check_help_coverage.py
+++ b/scripts/check_help_coverage.py
@@ -44,6 +44,8 @@ KNOWN_GAPS: set[str] = {
     "doc-orchestrator",
     "perf-audit",
     "rag-code-gen",
+    "release-gate",
+    "release-notes",
     "research-synthesis",
     "simplify-code",
     "test-audit",

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -95,6 +95,8 @@ PATH_ARG_REGISTRY: dict[str, PathArgSpec] = {
     "test-gen": PathArgSpec(kwarg="path"),
     # Category B — direct signature kwarg ``path: str = "."``
     "release-prep": PathArgSpec(kwarg="path"),
+    "release-gate": PathArgSpec(kwarg="path"),
+    "release-notes": PathArgSpec(kwarg="path"),
     "secure-release": PathArgSpec(kwarg="path"),
     # Category C — aliased to a different kwarg name
     "doc-orchestrator": PathArgSpec(kwarg="path"),

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -21,8 +21,9 @@
     "bug-predict", "code-review", "deep-review", "dependency-check",
     "discovery-sweep", "doc-audit", "doc-gen", "doc-orchestrator",
     "health-check", "orchestrated-health-check", "perf-audit", "rag-code-gen",
-    "refactor-plan", "release-prep", "research-synthesis", "secure-release",
-    "security-audit", "simplify-code", "test-audit", "test-gen"
+    "refactor-plan", "release-gate", "release-notes", "release-prep",
+    "research-synthesis", "secure-release", "security-audit", "simplify-code",
+    "test-audit", "test-gen"
   ];
   // <<< AUTO-GENERATED: WORKFLOW_NAMES
 

--- a/src/attune/ops/workflow_concern.py
+++ b/src/attune/ops/workflow_concern.py
@@ -89,6 +89,8 @@ _WORKFLOW_CONCERNS: dict[str, Concern] = {
     "dependency-check": "audit",
     # meta
     "release-prep": "meta",
+    "release-gate": "meta",
+    "release-notes": "meta",
     "secure-release": "meta",
     "orchestrated-health-check": "meta",
     "health-check": "meta",

--- a/src/attune/workflows/__init__.py
+++ b/src/attune/workflows/__init__.py
@@ -302,8 +302,14 @@ _DEFAULT_WORKFLOW_NAMES: dict[str, str] = {
     "secure-release": "SecureReleasePipeline",
     # Meta-orchestration workflows (v4.0.0)
     "orchestrated-health-check": "OrchestratedHealthCheckWorkflow",
-    # Release preparation (v5.2 — agent team is canonical)
+    # Release preparation. Two distinct workflows:
+    #   release-prep  — deterministic gate (real bandit/ruff/pytest + hard
+    #                   thresholds), the agent team (canonical). `release-gate`
+    #                   is a first-class synonym for the same class.
+    #   release-notes — advisory: drafts a changelog + LLM go/no-go (SDK).
     "release-prep": "ReleasePrepTeamWorkflow",
+    "release-gate": "ReleasePrepTeamWorkflow",
+    "release-notes": "ReleasePreparationWorkflow",
     # Research and synthesis workflows
     "research-synthesis": "ResearchSynthesisWorkflow",
     # code-review-sdk: Merged into code-review (v4.2.0)

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -90,12 +90,18 @@ that must be resolved before release.\
 
 
 class ReleasePreparationWorkflow(BaseWorkflow):
-    """Pre-release quality gate workflow powered by Agent SDK subagents.
+    """Release-notes draft + readiness advisory, powered by Agent SDK subagents.
 
     Delegates all analysis to four Agent SDK subagents rather than
     using the mixin stage system. Each subagent focuses on a specific
-    release-readiness domain (health, security, changelog, assessment).
-    The orchestrator synthesizes findings into a unified report.
+    release-readiness domain (health, security, changelog, assessment),
+    and the orchestrator synthesizes a draft changelog plus an LLM
+    go/no-go recommendation.
+
+    This is the *advisory* release workflow — it predicts and drafts; it
+    does not enforce hard quality gates. The deterministic gate (real
+    bandit/ruff/pytest with pass/fail thresholds) is the separate
+    ``release-prep`` agent team (``ReleasePrepTeamWorkflow``).
 
     Usage::
 
@@ -103,8 +109,8 @@ class ReleasePreparationWorkflow(BaseWorkflow):
         result = await workflow.execute(path=".", depth="standard")
     """
 
-    name = "release-prep"
-    description = "Pre-release quality gate with Agent SDK subagents"
+    name = "release-notes"
+    description = "Draft release notes + LLM readiness advice (Agent SDK subagents)"
     stages = ["agent-prep"]
     tier_map = {"agent-prep": ModelTier.CAPABLE}
 

--- a/tests/unit/workflows/test_release_prep_execute.py
+++ b/tests/unit/workflows/test_release_prep_execute.py
@@ -341,7 +341,7 @@ class TestErrorResult:
     def test_stage_metadata(self, workflow):
         result = workflow._error_result("nope")
         assert len(result.stages) == 1
-        assert result.stages[0].name == "release-prep"
+        assert result.stages[0].name == "release-notes"
         assert result.stages[0].tier == ModelTier.CAPABLE
 
     def test_timestamps_bounded(self, workflow):

--- a/tests/unit/workflows/test_workflows_init.py
+++ b/tests/unit/workflows/test_workflows_init.py
@@ -110,6 +110,26 @@ class TestGetWorkflow:
         with pytest.raises(KeyError, match="Unknown workflow"):
             get_workflow("nonexistent-workflow-xyz")
 
+    def test_release_slugs_resolve_to_distinct_workflows(self):
+        """The two release workflows are distinct and named for what they do.
+
+        ``release-prep`` and its synonym ``release-gate`` are the
+        deterministic agent-team gate; ``release-notes`` is the SDK
+        advisory workflow. They must NOT collide on one class (the
+        original bug was both classes carrying ``name="release-prep"``).
+        """
+        from attune.workflows import get_workflow
+
+        gate = get_workflow("release-prep")
+        gate_synonym = get_workflow("release-gate")
+        notes = get_workflow("release-notes")
+
+        assert gate.__name__ == "ReleasePrepTeamWorkflow"
+        assert gate_synonym is gate
+        assert notes.__name__ == "ReleasePreparationWorkflow"
+        assert notes is not gate
+        assert notes.name == "release-notes"
+
 
 class TestListWorkflows:
     """Tests for list_workflows."""

--- a/tests/workflows/test_release_prep.py
+++ b/tests/workflows/test_release_prep.py
@@ -26,7 +26,7 @@ class TestReleasePreparationWorkflowAttributes:
         from attune.workflows.release_prep import ReleasePreparationWorkflow
 
         wf = ReleasePreparationWorkflow()
-        assert wf.name == "release-prep"
+        assert wf.name == "release-notes"
 
     def test_stages(self):
         """Test single agent stage."""


### PR DESCRIPTION
## Summary

Resolves the `release-prep` two-implementation collision we diagnosed:
**two fully-built workflows both carried `name="release-prep"`**, reached
by different entry points (CLI → the deterministic agent-team gate; MCP →
the SDK advisory workflow). Per the decision, each is now named for what
it does — **without** rewiring the deeply-embedded crew slug.

- **`ReleasePreparationWorkflow`** (SDK, advisory) → renamed
  `release-prep` → **`release-notes`**. It drafts a changelog + an LLM
  go/no-go; it is *not* a hard gate. Description/docstring updated to say
  so. Registered as a CLI slug.
- **`ReleasePrepTeamWorkflow`** (the agent team) stays canonical
  **`release-prep`** — the deterministic gate (real bandit/ruff/pytest +
  hard thresholds), wired through ~20 files/10 subsystems. **`release-gate`**
  added as a first-class synonym slug (clearer name, zero rewire).

### Why this shape

Renaming the *crew* slug to `release-gate` would have rippled through
~20 files across ~10 subsystems (wizards, prompts, routing, ops,
verification, intent-detection, voice, …). Renaming the SDK orphan
instead resolves the actual collision with a tiny footprint, and a
synonym slug gives the `release-gate` name for free.

## Changes

- SDK `name`/`description`/docstring → release-notes (advisory framing).
- Registry: `release-notes` → SDK, `release-gate` → team (synonym).
- Ops drift-guard sync: `PathArgSpec` (`ops/data.py`), workflow concern
  (`ops/workflow_concern.py`), and the `runner.js` `WORKFLOW_NAMES`
  array (regenerated via `scripts/sync_runner_workflow_names.py`).

## Tests

- SDK stage-name assertion → `release-notes`.
- New guard: `release-prep`/`release-gate` resolve to the **team**,
  `release-notes` resolves to the **SDK**, and they're distinct classes —
  so the duplicate-name collision can't silently return.
- Local: `tests/unit/{workflows,ops,routing,mcp,meta_workflows,voice,verification}`
  green (the one failure is the pre-existing `TestRunAnalyzeImageLive`
  live-API test, skipped in keyless CI).

## Follow-up (not in this PR)

The MCP `release_prep` tool still runs the SDK (`release-notes`) via
direct class import — functional, but the *name* is now inconsistent.
Renaming that tool to `release_notes` + updating skill/help references is
a wider plugin-reference cascade, best done on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
