### PR TITLE
refactor(mcp): rename release_prep tool → release_notes (advisory disambiguation)

### DIFF
--- a/.agents/skills/release-prep/SKILL.md
+++ b/.agents/skills/release-prep/SKILL.md
@@ -21,26 +21,32 @@ Before running, ask:
 
 1. **Version**: "What version are you releasing? Or
    should I check the current version and suggest?"
-2. **Scope**: "Full release prep or a specific check?"
-   - Full: All 4 agents (security, testing, docs,
-     versioning)
+2. **Scope**: "Full advisory or a specific check?"
+   - Full: advisory across security, testing, docs,
+     versioning
    - Specific: Single check (e.g., just changelog)
 
 ## MCP Tools
 
 | Tool | What It Does |
 | ---- | ------------ |
-| `release_prep` | Full release readiness (4-agent team) |
+| `release_notes` | Changelog draft + go/no-go advisory (single-agent SDK) |
 | `health_check` | Project health score (tests + lint + coverage) |
 | `dependency_check` | Dependency audit and vulnerability scan |
 | `secure_release` | Full release pipeline with security gates |
 
+> **Advisory vs gate.** `release_notes` is *advisory* — it drafts a
+> changelog and gives a recommendation, it does not block. The
+> deterministic 4-agent gate (real bandit/ruff/pytest + hard
+> thresholds) is CLI-only: `attune workflow run release-gate`.
+
 ## Execution
 
-Call the `release_prep` MCP tool for a full assessment:
+Call the `release_notes` MCP tool for a changelog draft and
+go/no-go recommendation:
 
 ```
-release_prep(path="<project root>")
+release_notes(path="<project root>")
 ```
 
 For targeted checks, use individual tools:

--- a/.agents/skills/workflow-orchestration/SKILL.md
+++ b/.agents/skills/workflow-orchestration/SKILL.md
@@ -56,7 +56,7 @@ Based on the answer, route to the appropriate workflow.
 
 | Workflow | MCP Tool | What It Does |
 | -------- | -------- | ------------ |
-| Release Prep | `release_prep` | Health checks, changelog, dependency audits |
+| Release Notes | `release_notes` | Changelog draft + go/no-go advisory |
 
 ## Execution
 

--- a/docs/getting-started/mcp-integration.md
+++ b/docs/getting-started/mcp-integration.md
@@ -101,7 +101,7 @@ The Attune MCP server exposes all production workflows as tools:
 | `code_review` | Comprehensive code quality analysis with suggestions | `path` |
 | `test_generation` | Generate tests for code (supports batch mode) | `module`, `batch` (optional) |
 | `performance_audit` | Identify bottlenecks, memory leaks, optimization opportunities | `path` |
-| `release_prep` | Run release checks: health, security, changelog | `path` (optional) |
+| `release_notes` | Changelog draft + go/no-go advisory (not a gate) | `path` (optional) |
 | `doc_audit` | Audit documentation coverage and freshness | `path` |
 | `doc_gen` | Generate documentation for source code | `source_path` |
 | `test_audit` | Deep test coverage analysis | `path` |

--- a/plugin/skills/release-prep/SKILL.md
+++ b/plugin/skills/release-prep/SKILL.md
@@ -23,26 +23,32 @@ Before running, ask:
 
 1. **Version**: "What version are you releasing? Or
    should I check the current version and suggest?"
-2. **Scope**: "Full release prep or a specific check?"
-   - Full: All 4 agents (security, testing, docs,
-     versioning)
+2. **Scope**: "Full advisory or a specific check?"
+   - Full: advisory across security, testing, docs,
+     versioning
    - Specific: Single check (e.g., just changelog)
 
 ## MCP Tools
 
 | Tool | What It Does |
 | ---- | ------------ |
-| `release_prep` | Full release readiness (4-agent team) |
+| `release_notes` | Changelog draft + go/no-go advisory (single-agent SDK) |
 | `health_check` | Project health score (tests + lint + coverage) |
 | `dependency_check` | Dependency audit and vulnerability scan |
 | `secure_release` | Full release pipeline with security gates |
 
+> **Advisory vs gate.** `release_notes` is *advisory* — it drafts a
+> changelog and gives a recommendation, it does not block. The
+> deterministic 4-agent gate (real bandit/ruff/pytest + hard
+> thresholds) is CLI-only: `attune workflow run release-gate`.
+
 ## Execution
 
-Call the `release_prep` MCP tool for a full assessment:
+Call the `release_notes` MCP tool for a changelog draft and
+go/no-go recommendation:
 
 ```
-release_prep(path="<project root>")
+release_notes(path="<project root>")
 ```
 
 For targeted checks, use individual tools:

--- a/plugin/skills/workflow-orchestration/SKILL.md
+++ b/plugin/skills/workflow-orchestration/SKILL.md
@@ -58,7 +58,7 @@ Based on the answer, route to the appropriate workflow.
 
 | Workflow | MCP Tool | What It Does |
 | -------- | -------- | ------------ |
-| Release Prep | `release_prep` | Health checks, changelog, dependency audits |
+| Release Notes | `release_notes` | Changelog draft + go/no-go advisory |
 
 ## Execution
 

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -271,7 +271,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             "code_review": self._run_code_review,
             "test_generation": self._run_test_generation,
             "performance_audit": self._run_performance_audit,
-            "release_prep": self._run_release_prep,
+            "release_notes": self._run_release_notes,
             "doc_audit": self._run_doc_audit,
             "doc_gen": self._run_doc_gen,
             "doc_orchestrator": self._run_doc_orchestrator,
@@ -441,8 +441,8 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
 
         return _workflow_response(result, findings=("findings", []), score="score")
 
-    async def _run_release_prep(self, args: dict[str, Any]) -> dict[str, Any]:
-        """Run release preparation workflow."""
+    async def _run_release_notes(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Run the release-notes advisory workflow (changelog draft + go/no-go)."""
         from attune.security.path_validation import _validate_file_path
         from attune.workflows.release_prep import ReleasePreparationWorkflow
 

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -76,8 +76,8 @@ def get_workflow_tools() -> dict[str, dict[str, Any]]:
             param_desc="Path to directory or file to audit",
             required=True,
         ),
-        "release_prep": _pt(
-            "Run release preparation workflow. Checks health, security, changelog, and provides release recommendation.",
+        "release_notes": _pt(
+            "Run the release-notes advisory workflow. Drafts a changelog from git history and gives a go/no-go recommendation. Advisory only — not a gate; the deterministic 4-agent gate is CLI-only (attune workflow run release-gate).",
             param_desc="Path to project root",
         ),
         "doc_audit": _pt(

--- a/tests/monitoring/test_mcp_path_containment.py
+++ b/tests/monitoring/test_mcp_path_containment.py
@@ -50,9 +50,9 @@ class TestMCPWorkspaceContainment:
             await method({path_key: "/home/other/repo/file.py"})
 
     @pytest.mark.asyncio
-    async def test_release_prep_blocks_external_path(self, server):
+    async def test_release_notes_blocks_external_path(self, server):
         with pytest.raises(ValueError, match="outside allowed directory"):
-            await server._run_release_prep({"path": "/home/other/repo"})
+            await server._run_release_notes({"path": "/home/other/repo"})
 
     @pytest.mark.asyncio
     async def test_auth_recommend_blocks_external_path(self, server):

--- a/tests/unit/mcp/handlers/test_workflow_handlers.py
+++ b/tests/unit/mcp/handlers/test_workflow_handlers.py
@@ -1,7 +1,7 @@
 """Unit tests for workflow handler methods on EmpathyMCPServer.
 
 Tests cover _run_security_audit, _run_bug_predict, _run_code_review,
-_run_test_generation, _run_performance_audit, and _run_release_prep
+_run_test_generation, _run_performance_audit, and _run_release_notes
 via the server methods (previously tested via standalone functions in
 the deleted attune.mcp.handlers.workflow_handlers module).
 
@@ -329,11 +329,11 @@ class TestRunPerformanceAudit:
         mod.PerformanceAuditWorkflow.return_value.execute.assert_awaited_once_with(path="/app")
 
 
-class TestRunReleasePrep:
-    """Tests for _run_release_prep()."""
+class TestRunReleaseNotes:
+    """Tests for _run_release_notes()."""
 
     @pytest.mark.asyncio
-    async def test_run_release_prep_returns_expected_keys(self):
+    async def test_run_release_notes_returns_expected_keys(self):
         """Happy path: returns approved, health_score, recommendation, cost."""
         server = _make_server()
         result = _make_result(
@@ -350,7 +350,7 @@ class TestRunReleasePrep:
         )
 
         with patch.dict(sys.modules, {"attune.workflows.release_prep": mod}):
-            out = await server._run_release_prep({"path": "."})
+            out = await server._run_release_notes({"path": "."})
 
         assert out["success"] is True
         assert out["approved"] is True
@@ -359,7 +359,7 @@ class TestRunReleasePrep:
         assert out["cost"] == 0.08
 
     @pytest.mark.asyncio
-    async def test_run_release_prep_defaults_path_to_dot(self):
+    async def test_run_release_notes_defaults_path_to_dot(self):
         """When path is not in args, defaults to '.'."""
         server = _make_server()
         result = _make_result()
@@ -368,12 +368,12 @@ class TestRunReleasePrep:
         )
 
         with patch.dict(sys.modules, {"attune.workflows.release_prep": mod}):
-            out = await server._run_release_prep({})
+            out = await server._run_release_notes({})
 
         assert "success" in out
 
     @pytest.mark.asyncio
-    async def test_run_release_prep_instantiates_without_args(self):
+    async def test_run_release_notes_instantiates_without_args(self):
         """ReleasePreparationWorkflow is instantiated with no arguments."""
         server = _make_server()
         result = _make_result()
@@ -382,12 +382,12 @@ class TestRunReleasePrep:
         )
 
         with patch.dict(sys.modules, {"attune.workflows.release_prep": mod}):
-            await server._run_release_prep({"path": "/proj"})
+            await server._run_release_notes({"path": "/proj"})
 
         mod.ReleasePreparationWorkflow.assert_called_once_with()
 
     @pytest.mark.asyncio
-    async def test_run_release_prep_passes_path_to_execute(self):
+    async def test_run_release_notes_passes_path_to_execute(self):
         """execute() receives path kwarg."""
         server = _make_server()
         result = _make_result()
@@ -396,12 +396,12 @@ class TestRunReleasePrep:
         )
 
         with patch.dict(sys.modules, {"attune.workflows.release_prep": mod}):
-            await server._run_release_prep({"path": "/proj"})
+            await server._run_release_notes({"path": "/proj"})
 
         mod.ReleasePreparationWorkflow.return_value.execute.assert_awaited_once_with(path="/proj")
 
     @pytest.mark.asyncio
-    async def test_run_release_prep_handles_string_final_output(self):
+    async def test_run_release_notes_handles_string_final_output(self):
         """Regression: when ``final_output`` degrades to a plain string
         (workflow short-circuited with an error message), the handler
         must not AttributeError on ``.get()``. The string is surfaced as
@@ -417,7 +417,7 @@ class TestRunReleasePrep:
         )
 
         with patch.dict(sys.modules, {"attune.workflows.release_prep": mod}):
-            out = await server._run_release_prep({"path": "."})
+            out = await server._run_release_notes({"path": "."})
 
         assert out["success"] is False
         assert out["approved"] is None

--- a/tests/unit/mcp/test_tool_schemas.py
+++ b/tests/unit/mcp/test_tool_schemas.py
@@ -103,7 +103,7 @@ class TestGetWorkflowTools:
             "code_review",
             "test_generation",
             "performance_audit",
-            "release_prep",
+            "release_notes",
             "deep_review",
         }
         assert expected.issubset(tools.keys())


### PR DESCRIPTION
Completes the release-prep/release-notes disambiguation (#1018) on the **MCP tool surface** — the deferred Task 1 from the session starter.

## Why

The MCP tool ran the SDK **advisory** workflow (`ReleasePreparationWorkflow`, renamed to `release-notes` in #1018) but was still exposed as `release_prep`, and the `release-prep` skill described it as a *"4-agent team"* gate it never was. This makes the tool name and skill prose honest.

## Changes (source-only)

- **`tool_schemas.py` / `server.py`** — tool key + handler `_run_release_prep` → `_run_release_notes`. Still runs `ReleasePreparationWorkflow`; the module path `attune.workflows.release_prep` is unchanged.
- **Skills** — tool refs renamed; the `release-prep` skill now distinguishes the advisory `release_notes` tool from the deterministic 4-agent gate, which stays **CLI-only** (`attune workflow run release-gate`). No crew MCP tool, per the locked decision.
- **`docs/getting-started/mcp-integration.md`** + 2 MCP test files updated.

## Deliberately excluded

- **`plugin/help/generated/*`** — NOT regenerated here. Per the polish-cost-reduction spec, generated help refreshes at **release-prep cadence**, not per feature PR (the pre-commit hook is check-only/WARN). A full regen also sweeps in ~25 unrelated lessons-drift files.

## Note

This renames a public MCP tool (`release_prep` → `release_notes`) — a breaking change for any direct caller of that tool name. Skills (how Claude invokes it) are updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)