### PR TITLE
fix(mcp): make research_synthesis tool path-based to match the workflow

### DIFF
--- a/.agents/skills/planning/SKILL.md
+++ b/.agents/skills/planning/SKILL.md
@@ -29,10 +29,16 @@ High-level development planning and architecture design.
 
 | Tool | What It Does |
 | ---- | ------------ |
-| `research_synthesis` | Synthesize insights from multiple documents to inform planning |
+| `research_synthesis` | Synthesize insights from source documents at a path to inform planning |
 
 Use `research_synthesis` when the user needs to gather
-context from multiple files or docs before planning.
+context from a directory of files or docs before planning.
+Pass the directory (or file) as `path`; optionally set
+`depth` to `quick`, `standard`, or `deep`:
+
+```
+research_synthesis(path="<dir or file>", depth="standard")
+```
 
 ## Scoping
 

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -10639,3 +10639,31 @@ files.
   --oneline -1` after the switch. And discard `.help/templates/<feat>/`
   regen-hook artifacts left unstaged by editing that feature's source
   (existing "focused-PR .help regen" lesson) before they ride along.
+
+- **`scripts/generate_all.py` regenerates the WHOLE help corpus and
+  sweeps in unrelated lessons-drift — never run it for a focused
+  feature PR; generated help refreshes at RELEASE-PREP cadence**: hit
+  2026-06-23 on the `release_prep`→`release_notes` MCP tool rename
+  (#1020). A next-session-starter note said "regenerate, don't
+  hand-edit `plugin/help/generated/*`," but running
+  `python scripts/generate_all.py` re-derived dozens of UNRELATED files
+  (lessons-corpus `errors/`/`faqs/`/`warnings/` that had drifted on
+  main — `tags:` additions, new sections) PLUS many untracked `??`
+  files — turning a 7-file rename into a 30+-file scope-polluting diff.
+  Root cause: per the **polish-cost-reduction spec (lever 1, ratified
+  2026-06-10)** per-commit auto-regen was DELIBERATELY eliminated;
+  `plugin/help/generated/*` is refreshed at release-prep cadence via
+  `attune-author regenerate`, and the pre-commit
+  `regenerate_help_templates.py` hook is **check-only / WARN — it never
+  regenerates and never spends budget**. So for a feature PR that
+  touches `tool_schemas.py` / a `SKILL.md`: edit the SOURCE, and LEAVE
+  `plugin/help/generated/*` alone — revert any accidental regen with
+  `git checkout -- plugin/help/generated/ && git clean -fdq
+  plugin/help/generated/`. The rename rides into the next
+  release-cadence regen (which also absorbs the unrelated drift at
+  once). The starter's "regenerate, don't hand-edit" guidance predates
+  the spec and is now wrong for feature PRs. Extends the existing
+  ".help template regen = whole-feature re-polish, discard from focused
+  PRs" lesson to the `generate_all.py` / `plugin/help/generated`
+  surface (the `.help/templates/` lesson is the sibling on the
+  template side).

--- a/docs/getting-started/mcp-integration.md
+++ b/docs/getting-started/mcp-integration.md
@@ -110,7 +110,7 @@ The Attune MCP server exposes all production workflows as tools:
 | `simplify_code` | Find and simplify overly complex code | `path` |
 | `deep_review` | Multi-pass security + quality + test-gap review | `path` |
 | `health_check` | Comprehensive project health score | `project_root` |
-| `research_synthesis` | Synthesize multiple sources into a research answer | `sources`, `question` |
+| `research_synthesis` | Synthesize insights from local source documents at a path | `path` (optional), `depth` (optional) |
 | `analyze_batch` | Submit tasks to Anthropic Batch API (50% cost savings) | `requests` |
 | `rag_knowledge_query` | Query the RAG corpus for contextual knowledge | `query` |
 

--- a/plugin/skills/planning/SKILL.md
+++ b/plugin/skills/planning/SKILL.md
@@ -31,10 +31,16 @@ High-level development planning and architecture design.
 
 | Tool | What It Does |
 | ---- | ------------ |
-| `research_synthesis` | Synthesize insights from multiple documents to inform planning |
+| `research_synthesis` | Synthesize insights from source documents at a path to inform planning |
 
 Use `research_synthesis` when the user needs to gather
-context from multiple files or docs before planning.
+context from a directory of files or docs before planning.
+Pass the directory (or file) as `path`; optionally set
+`depth` to `quick`, `standard`, or `deep`:
+
+```
+research_synthesis(path="<dir or file>", depth="standard")
+```
 
 ## Scoping
 

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -161,21 +161,22 @@ def get_workflow_tools() -> dict[str, dict[str, Any]]:
             param_desc="Project root to check",
         ),
         "research_synthesis": {
-            "description": "Synthesize insights from multiple documents. Summarizes, analyzes patterns, and produces a unified answer.",
+            "description": "Synthesize insights from local source documents at a path. A 3-agent pipeline summarizes, analyzes patterns across, and produces a unified answer from the documents found at the given directory or file.",
             "input_schema": {
                 "type": "object",
                 "properties": {
-                    "sources": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "description": "List of document texts to synthesize (minimum 2)",
-                    },
-                    "question": {
+                    "path": {
                         "type": "string",
-                        "description": "Research question to answer",
+                        "description": "Directory or file of source documents to analyze",
+                        "default": ".",
+                    },
+                    "depth": {
+                        "type": "string",
+                        "enum": ["quick", "standard", "deep"],
+                        "description": "Synthesis depth / agent budget (default: standard)",
+                        "default": "standard",
                     },
                 },
-                "required": ["sources", "question"],
             },
         },
         "analyze_batch": {

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -437,31 +437,28 @@ class WorkflowHandlersMixin:
     # ------------------------------------------------------------------
 
     async def _run_research_synthesis(self, args: dict[str, Any]) -> dict[str, Any]:
-        """Run research synthesis workflow.
+        """Run the research-synthesis workflow over local documents.
 
         Args:
-            args: ``sources`` (list[str], required, min 2) and
-                ``question`` (str, required).
+            args: ``path`` (str, optional, default ".") — directory or
+                file of source documents to analyze; ``depth`` (str,
+                optional) — "quick", "standard" (default), or "deep".
 
         Returns:
-            Dict with synthesized answer and key insights.
+            Dict with the synthesized answer and key insights.
 
         """
         from attune.workflows.research_synthesis import (
             ResearchSynthesisWorkflow,
         )
 
-        sources = args.get("sources", [])
-        if len(sources) < 2:
-            return {
-                "success": False,
-                "error": "At least 2 sources are required.",
-            }
-
+        # The workflow is a path-driven 3-agent pipeline (it reads source
+        # documents at ``path``); passing the legacy ``sources``/``question``
+        # kwargs left ``path`` empty → "path argument is required".
         workflow = ResearchSynthesisWorkflow()
         result = await workflow.execute(
-            sources=sources,
-            question=args.get("question", ""),
+            path=self._validated_path(args),
+            depth=args.get("depth", "standard"),
         )
 
         final = result.final_output if hasattr(result, "final_output") else result

--- a/tests/unit/mcp/handlers/test_workflow_handlers_extra.py
+++ b/tests/unit/mcp/handlers/test_workflow_handlers_extra.py
@@ -219,9 +219,7 @@ class TestRunResearchSynthesisNonDict:
             "attune.workflows.research_synthesis.ResearchSynthesisWorkflow.execute",
             new=AsyncMock(return_value=mock_result),
         ):
-            result = await server._run_research_synthesis(
-                {"sources": ["src/", "docs/"], "question": "what is X?"}
-            )
+            result = await server._run_research_synthesis({"path": "docs", "depth": "quick"})
 
         assert result["success"] is True
         assert "output" in result

--- a/tests/unit/mcp/handlers/test_workflow_handlers_mixin.py
+++ b/tests/unit/mcp/handlers/test_workflow_handlers_mixin.py
@@ -696,10 +696,10 @@ class TestRunHealthCheck:
 
 
 class TestRunResearchSynthesis:
-    """Tests for _run_research_synthesis() — no path validation needed."""
+    """Tests for _run_research_synthesis() — path-driven workflow."""
 
     @pytest.mark.asyncio
-    async def test_returns_expected_keys(self):
+    async def test_returns_expected_keys(self, _bypass_path_validation):
         """Happy path: returns answer and insights."""
         server = _make_server()
         result = _make_result(
@@ -717,30 +717,45 @@ class TestRunResearchSynthesis:
         )
 
         with patch.dict(sys.modules, {"attune.workflows.research_synthesis": mod}):
-            out = await server._run_research_synthesis(
-                {
-                    "sources": ["src-a", "src-b"],
-                    "question": "what is X?",
-                }
-            )
+            out = await server._run_research_synthesis({"path": "docs", "depth": "quick"})
 
         assert out["success"] is True
         assert out["answer"] == "synthesis result"
         assert out["key_insights"] == ["insight-1"]
 
     @pytest.mark.asyncio
-    async def test_fewer_than_two_sources_returns_error(self):
-        """Returns error dict when fewer than 2 sources provided."""
+    async def test_passes_path_and_depth_to_execute(self, _bypass_path_validation):
+        """execute() receives validated path + depth (regression for the
+        sources/question kwarg drift that left path empty)."""
         server = _make_server()
-        out = await server._run_research_synthesis({"sources": ["only-one"]})
+        result = _make_result(final_output={"answer": "ok"})
+        mod = _make_workflow_module(
+            "attune.workflows.research_synthesis",
+            "ResearchSynthesisWorkflow",
+            result,
+        )
 
-        assert out["success"] is False
-        assert "2 sources" in out["error"]
+        with patch.dict(sys.modules, {"attune.workflows.research_synthesis": mod}):
+            await server._run_research_synthesis({"path": "research", "depth": "deep"})
+
+        mod.ResearchSynthesisWorkflow.return_value.execute.assert_awaited_once_with(
+            path="research", depth="deep"
+        )
 
     @pytest.mark.asyncio
-    async def test_empty_sources_returns_error(self):
-        """Returns error dict when no sources provided."""
+    async def test_depth_defaults_to_standard(self, _bypass_path_validation):
+        """Omitted depth defaults to 'standard'; omitted path defaults to '.'."""
         server = _make_server()
-        out = await server._run_research_synthesis({})
+        result = _make_result(final_output={"answer": "ok"})
+        mod = _make_workflow_module(
+            "attune.workflows.research_synthesis",
+            "ResearchSynthesisWorkflow",
+            result,
+        )
 
-        assert out["success"] is False
+        with patch.dict(sys.modules, {"attune.workflows.research_synthesis": mod}):
+            await server._run_research_synthesis({})
+
+        mod.ResearchSynthesisWorkflow.return_value.execute.assert_awaited_once_with(
+            path=".", depth="standard"
+        )

--- a/tests/unit/mcp/test_tool_schemas.py
+++ b/tests/unit/mcp/test_tool_schemas.py
@@ -113,11 +113,20 @@ class TestGetWorkflowTools:
         schema = get_workflow_tools()["test_generation"]["input_schema"]
         assert "module" in schema["required"]
 
-    def test_research_synthesis_requires_sources_and_question(self) -> None:
-        """research_synthesis requires both sources and question."""
+    def test_research_synthesis_is_path_based(self) -> None:
+        """research_synthesis takes optional path + depth (no required args).
+
+        The workflow is a path-driven 3-agent pipeline; the tool must not
+        require the legacy sources/question contract.
+        """
         schema = get_workflow_tools()["research_synthesis"]["input_schema"]
-        assert "sources" in schema["required"]
-        assert "question" in schema["required"]
+        props = schema["properties"]
+        assert "path" in props
+        assert "depth" in props
+        assert props["depth"]["enum"] == ["quick", "standard", "deep"]
+        assert "required" not in schema
+        assert "sources" not in props
+        assert "question" not in props
 
 
 # -- get_utility_tools ------------------------------------------------


### PR DESCRIPTION
Fixes the **broken `research_synthesis` MCP tool** — the last MCP handler with the kwarg-drift bug class from #1017 (this one semantic, not a rename). Task 2 from the session starter.

## The bug

The handler passed `execute(sources=..., question=...)`, but `ResearchSynthesisWorkflow` was refactored into a **path-driven 3-agent pipeline** (`execute(path=, depth=)`) that ignores `sources`/`question`. Result: **every call returned "path argument is required."** The schema also still declared `sources`/`question` as required — and `path` wasn't even accepted.

## Fix — Option A: realign the tool to the workflow

The workflow is the implementation; the tool drifted from it ("the code is the contract"). The `planning` skill's own intent ("gather context from multiple **files**") fits path-based better than inline source-texts.

- **handler** (`workflow_handlers.py`) — read `path` (validated via `_validated_path`, like `doc_audit`) + `depth`; drop the `sources<2` check and `sources`/`question` kwargs. Output handling already supported the new `WorkflowReport` format.
- **schema** (`tool_schemas.py`) — `path` (optional, default `.`) + `depth` enum `quick`/`standard`/`deep`; no required args.
- **docs + planning skill** — document the path/depth contract.
- **tests** — rewrite handler + schema tests to the path-based contract (incl. a regression test that `execute` receives `path`/`depth`).

## Not chosen

- **B (restore sources/question to the workflow)** — fights the 3-agent refactor, adds a parallel input path.
- **C (delete the tool)** — it's a distinct capability (local-doc synthesis, ≠ `/deep-research`'s web research) the planning skill documents.

## Note

`plugin/help/generated/*` intentionally not regenerated (release-prep cadence, per polish-cost-reduction spec). A lesson documenting that trap is included in `.claude/lessons.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)