### PR TITLE
docs(help): single-source memory via projector (13/25)

### DIFF
--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -176,18 +176,25 @@ features:
     doc_paths:
       - docs/how-to/help-system-maintenance.md
 
+  # memory is single-sourced (status: manual) from
+  # content/features/memory.md and rendered by
+  # attune_author.projector (scripts/project_features.py), which owns
+  # .help/templates/memory/*.md. The entry is marked `status: manual`
+  # — WITHOUT `files:` — so topic resolution routes here while
+  # staleness/maintenance never runs `attune-author generate memory
+  # --all-kinds` to overwrite the projected content with LLM output
+  # (DD5, help-docs-single-source decision, 2026-06-23). The retained
+  # faq.md stays on disk frozen until the four-channel FAQ Generator
+  # (D6/D7) replaces that path. The cross-cutting hand-authored
+  # docs/how-to/memory-graph.md and docs/how-to/unified-memory-system.md
+  # remain as-is (they are not projected feature pages). Description and
+  # tags are unchanged to preserve golden-query resolution (mem-002
+  # "storage"; rg-003 relies on memory using "lookup" not "retrieval").
+  # See docs/specs/help-docs-single-source/.
   memory:
     description: Memory subsystem — storage, lookup, and security
-    files:
-      - src/attune/memory/**
     tags: [memory, storage]
-    doc_paths:
-      - docs/how-to/memory-graph.md
-      - docs/how-to/unified-memory-system.md
-      - docs/how-to/context-management.md
-      - docs/how-to/learning-and-patterns.md
-      - docs/reference/pattern-library.md
-      - docs/reference/persistence.md
+    status: manual
 
   agents:
     description: Release agents, state persistence, and recovery

--- a/.help/templates/memory/comparison.md
+++ b/.help/templates/memory/comparison.md
@@ -3,88 +3,26 @@ type: comparison
 name: memory-comparison
 feature: memory
 depth: comparison
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
 ---
 
-# Comparison: Memory backends
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-## Overview
+## Comparison
 
-The memory subsystem offers two backend tiers — a base protocol (`MemoryBackend`) and an extended protocol (`SearchableMemoryBackend`) — plus two complementary integration paths: Redis-backed short-term memory and Claude Code file-based memory (`ClaudeMemoryLoader`). Choosing the right combination depends on whether you need distributed state, semantic search, or static project context loaded at startup.
+Memory's two tiers serve different retention horizons:
 
-## Backend protocol comparison
+| Tier | API | Lifetime | Backed by |
+|------|-----|----------|-----------|
+| Short-term | `stash` / `retrieve` | TTL-expiring (seconds–days) | Redis or in-process |
+| Long-term | `persist_pattern` / `recall_pattern` / `search_patterns` | Durable | Persistent storage |
+| Staging | `stage_pattern` / `promote_pattern` | Until promoted or expired | Short-term, then long-term |
+| Static | `ClaudeMemoryLoader.load_all_memory()` | Read-only project files | `CLAUDE.md` files |
 
-| Capability | `MemoryBackend` | `SearchableMemoryBackend` |
-|---|---|---|
-| Basic store / retrieve / delete | ✅ `stash`, `retrieve`, `delete` | ✅ inherits all base methods |
-| Key-pattern listing | ✅ `keys(pattern)` | ✅ |
-| Connection health check | ✅ `is_connected()`, `get_stats()` | ✅ |
-| Distributed support | runtime flag via `supports_distributed()` | runtime flag via `supports_distributed()` |
-| Real-time pub/sub support | runtime flag via `supports_realtime()` | runtime flag via `supports_realtime()` |
-| Semantic search | ❌ | ✅ `search(query, limit, **filters)` |
-| Long-term memory promotion | ❌ | ✅ `promote(session_id)` |
-| Content-addressed storage | ❌ | ✅ `remember(content, memory_id, session_id, topics)` |
-| Pruning by age | ❌ | ✅ `prune(max_age_days)` |
-| Recent-item retrieval | ❌ | ✅ `recent(limit, **filters)` |
-
-`SearchableMemoryBackend` is a strict superset of `MemoryBackend`. There is no scenario where the base protocol is preferable on features alone; the base protocol exists so that lightweight backends can satisfy the contract without implementing search infrastructure.
-
-## Storage path comparison
-
-| Dimension | Redis short-term memory | Claude file memory (`ClaudeMemoryLoader`) |
-|---|---|---|
-| **Backing store** | Redis instance (local or remote) | Filesystem (`CLAUDE.md` files) |
-| **Persistence** | TTL-controlled; evicted when TTL expires or Redis restarts | Persists as long as the file exists; survives process restarts |
-| **Scope** | Per-agent or shared across agents via `agent_id` param | Per-project; scoped by `project_root` in `ClaudeMemoryConfig` |
-| **Distributed** | Yes — multiple agents share one Redis | No — file reads are local to the process |
-| **Import depth** | N/A | Configurable via `max_import_depth` (default 5 levels) |
-| **File size guard** | N/A | Enforced via `max_file_size_bytes` (default 1 MB) |
-| **Entry point** | `get_redis_memory(url, use_mock)` | `ClaudeMemoryLoader(config).load_all_memory(project_root)` |
-| **Railway support** | `get_railway_redis()` — raises `OSError` if `REDIS_URL` is absent | Not applicable |
-| **Availability check** | `is_redis_available()` — safe to call without importing Redis | No equivalent; file presence is the availability signal |
-| **Typical data** | Ephemeral agent state, session keys, short-lived values | Project conventions, framework guidelines, reusable instructions |
-
-## Feature matrix: enterprise control plane
-
-`MemoryControlPanel` adds an operational layer on top of Redis short-term memory. It has no equivalent for file-based memory.
-
-| Operation | API method | Notes |
-|---|---|---|
-| Redis lifecycle | `start_redis(verbose)`, `stop_redis()` | Only relevant when `ControlPanelConfig.auto_start_redis` is `True` |
-| Health and stats | `health_check()`, `get_statistics()`, `status()` | Returns `MemoryStats` / `dict` |
-| Pattern management | `list_patterns(classification, limit)`, `delete_pattern(pattern_id, user_id)` | Supports classification filtering |
-| Bulk operations | `clear_short_term(agent_id)`, `export_patterns(output_path, classification)` | Export writes to a file path |
-| HTTP API surface | `run_api_server(panel, host, port, api_key, ...)` | Includes rate limiting, SSL, and CORS via `RateLimiter` and `APIKeyAuth` |
-
-There is no `MemoryControlPanel` equivalent for `ClaudeMemoryLoader`. If you need audit logging, PII scrubbing (`PIIScrubber`), secrets detection (`SecretsDetector`), or access classification (`ClassificationRules`), those are Redis-path concerns.
-
-## Decision guide
-
-**Use Redis short-term memory (`get_redis_memory`) when:**
-- Multiple agents need to share state within or across sessions — `supports_distributed()` must return `True`.
-- You need TTL-controlled eviction: stale values should disappear automatically.
-- You are deploying to Railway and have a Redis add-on; use `get_railway_redis()`.
-- You need the enterprise control plane: audit logging, pattern export, PII scrubbing, or the HTTP API.
-- You want real-time coordination between agents (pub/sub via `supports_realtime()`).
-
-**Use `ClaudeMemoryLoader` when:**
-- You need to inject static project context — coding conventions, framework rules, project-specific instructions — into an agent at startup.
-- The content lives in `CLAUDE.md` files and is edited by humans, not written programmatically.
-- You want zero infrastructure: no Redis, no network, no TTLs.
-- Memory must survive process restarts without any explicit persistence code.
-
-**Use `SearchableMemoryBackend` (over `MemoryBackend`) when:**
-- Your backend implementation supports semantic search and you want to expose `search`, `remember`, `promote`, and `prune` to callers.
-- You are writing a backend adapter and the underlying store (e.g., a vector database) can satisfy the full contract.
-
-**Stick with the base `MemoryBackend` when:**
-- You are implementing a lightweight backend (mock, in-memory, or test fixture) that does not need search.
-- You want to enforce at the type level that a component only uses simple key-value operations.
-
-## Source files
-
-- `src/attune/memory/**`
-
-**Tags:** `memory`, `storage`
+Reach for **short-term** working memory for transient state, **staging
++ promotion** when a pattern should be reviewed before it becomes
+durable, and **long-term patterns** for knowledge you'll search later.
+`UnifiedMemory` exposes all three; `ClaudeMemoryLoader` is the separate
+static-context path.

--- a/.help/templates/memory/concept.md
+++ b/.help/templates/memory/concept.md
@@ -3,52 +3,112 @@ type: concept
 name: memory-concept
 feature: memory
 depth: concept
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
-scaffold_hash: fc0d9984517f8c22ce4ac76cb18edf9fd2a3bcc4d42b5edbc949332d6846906e
 ---
 
-# Memory
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-Attune AI memory is a three-layer system that gives agents short-term working storage, searchable long-term pattern recall, and static project context — all with built-in classification, PII scrubbing, and secrets detection before anything reaches persistent storage.
+## Overview
 
-## Memory layers
+Attune's memory subsystem gives agents two tiers of storage behind one
+API: **short-term** working memory (fast, TTL-expiring, optionally
+Redis-backed) and **long-term** pattern memory (durable, searchable,
+classified). Security runs before anything durable is written —
+auto-classification, PII scrubbing, secrets detection, and at-rest
+encryption for sensitive patterns.
 
-Each layer serves a different retention horizon and access pattern.
+The recommended entry point is **`UnifiedMemory`**, which composes both
+tiers and the security layer behind a single object. It is
+environment-aware: a `MemoryConfig` auto-detected from the environment
+chooses backends (in-process for development, Redis for production) so
+the same code runs in either. For custom backends, two protocols —
+`MemoryBackend` and `SearchableMemoryBackend` — define the short-term
+and searchable contracts.
 
-**Short-term agent memory** is a keyed store scoped per `agent_id`, backed by any class that implements the `MemoryBackend` protocol. The core operations are `stash(key, value, ttl, agent_id)`, `retrieve(key, agent_id)`, `delete(key)`, and `keys(pattern)`. An optional `ttl` argument expires entries automatically. Two capability flags determine backend fitness for your deployment: `supports_realtime()` and `supports_distributed()`. A Redis-backed store passes both; an in-process mock typically passes neither. Call `is_connected()` before use and `get_stats()` for runtime metrics.
+You reach memory these ways:
 
-**Long-term searchable memory** extends `MemoryBackend` through the `SearchableMemoryBackend` protocol. Rather than retrieving by exact key, you query by content: `search(query, limit)` returns ranked results, and `recent(limit)` surfaces the most recently stored entries. Use `remember(content, topics=[...])` to store an entry, `promote(session_id)` to graduate session-scoped memories into the durable store, and `prune(max_age_days)` to expire stale entries.
+- the Python API — `from attune.memory import UnifiedMemory` (the
+  primary surface, documented throughout);
+- the **`MemoryBackend` / `SearchableMemoryBackend` protocols** (in
+  `attune.memory.backend`) — for wiring a custom store (any class
+  implementing the methods works);
+- **`ClaudeMemoryLoader`** — for static project context merged from
+  `CLAUDE.md` files;
+- **`MemoryControlPanel`** — a runtime management surface for browsing,
+  exporting, and clearing stored memory.
 
-**Static project context** comes from CLAUDE.md files resolved at enterprise, user, and project levels. `ClaudeMemoryLoader` reads these files in order — controlled by the `load_enterprise`, `load_user`, and `load_project` fields on `ClaudeMemoryConfig` — and returns a single merged string from `load_all_memory()`. Files that import other paths are followed recursively up to `max_import_depth` (default `5`). Set `validate_files=True` to reject any file that exceeds `max_file_size_bytes` (default `1000000` bytes). To bootstrap a new project, `create_default_project_memory(project_root, framework='empathy')` writes a starter `.claude/CLAUDE.md` with the expected structure.
+`UnifiedMemory`'s public methods are synchronous — call them directly,
+no `await`.
 
-## Security controls
+## Concepts
 
-Classification and scrubbing run before any pattern reaches durable storage. `ClassificationRules` assigns a `Classification` level using keyword lists (`HEALTHCARE_KEYWORDS`, `FINANCIAL_KEYWORDS`, `PROPRIETARY_KEYWORDS`) and type lists (`SENSITIVE_PATTERN_TYPES`, `INTERNAL_PATTERN_TYPES`). The `PIIScrubber` strips personally identifiable information, and `SecretsDetector` flags credential-like content. `EncryptionManager` handles at-rest encryption for patterns that require it. `AuditLogger` records every write and access as an `AuditEvent` for compliance trails.
+### Two tiers, one object
 
-## Enterprise control surface
+`UnifiedMemory(user_id=...)` exposes both tiers:
 
-`MemoryControlPanel` exposes runtime operations without requiring code changes. You can check `status()` and `health_check()`, browse stored patterns with `list_patterns(classification=None, limit=100)`, remove a specific pattern with `delete_pattern(pattern_id, user_id)`, bulk-clear short-term entries with `clear_short_term(agent_id)`, and export pattern sets to disk with `export_patterns(output_path)`.
+- **Short-term** — a keyed working store: `stash(key, value,
+  ttl_seconds=None)` writes, `retrieve(key)` reads. Entries expire
+  after `ttl_seconds` (or the config default). Backed by Redis when
+  available, an in-process store otherwise.
+- **Long-term** — durable, searchable **patterns**:
+  `persist_pattern(content, pattern_type, ...)` stores one,
+  `recall_pattern(pattern_id)` reads it back, and `search_patterns(
+  query=..., limit=10)` queries by content. Patterns can be **staged**
+  first (`stage_pattern(...)`) and later **promoted** to durable
+  storage (`promote_pattern(staged_id)`).
 
-The panel is configured through `ControlPanelConfig`, which defaults Redis to `localhost:6379` and uses `./memdocs_storage` for pattern documents. When `auto_start_redis=True`, the panel starts Redis automatically if it isn't already running.
+### Construction is environment-aware
 
-`run_api_server(panel, host, port)` wraps the panel in an HTTP server backed by `MemoryAPIHandler`, which handles `GET`, `POST`, `DELETE`, and `OPTIONS` requests. Optional arguments let you add TLS (`ssl_certfile`, `ssl_keyfile`), restrict access with `APIKeyAuth` (via `api_key`), and enforce request budgets with `RateLimiter` (`rate_limit_requests`, `rate_limit_window`). Set `allowed_origins` for CORS control.
+`UnifiedMemory` takes a required `user_id`, an optional `config`
+(`MemoryConfig`, default auto-detected from the environment), and an
+optional `access_tier` (`AccessTier`, default `CONTRIBUTOR`).
+`MemoryConfig.from_environment()` reads `ATTUNE_`-prefixed variables
+(`EMPATHY_` also accepted) — `ATTUNE_ENV` selects `development`,
+`staging`, or `production`, which in turn drives Redis and storage
+defaults. Construct one with explicit settings via
+`UnifiedMemory(user_id="me", config=MemoryConfig(...))`.
 
-For Railway deployments, `get_railway_redis()` reads `REDIS_URL` from the environment and raises `OSError` with setup instructions if the variable is absent.
+### Security runs before durable writes
 
-## Integration surface
+When you persist a pattern, classification and scrubbing run first.
+`auto_classify=True` (the default) assigns a `Classification` —
+`PUBLIC`, `INTERNAL`, or `SENSITIVE` — from the content and pattern
+type; PII is scrubbed and credential-like content is flagged before
+storage; `SENSITIVE` patterns are encrypted at rest. You can pass an
+explicit `classification` to override the auto-assignment. Reads honor
+the caller's `access_tier` unless you set `check_permissions=False` on
+`recall_pattern`.
 
-| Type | Name | Role |
-|------|------|------|
-| Protocol | `MemoryBackend` | Short-term key-value store with TTL and agent scoping |
-| Protocol | `SearchableMemoryBackend` | Extends `MemoryBackend` with semantic search, promotion, and pruning |
-| Dataclass | `ClaudeMemoryConfig` | Controls which CLAUDE.md levels load, import depth, and file-size limits |
-| Dataclass | `MemoryFile` | One resolved CLAUDE.md file: `level`, `path`, `content`, `imports`, `load_order` |
-| Class | `ClaudeMemoryLoader` | Resolves and merges CLAUDE.md files; primary entry point is `load_all_memory()` |
-| Class | `MemoryControlPanel` | Runtime management for patterns, short-term entries, and Redis lifecycle |
-| Dataclass | `ControlPanelConfig` | Redis coordinates (`redis_host`, `redis_port`) and storage paths for the control panel |
-| Function | `is_redis_available()` | Lightweight probe that checks Redis availability without importing the subsystem |
-| Function | `get_redis_memory(url, use_mock)` | Factory that reads environment config and returns a `RedisShortTermMemory` instance |
-| Function | `get_railway_redis()` | Railway-specific factory; raises `OSError` if `REDIS_URL` is absent |
-| Function | `create_default_project_memory(project_root, framework)` | Writes a starter CLAUDE.md to bootstrap a new project |
+### Capabilities tell you what the backend can do
+
+A deployment's backend may or may not support real-time updates,
+distribution across processes, or durable persistence. `UnifiedMemory`
+surfaces this: `get_capabilities()` returns a `dict[str, bool]`, and
+`supports_realtime()`, `supports_distributed()`, and
+`supports_persistence()` answer individually. `health_check()` and
+`get_backend_status()` report runtime state. Check capabilities before
+relying on, say, cross-process coordination.
+
+### Custom backends implement a protocol
+
+`MemoryBackend` is a `@runtime_checkable` `Protocol` for short-term
+stores: `stash(key, value, ttl, agent_id)`, `retrieve(key, agent_id)`,
+`delete(key)`, `keys(pattern)`, `is_connected()`, `get_stats()`,
+`close()`, plus `supports_realtime()` / `supports_distributed()`.
+`SearchableMemoryBackend` extends it with `search(query, limit)`,
+`remember(content, ...)`, `promote(session_id)`, `prune(max_age_days)`,
+and `recent(limit)`. Any class implementing the methods satisfies the
+protocol — no base class to inherit. (Note these protocol signatures —
+`stash(key, value, ttl, agent_id)` — differ from `UnifiedMemory`'s
+own `stash(key, value, ttl_seconds)`.)
+
+### Static project context
+
+`ClaudeMemoryLoader` resolves `CLAUDE.md` files at enterprise, user,
+and project levels and merges them via its `load_all_memory()` method.
+Which levels load is controlled by the `MemoryConfig` **fields**
+`load_enterprise_memory` / `load_user_memory` / `load_project_memory`
+(not loader methods). This is the static counterpart to the read/write
+tiers above.

--- a/.help/templates/memory/error.md
+++ b/.help/templates/memory/error.md
@@ -3,54 +3,40 @@ type: error
 name: memory-error
 feature: memory
 depth: error
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
 ---
 
-# Memory errors
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-## Common error signatures
+## Failure modes
 
-Failures in the memory subsystem fall into three categories: Redis connectivity errors, filesystem errors when loading `CLAUDE.md` memory files, and security/permission violations when accessing classified patterns.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `TypeError: __init__() missing 1 required positional argument: 'user_id'` | `UnifiedMemory()` constructed without `user_id` | Pass `user_id` — it is required | high |
+| `persist_pattern` / `stage_pattern` returns `None` | Long-term storage unavailable (e.g. no writable `storage_dir`) | Check `health_check()` / `get_backend_status()`; confirm storage config | medium |
+| `retrieve` returns `None` for a key you stashed | The entry expired (`ttl_seconds`) or the backend isn't persistent | Re-stash with a longer TTL; check `supports_persistence()` | medium |
+| Cross-process reads don't see another process's writes | The backend isn't distributed (in-process store) | Check `supports_distributed()`; configure Redis | medium |
+| `recall_pattern` returns `None` for a real id | `check_permissions=True` and the caller's `access_tier` is insufficient | Use a higher `access_tier`, or pass `check_permissions=False` for trusted callers | medium |
+| A `SENSITIVE` pattern stored unencrypted | `encryption_enabled` is off in the config | Enable encryption in `MemoryConfig` | medium |
 
-| Exception | Likely source | Typical cause |
-|---|---|---|
-| `OSError: REDIS_URL not found...` | `get_railway_redis()` | `REDIS_URL` environment variable is missing from the Railway project |
-| `OSError` | `create_default_project_memory()` | Target directory is not writable or `project_root` path does not exist |
-| `MemoryPermissionError` | Pattern access checks | Caller's access tier does not meet the pattern's `Classification` level |
-| `SecurityError` | `SecureMemDocsIntegration` | PII or secrets detected in content being stored |
-| `ValueError` | `parse_redis_url()` | Malformed Redis URL passed to connection setup |
-| `ConnectionError` | `MemoryBackend.is_connected()` | Redis process is not running or the configured host/port is unreachable |
+### Risk areas
 
-## Where errors originate
+- **`user_id` is required.** `UnifiedMemory` is per-user; there is no
+  zero-arg constructor.
+- **Protocol vs. `UnifiedMemory` signatures differ.** The protocol's
+  `stash(key, value, ttl, agent_id)` is not `UnifiedMemory`'s
+  `stash(key, value, ttl_seconds)` — don't conflate them.
+- **Capabilities are deployment-dependent.** Real-time, distribution,
+  and persistence vary by backend — check before relying on them.
 
-Errors can arise from any of the following entry points. The function that raises is usually not the one the caller invoked — trace the chained exception (`__cause__`) to find the original raise site.
+### Diagnosis order
 
-- **`get_railway_redis()`** — raises `OSError` when `REDIS_URL` is absent. The error message includes the exact Railway CLI command needed to add Redis.
-- **`get_redis_memory(url, use_mock)`** — wraps environment-based Redis setup; failures here usually mean the URL is malformed or the environment variable is unset.
-- **`parse_redis_url(url)`** — raises `ValueError` on a malformed URL before a connection is attempted.
-- **`create_default_project_memory(project_root, framework)`** — raises `OSError` if `.claude/CLAUDE.md` cannot be written.
-- **`ClaudeMemoryLoader.load_all_memory(project_root)`** — raises if `max_import_depth` is exceeded or a file exceeds `max_file_size_bytes` (default 1 000 000 bytes).
-- **`MemoryControlPanel.start_redis()`** / **`stop_redis()`** — failures surface as `RedisStatus` error states or raise if the subprocess cannot be managed.
-- **`MemoryBackend.stash()` / `retrieve()` / `delete()`** — raise when the backend is not connected; call `is_connected()` first to distinguish a connection failure from a logic error.
-
-## How to diagnose
-
-1. **Read the full exception chain.** When exceptions are re-raised with `from e`, Python prints both the original cause and the wrapper. The original cause names the exact operation that failed — do not stop at the outermost message.
-
-2. **Check whether Redis is reachable.** Call `is_redis_available()` to test whether the Redis subsystem can be imported, then call `check_redis_connection()` to verify the live connection. A `False` or error result from either narrows the problem to infrastructure rather than application logic.
-
-3. **Inspect `ClaudeMemoryConfig` fields when memory files fail to load.** Verify that `project_root` resolves to the correct directory, that `max_import_depth` (default 5) is not too low for your import graph, and that no file exceeds `max_file_size_bytes`. Set `validate_files = True` (the default) to surface malformed files early.
-
-4. **Check access tier for `MemoryPermissionError`.** Pattern access is gated by `Classification` rules. Confirm the agent's access tier against the pattern's classification level. Healthcare, financial, and proprietary patterns are governed by `HEALTHCARE_KEYWORDS`, `FINANCIAL_KEYWORDS`, and `PROPRIETARY_KEYWORDS` classification rules respectively.
-
-5. **Confirm the environment variable for Railway deployments.** `get_railway_redis()` requires `REDIS_URL`. If it is absent, the error message instructs you to run `railway add --database redis`. For external access, use `REDIS_PUBLIC_URL` instead.
-
-6. **Use `MemoryControlPanel.health_check()`** to get a structured report of Redis status, storage availability, and audit log accessibility in one call before diving into individual subsystems.
-
-## Source files
-
-- `src/attune/memory/**`
-
-**Tags:** `memory`, `storage`
+1. Confirm construction: `UnifiedMemory(user_id="...")`.
+2. `health_check()` / `get_backend_status()` for backend state.
+3. `get_capabilities()` to confirm realtime/distributed/persistence.
+4. For a missing short-term key, check the TTL and
+   `supports_persistence()`.
+5. For a missing pattern, check `pattern_id`, `access_tier`, and
+   `check_permissions`.

--- a/.help/templates/memory/faq.md
+++ b/.help/templates/memory/faq.md
@@ -3,60 +3,65 @@ type: faq
 name: memory-faq
 feature: memory
 depth: faq
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
-status: generated
+status: manual
 ---
 
 # Memory FAQ
 
-## What does the memory feature do?
+## What does the memory subsystem do?
 
-It provides storage, lookup, and security for agent memory. The module covers short-term backends (via `MemoryBackend` and `SearchableMemoryBackend`), Claude Code memory file loading (`ClaudeMemoryLoader`), and an enterprise control panel (`MemoryControlPanel`) for managing patterns, Redis, and audit logs.
+It gives agents two tiers of storage behind one API: short-term
+working memory (TTL-expiring, optionally Redis-backed) and long-term
+pattern memory (durable, searchable, classified). Security —
+auto-classification, PII scrubbing, secrets detection, and at-rest
+encryption for sensitive patterns — runs before anything durable is
+written. The recommended entry point is `UnifiedMemory`.
 
-## When do I need to use the memory feature?
+## What's the difference between short-term and long-term memory?
 
-Use it when your agent needs to store or retrieve state across steps, load project-level `CLAUDE.md` memory files, or manage long-term patterns with classification and security controls. If you only need simple key-value caching with no agent context, a plain dict or file may be sufficient.
+Short-term (`stash` / `retrieve`) is TTL-expiring working storage.
+Long-term (`persist_pattern` / `recall_pattern` / `search_patterns`)
+is durable, searchable, classified pattern storage. Patterns can be
+staged first (`stage_pattern`) and promoted later (`promote_pattern`).
 
-## How do I check whether Redis is available before using it?
+## How do I construct a UnifiedMemory?
 
-Call `is_redis_available()`. It checks the Redis subsystem without importing it, so it's safe to call at startup or in a conditional import path.
+`UnifiedMemory(user_id="...")`. `user_id` is required; `config`
+(a `MemoryConfig`, default auto-detected from the environment) and
+`access_tier` (default `AccessTier.CONTRIBUTOR`) are optional. Import
+it with `from attune.memory import UnifiedMemory`.
 
-## How do I get a Redis-backed memory instance?
+## Do I need Redis?
 
-Call `get_redis_memory(url=..., use_mock=...)`. It reads environment variables for configuration, so you can omit both arguments in most deployments. On Railway, use `get_railway_redis()` instead — it raises `OSError` with remediation instructions if `REDIS_URL` is not set.
+No. `UnifiedMemory` auto-detects the environment and uses an
+in-process store when Redis isn't available; Redis adds real-time and
+cross-process support. Check `supports_distributed()` /
+`get_capabilities()` to see what the active backend supports.
 
-## What is the difference between `MemoryBackend` and `SearchableMemoryBackend`?
+## Are the calls async?
 
-`MemoryBackend` is the base protocol: it covers `stash`, `retrieve`, `delete`, `keys`, `is_connected`, `get_stats`, `close`, `supports_realtime`, and `supports_distributed`. `SearchableMemoryBackend` extends it with semantic search (`search`), long-term memory methods (`remember`, `promote`, `prune`), and `recent`. Use `SearchableMemoryBackend` when your backend needs semantic search or cross-session promotion.
+No — `UnifiedMemory`'s public methods are synchronous. Call them
+directly, no `await`.
 
-## How do I load CLAUDE.md memory files into a project?
+## How is sensitive data protected?
 
-Instantiate `ClaudeMemoryLoader` with a `ClaudeMemoryConfig` and call `load_all_memory(project_root=...)`. The config controls which levels are loaded (`load_enterprise`, `load_user`, `load_project`), the search depth (`max_import_depth`, default `5`), and file-size limits (`max_file_size_bytes`, default `1000000`).
+On `persist_pattern`, content is auto-classified (`PUBLIC` /
+`INTERNAL` / `SENSITIVE`), PII is scrubbed, secrets are flagged, and
+`SENSITIVE` patterns are encrypted at rest when encryption is enabled.
+Keep `auto_classify=True` unless you set the level yourself.
 
-If you need a default memory file for a new project, call `create_default_project_memory(project_root, framework='empathy')` — it creates `.claude/CLAUDE.md` for you.
+## What is staging for?
 
-## How do I check the health of the memory control panel?
+`stage_pattern` holds a candidate pattern so you can review it
+(`get_staged_patterns()`) before `promote_pattern` commits it to
+durable storage (running classification and scrubbing on the way).
 
-Call `MemoryControlPanel.health_check()`. For a formatted overview of status and statistics, use `print_status(panel)` and `print_stats(panel)`.
+## How do I write a custom backend?
 
-## How do I clear short-term memory for an agent?
-
-Call `MemoryControlPanel.clear_short_term(agent_id=...)`. The default `agent_id` is `'admin'`.
-
-## How do I debug a memory problem?
-
-Start with `pytest -k "memory" -v` to confirm the tests pass. If they pass but your code still fails:
-
-1. Call `is_redis_available()` to rule out a missing Redis connection.
-2. Call `check_redis_connection()` for a detailed status dict.
-3. Call `MemoryControlPanel.health_check()` for control-panel-level diagnostics.
-4. Add `logger.debug` at the suspected failure point and re-run with logging enabled.
-
-For symptom-based issues, see the troubleshooting page for this feature.
-
-## Where are the source files?
-
-All memory source files are under `src/attune/memory/`.
+Implement the `MemoryBackend` protocol (or `SearchableMemoryBackend`
+for search) from `attune.memory.backend` — both are
+`@runtime_checkable`, so any class implementing the methods satisfies
+them. Note the protocol's `stash(key, value, ttl, agent_id)` differs
+from `UnifiedMemory`'s own `stash(key, value, ttl_seconds)`.
 
 **Tags:** `memory`, `storage`

--- a/.help/templates/memory/note.md
+++ b/.help/templates/memory/note.md
@@ -3,45 +3,127 @@ type: note
 name: memory-note
 feature: memory
 depth: note
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
 ---
 
-# Note: memory
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-## Context
+## Overview
 
-The memory subsystem (`src/attune/memory/`) covers short-term storage, semantic search, Claude Code memory file loading, Redis configuration, and an enterprise control panel. It is versioned at `2.2.0`.
+Attune's memory subsystem gives agents two tiers of storage behind one
+API: **short-term** working memory (fast, TTL-expiring, optionally
+Redis-backed) and **long-term** pattern memory (durable, searchable,
+classified). Security runs before anything durable is written —
+auto-classification, PII scrubbing, secrets detection, and at-rest
+encryption for sensitive patterns.
 
-## Two-layer public surface
+The recommended entry point is **`UnifiedMemory`**, which composes both
+tiers and the security layer behind a single object. It is
+environment-aware: a `MemoryConfig` auto-detected from the environment
+chooses backends (in-process for development, Redis for production) so
+the same code runs in either. For custom backends, two protocols —
+`MemoryBackend` and `SearchableMemoryBackend` — define the short-term
+and searchable contracts.
 
-The package exposes two protocol classes that define the storage contract and a set of top-level functions that configure and instantiate backends.
+You reach memory these ways:
 
-**Protocols** (defined in `src/attune/memory/backend.py`):
+- the Python API — `from attune.memory import UnifiedMemory` (the
+  primary surface, documented throughout);
+- the **`MemoryBackend` / `SearchableMemoryBackend` protocols** (in
+  `attune.memory.backend`) — for wiring a custom store (any class
+  implementing the methods works);
+- **`ClaudeMemoryLoader`** — for static project context merged from
+  `CLAUDE.md` files;
+- **`MemoryControlPanel`** — a runtime management surface for browsing,
+  exporting, and clearing stored memory.
 
-- `MemoryBackend` — the base protocol for short-term memory backends. Every backend must implement `stash`, `retrieve`, `delete`, `keys`, `is_connected`, `get_stats`, `close`, `supports_realtime`, and `supports_distributed`.
-- `SearchableMemoryBackend` — extends `MemoryBackend` with semantic operations: `search`, `remember`, `promote`, `prune`, and `recent`.
+`UnifiedMemory`'s public methods are synchronous — call them directly,
+no `await`.
 
-**Configuration and factory functions** (in `src/attune/memory/config.py` and `src/attune/memory/__init__.py`):
+## Concepts
 
-- `is_redis_available()` — probes Redis availability without importing the Redis subsystem, making it safe to call at startup.
-- `parse_redis_url(url)` — converts a Redis URL string into a connection-parameter dict.
-- `get_redis_config()` — reads connection parameters from environment variables; marked legacy because it returns a plain dict rather than a typed config object.
-- `get_redis_memory(url, use_mock)` — the preferred factory; returns a `RedisShortTermMemory` instance configured from the environment.
+### Two tiers, one object
 
-The functions and classes are designed to compose: factory functions typically return objects that satisfy `MemoryBackend` or `SearchableMemoryBackend`, and backend methods mirror the top-level function signatures.
+`UnifiedMemory(user_id=...)` exposes both tiers:
 
-## Claude Code memory integration
+- **Short-term** — a keyed working store: `stash(key, value,
+  ttl_seconds=None)` writes, `retrieve(key)` reads. Entries expire
+  after `ttl_seconds` (or the config default). Backed by Redis when
+  available, an in-process store otherwise.
+- **Long-term** — durable, searchable **patterns**:
+  `persist_pattern(content, pattern_type, ...)` stores one,
+  `recall_pattern(pattern_id)` reads it back, and `search_patterns(
+  query=..., limit=10)` queries by content. Patterns can be **staged**
+  first (`stage_pattern(...)`) and later **promoted** to durable
+  storage (`promote_pattern(staged_id)`).
 
-`ClaudeMemoryLoader` (in `src/attune/memory/claude_memory.py`) loads and caches `CLAUDE.md` files. Its behavior is controlled by `ClaudeMemoryConfig`, which lets you enable or disable each memory scope (`load_enterprise`, `load_user`, `load_project`), cap file size with `max_file_size_bytes` (default 1 000 000 bytes), and limit import recursion with `max_import_depth` (default 5). Each loaded file is represented as a `MemoryFile` dataclass carrying its `level`, `path`, `content`, `imports`, and `load_order`.
+### Construction is environment-aware
 
-`create_default_project_memory(project_root, framework)` writes a starter `.claude/CLAUDE.md` file into a project tree. The injected block is delimited by the markers `<!-- attune-lessons-start -->` and `<!-- attune-lessons-end -->`.
+`UnifiedMemory` takes a required `user_id`, an optional `config`
+(`MemoryConfig`, default auto-detected from the environment), and an
+optional `access_tier` (`AccessTier`, default `CONTRIBUTOR`).
+`MemoryConfig.from_environment()` reads `ATTUNE_`-prefixed variables
+(`EMPATHY_` also accepted) — `ATTUNE_ENV` selects `development`,
+`staging`, or `production`, which in turn drives Redis and storage
+defaults. Construct one with explicit settings via
+`UnifiedMemory(user_id="me", config=MemoryConfig(...))`.
 
-## Enterprise control panel
+### Security runs before durable writes
 
-`MemoryControlPanel` (configured via `ControlPanelConfig`) provides operational management: starting and stopping Redis, retrieving statistics via `get_statistics()`, listing or deleting stored patterns, clearing short-term memory with `clear_short_term()`, and exporting patterns with `export_patterns()`. `run_api_server()` exposes these operations over HTTP with optional API-key authentication (`APIKeyAuth`), rate limiting (`RateLimiter`), and TLS.
+When you persist a pattern, classification and scrubbing run first.
+`auto_classify=True` (the default) assigns a `Classification` —
+`PUBLIC`, `INTERNAL`, or `SENSITIVE` — from the content and pattern
+type; PII is scrubbed and credential-like content is flagged before
+storage; `SENSITIVE` patterns are encrypted at rest. You can pass an
+explicit `classification` to override the auto-assignment. Reads honor
+the caller's `access_tier` unless you set `check_permissions=False` on
+`recall_pattern`.
 
-## Railway deployment
+### Capabilities tell you what the backend can do
 
-`get_railway_redis()` is a convenience factory for Railway-hosted deployments. It raises `OSError` if `REDIS_URL` is not set in the environment, with a message directing you to run `railway add --database redis`.
+A deployment's backend may or may not support real-time updates,
+distribution across processes, or durable persistence. `UnifiedMemory`
+surfaces this: `get_capabilities()` returns a `dict[str, bool]`, and
+`supports_realtime()`, `supports_distributed()`, and
+`supports_persistence()` answer individually. `health_check()` and
+`get_backend_status()` report runtime state. Check capabilities before
+relying on, say, cross-process coordination.
+
+### Custom backends implement a protocol
+
+`MemoryBackend` is a `@runtime_checkable` `Protocol` for short-term
+stores: `stash(key, value, ttl, agent_id)`, `retrieve(key, agent_id)`,
+`delete(key)`, `keys(pattern)`, `is_connected()`, `get_stats()`,
+`close()`, plus `supports_realtime()` / `supports_distributed()`.
+`SearchableMemoryBackend` extends it with `search(query, limit)`,
+`remember(content, ...)`, `promote(session_id)`, `prune(max_age_days)`,
+and `recent(limit)`. Any class implementing the methods satisfies the
+protocol — no base class to inherit. (Note these protocol signatures —
+`stash(key, value, ttl, agent_id)` — differ from `UnifiedMemory`'s
+own `stash(key, value, ttl_seconds)`.)
+
+### Static project context
+
+`ClaudeMemoryLoader` resolves `CLAUDE.md` files at enterprise, user,
+and project levels and merges them via its `load_all_memory()` method.
+Which levels load is controlled by the `MemoryConfig` **fields**
+`load_enterprise_memory` / `load_user_memory` / `load_project_memory`
+(not loader methods). This is the static counterpart to the read/write
+tiers above.
+
+## Notes & tips
+
+- **Depend on the documented public surface.** The supported API is
+  `UnifiedMemory`, `MemoryConfig`, and the security/loader classes
+  re-exported from `attune.memory`, plus the `MemoryBackend` /
+  `SearchableMemoryBackend` protocols from `attune.memory.backend`.
+  Submodule internals (`mixins/`, `short_term/`, `long_term_*`) may
+  change.
+- **Let classification run.** Keep `auto_classify=True` unless you have
+  a reason to set the level yourself.
+- **Check capabilities, don't assume.** Use `get_capabilities()` /
+  `supports_*()` before relying on real-time or cross-process behavior.
+- **Close when done.** Call `close()` (or `save()`) to flush and
+  release the backend.

--- a/.help/templates/memory/quickstart.md
+++ b/.help/templates/memory/quickstart.md
@@ -3,94 +3,38 @@ type: quickstart
 name: memory-quickstart
 feature: memory
 depth: quickstart
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
 ---
 
-# Quickstart: Attune Memory
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-Store and retrieve persistent memory across agent sessions in under five minutes.
+## Quickstart
 
-```python
-from attune.memory import is_redis_available, get_redis_memory
-
-if is_redis_available():
-    mem = get_redis_memory()
-    mem.stash("greeting", "hello world")
-    print(mem.retrieve("greeting"))
-```
-
-**Expected output:**
-```
-hello world
-```
-
-## Prerequisites
-
-- Attune installed locally (`pip install attune`)
-- Redis running, or `use_mock=True` passed to `get_redis_memory()` for local testing
-
-## Step 1: Check your backend
-
-Before writing anything, confirm the memory subsystem is reachable:
+Create a memory for a user, stash some working data, and persist a
+durable pattern. Every call is synchronous:
 
 ```python
-from attune.memory import is_redis_available, check_redis_connection
+from attune.memory import UnifiedMemory
 
-print(is_redis_available())       # True if Redis is importable
-print(check_redis_connection())   # Returns a status dict
+memory = UnifiedMemory(user_id="agent@company.com")
+
+# Short-term working memory (expires)
+memory.stash("current_task", {"id": 42, "phase": "review"}, ttl_seconds=3600)
+task = memory.retrieve("current_task")
+
+# Long-term pattern memory (durable, classified)
+result = memory.persist_pattern(
+    content="Use heapq.nlargest for top-N instead of sorted()[:N]",
+    pattern_type="optimization",
+)
+if result:
+    pattern = memory.recall_pattern(result["pattern_id"])
+
+memory.close()
 ```
 
-If `is_redis_available()` returns `False`, pass `use_mock=True` to `get_redis_memory()` to use the in-memory mock backend instead.
-
-## Step 2: Stash and retrieve a value
-
-```python
-from attune.memory import get_redis_memory
-
-mem = get_redis_memory()          # reads REDIS_URL from environment
-mem.stash("user_pref", "dark_mode", ttl=3600)
-value = mem.retrieve("user_pref")
-print(value)                      # dark_mode
-```
-
-`stash` accepts an optional `ttl` (seconds) and an optional `agent_id` to scope the key to a specific agent.
-
-## Step 3: Set up project-level memory
-
-To give Claude Code a project-level `CLAUDE.md` memory file, run:
-
-```python
-from attune.memory.claude_memory import create_default_project_memory
-
-create_default_project_memory(".", framework="empathy")
-# Creates .claude/CLAUDE.md in the current directory
-```
-
-Then load it back with `ClaudeMemoryLoader`:
-
-```python
-from attune.memory import ClaudeMemoryLoader, ClaudeMemoryConfig
-
-config = ClaudeMemoryConfig(enabled=True, load_project=True)
-loader = ClaudeMemoryLoader(config)
-context = loader.load_all_memory(project_root=".")
-print(context[:200])
-```
-
-**Expected output:** The contents of `.claude/CLAUDE.md`, ready to inject into a Claude Code session.
-
-## Step 4: Verify connectivity and stats
-
-```python
-from attune.memory import MemoryControlPanel
-
-panel = MemoryControlPanel()
-print(panel.health_check())
-print(panel.get_statistics())
-```
-
-A healthy system returns a dict with no error keys from `health_check()`.
-
-**Next:** Explore semantic search and long-term pattern storage with `SearchableMemoryBackend.search()` and `SearchableMemoryBackend.remember()`. Run `/memory-and-context search` in Claude Code to try it interactively.
+`UnifiedMemory()` with no `config` auto-detects the environment, so the
+same code runs against an in-process store in development and Redis in
+production.

--- a/.help/templates/memory/task.md
+++ b/.help/templates/memory/task.md
@@ -3,152 +3,108 @@ type: task
 name: memory-task
 feature: memory
 depth: task
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
-scaffold_hash: de9d8b9e160093b1f9e12b058655c619120213c3afb90087452e3c0a307ae0a9
 ---
 
-# Work with memory
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-Use the memory module when you need agents to stash and retrieve short-term data across sessions, load project-level `CLAUDE.md` context files, or run an HTTP control panel for enterprise memory management.
+## Tasks
 
-## Prerequisites
+### Stash and retrieve short-term working memory
 
-- Redis running and reachable—locally at `localhost:6379` or remotely via `REDIS_URL`—for Redis-backed workflows
-- `attune-ai` installed in your Python environment
-- (Railway only) Redis service added to your Railway project and `REDIS_URL` exported
+**Goal:** keep transient working state that expires on its own.
 
-## Connect to Redis memory
+**Steps:**
 
-1. **Check Redis availability.**
-   Call `is_redis_available()` before attempting a connection. A return value of `False` means the Redis subsystem is not installed; subsequent calls to `get_redis_memory()` will fail.
+```python
+from attune.memory import UnifiedMemory
 
-   ```python
-   from attune.memory import is_redis_available
+memory = UnifiedMemory(user_id="me")
+memory.stash("draft", {"step": 3}, ttl_seconds=600)  # expires in 10 min
+print(memory.retrieve("draft"))                       # {"step": 3}
+memory.close()
+```
 
-   if not is_redis_available():
-       raise RuntimeError("Redis subsystem not available")
-   ```
+**Verify:** `stash` returns `True` on success; `retrieve` returns the
+value or `None` if missing/expired. `ttl_seconds` is optional — omit it
+to use the config default.
 
-2. **Create a memory instance.**
-   Call `get_redis_memory()` to build a `RedisShortTermMemory` configured from your environment. Pass `url` to override the default endpoint, or set `use_mock=True` to substitute a test double.
+### Persist, search, and recall long-term patterns
 
-   ```python
-   from attune.memory import get_redis_memory
+**Goal:** store a durable, classified pattern and find it later by
+content.
 
-   memory = get_redis_memory()
-   ```
+**Steps:**
 
-   For Railway deployments, call `get_railway_redis()` instead. It reads `REDIS_URL` from the Railway environment and raises `OSError` with remediation instructions if the variable is absent.
+```python
+from attune.memory import UnifiedMemory
 
-3. **Verify the connection.**
-   Call `check_redis_connection()` and inspect the returned dict for error keys before starting any agent workloads.
+memory = UnifiedMemory(user_id="me")
+result = memory.persist_pattern(
+    content="Validate file paths with _validate_file_path before writing",
+    pattern_type="security",
+)
+hits = memory.search_patterns(query="file path validation", limit=5)
+for hit in hits:
+    print(hit["pattern_id"])
+memory.close()
+```
 
-   ```python
-   from attune.memory import check_redis_connection
+**Verify:** `persist_pattern` returns a dict with a `pattern_id` (or
+`None` if storage is unavailable). `search_patterns` returns a list of
+dicts ranked by relevance; narrow it with `pattern_type=` or
+`classification=`. Classification is automatic unless you pass
+`classification=`.
 
-   status = check_redis_connection()
-   ```
+### Stage a pattern, then promote it
 
-4. **Stash and retrieve values.**
-   Use `stash(key, value, ttl, agent_id)` to write and `retrieve(key, agent_id)` to read. Supply `agent_id` to scope entries to a specific agent.
+**Goal:** hold a candidate pattern for review before committing it to
+durable storage.
 
-   ```python
-   memory.stash("last_query", "What is attune?", ttl=300, agent_id="agent-1")
-   result = memory.retrieve("last_query", agent_id="agent-1")
-   ```
+**Steps:**
 
-**You have succeeded when** `check_redis_connection()` returns without an `error` key and `memory.is_connected()` returns `True`.
+```python
+from attune.memory import UnifiedMemory
 
-## Load Claude Code memory files
+memory = UnifiedMemory(user_id="me")
+staged_id = memory.stage_pattern(
+    {"content": "Candidate: cache AST parses by file hash"},
+    pattern_type="optimization",
+)
+# ... review memory.get_staged_patterns() ...
+if staged_id:
+    memory.promote_pattern(staged_id)
+memory.close()
+```
 
-1. **Configure the loader.**
-   Build a `ClaudeMemoryConfig` with `enabled=True`. Toggle `load_enterprise`, `load_user`, and `load_project` to control which hierarchy levels are included. Set `project_root` to pin the search location.
+**Verify:** `stage_pattern` returns a staged id (or `None`);
+`get_staged_patterns()` lists what's pending; `promote_pattern`
+graduates it to durable storage (running classification/scrubbing) and
+returns the stored pattern dict.
 
-   ```python
-   from attune.memory import ClaudeMemoryConfig, ClaudeMemoryLoader
+### Record an SBAR handoff
 
-   config = ClaudeMemoryConfig(
-       enabled=True,
-       load_project=True,
-       load_user=True,
-       project_root="/path/to/your/project",
-   )
-   loader = ClaudeMemoryLoader(config)
-   ```
+**Goal:** leave a structured handoff for the next session or agent.
 
-2. **Load the files.**
-   Call `load_all_memory()` to discover, read, and merge all applicable `CLAUDE.md` files. The return value is combined text ready to inject into a system prompt.
+**Steps:**
 
-   ```python
-   context = loader.load_all_memory()
-   ```
+```python
+from attune.memory import UnifiedMemory
 
-3. **Inspect and refresh.**
-   Call `get_loaded_files()` to see which files were resolved and in what order. If the files on disk have changed, call `clear_cache()` before the next `load_all_memory()` call.
+memory = UnifiedMemory(user_id="me")
+memory.set_handoff(
+    situation="Mid-refactor of the release agents",
+    background="Split into focused submodules",
+    assessment="Tests green; docs not yet updated",
+    recommendation="Update docs/architecture/release.md next",
+)
+print(memory.generate_compact_state())
+memory.close()
+```
 
-   ```python
-   print(loader.get_loaded_files())
-   loader.clear_cache()
-   ```
-
-4. **Bootstrap a project with no `CLAUDE.md`.**
-   Call `create_default_project_memory(project_root, framework)` to write a starter file at `.claude/CLAUDE.md`. The `framework` argument defaults to `'empathy'`.
-
-   ```python
-   from attune.memory import create_default_project_memory
-
-   create_default_project_memory("/path/to/your/project")
-   ```
-
-**You have succeeded when** `loader.get_loaded_files()` returns a non-empty list and `load_all_memory()` returns non-empty text.
-
-## Run the memory control panel
-
-1. **Configure the panel.**
-   Create a `ControlPanelConfig` pointing at your Redis instance and storage directories, then pass it to `MemoryControlPanel`.
-
-   ```python
-   from attune.memory import ControlPanelConfig, MemoryControlPanel
-
-   config = ControlPanelConfig(
-       redis_host="localhost",
-       redis_port=6379,
-       storage_dir="./memdocs_storage",
-       audit_dir="./logs",
-   )
-   panel = MemoryControlPanel(config)
-   ```
-
-2. **Start the API server.**
-   Call `run_api_server()` with the panel. Set `api_key` to require authentication on every request, and supply `ssl_certfile` and `ssl_keyfile` for TLS. Tune request limits with `rate_limit_requests` and `rate_limit_window`.
-
-   ```python
-   from attune.memory import run_api_server
-
-   run_api_server(
-       panel,
-       host="localhost",
-       port=8765,
-       api_key="your-secret-key",
-       enable_rate_limit=True,
-   )
-   ```
-
-3. **Confirm the server is healthy.**
-   Call `panel.health_check()` before routing production traffic. Use `panel.get_statistics()` to review memory usage and pattern counts, and `print_stats(panel)` for a formatted summary.
-
-   ```python
-   print(panel.health_check())
-   print(panel.get_statistics())
-   ```
-
-**You have succeeded when** `panel.health_check()` returns without error and the server responds on the configured host and port.
-
-## Key files
-
-- `src/attune/memory/__init__.py` — top-level exports and `is_redis_available()`
-- `src/attune/memory/config.py` — `get_redis_memory()`, `parse_redis_url()`, `get_redis_config()`, `check_redis_connection()`, `get_railway_redis()`
-- `src/attune/memory/claude_memory.py` — `ClaudeMemoryConfig`, `ClaudeMemoryLoader`, `create_default_project_memory()`
-- `src/attune/memory/control_panel_api.py` — `MemoryControlPanel`, `ControlPanelConfig`, `run_api_server()`
+**Verify:** `set_handoff` takes the four SBAR fields plus arbitrary
+`**extra_context`. `generate_compact_state()` returns a string snapshot;
+`export_to_claude_md(path=None)` writes the state to a `CLAUDE.md`-style
+file and returns the `Path`.

--- a/.help/templates/memory/tip.md
+++ b/.help/templates/memory/tip.md
@@ -3,23 +3,24 @@ type: tip
 name: memory-tip
 feature: memory
 depth: tip
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
 ---
 
-# Tip: working effectively with memory
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-Call `is_redis_available()` before you instantiate any Redis-backed component.
+## Notes & tips
 
-This single guard prevents import-time failures in environments where Redis is not installed — the function checks availability without importing the Redis subsystem at all. Skipping it means a missing dependency surfaces as a confusing runtime error instead of a clear unavailability signal.
-
-**Why it works:** `is_redis_available()` is specifically designed for this pre-flight check, so you pay no import cost regardless of the result.
-
-**Tradeoff:** You still need to handle the `False` case explicitly — the function tells you Redis is unavailable but does not fall back to a mock automatically. Use `get_redis_memory(use_mock=True)` if you want an automatic fallback.
-
-## Source files
-
-- `src/attune/memory/**`
-
-**Tags:** `memory`, `storage`
+- **Depend on the documented public surface.** The supported API is
+  `UnifiedMemory`, `MemoryConfig`, and the security/loader classes
+  re-exported from `attune.memory`, plus the `MemoryBackend` /
+  `SearchableMemoryBackend` protocols from `attune.memory.backend`.
+  Submodule internals (`mixins/`, `short_term/`, `long_term_*`) may
+  change.
+- **Let classification run.** Keep `auto_classify=True` unless you have
+  a reason to set the level yourself.
+- **Check capabilities, don't assume.** Use `get_capabilities()` /
+  `supports_*()` before relying on real-time or cross-process behavior.
+- **Close when done.** Call `close()` (or `save()`) to flush and
+  release the backend.

--- a/.help/templates/memory/troubleshooting.md
+++ b/.help/templates/memory/troubleshooting.md
@@ -3,118 +3,40 @@ type: troubleshooting
 name: memory-troubleshooting
 feature: memory
 depth: troubleshooting
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
 ---
 
-# Troubleshoot memory
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-## Before you start
+## Failure modes
 
-The memory subsystem covers three concerns: short-term storage via `MemoryBackend` and `SearchableMemoryBackend`, Claude Code memory file loading via `ClaudeMemoryLoader`, and enterprise control panel operations via `MemoryControlPanel`. Identify which layer is failing before you dig in — Redis connectivity issues look different from CLAUDE.md import failures or pattern classification errors.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `TypeError: __init__() missing 1 required positional argument: 'user_id'` | `UnifiedMemory()` constructed without `user_id` | Pass `user_id` — it is required | high |
+| `persist_pattern` / `stage_pattern` returns `None` | Long-term storage unavailable (e.g. no writable `storage_dir`) | Check `health_check()` / `get_backend_status()`; confirm storage config | medium |
+| `retrieve` returns `None` for a key you stashed | The entry expired (`ttl_seconds`) or the backend isn't persistent | Re-stash with a longer TTL; check `supports_persistence()` | medium |
+| Cross-process reads don't see another process's writes | The backend isn't distributed (in-process store) | Check `supports_distributed()`; configure Redis | medium |
+| `recall_pattern` returns `None` for a real id | `check_permissions=True` and the caller's `access_tier` is insufficient | Use a higher `access_tier`, or pass `check_permissions=False` for trusted callers | medium |
+| A `SENSITIVE` pattern stored unencrypted | `encryption_enabled` is off in the config | Enable encryption in `MemoryConfig` | medium |
 
-## Symptom table
+### Risk areas
 
-| If you observe | Check |
-|----------------|-------|
-| `stash()` or `retrieve()` returns `None` or `False` unexpectedly | Call `is_connected()` on your backend instance; if it returns `False`, Redis is not reachable |
-| `get_railway_redis()` raises `OSError: REDIS_URL not found` | Confirm the `REDIS_URL` environment variable is set; on Railway, run `railway add --database redis` |
-| `ClaudeMemoryLoader.load_all_memory()` returns empty or partial content | Call `get_loaded_files()` to see which CLAUDE.md files were found; check `ClaudeMemoryConfig.max_import_depth` (default `5`) and `max_file_size_bytes` (default `1000000`) |
-| `MemoryControlPanel.health_check()` reports unhealthy | Check `status()` first — it shows Redis connectivity and storage directory state separately |
-| `search()` or `remember()` fails on a backend | Confirm your backend implements `SearchableMemoryBackend`, not just `MemoryBackend`; the base protocol does not expose those methods |
-| Intermittent `stash()`/`retrieve()` failures under load | Check `RateLimiter.get_remaining()` for the client IP; the default window is 100 requests per 60 seconds |
-| Pattern classification returns unexpected results | Verify content does not contain keywords from `HEALTHCARE_KEYWORDS`, `FINANCIAL_KEYWORDS`, or `PROPRIETARY_KEYWORDS` — matches elevate the classification automatically |
+- **`user_id` is required.** `UnifiedMemory` is per-user; there is no
+  zero-arg constructor.
+- **Protocol vs. `UnifiedMemory` signatures differ.** The protocol's
+  `stash(key, value, ttl, agent_id)` is not `UnifiedMemory`'s
+  `stash(key, value, ttl_seconds)` — don't conflate them.
+- **Capabilities are deployment-dependent.** Real-time, distribution,
+  and persistence vary by backend — check before relying on them.
 
-## Diagnosis steps
+### Diagnosis order
 
-Work through these in order — each step is cheaper than the one that follows.
-
-1. **Check Redis availability without importing it.**
-   Call `is_redis_available()` first. If it returns `False`, no backend that depends on Redis will work, and you can skip deeper investigation until connectivity is restored.
-
-   ```python
-   from attune.memory import is_redis_available
-   print(is_redis_available())
-   ```
-
-2. **Inspect the Redis connection details.**
-   Call `check_redis_connection()` for a structured status dict that includes the host, port, and any error message. If you are parsing a `REDIS_URL`, call `parse_redis_url(url)` to confirm it resolves to the expected host and port before passing it to `get_redis_memory()`.
-
-   ```python
-   from attune.memory import check_redis_connection
-   print(check_redis_connection())
-   ```
-
-3. **Verify backend connectivity and stats.**
-   On a live backend instance, call `is_connected()` and `get_stats()`. A backend can pass `is_redis_available()` but still fail `is_connected()` if credentials or the specific DB index are wrong.
-
-4. **Check which memory files were loaded.**
-   If the issue is in Claude memory loading, call `get_loaded_files()` on your `ClaudeMemoryLoader` instance. Cross-check the returned paths against the `project_root` in `ClaudeMemoryConfig`. If `validate_files` is `True` (the default), files that fail validation are silently skipped.
-
-   ```python
-   loader = ClaudeMemoryLoader()
-   loader.load_all_memory(project_root="/your/project")
-   print(loader.get_loaded_files())
-   ```
-
-5. **Run the control panel health check.**
-   For enterprise control panel issues, call `MemoryControlPanel.health_check()`, then `status()` for a breakdown. If Redis isn't running and `ControlPanelConfig.auto_start_redis` is `True`, call `start_redis(verbose=True)` and check the returned `RedisStatus`.
-
-6. **Run targeted tests.**
-   ```
-   pytest -k "memory" -v
-   ```
-   If a test covers your failing path, its fixtures give you a minimal reproduction environment.
-
-## Common fixes
-
-**Redis not reachable**
-Set `REDIS_URL` in your environment, or confirm the host and port in `ControlPanelConfig` (defaults: `redis_host='localhost'`, `redis_port=6379`). For Railway deployments, the variable must be `REDIS_URL`; `REDIS_PUBLIC_URL` is for external access only.
-
-```bash
-export REDIS_URL=redis://localhost:6379
-```
-
-**`load_all_memory()` returns less content than expected**
-Increase `max_import_depth` in `ClaudeMemoryConfig` if your project has deeply nested CLAUDE.md imports. Increase `max_file_size_bytes` if large files are being skipped. Set `validate_files=False` temporarily to confirm that validation is the cause — then fix the offending files rather than leaving validation off.
-
-```python
-config = ClaudeMemoryConfig(max_import_depth=10, max_file_size_bytes=5_000_000)
-loader = ClaudeMemoryLoader(config)
-```
-
-**No CLAUDE.md exists for a new project**
-Call `create_default_project_memory()` to generate a `.claude/CLAUDE.md` scaffold:
-
-```python
-from attune.memory.claude_memory import create_default_project_memory
-create_default_project_memory(project_root="/your/project", framework="empathy")
-```
-
-**`search()` or `remember()` raises `AttributeError`**
-Your backend only implements `MemoryBackend`. To use semantic search, promote it to `SearchableMemoryBackend`. This is a protocol change — you need a backend class that implements `search()`, `remember()`, `promote()`, `prune()`, and `recent()`.
-
-**Stale short-term memory causing wrong results**
-Clear short-term memory for the affected agent:
-
-```python
-panel = MemoryControlPanel()
-cleared = panel.clear_short_term(agent_id="your-agent-id")
-print(f"Cleared {cleared} entries")
-```
-
-To reset the loader's file cache between runs:
-
-```python
-loader.clear_cache()
-```
-
-**Version mismatch after a dependency upgrade**
-Run `pip show attune` to confirm the installed version. The module exposes `__version__ = '2.2.0'` — check that your code's expectations match this version before filing a bug.
-
-## Source files
-
-- `src/attune/memory/**`
-
-**Tags:** `memory`, `storage`
+1. Confirm construction: `UnifiedMemory(user_id="...")`.
+2. `health_check()` / `get_backend_status()` for backend state.
+3. `get_capabilities()` to confirm realtime/distributed/persistence.
+4. For a missing short-term key, check the TTL and
+   `supports_persistence()`.
+5. For a missing pattern, check `pattern_id`, `access_tier`, and
+   `check_permissions`.

--- a/.help/templates/memory/warning.md
+++ b/.help/templates/memory/warning.md
@@ -3,73 +3,40 @@ type: warning
 name: memory-warning
 feature: memory
 depth: warning
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 7d6a88f7e825fe56e3b06e3bce6dd904fe6a75cd1c13a3a134e4b44138df245e
+generated_at: 2026-06-23T21:52:16.487778+00:00
+source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
 status: generated
 ---
 
-# Memory cautions
+# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
 
-## What to watch for
+## Failure modes
 
-The memory subsystem spans short-term Redis storage, long-term `MemDocsStorage`, Claude memory file loading, and a security layer that classifies and encrypts patterns. The risks below reflect the points where these layers interact in ways that are easy to overlook.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `TypeError: __init__() missing 1 required positional argument: 'user_id'` | `UnifiedMemory()` constructed without `user_id` | Pass `user_id` — it is required | high |
+| `persist_pattern` / `stage_pattern` returns `None` | Long-term storage unavailable (e.g. no writable `storage_dir`) | Check `health_check()` / `get_backend_status()`; confirm storage config | medium |
+| `retrieve` returns `None` for a key you stashed | The entry expired (`ttl_seconds`) or the backend isn't persistent | Re-stash with a longer TTL; check `supports_persistence()` | medium |
+| Cross-process reads don't see another process's writes | The backend isn't distributed (in-process store) | Check `supports_distributed()`; configure Redis | medium |
+| `recall_pattern` returns `None` for a real id | `check_permissions=True` and the caller's `access_tier` is insufficient | Use a higher `access_tier`, or pass `check_permissions=False` for trusted callers | medium |
+| A `SENSITIVE` pattern stored unencrypted | `encryption_enabled` is off in the config | Enable encryption in `MemoryConfig` | medium |
 
-## Risk areas
+### Risk areas
 
-### Secrets and PII stored without classification
+- **`user_id` is required.** `UnifiedMemory` is per-user; there is no
+  zero-arg constructor.
+- **Protocol vs. `UnifiedMemory` signatures differ.** The protocol's
+  `stash(key, value, ttl, agent_id)` is not `UnifiedMemory`'s
+  `stash(key, value, ttl_seconds)` — don't conflate them.
+- **Capabilities are deployment-dependent.** Real-time, distribution,
+  and persistence vary by backend — check before relying on them.
 
-`MemDocsStorage` and `SecureMemDocsIntegration` apply classification rules automatically, but only when the content passes through their security layer. If you write directly to a `MemoryBackend` via `stash()`, the `SecretsDetector` and `PIIScrubber` are bypassed entirely. Content containing values that match `HEALTHCARE_KEYWORDS`, `FINANCIAL_KEYWORDS`, or `SENSITIVE_PATTERN_TYPES` will be stored in plaintext with no access controls.
+### Diagnosis order
 
-**Mitigation:** Route writes that may contain sensitive content through `SecureMemDocsIntegration` rather than calling `stash()` directly on a backend.
-
-### `get_redis_memory()` silently falls back to a mock backend
-
-`get_redis_memory()` accepts a `use_mock` parameter. When `use_mock` is `None` (the default), the function reads an environment variable to decide. In environments where that variable is unset or Redis is unreachable, it may silently return a mock backend. Code that assumes a real Redis connection — for example, anything relying on TTL expiry or pub/sub via `CHANNEL_SESSIONS` — will appear to work but will not persist data or coordinate across agents.
-
-**Mitigation:** Call `is_redis_available()` before `get_redis_memory()` to confirm the Redis subsystem is reachable, or check `is_connected()` on the returned backend before proceeding.
-
-### `get_railway_redis()` raises `OSError` when `REDIS_URL` is missing
-
-`get_railway_redis()` has no fallback. If `REDIS_URL` is not set in the environment, it raises `OSError` immediately with instructions to run `railway add --database redis`. This is intentional, but it means any startup path that calls this function without a guard will crash the process rather than degrading gracefully.
-
-**Mitigation:** Check for `REDIS_URL` in the environment before calling `get_railway_redis()`, or wrap the call and handle `OSError` explicitly.
-
-### `ClaudeMemoryLoader` follows imports up to `max_import_depth`
-
-`ClaudeMemoryConfig` defaults to `max_import_depth: int = 5`. `ClaudeMemoryLoader.load_all_memory()` follows `@import` directives in CLAUDE.md files recursively to that depth. A deeply nested or circular import chain will not raise an error at depth 5 — it will silently truncate. If your project memory relies on files at depth 6 or beyond, those files will not be loaded and `get_loaded_files()` will not list them.
-
-**Mitigation:** Keep import chains shallow. Call `get_loaded_files()` after `load_all_memory()` to verify the expected files were included.
-
-### `max_file_size_bytes` silently skips large memory files
-
-`ClaudeMemoryConfig` defaults to `max_file_size_bytes: int = 1000000` (1 MB). Files that exceed this limit are skipped without raising an exception. A CLAUDE.md that grows past 1 MB through accumulated lessons or imports will be excluded from the loaded context with no visible indication.
-
-**Mitigation:** Set `validate_files: bool = True` in your `ClaudeMemoryConfig` (the default) and monitor the size of memory files in long-running projects.
-
-### `promote()` on `SearchableMemoryBackend` moves all session data
-
-`SearchableMemoryBackend.promote()` transfers memory from a session to long-term storage. The `session_id` parameter is optional; if omitted, the method uses a default session. Calling `promote()` without an explicit `session_id` in a multi-agent setup — where multiple agents share a Redis instance via `KEY_ACTIVE_AGENTS` — can promote the wrong session's data.
-
-**Mitigation:** Always pass an explicit `session_id` to `promote()` when running more than one agent against the same backend.
-
-### `clear_short_term()` on `MemoryControlPanel` is not scoped by default
-
-`MemoryControlPanel.clear_short_term()` accepts an `agent_id` parameter that defaults to `'admin'`. Passing the wrong `agent_id`, or relying on the default in a multi-agent deployment, will clear memory belonging to a different agent rather than the intended one.
-
-**Mitigation:** Pass the specific `agent_id` whose short-term memory you intend to clear, and confirm with `get_statistics()` before and after.
-
-## How to avoid problems
-
-1. **Verify backend identity before writing.** Call `is_connected()` on any `MemoryBackend` instance before writing session-critical data. For Railway deployments, confirm `REDIS_URL` is set before calling `get_railway_redis()`.
-
-2. **Route sensitive content through the security layer.** Direct `stash()` calls bypass `SecretsDetector`, `PIIScrubber`, and `EncryptionManager`. Use `SecureMemDocsIntegration` for any content that might contain values matching the HEALTHCARE, FINANCIAL, or PROPRIETARY keyword sets.
-
-3. **Audit loaded memory files explicitly.** After `load_all_memory()`, call `get_loaded_files()` to confirm your expected CLAUDE.md files are present. Missing files are almost always caused by `max_import_depth` or `max_file_size_bytes` limits.
-
-4. **Scope destructive operations to a specific agent.** Pass explicit `agent_id` and `session_id` arguments to `clear_short_term()` and `promote()` to avoid operating on the wrong agent's data in shared-Redis deployments.
-
-## Source files
-
-- `src/attune/memory/**`
-
-**Tags:** `memory`, `storage`
+1. Confirm construction: `UnifiedMemory(user_id="...")`.
+2. `health_check()` / `get_backend_status()` for backend state.
+3. `get_capabilities()` to confirm realtime/distributed/persistence.
+4. For a missing short-term key, check the TTL and
+   `supports_persistence()`.
+5. For a missing pattern, check `pattern_id`, `access_tier`, and
+   `check_permissions`.

--- a/content/features/memory.md
+++ b/content/features/memory.md
@@ -1,0 +1,440 @@
+---
+feature: memory
+summary: Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
+tags: [memory, storage]
+source_globs:
+  - src/attune/memory/**
+nav:
+  help: memory
+  mkdocs:
+    how-to: how-to/memory
+    architecture: architecture/memory
+    reference: reference/memory
+---
+
+## Overview
+
+Attune's memory subsystem gives agents two tiers of storage behind one
+API: **short-term** working memory (fast, TTL-expiring, optionally
+Redis-backed) and **long-term** pattern memory (durable, searchable,
+classified). Security runs before anything durable is written —
+auto-classification, PII scrubbing, secrets detection, and at-rest
+encryption for sensitive patterns.
+
+The recommended entry point is **`UnifiedMemory`**, which composes both
+tiers and the security layer behind a single object. It is
+environment-aware: a `MemoryConfig` auto-detected from the environment
+chooses backends (in-process for development, Redis for production) so
+the same code runs in either. For custom backends, two protocols —
+`MemoryBackend` and `SearchableMemoryBackend` — define the short-term
+and searchable contracts.
+
+You reach memory these ways:
+
+- the Python API — `from attune.memory import UnifiedMemory` (the
+  primary surface, documented throughout);
+- the **`MemoryBackend` / `SearchableMemoryBackend` protocols** (in
+  `attune.memory.backend`) — for wiring a custom store (any class
+  implementing the methods works);
+- **`ClaudeMemoryLoader`** — for static project context merged from
+  `CLAUDE.md` files;
+- **`MemoryControlPanel`** — a runtime management surface for browsing,
+  exporting, and clearing stored memory.
+
+`UnifiedMemory`'s public methods are synchronous — call them directly,
+no `await`.
+
+## Concepts
+
+### Two tiers, one object
+
+`UnifiedMemory(user_id=...)` exposes both tiers:
+
+- **Short-term** — a keyed working store: `stash(key, value,
+  ttl_seconds=None)` writes, `retrieve(key)` reads. Entries expire
+  after `ttl_seconds` (or the config default). Backed by Redis when
+  available, an in-process store otherwise.
+- **Long-term** — durable, searchable **patterns**:
+  `persist_pattern(content, pattern_type, ...)` stores one,
+  `recall_pattern(pattern_id)` reads it back, and `search_patterns(
+  query=..., limit=10)` queries by content. Patterns can be **staged**
+  first (`stage_pattern(...)`) and later **promoted** to durable
+  storage (`promote_pattern(staged_id)`).
+
+### Construction is environment-aware
+
+`UnifiedMemory` takes a required `user_id`, an optional `config`
+(`MemoryConfig`, default auto-detected from the environment), and an
+optional `access_tier` (`AccessTier`, default `CONTRIBUTOR`).
+`MemoryConfig.from_environment()` reads `ATTUNE_`-prefixed variables
+(`EMPATHY_` also accepted) — `ATTUNE_ENV` selects `development`,
+`staging`, or `production`, which in turn drives Redis and storage
+defaults. Construct one with explicit settings via
+`UnifiedMemory(user_id="me", config=MemoryConfig(...))`.
+
+### Security runs before durable writes
+
+When you persist a pattern, classification and scrubbing run first.
+`auto_classify=True` (the default) assigns a `Classification` —
+`PUBLIC`, `INTERNAL`, or `SENSITIVE` — from the content and pattern
+type; PII is scrubbed and credential-like content is flagged before
+storage; `SENSITIVE` patterns are encrypted at rest. You can pass an
+explicit `classification` to override the auto-assignment. Reads honor
+the caller's `access_tier` unless you set `check_permissions=False` on
+`recall_pattern`.
+
+### Capabilities tell you what the backend can do
+
+A deployment's backend may or may not support real-time updates,
+distribution across processes, or durable persistence. `UnifiedMemory`
+surfaces this: `get_capabilities()` returns a `dict[str, bool]`, and
+`supports_realtime()`, `supports_distributed()`, and
+`supports_persistence()` answer individually. `health_check()` and
+`get_backend_status()` report runtime state. Check capabilities before
+relying on, say, cross-process coordination.
+
+### Custom backends implement a protocol
+
+`MemoryBackend` is a `@runtime_checkable` `Protocol` for short-term
+stores: `stash(key, value, ttl, agent_id)`, `retrieve(key, agent_id)`,
+`delete(key)`, `keys(pattern)`, `is_connected()`, `get_stats()`,
+`close()`, plus `supports_realtime()` / `supports_distributed()`.
+`SearchableMemoryBackend` extends it with `search(query, limit)`,
+`remember(content, ...)`, `promote(session_id)`, `prune(max_age_days)`,
+and `recent(limit)`. Any class implementing the methods satisfies the
+protocol — no base class to inherit. (Note these protocol signatures —
+`stash(key, value, ttl, agent_id)` — differ from `UnifiedMemory`'s
+own `stash(key, value, ttl_seconds)`.)
+
+### Static project context
+
+`ClaudeMemoryLoader` resolves `CLAUDE.md` files at enterprise, user,
+and project levels and merges them via its `load_all_memory()` method.
+Which levels load is controlled by the `MemoryConfig` **fields**
+`load_enterprise_memory` / `load_user_memory` / `load_project_memory`
+(not loader methods). This is the static counterpart to the read/write
+tiers above.
+
+## Quickstart
+
+Create a memory for a user, stash some working data, and persist a
+durable pattern. Every call is synchronous:
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="agent@company.com")
+
+# Short-term working memory (expires)
+memory.stash("current_task", {"id": 42, "phase": "review"}, ttl_seconds=3600)
+task = memory.retrieve("current_task")
+
+# Long-term pattern memory (durable, classified)
+result = memory.persist_pattern(
+    content="Use heapq.nlargest for top-N instead of sorted()[:N]",
+    pattern_type="optimization",
+)
+if result:
+    pattern = memory.recall_pattern(result["pattern_id"])
+
+memory.close()
+```
+
+`UnifiedMemory()` with no `config` auto-detects the environment, so the
+same code runs against an in-process store in development and Redis in
+production.
+
+## Tasks
+
+### Stash and retrieve short-term working memory
+
+**Goal:** keep transient working state that expires on its own.
+
+**Steps:**
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me")
+memory.stash("draft", {"step": 3}, ttl_seconds=600)  # expires in 10 min
+print(memory.retrieve("draft"))                       # {"step": 3}
+memory.close()
+```
+
+**Verify:** `stash` returns `True` on success; `retrieve` returns the
+value or `None` if missing/expired. `ttl_seconds` is optional — omit it
+to use the config default.
+
+### Persist, search, and recall long-term patterns
+
+**Goal:** store a durable, classified pattern and find it later by
+content.
+
+**Steps:**
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me")
+result = memory.persist_pattern(
+    content="Validate file paths with _validate_file_path before writing",
+    pattern_type="security",
+)
+hits = memory.search_patterns(query="file path validation", limit=5)
+for hit in hits:
+    print(hit["pattern_id"])
+memory.close()
+```
+
+**Verify:** `persist_pattern` returns a dict with a `pattern_id` (or
+`None` if storage is unavailable). `search_patterns` returns a list of
+dicts ranked by relevance; narrow it with `pattern_type=` or
+`classification=`. Classification is automatic unless you pass
+`classification=`.
+
+### Stage a pattern, then promote it
+
+**Goal:** hold a candidate pattern for review before committing it to
+durable storage.
+
+**Steps:**
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me")
+staged_id = memory.stage_pattern(
+    {"content": "Candidate: cache AST parses by file hash"},
+    pattern_type="optimization",
+)
+# ... review memory.get_staged_patterns() ...
+if staged_id:
+    memory.promote_pattern(staged_id)
+memory.close()
+```
+
+**Verify:** `stage_pattern` returns a staged id (or `None`);
+`get_staged_patterns()` lists what's pending; `promote_pattern`
+graduates it to durable storage (running classification/scrubbing) and
+returns the stored pattern dict.
+
+### Record an SBAR handoff
+
+**Goal:** leave a structured handoff for the next session or agent.
+
+**Steps:**
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me")
+memory.set_handoff(
+    situation="Mid-refactor of the release agents",
+    background="Split into focused submodules",
+    assessment="Tests green; docs not yet updated",
+    recommendation="Update docs/architecture/release.md next",
+)
+print(memory.generate_compact_state())
+memory.close()
+```
+
+**Verify:** `set_handoff` takes the four SBAR fields plus arbitrary
+`**extra_context`. `generate_compact_state()` returns a string snapshot;
+`export_to_claude_md(path=None)` writes the state to a `CLAUDE.md`-style
+file and returns the `Path`.
+
+## Reference
+
+The recommended surface is `UnifiedMemory` from `attune.memory`. The
+security/loader classes (`Classification`, `PIIScrubber`,
+`SecretsDetector`, `AuditLogger`, `ClaudeMemoryLoader`,
+`MemoryControlPanel`) are re-exported from `attune.memory` too; the
+backend **protocols** live in `attune.memory.backend` (they are not
+re-exported from the package root).
+
+### `UnifiedMemory` — `attune.memory`
+
+| Symbol | Purpose |
+|--------|---------|
+| `UnifiedMemory(user_id, config=MemoryConfig.from_environment(), access_tier=AccessTier.CONTRIBUTOR)` | Construct the unified memory. `user_id` is required. |
+| `stash(key, value, ttl_seconds=None) -> bool` | Write short-term working memory. |
+| `retrieve(key) -> Any \| None` | Read short-term memory; `None` if missing/expired. |
+| `persist_pattern(content, pattern_type, classification=None, auto_classify=True, metadata=None) -> dict \| None` | Store a durable pattern (classified + scrubbed first). |
+| `recall_pattern(pattern_id, check_permissions=True, use_cache=True) -> dict \| None` | Read a durable pattern by id. |
+| `search_patterns(query=None, pattern_type=None, classification=None, limit=10) -> list[dict]` | Query durable patterns by content/type/classification. |
+| `stage_pattern(pattern_data, pattern_type="general", ttl_hours=24) -> str \| None` | Stage a candidate pattern; returns a staged id. |
+| `promote_pattern(staged_pattern_id, classification=None, auto_classify=True) -> dict \| None` | Promote a staged pattern to durable storage. |
+| `get_staged_patterns() -> list[dict]` | List pending staged patterns. |
+| `get_capabilities() -> dict[str, bool]` | Backend capability flags. |
+| `supports_realtime() / supports_distributed() / supports_persistence() -> bool` | Individual capability checks. |
+| `health_check() -> dict` / `get_backend_status() -> dict` | Runtime state. |
+| `set_handoff(situation, background, assessment, recommendation, **extra)` | Record an SBAR handoff. |
+| `generate_compact_state() -> str` / `export_to_claude_md(path=None) -> Path` | Snapshot state; write it to a CLAUDE.md-style file. |
+| `clear_pattern_cache() -> int` / `save() -> None` / `close() -> None` | Cache and lifecycle management. |
+
+### `MemoryConfig` — selected fields
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `environment` | `Environment.DEVELOPMENT` | `development` / `staging` / `production`. |
+| `redis_url` / `redis_host` / `redis_port` | `None` / `localhost` / `6379` | Short-term backend coordinates. |
+| `redis_mock` / `redis_auto_start` / `redis_required` | `False` / — / — | In-process mock, auto-start, or require Redis. |
+| `default_ttl_seconds` | — | Default short-term expiry. |
+| `storage_dir` | — | Long-term pattern storage directory. |
+| `encryption_enabled` | — | Encrypt `SENSITIVE` patterns at rest. |
+| `load_enterprise_memory` / `load_user_memory` / `load_project_memory` | — | Which `CLAUDE.md` levels `ClaudeMemoryLoader` loads. |
+
+Build one from the environment with `MemoryConfig.from_environment()`.
+
+### Backend protocols — `attune.memory.backend`
+
+| Protocol | Methods |
+|----------|---------|
+| `MemoryBackend` | `stash(key, value, ttl, agent_id)`, `retrieve(key, agent_id)`, `delete(key)`, `keys(pattern)`, `is_connected()`, `get_stats()`, `close()`, `supports_realtime()`, `supports_distributed()`. |
+| `SearchableMemoryBackend` | Extends `MemoryBackend` with `search(query, limit)`, `remember(content, ...)`, `promote(session_id)`, `prune(max_age_days)`, `recent(limit)`. |
+
+Both are `@runtime_checkable` — any class implementing the methods
+satisfies the protocol.
+
+### Security and loader surface — `attune.memory`
+
+| Symbol | Role |
+|--------|------|
+| `Classification` | `PUBLIC` / `INTERNAL` / `SENSITIVE`. |
+| `PIIScrubber` | Strips personally identifiable information before storage. |
+| `SecretsDetector` | Flags credential-like content. |
+| `AuditLogger` | Records writes/reads as `AuditEvent`s for compliance. |
+| `ClaudeMemoryLoader` | Resolves + merges `CLAUDE.md` levels; entry point `load_all_memory()`. |
+| `MemoryControlPanel` | Runtime management — browse, export, and clear stored memory. |
+
+### Entry points
+
+| Surface | Invocation |
+|---------|------------|
+| Python (recommended) | `from attune.memory import UnifiedMemory`. |
+| Custom backend | Implement `MemoryBackend` / `SearchableMemoryBackend` (from `attune.memory.backend`). |
+| Static context | `ClaudeMemoryLoader().load_all_memory()`. |
+| Runtime management | `MemoryControlPanel`. |
+
+## Comparison
+
+Memory's two tiers serve different retention horizons:
+
+| Tier | API | Lifetime | Backed by |
+|------|-----|----------|-----------|
+| Short-term | `stash` / `retrieve` | TTL-expiring (seconds–days) | Redis or in-process |
+| Long-term | `persist_pattern` / `recall_pattern` / `search_patterns` | Durable | Persistent storage |
+| Staging | `stage_pattern` / `promote_pattern` | Until promoted or expired | Short-term, then long-term |
+| Static | `ClaudeMemoryLoader.load_all_memory()` | Read-only project files | `CLAUDE.md` files |
+
+Reach for **short-term** working memory for transient state, **staging
++ promotion** when a pattern should be reviewed before it becomes
+durable, and **long-term patterns** for knowledge you'll search later.
+`UnifiedMemory` exposes all three; `ClaudeMemoryLoader` is the separate
+static-context path.
+
+## Failure modes
+
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `TypeError: __init__() missing 1 required positional argument: 'user_id'` | `UnifiedMemory()` constructed without `user_id` | Pass `user_id` — it is required | high |
+| `persist_pattern` / `stage_pattern` returns `None` | Long-term storage unavailable (e.g. no writable `storage_dir`) | Check `health_check()` / `get_backend_status()`; confirm storage config | medium |
+| `retrieve` returns `None` for a key you stashed | The entry expired (`ttl_seconds`) or the backend isn't persistent | Re-stash with a longer TTL; check `supports_persistence()` | medium |
+| Cross-process reads don't see another process's writes | The backend isn't distributed (in-process store) | Check `supports_distributed()`; configure Redis | medium |
+| `recall_pattern` returns `None` for a real id | `check_permissions=True` and the caller's `access_tier` is insufficient | Use a higher `access_tier`, or pass `check_permissions=False` for trusted callers | medium |
+| A `SENSITIVE` pattern stored unencrypted | `encryption_enabled` is off in the config | Enable encryption in `MemoryConfig` | medium |
+
+### Risk areas
+
+- **`user_id` is required.** `UnifiedMemory` is per-user; there is no
+  zero-arg constructor.
+- **Protocol vs. `UnifiedMemory` signatures differ.** The protocol's
+  `stash(key, value, ttl, agent_id)` is not `UnifiedMemory`'s
+  `stash(key, value, ttl_seconds)` — don't conflate them.
+- **Capabilities are deployment-dependent.** Real-time, distribution,
+  and persistence vary by backend — check before relying on them.
+
+### Diagnosis order
+
+1. Confirm construction: `UnifiedMemory(user_id="...")`.
+2. `health_check()` / `get_backend_status()` for backend state.
+3. `get_capabilities()` to confirm realtime/distributed/persistence.
+4. For a missing short-term key, check the TTL and
+   `supports_persistence()`.
+5. For a missing pattern, check `pattern_id`, `access_tier`, and
+   `check_permissions`.
+
+## FAQ seeds
+
+> **Channel-4 input, not a rendered FAQ.** The FAQ is a dynamic source
+> of truth fed by four channels — unmatched user queries, telemetry
+> error-frequency, GitHub issues, and these author-curated seeds —
+> merged, deduplicated, and frequency-ranked by the FAQ Generator (see
+> doc-stack D3, and the help-docs-single-source spec's decisions.md D6).
+> This section is **not** projected verbatim as the FAQ; it contributes
+> the feature's author-curated seed questions.
+
+- **Q:** What's the difference between short-term and long-term memory?
+  **A:** Short-term (`stash`/`retrieve`) is TTL-expiring working
+  storage; long-term (`persist_pattern`/`search_patterns`) is durable,
+  searchable, classified pattern storage.
+- **Q:** Do I need Redis?
+  **A:** No. `UnifiedMemory` auto-detects the environment and uses an
+  in-process store when Redis isn't available; Redis adds real-time and
+  cross-process support. Check `supports_distributed()`.
+- **Q:** Are the calls async?
+  **A:** No — `UnifiedMemory`'s public methods are synchronous. Call
+  them directly.
+- **Q:** How is sensitive data protected?
+  **A:** On persist, content is auto-classified (`PUBLIC` / `INTERNAL`
+  / `SENSITIVE`), PII is scrubbed, secrets are flagged, and `SENSITIVE`
+  patterns are encrypted at rest when encryption is enabled.
+- **Q:** What's staging for?
+  **A:** `stage_pattern` holds a candidate so you can review it
+  (`get_staged_patterns()`) before `promote_pattern` commits it to
+  durable storage.
+
+## Notes & tips
+
+- **Depend on the documented public surface.** The supported API is
+  `UnifiedMemory`, `MemoryConfig`, and the security/loader classes
+  re-exported from `attune.memory`, plus the `MemoryBackend` /
+  `SearchableMemoryBackend` protocols from `attune.memory.backend`.
+  Submodule internals (`mixins/`, `short_term/`, `long_term_*`) may
+  change.
+- **Let classification run.** Keep `auto_classify=True` unless you have
+  a reason to set the level yourself.
+- **Check capabilities, don't assume.** Use `get_capabilities()` /
+  `supports_*()` before relying on real-time or cross-process behavior.
+- **Close when done.** Call `close()` (or `save()`) to flush and
+  release the backend.
+
+## Design & extension
+
+### Design decisions
+
+- **One object over two tiers.** `UnifiedMemory` composes short-term,
+  long-term, staging, and security so callers use one API instead of
+  wiring backends by hand. The tiers remain separately addressable via
+  the protocols.
+- **Environment-aware by default.** `MemoryConfig.from_environment()`
+  picks backends from `ATTUNE_`-prefixed variables, so the same code
+  runs in development (in-process) and production (Redis) without
+  branching.
+- **Security before durability.** Classification, PII scrubbing,
+  secrets detection, and encryption run on the persist path — durable
+  storage never receives unclassified or unscrubbed content.
+- **Protocols, not base classes.** `MemoryBackend` /
+  `SearchableMemoryBackend` are `@runtime_checkable` protocols, so a
+  custom store needs only to implement the methods.
+
+### Extension points
+
+- **Swap the backend:** implement `MemoryBackend` (or
+  `SearchableMemoryBackend`) and point the config at it.
+- **Tune retention:** set `default_ttl_seconds` and per-call
+  `ttl_seconds` / `ttl_hours`.
+- **Control classification:** pass an explicit `classification` to
+  `persist_pattern` / `promote_pattern`, or rely on `auto_classify`.
+- **Manage at runtime:** use `MemoryControlPanel` to browse, export,
+  and clear stored memory without code changes.

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -1,150 +1,136 @@
----
-type: architecture
-name: memory
-tags: [memory, storage, security, redis, architecture]
----
+# Memory
 
-# Memory architecture
+## Overview
 
-## Purpose
+Attune's memory subsystem gives agents two tiers of storage behind one
+API: **short-term** working memory (fast, TTL-expiring, optionally
+Redis-backed) and **long-term** pattern memory (durable, searchable,
+classified). Security runs before anything durable is written —
+auto-classification, PII scrubbing, secrets detection, and at-rest
+encryption for sensitive patterns.
 
-The memory subsystem stores, retrieves, and secures agent knowledge across two durability tiers: short-term (Redis-backed, TTL-scoped, session-aware) and long-term (MemDocs-backed, classified, pattern-lifecycle-managed). It also loads static CLAUDE.md files that Claude Code uses as persistent project rules. The subsystem does **not** handle conversation history (Claude manages that natively), help-system template rendering, or cross-linking between documentation templates — those live in `transformers.py` and `build_cross_links.py` respectively.
+The recommended entry point is **`UnifiedMemory`**, which composes both
+tiers and the security layer behind a single object. It is
+environment-aware: a `MemoryConfig` auto-detected from the environment
+chooses backends (in-process for development, Redis for production) so
+the same code runs in either. For custom backends, two protocols —
+`MemoryBackend` and `SearchableMemoryBackend` — define the short-term
+and searchable contracts.
 
-## Key classes
+You reach memory these ways:
 
-This table covers the architecturally significant classes. For the full inventory of ~90 classes, see the source files listed in each row.
+- the Python API — `from attune.memory import UnifiedMemory` (the
+  primary surface, documented throughout);
+- the **`MemoryBackend` / `SearchableMemoryBackend` protocols** (in
+  `attune.memory.backend`) — for wiring a custom store (any class
+  implementing the methods works);
+- **`ClaudeMemoryLoader`** — for static project context merged from
+  `CLAUDE.md` files;
+- **`MemoryControlPanel`** — a runtime management surface for browsing,
+  exporting, and clearing stored memory.
 
-| Class | Responsibility | File |
-|-------|---------------|------|
-| `MemoryBackend` | Protocol that every short-term backend must satisfy: `stash`, `retrieve`, `delete`, `keys`, `is_connected`, `get_stats`, `close`, `supports_realtime`, `supports_distributed`. | `src/attune/memory/backend.py` |
-| `SearchableMemoryBackend` | Extends `MemoryBackend` with `search` (full-text + filter) and `promote` (advances a session's staged patterns into broader visibility). | `src/attune/memory/backend.py` |
-| `RedisShortTermMemory` | Facade that composes `BaseOperations`, `BatchOperations`, `CacheManager`, `PatternStaging`, `SessionManager`, `PubSubManager`, `StreamManager`, and seven other mixins into the primary short-term backend. Satisfies `SearchableMemoryBackend`. | `src/attune/memory/short_term/facade.py` |
-| `UnifiedMemory` | Top-level entry point; assembles a short-term backend and a long-term backend via seven `*Mixin` classes (`BackendInitMixin`, `ShortTermOperationsMixin`, `LongTermOperationsMixin`, `PatternPromotionMixin`, `LifecycleMixin`, `CapabilitiesMixin`, `HandoffAndExportMixin`). Callers interact with this class, not the backends directly. | `src/attune/memory/unified.py` |
-| `LongTermMemory` / `MemDocsStorage` | Simplified persistent storage interface and its default mock/file backend; together they implement the long-term tier. | `src/attune/memory/simple_storage.py`, `src/attune/memory/storage_backend.py` |
-| `SecureMemDocsIntegration` | Bridges `ClaudeMemoryLoader` output and `MemDocsStorage`; enforces classification rules, runs PII scrubbing, and logs audit events before any pattern is persisted. | `src/attune/memory/long_term_integration.py` |
-| `ClaudeMemoryLoader` | Discovers, loads, and caches CLAUDE.md files from enterprise, user, and project levels (up to `max_import_depth`). Outputs merged content, not structured records. | `src/attune/memory/claude_memory.py` |
-| `MemoryControlPanel` | Enterprise admin surface: starts/stops Redis, lists/deletes patterns, clears short-term memory, exports patterns, and runs health checks. Not in the read/write hot path. | `src/attune/memory/control_panel.py` |
-| `MemoryAPIHandler` | HTTP handler (`do_GET`, `do_POST`, `do_DELETE`, `do_OPTIONS`) that exposes `MemoryControlPanel` operations over a local REST API. Handles CORS and delegates auth/rate-limiting to support classes. | `src/attune/memory/control_panel_api.py` |
-| `RateLimiter` | IP-windowed rate limiter (sliding window, configurable max requests) used by `MemoryAPIHandler` to protect the control panel API. | `src/attune/memory/control_panel_support.py` |
-| `APIKeyAuth` | Validates bearer tokens for the control panel API; no-ops when no key is configured. | `src/attune/memory/control_panel_support.py` |
-| `PIIScrubber` | Detects and redacts PII before storage using regex-based `PIIPattern` definitions; invoked by `SecureMemDocsIntegration` on SENSITIVE-classified writes. | `src/attune/memory/security/pii_scrubber.py` |
-| `SecretsDetector` | Detects credentials, tokens, and high-entropy strings via pattern matching and entropy analysis; raises `SecurityError` to abort storage if a secret is found. | `src/attune/memory/security/secrets_detector.py` |
-| `AuditLogger` | Persists structured `AuditEvent` records for every classified memory operation; composed from `AuditLogMethodsMixin`, `AuditQueryMixin`, and `AuditReportMixin`. | `src/attune/memory/security/audit_logger.py` |
-| `EncryptionManager` | Encrypts and decrypts SENSITIVE-tier patterns at rest. Optional dependency; `MemoryFeatures` reports whether it is available. | `src/attune/memory/encryption.py` |
-| `CrossSessionCoordinator` | Manages agent registration, heartbeats, and conflict negotiation via Redis pub/sub (`CHANNEL_SESSIONS`, `KEY_ACTIVE_AGENTS`). Used by `BackgroundService`. | `src/attune/memory/cross_session/coordinator.py` |
-| `MemoryGraph` | Knowledge graph (`Node`/`Edge`) for cross-workflow intelligence; nodes are typed (`BugNode`, `VulnerabilityNode`, `PatternNode`, etc.) and connected by typed `EdgeType` relationships. | `src/attune/memory/graph.py` |
-| `Classification` | Three-tier enum (`PUBLIC`, `INTERNAL`, `SENSITIVE`) applied to every stored pattern; drives encryption, PII scrubbing, and audit logging decisions throughout the long-term tier. | `src/attune/memory/long_term_types.py` |
-| `MemoryFeatures` | Probes optional dependencies at runtime and exposes `FeatureInfo` records so callers can gate on Redis, encryption, or distributed-mode availability without importing those modules. | `src/attune/memory/features.py` |
+`UnifiedMemory`'s public methods are synchronous — call them directly,
+no `await`.
 
-## Data flow
+## Concepts
 
-### Short-term write (agent stores a value)
+### Two tiers, one object
 
-```
-Agent
-  │  stash(key, value, ttl, agent_id)
-  ▼
-UnifiedMemory  (ShortTermOperationsMixin)
-  │
-  ▼
-RedisShortTermMemory  (facade)
-  ├── DataSanitizer          checks for secrets / sanitizes input
-  ├── BaseOperations         SET key in Redis with TTL
-  ├── CacheManager           updates local LRU cache
-  └── StreamManager          appends audit event to Redis Stream
-```
+`UnifiedMemory(user_id=...)` exposes both tiers:
 
-### Long-term write (pattern promoted to MemDocs)
+- **Short-term** — a keyed working store: `stash(key, value,
+  ttl_seconds=None)` writes, `retrieve(key)` reads. Entries expire
+  after `ttl_seconds` (or the config default). Backed by Redis when
+  available, an in-process store otherwise.
+- **Long-term** — durable, searchable **patterns**:
+  `persist_pattern(content, pattern_type, ...)` stores one,
+  `recall_pattern(pattern_id)` reads it back, and `search_patterns(
+  query=..., limit=10)` queries by content. Patterns can be **staged**
+  first (`stage_pattern(...)`) and later **promoted** to durable
+  storage (`promote_pattern(staged_id)`).
 
-```
-Agent / UnifiedMemory  (PatternPromotionMixin)
-  │  store pattern with classification + pattern_type
-  ▼
-SecureMemDocsIntegration
-  ├── SecretsDetector        abort if secret found  ──► SecurityError
-  ├── PIIScrubber            redact PII for SENSITIVE tier
-  ├── EncryptionManager      encrypt value for SENSITIVE tier
-  ├── ClassificationRules    enforce access-tier constraints
-  ├── AuditLogger            write AuditEvent record
-  └── MemDocsStorage / LongTermMemory   persist SecurePattern
-```
+### Construction is environment-aware
 
-### CLAUDE.md load (project rules injected into context)
+`UnifiedMemory` takes a required `user_id`, an optional `config`
+(`MemoryConfig`, default auto-detected from the environment), and an
+optional `access_tier` (`AccessTier`, default `CONTRIBUTOR`).
+`MemoryConfig.from_environment()` reads `ATTUNE_`-prefixed variables
+(`EMPATHY_` also accepted) — `ATTUNE_ENV` selects `development`,
+`staging`, or `production`, which in turn drives Redis and storage
+defaults. Construct one with explicit settings via
+`UnifiedMemory(user_id="me", config=MemoryConfig(...))`.
 
-```
-ClaudeMemoryConfig
-  (enabled, load_enterprise, load_user, load_project,
-   max_import_depth, max_file_size_bytes)
-  │
-  ▼
-ClaudeMemoryLoader.load_all_memory(project_root)
-  ├── discovers enterprise  ~/.attune/CLAUDE.md
-  ├── discovers user        ~/CLAUDE.md
-  └── discovers project     <project_root>/.claude/CLAUDE.md
-        │  follows @import directives up to max_import_depth
-        ▼
-  merged string  ──►  SecureMemDocsIntegration (optional)
-                 ──►  caller (Claude Code context injection)
-```
+### Security runs before durable writes
 
-### Cross-session coordination
+When you persist a pattern, classification and scrubbing run first.
+`auto_classify=True` (the default) assigns a `Classification` —
+`PUBLIC`, `INTERNAL`, or `SENSITIVE` — from the content and pattern
+type; PII is scrubbed and credential-like content is flagged before
+storage; `SENSITIVE` patterns are encrypted at rest. You can pass an
+explicit `classification` to override the auto-assignment. Reads honor
+the caller's `access_tier` unless you set `check_permissions=False` on
+`recall_pattern`.
 
-```
-BackgroundService  (daemon thread)
-  │  polls Redis every HEARTBEAT_INTERVAL_SECONDS
-  ▼
-CrossSessionCoordinator
-  ├── KEY_ACTIVE_AGENTS      registry of live agent IDs
-  ├── KEY_SERVICE_LOCK       distributed leader election
-  ├── CHANNEL_SESSIONS       pub/sub for session events
-  └── ConflictNegotiation    resolves write conflicts via ConflictStrategy
-```
+### Capabilities tell you what the backend can do
 
-### Control panel API
+A deployment's backend may or may not support real-time updates,
+distribution across processes, or durable persistence. `UnifiedMemory`
+surfaces this: `get_capabilities()` returns a `dict[str, bool]`, and
+`supports_realtime()`, `supports_distributed()`, and
+`supports_persistence()` answer individually. `health_check()` and
+`get_backend_status()` report runtime state. Check capabilities before
+relying on, say, cross-process coordination.
 
-```
-HTTP client
-  │  GET/POST/DELETE  localhost:8765
-  ▼
-MemoryAPIHandler
-  ├── APIKeyAuth             validate bearer token
-  ├── RateLimiter            enforce per-IP window
-  └── MemoryControlPanel
-        ├── status / health_check
-        ├── list_patterns / delete_pattern / export_patterns
-        └── start_redis / stop_redis / clear_short_term
-```
+### Custom backends implement a protocol
 
-## Design decisions
+`MemoryBackend` is a `@runtime_checkable` `Protocol` for short-term
+stores: `stash(key, value, ttl, agent_id)`, `retrieve(key, agent_id)`,
+`delete(key)`, `keys(pattern)`, `is_connected()`, `get_stats()`,
+`close()`, plus `supports_realtime()` / `supports_distributed()`.
+`SearchableMemoryBackend` extends it with `search(query, limit)`,
+`remember(content, ...)`, `promote(session_id)`, `prune(max_age_days)`,
+and `recent(limit)`. Any class implementing the methods satisfies the
+protocol — no base class to inherit. (Note these protocol signatures —
+`stash(key, value, ttl, agent_id)` — differ from `UnifiedMemory`'s
+own `stash(key, value, ttl_seconds)`.)
 
-### `UnifiedMemory` assembled from mixins, not inheritance
+### Static project context
 
-`UnifiedMemory` composes seven `*Mixin` classes (`BackendInitMixin`, `ShortTermOperationsMixin`, `LongTermOperationsMixin`, `PatternPromotionMixin`, `LifecycleMixin`, `CapabilitiesMixin`, `HandoffAndExportMixin`) rather than inheriting from `RedisShortTermMemory` or `LongTermMemory` directly. This keeps each mixin independently testable and prevents the short-term and long-term tiers from coupling. The cost is that `UnifiedMemory`'s MRO is non-trivial; when debugging method resolution, check `unified.py` and the `mixins/` directory together.
+`ClaudeMemoryLoader` resolves `CLAUDE.md` files at enterprise, user,
+and project levels and merges them via its `load_all_memory()` method.
+Which levels load is controlled by the `MemoryConfig` **fields**
+`load_enterprise_memory` / `load_user_memory` / `load_project_memory`
+(not loader methods). This is the static counterpart to the read/write
+tiers above.
 
-### `RedisShortTermMemory` as a composed facade
+## Design & extension
 
-The short-term tier splits across fifteen classes (`BaseOperations`, `BatchOperations`, `CacheManager`, `PatternStaging`, `SessionManager`, `PubSubManager`, `StreamManager`, `TimelineManager`, `TransactionManager`, `WorkingMemory`, `ConflictNegotiation`, `CrossSessionManager`, `QueueManager`, `Pagination`, `DataSanitizer`) and composes them into a single `RedisShortTermMemory` facade. A monolithic Redis class was rejected because each capability group (streaming, pub/sub, queuing, pagination) has distinct test and configuration concerns. Adding a new Redis capability means adding a new file in `src/attune/memory/short_term/` and composing it into the facade — not modifying existing classes.
+### Design decisions
 
-### `Classification` as a cross-cutting invariant
+- **One object over two tiers.** `UnifiedMemory` composes short-term,
+  long-term, staging, and security so callers use one API instead of
+  wiring backends by hand. The tiers remain separately addressable via
+  the protocols.
+- **Environment-aware by default.** `MemoryConfig.from_environment()`
+  picks backends from `ATTUNE_`-prefixed variables, so the same code
+  runs in development (in-process) and production (Redis) without
+  branching.
+- **Security before durability.** Classification, PII scrubbing,
+  secrets detection, and encryption run on the persist path — durable
+  storage never receives unclassified or unscrubbed content.
+- **Protocols, not base classes.** `MemoryBackend` /
+  `SearchableMemoryBackend` are `@runtime_checkable` protocols, so a
+  custom store needs only to implement the methods.
 
-Rather than letting callers decide when to encrypt or scrub PII, `SecureMemDocsIntegration` enforces those decisions based on the `Classification` enum value attached to every pattern. `SENSITIVE` always triggers `PIIScrubber` + `EncryptionManager` + `AuditLogger`; `INTERNAL` triggers `AuditLogger` only; `PUBLIC` writes straight through. This means classification is a contract, not a hint — changing a pattern's tier changes its entire storage path.
+### Extension points
 
-### Optional Redis with file-based fallback
+- **Swap the backend:** implement `MemoryBackend` (or
+  `SearchableMemoryBackend`) and point the config at it.
+- **Tune retention:** set `default_ttl_seconds` and per-call
+  `ttl_seconds` / `ttl_hours`.
+- **Control classification:** pass an explicit `classification` to
+  `persist_pattern` / `promote_pattern`, or rely on `auto_classify`.
+- **Manage at runtime:** use `MemoryControlPanel` to browse, export,
+  and clear stored memory without code changes.
 
-`MemoryFeatures` and `is_redis_available()` probe for Redis at runtime. When Redis is absent, `FileSessionMemory` (backed by `FileSessionConfig`, `PersistenceMixin`, `PatternStagingMixin`) provides session storage on disk under `~/.attune/memory/`. The two backends satisfy the same `MemoryBackend` protocol, so `UnifiedMemory` switches between them without conditional logic in the callers.
-
-## Extension points
-
-- **Add a new short-term backend** (e.g., Memcached): implement `MemoryBackend` (or `SearchableMemoryBackend` for search support) and pass an instance to `UnifiedMemory` via `MemoryConfig`. You do not need to touch `RedisShortTermMemory` or the facade.
-
-- **Add a new Redis capability** (e.g., geo queries): create a new operations class in `src/attune/memory/short_term/`, inherit from it in `RedisShortTermMemory` in `facade.py`, and add the corresponding mixin to `UnifiedMemory` if you need to expose it at the top level.
-
-- **Add a new node type to the memory graph**: subclass `Node` in `src/attune/memory/nodes.py` (following `BugNode`, `VulnerabilityNode`, `PatternNode`), and add the corresponding `NodeType` enum value. Register any new edge relationships in `EdgeType` in `edges.py`.
-
-- **Add a new classification-based security rule**: extend `ClassificationRules` in `src/attune/memory/long_term_types.py` and update `SecureMemDocsIntegration` to apply the rule in its write pipeline. All existing callers inherit the enforcement automatically.
-
-- **Add a new CLAUDE.md discovery level**: extend `ClaudeMemoryLoader.load_all_memory()` and add the corresponding flag to `ClaudeMemoryConfig`. The `max_import_depth` guard already applies to any level you add.
-
-- **Expose a new control panel operation over HTTP**: add the method to `MemoryControlPanel`, then add a route in `MemoryAPIHandler.do_GET` / `do_POST` / `do_DELETE`. `RateLimiter` and `APIKeyAuth` apply automatically to all routes.
-
-For usage — operations, storage behavior, and search syntax — see `references/skill-memory-and-context.md`.
+<!-- attune-generated: source_hash=544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b feature=memory kind=architecture generated_at=2026-06-23 -->

--- a/docs/features/memory.md
+++ b/docs/features/memory.md
@@ -1,0 +1,27 @@
+# Memory
+
+Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
+
+!!! tip "Start here"
+
+    [How-to guide](../how-to/memory.md) — task recipes for common goals.
+
+<div class="grid cards" markdown>
+
+-   __Reference__
+
+    ---
+
+    The full API and option reference.
+
+    [Open the reference](../reference/memory.md)
+
+-   __Architecture__
+
+    ---
+
+    How it works and how to extend it.
+
+    [Open the architecture](../architecture/memory.md)
+
+</div>

--- a/docs/how-to/memory.md
+++ b/docs/how-to/memory.md
@@ -1,14 +1,132 @@
----
-type: reference
-name: memory-reference
-feature: memory
-depth: reference
-generated_at: 2026-06-23T21:52:16.487778+00:00
-source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
-status: generated
----
+# Memory
 
-# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
+## Quickstart
+
+Create a memory for a user, stash some working data, and persist a
+durable pattern. Every call is synchronous:
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="agent@company.com")
+
+# Short-term working memory (expires)
+memory.stash("current_task", {"id": 42, "phase": "review"}, ttl_seconds=3600)
+task = memory.retrieve("current_task")
+
+# Long-term pattern memory (durable, classified)
+result = memory.persist_pattern(
+    content="Use heapq.nlargest for top-N instead of sorted()[:N]",
+    pattern_type="optimization",
+)
+if result:
+    pattern = memory.recall_pattern(result["pattern_id"])
+
+memory.close()
+```
+
+`UnifiedMemory()` with no `config` auto-detects the environment, so the
+same code runs against an in-process store in development and Redis in
+production.
+
+## Tasks
+
+### Stash and retrieve short-term working memory
+
+**Goal:** keep transient working state that expires on its own.
+
+**Steps:**
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me")
+memory.stash("draft", {"step": 3}, ttl_seconds=600)  # expires in 10 min
+print(memory.retrieve("draft"))                       # {"step": 3}
+memory.close()
+```
+
+**Verify:** `stash` returns `True` on success; `retrieve` returns the
+value or `None` if missing/expired. `ttl_seconds` is optional — omit it
+to use the config default.
+
+### Persist, search, and recall long-term patterns
+
+**Goal:** store a durable, classified pattern and find it later by
+content.
+
+**Steps:**
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me")
+result = memory.persist_pattern(
+    content="Validate file paths with _validate_file_path before writing",
+    pattern_type="security",
+)
+hits = memory.search_patterns(query="file path validation", limit=5)
+for hit in hits:
+    print(hit["pattern_id"])
+memory.close()
+```
+
+**Verify:** `persist_pattern` returns a dict with a `pattern_id` (or
+`None` if storage is unavailable). `search_patterns` returns a list of
+dicts ranked by relevance; narrow it with `pattern_type=` or
+`classification=`. Classification is automatic unless you pass
+`classification=`.
+
+### Stage a pattern, then promote it
+
+**Goal:** hold a candidate pattern for review before committing it to
+durable storage.
+
+**Steps:**
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me")
+staged_id = memory.stage_pattern(
+    {"content": "Candidate: cache AST parses by file hash"},
+    pattern_type="optimization",
+)
+# ... review memory.get_staged_patterns() ...
+if staged_id:
+    memory.promote_pattern(staged_id)
+memory.close()
+```
+
+**Verify:** `stage_pattern` returns a staged id (or `None`);
+`get_staged_patterns()` lists what's pending; `promote_pattern`
+graduates it to durable storage (running classification/scrubbing) and
+returns the stored pattern dict.
+
+### Record an SBAR handoff
+
+**Goal:** leave a structured handoff for the next session or agent.
+
+**Steps:**
+
+```python
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me")
+memory.set_handoff(
+    situation="Mid-refactor of the release agents",
+    background="Split into focused submodules",
+    assessment="Tests green; docs not yet updated",
+    recommendation="Update docs/architecture/release.md next",
+)
+print(memory.generate_compact_state())
+memory.close()
+```
+
+**Verify:** `set_handoff` takes the four SBAR fields plus arbitrary
+`**extra_context`. `generate_compact_state()` returns a string snapshot;
+`export_to_claude_md(path=None)` writes the state to a `CLAUDE.md`-style
+file and returns the `Path`.
 
 ## Reference
 
@@ -82,3 +200,5 @@ satisfies the protocol.
 | Custom backend | Implement `MemoryBackend` / `SearchableMemoryBackend` (from `attune.memory.backend`). |
 | Static context | `ClaudeMemoryLoader().load_all_memory()`. |
 | Runtime management | `MemoryControlPanel`. |
+
+<!-- attune-generated: source_hash=544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b feature=memory kind=how-to generated_at=2026-06-23 -->

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -1,14 +1,4 @@
----
-type: reference
-name: memory-reference
-feature: memory
-depth: reference
-generated_at: 2026-06-23T21:52:16.487778+00:00
-source_hash: 544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b
-status: generated
----
-
-# Two-tier memory subsystem — short-term working storage, long-term pattern lookup, and security
+# Memory
 
 ## Reference
 
@@ -82,3 +72,5 @@ satisfies the protocol.
 | Custom backend | Implement `MemoryBackend` / `SearchableMemoryBackend` (from `attune.memory.backend`). |
 | Static context | `ClaudeMemoryLoader().load_all_memory()`. |
 | Runtime management | `MemoryControlPanel`. |
+
+<!-- attune-generated: source_hash=544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b feature=memory kind=reference generated_at=2026-06-23 -->


### PR DESCRIPTION
## What

Single-source the **memory** feature (13/25 in the help-docs rollout) —
author `content/features/memory.md` and re-project its 10 `.help` kinds
+ how-to / architecture / reference docs + the hub via
`attune_author.projector`, replacing the prior LLM corpus.

The master centers on the verified **`UnifiedMemory`** public API (the
recommended entry point): short-term `stash`/`retrieve`, long-term
`persist_pattern`/`recall_pattern`/`search_patterns`, staging +
promotion, SBAR `set_handoff`, and capabilities/health — plus the
`MemoryBackend` / `SearchableMemoryBackend` protocols (extension
surface), `ClaudeMemoryLoader` (static `CLAUDE.md` context), and the
security layer (auto-classification, PII scrubbing, secrets detection,
at-rest encryption). All `UnifiedMemory` methods are synchronous.

## Loop receipts (r7-rollout-playbook)

- **Dry-run fact-check:** 0 findings. **Example gate:** 0 problems (5 blocks).
- **Independent adversarial review:** 0 false / 0 misleading after fixes.
  The catch the static check structurally missed: `MemoryBackend` /
  `SearchableMemoryBackend` are **not** re-exported from `attune.memory`
  — they live in `attune.memory.backend`; corrected every reference.
  Also clarified `load_enterprise/user/project_memory` are `MemoryConfig`
  **fields**, not `ClaudeMemoryLoader` methods.
- **faq** rewritten as a frozen `status: manual` file matching the master.
- **DD5:** `features.yaml` entry → `status: manual` (dropped `files:` and
  `doc_paths`). Description/tags unchanged to preserve golden-query
  resolution (`mem-002` "storage"; `rg-003` "lookup" not "retrieval").
- **Serve-verify** via `attune.ops.help_data`: 11/11 kinds, complete.
- **Full help suite:** 501 passed / 3 xfailed — the manifest-integrity
  symbol guard correctly skips memory now that it's `status: manual`.
- **mkdocs build --strict:** clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
