### PR TITLE
docs(help): single-source wizards via projector (15/25)

### DIFF
--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -304,13 +304,23 @@ features:
     tags: [spec, planning]
     status: manual
 
+  # wizards is single-sourced (status: manual) from
+  # content/features/wizards.md and rendered by
+  # attune_author.projector (scripts/project_features.py), which owns
+  # .help/templates/wizards/*.md. The entry is marked `status: manual`
+  # — WITHOUT `files:` — so topic resolution routes here while
+  # staleness/maintenance never runs `attune-author generate wizards
+  # --all-kinds` to overwrite the projected content with LLM output
+  # (DD5, help-docs-single-source decision, 2026-06-23). The retained
+  # faq.md stays on disk frozen until the four-channel FAQ Generator
+  # (D6/D7) replaces that path. The old hand-authored
+  # docs/reference/wizards.md is now the projected reference page.
+  # Description and tags are unchanged to preserve golden-query
+  # resolution (wz-002 "interactive"). See docs/specs/help-docs-single-source/.
   wizards:
     description: Multi-step guided interactive workflows
-    files:
-      - src/attune/wizards/**
     tags: [wizards, interactive]
-    doc_paths:
-      - docs/reference/wizards.md
+    status: manual
 
   configuration:
     description: Project configuration and settings management

--- a/.help/templates/wizards/comparison.md
+++ b/.help/templates/wizards/comparison.md
@@ -1,70 +1,27 @@
 ---
 type: comparison
+name: wizards-comparison
 feature: wizards
 depth: comparison
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Wizards vs direct AI calls
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-## Overview
+## Comparison
 
-Wizards provide structured, multi-step interactive workflows that guide users through complex development tasks. They differ from direct AI calls by offering predefined steps, form-based input collection, and built-in progress tracking.
+Wizards differ from workflows in interaction model:
 
-## Feature comparison
+| | Wizards | Workflows |
+|--|---------|-----------|
+| Interaction | Interactive — collect input mid-run via `question`/`confirm` steps | Non-interactive — run to completion from inputs |
+| Entry | `get_wizard(id)` + `await run()`, or `/wizard` skill | `attune workflow run <slug>` / the workflow class |
+| Output | `WizardResult` (collected data + generated output) | `WorkflowResult` |
 
-| Feature | Wizards | Direct AI calls |
-|---------|---------|-----------------|
-| **Structure** | Predefined steps with clear progression | One-off prompts without guidance |
-| **User interaction** | Form questions with validation | Free-form text input only |
-| **Progress tracking** | Built-in step completion and duration metrics | Manual tracking required |
-| **Cost estimation** | Predefined ranges (e.g., $0.01-$0.50) | No cost prediction |
-| **Reusability** | Registered and shareable across team | Ad-hoc, not reusable |
-| **Context management** | Automatic prompt context building | Manual context assembly |
-| **Error handling** | Structured error reporting and recovery | Basic error messages |
-| **Output format** | Consistent structured results | Variable response format |
-
-## Built-in wizard types
-
-The system includes five specialized wizards:
-
-- **DebugWizard**: Guided debugging with systematic problem isolation
-- **RefactorWizard**: Step-by-step code refactoring with safety checks
-- **ReleasePrepWizard**: Release checklist automation and validation
-- **SecurityWizard**: Security audit workflows with threat modeling
-- **TestGenWizard**: Comprehensive test generation for code coverage
-
-## When to use wizards
-
-Choose wizards when you need:
-
-- **Consistent workflows**: Repeatable processes that team members execute regularly
-- **Guided interaction**: Users benefit from structured questions rather than open prompts
-- **Progress tracking**: You need to monitor completion rates and duration
-- **Quality gates**: Built-in validation and review steps are essential
-- **Cost control**: Predefined token limits and cost estimates matter
-- **Team standardization**: Multiple developers need the same workflow experience
-
-Examples: code reviews, security audits, release preparation, debugging complex issues.
-
-## When to use direct AI calls
-
-Choose direct AI calls when you need:
-
-- **Exploratory work**: One-off questions or experimental prompts
-- **Maximum flexibility**: Custom prompting without workflow constraints
-- **Simple interactions**: Single-step operations that don't need structure
-- **Rapid iteration**: Testing different approaches without setup overhead
-- **Custom context**: Highly specific context that doesn't fit wizard patterns
-
-Examples: quick code explanations, ad-hoc refactoring ideas, experimental feature brainstorming.
-
-## Recommendation
-
-**Use wizards as your default for development workflows.** They provide better user experience, cost predictability, and team consistency. The built-in types (debug, refactor, release prep, security, test generation) cover most common scenarios.
-
-Fall back to direct AI calls only for exploratory work or when you need prompting flexibility that wizards don't support. You can always prototype with direct calls, then create a custom wizard if the workflow proves valuable.
-
-**Source files:** `src/attune/wizards/**`
+Reach for a **wizard** when the task needs the user in the loop
+(answering questions, confirming gates); reach for a **workflow** when
+the run is fully specified up front. Several builtins mirror a
+workflow (`release-prep`, `security`, `test-gen`) but wrap it in a
+guided, interactive flow.

--- a/.help/templates/wizards/error.md
+++ b/.help/templates/wizards/error.md
@@ -1,47 +1,38 @@
 ---
 type: error
+name: wizards-error
 feature: wizards
 depth: error
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Wizards errors
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-Failures in Attune AI's XML-enhanced wizard system, which provides guided multi-step workflows for development tasks like debugging, refactoring, and security audits.
+## Failure modes
 
-## Common error signatures
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `RuntimeWarning: coroutine 'BaseWizard.run' was never awaited` | `run()` called without `await` | It is a coroutine — `await` it or use `asyncio.run` | high |
+| `AttributeError: 'NoneType' object has no attribute ...` after `get_wizard` | The wizard id is unknown; `get_wizard` returned `None` | Check `get_wizard(id) is not None`; list ids with `list_wizards()` | high |
+| A `question` step never prompts / hangs | No `ask_user_callback` wired (outside Claude Code) | Pass an `ask_user_callback` to the wizard, or run via the `/wizard` skill | medium |
+| `WizardResult.success` is `False` with a populated `error` | A step failed (LLM call, validation, or an aborted confirm) | Read `result.error` and `result.steps_completed` to see where it stopped | medium |
+| Custom wizard not found by `get_wizard` | It was never `register_wizard`'d (or `save_custom_wizard`'d) | Register the class or save the definition first | low |
 
-- `ValueError: Cannot write wizard YAML: {error_details}` — Custom wizard save operations failed due to filesystem issues or invalid YAML structure
-- `ValueError: Cannot delete built-in wizard: '{wizard_id}'` — Attempted to delete a built-in wizard (DebugWizard, RefactorWizard, etc.)
-- `KeyError` or `None` returned from `get_wizard()` — Requested wizard ID not found in registry
-- Step execution failures during `BaseWizard.run()` — Wizard step conditions, prompt generation, or result processing errors
-- XML parsing errors in task decomposition — Invalid XML structure in decomposed task responses
+### Risk areas
 
-## Where errors originate
+- **`run()` is async.** Forgetting to `await` it is the most common
+  mistake.
+- **There is no registry class.** Use the module-level functions
+  (`list_wizards`, `get_wizard`, …) — not a `WizardRegistry`.
+- **`question` steps need a callback.** Outside the `/wizard` skill,
+  supply an `ask_user_callback` or the wizard can't collect input.
 
-Wizard errors typically start at these key entry points:
+### Diagnosis order
 
-- **Registry operations**: `register_wizard()`, `get_wizard()`, `list_wizards()` — Wizard registration and lookup failures
-- **Custom wizard management**: `save_custom_wizard()`, `delete_custom_wizard()` — File I/O and validation errors when persisting wizard definitions
-- **Wizard execution**: `BaseWizard.run()` — Step processing, condition evaluation, and prompt context building failures
-- **Step processing**: `build_prompt_context()`, `process_step_result()` — Individual wizard implementations failing to handle step data
-
-## How to diagnose
-
-1. **Check the wizard ID and registration status.** Use `list_wizards()` to verify the wizard exists and `get_wizard(wizard_id)` returns a valid class. Missing wizards return `None` rather than raising exceptions.
-
-2. **Examine custom wizard YAML structure.** If `save_custom_wizard()` fails, validate that your wizard definition matches the expected schema with required fields like `wizard_id`, `name`, `description`, and properly formatted `steps`.
-
-3. **Review step conditions and context.** When `BaseWizard.run()` fails mid-execution, check that step conditions (`WizardStep.condition`) evaluate correctly and that `build_prompt_context()` can access all required data from the wizard session.
-
-4. **Validate filesystem permissions.** Custom wizard save/delete operations require write access to the wizard definitions directory. Permission errors manifest as `ValueError` with "Cannot write wizard YAML" messages.
-
-5. **Check built-in wizard constraints.** Attempts to modify built-in wizards (DebugWizard, RefactorWizard, ReleasePrepWizard, SecurityWizard, TestGenWizard) will fail with explicit error messages about protected wizard IDs.
-
-## Source files
-
-- `src/attune/wizards/**`
-
-**Tags:** `wizards`, `interactive`
+1. Confirm you are awaiting: `await get_wizard(id)().run()`.
+2. Confirm the id exists: `get_wizard(id) is not None` /
+   `list_wizards()`.
+3. On failure, read `result.error` and `result.steps_completed`.
+4. If a `question` step stalls, check the `ask_user_callback` wiring.

--- a/.help/templates/wizards/faq.md
+++ b/.help/templates/wizards/faq.md
@@ -1,58 +1,81 @@
 ---
 type: faq
+name: wizards-faq
 feature: wizards
 depth: faq
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
-status: generated
+status: manual
 ---
 
 # Wizards FAQ
 
 ## What are wizards?
 
-Interactive, multi-step workflows that guide you through complex tasks like debugging, refactoring, security audits, and test generation.
-
-## When should I use wizards?
-
-Use wizards when you need guided assistance with development tasks that involve multiple steps or decisions. For example, use the DebugWizard when troubleshooting issues, or the RefactorWizard when restructuring code.
+Interactive, multi-step workflows that guide you through complex tasks
+— collecting input via `question` steps, running LLM calls, decomposing
+tasks, and gating on review/confirm — and return a `WizardResult` with
+the collected data, generated output, and cost/duration.
 
 ## Which wizards are available?
 
-Attune includes five built-in wizards:
+Five ship built in (run `list_wizards()` to confirm):
 
-- **DebugWizard** - Helps troubleshoot code issues
-- **RefactorWizard** - Guides code restructuring
-- **ReleasePrepWizard** - Assists with release preparation
-- **SecurityWizard** - Performs guided security audits
-- **TestGenWizard** - Helps generate test code
+- `debug` (`DebugWizard`) — systematic debugging
+- `refactor` (`RefactorWizard`) — code restructuring with safety checks
+- `release-prep` (`ReleasePrepWizard`) — release preparation
+- `security` (`SecurityWizard`) — guided security audit
+- `test-gen` (`TestGenWizard`) — interactive test generation
 
 ## How do I run a wizard?
 
-Get a wizard class using `get_wizard()`, then create an instance and call `run()`:
+`get_wizard(id)` returns the wizard class; instantiate it and `await`
+its `run()` — `run()` is a coroutine:
 
 ```python
+import asyncio
+
 from attune.wizards import get_wizard
 
-wizard_class = get_wizard("debug")
-wizard = wizard_class()
-result = wizard.run(initial_context={"file": "my_script.py"})
+
+async def main() -> None:
+    wizard_cls = get_wizard("debug")
+    if wizard_cls is not None:
+        result = await wizard_cls().run(initial_context={"file": "my_script.py"})
+        print(result.success)
+
+
+asyncio.run(main())
 ```
+
+There is no `attune wizard` CLI command and no MCP tool — run wizards
+through the Python API or the `/wizard` skill.
+
+## Are the calls async?
+
+`run()` is a coroutine — `await` it or use `asyncio.run`. The registry
+functions (`list_wizards`, `get_wizard`) are synchronous.
+
+## Is there a `WizardRegistry` class?
+
+No. The registry is module-level functions in `attune.wizards`:
+`list_wizards`, `get_wizard`, `register_wizard`, `save_custom_wizard`,
+`delete_custom_wizard`.
 
 ## How do I see all available wizards?
 
-Call `list_wizards()` to get configuration details for all registered wizards, including estimated cost and duration.
+Call `list_wizards()` — it returns a `WizardConfig` per registered
+wizard, with id, name, domain, and estimated cost/duration.
 
 ## Can I create custom wizards?
 
-Yes. Either extend `BaseWizard` for programmatic wizards or use `save_custom_wizard()` to create YAML-defined wizards that follow a structured format.
+Yes — subclass `BaseWizard` (implement `build_prompt_context` and
+`process_step_result`) and `register_wizard(id, cls)`, or build a
+`ConfigDrivenWizard(config, steps)` / persist one with
+`save_custom_wizard(data)`.
 
-## How do I debug wizard issues?
+## How do I debug a wizard failure?
 
-Run `pytest -k "wizards" -v` to verify the wizard system works correctly. If your specific wizard fails, check the `WizardResult.error` field for error details, or add logging to your wizard's `build_prompt_context()` and `process_step_result()` methods.
-
-## Where are the source files?
-
-- `src/attune/wizards/**`
+Check `WizardResult.error` and `WizardResult.steps_completed` to see
+where it stopped. If a `question` step stalls outside the `/wizard`
+skill, wire an `ask_user_callback` into the wizard.
 
 **Tags:** `wizards`, `interactive`

--- a/.help/templates/wizards/note.md
+++ b/.help/templates/wizards/note.md
@@ -1,49 +1,109 @@
 ---
 type: note
+name: wizards-note
 feature: wizards
 depth: note
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Note: wizards
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-## Context
+## Overview
 
-The wizards system provides XML-enhanced interactive workflows that guide users through complex, multi-step processes in Attune AI. Each wizard breaks down tasks like debugging, refactoring, or security auditing into structured steps with AI-powered prompts and user interactions.
+Wizards are **interactive, multi-step workflows** that guide a user
+through a complex development task by breaking it into sequential steps
+— questions that collect input, LLM calls, task decomposition, and
+review/confirm gates. Each wizard runs to a `WizardResult` carrying the
+collected data, generated output, and cost/duration metrics.
 
-## Architecture
+The registry is a set of **module-level functions** in
+`attune.wizards` (there is no registry class): `list_wizards()`,
+`get_wizard(id)`, `register_wizard(...)`, `save_custom_wizard(...)`, and
+`delete_custom_wizard(...)`. Five wizards ship built in — `debug`,
+`refactor`, `release-prep`, `security`, and `test-gen`.
 
-The wizards system separates data types from execution logic:
+You reach wizards two ways:
 
-**Core data types** (`_types.py`):
-- `WizardStep` — Defines individual workflow steps with prompts, questions, and execution modes
-- `WizardConfig` — Contains wizard metadata like name, domain, and estimated cost
-- `WizardResult` — Captures completion status, collected data, and execution metrics
-- `StepType` — Enum for step execution modes (question, action, review)
+- the Python API — `from attune.wizards import get_wizard, list_wizards`
+  (the primary surface, documented throughout);
+- the **`/wizard`** skill, inside a Claude Code conversation.
 
-**Base execution** (`base.py`):
-- `BaseWizard` — Abstract class that orchestrates step execution, context building, and result processing
+There is **no `attune wizard` CLI command and no MCP tool** — wizards
+run through the Python API or the skill. A wizard's `run()` method is
+**async** — `await` it.
 
-**Registry management** (`registry.py`):
-- Functions to register, retrieve, save, and delete wizard definitions
-- Support for both built-in and custom wizards stored as YAML
+## Concepts
 
-## Built-in wizards
+### The four core types
 
-Five specialized wizards extend `BaseWizard`:
+| Type | Role |
+|------|------|
+| `WizardStep` | One step — `id`, `name`, `description`, `step_type`, an optional `prompt_template`, `questions`, a `tier`, and a `condition`. |
+| `WizardConfig` | Wizard metadata — `wizard_id`, `name`, `description`, `domain`, `version`, `source`, `estimated_cost_range`, `estimated_duration_minutes`. |
+| `BaseWizard` | Abstract base all wizards inherit from; drives step execution via the async `run()` method. |
+| `WizardResult` | The outcome — `wizard_id`, `run_id`, `success`, `steps_completed`, `collected_data`, `generated_output`, `tasks`, `total_cost`, `total_duration_ms`, `error`. |
 
-- `DebugWizard` — Guides systematic debugging workflows
-- `RefactorWizard` — Structures code refactoring processes
-- `ReleasePrepWizard` — Orchestrates release preparation tasks
-- `SecurityWizard` — Facilitates security audit procedures
-- `TestGenWizard` — Assists with test generation workflows
+### Step types
 
-Each wizard customizes `build_prompt_context()` and `process_step_result()` to handle domain-specific logic while following the common execution pattern.
+A step's `step_type` is a `StepType`: `question` (collect user input),
+`llm_call` (run a model call), `task_decompose` (break work into an
+XML task tree via `TaskDecomposer`), `review`, `preview`, and
+`confirm` (human gates). The wizard walks the steps in order, honoring
+each step's optional `condition`.
 
-## Source files
+### Running a built-in wizard
 
-- `src/attune/wizards/**`
+`get_wizard(id)` returns the wizard **class** (or `None`); instantiate
+it and `await` its `run()`:
 
-**Tags:** `wizards`, `interactive`
+- `BaseWizard(ask_user_callback=None, provider=None, **workflow_kwargs)`
+  — the `ask_user_callback` is how the wizard collects input for
+  `question` steps (wired to `AskUserQuestion` inside Claude Code);
+- `run(initial_context=None)` is a coroutine returning a
+  `WizardResult`.
+
+A subclass customizes two hooks: `build_prompt_context(step)` (prepare
+the model prompt) and `process_step_result(step, result)` (handle a
+step's output).
+
+### The built-in wizards
+
+`list_wizards()` returns the registered `WizardConfig`s. Five ship
+built in:
+
+| `wizard_id` | Class | Guides |
+|-------------|-------|--------|
+| `debug` | `DebugWizard` | Systematic debugging, step by step. |
+| `refactor` | `RefactorWizard` | Code restructuring with safety checks. |
+| `release-prep` | `ReleasePrepWizard` | Release preparation and validation. |
+| `security` | `SecurityWizard` | Guided security audit with risk assessment. |
+| `test-gen` | `TestGenWizard` | Interactive test-suite generation. |
+
+### Custom wizards — subclass or config-driven
+
+Two ways to add a wizard:
+
+- **Subclass `BaseWizard`** and implement `build_prompt_context` /
+  `process_step_result`, then `register_wizard(id, cls)` to make it
+  discoverable.
+- **Config-driven** — build a `ConfigDrivenWizard(config, steps)` from
+  a `WizardConfig` + a list of `WizardStep`s (no subclass needed), or
+  persist a definition with `save_custom_wizard(data, base_dir=None)`
+  (returns the saved `Path`) and remove it with
+  `delete_custom_wizard(id, base_dir=None)`.
+
+## Notes & tips
+
+- **Depend on the documented public surface.** The supported API is
+  the registry functions plus `BaseWizard`, `ConfigDrivenWizard`, the
+  `WizardConfig` / `WizardStep` / `WizardResult` dataclasses, `StepType`,
+  and `WizardSession` — all from `attune.wizards`.
+- **`await` the run.** `run()` is the only async method; the registry
+  functions are sync.
+- **Use the skill for interactive runs.** `/wizard` wires the
+  `ask_user_callback` to `AskUserQuestion`; a bare Python run needs you
+  to supply one for `question` steps.
+- **Discover before you run.** `list_wizards()` gives ids, names,
+  domains, and cost/duration estimates.

--- a/.help/templates/wizards/quickstart.md
+++ b/.help/templates/wizards/quickstart.md
@@ -1,60 +1,38 @@
 ---
 type: quickstart
+name: wizards-quickstart
 feature: wizards
 depth: quickstart
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Quickstart: wizards
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-Run a built-in interactive wizard to guide you through common development tasks.
+## Quickstart
 
-```python
-from attune.wizards import DebugWizard
-
-wizard = DebugWizard()
-result = wizard.run({"error_message": "ImportError: No module named 'requests'"})
-print(f"Debugging complete: {result.success}")
-```
-
-## Prerequisites
-
-- Attune AI installed locally
-- Python environment with the attune package available
-
-## Run your first wizard
-
-1. **Choose a built-in wizard.** Start with `DebugWizard` for troubleshooting errors:
+List the built-in wizards, then run one. `run()` is a coroutine, so
+drive it with `asyncio.run`:
 
 ```python
-from attune.wizards import DebugWizard
+import asyncio
 
-wizard = DebugWizard()
+from attune.wizards import get_wizard, list_wizards
+
+
+async def main() -> None:
+    for cfg in list_wizards():
+        print(cfg.wizard_id, "-", cfg.name)
+
+    wizard_cls = get_wizard("debug")
+    if wizard_cls is not None:
+        result = await wizard_cls().run()
+        print(result.success, result.wizard_id)
+
+
+asyncio.run(main())
 ```
 
-2. **Run the wizard with context.** Provide an initial context like an error message or code snippet:
-
-```python
-result = wizard.run({"error_message": "ModuleNotFoundError: No module named 'pandas'"})
-```
-
-3. **Check the results.** The wizard returns a `WizardResult` with guidance and next steps:
-
-```python
-print(f"Success: {result.success}")
-print(f"Generated guidance: {result.generated_output}")
-print(f"Steps completed: {result.steps_completed}")
-```
-
-Expected output:
-```
-Success: True
-Generated guidance: Install pandas using: pip install pandas
-Steps completed: ['analyze_error', 'suggest_fix', 'verify_solution']
-```
-
-## Next steps
-
-**Next:** Browse available wizards with `list_wizards()` to see RefactorWizard, SecurityWizard, and TestGenWizard options.
+`get_wizard` returns the wizard class (or `None` if the id is
+unknown); instantiate it and `await run()`.

--- a/.help/templates/wizards/reference.md
+++ b/.help/templates/wizards/reference.md
@@ -1,109 +1,53 @@
 ---
 type: reference
+name: wizards-reference
 feature: wizards
 depth: reference
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Wizards reference
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-Build and run interactive, multi-step workflows. Register built-in wizards for debugging, refactoring, security audits, and test generation. Create custom wizards from YAML definitions.
+## Reference
 
-## Classes
+The public surface is the registry functions and the wizard
+classes/dataclasses, all re-exported from `attune.wizards`.
 
-| Class | Description |
-|-------|-------------|
-| `StepType` | Execution mode for a wizard step |
-| `WizardStep` | Definition of a single wizard step |
-| `WizardConfig` | Metadata for a wizard |
-| `WizardResult` | Result from a completed wizard run |
-| `BaseWizard` | Abstract base class for interactive, multi-step wizards |
-| `DebugWizard` | Guided debugging wizard |
-| `RefactorWizard` | Guided refactoring wizard |
-| `ReleasePrepWizard` | Guided release preparation wizard |
-| `SecurityWizard` | Guided security audit wizard |
-| `TestGenWizard` | Guided test generation wizard |
+### Registry functions — `attune.wizards`
 
-## WizardStep fields
+| Function | Purpose |
+|----------|---------|
+| `list_wizards() -> list[WizardConfig]` | All registered wizard configs (built-in + custom). |
+| `get_wizard(wizard_id) -> type[BaseWizard] \| None` | The wizard class for an id, or `None`. |
+| `register_wizard(wizard_id, wizard_class) -> None` | Register a `BaseWizard` subclass. |
+| `save_custom_wizard(wizard_data, base_dir=None) -> Path` | Persist a config-driven wizard definition; returns the saved path. |
+| `delete_custom_wizard(wizard_id, base_dir=None) -> bool` | Remove a saved custom wizard. |
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `id` | `str` | | Step identifier |
-| `name` | `str` | | Display name |
-| `description` | `str` | `''` | Step description |
-| `step_type` | `StepType` | `StepType.QUESTION` | Execution mode |
-| `prompt_template` | `str | None` | `None` | Template for LLM prompts |
-| `tier` | `str` | `'capable'` | Model tier requirement |
-| `questions` | `list[FormQuestion] | None` | `None` | User input questions |
-| `condition` | `Callable[[WizardSession], bool] | None` | `None` | Step execution condition |
-| `max_tokens` | `int` | `4096` | Maximum response tokens |
-| `prompt_context_template` | `dict[str, Any] | None` | `None` | Context for prompt rendering |
-| `review_source_step_id` | `str | None` | `None` | Step to review for output |
+### Classes — `attune.wizards`
 
-## WizardConfig fields
+| Symbol | Purpose |
+|--------|---------|
+| `BaseWizard(ask_user_callback=None, provider=None, **kwargs)` | Abstract base; async `run(initial_context=None) -> WizardResult`; hooks `build_prompt_context(step)` and `process_step_result(step, result)`. |
+| `ConfigDrivenWizard(config, steps, **kwargs)` | A wizard built from a `WizardConfig` + `list[WizardStep]`, no subclass needed. |
+| `WizardSession` | Per-run session state. |
+| `TaskDecomposer` / `DecomposedTask` | Back the `task_decompose` step type (XML task decomposition). |
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `wizard_id` | `str` | | Unique wizard identifier |
-| `name` | `str` | | Display name |
-| `description` | `str` | | Wizard description |
-| `domain` | `str` | `'development'` | Application domain |
-| `version` | `str` | `'1.0.0'` | Wizard version |
-| `source` | `str` | `'builtin'` | Source type |
-| `estimated_cost_range` | `tuple[float, float]` | `(0.01, 0.5)` | Cost estimate range |
-| `estimated_duration_minutes` | `int` | `5` | Time estimate |
+### Dataclasses — `attune.wizards`
 
-## WizardResult fields
+| Type | Fields |
+|------|--------|
+| `WizardConfig` | `wizard_id`, `name`, `description`, `domain`, `version`, `source`, `estimated_cost_range`, `estimated_duration_minutes`. |
+| `WizardStep` | `id`, `name`, `description`, `step_type`, `prompt_template`, `tier`, `questions`, `condition`, `max_tokens`, `prompt_context_template`, `review_source_step_id`. |
+| `WizardResult` | `wizard_id`, `run_id`, `success`, `steps_completed`, `collected_data`, `generated_output`, `tasks`, `total_cost`, `total_duration_ms`, `error`. |
+| `StepType` | `question`, `llm_call`, `task_decompose`, `review`, `preview`, `confirm`. |
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `wizard_id` | `str` | | Wizard that ran |
-| `run_id` | `str` | | Unique run identifier |
-| `success` | `bool` | | Whether wizard completed successfully |
-| `steps_completed` | `list[str]` | `[]` | IDs of completed steps |
-| `collected_data` | `dict[str, Any]` | `{}` | Data gathered from user |
-| `generated_output` | `str | dict[str, Any]` | `''` | Wizard output |
-| `tasks` | `list[dict[str, Any]]` | `[]` | Generated task list |
-| `total_cost` | `float` | `0.0` | Total API cost |
-| `total_duration_ms` | `float` | `0.0` | Total execution time |
-| `error` | `str | None` | `None` | Error message if failed |
+### Entry points
 
-## Functions
+| Surface | Invocation |
+|---------|------------|
+| Python | `get_wizard(<id>)`, then `await <cls>().run()`; `list_wizards()` to discover. |
+| Skill | `/wizard` in a Claude Code conversation. |
 
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `register_wizard` | `wizard_id: str, wizard_class: type[BaseWizard]` | `None` | Register a wizard class |
-| `get_wizard` | `wizard_id: str` | `type[BaseWizard] | None` | Get a wizard class by ID |
-| `list_wizards` | | `list[WizardConfig]` | List all registered wizard configs |
-| `save_custom_wizard` | `wizard_data: dict[str, Any], base_dir: str | None = None` | `Path` | Save a custom wizard definition to YAML |
-| `delete_custom_wizard` | `wizard_id: str, base_dir: str | None = None` | `bool` | Delete a custom wizard definition |
-
-## BaseWizard methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__` | `ask_user_callback: AskUserQuestionCallback | None = None, provider: str | None = None, **workflow_kwargs: Any` | `None` | Initialize wizard with callbacks |
-| `run` | `initial_context: dict[str, Any] | None = None` | `WizardResult` | Run the wizard workflow |
-| `build_prompt_context` | `step: WizardStep` | `PromptContext` | Build context for step prompts |
-| `process_step_result` | `step: WizardStep, result: dict[str, Any]` | `None` | Process step execution results |
-
-## WizardResult methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `to_dict` | `self` | `dict[str, Any]` | Convert result to dictionary |
-
-## Raises
-
-| Function | Exception | Message |
-|----------|-----------|---------|
-| `save_custom_wizard` | `ValueError` | `'Cannot write wizard YAML: {...}'` |
-| `delete_custom_wizard` | `ValueError` | `"Cannot delete built-in wizard: '{...}'"` |
-
-## Constants
-
-| Constant | Value |
-|----------|-------|
-| `SCHEMA_VERSION` | `'1.0'` |
+No `attune wizard` CLI command and no MCP tool exist for wizards.

--- a/.help/templates/wizards/task.md
+++ b/.help/templates/wizards/task.md
@@ -1,110 +1,91 @@
 ---
 type: task
+name: wizards-task
 feature: wizards
 depth: task
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Work with wizards
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-Use wizards when you need to create guided, multi-step interactive workflows that collect user input and generate structured output.
+## Tasks
 
-## Prerequisites
+### Run a built-in wizard
 
-- Access to the project source code
-- Understanding of the wizard system architecture in `src/attune/wizards/`
-- Python development environment configured
+**Goal:** run a guided wizard and read its result.
 
-## Steps
+**Steps:**
 
-1. **Choose your wizard approach**
+```python
+import asyncio
 
-   Determine whether to use a built-in wizard, extend an existing one, or create a custom wizard:
-   - For debugging workflows, use `DebugWizard`
-   - For code refactoring, use `RefactorWizard`
-   - For security audits, use `SecurityWizard`
-   - For test generation, use `TestGenWizard`
-   - For release preparation, use `ReleasePrepWizard`
+from attune.wizards import get_wizard
 
-2. **Register or retrieve your wizard**
 
-   For built-in wizards, retrieve them with:
-   ```python
-   from attune.wizards import get_wizard
-   wizard_class = get_wizard("debug")  # or "refactor", "security", etc.
-   ```
+async def main() -> None:
+    wizard_cls = get_wizard("security")
+    if wizard_cls is None:
+        print("unknown wizard")
+        return
 
-   For custom wizards, register them first:
-   ```python
-   from attune.wizards import register_wizard
-   register_wizard("my-custom-wizard", MyCustomWizardClass)
-   ```
+    result = await wizard_cls().run(initial_context={"path": "src/"})
+    print("success:", result.success)
+    print("output:", result.generated_output)
+    print("cost:", result.total_cost)
 
-3. **Configure wizard steps**
 
-   Create `WizardStep` instances with the required fields:
-   ```python
-   from attune.wizards import WizardStep, StepType
+asyncio.run(main())
+```
 
-   step = WizardStep(
-       id="analyze-code",
-       name="Code Analysis",
-       description="Analyze the codebase for issues",
-       step_type=StepType.QUESTION,
-       prompt_template="What specific issues should I look for?",
-       tier="capable"
-   )
-   ```
+**Verify:** `run()` is a coroutine — `await` it. The result is a
+`WizardResult` with `success`, `collected_data`, `generated_output`,
+`tasks`, `total_cost`, `total_duration_ms`, and `error` on failure.
+`initial_context` seeds the run.
 
-4. **Initialize and run the wizard**
+### Discover what's available
 
-   Create a wizard instance and execute it:
-   ```python
-   wizard = wizard_class(ask_user_callback=your_callback_function)
-   result = wizard.run(initial_context={"project_path": "/path/to/project"})
-   ```
+**Goal:** list the registered wizards and their metadata.
 
-5. **Process the wizard result**
+**Steps:**
 
-   Handle the `WizardResult` object returned:
-   ```python
-   if result.success:
-       print(f"Wizard completed {len(result.steps_completed)} steps")
-       print(f"Generated output: {result.generated_output}")
-       print(f"Total cost: ${result.total_cost:.2f}")
-   else:
-       print(f"Wizard failed: {result.error}")
-   ```
+```python
+from attune.wizards import get_wizard, list_wizards
 
-6. **Save custom wizard definitions (optional)**
+for cfg in list_wizards():
+    print(f"{cfg.wizard_id}: {cfg.name} ({cfg.domain})")
+    print(f"  ~{cfg.estimated_duration_minutes} min, {cfg.estimated_cost_range}")
 
-   For reusable custom wizards, save the configuration:
-   ```python
-   from attune.wizards import save_custom_wizard
+cls = get_wizard("test-gen")   # -> TestGenWizard class, or None
+```
 
-   wizard_data = {
-       "wizard_id": "my-workflow",
-       "name": "My Custom Workflow",
-       "description": "Custom workflow description",
-       "steps": [/* step definitions */]
-   }
-   save_custom_wizard(wizard_data)
-   ```
+**Verify:** `list_wizards()` returns `WizardConfig` objects (sync). The
+five built-ins are `debug`, `refactor`, `release-prep`, `security`,
+and `test-gen`. `get_wizard(id)` returns the class or `None`.
 
-## Verification
+### Register a custom wizard
 
-Run your wizard and verify:
-- All wizard steps execute in the correct order
-- User input is collected and processed correctly
-- The wizard generates the expected output format
-- The `WizardResult` contains complete execution data
-- Custom wizards appear in `list_wizards()` output
+**Goal:** make your own wizard discoverable.
 
-## Key files
+**Steps:**
 
-- `src/attune/wizards/base.py` - `BaseWizard` abstract class
-- `src/attune/wizards/types.py` - Data type definitions
-- `src/attune/wizards/builtin.py` - Pre-built wizard implementations
-- `src/attune/wizards/registry.py` - Wizard registration and management
+```python
+from attune.wizards import BaseWizard, register_wizard
+
+
+class MyWizard(BaseWizard):
+    def build_prompt_context(self, step):
+        ...
+
+    def process_step_result(self, step, result):
+        ...
+
+
+register_wizard("my-wizard", MyWizard)
+```
+
+**Verify:** after `register_wizard`, `get_wizard("my-wizard")` returns
+your class and it appears in `list_wizards()`. For a config-only
+wizard, build a `ConfigDrivenWizard(config, steps)` or persist a
+definition with `save_custom_wizard(data)`.

--- a/.help/templates/wizards/tip.md
+++ b/.help/templates/wizards/tip.md
@@ -1,22 +1,25 @@
 ---
 type: tip
+name: wizards-tip
 feature: wizards
 depth: tip
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Tip: working effectively with wizards
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-## Extend BaseWizard, don't configure from scratch
+## Notes & tips
 
-Inherit from `BaseWizard` and override `build_prompt_context()` and `process_step_result()` instead of creating config-driven wizards from YAML. The built-in wizards like `DebugWizard` and `RefactorWizard` show this pattern consistently.
-
-You get type safety, IDE support, and easier testing compared to string-based configuration. The tradeoff is less runtime flexibility — you can't modify wizard behavior without code changes.
-
-## Source files
-
-- `src/attune/wizards/**`
-
-**Tags:** `wizards`, `interactive`
+- **Depend on the documented public surface.** The supported API is
+  the registry functions plus `BaseWizard`, `ConfigDrivenWizard`, the
+  `WizardConfig` / `WizardStep` / `WizardResult` dataclasses, `StepType`,
+  and `WizardSession` — all from `attune.wizards`.
+- **`await` the run.** `run()` is the only async method; the registry
+  functions are sync.
+- **Use the skill for interactive runs.** `/wizard` wires the
+  `ask_user_callback` to `AskUserQuestion`; a bare Python run needs you
+  to supply one for `question` steps.
+- **Discover before you run.** `list_wizards()` gives ids, names,
+  domains, and cost/duration estimates.

--- a/.help/templates/wizards/troubleshooting.md
+++ b/.help/templates/wizards/troubleshooting.md
@@ -1,108 +1,38 @@
 ---
 type: troubleshooting
+name: wizards-troubleshooting
 feature: wizards
 depth: troubleshooting
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Troubleshoot wizards
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-## Before you start
+## Failure modes
 
-The wizards feature provides XML-enhanced interactive workflows for Attune AI. These multi-step guided processes help with debugging, refactoring, release preparation, security audits, and test generation.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `RuntimeWarning: coroutine 'BaseWizard.run' was never awaited` | `run()` called without `await` | It is a coroutine — `await` it or use `asyncio.run` | high |
+| `AttributeError: 'NoneType' object has no attribute ...` after `get_wizard` | The wizard id is unknown; `get_wizard` returned `None` | Check `get_wizard(id) is not None`; list ids with `list_wizards()` | high |
+| A `question` step never prompts / hangs | No `ask_user_callback` wired (outside Claude Code) | Pass an `ask_user_callback` to the wizard, or run via the `/wizard` skill | medium |
+| `WizardResult.success` is `False` with a populated `error` | A step failed (LLM call, validation, or an aborted confirm) | Read `result.error` and `result.steps_completed` to see where it stopped | medium |
+| Custom wizard not found by `get_wizard` | It was never `register_wizard`'d (or `save_custom_wizard`'d) | Register the class or save the definition first | low |
 
-## Symptom table
+### Risk areas
 
-| If you observe | Check |
-|----------------|-------|
-| `ValueError: Cannot write wizard YAML` | File permissions on the target directory and available disk space |
-| `ValueError: Cannot delete built-in wizard` | Whether you're trying to delete a built-in wizard (only custom wizards can be deleted) |
-| Wizard step skipped unexpectedly | The step's `condition` function and the current `WizardSession` state |
-| `WizardResult.success` is `False` but no error message | The `WizardResult.error` field and exception handling in `BaseWizard.run()` |
-| Wizard hangs on a step | Token limits (`max_tokens`) and provider response timeouts |
-| Empty or malformed wizard output | The `prompt_template` and `prompt_context_template` for the failing step |
+- **`run()` is async.** Forgetting to `await` it is the most common
+  mistake.
+- **There is no registry class.** Use the module-level functions
+  (`list_wizards`, `get_wizard`, …) — not a `WizardRegistry`.
+- **`question` steps need a callback.** Outside the `/wizard` skill,
+  supply an `ask_user_callback` or the wizard can't collect input.
 
-## Step-by-step diagnosis
+### Diagnosis order
 
-1. **Reproduce the failure with a minimal wizard run.**
-   Create a simple test that calls `BaseWizard.run()` with the same `initial_context` that triggers the issue. This isolates the problem from surrounding application logic.
-
-2. **Check wizard registration and retrieval.**
-   Verify the wizard is properly registered by running:
-   ```python
-   from attune.wizards import list_wizards, get_wizard
-   print([w.wizard_id for w in list_wizards()])
-   wizard_class = get_wizard("your-wizard-id")
-   print(f"Found: {wizard_class}")
-   ```
-
-3. **Enable debug logging and examine step execution.**
-   Set logging to `DEBUG` level before running the wizard. Look for patterns in the step processing, particularly around `build_prompt_context()` and `process_step_result()` calls.
-
-4. **Inspect the `WizardResult` object.**
-   After a failed run, examine these fields in order:
-   - `WizardResult.error` - Contains the failure reason
-   - `WizardResult.steps_completed` - Shows how far the wizard got
-   - `WizardResult.collected_data` - Reveals what data was gathered
-   - `WizardResult.total_cost` and `total_duration_ms` - Indicates resource usage
-
-5. **Validate step configuration.**
-   For each failing step, check:
-   - `step_type` matches the intended execution mode
-   - `prompt_template` is not None for steps that need AI interaction
-   - `questions` list is properly defined for form-based steps
-   - `tier` setting matches your provider capabilities
-
-## Common fixes
-
-- **Fix wizard registration errors.**
-  ```python
-  from attune.wizards import register_wizard
-  register_wizard("my-wizard", MyWizardClass)
-  ```
-  Ensure you call `register_wizard()` before trying to retrieve the wizard with `get_wizard()`.
-
-- **Resolve custom wizard file permissions.**
-  ```bash
-  # Make wizard directory writable
-  chmod 755 ~/.attune/wizards/
-  # Check available disk space
-  df -h ~/.attune/
-  ```
-
-- **Fix step condition logic.**
-  If steps are skipping unexpectedly, verify the condition function:
-  ```python
-  # In your WizardStep definition
-  condition=lambda session: session.collected_data.get('prerequisite_done', False)
-  ```
-
-- **Adjust token limits for complex steps.**
-  Increase `max_tokens` for steps that generate long outputs:
-  ```python
-  WizardStep(
-      id="analysis",
-      step_type=StepType.QUESTION,
-      max_tokens=8192  # Increase from default 4096
-  )
-  ```
-
-- **Handle missing ask_user_callback.**
-  For interactive wizards, ensure you provide a callback function:
-  ```python
-  def my_callback(question):
-      return input(f"{question}: ")
-
-  wizard = MyWizard(ask_user_callback=my_callback)
-  ```
-
-## Source files
-
-- `src/attune/wizards/base.py` - `BaseWizard` class and core logic
-- `src/attune/wizards/types.py` - Data structures (`WizardStep`, `WizardConfig`, etc.)
-- `src/attune/wizards/registry.py` - Wizard registration and management
-- `src/attune/wizards/builtin/` - Built-in wizard implementations
-
-**Tags:** `wizards`, `interactive`
+1. Confirm you are awaiting: `await get_wizard(id)().run()`.
+2. Confirm the id exists: `get_wizard(id) is not None` /
+   `list_wizards()`.
+3. On failure, read `result.error` and `result.steps_completed`.
+4. If a `question` step stalls, check the `ask_user_callback` wiring.

--- a/.help/templates/wizards/warning.md
+++ b/.help/templates/wizards/warning.md
@@ -1,54 +1,38 @@
 ---
 type: warning
+name: wizards-warning
 feature: wizards
 depth: warning
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 322dc43a8cc4749920887d066cffb815d8c6faee0b2e93968e78ac53228d58b1
+generated_at: 2026-06-23T22:36:36.999673+00:00
+source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
 status: generated
 ---
 
-# Wizards cautions
+# Multi-step guided interactive workflows that walk users through complex tasks
 
-## What to watch for
+## Failure modes
 
-The wizards framework provides multi-step guided workflows that can accumulate significant LLM costs and execute long-running operations. Several design patterns in the framework can lead to unexpected behavior if not handled carefully.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `RuntimeWarning: coroutine 'BaseWizard.run' was never awaited` | `run()` called without `await` | It is a coroutine — `await` it or use `asyncio.run` | high |
+| `AttributeError: 'NoneType' object has no attribute ...` after `get_wizard` | The wizard id is unknown; `get_wizard` returned `None` | Check `get_wizard(id) is not None`; list ids with `list_wizards()` | high |
+| A `question` step never prompts / hangs | No `ask_user_callback` wired (outside Claude Code) | Pass an `ask_user_callback` to the wizard, or run via the `/wizard` skill | medium |
+| `WizardResult.success` is `False` with a populated `error` | A step failed (LLM call, validation, or an aborted confirm) | Read `result.error` and `result.steps_completed` to see where it stopped | medium |
+| Custom wizard not found by `get_wizard` | It was never `register_wizard`'d (or `save_custom_wizard`'d) | Register the class or save the definition first | low |
 
-## Risk areas
+### Risk areas
 
-### Cost accumulation in wizard runs
+- **`run()` is async.** Forgetting to `await` it is the most common
+  mistake.
+- **There is no registry class.** Use the module-level functions
+  (`list_wizards`, `get_wizard`, …) — not a `WizardRegistry`.
+- **`question` steps need a callback.** Outside the `/wizard` skill,
+  supply an `ask_user_callback` or the wizard can't collect input.
 
-The `BaseWizard.run()` method executes multiple LLM calls across wizard steps, but cost tracking happens per step rather than with upfront validation. A wizard with many steps or high `max_tokens` values can exceed your budget before completion. Check the `estimated_cost_range` in `WizardConfig` before starting expensive wizards, and monitor `total_cost` in partial results.
+### Diagnosis order
 
-### Step condition evaluation timing
-
-The `condition` field in `WizardStep` gets evaluated during wizard execution, not at registration time. If your condition function depends on external state (file existence, network connectivity), it can cause steps to be skipped unexpectedly when that state changes between wizard initialization and step execution.
-
-### Custom wizard persistence edge cases
-
-`save_custom_wizard()` overwrites existing files without confirmation and can raise `ValueError` for filesystem issues that aren't obvious from the error message. The function creates the wizard directory if it doesn't exist, but won't create intermediate parent directories. Always verify the base directory structure exists before saving.
-
-### Registry state inconsistency
-
-The wizard registry is module-global state. Calling `register_wizard()` multiple times with the same `wizard_id` silently overwrites the previous registration. In test environments, this can cause tests to interfere with each other if they register wizards with identical IDs.
-
-### Step result processing mutations
-
-The `process_step_result()` method in wizard subclasses receives the raw result dictionary and can modify it in place. Changes made during processing affect the `collected_data` field in `WizardResult`, which can cause downstream steps to see modified data they weren't expecting.
-
-## How to avoid problems
-
-1. **Validate cost limits upfront.** Check `estimated_cost_range` and set reasonable `max_tokens` values for each step. Consider implementing cost guards that halt execution if `total_cost` approaches your budget.
-
-2. **Make step conditions resilient.** Write condition functions that handle missing files, network timeouts, and other transient failures gracefully. Return `False` rather than raising exceptions when external dependencies aren't available.
-
-3. **Use unique wizard IDs in tests.** Include test method names or random suffixes in wizard IDs when registering test wizards to avoid registry collisions between test runs.
-
-4. **Copy result data before processing.** If you need to modify step results in `process_step_result()`, work on a copy to avoid affecting the original data that gets stored in `WizardResult.collected_data`.
-
-5. **Verify directory structure for custom wizards.** Before calling `save_custom_wizard()`, ensure the base directory and any parent directories exist and are writable.
-
-## Source files
-
-- `src/attune/wizards/**`
-
-**Tags:** `wizards`, `interactive`
+1. Confirm you are awaiting: `await get_wizard(id)().run()`.
+2. Confirm the id exists: `get_wizard(id) is not None` /
+   `list_wizards()`.
+3. On failure, read `result.error` and `result.steps_completed`.
+4. If a `question` step stalls, check the `ask_user_callback` wiring.

--- a/content/features/wizards.md
+++ b/content/features/wizards.md
@@ -1,0 +1,359 @@
+---
+feature: wizards
+summary: Multi-step guided interactive workflows that walk users through complex tasks
+tags: [wizards, interactive]
+source_globs:
+  - src/attune/wizards/**
+nav:
+  help: wizards
+  mkdocs:
+    how-to: how-to/wizards
+    architecture: architecture/wizards
+    reference: reference/wizards
+---
+
+## Overview
+
+Wizards are **interactive, multi-step workflows** that guide a user
+through a complex development task by breaking it into sequential steps
+— questions that collect input, LLM calls, task decomposition, and
+review/confirm gates. Each wizard runs to a `WizardResult` carrying the
+collected data, generated output, and cost/duration metrics.
+
+The registry is a set of **module-level functions** in
+`attune.wizards` (there is no registry class): `list_wizards()`,
+`get_wizard(id)`, `register_wizard(...)`, `save_custom_wizard(...)`, and
+`delete_custom_wizard(...)`. Five wizards ship built in — `debug`,
+`refactor`, `release-prep`, `security`, and `test-gen`.
+
+You reach wizards two ways:
+
+- the Python API — `from attune.wizards import get_wizard, list_wizards`
+  (the primary surface, documented throughout);
+- the **`/wizard`** skill, inside a Claude Code conversation.
+
+There is **no `attune wizard` CLI command and no MCP tool** — wizards
+run through the Python API or the skill. A wizard's `run()` method is
+**async** — `await` it.
+
+## Concepts
+
+### The four core types
+
+| Type | Role |
+|------|------|
+| `WizardStep` | One step — `id`, `name`, `description`, `step_type`, an optional `prompt_template`, `questions`, a `tier`, and a `condition`. |
+| `WizardConfig` | Wizard metadata — `wizard_id`, `name`, `description`, `domain`, `version`, `source`, `estimated_cost_range`, `estimated_duration_minutes`. |
+| `BaseWizard` | Abstract base all wizards inherit from; drives step execution via the async `run()` method. |
+| `WizardResult` | The outcome — `wizard_id`, `run_id`, `success`, `steps_completed`, `collected_data`, `generated_output`, `tasks`, `total_cost`, `total_duration_ms`, `error`. |
+
+### Step types
+
+A step's `step_type` is a `StepType`: `question` (collect user input),
+`llm_call` (run a model call), `task_decompose` (break work into an
+XML task tree via `TaskDecomposer`), `review`, `preview`, and
+`confirm` (human gates). The wizard walks the steps in order, honoring
+each step's optional `condition`.
+
+### Running a built-in wizard
+
+`get_wizard(id)` returns the wizard **class** (or `None`); instantiate
+it and `await` its `run()`:
+
+- `BaseWizard(ask_user_callback=None, provider=None, **workflow_kwargs)`
+  — the `ask_user_callback` is how the wizard collects input for
+  `question` steps (wired to `AskUserQuestion` inside Claude Code);
+- `run(initial_context=None)` is a coroutine returning a
+  `WizardResult`.
+
+A subclass customizes two hooks: `build_prompt_context(step)` (prepare
+the model prompt) and `process_step_result(step, result)` (handle a
+step's output).
+
+### The built-in wizards
+
+`list_wizards()` returns the registered `WizardConfig`s. Five ship
+built in:
+
+| `wizard_id` | Class | Guides |
+|-------------|-------|--------|
+| `debug` | `DebugWizard` | Systematic debugging, step by step. |
+| `refactor` | `RefactorWizard` | Code restructuring with safety checks. |
+| `release-prep` | `ReleasePrepWizard` | Release preparation and validation. |
+| `security` | `SecurityWizard` | Guided security audit with risk assessment. |
+| `test-gen` | `TestGenWizard` | Interactive test-suite generation. |
+
+### Custom wizards — subclass or config-driven
+
+Two ways to add a wizard:
+
+- **Subclass `BaseWizard`** and implement `build_prompt_context` /
+  `process_step_result`, then `register_wizard(id, cls)` to make it
+  discoverable.
+- **Config-driven** — build a `ConfigDrivenWizard(config, steps)` from
+  a `WizardConfig` + a list of `WizardStep`s (no subclass needed), or
+  persist a definition with `save_custom_wizard(data, base_dir=None)`
+  (returns the saved `Path`) and remove it with
+  `delete_custom_wizard(id, base_dir=None)`.
+
+## Quickstart
+
+List the built-in wizards, then run one. `run()` is a coroutine, so
+drive it with `asyncio.run`:
+
+```python
+import asyncio
+
+from attune.wizards import get_wizard, list_wizards
+
+
+async def main() -> None:
+    for cfg in list_wizards():
+        print(cfg.wizard_id, "-", cfg.name)
+
+    wizard_cls = get_wizard("debug")
+    if wizard_cls is not None:
+        result = await wizard_cls().run()
+        print(result.success, result.wizard_id)
+
+
+asyncio.run(main())
+```
+
+`get_wizard` returns the wizard class (or `None` if the id is
+unknown); instantiate it and `await run()`.
+
+## Tasks
+
+### Run a built-in wizard
+
+**Goal:** run a guided wizard and read its result.
+
+**Steps:**
+
+```python
+import asyncio
+
+from attune.wizards import get_wizard
+
+
+async def main() -> None:
+    wizard_cls = get_wizard("security")
+    if wizard_cls is None:
+        print("unknown wizard")
+        return
+
+    result = await wizard_cls().run(initial_context={"path": "src/"})
+    print("success:", result.success)
+    print("output:", result.generated_output)
+    print("cost:", result.total_cost)
+
+
+asyncio.run(main())
+```
+
+**Verify:** `run()` is a coroutine — `await` it. The result is a
+`WizardResult` with `success`, `collected_data`, `generated_output`,
+`tasks`, `total_cost`, `total_duration_ms`, and `error` on failure.
+`initial_context` seeds the run.
+
+### Discover what's available
+
+**Goal:** list the registered wizards and their metadata.
+
+**Steps:**
+
+```python
+from attune.wizards import get_wizard, list_wizards
+
+for cfg in list_wizards():
+    print(f"{cfg.wizard_id}: {cfg.name} ({cfg.domain})")
+    print(f"  ~{cfg.estimated_duration_minutes} min, {cfg.estimated_cost_range}")
+
+cls = get_wizard("test-gen")   # -> TestGenWizard class, or None
+```
+
+**Verify:** `list_wizards()` returns `WizardConfig` objects (sync). The
+five built-ins are `debug`, `refactor`, `release-prep`, `security`,
+and `test-gen`. `get_wizard(id)` returns the class or `None`.
+
+### Register a custom wizard
+
+**Goal:** make your own wizard discoverable.
+
+**Steps:**
+
+```python
+from attune.wizards import BaseWizard, register_wizard
+
+
+class MyWizard(BaseWizard):
+    def build_prompt_context(self, step):
+        ...
+
+    def process_step_result(self, step, result):
+        ...
+
+
+register_wizard("my-wizard", MyWizard)
+```
+
+**Verify:** after `register_wizard`, `get_wizard("my-wizard")` returns
+your class and it appears in `list_wizards()`. For a config-only
+wizard, build a `ConfigDrivenWizard(config, steps)` or persist a
+definition with `save_custom_wizard(data)`.
+
+## Reference
+
+The public surface is the registry functions and the wizard
+classes/dataclasses, all re-exported from `attune.wizards`.
+
+### Registry functions — `attune.wizards`
+
+| Function | Purpose |
+|----------|---------|
+| `list_wizards() -> list[WizardConfig]` | All registered wizard configs (built-in + custom). |
+| `get_wizard(wizard_id) -> type[BaseWizard] \| None` | The wizard class for an id, or `None`. |
+| `register_wizard(wizard_id, wizard_class) -> None` | Register a `BaseWizard` subclass. |
+| `save_custom_wizard(wizard_data, base_dir=None) -> Path` | Persist a config-driven wizard definition; returns the saved path. |
+| `delete_custom_wizard(wizard_id, base_dir=None) -> bool` | Remove a saved custom wizard. |
+
+### Classes — `attune.wizards`
+
+| Symbol | Purpose |
+|--------|---------|
+| `BaseWizard(ask_user_callback=None, provider=None, **kwargs)` | Abstract base; async `run(initial_context=None) -> WizardResult`; hooks `build_prompt_context(step)` and `process_step_result(step, result)`. |
+| `ConfigDrivenWizard(config, steps, **kwargs)` | A wizard built from a `WizardConfig` + `list[WizardStep]`, no subclass needed. |
+| `WizardSession` | Per-run session state. |
+| `TaskDecomposer` / `DecomposedTask` | Back the `task_decompose` step type (XML task decomposition). |
+
+### Dataclasses — `attune.wizards`
+
+| Type | Fields |
+|------|--------|
+| `WizardConfig` | `wizard_id`, `name`, `description`, `domain`, `version`, `source`, `estimated_cost_range`, `estimated_duration_minutes`. |
+| `WizardStep` | `id`, `name`, `description`, `step_type`, `prompt_template`, `tier`, `questions`, `condition`, `max_tokens`, `prompt_context_template`, `review_source_step_id`. |
+| `WizardResult` | `wizard_id`, `run_id`, `success`, `steps_completed`, `collected_data`, `generated_output`, `tasks`, `total_cost`, `total_duration_ms`, `error`. |
+| `StepType` | `question`, `llm_call`, `task_decompose`, `review`, `preview`, `confirm`. |
+
+### Entry points
+
+| Surface | Invocation |
+|---------|------------|
+| Python | `get_wizard(<id>)`, then `await <cls>().run()`; `list_wizards()` to discover. |
+| Skill | `/wizard` in a Claude Code conversation. |
+
+No `attune wizard` CLI command and no MCP tool exist for wizards.
+
+## Comparison
+
+Wizards differ from workflows in interaction model:
+
+| | Wizards | Workflows |
+|--|---------|-----------|
+| Interaction | Interactive — collect input mid-run via `question`/`confirm` steps | Non-interactive — run to completion from inputs |
+| Entry | `get_wizard(id)` + `await run()`, or `/wizard` skill | `attune workflow run <slug>` / the workflow class |
+| Output | `WizardResult` (collected data + generated output) | `WorkflowResult` |
+
+Reach for a **wizard** when the task needs the user in the loop
+(answering questions, confirming gates); reach for a **workflow** when
+the run is fully specified up front. Several builtins mirror a
+workflow (`release-prep`, `security`, `test-gen`) but wrap it in a
+guided, interactive flow.
+
+## Failure modes
+
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `RuntimeWarning: coroutine 'BaseWizard.run' was never awaited` | `run()` called without `await` | It is a coroutine — `await` it or use `asyncio.run` | high |
+| `AttributeError: 'NoneType' object has no attribute ...` after `get_wizard` | The wizard id is unknown; `get_wizard` returned `None` | Check `get_wizard(id) is not None`; list ids with `list_wizards()` | high |
+| A `question` step never prompts / hangs | No `ask_user_callback` wired (outside Claude Code) | Pass an `ask_user_callback` to the wizard, or run via the `/wizard` skill | medium |
+| `WizardResult.success` is `False` with a populated `error` | A step failed (LLM call, validation, or an aborted confirm) | Read `result.error` and `result.steps_completed` to see where it stopped | medium |
+| Custom wizard not found by `get_wizard` | It was never `register_wizard`'d (or `save_custom_wizard`'d) | Register the class or save the definition first | low |
+
+### Risk areas
+
+- **`run()` is async.** Forgetting to `await` it is the most common
+  mistake.
+- **There is no registry class.** Use the module-level functions
+  (`list_wizards`, `get_wizard`, …) — not a `WizardRegistry`.
+- **`question` steps need a callback.** Outside the `/wizard` skill,
+  supply an `ask_user_callback` or the wizard can't collect input.
+
+### Diagnosis order
+
+1. Confirm you are awaiting: `await get_wizard(id)().run()`.
+2. Confirm the id exists: `get_wizard(id) is not None` /
+   `list_wizards()`.
+3. On failure, read `result.error` and `result.steps_completed`.
+4. If a `question` step stalls, check the `ask_user_callback` wiring.
+
+## FAQ seeds
+
+> **Channel-4 input, not a rendered FAQ.** The FAQ is a dynamic source
+> of truth fed by four channels — unmatched user queries, telemetry
+> error-frequency, GitHub issues, and these author-curated seeds —
+> merged, deduplicated, and frequency-ranked by the FAQ Generator (see
+> doc-stack D3, and the help-docs-single-source spec's decisions.md D6).
+> This section is **not** projected verbatim as the FAQ; it contributes
+> the feature's author-curated seed questions.
+
+- **Q:** How do I run a wizard?
+  **A:** `get_wizard(id)` returns the class; instantiate it and
+  `await run()`. Or use the `/wizard` skill in a conversation. There's
+  no `attune wizard` CLI command.
+- **Q:** Which wizards ship built in?
+  **A:** Five — `debug`, `refactor`, `release-prep`, `security`,
+  `test-gen` (`list_wizards()` to confirm).
+- **Q:** Are the calls async?
+  **A:** `run()` is a coroutine — `await` it. The registry functions
+  (`list_wizards`, `get_wizard`) are synchronous.
+- **Q:** Is there a `WizardRegistry` class?
+  **A:** No. The registry is module-level functions in
+  `attune.wizards` (`list_wizards`, `get_wizard`, `register_wizard`,
+  `save_custom_wizard`, `delete_custom_wizard`).
+- **Q:** How do I add my own wizard?
+  **A:** Subclass `BaseWizard` and `register_wizard(id, cls)`, or build
+  a `ConfigDrivenWizard` / `save_custom_wizard(data)`.
+
+## Notes & tips
+
+- **Depend on the documented public surface.** The supported API is
+  the registry functions plus `BaseWizard`, `ConfigDrivenWizard`, the
+  `WizardConfig` / `WizardStep` / `WizardResult` dataclasses, `StepType`,
+  and `WizardSession` — all from `attune.wizards`.
+- **`await` the run.** `run()` is the only async method; the registry
+  functions are sync.
+- **Use the skill for interactive runs.** `/wizard` wires the
+  `ask_user_callback` to `AskUserQuestion`; a bare Python run needs you
+  to supply one for `question` steps.
+- **Discover before you run.** `list_wizards()` gives ids, names,
+  domains, and cost/duration estimates.
+
+## Design & extension
+
+### Design decisions
+
+- **Functions, not a registry class.** The registry is a small set of
+  module-level functions over a dict of wizard classes — simpler than a
+  class, and the built-ins register themselves at import.
+- **Steps as data.** A wizard is a sequence of `WizardStep`s with typed
+  `StepType`s; `ConfigDrivenWizard` runs a config + steps with no
+  subclass, so simple wizards need no code.
+- **Interactive by design.** `question` / `confirm` steps put the user
+  in the loop via the `ask_user_callback`, distinguishing wizards from
+  fire-and-forget workflows.
+- **The result is data.** `run()` returns a `WizardResult` (collected
+  data, generated output, tasks, cost/duration) — the skill and any
+  caller render the same object.
+
+### Extension points
+
+- **Add a wizard:** subclass `BaseWizard` + `register_wizard`, or build
+  a `ConfigDrivenWizard` from a config + steps.
+- **Persist a definition:** `save_custom_wizard(data)` /
+  `delete_custom_wizard(id)`.
+- **Customize prompting:** override `build_prompt_context(step)` and
+  `process_step_result(step, result)`.
+- **Decompose work:** use a `task_decompose` step (backed by
+  `TaskDecomposer`) to break a task into an XML task tree.

--- a/docs/architecture/wizards.md
+++ b/docs/architecture/wizards.md
@@ -1,14 +1,4 @@
----
-type: concept
-name: wizards-concept
-feature: wizards
-depth: concept
-generated_at: 2026-06-23T22:36:36.999673+00:00
-source_hash: 0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0
-status: generated
----
-
-# Multi-step guided interactive workflows that walk users through complex tasks
+# Wizards
 
 ## Overview
 
@@ -93,3 +83,33 @@ Two ways to add a wizard:
   persist a definition with `save_custom_wizard(data, base_dir=None)`
   (returns the saved `Path`) and remove it with
   `delete_custom_wizard(id, base_dir=None)`.
+
+## Design & extension
+
+### Design decisions
+
+- **Functions, not a registry class.** The registry is a small set of
+  module-level functions over a dict of wizard classes — simpler than a
+  class, and the built-ins register themselves at import.
+- **Steps as data.** A wizard is a sequence of `WizardStep`s with typed
+  `StepType`s; `ConfigDrivenWizard` runs a config + steps with no
+  subclass, so simple wizards need no code.
+- **Interactive by design.** `question` / `confirm` steps put the user
+  in the loop via the `ask_user_callback`, distinguishing wizards from
+  fire-and-forget workflows.
+- **The result is data.** `run()` returns a `WizardResult` (collected
+  data, generated output, tasks, cost/duration) — the skill and any
+  caller render the same object.
+
+### Extension points
+
+- **Add a wizard:** subclass `BaseWizard` + `register_wizard`, or build
+  a `ConfigDrivenWizard` from a config + steps.
+- **Persist a definition:** `save_custom_wizard(data)` /
+  `delete_custom_wizard(id)`.
+- **Customize prompting:** override `build_prompt_context(step)` and
+  `process_step_result(step, result)`.
+- **Decompose work:** use a `task_decompose` step (backed by
+  `TaskDecomposer`) to break a task into an XML task tree.
+
+<!-- attune-generated: source_hash=0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0 feature=wizards kind=architecture generated_at=2026-06-23 -->

--- a/docs/features/wizards.md
+++ b/docs/features/wizards.md
@@ -1,0 +1,27 @@
+# Wizards
+
+Multi-step guided interactive workflows that walk users through complex tasks
+
+!!! tip "Start here"
+
+    [How-to guide](../how-to/wizards.md) — task recipes for common goals.
+
+<div class="grid cards" markdown>
+
+-   __Reference__
+
+    ---
+
+    The full API and option reference.
+
+    [Open the reference](../reference/wizards.md)
+
+-   __Architecture__
+
+    ---
+
+    How it works and how to extend it.
+
+    [Open the architecture](../architecture/wizards.md)
+
+</div>

--- a/docs/how-to/wizards.md
+++ b/docs/how-to/wizards.md
@@ -1,0 +1,152 @@
+# Wizards
+
+## Quickstart
+
+List the built-in wizards, then run one. `run()` is a coroutine, so
+drive it with `asyncio.run`:
+
+```python
+import asyncio
+
+from attune.wizards import get_wizard, list_wizards
+
+
+async def main() -> None:
+    for cfg in list_wizards():
+        print(cfg.wizard_id, "-", cfg.name)
+
+    wizard_cls = get_wizard("debug")
+    if wizard_cls is not None:
+        result = await wizard_cls().run()
+        print(result.success, result.wizard_id)
+
+
+asyncio.run(main())
+```
+
+`get_wizard` returns the wizard class (or `None` if the id is
+unknown); instantiate it and `await run()`.
+
+## Tasks
+
+### Run a built-in wizard
+
+**Goal:** run a guided wizard and read its result.
+
+**Steps:**
+
+```python
+import asyncio
+
+from attune.wizards import get_wizard
+
+
+async def main() -> None:
+    wizard_cls = get_wizard("security")
+    if wizard_cls is None:
+        print("unknown wizard")
+        return
+
+    result = await wizard_cls().run(initial_context={"path": "src/"})
+    print("success:", result.success)
+    print("output:", result.generated_output)
+    print("cost:", result.total_cost)
+
+
+asyncio.run(main())
+```
+
+**Verify:** `run()` is a coroutine — `await` it. The result is a
+`WizardResult` with `success`, `collected_data`, `generated_output`,
+`tasks`, `total_cost`, `total_duration_ms`, and `error` on failure.
+`initial_context` seeds the run.
+
+### Discover what's available
+
+**Goal:** list the registered wizards and their metadata.
+
+**Steps:**
+
+```python
+from attune.wizards import get_wizard, list_wizards
+
+for cfg in list_wizards():
+    print(f"{cfg.wizard_id}: {cfg.name} ({cfg.domain})")
+    print(f"  ~{cfg.estimated_duration_minutes} min, {cfg.estimated_cost_range}")
+
+cls = get_wizard("test-gen")   # -> TestGenWizard class, or None
+```
+
+**Verify:** `list_wizards()` returns `WizardConfig` objects (sync). The
+five built-ins are `debug`, `refactor`, `release-prep`, `security`,
+and `test-gen`. `get_wizard(id)` returns the class or `None`.
+
+### Register a custom wizard
+
+**Goal:** make your own wizard discoverable.
+
+**Steps:**
+
+```python
+from attune.wizards import BaseWizard, register_wizard
+
+
+class MyWizard(BaseWizard):
+    def build_prompt_context(self, step):
+        ...
+
+    def process_step_result(self, step, result):
+        ...
+
+
+register_wizard("my-wizard", MyWizard)
+```
+
+**Verify:** after `register_wizard`, `get_wizard("my-wizard")` returns
+your class and it appears in `list_wizards()`. For a config-only
+wizard, build a `ConfigDrivenWizard(config, steps)` or persist a
+definition with `save_custom_wizard(data)`.
+
+## Reference
+
+The public surface is the registry functions and the wizard
+classes/dataclasses, all re-exported from `attune.wizards`.
+
+### Registry functions — `attune.wizards`
+
+| Function | Purpose |
+|----------|---------|
+| `list_wizards() -> list[WizardConfig]` | All registered wizard configs (built-in + custom). |
+| `get_wizard(wizard_id) -> type[BaseWizard] \| None` | The wizard class for an id, or `None`. |
+| `register_wizard(wizard_id, wizard_class) -> None` | Register a `BaseWizard` subclass. |
+| `save_custom_wizard(wizard_data, base_dir=None) -> Path` | Persist a config-driven wizard definition; returns the saved path. |
+| `delete_custom_wizard(wizard_id, base_dir=None) -> bool` | Remove a saved custom wizard. |
+
+### Classes — `attune.wizards`
+
+| Symbol | Purpose |
+|--------|---------|
+| `BaseWizard(ask_user_callback=None, provider=None, **kwargs)` | Abstract base; async `run(initial_context=None) -> WizardResult`; hooks `build_prompt_context(step)` and `process_step_result(step, result)`. |
+| `ConfigDrivenWizard(config, steps, **kwargs)` | A wizard built from a `WizardConfig` + `list[WizardStep]`, no subclass needed. |
+| `WizardSession` | Per-run session state. |
+| `TaskDecomposer` / `DecomposedTask` | Back the `task_decompose` step type (XML task decomposition). |
+
+### Dataclasses — `attune.wizards`
+
+| Type | Fields |
+|------|--------|
+| `WizardConfig` | `wizard_id`, `name`, `description`, `domain`, `version`, `source`, `estimated_cost_range`, `estimated_duration_minutes`. |
+| `WizardStep` | `id`, `name`, `description`, `step_type`, `prompt_template`, `tier`, `questions`, `condition`, `max_tokens`, `prompt_context_template`, `review_source_step_id`. |
+| `WizardResult` | `wizard_id`, `run_id`, `success`, `steps_completed`, `collected_data`, `generated_output`, `tasks`, `total_cost`, `total_duration_ms`, `error`. |
+| `StepType` | `question`, `llm_call`, `task_decompose`, `review`, `preview`, `confirm`. |
+
+### Entry points
+
+| Surface | Invocation |
+|---------|------------|
+| Python | `get_wizard(<id>)`, then `await <cls>().run()`; `list_wizards()` to discover. |
+| Skill | `/wizard` in a Claude Code conversation. |
+
+No `attune wizard` CLI command and no MCP tool exist for wizards.
+
+<!-- attune-generated: source_hash=0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0 feature=wizards kind=how-to generated_at=2026-06-23 -->

--- a/docs/reference/wizards.md
+++ b/docs/reference/wizards.md
@@ -1,350 +1,45 @@
----
-description: Reference for `attune.wizards` — guided multi-step wizards with XML task decomposition. Covers the 5 built-in developer wizards, the `BaseWizard` lifecycle, and config-driven YAML wizards.
----
-
 # Wizards
 
-`attune.wizards` is the runtime for **guided, multi-step interactive
-wizards** in Attune AI. A wizard is an ordered sequence of typed steps
-(questions, LLM calls, task decomposition, review, preview, confirm)
-that walks a user through a task with structured prompts and
-checkpoints.
+## Reference
 
-It ships with 5 built-in developer-focused wizards and a config-driven
-mode that lets users define custom wizards in YAML — no Python
-required.
+The public surface is the registry functions and the wizard
+classes/dataclasses, all re-exported from `attune.wizards`.
 
-> **Note**: This is not a collection of "industry-specific" or
-> "domain-compliance" wizards. The package has no Healthcare, Finance,
-> Legal, HIPAA, or SOC2 wizards. Earlier docs that described such a
-> surface were fiction — see the `doc-fiction-cleanup` spec.
+### Registry functions — `attune.wizards`
 
----
+| Function | Purpose |
+|----------|---------|
+| `list_wizards() -> list[WizardConfig]` | All registered wizard configs (built-in + custom). |
+| `get_wizard(wizard_id) -> type[BaseWizard] \| None` | The wizard class for an id, or `None`. |
+| `register_wizard(wizard_id, wizard_class) -> None` | Register a `BaseWizard` subclass. |
+| `save_custom_wizard(wizard_data, base_dir=None) -> Path` | Persist a config-driven wizard definition; returns the saved path. |
+| `delete_custom_wizard(wizard_id, base_dir=None) -> bool` | Remove a saved custom wizard. |
 
-## Public API at a glance
+### Classes — `attune.wizards`
 
-```python
-from attune.wizards import (
-    BaseWizard,
-    ConfigDrivenWizard,
-    DecomposedTask,
-    StepType,
-    TaskDecomposer,
-    WizardConfig,
-    WizardResult,
-    WizardSession,
-    WizardStep,
-    delete_custom_wizard,
-    get_wizard,
-    list_wizards,
-    register_wizard,
-    save_custom_wizard,
-)
-```
+| Symbol | Purpose |
+|--------|---------|
+| `BaseWizard(ask_user_callback=None, provider=None, **kwargs)` | Abstract base; async `run(initial_context=None) -> WizardResult`; hooks `build_prompt_context(step)` and `process_step_result(step, result)`. |
+| `ConfigDrivenWizard(config, steps, **kwargs)` | A wizard built from a `WizardConfig` + `list[WizardStep]`, no subclass needed. |
+| `WizardSession` | Per-run session state. |
+| `TaskDecomposer` / `DecomposedTask` | Back the `task_decompose` step type (XML task decomposition). |
 
-These are the only names exported from `attune.wizards`
-(`src/attune/wizards/__init__.py`).
+### Dataclasses — `attune.wizards`
 
----
+| Type | Fields |
+|------|--------|
+| `WizardConfig` | `wizard_id`, `name`, `description`, `domain`, `version`, `source`, `estimated_cost_range`, `estimated_duration_minutes`. |
+| `WizardStep` | `id`, `name`, `description`, `step_type`, `prompt_template`, `tier`, `questions`, `condition`, `max_tokens`, `prompt_context_template`, `review_source_step_id`. |
+| `WizardResult` | `wizard_id`, `run_id`, `success`, `steps_completed`, `collected_data`, `generated_output`, `tasks`, `total_cost`, `total_duration_ms`, `error`. |
+| `StepType` | `question`, `llm_call`, `task_decompose`, `review`, `preview`, `confirm`. |
 
-## Listing and running wizards
+### Entry points
 
-### Listing wizards (Python)
+| Surface | Invocation |
+|---------|------------|
+| Python | `get_wizard(<id>)`, then `await <cls>().run()`; `list_wizards()` to discover. |
+| Skill | `/wizard` in a Claude Code conversation. |
 
-`list_wizards()` is a module-level function. It returns a list of
-`WizardConfig` objects sorted by `wizard_id`, covering built-ins plus
-any custom YAML wizards loaded from `.attune/wizards/`.
+No `attune wizard` CLI command and no MCP tool exist for wizards.
 
-```python
-from attune.wizards import list_wizards
-
-for cfg in list_wizards():
-    print(f"{cfg.wizard_id:14} {cfg.name:30} ({cfg.source})")
-```
-
-### Getting and running a wizard (Python)
-
-```python
-import asyncio
-from attune.wizards import get_wizard
-
-WizardCls = get_wizard("debug")          # type[BaseWizard] | None
-wizard = WizardCls(ask_user_callback=None)
-result = asyncio.run(wizard.run({"error": "TypeError: ..."}))
-
-print(result.success, result.steps_completed)
-```
-
-`get_wizard()` checks the in-memory registry, then triggers entry-point
-discovery (group `empathy.wizards`), then loads built-ins, then loads
-custom YAML wizards from `.attune/wizards/`. Returns `None` if the
-wizard ID is not found.
-
-### Listing and running wizards (Claude Code skill)
-
-In Claude Code, the `/wizard` skill drives the runtime. Routes (from
-`.claude/skills/wizard/SKILL.md`):
-
-```text
-/wizard                      Ask what to do
-/wizard list                 List available wizards
-/wizard run debug            Debug wizard
-/wizard run test-gen         Test generation wizard
-/wizard run refactor         Refactoring wizard
-/wizard run security         Security wizard
-/wizard run release-prep     Release prep wizard
-/wizard create               Create a custom wizard
-/wizard edit                 Edit a wizard
-```
-
-The skill aliases (e.g. `wizard-debug`, `wizard-create`) are listed in
-`src/attune/cli_router.py`.
-
-> There is currently no top-level `attune wizard ...` subcommand on
-> the Python CLI. `attune health` does include a wizard discovery
-> probe — it calls `list_wizards()` and reports the count.
-
----
-
-## The 5 built-in wizards
-
-The built-in set is defined in
-`src/attune/wizards/builtin/__init__.py` as the `BUILTIN_WIZARDS` dict:
-
-| Wizard ID      | Class               | Domain      | What it does                                                |
-|----------------|---------------------|-------------|-------------------------------------------------------------|
-| `debug`        | `DebugWizard`       | development | Gather error details, analyze root cause, decompose a fix   |
-| `test-gen`     | `TestGenWizard`     | testing     | Pick a target, analyze untested paths, plan test files      |
-| `refactor`     | `RefactorWizard`    | development | Describe goal, analyze structure, plan incremental refactor |
-| `security`     | `SecurityWizard`    | (varies)    | Scope a scan, generate findings, plan remediations          |
-| `release-prep` | `ReleasePrepWizard` | release     | Version info, readiness check, optional changelog, plan     |
-
-Each built-in subclasses `BaseWizard`, defines a `WizardConfig`, and
-declares an ordered `steps` list. For example, `DebugWizard` runs:
-
-1. `gather_info` (QUESTION) — error description, file, stack-trace flag
-2. `analyze` (LLM_CALL, `bug-analysis` template, `capable` tier)
-3. `review_analysis` (REVIEW of the `analyze` result)
-4. `decompose_fix` (TASK_DECOMPOSE)
-5. `preview` (PREVIEW)
-6. `confirm` (CONFIRM)
-
-`RefactorWizard` and `SecurityWizard` additionally delegate their
-analysis step to a heavier workflow (`RefactorPlanWorkflow` and
-`SecurityAuditWorkflow` respectively) for multi-stage scanning while
-preserving the wizard-guided UX.
-
----
-
-## Step types
-
-The wizard runtime supports six step types, defined as the `StepType`
-enum in `src/attune/wizards/_types.py`:
-
-| `StepType`        | What it does                                                                                  |
-|-------------------|-----------------------------------------------------------------------------------------------|
-| `QUESTION`        | Collect user input via `AskUserQuestion` (rendered through `SocraticFormEngine`).             |
-| `LLM_CALL`        | Render an XML prompt and call an LLM at the step's tier (`cheap` / `capable` / `premium`).    |
-| `TASK_DECOMPOSE`  | Use `TaskDecomposer` to break the current problem into structured XML sub-tasks.              |
-| `REVIEW`          | Show the result of a prior `LLM_CALL` step and ask "does this look right?" (up to 2 retries). |
-| `PREVIEW`         | Format collected data, step results, and tasks into a preview block and store it.             |
-| `CONFIRM`         | Final yes/no gate; "no" aborts the wizard cleanly.                                            |
-
-A step can also carry a `condition: Callable[[WizardSession], bool]`
-that, when it returns `False`, causes the step to be skipped.
-`ReleasePrepWizard` uses this to skip changelog generation when the
-user opts out.
-
----
-
-## `BaseWizard` lifecycle
-
-`BaseWizard` (in `src/attune/wizards/base.py`) is an abstract class.
-Subclasses must define:
-
-- `config: WizardConfig` — wizard identity and cost/duration estimates.
-- `steps: list[WizardStep]` — the ordered step list.
-- `build_prompt_context(step) -> PromptContext` — builds the prompt
-  context for `LLM_CALL` and `TASK_DECOMPOSE` steps from session state.
-- `process_step_result(step, result) -> None` — stores or transforms
-  the LLM response for use by later steps.
-
-Everything else — step dispatch, retries, the session, the form
-engine, the XML prompt rendering, the preview/confirm UX — is provided
-for free.
-
-`BaseWizard.run(initial_context=None)` is the single entry point. It
-is `async`, creates a fresh `WizardSession`, iterates over `self.steps`,
-dispatches each one by `StepType`, and returns a `WizardResult` with:
-
-- `success: bool`
-- `steps_completed: list[str]`
-- `collected_data: dict[str, Any]` (everything from QUESTION steps)
-- `generated_output: str | dict` (the PREVIEW text)
-- `tasks: list[dict]` (from TASK_DECOMPOSE)
-- `total_cost: float` and `total_duration_ms: float`
-- `error: str | None` if the run failed
-
-If a `CONFIRM` step gets a "no" answer, the wizard raises an internal
-`_WizardAbort` and exits cleanly with `success=True` but no further
-steps.
-
-### Minimal custom wizard (Python)
-
-```python
-from typing import Any
-from attune.meta_workflows.models import FormQuestion, QuestionType
-from attune.prompts import PromptContext
-from attune.wizards import BaseWizard, StepType, WizardConfig, WizardStep
-
-
-class HelloWizard(BaseWizard):
-    config = WizardConfig(
-        wizard_id="hello",
-        name="Hello Wizard",
-        description="Trivial example",
-    )
-
-    steps = [
-        WizardStep(
-            id="ask",
-            name="Ask name",
-            step_type=StepType.QUESTION,
-            questions=[
-                FormQuestion(
-                    id="name",
-                    text="What's your name?",
-                    type=QuestionType.TEXT_INPUT,
-                ),
-            ],
-        ),
-        WizardStep(
-            id="greet",
-            name="Generate greeting",
-            step_type=StepType.LLM_CALL,
-            tier="cheap",
-        ),
-        WizardStep(id="preview", name="Preview", step_type=StepType.PREVIEW),
-        WizardStep(id="confirm", name="Confirm", step_type=StepType.CONFIRM),
-    ]
-
-    def build_prompt_context(self, step: WizardStep) -> PromptContext:
-        name = self._session.get("name", "stranger")
-        return PromptContext(
-            role="friendly assistant",
-            goal=f"Write a one-sentence greeting for {name}.",
-            instructions=["Be warm and concise."],
-            input_type="name",
-            input_payload=name,
-        )
-
-    def process_step_result(self, step: WizardStep, result: dict[str, Any]) -> None:
-        self._session.set("greeting", result.get("summary", ""))
-```
-
-Register it (once per process) with `register_wizard("hello", HelloWizard)`,
-or expose it via the `empathy.wizards` entry-point group for automatic
-discovery.
-
----
-
-## Config-driven wizards (YAML)
-
-`ConfigDrivenWizard` lets users author wizards entirely in YAML. A
-custom wizard is a single file under `.attune/wizards/<wizard_id>.yaml`.
-
-### YAML schema (v1.0)
-
-Required top-level fields (validated by `_validate_schema` in
-`config_driven.py`):
-
-- `wizard_id`
-- `name`
-- `steps` (non-empty list)
-
-Optional: `description`, `domain`, `version`,
-`estimated_cost_range` (list of two floats),
-`estimated_duration_minutes`, `schema_version`.
-
-Each step must include `id` and a valid `step_type`
-(`question`, `llm_call`, `task_decompose`, `review`, `preview`, `confirm`).
-For `llm_call` steps, supply a declarative `prompt_context` block —
-`role`, `goal`, `instructions`, `constraints`, `input_type`,
-`input_payload` — with `{session.var_name}` placeholders that the
-runtime substitutes from current session state.
-
-### Example
-
-```yaml
-schema_version: "1.0"
-wizard_id: "code-migration"
-name: "Code Migration Wizard"
-description: "Guide through migrating code between frameworks"
-domain: "development"
-
-steps:
-  - id: "gather_info"
-    name: "Migration Scope"
-    step_type: "question"
-    questions:
-      - id: "source"
-        text: "Migrating FROM which framework?"
-        type: "text_input"
-  - id: "analyze"
-    step_type: "llm_call"
-    tier: "capable"
-    prompt_context:
-      role: "migration specialist"
-      goal: "Plan migration from {session.source}"
-```
-
-### Lifecycle helpers
-
-- `save_custom_wizard(data, base_dir=None)` — validate, write
-  `<wizard_id>.yaml` under `.attune/wizards/` (or `base_dir`), and
-  register the wizard.
-- `delete_custom_wizard(wizard_id, base_dir=None)` — remove the YAML
-  and unregister. Raises `ValueError` if `wizard_id` is a built-in
-  (the five IDs in `BUILTIN_WIZARDS`).
-
----
-
-## Sessions
-
-`WizardSession` (in `src/attune/wizards/session.py`) is the mutable
-state object that lives for the duration of one `wizard.run()` call.
-It is created automatically; subclasses interact with it via
-`self._session` in `build_prompt_context` and `process_step_result`.
-
-Key fields: `wizard_id`, `run_id` (12-hex), `initial_context`,
-`collected_data`, `step_results`, `tasks`, `steps_completed`,
-`steps_skipped`, `generated_output`, `total_cost`, `started_at`.
-
-`session.get(key, default)` does a layered lookup —
-`collected_data` first, then `initial_context`.
-
----
-
-## Discovery & registration
-
-`get_wizard()` and `list_wizards()` both trigger three loaders, each
-guarded so they run at most once per process:
-
-1. `_discover_wizards()` — entry-point group `empathy.wizards`
-2. `_load_builtins()` — the `BUILTIN_WIZARDS` dict
-3. `_load_custom_wizards()` — YAML files in `.attune/wizards/`
-
-`register_wizard(wizard_id, wizard_class)` is the manual hook — useful
-for tests or in-process registration of Python wizards.
-
----
-
-## See also
-
-- `src/attune/wizards/` — implementation (start with `__init__.py`,
-  `base.py`, `_types.py`, `registry.py`, `config_driven.py`).
-- `src/attune/wizards/builtin/` — the five built-in wizards.
-- `.claude/skills/wizard/SKILL.md` — the Claude Code skill that drives
-  the wizard runtime in a session.
-- `attune health` — includes a wizard discovery probe that calls
-  `list_wizards()`.
+<!-- attune-generated: source_hash=0383bd1ba48703a82f700d50a22fc06aa7d00b38cf01550ca0a1f41adea84bc0 feature=wizards kind=reference generated_at=2026-06-23 -->


### PR DESCRIPTION
## What

Single-source the **wizards** feature (15/25 in the help-docs rollout) —
author `content/features/wizards.md` and re-project its 10 `.help` kinds
+ how-to / architecture / reference docs + the hub via
`attune_author.projector`.

The master centers on the verified public API: the **module-level
registry functions** (`list_wizards` / `get_wizard` / `register_wizard`
/ `save_custom_wizard` / `delete_custom_wizard` — there is **no
`WizardRegistry` class**), `BaseWizard` (async `run()`),
`ConfigDrivenWizard`, the `WizardConfig` / `WizardStep` / `WizardResult`
dataclasses, `StepType` (question/llm_call/task_decompose/review/preview/
confirm), and the 5 builtins (debug/refactor/release-prep/security/
test-gen). Entry points are the Python API + the `/wizard` skill — **no
CLI command, no MCP tool**.

## The win — fiction replaced

The prior faq called `run()` **synchronously** (it's `async`); fixed,
and the faq rewritten as a frozen `status: manual` file.

## Loop receipts (r7-rollout-playbook)

- **Dry-run fact-check:** 0 findings. **Example gate:** 0 problems (4 blocks).
- **Independent adversarial review:** **0 false / 0 misleading** on the
  first pass — every signature, async-ness, dataclass field, `StepType`
  value, builtin mapping, re-export, and the no-CLI/no-MCP claims
  verified against source.
- **DD5:** `features.yaml` → `status: manual` (dropped `files:` +
  `doc_paths`). Description/tags unchanged (wz-002 "interactive").
- **Serve-verify** via `attune.ops.help_data`: 11/11 kinds, complete.
- **golden_queries + manifest_integrity:** 75 passed / 3 xfailed.
- **mkdocs build --strict:** clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
