### PR TITLE
release: 8.9.0 — MCP reliability fixes + release_prep→release_notes rename

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.8.0"
+    "version": "8.9.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.8.0
+# Attune AI Framework v8.9.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.8.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.9.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.9.0] — 2026-06-23
+
+Runtime patch — MCP reliability fixes plus a tool-name
+disambiguation. No new features.
+
+### Changed
+
+- **`release_prep` MCP tool renamed to `release_notes`.** The SDK
+  workflow that drafts release notes and LLM go/no-go advice is now
+  exposed as the `release_notes` MCP tool (and `release-notes`
+  workflow), disambiguating it from the deterministic `release-prep`
+  readiness gate — the agent-team workflow and the `release-prep`
+  skill keep their names. **Breaking for MCP clients that called
+  `release_prep`**: switch to `release_notes`. (#1018, #1020)
+
+### Fixed
+
+- **MCP handler keyword arguments dropped by the v4.2.0 SDK execute
+  migration are restored** — tool calls that pass options now receive
+  them again. (#1017)
+- **`research_synthesis` MCP tool is now path-based**, matching its
+  underlying workflow's signature. (#1021)
+
 ## [8.8.0] — 2026-06-22
 
 Two opt-in features — an extended prompt-cache window for the

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 A spec-driven development platform for Claude Code. Four pillars — AI
 workflows, project memory, retrieval grounding, and verification — turn
-requirements into reliable software. 20 workflows (17 multi-stage),
+requirements into reliable software. 21 workflows (17 multi-stage),
 17 auto-triggering skills, and 41 MCP tools run specialist teams of 2–6
 Claude subagents that review your code, surface vulnerabilities, generate
 tests, and plan refactors — grounded in your real source, with findings
@@ -218,6 +218,7 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 | **refactor-plan** | debt-scanner, impact, plan-generator | Plans large-scale refactors |
 | **simplify-code** | complexity, simplification, safety | Proposes simplifications with safety review |
 | **release-prep** | health, security, changelog, assessor | Go/no-go readiness check |
+| **release-notes** | agent-prep | Drafts release notes + LLM readiness advice |
 | **doc-orchestrator** | inventory, outline, content, polish | Full-project documentation |
 | **secure-release** | security, health, dep-auditor, gater | Release pipeline with risk scoring |
 | **research-synthesis** | summarizer, pattern-analyst, writer | Multi-source research synthesis |
@@ -237,7 +238,7 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 `performance_audit` `refactor_plan` `simplify_code`
 `deep_review` `test_generation` `test_audit`
 `test_gen_parallel` `doc_gen` `doc_audit`
-`doc_orchestrator` `release_prep` `health_check`
+`doc_orchestrator` `release_notes` `health_check`
 `dependency_check` `secure_release` `research_synthesis`
 `analyze_batch` `analyze_image` `rag_knowledge_query`
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.8.0
+**Version:** 8.9.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.8.0 | **License:** Apache 2.0
+**Version:** 8.9.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.8.0"
+    "version": "8.9.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.8.0"
+__version__ = "8.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.8.0"
+version = "8.9.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.8.0"
+version = "8.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## 8.9.0 — runtime patch

MCP reliability fixes plus a tool-name disambiguation. No new features.
Ships unreleased `src/` work sitting on top of the v8.8.0 tag.

### Changed

- **`release_prep` MCP tool renamed to `release_notes`** (#1018, #1020).
  The SDK workflow that drafts release notes + LLM go/no-go advice is now
  the `release_notes` MCP tool (and `release-notes` workflow),
  disambiguating it from the deterministic `release-prep` readiness gate.
  The agent-team workflow and the `release-prep` skill keep their names.
  **Breaking for MCP clients that called `release_prep`** → use
  `release_notes`.

### Fixed

- **MCP handler keyword arguments dropped by the v4.2.0 SDK execute
  migration are restored** (#1017).
- **`research_synthesis` MCP tool is now path-based**, matching its
  workflow signature (#1021).

### Release mechanics

- Version bumped to 8.9.0 across all 7 sites (`scripts/bump_version.py`).
- `uv.lock` refreshed (attune-ai 8.8.0 → 8.9.0).
- README: added the `release-notes` workflow row, swapped
  `release_prep` → `release_notes` in the MCP tool list, workflow count
  20 → 21 (verified against `list_workflows()`; `release-gate` confirmed
  an alias of `release-prep`, not a distinct workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
