### PR TITLE
docs(help): single-source configuration via projector (Tier-3 2/9)

### DIFF
--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -347,12 +347,17 @@ features:
     status: manual
 
   configuration:
+    # Single-sourced via content/features/configuration.md (projector).
+    # Scope = the attune.config package, which spans FOUR layers with
+    # overlapping names: the unified tree (UnifiedConfig + sections +
+    # config.loader + validation), agent config (UnifiedAgentConfig),
+    # the XML/empathy layer (EmpathyXMLConfig via get_config/set_config),
+    # and the legacy AttuneConfig (== EmpathyConfig) dataclass loaded by
+    # load_config. The doc distinguishes all four (the prior generated
+    # concept doc mis-attributed config.loader symbols to config.unified).
     description: Project configuration and settings management
-    files:
-      - src/attune/config/**
     tags: [config, settings]
-    doc_paths:
-      - docs/reference/configuration.md
+    status: manual
 
   # rag-grounding is single-sourced (status: manual) from
   # content/features/rag-grounding.md and rendered by

--- a/.help/templates/configuration/comparison.md
+++ b/.help/templates/configuration/comparison.md
@@ -3,60 +3,23 @@ type: comparison
 name: configuration-comparison
 feature: configuration
 depth: comparison
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Comparison: Configuration Approaches
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-## Context
+## Comparison
 
-Attune exposes two distinct configuration systems side by side:
+Four layers, distinct jobs:
 
-- **`UnifiedConfig` / `ConfigLoader`** — a file-backed, section-structured config used by the agent and workflow layer
-- **`EmpathyXMLConfig`** — a legacy global-singleton config loaded from `.attune/config.json` or environment variables
+| | Unified config | Agent config | XML/empathy config | Legacy dataclass |
+|--|----------------|--------------|--------------------|------------------|
+| Class | `UnifiedConfig` | `UnifiedAgentConfig` | `EmpathyXMLConfig` | `AttuneConfig` |
+| Entry | `load_unified_config()` | construct / `for_book_production` | `get_config()` | `load_config()` |
+| Scope | App-wide sections | LLM agent runtime | Empathy subsystem | Back-compat |
+| Status | Modern (preferred) | Active | Active (subsystem) | Legacy |
 
-Understanding which system owns what prevents subtle conflicts, especially when environment variable overrides are involved.
-
-## Feature comparison
-
-| Capability | `UnifiedConfig` + `ConfigLoader` | `EmpathyXMLConfig` |
-|---|---|---|
-| **Primary entry point** | `load_unified_config()` / `get_loader()` | `get_config()` / `set_config()` |
-| **File format** | YAML or JSON (auto-discovered) | JSON only (`.attune/config.json`) |
-| **Search path** | `./attune.config.json`, `~/.attune/config.json`, `~/.config/attune/config.json` | Fixed: `.attune/config.json` |
-| **Environment overrides** | `ConfigLoader.apply_env_overrides()` reads `ATTUNE_` prefix | `EmpathyXMLConfig.from_env()` reads `ATTUNE_` prefix |
-| **Env variable lookup** | `get_attune_env()` — checks `ATTUNE_` first, falls back to `EMPATHY_` | Same fallback via `from_env()` |
-| **Structured sections** | Yes — `AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`, `RoutingConfig`, `TelemetryConfig`, `WorkflowConfig` | No — flat sub-objects: `XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`, `MetricsConfig` |
-| **Validation** | `validate_config(config)` returns `list[ValidationError]` | None exposed in public API |
-| **Agent/workflow integration** | Direct — `UnifiedAgentConfig`, `BookProductionConfig`, `WorkflowMode` all consume `UnifiedConfig` | Indirect — agents read global singleton via `get_config()` |
-| **Serialization** | `UnifiedConfig.to_dict()` / `from_dict()` on every section | `save_to_file()` / `load_from_file()` on the top-level object |
-| **Save location control** | `save_unified_config(config, path)` accepts an explicit path | `save_to_file(config_file=...)` accepts an explicit path |
-| **Global singleton** | No — instantiate `ConfigLoader` or call `load_unified_config()` | Yes — `get_config()` / `set_config()` manage a module-level instance |
-| **Key–value access** | `UnifiedConfig.get_value(key)` / `set_value(key, value)` / `get_all_keys()` | Not available |
-
-## Tradeoffs
-
-**`UnifiedConfig` + `ConfigLoader` is the right default.** It is the system that agent classes, workflow modes, and book-production pipelines are built on. `ConfigLoader.apply_env_overrides()` gives you a single, explicit place where environment variables win, and `validate_config()` surfaces `ValidationError` objects at load time rather than at the point of use. The three-path discovery order (`./attune.config.json` → `~/.attune/config.json` → `~/.config/attune/config.json`) means the same code works across developer workstations, CI, and production without any changes.
-
-**`EmpathyXMLConfig` is a narrower, legacy surface.** Its global-singleton pattern (`get_config()` / `set_config()`) is convenient for code that predates the unified system but makes testing harder — replacing the singleton in one test can affect another. It has no built-in validation pass, so missing or malformed values surface as runtime errors rather than startup errors. Use it only when integrating with existing code that already calls `get_config()`.
-
-One practical difference worth noting: `get_attune_env()` checks `ATTUNE_` first and then falls back to `EMPATHY_` for backward compatibility. Both systems share this fallback, so a variable set as `EMPATHY_FOO` is visible through either path. `iter_attune_env_prefix(prefix, suffix)` lets you enumerate all variables matching `ATTUNE_{prefix}*{suffix}`, which is useful when the unified config section names map directly to env var prefixes.
-
-## Use X when…
-
-**Use `UnifiedConfig` + `ConfigLoader` when:**
-- You are writing new agent, workflow, or book-production code — `UnifiedAgentConfig` and `BookProductionConfig` depend on it directly
-- You need structured, validated sections (`AuthConfig`, `TelemetryConfig`, `PersistenceConfig`, etc.) with `validate_config()` catching problems at startup
-- You want explicit, path-controlled saves via `save_unified_config(config, path)`
-- You are writing tests that must swap config without global state leaking between cases
-
-**Use `EmpathyXMLConfig` when:**
-- You are maintaining or extending existing code that already calls `get_config()` / `set_config()`
-- You need to construct config entirely from environment variables via `EmpathyXMLConfig.from_env()` with no file on disk
-- The sub-objects you need (`OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`, `MetricsConfig`) are only modeled in this system
-
-**Do not use either system directly when:**
-- You need runtime behavior that no public method exposes — extend the relevant section class rather than patching internals
-- You are writing a throwaway script that reads one or two values — call `get_attune_env(name, default)` directly instead of loading a full config object
+`load_config()` and `load_unified_config()` return **different types**
+(`AttuneConfig` vs `UnifiedConfig`) — they are not interchangeable.

--- a/.help/templates/configuration/concept.md
+++ b/.help/templates/configuration/concept.md
@@ -3,47 +3,88 @@ type: concept
 name: configuration-concept
 feature: configuration
 depth: concept
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Configuration
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-Attune's configuration system is a layered set of typed dataclasses, a file loader, and an environment-variable compatibility layer that together resolve a single `UnifiedConfig` object at runtime.
+## Overview
 
-## The two config trees
+Attune's configuration lives under `attune.config` and is **layered** —
+several typed systems that serve different parts of the framework. The
+one most code reaches for is the **unified config tree**; alongside it
+are an **agent config** layer, an **XML/empathy config** layer, and a
+**legacy dataclass** kept for backward compatibility.
 
-The system has two distinct trees that serve different purposes:
+The four layers, and when each matters:
 
-**Agent configuration** (`config.agent_config`) models the runtime behavior of LLM-backed agents. `UnifiedAgentConfig` is the central class: it normalizes agent roles via `normalize_role`, resolves a model identifier via `get_model_id`, and produces a `BookProductionConfig` view via `for_book_production`. `BookProductionConfig` exposes backward-compatible properties — `model`, `max_tokens`, `temperature`, `timeout`, `retry_attempts`, and `retry_delay` — so older call sites continue to work while the underlying config evolves. Supporting enumerations `ModelTier`, `Provider`, and `WorkflowMode` constrain the values callers can supply, catching bad input before it reaches an API call.
+- **Unified application config** — `UnifiedConfig` (`config.unified`)
+  organized into named sections (`config.sections`), loaded and saved by
+  `ConfigLoader` / `load_unified_config` (`config.loader`) and checked by
+  `validate_config` (`config.validation`). This is the modern structured
+  config.
+- **Agent config** — `UnifiedAgentConfig` and `BookProductionConfig`
+  (`config.agent_config`), constrained by the `ModelTier`, `Provider`,
+  and `WorkflowMode` enums — the runtime behavior of LLM-backed agents.
+- **XML/empathy config** — `EmpathyXMLConfig`, the global instance read
+  and replaced via `get_config()` / `set_config()`, with sub-objects
+  `XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`,
+  `MetricsConfig`.
+- **Legacy dataclass** — `AttuneConfig` (aliased as `EmpathyConfig`),
+  loaded by `load_config()`. Kept for backward compatibility; new code
+  should prefer the unified tree.
 
-**Unified application configuration** (`config.unified`, `config.sections`) organizes everything else into named sections: `AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`, `RoutingConfig`, `TelemetryConfig`, and `WorkflowConfig`. Each section implements `to_dict` and `from_dict`, so it can round-trip through YAML or JSON without losing type information. `UnifiedConfig` wraps all sections and adds `get_value`, `set_value`, and `get_all_keys` for key-path access when you need to read or write a deeply nested field by name.
+## Concepts
 
-## How values are resolved
+### The unified config tree
 
-`ConfigLoader` orchestrates loading and saving. When you call `load_unified_config()`, the loader:
+`UnifiedConfig` is the modern config object. It holds seven typed
+sections — `analysis`, `auth`, `environment`, `persistence`, `routing`,
+`telemetry`, `workflows` (the classes in `config.sections`:
+`AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`,
+`RoutingConfig`, `TelemetryConfig`, `WorkflowConfig`). Each section
+round-trips through `to_dict` / `from_dict`. `UnifiedConfig` adds
+key-path access — `get_value`, `set_value`, `get_all_keys` — for reading
+or writing a nested field by name.
 
-1. Searches `CONFIG_SEARCH_PATHS` (`./attune.config.json`, `~/.attune/config.json`, `~/.config/attune/config.json`) via `discover_config_path`.
-2. Deserializes the file into a `UnifiedConfig` using each section's `from_dict`.
-3. Applies environment-variable overrides through `apply_env_overrides`.
+`ConfigLoader` (`config.loader`) orchestrates loading and saving;
+`load_unified_config(path=None)` is the convenience entry. The loader
+searches `CONFIG_SEARCH_PATHS` (`./attune.config.json`,
+`~/.attune/config.json`, `~/.config/attune/config.json`), deserializes
+into a `UnifiedConfig`, and applies environment overrides. Env variables
+take precedence: `get_attune_env` (`config.env_compat`) reads
+`ATTUNE_`-prefixed variables first and falls back to the legacy
+`EMPATHY_` prefix, so a project migrating prefixes need not update its
+environment immediately.
 
-Environment variables take precedence over file values. `get_attune_env` checks `ATTUNE_`-prefixed variables first, then falls back to the legacy `EMPATHY_` prefix, so projects migrating from an older prefix do not need to update their environment immediately. `iter_attune_env_prefix` lets you scan all variables that match a given `ATTUNE_{prefix}*{suffix}` pattern, which is how bulk overrides (for example, overriding every routing key at once) are applied.
+`validate_config(config)` (`config.validation`) returns a list of
+`ValidationError` for a `UnifiedConfig`; `ConfigValidator` lets you
+validate a single section.
 
-After loading, pass the result to `validate_config` to get a list of `ValidationError` objects before any agent work begins. `ConfigValidator.validate_section` lets you target a single section if you only need to check part of the config.
+### Agent config
 
-## The XML/empathy config layer
+`UnifiedAgentConfig` (`config.agent_config`) models how LLM-backed
+agents run. `BookProductionConfig` is a backward-compatible view exposing
+properties like `model`, `max_tokens`, `temperature`, `timeout`. The
+enums `ModelTier`, `Provider`, and `WorkflowMode` constrain the values
+callers may supply, catching bad input before it reaches an API call.
 
-`EmpathyXMLConfig` is a separate global config object used by the empathy subsystem. You load it with `EmpathyXMLConfig.load_from_file` (defaulting to `.attune/config.json`) or build it from the environment with `EmpathyXMLConfig.from_env`. The module-level `get_config` and `set_config` functions let any part of the codebase read or replace the active instance without holding a direct reference to it. Its sub-objects — `XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`, and `MetricsConfig` — cover rendering, optimization hints, internationalization, and metrics collection respectively.
+### The XML/empathy config layer
 
-## When each part matters
+`EmpathyXMLConfig` is a separate global config used by the empathy
+subsystem. Load it with `EmpathyXMLConfig.load_from_file(config_file=
+".attune/config.json")` or `EmpathyXMLConfig.from_env()`; the
+module-level `get_config()` / `set_config()` read or replace the active
+instance without holding a direct reference. Its sub-objects —
+`XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`,
+`MetricsConfig` — cover rendering, optimization hints, i18n, and metrics.
 
-| Situation | What to reach for |
-|---|---|
-| Configuring an agent's model, tokens, or retry behavior | `UnifiedAgentConfig` → `BookProductionConfig` |
-| Reading or writing a named config value at runtime | `UnifiedConfig.get_value` / `set_value` |
-| Loading config from disk in one call | `load_unified_config()` |
-| Persisting changes back to disk | `save_unified_config()` |
-| Checking config before starting a workflow | `validate_config()` |
-| Reading an env var with legacy-prefix fallback | `get_attune_env()` |
-| Accessing the empathy subsystem's global config | `get_config()` / `set_config()` |
+### The legacy dataclass
+
+`AttuneConfig` (exported also as `EmpathyConfig` — the same class) is the
+older empathy-era dataclass. `load_config(filepath=None, use_env=True)`
+returns one. It carries `from_yaml` / `to_yaml` / `from_env` /
+`validate`. New code should prefer the unified tree; this remains for
+back-compat.

--- a/.help/templates/configuration/error.md
+++ b/.help/templates/configuration/error.md
@@ -3,48 +3,35 @@ type: error
 name: configuration-error
 feature: configuration
 depth: error
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Configuration errors
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-Configuration errors in Attune fall into three categories: missing or unresolvable config files, invalid or unrecognized field values, and environment variable mismatches.
+## Failure modes
 
-## Common error signatures
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `AttributeError` mixing the two configs | Treating a `UnifiedConfig` like an `AttuneConfig` (or vice versa) | They are different types — use one tree's API consistently | high |
+| Env override ignored | Variable not `ATTUNE_`/`EMPATHY_`-prefixed, or set after load | Prefix correctly; reload after setting | medium |
+| `validate_config` reports errors | A section value is out of range/invalid | Read each `ValidationError`; fix the named field | medium |
+| `get_value`/`set_value` `KeyError` | Key path not in `get_all_keys()` | List `get_all_keys()` first | low |
+| XML config changes not seen elsewhere | Replaced a local instance, not the global | Use `set_config()` to swap the global instance | medium |
 
-| Symptom | Likely cause |
-|---|---|
-| `FileNotFoundError` from `ConfigLoader.load()` | None of the search paths (`./attune.config.json`, `~/.attune/config.json`, `~/.config/attune/config.json`) contain a readable file and no path was passed explicitly. |
-| `ValidationError` returned by `validate_config()` | A `UnifiedConfig` field contains a value that fails `ConfigValidator.validate_section()` — for example, an unrecognized `WorkflowMode` or an empty required field in `AuthConfig`. |
-| `AgentOperationError` wrapping another exception | `UnifiedAgentConfig` caught an exception during an agent operation and re-raised it with operation context. Inspect `cause` for the original error. |
-| `KeyError` or `AttributeError` from `UnifiedConfig.get_value()` | The key passed does not appear in `get_all_keys()` — often a typo or a key from an older config schema. |
-| `EmpathyXMLConfig.load_from_file()` raises `FileNotFoundError` or `JSONDecodeError` | `.attune/config.json` is absent, empty, or not valid JSON. |
-| Environment variable silently ignored | The variable was set with the legacy `EMPATHY_` prefix but the code now reads `ATTUNE_` first via `get_attune_env()`. The `EMPATHY_` value is used only as a fallback. |
+### Risk areas
 
-## Where errors originate
+- **Two return types.** `load_config` → `AttuneConfig`;
+  `load_unified_config` → `UnifiedConfig`. Don't cross their APIs.
+- **Env precedence.** `ATTUNE_` wins over `EMPATHY_` wins over file.
+- **Global XML config.** `get_config`/`set_config` operate on a shared
+  instance; a local `EmpathyXMLConfig(...)` is not the global one.
 
-- **`ConfigLoader.load()`** — Attempts to read from the discovered or default config path. Fails with a filesystem error if the file is missing or unreadable. Call `ConfigLoader.discover_config_path()` beforehand to confirm which path the loader resolves to.
-- **`load_unified_config(path)`** — Wraps `ConfigLoader.load()`; passing `None` triggers automatic path discovery against `CONFIG_SEARCH_PATHS`. If discovery returns nothing, the loader falls back to `ConfigLoader.get_default_config_path()`.
-- **`validate_config(config)`** — Returns a list of `ValidationError` objects rather than raising. An empty return value means the config is valid. A non-empty list means one or more sections failed `ConfigValidator.validate_section()`.
-- **`get_attune_env(name)`** — Checks `ATTUNE_{name}` first, then `EMPATHY_{name}`. Returns `None` (not an exception) when neither is set, so callers that do not check the return value may propagate `None` silently.
-- **`EmpathyXMLConfig.load_from_file()`** — Reads `.attune/config.json` by default. Any parse failure raises immediately and is not caught internally.
+### Diagnosis order
 
-## How to diagnose
-
-1. **Check which config file was loaded.** Call `ConfigLoader.discover_config_path()` to see which path the loader resolved, or `ConfigLoader.get_default_config_path()` to see the fallback. If `discover_config_path()` returns `None`, no file matched any of the `CONFIG_SEARCH_PATHS` entries.
-
-2. **Run `validate_config()` explicitly and inspect the list.** `validate_config()` returns `list[ValidationError]`, not an exception — iterate the result and print each `ValidationError` to identify which section and field failed. A return value of `[]` means validation passed.
-
-3. **Check the `AgentOperationError.cause` attribute.** When you catch an `AgentOperationError`, the wrapped `cause` exception holds the original traceback. Log or print `cause` before handling the outer error to avoid losing the root cause.
-
-4. **Audit environment variable names.** Use `iter_attune_env_prefix(prefix)` to list all `ATTUNE_{prefix}*` variables currently set. If you expect a value and `get_attune_env(name)` returns `None`, confirm the variable is spelled with the `ATTUNE_` prefix, not only `EMPATHY_`.
-
-5. **Validate the JSON config file independently.** If `EmpathyXMLConfig.load_from_file()` fails, open `.attune/config.json` in a JSON linter before re-running. An empty file or a trailing comma produces a `JSONDecodeError` that is otherwise reported without the offending line number.
-
-## Source files
-
-- `src/attune/config/**`
-
-**Tags:** `config`, `settings`
+1. Which tree are you on? `type(cfg).__name__`.
+2. For the unified tree, `validate_config(cfg)` then read each error.
+3. For env issues, confirm the `ATTUNE_`/`EMPATHY_` prefix and load
+   order.
+4. For key-path issues, `cfg.get_all_keys()`.

--- a/.help/templates/configuration/faq.md
+++ b/.help/templates/configuration/faq.md
@@ -3,9 +3,7 @@ type: faq
 name: configuration-faq
 feature: configuration
 depth: faq
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
-status: generated
+status: manual
 ---
 
 # Configuration FAQ

--- a/.help/templates/configuration/quickstart.md
+++ b/.help/templates/configuration/quickstart.md
@@ -3,99 +3,23 @@ type: quickstart
 name: configuration-quickstart
 feature: configuration
 depth: quickstart
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Quickstart: Attune Configuration
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-Load your first `UnifiedConfig` object and confirm it reads correctly:
+## Quickstart
 
-```python
-from attune.config.loader import load_unified_config
-
-config = load_unified_config()
-print(config.to_dict())
-```
-
-If a config file exists at one of the default search paths (`./attune.config.json`, `~/.attune/config.json`, or `~/.config/attune/config.json`), you'll see its contents printed as a dictionary. If no file is found, you'll see the defaults.
-
-## Prerequisites
-
-- The package is installed in your local environment
-- Optionally, a config file exists at one of the `CONFIG_SEARCH_PATHS` locations
-
-## Step 1: Validate the loaded config
-
-Pass the config object to `validate_config` to catch any missing or malformed values before they cause runtime errors:
+Load the unified config and validate it:
 
 ```python
 from attune.config.loader import load_unified_config
 from attune.config.validation import validate_config
 
-config = load_unified_config()
-errors = validate_config(config)
-
-if errors:
-    for e in errors:
-        print(e)
-else:
-    print("Config is valid.")
+cfg = load_unified_config()        # searches CONFIG_SEARCH_PATHS
+errors = validate_config(cfg)
+print(type(cfg).__name__, "with", len(errors), "validation error(s)")
+print(cfg.routing.to_dict())
 ```
-
-Expected output when config is valid:
-
-```
-Config is valid.
-```
-
-## Step 2: Override a value and save
-
-Use `set_value` to change a config value in memory, then write it back to disk with `save_unified_config`:
-
-```python
-from attune.config.loader import load_unified_config, save_unified_config
-
-config = load_unified_config()
-config.set_value("telemetry.enabled", False)
-
-saved_path = save_unified_config(config)
-print(f"Saved to: {saved_path}")
-```
-
-Expected output:
-
-```
-Saved to: /home/you/.attune/config.json
-```
-
-## Step 3: Apply environment variable overrides
-
-`ATTUNE_` environment variables override file-based config at load time. To apply them explicitly to an existing config object, call `apply_env_overrides`:
-
-```python
-from attune.config.loader import load_unified_config, ConfigLoader
-
-config = load_unified_config()
-config = ConfigLoader.apply_env_overrides(config)
-print(config.get_value("telemetry.enabled"))
-```
-
-Set `ATTUNE_TELEMETRY_ENABLED=false` in your shell before running to see the override take effect.
-
-## Step 4: Read a value and check all available keys
-
-```python
-from attune.config.loader import load_unified_config
-
-config = load_unified_config()
-print(config.get_all_keys())
-print(config.get_value("telemetry.enabled"))
-```
-
-This prints every key the config object knows about, then the current value of one of them — confirming the config is fully loaded and accessible.
-
----
-
-**Next:** Read the `UnifiedAgentConfig` reference to learn how agent-specific settings — including `ModelTier`, `Provider`, and `WorkflowMode` — layer on top of `UnifiedConfig`.

--- a/.help/templates/configuration/reference.md
+++ b/.help/templates/configuration/reference.md
@@ -3,137 +3,41 @@ type: reference
 name: configuration-reference
 feature: configuration
 depth: reference
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Configuration reference
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-Load, validate, and manage Attune AI configuration across agents, workflows, and environments.
+## Reference
 
-## Classes
+### `attune.config` (package top level)
 
-| Class | Description |
-|-------|-------------|
-| `ModelTier` | Model tier for cost optimization. |
-| `Provider` | LLM provider options. |
-| `WorkflowMode` | Workflow execution modes. |
-| `AgentOperationError` | Error during agent operation with context. |
-| `UnifiedAgentConfig` | Unified configuration model for all agents. |
-| `MemDocsConfig` | Configuration for MemDocs pattern storage integration. |
-| `RedisConfig` | Configuration for Redis state management. |
-| `BookProductionConfig` | Unified configuration for book production agents. |
-| `WorkflowConfig` | Configuration for agent workflows. |
-| `ConfigLoader` | Load, save, and manage Attune AI configuration. |
-| `AnalysisConfig` | Code analysis and scanning configuration. |
-| `AuthConfig` | Authentication and API key configuration. |
-| `EnvironmentConfig` | Environment and display configuration. |
-| `PersistenceConfig` | Data persistence and memory configuration. |
-| `RoutingConfig` | Model routing and tier selection configuration. |
-| `TelemetryConfig` | Telemetry and usage tracking configuration. |
-| `WorkflowConfig` | Workflow execution configuration. |
-| `UnifiedConfig` | Unified configuration for Attune AI. |
-| `ValidationError` | Represents a configuration validation error. |
-| `ConfigValidator` | Validate Attune AI configuration. |
-| `XMLConfig` | XML prompting configuration. |
-| `OptimizationConfig` | Context window optimization configuration. |
-| `AdaptiveConfig` | Adaptive prompting configuration. |
-| `I18nConfig` | Internationalization configuration. |
-| `MetricsConfig` | Metrics tracking configuration. |
-| `EmpathyXMLConfig` | Main Empathy XML enhancement configuration. |
+| Symbol | Purpose |
+|--------|---------|
+| `load_config(filepath=None, use_env=True) -> AttuneConfig` | Load the legacy dataclass. |
+| `AttuneConfig` / `EmpathyConfig` | The legacy config dataclass (same class). |
+| `get_config() -> EmpathyXMLConfig` / `set_config(config)` | Read/replace the global XML/empathy config. |
+| `EmpathyXMLConfig`, `XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`, `MetricsConfig` | XML/empathy config + sub-objects. |
+| `UnifiedAgentConfig`, `BookProductionConfig` | Agent config. |
+| `ModelTier`, `Provider`, `WorkflowMode` | Agent config enums. |
+| `RedisConfig` | Redis section. |
 
-### `BookProductionConfig` properties
+### `attune.config.loader`
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `model` | `str` | Get model ID for backward compatibility. |
-| `max_tokens` | `int` | Get max tokens for backward compatibility. |
-| `temperature` | `float` | Get temperature for backward compatibility. |
-| `timeout` | `int` | Get timeout for backward compatibility. |
-| `retry_attempts` | `int` | Get retry attempts for backward compatibility. |
-| `retry_delay` | `float` | Get retry delay for backward compatibility. |
+| Symbol | Purpose |
+|--------|---------|
+| `load_unified_config(path=None) -> UnifiedConfig` | Load the unified tree. |
+| `save_unified_config(...)` | Persist a `UnifiedConfig`. |
+| `ConfigLoader` | Loader class (`load`, `save`, `get_config`, `apply_env_overrides`, `discover_config_path`). |
+| `CONFIG_SEARCH_PATHS` | The ordered search paths. |
 
-### `ConfigLoader` methods
+### `attune.config.unified` / `.sections` / `.validation` / `.env_compat`
 
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `__init__` | `config_path: str | Path | None = None` | `None` | Initialize the loader with an optional config path. |
-| `discover_config_path` | — | `Path | None` | Discover a config file from the standard search paths. |
-| `get_default_config_path` | — | `Path` | Return the default config file path. |
-| `get_config_path` | — | `Path | None` | Return the config path this loader was initialized with. |
-| `load` | — | `UnifiedConfig` | Load configuration from disk. |
-| `save` | `config: UnifiedConfig, path: Path | None = None` | `Path` | Save configuration to disk and return the written path. |
-| `apply_env_overrides` | `config: UnifiedConfig` | `UnifiedConfig` | Apply environment variable overrides to a config object. |
-| `get_config` | — | `UnifiedConfig` | Return the loaded configuration, loading it if necessary. |
-
-### `UnifiedAgentConfig` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `normalize_role` | `v: str` | `str` | Normalize a role string value. |
-| `get_model_id` | — | `str` | Return the model ID for this agent configuration. |
-| `for_book_production` | — | `BookProductionConfig` | Return a `BookProductionConfig` derived from this config. |
-
-### `UnifiedConfig` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `touch` | — | `None` | Mark the config as modified. |
-| `to_dict` | — | `dict` | Serialize the config to a dictionary. |
-| `from_dict` | `data: dict` | `UnifiedConfig` | Deserialize a config from a dictionary. |
-| `get_value` | `key: str` | `object` | Return the value for the given key. |
-| `set_value` | `key: str, value: object` | `None` | Set the value for the given key. |
-| `get_all_keys` | — | `list[str]` | Return all keys present in the config. |
-
-### `EmpathyXMLConfig` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `load_from_file` | `config_file: str = '.attune/config.json'` | `EmpathyXMLConfig` | Load configuration from a JSON file. |
-| `save_to_file` | `config_file: str = '.attune/config.json'` | `None` | Save configuration to a JSON file. |
-| `from_env` | — | `EmpathyXMLConfig` | Build configuration from environment variables. |
-
-### `ConfigValidator` methods
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `validate` | `config: UnifiedConfig` | `list[ValidationError]` | Validate a `UnifiedConfig` and return any errors found. |
-| `validate_section` | `section: Any, section_name: str` | `list[ValidationError]` | Validate a single config section and return any errors found. |
-
-### Section config methods
-
-Each of `AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`, `RoutingConfig`, `TelemetryConfig`, and `WorkflowConfig` exposes the following methods:
-
-| Method | Parameters | Returns | Description |
-|--------|------------|---------|-------------|
-| `to_dict` | — | `dict` | Serialize the section to a dictionary. |
-| `from_dict` | `data: dict` | *(section class)* | Deserialize the section from a dictionary. |
-
-## Functions
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `get_attune_env` | `name: str, default: str \| None = None` | `str \| None` | Get an environment variable, checking `ATTUNE_` first then `EMPATHY_` fallback. |
-| `iter_attune_env_prefix` | `prefix: str, suffix: str = ''` | `Iterator[tuple[str, str]]` | Yield `(middle_part, value)` for env vars matching `ATTUNE_{prefix}*{suffix}`. |
-| `get_loader` | — | `ConfigLoader` | Return the global `ConfigLoader` instance. |
-| `load_unified_config` | `path: str \| Path \| None = None` | `UnifiedConfig` | Load unified configuration from the given path, or discover it automatically. |
-| `save_unified_config` | `config: UnifiedConfig, path: str \| Path \| None = None` | `Path` | Save unified configuration to the given path and return the written path. |
-| `validate_config` | `config: UnifiedConfig` | `list[ValidationError]` | Validate a `UnifiedConfig` and return all validation errors. |
-| `get_config` | — | `EmpathyXMLConfig` | Return the global `EmpathyXMLConfig` instance. |
-| `set_config` | `config: EmpathyXMLConfig` | `None` | Replace the global `EmpathyXMLConfig` instance. |
-
-## Constants
-
-| Constant | Type | Values |
-|----------|------|--------|
-| `ENV_PREFIX` | `str` | `'ATTUNE_'` |
-| `CONFIG_SEARCH_PATHS` | `list` | `'./attune.config.json'`, `'~/.attune/config.json'`, `'~/.config/attune/config.json'` |
-
-## Source files
-
-- `src/attune/config/**`
-
-## Tags
-
-`config`, `settings`
+| Symbol | Purpose |
+|--------|---------|
+| `UnifiedConfig` | Modern config; sections + `get_value`/`set_value`/`get_all_keys`. |
+| `AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`, `RoutingConfig`, `TelemetryConfig`, `WorkflowConfig` | The seven sections. |
+| `validate_config(config) -> list[ValidationError]`, `ValidationError`, `ConfigValidator` | Validation. |
+| `get_attune_env(name, default=None)`, `iter_attune_env_prefix(prefix, suffix="")` | `ATTUNE_`/`EMPATHY_` env access. |

--- a/.help/templates/configuration/task.md
+++ b/.help/templates/configuration/task.md
@@ -3,129 +3,82 @@ type: task
 name: configuration-task
 feature: configuration
 depth: task
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Work with configuration
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-Use Attune's configuration system when you need to load, validate, override, or persist settings across environments without changing your source code.
+## Tasks
 
-## Prerequisites
+### Load and validate the unified config
 
-- Access to the project source code under `src/attune/config/`
-- Python environment with the Attune package installed
+**Goal:** get a typed `UnifiedConfig` and check it.
 
-## Load configuration
+**Steps:**
 
-1. **Load the unified config from disk.** Call `load_unified_config()` with an optional path. If you omit the path, the loader searches `./attune.config.json`, `~/.attune/config.json`, and `~/.config/attune/config.json` in order.
+```python
+from attune.config.loader import load_unified_config
+from attune.config.validation import validate_config
 
-   ```python
-   from attune.config.loader import load_unified_config
-
-   config = load_unified_config()          # auto-discover
-   config = load_unified_config("my.json") # explicit path
-   ```
-
-2. **Apply environment variable overrides.** Call `ConfigLoader.apply_env_overrides()` to layer `ATTUNE_`-prefixed environment variables on top of the loaded config. This happens automatically when you use `load_unified_config()`, but you can call it explicitly after manual edits.
-
-   ```python
-   from attune.config.loader import get_loader
-
-   loader = get_loader()
-   config = loader.get_config()  # loads and applies env overrides
-   ```
-
-3. **Read individual environment variables.** Use `get_attune_env()` when you need a single value. It checks `ATTUNE_<NAME>` first, then falls back to `EMPATHY_<NAME>`.
-
-   ```python
-   from attune.config.env_compat import get_attune_env
-
-   api_url = get_attune_env("API_URL", default="http://localhost")
-   ```
-
-## Read and write config values
-
-1. **Get a value by key.** Call `UnifiedConfig.get_value()` with the dot-separated key you want to inspect.
-
-   ```python
-   value = config.get_value("auth.token")
-   ```
-
-2. **List all available keys.** Call `config.get_all_keys()` to see every key the loaded config exposes.
-
-3. **Set a value.** Call `config.set_value()` to update a key in memory, then save the result.
-
-   ```python
-   config.set_value("telemetry.enabled", False)
-   ```
-
-4. **Save the updated config to disk.** Call `save_unified_config()`. The function returns the `Path` it wrote to.
-
-   ```python
-   from attune.config.loader import save_unified_config
-
-   written_path = save_unified_config(config)
-   print(f"Saved to {written_path}")
-   ```
-
-## Validate configuration
-
-1. **Run validation against the loaded config.** Call `validate_config()` and inspect the returned list. An empty list means validation passed.
-
-   ```python
-   from attune.config.validation import validate_config
-
-   errors = validate_config(config)
-   if errors:
-       for err in errors:
-           print(err)
-   ```
-
-2. **Fix any reported errors** before saving or passing the config to other components. Each `ValidationError` describes the field and constraint that failed.
-
-## Configure agents and book production
-
-1. **Build a `UnifiedAgentConfig`.** Set the `role`, `provider` (`Provider`), and `model_tier` (`ModelTier`) fields. Call `normalize_role()` to canonicalize the role string before use.
-
-2. **Derive a `BookProductionConfig`.** Call `UnifiedAgentConfig.for_book_production()` to get a pre-populated config with `model`, `max_tokens`, `temperature`, `timeout`, `retry_attempts`, and `retry_delay` properties ready for agent use.
-
-   ```python
-   from attune.config.agent_config import UnifiedAgentConfig, Provider, ModelTier
-
-   agent_cfg = UnifiedAgentConfig(role="editor", provider=Provider.OPENAI, model_tier=ModelTier.STANDARD)
-   book_cfg = agent_cfg.for_book_production()
-   print(book_cfg.model, book_cfg.max_tokens)
-   ```
-
-## Manage the global EmpathyXMLConfig
-
-1. **Load from a JSON file.** Call `EmpathyXMLConfig.load_from_file()`. The default path is `.attune/config.json`.
-
-   ```python
-   from attune.config.xml_config import EmpathyXMLConfig
-
-   cfg = EmpathyXMLConfig.load_from_file()
-   ```
-
-2. **Load from environment variables.** Call `EmpathyXMLConfig.from_env()` when no config file is present.
-
-3. **Set the global instance.** Call `set_config()` so that other components that call `get_config()` receive your updated config.
-
-   ```python
-   from attune.config import set_config
-   set_config(cfg)
-   ```
-
-4. **Save changes back to disk.** Call `cfg.save_to_file()` with an optional path.
-
-## Verify the task succeeded
-
-Run the configuration-related tests to confirm your changes load, validate, and save correctly:
-
-```bash
-pytest -k "configuration"
+cfg = load_unified_config()
+for err in validate_config(cfg):
+    print(err)
 ```
 
-A passing test run with no `ValidationError` objects returned by `validate_config()` confirms the configuration is well-formed. If you called `save_unified_config()`, check that the returned `Path` exists on disk and contains your updated values.
+**Verify:** `load_unified_config()` returns a `UnifiedConfig`;
+`validate_config(cfg)` returns a `list[ValidationError]` (empty when the
+config is valid).
+
+### Read or write a nested value by key path
+
+**Goal:** access a deeply nested field without walking sections.
+
+**Steps:**
+
+```python
+from attune.config.loader import load_unified_config
+
+cfg = load_unified_config()
+keys = cfg.get_all_keys()          # every settable key path
+value = cfg.get_value("routing.default_tier")
+cfg.set_value("routing.default_tier", "capable")
+```
+
+**Verify:** `get_all_keys()` lists the key paths; `get_value` /
+`set_value` read and write by dotted path.
+
+### Override config from the environment
+
+**Goal:** change a value without editing the file.
+
+**Steps:** set an `ATTUNE_`-prefixed variable (the loader applies it
+over the file value). `get_attune_env` also accepts the legacy
+`EMPATHY_` prefix as a fallback.
+
+```python
+from attune.config.env_compat import get_attune_env
+
+# reads ATTUNE_LOG_LEVEL, then EMPATHY_LOG_LEVEL, then the default
+level = get_attune_env("LOG_LEVEL", default="INFO")
+```
+
+**Verify:** `get_attune_env(name, default)` returns the `ATTUNE_`-
+prefixed value if set, else the `EMPATHY_`-prefixed value, else the
+default.
+
+### Load the legacy dataclass
+
+**Goal:** interoperate with code that still uses `AttuneConfig`.
+
+**Steps:**
+
+```python
+from attune.config import load_config
+
+cfg = load_config()                # -> AttuneConfig (== EmpathyConfig)
+```
+
+**Verify:** `load_config(filepath=None, use_env=True)` returns an
+`AttuneConfig`; it is the legacy dataclass, distinct from `UnifiedConfig`.

--- a/.help/templates/configuration/tip.md
+++ b/.help/templates/configuration/tip.md
@@ -3,19 +3,19 @@ type: tip
 name: configuration-tip
 feature: configuration
 depth: tip
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Tip: Use `load_unified_config()` as your entry point
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-Call `load_unified_config()` rather than constructing a `ConfigLoader` directly. It applies environment variable overrides automatically and searches the standard config paths (`./attune.config.json`, `~/.attune/config.json`, `~/.config/attune/config.json`) without you having to wire that logic yourself.
+## Notes & tips
 
-**Why:** `ConfigLoader.apply_env_overrides()` respects the `ATTUNE_` prefix and the `EMPATHY_` fallback — both of which you lose if you load a config file and skip that step.
-
-**Tradeoff:** `load_unified_config()` always resolves the path through `ConfigLoader.discover_config_path()`. If you need to load from an explicit, non-standard path in a test or script, pass that path directly: `load_unified_config(path="my/custom/config.json")`. In that case you still get override resolution, but path discovery is bypassed.
-
-**Reading environment variables directly?** Use `get_attune_env(name)` instead of `os.environ.get()`. It checks `ATTUNE_{name}` first and falls back to `EMPATHY_{name}`, which keeps your code consistent with how the loader itself reads the environment. To iterate a namespace of related variables, use `iter_attune_env_prefix(prefix)`.
-
-**Tags:** `config`, `settings`
+- **Prefer the unified tree for new code.** `UnifiedConfig` +
+  `load_unified_config` + `validate_config` is the modern path.
+- **`AttuneConfig` ≡ `EmpathyConfig`.** Same class, two names.
+- **`load_config` and `load_unified_config` differ.** Different return
+  types; pick one and stay consistent.
+- **Use `set_config()` for the XML config.** It swaps the global
+  instance other code reads.

--- a/.help/templates/configuration/troubleshooting.md
+++ b/.help/templates/configuration/troubleshooting.md
@@ -3,155 +3,35 @@ type: troubleshooting
 name: configuration-troubleshooting
 feature: configuration
 depth: troubleshooting
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Troubleshoot configuration
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-## Symptom table
+## Failure modes
 
-| If you observe | Check |
-|----------------|-------|
-| `AgentOperationError` raised during agent startup | The `operation` and `cause` fields on the exception — they name the failing step and its root cause |
-| Config values not reflecting environment variables | Whether you set `ATTUNE_` or `EMPATHY_` prefixes — `get_attune_env()` checks `ATTUNE_` first, then falls back to `EMPATHY_` |
-| `load_unified_config()` returns unexpected values | Whether a config file exists at one of the three search paths: `./attune.config.json`, `~/.attune/config.json`, or `~/.config/attune/config.json` |
-| `validate_config()` returns a non-empty list | Each `ValidationError` in the list — check `section_name` to isolate which config section is invalid |
-| `EmpathyXMLConfig.load_from_file()` fails | Whether `.attune/config.json` exists and is valid JSON; it's the default path |
-| Config changes not persisting | Whether you called `save_unified_config()` and that it wrote to the expected path (it returns the `Path` it saved to) |
-| `BookProductionConfig` properties returning wrong values | The underlying `UnifiedAgentConfig` — call `get_model_id()` directly to verify the model resolved correctly |
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `AttributeError` mixing the two configs | Treating a `UnifiedConfig` like an `AttuneConfig` (or vice versa) | They are different types — use one tree's API consistently | high |
+| Env override ignored | Variable not `ATTUNE_`/`EMPATHY_`-prefixed, or set after load | Prefix correctly; reload after setting | medium |
+| `validate_config` reports errors | A section value is out of range/invalid | Read each `ValidationError`; fix the named field | medium |
+| `get_value`/`set_value` `KeyError` | Key path not in `get_all_keys()` | List `get_all_keys()` first | low |
+| XML config changes not seen elsewhere | Replaced a local instance, not the global | Use `set_config()` to swap the global instance | medium |
 
-## Diagnose the problem
+### Risk areas
 
-### 1. Check which config file is being loaded
+- **Two return types.** `load_config` → `AttuneConfig`;
+  `load_unified_config` → `UnifiedConfig`. Don't cross their APIs.
+- **Env precedence.** `ATTUNE_` wins over `EMPATHY_` wins over file.
+- **Global XML config.** `get_config`/`set_config` operate on a shared
+  instance; a local `EmpathyXMLConfig(...)` is not the global one.
 
-`ConfigLoader.discover_config_path()` searches the three known locations in order. Confirm which file it finds — or whether it finds none — before assuming your edits took effect:
+### Diagnosis order
 
-```python
-from attune.config.loader import ConfigLoader
-
-path = ConfigLoader.discover_config_path()
-print(path)  # None means no file was found; defaults apply
-```
-
-If `path` is `None`, call `ConfigLoader.get_default_config_path()` to see where a new file would be written.
-
-### 2. Verify environment variable resolution
-
-`get_attune_env()` checks `ATTUNE_<name>` first and falls back to `EMPATHY_<name>`. If a value is not resolving as expected, print both candidates:
-
-```python
-import os
-name = "MY_VAR"
-print(os.environ.get(f"ATTUNE_{name}"))
-print(os.environ.get(f"EMPATHY_{name}"))
-```
-
-To inspect all variables under a prefix — for example, all routing overrides — use `iter_attune_env_prefix()`:
-
-```python
-from attune.config.env_compat import iter_attune_env_prefix
-
-for middle, value in iter_attune_env_prefix("ROUTING_"):
-    print(middle, value)
-```
-
-### 3. Run validation and read every error
-
-Call `validate_config()` on your loaded config and print the full list of `ValidationError` objects. Each error names the offending section:
-
-```python
-from attune.config.loader import load_unified_config
-from attune.config.validation import validate_config
-
-config = load_unified_config()
-errors = validate_config(config)
-for err in errors:
-    print(err)
-```
-
-Zero errors here rules out malformed config as the cause.
-
-### 4. Confirm environment overrides are applied
-
-`ConfigLoader.apply_env_overrides()` is a separate step from loading. If you load a config manually and skip this call, environment variables will not be reflected:
-
-```python
-from attune.config.loader import get_loader
-
-loader = get_loader()
-config = loader.load()
-config = loader.apply_env_overrides(config)
-```
-
-Use `load_unified_config()` instead of `loader.load()` directly if you want both steps handled for you.
-
-### 5. Inspect individual values and all known keys
-
-Use `UnifiedConfig.get_all_keys()` to enumerate every key the config object knows about, then `get_value()` to spot-check suspicious ones:
-
-```python
-config = load_unified_config()
-for key in config.get_all_keys():
-    print(key, config.get_value(key))
-```
-
-### 6. Run the configuration tests
-
-```bash
-pytest -k "config" -v
-```
-
-A failing test that exercises your code path is the fastest way to isolate whether the problem is in the config layer itself or in how it is called.
-
-## Common fixes
-
-**Missing or wrong config file path**
-Pass the path explicitly to avoid relying on discovery:
-
-```python
-from attune.config.loader import load_unified_config
-config = load_unified_config(path="/absolute/path/to/attune.config.json")
-```
-
-**Environment variable not picked up**
-Prefix your variable with `ATTUNE_` (preferred) or `EMPATHY_` (legacy fallback). Both are checked by `get_attune_env()`. Variables without either prefix are invisible to the config system.
-
-**Config saved to the wrong location**
-`save_unified_config()` returns the `Path` it actually wrote to. Capture and log it:
-
-```python
-from attune.config.loader import save_unified_config
-saved_path = save_unified_config(config)
-print(f"Saved to: {saved_path}")
-```
-
-**`EmpathyXMLConfig` not reflecting code changes**
-`get_config()` returns a global singleton. If you need to replace it in tests or after a reload, call `set_config()` explicitly with a new `EmpathyXMLConfig` instance. Otherwise the old instance persists for the lifetime of the process.
-
-**`BookProductionConfig` properties returning stale values**
-`BookProductionConfig` exposes `model`, `max_tokens`, `temperature`, `timeout`, `retry_attempts`, and `retry_delay` as computed properties derived from `UnifiedAgentConfig`. If any of these look wrong, inspect the parent config by calling `UnifiedAgentConfig.get_model_id()` and checking the `ModelTier` and `Provider` fields directly.
-
-**Validation errors in a specific section**
-Each config section (`AuthConfig`, `RoutingConfig`, `TelemetryConfig`, `AnalysisConfig`, `PersistenceConfig`, `EnvironmentConfig`, `WorkflowConfig`) exposes `to_dict()` and `from_dict()`. Round-trip the failing section to confirm it survives serialization:
-
-```python
-section_dict = config_section.to_dict()
-restored = type(config_section).from_dict(section_dict)
-```
-
-A mismatch between `section_dict` and the restored object identifies which field is not serializing correctly.
-
-**YAML not available**
-`YAML_AVAILABLE` is a module-level flag in `config`. If it is `False`, YAML-format config files will not load. Install PyYAML:
-
-```bash
-pip install pyyaml
-```
-
-## Source files
-
-- `src/attune/config/**`
-
-**Tags:** `config`, `settings`
+1. Which tree are you on? `type(cfg).__name__`.
+2. For the unified tree, `validate_config(cfg)` then read each error.
+3. For env issues, confirm the `ATTUNE_`/`EMPATHY_` prefix and load
+   order.
+4. For key-path issues, `cfg.get_all_keys()`.

--- a/.help/templates/configuration/warning.md
+++ b/.help/templates/configuration/warning.md
@@ -3,75 +3,35 @@ type: warning
 name: configuration-warning
 feature: configuration
 depth: warning
-generated_at: 2026-06-22T10:11:35.814147+00:00
-source_hash: 5e48805be1a999be45deb9a9c24e4965ca3ad0e741320a5c68a4675f40612ac8
+generated_at: 2026-06-24T01:14:11.680426+00:00
+source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
 status: generated
 ---
 
-# Configuration cautions
+# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
 
-## Risk areas
+## Failure modes
 
-### Silent fallback in `get_attune_env()` masks missing variables
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `AttributeError` mixing the two configs | Treating a `UnifiedConfig` like an `AttuneConfig` (or vice versa) | They are different types — use one tree's API consistently | high |
+| Env override ignored | Variable not `ATTUNE_`/`EMPATHY_`-prefixed, or set after load | Prefix correctly; reload after setting | medium |
+| `validate_config` reports errors | A section value is out of range/invalid | Read each `ValidationError`; fix the named field | medium |
+| `get_value`/`set_value` `KeyError` | Key path not in `get_all_keys()` | List `get_all_keys()` first | low |
+| XML config changes not seen elsewhere | Replaced a local instance, not the global | Use `set_config()` to swap the global instance | medium |
 
-`get_attune_env()` checks `ATTUNE_` prefixed variables first, then silently falls back to the legacy `EMPATHY_` prefix. If you rename an environment variable from `EMPATHY_*` to `ATTUNE_*` in one environment but not another, the function returns the stale `EMPATHY_` value without any warning. You will not see an error — just behavior driven by an outdated variable.
+### Risk areas
 
-**Mitigation:** After migrating variable names, explicitly verify that no `EMPATHY_` counterparts remain set in your environment. Search your shell configuration, CI secrets, and deployment manifests.
+- **Two return types.** `load_config` → `AttuneConfig`;
+  `load_unified_config` → `UnifiedConfig`. Don't cross their APIs.
+- **Env precedence.** `ATTUNE_` wins over `EMPATHY_` wins over file.
+- **Global XML config.** `get_config`/`set_config` operate on a shared
+  instance; a local `EmpathyXMLConfig(...)` is not the global one.
 
----
+### Diagnosis order
 
-### `get_loader()` returns a shared global instance
-
-`get_loader()` returns a single global `ConfigLoader` instance. Calling `ConfigLoader.apply_env_overrides()` or mutating the config through `set_value()` on that instance affects every caller in the same process. In tests, this means a configuration change in one test can leak into later tests.
-
-**Mitigation:** In test code, construct a separate `ConfigLoader` instance directly rather than using `get_loader()`. Reset any shared state explicitly between tests.
-
----
-
-### `load_unified_config()` path discovery can load an unexpected file
-
-When you call `load_unified_config()` without a `path` argument, `ConfigLoader.discover_config_path()` searches the following locations in order:
-
-- `./attune.config.json`
-- `~/.attune/config.json`
-- `~/.config/attune/config.json`
-
-If a file exists at a higher-priority path that you did not intend to use — for example, a leftover `./attune.config.json` in the working directory — it silently takes precedence over your user-level config. Behavior differs between environments without any error.
-
-**Mitigation:** Pass an explicit `path` argument to `load_unified_config()` in production code and CI scripts. Reserve path-discovery for interactive use only.
-
----
-
-### `save_unified_config()` overwrites without a backup
-
-`save_unified_config()` writes the `UnifiedConfig` to disk immediately. There is no built-in versioning, confirmation step, or rollback mechanism. Passing a partially constructed `UnifiedConfig` — for example, one where `validate_config()` returns `ValidationError` items — will overwrite a valid config file with invalid data.
-
-**Mitigation:** Call `validate_config(config)` and confirm the returned list is empty before calling `save_unified_config()`. Consider writing to a temporary path first and renaming only on success.
-
----
-
-### `iter_attune_env_prefix()` yields unexpected keys when the suffix is empty
-
-`iter_attune_env_prefix(prefix, suffix='')` matches any environment variable of the form `ATTUNE_{prefix}*{suffix}`. With the default empty suffix, this is a prefix-only match, so an environment that contains loosely named variables (for example, `ATTUNE_MODEL_EXTRA_DEBUG`) can produce unexpected entries alongside the ones you intended to iterate.
-
-**Mitigation:** Pass an explicit `suffix` when you need to narrow the match. Enumerate the yielded `(middle_part, value)` pairs in a log statement during development to confirm you are capturing exactly the variables you expect.
-
----
-
-### `set_config()` replaces the process-wide `EmpathyXMLConfig` instance
-
-`set_config()` overwrites the global `EmpathyXMLConfig` returned by every subsequent call to `get_config()`. Calling it mid-request or during concurrent operations leaves part of the call graph using the old config and part using the new one, with no coordination between them.
-
-**Mitigation:** Call `set_config()` only during application startup, before any concurrent work begins. Treat the global config as immutable after that point.
-
----
-
-## How to avoid problems
-
-1. **Validate before saving.** Call `validate_config(config)` and check that it returns an empty list before persisting changes with `save_unified_config()`.
-
-2. **Isolate global state in tests.** Avoid `get_loader()` and `get_config()` in test code. Instantiate `ConfigLoader` directly and pass config objects explicitly to keep tests independent.
-
-3. **Prefer explicit paths in automation.** Supply a `path` argument to `load_unified_config()` and `save_unified_config()` in scripts and CI pipelines so the file being read or written is always unambiguous.
-
-4. **Depend only on the public API.** Names starting with `_` — such as `_validate_file_path` — can change without notice. Use the exported names listed in `__all__` instead.
+1. Which tree are you on? `type(cfg).__name__`.
+2. For the unified tree, `validate_config(cfg)` then read each error.
+3. For env issues, confirm the `ATTUNE_`/`EMPATHY_` prefix and load
+   order.
+4. For key-path issues, `cfg.get_all_keys()`.

--- a/content/features/configuration.md
+++ b/content/features/configuration.md
@@ -1,0 +1,304 @@
+---
+feature: configuration
+summary: Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
+tags: [config, settings]
+source_globs:
+  - src/attune/config/**
+nav:
+  help: configuration
+  mkdocs:
+    how-to: how-to/configuration
+    architecture: architecture/configuration
+    reference: reference/configuration
+---
+
+## Overview
+
+Attune's configuration lives under `attune.config` and is **layered** —
+several typed systems that serve different parts of the framework. The
+one most code reaches for is the **unified config tree**; alongside it
+are an **agent config** layer, an **XML/empathy config** layer, and a
+**legacy dataclass** kept for backward compatibility.
+
+The four layers, and when each matters:
+
+- **Unified application config** — `UnifiedConfig` (`config.unified`)
+  organized into named sections (`config.sections`), loaded and saved by
+  `ConfigLoader` / `load_unified_config` (`config.loader`) and checked by
+  `validate_config` (`config.validation`). This is the modern structured
+  config.
+- **Agent config** — `UnifiedAgentConfig` and `BookProductionConfig`
+  (`config.agent_config`), constrained by the `ModelTier`, `Provider`,
+  and `WorkflowMode` enums — the runtime behavior of LLM-backed agents.
+- **XML/empathy config** — `EmpathyXMLConfig`, the global instance read
+  and replaced via `get_config()` / `set_config()`, with sub-objects
+  `XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`,
+  `MetricsConfig`.
+- **Legacy dataclass** — `AttuneConfig` (aliased as `EmpathyConfig`),
+  loaded by `load_config()`. Kept for backward compatibility; new code
+  should prefer the unified tree.
+
+## Concepts
+
+### The unified config tree
+
+`UnifiedConfig` is the modern config object. It holds seven typed
+sections — `analysis`, `auth`, `environment`, `persistence`, `routing`,
+`telemetry`, `workflows` (the classes in `config.sections`:
+`AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`,
+`RoutingConfig`, `TelemetryConfig`, `WorkflowConfig`). Each section
+round-trips through `to_dict` / `from_dict`. `UnifiedConfig` adds
+key-path access — `get_value`, `set_value`, `get_all_keys` — for reading
+or writing a nested field by name.
+
+`ConfigLoader` (`config.loader`) orchestrates loading and saving;
+`load_unified_config(path=None)` is the convenience entry. The loader
+searches `CONFIG_SEARCH_PATHS` (`./attune.config.json`,
+`~/.attune/config.json`, `~/.config/attune/config.json`), deserializes
+into a `UnifiedConfig`, and applies environment overrides. Env variables
+take precedence: `get_attune_env` (`config.env_compat`) reads
+`ATTUNE_`-prefixed variables first and falls back to the legacy
+`EMPATHY_` prefix, so a project migrating prefixes need not update its
+environment immediately.
+
+`validate_config(config)` (`config.validation`) returns a list of
+`ValidationError` for a `UnifiedConfig`; `ConfigValidator` lets you
+validate a single section.
+
+### Agent config
+
+`UnifiedAgentConfig` (`config.agent_config`) models how LLM-backed
+agents run. `BookProductionConfig` is a backward-compatible view exposing
+properties like `model`, `max_tokens`, `temperature`, `timeout`. The
+enums `ModelTier`, `Provider`, and `WorkflowMode` constrain the values
+callers may supply, catching bad input before it reaches an API call.
+
+### The XML/empathy config layer
+
+`EmpathyXMLConfig` is a separate global config used by the empathy
+subsystem. Load it with `EmpathyXMLConfig.load_from_file(config_file=
+".attune/config.json")` or `EmpathyXMLConfig.from_env()`; the
+module-level `get_config()` / `set_config()` read or replace the active
+instance without holding a direct reference. Its sub-objects —
+`XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`,
+`MetricsConfig` — cover rendering, optimization hints, i18n, and metrics.
+
+### The legacy dataclass
+
+`AttuneConfig` (exported also as `EmpathyConfig` — the same class) is the
+older empathy-era dataclass. `load_config(filepath=None, use_env=True)`
+returns one. It carries `from_yaml` / `to_yaml` / `from_env` /
+`validate`. New code should prefer the unified tree; this remains for
+back-compat.
+
+## Quickstart
+
+Load the unified config and validate it:
+
+```python
+from attune.config.loader import load_unified_config
+from attune.config.validation import validate_config
+
+cfg = load_unified_config()        # searches CONFIG_SEARCH_PATHS
+errors = validate_config(cfg)
+print(type(cfg).__name__, "with", len(errors), "validation error(s)")
+print(cfg.routing.to_dict())
+```
+
+## Tasks
+
+### Load and validate the unified config
+
+**Goal:** get a typed `UnifiedConfig` and check it.
+
+**Steps:**
+
+```python
+from attune.config.loader import load_unified_config
+from attune.config.validation import validate_config
+
+cfg = load_unified_config()
+for err in validate_config(cfg):
+    print(err)
+```
+
+**Verify:** `load_unified_config()` returns a `UnifiedConfig`;
+`validate_config(cfg)` returns a `list[ValidationError]` (empty when the
+config is valid).
+
+### Read or write a nested value by key path
+
+**Goal:** access a deeply nested field without walking sections.
+
+**Steps:**
+
+```python
+from attune.config.loader import load_unified_config
+
+cfg = load_unified_config()
+keys = cfg.get_all_keys()          # every settable key path
+value = cfg.get_value("routing.default_tier")
+cfg.set_value("routing.default_tier", "capable")
+```
+
+**Verify:** `get_all_keys()` lists the key paths; `get_value` /
+`set_value` read and write by dotted path.
+
+### Override config from the environment
+
+**Goal:** change a value without editing the file.
+
+**Steps:** set an `ATTUNE_`-prefixed variable (the loader applies it
+over the file value). `get_attune_env` also accepts the legacy
+`EMPATHY_` prefix as a fallback.
+
+```python
+from attune.config.env_compat import get_attune_env
+
+# reads ATTUNE_LOG_LEVEL, then EMPATHY_LOG_LEVEL, then the default
+level = get_attune_env("LOG_LEVEL", default="INFO")
+```
+
+**Verify:** `get_attune_env(name, default)` returns the `ATTUNE_`-
+prefixed value if set, else the `EMPATHY_`-prefixed value, else the
+default.
+
+### Load the legacy dataclass
+
+**Goal:** interoperate with code that still uses `AttuneConfig`.
+
+**Steps:**
+
+```python
+from attune.config import load_config
+
+cfg = load_config()                # -> AttuneConfig (== EmpathyConfig)
+```
+
+**Verify:** `load_config(filepath=None, use_env=True)` returns an
+`AttuneConfig`; it is the legacy dataclass, distinct from `UnifiedConfig`.
+
+## Reference
+
+### `attune.config` (package top level)
+
+| Symbol | Purpose |
+|--------|---------|
+| `load_config(filepath=None, use_env=True) -> AttuneConfig` | Load the legacy dataclass. |
+| `AttuneConfig` / `EmpathyConfig` | The legacy config dataclass (same class). |
+| `get_config() -> EmpathyXMLConfig` / `set_config(config)` | Read/replace the global XML/empathy config. |
+| `EmpathyXMLConfig`, `XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`, `MetricsConfig` | XML/empathy config + sub-objects. |
+| `UnifiedAgentConfig`, `BookProductionConfig` | Agent config. |
+| `ModelTier`, `Provider`, `WorkflowMode` | Agent config enums. |
+| `RedisConfig` | Redis section. |
+
+### `attune.config.loader`
+
+| Symbol | Purpose |
+|--------|---------|
+| `load_unified_config(path=None) -> UnifiedConfig` | Load the unified tree. |
+| `save_unified_config(...)` | Persist a `UnifiedConfig`. |
+| `ConfigLoader` | Loader class (`load`, `save`, `get_config`, `apply_env_overrides`, `discover_config_path`). |
+| `CONFIG_SEARCH_PATHS` | The ordered search paths. |
+
+### `attune.config.unified` / `.sections` / `.validation` / `.env_compat`
+
+| Symbol | Purpose |
+|--------|---------|
+| `UnifiedConfig` | Modern config; sections + `get_value`/`set_value`/`get_all_keys`. |
+| `AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`, `RoutingConfig`, `TelemetryConfig`, `WorkflowConfig` | The seven sections. |
+| `validate_config(config) -> list[ValidationError]`, `ValidationError`, `ConfigValidator` | Validation. |
+| `get_attune_env(name, default=None)`, `iter_attune_env_prefix(prefix, suffix="")` | `ATTUNE_`/`EMPATHY_` env access. |
+
+## Comparison
+
+Four layers, distinct jobs:
+
+| | Unified config | Agent config | XML/empathy config | Legacy dataclass |
+|--|----------------|--------------|--------------------|------------------|
+| Class | `UnifiedConfig` | `UnifiedAgentConfig` | `EmpathyXMLConfig` | `AttuneConfig` |
+| Entry | `load_unified_config()` | construct / `for_book_production` | `get_config()` | `load_config()` |
+| Scope | App-wide sections | LLM agent runtime | Empathy subsystem | Back-compat |
+| Status | Modern (preferred) | Active | Active (subsystem) | Legacy |
+
+`load_config()` and `load_unified_config()` return **different types**
+(`AttuneConfig` vs `UnifiedConfig`) — they are not interchangeable.
+
+## Failure modes
+
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `AttributeError` mixing the two configs | Treating a `UnifiedConfig` like an `AttuneConfig` (or vice versa) | They are different types — use one tree's API consistently | high |
+| Env override ignored | Variable not `ATTUNE_`/`EMPATHY_`-prefixed, or set after load | Prefix correctly; reload after setting | medium |
+| `validate_config` reports errors | A section value is out of range/invalid | Read each `ValidationError`; fix the named field | medium |
+| `get_value`/`set_value` `KeyError` | Key path not in `get_all_keys()` | List `get_all_keys()` first | low |
+| XML config changes not seen elsewhere | Replaced a local instance, not the global | Use `set_config()` to swap the global instance | medium |
+
+### Risk areas
+
+- **Two return types.** `load_config` → `AttuneConfig`;
+  `load_unified_config` → `UnifiedConfig`. Don't cross their APIs.
+- **Env precedence.** `ATTUNE_` wins over `EMPATHY_` wins over file.
+- **Global XML config.** `get_config`/`set_config` operate on a shared
+  instance; a local `EmpathyXMLConfig(...)` is not the global one.
+
+### Diagnosis order
+
+1. Which tree are you on? `type(cfg).__name__`.
+2. For the unified tree, `validate_config(cfg)` then read each error.
+3. For env issues, confirm the `ATTUNE_`/`EMPATHY_` prefix and load
+   order.
+4. For key-path issues, `cfg.get_all_keys()`.
+
+## FAQ seeds
+
+> **Channel-4 input, not a rendered FAQ.** Author-curated seed
+> questions, merged by the FAQ Generator with unmatched queries,
+> telemetry, and issues. Not projected verbatim.
+
+- **Q:** Which config should I use?
+  **A:** The unified tree — `load_unified_config()` → `UnifiedConfig`
+  with typed sections. `AttuneConfig`/`load_config()` is the legacy
+  dataclass; `EmpathyXMLConfig` (`get_config()`) is the empathy
+  subsystem's config.
+- **Q:** Why are there `AttuneConfig` and `EmpathyConfig`?
+  **A:** They are the **same class** — `EmpathyConfig` is an alias of
+  `AttuneConfig` (the legacy dataclass).
+- **Q:** How do environment overrides work?
+  **A:** `ATTUNE_`-prefixed variables override file values; the legacy
+  `EMPATHY_` prefix is honored as a fallback (`get_attune_env`).
+- **Q:** Where does config load from?
+  **A:** `CONFIG_SEARCH_PATHS` — `./attune.config.json`,
+  `~/.attune/config.json`, `~/.config/attune/config.json`.
+
+## Notes & tips
+
+- **Prefer the unified tree for new code.** `UnifiedConfig` +
+  `load_unified_config` + `validate_config` is the modern path.
+- **`AttuneConfig` ≡ `EmpathyConfig`.** Same class, two names.
+- **`load_config` and `load_unified_config` differ.** Different return
+  types; pick one and stay consistent.
+- **Use `set_config()` for the XML config.** It swaps the global
+  instance other code reads.
+
+## Design & extension
+
+### Design decisions
+
+- **Sectioned unified config.** Splitting `UnifiedConfig` into typed
+  sections keeps each concern cohesive and round-trippable via
+  `to_dict`/`from_dict`.
+- **Env compatibility shim.** `get_attune_env` honors both `ATTUNE_`
+  and legacy `EMPATHY_` prefixes so prefix migration is non-breaking.
+- **Layers, not one config.** Agent config, the XML/empathy config, and
+  the legacy dataclass coexist deliberately — each serves a subsystem;
+  the unified tree is the modern front door.
+
+### Extension points
+
+- **Add a setting:** extend the relevant `config.sections` dataclass
+  (it gets `to_dict`/`from_dict` round-tripping and key-path access).
+- **Custom validation:** add to `config.validation` /
+  `ConfigValidator`.
+- **New env override:** read it via `get_attune_env` /
+  `iter_attune_env_prefix`.

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -1,14 +1,4 @@
----
-type: note
-name: configuration-note
-feature: configuration
-depth: note
-generated_at: 2026-06-24T01:14:11.680426+00:00
-source_hash: 7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1
-status: generated
----
-
-# Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
+# Configuration
 
 ## Overview
 
@@ -89,12 +79,26 @@ returns one. It carries `from_yaml` / `to_yaml` / `from_env` /
 `validate`. New code should prefer the unified tree; this remains for
 back-compat.
 
-## Notes & tips
+## Design & extension
 
-- **Prefer the unified tree for new code.** `UnifiedConfig` +
-  `load_unified_config` + `validate_config` is the modern path.
-- **`AttuneConfig` ≡ `EmpathyConfig`.** Same class, two names.
-- **`load_config` and `load_unified_config` differ.** Different return
-  types; pick one and stay consistent.
-- **Use `set_config()` for the XML config.** It swaps the global
-  instance other code reads.
+### Design decisions
+
+- **Sectioned unified config.** Splitting `UnifiedConfig` into typed
+  sections keeps each concern cohesive and round-trippable via
+  `to_dict`/`from_dict`.
+- **Env compatibility shim.** `get_attune_env` honors both `ATTUNE_`
+  and legacy `EMPATHY_` prefixes so prefix migration is non-breaking.
+- **Layers, not one config.** Agent config, the XML/empathy config, and
+  the legacy dataclass coexist deliberately — each serves a subsystem;
+  the unified tree is the modern front door.
+
+### Extension points
+
+- **Add a setting:** extend the relevant `config.sections` dataclass
+  (it gets `to_dict`/`from_dict` round-tripping and key-path access).
+- **Custom validation:** add to `config.validation` /
+  `ConfigValidator`.
+- **New env override:** read it via `get_attune_env` /
+  `iter_attune_env_prefix`.
+
+<!-- attune-generated: source_hash=7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1 feature=configuration kind=architecture generated_at=2026-06-24 -->

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -1,0 +1,27 @@
+# Configuration
+
+Layered configuration — the unified config tree, agent config, and the XML/empathy config layer
+
+!!! tip "Start here"
+
+    [How-to guide](../how-to/configuration.md) — task recipes for common goals.
+
+<div class="grid cards" markdown>
+
+-   __Reference__
+
+    ---
+
+    The full API and option reference.
+
+    [Open the reference](../reference/configuration.md)
+
+-   __Architecture__
+
+    ---
+
+    How it works and how to extend it.
+
+    [Open the architecture](../architecture/configuration.md)
+
+</div>

--- a/docs/how-to/configuration.md
+++ b/docs/how-to/configuration.md
@@ -1,0 +1,122 @@
+# Configuration
+
+## Quickstart
+
+Load the unified config and validate it:
+
+```python
+from attune.config.loader import load_unified_config
+from attune.config.validation import validate_config
+
+cfg = load_unified_config()        # searches CONFIG_SEARCH_PATHS
+errors = validate_config(cfg)
+print(type(cfg).__name__, "with", len(errors), "validation error(s)")
+print(cfg.routing.to_dict())
+```
+
+## Tasks
+
+### Load and validate the unified config
+
+**Goal:** get a typed `UnifiedConfig` and check it.
+
+**Steps:**
+
+```python
+from attune.config.loader import load_unified_config
+from attune.config.validation import validate_config
+
+cfg = load_unified_config()
+for err in validate_config(cfg):
+    print(err)
+```
+
+**Verify:** `load_unified_config()` returns a `UnifiedConfig`;
+`validate_config(cfg)` returns a `list[ValidationError]` (empty when the
+config is valid).
+
+### Read or write a nested value by key path
+
+**Goal:** access a deeply nested field without walking sections.
+
+**Steps:**
+
+```python
+from attune.config.loader import load_unified_config
+
+cfg = load_unified_config()
+keys = cfg.get_all_keys()          # every settable key path
+value = cfg.get_value("routing.default_tier")
+cfg.set_value("routing.default_tier", "capable")
+```
+
+**Verify:** `get_all_keys()` lists the key paths; `get_value` /
+`set_value` read and write by dotted path.
+
+### Override config from the environment
+
+**Goal:** change a value without editing the file.
+
+**Steps:** set an `ATTUNE_`-prefixed variable (the loader applies it
+over the file value). `get_attune_env` also accepts the legacy
+`EMPATHY_` prefix as a fallback.
+
+```python
+from attune.config.env_compat import get_attune_env
+
+# reads ATTUNE_LOG_LEVEL, then EMPATHY_LOG_LEVEL, then the default
+level = get_attune_env("LOG_LEVEL", default="INFO")
+```
+
+**Verify:** `get_attune_env(name, default)` returns the `ATTUNE_`-
+prefixed value if set, else the `EMPATHY_`-prefixed value, else the
+default.
+
+### Load the legacy dataclass
+
+**Goal:** interoperate with code that still uses `AttuneConfig`.
+
+**Steps:**
+
+```python
+from attune.config import load_config
+
+cfg = load_config()                # -> AttuneConfig (== EmpathyConfig)
+```
+
+**Verify:** `load_config(filepath=None, use_env=True)` returns an
+`AttuneConfig`; it is the legacy dataclass, distinct from `UnifiedConfig`.
+
+## Reference
+
+### `attune.config` (package top level)
+
+| Symbol | Purpose |
+|--------|---------|
+| `load_config(filepath=None, use_env=True) -> AttuneConfig` | Load the legacy dataclass. |
+| `AttuneConfig` / `EmpathyConfig` | The legacy config dataclass (same class). |
+| `get_config() -> EmpathyXMLConfig` / `set_config(config)` | Read/replace the global XML/empathy config. |
+| `EmpathyXMLConfig`, `XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`, `MetricsConfig` | XML/empathy config + sub-objects. |
+| `UnifiedAgentConfig`, `BookProductionConfig` | Agent config. |
+| `ModelTier`, `Provider`, `WorkflowMode` | Agent config enums. |
+| `RedisConfig` | Redis section. |
+
+### `attune.config.loader`
+
+| Symbol | Purpose |
+|--------|---------|
+| `load_unified_config(path=None) -> UnifiedConfig` | Load the unified tree. |
+| `save_unified_config(...)` | Persist a `UnifiedConfig`. |
+| `ConfigLoader` | Loader class (`load`, `save`, `get_config`, `apply_env_overrides`, `discover_config_path`). |
+| `CONFIG_SEARCH_PATHS` | The ordered search paths. |
+
+### `attune.config.unified` / `.sections` / `.validation` / `.env_compat`
+
+| Symbol | Purpose |
+|--------|---------|
+| `UnifiedConfig` | Modern config; sections + `get_value`/`set_value`/`get_all_keys`. |
+| `AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`, `RoutingConfig`, `TelemetryConfig`, `WorkflowConfig` | The seven sections. |
+| `validate_config(config) -> list[ValidationError]`, `ValidationError`, `ConfigValidator` | Validation. |
+| `get_attune_env(name, default=None)`, `iter_attune_env_prefix(prefix, suffix="")` | `ATTUNE_`/`EMPATHY_` env access. |
+
+<!-- attune-generated: source_hash=7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1 feature=configuration kind=how-to generated_at=2026-06-24 -->

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,81 +1,35 @@
----
-description: Configure Attune AI with Python, YAML, JSON, or environment variables. Flexible configuration with validation and defaults.
----
-
 # Configuration
 
-Learn how to configure the Attune AI for your needs.
+## Reference
 
-## Configuration Methods
+### `attune.config` (package top level)
 
-### 1. Direct Instantiation
+| Symbol | Purpose |
+|--------|---------|
+| `load_config(filepath=None, use_env=True) -> AttuneConfig` | Load the legacy dataclass. |
+| `AttuneConfig` / `EmpathyConfig` | The legacy config dataclass (same class). |
+| `get_config() -> EmpathyXMLConfig` / `set_config(config)` | Read/replace the global XML/empathy config. |
+| `EmpathyXMLConfig`, `XMLConfig`, `OptimizationConfig`, `AdaptiveConfig`, `I18nConfig`, `MetricsConfig` | XML/empathy config + sub-objects. |
+| `UnifiedAgentConfig`, `BookProductionConfig` | Agent config. |
+| `ModelTier`, `Provider`, `WorkflowMode` | Agent config enums. |
+| `RedisConfig` | Redis section. |
 
-```python
-from attune import EmpathyOS
+### `attune.config.loader`
 
-empathy = EmpathyOS(
-    user_id="user_123",
-    target_level=4,
-    confidence_threshold=0.75,
-    persistence_enabled=True
-)
-```
+| Symbol | Purpose |
+|--------|---------|
+| `load_unified_config(path=None) -> UnifiedConfig` | Load the unified tree. |
+| `save_unified_config(...)` | Persist a `UnifiedConfig`. |
+| `ConfigLoader` | Loader class (`load`, `save`, `get_config`, `apply_env_overrides`, `discover_config_path`). |
+| `CONFIG_SEARCH_PATHS` | The ordered search paths. |
 
-### 2. YAML Configuration File
+### `attune.config.unified` / `.sections` / `.validation` / `.env_compat`
 
-Create `empathy.config.yml`:
+| Symbol | Purpose |
+|--------|---------|
+| `UnifiedConfig` | Modern config; sections + `get_value`/`set_value`/`get_all_keys`. |
+| `AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`, `PersistenceConfig`, `RoutingConfig`, `TelemetryConfig`, `WorkflowConfig` | The seven sections. |
+| `validate_config(config) -> list[ValidationError]`, `ValidationError`, `ConfigValidator` | Validation. |
+| `get_attune_env(name, default=None)`, `iter_attune_env_prefix(prefix, suffix="")` | `ATTUNE_`/`EMPATHY_` env access. |
 
-```yaml
-user_id: "user_123"
-target_level: 4
-confidence_threshold: 0.75
-persistence_enabled: true
-persistence_backend: "sqlite"
-persistence_path: ".attune"
-```
-
-Load it:
-
-```python
-from attune import load_config
-
-config = load_config(filepath="empathy.config.yml")
-empathy = EmpathyOS.from_config(config)
-```
-
-### 3. Environment Variables
-
-```bash
-export ATTUNE_USER_ID="user_123"
-export ATTUNE_TARGET_LEVEL=4
-export ATTUNE_CONFIDENCE_THRESHOLD=0.75
-```
-
-## Configuration Options
-
-### Core Settings
-
-- `user_id` (str): Unique user identifier
-- `target_level` (int): Target empathy level (1-5)
-- `confidence_threshold` (float): Minimum confidence for predictions (0.0-1.0)
-
-### Trust Settings
-
-- `trust_building_rate` (float): How fast trust increases (default: 0.05)
-- `trust_erosion_rate` (float): How fast trust decreases on failures (default: 0.10)
-
-### Persistence Settings
-
-- `persistence_enabled` (bool): Enable pattern storage (default: True)
-- `persistence_backend` (str): Backend type ("sqlite", "postgresql")
-- `persistence_path` (str): Storage location (default: ".attune")
-
-### Metrics Settings
-
-- `metrics_enabled` (bool): Enable metrics collection (default: True)
-- `metrics_path` (str): Metrics storage location
-
-## Next Steps
-
-- **[Examples](../tutorials/examples/simple-chatbot.md)**: See configuration in action
-- **[API Reference](../reference/empathy-os.md)**: Complete API documentation
+<!-- attune-generated: source_hash=7359a1b70578c0d83b0fc6af405ebd38e3949c66a7f64b303c05e961504871c1 feature=configuration kind=reference generated_at=2026-06-24 -->


### PR DESCRIPTION
Feature 2 of 9. Authors `content/features/configuration.md` → 14 projected outputs.

**Notable:** the `configuration` feature spans **four** overlapping config layers — unified tree (`UnifiedConfig`+sections+loader+validation), agent config (`UnifiedAgentConfig`), XML/empathy (`EmpathyXMLConfig` via `get_config`/`set_config`), and the legacy `AttuneConfig`(≡`EmpathyConfig`) dataclass via `load_config`. `load_config` and `load_unified_config` return **different types**.

**Bug surfaced & fixed:** the prior generated concept doc mis-attributed `config.loader` symbols (`ConfigLoader`/`load_unified_config`/`CONFIG_SEARCH_PATHS`) to `config.unified`, and treated `ConfigLoader` methods as module functions. Corrected. **Adversarial review: CLEAN** (0 false / 0 misleading; all examples run).

faq frozen `status:manual` (was already accurate — preserved).

**Gates:** dry-run 0 · example gate 0 · golden+manifest green · `mkdocs --strict` exit 0 · full `tests/unit/help/` **408 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)