### PR TITLE
docs(help): single-source plugin via projector (Tier-3 7/9)

### DIFF
--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -303,12 +303,19 @@ features:
     tags: [telemetry, metrics]
     status: manual
 
+  # plugin is single-sourced (status: manual) from
+  # content/features/plugin.md and rendered by
+  # attune_author.projector (scripts/project_features.py), which owns
+  # .help/templates/plugin/*.md. The entry is retained — WITHOUT
+  # `files:`/`arch_path:` and marked `status: manual` — so topic
+  # resolution still routes here while staleness/maintenance never runs
+  # the LLM generator to overwrite the projected content (DD5,
+  # help-docs-single-source decision, 2026-06-24). The retained faq.md
+  # stays on disk frozen as a manual file.
   plugin:
     description: Claude Code plugin — skills, hooks, commands, and MCP config
-    files:
-      - plugin/**
     tags: [plugin, claude-code]
-    arch_path: docs/architecture/plugin-system.md
+    status: manual
 
   # spec-engine is single-sourced (status: manual) from
   # content/features/spec-engine.md and rendered by

--- a/.help/templates/plugin/comparison.md
+++ b/.help/templates/plugin/comparison.md
@@ -3,58 +3,23 @@ type: comparison
 name: plugin-comparison
 feature: plugin
 depth: comparison
-generated_at: 2026-06-10T07:07:04.688941+00:00
-source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
 status: generated
 ---
 
-# Comparison: Plugin hooks vs direct scripting
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-## Context
+## Comparison
 
-The attune Claude Code plugin ships a suite of lifecycle hooks — session continuity, security validation, spec orientation, transcript monitoring, and formatting. Each hook exposes a `main()` entry point and shares state helpers from `hooks._state`. The question this page answers: **should you wire up the plugin hooks, or solve the problem with a standalone script?**
+The plugin is the **packaging surface**; the things it ships are
+separate features:
 
-## Feature comparison
+| | plugin | mcp-server | hooks |
+|--|--------|------------|-------|
+| Role | The installable bundle (manifest + components) | One bundled component — the MCP tool server | One bundled component — lifecycle hook scripts |
+| Artifact | `plugin/` + `plugin.json` / `marketplace.json` | `python -m attune.mcp.server` + `.mcp.json` | `hooks/hooks.json` + scripts |
+| Documented by | This page | mcp-server feature | hooks feature |
 
-| Capability | Plugin hooks | Standalone script |
-|---|---|---|
-| **Session continuity** | `session_recall.main()`, `session_stash.main()` handle sentinel creation, pruning, and resume-prompt rendering automatically | You implement sentinel logic from scratch; no TTL pruning |
-| **Resume prompt quality** | `build_resume_prompt()` is the single source of truth for prompt format, incorporating `SpecInfo` and `GitState` | You assemble the prompt manually; format drifts from the canonical shape |
-| **Spec discovery** | `discover_specs(roots)` walks `specs/` and `docs/specs/` subdirectories and returns typed `SpecInfo` objects | You write your own directory walker with no `effective_status` or `status_conflict` resolution |
-| **Git state snapshot** | `git_state(cwd)` returns a `GitState` with `branch`, `last_sha`, `last_subject`, and `uncommitted` files in one call | You shell out to git and parse output yourself |
-| **Transcript monitoring** | `estimate_utilization(transcript_path)` returns a `[0.0, 1.0]` float; `format_warning()` composes the user-facing alert | You approximate token load without a calibrated utilization curve |
-| **Security validation** | `validate_bash_command()` and `validate_file_path()` check against `SYSTEM_DIRECTORIES` and `SEARCH_COMMAND_PREFIXES` | You maintain your own allowlist/blocklist |
-| **Spec orientation** | `format_orientation()` and `render_spec_pin()` render context-aware spec summaries with a configurable `char_budget` | You write and maintain your own rendering logic |
-| **JIT recall** | `jit_recall.main()` fires per-session recall with sentinel deduplication via `_SENTINEL_PREFIX` | No deduplication; you re-fire on every invocation |
-| **Stale sentinel cleanup** | `prune_stale_sentinels(now)` removes expired files automatically | Manual cleanup or accumulating sentinel files |
-| **Entry-point contract** | All hooks return `int` (0 on success) or `None`; never raises | Contract is whatever you write |
-
-## Key tradeoffs
-
-**Plugin hooks are more constrained, on purpose.** Each hook does one thing and exposes a narrow surface. If you need to combine `git_state()` with `discover_specs()` in a way the hooks don't anticipate, you call those functions directly from `hooks._state` — the helpers are public.
-
-**Standalone scripts are faster to prototype but slower to maintain.** You avoid the hook wiring overhead, but you re-implement state discovery, sentinel logic, and prompt formatting that the plugin already handles correctly. Once your script grows beyond ~50 lines of state manipulation, you are reimplementing the plugin.
-
-**Security validation is non-trivial to get right.** `validate_bash_command()` and `validate_file_path()` encode specific rules about `SYSTEM_DIRECTORIES` and `SEARCH_COMMAND_PREFIXES`. A standalone script that skips these checks is not equivalent — it is less safe.
-
-## Use plugin hooks when…
-
-- You are hooking into Claude Code lifecycle events (session start/end, post-commit, pre-save, error, compact warning).
-- You need reliable resume prompts that stay consistent with `build_resume_prompt()` as the canonical format.
-- You want spec-aware orientation (`spec_orient`) or JIT recall without writing your own discovery and deduplication logic.
-- Security validation of bash commands or file paths is in scope — use `validate_bash_command()` and `validate_file_path()` rather than rolling your own.
-- You need transcript utilization monitoring via `estimate_utilization()`.
-
-## Use a standalone script when…
-
-- You need a one-off automation that touches none of the session, spec, or git state the hooks manage.
-- You are prototyping behavior before deciding whether it belongs in a hook at all.
-- Your logic genuinely doesn't fit any of the hook entry points and you don't need the shared state infrastructure.
-
-In practice, most persistent Claude Code workflow automation belongs in a hook. Standalone scripts are the right starting point, not the right finishing point.
-
-## Source files
-
-- `plugin/**`
-
-**Tags:** `plugin`, `claude-code`
+The plugin is the box; mcp-server and hooks are two of the things
+inside it. Install the box and Claude Code unpacks every component.

--- a/.help/templates/plugin/error.md
+++ b/.help/templates/plugin/error.md
@@ -3,60 +3,42 @@ type: error
 name: plugin-error
 feature: plugin
 depth: error
-generated_at: 2026-06-10T07:07:04.668091+00:00
-source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
 status: generated
 ---
 
-# Plugin errors
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-## Common error signatures
+## Failure modes
 
-Errors in the plugin's hook modules typically fall into three categories:
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `claude plugin install attune-ai@attune-ai` can't find the plugin | The marketplace wasn't added first | Run `claude plugin marketplace add Smart-AI-Memory/attune-ai` before installing | high |
+| Components don't appear after install | A component folder or the manifest is malformed | Confirm `plugin/.claude-plugin/plugin.json` parses and the folders exist | high |
+| MCP tools missing but skills present | The `.mcp.json` server didn't launch (`uvx`/`attune-ai` unavailable) | See the mcp-server feature; confirm `uvx --from attune-ai python -m attune.mcp.server` runs | medium |
+| Hooks not firing | `hooks/hooks.json` event wiring | See the hooks feature; this page only confirms the file is shipped | medium |
+| Version looks stale | `plugin/core/__init__.py` / manifest version not bumped at release | The plugin version is set at release; the runtime is the pip `attune-ai` | low |
 
-- **Filesystem errors** (`OSError`, `FileNotFoundError`) — `discover_specs()` walks `specs/` and `docs/specs/` directories under each workspace root. If a root is inaccessible or the path doesn't exist, it raises before returning any `SpecInfo` list. Similarly, `session_sentinel_path()` and `prune_stale_sentinels()` read and delete files under the workspace; permission problems surface here.
+### Risk areas
 
-- **Git errors** (`subprocess` exceptions, `ValueError`) — `git_state()` shells out to git in the given `cwd`. If `cwd` is not inside a git repository, or git is not on `PATH`, the call fails before populating `GitState.branch`, `GitState.last_sha`, or `GitState.uncommitted`.
+- **Marketplace before install.** `install` resolves the plugin from a
+  registered marketplace — adding the marketplace is the required first
+  step.
+- **Two names, not one.** `attune-ai-plugin` (marketplace) ≠
+  `attune-ai` (plugin). The install string is `plugin@marketplace`,
+  which here reads `attune-ai@attune-ai`.
+- **The bundle ships, it doesn't implement.** MCP-server and hook
+  behavior live in their own features; debugging those means going
+  there, not here.
 
-- **Validation rejections** (returns `tuple[bool, str]` with `False`) — `validate_bash_command()` and `validate_file_path()` in `hooks.security_guard` do not raise; they return `(False, reason)`. If downstream code treats a falsy result as success, the command or path is silently permitted. Check that callers inspect the first element of the returned tuple.
+### Diagnosis order
 
-- **Utilization out-of-range** — `estimate_utilization()` returns a `float` in `[0.0, 1.0]`. A value at or above the threshold passed to `format_warning()` triggers the compact warning prompt. If the transcript path is missing or unreadable, the estimate cannot be computed.
-
-- **Malformed spec metadata** — `SpecInfo.status_conflict` is set to `True` when the `status` field in the spec header disagrees with a derived status. Code that reads `effective_status` without checking `status_conflict` may act on a stale or ambiguous value.
-
-## Where errors originate
-
-Each hook module exposes a `main()` entry point. Failures inside the helpers they call will appear in the traceback under that entry point:
-
-- `hooks._handoff_cli.main()` — orchestrates handoff; depends on `git_state()` and `discover_specs()`.
-- `hooks._resume_prompt.build_resume_prompt()` — requires a valid `GitState` and optionally a `SpecInfo`; fails if either is malformed.
-- `hooks._state.discover_specs()` — requires readable `specs/` or `docs/specs/` directories under each root returned by `workspace_roots()`.
-- `hooks._state.git_state()` — requires a valid git repository at `cwd`.
-- `hooks._state.session_sentinel_path()` — constructs the path for a `.jit-recalled-` sentinel file; fails if the session ID produces an invalid path.
-- `hooks.security_guard.main()` — returns a result dict; errors inside `validate_bash_command()` or `validate_file_path()` are reflected in that dict rather than raised.
-- `hooks.compact_warning.main()` — calls `estimate_utilization()` and `format_warning()`; a missing or unreadable transcript path causes the utilization estimate to fail before the warning is composed.
-
-## How to diagnose
-
-1. **Identify the failing hook.** The traceback's outermost frame will name one of the `main()` entry points above. That tells you which hook fired and which helpers it called.
-
-2. **Check `SpecInfo` fields for conflicts.** If `status_conflict` is `True` on a returned `SpecInfo`, the `status` header disagrees with the derived value. Inspect both `status` and `effective_status` to understand which value the failing code used. Valid terminal statuses are: `closed`, `complete`, `completed`, `retired`, `superseded`, `shipped`, `done`.
-
-3. **Verify workspace roots.** `workspace_roots()` makes a best-effort guess at roots to scan. If `discover_specs()` returns an empty list unexpectedly, confirm that the expected root contains a `specs/` or `docs/specs/` subdirectory and is readable.
-
-4. **Confirm git repository state.** `git_state()` needs a git repo at `cwd`. Run `git status` in that directory to confirm it is a valid worktree. A detached HEAD or a missing repo produces an unusable `GitState`.
-
-5. **Inspect the security guard return value.** Because `validate_bash_command()` and `validate_file_path()` return `(bool, str)` rather than raising, a failure won't produce a traceback. Log or print the full return value of `hooks.security_guard.main()` to see the rejection reason.
-
-6. **Check sentinel files.** Stale `.jit-recalled-` sentinel files can cause `session_recall` or `jit_recall` behavior to appear skipped. Run `prune_stale_sentinels()` manually and confirm it returns a count greater than zero if files were accumulating.
-
-## Source files
-
-- `hooks/_handoff_cli.py`
-- `hooks/_resume_prompt.py`
-- `hooks/_state.py`
-- `hooks/_transcript_size.py`
-- `hooks/compact_warning.py`
-- `hooks/security_guard.py`
-
-**Tags:** `plugin`, `claude-code`
+1. Confirm the marketplace was added: `claude plugin marketplace add
+   Smart-AI-Memory/attune-ai`.
+2. Confirm the manifest parses: `cat
+   plugin/.claude-plugin/plugin.json`.
+3. Confirm the component folders exist: `ls plugin/skills
+   plugin/agents plugin/commands`.
+4. For missing MCP tools, go to the mcp-server feature; for hooks, the
+   hooks feature.

--- a/.help/templates/plugin/faq.md
+++ b/.help/templates/plugin/faq.md
@@ -3,66 +3,68 @@ type: faq
 name: plugin-faq
 feature: plugin
 depth: faq
-generated_at: 2026-06-10T07:07:04.679170+00:00
-source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
-status: generated
+status: manual
 ---
 
 # Plugin FAQ
 
-## What is the plugin?
+## How do I install the attune plugin?
 
-The plugin is attune's Claude Code integration — it bundles skills, hooks, slash commands, and MCP configuration that Claude Code needs to work with attune workspaces.
+Two commands:
 
-## What hooks does the plugin provide?
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-ai@attune-ai
+```
 
-Each hook is an independent entry point with its own `main()` function:
+The first registers this repo as a Claude Code marketplace; the second
+installs the `attune-ai` plugin from it. After install, Claude Code
+auto-discovers the bundle's components and they become available in your
+session.
 
-| Module | What it does |
+## Why is the install string `attune-ai@attune-ai`?
+
+It reads as `plugin-name@marketplace-plugin`. This repo is a
+single-plugin marketplace named `attune-ai-plugin` that offers one
+plugin, also named `attune-ai` — so the plugin name appears on both
+sides of the `@`. The marketplace name (`attune-ai-plugin`) and the
+plugin name (`attune-ai`) are deliberately different.
+
+## What does the plugin actually contain?
+
+A manifest plus auto-discovered component folders:
+
+| Component | What's there |
 |---|---|
-| `hooks.compact_warning` | Warns when context utilization (via `estimate_utilization`) exceeds a threshold and injects a resume prompt |
-| `hooks.format_on_save` | Runs formatting when a file is saved |
-| `hooks.help_freshness_check` | Checks whether help content is stale |
-| `hooks.help_on_error` | Surfaces help content when an error occurs |
-| `hooks.help_post_commit` | Surfaces help content after a commit |
-| `hooks.jit_recall` | Just-in-time recall of relevant rules at decision points |
-| `hooks.security_guard` | Validates bash commands and file paths before execution |
-| `hooks.session_recall` | Restores session context at the start of a session |
-| `hooks.session_stash` | Saves session context when a session ends |
-| `hooks.spec_orient` | Summarizes in-flight specs to orient Claude at session start |
-| `hooks.welcome` | Runs on first connection to greet and orient Claude |
-| `hooks._handoff_cli` | CLI wrapper for the `/handoff` slash command |
+| `commands/` | 1 slash command — `/handoff` |
+| `skills/` | 17 skills (`/spec`, `/security-audit`, …) |
+| `agents/` | 6 subagents |
+| `hooks/` | `hooks.json` + the hook scripts |
+| `help/` | the help bundle (`generated/`, `templates/`, `schemas/`) |
+| `.mcp.json` | the MCP server registration |
 
-## How does the plugin know which specs are in flight?
+The two manifests live in `plugin/.claude-plugin/` — `plugin.json`
+(plugin identity) and `marketplace.json` (the marketplace listing).
 
-`discover_specs(roots)` in `hooks._state` walks `specs/` and `docs/specs/` directories under each workspace root and returns a list of `SpecInfo` objects. Each `SpecInfo` carries the spec's `slug`, `path`, `layer`, `phase`, `status`, `mtime`, `effective_status`, `status_source`, and `status_conflict` fields. Call `workspace_roots()` first if you don't already have a list of roots.
+## Is the plugin the same as the MCP server?
 
-## How does the plugin decide a spec is "done"?
+No. The plugin is the **bundle**; the MCP server is one component it
+ships (registered in `.mcp.json`). The server itself — its tools,
+transport, and rate limiting — is documented by the **mcp-server**
+feature, not here.
 
-It compares `effective_status` against the terminal verdicts `{'closed', 'complete', 'completed', 'retired', 'superseded', 'shipped', 'done'}`. Any spec whose status matches one of those values is treated as finished and excluded from active orientation output.
+## Does the plugin contain the runtime code?
 
-## What does `security_guard` actually check?
+No. `plugin/core/__init__.py` is just a `__version__`. The real runtime
+is the pip-installed `attune-ai` package, which `.mcp.json` pulls at
+launch with `uvx --from attune-ai python -m attune.mcp.server`.
 
-`validate_bash_command(command)` blocks commands that touch system directories such as `/etc`, `/sys`, `/proc`, and `/dev`. `validate_file_path(file_path)` checks the target path against the same set of protected locations. Both functions return a `(bool, str)` tuple — `True` with an empty message means the input is allowed; `False` means it was blocked, and the string explains why.
+## Why aren't the hooks documented here?
 
-## How does compact warning decide when to fire?
-
-`estimate_utilization(transcript_path)` returns a float in `[0.0, 1.0]` representing how full the context window is. `format_warning(util, threshold, resume_body)` composes the warning message only when `util` exceeds `threshold`. The resume body is built by `build_resume_prompt()` in `hooks._resume_prompt`.
-
-## How do I build the resume prompt myself?
-
-Call `build_resume_prompt(spec_info, git_state, workspace_path=..., todo_summary=...)` from `hooks._resume_prompt`. Pass a `SpecInfo` (or `None` if there is no active spec) and a `GitState` snapshot from `hooks._state.git_state(cwd)`. The function returns a formatted string ready to inject into a prompt.
-
-## What git information does the plugin capture?
-
-`git_state(cwd)` returns a `GitState` with four fields: `branch`, `last_sha`, `last_subject`, and `uncommitted` (a tuple of changed file paths). The plugin uses this snapshot in resume prompts and handoff output.
-
-## What are session sentinels, and why do they exist?
-
-A session sentinel is a file whose presence tells `jit_recall` that it has already fired once in the current session, preventing duplicate recalls. `session_sentinel_path(session_id)` returns the path for a given session. `prune_stale_sentinels()` deletes sentinel files older than the TTL and returns the count of files removed.
-
-## Where are the source files?
-
-All hook modules live under `plugin/**`. The shared state helpers (`SpecInfo`, `GitState`, `discover_specs`, `git_state`, `workspace_roots`, and the sentinel functions) are in `hooks._state`.
+The plugin **ships** the hooks (`hooks/hooks.json` wires them to the
+`SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`, and
+`UserPromptSubmit` events), but what each hook *does* is the **hooks**
+feature's page. This page is about the bundle — manifest, install, and
+the component layout Claude Code discovers.
 
 **Tags:** `plugin`, `claude-code`

--- a/.help/templates/plugin/note.md
+++ b/.help/templates/plugin/note.md
@@ -3,39 +3,108 @@ type: note
 name: plugin-note
 feature: plugin
 depth: note
-generated_at: 2026-06-10T07:07:04.686067+00:00
-source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
 status: generated
 ---
 
-# Note: plugin
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-## Context
+## Overview
 
-The plugin is a Claude Code extension that wires together skills, hooks, slash commands, and MCP configuration. All hook entry points live under `hooks/` and follow a consistent shape: a public `main()` function that the Claude Code runtime calls directly.
+The **plugin** is how attune installs into Claude Code. It is a
+**bundle** — a directory under `plugin/` with a manifest and a set of
+component folders that Claude Code discovers automatically when the
+plugin is installed. It is a packaging artifact, not a Python API:
+`plugin/core` carries only a `__version__`.
 
-## Public surface
+This page documents the **bundle itself** — its manifest
+(`plugin.json`), its marketplace listing (`marketplace.json`), how a
+user installs it, and the component directories Claude Code reads. It
+does **not** document the MCP server internals (that is the
+**mcp-server** feature) or the individual hook scripts (that is the
+**hooks** feature); the plugin just *ships* those.
 
-The plugin's shared state layer (`hooks/_state.py`) defines two dataclasses that flow through most of the hook pipeline:
+You reach it these ways:
 
-- **`SpecInfo`** — represents one in-flight spec discovered under a workspace root. Fields: `slug`, `path`, `layer`, `phase`, `status`, `mtime`, `effective_status`, `status_source`, and `status_conflict`.
-- **`GitState`** — a snapshot of the worktree at hook-fire time. Fields: `branch`, `last_sha`, `last_subject`, and `uncommitted`.
+- **install** — `claude plugin marketplace add
+  Smart-AI-Memory/attune-ai` then `claude plugin install
+  attune-ai@attune-ai`; Claude Code reads the manifest and registers
+  every component;
+- **inspect** — the `plugin/` directory: `plugin/.claude-plugin/` holds
+  the two manifests, and the sibling folders (`commands/`, `skills/`,
+  `agents/`, `hooks/`, `help/`) are the auto-discovered components.
 
-Functions in the same module populate these types:
+## Concepts
 
-- `discover_specs(roots)` — walks `specs/` directories under each root and returns a list of `SpecInfo` instances.
-- `git_state(cwd)` — returns a `GitState` for the given working directory.
-- `workspace_roots(cwd)` — makes a best-effort guess at which roots to scan.
-- `session_sentinel_path(session_id)` — returns the path to a per-session compact-warning sentinel file.
-- `prune_stale_sentinels(now)` — removes sentinel files older than the TTL.
+### The two manifests
 
-Other hooks consume these types directly:
+The bundle is described by two JSON files in
+`plugin/.claude-plugin/`:
 
-- `hooks._resume_prompt.build_resume_prompt(spec_info, git_state, ...)` — renders the user-facing resume prompt from a `SpecInfo` and a `GitState`.
-- `hooks.spec_orient.format_orientation(specs)` and `render_spec_pin(spec, char_budget)` — format spec orientation output for display.
-- `hooks.compact_warning.format_warning(util, threshold, resume_body)` — composes the compact-warning message from a utilization float produced by `hooks._transcript_size.estimate_utilization(transcript_path)`.
-- `hooks.security_guard.validate_bash_command(command)` and `validate_file_path(file_path)` — each return a `(bool, str)` verdict tuple checked before shell operations run.
+- **`plugin.json`** — the plugin manifest. Its `name` is `attune-ai`,
+  with `version`, `description`, `author`, `homepage`, `repository`,
+  `license` (`Apache-2.0`), and `keywords`. This is what Claude Code
+  reads to register the plugin.
+- **`marketplace.json`** — the marketplace listing. Its top-level
+  `name` is **`attune-ai-plugin`** (the marketplace name, distinct from
+  the plugin name), with an `owner` and `metadata`, and a `plugins`
+  array. The single entry has `name` `attune-ai`, `source` `./` (the
+  plugin lives at the marketplace root), `category` `developer-tools`,
+  and its own `tags`.
 
-## Design note
+The marketplace name (`attune-ai-plugin`) and the plugin name
+(`attune-ai`) are deliberately different — the install command
+(`attune-ai@attune-ai`) references the *plugin* name twice (plugin @
+marketplace), because this repo is its own single-plugin marketplace.
 
-The dataclasses in `hooks/_state.py` act as the shared vocabulary of the hook pipeline. Functions that discover or snapshot state return these types; functions that present or validate state accept them. This keeps discovery logic in one place and lets individual hooks stay focused on a single responsibility.
+### Auto-discovered components
+
+Claude Code reads fixed-name folders inside the bundle. Each is a
+component type:
+
+| Folder | What it holds | Count |
+|--------|---------------|-------|
+| `commands/` | Slash commands (`.md`) | 1 (`handoff`) |
+| `skills/` | Skills (one dir each, `SKILL.md`) | 17 |
+| `agents/` | Subagent definitions (`.md`) | 6 |
+| `hooks/` | `hooks.json` + hook scripts | ~20 scripts |
+| `help/` | Generated help, templates, schemas | — |
+| `.mcp.json` | MCP server registration | 1 server |
+
+`commands/` ships `handoff` (the `/handoff` resume-prompt command).
+The 17 skills are the developer-workflow surface (`spec`,
+`security-audit`, `code-quality`, `smart-test`, `release-prep`, …). The
+6 agents are read-only or planning subagents
+(`security-reviewer`, `refactor-planner`, `release-prep-auditor`,
+`spec-author`, `setup-guide`, `help-content-explainer`).
+
+### Hooks and MCP — shipped, not owned here
+
+`hooks/hooks.json` wires hook scripts to five Claude Code lifecycle
+events — `SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`,
+`UserPromptSubmit`. `.mcp.json` registers the MCP server
+(`uvx --from attune-ai python -m attune.mcp.server`). The plugin
+**bundles** both, but their behavior is documented by the **hooks** and
+**mcp-server** features respectively — this page covers only that they
+are part of the bundle.
+
+### The bundled core
+
+`plugin/core/` exists so the plugin can carry a version for standalone
+operation; `plugin/core/__init__.py` is just
+`__version__ = "8.9.0"`. The real runtime is the pip-installed
+`attune-ai` package, which the `.mcp.json` server pulls via
+`uvx --from attune-ai`.
+
+## Notes & tips
+
+- **Add the marketplace first.** `install` needs a registered
+  marketplace to resolve `attune-ai@attune-ai` against.
+- **Mind the two names.** Marketplace `attune-ai-plugin`, plugin
+  `attune-ai`. The install string repeats the plugin name on purpose.
+- **The folders are the contract.** Claude Code discovers components by
+  fixed folder names (`commands/`, `skills/`, `agents/`, `hooks/`,
+  `help/`) — that layout *is* the plugin's interface.
+- **Go to the component's feature to debug it.** MCP tools → mcp-server;
+  hook behavior → hooks. This page is the bundle.

--- a/.help/templates/plugin/quickstart.md
+++ b/.help/templates/plugin/quickstart.md
@@ -3,53 +3,31 @@ type: quickstart
 name: plugin-quickstart
 feature: plugin
 depth: quickstart
-generated_at: 2026-06-10T07:07:04.681583+00:00
-source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
-status: manual
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+status: generated
 ---
 
-# Quickstart: Install the attune-ai plugin
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-Add attune-ai skills to Claude Code with one command.
+## Quickstart
 
+Install the plugin into Claude Code from the marketplace:
+
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-ai@attune-ai
 ```
-claude plugin marketplace add Smart-AI-Memory/attune-ai && claude plugin install attune-ai@attune-ai
+
+The first command registers this repo as a marketplace; the second
+installs the `attune-ai` plugin from it. After install, Claude Code
+auto-discovers the components — the slash command, the 17 skills, the 6
+agents, the hooks, and the MCP server — and they become available in
+your session.
+
+To inspect the bundle locally:
+
+```bash
+cat plugin/.claude-plugin/plugin.json
+ls plugin/skills plugin/agents plugin/commands
 ```
-
-**Result:** 17 skills available via slash commands in Claude Code.
-
-## Step 1: Verify the plugin loaded
-
-Open a Claude Code session and run `/attune`. The hub skill responds with
-guided discovery — if it answers, the plugin's skills and hooks are active.
-
-## Step 2: Read your session orientation
-
-Start a new session in a project directory. The plugin's SessionStart hooks
-print a **Session orientation** block automatically: your worktree and
-branch, the last commit, and any in-flight specs found under `docs/specs/`.
-
-**Result:** You know where you are and what work is open before typing
-anything.
-
-## Step 3: Check in-flight specs
-
-The orientation block lists each in-flight spec with its phase and status
-(for example `docs/specs/my-feature — design approved`). To browse them
-directly, look in `docs/specs/<slug>/` — each spec keeps its
-`requirements.md`, `design.md`, and `tasks.md` there.
-
-**Result:** An empty list means no in-flight specs exist yet — start one
-with `/spec`.
-
-## Step 4: Resume interrupted work
-
-When you return after a break, the plugin builds a resume prompt from your
-most recent in-flight spec and the current git state, so a fresh session
-can pick up exactly where the last one stopped.
-
-**Result:** The formatted resume prompt Claude Code displays when you
-return to an interrupted session.
-
-**Next:** Type `/attune` in any session to route a request to the right
-workflow, or `/help` for the full command reference.

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -3,101 +3,58 @@ type: reference
 name: plugin-reference
 feature: plugin
 depth: reference
-generated_at: 2026-06-22T10:00:48.764701+00:00
-source_hash: 843f895eed3fa2d3d0b8021830c8c31e3c292c176a967396a76c27deb5a60deb
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
 status: generated
-scaffold_hash: 6f4dd2b63d52d539274f6852ceaf44e9ec2a4b35ec27f4d69ffcdcd7d8193d4f
 ---
 
-# Plugin reference
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-Claude Code plugin — hooks, session management, and security APIs
+## Reference
 
-Use the `hooks` package to build on or extend the attune-ai Claude Code plugin. The package lets you discover in-flight specs, snapshot git state, gate execution in SDK subprocess sessions, validate shell commands, and compose session-start or resume prompts.
+The plugin is a packaging artifact; its "API" is the manifest schema
+and the component folder layout.
 
-## Classes
+### `plugin/.claude-plugin/plugin.json`
 
-| Class | Description |
-|-------|-------------|
-| `SpecInfo` | One in-flight spec discovered under a workspace root. |
-| `GitState` | Snapshot of the worktree's git state at hook fire time. |
+| Field | Value / Purpose |
+|-------|-----------------|
+| `name` | `attune-ai` — the plugin name. |
+| `version` | Plugin bundle version (`8.9.0`). |
+| `description` | One-line plugin summary shown in Claude Code. |
+| `author` | `{name, email}` — Smart AI Memory. |
+| `homepage` / `repository` | Project links. |
+| `license` | `Apache-2.0`. |
+| `keywords` | Discovery keywords (include `claude-code`). |
 
-Both are dataclasses defined in `plugin/hooks/_state.py`.
+### `plugin/.claude-plugin/marketplace.json`
 
-### `SpecInfo` fields
+| Field | Value / Purpose |
+|-------|-----------------|
+| `name` | `attune-ai-plugin` — the **marketplace** name. |
+| `owner` | `{name, email}` of the marketplace. |
+| `metadata` | `{description, version}`. |
+| `plugins[]` | The plugin entries; one here. |
+| `plugins[0].name` | `attune-ai` — the plugin offered. |
+| `plugins[0].source` | `./` — plugin at the marketplace root. |
+| `plugins[0].category` | `developer-tools`. |
+| `plugins[0].tags` | Marketplace listing tags. |
 
-| Field | Type | Default |
-|-------|------|---------|
-| `slug` | `str` | |
-| `path` | `Path` | |
-| `layer` | `str` | |
-| `phase` | `str` | |
-| `status` | `str` | |
-| `mtime` | `float` | |
-| `effective_status` | `str` | `''` |
-| `status_source` | `str` | `'header'` |
-| `status_conflict` | `bool` | `False` |
+### Component folders
 
-### `GitState` fields
+| Folder | Component | Notes |
+|--------|-----------|-------|
+| `commands/` | Slash commands | `handoff.md` → `/handoff`. |
+| `skills/` | Skills | 17 dirs, each with `SKILL.md`. |
+| `agents/` | Subagents | 6 `.md` definitions. |
+| `hooks/` | Hooks | `hooks.json` + ~20 scripts → 5 events. |
+| `help/` | Help | `generated/`, `templates/`, `schemas/`. |
+| `core/` | Version | `__version__` only. |
+| `.mcp.json` | MCP server | `uvx --from attune-ai python -m attune.mcp.server`. |
 
-| Field | Type | Default |
-|-------|------|---------|
-| `branch` | `str` | |
-| `last_sha` | `str` | |
-| `last_subject` | `str` | |
-| `uncommitted` | `tuple[str, ...]` | |
+### Install
 
-## Functions
-
-| Function | Parameters | Returns | Description | File |
-|----------|------------|---------|-------------|------|
-| `main` | — | `int` | Entry point for the `/handoff` slash command; always returns `0`. | `plugin/hooks/_handoff_cli.py` |
-| `build_resume_prompt` | `spec_info: SpecInfo \| None, git_state: GitState, *, workspace_path: str = '~/attune', todo_summary: str \| None = None` | `str` | Render the user-facing resume prompt body. | `plugin/hooks/_resume_prompt.py` |
-| `is_sdk_subprocess` | — | `bool` | True when running inside an SDK-spawned `claude` subprocess. | `plugin/hooks/_sdk_gate.py` |
-| `exit_if_sdk_subprocess` | — | `None` | Exit 0 with no output when inside an SDK subprocess session. | `plugin/hooks/_sdk_gate.py` |
-| `discover_specs` | `roots: list[Path]` | `list[SpecInfo]` | Walk `specs/` directories under each root for in-flight specs. | `plugin/hooks/_state.py` |
-| `git_state` | `cwd: Path` | `GitState` | Return branch, last commit, and uncommitted files for `cwd`. | `plugin/hooks/_state.py` |
-| `session_sentinel_path` | `session_id: str \| None` | `Path` | Path to the once-per-session compact-warning sentinel. | `plugin/hooks/_state.py` |
-| `prune_stale_sentinels` | `now: float \| None = None` | `int` | Delete sentinel files older than the TTL. | `plugin/hooks/_state.py` |
-| `workspace_roots` | `cwd: Path \| None = None` | `list[Path]` | Best-effort guess at workspace roots to scan for specs. | `plugin/hooks/_state.py` |
-| `estimate_utilization` | `transcript_path: str \| Path` | `float` | Return estimated context utilization in `[0.0, 1.0]`. | `plugin/hooks/_transcript_size.py` |
-| `format_warning` | `util: float, threshold: float, resume_body: str` | `str` | Compose the user-facing compact warning and resume prompt. | `plugin/hooks/compact_warning.py` |
-| `main` | — | `int` | Entry point for compact warning; never raises. | `plugin/hooks/compact_warning.py` |
-| `main` | — | `None` | Read tool result from stdin and format Python files. | `plugin/hooks/format_on_save.py` |
-| `main` | — | `None` | Check help template freshness on session start. | `plugin/hooks/help_freshness_check.py` |
-| `main` | — | `None` | Read `PostToolUse` payload and suggest help if applicable. | `plugin/hooks/help_on_error.py` |
-| `main` | — | `None` | Check for stale help after git commit. | `plugin/hooks/help_post_commit.py` |
-| `main` | — | `int` | Surface matching rules once per session; never raises. | `plugin/hooks/jit_recall.py` |
-| `main` | — | `int` | Surface top-scoring lessons for this prompt, once per session each. | `plugin/hooks/lesson_recall.py` |
-| `main` | — | `int` | Surface the anonymous-usage consent ask once per workspace (MCP / Claude Code). | `plugin/hooks/usage_consent_notice.py` |
-| `validate_bash_command` | `command: str` | `tuple[bool, str]` | Validate a Bash command against security policies. | `plugin/hooks/security_guard.py` |
-| `validate_file_path` | `file_path: str` | `tuple[bool, str]` | Validate a file path against security policies. | `plugin/hooks/security_guard.py` |
-| `main` | `context: dict[str, Any]` | `dict[str, Any]` | Validate a tool call against security policies. | `plugin/hooks/security_guard.py` |
-| `main` | — | `int` | Entry point for session recall. | `plugin/hooks/session_recall.py` |
-| `main` | — | `int` | Act once per substantive session; never raises. | `plugin/hooks/session_stash.py` |
-| `format_orientation` | `specs: list[SpecInfo]` | `str` | Short markdown list of in-flight specs for non-compact starts. | `plugin/hooks/spec_orient.py` |
-| `render_spec_pin` | `spec: SpecInfo, char_budget: int = _POST_COMPACT_CHAR_BUDGET` | `str` | Render a spec body for post-compact context restoration. | `plugin/hooks/spec_orient.py` |
-| `main` | — | `int` | Branch on `source`; never raises. | `plugin/hooks/spec_orient.py` |
-| `main` | — | `None` | Print welcome message to stderr (Claude Code surfaces stderr). | `plugin/hooks/welcome.py` |
-
-## Constants
-
-| Constant | Type | Values | Description |
-|----------|------|--------|-------------|
-| `__version__` | `str` | `'8.4.0'` | Package version string. |
-| `_TERMINAL_VERDICTS` | `frozenset` | `{'closed', 'complete', 'completed', 'retired', 'superseded', 'shipped', 'done'}` | Spec status values that mark a spec as finished. |
-| `_ONGOING_VERDICTS` | `frozenset` | `{'living', 'ongoing'}` | Spec status values that mark a spec as actively in progress. |
-| `_SPEC_SUBDIRS` | `tuple` | `{'specs', 'docs/specs'}` | Directory names searched for spec files under each workspace root. |
-| `_SENTINEL_PREFIX` | `str` | `'.jit-recalled-'` | File prefix for per-session JIT recall sentinels (`hooks/jit_recall`). |
-| `_SENTINEL_PREFIX` | `str` | `'.lesson-recalled-'` | File prefix for per-session lesson recall sentinels (`hooks/lesson_recall`). |
-| `SYSTEM_DIRECTORIES` | `frozenset` | `{'/etc', '/sys', '/proc', '/dev', '/boot', '/sbin', '/usr/sbin', '/private/etc', '/private/var'}` | Filesystem paths blocked by the security guard. |
-| `SEARCH_COMMAND_PREFIXES` | `frozenset` | `{'grep', 'rg', 'ack', 'ag', 'git grep', 'git log', 'git diff'}` | Read-only search prefixes that bypass security blocking. |
-| `_VALID_TYPES` | `set` | `{'decision', 'pattern', 'bug', 'reference', 'note'}` | Allowed values for a spec's `type` field. |
-
-## Source files
-
-- `plugin/**`
-
-## Tags
-
-`plugin`, `claude-code`
+| Step | Command |
+|------|---------|
+| Add marketplace | `claude plugin marketplace add Smart-AI-Memory/attune-ai` |
+| Install plugin | `claude plugin install attune-ai@attune-ai` |

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -3,67 +3,61 @@ type: task
 name: plugin-task
 feature: plugin
 depth: task
-generated_at: 2026-06-22T10:00:48.764701+00:00
-source_hash: 843f895eed3fa2d3d0b8021830c8c31e3c292c176a967396a76c27deb5a60deb
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
 status: generated
-scaffold_hash: 50c1caa20aa764e3b2db2159a2560e5480f7bfc5f82efed9516912df86eebf1d
 ---
 
-# Work with the plugin
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-Use the plugin when you need to change how attune-ai integrates with Claude Code — including hook behavior, session recall, spec orientation, SDK subprocess gating, or the `/handoff` slash command.
+## Tasks
 
-## Prerequisites
+### Install the plugin
 
-- Access to the project source code
-- Python environment with `pytest` available
+**Goal:** add attune to Claude Code.
 
-## Identify the right hook
+**Steps:**
 
-Each module in `hooks/` owns a single responsibility. Match your goal to the correct entry point before you edit anything:
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-ai@attune-ai
+```
 
-| Goal | Module | Entry point |
-|---|---|---|
-| Customize the `/handoff` slash command | `hooks/_handoff_cli.py` | `main()` |
-| Change the resume-prompt format | `hooks/_resume_prompt.py` | `build_resume_prompt()` |
-| Gate a hook from running inside an SDK subprocess | `hooks/_sdk_gate.py` | `exit_if_sdk_subprocess()` |
-| Discover in-flight specs under workspace roots | `hooks/_state.py` | `discover_specs()` |
-| Snapshot branch, last commit, and dirty files | `hooks/_state.py` | `git_state()` |
-| Manage compact-warning sentinels | `hooks/_state.py` | `session_sentinel_path()`, `prune_stale_sentinels()` |
-| Estimate context utilization from a transcript | `hooks/_transcript_size.py` | `estimate_utilization()` |
-| Validate bash commands or file paths | `hooks/security_guard.py` | `validate_bash_command()`, `validate_file_path()` |
-| Show the usage-consent notice to MCP users (SessionStart) | `hooks/usage_consent_notice.py` | `main()` |
-| Orient the session around active specs | `hooks/spec_orient.py` | `main()` |
+**Verify:** the `/attune` and `/handoff` commands appear, and the
+attune skills (`/spec`, `/security-audit`, …) are available in the
+session. `attune-ai@attune-ai` is `plugin-name@marketplace-plugin` —
+both resolve to the `attune-ai` plugin in this single-plugin
+marketplace.
 
-## Modify the hook
+### Read the manifest
 
-1. **Open the target module.** Read the function's signature, docstring, and return type to confirm it owns the behavior you want to change.
+**Goal:** confirm the bundle's identity and version.
 
-2. **Edit the function.** To change how the resume prompt is structured, edit `build_resume_prompt()` in `hooks/_resume_prompt.py`:
+**Steps:**
 
-   ```python
-   build_resume_prompt(
-       spec_info: SpecInfo | None,
-       git_state: GitState,
-       *,
-       workspace_path: str = '~/attune',
-       todo_summary: str | None = None,
-   ) -> str
-   ```
+```bash
+cat plugin/.claude-plugin/plugin.json
+```
 
-   `SpecInfo` provides `slug`, `path`, `layer`, `phase`, `status`, and `mtime` for each in-flight spec. `GitState` provides `branch`, `last_sha`, `last_subject`, and `uncommitted` files.
+**Verify:** `name` is `attune-ai`, `license` is `Apache-2.0`, and
+`keywords` include `claude-code`. The `version` here is the plugin
+bundle version (`8.9.0`); the sibling `marketplace.json` carries a
+matching version in `metadata.version` and `plugins[0].version`.
 
-3. **Add SDK subprocess gating if needed.** If your hook must not run inside an SDK-spawned `claude` subprocess, call `exit_if_sdk_subprocess()` at the top of `main()`. To check the condition without exiting, call `is_sdk_subprocess()` directly.
+### List the components Claude Code will discover
 
-4. **Run the tests** to catch regressions:
+**Goal:** see what the bundle ships.
 
-   ```
-   pytest -k "plugin"
-   ```
+**Steps:**
 
-## Verify success
+```bash
+ls plugin/commands   # 1 command (handoff.md)
+ls plugin/skills     # 17 skill directories
+ls plugin/agents     # 6 agent definitions
+cat plugin/.mcp.json # the MCP server registration
+```
 
-Your change is complete when both of the following are true:
-
-- `pytest -k "plugin"` exits with no failures.
-- The hook produces the output you intended when triggered manually or through the normal Claude Code flow.
+**Verify:** each folder name is the component type Claude Code reads.
+`hooks/hooks.json` binds scripts to the five lifecycle events; for what
+those hooks do, see the **hooks** feature, and for the MCP server, the
+**mcp-server** feature.

--- a/.help/templates/plugin/tip.md
+++ b/.help/templates/plugin/tip.md
@@ -3,15 +3,21 @@ type: tip
 name: plugin-tip
 feature: plugin
 depth: tip
-generated_at: 2026-06-10T07:07:04.684068+00:00
-source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
 status: generated
 ---
 
-# Tip: working effectively with plugin
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-Call `estimate_utilization()` before you call `build_resume_prompt()` — passing a bloated transcript into the resume builder wastes context budget that the prompt itself needs.
+## Notes & tips
 
-**Why it sticks:** `estimate_utilization` returns a `float` in `[0.0, 1.0]`; if it's already high, `format_warning` in `hooks.compact_warning` can surface that to the user before you spend tokens on the full resume prompt.
-
-**Tradeoff:** Adding the utilization check is an extra call to `hooks._transcript_size.estimate_utilization`. In fast-path hooks where transcript I/O is expensive, you may choose to skip it and call `build_resume_prompt` unconditionally — just know you're trading responsiveness for accuracy.
+- **Add the marketplace first.** `install` needs a registered
+  marketplace to resolve `attune-ai@attune-ai` against.
+- **Mind the two names.** Marketplace `attune-ai-plugin`, plugin
+  `attune-ai`. The install string repeats the plugin name on purpose.
+- **The folders are the contract.** Claude Code discovers components by
+  fixed folder names (`commands/`, `skills/`, `agents/`, `hooks/`,
+  `help/`) — that layout *is* the plugin's interface.
+- **Go to the component's feature to debug it.** MCP tools → mcp-server;
+  hook behavior → hooks. This page is the bundle.

--- a/.help/templates/plugin/troubleshooting.md
+++ b/.help/templates/plugin/troubleshooting.md
@@ -3,93 +3,42 @@ type: troubleshooting
 name: plugin-troubleshooting
 feature: plugin
 depth: troubleshooting
-generated_at: 2026-06-10T07:07:04.676749+00:00
-source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
 status: generated
 ---
 
-# Troubleshoot plugin
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-## Before you start
+## Failure modes
 
-These steps cover the attune plugin's hooks, slash commands, and MCP configuration — including session continuity hooks, security guards, spec discovery, and transcript monitoring.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `claude plugin install attune-ai@attune-ai` can't find the plugin | The marketplace wasn't added first | Run `claude plugin marketplace add Smart-AI-Memory/attune-ai` before installing | high |
+| Components don't appear after install | A component folder or the manifest is malformed | Confirm `plugin/.claude-plugin/plugin.json` parses and the folders exist | high |
+| MCP tools missing but skills present | The `.mcp.json` server didn't launch (`uvx`/`attune-ai` unavailable) | See the mcp-server feature; confirm `uvx --from attune-ai python -m attune.mcp.server` runs | medium |
+| Hooks not firing | `hooks/hooks.json` event wiring | See the hooks feature; this page only confirms the file is shipped | medium |
+| Version looks stale | `plugin/core/__init__.py` / manifest version not bumped at release | The plugin version is set at release; the runtime is the pip `attune-ai` | low |
 
-## Symptom table
+### Risk areas
 
-| If you observe | Check |
-|----------------|-------|
-| `/attune` or other skill commands show no matches | Run `claude plugin list` and confirm `attune-ai` appears |
-| Skills appear but produce no output | Run `claude plugin marketplace list` and verify the marketplace was added |
-| Two conflicting skill triggers fire | Run `claude plugin list` and check for both `attune-lite` and `attune-ai` — only one should be installed |
-| `session_recall` or `session_stash` produces unexpected results | Check for stale sentinel files: call `prune_stale_sentinels()` and inspect the path returned by `session_sentinel_path(session_id)` |
-| `spec_orient` shows no specs or wrong specs | Confirm `workspace_roots()` returns the expected paths, then verify `discover_specs(roots)` finds `.yaml` files under `specs/` or `docs/specs/` subdirectories |
-| Compact warning fires every session instead of once | A sentinel file under the prefix `.jit-recalled-` may be missing or stale — call `prune_stale_sentinels()` to clean up |
-| `security_guard` blocks a command you expect to allow | Pass the command string to `validate_bash_command(command)` and inspect the returned `(bool, str)` reason |
-| Context utilization reading seems wrong | Call `estimate_utilization(transcript_path)` directly and confirm the returned float is in `[0.0, 1.0]` |
-| `spec_orient` reports a status conflict | Check the `SpecInfo` fields `status_conflict` and `status_source` on the affected spec |
+- **Marketplace before install.** `install` resolves the plugin from a
+  registered marketplace — adding the marketplace is the required first
+  step.
+- **Two names, not one.** `attune-ai-plugin` (marketplace) ≠
+  `attune-ai` (plugin). The install string is `plugin@marketplace`,
+  which here reads `attune-ai@attune-ai`.
+- **The bundle ships, it doesn't implement.** MCP-server and hook
+  behavior live in their own features; debugging those means going
+  there, not here.
 
-## Step-by-step diagnosis
+### Diagnosis order
 
-1. **Reproduce the failure in isolation.**
-   Confirm the failure occurs outside its normal trigger context. For hook entry points, call `main()` directly from a shell or a one-line Python script with the minimal required environment.
-
-2. **Check plugin installation.**
-   Run `claude plugin list` to confirm `attune-ai` is installed and no conflicting plugin (such as `attune-lite`) is also present. If the plugin is missing, reinstall it:
-   ```
-   claude plugin marketplace add Smart-AI-Memory/attune-ai
-   claude plugin install attune-ai@attune-ai
-   ```
-
-3. **Inspect workspace and spec discovery.**
-   Call `workspace_roots()` to confirm it returns your expected project root, then pass those roots to `discover_specs(roots)` to verify it returns the `SpecInfo` objects you expect. Check the `slug`, `path`, `layer`, `phase`, `status`, and `effective_status` fields on each result.
-
-4. **Check git state.**
-   Call `git_state(cwd)` with your working directory. Confirm that `branch`, `last_sha`, `last_subject`, and `uncommitted` reflect the actual repository state. A wrong `cwd` is a common cause of stale or empty `GitState` values.
-
-5. **Audit sentinel files.**
-   Call `session_sentinel_path(session_id)` to find the expected sentinel path, then call `prune_stale_sentinels()` to remove any files older than the TTL. Re-run the failing hook after pruning.
-
-6. **Check the security guard.**
-   If `security_guard` is blocking or allowing something unexpectedly, call `validate_bash_command(command)` or `validate_file_path(file_path)` directly. Each returns a `(bool, str)` tuple — the string explains the verdict. Paths under `SYSTEM_DIRECTORIES` (`/etc`, `/sys`, `/proc`, and others) are always blocked.
-
-7. **Check transcript utilization.**
-   If `compact_warning` behaves unexpectedly, call `estimate_utilization(transcript_path)` and compare the result against the threshold passed to `format_warning(util, threshold, resume_body)`. Confirm the transcript path is correct and the file is not empty.
-
-8. **Run the related tests.**
-   Run `pytest -k "plugin" -v` to confirm which paths are covered. A failing test that exercises your symptom narrows the search immediately.
-
-## Common fixes
-
-- **Conflicting plugins.** Remove the duplicate before reinstalling:
-  ```
-  claude plugin uninstall attune-lite
-  claude plugin install attune-ai@attune-ai
-  ```
-
-- **Missing marketplace source.** If `claude plugin list` shows nothing, add the marketplace first:
-  ```
-  claude plugin marketplace add Smart-AI-Memory/attune-ai
-  claude plugin install attune-ai@attune-ai
-  ```
-
-- **Stale sentinels causing repeated compact warnings.** Call `prune_stale_sentinels()` from Python or add a one-time invocation to your session setup. The function returns the count of deleted files.
-
-- **Wrong workspace root.** If `discover_specs()` returns an empty list, `workspace_roots()` may be resolving to the wrong directory. Pass an explicit `cwd` argument to override the default (`~/attune`).
-
-- **`SpecInfo` status conflict.** When `status_conflict` is `True`, the spec's `status_source` field indicates whether the status came from its header or another source. Resolve the conflict by editing the spec file directly so the header status matches the intended `effective_status`.
-
-- **Dependency or environment drift.** If a hook worked previously without a code change, confirm your Python environment is clean. Run `pip show` on any recently updated packages and verify the installed versions match what the plugin was last tested against.
-
-## Source files
-
-- `hooks/_handoff_cli.py`
-- `hooks/_resume_prompt.py`
-- `hooks/_state.py`
-- `hooks/_transcript_size.py`
-- `hooks/compact_warning.py`
-- `hooks/security_guard.py`
-- `hooks/session_recall.py`
-- `hooks/session_stash.py`
-- `hooks/spec_orient.py`
-
-**Tags:** `plugin`, `claude-code`
+1. Confirm the marketplace was added: `claude plugin marketplace add
+   Smart-AI-Memory/attune-ai`.
+2. Confirm the manifest parses: `cat
+   plugin/.claude-plugin/plugin.json`.
+3. Confirm the component folders exist: `ls plugin/skills
+   plugin/agents plugin/commands`.
+4. For missing MCP tools, go to the mcp-server feature; for hooks, the
+   hooks feature.

--- a/.help/templates/plugin/warning.md
+++ b/.help/templates/plugin/warning.md
@@ -3,45 +3,42 @@ type: warning
 name: plugin-warning
 feature: plugin
 depth: warning
-generated_at: 2026-06-10T07:07:04.674384+00:00
-source_hash: 97a2943dbbe1f0524955dd7678a2b8b4eb09cacaf89d2950ee2705251fcd2249
+generated_at: 2026-06-24T05:04:42.110775+00:00
+source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
 status: generated
 ---
 
-# Plugin cautions
+# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
 
-## Stale sentinels accumulate if you skip pruning
+## Failure modes
 
-`session_sentinel_path()` writes a file prefixed with `.jit-recalled-` to mark that a session has already received a compact warning. These sentinel files are not cleaned up automatically — if you call `session_sentinel_path()` without periodically calling `prune_stale_sentinels()`, old sentinels accumulate and can suppress warnings in sessions that should receive them.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `claude plugin install attune-ai@attune-ai` can't find the plugin | The marketplace wasn't added first | Run `claude plugin marketplace add Smart-AI-Memory/attune-ai` before installing | high |
+| Components don't appear after install | A component folder or the manifest is malformed | Confirm `plugin/.claude-plugin/plugin.json` parses and the folders exist | high |
+| MCP tools missing but skills present | The `.mcp.json` server didn't launch (`uvx`/`attune-ai` unavailable) | See the mcp-server feature; confirm `uvx --from attune-ai python -m attune.mcp.server` runs | medium |
+| Hooks not firing | `hooks/hooks.json` event wiring | See the hooks feature; this page only confirms the file is shipped | medium |
+| Version looks stale | `plugin/core/__init__.py` / manifest version not bumped at release | The plugin version is set at release; the runtime is the pip `attune-ai` | low |
 
-**Mitigation:** Call `prune_stale_sentinels()` at a predictable point in your hook lifecycle (for example, at startup or after a session ends). Its return value tells you how many files were removed, which is useful for debugging runaway accumulation.
+### Risk areas
 
-## `status_conflict` in `SpecInfo` silently overrides `effective_status`
+- **Marketplace before install.** `install` resolves the plugin from a
+  registered marketplace — adding the marketplace is the required first
+  step.
+- **Two names, not one.** `attune-ai-plugin` (marketplace) ≠
+  `attune-ai` (plugin). The install string is `plugin@marketplace`,
+  which here reads `attune-ai@attune-ai`.
+- **The bundle ships, it doesn't implement.** MCP-server and hook
+  behavior live in their own features; debugging those means going
+  there, not here.
 
-`discover_specs()` populates `SpecInfo` fields including `effective_status` and `status_conflict`. When `status_conflict` is `True`, the `effective_status` field does not simply reflect the `status` header — there is a disagreement between sources. Code that reads `effective_status` without checking `status_conflict` first can act on a resolved value that masks an underlying inconsistency.
+### Diagnosis order
 
-**Mitigation:** Always check `spec.status_conflict` before trusting `spec.effective_status` in any logic that gates on spec state (for example, filtering out terminal statuses from `_TERMINAL_VERDICTS`).
-
-## `build_resume_prompt()` silently uses a default workspace path
-
-`build_resume_prompt()` accepts `workspace_path` with a default of `~/attune`. If the actual workspace is elsewhere and you omit this argument, the rendered resume prompt will reference the wrong path — and the error will not surface as an exception; the output will simply be wrong.
-
-**Mitigation:** Always pass `workspace_path` explicitly. Derive it from `workspace_roots()` rather than relying on the default.
-
-## `estimate_utilization()` returns a float in `[0.0, 1.0]`, not a percentage
-
-`estimate_utilization()` returns a value between `0.0` and `1.0`. Passing this directly to `format_warning()` as the `threshold` argument without converting to the same scale as your threshold constant will produce incorrect warning behavior — for example, a threshold of `80` will never be reached by a utilization of `0.95`.
-
-**Mitigation:** Keep your threshold and the return value of `estimate_utilization()` on the same scale. If your threshold is a fraction, express it as a value in `[0.0, 1.0]` as well.
-
-## `git_state()` reflects the working directory at call time
-
-`git_state()` returns a `GitState` snapshot — `branch`, `last_sha`, `last_subject`, and `uncommitted` files — captured at the moment of the call. If you call it once and cache the result across multiple hook operations, the snapshot can go stale: a commit, stash, or branch switch between calls will not be reflected.
-
-**Mitigation:** Call `git_state()` as late as possible in your hook, immediately before you need the data, rather than capturing it at startup.
-
-## Private helpers in `hooks._state` can change without notice
-
-`discover_specs()`, `workspace_roots()`, and `session_sentinel_path()` are public, but several internal behaviors they depend on — including `_SPEC_SUBDIRS`, `_SENTINEL_PREFIX`, and `_TERMINAL_VERDICTS` — are private module-level constants. Code that reaches past the public functions and reads these constants directly will break silently during refactors.
-
-**Mitigation:** Use only the public functions listed in the API. If you need the list of terminal statuses for comparison, derive it from `SpecInfo.effective_status` values returned by `discover_specs()` rather than importing `_TERMINAL_VERDICTS` directly.
+1. Confirm the marketplace was added: `claude plugin marketplace add
+   Smart-AI-Memory/attune-ai`.
+2. Confirm the manifest parses: `cat
+   plugin/.claude-plugin/plugin.json`.
+3. Confirm the component folders exist: `ls plugin/skills
+   plugin/agents plugin/commands`.
+4. For missing MCP tools, go to the mcp-server feature; for hooks, the
+   hooks feature.

--- a/content/features/plugin.md
+++ b/content/features/plugin.md
@@ -1,0 +1,343 @@
+---
+feature: plugin
+summary: The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
+tags: [plugin, claude-code]
+source_globs:
+  - plugin/**
+nav:
+  help: plugin
+  mkdocs:
+    how-to: how-to/plugin
+    architecture: architecture/plugin
+    reference: reference/plugin
+---
+
+## Overview
+
+The **plugin** is how attune installs into Claude Code. It is a
+**bundle** — a directory under `plugin/` with a manifest and a set of
+component folders that Claude Code discovers automatically when the
+plugin is installed. It is a packaging artifact, not a Python API:
+`plugin/core` carries only a `__version__`.
+
+This page documents the **bundle itself** — its manifest
+(`plugin.json`), its marketplace listing (`marketplace.json`), how a
+user installs it, and the component directories Claude Code reads. It
+does **not** document the MCP server internals (that is the
+**mcp-server** feature) or the individual hook scripts (that is the
+**hooks** feature); the plugin just *ships* those.
+
+You reach it these ways:
+
+- **install** — `claude plugin marketplace add
+  Smart-AI-Memory/attune-ai` then `claude plugin install
+  attune-ai@attune-ai`; Claude Code reads the manifest and registers
+  every component;
+- **inspect** — the `plugin/` directory: `plugin/.claude-plugin/` holds
+  the two manifests, and the sibling folders (`commands/`, `skills/`,
+  `agents/`, `hooks/`, `help/`) are the auto-discovered components.
+
+## Concepts
+
+### The two manifests
+
+The bundle is described by two JSON files in
+`plugin/.claude-plugin/`:
+
+- **`plugin.json`** — the plugin manifest. Its `name` is `attune-ai`,
+  with `version`, `description`, `author`, `homepage`, `repository`,
+  `license` (`Apache-2.0`), and `keywords`. This is what Claude Code
+  reads to register the plugin.
+- **`marketplace.json`** — the marketplace listing. Its top-level
+  `name` is **`attune-ai-plugin`** (the marketplace name, distinct from
+  the plugin name), with an `owner` and `metadata`, and a `plugins`
+  array. The single entry has `name` `attune-ai`, `source` `./` (the
+  plugin lives at the marketplace root), `category` `developer-tools`,
+  and its own `tags`.
+
+The marketplace name (`attune-ai-plugin`) and the plugin name
+(`attune-ai`) are deliberately different — the install command
+(`attune-ai@attune-ai`) references the *plugin* name twice (plugin @
+marketplace), because this repo is its own single-plugin marketplace.
+
+### Auto-discovered components
+
+Claude Code reads fixed-name folders inside the bundle. Each is a
+component type:
+
+| Folder | What it holds | Count |
+|--------|---------------|-------|
+| `commands/` | Slash commands (`.md`) | 1 (`handoff`) |
+| `skills/` | Skills (one dir each, `SKILL.md`) | 17 |
+| `agents/` | Subagent definitions (`.md`) | 6 |
+| `hooks/` | `hooks.json` + hook scripts | ~20 scripts |
+| `help/` | Generated help, templates, schemas | — |
+| `.mcp.json` | MCP server registration | 1 server |
+
+`commands/` ships `handoff` (the `/handoff` resume-prompt command).
+The 17 skills are the developer-workflow surface (`spec`,
+`security-audit`, `code-quality`, `smart-test`, `release-prep`, …). The
+6 agents are read-only or planning subagents
+(`security-reviewer`, `refactor-planner`, `release-prep-auditor`,
+`spec-author`, `setup-guide`, `help-content-explainer`).
+
+### Hooks and MCP — shipped, not owned here
+
+`hooks/hooks.json` wires hook scripts to five Claude Code lifecycle
+events — `SessionStart`, `Stop`, `PreToolUse`, `PostToolUse`,
+`UserPromptSubmit`. `.mcp.json` registers the MCP server
+(`uvx --from attune-ai python -m attune.mcp.server`). The plugin
+**bundles** both, but their behavior is documented by the **hooks** and
+**mcp-server** features respectively — this page covers only that they
+are part of the bundle.
+
+### The bundled core
+
+`plugin/core/` exists so the plugin can carry a version for standalone
+operation; `plugin/core/__init__.py` is just
+`__version__ = "8.9.0"`. The real runtime is the pip-installed
+`attune-ai` package, which the `.mcp.json` server pulls via
+`uvx --from attune-ai`.
+
+## Quickstart
+
+Install the plugin into Claude Code from the marketplace:
+
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-ai@attune-ai
+```
+
+The first command registers this repo as a marketplace; the second
+installs the `attune-ai` plugin from it. After install, Claude Code
+auto-discovers the components — the slash command, the 17 skills, the 6
+agents, the hooks, and the MCP server — and they become available in
+your session.
+
+To inspect the bundle locally:
+
+```bash
+cat plugin/.claude-plugin/plugin.json
+ls plugin/skills plugin/agents plugin/commands
+```
+
+## Tasks
+
+### Install the plugin
+
+**Goal:** add attune to Claude Code.
+
+**Steps:**
+
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-ai@attune-ai
+```
+
+**Verify:** the `/attune` and `/handoff` commands appear, and the
+attune skills (`/spec`, `/security-audit`, …) are available in the
+session. `attune-ai@attune-ai` is `plugin-name@marketplace-plugin` —
+both resolve to the `attune-ai` plugin in this single-plugin
+marketplace.
+
+### Read the manifest
+
+**Goal:** confirm the bundle's identity and version.
+
+**Steps:**
+
+```bash
+cat plugin/.claude-plugin/plugin.json
+```
+
+**Verify:** `name` is `attune-ai`, `license` is `Apache-2.0`, and
+`keywords` include `claude-code`. The `version` here is the plugin
+bundle version (`8.9.0`); the sibling `marketplace.json` carries a
+matching version in `metadata.version` and `plugins[0].version`.
+
+### List the components Claude Code will discover
+
+**Goal:** see what the bundle ships.
+
+**Steps:**
+
+```bash
+ls plugin/commands   # 1 command (handoff.md)
+ls plugin/skills     # 17 skill directories
+ls plugin/agents     # 6 agent definitions
+cat plugin/.mcp.json # the MCP server registration
+```
+
+**Verify:** each folder name is the component type Claude Code reads.
+`hooks/hooks.json` binds scripts to the five lifecycle events; for what
+those hooks do, see the **hooks** feature, and for the MCP server, the
+**mcp-server** feature.
+
+## Reference
+
+The plugin is a packaging artifact; its "API" is the manifest schema
+and the component folder layout.
+
+### `plugin/.claude-plugin/plugin.json`
+
+| Field | Value / Purpose |
+|-------|-----------------|
+| `name` | `attune-ai` — the plugin name. |
+| `version` | Plugin bundle version (`8.9.0`). |
+| `description` | One-line plugin summary shown in Claude Code. |
+| `author` | `{name, email}` — Smart AI Memory. |
+| `homepage` / `repository` | Project links. |
+| `license` | `Apache-2.0`. |
+| `keywords` | Discovery keywords (include `claude-code`). |
+
+### `plugin/.claude-plugin/marketplace.json`
+
+| Field | Value / Purpose |
+|-------|-----------------|
+| `name` | `attune-ai-plugin` — the **marketplace** name. |
+| `owner` | `{name, email}` of the marketplace. |
+| `metadata` | `{description, version}`. |
+| `plugins[]` | The plugin entries; one here. |
+| `plugins[0].name` | `attune-ai` — the plugin offered. |
+| `plugins[0].source` | `./` — plugin at the marketplace root. |
+| `plugins[0].category` | `developer-tools`. |
+| `plugins[0].tags` | Marketplace listing tags. |
+
+### Component folders
+
+| Folder | Component | Notes |
+|--------|-----------|-------|
+| `commands/` | Slash commands | `handoff.md` → `/handoff`. |
+| `skills/` | Skills | 17 dirs, each with `SKILL.md`. |
+| `agents/` | Subagents | 6 `.md` definitions. |
+| `hooks/` | Hooks | `hooks.json` + ~20 scripts → 5 events. |
+| `help/` | Help | `generated/`, `templates/`, `schemas/`. |
+| `core/` | Version | `__version__` only. |
+| `.mcp.json` | MCP server | `uvx --from attune-ai python -m attune.mcp.server`. |
+
+### Install
+
+| Step | Command |
+|------|---------|
+| Add marketplace | `claude plugin marketplace add Smart-AI-Memory/attune-ai` |
+| Install plugin | `claude plugin install attune-ai@attune-ai` |
+
+## Comparison
+
+The plugin is the **packaging surface**; the things it ships are
+separate features:
+
+| | plugin | mcp-server | hooks |
+|--|--------|------------|-------|
+| Role | The installable bundle (manifest + components) | One bundled component — the MCP tool server | One bundled component — lifecycle hook scripts |
+| Artifact | `plugin/` + `plugin.json` / `marketplace.json` | `python -m attune.mcp.server` + `.mcp.json` | `hooks/hooks.json` + scripts |
+| Documented by | This page | mcp-server feature | hooks feature |
+
+The plugin is the box; mcp-server and hooks are two of the things
+inside it. Install the box and Claude Code unpacks every component.
+
+## Failure modes
+
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `claude plugin install attune-ai@attune-ai` can't find the plugin | The marketplace wasn't added first | Run `claude plugin marketplace add Smart-AI-Memory/attune-ai` before installing | high |
+| Components don't appear after install | A component folder or the manifest is malformed | Confirm `plugin/.claude-plugin/plugin.json` parses and the folders exist | high |
+| MCP tools missing but skills present | The `.mcp.json` server didn't launch (`uvx`/`attune-ai` unavailable) | See the mcp-server feature; confirm `uvx --from attune-ai python -m attune.mcp.server` runs | medium |
+| Hooks not firing | `hooks/hooks.json` event wiring | See the hooks feature; this page only confirms the file is shipped | medium |
+| Version looks stale | `plugin/core/__init__.py` / manifest version not bumped at release | The plugin version is set at release; the runtime is the pip `attune-ai` | low |
+
+### Risk areas
+
+- **Marketplace before install.** `install` resolves the plugin from a
+  registered marketplace — adding the marketplace is the required first
+  step.
+- **Two names, not one.** `attune-ai-plugin` (marketplace) ≠
+  `attune-ai` (plugin). The install string is `plugin@marketplace`,
+  which here reads `attune-ai@attune-ai`.
+- **The bundle ships, it doesn't implement.** MCP-server and hook
+  behavior live in their own features; debugging those means going
+  there, not here.
+
+### Diagnosis order
+
+1. Confirm the marketplace was added: `claude plugin marketplace add
+   Smart-AI-Memory/attune-ai`.
+2. Confirm the manifest parses: `cat
+   plugin/.claude-plugin/plugin.json`.
+3. Confirm the component folders exist: `ls plugin/skills
+   plugin/agents plugin/commands`.
+4. For missing MCP tools, go to the mcp-server feature; for hooks, the
+   hooks feature.
+
+## FAQ seeds
+
+> **Channel-4 input, not a rendered FAQ.** The FAQ is a dynamic source
+> of truth fed by four channels — unmatched user queries, telemetry
+> error-frequency, GitHub issues, and these author-curated seeds —
+> merged, deduplicated, and frequency-ranked by the FAQ Generator (see
+> doc-stack D3, and the help-docs-single-source spec's decisions.md D6).
+> This section is **not** projected verbatim as the FAQ; it contributes
+> the feature's author-curated seed questions.
+
+- **Q:** How do I install the attune plugin?
+  **A:** `claude plugin marketplace add Smart-AI-Memory/attune-ai`,
+  then `claude plugin install attune-ai@attune-ai`. The first adds the
+  marketplace; the second installs the plugin.
+- **Q:** Why is the install string `attune-ai@attune-ai`?
+  **A:** It's `plugin-name@marketplace-plugin`. This repo is a
+  single-plugin marketplace named `attune-ai-plugin`, offering the
+  `attune-ai` plugin — so the plugin name appears on both sides.
+- **Q:** What does the plugin actually contain?
+  **A:** A manifest plus auto-discovered components: 1 slash command
+  (`/handoff`), 17 skills, 6 agents, the hook scripts, the help bundle,
+  and an `.mcp.json` that registers the MCP server.
+- **Q:** Is the plugin the same as the MCP server?
+  **A:** No. The plugin is the bundle; the MCP server is one component
+  it ships (`.mcp.json`). The server is documented by the mcp-server
+  feature.
+- **Q:** Does the plugin contain the runtime code?
+  **A:** No — `plugin/core` is just a `__version__`. The runtime is the
+  pip-installed `attune-ai` package, which `.mcp.json` pulls with
+  `uvx --from attune-ai`.
+
+## Notes & tips
+
+- **Add the marketplace first.** `install` needs a registered
+  marketplace to resolve `attune-ai@attune-ai` against.
+- **Mind the two names.** Marketplace `attune-ai-plugin`, plugin
+  `attune-ai`. The install string repeats the plugin name on purpose.
+- **The folders are the contract.** Claude Code discovers components by
+  fixed folder names (`commands/`, `skills/`, `agents/`, `hooks/`,
+  `help/`) — that layout *is* the plugin's interface.
+- **Go to the component's feature to debug it.** MCP tools → mcp-server;
+  hook behavior → hooks. This page is the bundle.
+
+## Design & extension
+
+### Design decisions
+
+- **Self-marketplace.** The repo is its own single-plugin marketplace
+  (`source: ./`), so `marketplace add` + `install` point at one
+  GitHub repo — no separate registry to publish to.
+- **Convention over configuration.** Components are discovered by fixed
+  folder names rather than enumerated in the manifest, keeping
+  `plugin.json` to identity/metadata.
+- **Thin bundled core.** `plugin/core` carries only a version; the
+  heavy runtime stays in the pip package the MCP server pulls, so the
+  bundle stays small and the runtime updates independently.
+- **Separation of concerns.** The bundle ships the MCP server and hooks
+  but documents them as their own features — the plugin page stays about
+  packaging.
+
+### Extension points
+
+- **Add a command/skill/agent:** drop a file into the matching folder
+  (`commands/*.md`, `skills/<name>/SKILL.md`, `agents/*.md`); Claude
+  Code auto-discovers it on install.
+- **Add a hook:** wire it in `hooks/hooks.json` (see the hooks
+  feature).
+- **Change marketplace metadata:** edit
+  `plugin/.claude-plugin/marketplace.json` (name, category, tags).
+- **Bump the bundle version:** update `plugin.json`,
+  `marketplace.json`, and `plugin/core/__init__.py` together at
+  release.

--- a/docs/architecture/plugin.md
+++ b/docs/architecture/plugin.md
@@ -1,14 +1,4 @@
----
-type: concept
-name: plugin-concept
-feature: plugin
-depth: concept
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
-status: generated
----
-
-# The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
+# Plugin
 
 ## Overview
 
@@ -96,3 +86,35 @@ operation; `plugin/core/__init__.py` is just
 `__version__ = "8.9.0"`. The real runtime is the pip-installed
 `attune-ai` package, which the `.mcp.json` server pulls via
 `uvx --from attune-ai`.
+
+## Design & extension
+
+### Design decisions
+
+- **Self-marketplace.** The repo is its own single-plugin marketplace
+  (`source: ./`), so `marketplace add` + `install` point at one
+  GitHub repo — no separate registry to publish to.
+- **Convention over configuration.** Components are discovered by fixed
+  folder names rather than enumerated in the manifest, keeping
+  `plugin.json` to identity/metadata.
+- **Thin bundled core.** `plugin/core` carries only a version; the
+  heavy runtime stays in the pip package the MCP server pulls, so the
+  bundle stays small and the runtime updates independently.
+- **Separation of concerns.** The bundle ships the MCP server and hooks
+  but documents them as their own features — the plugin page stays about
+  packaging.
+
+### Extension points
+
+- **Add a command/skill/agent:** drop a file into the matching folder
+  (`commands/*.md`, `skills/<name>/SKILL.md`, `agents/*.md`); Claude
+  Code auto-discovers it on install.
+- **Add a hook:** wire it in `hooks/hooks.json` (see the hooks
+  feature).
+- **Change marketplace metadata:** edit
+  `plugin/.claude-plugin/marketplace.json` (name, category, tags).
+- **Bump the bundle version:** update `plugin.json`,
+  `marketplace.json`, and `plugin/core/__init__.py` together at
+  release.
+
+<!-- attune-generated: source_hash=db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53 feature=plugin kind=architecture generated_at=2026-06-24 -->

--- a/docs/features/plugin.md
+++ b/docs/features/plugin.md
@@ -1,0 +1,27 @@
+# Plugin
+
+The Claude Code plugin bundle — its manifest, marketplace listing, install flow, and the components Claude Code auto-discovers
+
+!!! tip "Start here"
+
+    [How-to guide](../how-to/plugin.md) — task recipes for common goals.
+
+<div class="grid cards" markdown>
+
+-   __Reference__
+
+    ---
+
+    The full API and option reference.
+
+    [Open the reference](../reference/plugin.md)
+
+-   __Architecture__
+
+    ---
+
+    How it works and how to extend it.
+
+    [Open the architecture](../architecture/plugin.md)
+
+</div>

--- a/docs/how-to/plugin.md
+++ b/docs/how-to/plugin.md
@@ -1,158 +1,126 @@
----
-type: how-to
-name: plugin
-tags: [plugin, claude-code, hooks, mcp]
-source: developer-guidance
----
+# Plugin
 
-# How to use the Claude Code plugin
+## Quickstart
 
-Use this guide when you need to wire up, call, or extend the Claude Code plugin's hooks and commands — session continuity, security validation, spec orientation, and context-utilization warnings.
+Install the plugin into Claude Code from the marketplace:
 
-## Quick start
-
-The following snippet checks context utilization and prints a compact warning when the transcript is getting full:
-
-```python
-from hooks._transcript_size import estimate_utilization
-from hooks._state import git_state, workspace_roots, discover_specs
-from hooks._resume_prompt import build_resume_prompt
-from hooks.compact_warning import format_warning
-from pathlib import Path
-
-cwd = Path.cwd()
-roots = workspace_roots(cwd)
-specs = discover_specs(roots)
-spec = specs[0] if specs else None
-
-util = estimate_utilization("~/.claude/transcript.jsonl")
-if util > 0.8:
-    state = git_state(cwd)
-    resume = build_resume_prompt(spec, state, workspace_path="~/attune")
-    print(format_warning(util, threshold=0.8, resume_body=resume))
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-ai@attune-ai
 ```
 
-Running this prints a formatted warning block to stdout when the transcript exceeds 80 % utilization.
+The first command registers this repo as a marketplace; the second
+installs the `attune-ai` plugin from it. After install, Claude Code
+auto-discovers the components — the slash command, the 17 skills, the 6
+agents, the hooks, and the MCP server — and they become available in
+your session.
 
-## Core API
+To inspect the bundle locally:
 
-Each hook module exposes a `main()` entry point callable by Claude Code directly. The shared helpers in `hooks._state` and `hooks._transcript_size` are the building blocks the other hooks rely on.
-
-### State discovery (`hooks._state`)
-
-| Function / Class | Purpose |
-|---|---|
-| `workspace_roots(cwd)` | Returns candidate workspace root paths to scan for specs |
-| `discover_specs(roots)` | Walks `specs/` directories under each root; returns `list[SpecInfo]` |
-| `git_state(cwd)` | Snapshots branch, last commit SHA + subject, and uncommitted files |
-| `session_sentinel_path(session_id)` | Returns the path of the once-per-session compact-warning sentinel file |
-| `prune_stale_sentinels(now)` | Deletes sentinel files older than the TTL; returns count removed |
-| `SpecInfo` | Dataclass: `slug`, `path`, `layer`, `phase`, `status`, `mtime` |
-| `GitState` | Dataclass: `branch`, `last_sha`, `last_subject`, `uncommitted` |
-
-### Context utilization (`hooks._transcript_size`)
-
-| Function | Purpose |
-|---|---|
-| `estimate_utilization(transcript_path)` | Returns context utilization as a float in `[0.0, 1.0]` |
-
-### Resume prompt (`hooks._resume_prompt`)
-
-| Function | Purpose |
-|---|---|
-| `build_resume_prompt(spec_info, git_state, *, workspace_path, todo_summary)` | Renders the user-facing resume prompt body |
-
-### Compact warning (`hooks.compact_warning`)
-
-| Function | Purpose |
-|---|---|
-| `format_warning(util, threshold, resume_body)` | Composes the full warning message + resume prompt |
-
-### Security (`hooks.security_guard`)
-
-| Function | Purpose |
-|---|---|
-| `validate_bash_command(command)` | Checks a Bash command against security policies; returns `(allowed, reason)` |
-| `validate_file_path(file_path)` | Checks a file path against security policies; returns `(allowed, reason)` |
-| `main(context)` | Validates a tool call dict; returns an updated context dict |
-
-### Spec orientation (`hooks.spec_orient`)
-
-| Function | Purpose |
-|---|---|
-| `format_orientation(specs)` | Returns a short markdown list of in-flight specs for session start |
-| `render_spec_pin(spec, char_budget)` | Renders a spec body for post-compact context restoration |
-
-### Hook entry points
-
-| Module | `main()` behavior |
-|---|---|
-| `hooks._handoff_cli` | CLI wrapper for the `/handoff` slash command |
-| `hooks.compact_warning` | Entry point — never raises |
-| `hooks.format_on_save` | Reads a tool result from stdin and formats Python files |
-| `hooks.help_freshness_check` | Checks help-template freshness on session start |
-| `hooks.help_on_error` | Reads a `PostToolUse` payload and suggests help if applicable |
-| `hooks.help_post_commit` | Checks for stale help after a git commit |
-| `hooks.spec_orient` | Branches on `source`; never raises |
-| `hooks.welcome` | Prints a welcome message to stderr (Claude Code surfaces stderr) |
-
-## Integration patterns
-
-### Security guard in a tool-call pipeline
-
-Wrap any outgoing tool call through `hooks.security_guard.main()` before execution. The function accepts the raw context dict Claude Code passes to a `PreToolUse` hook and returns the same dict, potentially with a blocking annotation:
-
-```python
-from hooks.security_guard import main as security_check, validate_bash_command
-
-# Quick inline check
-allowed, reason = validate_bash_command("rm -rf /private/etc/hosts")
-if not allowed:
-    raise PermissionError(reason)
-
-# Full hook integration — called by Claude Code automatically,
-# but you can invoke it directly in tests:
-context = {"tool": "Bash", "input": {"command": "ls -la"}}
-result = security_check(context)
+```bash
+cat plugin/.claude-plugin/plugin.json
+ls plugin/skills plugin/agents plugin/commands
 ```
 
-`SYSTEM_DIRECTORIES` (`{'/etc', '/sys', '/proc', ...}`) and `SEARCH_COMMAND_PREFIXES` are the policy constants the validator checks against.
+## Tasks
 
-### Spec orientation at session start
+### Install the plugin
 
-Call `format_orientation` immediately after `discover_specs` to surface in-flight work to the model:
+**Goal:** add attune to Claude Code.
 
-```python
-from hooks._state import workspace_roots, discover_specs
-from hooks.spec_orient import format_orientation, render_spec_pin
-from pathlib import Path
+**Steps:**
 
-roots = workspace_roots(Path.cwd())
-specs = discover_specs(roots)
-
-# Short list for a fresh session
-print(format_orientation(specs))
-
-# Detailed pin for post-compact restoration (default 4 000-char budget)
-if specs:
-    print(render_spec_pin(specs[0]))
+```bash
+claude plugin marketplace add Smart-AI-Memory/attune-ai
+claude plugin install attune-ai@attune-ai
 ```
 
-## See also
+**Verify:** the `/attune` and `/handoff` commands appear, and the
+attune skills (`/spec`, `/security-audit`, …) are available in the
+session. `attune-ai@attune-ai` is `plugin-name@marketplace-plugin` —
+both resolve to the `attune-ai` plugin in this single-plugin
+marketplace.
 
-- `concepts/task-template-design-patterns.md` — how attune structures help content the plugin surfaces
-- `concepts/task-template-migration.md` — background on the session-continuity model the hooks support
+### Read the manifest
 
-## Unresolved references
+**Goal:** confirm the bundle's identity and version.
 
-> Auto-generated by attune-author fact-check. Review and either
-> fix the source code, fix this doc, or add an override.
+**Steps:**
 
-| Location | Severity | Issue |
-|---|---|---|
-| Line 16 (code fence) | error | `from hooks._transcript_size import …` — module not importable |
-| Line 16 (code fence) | error | `from hooks._state import …` — module not importable |
-| Line 16 (code fence) | error | `from hooks._resume_prompt import …` — module not importable |
-| Line 16 (code fence) | error | `from hooks.compact_warning import …` — module not importable |
-| Line 105 (code fence) | error | `from hooks.security_guard import …` — module not importable |
-| Line 125 (code fence) | error | `from hooks.spec_orient import …` — module not importable |
+```bash
+cat plugin/.claude-plugin/plugin.json
+```
+
+**Verify:** `name` is `attune-ai`, `license` is `Apache-2.0`, and
+`keywords` include `claude-code`. The `version` here is the plugin
+bundle version (`8.9.0`); the sibling `marketplace.json` carries a
+matching version in `metadata.version` and `plugins[0].version`.
+
+### List the components Claude Code will discover
+
+**Goal:** see what the bundle ships.
+
+**Steps:**
+
+```bash
+ls plugin/commands   # 1 command (handoff.md)
+ls plugin/skills     # 17 skill directories
+ls plugin/agents     # 6 agent definitions
+cat plugin/.mcp.json # the MCP server registration
+```
+
+**Verify:** each folder name is the component type Claude Code reads.
+`hooks/hooks.json` binds scripts to the five lifecycle events; for what
+those hooks do, see the **hooks** feature, and for the MCP server, the
+**mcp-server** feature.
+
+## Reference
+
+The plugin is a packaging artifact; its "API" is the manifest schema
+and the component folder layout.
+
+### `plugin/.claude-plugin/plugin.json`
+
+| Field | Value / Purpose |
+|-------|-----------------|
+| `name` | `attune-ai` — the plugin name. |
+| `version` | Plugin bundle version (`8.9.0`). |
+| `description` | One-line plugin summary shown in Claude Code. |
+| `author` | `{name, email}` — Smart AI Memory. |
+| `homepage` / `repository` | Project links. |
+| `license` | `Apache-2.0`. |
+| `keywords` | Discovery keywords (include `claude-code`). |
+
+### `plugin/.claude-plugin/marketplace.json`
+
+| Field | Value / Purpose |
+|-------|-----------------|
+| `name` | `attune-ai-plugin` — the **marketplace** name. |
+| `owner` | `{name, email}` of the marketplace. |
+| `metadata` | `{description, version}`. |
+| `plugins[]` | The plugin entries; one here. |
+| `plugins[0].name` | `attune-ai` — the plugin offered. |
+| `plugins[0].source` | `./` — plugin at the marketplace root. |
+| `plugins[0].category` | `developer-tools`. |
+| `plugins[0].tags` | Marketplace listing tags. |
+
+### Component folders
+
+| Folder | Component | Notes |
+|--------|-----------|-------|
+| `commands/` | Slash commands | `handoff.md` → `/handoff`. |
+| `skills/` | Skills | 17 dirs, each with `SKILL.md`. |
+| `agents/` | Subagents | 6 `.md` definitions. |
+| `hooks/` | Hooks | `hooks.json` + ~20 scripts → 5 events. |
+| `help/` | Help | `generated/`, `templates/`, `schemas/`. |
+| `core/` | Version | `__version__` only. |
+| `.mcp.json` | MCP server | `uvx --from attune-ai python -m attune.mcp.server`. |
+
+### Install
+
+| Step | Command |
+|------|---------|
+| Add marketplace | `claude plugin marketplace add Smart-AI-Memory/attune-ai` |
+| Install plugin | `claude plugin install attune-ai@attune-ai` |
+
+<!-- attune-generated: source_hash=db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53 feature=plugin kind=how-to generated_at=2026-06-24 -->

--- a/docs/reference/plugin.md
+++ b/docs/reference/plugin.md
@@ -1,111 +1,52 @@
-# Plugin CLI reference
+# Plugin
 
-Claude Code plugin — skills, hooks, commands, and MCP config.
+## Reference
 
-## Description
+The plugin is a packaging artifact; its "API" is the manifest schema
+and the component folder layout.
 
-The attune-ai plugin bundles the runtime hooks, security guards, and session-continuity helpers that back Claude Code slash commands and MCP tooling. Each hook module exposes a `main()` entry point invoked by Claude Code at specific lifecycle events. Supporting functions handle state discovery, transcript sizing, and prompt rendering.
+### `plugin/.claude-plugin/plugin.json`
 
-## Usage
+| Field | Value / Purpose |
+|-------|-----------------|
+| `name` | `attune-ai` — the plugin name. |
+| `version` | Plugin bundle version (`8.9.0`). |
+| `description` | One-line plugin summary shown in Claude Code. |
+| `author` | `{name, email}` — Smart AI Memory. |
+| `homepage` / `repository` | Project links. |
+| `license` | `Apache-2.0`. |
+| `keywords` | Discovery keywords (include `claude-code`). |
 
-```
-plugin [OPTIONS] SUBCOMMAND [ARGS]
-```
+### `plugin/.claude-plugin/marketplace.json`
 
-## Subcommands
+| Field | Value / Purpose |
+|-------|-----------------|
+| `name` | `attune-ai-plugin` — the **marketplace** name. |
+| `owner` | `{name, email}` of the marketplace. |
+| `metadata` | `{description, version}`. |
+| `plugins[]` | The plugin entries; one here. |
+| `plugins[0].name` | `attune-ai` — the plugin offered. |
+| `plugins[0].source` | `./` — plugin at the marketplace root. |
+| `plugins[0].category` | `developer-tools`. |
+| `plugins[0].tags` | Marketplace listing tags. |
 
-### Hook entry points
+### Component folders
 
-| Subcommand | Module | Description |
-|---|---|---|
-| `compact-warning main` | `hooks.compact_warning` | Fires when context utilization crosses a threshold; emits a warning and resume prompt to stderr. Never raises. |
-| `format-on-save main` | `hooks.format_on_save` | Reads a PostToolUse payload from stdin and formats Python files in place. |
-| `help-freshness-check main` | `hooks.help_freshness_check` | Checks help-template freshness at session start. |
-| `help-on-error main` | `hooks.help_on_error` | Reads a PostToolUse payload and suggests relevant help if a tool error is detected. |
-| `help-post-commit main` | `hooks.help_post_commit` | Checks for stale help templates after a git commit. |
-| `handoff main` | `hooks._handoff_cli` | CLI wrapper for the `/handoff` slash command. Returns `0` on success. |
-| `spec-orient main` | `hooks.spec_orient` | Branches on `source`; prints orientation content for in-flight specs. Never raises. |
-| `security-guard main` | `hooks.security_guard` | Validates a tool call against security policies. Accepts a context dict; returns a result dict. |
-| `welcome main` | `hooks.welcome` | Prints a welcome message to stderr. Claude Code surfaces stderr to the user. |
+| Folder | Component | Notes |
+|--------|-----------|-------|
+| `commands/` | Slash commands | `handoff.md` → `/handoff`. |
+| `skills/` | Skills | 17 dirs, each with `SKILL.md`. |
+| `agents/` | Subagents | 6 `.md` definitions. |
+| `hooks/` | Hooks | `hooks.json` + ~20 scripts → 5 events. |
+| `help/` | Help | `generated/`, `templates/`, `schemas/`. |
+| `core/` | Version | `__version__` only. |
+| `.mcp.json` | MCP server | `uvx --from attune-ai python -m attune.mcp.server`. |
 
-### State and prompt helpers
+### Install
 
-| Subcommand | Signature | Description |
-|---|---|---|
-| `build-resume-prompt` | `spec_info: SpecInfo \| None, git_state: GitState, *, workspace_path='~/attune', todo_summary=None` | Renders the user-facing resume-prompt body as a string. |
-| `discover-specs` | `roots: list[Path]` | Walks `specs/` directories under each root and returns a list of `SpecInfo` for in-flight specs. |
-| `git-state` | `cwd: Path` | Returns branch name, last commit SHA, last commit subject, and uncommitted files for `cwd`. |
-| `session-sentinel-path` | `session_id: str \| None` | Returns the filesystem path for the once-per-session compact-warning sentinel. |
-| `prune-stale-sentinels` | `now: float \| None = None` | Deletes sentinel files older than the TTL. Returns the count of deleted files. |
-| `workspace-roots` | `cwd: Path \| None = None` | Returns a best-effort list of workspace roots to scan for specs. |
-| `estimate-utilization` | `transcript_path: str \| Path` | Returns estimated context utilization as a float in `[0.0, 1.0]`. |
-| `format-warning` | `util: float, threshold: float, resume_body: str` | Composes the user-facing warning string and resume prompt. |
-| `format-orientation` | `specs: list[SpecInfo]` | Returns a short Markdown list of in-flight specs, used on non-compact session starts. |
-| `render-spec-pin` | `spec: SpecInfo, char_budget: int` | Renders a spec body for post-compact context restoration, respecting `char_budget`. |
-| `validate-bash-command` | `command: str` | Validates a Bash command against security policies. Returns `(allowed: bool, reason: str)`. |
-| `validate-file-path` | `file_path: str` | Validates a file path against security policies. Returns `(allowed: bool, reason: str)`. |
-
-## Options
-
-| Option | Description |
-|--------|-------------|
-| `--help` | Show help and exit. |
-
-## Data types
-
-### `SpecInfo`
-
-One in-flight spec discovered under a workspace root.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `slug` | `str` | Short identifier for the spec. |
-| `path` | `Path` | Absolute path to the spec file. |
-| `layer` | `str` | Architectural layer the spec belongs to. |
-| `phase` | `str` | Current lifecycle phase. |
-| `status` | `str` | Current status string. |
-| `mtime` | `float` | Last-modified timestamp (Unix epoch). |
-
-### `GitState`
-
-Snapshot of the worktree's git state at hook fire time.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `branch` | `str` | Current branch name. |
-| `last_sha` | `str` | SHA of the most recent commit. |
-| `last_subject` | `str` | Subject line of the most recent commit. |
-| `uncommitted` | `tuple[str, ...]` | Paths of uncommitted changes. |
-
-## Output
-
-Hook entry points write to stderr; Claude Code surfaces stderr in the conversation. Example output from `compact-warning main`:
-
-```
-⚠️  Context utilization is high. Consider compacting soon.
-
-## Resume from here
-
-Branch: main | a1b2c3d fix: update spec routing
-Uncommitted: src/attune/hooks/_state.py
-
-In-flight specs:
-- auth-redesign (feature / in-progress)
-```
-
-`handoff main` and `spec-orient main` exit with `0` on success and write structured prompt content to stdout for Claude Code to consume.
-
-## Exit codes
-
-| Code | Meaning |
+| Step | Command |
 |------|---------|
-| `0` | Success. Applies to `handoff main`, `spec-orient main`, and `compact-warning main`. |
-| `1` | Unhandled error. Hook entry points documented as "never raises" suppress exceptions internally and may return `0` even when an internal error occurs. |
+| Add marketplace | `claude plugin marketplace add Smart-AI-Memory/attune-ai` |
+| Install plugin | `claude plugin install attune-ai@attune-ai` |
 
-## Related commands
-
-- `claude plugin install attune-ai@attune-ai` — install the plugin into Claude Code (see `tasks/install-plugin.md`)
-- `/attune` — verify the plugin is active inside a Claude Code session
-- `/coach` — skill entry point backed by this plugin runtime (see `quickstarts/skill-coach.md`)
-
-<!-- attune-generated: source_hash=ff7ee791016c71dc1aca7ef059da6fba3d0f06aa842c544cc71910c9900d0b2f feature=plugin kind=cli-reference generated_at=2026-05-27 -->
+<!-- attune-generated: source_hash=db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53 feature=plugin kind=reference generated_at=2026-06-24 -->


### PR DESCRIPTION
## Summary

Single-sources the **`plugin`** feature (Tier-3 rollout, 7 of 9) — the Claude Code plugin **bundle**: manifest (`plugin.json`), marketplace listing (`marketplace.json`), install flow, and the auto-discovered component folders. Authored `content/features/plugin.md` and projected it via `scripts/project_features.py`.

Scope is the **bundle/packaging**, deliberately **not** the MCP server internals (the `mcp-server` feature) or the individual hook scripts (the `hooks` feature) — the plugin only *ships* those.

## What changed

- **New master:** `content/features/plugin.md`
- **Projected (10 .help kinds + how-to/architecture/reference + hub):** `.help/templates/plugin/*`, `docs/{how-to,architecture,reference,features}/plugin.md`
- **FAQ rewritten as frozen `status: manual`:** the old `faq.md` over-documented hook-system internals (`SpecInfo`/`GitState`/`discover_specs`/`security_guard`/sentinels) — a scope conflation with the `hooks` feature. Reseeded from the master's verified bundle-scoped FAQ.
- **DD5:** `features.yaml` `plugin` entry → `status: manual`, dropped `files:` and the special `arch_path:` key; kept description + golden-query tags `[plugin, claude-code]`.
- The hand-written `docs/architecture/plugin-system.md` (custom-plugin authoring) is left untouched in nav.

## Gates (all green)

- Dry-run fact-check: **0 errors**
- Example gate: **0** (shell + JSON only, no Python blocks)
- **Adversarial subagent review: 0 false / 0 misleading** — every manifest field, component count (1 command, 17 skills, 6 agents, ~20 hook scripts, 5 hook events), `.mcp.json` command, and install string verified against source
- Golden queries + manifest integrity: green (57 passed)
- Full `tests/unit/help/`: **398 passed, 3 xfailed**
- `mkdocs build --strict`: **exit 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)