### PR TITLE
docs(ops): single-source ops-dashboard via projector (Tier-3 9/9)

### DIFF
--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -144,11 +144,22 @@ features:
     tags: [release, publishing, quality]
     status: manual
 
+  # ops-dashboard is single-sourced (status: manual) from
+  # content/features/ops-dashboard.md and rendered by
+  # attune_author.projector (scripts/project_features.py), which owns
+  # .help/templates/ops-dashboard/*.md. Marked `status: manual` WITHOUT
+  # `files:` so topic resolution routes here while staleness/maintenance
+  # never overwrites the projected content with LLM output (DD5,
+  # help-docs-single-source). The frozen faq.md stays on disk until the
+  # four-channel FAQ Generator (D6/D7) replaces it. Scope is the runner
+  # CORE (src/attune/ops/**) — cost/telemetry/help shown on the
+  # dashboard (ops.anthropic_cost / ops.data / ops.help_data) are
+  # adjacent READ-ONLY surfaces owned by their own features, not this
+  # one. Description/tags unchanged to preserve topic resolution.
   ops-dashboard:
     description: Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming
-    files:
-      - src/attune/ops/**
     tags: [ops, dashboard, runner, workflows, scope-picker, persistence, sse]
+    status: manual
 
   # refactor-plan is single-sourced (status: manual) from
   # content/features/refactor-plan.md and rendered by

--- a/.help/templates/ops-dashboard/comparison.md
+++ b/.help/templates/ops-dashboard/comparison.md
@@ -3,61 +3,23 @@ type: comparison
 name: ops-dashboard-comparison
 feature: ops-dashboard
 depth: comparison
-generated_at: 2026-06-10T07:07:04.679153+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Comparison: Ops Dashboard vs alternatives
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-## Context
+## Comparison
 
-The ops dashboard (`attune ops` / `python -m attune.ops`) is a local server that combines a workflow runner, per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming into a single interface. It exposes a FastAPI application via `create_app()` and reads project and attune state through a `Config` dataclass.
+The ops dashboard is one of three front doors to attune's workflows:
 
-## Feature comparison
+| | ops-dashboard | mcp-server | CLI |
+|--|---------------|-----------|-----|
+| Surface | Local web UI (HTTP) | MCP tools (stdio) | `attune workflow run` |
+| Strength | Scope picker, run history, chaining, live SSE | In-conversation tool calls | Scriptable one-shots |
+| Entry | `attune ops` | `python -m attune.mcp.server` | `attune workflow run <slug>` |
 
-| Capability | Ops dashboard | Ad-hoc script | Direct CLI invocation |
-|---|---|---|---|
-| **Workflow execution** | Full — scope picker, `WorkflowEntry` stage map, workflow chaining | Manual — you wire the calls yourself | Single workflow only, no chaining |
-| **Run history** | Persisted to `Config.runs_dir`; retained for `runs_retention_days` days (default 30) | None unless you add it yourself | None |
-| **Cost visibility** | Live Anthropic cost report via `fetch_summary()` with `CostSummary` fields (`today_usd`, `seven_day_usd`, `month_to_date_usd`, `thirty_day_usd`, `by_model`) | None | None |
-| **Session tracking** | `Session` records surfaced on `/sessions` page (message count, duration, starter prompt) | None | None |
-| **Spec completion candidates** | Detected via `detect_candidates()` when `specs_candidates_enabled = True` | None | None |
-| **Scope targeting** | Feature-level via `.help/features.yaml` `Feature` entries and `PathArgSpec` | Hardcoded paths | Single `--path` argument at most |
-| **Telemetry** | `TelemetrySummary` tracks requests, cost, savings, and per-workflow breakdowns | None | None |
-| **Startup overhead** | FastAPI server + SSE — not suitable for quick one-off commands | Near-zero | Near-zero |
-| **Remote access** | Configurable `host`/`port`; `trusted_hosts` whitelist | N/A | N/A |
-| **Admin API key required** | Yes, for `fetch_summary()` — `load_admin_key()` returns `None` if unavailable; cost panel is skipped gracefully | N/A | N/A |
-
-## Tradeoffs
-
-**Ops dashboard wins when** you need any combination of: cross-workflow visibility, cost tracking, session history, or scope-targeted execution. All of that infrastructure is built in and requires no extra code on your part.
-
-**Ops dashboard loses when** you need a fast, stateless command. The server starts on `host:port` (default `127.0.0.1:8765`) and blocks (`cmd_ops()` returns `0` only on clean shutdown). For a single workflow run with no need for history or cost data, launching the full server is unnecessary overhead.
-
-**Cost data is optional, not required.** `fetch_summary(refresh=False)` returns a `(CostSummary | None, CostFetchError | None)` tuple. If `load_admin_key()` returns `None`, the dashboard still runs — cost panels are simply absent. You do not need Anthropic admin credentials to use the workflow runner.
-
-**`allow_run`** defaults to `False` in `Config`. The dashboard can display workflow metadata without being allowed to execute runs. This is the safe default for read-only inspection.
-
-## When to use the ops dashboard
-
-Use the ops dashboard when at least one of these is true:
-
-- You are running multiple workflows against different features and want a scope picker rather than manually specifying paths on every invocation.
-- You need to inspect run history across sessions — `Config.runs_dir` and `runs_retention_days` give you durable records without any extra tooling.
-- You want live Anthropic cost data (`CostSummary.today_usd`, `by_model`, etc.) visible alongside your workflow activity.
-- You are working on a project with spec completion tracking and want `detect_candidates()` surfaced automatically (`specs_candidates_enabled = True`).
-- You want clickable workflow chaining — advancing from one `WorkflowEntry` stage to the next without returning to the terminal.
-
-## When to use an alternative instead
-
-- **Single, quick command with no history needed:** invoke the workflow directly via the `attune` CLI. The ops dashboard's server startup and SSE infrastructure add latency that a one-shot command does not justify.
-- **Automated or CI context:** a blocking server (`cmd_ops`) is the wrong shape for a pipeline step. Call the relevant function directly or use the CLI subcommand in a non-interactive script.
-- **Exploratory or throwaway work:** a small script that calls the relevant functions directly is simpler than standing up a dashboard you will discard.
-- **You need behavior not exposed in `__all__`** (`create_app`, `build_config`, `Config`): do not reach into private internals — the surface is intentionally narrow. File an issue or propose an extension point instead.
-
-## Source files
-
-- `src/attune/ops/**`
-
-**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`
+It is the *browser* front door; the MCP server is the *conversational*
+one; the CLI is the *terminal* one. The dashboard renders cost,
+telemetry, and help data those other features own.

--- a/.help/templates/ops-dashboard/concept.md
+++ b/.help/templates/ops-dashboard/concept.md
@@ -3,54 +3,99 @@ type: concept
 name: ops-dashboard-concept
 feature: ops-dashboard
 depth: concept
-generated_at: 2026-06-22T10:00:48.764701+00:00
-source_hash: dd650b4658efc1f6876bf6f2701d846e9091228187573660cdcfc10ab83fa6c2
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Ops Dashboard
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-## What the ops dashboard is
+## Overview
 
-The ops dashboard is a locally running web server — the operations layer of the attune workflow OS — that lets you run workflows against a specific feature scope, browse persisted run history, chain workflows with a single click, and stream live logs over SSE.
+The ops dashboard is attune's **local operations layer** — a FastAPI
+web app you run on your own machine to execute workflows against a
+chosen feature scope, browse persisted run history, chain workflows
+with a click, and watch live logs stream over **SSE**. It lives in
+**`src/attune/ops/`** and is launched with `attune ops` (or `python -m
+attune.ops`), binding to **`127.0.0.1:8765`** by default.
 
-You start it with `attune ops` (or `python -m attune.ops`). It binds to `127.0.0.1:8765` by default and serves a browser UI backed by a FastAPI application created by `create_app`.
+This page documents the **runner core** — the server, its config, and
+the `RunnerService`/`Run` execution model. The dashboard also *displays*
+data owned by other features — Anthropic cost (`ops.anthropic_cost`),
+telemetry (`ops.data` reads the telemetry store), and help coverage
+(`ops.help_data`) — but those are **adjacent** surfaces it renders, not
+its own; each belongs to its respective feature (telemetry, help-system).
 
-## How the pieces fit together
+The public API is deliberately tiny — `__all__` is exactly
+**`create_app`, `build_config`, `Config`**. Everything else
+(`RunnerService`, `Run`, the `ops.data` readers) is reached through
+those or imported from its submodule.
 
-The dashboard is built from five cooperating concerns: configuration, cost reporting, telemetry, spend-anomaly detection, and spec-completion detection.
+You reach it these ways:
 
-**Configuration** is the root. `Config` tells every other part of the dashboard where to look for project state and attune state:
+- the **CLI** — `attune ops` / `python -m attune.ops` starts the server;
+- the **Python API** — `from attune.ops import create_app, build_config,
+  Config` to build and embed the app (e.g. in tests).
 
-- `project_root` and `attune_home` anchor all relative paths.
-- Derived properties — `runs_dir`, `sessions_dir`, `bulletin_dir`, `memory_dir`, `telemetry_path` — point to the directories where the dashboard reads and writes persisted data.
-- `specs_roots` lists the directories that the candidate detector scans.
-- `allow_run` must be `True` before the dashboard will actually execute a workflow; this is a deliberate safety gate.
-- `trusted_hosts` restricts which remote hosts may connect.
-- `runs_retention_days` (default `30`) controls how long run history is kept on disk.
+## Concepts
 
-**Cost reporting** calls the Anthropic admin cost-report endpoint at `https://api.anthropic.com/v1/organizations/cost_report`. `fetch_summary(refresh=False)` returns either a `CostSummary` or a `CostFetchError`. `CostSummary` breaks spending down along three axes — `by_day`, `by_model`, and `by_cost_type` — plus rolled-up totals (`today_usd`, `seven_day_usd`, `month_to_date_usd`, `thirty_day_usd`). The `source` field tells you whether the data came from a live API call or an in-memory cache. When the fetch fails, `CostFetchError` carries a `kind` (a `CostFetchErrorKind` enum) and a human-readable `message` so the UI can display a precise error rather than a generic one.
+### The public surface: `build_config` → `create_app`
 
-**Spend-anomaly detection** (R6) raises alerts when daily API spend becomes anomalous or approaches the monthly ceiling. `SpendAlarm` independently flags two triggers: (1) today's spend is a statistical outlier versus the trailing baseline (z-score, with a flat-multiplier fallback when variance is zero), and (2) month-to-date spend reaches 80% of the monthly cap (default $350). The alarm prefers account-level spend (the admin cost-report, which also sees CI spend) and falls back to local `usage.jsonl` when no admin key is configured. Its `detail` field carries a one-line explanation for display.
+`build_config(project_root, *, host, port, allow_run, …)` produces a
+`Config`; `create_app(config, *, runner=None)` returns a ready
+`FastAPI` app. Both are **synchronous**. `Config` anchors every path the
+dashboard reads or writes via derived **properties**: `runs_dir`,
+`sessions_dir`, `bulletin_dir`, `memory_dir`, `telemetry_path`
+(`attune_home()` resolves the attune state root).
 
-**Telemetry** is recorded locally. `TelemetrySummary` aggregates the requests the dashboard has processed: `total_requests`, `total_cost`, `total_savings`, and breakdowns `by_workflow` and `by_day`. The UI uses this data to show you which workflows you run most and what they cost.
+### The run-safety gate
 
-**Spec-completion detection** is opt-in (`specs_candidates_enabled` in `Config`). When enabled, `detect_candidates` scans the configured `specs_roots` and returns a list of `Candidate` objects — one per spec that looks ready to close out. Each `Candidate` carries the spec's `slug`, `path`, `current_status`, supporting `evidence`, and a `snapshot_hash` so the detector can avoid re-surfacing a candidate you have already dismissed.
+`Config.allow_run` defaults to **`False`** — the dashboard will not
+execute a workflow unless it is `True`. The **CLI flips it on by
+default**, disabling it only when you pass `--read-only`. So `attune
+ops` can run workflows out of the box; `attune ops --read-only` serves a
+look-but-don't-run dashboard.
 
-## Scope picker and session tracking
+### `RunnerService` and `Run` — the execution model
 
-The dashboard's feature scope picker reads from `.help/features.yaml`. Each `Feature` entry has a `name`, `description`, optional `path`, and `tags`. When you select a scope, the dashboard filters the workflow list and records the interaction (the `scope_picker_change` event is one of the tracked `EVENTS`, alongside `pill_click` and `rec_card_click`).
+`RunnerService` owns workflow execution. Its one **async** method is the
+killer to remember:
 
-Sessions — individual Claude Code conversations — surface on the `/sessions` page. Each `Session` record captures `started_at`, `last_activity`, `duration_seconds`, `message_count`, and the `starter_prompt` that opened the conversation.
+- **`start(workflow, *, path=None) -> Run` is a coroutine** — `await`
+  it. It launches a workflow (optionally scoped to a `path`) and returns
+  a `Run`.
+- `recent`, `get`, `get_or_load`, `handle_stdout_line` are
+  **synchronous**; `current` and `persistence_dir` are properties.
+- Only **one run at a time**: starting a second while one is active
+  raises **`RunnerBusyError(current_run_id)`**.
 
-## When this matters
+A `Run` is one execution. `Run.subscribe()` is an **async iterator** of
+events — this is the SSE feed the browser consumes. `append_line`,
+`mark_done`, `to_dict`/`to_record` are sync; `duration_seconds` and
+`is_terminal` are properties.
 
-You need the ops dashboard when you want to:
+### Scope picker, persistence, and chaining
 
-- Monitor daily API-spend anomalies and month-to-date spending against an automated ceiling gauge.
-- Track Anthropic API spend across models and days without leaving your project.
-- Run attune workflows from a browser UI rather than typing CLI commands, especially when you want to chain multiple workflows in sequence.
-- Review persisted run history beyond the `runs_retention_days` window to audit what ran and when.
-- Let the spec-completion detector surface specs that have accumulated enough evidence to close.
+The feature **scope picker** reads `.help/features.yaml` so you can
+narrow a run to one feature; `ops.data.workflow_default_scope` supplies
+the default. Run history is **persisted** to `Config.runs_dir` and
+survives restarts (`get_or_load` rehydrates a past run);
+`prune_old_runs` trims beyond `runs_retention_days` (default 30). UI
+interactions are counted via `ops.interaction_counters.EVENTS`
+(`pill_click`, `rec_card_click`, `scope_picker_change`).
 
-If you only need a single workflow run from the command line and have no interest in the browser UI, the dashboard is more than you need — individual workflows can still be invoked directly through the `attune` CLI without starting the server.
+### Adjacent read-only surfaces
+
+The dashboard renders data it does not own:
+
+| Submodule | Role | Owning feature |
+|---|---|---|
+| `ops.data` | Reads telemetry/workflows/sessions/KPIs | telemetry |
+| `ops.anthropic_cost` | `fetch_summary()` → cost report | (account-level) |
+| `ops.help_data` | Help coverage + search (the help tab) | help-system |
+| `ops.spec_lifecycle` | `derive_lifecycle(spec)` → status label | spec tooling |
+
+`ops.spec_lifecycle`'s only public function is `derive_lifecycle(spec,
+*, now=None) -> str` (plus the `STALE_THRESHOLD_DAYS` constant) — it
+labels a spec's lifecycle bucket from its phases and last-modified time.
+(There is no candidate-detection API here.)

--- a/.help/templates/ops-dashboard/error.md
+++ b/.help/templates/ops-dashboard/error.md
@@ -3,47 +3,38 @@ type: error
 name: ops-dashboard-error
 feature: ops-dashboard
 depth: error
-generated_at: 2026-06-10T07:07:04.658159+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Ops Dashboard errors
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-## Common error signatures
+## Failure modes
 
-Most failures in the ops dashboard fall into one of two categories: cost-report fetch errors and configuration errors.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `RuntimeWarning: coroutine 'RunnerService.start' was never awaited` | `start()` called without `await` | It's async — `await` it / `asyncio.run` | high |
+| Workflows won't run from the UI | `Config.allow_run` is `False` (e.g. `--read-only`) | Start without `--read-only` | high |
+| `RunnerBusyError` on start | A run is already active (one at a time) | Wait for / inspect `runner.current` | medium |
+| `TypeError` calling `config.runs_dir()` | `runs_dir` is a property | Drop the `()` | medium |
+| Cost panel shows an error | `fetch_summary` returned a `CostFetchError` (no admin key, network) | Inspect the error `kind`/`message`; cost is an adjacent surface | low |
 
-**Cost-report fetch errors** are represented by `CostFetchError`, a dataclass with two fields:
+### Risk areas
 
-- `kind: CostFetchErrorKind` — a categorized enum value identifying what went wrong (for example, a missing admin key, a network failure, or an unexpected API response)
-- `message: str` — a human-readable description of the failure
+- **`RunnerService.start` and `Run.subscribe` are async.** They are the
+  two awaitable surfaces; everything else on the runner is sync.
+- **`allow_run` is a real gate.** Off by default in `Config`; the CLI
+  turns it on unless `--read-only`.
+- **Scope confusion.** Cost/telemetry/help shown on the dashboard are
+  *adjacent* surfaces — owned by other features, only read here.
 
-`fetch_summary()` always returns a `(CostSummary | None, CostFetchError | None)` tuple. When the second element is not `None`, the fetch failed and the first element is `None`. A `CostSummary` with `source='cached'` means the live fetch failed silently and an older result was served instead — check the `fetched_at` field to assess staleness.
+### Diagnosis order
 
-**Configuration errors** surface when `build_config()` cannot construct a valid `Config`. Missing or inaccessible paths for `project_root` or `attune_home` are the most common cause.
-
-## Where errors originate
-
-- `fetch_summary(*, refresh: bool = False)` — Returns `(None, CostFetchError)` when the Anthropic admin cost-report endpoint at `https://api.anthropic.com/v1/organizations/cost_report` is unreachable, returns a non-success status, or when `load_admin_key()` returns `None`.
-- `load_admin_key()` — Returns `None` rather than raising when the admin API key is absent. A `None` result here is the most common upstream cause of a failed `fetch_summary()` call.
-- `build_config()` — Raises during startup if the resolved `Config` fields (such as `project_root` or `attune_home`) refer to paths the process cannot access.
-- `create_app()` — Defers the FastAPI import until call time; an `ImportError` here means FastAPI is not installed in the current environment.
-
-## How to diagnose
-
-1. **Check whether `fetch_summary()` returned a `CostFetchError`.** Inspect the `kind` and `message` fields directly — they identify the failure category without requiring a stack trace.
-
-2. **Verify the admin key is available.** Call `load_admin_key()` in isolation. If it returns `None`, the dashboard cannot reach the cost-report API regardless of network state. Ensure the key is present in the expected environment variable or credentials file before investigating further.
-
-3. **Confirm `CostSummary.source`.** If the dashboard is displaying cost data but the figures look stale, check whether `source == 'cached'`. Compare `fetched_at` against the current time to determine how old the cached result is, then investigate why the live fetch failed.
-
-4. **Reproduce the `build_config()` failure path.** If the dashboard fails to start, run `python -m attune.ops` directly. A startup error will print the exception and the `Config` field that could not be resolved, making it straightforward to identify which path is missing or inaccessible.
-
-5. **Check for a missing FastAPI installation.** If `create_app()` raises `ImportError`, FastAPI is not installed. The lazy-import design means this error only appears at server startup, not at import time.
-
-## Source files
-
-- `src/attune/ops/**`
-
-**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`
+1. Confirm the app builds: `create_app(build_config(Path(".")))`.
+2. Confirm runs are allowed: `config.allow_run` (and no `--read-only`).
+3. For a run that won't start: check `runner.current` /
+   `RunnerBusyError`.
+4. For async warnings: `await` `start()` / iterate `subscribe()`.
+5. For a data panel: that data is owned by its feature (telemetry /
+   help-system / cost).

--- a/.help/templates/ops-dashboard/faq.md
+++ b/.help/templates/ops-dashboard/faq.md
@@ -3,55 +3,81 @@ type: faq
 name: ops-dashboard-faq
 feature: ops-dashboard
 depth: faq
-generated_at: 2026-06-10T07:07:04.669090+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
-status: generated
+status: manual
 ---
 
 # Ops Dashboard FAQ
 
 ## What is the ops dashboard?
 
-A local operations dashboard that lets you run workflows against a specific feature scope, view persisted run history, chain workflows with a single click, and stream live logs over SSE. You start it with `python -m attune.ops` or via `attune ops` on the CLI.
+A local FastAPI web app that lets you run attune workflows against a
+specific feature scope, browse persisted run history, chain workflows
+with a single click, and stream live logs over SSE. Start it with
+`attune ops` or `python -m attune.ops` (default `127.0.0.1:8765`).
 
-## How do I start the dashboard?
+## How do I start it?
 
-Run `python -m attune.ops` (calls `main()`) or use the `attune ops` subcommand (registered by `add_subparser()`). Both block until you stop the server. By default the server listens on `127.0.0.1:8765`; you can change the host and port in `Config`.
+Run `attune ops` (the CLI subcommand registered by `add_subparser()`) or
+`python -m attune.ops` (calls `main()`). Both block until you stop the
+server. Workflow execution is **enabled by default**; pass `--read-only`
+for a look-but-don't-run dashboard.
+
+## What's the public API?
+
+Exactly three names — `attune.ops.__all__` is `create_app`,
+`build_config`, and `Config`. Build a config with `build_config(...)`
+(don't instantiate `Config` directly), then `create_app(config)` returns
+the `FastAPI` app. Both are synchronous. The runner lives in
+`attune.ops.runner`.
 
 ## What does `Config` control?
 
-`Config` is the central settings dataclass for the dashboard. Its key fields are:
+`Config` anchors every path the dashboard reads or writes. Key fields:
+`host`/`port` (default `127.0.0.1:8765`), `allow_run` (default `False`),
+`specs_roots`, `runs_retention_days` (default 30), and
+`specs_candidates_enabled`. Derived **properties** (no parentheses)
+include `runs_dir`, `sessions_dir`, `bulletin_dir`, `memory_dir`, and
+`telemetry_path`.
 
-| Field | What it controls |
-|---|---|
-| `project_root` | Root of your project tree |
-| `attune_home` | Where attune reads and writes state |
-| `host` / `port` | Server bind address (default `127.0.0.1:8765`) |
-| `allow_run` | Whether workflow execution is permitted |
-| `specs_roots` | Directories the candidate detector scans |
-| `runs_retention_days` | How long persisted run history is kept (default 30) |
-| `specs_candidates_enabled` | Whether spec-completion candidate detection is active |
+## Why won't my workflow run?
 
-Use `build_config()` to construct a `Config` rather than instantiating it directly.
+`Config.allow_run` must be `True`. It defaults to `False`; the CLI
+enables it (`allow_run = not --read-only`), so `attune ops` can run
+workflows out of the box while `attune ops --read-only` cannot.
 
-## How does cost reporting work?
+## How do I run a workflow from Python?
 
-Call `fetch_summary()` to get account-level Anthropic API cost data. It returns a `(CostSummary | None, CostFetchError | None)` tuple. Pass `refresh=True` to bypass the in-memory cache. The `CostSummary` fields cover today, the last 7 days, month-to-date, and the last 30 days, plus breakdowns by day, model, and cost type. If the fetch fails, the `CostFetchError` tells you the `kind` and a human-readable `message`. The dashboard fetches from `https://api.anthropic.com/v1/organizations/cost_report` and requires an admin API key, which `load_admin_key()` resolves.
+Use `RunnerService`. Its `start(workflow, *, path=None)` method is a
+**coroutine** — `await` it; it returns a `Run`. Only one run is active
+at a time, so a concurrent `start()` raises `RunnerBusyError` (which
+carries `current_run_id`).
 
-## How do I tell whether cost data is live or cached?
+## How does the live log stream work?
 
-Check the `source` field on the returned `CostSummary`. It is either `'live'` or `'cached'`. The `fetched_at` field tells you when the data was last retrieved.
+`Run.subscribe()` is an **async iterator** of events — the SSE feed the
+browser consumes. Iterate it with `async for`; `Run.is_terminal` (a
+property) flips true when the run finishes.
 
-## What are spec-completion candidates?
+## Does the dashboard own the cost / telemetry / help data it shows?
 
-When `specs_candidates_enabled` is `True` in your `Config`, `detect_candidates()` scans your `specs_roots` and returns a list of `Candidate` objects — specs that appear ready to move to the next phase based on file evidence. Each `Candidate` includes a `slug`, `path`, `current_status`, supporting `evidence`, and a `snapshot_hash`.
+No. Those are **adjacent** read-only surfaces it renders:
+`ops.anthropic_cost.fetch_summary()` (account cost), `ops.data` (reads
+the telemetry store), and `ops.help_data` (the help tab). Each is owned
+by its own feature (telemetry, help-system); the dashboard only displays
+them.
 
-## How do I run the dashboard in tests?
+## How do I label a spec's lifecycle?
 
-Use `clear_cache()` (available in both `attune.ops.anthropic_cost` and the candidate-detector module) to reset in-memory caches between test cases. This is a test-only helper and is not part of the public API (`__all__` exports only `create_app`, `build_config`, and `Config`).
+`ops.spec_lifecycle.derive_lifecycle(spec, *, now=None)` returns a status
+string from the spec's phases and last-modified time. That is the only
+public function in the module — there is no candidate-detection API.
+
+## How long is run history kept?
+
+`runs_retention_days` (default 30). History is persisted to
+`Config.runs_dir` and survives restarts (`get_or_load` rehydrates a past
+run); `prune_old_runs` trims older entries.
 
 ## Where are the source files?
 
-All dashboard source lives under `src/attune/ops/`.
-
-**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`
+- `src/attune/ops/**`

--- a/.help/templates/ops-dashboard/note.md
+++ b/.help/templates/ops-dashboard/note.md
@@ -3,41 +3,111 @@ type: note
 name: ops-dashboard-note
 feature: ops-dashboard
 depth: note
-generated_at: 2026-06-10T07:07:04.676642+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Note: ops dashboard
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-## What the ops dashboard is
+## Overview
 
-`attune ops` is a local operations dashboard for the workflow OS. You run it as a blocking server process — either via `python -m attune.ops` (the `main()` entry point) or through the `attune` CLI after `add_subparser` registers the `ops` subcommand. The server address and port default to `127.0.0.1:8765`, both configurable through `Config`.
+The ops dashboard is attune's **local operations layer** — a FastAPI
+web app you run on your own machine to execute workflows against a
+chosen feature scope, browse persisted run history, chain workflows
+with a click, and watch live logs stream over **SSE**. It lives in
+**`src/attune/ops/`** and is launched with `attune ops` (or `python -m
+attune.ops`), binding to **`127.0.0.1:8765`** by default.
 
-The dashboard provides a per-feature scope picker, persisted workflow run history, clickable workflow chaining, and live SSE log streaming. Run history is retained for `runs_retention_days` days (default: 30); the disk root for persisted runs is available at `Config.runs_dir`.
+This page documents the **runner core** — the server, its config, and
+the `RunnerService`/`Run` execution model. The dashboard also *displays*
+data owned by other features — Anthropic cost (`ops.anthropic_cost`),
+telemetry (`ops.data` reads the telemetry store), and help coverage
+(`ops.help_data`) — but those are **adjacent** surfaces it renders, not
+its own; each belongs to its respective feature (telemetry, help-system).
 
-## Public surface
+The public API is deliberately tiny — `__all__` is exactly
+**`create_app`, `build_config`, `Config`**. Everything else
+(`RunnerService`, `Run`, the `ops.data` readers) is reached through
+those or imported from its submodule.
 
-Three names are exported at the package boundary via `__all__`: `create_app`, `build_config`, and `Config`.
+You reach it these ways:
 
-- **`create_app()`** — lazily imports the FastAPI application factory, so importing `attune` does not pull in FastAPI as a side effect.
-- **`build_config()`** — lazily imports the config builder that produces a `Config` instance.
-- **`Config`** — the central configuration dataclass. It locates `project_root`, `attune_home`, spec roots, and derived paths such as `telemetry_path`, `runs_dir`, `memory_dir`, `sessions_dir`, and `bulletin_dir`.
+- the **CLI** — `attune ops` / `python -m attune.ops` starts the server;
+- the **Python API** — `from attune.ops import create_app, build_config,
+  Config` to build and embed the app (e.g. in tests).
 
-## Cost reporting
+## Concepts
 
-Anthropic API cost data is fetched from `https://api.anthropic.com/v1/organizations/cost_report` using API version `2023-06-01`. The result is a `CostSummary`, which carries today's spend, 7-day, month-to-date, and 30-day totals, plus breakdowns by day, model, and cost type. The `source` field indicates whether the data came from a live request or the in-memory cache.
+### The public surface: `build_config` → `create_app`
 
-`fetch_summary(*, refresh: bool = False)` returns a `(CostSummary | None, CostFetchError | None)` tuple. A `CostFetchError` pairs a `CostFetchErrorKind` with a human-readable `message`; it is returned rather than raised so callers can handle partial failures without exception handling.
+`build_config(project_root, *, host, port, allow_run, …)` produces a
+`Config`; `create_app(config, *, runner=None)` returns a ready
+`FastAPI` app. Both are **synchronous**. `Config` anchors every path the
+dashboard reads or writes via derived **properties**: `runs_dir`,
+`sessions_dir`, `bulletin_dir`, `memory_dir`, `telemetry_path`
+(`attune_home()` resolves the attune state root).
 
-`load_admin_key()` returns the admin API key or `None` if unavailable. `clear_cache()` empties the in-memory cache and is intended for use in tests only.
+### The run-safety gate
 
-## Spec completion detection
+`Config.allow_run` defaults to **`False`** — the dashboard will not
+execute a workflow unless it is `True`. The **CLI flips it on by
+default**, disabling it only when you pass `--read-only`. So `attune
+ops` can run workflows out of the box; `attune ops --read-only` serves a
+look-but-don't-run dashboard.
 
-When `Config.specs_candidates_enabled` is `True`, `detect_candidates(config)` scans the configured `specs_roots` and returns a list of `Candidate` dataclasses. Each `Candidate` carries a `slug`, a `path`, a `current_status`, a list of `evidence` strings, and a `snapshot_hash`. Dismissed candidates are tracked in `spec_completion_dismissed.json` under the `ops` subdirectory of `attune_home`.
+### `RunnerService` and `Run` — the execution model
 
-## Source
+`RunnerService` owns workflow execution. Its one **async** method is the
+killer to remember:
 
-`src/attune/ops/**`
+- **`start(workflow, *, path=None) -> Run` is a coroutine** — `await`
+  it. It launches a workflow (optionally scoped to a `path`) and returns
+  a `Run`.
+- `recent`, `get`, `get_or_load`, `handle_stdout_line` are
+  **synchronous**; `current` and `persistence_dir` are properties.
+- Only **one run at a time**: starting a second while one is active
+  raises **`RunnerBusyError(current_run_id)`**.
 
-**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`
+A `Run` is one execution. `Run.subscribe()` is an **async iterator** of
+events — this is the SSE feed the browser consumes. `append_line`,
+`mark_done`, `to_dict`/`to_record` are sync; `duration_seconds` and
+`is_terminal` are properties.
+
+### Scope picker, persistence, and chaining
+
+The feature **scope picker** reads `.help/features.yaml` so you can
+narrow a run to one feature; `ops.data.workflow_default_scope` supplies
+the default. Run history is **persisted** to `Config.runs_dir` and
+survives restarts (`get_or_load` rehydrates a past run);
+`prune_old_runs` trims beyond `runs_retention_days` (default 30). UI
+interactions are counted via `ops.interaction_counters.EVENTS`
+(`pill_click`, `rec_card_click`, `scope_picker_change`).
+
+### Adjacent read-only surfaces
+
+The dashboard renders data it does not own:
+
+| Submodule | Role | Owning feature |
+|---|---|---|
+| `ops.data` | Reads telemetry/workflows/sessions/KPIs | telemetry |
+| `ops.anthropic_cost` | `fetch_summary()` → cost report | (account-level) |
+| `ops.help_data` | Help coverage + search (the help tab) | help-system |
+| `ops.spec_lifecycle` | `derive_lifecycle(spec)` → status label | spec tooling |
+
+`ops.spec_lifecycle`'s only public function is `derive_lifecycle(spec,
+*, now=None) -> str` (plus the `STALE_THRESHOLD_DAYS` constant) — it
+labels a spec's lifecycle bucket from its phases and last-modified time.
+(There is no candidate-detection API here.)
+
+## Notes & tips
+
+- **Depend on the documented public surface:** `create_app`,
+  `build_config`, `Config` from `attune.ops`. The runner and readers are
+  reached from their submodules.
+- **`await` the two async surfaces.** `RunnerService.start` and
+  `Run.subscribe`; everything else on the runner is sync.
+- **Paths are properties.** `runs_dir`, `sessions_dir`,
+  `telemetry_path` — no `()`.
+- **`--read-only` for a safe demo.** It serves the dashboard with
+  execution disabled.

--- a/.help/templates/ops-dashboard/quickstart.md
+++ b/.help/templates/ops-dashboard/quickstart.md
@@ -3,74 +3,30 @@ type: quickstart
 name: ops-dashboard-quickstart
 feature: ops-dashboard
 depth: quickstart
-generated_at: 2026-06-10T07:07:04.671892+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Quickstart: ops dashboard
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-Launch the local operations dashboard — a workflow runner with a per-feature scope picker, persisted run history, and live SSE log streaming.
+## Quickstart
 
-```bash
-python -m attune.ops
-```
-
-The server starts on `127.0.0.1:8765` by default. Open that address in your browser to see the dashboard.
-
-## Step 1: Build a config
-
-Use `build_config()` to wire up the project root and attune home before starting the server:
-
-```python
-from attune.ops import build_config
-
-config = build_config()
-print(config.host, config.port)  # 127.0.0.1  8765
-```
-
-Expected output:
-```
-127.0.0.1 8765
-```
-
-## Step 2: Create the app
-
-Pass the config to `create_app()` to get a FastAPI application instance without pulling FastAPI into the import chain until you need it:
-
-```python
-from attune.ops import create_app
-
-app = create_app()
-```
-
-## Step 3: Run the server from the CLI
-
-Start the dashboard with the `ops` subcommand. `cmd_ops` returns `0` on clean exit:
+Start the dashboard from the CLI (runs enabled unless `--read-only`):
 
 ```bash
-python -m attune.ops
+attune ops                 # http://127.0.0.1:8765
+python -m attune.ops --read-only --port 9000
 ```
 
-Navigate to `http://127.0.0.1:8765` in your browser. You should see the workflow list, scope picker, and run history panels.
-
-## Step 4: Verify cost data loads
-
-If you have an Anthropic admin key available, confirm the cost summary fetches correctly:
+Build the app from Python (e.g. to embed or test it):
 
 ```python
-from attune.ops.anthropic_cost import fetch_summary
+from pathlib import Path
 
-summary, error = fetch_summary()
-if summary:
-    print(summary.today_usd, summary.source)
-else:
-    print(error.kind, error.message)
-```
+from attune.ops import build_config, create_app
 
-Expected output when the key is present and the fetch succeeds:
+config = build_config(Path("."), host="127.0.0.1", port=8765)
+app = create_app(config)
+print(type(app).__name__, "| runs allowed:", config.allow_run)
 ```
-0.42 live
-```
-
-**Next:** Add `specs_roots` to your `Config` to enable the spec-completion candidate detector — set `specs_candidates_enabled=True` and call `detect_candidates(config)` to see which specs are ready to close out.

--- a/.help/templates/ops-dashboard/reference.md
+++ b/.help/templates/ops-dashboard/reference.md
@@ -3,301 +3,61 @@ type: reference
 name: ops-dashboard-reference
 feature: ops-dashboard
 depth: reference
-generated_at: 2026-06-22T10:00:48.764701+00:00
-source_hash: dd650b4658efc1f6876bf6f2701d846e9091228187573660cdcfc10ab83fa6c2
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Ops Dashboard reference
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-Run and monitor the attune workflow OS from a local web dashboard. The dashboard exposes a per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming. Start it with `attune ops` or `python -m attune.ops`.
+## Reference
 
-## Classes
+The public API is `create_app`, `build_config`, and `Config`, exported
+from `attune.ops`. The runner and read-side helpers are imported from
+their submodules.
 
-| Class | Description |
-|-------|-------------|
-| `CostFetchError` | Categorized failure for a cost-report fetch. |
-| `CostSummary` | Account-level cost data from the Anthropic admin cost-report. |
-| `Candidate` | One completion-candidate spec returned by the detector. |
-| `Config` | Project and attune-state configuration that `attune ops` reads at startup. |
-| `TelemetrySummary` | Aggregated telemetry — request counts, costs, savings, and per-workflow breakdowns. |
-| `WorkflowEntry` | One entry in the registered workflow catalog. |
-| `PathArgSpec` | How a workflow accepts a scope path on the CLI. |
-| `Feature` | One feature from `.help/features.yaml` for the scope picker. |
-| `Session` | One Claude Code session surfaced on the dashboard's `/sessions` page. |
-| `FamilyVersion` | Package name, version, and resolution source for one attune family member. |
-| `DailyCost` | One day's cost for the home-page sparkline. |
-| `HomeKpis` | Summary numbers shown above the fold on the home page. |
-| `SpendAlarm` | Daily API-spend anomaly verdict with ceiling-approach gauge for the dashboard (R6). |
-| `SweepChipCounts` | Per-bucket counts loaded from a persisted discovery-sweep result. |
-| `DismissEntry` | One dismissed candidate's persisted state. |
-| `TemplateRecord` | One template file in the help corpus. |
-| `FeatureSummary` | One feature — name plus which template kinds exist for it. |
-| `SearchHit` | One ranked hit from a help-corpus search query. |
-| `GapsReport` | Coverage-gap signals — incomplete sets and stale templates. |
-| `HelpRegenJob` | One regen invocation — status, captured stdout, and exit code. |
-| `HelpRegenRunner` | Owns the regen-job history and active subprocess. |
-| `HelpRegenBusyError` | Raised when a regen job is requested while one is already running. |
-| `InteractionCounters` | Process-lifetime counters for dashboard UI interactions. |
-| `TrustedHostMiddleware` | Rejects requests whose `Host` header is not on the allowlist. |
-| `JournalEntry` | One pending-writes journal entry. |
-| `InteractionEvent` | Request body for `POST /api/telemetry/interaction`. |
-| `SpecPhase` | One phase file's status snapshot. |
-| `SpecRecord` | One spec's summary — directory plus the status of each phase file present. |
-| `RunnerBusyError` | Raised when a run is already pending or running. |
-| `Run` | Single workflow execution and its broadcast state. |
-| `RunnerService` | Owns the run history and concurrency lock. |
-| `RedactionResult` | Outcome of a redaction pass. |
-| `SummaryResult` | One Haiku-or-cache result, ready to slot into a `Session`. |
-| `Budget` | Mutable spend ledger for one page-load summarization loop. |
-| `CacheKey` | Stable key that invalidates a cached summary when the source moves. |
-| `CachedSummary` | One persisted session summary plus the metadata needed to validate it. |
+### `attune.ops`
 
----
+| Symbol | Purpose |
+|---|---|
+| `build_config(project_root=None, *, host="127.0.0.1", port=8765, allow_run=False, specs_roots=None, trusted_hosts=None, runs_retention_days=30, specs_candidates_enabled=False) -> Config` | Build the dashboard config. |
+| `create_app(config, *, runner=None) -> FastAPI` | Build the FastAPI app (sync). |
+| `Config` | Settings dataclass. **Properties:** `bulletin_dir`, `memory_dir`, `runs_dir`, `sessions_dir`, `telemetry_path`. `allow_run` defaults `False`. |
 
-### `CostFetchError` fields
+### `attune.ops.runner`
 
-| Field | Type |
-|-------|------|
-| `kind` | `CostFetchErrorKind` |
-| `message` | `str` |
+| Symbol | Purpose |
+|---|---|
+| `RunnerService(*, history_limit=20, command_builder=None, executor=None, persistence_dir=None, project_root=None, bulletin=None, actor_id=None, actor_kind="dashboard")` | Workflow runner. |
+| `RunnerService.start(workflow, *, path=None) -> Run` | **Async.** Launch a run (one at a time). |
+| `RunnerService.recent` / `.get` / `.get_or_load` / `.handle_stdout_line` | Sync history/lookup helpers. |
+| `RunnerService.current` / `.persistence_dir` | Properties. |
+| `Run.subscribe() -> AsyncIterator` | **Async.** SSE event feed. |
+| `Run.append_line` / `.mark_done` / `.to_dict` / `.to_record` | Sync run helpers. |
+| `Run.duration_seconds` / `.is_terminal` | Properties. |
+| `RunnerBusyError(current_run_id)` | Raised on a concurrent `start()`. |
+| `prune_old_runs(...)` / `echo_command_builder` | Retention + a default command builder. |
 
----
+### Read-side submodules
 
-### `CostSummary` fields
+| Module | Key public API |
+|---|---|
+| `ops.data` | `read_telemetry_summary`, `list_workflows`, `list_features`, `home_kpis`, `list_recent_sessions`, `env_health`, `family_versions`, `workflow_default_scope`, `sparkline_points`, … |
+| `ops.anthropic_cost` | `fetch_summary(*, refresh=False) -> tuple[CostSummary \| None, CostFetchError \| None]`; `CostSummary`, `CostFetchError`, `CostFetchErrorKind`. |
+| `ops.help_data` | `coverage_gaps`, `search`, `list_features`, `get_template`. |
+| `ops.spec_lifecycle` | `derive_lifecycle(spec, *, now=None) -> str` (only public function) + `STALE_THRESHOLD_DAYS`. |
+| `ops.interaction_counters` | `EVENTS = ('pill_click', 'rec_card_click', 'scope_picker_change')`. |
+| `ops.cli` | `add_subparser`, `cmd_ops`, `main`. |
 
-| Field | Type |
-|-------|------|
-| `today_usd` | `float` |
-| `seven_day_usd` | `float` |
-| `month_to_date_usd` | `float` |
-| `thirty_day_usd` | `float` |
-| `by_day` | `list[tuple[date, float]]` |
-| `by_model` | `list[tuple[str, float]]` |
-| `by_cost_type` | `list[tuple[str, float]]` |
-| `fetched_at` | `datetime` |
-| `source` | `Literal['live', 'cached']` |
+### CLI flags (`attune ops` / `python -m attune.ops`)
 
----
-
-### `Candidate` fields
-
-| Field | Type |
-|-------|------|
-| `slug` | `str` |
-| `path` | `str` |
-| `current_status` | `str` |
-| `evidence` | `list[str]` |
-| `snapshot_hash` | `str` |
-
----
-
-### `Config` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `project_root` | `Path` | — |
-| `attune_home` | `Path` | — |
-| `host` | `str` | `'127.0.0.1'` |
-| `port` | `int` | `8765` |
-| `allow_run` | `bool` | `False` |
-| `specs_roots` | `tuple[Path, ...]` | `()` |
-| `trusted_hosts` | `tuple[str, ...]` | `()` |
-| `runs_retention_days` | `int` | `30` |
-| `specs_candidates_enabled` | `bool` | `False` |
-
-### `Config` properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `telemetry_path` | `Path` | Path to the telemetry data file. |
-| `runs_dir` | `Path` | Disk root for persisted ops runs. May not exist until first write. |
-| `memory_dir` | `Path` | Path to the memory directory. |
-| `sessions_dir` | `Path` | Path to the sessions directory. |
-| `bulletin_dir` | `Path` | Directory for the multi-actor bulletin's active log and archive. |
-
----
-
-### `TelemetrySummary` fields
-
-| Field | Type |
-|-------|------|
-| `total_requests` | `int` |
-| `total_cost` | `float` |
-| `total_savings` | `float` |
-| `by_workflow` | `list[tuple[str, int, float]]` |
-| `by_day` | `list[tuple[str, int, float]]` |
-| `last_event_at` | `str | None` |
-
----
-
-### `WorkflowEntry` fields
-
-| Field | Type |
-|-------|------|
-| `name` | `str` |
-| `description` | `str` |
-| `stages` | `int` |
-| `tier_map` | `dict[str, str]` |
-
----
-
-### `PathArgSpec` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `kwarg` | `str` | — |
-| `required` | `bool` | `False` |
-
----
-
-### `Feature` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `name` | `str` | — |
-| `description` | `str` | — |
-| `path` | `str | None` | — |
-| `tags` | `tuple[str, ...]` | `()` |
-
----
-
-### `Session` fields
-
-| Field | Type | Default |
-|-------|------|---------|
-| `id` | `str` | — |
-| `started_at` | `str` | — |
-| `last_activity` | `str` | — |
-| `duration_seconds` | `float` | — |
-| `message_count` | `int` | — |
-| `starter_prompt` | `str` | — |
-| `source` | `str` | `'heuristic'` |
-
----
-
-### `FamilyVersion` fields
-
-| Field | Type |
-|-------|------|
-| `package` | `str` |
-| `version` | `str | None` |
-| `source` | `str` |
-
----
-
-### `SpendAlarm` fields
-
-| Field | Type |
-|-------|------|
-| `level` | `str` — `"ok"` \| `"alarm"` \| `"insufficient_data"` |
-| `triggered_by` | `tuple[str, ...]` — subset of `{"daily_anomaly", "ceiling"}` |
-| `today_cost` | `float` |
-| `baseline_mean` | `float` |
-| `baseline_days` | `int` |
-| `method` | `str` — `"zscore"` \| `"multiplier"` \| `"none"` |
-| `z_score` | `float \| None` |
-| `month_to_date` | `float` |
-| `monthly_ceiling` | `float` |
-| `ceiling_pct` | `float` |
-| `source` | `str` — `"account"` \| `"local"` |
-| `detail` | `str` — one-line human explanation |
-
-## Functions
-
-The tables below are organized by source module.
-
-### `src/attune/ops/__init__.py`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `create_app` | `*args, **kwargs` | — | Lazy-import the FastAPI factory so importing attune doesn't pull FastAPI. |
-| `build_config` | `*args, **kwargs` | — | Lazy import of the config builder. |
-
----
-
-### `src/attune/ops/anthropic_cost.py`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `clear_cache` | — | `None` | Empty the in-memory cache. Test-only convenience. |
-| `load_admin_key` | — | `str | None` | Return the admin API key, or `None` if unavailable. |
-| `fetch_summary` | `*, refresh: bool = False` | `tuple[CostSummary | None, CostFetchError | None]` | Return the current cost summary or a categorized error. |
-
----
-
-### `src/attune/ops/cli.py`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `add_subparser` | `subparsers: argparse._SubParsersAction` | `None` | Register the `ops` subparser on the main attune CLI parser. |
-| `cmd_ops` | `args: argparse.Namespace` | `int` | Run the dashboard server (blocking). Returns `0`. |
-| `main` | — | `int` | Standalone entry point: `python -m attune.ops`. |
-
----
-
-### `src/attune/ops/completion_candidates.py`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `clear_cache` | — | `None` | Reset the in-memory caches. Test helper. |
-| `detect_candidates` | `config: Config, *, now: float | None = None` | `list[Candidate]` | Return all completion candidates across the configured spec roots. |
-
----
-
-### `src/attune/ops/config.py`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `attune_home` | — | `Path` | Resolve the user's attune home directory (env override → `~/.attune`). |
-| `build_config` | `project_root: Path | None = None, *, host: str = '127.0.0.1', port: int = 8765, allow_run: bool = False, specs_roots: tuple[Path, ...] | None = None, trusted_hosts: tuple[str, ...] | None = None, runs_retention_days: int = 30, specs_candidates_enabled: bool = False` | `Config` | Build a `Config` from inputs and environment defaults. |
-
----
-
-### `src/attune/ops/data.py`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `list_features` | `project_root: Path | str` | `list[Feature]` | Return features parsed from `<project_root>/.help/features.yaml`. |
-| `first_feature` | `project_root: Path | str` | `Feature | None` | Return the alphabetically-first feature with a renderable scope. |
-| `workflow_default_scope` | `workflow_name: str, project_root: Path | str` | `str` | Return the default scope for one workflow on first paint. |
-| `derive_project_name` | `project_root: Path | str` | `str` | Return a human-readable project name for the dashboard header. |
-| `claude_sessions_dir` | `project_root: Path | str` | `Path` | Return the canonical directory Claude Code uses to store sessions for this project. |
-| `enumerate_project_encoded_keys` | `project_root: Path | str` | `list[Path]` | Return all `~/.claude/projects/` directories belonging to this logical project. |
-| `list_recent_sessions_with_paths` | `project_root: Path | str, *, days: int = 3, limit: int | None = DEFAULT_SESSION_LIST_CAP, now: datetime | None = None, parser: Callable[[Path], Session | None] | None = None` | `list[tuple[Session, Path]]` | Same as `list_recent_sessions` but also returns each session's source path. |
-| `list_recent_sessions` | `project_root: Path | str, *, days: int = 3, limit: int | None = DEFAULT_SESSION_LIST_CAP, now: datetime | None = None, parser: Callable[[Path], Session | None] | None = None` | `list[Session]` | Return `Session` records for this project's last `days` of activity. |
-| `home_kpis` | `summary: TelemetrySummary, *, today: date | None = None` | `HomeKpis` | Derive home-page KPIs from a telemetry summary. |
-| `sparkline_points` | `values: list[float], *, width: int = 240, height: int = 40` | `str` | Render values as an SVG `polyline` `points` string. |
-| `read_telemetry_summary` | `config: Config, *, recent_days: int = 7, today: date | None = None` | `TelemetrySummary` | Aggregate `usage.jsonl` into a UI-friendly summary. |
-| `read_sweep_chip_counts` | `scope_path: str, config: Config` | `SweepChipCounts` | Read the latest persisted sweep result for `scope_path` and tally chips. |
-| `read_daily_spend` | `config: Config, *, days: int = 35, today: date \| None = None` | `dict[str, float]` | Daily API spend (USD) bucketed by timestamp from `usage.jsonl`. |
-| `spend_alarm` | `daily: dict[str, float], *, today: date \| None = None, monthly_ceiling: float = 350.0, ceiling_fraction: float = 0.8, z_threshold: float = 3.0, flat_multiplier: float = 3.0, min_baseline_days: int = 3, ...` | `SpendAlarm` | Flag anomalous daily API spend and approach to the monthly ceiling. |
-| `build_spend_alarm` | `config: Config, cost_summary: Any \| None = None, *, today: date \| None = None` | `SpendAlarm` | Assemble the spend alarm, preferring account-level spend from the cost summary. |
-| `list_workflows` | — | `list[WorkflowEntry]` | Return the registered workflow catalog. Empty if the registry is unavailable. |
-| `family_versions` | — | `list[FamilyVersion]` | Resolve installed versions for every related attune package. |
-| `env_health` | `config: Config` | `dict[str, Any]` | Lightweight environment snapshot for the Health page. |
-
----
-
-### `src/attune/ops/dismiss_store.py`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `store_path` | `config: Config` | `Path` | Return the absolute path to the dismiss-store JSON file. |
-| `load` | `config: Config` | `dict[str, DismissEntry]` | Read the dismiss store. Missing or corrupt file returns `{}`. |
-| `save` | `slug: str, snapshot_hash: str, config: Config, *, ttl_days: int = DEFAULT_TTL_DAYS, now: datetime | None = None` | `None` | Persist a dismiss entry for `slug`, overwriting any prior entry. |
-| `clear` | `slug: str, config: Config` | `None` | Remove the entry for `slug`. No-op if absent. |
-| `is_active` | `slug: str, current_hash: str, config: Config, *, now: datetime | None = None` | `bool` | Return `True` iff a dismiss for `slug` is currently suppressing it. |
-
----
-
-### `src/attune/ops/help_data.py`
-
-| Function | Parameters | Returns | Description |
-|----------|------------|---------|-------------|
-| `corpus_root` | `config: Config` | `Path` | Return the `.help/templates/` directory for this project. |
-| `list_features` | `config: Config` | `list[FeatureSummary]` | All features in the corpus, alphabetical. |
-| `get_template` | `config: Config, feature: str, kind: str` | `TemplateRecord | None` | Load one template by feature and kind. Returns `None` if missing. |
-| `search` | `config: Config, query: str, *, limit: int = 20` | `list[SearchHit]` | Run a keyword search against the help corpus. |
-| `coverage_gaps` | `config: Config` | `GapsReport` | Compute incomplete sets and stale templates across the corpus. |
-| `recently_regenerated
+| Flag | Effect |
+|---|---|
+| `--host` / `--port` | Bind address (default `127.0.0.1:8765`). |
+| `--project-root` | Project to serve. |
+| `--no-browser` | Don't auto-open a browser. |
+| `--read-only` | Disable runs (`allow_run=False`); runs are **enabled** otherwise. |
+| `--specs-root DIR` | Spec directory (repeatable). |
+| `--trusted-host` | Allow a remote host. |
+| `--runs-retention-days` | History retention (default 30). |
+| `--specs-candidates` / `--no-specs-candidates` | Toggle spec candidate display. |

--- a/.help/templates/ops-dashboard/task.md
+++ b/.help/templates/ops-dashboard/task.md
@@ -3,124 +3,96 @@ type: task
 name: ops-dashboard-task
 feature: ops-dashboard
 depth: task
-generated_at: 2026-06-22T10:00:48.764701+00:00
-source_hash: dd650b4658efc1f6876bf6f2701d846e9091228187573660cdcfc10ab83fa6c2
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Work with the ops dashboard
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-Use the ops dashboard when you need to run workflows, browse per-feature scopes, inspect persisted run history, or monitor live cost data for your Anthropic account.
+## Tasks
 
-## Prerequisites
+### Configure where the dashboard reads and writes
 
-- Access to the project source code under `src/attune/ops/`
-- An Anthropic admin API key if you intend to use cost reporting (returned by `load_admin_key()`)
+**Goal:** point the dashboard at a project and inspect its derived
+paths.
 
-## Start the dashboard server
+**Steps:**
 
-1. **Launch the server from the CLI.**
-   Run the following command to start the dashboard in blocking mode:
+```python
+from pathlib import Path
 
-   ```
-   python -m attune.ops
-   ```
+from attune.ops import build_config
 
-   This calls `main()`, which delegates to `cmd_ops()`. The server binds to `127.0.0.1:8765` by default (set by `Config.host` and `Config.port`).
-
-2. **Verify the server is running.**
-   `cmd_ops()` returns `0` on success. If the process is blocking and no error is printed, the dashboard is live at `http://127.0.0.1:8765`.
-
-## Configure the dashboard
-
-1. **Locate the `Config` dataclass** in `src/attune/ops/__init__.py`. It controls all runtime paths and feature flags.
-
-2. **Set the fields relevant to your environment:**
-
-   | Field | Default | Purpose |
-   |---|---|---|
-   | `host` | `'127.0.0.1'` | Address the server binds to |
-   | `port` | `8765` | Port the server listens on |
-   | `allow_run` | `False` | Permit workflow execution |
-   | `specs_roots` | `()` | Paths scanned for spec files |
-   | `trusted_hosts` | `()` | Hosts allowed to make requests |
-   | `runs_retention_days` | `30` | How long persisted run history is kept |
-   | `specs_candidates_enabled` | `False` | Enable spec completion candidate detection |
-
-3. **Use `build_config()`** (exported from `src/attune/ops/__init__.py`) to construct a `Config` instance rather than instantiating it directly. This ensures all derived properties (`telemetry_path`, `runs_dir`, `memory_dir`, `sessions_dir`, `bulletin_dir`) resolve correctly.
-
-## Fetch Anthropic cost data
-
-1. **Check that an admin key is available.**
-   Call `load_admin_key()` from `src/attune/ops/anthropic_cost.py`. It returns the key string or `None` if unavailable. The dashboard cannot retrieve cost data without a valid key.
-
-2. **Call `fetch_summary()`** to retrieve account-level cost data:
-
-   ```python
-   summary, error = fetch_summary()
-   ```
-
-   - On success, `summary` is a `CostSummary` with fields `today_usd`, `seven_day_usd`, `month_to_date_usd`, `thirty_day_usd`, `by_day`, `by_model`, `by_cost_type`, `fetched_at`, and `source`.
-   - On failure, `error` is a `CostFetchError` with a `kind` (`CostFetchErrorKind`) and a `message` string.
-
-3. **Force a cache refresh** by passing `refresh=True`:
-
-   ```python
-   summary, error = fetch_summary(refresh=True)
-   ```
-
-4. **Clear the in-memory cache** during testing by calling `clear_cache()` from `src/attune/ops/anthropic_cost.py`.
-
-## Monitor spend anomalies and ceiling approach
-
-1. **Assemble the alarm** with `build_spend_alarm()` from `src/attune/ops/data.py`:
-
-   ```python
-   from attune.ops import data, anthropic_cost
-
-   cost_summary, _ = anthropic_cost.fetch_summary()
-   alarm = data.build_spend_alarm(config, cost_summary)
-   ```
-
-   - `alarm.level` is `"ok"`, `"alarm"`, or `"insufficient_data"`.
-   - `alarm.triggered_by` lists which condition(s) fired: `"daily_anomaly"` and/or `"ceiling"`.
-   - `alarm.source` is `"account"` (admin cost-report) or `"local"` (`usage.jsonl`).
-
-2. **Daily-anomaly trigger:** today's spend is flagged when it exceeds the
-   z-score threshold (default `3.0`) versus the trailing baseline, or — when
-   the baseline has zero variance — when it exceeds `baseline_mean * 3.0`.
-   Fewer than 3 prior active (non-zero) days skips the check.
-
-3. **Ceiling trigger:** month-to-date spend is flagged once it reaches
-   `ceiling_fraction` (default `0.8`) of `monthly_ceiling` (default `$350`).
-   Pass `monthly_ceiling=` to override for your org.
-
-4. **Access raw data** with `read_daily_spend()` (local only) for a
-   `{YYYY-MM-DD: total_cost}` dict, then pass it to `spend_alarm()` with
-   custom thresholds when you need fine-grained control.
-
-## Detect spec completion candidates
-
-1. **Enable candidate detection** by setting `specs_candidates_enabled = True` in your `Config` and populating `specs_roots` with the paths to scan.
-
-2. **Call `detect_candidates()`** from `src/attune/ops/spec_candidates.py`:
-
-   ```python
-   candidates = detect_candidates(config)
-   ```
-
-   Each returned `Candidate` has a `slug`, `path`, `current_status`, `evidence` list, and `snapshot_hash`.
-
-## Register the CLI subcommand
-
-If you need to extend or re-register the `ops` subcommand on the main `attune` CLI parser, call `add_subparser()` from `src/attune/ops/cli.py` and pass the parent `subparsers` action. This wires `cmd_ops()` as the handler for `attune ops`.
-
-## Verify your changes
-
-Run the ops-related tests to confirm nothing is broken:
-
-```
-pytest -k "ops"
+config = build_config(Path("."), runs_retention_days=14)
+print("runs:", config.runs_dir)
+print("sessions:", config.sessions_dir)
+print("telemetry:", config.telemetry_path)
 ```
 
-A passing test suite with no new failures confirms that the dashboard server, cost-reporting, and candidate detection behave correctly. If you modified `Config`, also check that `build_config()` still returns a valid instance with all path properties resolving to accessible locations.
+**Verify:** `build_config()` returns a `Config`. `runs_dir`,
+`sessions_dir`, and `telemetry_path` are **properties** (no `()`), all
+anchored under the attune home / project root.
+
+### Run a workflow with the runner
+
+**Goal:** execute a workflow and get a `Run` back.
+
+**Steps:**
+
+```python
+import asyncio
+
+from attune.ops.runner import RunnerService, RunnerBusyError
+
+
+async def main() -> None:
+    runner = RunnerService()
+    try:
+        run = await runner.start("security-audit", path="src/attune/config")
+        print("started:", run.id)
+    except RunnerBusyError as exc:
+        print("busy with:", exc.current_run_id)
+
+
+asyncio.run(main())
+```
+
+**Verify:** `start()` is a **coroutine** — `await` it; it returns a
+`Run`. Only one run is active at a time, so a concurrent `start()`
+raises `RunnerBusyError`.
+
+### Stream a run's output over SSE
+
+**Goal:** consume a run's live event feed (what the browser does).
+
+**Steps:**
+
+```python
+async def stream(run) -> None:
+    async for event in run.subscribe():
+        print(event)
+        if run.is_terminal:
+            break
+```
+
+**Verify:** `Run.subscribe()` is an **async iterator** of events;
+`is_terminal` flips true when the run finishes.
+
+### Label a spec's lifecycle
+
+**Goal:** ask the dashboard's spec helper what bucket a spec is in.
+
+**Steps:**
+
+```python
+from types import SimpleNamespace
+
+from attune.ops.spec_lifecycle import derive_lifecycle
+
+spec = SimpleNamespace(phases=[], last_modified=None)
+print(derive_lifecycle(spec))
+```
+
+**Verify:** `derive_lifecycle(spec, *, now=None)` returns a status
+**string**. It is the only public function in `ops.spec_lifecycle`.

--- a/.help/templates/ops-dashboard/tip.md
+++ b/.help/templates/ops-dashboard/tip.md
@@ -3,19 +3,21 @@ type: tip
 name: ops-dashboard-tip
 feature: ops-dashboard
 depth: tip
-generated_at: 2026-06-10T07:07:04.674537+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Tip: working effectively with ops dashboard
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-Use `fetch_summary(refresh=False)` as your entry point for cost data — it handles caching and returns a typed `(CostSummary | None, CostFetchError | None)` tuple so you never have to catch raw HTTP errors yourself.
+## Notes & tips
 
-**Why it sticks:** the cache layer means repeated calls inside a single dashboard render are free; setting `refresh=True` only when you genuinely need live data keeps the Anthropic admin API from rate-limiting you.
-
-**Tradeoff:** the cached value reflects the moment it was last populated, not wall-clock now. Check `CostSummary.fetched_at` and `CostSummary.source` (either `'live'` or `'cached'`) before presenting figures to a user who needs precision.
-
-The three other stable entry points are `create_app()` (the FastAPI factory), `build_config()` (the config builder), and `clear_cache()` — all exported via `__all__` in `src/attune/ops/__init__.py`. Everything else, including anything prefixed with an underscore such as `_COST_REPORT_URL` or `_API_VERSION`, is internal and may change without notice.
-
-**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`
+- **Depend on the documented public surface:** `create_app`,
+  `build_config`, `Config` from `attune.ops`. The runner and readers are
+  reached from their submodules.
+- **`await` the two async surfaces.** `RunnerService.start` and
+  `Run.subscribe`; everything else on the runner is sync.
+- **Paths are properties.** `runs_dir`, `sessions_dir`,
+  `telemetry_path` — no `()`.
+- **`--read-only` for a safe demo.** It serves the dashboard with
+  execution disabled.

--- a/.help/templates/ops-dashboard/troubleshooting.md
+++ b/.help/templates/ops-dashboard/troubleshooting.md
@@ -3,110 +3,38 @@ type: troubleshooting
 name: ops-dashboard-troubleshooting
 feature: ops-dashboard
 depth: troubleshooting
-generated_at: 2026-06-10T07:07:04.666526+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Troubleshoot ops dashboard
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-## Before you start
+## Failure modes
 
-The ops dashboard (`attune ops` / `python -m attune.ops`) is a local FastAPI server that provides a workflow runner with a per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming. It binds to `127.0.0.1:8765` by default and reads project state from the paths defined in `Config`.
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `RuntimeWarning: coroutine 'RunnerService.start' was never awaited` | `start()` called without `await` | It's async — `await` it / `asyncio.run` | high |
+| Workflows won't run from the UI | `Config.allow_run` is `False` (e.g. `--read-only`) | Start without `--read-only` | high |
+| `RunnerBusyError` on start | A run is already active (one at a time) | Wait for / inspect `runner.current` | medium |
+| `TypeError` calling `config.runs_dir()` | `runs_dir` is a property | Drop the `()` | medium |
+| Cost panel shows an error | `fetch_summary` returned a `CostFetchError` (no admin key, network) | Inspect the error `kind`/`message`; cost is an adjacent surface | low |
 
-## Symptom table
+### Risk areas
 
-| If you observe | Check |
-|---|---|
-| Dashboard server won't start | Confirm no other process is using port `8765` (or your configured `Config.port`). Check that `Config.project_root` and `Config.attune_home` resolve to real directories. |
-| Cost data missing or stale | Call `fetch_summary(refresh=True)` to bypass the in-memory cache. Check that `load_admin_key()` returns a non-`None` value — if it returns `None`, the Anthropic admin key is absent or unreadable. |
-| `CostFetchError` returned instead of `CostSummary` | Inspect the `CostFetchError.kind` and `CostFetchError.message` fields. The `kind` field narrows the failure to a specific `CostFetchErrorKind` category (auth, network, parsing, etc.). |
-| `CostSummary.source` is `'cached'` when you expect live data | Call `clear_cache()` then re-request. This empties the in-memory cache and forces a fresh fetch on the next call to `fetch_summary()`. |
-| Spec completion candidates not appearing | Verify `Config.specs_candidates_enabled` is `True` and that `Config.specs_roots` is non-empty. Run `detect_candidates(config)` directly and inspect the returned `list[Candidate]`. |
-| Sessions page is empty | Check that `Config.sessions_dir` exists on disk. The directory is under `Config.attune_home` and may not be created until the first session write. |
-| Run history missing | Check that `Config.runs_dir` exists. Like `sessions_dir`, it is only created on the first write. Confirm `Config.runs_retention_days` (default `30`) has not expired old entries. |
-| `cmd_ops` exits immediately with a non-zero code | Check the return value and any stderr output. `cmd_ops` returns `0` on clean exit; any other value indicates a startup failure. |
+- **`RunnerService.start` and `Run.subscribe` are async.** They are the
+  two awaitable surfaces; everything else on the runner is sync.
+- **`allow_run` is a real gate.** Off by default in `Config`; the CLI
+  turns it on unless `--read-only`.
+- **Scope confusion.** Cost/telemetry/help shown on the dashboard are
+  *adjacent* surfaces — owned by other features, only read here.
 
-## Diagnosis steps
+### Diagnosis order
 
-1. **Reproduce the failure with the minimal invocation.**
-   Run `python -m attune.ops` (or `attune ops`) in your project root with no extra flags. If the failure disappears, a CLI flag or environment variable in your normal invocation is the cause.
-
-2. **Confirm the admin API key is present.**
-   Call `load_admin_key()` in a Python REPL. If it returns `None`, the dashboard cannot reach the Anthropic cost-report endpoint at `https://api.anthropic.com/v1/organizations/cost_report`. Set the key in your environment before proceeding.
-
-3. **Check the cache before deeper investigation.**
-   Call `clear_cache()` and retry the failing operation. Cost-fetch failures and stale data are often explained by a poisoned in-memory cache, and clearing it takes seconds.
-
-4. **Inspect `Config` field values.**
-   Build a config with `build_config()` and print the relevant fields (`project_root`, `attune_home`, `host`, `port`, `specs_roots`, `specs_candidates_enabled`). Mismatched paths are a common root cause for missing data and silent failures.
-
-5. **Call `fetch_summary` directly and examine the error.**
-   ```python
-   summary, error = fetch_summary(refresh=True)
-   if error:
-       print(error.kind, error.message)
-   ```
-   The `CostFetchError.kind` field tells you whether the failure is an auth error, a network error, or a parsing error — each has a different fix.
-
-6. **Run `detect_candidates` directly for spec-completion issues.**
-   ```python
-   from attune.ops import build_config
-   from attune.ops.specs_candidates import detect_candidates
-   config = build_config()
-   candidates = detect_candidates(config)
-   ```
-   If the list is empty, check `config.specs_roots` and `config.specs_candidates_enabled`.
-
-7. **Run the related tests.**
-   ```
-   pytest -k "ops" -v
-   ```
-   A failing test that exercises your symptom confirms the regression and provides a fixture you can adapt for further isolation.
-
-## Common fixes
-
-- **Admin key not loaded — cost data unavailable.**
-  `load_admin_key()` reads the key from your environment. Export the key before starting the server:
-  ```bash
-  export ANTHROPIC_ADMIN_KEY="sk-admin-..."
-  attune ops
-  ```
-
-- **Stale cost data.**
-  Force a cache reset without restarting the server:
-  ```python
-  from attune.ops.anthropic_cost import clear_cache
-  clear_cache()
-  ```
-  The next call to `fetch_summary()` will hit the live endpoint.
-
-- **Port already in use.**
-  Change the port in your `Config` (field: `port`) or free the existing listener:
-  ```bash
-  lsof -i :8765        # find the PID
-  kill <PID>
-  attune ops
-  ```
-
-- **Missing runs or sessions directory.**
-  `Config.runs_dir` and `Config.sessions_dir` are created on first write, not on startup. If you need them to exist before the first run (for example, in a CI setup), create them manually:
-  ```bash
-  mkdir -p "$(python -c 'from attune.ops import build_config; print(build_config().runs_dir)')"
-  ```
-
-- **Spec candidates disabled or no roots configured.**
-  In your config source, set `specs_candidates_enabled = True` and populate `specs_roots` with at least one valid path. This change is in your project's config, outside the dashboard itself.
-
-- **Dependency version drift.**
-  A FastAPI or Anthropic SDK upgrade can silently change behavior. Check installed versions:
-  ```bash
-  pip show fastapi anthropic
-  ```
-  Pin to the versions your project targets if the output differs from expectations.
-
-## Source files
-
-- `src/attune/ops/**`
-
-**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`
+1. Confirm the app builds: `create_app(build_config(Path(".")))`.
+2. Confirm runs are allowed: `config.allow_run` (and no `--read-only`).
+3. For a run that won't start: check `runner.current` /
+   `RunnerBusyError`.
+4. For async warnings: `await` `start()` / iterate `subscribe()`.
+5. For a data panel: that data is owned by its feature (telemetry /
+   help-system / cost).

--- a/.help/templates/ops-dashboard/warning.md
+++ b/.help/templates/ops-dashboard/warning.md
@@ -3,55 +3,38 @@ type: warning
 name: ops-dashboard-warning
 feature: ops-dashboard
 depth: warning
-generated_at: 2026-06-10T07:07:04.664173+00:00
-source_hash: 5a9cf489e3626794b14e2ce54ec4ec47a2ac21cb2d5f13fcb3e0dd6147f0d24f
+generated_at: 2026-06-24T12:00:17.825226+00:00
+source_hash: 1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7
 status: generated
 ---
 
-# Ops Dashboard Cautions
+# The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
 
-The ops dashboard runs a local FastAPI server (`python -m attune.ops`) that combines a workflow runner, a per-feature scope picker, persisted run history, and live SSE log streaming. Most surprises come from three areas: the in-memory cost cache, the admin API key lookup, and configuration fields that silently restrict what the server allows.
+## Failure modes
 
-## Risk areas
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `RuntimeWarning: coroutine 'RunnerService.start' was never awaited` | `start()` called without `await` | It's async — `await` it / `asyncio.run` | high |
+| Workflows won't run from the UI | `Config.allow_run` is `False` (e.g. `--read-only`) | Start without `--read-only` | high |
+| `RunnerBusyError` on start | A run is already active (one at a time) | Wait for / inspect `runner.current` | medium |
+| `TypeError` calling `config.runs_dir()` | `runs_dir` is a property | Drop the `()` | medium |
+| Cost panel shows an error | `fetch_summary` returned a `CostFetchError` (no admin key, network) | Inspect the error `kind`/`message`; cost is an adjacent surface | low |
 
-### `fetch_summary()` returns stale data by default
+### Risk areas
 
-`fetch_summary(*, refresh: bool = False)` returns a cached `CostSummary` when `refresh` is `False`. If you call it without setting `refresh=True`, the `source` field on the returned `CostSummary` will be `'cached'`, and the cost figures (`today_usd`, `seven_day_usd`, `month_to_date_usd`, `thirty_day_usd`) will reflect whenever the cache was last populated — not the current moment. Always check `CostSummary.source` before presenting figures as live, and pass `refresh=True` when you need a current snapshot.
+- **`RunnerService.start` and `Run.subscribe` are async.** They are the
+  two awaitable surfaces; everything else on the runner is sync.
+- **`allow_run` is a real gate.** Off by default in `Config`; the CLI
+  turns it on unless `--read-only`.
+- **Scope confusion.** Cost/telemetry/help shown on the dashboard are
+  *adjacent* surfaces — owned by other features, only read here.
 
-### `load_admin_key()` returns `None` silently
+### Diagnosis order
 
-`load_admin_key()` returns `None` if the admin API key is unavailable rather than raising an exception. Code that passes the result directly to an HTTP client will fail later with a confusing auth error instead of a clear "key not configured" message. Check for `None` before use and surface a clear error to the user at that point.
-
-### `clear_cache()` is a test helper, not a lifecycle hook
-
-`clear_cache()` in `attune.ops.anthropic_cost` is documented as a test-only convenience. Calling it in production code to force a refresh will work, but it bypasses the `refresh` parameter contract of `fetch_summary()` and can cause cache stampedes if multiple requests arrive simultaneously. Use `fetch_summary(refresh=True)` instead.
-
-### `Config.allow_run` gates workflow execution
-
-`Config.allow_run` defaults to `False`. With that default, the dashboard will load and display workflows but silently refuse to execute them. If you deploy the dashboard and find that run buttons have no effect, check this field first. Set it to `True` only in environments where you intend to allow workflow execution.
-
-### `Config.trusted_hosts` controls which origins the server accepts
-
-`Config.trusted_hosts` defaults to an empty tuple. Requests from hosts not in this tuple will be rejected. When running the dashboard behind a proxy or in a non-localhost environment, add the proxy's hostname to `trusted_hosts` before starting the server — otherwise every request will fail and the error will appear to come from the network layer, not from configuration.
-
-### `create_app()` and `build_config()` defer their imports
-
-Both functions use lazy imports to avoid pulling FastAPI into the `attune` namespace at import time. If FastAPI is missing from the environment, the failure surfaces only when you first call one of these functions, not at `import attune`. If the server fails to start unexpectedly, verify FastAPI is installed before looking elsewhere.
-
-## How to avoid problems
-
-1. **Check `CostSummary.source` after every `fetch_summary()` call.** A value of `'cached'` means the figures may be hours old. Pass `refresh=True` when you need current data.
-
-2. **Guard against `None` from `load_admin_key()`.** Treat a `None` return as a configuration error and fail fast with a descriptive message rather than propagating `None` into downstream calls.
-
-3. **Set `allow_run` and `trusted_hosts` explicitly in production configs.** Both fields have defaults that are safe for local development but will cause silent failures in other environments.
-
-4. **Use `fetch_summary(refresh=True)` instead of `clear_cache()`.** Reserve `clear_cache()` for test setup and teardown only.
-
-5. **Depend only on the public API.** `__all__` exports `create_app`, `build_config`, and `Config`. Functions and constants prefixed with `_` (such as `_COST_REPORT_URL` and `_API_VERSION`) can change without notice.
-
-## Source files
-
-- `src/attune/ops/**`
-
-**Tags:** `ops`, `dashboard`, `runner`, `workflows`, `scope-picker`, `persistence`, `sse`
+1. Confirm the app builds: `create_app(build_config(Path(".")))`.
+2. Confirm runs are allowed: `config.allow_run` (and no `--read-only`).
+3. For a run that won't start: check `runner.current` /
+   `RunnerBusyError`.
+4. For async warnings: `await` `start()` / iterate `subscribe()`.
+5. For a data panel: that data is owned by its feature (telemetry /
+   help-system / cost).

--- a/content/features/ops-dashboard.md
+++ b/content/features/ops-dashboard.md
@@ -1,0 +1,379 @@
+---
+feature: ops-dashboard
+summary: The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
+tags: [ops, dashboard, runner, workflows, scope-picker, persistence, sse]
+source_globs:
+  - src/attune/ops/**
+nav:
+  help: ops-dashboard
+  mkdocs:
+    how-to: how-to/ops-dashboard
+    architecture: architecture/ops-dashboard
+    reference: reference/ops-dashboard
+---
+
+## Overview
+
+The ops dashboard is attune's **local operations layer** — a FastAPI
+web app you run on your own machine to execute workflows against a
+chosen feature scope, browse persisted run history, chain workflows
+with a click, and watch live logs stream over **SSE**. It lives in
+**`src/attune/ops/`** and is launched with `attune ops` (or `python -m
+attune.ops`), binding to **`127.0.0.1:8765`** by default.
+
+This page documents the **runner core** — the server, its config, and
+the `RunnerService`/`Run` execution model. The dashboard also *displays*
+data owned by other features — Anthropic cost (`ops.anthropic_cost`),
+telemetry (`ops.data` reads the telemetry store), and help coverage
+(`ops.help_data`) — but those are **adjacent** surfaces it renders, not
+its own; each belongs to its respective feature (telemetry, help-system).
+
+The public API is deliberately tiny — `__all__` is exactly
+**`create_app`, `build_config`, `Config`**. Everything else
+(`RunnerService`, `Run`, the `ops.data` readers) is reached through
+those or imported from its submodule.
+
+You reach it these ways:
+
+- the **CLI** — `attune ops` / `python -m attune.ops` starts the server;
+- the **Python API** — `from attune.ops import create_app, build_config,
+  Config` to build and embed the app (e.g. in tests).
+
+## Concepts
+
+### The public surface: `build_config` → `create_app`
+
+`build_config(project_root, *, host, port, allow_run, …)` produces a
+`Config`; `create_app(config, *, runner=None)` returns a ready
+`FastAPI` app. Both are **synchronous**. `Config` anchors every path the
+dashboard reads or writes via derived **properties**: `runs_dir`,
+`sessions_dir`, `bulletin_dir`, `memory_dir`, `telemetry_path`
+(`attune_home()` resolves the attune state root).
+
+### The run-safety gate
+
+`Config.allow_run` defaults to **`False`** — the dashboard will not
+execute a workflow unless it is `True`. The **CLI flips it on by
+default**, disabling it only when you pass `--read-only`. So `attune
+ops` can run workflows out of the box; `attune ops --read-only` serves a
+look-but-don't-run dashboard.
+
+### `RunnerService` and `Run` — the execution model
+
+`RunnerService` owns workflow execution. Its one **async** method is the
+killer to remember:
+
+- **`start(workflow, *, path=None) -> Run` is a coroutine** — `await`
+  it. It launches a workflow (optionally scoped to a `path`) and returns
+  a `Run`.
+- `recent`, `get`, `get_or_load`, `handle_stdout_line` are
+  **synchronous**; `current` and `persistence_dir` are properties.
+- Only **one run at a time**: starting a second while one is active
+  raises **`RunnerBusyError(current_run_id)`**.
+
+A `Run` is one execution. `Run.subscribe()` is an **async iterator** of
+events — this is the SSE feed the browser consumes. `append_line`,
+`mark_done`, `to_dict`/`to_record` are sync; `duration_seconds` and
+`is_terminal` are properties.
+
+### Scope picker, persistence, and chaining
+
+The feature **scope picker** reads `.help/features.yaml` so you can
+narrow a run to one feature; `ops.data.workflow_default_scope` supplies
+the default. Run history is **persisted** to `Config.runs_dir` and
+survives restarts (`get_or_load` rehydrates a past run);
+`prune_old_runs` trims beyond `runs_retention_days` (default 30). UI
+interactions are counted via `ops.interaction_counters.EVENTS`
+(`pill_click`, `rec_card_click`, `scope_picker_change`).
+
+### Adjacent read-only surfaces
+
+The dashboard renders data it does not own:
+
+| Submodule | Role | Owning feature |
+|---|---|---|
+| `ops.data` | Reads telemetry/workflows/sessions/KPIs | telemetry |
+| `ops.anthropic_cost` | `fetch_summary()` → cost report | (account-level) |
+| `ops.help_data` | Help coverage + search (the help tab) | help-system |
+| `ops.spec_lifecycle` | `derive_lifecycle(spec)` → status label | spec tooling |
+
+`ops.spec_lifecycle`'s only public function is `derive_lifecycle(spec,
+*, now=None) -> str` (plus the `STALE_THRESHOLD_DAYS` constant) — it
+labels a spec's lifecycle bucket from its phases and last-modified time.
+(There is no candidate-detection API here.)
+
+## Quickstart
+
+Start the dashboard from the CLI (runs enabled unless `--read-only`):
+
+```bash
+attune ops                 # http://127.0.0.1:8765
+python -m attune.ops --read-only --port 9000
+```
+
+Build the app from Python (e.g. to embed or test it):
+
+```python
+from pathlib import Path
+
+from attune.ops import build_config, create_app
+
+config = build_config(Path("."), host="127.0.0.1", port=8765)
+app = create_app(config)
+print(type(app).__name__, "| runs allowed:", config.allow_run)
+```
+
+## Tasks
+
+### Configure where the dashboard reads and writes
+
+**Goal:** point the dashboard at a project and inspect its derived
+paths.
+
+**Steps:**
+
+```python
+from pathlib import Path
+
+from attune.ops import build_config
+
+config = build_config(Path("."), runs_retention_days=14)
+print("runs:", config.runs_dir)
+print("sessions:", config.sessions_dir)
+print("telemetry:", config.telemetry_path)
+```
+
+**Verify:** `build_config()` returns a `Config`. `runs_dir`,
+`sessions_dir`, and `telemetry_path` are **properties** (no `()`), all
+anchored under the attune home / project root.
+
+### Run a workflow with the runner
+
+**Goal:** execute a workflow and get a `Run` back.
+
+**Steps:**
+
+```python
+import asyncio
+
+from attune.ops.runner import RunnerService, RunnerBusyError
+
+
+async def main() -> None:
+    runner = RunnerService()
+    try:
+        run = await runner.start("security-audit", path="src/attune/config")
+        print("started:", run.id)
+    except RunnerBusyError as exc:
+        print("busy with:", exc.current_run_id)
+
+
+asyncio.run(main())
+```
+
+**Verify:** `start()` is a **coroutine** — `await` it; it returns a
+`Run`. Only one run is active at a time, so a concurrent `start()`
+raises `RunnerBusyError`.
+
+### Stream a run's output over SSE
+
+**Goal:** consume a run's live event feed (what the browser does).
+
+**Steps:**
+
+```python
+async def stream(run) -> None:
+    async for event in run.subscribe():
+        print(event)
+        if run.is_terminal:
+            break
+```
+
+**Verify:** `Run.subscribe()` is an **async iterator** of events;
+`is_terminal` flips true when the run finishes.
+
+### Label a spec's lifecycle
+
+**Goal:** ask the dashboard's spec helper what bucket a spec is in.
+
+**Steps:**
+
+```python
+from types import SimpleNamespace
+
+from attune.ops.spec_lifecycle import derive_lifecycle
+
+spec = SimpleNamespace(phases=[], last_modified=None)
+print(derive_lifecycle(spec))
+```
+
+**Verify:** `derive_lifecycle(spec, *, now=None)` returns a status
+**string**. It is the only public function in `ops.spec_lifecycle`.
+
+## Reference
+
+The public API is `create_app`, `build_config`, and `Config`, exported
+from `attune.ops`. The runner and read-side helpers are imported from
+their submodules.
+
+### `attune.ops`
+
+| Symbol | Purpose |
+|---|---|
+| `build_config(project_root=None, *, host="127.0.0.1", port=8765, allow_run=False, specs_roots=None, trusted_hosts=None, runs_retention_days=30, specs_candidates_enabled=False) -> Config` | Build the dashboard config. |
+| `create_app(config, *, runner=None) -> FastAPI` | Build the FastAPI app (sync). |
+| `Config` | Settings dataclass. **Properties:** `bulletin_dir`, `memory_dir`, `runs_dir`, `sessions_dir`, `telemetry_path`. `allow_run` defaults `False`. |
+
+### `attune.ops.runner`
+
+| Symbol | Purpose |
+|---|---|
+| `RunnerService(*, history_limit=20, command_builder=None, executor=None, persistence_dir=None, project_root=None, bulletin=None, actor_id=None, actor_kind="dashboard")` | Workflow runner. |
+| `RunnerService.start(workflow, *, path=None) -> Run` | **Async.** Launch a run (one at a time). |
+| `RunnerService.recent` / `.get` / `.get_or_load` / `.handle_stdout_line` | Sync history/lookup helpers. |
+| `RunnerService.current` / `.persistence_dir` | Properties. |
+| `Run.subscribe() -> AsyncIterator` | **Async.** SSE event feed. |
+| `Run.append_line` / `.mark_done` / `.to_dict` / `.to_record` | Sync run helpers. |
+| `Run.duration_seconds` / `.is_terminal` | Properties. |
+| `RunnerBusyError(current_run_id)` | Raised on a concurrent `start()`. |
+| `prune_old_runs(...)` / `echo_command_builder` | Retention + a default command builder. |
+
+### Read-side submodules
+
+| Module | Key public API |
+|---|---|
+| `ops.data` | `read_telemetry_summary`, `list_workflows`, `list_features`, `home_kpis`, `list_recent_sessions`, `env_health`, `family_versions`, `workflow_default_scope`, `sparkline_points`, … |
+| `ops.anthropic_cost` | `fetch_summary(*, refresh=False) -> tuple[CostSummary \| None, CostFetchError \| None]`; `CostSummary`, `CostFetchError`, `CostFetchErrorKind`. |
+| `ops.help_data` | `coverage_gaps`, `search`, `list_features`, `get_template`. |
+| `ops.spec_lifecycle` | `derive_lifecycle(spec, *, now=None) -> str` (only public function) + `STALE_THRESHOLD_DAYS`. |
+| `ops.interaction_counters` | `EVENTS = ('pill_click', 'rec_card_click', 'scope_picker_change')`. |
+| `ops.cli` | `add_subparser`, `cmd_ops`, `main`. |
+
+### CLI flags (`attune ops` / `python -m attune.ops`)
+
+| Flag | Effect |
+|---|---|
+| `--host` / `--port` | Bind address (default `127.0.0.1:8765`). |
+| `--project-root` | Project to serve. |
+| `--no-browser` | Don't auto-open a browser. |
+| `--read-only` | Disable runs (`allow_run=False`); runs are **enabled** otherwise. |
+| `--specs-root DIR` | Spec directory (repeatable). |
+| `--trusted-host` | Allow a remote host. |
+| `--runs-retention-days` | History retention (default 30). |
+| `--specs-candidates` / `--no-specs-candidates` | Toggle spec candidate display. |
+
+## Comparison
+
+The ops dashboard is one of three front doors to attune's workflows:
+
+| | ops-dashboard | mcp-server | CLI |
+|--|---------------|-----------|-----|
+| Surface | Local web UI (HTTP) | MCP tools (stdio) | `attune workflow run` |
+| Strength | Scope picker, run history, chaining, live SSE | In-conversation tool calls | Scriptable one-shots |
+| Entry | `attune ops` | `python -m attune.mcp.server` | `attune workflow run <slug>` |
+
+It is the *browser* front door; the MCP server is the *conversational*
+one; the CLI is the *terminal* one. The dashboard renders cost,
+telemetry, and help data those other features own.
+
+## Failure modes
+
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `RuntimeWarning: coroutine 'RunnerService.start' was never awaited` | `start()` called without `await` | It's async — `await` it / `asyncio.run` | high |
+| Workflows won't run from the UI | `Config.allow_run` is `False` (e.g. `--read-only`) | Start without `--read-only` | high |
+| `RunnerBusyError` on start | A run is already active (one at a time) | Wait for / inspect `runner.current` | medium |
+| `TypeError` calling `config.runs_dir()` | `runs_dir` is a property | Drop the `()` | medium |
+| Cost panel shows an error | `fetch_summary` returned a `CostFetchError` (no admin key, network) | Inspect the error `kind`/`message`; cost is an adjacent surface | low |
+
+### Risk areas
+
+- **`RunnerService.start` and `Run.subscribe` are async.** They are the
+  two awaitable surfaces; everything else on the runner is sync.
+- **`allow_run` is a real gate.** Off by default in `Config`; the CLI
+  turns it on unless `--read-only`.
+- **Scope confusion.** Cost/telemetry/help shown on the dashboard are
+  *adjacent* surfaces — owned by other features, only read here.
+
+### Diagnosis order
+
+1. Confirm the app builds: `create_app(build_config(Path(".")))`.
+2. Confirm runs are allowed: `config.allow_run` (and no `--read-only`).
+3. For a run that won't start: check `runner.current` /
+   `RunnerBusyError`.
+4. For async warnings: `await` `start()` / iterate `subscribe()`.
+5. For a data panel: that data is owned by its feature (telemetry /
+   help-system / cost).
+
+## FAQ seeds
+
+> **Channel-4 input, not a rendered FAQ.** The FAQ is a dynamic source
+> of truth fed by four channels — unmatched user queries, telemetry
+> error-frequency, GitHub issues, and these author-curated seeds —
+> merged, deduplicated, and frequency-ranked by the FAQ Generator (see
+> doc-stack D3, and the help-docs-single-source spec's decisions.md D6).
+> This section is **not** projected verbatim as the FAQ; it contributes
+> the feature's author-curated seed questions.
+
+- **Q:** What is the ops dashboard?
+  **A:** A local FastAPI web app for running attune workflows against a
+  feature scope, with persisted run history, workflow chaining, and live
+  SSE log streaming. Start it with `attune ops` (default
+  `127.0.0.1:8765`).
+- **Q:** How do I start it?
+  **A:** `attune ops` or `python -m attune.ops`. Runs are enabled by
+  default; pass `--read-only` for a look-but-don't-run dashboard.
+- **Q:** What's the public API?
+  **A:** Exactly `create_app`, `build_config`, and `Config`
+  (`attune.ops.__all__`). The runner is `attune.ops.runner`.
+- **Q:** Why won't my workflow run?
+  **A:** `Config.allow_run` must be `True`. It defaults to `False`; the
+  CLI enables it unless you pass `--read-only`.
+- **Q:** What's async on the runner?
+  **A:** `RunnerService.start()` and `Run.subscribe()`. The history and
+  lookup helpers (`recent`, `get`, `get_or_load`) are synchronous.
+- **Q:** Can I run two workflows at once?
+  **A:** No — one at a time. A concurrent `start()` raises
+  `RunnerBusyError`.
+- **Q:** Does it own the cost/telemetry/help data it shows?
+  **A:** No. Those are adjacent surfaces — `ops.data`/
+  `ops.anthropic_cost`/`ops.help_data` only read data owned by the
+  telemetry and help-system features.
+
+## Notes & tips
+
+- **Depend on the documented public surface:** `create_app`,
+  `build_config`, `Config` from `attune.ops`. The runner and readers are
+  reached from their submodules.
+- **`await` the two async surfaces.** `RunnerService.start` and
+  `Run.subscribe`; everything else on the runner is sync.
+- **Paths are properties.** `runs_dir`, `sessions_dir`,
+  `telemetry_path` — no `()`.
+- **`--read-only` for a safe demo.** It serves the dashboard with
+  execution disabled.
+
+## Design & extension
+
+### Design decisions
+
+- **Tiny public surface.** `__all__` is just `create_app`,
+  `build_config`, `Config` — the runner and readers stay internal-ish so
+  the supported API is small and stable.
+- **Runs off by default in `Config`.** Execution is opt-in
+  (`allow_run`); the CLI enables it deliberately so embedding the app is
+  safe by default.
+- **One run at a time.** `RunnerService` is single-flight
+  (`RunnerBusyError`), keeping run state and the SSE feed unambiguous.
+- **Read-only adjacency.** The dashboard *renders* cost/telemetry/help
+  via `ops.data`/`ops.anthropic_cost`/`ops.help_data` but never owns
+  that data — each stays the responsibility of its feature.
+
+### Extension points
+
+- **Custom command builder / executor:** pass `command_builder` /
+  `executor` to `RunnerService` (default `echo_command_builder`).
+- **Inject a runner:** `create_app(config, runner=...)` for tests or a
+  custom execution backend.
+- **Retention:** tune `runs_retention_days` (or call `prune_old_runs`).
+- **New read panel:** add a reader to `ops.data` and surface it in the
+  app — keep ownership with the source feature.

--- a/docs/architecture/ops-dashboard.md
+++ b/docs/architecture/ops-dashboard.md
@@ -1,109 +1,119 @@
-# Ops Dashboard architecture
+# Ops Dashboard
 
-Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
+## Overview
 
-## Purpose
+The ops dashboard is attune's **local operations layer** — a FastAPI
+web app you run on your own machine to execute workflows against a
+chosen feature scope, browse persisted run history, chain workflows
+with a click, and watch live logs stream over **SSE**. It lives in
+**`src/attune/ops/`** and is launched with `attune ops` (or `python -m
+attune.ops`), binding to **`127.0.0.1:8765`** by default.
 
-`attune ops` serves as the workflow OS's local web dashboard. It is responsible for: presenting home-page KPIs and cost sparklines, letting users pick a feature scope and trigger workflow runs, streaming live run output over SSE, persisting run history to disk, and enforcing trusted-host access control.
+This page documents the **runner core** — the server, its config, and
+the `RunnerService`/`Run` execution model. The dashboard also *displays*
+data owned by other features — Anthropic cost (`ops.anthropic_cost`),
+telemetry (`ops.data` reads the telemetry store), and help coverage
+(`ops.help_data`) — but those are **adjacent** surfaces it renders, not
+its own; each belongs to its respective feature (telemetry, help-system).
 
-It is **not** responsible for defining workflows themselves, managing the attune agent, or writing telemetry data — those concerns live outside this module. `attune ops` reads telemetry and run state; it does not produce them.
+The public API is deliberately tiny — `__all__` is exactly
+**`create_app`, `build_config`, `Config`**. Everything else
+(`RunnerService`, `Run`, the `ops.data` readers) is reached through
+those or imported from its submodule.
 
-## Key classes
+You reach it these ways:
 
-| Class | Responsibility | File |
-|-------|----------------|------|
-| `Config` | Holds all resolved paths and server settings (host, port, retention policy, trusted hosts) that the dashboard reads at startup. | `src/attune/ops/config.py` |
-| `TrustedHostMiddleware` | Rejects any request whose `Host` header is not on the configured allowlist before it reaches a route handler. | `src/attune/ops/middleware.py` |
-| `RunnerService` | Owns the run history list and the concurrency lock; enforces the one-active-run-at-a-time constraint. | `src/attune/ops/runner.py` |
-| `Run` | Represents a single workflow execution and its associated SSE broadcast state; created and managed by `RunnerService`. | `src/attune/ops/runner.py` |
-| `RunnerBusyError` | Signals that a new run was requested while one is already pending or running; raised by `RunnerService`. | `src/attune/ops/runner.py` |
-| `HomeKpis` | Aggregates today's event count, rolling 7-day cost and savings, and the sparkline data shown above the fold on the home page. | `src/attune/ops/data.py` |
-| `DailyCost` | Carries one day's event count and cost; the list of these forms the sparkline fed into `HomeKpis`. | `src/attune/ops/data.py` |
-| `TelemetrySummary` | Read-only snapshot of aggregate telemetry: total requests, cost, savings, and breakdowns by workflow and by day. | `src/attune/ops/data.py` |
-| `WorkflowEntry` | Describes one workflow available for dispatch: name, description, stage count, and CLI tier mapping. | `src/attune/ops/data.py` |
-| `PathArgSpec` | Describes how a workflow accepts a scope path on the CLI (`kwarg` name and whether it is required). | `src/attune/ops/data.py` |
-| `Feature` | Represents one entry from `.help/features.yaml`; drives the scope picker that lets users target a specific feature path. | `src/attune/ops/data.py` |
-| `FamilyVersion` | Records one package's resolved version and source; used by the dashboard to surface dependency info. | `src/attune/ops/data.py` |
-| `SpecPhase` | Snapshot of one phase file's existence and status string within a spec directory. | `src/attune/ops/routes/specs.py` |
-| `SpecRecord` | Aggregates a spec directory's path and the `SpecPhase` snapshot for each of the four phase files (`decisions.md`, `requirements.md`, `design.md`, `tasks.md`). | `src/attune/ops/routes/specs.py` |
+- the **CLI** — `attune ops` / `python -m attune.ops` starts the server;
+- the **Python API** — `from attune.ops import create_app, build_config,
+  Config` to build and embed the app (e.g. in tests).
 
-> **Note:** `Run` and `RunnerService` together do three things — execution lifecycle, SSE broadcast state, and history retention — which may be worth splitting if the runner grows more complex.
+## Concepts
 
-## Data flow
+### The public surface: `build_config` → `create_app`
 
-```
-CLI / browser request
-        |
-        v
-TrustedHostMiddleware  ──── rejects unlisted Host headers
-        |
-        v
-   FastAPI app  (create_app())
-   ┌────────────────────────────────────────────┐
-   │                                            │
-   │  GET /                                     │
-   │    TelemetrySummary ──> home_kpis()        │
-   │                             └──> HomeKpis  │
-   │                                   (KPI     │
-   │                                    panel + │
-   │                                    sparkline│
-   │                                    of      │
-   │                                    DailyCost)
-   │                                            │
-   │  GET /workflows                            │
-   │    WorkflowEntry[]  (scope: PathArgSpec)   │
-   │                                            │
-   │  GET /features                             │
-   │    list_features() ──> Feature[]           │
-   │    first_feature() ──> Feature | None      │
-   │                                            │
-   │  POST /workflows/{name}/run                │
-   │    RunnerService.start()                   │
-   │      ├── RunnerBusyError (409 if busy)     │
-   │      └── Run (new execution)               │
-   │            └── SSE  /runs/{run_id}/stream  │
-   │                                            │
-   │  GET /specs                                │
-   │    SpecRecord[]                            │
-   │      └── SpecPhase × 4 per spec           │
-   └────────────────────────────────────────────┘
-        |
-        v
-  Config  (read at startup: paths, host, port,
-           trusted_hosts, runs_retention_days)
-  ├── telemetry_path  →  TelemetrySummary source
-  ├── runs_dir        →  persisted Run history
-  ├── memory_dir      →  agent memory (read-only)
-  └── sessions_dir    →  session records (read-only)
-```
+`build_config(project_root, *, host, port, allow_run, …)` produces a
+`Config`; `create_app(config, *, runner=None)` returns a ready
+`FastAPI` app. Both are **synchronous**. `Config` anchors every path the
+dashboard reads or writes via derived **properties**: `runs_dir`,
+`sessions_dir`, `bulletin_dir`, `memory_dir`, `telemetry_path`
+(`attune_home()` resolves the attune state root).
 
-## Design decisions
+### The run-safety gate
 
-**Lazy FastAPI import via `create_app()`**
-`create_app()` and `build_config()` are thin wrappers that import FastAPI only when the dashboard is actually started. This keeps `import attune` fast for all other subcommands that don't need a web server.
+`Config.allow_run` defaults to **`False`** — the dashboard will not
+execute a workflow unless it is `True`. The **CLI flips it on by
+default**, disabling it only when you pass `--read-only`. So `attune
+ops` can run workflows out of the box; `attune ops --read-only` serves a
+look-but-don't-run dashboard.
 
-**One active run at a time**
-`RunnerService` holds a concurrency lock and raises `RunnerBusyError` when a second run is attempted. The alternative — queuing runs — was not chosen because the dashboard is a local single-user tool; silent queueing would obscure whether a previous run was still in progress.
+### `RunnerService` and `Run` — the execution model
 
-**`Config` as a resolved-paths dataclass, not a live reader**
-`build_config()` resolves all paths and environment variables once at startup and freezes them into a `Config` dataclass. Routes read `Config` fields directly rather than re-reading the environment on each request, so there is no ambiguity about which config values are active.
+`RunnerService` owns workflow execution. Its one **async** method is the
+killer to remember:
 
-**`allow_run` flag**
-Workflow execution is disabled by default (`allow_run = False`). This is an explicit opt-in so that dashboard deployments used purely for observability cannot accidentally trigger runs.
+- **`start(workflow, *, path=None) -> Run` is a coroutine** — `await`
+  it. It launches a workflow (optionally scoped to a `path`) and returns
+  a `Run`.
+- `recent`, `get`, `get_or_load`, `handle_stdout_line` are
+  **synchronous**; `current` and `persistence_dir` are properties.
+- Only **one run at a time**: starting a second while one is active
+  raises **`RunnerBusyError(current_run_id)`**.
 
-**Trusted-host enforcement at middleware layer**
-`TrustedHostMiddleware` runs before any route handler, so the allowlist check cannot be bypassed by a misconfigured route. The `trusted_hosts` tuple in `Config` is the single source of truth for this list.
+A `Run` is one execution. `Run.subscribe()` is an **async iterator** of
+events — this is the SSE feed the browser consumes. `append_line`,
+`mark_done`, `to_dict`/`to_record` are sync; `duration_seconds` and
+`is_terminal` are properties.
 
-## Extension points
+### Scope picker, persistence, and chaining
 
-- **Add a new route:** register it on the FastAPI app returned by `create_app()`. Place data-shape dataclasses in `src/attune/ops/data.py` and route logic under `src/attune/ops/routes/`.
-- **Change server settings** (host, port, retention, trusted hosts): pass arguments to `build_config()` or set the corresponding environment variables — `build_config()` merges both sources.
-- **Support additional spec phase files:** add filenames to the `_PHASE_FILES` tuple in `src/attune/ops/routes/specs.py`. Valid status strings are governed by `_VALID_STATUSES` in the same file.
-- **Extend the scope picker:** add entries to `.help/features.yaml` in the project root. `list_features()` and `first_feature()` parse this file; no code changes are needed for new features.
-- **Add a new run backend:** replace or subclass `RunnerService`. The concurrency contract is: raise `RunnerBusyError` if a run is already active, return a `Run` instance otherwise. SSE consumers depend on `Run`'s broadcast interface.
+The feature **scope picker** reads `.help/features.yaml` so you can
+narrow a run to one feature; `ops.data.workflow_default_scope` supplies
+the default. Run history is **persisted** to `Config.runs_dir` and
+survives restarts (`get_or_load` rehydrates a past run);
+`prune_old_runs` trims beyond `runs_retention_days` (default 30). UI
+interactions are counted via `ops.interaction_counters.EVENTS`
+(`pill_click`, `rec_card_click`, `scope_picker_change`).
 
-## See also
+### Adjacent read-only surfaces
 
-- [How-to: use the ops dashboard](../how-to/ops-dashboard.md) — task-focused recipes for the dashboard's core API
-- [Tutorial: ops-dashboard walkthrough](../tutorials/ops-dashboard.md) — end-to-end first run
-- [Reference: ops-dashboard CLI](../reference/ops-dashboard.md) — every command-line flag, environment variable, and exit code
+The dashboard renders data it does not own:
+
+| Submodule | Role | Owning feature |
+|---|---|---|
+| `ops.data` | Reads telemetry/workflows/sessions/KPIs | telemetry |
+| `ops.anthropic_cost` | `fetch_summary()` → cost report | (account-level) |
+| `ops.help_data` | Help coverage + search (the help tab) | help-system |
+| `ops.spec_lifecycle` | `derive_lifecycle(spec)` → status label | spec tooling |
+
+`ops.spec_lifecycle`'s only public function is `derive_lifecycle(spec,
+*, now=None) -> str` (plus the `STALE_THRESHOLD_DAYS` constant) — it
+labels a spec's lifecycle bucket from its phases and last-modified time.
+(There is no candidate-detection API here.)
+
+## Design & extension
+
+### Design decisions
+
+- **Tiny public surface.** `__all__` is just `create_app`,
+  `build_config`, `Config` — the runner and readers stay internal-ish so
+  the supported API is small and stable.
+- **Runs off by default in `Config`.** Execution is opt-in
+  (`allow_run`); the CLI enables it deliberately so embedding the app is
+  safe by default.
+- **One run at a time.** `RunnerService` is single-flight
+  (`RunnerBusyError`), keeping run state and the SSE feed unambiguous.
+- **Read-only adjacency.** The dashboard *renders* cost/telemetry/help
+  via `ops.data`/`ops.anthropic_cost`/`ops.help_data` but never owns
+  that data — each stays the responsibility of its feature.
+
+### Extension points
+
+- **Custom command builder / executor:** pass `command_builder` /
+  `executor` to `RunnerService` (default `echo_command_builder`).
+- **Inject a runner:** `create_app(config, runner=...)` for tests or a
+  custom execution backend.
+- **Retention:** tune `runs_retention_days` (or call `prune_old_runs`).
+- **New read panel:** add a reader to `ops.data` and surface it in the
+  app — keep ownership with the source feature.
+
+<!-- attune-generated: source_hash=1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7 feature=ops-dashboard kind=architecture generated_at=2026-06-24 -->

--- a/docs/features/ops-dashboard.md
+++ b/docs/features/ops-dashboard.md
@@ -1,0 +1,27 @@
+# Ops Dashboard
+
+The local FastAPI operations dashboard — a workflow runner with per-feature scope, persisted run history, workflow chaining, and live SSE log streaming
+
+!!! tip "Start here"
+
+    [How-to guide](../how-to/ops-dashboard.md) — task recipes for common goals.
+
+<div class="grid cards" markdown>
+
+-   __Reference__
+
+    ---
+
+    The full API and option reference.
+
+    [Open the reference](../reference/ops-dashboard.md)
+
+-   __Architecture__
+
+    ---
+
+    How it works and how to extend it.
+
+    [Open the architecture](../architecture/ops-dashboard.md)
+
+</div>

--- a/docs/how-to/ops-dashboard.md
+++ b/docs/how-to/ops-dashboard.md
@@ -1,129 +1,163 @@
----
-type: how-to
-name: ops-dashboard
-tags: [ops, dashboard, runner, workflows, scope-picker, persistence, sse]
-source: ops-dashboard
----
+# Ops Dashboard
 
-# How to use the ops dashboard
+## Quickstart
 
-Use this guide when you want to launch the attune operations dashboard, configure its server settings, and work with its core APIs to surface workflow runs, telemetry, and spec status in your project.
-
-## Quick start
-
-Start the dashboard from the command line against your project root:
+Start the dashboard from the CLI (runs enabled unless `--read-only`):
 
 ```bash
-attune ops --project-root /path/to/your/project --port 8765
+attune ops                 # http://127.0.0.1:8765
+python -m attune.ops --read-only --port 9000
 ```
 
-Or launch it directly as a Python module:
-
-```bash
-python -m attune.ops
-```
-
-The dashboard starts a blocking server at `http://127.0.0.1:8765`. Open that URL to see the home page with today's KPIs, a cost sparkline, and the workflow catalog. Press `Ctrl+C` in the terminal to stop the server.
-
-## Core API
-
-| Function or class | Purpose |
-|---|---|
-| `build_config(project_root, *, host, port, allow_run, ...)` | Build a `Config` from explicit inputs and environment defaults. |
-| `create_app()` | Build the FastAPI app, wiring `Config` and templates into request state. |
-| `cmd_ops(args)` | Run the dashboard server (blocking); returns `0` on clean exit. |
-| `main()` | Standalone entry point for `python -m attune.ops`. |
-| `attune_home()` | Resolve the user's attune home directory (`ATTUNE_HOME` env override → `~/.attune`). |
-| `list_features(project_root)` | Return features parsed from `<project_root>/.help/features.yaml`. |
-| `first_feature(project_root)` | Return the alphabetically first feature that has a renderable scope. |
-| `home_kpis(summary, *, today)` | Derive home-page KPI numbers from a `TelemetrySummary`. |
-| `list_workflows()` | Return the registered workflow catalog; empty list if the registry is unavailable. |
-| `env_health()` | Lightweight environment snapshot for the Health page. |
-| `family_versions()` | Resolve installed versions for every related attune package. |
-| `list_runs(workflow)` | Return up to 20 newest runs for a workflow, newest first. |
-| `prune_old_runs(days)` | Delete persisted run files older than `days`; returns the deletion count. |
-| `list_specs()` | Federated listing of specs across all configured spec roots. |
-| `update_phase_status()` | Rewrite the `**Status**` line in a named phase file. |
-| `read_telemetry_summary()` | Aggregate `usage.jsonl` into a UI-friendly `TelemetrySummary`. |
-| `compute_allowlist()` | Compute the merged default + user-supplied `Host` header allowlist. |
-| `is_persistence_enabled()` | Returns `True` when `ATTUNE_OPS_SWEEP_RESULTS` is set to a non-empty value. |
-| `persist_result()` | Atomically write a `SweepResult` to `<attune_home>/ops/sweep-results/<hash>.json`. |
-| `watch_and_persist()` | Subscribe to a discovery-sweep run and persist its result on success. |
-
-### Key dataclasses
-
-| Class | Purpose |
-|---|---|
-| `Config` | Holds all runtime configuration for the dashboard (paths, host, port, retention, etc.). |
-| `HomeKpis` | Summary numbers shown above the fold on the home page. |
-| `TelemetrySummary` | Aggregated request counts, costs, and savings by workflow and day. |
-| `WorkflowEntry` | One entry in the workflow catalog (name, description, stage count, tier map). |
-| `Feature` | One feature from `.help/features.yaml`, used by the scope picker. |
-| `SpecPhase` | Status snapshot for one phase file within a spec. |
-
-## Configuration
-
-`build_config()` accepts these parameters, all of which fall back to sensible defaults:
-
-| Parameter | Default | Purpose |
-|---|---|---|
-| `project_root` | current directory | Root of the project being inspected. |
-| `host` | `127.0.0.1` | Interface the server binds to. |
-| `port` | `8765` | Port the server listens on. |
-| `allow_run` | `False` | Enable the workflow run-trigger endpoint. |
-| `specs_roots` | `()` | Additional directories to include in the federated spec listing. |
-| `trusted_hosts` | `()` | Extra hostnames added to the `Host` header allowlist. |
-| `runs_retention_days` | `30` | How many days to keep persisted run files before `prune_old_runs()` removes them. |
-
-The `ATTUNE_OPS_SWEEP_RESULTS` environment variable must be set to a non-empty value to enable sweep-result persistence (`is_persistence_enabled()`).
-
-## Integration patterns
-
-### Building a config and launching the app programmatically
-
-When you want to embed the dashboard inside a larger process rather than use the CLI, build a `Config` explicitly and pass it to `create_app()`. Keep the bind on `127.0.0.1` so the dashboard isn't reachable from outside the local machine:
+Build the app from Python (e.g. to embed or test it):
 
 ```python
 from pathlib import Path
+
 from attune.ops import build_config, create_app
 
-config = build_config(
-    project_root=Path("/path/to/your/project"),
-    host="127.0.0.1",
-    port=9000,
-    allow_run=True,
-)
-
+config = build_config(Path("."), host="127.0.0.1", port=8765)
 app = create_app(config)
-
-# Hand `app` to any ASGI server, e.g. uvicorn:
-import uvicorn
-uvicorn.run(app, host=config.host, port=config.port)
+print(type(app).__name__, "| runs allowed:", config.allow_run)
 ```
 
-If you genuinely need to reach the dashboard from another machine, prefer an SSH tunnel (`ssh -L 8765:127.0.0.1:8765 user@host`) or a reverse proxy that handles auth — do not bind the server to `0.0.0.0` directly. The dashboard has no built-in authentication.
+## Tasks
 
-### Reading telemetry and KPIs without starting the server
+### Configure where the dashboard reads and writes
 
-If you only need the dashboard's data layer — for example, to pipe numbers into a CI report — you can call the reader functions directly without launching the HTTP server:
+**Goal:** point the dashboard at a project and inspect its derived
+paths.
+
+**Steps:**
 
 ```python
 from pathlib import Path
-from attune.ops import build_config, read_telemetry_summary, home_kpis
 
-config = build_config(project_root=Path("/path/to/your/project"))
+from attune.ops import build_config
 
-summary = read_telemetry_summary(config.telemetry_path)
-kpis = home_kpis(summary)
-
-print(f"Today: {kpis.today_events} events, ${kpis.today_cost:.4f}")
-print(f"7-day savings: ${kpis.seven_day_savings:.4f}")
+config = build_config(Path("."), runs_retention_days=14)
+print("runs:", config.runs_dir)
+print("sessions:", config.sessions_dir)
+print("telemetry:", config.telemetry_path)
 ```
 
-## See also
+**Verify:** `build_config()` returns a `Config`. `runs_dir`,
+`sessions_dir`, and `telemetry_path` are **properties** (no `()`), all
+anchored under the attune home / project root.
 
-- [Tutorial: ops-dashboard walkthrough](../tutorials/ops-dashboard.md) — end-to-end first run, including the workflow runner and scope picker
-- [Reference: ops-dashboard API](../reference/ops-dashboard.md) — full symbol-by-symbol API listing
-- [Architecture: ops-dashboard](../architecture/ops-dashboard.md) — how the configuration, FastAPI app, and persistence layers fit together
+### Run a workflow with the runner
 
-<!-- attune-generated: source_hash=395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42 feature=ops-dashboard kind=how-to generated_at=2026-05-14 -->
+**Goal:** execute a workflow and get a `Run` back.
+
+**Steps:**
+
+```python
+import asyncio
+
+from attune.ops.runner import RunnerService, RunnerBusyError
+
+
+async def main() -> None:
+    runner = RunnerService()
+    try:
+        run = await runner.start("security-audit", path="src/attune/config")
+        print("started:", run.id)
+    except RunnerBusyError as exc:
+        print("busy with:", exc.current_run_id)
+
+
+asyncio.run(main())
+```
+
+**Verify:** `start()` is a **coroutine** — `await` it; it returns a
+`Run`. Only one run is active at a time, so a concurrent `start()`
+raises `RunnerBusyError`.
+
+### Stream a run's output over SSE
+
+**Goal:** consume a run's live event feed (what the browser does).
+
+**Steps:**
+
+```python
+async def stream(run) -> None:
+    async for event in run.subscribe():
+        print(event)
+        if run.is_terminal:
+            break
+```
+
+**Verify:** `Run.subscribe()` is an **async iterator** of events;
+`is_terminal` flips true when the run finishes.
+
+### Label a spec's lifecycle
+
+**Goal:** ask the dashboard's spec helper what bucket a spec is in.
+
+**Steps:**
+
+```python
+from types import SimpleNamespace
+
+from attune.ops.spec_lifecycle import derive_lifecycle
+
+spec = SimpleNamespace(phases=[], last_modified=None)
+print(derive_lifecycle(spec))
+```
+
+**Verify:** `derive_lifecycle(spec, *, now=None)` returns a status
+**string**. It is the only public function in `ops.spec_lifecycle`.
+
+## Reference
+
+The public API is `create_app`, `build_config`, and `Config`, exported
+from `attune.ops`. The runner and read-side helpers are imported from
+their submodules.
+
+### `attune.ops`
+
+| Symbol | Purpose |
+|---|---|
+| `build_config(project_root=None, *, host="127.0.0.1", port=8765, allow_run=False, specs_roots=None, trusted_hosts=None, runs_retention_days=30, specs_candidates_enabled=False) -> Config` | Build the dashboard config. |
+| `create_app(config, *, runner=None) -> FastAPI` | Build the FastAPI app (sync). |
+| `Config` | Settings dataclass. **Properties:** `bulletin_dir`, `memory_dir`, `runs_dir`, `sessions_dir`, `telemetry_path`. `allow_run` defaults `False`. |
+
+### `attune.ops.runner`
+
+| Symbol | Purpose |
+|---|---|
+| `RunnerService(*, history_limit=20, command_builder=None, executor=None, persistence_dir=None, project_root=None, bulletin=None, actor_id=None, actor_kind="dashboard")` | Workflow runner. |
+| `RunnerService.start(workflow, *, path=None) -> Run` | **Async.** Launch a run (one at a time). |
+| `RunnerService.recent` / `.get` / `.get_or_load` / `.handle_stdout_line` | Sync history/lookup helpers. |
+| `RunnerService.current` / `.persistence_dir` | Properties. |
+| `Run.subscribe() -> AsyncIterator` | **Async.** SSE event feed. |
+| `Run.append_line` / `.mark_done` / `.to_dict` / `.to_record` | Sync run helpers. |
+| `Run.duration_seconds` / `.is_terminal` | Properties. |
+| `RunnerBusyError(current_run_id)` | Raised on a concurrent `start()`. |
+| `prune_old_runs(...)` / `echo_command_builder` | Retention + a default command builder. |
+
+### Read-side submodules
+
+| Module | Key public API |
+|---|---|
+| `ops.data` | `read_telemetry_summary`, `list_workflows`, `list_features`, `home_kpis`, `list_recent_sessions`, `env_health`, `family_versions`, `workflow_default_scope`, `sparkline_points`, … |
+| `ops.anthropic_cost` | `fetch_summary(*, refresh=False) -> tuple[CostSummary \| None, CostFetchError \| None]`; `CostSummary`, `CostFetchError`, `CostFetchErrorKind`. |
+| `ops.help_data` | `coverage_gaps`, `search`, `list_features`, `get_template`. |
+| `ops.spec_lifecycle` | `derive_lifecycle(spec, *, now=None) -> str` (only public function) + `STALE_THRESHOLD_DAYS`. |
+| `ops.interaction_counters` | `EVENTS = ('pill_click', 'rec_card_click', 'scope_picker_change')`. |
+| `ops.cli` | `add_subparser`, `cmd_ops`, `main`. |
+
+### CLI flags (`attune ops` / `python -m attune.ops`)
+
+| Flag | Effect |
+|---|---|
+| `--host` / `--port` | Bind address (default `127.0.0.1:8765`). |
+| `--project-root` | Project to serve. |
+| `--no-browser` | Don't auto-open a browser. |
+| `--read-only` | Disable runs (`allow_run=False`); runs are **enabled** otherwise. |
+| `--specs-root DIR` | Spec directory (repeatable). |
+| `--trusted-host` | Allow a remote host. |
+| `--runs-retention-days` | History retention (default 30). |
+| `--specs-candidates` / `--no-specs-candidates` | Toggle spec candidate display. |
+
+<!-- attune-generated: source_hash=1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7 feature=ops-dashboard kind=how-to generated_at=2026-06-24 -->

--- a/docs/reference/ops-dashboard.md
+++ b/docs/reference/ops-dashboard.md
@@ -1,108 +1,55 @@
-# Ops Dashboard CLI reference
+# Ops Dashboard
 
-Local operations dashboard — workflow runner with per-feature scope picker, persisted run history, clickable workflow chaining, and live SSE log streaming.
+## Reference
 
-## Description
+The public API is `create_app`, `build_config`, and `Config`, exported
+from `attune.ops`. The runner and read-side helpers are imported from
+their submodules.
 
-`attune ops` starts a blocking local web server that serves the operations dashboard UI. It reads project and attune state from a `Config` object built from your project root, host, port, and environment defaults. The dashboard exposes workflow execution, telemetry summaries, spec browsing, and run history over HTTP. You can also invoke it directly as `python -m attune.ops`.
+### `attune.ops`
 
-## Usage
+| Symbol | Purpose |
+|---|---|
+| `build_config(project_root=None, *, host="127.0.0.1", port=8765, allow_run=False, specs_roots=None, trusted_hosts=None, runs_retention_days=30, specs_candidates_enabled=False) -> Config` | Build the dashboard config. |
+| `create_app(config, *, runner=None) -> FastAPI` | Build the FastAPI app (sync). |
+| `Config` | Settings dataclass. **Properties:** `bulletin_dir`, `memory_dir`, `runs_dir`, `sessions_dir`, `telemetry_path`. `allow_run` defaults `False`. |
 
-```
-attune ops [--host HOST] [--port PORT] [--project-root PATH] [--no-browser]
-           [--read-only] [--specs-root PATH] [--trusted-host HOST]
-           [--runs-retention-days DAYS]
-```
+### `attune.ops.runner`
 
-## Options
+| Symbol | Purpose |
+|---|---|
+| `RunnerService(*, history_limit=20, command_builder=None, executor=None, persistence_dir=None, project_root=None, bulletin=None, actor_id=None, actor_kind="dashboard")` | Workflow runner. |
+| `RunnerService.start(workflow, *, path=None) -> Run` | **Async.** Launch a run (one at a time). |
+| `RunnerService.recent` / `.get` / `.get_or_load` / `.handle_stdout_line` | Sync history/lookup helpers. |
+| `RunnerService.current` / `.persistence_dir` | Properties. |
+| `Run.subscribe() -> AsyncIterator` | **Async.** SSE event feed. |
+| `Run.append_line` / `.mark_done` / `.to_dict` / `.to_record` | Sync run helpers. |
+| `Run.duration_seconds` / `.is_terminal` | Properties. |
+| `RunnerBusyError(current_run_id)` | Raised on a concurrent `start()`. |
+| `prune_old_runs(...)` / `echo_command_builder` | Retention + a default command builder. |
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--host HOST` | `127.0.0.1` | Interface address the dashboard server binds to |
-| `--port PORT` | `8765` | TCP port the dashboard server listens on |
-| `--project-root PATH` | cwd | Project directory to inspect |
-| `--no-browser` | (off) | Don't auto-open a browser tab on startup |
-| `--read-only` | (off) | Disable workflow execution from the dashboard. Runs are enabled by default; pass this flag to make the dashboard purely observational. |
-| `--specs-root PATH` | — | Add a root directory to the federated spec listing; repeatable |
-| `--trusted-host HOST` | — | Add a hostname (optionally `host:port`) to the `Host`-header allowlist; repeatable. Use when reaching the dashboard via a tunnel or reverse proxy. |
-| `--runs-retention-days DAYS` | `30` | Delete persisted run files older than this many days at startup. Set to `0` to disable pruning. |
+### Read-side submodules
 
-## Output
+| Module | Key public API |
+|---|---|
+| `ops.data` | `read_telemetry_summary`, `list_workflows`, `list_features`, `home_kpis`, `list_recent_sessions`, `env_health`, `family_versions`, `workflow_default_scope`, `sparkline_points`, … |
+| `ops.anthropic_cost` | `fetch_summary(*, refresh=False) -> tuple[CostSummary \| None, CostFetchError \| None]`; `CostSummary`, `CostFetchError`, `CostFetchErrorKind`. |
+| `ops.help_data` | `coverage_gaps`, `search`, `list_features`, `get_template`. |
+| `ops.spec_lifecycle` | `derive_lifecycle(spec, *, now=None) -> str` (only public function) + `STALE_THRESHOLD_DAYS`. |
+| `ops.interaction_counters` | `EVENTS = ('pill_click', 'rec_card_click', 'scope_picker_change')`. |
+| `ops.cli` | `add_subparser`, `cmd_ops`, `main`. |
 
-`attune ops` is a blocking server process. On successful startup it prints the listening address and then runs until interrupted:
+### CLI flags (`attune ops` / `python -m attune.ops`)
 
-```
-INFO:     Started server process [38201]
-INFO:     Waiting for application startup.
-INFO:     Application startup complete.
-INFO:     Uvicorn running on http://127.0.0.1:8765 (Press CTRL+C to quit)
-```
+| Flag | Effect |
+|---|---|
+| `--host` / `--port` | Bind address (default `127.0.0.1:8765`). |
+| `--project-root` | Project to serve. |
+| `--no-browser` | Don't auto-open a browser. |
+| `--read-only` | Disable runs (`allow_run=False`); runs are **enabled** otherwise. |
+| `--specs-root DIR` | Spec directory (repeatable). |
+| `--trusted-host` | Allow a remote host. |
+| `--runs-retention-days` | History retention (default 30). |
+| `--specs-candidates` / `--no-specs-candidates` | Toggle spec candidate display. |
 
-The dashboard UI is then available in your browser at the printed URL. API responses from the server are JSON; for example, the home-page KPIs endpoint returns:
-
-```json
-{
-  "today_events": 14,
-  "today_cost": 0.032,
-  "seven_day_cost": 0.187,
-  "seven_day_savings": 0.054,
-  "sparkline": [
-    {"day": "2026-05-08", "events": 3, "cost": 0.021},
-    {"day": "2026-05-09", "events": 11, "cost": 0.166}
-  ]
-}
-```
-
-## Exit codes
-
-| Code | Meaning |
-|------|---------|
-| `0` | Server shut down cleanly (process interrupted or stopped normally) |
-| `1` | Startup failed — for example, the port is already in use or a required path is invalid |
-
-## Environment variables
-
-| Variable | Description |
-|----------|-------------|
-| `ATTUNE_HOME` | Overrides the default attune home directory (`~/.attune`) |
-| `ATTUNE_OPS_SWEEP_RESULTS` | When set to a non-empty value, enables persistence of discovery-sweep results under `<attune_home>/ops/sweep-results/` |
-
-## Localhost security model
-
-The dashboard is a single-user, same-machine tool. Its protection is
-layered, not a multi-user auth system (network exposure is an explicit
-non-goal):
-
-1. **Loopback bind.** The server binds `127.0.0.1` by default — not
-   reachable off the machine.
-2. **Trusted-host middleware.** Requests whose `Host` header isn't on
-   the allowlist are rejected (`--trusted-host` extends it).
-3. **Read-only flag.** `--read-only` disables all mutation (workflow
-   runs, status writes) — purely observational.
-4. **Per-process client token.** Every mutating endpoint
-   (`POST /workflows/{name}/run`, `PUT /api/specs/{slug}/{phase}/status`,
-   the curator/help/dismiss mutations, …) requires an `X-Attune-Client`
-   header matching a token minted at startup. The page reads the token
-   once (a `<meta name="attune-client-token">` tag) and echoes it on
-   mutating requests; `GET /api/session/token` exposes it for
-   bootstrap. A client that never loaded the page — a stray `curl`, a
-   browser extension, an a11y-traversing tool — gets `403` and cannot
-   mutate state. The token resets each server run.
-
-The token gate closes the "accidental mutation from a non-page client"
-bug class (see `docs/specs/ops-mutating-endpoint-auth/`). It is *not* a
-defense against a local attacker who can read process memory or the
-page — that's out of scope for a localhost dev tool.
-
-## Related commands
-
-- `attune help-docs` — browse the help template library with optional `--tag` filters
-- `python -m attune.ops` — standalone entry point; equivalent to `attune ops` without the main CLI parser
-
-## See also
-
-- [How-to: use the ops dashboard](../how-to/ops-dashboard.md) — quick start, programmatic API, and integration patterns
-- [Tutorial: ops-dashboard walkthrough](../tutorials/ops-dashboard.md) — end-to-end first run with the workflow runner and scope picker
-- [Architecture: ops-dashboard](../architecture/ops-dashboard.md) — design decisions and the data-flow diagram
-
-<!-- attune-generated: source_hash=395f221f9a789d9b8851955c90a8bcc4904e7c84a247bacee7036e1583b0ea42 feature=ops-dashboard kind=cli-reference generated_at=2026-05-14 -->
+<!-- attune-generated: source_hash=1cad6797952953474159da11cd78e2e6f3b36b4845377e700eb2570427d138e7 feature=ops-dashboard kind=reference generated_at=2026-06-24 -->


### PR DESCRIPTION
## Tier-3 single-sourcing: ops-dashboard (9 of 9 — final)

Single-sources the **ops-dashboard** feature and completes Tier 3 — the
remaining single-source set is now **empty**.

Authors `content/features/ops-dashboard.md` and projects it to the 10
`.help` kinds + how-to/architecture/reference + hub. Scope = the runner
**core** (`src/attune/ops/**`): server, `Config`, the
`RunnerService`/`Run` execution model, scope picker, persistence, SSE.

### Scope discipline

Cost/telemetry/help shown *on* the dashboard (`ops.anthropic_cost`,
`ops.data`, `ops.help_data`) are documented as **adjacent read-only
surfaces** owned by their own features (telemetry, help-system), not by
ops-dashboard.

### Fiction killed

The old generated docs invented a spec-completion API
(`detect_candidates()` / `Candidate` with slug/path/evidence/snapshot) —
**neither exists**. The real surface is
`ops.spec_lifecycle.derive_lifecycle(spec) -> str`. The frozen `faq.md`
was rewritten `status: manual` to drop that fiction.

### Adversarial review findings (fixed)

1. **`run.run_id` crashed the example** — the `Run` dataclass field is
   `id`; fixed to `run.id`.
2. **`spec_lifecycle` "only" imprecision** — it also exports the
   `STALE_THRESHOLD_DAYS` constant; clarified.

Otherwise the master was clean — `RunnerService.start`/`Run.subscribe`
async, the sync helpers, all `Config` properties, the tuple return of
`fetch_summary`, `EVENTS`, and every CLI flag verified against source.

### DD5

`features.yaml` entry set `status: manual`, `files:` dropped,
description + tags preserved.

### Verification

- dry-run fact-check: **0 warnings**; example gate: **0 problems**
- safe snippets executed; async surfaces introspection-verified
- golden queries + manifest integrity: pass
- `help_data`: ops-dashboard shows **11/11 kinds**, `missing_kinds=()`
- `mkdocs build --strict`: **exit 0**
- full `tests/unit/help/`: **394 passed, 2 skipped, 3 xfailed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
