### PR TITLE
docs(spec): close out help-docs-single-source — rollout complete

### DIFF
--- a/docs/specs/help-docs-single-source/r7-rollout-playbook.md
+++ b/docs/specs/help-docs-single-source/r7-rollout-playbook.md
@@ -1,9 +1,12 @@
 # R7 — Rollout Playbook: Single-Source Help + Docs
 
-**Status:** drafted from the pilot (2026-06-21); **nav/hub gate
-implemented** (P4/P6 done via the help-docs-rollout-gate spec,
-2026-06-21) — the per-feature loop no longer requires a manual
-`mkdocs.yml` edit · **Builds on:** [design.md](design.md),
+**Status:** rollout COMPLETE (2026-06-24) — every feature is
+single-sourced (`status: manual`); the `remaining` set in
+`.help/features.yaml` is empty. Drafted from the pilot (2026-06-21);
+**nav/hub gate implemented** (P4/P6 done via the help-docs-rollout-gate
+spec, 2026-06-21) — the per-feature loop no longer requires a manual
+`mkdocs.yml` edit. The recipe below stays the canonical procedure for
+single-sourcing any NEW feature. · **Builds on:** [design.md](design.md),
 [decisions.md](decisions.md) (D6–D13),
 [t2-projector-build.md](t2-projector-build.md),
 [follow-ups.md](follow-ups.md)

--- a/docs/specs/help-docs-single-source/tasks.md
+++ b/docs/specs/help-docs-single-source/tasks.md
@@ -1,6 +1,11 @@
 # Tasks: Single-Source Help + Docs (pilot)
 
-**Status:** tasks (awaiting approval to execute)
+**Status:** complete (2026-06-24) — pilot executed and the full rollout
+landed. Every feature in `.help/features.yaml` is single-sourced
+(`status: manual`, projected from `content/features/<F>.md`); the
+`remaining` set is empty. The Tier-3 batch finished with help-system
+(#1043) and ops-dashboard (#1044). See the closeout note under Exit
+criteria.
 **Created:** 2026-06-21
 **Builds on:** [requirements.md](requirements.md),
 [decisions.md](decisions.md), [design.md](design.md)
@@ -161,3 +166,30 @@ CLI-reference projection, tables, and `cli_refs` fact-check.
   consumers, fact-check/grounding green, regen-overwrite defused.
 - The chain is repeatable and the rollout playbook is written.
 - No regression in the in-tool help system or `mkdocs build`.
+
+---
+
+## Closeout (2026-06-24) — rollout complete
+
+The pilot exit criteria were met and the full rollout ran to completion
+using the R7 playbook. Every feature in `.help/features.yaml` is now
+single-sourced (`status: manual`, no `files:`); the projector owns the
+`.help/templates/<F>/` kinds and the `docs/{how-to,architecture,
+reference}/<F>.md` pages; frozen `faq.md` files await the four-channel
+FAQ Generator (D6/D7).
+
+- **Tier-3 finishers:** help-system (#1043, the help ENGINE) and
+  ops-dashboard (#1044, the runner CORE). Earlier Tier-3: telemetry
+  #1034, configuration #1035, resilience #1036, hooks #1037, cli #1038,
+  orchestration #1040, plugin #1042.
+- **What the adversarial gate kept catching to the end:** behavioral and
+  scope fiction the static gates can't see — re-export/import paths,
+  async-vs-sync, property-vs-method, deprecated-as-canonical, and
+  invented APIs (e.g. ops-dashboard's non-existent `detect_candidates`/
+  `Candidate`). Mandatory subagent review stays the load-bearing step.
+
+**Not in scope of this spec (open follow-up):** the rollout edits
+repo-root `content/`/`.help/`/`docs/`, which reach ops/website/mkdocs
+but NOT `pip install attune-ai`. Delivering to pip users needs a
+release-prep-cadence pass that regenerates `plugin/help/generated/`
+under the wheel-packaged path. Tracked in the next-session handoff.


### PR DESCRIPTION
## Tier-3 closeout

The help-docs-single-source pilot spec was stale at **"tasks (awaiting
approval to execute)"** even though the pilot executed and the full
rollout reached **9/9 Tier-3**. This updates the spec status to reflect
reality — every feature in `.help/features.yaml` is single-sourced
(`status: manual`), the `remaining` set is empty.

- **tasks.md** — Status → `complete (2026-06-24)`; adds a Closeout
  section (Tier-3 finishers help-system #1043 + ops-dashboard #1044, the
  adversarial-review gate, and the out-of-scope PyPI-wheel follow-up).
- **r7-rollout-playbook.md** — Status → rollout COMPLETE; the recipe
  stays canonical for single-sourcing any new feature.

Docs-only; no code, no `features.yaml` change.

**Merge order:** land **after** [#1044](https://github.com/Smart-AI-Memory/attune-ai/pull/1044)
so the "remaining set is empty" claim is true on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)