### PR TITLE
feat(help): serve single-source content in-conversation + release 8.9.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.9.0"
+    "version": "8.9.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "8.9.0",
+      "version": "8.9.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.9.0
+# Attune AI Framework v8.9.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.9.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.9.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/.help/templates/plugin/comparison.md
+++ b/.help/templates/plugin/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: plugin-comparison
 feature: plugin
 depth: comparison
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 

--- a/.help/templates/plugin/concept.md
+++ b/.help/templates/plugin/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: plugin-concept
 feature: plugin
 depth: concept
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 
@@ -93,6 +93,6 @@ are part of the bundle.
 
 `plugin/core/` exists so the plugin can carry a version for standalone
 operation; `plugin/core/__init__.py` is just
-`__version__ = "8.9.0"`. The real runtime is the pip-installed
+`__version__ = "8.9.1"`. The real runtime is the pip-installed
 `attune-ai` package, which the `.mcp.json` server pulls via
 `uvx --from attune-ai`.

--- a/.help/templates/plugin/error.md
+++ b/.help/templates/plugin/error.md
@@ -3,8 +3,8 @@ type: error
 name: plugin-error
 feature: plugin
 depth: error
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 

--- a/.help/templates/plugin/note.md
+++ b/.help/templates/plugin/note.md
@@ -3,8 +3,8 @@ type: note
 name: plugin-note
 feature: plugin
 depth: note
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 
@@ -93,7 +93,7 @@ are part of the bundle.
 
 `plugin/core/` exists so the plugin can carry a version for standalone
 operation; `plugin/core/__init__.py` is just
-`__version__ = "8.9.0"`. The real runtime is the pip-installed
+`__version__ = "8.9.1"`. The real runtime is the pip-installed
 `attune-ai` package, which the `.mcp.json` server pulls via
 `uvx --from attune-ai`.
 

--- a/.help/templates/plugin/quickstart.md
+++ b/.help/templates/plugin/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: plugin-quickstart
 feature: plugin
 depth: quickstart
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 

--- a/.help/templates/plugin/reference.md
+++ b/.help/templates/plugin/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: plugin-reference
 feature: plugin
 depth: reference
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 
@@ -20,7 +20,7 @@ and the component folder layout.
 | Field | Value / Purpose |
 |-------|-----------------|
 | `name` | `attune-ai` — the plugin name. |
-| `version` | Plugin bundle version (`8.9.0`). |
+| `version` | Plugin bundle version (`8.9.1`). |
 | `description` | One-line plugin summary shown in Claude Code. |
 | `author` | `{name, email}` — Smart AI Memory. |
 | `homepage` / `repository` | Project links. |

--- a/.help/templates/plugin/task.md
+++ b/.help/templates/plugin/task.md
@@ -3,8 +3,8 @@ type: task
 name: plugin-task
 feature: plugin
 depth: task
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 
@@ -41,7 +41,7 @@ cat plugin/.claude-plugin/plugin.json
 
 **Verify:** `name` is `attune-ai`, `license` is `Apache-2.0`, and
 `keywords` include `claude-code`. The `version` here is the plugin
-bundle version (`8.9.0`); the sibling `marketplace.json` carries a
+bundle version (`8.9.1`); the sibling `marketplace.json` carries a
 matching version in `metadata.version` and `plugins[0].version`.
 
 ### List the components Claude Code will discover

--- a/.help/templates/plugin/tip.md
+++ b/.help/templates/plugin/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: plugin-tip
 feature: plugin
 depth: tip
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 

--- a/.help/templates/plugin/troubleshooting.md
+++ b/.help/templates/plugin/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: plugin-troubleshooting
 feature: plugin
 depth: troubleshooting
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 

--- a/.help/templates/plugin/warning.md
+++ b/.help/templates/plugin/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: plugin-warning
 feature: plugin
 depth: warning
-generated_at: 2026-06-24T05:04:42.110775+00:00
-source_hash: db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53
+generated_at: 2026-06-24T12:40:17.276596+00:00
+source_hash: b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6
 status: generated
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.9.1] — 2026-06-24
+
+Help-serving patch — the in-conversation help surface now serves the
+single-sourced feature content. No runtime API change.
+
+### Fixed
+
+- **In-conversation help (`help_lookup` / `populate`) now serves the
+  single-source content.** The help-docs-single-source rollout populated
+  `.help/templates/<feature>/` (feature-organized), but the engine
+  resolver only read the type-organized `plugin/help/generated/` bundle —
+  so the grounded, fiction-free help reached the ops dashboard and the
+  website but **not** the MCP/plugin help surface. The resolver now falls
+  back to `.help/templates/<feature>/<kind>.md` when an ID is absent from
+  the bundle, so single-sourced features resolve in-conversation. Bundle-
+  only IDs (system concepts, lessons/skill-derived templates) are
+  unchanged. (help-serving-bridge spec, D1)
+
+### Notes
+
+- Scope is the **Claude Code plugin** channel (which ships
+  `.help/templates`). Packaging the in-tool help into the **pip wheel**
+  remains out of scope (D2). Cross-links/progressive-depth for the
+  fallback-served content are a tracked follow-up (D3).
+
 ## [8.9.0] — 2026-06-23
 
 Runtime patch — MCP reliability fixes plus a tool-name

--- a/content/features/plugin.md
+++ b/content/features/plugin.md
@@ -95,7 +95,7 @@ are part of the bundle.
 
 `plugin/core/` exists so the plugin can carry a version for standalone
 operation; `plugin/core/__init__.py` is just
-`__version__ = "8.9.0"`. The real runtime is the pip-installed
+`__version__ = "8.9.1"`. The real runtime is the pip-installed
 `attune-ai` package, which the `.mcp.json` server pulls via
 `uvx --from attune-ai`.
 
@@ -152,7 +152,7 @@ cat plugin/.claude-plugin/plugin.json
 
 **Verify:** `name` is `attune-ai`, `license` is `Apache-2.0`, and
 `keywords` include `claude-code`. The `version` here is the plugin
-bundle version (`8.9.0`); the sibling `marketplace.json` carries a
+bundle version (`8.9.1`); the sibling `marketplace.json` carries a
 matching version in `metadata.version` and `plugins[0].version`.
 
 ### List the components Claude Code will discover
@@ -183,7 +183,7 @@ and the component folder layout.
 | Field | Value / Purpose |
 |-------|-----------------|
 | `name` | `attune-ai` — the plugin name. |
-| `version` | Plugin bundle version (`8.9.0`). |
+| `version` | Plugin bundle version (`8.9.1`). |
 | `description` | One-line plugin summary shown in Claude Code. |
 | `author` | `{name, email}` — Smart AI Memory. |
 | `homepage` / `repository` | Project links. |

--- a/docs/architecture/plugin.md
+++ b/docs/architecture/plugin.md
@@ -83,7 +83,7 @@ are part of the bundle.
 
 `plugin/core/` exists so the plugin can carry a version for standalone
 operation; `plugin/core/__init__.py` is just
-`__version__ = "8.9.0"`. The real runtime is the pip-installed
+`__version__ = "8.9.1"`. The real runtime is the pip-installed
 `attune-ai` package, which the `.mcp.json` server pulls via
 `uvx --from attune-ai`.
 
@@ -117,4 +117,4 @@ operation; `plugin/core/__init__.py` is just
   `marketplace.json`, and `plugin/core/__init__.py` together at
   release.
 
-<!-- attune-generated: source_hash=db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53 feature=plugin kind=architecture generated_at=2026-06-24 -->
+<!-- attune-generated: source_hash=b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6 feature=plugin kind=architecture generated_at=2026-06-24 -->

--- a/docs/how-to/plugin.md
+++ b/docs/how-to/plugin.md
@@ -53,7 +53,7 @@ cat plugin/.claude-plugin/plugin.json
 
 **Verify:** `name` is `attune-ai`, `license` is `Apache-2.0`, and
 `keywords` include `claude-code`. The `version` here is the plugin
-bundle version (`8.9.0`); the sibling `marketplace.json` carries a
+bundle version (`8.9.1`); the sibling `marketplace.json` carries a
 matching version in `metadata.version` and `plugins[0].version`.
 
 ### List the components Claude Code will discover
@@ -84,7 +84,7 @@ and the component folder layout.
 | Field | Value / Purpose |
 |-------|-----------------|
 | `name` | `attune-ai` — the plugin name. |
-| `version` | Plugin bundle version (`8.9.0`). |
+| `version` | Plugin bundle version (`8.9.1`). |
 | `description` | One-line plugin summary shown in Claude Code. |
 | `author` | `{name, email}` — Smart AI Memory. |
 | `homepage` / `repository` | Project links. |
@@ -123,4 +123,4 @@ and the component folder layout.
 | Add marketplace | `claude plugin marketplace add Smart-AI-Memory/attune-ai` |
 | Install plugin | `claude plugin install attune-ai@attune-ai` |
 
-<!-- attune-generated: source_hash=db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53 feature=plugin kind=how-to generated_at=2026-06-24 -->
+<!-- attune-generated: source_hash=b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6 feature=plugin kind=how-to generated_at=2026-06-24 -->

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.9.0
+**Version:** 8.9.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.9.0 | **License:** Apache 2.0
+**Version:** 8.9.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/docs/reference/plugin.md
+++ b/docs/reference/plugin.md
@@ -10,7 +10,7 @@ and the component folder layout.
 | Field | Value / Purpose |
 |-------|-----------------|
 | `name` | `attune-ai` — the plugin name. |
-| `version` | Plugin bundle version (`8.9.0`). |
+| `version` | Plugin bundle version (`8.9.1`). |
 | `description` | One-line plugin summary shown in Claude Code. |
 | `author` | `{name, email}` — Smart AI Memory. |
 | `homepage` / `repository` | Project links. |
@@ -49,4 +49,4 @@ and the component folder layout.
 | Add marketplace | `claude plugin marketplace add Smart-AI-Memory/attune-ai` |
 | Install plugin | `claude plugin install attune-ai@attune-ai` |
 
-<!-- attune-generated: source_hash=db043c60a7143c7669b27c81b171e2b6169746b1daae7d276d9b914b20fb8c53 feature=plugin kind=reference generated_at=2026-06-24 -->
+<!-- attune-generated: source_hash=b2da4bbb5a02defe23a5d626662d1309cad3c1d550e9fe54c614bf96cdf2c6f6 feature=plugin kind=reference generated_at=2026-06-24 -->

--- a/docs/specs/help-serving-bridge/decisions.md
+++ b/docs/specs/help-serving-bridge/decisions.md
@@ -1,0 +1,95 @@
+# Decisions: Help-Serving Bridge
+
+**Status:** approved (2026-06-24)
+**Created:** 2026-06-24
+
+Each decision lists the choice, the alternative(s), and the rationale.
+D1–D4 RATIFIED 2026-06-24; OQ1/OQ2 resolved (see below).
+
+---
+
+## D1 — Resolver fallback, not bundle emission (RATIFIED)
+
+**Choice:** Add a fallback to the engine's template resolver
+(`attune.help.templates._find_template_file`): when an ID is not found
+in `plugin/help/generated/<type>/<name>.md`, resolve it against
+`.help/templates/<name>/<kind>.md` (mapping the ID prefix to the
+singular kind filename). `populate()` and everything above it (MCP
+`help_lookup`) then serve single-source content with no other change.
+
+**Alternative (Design B):** Make the projector also emit a
+type-organized copy into `plugin/help/generated/`, then rebuild
+`cross_links.json` + `source_manifest`. Fuller integration but
+duplicates content on disk, enlarges `generate_all.py`, and forces an
+ID-naming convention.
+
+**Rationale:** A is ~15 lines, introduces no second copy (NFR1), no LLM
+spend (NFR2), and preserves all bundle-only IDs (FR2). The ID→file
+mapping is already deterministic and the engine parser already reads the
+single-source files. B's cross-link/progression integration is real but
+can be layered on later (D3) without redoing A.
+
+**Cost:** Under A, cross-links (`related`) and progressive-depth chains
+are not wired for fallback content initially — see D3.
+
+---
+
+## D2 — Defer pip-wheel help packaging (RATIFIED)
+
+**Choice:** Scope this spec to the **Claude Code plugin** channel (which
+ships `.help/templates`). Do **not** package the help bundle into the
+pip wheel in this spec.
+
+**Alternative:** Also package `.help/templates` (or a generated bundle)
+under `src/attune` so `pip install attune-ai` serves in-tool help, and
+make the resolver find it there.
+
+**Rationale:** attune-ai is consumed as a Claude Code plugin; the
+in-conversation `.help` surface is a plugin feature. The plugin already
+ships `.help/templates`, so the bridge reaches real users without
+packaging work. Pip-wheel help is a distinct effort (packaging +
+resolver path discovery in `site-packages`) with unclear demand. Record
+it as a follow-up; pull in only if pip users are a target.
+
+---
+
+## D3 — Cross-links & progression for fallback content = follow-up (RATIFIED)
+
+**Choice:** Ship D1 without cross-link/`related` resolution or
+progressive-depth chaining for fallback-served content; track wiring
+them as a follow-up.
+
+**Alternative:** Build cross-links for `.help/templates` content as part
+of this spec.
+
+**Rationale:** The grounded body, title, tags, and per-kind lookup are
+the core value and unblock the release. Cross-links/progression are
+enhancements; bundling them expands scope and risks the release. The
+projector already emits cross-reference-friendly content, so a later
+pass can populate `related` without reworking D1.
+
+---
+
+## D4 — Release as a patch to the plugin channel (RATIFIED)
+
+**Choice:** Ship the bridge as a **patch** bump (`8.9.0 → 8.9.1`) — no
+runtime API change, a help-serving behavior fix — with a changelog entry
+that is explicit: single-source help now served in-conversation (plugin/
+MCP); website/ops already had it; pip-wheel help still out of scope.
+
+**Alternative:** Minor bump (`8.10.0`) framing it as a feature.
+
+**Rationale:** Behavior-fix/wiring with no public API change fits a
+patch (consistent with 8.7.1's docs/distribution patch precedent). The
+changelog carries the nuance so the scope is not over-claimed.
+
+---
+
+## Resolved questions
+
+- **OQ1 (resolved 2026-06-24)** — The resolver prefers the **bundle
+  first, `.help/templates` fallback second** — preserving current
+  behavior for any colliding ID. Single-source IDs like `con-<feature>`
+  don't collide with bundle `con-tool-<skill>`.
+- **OQ2 (resolved 2026-06-24)** — Pip-wheel help is **not** wanted now;
+  D2 stands (plugin channel only).

--- a/docs/specs/help-serving-bridge/requirements.md
+++ b/docs/specs/help-serving-bridge/requirements.md
@@ -1,0 +1,103 @@
+# Requirements: Help-Serving Bridge
+
+**Status:** approved (2026-06-24)
+**Created:** 2026-06-24
+**Owner:** Patrick + agent
+**Related:** [help-docs-single-source](../help-docs-single-source/)
+(now complete — every feature single-sourced)
+
+---
+
+## Problem
+
+The help-docs-single-source rollout is complete: every feature has a
+hand-authored, adversarially-verified master in `content/features/<F>.md`
+projected to `.help/templates/<F>/<kind>.md`, `docs/`, and the website.
+
+But the surface real users hit does **not** serve that content. The
+in-conversation `.help` lookup (MCP `help_lookup` → `attune.help.engine`
+→ `populate()`) reads a **different** bundle:
+`plugin/help/generated/<type>/<name>.md` — a type-organized corpus built
+by `scripts/generate_all.py` from `.claude/CLAUDE.md` lessons +
+`plugin/skills/*/SKILL.md`. It never reads the single-source content.
+
+Consequence: the grounded, fiction-free help reaches the **ops dashboard
+help tab** (`ops.help_data` reads `.help/templates/`) and the
+**website/mkdocs** (`docs/`), but **not** MCP / the Claude Code plugin's
+in-conversation help. Those still serve the older, separately-sourced
+bundle (~800 templates stale at last check).
+
+### Evidence (verified 2026-06-24)
+
+- `attune.help.templates._DEFAULT_GENERATED_DIR` =
+  `<root>/plugin/help/generated`; `populate()` resolves IDs there.
+- MCP `_handle_help_lookup_impl` (`src/attune/mcp/server.py`) calls
+  `populate_progressive` / `get_workflow_help` etc. from
+  `attune.help.engine` — all using that default dir.
+- `populate("con-help-system")` → `None` (no single-source content in
+  the bundle); `populate("con-progressive-depth")` → a hand-curated
+  *system* concept that lives only in the bundle.
+- `generate_all.py` and the per-type generators read lessons + skills,
+  never `content/features/` or `.help/templates/`.
+- The bundle parser (`_parse_template_file`) reads a single-source
+  `.help/templates/<F>/<kind>.md` file cleanly.
+- The wheel packages **neither** `.help/templates` nor
+  `plugin/help/generated` (both live outside `src/attune`; not grafted
+  in `MANIFEST.in`). attune-ai is consumed primarily as a **Claude Code
+  plugin**, which *does* ship `.help/templates` (286 tracked files) and
+  `plugin/help/generated` (905 tracked files).
+
+---
+
+## Goal
+
+Make the in-conversation help surface (MCP `help_lookup` / the plugin)
+serve the single-source content for every feature, without losing the
+hand-curated system concepts (`progressive-depth`, `audience-adaptation`,
+…) that live only in the bundle.
+
+---
+
+## Functional requirements
+
+- **FR1** — `populate("<prefix>-<feature>")` returns the single-source
+  body from `.help/templates/<feature>/<kind>.md` for every projected
+  feature and every projected kind (concept, task, reference,
+  quickstart, comparison, error, troubleshooting, warning, note, tip,
+  faq).
+- **FR2** — Existing bundle-only templates (system concepts, lessons/
+  skill-derived `tool-<skill>` and `err-*` entries) continue to resolve
+  unchanged. No regression for any ID currently served.
+- **FR3** — MCP `help_lookup` (all modes that resolve a template) serves
+  the single-source content for single-sourced features, verified by a
+  live call returning the grounded body (not the old bundle body).
+- **FR4** — The change ships to the channel users consume (the Claude
+  Code plugin) via a version bump + changelog + release.
+
+## Non-functional / constraints
+
+- **NFR1** — Smallest viable change; no duplication of content into a
+  second on-disk copy unless a decision explicitly chooses emission.
+- **NFR2** — No new LLM spend (this is wiring, not regeneration).
+- **NFR3** — `mkdocs build --strict` and the full `tests/unit/help/`
+  suite stay green; add coverage for the new resolution path.
+
+## Out of scope (this spec)
+
+- **Pip-wheel help packaging.** Making `pip install attune-ai` ship the
+  in-tool help bundle is a separate packaging task (both dirs are
+  outside `src/attune`). Deferred unless explicitly pulled in — see
+  decisions D2.
+- **Retiring the lessons/skills bundle** or the `tool-<skill>` concepts.
+- **Rewriting `generate_all.py`.**
+
+## Acceptance criteria
+
+- `populate("con-<feature>")` and the other ten kinds return the
+  single-source body for a sampled set of features (incl. help-system,
+  ops-dashboard, security-audit).
+- A live MCP `help_lookup` call for a single-sourced feature returns the
+  grounded content.
+- All previously-resolving IDs still resolve (regression test).
+- Full `tests/unit/help/` green; `mkdocs build --strict` exit 0.
+- Released to the plugin channel (version bump + changelog).

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.9.0"
+    "version": "8.9.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.9.0",
+      "version": "8.9.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.9.0",
+  "version": "8.9.1",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.9.0"
+__version__ = "8.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.9.0"
+version = "8.9.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/src/attune/help/templates.py
+++ b/src/attune/help/templates.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_GENERATED_DIR = Path(__file__).resolve().parents[3] / "plugin" / "help" / "generated"
 
+# Single-source projector output (feature-organized:
+# .help/templates/<feature>/<kind>.md). The resolver falls back here
+# when an ID is absent from the type-organized bundle, so the
+# in-conversation help surface serves the single-sourced content.
+# (help-serving-bridge spec, D1, 2026-06-24.)
+_DEFAULT_TEMPLATES_DIR = Path(__file__).resolve().parents[3] / ".help" / "templates"
+
 # Cross-links cache: loaded once per process, thread-safe.
 # Call invalidate_cross_links_cache() to force a reload.
 _CROSS_LINKS_CACHE: dict[str, dict[str, Any]] = {}
@@ -95,12 +102,56 @@ _PREFIX_MAP = {
     "com": "comparisons",
 }
 
+# ID prefix -> singular kind filename in the single-source layout
+# (.help/templates/<feature>/<kind>.md). Mirrors _PREFIX_MAP, whose
+# values are the type-organized bundle's plural directory names.
+_PREFIX_TO_KIND = {
+    "err": "error",
+    "war": "warning",
+    "tip": "tip",
+    "ref": "reference",
+    "tas": "task",
+    "faq": "faq",
+    "not": "note",
+    "qui": "quickstart",
+    "con": "concept",
+    "tro": "troubleshooting",
+    "com": "comparison",
+}
+
+
+def _templates_dir_for(generated_dir: Path) -> Path | None:
+    """Derive the single-source templates dir paired with a bundle dir.
+
+    The canonical bundle is ``<root>/plugin/help/generated``; the
+    single-source projector writes to ``<root>/.help/templates``. Only
+    the canonical bundle layout gets an implicit fallback, so a custom
+    ``generated_dir`` (e.g. a test tmp dir) resolves deterministically
+    with no surprise fallback.
+
+    Args:
+        generated_dir: The bundle directory being resolved against.
+
+    Returns:
+        The paired ``.help/templates`` dir, or None for non-canonical
+        layouts.
+    """
+    resolved = generated_dir.resolve()
+    if resolved.parts[-3:] == ("plugin", "help", "generated"):
+        return resolved.parents[2] / ".help" / "templates"
+    return None
+
 
 def _find_template_file(
     template_id: str,
     generated_dir: Path,
 ) -> Path | None:
     """Locate a template file on disk.
+
+    Resolves an ID against the type-organized bundle first; if absent,
+    falls back to the single-source layout
+    (``.help/templates/<feature>/<kind>.md``) so the in-conversation
+    help surface serves single-sourced content (help-serving-bridge D1).
 
     Args:
         template_id: Template identifier string.
@@ -129,6 +180,49 @@ def _find_template_file(
 
     if filepath.exists():
         return filepath
+
+    # Fallback: single-source content (help-serving-bridge D1).
+    fallback = _find_single_source_file(prefix, name, generated_dir)
+    if fallback is not None:
+        return fallback
+    return None
+
+
+def _find_single_source_file(
+    prefix: str,
+    name: str,
+    generated_dir: Path,
+) -> Path | None:
+    """Resolve an ID to a single-source template, or None.
+
+    Args:
+        prefix: ID type prefix (e.g. ``con``).
+        name: Feature slug (the ID's second segment).
+        generated_dir: The bundle dir being resolved against.
+
+    Returns:
+        Path to ``.help/templates/<name>/<kind>.md`` if it exists and is
+        contained within the templates dir, else None.
+    """
+    kind = _PREFIX_TO_KIND.get(prefix)
+    if kind is None:
+        return None
+
+    templates_dir = _templates_dir_for(generated_dir)
+    if templates_dir is None:
+        return None
+
+    candidate = templates_dir / name / f"{kind}.md"
+
+    # Containment check: prevent path traversal (CWE-22)
+    try:
+        candidate.resolve().relative_to(templates_dir.resolve())
+    except ValueError:
+        logger.warning("Path traversal blocked (fallback): %s-%s", prefix, name)
+        return None
+
+    if candidate.exists():
+        return candidate
     return None
 
 

--- a/tests/unit/help/test_help_serving_bridge.py
+++ b/tests/unit/help/test_help_serving_bridge.py
@@ -1,0 +1,97 @@
+"""Tests for the help-serving bridge (D1 resolver fallback).
+
+The in-conversation help surface resolves a template ID against the
+type-organized bundle (plugin/help/generated) first, then falls back to
+the single-source layout (.help/templates/<feature>/<kind>.md). These
+tests pin that behavior and guard against regressing bundle-only IDs.
+
+Spec: docs/specs/help-serving-bridge/ (decisions D1).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.help.templates import (
+    _DEFAULT_TEMPLATES_DIR,
+    _PREFIX_TO_KIND,
+    _find_single_source_file,
+    _find_template_file,
+    _templates_dir_for,
+    populate,
+)
+
+_BUNDLE = Path(__file__).resolve().parents[3] / "plugin" / "help" / "generated"
+
+
+def _has_single_source(feature: str) -> bool:
+    """True when the single-source concept for *feature* exists."""
+    return (_DEFAULT_TEMPLATES_DIR / feature / "concept.md").exists()
+
+
+def test_fallback_serves_single_source_feature():
+    """populate() serves single-source content absent from the bundle."""
+    if not _has_single_source("help-system"):
+        pytest.skip("single-source help-system not present")
+
+    result = populate("con-help-system")
+
+    assert result is not None
+    assert result.body.strip()
+
+
+def test_fallback_covers_all_kinds():
+    """Every projected kind resolves through the fallback."""
+    feature = "help-system"
+    if not _has_single_source(feature):
+        pytest.skip("single-source help-system not present")
+
+    feature_dir = _DEFAULT_TEMPLATES_DIR / feature
+    prefix_for_kind = {kind: prefix for prefix, kind in _PREFIX_TO_KIND.items()}
+
+    for kind_file in feature_dir.glob("*.md"):
+        prefix = prefix_for_kind.get(kind_file.stem)
+        if prefix is None:
+            continue
+        assert populate(f"{prefix}-{feature}") is not None, kind_file.stem
+
+
+def test_bundle_ids_still_resolve():
+    """Bundle-only IDs keep resolving — no fallback regression."""
+    # progressive-depth is a hand-curated system concept that exists
+    # only in the bundle, never in the single-source layout.
+    if not (_BUNDLE / "concepts" / "progressive-depth.md").exists():
+        pytest.skip("bundle concept not present")
+
+    assert populate("con-progressive-depth") is not None
+
+
+def test_unknown_id_returns_none():
+    """An ID matching neither source resolves to None."""
+    assert populate("con-definitely-not-a-real-feature-xyz") is None
+
+
+def test_custom_generated_dir_has_no_implicit_fallback(tmp_path):
+    """A non-canonical bundle dir gets no surprise .help/templates fallback."""
+    # tmp_path is not <root>/plugin/help/generated, so no fallback applies.
+    assert _templates_dir_for(tmp_path) is None
+    assert _find_template_file("con-help-system", tmp_path) is None
+
+
+def test_templates_dir_derived_for_canonical_bundle():
+    """The canonical bundle layout derives the paired templates dir."""
+    derived = _templates_dir_for(_BUNDLE)
+    assert derived is not None
+    assert derived == _DEFAULT_TEMPLATES_DIR
+
+
+def test_fallback_blocks_path_traversal():
+    """A traversing feature name cannot escape the templates dir."""
+    assert _find_single_source_file("con", "../../../etc/passwd", _BUNDLE) is None
+
+
+def test_unknown_prefix_has_no_fallback():
+    """An unmapped prefix yields no single-source path."""
+    assert _find_single_source_file("zzz", "help-system", _BUNDLE) is None

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.9.0"
+version = "8.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Help-serving bridge + release 8.9.1

Implements the approved **help-serving-bridge** spec
([requirements](docs/specs/help-serving-bridge/requirements.md) ·
[decisions](docs/specs/help-serving-bridge/decisions.md)).

### Problem

The help-docs-single-source rollout (now 9/9 complete) populated
`.help/templates/<feature>/`, but the in-conversation help surface
(`help_lookup` → `attune.help.engine` → `populate`) only read the
type-organized `plugin/help/generated/` bundle. So the grounded,
adversarially-verified content reached the **ops dashboard** and the
**website**, but **not** MCP / the Claude Code plugin's help.

### Fix (D1 — resolver fallback)

`_find_template_file` now falls back to
`.help/templates/<feature>/<kind>.md` when an ID isn't in the bundle
(deterministic prefix→kind map, canonical-layout-only so custom dirs
don't get surprise fallbacks, path-traversal guarded). Bundle-only IDs
(system concepts, lessons/skill-derived templates) resolve unchanged.

Verified live: `populate("con-help-system")`,
`populate_progressive("help-system")` (progression works),
`populate("ref-security-audit")` all serve the single-source body;
`con-progressive-depth` (bundle-only) still resolves.

### Release 8.9.1 (patch, D4)

No runtime API change — a help-serving fix. Version bumped across
pyproject, plugin/core, both `marketplace.json`, `plugin.json`,
`uv.lock`, `.claude/CLAUDE.md`, `API_REFERENCE.md` chips, and the
`content/features/plugin.md` manifest examples (re-projected so
`docs/*/plugin.md` + `.help/templates/plugin/` stay in sync). CHANGELOG
entry is explicit that pip-wheel help is out of scope (D2) and
cross-links/progression for fallback content are a follow-up (D3).

### Verification

- New `tests/unit/help/test_help_serving_bridge.py` — 8 tests (fallback,
  all-kinds, no-regression, no-implicit-fallback-for-custom-dirs,
  traversal-blocked).
- Full `tests/unit/help/`: **402 passed**, 2 skipped, 3 xfailed.
- Version-consistency tests: **140 passed**.
- `mkdocs build --strict`: **exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
