### PR TITLE
fix(help): close code-review findings on the bundle-sync script

### DIFF
--- a/scripts/sync_help_bundle.py
+++ b/scripts/sync_help_bundle.py
@@ -25,6 +25,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -72,6 +73,7 @@ def _planned_outputs(
     bundle_dir = root / "plugin" / "help" / "generated"
     plan: list[tuple[Path, Path, str, list[str]]] = []
 
+    bundle_root = bundle_dir.resolve()
     for feature, entry in sorted(features.items()):
         feat_dir = templates_dir / feature
         if not feat_dir.is_dir():
@@ -82,6 +84,17 @@ def _planned_outputs(
             if type_dir is None:
                 continue  # unknown kind — skip
             dest = bundle_dir / type_dir / f"{feature}.md"
+            # Containment check (CWE-22): `feature` is a features.yaml key;
+            # a `..`/separator in it must not write outside the bundle.
+            # Mirrors the read-side guards in attune.help.templates.
+            try:
+                dest.resolve().relative_to(bundle_root)
+            except ValueError:
+                print(
+                    f"  SKIP unsafe feature key: {feature!r}",
+                    file=sys.stderr,
+                )
+                continue
             plan.append((kind_file, dest, feature, list(tags)))
     return plan
 
@@ -97,7 +110,12 @@ def _render_bundle_file(
     (type, name, tags, source) so cross-link + source-manifest builders
     pick it up. `source` points at the single-source master.
     """
-    post = frontmatter.load(str(src))
+    try:
+        post = frontmatter.load(str(src))
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: name the offending file — a malformed template
+        # otherwise aborts the whole sync with an opaque traceback.
+        raise RuntimeError(f"failed to parse {src}: {exc}") from exc
     kind = src.stem
     out = frontmatter.Post(post.content)
     out["type"] = post.get("type", kind)
@@ -109,8 +127,11 @@ def _render_bundle_file(
 
 def _rebuild_indexes(bundle_dir: Path) -> None:
     """Rebuild cross_links.json and source_manifest.json in place."""
-    sys.path.insert(0, str(Path(__file__).resolve().parent))
-    import json
+    # Sibling scripts live in this dir; insert once (idempotent) so repeat
+    # calls don't stack entries. These modules are not importable packages.
+    scripts_dir = str(Path(__file__).resolve().parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
 
     from build_cross_links import build_cross_links
     from generate_all import _build_source_manifest
@@ -151,6 +172,10 @@ def main(argv: list[str] | None = None) -> int:
     for src, dest, feature, tags in plan:
         rendered = _render_bundle_file(src, feature, tags)
         current = dest.read_text(encoding="utf-8") if dest.exists() else None
+        # NOTE: byte-exact compare. This (and the drift-guard test) couples
+        # to frontmatter.dumps()/PyYAML output formatting — a library bump
+        # that changes serialization would flag every file stale until a
+        # re-sync. Intentional (cheap, catches real drift); re-sync if so.
         if current == rendered:
             continue
         stale += 1

--- a/tests/unit/help/test_help_bundle_sync.py
+++ b/tests/unit/help/test_help_bundle_sync.py
@@ -79,3 +79,54 @@ def test_planned_outputs_cover_known_features():
     # every feature emits a concept named <feature>.md
     assert "help-system.md" in dests
     assert "ops-dashboard.md" in dests
+
+
+def test_planned_outputs_skips_traversing_feature_key(tmp_path):
+    """A feature key with `..` must not produce a dest outside the bundle.
+
+    Guards the write-side path-traversal fix (CWE-22): the read side
+    already blocks traversal; the emission planner must too.
+    """
+    root = tmp_path / "repo"
+    templates = root / ".help" / "templates"
+    bundle = root / "plugin" / "help" / "generated"
+    bundle.mkdir(parents=True)
+    (tmp_path / "outside").mkdir()
+
+    evil = "../../../outside/evil"
+    feat_dir = templates / evil  # resolves to tmp_path/outside/evil
+    feat_dir.mkdir(parents=True, exist_ok=True)
+    (feat_dir / "concept.md").write_text("---\ntype: concept\n---\nbody\n", encoding="utf-8")
+
+    plan = shb._planned_outputs(root, {evil: {"status": "manual", "tags": []}})
+
+    # the traversing dest is skipped entirely
+    assert plan == []
+
+
+def test_render_bundle_file_normalizes_frontmatter():
+    """Emitted frontmatter is normalized to the bundle shape."""
+    import frontmatter
+
+    src = _REPO / ".help" / "templates" / "help-system" / "concept.md"
+    rendered = shb._render_bundle_file(src, "help-system", ["help", "docs"])
+    post = frontmatter.loads(rendered)
+
+    assert post["type"] == "concept"
+    assert post["name"] == "help-system"
+    assert post["tags"] == ["help", "docs"]
+    assert post["source"] == "content/features/help-system.md"
+    # single-source-only fields are dropped from the bundle shape
+    assert "source_hash" not in post.metadata
+    assert post.content.strip()  # body preserved
+
+
+def test_check_mode_exit_zero_when_in_sync():
+    """`--check` returns 0 when the bundle matches the single source."""
+    assert shb.main(["--check"]) == 0
+
+
+def test_check_mode_exit_one_when_stale(monkeypatch):
+    """`--check` returns 1 when an emitted file would differ."""
+    monkeypatch.setattr(shb, "_render_bundle_file", lambda *a, **k: "DRIFT\n")
+    assert shb.main(["--check"]) == 1


### PR DESCRIPTION
Closes the findings from the review of the help-serving-bridge code.

### Security

- **HIGH (CWE-22) — write-side path traversal.** `scripts/sync_help_bundle.py`
  built `dest` from an unsanitized `features.yaml` key with no containment
  check before `write_text`. A key containing `..`/separators could write
  outside the bundle. Added a `.resolve().relative_to(bundle_root)` guard
  in `_planned_outputs` that **skips** unsafe keys — mirroring the
  read-side guards already in `attune.help.templates`. (`features.yaml` is
  repo-controlled so low likelihood, but it closes the read/write
  asymmetry and satisfies the path-validation rule.)

### Polish

- Guarded the `sys.path.insert` in `_rebuild_indexes` (idempotent) and
  lifted `import json` to module level.
- `_render_bundle_file` now names the offending file on a parse error
  (was an opaque abort).
- Commented the byte-exact compare's coupling to `frontmatter.dumps`/
  PyYAML formatting (affects `--check` + the drift guard).

### Tests (+4)

- write-side traversal guard skips a `..` feature key
- `--check` exit code: **0** in sync, **1** when stale (the CI contract,
  previously untested)
- `_render_bundle_file` normalization (sets `source`, drops `source_hash`,
  preserves body)

Full `tests/unit/help/`: **409 passed**, 2 skipped, 3 xfailed. Bundle
still in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)