### PR TITLE
docs(spec): close out help-docs-single-source requirements status

### DIFF
--- a/docs/specs/help-docs-single-source/requirements.md
+++ b/docs/specs/help-docs-single-source/requirements.md
@@ -1,6 +1,9 @@
 # Requirements: Single-Source Help + Docs
 
-**Status:** requirements (awaiting approval)
+**Status:** approved and executed (2026-06-24) — requirements were
+ratified and the full rollout landed; every feature is single-sourced
+(`status: manual`). See [tasks.md](tasks.md) closeout and
+[r7-rollout-playbook.md](r7-rollout-playbook.md).
 **Created:** 2026-06-21
 **Owner:** Patrick + agent
 


### PR DESCRIPTION
## What

`docs/specs/help-docs-single-source/requirements.md` still read
**"requirements (awaiting approval)"** while the rest of the spec had
already self-truthed: `tasks.md` and `r7-rollout-playbook.md` are both
marked **complete (2026-06-24)** and the full Tier-3 rollout landed
(help-system #1043, ops-dashboard #1044; every feature is `status:
manual`).

This updates the requirements header to **approved and executed** with
pointers to the tasks closeout and the playbook, so all three spec docs
agree.

## Scope

Docs-only, one file. No code, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)