### PR TITLE
feat(reach-snapshot): resumable partial write so a 429 doesn't lose progress

### DIFF
--- a/docs/specs/reach-snapshot-resilience/requirements.md
+++ b/docs/specs/reach-snapshot-resilience/requirements.md
@@ -1,8 +1,25 @@
 # Reach Snapshot Resilience
 
-**Status:** draft — awaiting review
+**Status:** implemented (2026-06-24) — Option A shipped in
+`scripts/reach_snapshot.py`; tests in
+`tests/unit/scripts/test_reach_snapshot.py`.
 **Owner:** Patrick + agent
 **Created:** 2026-06-22
+
+---
+
+## Decisions
+
+- **D1 → A (resumable partial write).** Each package is persisted to
+  the day file as it succeeds (atomic temp+rename); a rerun loads the
+  day file, skips already-captured packages, and fetches only the
+  remainder. The rate-limit discipline is unchanged (still spaces
+  requests, still aborts on the first 429). C (scheduled cadence) is
+  left as an optional fast-follow, not done here.
+- **Retention → merge/skip within a day.** A rerun the same day merges
+  into the existing `<date>.json` and skips packages already present —
+  it does not overwrite. The GitHub line is filled in by whichever run
+  completes the full package set.
 
 ---
 

--- a/scripts/reach_snapshot.py
+++ b/scripts/reach_snapshot.py
@@ -17,6 +17,14 @@ bursts and the penalty outlasts minutes of retrying — this script
 spaces requests (default 60s) and ABORTS on the first 429 with a
 "wait 15 minutes" message instead of hammering.
 
+Resumable partial progress (reach-snapshot-resilience): each
+package is persisted to the day file *as it succeeds* (atomic
+temp+rename). On rerun the same day, already-captured packages are
+loaded and skipped, so a 429 degrades to "rerun later to finish the
+remainder" instead of discarding the packages already fetched. The
+GitHub line stays best-effort and is filled in on the run that
+completes the set.
+
 Usage:
     python scripts/reach_snapshot.py
     python scripts/reach_snapshot.py --spacing 60 --out docs/specs/usage-signals/snapshots
@@ -124,29 +132,51 @@ def fetch_github_signals(repo: str = REPO) -> dict[str, object]:
 def build_snapshot(
     packages: list[str],
     spacing_seconds: float,
+    *,
+    seed: dict[str, dict[str, int]] | None = None,
+    date: str | None = None,
     fetcher=None,
     sleeper=None,
+    persist=None,
 ) -> dict[str, object]:
-    """Fetch all package stats with rate-limit spacing between calls.
+    """Fetch package stats with rate-limit spacing, preserving progress.
 
     fetcher/sleeper default to the module-level functions, resolved
     at CALL time (not def time) so tests can monkeypatch the module
     attributes — a def-time default would bind the original function
     object and silently bypass patches.
+
+    seed pre-loads already-captured packages (from today's day file);
+    those are skipped, so a rerun only fetches the remainder. persist,
+    if given, is called with the current snapshot after EACH successful
+    fetch — so a later 429 (raised by fetcher) leaves the packages
+    fetched so far durably written. The GitHub line is fetched once at
+    the end (on the run that completes the set); partial writes carry
+    an empty github until then.
     """
     fetcher = fetcher or fetch_pypistats_recent
     sleeper = sleeper or time.sleep
-    pypi: dict[str, dict[str, int]] = {}
-    for i, pkg in enumerate(packages):
+    now = datetime.now(timezone.utc)
+    date = date or now.strftime("%Y-%m-%d")
+    taken_at = now.isoformat()
+    pypi: dict[str, dict[str, int]] = dict(seed or {})
+
+    def snapshot(github: dict[str, object]) -> dict[str, object]:
+        return {
+            "date": date,
+            "taken_at": taken_at,
+            "pypi_recent": pypi,
+            "github": github,
+        }
+
+    remaining = [pkg for pkg in packages if pkg not in pypi]
+    for i, pkg in enumerate(remaining):
         if i:
             sleeper(spacing_seconds)
         pypi[pkg] = fetcher(pkg)
-    return {
-        "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-        "taken_at": datetime.now(timezone.utc).isoformat(),
-        "pypi_recent": pypi,
-        "github": fetch_github_signals(),
-    }
+        if persist is not None:
+            persist(snapshot({}))
+    return snapshot(fetch_github_signals())
 
 
 def render_table(snapshot: dict[str, object]) -> str:
@@ -169,6 +199,33 @@ def render_table(snapshot: dict[str, object]) -> str:
         parts = ", ".join(f"{k}={v}" for k, v in gh.items())
         lines += ["", f"GitHub: {parts}"]
     return "\n".join(lines) + "\n"
+
+
+def _load_seed(path: Path) -> dict[str, dict[str, int]]:
+    """Load already-captured pypi_recent from today's day file, if any.
+
+    Best-effort: a missing or malformed file degrades to an empty seed
+    (a fresh full run), never an error.
+    """
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("could not load existing snapshot %s: %s", path, e)
+        return {}
+    pypi = data.get("pypi_recent", {})
+    if not isinstance(pypi, dict):
+        return {}
+    return {pkg: stats for pkg, stats in pypi.items() if isinstance(stats, dict)}
+
+
+def _atomic_write_json(path: Path, data: dict[str, object]) -> None:
+    """Write JSON via temp+rename so a partial file is never observed."""
+    text = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -195,18 +252,32 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
 
+    args.out.mkdir(parents=True, exist_ok=True)
+    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    out_path = args.out / f"{date}.json"
+    seed = _load_seed(out_path)
+
+    def persist(snapshot: dict[str, object]) -> None:
+        _atomic_write_json(out_path, snapshot)
+
     try:
-        snapshot = build_snapshot(args.packages, args.spacing)
+        snapshot = build_snapshot(
+            args.packages, args.spacing, seed=seed, date=date, persist=persist
+        )
     except RateLimitedError as e:
+        captured = len(_load_seed(out_path))
+        total = len(args.packages)
         print(f"error: {e}", file=sys.stderr)
+        print(
+            f"captured {captured}/{total} today; rerun after the cooldown " "to finish the rest.",
+            file=sys.stderr,
+        )
         return 1
     except (urllib.error.URLError, OSError) as e:
         print(f"error: network failure: {e}", file=sys.stderr)
         return 1
 
-    args.out.mkdir(parents=True, exist_ok=True)
-    out_path = args.out / f"{snapshot['date']}.json"
-    out_path.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _atomic_write_json(out_path, snapshot)
     print(render_table(snapshot))
     print(f"wrote {out_path}")
     return 0

--- a/tests/unit/scripts/test_reach_snapshot.py
+++ b/tests/unit/scripts/test_reach_snapshot.py
@@ -63,6 +63,59 @@ class TestBuildSnapshot:
             )
         assert fetched == ["a", "b"]  # c never attempted
 
+    def test_seed_skips_already_captured_no_duplicate_fetch(self, mod, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {})
+        fetched: list[str] = []
+
+        def fetcher(pkg: str):
+            fetched.append(pkg)
+            return dict(STATS)
+
+        snap = mod.build_snapshot(
+            ["a", "b", "c"],
+            spacing_seconds=0,
+            seed={"a": dict(STATS), "b": dict(STATS)},
+            fetcher=fetcher,
+            sleeper=lambda s: None,
+        )
+        assert fetched == ["c"]  # only the remainder fetched
+        assert set(snap["pypi_recent"]) == {"a", "b", "c"}  # seed preserved
+
+    def test_persist_called_after_each_success(self, mod, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {})
+        writes: list[set[str]] = []
+
+        snap = mod.build_snapshot(
+            ["a", "b"],
+            spacing_seconds=0,
+            fetcher=lambda pkg: dict(STATS),
+            sleeper=lambda s: None,
+            persist=lambda s: writes.append(set(s["pypi_recent"])),
+        )
+        # one persist per fetched package, growing the set each time
+        assert writes == [{"a"}, {"a", "b"}]
+        assert set(snap["pypi_recent"]) == {"a", "b"}
+
+    def test_rate_limit_persists_packages_fetched_before_it(self, mod, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {})
+        last_write: dict[str, set[str]] = {}
+
+        def fetcher(pkg: str):
+            if pkg == "c":
+                raise mod.RateLimitedError("wait 15 minutes")
+            return dict(STATS)
+
+        with pytest.raises(mod.RateLimitedError):
+            mod.build_snapshot(
+                ["a", "b", "c"],
+                spacing_seconds=0,
+                fetcher=fetcher,
+                sleeper=lambda s: None,
+                persist=lambda s: last_write.update(seen=set(s["pypi_recent"])),
+            )
+        # a and b were persisted before c's 429 discarded the run
+        assert last_write["seen"] == {"a", "b"}
+
 
 class TestRenderTable:
     def test_table_has_all_packages_and_github_line(self, mod) -> None:
@@ -107,3 +160,56 @@ class TestCli:
         assert rc == 1
         assert "Wait 15 minutes" in capsys.readouterr().err
         assert not list(tmp_path.glob("*.json"))
+
+    def test_partial_then_rate_limit_persists_progress(
+        self, mod, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {})
+
+        def fetcher(pkg: str):
+            if pkg == "c":
+                raise mod.RateLimitedError("Wait 15 minutes")
+            return dict(STATS)
+
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", fetcher)
+        rc = mod.main(["--out", str(tmp_path), "--spacing", "0", "--packages", "a", "b", "c"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "captured 2/3 today" in err
+        # the day file holds the two packages fetched before the 429
+        files = list(tmp_path.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text(encoding="utf-8"))
+        assert set(data["pypi_recent"]) == {"a", "b"}
+
+    def test_rerun_completes_remainder_then_clears(
+        self, mod, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {"stars": 9})
+        fetched: list[str] = []
+        flaky = {"raise_on_c": True}
+
+        def fetcher(pkg: str):
+            fetched.append(pkg)
+            if pkg == "c" and flaky["raise_on_c"]:
+                raise mod.RateLimitedError("Wait 15 minutes")
+            return dict(STATS)
+
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", fetcher)
+        argv = ["--out", str(tmp_path), "--spacing", "0", "--packages", "a", "b", "c"]
+
+        # first run: a,b succeed, c 429s
+        assert mod.main(argv) == 1
+        assert fetched == ["a", "b", "c"]
+
+        # cooldown over: rerun skips a,b and fetches only c
+        flaky["raise_on_c"] = False
+        fetched.clear()
+        assert mod.main(argv) == 0
+        assert fetched == ["c"]  # a,b not re-fetched
+
+        files = list(tmp_path.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text(encoding="utf-8"))
+        assert set(data["pypi_recent"]) == {"a", "b", "c"}
+        assert data["github"] == {"stars": 9}


### PR DESCRIPTION
## Summary

`reach-snapshot-resilience` **Option A** — make `scripts/reach_snapshot.py` preserve partial progress so a pypistats 429 no longer discards the packages already fetched.

Previously the script aborted the entire run on the first 429, writing nothing — so a run that got 3 of 5 packages then 429'd lost all of it, and the next run started from zero (and was likely to 429 again). This bit twice in one day on the 8.7.0/8.7.1 ships, so the before/after pair R4 promises was frequently never captured.

## What changed

- `build_snapshot` gains `seed=` / `persist=` / `date=`; it persists each package to the day file **the moment it succeeds** (atomic temp+rename).
- `main` seeds from today's `<date>.json`, **skips already-captured packages**, and on a 429 reports `captured N/total today; rerun after the cooldown to finish the rest.`
- Adds `_load_seed` (best-effort; malformed/missing → empty seed) and `_atomic_write_json`.
- Rate-limit discipline is **unchanged** (still spaces requests, still aborts on the first 429). The CLI contract is unchanged, so the release ritual needs no edit.
- GitHub line stays best-effort, filled in by whichever run completes the package set.

## Decisions recorded in the spec

- **D1 → A** (resumable partial write). Option C (scheduled cadence off the release path) left as an optional fast-follow.
- **Retention → merge/skip within a day** — a same-day rerun merges into the existing day file, does not overwrite.

## Tests

11/11 pass (6 original unchanged + 5 new), including a full **two-run round trip**: 429 → cooldown → rerun fetches only the remainder, day file ends with the complete set. Real file I/O and CLI `main` run; only the pypistats/gh network boundary is stubbed.

Deliberately did **not** run a live pypistats fetch — a real 429 would poison the actual release snapshot the script exists to capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)