### PR TITLE
test(version-check): mark real-socket resilience tests `network`; thread the stub

### DIFF
--- a/tests/unit/mcp/test_version_check_resilience.py
+++ b/tests/unit/mcp/test_version_check_resilience.py
@@ -9,6 +9,14 @@ only the destination URL is redirected to the stub, behavior is not mocked.
 
 This is the receipt that "network failures are silently ignored"
 (the module's promise) actually holds against real failure modes.
+
+Marked ``network`` so CI's parallel unit lane skips it
+(``pytest -n auto --timeout-method=thread -m "not network"``): real
+sockets + ``--timeout-method=thread`` turn any scheduling-induced hang
+into an ``os._exit`` worker crash, and the work distribution that
+triggers it shifts whenever unrelated test files are added or removed.
+The mocked sibling ``test_version_check.py`` keeps the parse/compare
+logic covered in CI; run these locally with ``-m network``.
 """
 
 from __future__ import annotations
@@ -17,11 +25,15 @@ import json
 import threading
 import time
 import urllib.request
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
 from attune.mcp import version_check
+
+# All tests here drive a real localhost socket; isolate them from the
+# parallel xdist lane (see module docstring).
+pytestmark = pytest.mark.network
 
 _REAL_URLOPEN = urllib.request.urlopen
 
@@ -50,9 +62,14 @@ class _StubHandler(BaseHTTPRequestHandler):
             self.wfile.write(b"not valid json {{{")
         elif self.path == "/slow":
             time.sleep(3)  # exceeds the check's hardcoded 2s timeout
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b"{}")
+            try:
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"{}")
+            except OSError:
+                # The client already timed out at 2s and closed the
+                # socket; writing to it now is expected to fail.
+                pass
         else:
             self.send_response(404)
             self.end_headers()
@@ -60,8 +77,14 @@ class _StubHandler(BaseHTTPRequestHandler):
 
 @pytest.fixture
 def stub_server():
-    """A real localhost HTTP server; yields its base URL."""
-    server = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    """A real localhost HTTP server; yields its base URL.
+
+    Threaded so a slow in-flight handler can't block ``shutdown()`` in
+    teardown (the single-threaded server would wait out the ``/slow``
+    sleep, racing the per-test timeout).
+    """
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _StubHandler)
+    server.daemon_threads = True
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     host, port = server.server_address


### PR DESCRIPTION
## Problem

`tests/unit/mcp/test_version_check_resilience.py` has 4 non-mocked tests that drive a **real localhost socket** through the real `urllib` stack. Under CI's `pytest -n auto --timeout=60 --timeout-method=thread`, a scheduling-induced hang in the real-socket path becomes an `os._exit` **worker crash** (`worker 'gwN' crashed`) rather than a graceful timeout.

The work distribution that triggers it shifts whenever unrelated test files are added/removed. Surfaced by #1060 (removes ~70 socratic test files): **only its macOS lane crashed, deterministically (original run + rerun)** on `test_real_http_timeout_degrades_to_none`, while `main` and the sibling deletion PRs (#1061/#1062) stayed green.

## Fix

- **`pytestmark = pytest.mark.network`** — every CI lane already runs `-m "not network"` *precisely* to keep real-socket tests off the parallel xdist lane (per `pytest.ini`'s marker doc). This file just lacked the marker. The mocked sibling `test_version_check.py` keeps `version_check.py`'s parse/compare logic covered in CI.
- **`HTTPServer` → `ThreadingHTTPServer`** (+ defensive write on the `/slow` handler) so a slow in-flight request can't block `shutdown()` in teardown and race the per-test timeout when the tests are run locally (`-m network`).

## Verification

- `4 passed` ×3 locally (~3.7s); `-m "not network"` deselects all 4 (confirms removal from the crashing lane).
- `ruff` + `black` clean.

Once merged, #1060's macOS lane should clear on rerun. Standalone — the flaky test is unrelated to the socratic deletion.