### PR TITLE
chore(skills): disambiguate auto-trigger phrases so the right skill fires

### DIFF
--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attune-hub
-description: "Developer workflow hub — routes to the right skill based on what you need. Triggers on: attune, help me, what can you do, workflows, setup, configure, capabilities."
+description: "Developer workflow hub — routes to the right skill based on what you need. Triggers on: attune, what can attune do, what can you do, capabilities, where do I start, get started."
 argument-hint: "<what you need help with>"
 ---
 

--- a/plugin/skills/bug-predict/SKILL.md
+++ b/plugin/skills/bug-predict/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bug-predict
-description: "Predict likely bug locations from code patterns and complexity. Triggers on: predict bugs, find bugs, risky code, code risk, what might break, likely bugs."
+description: "Predict likely bug locations from code patterns and complexity. Triggers on: predict bugs, find bugs, risky code, code risk, what might break, likely bugs, bug hotspots."
 argument-hint: "<path or directory to scan>"
 ---
 

--- a/plugin/skills/coach/SKILL.md
+++ b/plugin/skills/coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coach
-description: "Progressive help for any topic. Repeat to go deeper: concept -> procedural -> reference. Triggers on: coach, learn, explain, help, tell me more, how does, what is, help with, deeper."
+description: "Progressive help for any topic. Repeat to go deeper: concept -> procedural -> reference. Triggers on: coach, learn, explain, teach me, tell me more, how does, what is, go deeper."
 argument-hint: "<topic | init | status | maintain | update>"
 ---
 

--- a/plugin/skills/code-quality/SKILL.md
+++ b/plugin/skills/code-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality
-description: "Code review and bug prediction to find quality issues, style violations, and likely bugs. Triggers on: review, quality, code review, analyze, lint, bugs, predict, code smell."
+description: "Code review to find quality issues, style violations, and code smells. Triggers on: review, code review, quality, lint, code smell, analyze code."
 argument-hint: "<path or directory to review>"
 ---
 

--- a/plugin/skills/memory-and-context/SKILL.md
+++ b/plugin/skills/memory-and-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-and-context
-description: "Store, retrieve, search, and manage persistent memory across sessions. Triggers on: memory, store, remember, retrieve, forget, pattern, context."
+description: "Store, retrieve, search, and manage persistent memory across sessions. Triggers on: store memory, save this, retrieve, forget, manage memory, context, pattern."
 argument-hint: "<operation: store|retrieve|search|forget|empathy>"
 disable-model-invocation: true
 ---

--- a/plugin/skills/rag-code-gen/SKILL.md
+++ b/plugin/skills/rag-code-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rag-code-gen
-description: "RAG-grounded code generation with source citations. Triggers on: grounded code, ground this, cite sources, show me with sources, how do I with attune, reference attune docs, verify against attune."
+description: "RAG-grounded code generation with source citations. Triggers on: grounded code, ground this, cite sources, show me with sources, how do I with attune, reference attune docs, grounded against attune docs."
 argument-hint: "<what you want generated + any specifics>"
 ---
 

--- a/plugin/skills/refactor-plan/SKILL.md
+++ b/plugin/skills/refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor-plan
-description: "Code-level refactoring analysis and roadmap. Detects smells, duplication, complexity. Triggers on: refactor, tech debt, simplify, code smell, clean up, modularize, DRY."
+description: "Code-level refactoring analysis and roadmap. Detects duplication and complexity. Triggers on: refactor, tech debt, simplify, clean up, modularize, DRY, restructure."
 argument-hint: "<path to analyze>"
 ---
 

--- a/plugin/skills/workflow-orchestration/SKILL.md
+++ b/plugin/skills/workflow-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-orchestration
-description: "Run analysis workflows — security, code review, tests, perf, bugs, docs, release. Triggers on: workflow, run, execute, analyze, security, review, test, perf, release, bugs, docs, audit."
+description: "Run several analysis workflows together in one sweep. Triggers on: run all workflows, run multiple workflows, full analysis sweep, workflow orchestration."
 argument-hint: "<workflow: security, review, tests, perf, release, bugs, docs>"
 ---
 


### PR DESCRIPTION
## Why

The plugin's headline promise — *"say what you need and the right skill fires automatically"* — leaked: of 17 skills, several shared trigger words, so the wrong one could fire. Worst offender: `workflow-orchestration` triggered on `analyze, security, review, test, perf, release, bugs, docs, audit` — shadowing ~7 specific skills.

## What changed (8 skills, frontmatter only)

| Skill | Change |
|---|---|
| `workflow-orchestration` | **demoted to explicit-only** ("run all workflows", "full analysis sweep") — dropped all 9 domain words |
| `code-quality` | owns review/quality/lint/**code smell**; dropped bugs/predict |
| `bug-predict` | sole owner of bugs/predict/risky code (was a head-on collision with code-quality) |
| `refactor-plan` | dropped "code smell" (→ code-quality) |
| `memory-and-context` | dropped "remember" (→ recall) |
| `coach` | dropped bare "help"/"help with" |
| `attune-hub` | dropped "help me" |
| `rag-code-gen` | "verify against attune" → "grounded against attune docs" |

After: each high-risk word (`bugs`, `predict`, `code smell`, `remember`, `security`, `audit`, `review`) is owned by exactly one skill; nothing ambient-fires on bare "help".

## Scope

Pure frontmatter; **17 skills intact**, no code, 122 plugin tests pass. The `bug-predict → code-quality` **merge** is deliberately *not* here — it cascades into the generated help corpus + a skill-sync test, so it gets its own PR.