### PR TITLE
chore(release): prepare 8.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.9.2"
+    "version": "8.10.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "8.9.2",
+      "version": "8.10.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.9.2
+# Attune AI Framework v8.10.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.9.2 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 8.10.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.10.0] — 2026-06-25
+
+attune-ai is now focused on being the **Claude Code workflow plugin**.
+This release removes ~18k LOC of dead framework code, deprecates the
+legacy "Empathy" framework, and sharpens the plugin's auto-trigger UX.
+The workflow tools, auth/tier routing, memory, and help systems are
+unaffected.
+
+### Removed
+
+- **~18k LOC of dead framework code.** The `socratic/` package (55
+  modules), `trust/` + `trust_building.py`, and `emergence.py` — all
+  confirmed off the product runtime path by a reachability audit (zero
+  imports from any CLI/MCP/plugin/workflow entry point). The
+  `TrustBuildingBehaviors` and `EmergenceDetector` public exports are
+  removed with them; nothing in the plugin used them.
+
 ### Deprecated
 
 - **Legacy "Empathy" framework API.** `EmpathyOS`, the five-level
   maturity model (`Level1Reactive`…`Level5Systems`),
-  `FeedbackLoopDetector`, and `LeveragePointAnalyzer` are deprecated.
-  attune-ai now focuses on the Claude Code workflow plugin (MCP tools),
-  which does not use any of these at runtime — a reachability audit
-  (2026-06-25) confirmed zero product-path imports. Accessing these
-  symbols via `from attune import …` now emits a `DeprecationWarning`.
-  They will be removed in a future release; migrate off them now. The
-  workflow tools, auth/tier routing, memory, and help systems are
-  unaffected.
+  `FeedbackLoopDetector`, and `LeveragePointAnalyzer` now emit a
+  `DeprecationWarning` and will be removed in a future release. Migrate
+  off them now.
+
+### Changed
+
+- The package now leads as the Claude Code workflow plugin (package
+  docstring + README), not a "five-level maturity model" framework.
+- **Skill auto-triggers disambiguated** so the right skill fires:
+  `workflow-orchestration` is now explicit-only (it was shadowing ~7
+  specific skills), and overlapping trigger words (bugs/predict, code
+  smell, remember, "help") each now belong to a single skill.
+
+### Fixed
+
+- macOS CI worker crash on the non-mocked version-check resilience
+  tests — marked `network` so they stay off the parallel xdist lane (a
+  real-socket test under `--timeout-method=thread` could crash a
+  worker; surfaced when removing test files reshuffled the xdist work
+  distribution).
+- README accuracy: added `attune-verify` to the ecosystem, corrected
+  the skill (17) and workflow (22) counts, and refreshed version
+  references.
 
 ## [8.9.2] — 2026-06-24
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.9.2
+**Version:** 8.10.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1225,5 +1225,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.9.2 | **License:** Apache 2.0
+**Version:** 8.10.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.9.2"
+    "version": "8.10.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.9.2",
+      "version": "8.10.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.9.2",
+  "version": "8.10.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.9.2"
+__version__ = "8.10.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.9.2"
+version = "8.10.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -236,7 +236,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.9.2"
+version = "8.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 8.10.0 — plugin-focus

Bumps `8.9.2 → 8.10.0` (7 release-artifact files via `bump_version.py` + `uv.lock`) and consolidates the CHANGELOG.

### What's in this release (already merged to main)

- **Removed ~18k LOC of dead framework code** — `socratic/`, `trust/` + `trust_building.py`, `emergence.py`, and the `TrustBuildingBehaviors`/`EmergenceDetector` exports (all confirmed off the product path).
- **Deprecated the legacy Empathy framework** — `EmpathyOS`, `Level1Reactive`…`Level5Systems`, `FeedbackLoopDetector`, `LeveragePointAnalyzer` now emit `DeprecationWarning`.
- **Plugin-first identity** — package docstring + README lead with the Claude Code workflow plugin.
- **macOS xdist flake fixed** — version-check resilience tests marked `network`.
- **README accuracy** — `attune-verify` added, counts + versions corrected.

### Also landing in this release (separate PR)

- **#1068 — skill auto-trigger disambiguation** (must merge before the tag; the CHANGELOG already credits it).

### Version rationale

Minor, not major: the removed exports were unreachable dead code. **9.0.0 is reserved** for the Phase 2 EmpathyOS removal after its deprecation window.

### Before tagging (tomorrow)

1. Merge #1068.
2. Merge this PR.
3. Tag `v8.10.0` from the merge SHA → approve publish → verify on PyPI (run `attune-release-check` first).