### PR TITLE
docs(spec): resolve socratic-ambiguity-calibration design Q1-Q3

### DIFF
--- a/docs/specs/socratic-ambiguity-calibration/decisions.md
+++ b/docs/specs/socratic-ambiguity-calibration/decisions.md
@@ -1,0 +1,85 @@
+# Socratic Ambiguity Calibration — Decisions
+
+Design-phase decisions for [requirements.md](requirements.md).
+Sequencing unchanged: implementation queued **behind 9.0.0**.
+
+---
+
+## d1 — Calibrated, not reflexive "always ask" (Q1)
+
+**Decided:** 2026-06-25 · **By:** Patrick
+
+The Socratic Interaction Rule moves from reflexive *"ALWAYS ask,
+NEVER skip to execution"* to the **calibrated** three-arm form:
+
+1. **Ask on genuine ambiguity** — a decision the workflow must make
+   has ≥2 plausible answers with materially different outcomes, and
+   the user hasn't already specified it.
+2. **Proceed when clear** — if scope/target/focus is given, don't
+   re-ask; proceed and state the assumption in one line.
+3. **Never guess on genuine ambiguity** — the safeguard against
+   under-asking; a wrong guess builds real work on a wrong premise.
+
+**Why:** reflexive "always ask" has its own failure mode — re-asking
+for scope the user already gave (`audit src/ for secrets` →
+"which path?"). Over-asking erodes trust as much as guessing does and
+makes questioning feel like a form, not intelligence. Calibrated keeps
+the safeguard (arm 3) while removing the fatigue, and is the stronger
+differentiator: attune asks only when it sharpens the user's intent.
+
+**Rejected:** keep always-ask (brand stance); hybrid-by-surface
+(always-ask for `/attune` entry, calibrated for workflow skills) —
+more copy to maintain for marginal gain.
+
+---
+
+## d2 — Scope to skills + rule; form engine out of scope (Q2)
+
+**Decided:** 2026-06-25 · **By:** Patrick
+
+Calibration scope is the **rule + 16 `SKILL.md` Scoping sections +
+the skill template**. The Python `SocraticFormEngine`
+(`src/attune/meta_workflows/form_engine.py`) is **out of scope**,
+noted as a possible follow-up.
+
+**Why:** the engine is schema-driven — `ask_questions()` asks whatever
+a `FormSchema` defines; it does not reflexively over-ask the way the
+"always ask" rule does. Calibrating it would mean adding
+conditional/skip-if-already-known logic to the engine + schema format
+— a separable, heavier code change, ill-timed against the 9.0.0
+removal churn. The reflexive over-asking this spec targets lives in
+skill copy + the rule, so that is where the win is.
+
+**Follow-up (deferred):** if form schemas later need
+ask-only-what's-open behavior, add a `skip_if` predicate to
+`FormQuestion` and have `ask_questions()` honor already-known inputs.
+
+---
+
+## d3 — Shared test + per-skill table (Q3)
+
+**Decided:** 2026-06-25 · **By:** Patrick
+
+"Genuinely ambiguous" is operationalized **at author time**, not via
+a runtime detector, with two layers:
+
+1. **Shared one-line test**, stated once in the rule + skill template:
+   > Ask about an input only if it has ≥2 plausible values that lead
+   > to materially different outcomes **and** the user didn't already
+   > specify it. Otherwise proceed and state the assumption.
+2. **Per-skill conditional `Scoping` table** in each `SKILL.md` that
+   instantiates the test for that skill's actual inputs
+   (Input | Ask only if… | If the user gave it).
+
+**Why:** the shared test keeps the definition DRY and consistent
+across skills (no drift); the per-skill table makes it concrete for
+each workflow so the agent has less to interpret. Rejected:
+per-skill-table-only (duplication, drift) and shared-test-only (too
+abstract per workflow).
+
+---
+
+## Status
+
+All three design-phase open questions (Q1–Q3) resolved. Spec moves
+**draft → approved**. Implementation remains queued **behind 9.0.0**.

--- a/docs/specs/socratic-ambiguity-calibration/requirements.md
+++ b/docs/specs/socratic-ambiguity-calibration/requirements.md
@@ -1,6 +1,7 @@
 # Socratic Ambiguity Calibration — Requirements
 
-**Status:** draft (2026-06-25) · **Owner:** Patrick + agent
+**Status:** approved (2026-06-25; design Q1–Q3 resolved — see
+[decisions.md](decisions.md)) · **Owner:** Patrick + agent
 **Sequencing:** queued **behind 9.0.0** (the Empathy framework removal).
 **Born:** the 8.10.0-ship session (2026-06-25). After a compound reply
 I'd *guessed* at, Patrick's feedback was "always query me on an
@@ -107,15 +108,13 @@ ambiguous; honor anything they already specified.
   (`src/attune/meta_workflows/form_engine.py`) if the calibration
   should reach the code-level questioning path too — design decision.
 
-## Open questions (for the design phase)
+## Open questions (resolved 2026-06-25 — see [decisions.md](decisions.md))
 
-- Q1. Is "always ask" a deliberate brand stance Patrick wants to keep,
-  or is the calibrated version strictly better? (This spec assumes
-  calibrated-is-better; confirm before executing.)
-- Q2. Does the calibration apply only to the agent-prompt skills, or
-  also to the Python `SocraticFormEngine` (the code-level form path)?
-- Q3. How is "genuinely ambiguous" operationalized in skill copy so
-  the agent applies it consistently without a runtime detector?
+- Q1. Always-ask vs calibrated? → **calibrated** (d1).
+- Q2. Reach the Python `SocraticFormEngine`? → **no — skills + rule
+  only**; engine is a deferred follow-up (d2).
+- Q3. How to operationalize "genuinely ambiguous"? → **shared one-line
+  test (rule + template) + per-skill conditional `Scoping` table** (d3).
 
 ## Related
 


### PR DESCRIPTION
Resolves the three design-phase open questions for
`docs/specs/socratic-ambiguity-calibration/`; moves the spec
**draft → approved**. No code changes — spec docs only.

## Decisions (see decisions.md)

- **d1 (Q1):** calibrated three-arm rule (ask-on-ambiguity /
  proceed-when-clear / never-guess), not reflexive "always ask"
- **d2 (Q2):** scope to skills + rule; `SocraticFormEngine` out of
  scope (deferred follow-up: `skip_if` predicate on `FormQuestion`)
- **d3 (Q3):** shared one-line ambiguity test (rule + template) +
  per-skill conditional `Scoping` table

Implementation (rule edit + 16 `SKILL.md` Scoping sections + template)
remains queued **behind 9.0.0** per the sequencing in requirements.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)