### PR TITLE
docs(spec): add discovery-sweep-access spec

### DIFF
--- a/docs/specs/discovery-sweep-access/decisions.md
+++ b/docs/specs/discovery-sweep-access/decisions.md
@@ -1,0 +1,66 @@
+# Discovery-Sweep Access — Decisions
+
+Decisions recorded during scoping. Agent recommendations marked; Patrick
+to confirm/edit in spec review.
+
+---
+
+## D1 — Surface scope: MCP tool + thin skill
+
+**Decided (Patrick, 2026-06-25).** Add a `discovery_sweep` MCP tool plus a
+thin skill. Not full first-class (no dedicated CLI command, no
+`features.ts`); not MCP-only (would stay undiscoverable); not skill-only
+(inconsistent with the other 21 workflows). This is the smallest change
+that closes the access gap and matches the sibling pattern.
+
+## D2 — Response format: force `output_format="json"`
+
+**Agent recommendation.** The handler forces `output_format="json"` so
+the MCP response carries `queue` / `questions` / `rejected` as structured
+data Claude can act on, rather than pre-rendered markdown. The CLI keeps
+its markdown default; only the MCP surface forces json. Rejected
+alternative: return markdown (simpler, but Claude would have to parse
+prose to act on findings).
+
+## D3 — Input surface: `path` + `budget_usd` + `no_llm` only
+
+**Agent recommendation.** Expose only kwargs `execute()` actually accepts
+and that a caller reasonably sets: `path` (required), `budget_usd`,
+`no_llm`. Deliberately omitted: `min_severity` (not an `execute()` kwarg —
+the threshold is in `verification.py`); `source` filter and `sweep_id`
+(power-user / correlation knobs, not needed for the interactive surface);
+`event_sink` (daemon-only, out of scope). Keep the tool surface minimal;
+widen later only if a use case demands it.
+
+## D4 — Auto-trigger disambiguation
+
+**Agent recommendation.** The skill auto-triggers on aggregate-intent
+phrasing only — "run all audits / full sweep / audit everything / what
+should I fix / triage findings" — and explicitly does **not** claim the
+single-audit phrases owned by `security-audit`, `bug-predict`,
+`code-quality`/`deep-review`, or the multi-workflow phrase owned by the
+explicit-only `workflow-orchestration`. Follows the #1068 lesson
+(disambiguate auto-trigger phrases so the right skill fires). Fallback if
+phrasing proves greedy in practice: make the skill explicit-only.
+
+## D5 — No engine changes
+
+**Decided.** This spec is surface-only. `workflow.py`,
+`verification.py`, and `sources/` are untouched. If the json return path
+turns out to need a shape tweak for clean bucket extraction, that is a
+separate, explicitly-flagged change — not folded in silently.
+
+## D6 — Out-of-scope boundary with the ops daemon
+
+**Decided.** The `event_sink` / scheduled-daemon use case stays in its own
+`discovery-sweep-ops-integration` Phase-2 track. This spec does not touch
+it; the interactive MCP surface and the daemon surface are independent.
+
+---
+
+## Open for review
+
+- **OQ1:** Confirm D2 (force json) vs. returning markdown — does any
+  expected caller want the rendered report instead of structured buckets?
+- **OQ2:** Confirm D4's trigger phrasing, or start explicit-only and add
+  auto-triggers after observing real shadowing behavior.

--- a/docs/specs/discovery-sweep-access/design.md
+++ b/docs/specs/discovery-sweep-access/design.md
@@ -1,0 +1,158 @@
+# Discovery-Sweep Access — Design
+
+Grounded in the existing `bug_predict` MCP-tool wiring (the canonical
+workflow-tool pattern). Reference chain per
+`.claude/rules/attune/plugin-reference-validation.md`:
+**Command/Skill → MCP tool schema → dispatch → handler → workflow class.**
+
+---
+
+## Touch points
+
+| Layer | File | Change |
+|-------|------|--------|
+| Schema | `src/attune/mcp/tool_schemas.py` | add `discovery_sweep` to `get_workflow_tools()` |
+| Dispatch | `src/attune/mcp/server.py` `_build_dispatch_table()` | add `"discovery_sweep": self._run_discovery_sweep` |
+| Handler | `src/attune/mcp/server.py` | add `_run_discovery_sweep()` |
+| Skill | `plugin/skills/discovery-sweep/SKILL.md` | new thin skill |
+| Tests | `tests/unit/test_mcp_memory_tools.py`, `tests/unit/mcp/test_tool_schemas.py` | bump counts, add schema assertion |
+| Docs | `README.md` (+ any MCP-tool-count claim) | bump count (doc-audit checks it) |
+
+No change to `workflows/discovery_sweep/`.
+
+---
+
+## 1. Tool schema (`get_workflow_tools()`)
+
+`discovery_sweep` needs more than the `_path_tool` helper (it has knobs),
+so it uses an explicit `input_schema` like `test_generation`/`doc_gen`:
+
+```python
+"discovery_sweep": {
+    "description": (
+        "Run the discovery-sweep meta-workflow: fans out across all "
+        "audit sources (pattern scan, bug-predict, security, deps, "
+        "perf, docs, tests), dedups, and triages findings into "
+        "queue / questions / rejected buckets. Use for a full "
+        "'what should I fix' pass; single-purpose audits have their "
+        "own tools."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Directory or file to sweep",
+            },
+            "budget_usd": {
+                "type": "number",
+                "description": "Total LLM spend cap (default 10.00)",
+                "default": 10.0,
+            },
+            "no_llm": {
+                "type": "boolean",
+                "description": "Fast pattern-only sweep (skip LLM sources)",
+                "default": False,
+            },
+        },
+        "required": ["path"],
+    },
+},
+```
+
+`min_severity` is intentionally **not** exposed — the triage threshold
+lives in `verification.py`, not an `execute()` kwarg. Keep the surface to
+what the engine actually accepts.
+
+---
+
+## 2. Handler (`server.py`)
+
+Mirrors `_run_bug_predict`, forcing `output_format="json"` so the buckets
+return structured (FR-4). `sources` defaults to `default_sources()`
+inside `execute()`, so the handler doesn't assemble them:
+
+```python
+async def _run_discovery_sweep(self, args: dict[str, Any]) -> dict[str, Any]:
+    """Run the discovery-sweep triage meta-workflow."""
+    from attune.security.path_validation import _validate_file_path
+    from attune.workflows.discovery_sweep import DiscoverySweepWorkflow
+
+    validated_path = str(
+        _validate_file_path(args["path"], allowed_dir=self._workspace_root)
+    )
+    workflow = DiscoverySweepWorkflow()
+    result = await workflow.execute(
+        path=validated_path,
+        budget_usd=float(args.get("budget_usd", 10.0)),
+        no_llm=bool(args.get("no_llm", False)),
+        output_format="json",
+    )
+    return _workflow_response(
+        result,
+        queue=("queue", []),
+        questions=("questions", []),
+        rejected=("rejected", []),
+    )
+```
+
+**Verify during implementation:** the exact keys `execute()` puts on
+`WorkflowResult` for the three buckets (read the `output_format="json"`
+return path in `workflow.py` around the `WorkflowResult(...)` build — the
+`_workflow_response` extractor keys must match). Do not assume.
+
+---
+
+## 3. Dispatch entry
+
+In `_build_dispatch_table()`, beside the other workflow entries:
+
+```python
+"discovery_sweep": self._run_discovery_sweep,
+```
+
+---
+
+## 4. Skill (`plugin/skills/discovery-sweep/SKILL.md`)
+
+Thin skill modeled on `bug-predict/SKILL.md`. Frontmatter `description`
+carries the auto-triggers, **disambiguated** (NFR-2):
+
+- **Fires on:** "run all audits", "full sweep", "audit everything",
+  "what should I fix", "triage findings", "discovery sweep",
+  "sweep the codebase".
+- **Does NOT claim:** bare "security" / "find bugs" / "review" / "predict
+  bugs" (those belong to `security-audit` / `bug-predict` /
+  `code-quality` / `deep-review`); nor "run multiple workflows" (that is
+  `workflow-orchestration`, which is explicit-only).
+
+Body: one-paragraph what-it-is, the three-bucket explanation, and a
+single instruction to call the `discovery_sweep` MCP tool with `path`
+(+ optional `budget_usd` / `no_llm`). It must reference only the real
+tool name `discovery_sweep`.
+
+---
+
+## 5. Tests & counts
+
+- `tests/unit/test_mcp_memory_tools.py:35` `>= 41` still holds; **line 46
+  `== 46` (with redis) → `== 47`**.
+- `tests/unit/mcp/test_tool_schemas.py` — add a `discovery_sweep` schema
+  assertion (present, has required `path`).
+- `tests/unit/plugins/test_plugin_reference_validation.py` — passes
+  automatically once the skill references a real tool; run it.
+- `README.md` — if it states an MCP-tool count, bump it (the `doc-audit`
+  workflow's README-claim check fails otherwise).
+
+---
+
+## Risks
+
+- **R1 (medium):** wrong bucket keys in `_workflow_response` → empty
+  buckets in the response. Mitigation: read the json return path; assert
+  on a real sweep in the handler test.
+- **R2 (low):** auto-trigger shadowing regresses sibling skills.
+  Mitigation: explicit-only fallback if phrasing proves greedy; the
+  `skill-sync` / disambiguation test guards it.
+- **R3 (low):** count drift across the 3+ count sites. Mitigation: the
+  acceptance checklist enumerates every site.

--- a/docs/specs/discovery-sweep-access/requirements.md
+++ b/docs/specs/discovery-sweep-access/requirements.md
@@ -1,0 +1,113 @@
+# Discovery-Sweep Access — Requirements
+
+**Status:** draft (2026-06-25)
+**Owner:** Patrick + agent
+**Scope:** surface layer only — the engine already exists at
+`src/attune/workflows/discovery_sweep/`.
+
+---
+
+## Problem
+
+`discovery-sweep` is a fully-built, registered workflow with **zero
+user-facing entry points**. An accessibility audit (2026-06-25) found it
+is the only one of 22 registry workflows with no MCP tool, no skill, no
+slash command, and no catalog listing. A Claude Code plugin user cannot
+discover or trigger it; the sole path is the raw
+`attune workflow run discovery-sweep` CLI invocation.
+
+Every other workflow is reachable via at least one user-facing surface.
+This spec closes that gap.
+
+---
+
+## What discovery-sweep does (context)
+
+A deterministic triage meta-workflow. It fans out across seven audit
+sources (`PatternScan` non-LLM + `bug-predict`, `security-audit`,
+`dependency-check`, `perf-audit`, `doc-audit`, `test-audit`), dedups by
+location, and routes findings — with LLM-free logic — into three buckets:
+
+- `queue` — act on (high confidence, located, severity ≥ threshold)
+- `questions` — needs human judgment (no location, low confidence,
+  conflicting severity, or the source crashed)
+- `rejected` — filtered noise (below threshold, duplicate)
+
+It is budget-capped (`DEFAULT_BUDGET_USD = $10`) and fault-tolerant (a
+crashing source becomes one `questions` entry, never a failed sweep).
+
+---
+
+## Use cases
+
+1. **Pre-PR "what did I break"** — one call runs the full audit panel
+   over changed code, returning a prioritized queue with noise stripped.
+2. **Inherited / unfamiliar codebase triage** — first-pass landmine map
+   across bugs, security, deps, perf, docs, and test gaps.
+3. **Tech-debt backlog intake** — the three buckets are a grooming
+   pipeline (queue→tickets, questions→review, rejected→documented noise).
+4. **Noise-filtered aggregation** — dedup + severity + confidence
+   routing extracts signal from six overlapping scanners.
+5. **Broad pre-release scan** — wide quality sweep, complementary to the
+   deterministic CLI-only `release-gate`.
+
+(The scheduled-daemon / `event_sink` use case is a separate Phase-2 ops
+integration and is explicitly **out of scope** here.)
+
+---
+
+## Functional requirements
+
+- **FR-1** A `discovery_sweep` MCP tool exists and appears in
+  `get_workflow_tools()`, so Claude can invoke the workflow directly.
+- **FR-2** The tool accepts: `path` (string, **required**, scope to
+  sweep), `budget_usd` (number, optional, default `$10.00`), `no_llm`
+  (boolean, optional, fast non-LLM-only sweep).
+- **FR-3** The handler validates `path` with `_validate_file_path(...,
+  allowed_dir=self._workspace_root)` (same guard as every sibling tool).
+- **FR-4** The handler forces `output_format="json"` so the response
+  carries all three buckets as structured data (not rendered markdown).
+- **FR-5** A `discovery-sweep` skill exists under `plugin/skills/` with a
+  description whose auto-triggers are **disambiguated** from
+  `security-audit`, `bug-predict`, `deep-review`, and
+  `workflow-orchestration` (see NFR-2).
+- **FR-6** The skill routes to the `discovery_sweep` MCP tool, not a raw
+  CLI shell-out.
+
+## Non-functional requirements
+
+- **NFR-1** No change to the engine (`workflow.py`, `verification.py`,
+  `sources/`). Surface-only — the spec adds adapters, not behavior.
+- **NFR-2** Auto-trigger phrases must fire for "run all audits / full
+  sweep / what should I fix / triage findings / audit everything" and
+  must **not** shadow the single-purpose audit skills (the #1068
+  disambiguation discipline).
+- **NFR-3** All reference-validation invariants hold: the skill names
+  only real MCP tools; the tool count test and any README MCP-tool-count
+  claim are updated in lockstep (`doc-audit` checks the README claim).
+
+---
+
+## Acceptance criteria (Done when)
+
+- [ ] `discovery_sweep` appears in `EmpathyMCPServer._build_dispatch_table()`
+  and the live tool list (count 41→42 base, 46→47 with redis plugin).
+- [ ] Invoking the tool on a path returns `{queue, questions, rejected}`
+  structured buckets; a crashing source degrades to a `questions` entry.
+- [ ] `plugin/skills/discovery-sweep/SKILL.md` exists, lints clean, and
+  references only real tool names; `test_plugin_reference_validation`
+  passes.
+- [ ] Tool-count tests and README MCP-tool-count claim updated; full MCP
+  test suite green.
+- [ ] No edits under `workflows/discovery_sweep/` except, if needed, a
+  one-line registry/exposure note.
+
+---
+
+## Out of scope
+
+- The `event_sink` / ops-dashboard daemon path (separate Phase-2 spec
+  `discovery-sweep-ops-integration`).
+- A dedicated `attune discovery-sweep` CLI command (the generic
+  `attune workflow run discovery-sweep` already works).
+- Website `features.ts` / marketing surfaces.

--- a/docs/specs/discovery-sweep-access/tasks.md
+++ b/docs/specs/discovery-sweep-access/tasks.md
@@ -1,0 +1,163 @@
+# Discovery-Sweep Access — Tasks
+
+XML-enhanced task blocks (per
+`.claude/rules/attune/xml-enhanced-prompts.md`). Three production tasks
++ one verification task. T1→T2 are sequential (handler needs the schema);
+T3 is independent; T4 gates the PR.
+
+---
+
+## T1 — MCP tool schema
+
+```xml
+<task id="1" name="discovery-sweep-schema">
+  <objective>
+    Register the discovery_sweep tool schema so it appears in the MCP
+    tool list and Claude can call it.
+  </objective>
+  <context>
+    <existing-code path="src/attune/mcp/tool_schemas.py">
+      get_workflow_tools() returns a dict of tool-name -> schema. Tools
+      with options use an explicit input_schema (see test_generation,
+      doc_gen); path-only tools use the _pt/_path_tool helper.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/mcp/tool_schemas.py">
+      <change location="get_workflow_tools() return dict">
+        Add "discovery_sweep" with explicit input_schema:
+        required path (string); optional budget_usd (number, default
+        10.0) and no_llm (boolean, default false). Description per
+        design.md §1 — name the three buckets, point single-audit
+        intent at the dedicated tools.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>get_workflow_tools()["discovery_sweep"]["input_schema"]["required"] == ["path"]</check>
+    <check>EmpathyMCPServer()._build_dispatch_table() length increases by 1 once T2 lands</check>
+  </validation>
+</task>
+```
+
+## T2 — Handler + dispatch
+
+```xml
+<task id="2" name="discovery-sweep-handler">
+  <objective>
+    Add the _run_discovery_sweep handler and wire it into the dispatch
+    table, forcing JSON output so the three buckets return structured.
+  </objective>
+  <context>
+    <existing-code path="src/attune/mcp/server.py">
+      _run_bug_predict (line ~391) is the pattern: validate path with
+      _validate_file_path(..., allowed_dir=self._workspace_root), import
+      the workflow lazily, await workflow.execute(...), return
+      _workflow_response(result, ...). Dispatch entries live in
+      _build_dispatch_table() (line ~270).
+    </existing-code>
+    <existing-code path="src/attune/workflows/discovery_sweep/workflow.py">
+      DiscoverySweepWorkflow.execute(**kwargs) accepts path, budget_usd,
+      no_llm, output_format ("markdown"|"json"); sources defaults to
+      default_sources(). VERIFY the exact result keys for the buckets on
+      the json return path before writing _workflow_response extractors.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/mcp/server.py">
+      <change location="new method near _run_bug_predict">
+        Add async _run_discovery_sweep(self, args) per design.md §2.
+      </change>
+      <change location="_build_dispatch_table()">
+        Add "discovery_sweep": self._run_discovery_sweep.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>await _run_discovery_sweep({"path": "src/attune/security"}) returns dict with queue/questions/rejected keys</check>
+    <check>a deliberately-crashing source surfaces as a questions entry, not an exception</check>
+    <check>path traversal (../../etc) is rejected by _validate_file_path</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Bucket key names guessed instead of read from the json return path — yields empty buckets. Read workflow.py first.</risk>
+  </risks>
+</task>
+```
+
+## T3 — Thin skill
+
+```xml
+<task id="3" name="discovery-sweep-skill">
+  <objective>
+    Add a discovery-sweep skill so the workflow is discoverable in the
+    catalog and auto-triggers on aggregate-audit intent.
+  </objective>
+  <context>
+    <existing-code path="plugin/skills/bug-predict/SKILL.md">
+      Thin-skill template: frontmatter (name, description with trigger
+      phrases) + a short body that instructs calling the MCP tool.
+    </existing-code>
+  </context>
+  <files-to-create>
+    <file path="plugin/skills/discovery-sweep/SKILL.md">
+      Frontmatter description with disambiguated triggers per design.md
+      §4 / decisions D4. Body: what-it-is, the three buckets, and the
+      single instruction to call the discovery_sweep MCP tool with path
+      (+ optional budget_usd / no_llm). Reference only the real tool name.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>ls plugin/skills/discovery-sweep/SKILL.md</check>
+    <check>grep -w discovery_sweep src/attune/mcp/tool_schemas.py (the skill's named tool resolves)</check>
+    <check>markdown lints clean; skill frontmatter matches the IDE linter (ground truth, not docs)</check>
+  </validation>
+</task>
+```
+
+## T4 — Tests, counts, README (PR gate)
+
+```xml
+<task id="4" name="discovery-sweep-tests-counts">
+  <objective>
+    Update tool-count assertions and the README MCP-tool-count claim, add
+    a schema test, and run the reference-validation + MCP suites green.
+  </objective>
+  <context>
+    <existing-code path="tests/unit/test_mcp_memory_tools.py">
+      Line ~35 asserts len(tools) >= 41 (still holds). Line ~46 asserts
+      == 46 with the redis plugin -> becomes 47.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="tests/unit/test_mcp_memory_tools.py">
+      <change location="redis-plugin count assertion">46 -> 47</change>
+    </file>
+    <file path="tests/unit/mcp/test_tool_schemas.py">
+      <change location="schema assertions">Add discovery_sweep present + required path</change>
+    </file>
+    <file path="README.md">
+      <change location="MCP tool count claim, if present">bump by 1 (doc-audit checks this)</change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>pytest tests/unit/test_mcp_memory_tools.py tests/unit/mcp/test_tool_schemas.py -q  (green)</check>
+    <check>pytest tests/unit/plugins/test_plugin_reference_validation.py -q  (green)</check>
+    <check>grep -rn "MCP tool" README.md  — claimed count matches live tool count</check>
+  </validation>
+  <risks>
+    <risk severity="low">Other count sites (docs, website) drift. Out of scope here; note any found for a follow-up.</risk>
+  </risks>
+</task>
+```
+
+---
+
+## Sequencing
+
+- **T1 → T2** (handler references the schema's params).
+- **T3** independent (can run in parallel with T1/T2).
+- **T4** last — gates the PR; depends on T1–T3.
+
+One PR. Concerns: `impl` (T1–T3) + `test` (T4) + `release-notes`
+(README count + CHANGELOG entry). No `regression-guard` (feature add, not
+a bug fix); no `migration` (additive).


### PR DESCRIPTION
## Summary

Adds the **`discovery-sweep-access`** spec — surfacing the existing
`discovery-sweep` workflow to plugin users via an **MCP tool + thin
skill**. Docs-only; no implementation yet (lands the decisions
independently per the docs-only-spec-PR pattern).

## Why

An accessibility audit (2026-06-25) found `discovery-sweep` is the **only
one of 22 registry workflows** with no MCP tool, no skill, no slash
command, and no catalog entry. A Claude Code plugin user can't discover
or trigger it — the sole path is raw `attune workflow run discovery-sweep`.
The other 21 workflows each have at least one user-facing surface.

## What's in the spec

`docs/specs/discovery-sweep-access/`:

- **requirements.md** — problem, 5 use cases, FR-1…6 / NFR-1…3,
  acceptance checklist, explicit out-of-scope (the `event_sink` daemon
  path stays in its own Phase-2 track).
- **design.md** — exact wiring grounded in the existing `bug_predict`
  MCP-tool pattern: `discovery_sweep` schema, `_run_discovery_sweep`
  handler (forces `output_format="json"` so Claude gets the three
  buckets structured), dispatch entry, thin skill with disambiguated
  auto-triggers, and the 3 tool-count sites.
- **decisions.md** — D1 (scope: MCP + skill) confirmed; D2–D6 agent
  recommendations + 2 open questions (json vs markdown; auto-triggers
  vs explicit-only).
- **tasks.md** — 4 XML-enhanced tasks (schema → handler → skill →
  tests/counts) with validation + risks.

Engine (`src/attune/workflows/discovery_sweep/`) is untouched — surface
layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
