### PR TITLE
feat(mcp): surface discovery-sweep via MCP tool + skill

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attune-hub
-description: "Developer workflow hub — routes to the right skill based on what you need. Triggers on: attune, help me, what can you do, workflows, setup, configure, capabilities."
+description: "Developer workflow hub — routes to the right skill based on what you need. Triggers on: attune, what can attune do, what can you do, capabilities, where do I start, get started."
 ---
 # Attune Hub
 
@@ -53,6 +53,7 @@ intent so Claude matches the right skill:
 | "performance", "bottleneck", "optimize" | workflow-orchestration skill |
 | "release", "publish", "ship" | release-prep skill |
 | "bug", "predict", "risk" | bug-predict skill |
+| "run all audits", "full sweep", "what should I fix" | discovery-sweep skill |
 | "memory", "store", "remember" | memory-and-context skill |
 | "docs", "documentation" | doc-gen skill |
 | "plan", "feature", "architecture" | planning skill |
@@ -83,6 +84,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | security-audit | security, vulnerability, audit, scan |
 | code-quality | review, quality, bugs, code smell |
 | bug-predict | predict bugs, risky code, what might break |
+| discovery-sweep | run all audits, full sweep, what should I fix, triage findings |
 | doc-gen | generate docs, documentation, README |
 | smart-test | generate tests, test gaps, coverage |
 | fix-test | fix test, broken test, debug test |

--- a/.agents/skills/discovery-sweep/SKILL.md
+++ b/.agents/skills/discovery-sweep/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: discovery-sweep
+description: "Run every audit at once and triage the findings into act-now / needs-a-look / dismissed buckets. Triggers on: run all audits, full sweep, audit everything, what should I fix, triage findings, discovery sweep, sweep the codebase."
+---
+# Discovery Sweep
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="discovery-sweep", mode="preamble")` and
+display the returned `preamble` text as a blockquote. Then tell
+the user they can say "tell me more" for a step-by-step guide, or
+answer the scoping questions below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Discovery Sweep** — Fans out across every audit source
+> (pattern scan, bug-predict, security, dependencies, performance,
+> docs, tests), dedups overlapping findings, and triages everything
+> into three buckets so you know what to fix first.
+
+This is the aggregate "what should I fix?" pass. For a single
+focused audit, use the dedicated skill instead — `security-audit`,
+`bug-predict`, `code-quality`, or `deep-review`.
+
+## Scoping
+
+Before running, ask:
+
+1. **Target path**: "Which files or directory should I sweep?"
+   Default to `src/` if not specified.
+2. **Speed vs. depth**: "Fast pattern-only sweep, or include the
+   LLM-backed sources?" (LLM sources cost budget; pattern-only is
+   free and quick.)
+3. **Budget**: only if including LLM sources — "Spend cap? Default
+   is $10.00."
+
+## Execution
+
+Call the `discovery_sweep` MCP tool with the scoped path:
+
+```
+discovery_sweep(path="<user-specified path>")
+```
+
+Optional knobs:
+
+```
+discovery_sweep(path="src/", no_llm=true)          # fast, free
+discovery_sweep(path="src/", budget_usd=5.0)       # cap LLM spend
+```
+
+Or via CLI:
+
+```bash
+uv run attune workflow run discovery-sweep --path <target>
+```
+
+## Output
+
+The tool returns three buckets. Present each as its own section:
+
+- **Queue** — findings that auto-routed to "act on these now."
+  Render as a markdown table grouped by severity (critical first)
+  with clickable file links.
+- **Questions** — findings the engine could not auto-route (missing
+  location, low confidence, severity conflict, or a source that
+  crashed). Show each finding's `reason` and `next_step`.
+- **Rejected** — findings filtered out by a deterministic rule
+  (below threshold, duplicate of another source). Summarize the
+  count; expand only if the user asks.
+
+Close with the run metadata: spend vs. budget, sources that ran,
+any source failures, and duration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`discovery_sweep` MCP tool + `discovery-sweep` skill.** The
+  discovery-sweep meta-workflow (fan-out across all audit sources →
+  dedup → triage into queue / questions / rejected buckets) now has a
+  user surface: an MCP tool taking `path` (+ optional `budget_usd`,
+  `no_llm`) and a thin auto-triggering skill. Previously the workflow
+  was reachable only from internal code. Brings the count to 42 MCP
+  tools and 18 skills.
+
 ## [8.10.0] — 2026-06-25
 
 attune-ai is now focused on being the **Claude Code workflow plugin**.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 A spec-driven development platform for Claude Code. Four pillars — AI
 workflows, project memory, retrieval grounding, and verification — turn
 requirements into reliable software. 22 workflows (19 multi-stage),
-17 auto-triggering skills, and 41 MCP tools run specialist teams of 2–6
+18 auto-triggering skills, and 42 MCP tools run specialist teams of 2–6
 Claude subagents that review your code, surface vulnerabilities, generate
 tests, and plan refactors — grounded in your real source, with findings
 remembered across sessions. The same system doubles as the authoring and
@@ -167,10 +167,10 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 
 | Capability | Plugin only | Plugin + pip |
 | ---------- | ----------- | ------------ |
-| 17 auto-triggering skills | Yes | Yes |
+| 18 auto-triggering skills | Yes | Yes |
 | Security hooks | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| 41 MCP tools | -- | Yes |
+| 42 MCP tools | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Help system maintenance | -- | Yes |
@@ -234,14 +234,14 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 
 ## MCP Tools
 
-41 tools organized into 5 categories:
+42 tools organized into 5 categories:
 
-### Workflow (21)
+### Workflow (22)
 
 `security_audit` `code_review` `bug_predict`
-`performance_audit` `refactor_plan` `simplify_code`
-`deep_review` `test_generation` `test_audit`
-`test_gen_parallel` `doc_gen` `doc_audit`
+`discovery_sweep` `performance_audit` `refactor_plan`
+`simplify_code` `deep_review` `test_generation`
+`test_audit` `test_gen_parallel` `doc_gen` `doc_audit`
 `doc_orchestrator` `release_notes` `health_check`
 `dependency_check` `secure_release` `research_synthesis`
 `analyze_batch` `analyze_image` `rag_knowledge_query`
@@ -311,8 +311,8 @@ from retrieval. Full methodology:
 | --- | --- | --- | --- | --- |
 | **Ready-to-use workflows** | 22 built-in | None | Build from scratch | None |
 | **Multi-agent teams** | 2–6 agents per workflow | None | Yes | No |
-| **MCP integration** | 41 native tools | None | No | No |
-| **Auto-triggering skills** | 17 skills, natural language | None | None | None |
+| **MCP integration** | 42 native tools | None | No | No |
+| **Auto-triggering skills** | 18 skills, natural language | None | None | None |
 | **Socratic discovery** | Questions before execution | None | None | None |
 | **Portable security hooks** | PreToolUse + PostToolUse | None | No | No |
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,7 +1,7 @@
 # attune-ai
 
 Spec-driven development for Claude Code — turn requirements
-into reliable software. 17 auto-triggering skills, zero
+into reliable software. 18 auto-triggering skills, zero
 commands: say what you need and Claude picks the right skill.
 
 **Version:** 8.5.0 | **License:** Apache 2.0
@@ -79,7 +79,7 @@ The plugin ships two security hooks:
 ## Python Package (optional — unlocks CLI + MCP)
 
 The plugin works standalone. Add the Python package
-for CLI automation, 41 MCP tools, multi-agent
+for CLI automation, 42 MCP tools, multi-agent
 workflows, and cost tracking:
 
 ```bash
@@ -88,9 +88,9 @@ pip install 'attune-ai[developer]'
 
 | Capability | Plugin only | + pip |
 | ---------- | ----------- | ----- |
-| 17 auto-triggering skills | Yes | Yes |
+| 18 auto-triggering skills | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| 41 MCP tools | -- | Yes |
+| 42 MCP tools | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Cost tracking | -- | Yes |

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -55,6 +55,7 @@ intent so Claude matches the right skill:
 | "performance", "bottleneck", "optimize" | workflow-orchestration skill |
 | "release", "publish", "ship" | release-prep skill |
 | "bug", "predict", "risk" | bug-predict skill |
+| "run all audits", "full sweep", "what should I fix" | discovery-sweep skill |
 | "memory", "store", "remember" | memory-and-context skill |
 | "docs", "documentation" | doc-gen skill |
 | "plan", "feature", "architecture" | planning skill |
@@ -85,6 +86,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | security-audit | security, vulnerability, audit, scan |
 | code-quality | review, quality, bugs, code smell |
 | bug-predict | predict bugs, risky code, what might break |
+| discovery-sweep | run all audits, full sweep, what should I fix, triage findings |
 | doc-gen | generate docs, documentation, README |
 | smart-test | generate tests, test gaps, coverage |
 | fix-test | fix test, broken test, debug test |

--- a/plugin/skills/discovery-sweep/SKILL.md
+++ b/plugin/skills/discovery-sweep/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: discovery-sweep
+description: "Run every audit at once and triage the findings into act-now / needs-a-look / dismissed buckets. Triggers on: run all audits, full sweep, audit everything, what should I fix, triage findings, discovery sweep, sweep the codebase."
+argument-hint: "<path or directory to sweep>"
+---
+
+# Discovery Sweep
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="discovery-sweep", mode="preamble")` and
+display the returned `preamble` text as a blockquote. Then tell
+the user they can say "tell me more" for a step-by-step guide, or
+answer the scoping questions below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Discovery Sweep** — Fans out across every audit source
+> (pattern scan, bug-predict, security, dependencies, performance,
+> docs, tests), dedups overlapping findings, and triages everything
+> into three buckets so you know what to fix first.
+
+This is the aggregate "what should I fix?" pass. For a single
+focused audit, use the dedicated skill instead — `security-audit`,
+`bug-predict`, `code-quality`, or `deep-review`.
+
+## Scoping
+
+Before running, ask:
+
+1. **Target path**: "Which files or directory should I sweep?"
+   Default to `src/` if not specified.
+2. **Speed vs. depth**: "Fast pattern-only sweep, or include the
+   LLM-backed sources?" (LLM sources cost budget; pattern-only is
+   free and quick.)
+3. **Budget**: only if including LLM sources — "Spend cap? Default
+   is $10.00."
+
+## Execution
+
+Call the `discovery_sweep` MCP tool with the scoped path:
+
+```
+discovery_sweep(path="<user-specified path>")
+```
+
+Optional knobs:
+
+```
+discovery_sweep(path="src/", no_llm=true)          # fast, free
+discovery_sweep(path="src/", budget_usd=5.0)       # cap LLM spend
+```
+
+Or via CLI:
+
+```bash
+uv run attune workflow run discovery-sweep --path <target>
+```
+
+## Output
+
+The tool returns three buckets. Present each as its own section:
+
+- **Queue** — findings that auto-routed to "act on these now."
+  Render as a markdown table grouped by severity (critical first)
+  with clickable file links.
+- **Questions** — findings the engine could not auto-route (missing
+  location, low confidence, severity conflict, or a source that
+  crashed). Show each finding's `reason` and `next_step`.
+- **Rejected** — findings filtered out by a deterministic rule
+  (below threshold, duplicate of another source). Summarize the
+  count; expand only if the user asks.
+
+Close with the run metadata: spend vs. budget, sources that ran,
+any source failures, and duration.

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -268,6 +268,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         return {
             "security_audit": self._run_security_audit,
             "bug_predict": self._run_bug_predict,
+            "discovery_sweep": self._run_discovery_sweep,
             "code_review": self._run_code_review,
             "test_generation": self._run_test_generation,
             "performance_audit": self._run_performance_audit,
@@ -400,6 +401,55 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         result = await workflow.execute(path=validated_path)
 
         return _workflow_response(result, predictions=("predictions", []))
+
+    async def _run_discovery_sweep(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Run the discovery-sweep triage meta-workflow.
+
+        Unlike the single-audit handlers, discovery-sweep renders its
+        three buckets into ``final_output`` as a JSON *string*
+        (``output_format="json"``), so ``_workflow_response`` would see a
+        non-dict and yield empty buckets. The structured ``SweepResult``
+        lives on ``result.metadata["sweep"]`` instead — extract the
+        buckets from there.
+        """
+        from dataclasses import asdict
+
+        from attune.security.path_validation import _validate_file_path
+        from attune.workflows.discovery_sweep import DiscoverySweepWorkflow
+
+        validated_path = str(_validate_file_path(args["path"], allowed_dir=self._workspace_root))
+        workflow = DiscoverySweepWorkflow()
+        result = await workflow.execute(
+            path=validated_path,
+            budget_usd=float(args.get("budget_usd", 10.0)),
+            no_llm=bool(args.get("no_llm", False)),
+            output_format="json",
+        )
+
+        cost_report = getattr(result, "cost_report", None)
+        cost = cost_report.total_cost if cost_report is not None else 0.0
+
+        sweep = (getattr(result, "metadata", None) or {}).get("sweep")
+        if sweep is None:
+            # execute() returned an error result (e.g. empty path) — no
+            # sweep was built. Surface the message, keep buckets empty.
+            return {
+                "success": result.success,
+                "error": None if result.success else result.final_output,
+                "queue": [],
+                "questions": [],
+                "rejected": [],
+                "cost": cost,
+            }
+
+        return {
+            "success": result.success,
+            "queue": [asdict(f) for f in sweep.queue],
+            "questions": [asdict(q) for q in sweep.questions],
+            "rejected": [asdict(r) for r in sweep.rejected],
+            "metadata": asdict(sweep.metadata),
+            "cost": cost,
+        }
 
     async def _run_code_review(self, args: dict[str, Any]) -> dict[str, Any]:
         """Run code review workflow."""

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -51,6 +51,36 @@ def get_workflow_tools() -> dict[str, dict[str, Any]]:
             param_desc="Path to directory or file to analyze",
             required=True,
         ),
+        "discovery_sweep": {
+            "description": (
+                "Run the discovery-sweep meta-workflow: fans out across all "
+                "audit sources (pattern scan, bug-predict, security, deps, "
+                "perf, docs, tests), dedups, and triages findings into "
+                "queue / questions / rejected buckets. Use for a full "
+                "'what should I fix' pass; single-purpose audits have their "
+                "own tools (security_audit, bug_predict, deep_review)."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Directory or file to sweep",
+                    },
+                    "budget_usd": {
+                        "type": "number",
+                        "description": "Total LLM spend cap (default 10.00)",
+                        "default": 10.0,
+                    },
+                    "no_llm": {
+                        "type": "boolean",
+                        "description": "Fast pattern-only sweep (skip LLM sources)",
+                        "default": False,
+                    },
+                },
+                "required": ["path"],
+            },
+        },
         "code_review": _pt(
             "Run code review workflow. Provides comprehensive code quality analysis with suggestions for improvement.",
             param_desc="Path to directory or file to review",

--- a/tests/unit/mcp/test_tool_schemas.py
+++ b/tests/unit/mcp/test_tool_schemas.py
@@ -108,6 +108,16 @@ class TestGetWorkflowTools:
         }
         assert expected.issubset(tools.keys())
 
+    def test_discovery_sweep_present_with_required_path(self) -> None:
+        """discovery_sweep is registered and requires only 'path'."""
+        tools = get_workflow_tools()
+        assert "discovery_sweep" in tools
+        schema = tools["discovery_sweep"]["input_schema"]
+        assert schema["required"] == ["path"]
+        props = schema["properties"]
+        assert "budget_usd" in props
+        assert "no_llm" in props
+
     def test_test_generation_has_module_required(self) -> None:
         """test_generation requires 'module' param."""
         schema = get_workflow_tools()["test_generation"]["input_schema"]

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -302,8 +302,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 17, (
-            f"Expected 17 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 18, (
+            f"Expected 18 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -24,15 +24,15 @@ def server():
 
 
 class TestToolRegistration:
-    """Verify all tools are registered (41 core + 5 optional redis plugin)."""
+    """Verify all tools are registered (42 core + 5 optional redis plugin)."""
 
     def test_tools_list_returns_at_least_core_count(self, server: EmpathyMCPServer):
-        """Core tools (41) are always registered; attune-redis adds 5 more."""
+        """Core tools (42) are always registered; attune-redis adds 5 more."""
         tools = server.get_tool_list()
         tool_names = {t["name"] for t in tools}
 
-        # 41 core tools must always be present
-        assert len(tools) >= 41
+        # 42 core tools must always be present
+        assert len(tools) >= 42
 
         # When attune-redis plugin is installed, all 5 redis tools are present
         redis_tools = {
@@ -43,7 +43,7 @@ class TestToolRegistration:
             "redis_memory_store",
         }
         if redis_tools.issubset(tool_names):
-            assert len(tools) == 46, f"Expected 46 tools with redis plugin, got {len(tools)}"
+            assert len(tools) == 47, f"Expected 47 tools with redis plugin, got {len(tools)}"
 
     def test_memory_tools_registered(self, server: EmpathyMCPServer):
         """Test that all memory tools are in the tool list."""


### PR DESCRIPTION
## What

Gives the **discovery-sweep** meta-workflow a user surface. It had zero
access path — reachable only from internal code. Executes the merged
spec [docs/specs/discovery-sweep-access/](https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/specs/discovery-sweep-access) (#1074).

## Changes

- **MCP tool** `discovery_sweep` — required `path`, optional `budget_usd`
  (default 10.0) and `no_llm` (pattern-only fast path).
- **Handler** `_run_discovery_sweep` — forces `output_format="json"` and
  reads the three buckets from `result.metadata["sweep"]` (a
  `SweepResult` dataclass). It deliberately does **not** use
  `_workflow_response`: the workflow renders `final_output` as a JSON
  *string*, so the generic extractor's `isinstance(fo, dict)` branch
  would yield empty buckets (spec risk **R1** — verified, defeated).
- **Skill** `plugin/skills/discovery-sweep/SKILL.md` — thin, disambiguated
  triggers ("run all audits", "what should I fix", "triage findings");
  synced to `.agents/skills/`; referenced in attune-hub routing + Skills
  Reference.
- **Counts** — 41 to 42 MCP tools, 17 to 18 skills (README, plugin/README,
  and the two count tests). CHANGELOG `Added` entry.

## Verification

- Functional smoke (worktree PYTHONPATH): schema `required == ["path"]`,
  dispatch registered (42 handlers), path traversal rejected, and a
  crafted file produces a real **queue** (eval-call to high) + **rejected**
  (TODO to low) — buckets populate, R1 defeated.
- `pytest` of the two count suites + reference-validation + sync suites
  → **128 passed, 3 skipped**.
- Full `tests/unit/mcp/` → 341 passed (1 unrelated *live* network test
  fails 401 on keyless local env).
- Pinned black + ruff clean; all pre-commit hooks passed.

## Out of scope (follow-up)

- Pre-existing count drift in `docs/**`, `plugin/help/generated/**`, and
  `docs/pitch/` (spec risk R3, noted as follow-up). Not touched.
- Pre-existing description drift between `plugin/skills/` and
  `.agents/skills/` for 8 unrelated skills (not caught by any test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
