### PR TITLE
chore(skills): re-sync .agents/skills descriptions from plugin sources

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: attune-hub
-description: "Developer workflow hub — routes to the right skill based on what you need. Triggers on: attune, help me, what can you do, workflows, setup, configure, capabilities."
+description: "Developer workflow hub — routes to the right skill based on what you need. Triggers on: attune, what can attune do, what can you do, capabilities, where do I start, get started."
 ---
 # Attune Hub
 

--- a/.agents/skills/bug-predict/SKILL.md
+++ b/.agents/skills/bug-predict/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bug-predict
-description: "Predict likely bug locations from code patterns and complexity. Triggers on: predict bugs, find bugs, risky code, code risk, what might break, likely bugs."
+description: "Predict likely bug locations from code patterns and complexity. Triggers on: predict bugs, find bugs, risky code, code risk, what might break, likely bugs, bug hotspots."
 ---
 # Bug Prediction
 

--- a/.agents/skills/coach/SKILL.md
+++ b/.agents/skills/coach/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coach
-description: "Progressive help for any topic. Repeat to go deeper: concept -> procedural -> reference. Triggers on: coach, learn, explain, help, tell me more, how does, what is, help with, deeper."
+description: "Progressive help for any topic. Repeat to go deeper: concept -> procedural -> reference. Triggers on: coach, learn, explain, teach me, tell me more, how does, what is, go deeper."
 ---
 # Coach
 

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-quality
-description: "Code review and bug prediction to find quality issues, style violations, and likely bugs. Triggers on: review, quality, code review, analyze, lint, bugs, predict, code smell."
+description: "Code review to find quality issues, style violations, and code smells. Triggers on: review, code review, quality, lint, code smell, analyze code."
 ---
 # Code Quality
 

--- a/.agents/skills/memory-and-context/SKILL.md
+++ b/.agents/skills/memory-and-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-and-context
-description: "Store, retrieve, search, and manage persistent memory across sessions. Triggers on: memory, store, remember, retrieve, forget, pattern, context."
+description: "Store, retrieve, search, and manage persistent memory across sessions. Triggers on: store memory, save this, retrieve, forget, manage memory, context, pattern."
 ---
 # Memory and Context
 

--- a/.agents/skills/rag-code-gen/SKILL.md
+++ b/.agents/skills/rag-code-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rag-code-gen
-description: "RAG-grounded code generation with source citations. Triggers on: grounded code, ground this, cite sources, show me with sources, how do I with attune, reference attune docs, verify against attune."
+description: "RAG-grounded code generation with source citations. Triggers on: grounded code, ground this, cite sources, show me with sources, how do I with attune, reference attune docs, grounded against attune docs."
 ---
 # RAG-grounded code generation
 

--- a/.agents/skills/refactor-plan/SKILL.md
+++ b/.agents/skills/refactor-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor-plan
-description: "Code-level refactoring analysis and roadmap. Detects smells, duplication, complexity. Triggers on: refactor, tech debt, simplify, code smell, clean up, modularize, DRY."
+description: "Code-level refactoring analysis and roadmap. Detects duplication and complexity. Triggers on: refactor, tech debt, simplify, clean up, modularize, DRY, restructure."
 ---
 # Refactor Planning
 

--- a/.agents/skills/workflow-orchestration/SKILL.md
+++ b/.agents/skills/workflow-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-orchestration
-description: "Run analysis workflows — security, code review, tests, perf, bugs, docs, release. Triggers on: workflow, run, execute, analyze, security, review, test, perf, release, bugs, docs, audit."
+description: "Run several analysis workflows together in one sweep. Triggers on: run all workflows, run multiple workflows, full analysis sweep, workflow orchestration."
 ---
 # Workflow Orchestration
 


### PR DESCRIPTION
## What

Re-runs `scripts/sync_agents_skills.py` to regenerate the
agentskills.io copies under `.agents/skills/`. Eight skills had
frontmatter `description:` fields that had drifted from their
`plugin/skills/` sources because the sync was not re-run after the
plugin descriptions were edited.

## Files changed (8, description-frontmatter only)

- `attune-hub`
- `bug-predict`
- `coach`
- `code-quality`
- `memory-and-context`
- `rag-code-gen`
- `refactor-plan`
- `workflow-orchestration`

Each diff is a single `description:` line. Skill bodies are unchanged.

## Why it accumulated

`tests/unit/plugins/test_sync_agents_skills.py` only compares the
**body** after the frontmatter and the **dir set** — not the
description frontmatter — so this drift was never caught.

## Verification

- `python3 scripts/sync_agents_skills.py --check` → 17 ok, 0 failed
- `pytest tests/unit/plugins/test_sync_agents_skills.py` → 32 passed
- Each `.agents/skills/*/SKILL.md` `description:` now equals its
  `plugin/skills/` source.

## Follow-up (separate PR)

Consider strengthening the sync test to also compare the (stripped)
frontmatter so this can't drift silently again. Kept out of this PR
to keep it a clean, mechanical re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
