### PR TITLE
test(skills): guard against frontmatter drift in agents-skills sync

### DIFF
--- a/tests/unit/plugins/test_sync_agents_skills.py
+++ b/tests/unit/plugins/test_sync_agents_skills.py
@@ -400,6 +400,24 @@ class TestAgentSkillsIntegration:
                 f"Run: python scripts/sync_agents_skills.py"
             )
 
+    def test_frontmatter_in_sync(self) -> None:
+        """Test .agents/ SKILL.md matches sync output exactly.
+
+        ``sync_one`` in check mode compares the full generated
+        file (frontmatter *and* body) byte-for-byte. This guards
+        against frontmatter drift -- e.g. a ``description`` edited
+        in plugin/skills/ but never re-synced -- which the
+        body-only and dir-set checks above do not catch.
+        """
+        for skill_dir in PLUGIN_SKILLS.iterdir():
+            if not skill_dir.is_dir():
+                continue
+            plugin_file = skill_dir / "SKILL.md"
+            if not plugin_file.exists():
+                continue
+            ok, msg = sync_one(plugin_file, AGENTS_SKILLS, check=True)
+            assert ok, f"{msg}. Run: python scripts/sync_agents_skills.py"
+
     def test_no_claude_code_fields_in_agents(self) -> None:
         """Test .agents/ skills have no Claude Code fields."""
         for skill_dir in AGENTS_SKILLS.iterdir():


### PR DESCRIPTION
## What

Adds `test_frontmatter_in_sync` to `TestAgentSkillsIntegration`. It
runs each `plugin/skills/` source through `sync_one(..., check=True)`,
which compares the **full** generated file (frontmatter *and* body)
byte-for-byte against the `.agents/skills/` copy.

## Why

The existing integration checks only compare the **body** after the
frontmatter and the **dir set** — never the frontmatter itself. That
gap let `description:` edits in `plugin/skills/` drift silently into
`.agents/skills/` (the drift fixed in #1078). This guard fails CI on
any such drift, across all allowed frontmatter fields, not just
description.

## Verification

- 33 passed (was 32) against current `main`.
- Negative check: temporarily mutating a `.agents/skills/*/SKILL.md`
  makes the new test fail with `coach: out of sync`; restoring it
  passes again.

Follow-up to #1078 (the mechanical re-sync). This PR adds only the
regression guard; one file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
