### PR TITLE
test(resilience): widen concurrent-timeout test margin to de-flake CI

### DIFF
--- a/tests/unit/resilience/test_timeout.py
+++ b/tests/unit/resilience/test_timeout.py
@@ -432,9 +432,16 @@ class TestTimeoutEdgeCases:
 
     @pytest.mark.asyncio
     async def test_concurrent_timeout_calls(self):
-        """Test concurrent calls with timeouts."""
+        """Test concurrent calls with timeouts.
 
-        @timeout(0.2)
+        The timeout budget is kept well above the work duration
+        (1.0s vs 0.05s) so this stays green on contended CI
+        runners, where event-loop starvation under xdist can push
+        a tight 0.2s budget past its limit (a timing flake, not a
+        real timeout). See clock-tz lane flake, 2026-06-25.
+        """
+
+        @timeout(1.0)
         async def slow_func(value):
             await asyncio.sleep(0.05)
             return value


### PR DESCRIPTION
## What

Widens the `@timeout` budget in
`tests/unit/resilience/test_timeout.py::TestTimeoutEdgeCases::test_concurrent_timeout_calls`
from `0.2s` to `1.0s` (still 20× the 0.05s of work the test does).

## Why

The test runs 3 concurrent coroutines, each `await asyncio.sleep(0.05)`,
under a tight `0.2s` timeout. On contended CI runners (full suite under
xdist) event-loop starvation can push the 0.05s work past the 0.2s
wall-clock budget, raising a spurious `TimeoutError` — a timing flake,
not a real timeout.

Observed 2026-06-25 on the `clock-tz (Pacific/Kiritimati)` lane of an
unrelated PR (#1080). The test has nothing to do with timezones, and
that PR's diff never touched `resilience/`; the lane simply runs the
whole suite under an exotic TZ and happened to hit the flake.

## What it does NOT change

The assertion is unchanged — all three concurrent calls must still
complete and return their values. Only the wall-clock margin is widened.

## Verification

`pytest tests/unit/resilience/test_timeout.py` → 34 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
