### PR TITLE
fix(ci-runner-hang): spawn-based scanner Pool + process-fd hang probe

### DIFF
--- a/docs/specs/ci-runner-hang/evidence/run-28188352287/hang-controller.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-28188352287/hang-controller.txt
@@ -1,0 +1,46 @@
+Timeout (0:10:00)!
+Thread 0x00007f4d1ffff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f4d2d8fd6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f4d2e8fe6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f4d2f8ff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f4d3bdf7b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 331 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/queue.py", line 180 in get
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/xdist/dsession.py", line 154 in loop_once
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/xdist/dsession.py", line 138 in pytest_runtestloop
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 384 in _main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 330 in wrap_session
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/main.py", line 377 in pytest_cmdline_main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 121 in _multicall
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 120 in _hookexec
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_hooks.py", line 512 in __call__
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 229 in _main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 253 in _console_main
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/bin/pytest", line 6 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-28188352287/hang-gw0.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-28188352287/hang-gw0.txt
@@ -1,0 +1,16 @@
+Timeout (0:10:00)!
+Thread 0x00007f982abff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007f982c498b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-28188352287/hang-gw1.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-28188352287/hang-gw1.txt
@@ -1,0 +1,16 @@
+Timeout (0:10:00)!
+Thread 0x00007ff84a9ff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007ff84c246b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/evidence/run-28188352287/hang-gw2.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-28188352287/hang-gw2.txt
@@ -1,0 +1,16 @@
+Timeout (0:10:00)!
+Thread 0x00007faf3efff6c0 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 534 in read
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 567 in from_io
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1160 in _thread_receiver
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 341 in run
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00007faf40841b80 (most recent call first):
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 327 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/threading.py", line 629 in wait
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 385 in integrate_as_primary_thread
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1273 in serve
+  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/execnet/gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/phase2-findings.md
+++ b/docs/specs/ci-runner-hang/phase2-findings.md
@@ -300,3 +300,76 @@ sys.modules flake (the right fix was removing the `clear()`). The
 heartbeat thread remains only a (weakened) suspect for the H4
 finalize-wedge above, still gated on N>1 dumps — do not let the
 sys.modules symptom revive it.
+
+---
+
+## Phase 2 update — 3rd capture, heartbeat exonerated, spawn fix + FD probe (2026-06-25)
+
+A third hang was captured on the `coverage` lane of PR #1081 (run
+`28188352287`, a trivial test-only PR). Dumps saved under
+`evidence/run-28188352287/`.
+
+### The signature is now confirmed and stable across 3 captures
+
+All of `run-27541609728`, `run-27615182285`, and `run-28188352287`
+show the identical end-of-session shape:
+
+- **Controller:** wedged in `xdist/dsession.py loop_once -> queue.get()`
+  (waiting on a worker event that never arrives); its N `_thread_receiver`
+  threads all blocked in `execnet ... read`.
+- **Workers:** every worker idle in `execnet ... serve()`
+  (`integrate_as_primary_thread`) with **no test frame and no Pool
+  frame** — i.e. they finished their assigned tests and returned to the
+  execnet idle loop. Linux-only.
+
+### The leaked heartbeat thread is exonerated as the cause
+
+The `cross_session` heartbeat daemon thread (the prior "prime suspect")
+appears in **only the oldest** capture (`run-27541609728`,
+`coordinator.py:289 _heartbeat_loop`). The autouse
+`_stop_leaked_heartbeat_threads` fixture shipped in **#914**
+(2026-06-15); the two captures *after* it (06-16 and 06-25) contain
+**no** heartbeat thread, yet the **identical** hang recurs. It is also
+`daemon=True`, so it cannot block worker/process exit regardless.
+Conclusion: not the cause. Do not revive it (see the sys.modules note
+above for the prior near-miss).
+
+### The signature matches a previously-fixed bug class (#930)
+
+`tests.yml`'s coverage step documents the same shape, root-caused in
+**#930**: *a fork-based `multiprocessing.Pool` inside an xdist worker
+leaked the execnet socket fd, deadlocking the controller at ~99%;
+Linux-only because macOS uses spawn.* An orphan fork/Pool child holding
+a **dup** of a worker's execnet socket keeps the controller from ever
+seeing EOF — and such a child is **invisible to faulthandler** (it
+dumps only the controller + named workers), which is exactly why the
+workers look idle with nothing pending.
+
+#930's fix was a **threshold guard** (`_PARALLEL_MIN_FILES=50`) that
+only *narrows* the window — it left
+`scanner_parallel.py` building its Pool with the Linux-default **fork**.
+
+### Actions taken this PR
+
+1. **`scanner_parallel.py` -> `mp.get_context("spawn").Pool(...)`** —
+   removes the fork-fd-inheritance hazard outright (macOS already does
+   this). Verified a real 55-file parallel scan works under spawn.
+   Regression test `test_large_scan_uses_a_spawn_pool` pins
+   `get_context("spawn")`.
+2. **Process-state probe** added to the conftest hang-watchdog: at the
+   same threshold it writes `hang-dumps/hang-<worker>-proc.txt` with the
+   global `ps` tree (cmdlines name a leaking child) and, on the
+   controller, a socket-inode -> pid map (a worker's execnet inode held
+   by an unexpected pid is the leaked fd). The captured hangs release
+   the GIL (`queue.get` / socket `read`), so a Python timer fires.
+
+### Caveat / why the probe still matters
+
+The scanner Pool is **mocked in its unit tests** and `subprocess` calls
+are `close_fds`-safe by default, so static analysis does **not** confirm
+the scanner is the live trigger inside the coverage suite. The spawn fix
+closes the one *known* fork hazard; the probe is what will **name the
+actual orphan** on the next hang if a different fork/Pool path is
+responsible. Tar-pit guard: if the next captured `*-proc.txt` shows no
+leaked socket dup, the cause is genuinely xdist/execnet-internal and the
+spec should go `monitoring` rather than chase further.

--- a/src/attune/project_index/scanner_parallel.py
+++ b/src/attune/project_index/scanner_parallel.py
@@ -216,7 +216,16 @@ class ParallelProjectScanner(ProjectScanner):
         # Process files in parallel
         records: list[FileRecord] = []
 
-        with mp.Pool(processes=self.workers) as pool:
+        # Force the 'spawn' start method. 'fork' (the Linux default) makes
+        # each Pool child inherit a copy of every parent fd -- including the
+        # xdist worker's execnet socket -- and a lingering child holding that
+        # dup kept the controller from ever seeing the worker exit, wedging
+        # CI at ~99% (scanner-pool-fork-hang / ci-runner-hang spec). The
+        # _PARALLEL_MIN_FILES guard alone only narrows the window; 'spawn'
+        # starts clean children with no inherited fds and removes the hazard
+        # outright (macOS already defaults to spawn -- which is why the hang
+        # was Linux-only).
+        with mp.get_context("spawn").Pool(processes=self.workers) as pool:
             # Map file paths to string for pickling
             file_path_strs = [str(f) for f in all_files]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,102 @@ if os.environ.get("CI"):
         # but safe.
         faulthandler.dump_traceback_later(_hang_secs, repeat=False)
 
+    # -------------------------------------------------------------------------
+    # ci-runner-hang Phase 2: process-tree + open-socket-fd probe.
+    # -------------------------------------------------------------------------
+    # The faulthandler dump above names the wedged *threads*, but the three
+    # captured hangs all show the controller idle in xdist loop_once with
+    # every worker idle in execnet serve() and NO test/Pool frame — the
+    # signature of an orphan child process (a fork/Pool child or subprocess)
+    # holding a *dup* of a worker's execnet socket fd, so the controller
+    # never sees EOF. That child is invisible to faulthandler (it dumps only
+    # the controller + named xdist workers). This probe names it: the global
+    # process tree (ps cmdlines reveal the culprit) plus, on the controller,
+    # a socket-inode -> pid map (a worker's execnet inode also held by an
+    # unexpected pid is the leaked fd). Daemon timer at the same threshold;
+    # the captured hangs release the GIL (queue.get / socket read) so a
+    # Python timer fires. Best-effort and self-contained — a failure here
+    # must never affect collection or a healthy run.
+    import threading as _threading
+
+    def _dump_process_state() -> None:
+        out: list[str] = [
+            f"# ci-runner-hang process-state probe "
+            f"(worker={_hang_worker} pid={os.getpid()} ppid={os.getppid()})",
+        ]
+        # This process's own open socket fds (Linux /proc).
+        try:
+            self_fd = Path("/proc/self/fd")
+            if self_fd.is_dir():
+                out.append("## own socket fds")
+                socks = []
+                for fd in sorted(self_fd.iterdir(), key=lambda p: p.name):
+                    try:
+                        target = os.readlink(str(fd))
+                    except OSError:
+                        continue
+                    if "socket:" in target:
+                        socks.append(f"  fd {fd.name} -> {target}")
+                out.extend(socks or ["  (none)"])
+        except Exception as exc:  # noqa: BLE001
+            out.append(f"## own socket fds unavailable: {exc!r}")
+        # Controller only: socket-inode -> pid map across all processes, so a
+        # leaked dup (same inode held by an unexpected pid) is visible.
+        if _hang_worker == "controller":
+            try:
+                out.append("## socket-inode -> pid map (all /proc)")
+                for proc in sorted(Path("/proc").glob("[0-9]*")):
+                    pid_s = proc.name
+                    try:
+                        cmd = (
+                            (proc / "cmdline")
+                            .read_bytes()
+                            .replace(b"\x00", b" ")
+                            .decode("utf-8", "replace")
+                            .strip()
+                        )
+                        inodes = []
+                        for fd in (proc / "fd").iterdir():
+                            try:
+                                t = os.readlink(str(fd))
+                            except OSError:
+                                continue
+                            if "socket:" in t:
+                                inodes.append(t)
+                        if inodes:
+                            out.append(f"  pid {pid_s} [{cmd[:120]}]")
+                            out.extend(f"    {i}" for i in sorted(inodes))
+                    except (OSError, ValueError):
+                        continue
+            except Exception as exc:  # noqa: BLE001
+                out.append(f"## inode map unavailable: {exc!r}")
+        # Cross-platform fallback / cmdline + ppid + etime view.
+        try:
+            import subprocess
+
+            ps = subprocess.run(
+                ["ps", "-ww", "-eo", "pid,ppid,pgid,stat,etime,args"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            out.append("## ps tree")
+            out.append(ps.stdout or ps.stderr or "(no ps output)")
+        except Exception as exc:  # noqa: BLE001
+            out.append(f"## ps unavailable: {exc!r}")
+        try:
+            (_hang_dir / f"hang-{_hang_worker}-proc.txt").write_text("\n".join(out))
+        except OSError:
+            pass  # diagnostic only
+
+    try:
+        _proc_timer = _threading.Timer(_hang_secs, _dump_process_state)
+        _proc_timer.daemon = True
+        _proc_timer.start()
+    except Exception:  # noqa: BLE001
+        pass  # never break a run on a diagnostic
+
 # =============================================================================
 # Import Guard - Ensure workflows package is properly initialized
 # =============================================================================

--- a/tests/unit/project_index/test_scanner_parallel.py
+++ b/tests/unit/project_index/test_scanner_parallel.py
@@ -22,7 +22,11 @@ from attune.project_index.scanner_parallel import (
     ParallelProjectScanner,
 )
 
-POOL = "attune.project_index.scanner_parallel.mp.Pool"
+# The scanner builds its Pool via ``mp.get_context("spawn").Pool`` (spawn,
+# not fork — see scanner_parallel.py's fork-fd-leak note), so the parallel
+# path is observed by patching ``mp.get_context``: ``.return_value.Pool`` is
+# the Pool factory.
+GET_CONTEXT = "attune.project_index.scanner_parallel.mp.get_context"
 
 
 def _make_py_files(tmp_path, count: int) -> None:
@@ -37,36 +41,42 @@ class TestParallelMinFilesGuard:
     def test_empty_scan_does_not_fork_a_pool(self, tmp_path):
         """0 files (the CI hang scenario) must stay sequential — no Pool."""
         scanner = ParallelProjectScanner(str(tmp_path), workers=4)
-        with patch(POOL) as pool_ctor:
+        with patch(GET_CONTEXT) as get_ctx:
             scanner.scan(analyze_dependencies=False)
-        pool_ctor.assert_not_called()
+        get_ctx.assert_not_called()
 
     def test_small_scan_does_not_fork_a_pool(self, tmp_path):
         """A handful of files (< threshold) must stay sequential — no Pool."""
         _make_py_files(tmp_path, 3)
         scanner = ParallelProjectScanner(str(tmp_path), workers=4)
-        with patch(POOL) as pool_ctor:
+        with patch(GET_CONTEXT) as get_ctx:
             records, summary = scanner.scan(analyze_dependencies=False)
-        pool_ctor.assert_not_called()
+        get_ctx.assert_not_called()
         # The sequential fallback still produces records.
         assert summary.total_files == 3
         assert len(records) == 3
 
-    def test_large_scan_uses_a_pool(self, tmp_path):
-        """At/above the threshold the parallel path is taken (Pool created)."""
+    def test_large_scan_uses_a_spawn_pool(self, tmp_path):
+        """At/above the threshold the parallel path is taken via a SPAWN Pool.
+
+        Pins the fork-fd-leak fix (ci-runner-hang): the Pool must be built
+        from the ``spawn`` context, never the Linux-default ``fork``.
+        """
         _make_py_files(tmp_path, _PARALLEL_MIN_FILES + 5)
         scanner = ParallelProjectScanner(str(tmp_path), workers=2)
-        with patch(POOL) as pool_ctor:
+        with patch(GET_CONTEXT) as get_ctx:
             # Keep the test itself fork-free: the patched Pool's context
             # manager returns no records.
+            pool_ctor = get_ctx.return_value.Pool
             pool_ctor.return_value.__enter__.return_value.map.return_value = []
             scanner.scan(analyze_dependencies=False)
+        get_ctx.assert_called_once_with("spawn")
         pool_ctor.assert_called_once()
 
     def test_single_worker_never_forks(self, tmp_path):
         """workers=1 is sequential regardless of file count."""
         _make_py_files(tmp_path, _PARALLEL_MIN_FILES + 5)
         scanner = ParallelProjectScanner(str(tmp_path), workers=1)
-        with patch(POOL) as pool_ctor:
+        with patch(GET_CONTEXT) as get_ctx:
             scanner.scan(analyze_dependencies=False)
-        pool_ctor.assert_not_called()
+        get_ctx.assert_not_called()

--- a/tests/unit/project_index/test_scanner_parallel.py
+++ b/tests/unit/project_index/test_scanner_parallel.py
@@ -80,3 +80,28 @@ class TestParallelMinFilesGuard:
         with patch(GET_CONTEXT) as get_ctx:
             scanner.scan(analyze_dependencies=False)
         get_ctx.assert_not_called()
+
+
+class TestRealSpawnPool:
+    """Exercise the REAL (unmocked) spawn Pool end-to-end.
+
+    The guard tests above mock ``mp.get_context`` and only pin the
+    *intent* (spawn is requested). This test actually spins up the
+    process Pool so CI executes the spawn path on every run: it proves
+    the worker target and its ``partial`` args are picklable, that the
+    spawned children re-import cleanly, and that records come back —
+    breakage a mock can't catch (e.g. an unpicklable arg added later).
+    It also confirms the parallel scan does not itself wedge. See the
+    ci-runner-hang spec: ``fork`` here once leaked the execnet socket
+    fd; ``spawn`` must work AND not hang.
+    """
+
+    def test_large_scan_runs_real_spawn_pool(self, tmp_path):
+        """A >=threshold scan completes via a real spawn Pool with records."""
+        n = _PARALLEL_MIN_FILES + 5
+        _make_py_files(tmp_path, n)
+        scanner = ParallelProjectScanner(str(tmp_path), workers=2)
+        # No patching: this forks/spawns a genuine multiprocessing.Pool.
+        records, summary = scanner.scan(analyze_dependencies=False)
+        assert summary.total_files == n
+        assert len(records) == n


### PR DESCRIPTION
## Summary

Phase 2 of the **ci-runner-hang** spec. A 3rd hang capture (the
`coverage` lane of #1081 — a one-line test PR) confirms a stable,
repeatable signature and lets us **exonerate the prior prime suspect**
and ship a real fix for the most likely cause.

## What the three captures show

`run-27541609728`, `run-27615182285`, `run-28188352287` all share one
end-of-session shape:

- **Controller** wedged in `xdist/dsession.py loop_once → queue.get()`,
  receiver threads blocked in `execnet … read`.
- **Workers** all idle in `execnet … serve()` — finished their tests,
  no test/Pool frame. **Linux-only.**

## Heartbeat thread: exonerated

The leaked `cross_session` heartbeat daemon appears only in the
**oldest** capture. The cleanup fixture shipped in #914 (2026-06-15);
both captures *after* it show **no** heartbeat thread, yet the identical
hang recurs — and it's `daemon=True`, so it can't block exit anyway.

## Likely cause + fix

The signature matches the fork-`Pool` execnet-fd-leak class root-caused
in **#930**. That fix only added a *file-count threshold guard* and left
`scanner_parallel.py` building its Pool with the Linux-default **fork**.
An orphan fork child holding a **dup** of a worker's execnet socket
keeps the controller from ever seeing EOF — and is invisible to
faulthandler (it dumps only the controller + named workers), which is
exactly why the workers look idle with nothing pending.

- **`scanner_parallel.py`** now builds the Pool from
  `mp.get_context("spawn")` — children inherit no fds (macOS already
  does this → why the hang was Linux-only). Verified a real 55-file
  parallel scan works under spawn.
- **`test_scanner_parallel.py`** patches `mp.get_context`; new
  `test_large_scan_uses_a_spawn_pool` pins the spawn start method.

## Diagnostic for the next hang

The scanner Pool is **mocked** in its tests and `subprocess` is
`close_fds`-safe, so static analysis can't confirm the scanner is the
*live* trigger in the coverage suite. So this also adds a **process-state
probe** to the conftest hang-watchdog: at the same threshold it writes
`hang-dumps/hang-<worker>-proc.txt` with the `ps` tree (cmdlines name a
leaking child) and, on the controller, a **socket-inode → pid map** (a
worker's execnet inode held by an unexpected pid = the leaked fd). The
captured hangs release the GIL (`queue.get`/socket `read`), so a Python
timer fires. It rides the existing `hang-dumps/*.txt` upload.

If the next `*-proc.txt` shows no leaked socket dup, the cause is
xdist/execnet-internal and the spec should go `monitoring` (tar-pit
guard).

## Verification

- `pytest tests/unit/project_index/test_scanner_parallel.py` → 4 passed
- Real 55-file spawn scan → 55 records, no hang
- Probe smoke (1s threshold, sleeping test) → writes `hang-*-proc.txt`
- black + ruff clean on all edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
