### PR TITLE
feat(skills): surface personal-memory + image-analysis (orphan tools)

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -100,6 +100,8 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | verify | verify docs, fact-check, did the model hallucinate, check generated content |
 | bulk | batch, bulk process, 50% savings, overnight analysis |
 | catalog | catalog, list capabilities, browse, what can attune do |
+| personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
+| image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
 
 ## MCP Server Not Running
 

--- a/.agents/skills/image-analysis/SKILL.md
+++ b/.agents/skills/image-analysis/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: image-analysis
+description: "Analyze an image — screenshot, diagram, UI mockup, or chart — with Claude's vision. Triggers on: analyze this image, look at this screenshot, what's in this diagram, read this mockup, describe this picture, analyze image."
+---
+# Image Analysis
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="image-analysis", mode="preamble")` and
+display the returned `preamble` text as a blockquote. Then tell the
+user they can say "tell me more" for a step-by-step guide, or answer
+the scoping question below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Image Analysis** — Sends an image (screenshot, diagram, UI
+> mockup, chart) to Claude's vision model and returns a description
+> or answers a question about it. Supports PNG, JPEG, GIF, and WebP.
+
+## Scoping
+
+Before running, ask:
+
+1. **Image path**: "Which image file should I analyze?"
+2. **Focus** (optional): "Anything specific to look for, or a general
+   description?"
+
+## Execution
+
+Call the `analyze_image` MCP tool:
+
+**Parameters:**
+
+- **image_path** (required): Path to the image file (PNG, JPEG, GIF,
+  or WebP).
+- **prompt** (optional): A specific question or instruction. Omit for
+  a general description.
+
+```python
+analyze_image(image_path="docs/architecture.png")
+
+analyze_image(
+    image_path="screenshot.png",
+    prompt="What error is shown in this dialog?",
+)
+```
+
+## Output
+
+Present the model's analysis as readable prose. When the user asked a
+specific question, lead with the direct answer, then supporting
+detail.
+
+## When to Use
+
+- Reading text or errors out of a screenshot.
+- Describing or critiquing a UI mockup or diagram.
+- Extracting structure from a chart or whiteboard photo.
+
+## Anti-Patterns
+
+- DO NOT use for non-image files — this is vision-only (PNG/JPEG/
+  GIF/WebP).
+- DO NOT pass a URL — the tool reads a local file path.

--- a/.agents/skills/personal-memory/SKILL.md
+++ b/.agents/skills/personal-memory/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: personal-memory
+description: "Capture and recall curated cross-session personal memory — decisions, preferences, findings by topic. Triggers on: remember this for me, capture this decision, save to personal memory, my saved topics, forget topic, personal memory."
+---
+# Personal Memory
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="personal-memory", mode="preamble")` and
+display the returned `preamble` text as a blockquote. Then tell the
+user they can say "tell me more" for a step-by-step guide, or answer
+the scoping question below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Personal Memory** — Deliberately capture and recall curated
+> cross-session knowledge — decisions, preferences, and findings —
+> organized by topic so it persists across projects and sessions.
+
+## How this differs from the other memory skills
+
+attune has three memory surfaces; pick the right one:
+
+| You want to… | Use |
+|--------------|-----|
+| Deliberately save a decision/preference/finding to recall later, by topic | **this skill** (`personal_memory_*`) |
+| Store a classified or cross-agent *pattern* in project memory | `memory-and-context` (`memory_*`) |
+| Pull findings auto-stashed from past sessions + the lessons corpus | `recall` (`session_stash`) |
+
+This skill is the curated, intentional store: content is polished and
+filed under a `topic` (and optional `kind`), not auto-captured.
+
+## Scoping
+
+Before running, ask which operation the user needs:
+
+1. **Operation**: "Capture something, recall by query, list your
+   topics, or forget a topic?"
+2. For **capture**: "What topic should it live under, and is this
+   global or project-local?"
+3. For **recall**: "What should I search for?"
+
+## Execution
+
+Call the matching MCP tool:
+
+### personal_memory_capture
+
+Save a decision, pattern, finding, or reference to personal memory.
+
+**Parameters:**
+
+- **topic** (required): The topic to file this under.
+- **content** (required): The text to store (it is polished before
+  storage).
+- **kind** (optional): A sub-category within the topic (e.g.
+  `decision`, `preference`, `reference`).
+- **project_local** (optional, boolean): Store only for the current
+  project instead of globally. Default is global.
+
+```python
+personal_memory_capture(
+    topic="release-process",
+    content="Always verify the merge SHA contains the version bump before tagging.",
+    kind="decision",
+)
+```
+
+### personal_memory_recall
+
+Search personal memory with a natural-language query.
+
+**Parameters:**
+
+- **query** (required): What to search for.
+- **k** (optional, integer): Max results to return.
+- **kind_filter** (optional): Restrict to a single `kind`.
+
+```python
+personal_memory_recall(query="how do I tag a release", k=5)
+```
+
+### personal_memory_topics
+
+List every topic currently stored. No parameters.
+
+```python
+personal_memory_topics()
+```
+
+### personal_memory_forget
+
+Delete a topic, or one `kind` within a topic.
+
+**Parameters:**
+
+- **topic** (required): The topic to remove.
+- **kind** (optional): Remove only this kind; omit to remove the
+  whole topic.
+
+```python
+personal_memory_forget(topic="release-process", kind="decision")
+```
+
+## Output
+
+- **capture**: confirm the topic (and kind) it was filed under.
+- **recall**: present hits newest/most-relevant first, annotated with
+  their topic and kind.
+- **topics**: render the topic list, grouped if kinds are present.
+- **forget**: confirm exactly what was removed.
+
+## Anti-Patterns
+
+- DO NOT use this for auto-captured session findings — that is the
+  `recall` skill's job.
+- DO NOT use this for classified or cross-agent patterns — use
+  `memory-and-context` (`memory_store` with a classification).
+- DO NOT capture secrets or PII — personal memory is not an encrypted
+  store; use `memory_store(classification="SENSITIVE")` for that.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`personal-memory` + `image-analysis` skills.** Two MCP tool
+  clusters that shipped working but had no model-discoverable skill are
+  now surfaced: `personal-memory` covers the curated cross-session
+  personal store (`personal_memory_capture` / `recall` / `topics` /
+  `forget`), and `image-analysis` covers `analyze_image` (vision over
+  screenshots/diagrams/mockups). This empties the registry-coverage
+  guard's orphan-tool backlog (only CLI-surfaced infra tools remain
+  allowlisted). Brings the count to 22 skills; no new MCP tools (the
+  tools already existed).
+
 - **`bulk` + `catalog` skills + `list_capabilities` MCP tool.** Two
   left-behind skills now ship in the plugin: `bulk` surfaces the
   existing `analyze_batch` tool for 50%-cost batch processing, and

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -102,6 +102,8 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | verify | verify docs, fact-check, did the model hallucinate, check generated content |
 | bulk | batch, bulk process, 50% savings, overnight analysis |
 | catalog | catalog, list capabilities, browse, what can attune do |
+| personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
+| image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
 
 ## MCP Server Not Running
 

--- a/plugin/skills/image-analysis/SKILL.md
+++ b/plugin/skills/image-analysis/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: image-analysis
+description: "Analyze an image — screenshot, diagram, UI mockup, or chart — with Claude's vision. Triggers on: analyze this image, look at this screenshot, what's in this diagram, read this mockup, describe this picture, analyze image."
+argument-hint: "<path to image file>"
+---
+
+# Image Analysis
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="image-analysis", mode="preamble")` and
+display the returned `preamble` text as a blockquote. Then tell the
+user they can say "tell me more" for a step-by-step guide, or answer
+the scoping question below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Image Analysis** — Sends an image (screenshot, diagram, UI
+> mockup, chart) to Claude's vision model and returns a description
+> or answers a question about it. Supports PNG, JPEG, GIF, and WebP.
+
+## Scoping
+
+Before running, ask:
+
+1. **Image path**: "Which image file should I analyze?"
+2. **Focus** (optional): "Anything specific to look for, or a general
+   description?"
+
+## Execution
+
+Call the `analyze_image` MCP tool:
+
+**Parameters:**
+
+- **image_path** (required): Path to the image file (PNG, JPEG, GIF,
+  or WebP).
+- **prompt** (optional): A specific question or instruction. Omit for
+  a general description.
+
+```python
+analyze_image(image_path="docs/architecture.png")
+
+analyze_image(
+    image_path="screenshot.png",
+    prompt="What error is shown in this dialog?",
+)
+```
+
+## Output
+
+Present the model's analysis as readable prose. When the user asked a
+specific question, lead with the direct answer, then supporting
+detail.
+
+## When to Use
+
+- Reading text or errors out of a screenshot.
+- Describing or critiquing a UI mockup or diagram.
+- Extracting structure from a chart or whiteboard photo.
+
+## Anti-Patterns
+
+- DO NOT use for non-image files — this is vision-only (PNG/JPEG/
+  GIF/WebP).
+- DO NOT pass a URL — the tool reads a local file path.

--- a/plugin/skills/personal-memory/SKILL.md
+++ b/plugin/skills/personal-memory/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: personal-memory
+description: "Capture and recall curated cross-session personal memory — decisions, preferences, findings by topic. Triggers on: remember this for me, capture this decision, save to personal memory, my saved topics, forget topic, personal memory."
+argument-hint: "<operation: capture|recall|topics|forget>"
+---
+
+# Personal Memory
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="personal-memory", mode="preamble")` and
+display the returned `preamble` text as a blockquote. Then tell the
+user they can say "tell me more" for a step-by-step guide, or answer
+the scoping question below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Personal Memory** — Deliberately capture and recall curated
+> cross-session knowledge — decisions, preferences, and findings —
+> organized by topic so it persists across projects and sessions.
+
+## How this differs from the other memory skills
+
+attune has three memory surfaces; pick the right one:
+
+| You want to… | Use |
+|--------------|-----|
+| Deliberately save a decision/preference/finding to recall later, by topic | **this skill** (`personal_memory_*`) |
+| Store a classified or cross-agent *pattern* in project memory | `memory-and-context` (`memory_*`) |
+| Pull findings auto-stashed from past sessions + the lessons corpus | `recall` (`session_stash`) |
+
+This skill is the curated, intentional store: content is polished and
+filed under a `topic` (and optional `kind`), not auto-captured.
+
+## Scoping
+
+Before running, ask which operation the user needs:
+
+1. **Operation**: "Capture something, recall by query, list your
+   topics, or forget a topic?"
+2. For **capture**: "What topic should it live under, and is this
+   global or project-local?"
+3. For **recall**: "What should I search for?"
+
+## Execution
+
+Call the matching MCP tool:
+
+### personal_memory_capture
+
+Save a decision, pattern, finding, or reference to personal memory.
+
+**Parameters:**
+
+- **topic** (required): The topic to file this under.
+- **content** (required): The text to store (it is polished before
+  storage).
+- **kind** (optional): A sub-category within the topic (e.g.
+  `decision`, `preference`, `reference`).
+- **project_local** (optional, boolean): Store only for the current
+  project instead of globally. Default is global.
+
+```python
+personal_memory_capture(
+    topic="release-process",
+    content="Always verify the merge SHA contains the version bump before tagging.",
+    kind="decision",
+)
+```
+
+### personal_memory_recall
+
+Search personal memory with a natural-language query.
+
+**Parameters:**
+
+- **query** (required): What to search for.
+- **k** (optional, integer): Max results to return.
+- **kind_filter** (optional): Restrict to a single `kind`.
+
+```python
+personal_memory_recall(query="how do I tag a release", k=5)
+```
+
+### personal_memory_topics
+
+List every topic currently stored. No parameters.
+
+```python
+personal_memory_topics()
+```
+
+### personal_memory_forget
+
+Delete a topic, or one `kind` within a topic.
+
+**Parameters:**
+
+- **topic** (required): The topic to remove.
+- **kind** (optional): Remove only this kind; omit to remove the
+  whole topic.
+
+```python
+personal_memory_forget(topic="release-process", kind="decision")
+```
+
+## Output
+
+- **capture**: confirm the topic (and kind) it was filed under.
+- **recall**: present hits newest/most-relevant first, annotated with
+  their topic and kind.
+- **topics**: render the topic list, grouped if kinds are present.
+- **forget**: confirm exactly what was removed.
+
+## Anti-Patterns
+
+- DO NOT use this for auto-captured session findings — that is the
+  `recall` skill's job.
+- DO NOT use this for classified or cross-agent patterns — use
+  `memory-and-context` (`memory_store` with a classification).
+- DO NOT capture secrets or PII — personal memory is not an encrypted
+  store; use `memory_store(classification="SENSITIVE")` for that.

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -302,8 +302,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 20, (
-            f"Expected 20 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 22, (
+            f"Expected 22 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:

--- a/tests/unit/plugins/test_registry_coverage.py
+++ b/tests/unit/plugins/test_registry_coverage.py
@@ -176,13 +176,9 @@ TOOLS_WITHOUT_SKILL_SURFACE: dict[str, str] = {
     "auth_status": "Utility/infra; surfaced via CLI auth commands, not a skill.",
     "auth_recommend": "Utility/infra; surfaced via CLI auth commands, not a skill.",
     "telemetry_stats": "Utility/infra; surfaced via CLI telemetry commands.",
-    # Additive-access backlog — skills specced/planned, not yet shipped.
-    # (analyze_batch now surfaced by the bulk skill — removed from this list.)
-    "analyze_image": "Pending an image-analysis skill (orphan-tool skills runway).",
-    "personal_memory_capture": "Pending a personal-memory skill (orphan-tool runway).",
-    "personal_memory_recall": "Pending a personal-memory skill (orphan-tool runway).",
-    "personal_memory_topics": "Pending a personal-memory skill (orphan-tool runway).",
-    "personal_memory_forget": "Pending a personal-memory skill (orphan-tool runway).",
+    # The additive-access backlog is now empty: analyze_batch -> bulk skill,
+    # analyze_image -> image-analysis skill, personal_memory_* -> the
+    # personal-memory skill. Only the CLI-surfaced infra tools remain.
 }
 
 


### PR DESCRIPTION
## What

Surfaces two MCP tool clusters that shipped working but had **no
model-discoverable skill** — the natural-language UX never invoked them.
Both were flagged in the registry-coverage guard's allowlist (#1079) as
the "additive-access backlog."

| New skill | Surfaces | Was hidden because |
|-----------|----------|--------------------|
| `personal-memory` | `personal_memory_capture` / `recall` / `topics` / `forget` | no skill named these tools |
| `image-analysis` | `analyze_image` (vision) | no skill named this tool |

## Why these are distinct (not duplicates)

`personal-memory` is the **curated, intentional** cross-session store
(content filed by topic/kind). The skill body includes a table
distinguishing it from the other two memory surfaces:

- `memory-and-context` → `memory_*` (classified / cross-agent project patterns)
- `recall` → `session_stash` (auto-stashed session findings + lessons corpus)
- `personal-memory` → `personal_memory_*` (deliberate personal store) ← new

## Details

- Both follow the discovery-sweep/bulk convention: model-invocable,
  `help_lookup` preamble + fallback, scoping → execution → anti-patterns,
  exact tool params documented.
- Synced to `.agents/` via `scripts/sync_agents_skills.py`.
- Added to the **attune-hub Skills Reference** (router discoverability).
- `TOOLS_WITHOUT_SKILL_SURFACE` backlog **emptied** — only CLI-surfaced
  infra (`auth_*`, `telemetry_stats`) remains allowlisted; the guard's
  stale-entry test enforces the list can't silently grow back.
- Skill count guard 20 → 22. **No new MCP tools** (the tools existed).

## Verification

- `pytest tests/unit/plugins/` → 130 passed, 3 skipped
- `sync_agents_skills.py --check` → 22 ok, 0 failed
- pre-commit (black/ruff/bandit/markdown) clean on all changed files

## Follow-up (separate PR)

Agent templates are absent from `list_capabilities` (the catalog
enumerates workflows/wizards/tools, not agents) — a hidden *registry*.
A follow-up will surface agents in the catalog and extend the
registry-coverage guard with a catalog-completeness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
