### PR TITLE
docs(spec): add interactive-orchestration-access spec

### DIFF
--- a/docs/specs/interactive-orchestration-access/decisions.md
+++ b/docs/specs/interactive-orchestration-access/decisions.md
@@ -1,0 +1,75 @@
+# Decisions: Interactive Orchestration Access
+
+**Status:** draft
+**Requirements:** [requirements.md](requirements.md) ·
+**Design:** [design.md](design.md)
+
+---
+
+## Decision log
+
+### D1 — Scope: both wizards and agents, phased (decided 2026-06-25)
+
+Cover both registries in one spec but sequence delivery: **Phase 1
+wizards**, **Phase 2 agent teams**. Wizards are the simpler, more
+uniform problem (5 of them, a clean guided-Q&A pattern); agent-team
+orchestration is harder and its build/run API is less settled.
+
+**Why:** one spec keeps the "interactive pair" together (they share
+the same root cause and the same "model drives, engine works"
+solution), while phasing avoids blocking the easy win on the hard one.
+
+### D2 — Bridge: Claude-driven skill, not stateful MCP tools
+(decided 2026-06-25)
+
+The model drives the interactive loop via `AskUserQuestion`, holding
+the wizard `context` across conversation turns; the engine exposes a
+thin step-wise API (`list_steps` / `submit_step`) and keeps all step
+logic.
+
+**Why:** the model is already an interactive agent that pauses and
+resumes turn to turn — that IS the pause/collect/resume mechanism, so
+no server-side session store is needed. It is lighter than a
+`start/answer/status/resume` MCP-tool quartet and matches how the
+existing skills work.
+
+**Rejected alternative:** stateful MCP tools holding session state
+server-side. More robust for **non-Claude** agentskills.io consumers,
+but heavier (session lifecycle, expiry, concurrency) and unnecessary
+while the only consumer is Claude. Revisit only if a non-Claude run
+surface becomes a requirement (a Non-Goal here).
+
+---
+
+## Open decisions (resolve during Phase 1)
+
+- **OD1 — `run()` re-use vs parallel path.** Strong preference: refactor
+  `BaseWizard.run()` to loop over the new `submit_step()` so there is a
+  single execution path (kills the drift risk in design.md). Confirm
+  this is feasible for all six `StepType`s before committing.
+- **OD2 — `StepView` shape.** Audit all 5 wizards' declarative `steps`
+  first; `StepView` must express every `question`-step's prompt/options
+  faithfully enough for `AskUserQuestion`, and flag non-question steps
+  as engine-executed. Decide after the audit.
+- **OD3 — skill naming collision.** A `wizard` skill name will exist in
+  both `plugin/skills/` (new, shipped) and `.claude/skills/` (old, dev).
+  Decide whether the dev one is retired or left as-is (per the
+  three-skill-dir lesson, `.claude/skills/` is a separate non-shipped
+  set; likely leave it, but confirm no loader picks both).
+- **OD4 — guard for "runnable".** Extend `test_registry_coverage.py`
+  with a wizard→run-surface check (every `list_wizards()` id named by
+  the `wizard` skill). Mirror for agents in Phase 2.
+
+---
+
+## Cross-references
+
+- Surfaced-but-not-runnable finding + sweep: this session's
+  hidden-functionality audit (catalog completeness shipped in #1088).
+- `.claude/rules/attune/xml-enhanced-prompts.md` — the engine step-API
+  change is implementation work; its tasks use XML-enhanced prompts.
+- `.claude/rules/attune/decision-routine.md` — spec origination path.
+- Engine: `src/attune/wizards/base.py` (`BaseWizard`, `WizardStep`,
+  `StepType`); registry: `src/attune/wizards/registry.py`
+  (`list_wizards`). Agents: `src/attune/orchestration/agent_templates/`
+  (`get_all_templates`), `team_builder.py`, `meta_orchestrator.py`.

--- a/docs/specs/interactive-orchestration-access/decisions.md
+++ b/docs/specs/interactive-orchestration-access/decisions.md
@@ -1,6 +1,6 @@
 # Decisions: Interactive Orchestration Access
 
-**Status:** draft
+**Status:** approved
 **Requirements:** [requirements.md](requirements.md) ·
 **Design:** [design.md](design.md)
 

--- a/docs/specs/interactive-orchestration-access/design.md
+++ b/docs/specs/interactive-orchestration-access/design.md
@@ -1,6 +1,6 @@
 # Design: Interactive Orchestration Access
 
-**Status:** draft
+**Status:** approved
 **Requirements:** [requirements.md](requirements.md) ·
 **Decisions:** [decisions.md](decisions.md)
 

--- a/docs/specs/interactive-orchestration-access/design.md
+++ b/docs/specs/interactive-orchestration-access/design.md
@@ -1,0 +1,122 @@
+# Design: Interactive Orchestration Access
+
+**Status:** draft
+**Requirements:** [requirements.md](requirements.md) ·
+**Decisions:** [decisions.md](decisions.md)
+
+---
+
+## The seam
+
+The wizard engine is already **declarative**:
+
+- `BaseWizard.steps: list[WizardStep]` — an ordered list of step
+  definitions (`src/attune/wizards/base.py`).
+- `StepType` ∈ {`question`, `llm`, `review`, `decompose`, `preview`,
+  `confirm`} — each handled by a private `_run_*_step` coroutine.
+- `async run(initial_context)` — loops the steps, pausing inside
+  `question`/`review`/`confirm` steps to collect input.
+
+The interaction (asking the human) and the work (LLM calls,
+decomposition, building results) are *tangled* inside `run()`. The
+design **splits** them:
+
+- **Engine keeps the work** — every `_run_*_step` stays in the engine.
+- **Skill provides the human I/O** — the model drives the loop,
+  rendering `question` steps via `AskUserQuestion` and feeding answers
+  back to the engine.
+
+This avoids re-implementing step logic in the skill (Goal 3).
+
+---
+
+## Chosen approach: Claude-driven skill + a step-wise engine API
+
+Add a minimal **resumable driver API** to `BaseWizard`, leaving
+`run()` intact for the CLI:
+
+```text
+list_steps() -> list[StepView]
+    # Declarative view of each step: id, type, prompt/options for
+    # `question` steps; for non-question steps, a flag that the engine
+    # will execute it (no human input needed).
+
+submit_step(step_id, answers, context) -> StepOutcome
+    # Engine executes ONE step with the supplied answers (for question
+    # steps) or no answers (for llm/review/etc.), mutates/returns the
+    # running context, and returns either:
+    #   - content to display (llm/review/preview output), or
+    #   - the next step id, or
+    #   - a terminal WizardResult.
+```
+
+`StepView` / `StepOutcome` are small dataclasses; `context` is the
+same dict `run()` threads today, so the two code paths share state
+semantics.
+
+### Flow (the `wizard` skill drives this)
+
+```text
+1. user: "run the debug wizard [on X]"
+2. skill: resolve wizard via list_wizards(); seed initial_context
+3. loop over list_steps():
+     - question step  -> AskUserQuestion(step.prompt, step.options)
+                         -> submit_step(id, answers, context)
+     - other step     -> submit_step(id, {}, context); display content
+   (the SKILL holds `context` across conversation turns — it is the
+    pause/resume mechanism; no server-side session store needed)
+4. render the terminal WizardResult
+```
+
+The model is the natural driver: it already pauses for
+`AskUserQuestion` and resumes on the user's reply, turn to turn. The
+skill file is the script that tells it how.
+
+### Why not stateful MCP tools
+
+A `start/answer/status/resume` MCP-tool quartet holding session state
+server-side also works and would serve non-Claude consumers — but it
+is heavier (server-side session lifecycle, expiry, concurrency) and
+the model would still have to poll it. Since the model is *already* an
+interactive agent, letting it hold `context` and drive
+`AskUserQuestion` is lighter and matches the existing skill model.
+Recorded as the rejected alternative in decisions.md (D2); revisit
+only if a non-Claude surface is required.
+
+---
+
+## Phase 2 (agents) — sketch only
+
+Agent-team access reuses the same "model drives, engine works"
+principle:
+
+- Enumerate templates via `get_all_templates()` (already surfaced in
+  the catalog).
+- An `agent` skill: ask the user the goal → select matching templates
+  (`get_templates_by_capability` / `_by_tier`) → build a team
+  (`TeamBuilder` / meta-orchestrator) → run it → present results.
+
+The exact build/run API (`team_builder.py`, `meta_orchestrator.py`)
+is **not** pinned here — finalize it when Phase 1's seam is proven and
+the engine API has settled.
+
+---
+
+## Guard change (reverse coverage, run-surface)
+
+Today's registry-coverage guard checks "wizard is *listed* in the
+catalog" (catalog-completeness) — not "wizard is *runnable*". Add a
+check that every `list_wizards()` entry is named by a run-surface skill
+(the `wizard` skill), mirroring the existing tool→skill check. Same for
+agents in Phase 2. This is what stops the gap from silently returning.
+
+---
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Engine `run()` and `submit_step()` drift (two code paths) | medium | `submit_step` is the unit `run()` calls per step; refactor `run()` to loop over `submit_step` so there is ONE execution path. |
+| A wizard step type needs mid-step human input the StepView can't express | medium | Phase-1 audit of all 5 wizards' step definitions before finalizing `StepView`; cover every `StepType` in tests. |
+| Model mis-drives the loop (skips/reorders steps) | low | The skill script is explicit and step-gated; `submit_step` returns the authoritative next step id rather than trusting the model to sequence. |
+| Phase-2 team API shifts under the sketch | low | Phase 2 design deferred until Phase 1 lands. |

--- a/docs/specs/interactive-orchestration-access/requirements.md
+++ b/docs/specs/interactive-orchestration-access/requirements.md
@@ -1,6 +1,7 @@
 # Requirements: Interactive Orchestration Access
 
-**Status:** draft
+**Status:** approved
+
 **Created:** 2026-06-25
 **Owner:** Patrick + agent
 

--- a/docs/specs/interactive-orchestration-access/requirements.md
+++ b/docs/specs/interactive-orchestration-access/requirements.md
@@ -1,0 +1,123 @@
+# Requirements: Interactive Orchestration Access
+
+**Status:** draft
+**Created:** 2026-06-25
+**Owner:** Patrick + agent
+
+---
+
+## Problem
+
+attune ships two capability registries that a shipped-plugin user can
+now **see but cannot run**:
+
+- **Wizards** (5: `debug`, `refactor`, `release-prep`, `security`,
+  `test-gen`) — guided multi-step flows.
+- **Agent templates** (14) — reusable agent archetypes for
+  multi-agent teams.
+
+Since #1088 both registries are enumerated by `list_capabilities`
+(the `catalog` skill), so they are *discoverable*. But there is **no
+shipped invocation surface**: no `plugin/skills/` skill names them, no
+MCP tool runs them, and there is no `attune wizard` / `attune agent`
+CLI subcommand. They are runnable only from the repo's own dev-time
+`.claude/skills/{wizard,agent}`, which are **not** part of the
+distributed plugin.
+
+### Why they were left out (not an oversight)
+
+Wizards/agents run on an **interactive** engine: `BaseWizard.run()`
+loops over declarative `steps` (`StepType` = question / llm / review /
+decompose / preview / confirm), pausing to collect human answers
+mid-flow. A single-shot MCP tool cannot drive pause → collect →
+resume, so the existing "thin MCP tool" surfacing pattern (used for
+workflows) does not fit. Surfacing them needs a **Claude-driven
+bridge**, which is more design than a mechanical wrapper — hence the
+deferral. (The CHANGELOG referenced an "interactive-orchestration-
+access spec" that did not yet exist; this is that spec.)
+
+---
+
+## Goals
+
+1. A shipped-plugin user can **run** any registered wizard through the
+   natural-language surface, answering its steps conversationally.
+2. A shipped-plugin user can **create and run** an agent team from the
+   builtin templates through the natural-language surface.
+3. The interaction is driven by Claude (the model) using
+   `AskUserQuestion`, with the wizard/agent **engine retaining all
+   step logic** — no duplication of step execution in the skill.
+4. The new surfaces are caught by the registry-coverage guard so they
+   cannot silently regress (extend the existing reverse-coverage gate).
+
+## Non-Goals
+
+- Re-architecting the wizard/agent engines beyond the minimal seam
+  needed to drive them step-wise.
+- Surfacing wizards/agents to **non-Claude** agentskills.io consumers
+  (a stateful-server variant is noted as an alternative in design.md
+  but is explicitly out of scope here).
+- Changing what any individual wizard or agent template *does*.
+
+---
+
+## Scope (phased)
+
+| Phase | Scope |
+|-------|-------|
+| **1** | Wizards — a `wizard` plugin skill that lists and runs the 5 registered wizards step-by-step. |
+| **2** | Agent teams — an `agent` plugin skill that builds and runs a team from the 14 builtin templates. |
+
+Phase 2 is gated on Phase 1 landing and its seam proving out; its
+design is sketched, not finalized, here (avoid over-speccing a future
+phase against an engine API that may shift).
+
+---
+
+## User stories
+
+- *As a plugin user*, when I say "walk me through the debug wizard",
+  the model lists the wizard's steps and asks me each question via
+  `AskUserQuestion`, then shows the wizard's output — without me
+  touching the CLI.
+- *As a plugin user*, when I say "run the security wizard on `src/`",
+  the model starts that wizard with my path as initial context and
+  drives it to completion.
+- *As a plugin user*, when I say "set up a test-coverage agent team",
+  the model picks the matching templates and runs the team. *(Phase 2)*
+
+---
+
+## Acceptance criteria
+
+**Phase 1 (wizards):**
+
+- [ ] A `plugin/skills/wizard/SKILL.md` exists, is model-invocable,
+      and is synced to `.agents/`.
+- [ ] The skill can enumerate wizards (live, via `list_wizards()` /
+      `list_capabilities`) and run a chosen one to a `WizardResult`.
+- [ ] Each `StepType` is handled: `question` steps render through
+      `AskUserQuestion`; `llm`/`review`/`decompose`/`preview`/`confirm`
+      steps execute in the engine and surface their content.
+- [ ] The engine exposes a step-wise driving API (see design.md) with
+      unit tests; the monolithic `run()` still works for the CLI.
+- [ ] Registry-coverage guard updated so "wizard registered ⇒ has a
+      run surface" is enforced (not just "is listed").
+- [ ] `attune-hub` Skills Reference + skill-count guard updated.
+
+**Phase 2 (agents):**
+
+- [ ] An `agent` plugin skill builds + runs a team from builtin
+      templates; coverage guard extended to agents' run surface.
+
+---
+
+## Constraints
+
+- The bridge must not weaken the **interactive** UX the wizards were
+  designed for (Socratic, step-gated) — see `.claude/CLAUDE.md`
+  Socratic Interaction Rule.
+- Per `decision-routine.md`, the engine step-API change is real
+  implementation work → its tasks use XML-enhanced prompts.
+- Markdown/skill-frontmatter rules and the 250-char description cap
+  apply to the new skills.


### PR DESCRIPTION
## What

Adds the **interactive-orchestration-access** spec — the design for
surfacing the last remaining hidden functionality from this session's
audit: **wizards (5)** and **agent templates (14)** are now *listable*
via the catalog (#1088) but **not runnable** through any shipped
surface (only the repo-dev `.claude/skills/{wizard,agent}` can run
them, and those don't ship in the plugin).

This is the spec the CHANGELOG (#1080) referenced but that never
actually existed.

## Decisions

- **D1 — scope:** both, phased. Wizards = Phase 1 (5, uniform Q&A
  pattern); agent teams = Phase 2 (harder, less-settled build/run API).
- **D2 — bridge:** a **Claude-driven skill**, not stateful MCP tools.
  The model drives the interactive loop via `AskUserQuestion`, holding
  the wizard `context` across conversation turns (that *is* the
  pause/resume mechanism). The engine exposes a thin step-wise API
  (`list_steps` / `submit_step`) and keeps all step logic — no
  duplication. Stateful MCP tools recorded as the rejected alternative
  (heavier; only needed for non-Claude consumers, a Non-Goal).

## Why the design is clean

`BaseWizard` is already declarative (`steps: list[WizardStep]`,
`StepType` ∈ question/llm/review/decompose/preview/confirm). The seam
is "model does the human I/O, engine does the work," with a single
execution path (refactor `run()` to loop over `submit_step`).

## Deliberately deferred

Open decisions (run() reuse, `StepView` shape from a per-wizard audit,
`wizard` skill-name collision with the dev set, and the
runnable-coverage guard) are left to Phase 1 implementation rather than
pre-decided — and Phase 2's agent-team API is sketched, not pinned.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
