### PR TITLE
feat(wizard): run wizards conversationally (interactive-orch Phase 1)

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -102,6 +102,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | catalog | catalog, list capabilities, browse, what can attune do |
 | personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
+| wizard | run a wizard, debug/refactor/security/test-gen wizard, walk me through, guided wizard |
 
 ## MCP Server Not Running
 

--- a/.agents/skills/wizard/SKILL.md
+++ b/.agents/skills/wizard/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: wizard
+description: "Run a guided multi-step wizard (debug, refactor, release-prep, security, test-gen) conversationally. Triggers on: run a wizard, debug wizard, refactor wizard, security wizard, test-gen wizard, walk me through, guided wizard."
+---
+# Wizard
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="wizard", mode="preamble")` and display the
+returned `preamble` text as a blockquote. Then tell the user they can
+say "tell me more" for a step-by-step guide, or answer the scoping
+question below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Wizard** — Runs a guided, multi-step wizard. I'll show you the
+> wizard's steps, ask you each question, then run it and present the
+> result.
+
+## Scoping
+
+1. **Which wizard?** If the user didn't name one, list the registered
+   wizards (id + description) and ask. Get the live list — never
+   hand-author it:
+
+   ```bash
+   python -c "import json; from attune.wizards import list_wizards; print(json.dumps([{'id': w.wizard_id, 'description': w.description} for w in list_wizards()]))"
+   ```
+
+2. **Any starting context?** e.g. a file path or error message the
+   wizard should begin from.
+
+## Execution
+
+This wizard runs on an interactive engine, so you (the model) drive it:
+show the steps, collect the answers, then run it once with those
+answers supplied.
+
+1. **Inspect the steps** for the chosen wizard:
+
+   ```bash
+   python -c "import json; from attune.wizards import describe_wizard_steps; print(json.dumps(describe_wizard_steps('debug')))"
+   ```
+
+   Each entry has `id`, `type`, `name`, `description`; `question` steps
+   also carry `questions` (in `AskUserQuestion` format).
+
+2. **Ask the user the question-step questions** via `AskUserQuestion`
+   (batch up to 4 at a time). Collect answers keyed by each question's
+   `question_id`. `review`/`confirm` steps need no upfront answer — the
+   engine auto-proceeds on their defaults this cut.
+
+3. **Run the wizard** with the collected answers. Write them to a temp
+   JSON file (avoids shell-quoting issues) and run:
+
+   ```bash
+   ANSWERS_JSON=/tmp/wizard_answers.json python -c "
+   import json, os, asyncio
+   from attune.wizards import run_wizard_prefilled
+   answers = json.load(open(os.environ['ANSWERS_JSON']))
+   result = asyncio.run(run_wizard_prefilled('debug', answers=answers, initial_context={}))
+   print(json.dumps(result.to_dict() if hasattr(result, 'to_dict') else result.__dict__, default=str))
+   "
+   ```
+
+   Pass `initial_context` (e.g. `{"target": "src/foo.py"}`) when the
+   user gave a starting path or error.
+
+## Output
+
+Present the `WizardResult` readably: lead with `generated_output`, then
+any `tasks` it produced (as a checklist), then run metadata (steps
+completed, cost, duration). If `success` is false, surface `error`.
+
+## How this differs from other skills
+
+- **wizard** *runs* a guided flow step-by-step (this skill).
+- **catalog** *lists* wizards (and workflows, agents, tools) but does
+  not run them.
+- **attune-hub** *routes* you to the right skill for a goal.
+
+## Anti-Patterns
+
+- DO NOT hand-author the wizard list or its steps — always read them
+  live (`list_wizards()` / `describe_wizard_steps()`).
+- DO NOT skip the question steps — collect every `question`-step answer
+  before running, or the wizard runs with missing input.
+- DO NOT use this to *create* a wizard — that is the authoring flow,
+  not this runner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`wizard` skill — run guided wizards conversationally
+  (interactive-orchestration-access Phase 1).** The 5 wizards (debug,
+  refactor, release-prep, security, test-gen) were listable but not
+  runnable in the shipped plugin. New `BaseWizard.list_steps()` exposes a
+  wizard's steps declaratively, and `attune.wizards.driver`
+  (`describe_wizard_steps`, `run_wizard_prefilled`,
+  `prefilled_answer_callback`) lets the Claude-driven `wizard` skill
+  collect a wizard's question answers via `AskUserQuestion`, then run it
+  once with those answers — no engine `run()` refactor. Brings the count
+  to 23 skills. Agent-team access is Phase 2.
 - **Agent templates surfaced in the catalog + catalog-completeness
   guard.** `list_capabilities` now also enumerates the 14 builtin agent
   templates (via `get_all_templates()`) — previously it read only
@@ -44,6 +54,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `no_llm`) and a thin auto-triggering skill. Previously the workflow
   was reachable only from internal code. Brings the count to 42 MCP
   tools and 18 skills.
+
+### Fixed
+
+- **Wizard `confirm`/`review` steps crashed at runtime.**
+  `_run_confirm_step`/`_run_review_step` built
+  `FormQuestion(type="single_select")` with a plain string, but
+  `to_ask_user_format()` calls `self.type.value` — so any wizard
+  reaching a confirm or review step raised `AttributeError: 'str'
+  object has no attribute 'value'`. Latent because the full interactive
+  run was never dogfooded end-to-end. Fixed to use
+  `QuestionType.SINGLE_SELECT`; covered by an offline wizard-run test.
 
 ### Removed (BREAKING)
 

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -104,6 +104,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | catalog | catalog, list capabilities, browse, what can attune do |
 | personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
+| wizard | run a wizard, debug/refactor/security/test-gen wizard, walk me through, guided wizard |
 
 ## MCP Server Not Running
 

--- a/plugin/skills/wizard/SKILL.md
+++ b/plugin/skills/wizard/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: wizard
+description: "Run a guided multi-step wizard (debug, refactor, release-prep, security, test-gen) conversationally. Triggers on: run a wizard, debug wizard, refactor wizard, security wizard, test-gen wizard, walk me through, guided wizard."
+argument-hint: "<wizard id, or leave empty to list>"
+---
+
+# Wizard
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="wizard", mode="preamble")` and display the
+returned `preamble` text as a blockquote. Then tell the user they can
+say "tell me more" for a step-by-step guide, or answer the scoping
+question below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Wizard** — Runs a guided, multi-step wizard. I'll show you the
+> wizard's steps, ask you each question, then run it and present the
+> result.
+
+## Scoping
+
+1. **Which wizard?** If the user didn't name one, list the registered
+   wizards (id + description) and ask. Get the live list — never
+   hand-author it:
+
+   ```bash
+   python -c "import json; from attune.wizards import list_wizards; print(json.dumps([{'id': w.wizard_id, 'description': w.description} for w in list_wizards()]))"
+   ```
+
+2. **Any starting context?** e.g. a file path or error message the
+   wizard should begin from.
+
+## Execution
+
+This wizard runs on an interactive engine, so you (the model) drive it:
+show the steps, collect the answers, then run it once with those
+answers supplied.
+
+1. **Inspect the steps** for the chosen wizard:
+
+   ```bash
+   python -c "import json; from attune.wizards import describe_wizard_steps; print(json.dumps(describe_wizard_steps('debug')))"
+   ```
+
+   Each entry has `id`, `type`, `name`, `description`; `question` steps
+   also carry `questions` (in `AskUserQuestion` format).
+
+2. **Ask the user the question-step questions** via `AskUserQuestion`
+   (batch up to 4 at a time). Collect answers keyed by each question's
+   `question_id`. `review`/`confirm` steps need no upfront answer — the
+   engine auto-proceeds on their defaults this cut.
+
+3. **Run the wizard** with the collected answers. Write them to a temp
+   JSON file (avoids shell-quoting issues) and run:
+
+   ```bash
+   ANSWERS_JSON=/tmp/wizard_answers.json python -c "
+   import json, os, asyncio
+   from attune.wizards import run_wizard_prefilled
+   answers = json.load(open(os.environ['ANSWERS_JSON']))
+   result = asyncio.run(run_wizard_prefilled('debug', answers=answers, initial_context={}))
+   print(json.dumps(result.to_dict() if hasattr(result, 'to_dict') else result.__dict__, default=str))
+   "
+   ```
+
+   Pass `initial_context` (e.g. `{"target": "src/foo.py"}`) when the
+   user gave a starting path or error.
+
+## Output
+
+Present the `WizardResult` readably: lead with `generated_output`, then
+any `tasks` it produced (as a checklist), then run metadata (steps
+completed, cost, duration). If `success` is false, surface `error`.
+
+## How this differs from other skills
+
+- **wizard** *runs* a guided flow step-by-step (this skill).
+- **catalog** *lists* wizards (and workflows, agents, tools) but does
+  not run them.
+- **attune-hub** *routes* you to the right skill for a goal.
+
+## Anti-Patterns
+
+- DO NOT hand-author the wizard list or its steps — always read them
+  live (`list_wizards()` / `describe_wizard_steps()`).
+- DO NOT skip the question steps — collect every `question`-step answer
+  before running, or the wizard runs with missing input.
+- DO NOT use this to *create* a wizard — that is the authoring flow,
+  not this runner.

--- a/src/attune/wizards/__init__.py
+++ b/src/attune/wizards/__init__.py
@@ -27,6 +27,11 @@ Licensed under Apache 2.0
 from .base import BaseWizard, StepType, WizardConfig, WizardResult, WizardStep
 from .config_driven import ConfigDrivenWizard
 from .decomposer import DecomposedTask, TaskDecomposer
+from .driver import (
+    describe_wizard_steps,
+    prefilled_answer_callback,
+    run_wizard_prefilled,
+)
 from .registry import (
     delete_custom_wizard,
     get_wizard,
@@ -47,8 +52,11 @@ __all__ = [
     "WizardSession",
     "WizardStep",
     "delete_custom_wizard",
+    "describe_wizard_steps",
     "get_wizard",
     "list_wizards",
+    "prefilled_answer_callback",
     "register_wizard",
+    "run_wizard_prefilled",
     "save_custom_wizard",
 ]

--- a/src/attune/wizards/base.py
+++ b/src/attune/wizards/base.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from attune.meta_workflows.form_engine import AskUserQuestionCallback, SocraticFormEngine
-from attune.meta_workflows.models import FormQuestion, FormSchema
+from attune.meta_workflows.models import FormQuestion, FormSchema, QuestionType
 from attune.prompts import PromptContext
 from attune.workflows.compat import ModelTier
 
@@ -174,6 +174,39 @@ class BaseWizard(ABC):
         )
 
     # -----------------------------------------------------------------
+    # Introspection (for the Claude-driven `wizard` skill)
+    # -----------------------------------------------------------------
+
+    def list_steps(self) -> list[dict[str, Any]]:
+        """Return a declarative, serializable view of this wizard's steps.
+
+        Lets a caller inspect what each step does — and, for ``QUESTION``
+        steps, the exact questions to ask — WITHOUT running the
+        interactive engine. The Claude-driven ``wizard`` skill uses this
+        to ask the user a wizard's questions up front (via
+        ``AskUserQuestion``), then feeds the answers back through
+        ``attune.wizards.driver.prefilled_answer_callback``.
+
+        Returns:
+            One dict per step with ``id``, ``name``, ``type`` (the
+            ``StepType`` value), and ``description``. ``QUESTION`` steps
+            also carry ``questions`` in ``AskUserQuestion`` format.
+
+        """
+        views: list[dict[str, Any]] = []
+        for step in self.steps:
+            view: dict[str, Any] = {
+                "id": step.id,
+                "name": step.name,
+                "type": step.step_type.value,
+                "description": step.description,
+            }
+            if step.step_type == StepType.QUESTION and step.questions:
+                view["questions"] = [q.to_ask_user_format() for q in step.questions]
+            views.append(view)
+        return views
+
+    # -----------------------------------------------------------------
     # Step dispatch
     # -----------------------------------------------------------------
 
@@ -313,7 +346,7 @@ class BaseWizard(ABC):
             review_question = FormQuestion(
                 id="review_approval",
                 text=(f"Here's what the analysis found:\n\n{summary}\n\n" "Does this look right?"),
-                type="single_select",
+                type=QuestionType.SINGLE_SELECT,
                 options=["Yes, continue", "No, try again"],
                 default="Yes, continue",
             )
@@ -458,7 +491,7 @@ class BaseWizard(ABC):
         confirm_question = FormQuestion(
             id="confirm",
             text=step.description or "Proceed with these changes?",
-            type="single_select",
+            type=QuestionType.SINGLE_SELECT,
             options=["Yes, proceed", "No, cancel"],
             default="Yes, proceed",
         )

--- a/src/attune/wizards/driver.py
+++ b/src/attune/wizards/driver.py
@@ -1,0 +1,103 @@
+"""Claude-driven driving helpers for interactive wizards.
+
+The wizards run on an interactive engine (``BaseWizard.run()`` pauses on
+``QUESTION``/``REVIEW``/``CONFIRM`` steps to collect human input). A
+single-shot tool cannot drive that pause/resume, so the shipped
+``wizard`` skill drives it from the model side:
+
+1. ``describe_wizard_steps(wizard_id)`` — show the user what the wizard
+   does and which questions it will ask (no engine run).
+2. The model collects the ``QUESTION``-step answers via
+   ``AskUserQuestion``.
+3. ``run_wizard_prefilled(wizard_id, answers, initial_context)`` — run
+   the wizard once with those answers supplied through the engine's
+   existing ``ask_user_callback`` seam.
+
+Questions with no pre-supplied answer (a ``REVIEW``/``CONFIRM`` step's
+approval prompt) are omitted, so the engine falls back to that step's
+own default (proceed / approve). Full mid-run review interactivity is a
+documented follow-on; see ``docs/specs/interactive-orchestration-access``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from attune.meta_workflows.form_engine import AskUserQuestionCallback
+
+from .base import BaseWizard, WizardResult
+from .registry import get_wizard
+
+
+def prefilled_answer_callback(answers: dict[str, Any]) -> AskUserQuestionCallback:
+    """Build an ``ask_user_callback`` that returns pre-collected answers.
+
+    Args:
+        answers: Mapping of ``question_id`` to the user's answer, collected
+            by the model up front.
+
+    Returns:
+        A callback matching ``AskUserQuestionCallback`` that, given a batch
+        of questions, returns the pre-supplied answer for each question it
+        recognises and omits the rest (letting the engine apply that
+        step's default).
+
+    """
+
+    def _callback(questions: list[dict[str, Any]]) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        for q in questions:
+            qid = q.get("question_id") or q.get("header") or q.get("question")
+            if qid in answers:
+                out[qid] = answers[qid]
+        return out
+
+    return _callback
+
+
+def _resolve_wizard_class(wizard_id: str) -> type[BaseWizard]:
+    """Resolve a registered wizard class by id or raise ``KeyError``."""
+    cls = get_wizard(wizard_id)
+    if cls is None:
+        raise KeyError(f"Unknown wizard: {wizard_id!r}")
+    return cls
+
+
+def describe_wizard_steps(wizard_id: str) -> list[dict[str, Any]]:
+    """Return the declarative step views for a registered wizard.
+
+    Args:
+        wizard_id: A registered wizard id (e.g. ``"debug"``).
+
+    Returns:
+        The list produced by ``BaseWizard.list_steps()``.
+
+    Raises:
+        KeyError: If ``wizard_id`` is not registered.
+
+    """
+    return _resolve_wizard_class(wizard_id)().list_steps()
+
+
+async def run_wizard_prefilled(
+    wizard_id: str,
+    answers: dict[str, Any] | None = None,
+    initial_context: dict[str, Any] | None = None,
+) -> WizardResult:
+    """Run a registered wizard with pre-collected answers (non-interactive).
+
+    Args:
+        wizard_id: A registered wizard id.
+        answers: ``question_id`` -> answer collected up front by the model.
+        initial_context: Optional starting context (e.g. a file path).
+
+    Returns:
+        The ``WizardResult`` from the completed run.
+
+    Raises:
+        KeyError: If ``wizard_id`` is not registered.
+
+    """
+    cls = _resolve_wizard_class(wizard_id)
+    wizard = cls(ask_user_callback=prefilled_answer_callback(answers or {}))
+    return await wizard.run(initial_context or {})

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -302,8 +302,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 22, (
-            f"Expected 22 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 23, (
+            f"Expected 23 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:

--- a/tests/unit/plugins/test_registry_coverage.py
+++ b/tests/unit/plugins/test_registry_coverage.py
@@ -307,5 +307,43 @@ class TestCatalogCompleteness:
         )
 
 
+# ---------------------------------------------------------------------------
+# Wizard RUN surface (not just discovery)
+# ---------------------------------------------------------------------------
+#
+# The catalog makes wizards DISCOVERABLE; this checks they are RUNNABLE.
+# The `wizard` skill is a generic driver (it runs any registered wizard via
+# describe_wizard_steps / run_wizard_prefilled), so the surface is the skill
+# existing and naming the driver — not a per-wizard skill. This is the
+# run-surface twin of catalog-completeness; it fails if the run skill is
+# removed while wizards still exist (the listable-but-not-runnable gap the
+# interactive-orchestration-access spec closed).
+
+
+class TestWizardRunSurface:
+    """Registered wizards have a run surface (the `wizard` skill), not just
+    a catalog listing."""
+
+    def test_wizard_run_skill_exists_and_names_the_driver(self) -> None:
+        body = SKILL_BODIES.get("wizard")
+        assert body is not None, (
+            "wizards are registered but there is no `wizard` run skill in "
+            "plugin/skills/ — they would be listable-but-not-runnable."
+        )
+        assert (
+            "run_wizard_prefilled" in body
+        ), "the `wizard` skill must drive runs via run_wizard_prefilled"
+        assert (
+            "describe_wizard_steps" in body or "list_wizards" in body
+        ), "the `wizard` skill must read wizards/steps live, not hand-author them"
+
+    def test_wizards_exist_to_run(self) -> None:
+        try:
+            from attune.wizards import list_wizards
+        except ImportError:  # pragma: no cover - minimal env
+            pytest.skip("wizards not importable in this environment")
+        assert len(list_wizards()) >= 1, "no wizards registered for the run skill to drive"
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])

--- a/tests/unit/wizards/test_driver.py
+++ b/tests/unit/wizards/test_driver.py
@@ -1,0 +1,147 @@
+"""Tests for the Claude-driven wizard driver (Phase 1).
+
+Covers ``BaseWizard.list_steps()`` and
+``attune.wizards.driver`` (``prefilled_answer_callback``,
+``describe_wizard_steps``, ``run_wizard_prefilled``) — the
+interactive-orchestration-access bridge.
+
+All wizard *runs* here use offline fakes (question + confirm steps only,
+no ``llm_call``), so the suite never makes a real API call.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.meta_workflows.models import FormQuestion, QuestionType
+from attune.prompts import PromptContext
+from attune.wizards import (
+    WizardConfig,
+    describe_wizard_steps,
+    list_wizards,
+    prefilled_answer_callback,
+    run_wizard_prefilled,
+)
+from attune.wizards.base import BaseWizard, StepType, WizardStep
+
+
+class _FakeWizard(BaseWizard):
+    """Minimal question -> confirm wizard — runs fully offline (no LLM)."""
+
+    config = WizardConfig(wizard_id="fake-test", name="Fake", description="t")
+    steps = [
+        WizardStep(
+            id="ask",
+            name="Ask",
+            description="gather",
+            step_type=StepType.QUESTION,
+            questions=[FormQuestion(id="topic", text="What topic?", type=QuestionType.TEXT_INPUT)],
+        ),
+        WizardStep(
+            id="confirm",
+            name="Confirm",
+            description="ok?",
+            step_type=StepType.CONFIRM,
+        ),
+    ]
+
+    def build_prompt_context(self, step: WizardStep) -> PromptContext:  # pragma: no cover
+        return PromptContext(role="r", goal="g", instructions="i")
+
+    def process_step_result(self, step, result):  # pragma: no cover
+        pass
+
+
+@pytest.fixture
+def registered_fake():
+    """Register ``_FakeWizard`` for the duration of a test, then remove it."""
+    from attune.wizards import register_wizard
+    from attune.wizards.registry import _WIZARD_REGISTRY
+
+    register_wizard("fake-test", _FakeWizard)
+    yield "fake-test"
+    _WIZARD_REGISTRY.pop("fake-test", None)
+
+
+@pytest.mark.unit
+class TestListSteps:
+    def test_list_steps_shape(self) -> None:
+        views = _FakeWizard().list_steps()
+        assert [v["id"] for v in views] == ["ask", "confirm"]
+        assert views[0]["type"] == "question"
+        assert views[1]["type"] == "confirm"
+
+    def test_question_step_carries_questions(self) -> None:
+        views = _FakeWizard().list_steps()
+        assert "questions" in views[0]
+        assert views[0]["questions"][0]["question_id"] == "topic"
+
+    def test_non_question_step_has_no_questions(self) -> None:
+        views = _FakeWizard().list_steps()
+        assert "questions" not in views[1]
+
+
+@pytest.mark.unit
+class TestPrefilledAnswerCallback:
+    def test_returns_known_answers(self) -> None:
+        cb = prefilled_answer_callback({"topic": "auth", "scope": "src"})
+        out = cb([{"question_id": "topic"}, {"question_id": "scope"}])
+        assert out == {"topic": "auth", "scope": "src"}
+
+    def test_omits_unknown_questions(self) -> None:
+        """A review/confirm approval with no pre-supplied answer is omitted
+        so the engine falls back to that step's default."""
+        cb = prefilled_answer_callback({"topic": "auth"})
+        out = cb([{"question_id": "topic"}, {"question_id": "review_approval"}])
+        assert out == {"topic": "auth"}
+        assert "review_approval" not in out
+
+    def test_falls_back_to_header_or_question_key(self) -> None:
+        cb = prefilled_answer_callback({"H": "v"})
+        assert cb([{"header": "H"}]) == {"H": "v"}
+
+
+@pytest.mark.unit
+class TestDescribe:
+    def test_describe_wizard_steps_for_real_wizard(self) -> None:
+        """Introspection only — no run, so no API calls."""
+        steps = describe_wizard_steps("debug")
+        assert len(steps) >= 1
+        assert all("id" in s and "type" in s for s in steps)
+
+    def test_describe_unknown_wizard_raises(self) -> None:
+        with pytest.raises(KeyError):
+            describe_wizard_steps("does-not-exist")
+
+
+@pytest.mark.unit
+class TestRunPrefilled:
+    async def test_run_unknown_wizard_raises(self) -> None:
+        with pytest.raises(KeyError):
+            await run_wizard_prefilled("does-not-exist")
+
+    async def test_run_offline_fake_via_registry(self, registered_fake: str) -> None:
+        """Drive a registered offline wizard end-to-end with prefilled
+        answers; question resolves from the callback, confirm auto-proceeds."""
+        result = await run_wizard_prefilled(
+            registered_fake,
+            answers={"topic": "auth"},
+            initial_context={},
+        )
+        assert result.wizard_id == registered_fake
+        assert result.success is True
+        assert "ask" in result.steps_completed
+        assert result.collected_data.get("topic") == "auth"
+
+    async def test_run_direct_instantiation_offline(self) -> None:
+        """Same path without the registry — prefilled callback + run()."""
+        wizard = _FakeWizard(ask_user_callback=prefilled_answer_callback({"topic": "x"}))
+        result = await wizard.run({})
+        assert result.success is True
+        assert result.collected_data.get("topic") == "x"
+
+    def test_at_least_one_real_wizard_is_registered(self) -> None:
+        assert len(list_wizards()) >= 1


### PR DESCRIPTION
## What

**Phase 1** of the approved interactive-orchestration-access spec
(#1089). The 5 wizards (debug, refactor, release-prep, security,
test-gen) were *listable* via the catalog but had **no shipped run
surface**. This makes them runnable through a Claude-driven `wizard`
skill — using the engine's existing `ask_user_callback` seam, so **no
risky `run()` refactor**.

## How it works

1. `BaseWizard.list_steps()` — declarative, serializable view of a
   wizard's steps (and, for `QUESTION` steps, the questions) without
   running the engine.
2. `attune.wizards.driver` — `describe_wizard_steps`,
   `run_wizard_prefilled`, `prefilled_answer_callback`.
3. The `wizard` skill: lists wizards → inspects steps → asks the user
   the question-step questions via `AskUserQuestion` → runs the wizard
   once with those answers supplied.

`review`/`confirm` steps auto-proceed on their built-in defaults this
cut; full mid-run review interactivity is the documented follow-on
(spec OD1). Agent-team access is **Phase 2**.

## Bug fix (surfaced by actually running wizards)

`_run_confirm_step`/`_run_review_step` built
`FormQuestion(type="single_select")` with a **plain string**, but
`to_ask_user_format()` calls `self.type.value` → **every** wizard
reaching a confirm/review step raised
`AttributeError: 'str' object has no attribute 'value'`. Latent because
the full interactive run was never dogfooded end-to-end. Fixed to
`QuestionType.SINGLE_SELECT`; covered by an offline wizard-run test that
drives a confirm step.

## Surfaces + guards

- `plugin/skills/wizard/SKILL.md` (model-invocable) + `.agents/` sync.
- attune-hub Skills Reference + skill-count guard 22 → 23.
- New `TestWizardRunSurface` — wizards have a **run** surface, not just a
  catalog listing (the run-surface twin of catalog-completeness).

## Verification

- `tests/unit/wizards/` + `tests/unit/plugins/` → 602 passed, 3 skipped.
- New driver tests run wizards **offline** (fakes, no `llm_call`) — no
  API calls; a registered-fake test drives a real confirm step.
- `sync_agents_skills.py --check` → 23 ok; black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
