### PR TITLE
feat(agent): compose + run agent teams (interactive-orch Phase 2)

### DIFF
--- a/.agents/skills/agent/SKILL.md
+++ b/.agents/skills/agent/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: agent
+description: "Compose and run a multi-agent team from the builtin templates for a goal. Triggers on: run an agent team, set up an agent team, multi-agent, orchestrate agents, agent team for, build a team."
+---
+# Agent Team
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="agent", mode="preamble")` and display the
+returned `preamble` text as a blockquote. Then tell the user they can
+say "tell me more" for a step-by-step guide, or answer the scoping
+question below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Agent Team** — Composes a multi-agent team from the builtin agent
+> templates for your goal, shows you the proposed team and its
+> estimated cost, then runs it once you confirm.
+
+## Scoping
+
+1. **Goal** — "What should the team accomplish?" (e.g. "improve test
+   coverage to 90%", "audit this module for security").
+2. **Context** (optional) — any starting facts (a path, a current
+   metric) to inform composition.
+
+## Execution
+
+Two steps: preview the composed team (free, deterministic), then run it
+(LLM-heavy) only after the user confirms.
+
+1. **Preview the team** — compose a plan without running it:
+
+   ```bash
+   python -c "import json; from attune.orchestration import describe_team_for_task; print(json.dumps(describe_team_for_task('improve test coverage to 90%'), default=str))"
+   ```
+
+   Returns `{task, strategy, agents:[{id, role}], estimated_cost,
+   estimated_duration, quality_gates}`. Present the proposed agents,
+   the composition `strategy`, and the **estimated cost** to the user.
+
+2. **Confirm before running** — use `AskUserQuestion`:
+   "Run this team? (est. cost ~$X)" → Yes / No. This is a paid,
+   multi-agent run; never skip the confirmation.
+
+3. **Run the team** (only on Yes). This makes real multi-agent LLM
+   calls:
+
+   ```bash
+   python -c "
+   import json, asyncio
+   from attune.orchestration import run_team_for_task
+   result = asyncio.run(run_team_for_task('improve test coverage to 90%', context={}, input_data={}))
+   print(json.dumps(result.to_dict() if hasattr(result, 'to_dict') else result.__dict__, default=str))
+   "
+   ```
+
+## Output
+
+Present the `DynamicTeamResult` readably: lead with the aggregated
+outcome, then per-agent contributions, then run metadata (cost,
+duration, which quality gates passed). If it failed, surface the error.
+
+## How this differs from other skills
+
+- **agent** *composes and runs a multi-agent team* (this skill).
+- **wizard** runs a single guided step-by-step flow.
+- **catalog** *lists* agent templates (and workflows, wizards, tools)
+  but does not run them.
+- The 6 Claude Code subagents in `plugin/agents/` are a different
+  thing — reached via the Agent/Task tool, not this skill.
+
+## Anti-Patterns
+
+- DO NOT run the team without previewing the plan and confirming the
+  cost first — it is a paid multi-agent run.
+- DO NOT hand-author the team — always compose it live via
+  `describe_team_for_task` / `run_team_for_task`.
+- DO NOT use this for a single-step task — a plain workflow or the
+  `wizard` skill is cheaper.

--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -103,6 +103,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
 | wizard | run a wizard, debug/refactor/security/test-gen wizard, walk me through, guided wizard |
+| agent | run an agent team, multi-agent, orchestrate agents, agent team for, build a team |
 
 ## MCP Server Not Running
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`agent` skill — compose and run a multi-agent team
+  (interactive-orchestration-access Phase 2).** The 14 builtin agent
+  templates were listable via the catalog but not runnable. New
+  `attune.orchestration.team_driver` (`describe_team_for_task`,
+  `run_team_for_task`) gives the Claude-driven `agent` skill a
+  two-step bridge: `describe_team_for_task` composes a team plan
+  deterministically (no LLM — which agents, strategy, estimated cost)
+  for a preview, then `run_team_for_task` executes the composed team
+  after the user confirms the cost. Brings the count to 24 skills; new
+  guard `TestAgentRunSurface`.
 - **`wizard` skill — run guided wizards conversationally
   (interactive-orchestration-access Phase 1).** The 5 wizards (debug,
   refactor, release-prep, security, test-gen) were listable but not

--- a/docs/specs/interactive-orchestration-access/design.md
+++ b/docs/specs/interactive-orchestration-access/design.md
@@ -85,20 +85,26 @@ only if a non-Claude surface is required.
 
 ---
 
-## Phase 2 (agents) — sketch only
+## Phase 2 (agents) — IMPLEMENTED
 
 Agent-team access reuses the same "model drives, engine works"
-principle:
+principle, with a deterministic preview + a gated run:
 
-- Enumerate templates via `get_all_templates()` (already surfaced in
-  the catalog).
-- An `agent` skill: ask the user the goal → select matching templates
-  (`get_templates_by_capability` / `_by_tier`) → build a team
-  (`TeamBuilder` / meta-orchestrator) → run it → present results.
+- `attune.orchestration.team_driver.describe_team_for_task(task)` —
+  deterministic, **no LLM**. Wraps
+  `MetaOrchestrator().analyze_and_compose(task)` and serializes the
+  resulting `ExecutionPlan` (agents from the templates, composition
+  strategy, estimated cost/duration, quality gates) for a preview.
+- `team_driver.run_team_for_task(task, ...)` — composes AND executes:
+  `MetaOrchestrator().compose_team(task)` → `DynamicTeam.execute()`.
+  This is the LLM-heavy step.
+- The `agent` skill: goal → `describe_team_for_task` preview → confirm
+  the cost via `AskUserQuestion` → `run_team_for_task` → present the
+  `DynamicTeamResult`.
 
-The exact build/run API (`team_builder.py`, `meta_orchestrator.py`)
-is **not** pinned here — finalize it when Phase 1's seam is proven and
-the engine API has settled.
+Guard `TestAgentRunSurface` enforces the run surface. Tests cover the
+deterministic compose/preview offline; the LLM-heavy run is left to
+manual/integration use (cost + keyed-CI hazard), mirroring Phase 1.
 
 ---
 

--- a/plugin/skills/agent/SKILL.md
+++ b/plugin/skills/agent/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: agent
+description: "Compose and run a multi-agent team from the builtin templates for a goal. Triggers on: run an agent team, set up an agent team, multi-agent, orchestrate agents, agent team for, build a team."
+argument-hint: "<the goal for the team>"
+---
+
+# Agent Team
+
+**IMPORTANT: Start your response with a context preamble.**
+
+Call `help_lookup(topic="agent", mode="preamble")` and display the
+returned `preamble` text as a blockquote. Then tell the user they can
+say "tell me more" for a step-by-step guide, or answer the scoping
+question below to proceed.
+
+If the MCP call fails, fall back to:
+
+> **Agent Team** — Composes a multi-agent team from the builtin agent
+> templates for your goal, shows you the proposed team and its
+> estimated cost, then runs it once you confirm.
+
+## Scoping
+
+1. **Goal** — "What should the team accomplish?" (e.g. "improve test
+   coverage to 90%", "audit this module for security").
+2. **Context** (optional) — any starting facts (a path, a current
+   metric) to inform composition.
+
+## Execution
+
+Two steps: preview the composed team (free, deterministic), then run it
+(LLM-heavy) only after the user confirms.
+
+1. **Preview the team** — compose a plan without running it:
+
+   ```bash
+   python -c "import json; from attune.orchestration import describe_team_for_task; print(json.dumps(describe_team_for_task('improve test coverage to 90%'), default=str))"
+   ```
+
+   Returns `{task, strategy, agents:[{id, role}], estimated_cost,
+   estimated_duration, quality_gates}`. Present the proposed agents,
+   the composition `strategy`, and the **estimated cost** to the user.
+
+2. **Confirm before running** — use `AskUserQuestion`:
+   "Run this team? (est. cost ~$X)" → Yes / No. This is a paid,
+   multi-agent run; never skip the confirmation.
+
+3. **Run the team** (only on Yes). This makes real multi-agent LLM
+   calls:
+
+   ```bash
+   python -c "
+   import json, asyncio
+   from attune.orchestration import run_team_for_task
+   result = asyncio.run(run_team_for_task('improve test coverage to 90%', context={}, input_data={}))
+   print(json.dumps(result.to_dict() if hasattr(result, 'to_dict') else result.__dict__, default=str))
+   "
+   ```
+
+## Output
+
+Present the `DynamicTeamResult` readably: lead with the aggregated
+outcome, then per-agent contributions, then run metadata (cost,
+duration, which quality gates passed). If it failed, surface the error.
+
+## How this differs from other skills
+
+- **agent** *composes and runs a multi-agent team* (this skill).
+- **wizard** runs a single guided step-by-step flow.
+- **catalog** *lists* agent templates (and workflows, wizards, tools)
+  but does not run them.
+- The 6 Claude Code subagents in `plugin/agents/` are a different
+  thing — reached via the Agent/Task tool, not this skill.
+
+## Anti-Patterns
+
+- DO NOT run the team without previewing the plan and confirming the
+  cost first — it is a paid multi-agent run.
+- DO NOT hand-author the team — always compose it live via
+  `describe_team_for_task` / `run_team_for_task`.
+- DO NOT use this for a single-step task — a plain workflow or the
+  `wizard` skill is cheaper.

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -105,6 +105,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
 | wizard | run a wizard, debug/refactor/security/test-gen wizard, walk me through, guided wizard |
+| agent | run an agent team, multi-agent, orchestrate agents, agent team for, build a team |
 
 ## MCP Server Not Running
 

--- a/src/attune/orchestration/__init__.py
+++ b/src/attune/orchestration/__init__.py
@@ -46,6 +46,7 @@ from attune.orchestration.meta_orchestrator import (
     TaskRequirements,
 )
 from attune.orchestration.team_builder import DynamicTeamBuilder
+from attune.orchestration.team_driver import describe_team_for_task, run_team_for_task
 from attune.orchestration.team_store import TeamSpecification, TeamStore
 from attune.orchestration.workflow_agent_adapter import WorkflowAgentAdapter
 from attune.orchestration.workflow_composer import WorkflowComposer
@@ -68,6 +69,9 @@ __all__ = [
     "DynamicTeamResult",
     "TeamSpecification",
     "TeamStore",
+    # Claude-driven team access (interactive-orchestration-access Phase 2)
+    "describe_team_for_task",
+    "run_team_for_task",
     # Workflow Composition
     "WorkflowAgentAdapter",
     "WorkflowComposer",

--- a/src/attune/orchestration/team_driver.py
+++ b/src/attune/orchestration/team_driver.py
@@ -1,0 +1,82 @@
+"""Claude-driven access to agent-team orchestration (Phase 2).
+
+The 14 builtin agent templates are *listable* via the catalog but were
+not *runnable* through a shipped surface. This module gives the
+Claude-driven ``agent`` skill a clean two-step bridge, mirroring the
+wizard driver:
+
+1. ``describe_team_for_task(task)`` — deterministic, no LLM. Composes a
+   team plan from the templates (which agents, what strategy, estimated
+   cost/duration) so the model can preview it for the user and confirm.
+2. ``run_team_for_task(task, ...)`` — composes AND executes the team.
+   This is the LLM-heavy step; only call it after the user confirms.
+
+See ``docs/specs/interactive-orchestration-access`` (Phase 2).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def describe_team_for_task(
+    task: str,
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Compose (but do not run) an agent team for a task.
+
+    Deterministic / no LLM — safe to call for a preview.
+
+    Args:
+        task: Natural-language goal (e.g. "improve test coverage to 90%").
+        context: Optional context dict.
+
+    Returns:
+        A serializable plan: ``task``, ``strategy``, ``agents``
+        (``{id, role}`` from the templates), ``estimated_cost``,
+        ``estimated_duration``, ``quality_gates``.
+
+    Raises:
+        ValueError: If ``task`` is empty/invalid (from the orchestrator).
+
+    """
+    from attune.orchestration.meta_orchestrator import MetaOrchestrator
+
+    plan = MetaOrchestrator().analyze_and_compose(task, context or {})
+    return {
+        "task": task,
+        "strategy": plan.strategy.value,
+        "agents": [{"id": t.id, "role": t.role} for t in plan.agents],
+        "estimated_cost": plan.estimated_cost,
+        "estimated_duration": plan.estimated_duration,
+        "quality_gates": list(plan.quality_gates),
+    }
+
+
+async def run_team_for_task(
+    task: str,
+    context: dict[str, Any] | None = None,
+    input_data: dict[str, Any] | None = None,
+) -> Any:
+    """Compose AND execute an agent team for a task.
+
+    LLM-heavy: spins up the composed multi-agent team and runs it. Call
+    only after a preview (``describe_team_for_task``) and user
+    confirmation.
+
+    Args:
+        task: Natural-language goal.
+        context: Optional context for composition.
+        input_data: Structured input forwarded to the agents.
+
+    Returns:
+        The team's ``DynamicTeamResult``.
+
+    Raises:
+        ValueError: If ``task`` is empty/invalid.
+
+    """
+    from attune.orchestration.meta_orchestrator import MetaOrchestrator
+
+    team = MetaOrchestrator().compose_team(task, context or {})
+    return await team.execute(input_data or {})

--- a/tests/unit/orchestration/test_team_driver.py
+++ b/tests/unit/orchestration/test_team_driver.py
@@ -1,0 +1,59 @@
+"""Tests for the Claude-driven agent-team driver (Phase 2).
+
+Covers ``attune.orchestration.team_driver.describe_team_for_task`` — the
+deterministic, no-LLM compose/preview surface the `agent` skill uses.
+
+``run_team_for_task`` is NOT exercised here: it spins up a real
+multi-agent LLM run (cost + the keyed-CI hazard), so it is left to
+manual/integration use, mirroring the wizard driver tests.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.orchestration import describe_team_for_task, run_team_for_task
+
+
+@pytest.mark.unit
+class TestDescribeTeamForTask:
+    def test_returns_serializable_plan(self) -> None:
+        plan = describe_team_for_task("improve test coverage to 90%")
+        assert plan["task"] == "improve test coverage to 90%"
+        assert isinstance(plan["agents"], list)
+        assert plan["agents"], "expected at least one composed agent"
+        assert all("id" in a and "role" in a for a in plan["agents"])
+        assert isinstance(plan["strategy"], str)
+        # estimated_cost / quality_gates present and JSON-friendly
+        assert "estimated_cost" in plan
+        assert isinstance(plan["quality_gates"], list)
+
+    def test_agents_come_from_real_templates(self) -> None:
+        from attune.orchestration.agent_templates import get_registry
+
+        known = set(get_registry().keys())
+        plan = describe_team_for_task("audit this module for security issues")
+        assert {a["id"] for a in plan["agents"]} <= known
+
+    def test_empty_task_raises(self) -> None:
+        with pytest.raises(ValueError):
+            describe_team_for_task("")
+
+    def test_describe_does_not_require_a_run(self) -> None:
+        """Two previews are cheap/deterministic — same task, same agents."""
+        a = describe_team_for_task("improve test coverage")
+        b = describe_team_for_task("improve test coverage")
+        assert [x["id"] for x in a["agents"]] == [x["id"] for x in b["agents"]]
+
+
+@pytest.mark.unit
+class TestRunTeamExported:
+    def test_run_team_for_task_is_exported_and_async(self) -> None:
+        """The skill drives runs through this; just confirm it's importable
+        and a coroutine function (no execution — that would call LLMs)."""
+        import inspect
+
+        assert inspect.iscoroutinefunction(run_team_for_task)

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -302,8 +302,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 23, (
-            f"Expected 23 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 24, (
+            f"Expected 24 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:

--- a/tests/unit/plugins/test_registry_coverage.py
+++ b/tests/unit/plugins/test_registry_coverage.py
@@ -345,5 +345,29 @@ class TestWizardRunSurface:
         assert len(list_wizards()) >= 1, "no wizards registered for the run skill to drive"
 
 
+class TestAgentRunSurface:
+    """Agent templates have a RUN surface (the `agent` skill), not just a
+    catalog listing — the Phase 2 twin of TestWizardRunSurface."""
+
+    def test_agent_run_skill_exists_and_names_the_driver(self) -> None:
+        body = SKILL_BODIES.get("agent")
+        assert body is not None, (
+            "agent templates are registered but there is no `agent` run skill "
+            "in plugin/skills/ — they would be listable-but-not-runnable."
+        )
+        assert "run_team_for_task" in body, "the `agent` skill must run teams via run_team_for_task"
+        assert "describe_team_for_task" in body, (
+            "the `agent` skill must preview the composed team via "
+            "describe_team_for_task before running (cost gate)"
+        )
+
+    def test_agent_templates_exist_to_run(self) -> None:
+        try:
+            from attune.orchestration.agent_templates import get_all_templates
+        except ImportError:  # pragma: no cover - minimal env
+            pytest.skip("agent templates not importable in this environment")
+        assert len(get_all_templates()) >= 1, "no agent templates for the run skill to compose"
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

**Phase 2** (final) of the interactive-orchestration-access spec
(#1089). The 14 builtin agent templates were *listable* via the catalog
(#1088) but **not runnable**. This makes them runnable through a
Claude-driven `agent` skill — same "model drives, engine works" bridge
as Phase 1 (#1091).

## How it works

`attune.orchestration.team_driver`:

- `describe_team_for_task(task)` — **deterministic, no LLM.** Wraps
  `MetaOrchestrator().analyze_and_compose()` and serializes the
  `ExecutionPlan` (which agents from the templates, composition
  strategy, estimated cost/duration, quality gates). Safe to call for a
  preview.
- `run_team_for_task(task, ...)` — `compose_team()` →
  `DynamicTeam.execute()`. LLM-heavy.

The `agent` skill: goal → **preview** the composed team + estimated cost
→ **confirm** via `AskUserQuestion` → **run** → present the
`DynamicTeamResult`. The cost gate is mandatory (it's a paid
multi-agent run).

## Surfaces + guards

- `plugin/skills/agent/SKILL.md` (model-invocable) + `.agents/` sync.
- attune-hub Skills Reference + skill-count guard 23 → 24.
- New `TestAgentRunSurface` — the run-surface twin of catalog-completeness.
- Spec `design.md` Phase 2 updated from "sketch only" → IMPLEMENTED.

## Verification

- `tests/unit/plugins/` + `tests/unit/orchestration/test_team_driver.py`
  → 142 passed, 3 skipped.
- Driver tests cover `describe_team_for_task` **offline** (deterministic
  compose — no API calls); `run_team_for_task` is left to
  manual/integration use (real multi-agent LLM run), mirroring Phase 1.
- `sync_agents_skills.py --check` → 24 ok; black + ruff clean.

## This closes the hidden-functionality thread

Wizards (Phase 1, #1091) and agent teams (this PR) are now both
runnable. Every capability registry — workflows, MCP tools, wizards,
agents — is both discoverable (catalog) and invokable, each enforced by
a coverage guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
