### PR TITLE
fix(wizards): repair XML decomposition so interactive wizards produce tasks

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -11507,3 +11507,36 @@ files.
   confirm/review `FormQuestion` `QuestionType`-enum fix), KEEP the fix
   with its own driver-free regression test — don't let it ride out with
   the dead feature.
+
+- **The EmpathyLLM `interact()` path SILENTLY DROPS the caller's
+  `system` prompt and applies a level-based Socratic system prompt
+  instead — so structured output via `_call_llm` through
+  `WizardInternalWorkflow` must put the schema in the USER message, not
+  `system`.** Fixing the wizard `_call_llm` arg-drift (#1097) was
+  necessary-not-sufficient: with args corrected, the live call reached
+  the API but the model answered with "## Clarifying Questions" prose,
+  not `<tasks>` XML. Root cause chain (introspected, not guessed):
+  `_call_llm(tier, system, user_message)` → `empathy_executor.run`
+  stuffs `system` into `full_context["system_prompt"]` → `EmpathyLLM
+  .interact()` routes by `_determine_level(state)` (defaults to **level
+  2 "guided — ask clarifying questions"**) → every `_level_N_*` handler
+  builds its prompt from `_build_system_prompt(level)` =
+  `EmpathyLevel.get_system_prompt(level)` (+ Claude memory) and NEVER
+  reads `context["system_prompt"]`. So the task schema is discarded and
+  a Socratic system prompt is substituted. Two diagnostic tells: (1) the
+  response is byte-identical across system-prompt changes → `_call_llm`
+  caches and the cache key excludes `system` (vary `user_message`/
+  `stage_name` to bust); (2) `out_tokens` reported as 0 despite real
+  text. Fix that WORKED (dogfood: 2 parsed `<tasks>` for "add --dry-run
+  flag"): fold the schema into `user_message` (`system=""`) and tighten
+  it to forbid prose/questions and require output to begin with
+  `<tasks>`. This affects ANY structured-output use of `_call_llm` via
+  that executor — workflows that rely on `system` to carry a schema are
+  also at risk; the broader fix (honor `system`, or a non-Socratic
+  completion mode / `force_level=1`) is deferred. Pairs with the
+  "runnable ≠ runnable until dogfooded" lesson: the arg fix passed 467
+  mocked tests while the live feature still produced 0 tasks — only the
+  real-API dogfood exposed the second bug. Also: subscription mode ≠ raw
+  API — this path uses the `anthropic` SDK and needs a funded API key; a
+  stale repo-root `.env` (108-char dead key) shadowed the live key in
+  `~/.attune/anthropic.env` and 401'd until sourced explicitly.

--- a/src/attune/wizards/base.py
+++ b/src/attune/wizards/base.py
@@ -255,12 +255,15 @@ class BaseWizard(ABC):
 
         tier = _resolve_tier(step.tier)
 
-        # Call LLM — returns tuple[str, int, int] or str depending on executor
-        result = await self._workflow._call_llm(prompt, tier, step.id)
-        if isinstance(result, tuple):
-            response_text, _input_tokens, _output_tokens = result
-        else:
-            response_text = str(result)
+        # Call LLM — _call_llm(tier, system, user_message, ...) returns
+        # (text, input_tokens, output_tokens). The rendered XML prompt carries
+        # the role/goal/instructions, so it is the user message.
+        response_text, _input_tokens, _output_tokens = await self._workflow._call_llm(
+            tier=tier,
+            system="Follow the XML task specification precisely.",
+            user_message=prompt,
+            stage_name=step.id,
+        )
 
         # Parse response
         parsed = self._workflow._parse_xml_response(response_text)

--- a/src/attune/wizards/decomposer.py
+++ b/src/attune/wizards/decomposer.py
@@ -26,7 +26,15 @@ DECOMPOSITION_SYSTEM_PROMPT = """\
 You are a task decomposition specialist. Given a problem description and
 codebase context, break the work into self-contained sub-tasks.
 
-Respond ONLY with XML in this format (no other text):
+CRITICAL OUTPUT RULES — follow exactly:
+- Output ONLY the XML document. No prose, no markdown, no headings, no
+  code fences, no commentary before or after the XML.
+- Your response MUST begin with the literal characters `<tasks>` and end
+  with `</tasks>`.
+- Do NOT ask clarifying questions. If details are missing or ambiguous,
+  make reasonable assumptions and proceed.
+
+Use exactly this XML format:
 
 <tasks>
   <task id="1" name="short-name">
@@ -203,30 +211,31 @@ class TaskDecomposer:
         """
         constraints = constraints or []
 
-        prompt_parts = [
-            DECOMPOSITION_SYSTEM_PROMPT,
-            "",
-            f"Problem: {problem_description}",
-            "",
-        ]
+        # The schema and the problem go together in the user message: the
+        # EmpathyLLM interaction layer builds its own level-based system
+        # prompt and ignores the ``system`` argument, so the decomposition
+        # schema must travel in the user turn to actually reach the model.
+        user_parts = [DECOMPOSITION_SYSTEM_PROMPT, "", f"Problem: {problem_description}", ""]
 
         if codebase_context:
-            prompt_parts.append(f"Codebase context:\n{codebase_context}")
-            prompt_parts.append("")
+            user_parts.append(f"Codebase context:\n{codebase_context}")
+            user_parts.append("")
 
         if constraints:
-            prompt_parts.append("Constraints:")
+            user_parts.append("Constraints:")
             for c in constraints:
-                prompt_parts.append(f"- {c}")
+                user_parts.append(f"- {c}")
 
-        prompt = "\n".join(prompt_parts)
+        user_message = "\n".join(user_parts)
 
+        # _call_llm(tier, system, user_message, ...) -> (text, in_tokens, out_tokens).
         try:
-            result = await self._workflow._call_llm(prompt, ModelTier.CAPABLE, "decompose")
-            if isinstance(result, tuple):
-                response_text = result[0]
-            else:
-                response_text = str(result)
+            response_text, _in_tokens, _out_tokens = await self._workflow._call_llm(
+                tier=ModelTier.CAPABLE,
+                system="",
+                user_message=user_message,
+                stage_name="decompose",
+            )
         except Exception as e:  # noqa: BLE001
             logger.error("Task decomposition LLM call failed: %s", e)
             return []

--- a/src/attune/wizards/internal_workflow.py
+++ b/src/attune/wizards/internal_workflow.py
@@ -7,9 +7,10 @@ linear stage-pipeline execution model.
 
 Wizards call mixin methods directly via ``self._workflow``:
 
-    response = await self._workflow._call_llm(prompt, tier, "analyze")
-    prompt   = self._workflow._render_xml_prompt(role=..., goal=..., ...)
-    parsed   = self._workflow._parse_xml_response(response_text)
+    text, _in, _out = await self._workflow._call_llm(
+        tier=tier, system=..., user_message=..., stage_name="analyze")
+    prompt = self._workflow._render_xml_prompt(role=..., goal=..., ...)
+    parsed = self._workflow._parse_xml_response(text)
 
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0

--- a/tests/unit/wizards/test_wizard_base.py
+++ b/tests/unit/wizards/test_wizard_base.py
@@ -472,7 +472,7 @@ class TestRunLlmStep:
             ),
         ]
         wizard._workflow._render_xml_prompt = MagicMock(return_value="<prompt/>")
-        wizard._workflow._call_llm = AsyncMock(return_value="plain text response")
+        wizard._workflow._call_llm = AsyncMock(return_value=("plain text response", 10, 5))
         wizard._workflow._parse_xml_response = MagicMock(return_value=None)
 
         result = await wizard.run()

--- a/tests/unit/wizards/test_wizard_core.py
+++ b/tests/unit/wizards/test_wizard_core.py
@@ -240,7 +240,7 @@ class TestBaseWizardLLMStep:
         wizard = _SimpleWizard([step]).build()
 
         wizard._workflow._render_xml_prompt = MagicMock(return_value="<prompt/>")
-        wizard._workflow._call_llm = AsyncMock(return_value="<output>done</output>")
+        wizard._workflow._call_llm = AsyncMock(return_value=("<output>done</output>", 100, 50))
         wizard._workflow._parse_xml_response = MagicMock(return_value={"summary": "done"})
 
         result: WizardResult = await wizard.run()

--- a/tests/unit/wizards/test_wizard_coverage_boost.py
+++ b/tests/unit/wizards/test_wizard_coverage_boost.py
@@ -556,7 +556,7 @@ class TestBaseWizardLLMStep:
         wizard._session = WizardSession(wizard_id="cov-test")
 
         wizard._workflow._render_xml_prompt = MagicMock(return_value="<prompt/>")
-        wizard._workflow._call_llm = AsyncMock(return_value="plain response")
+        wizard._workflow._call_llm = AsyncMock(return_value=("plain response", 100, 50))
         wizard._workflow._parse_xml_response = MagicMock(return_value=None)
 
         step = WizardStep(id="llm2", name="LLM Step", step_type=StepType.LLM_CALL)

--- a/tests/unit/wizards/test_wizard_decomposer.py
+++ b/tests/unit/wizards/test_wizard_decomposer.py
@@ -336,11 +336,22 @@ class TestTaskDecomposerDecompose:
         mock_workflow._call_llm.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_decompose_non_tuple_result(self):
-        """Test decompose handles non-tuple LLM result."""
+    async def test_decompose_sends_schema_in_user_message(self):
+        """Test decompose folds the schema into the user message.
+
+        The EmpathyLLM interaction layer overrides the ``system`` argument
+        with its own level-based prompt, so the decomposition schema must
+        travel in the user turn to actually reach the model.
+        """
+        from attune.wizards.decomposer import DECOMPOSITION_SYSTEM_PROMPT
+
         mock_workflow = MagicMock()
         mock_workflow._call_llm = AsyncMock(
-            return_value='<tasks><task id="1" name="t"><objective>O</objective></task></tasks>'
+            return_value=(
+                '<tasks><task id="1" name="t"><objective>O</objective></task></tasks>',
+                10,
+                5,
+            )
         )
         decomposer = TaskDecomposer(workflow=mock_workflow)
 
@@ -350,6 +361,9 @@ class TestTaskDecomposerDecompose:
         )
 
         assert len(tasks) == 1
+        call_args = mock_workflow._call_llm.call_args
+        assert call_args.kwargs["system"] == ""
+        assert DECOMPOSITION_SYSTEM_PROMPT in call_args.kwargs["user_message"]
 
     @pytest.mark.asyncio
     async def test_decompose_llm_failure(self):
@@ -393,7 +407,7 @@ class TestTaskDecomposerDecompose:
 
         # Verify codebase context section is not in prompt
         call_args = mock_workflow._call_llm.call_args
-        prompt = call_args[0][0]
+        prompt = call_args.kwargs["user_message"]
         assert "Codebase context:" not in prompt
 
 
@@ -677,7 +691,7 @@ class TestDecomposeWithParams:
         )
 
         call_args = mock_workflow._call_llm.call_args
-        prompt = call_args[0][0]
+        prompt = call_args.kwargs["user_message"]
         assert "No breaking changes" in prompt
         assert "Keep coverage > 80%" in prompt
 
@@ -694,7 +708,7 @@ class TestDecomposeWithParams:
         )
 
         call_args = mock_workflow._call_llm.call_args
-        prompt = call_args[0][0]
+        prompt = call_args.kwargs["user_message"]
         assert "Flask app with Postgres" in prompt
         assert "Codebase context:" in prompt
 
@@ -712,7 +726,7 @@ class TestDecomposeWithParams:
         )
 
         call_args = mock_workflow._call_llm.call_args
-        prompt = call_args[0][0]
+        prompt = call_args.kwargs["user_message"]
         assert "Constraints:" not in prompt
 
     @pytest.mark.asyncio
@@ -728,7 +742,7 @@ class TestDecomposeWithParams:
         )
 
         call_args = mock_workflow._call_llm.call_args
-        prompt = call_args[0][0]
+        prompt = call_args.kwargs["user_message"]
         assert "Implement OAuth2 login flow" in prompt
 
     @pytest.mark.asyncio
@@ -746,7 +760,7 @@ class TestDecomposeWithParams:
         )
 
         call_args = mock_workflow._call_llm.call_args
-        tier_arg = call_args[0][1]
+        tier_arg = call_args.kwargs["tier"]
         assert tier_arg == ModelTier.CAPABLE
 
     @pytest.mark.asyncio
@@ -762,5 +776,5 @@ class TestDecomposeWithParams:
         )
 
         call_args = mock_workflow._call_llm.call_args
-        step_id_arg = call_args[0][2]
+        step_id_arg = call_args.kwargs["stage_name"]
         assert step_id_arg == "decompose"


### PR DESCRIPTION
## What

Repairs the wizard **XML-enhanced decomposition** so interactive wizards actually produce tasks. The XML feature was non-functional on two counts — both fixed here, with a live dogfood receipt.

## The two bugs

**1. `_call_llm` argument drift.** `base.py::_run_llm_step` and `decomposer.py::decompose()` called `_call_llm(prompt, tier, label)`, but the real signature is `_call_llm(tier, system, user_message, ...)`. The prompt string landed in the `tier` slot, so every wizard LLM step / decompose crashed before reaching the model (`'str' has no attribute 'value'`). Now called with keyword args, unpacking `(text, in_tokens, out_tokens)`.

**2. Dropped system prompt.** The EmpathyLLM interaction layer (`interact()` → `_level_N_*`) builds its own level-based system prompt and **ignores the caller's `system` argument**. So `decompose()`'s schema-as-system never reached the model — it answered with Socratic clarifying questions instead of XML. Fixed by folding the decomposition schema into the **user message** (where it actually reaches the model) and tightening it to forbid prose/questions and require output to begin with `<tasks>`.

## Dogfood receipt (real API, CAPABLE tier)

`decompose("Add a --dry-run flag to the export CLI command", …)` →

```
2 task(s):
  [1] add-dry-run-flag   — modify=1, checks=3
  [2] unit-test-dry-run  — create=1, checks=3
```

Proper `<tasks>` XML, parsed into `DecomposedTask` objects. Before the fix this returned 0 tasks (crash, then Socratic prose).

## Preserved (unchanged)

`_render_xml_prompt`, the `<task>` schema, `DecomposedTask.to_xml()`, and `_parse_tasks_from_xml` (live via `pipeline/spec_reader.py`) are all untouched — this restores the path that delivers them to the model. Tests updated to pin the corrected keyword contract; **467 wizard + spec_reader tests green**.

## Follow-up (noted, not in scope)

The EmpathyLLM `interact()` path discarding the caller's `system` prompt is a broader limitation affecting any structured-output use of `_call_llm` via that executor. Worked around here (schema in user message); a proper fix (honor `system`, or a non-Socratic completion mode) is a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
