### PR TITLE
feat(agents): generic parallel agent teams (generic-agent-teams spec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Generic parallel agent-team infrastructure (`attune.agents.team`).**
+  A reusable `AgentTeam` coordinator + `WorkflowAgent` that wraps a
+  `BaseWorkflow`, fans agents out via `asyncio.gather`, aggregates their
+  0–100 scores, and gates on declarative `GateSpec`s (critical → blocker,
+  else warning). Generalizes the working `ReleasePrepTeam` pattern; does
+  not revive the dead engine removed in #1096. The `/spec` quality gate
+  (`pipeline.orchestrator._run_quality_gate`) is re-seated onto it as the
+  first consumer — behavior preserved (empty-file trivial pass, file cap,
+  per-file min, fail-closed-on-error). A non-mocked dogfood confirms a
+  real `code-review` + `security-audit` team blocks a vulnerable file
+  with real sub-threshold scores and non-zero cost. See
+  `docs/specs/generic-agent-teams/`.
 - **Catalog-completeness guard.** A new `TestCatalogCompleteness` guard
   (in `test_registry_coverage.py`) fails if any surfaced registry drops
   out of `list_capabilities` or its count drifts from the live registry —

--- a/docs/specs/generic-agent-teams/decisions.md
+++ b/docs/specs/generic-agent-teams/decisions.md
@@ -1,0 +1,127 @@
+# Decisions: Generic parallel agent teams
+
+**Status:** APPROVED (2026-06-26) — ready to execute (T1)
+**Requirements:** [requirements.md](requirements.md) ·
+**Design:** [design.md](design.md)
+
+---
+
+## Decision log
+
+### D1 — Agent unit of work is a `BaseWorkflow` (decided 2026-06-26)
+
+Each team agent wraps a registered `BaseWorkflow`; its job is to run
+that workflow over a target and surface a 0–100 score.
+
+**Why:** maximum leverage — reuses all existing workflow infra
+(tiering, output, cost) and matches what the fixed `/spec` gate
+already does ad-hoc with `CodeReviewWorkflow` + `SecurityAuditWorkflow`.
+
+**Rejected:** arbitrary callable/tool (rebuilds result/score
+conventions per tool); prompt+role LLM-native (needs the real
+execution backend `StubAgent` never had — the thing #1096 deleted).
+
+### D2 — Parallel fan-out only for v1 (decided 2026-06-26)
+
+`asyncio.gather` over independent agents, then aggregate + gate.
+No sequential stages, no DAG.
+
+**Why:** it is the proven `ReleasePrepTeam` shape and covers both
+live consumers. Sequential/DAG needs a plan representation that adds
+design surface and slows the first dogfood. Deferred to a follow-up.
+
+### D3 — First consumer is the `/spec` quality gate (decided 2026-06-26)
+
+`_run_quality_gate` is re-seated onto `AgentTeam`.
+
+**Why:** it is live, dogfooded on every `/spec` run, and already the
+exact two-agent parallel-review shape — zero orphaned-motivation risk
+(the failure mode that reversed #1093/#1096). A user-facing `/team`
+CLI is explicitly a non-goal for the same reason.
+
+---
+
+## Resolved open questions
+
+### OQ1 → D4 — Home is `attune.agents`, not `attune.orchestration`
+
+New module `src/attune/agents/team.py` houses `WorkflowAgent`,
+`AgentTeam`, `GateSpec`, `AgentResult`, `TeamReport`.
+
+**Why:** the working base it generalizes (`ReleaseAgent`,
+`ReleasePrepTeam`, `AgentStateStore`) already lives in
+`attune.agents`. `attune.orchestration` was just pruned to
+agent-templates + execution-strategies (#1096) and is semantically
+the dead-engine namespace; re-introducing "team" there invites
+confusion with the symbols we deleted. Keep the generalization next to
+the code it lifts from.
+
+### OQ2 → D5 — One canonical score extractor, overridable
+
+`WorkflowAgent` owns a default `extract_score(result) -> float` that
+mirrors the existing gate logic: `findings["score"]` →
+`metadata["score"]` → the `score:\s*N/100` regex fallback
+(`_SCORE_RE`) → a configured default. A `WorkflowAgent` may pass a
+`score_fn` override for workflows that report differently.
+
+**Why:** de-duplicating this is half the point of the abstraction —
+today the logic is inline in `pipeline/orchestrator.py`
+(`_extract_score`/`_SCORE_RE`) and again, differently, in
+`ReleasePrepTeam._evaluate_quality_gates` (`findings["coverage_percent"]`
+etc.). One shared extractor with a per-agent escape hatch covers both
+without forcing every workflow into one score shape.
+
+### OQ3 → D6 — Reuse `QualityGate`; add a thin `GateSpec` input
+
+Input: `GateSpec(name, agent_key, threshold, critical=True)`.
+Evaluated output: the existing `QualityGate(name, threshold, actual,
+passed, critical, message)` dataclass (lift it to a shared location).
+
+**Why:** `QualityGate` already carries the critical-vs-warning flag the
+team needs to split blockers from warnings; a slimmer spec would lose
+it. The declarative `GateSpec` (which agent, what threshold) is the
+only new shape, and it is what lets one team config differ from
+another without code.
+
+### OQ4 → D7 — The team contract is **async**; sync agents adapt internally
+
+`AgentTeam.run()` does `await asyncio.gather(*[a.run(path) for a in
+agents])`. `WorkflowAgent.run()` is natively async (it `await`s the
+workflow). Sync agents (the subprocess-based release agents) implement
+the same async `run()` by offloading their existing sync `process()`
+via `loop.run_in_executor` — the shim moves *into* the agent, out of
+the coordinator.
+
+**Why:** workflows are async, so a natively-async team avoids the
+executor round-trip for the primary (D1) case. Making the *contract*
+async and letting sync agents adapt keeps the coordinator uniform and
+still satisfies R6 (re-seat `ReleasePrepTeam`) without rewriting its
+subprocess agents.
+
+---
+
+## D8 — Escalation and Redis/state opt-in, off by default (2026-06-26)
+
+`WorkflowAgent` does not escalate tiers or require Redis/`AgentStateStore`
+by default. Escalation is `escalate=False`; `state_store`/`redis` default
+`None` (no-op, as in the base).
+
+**Why:** the `/spec` consumer's wrapped workflows already self-tier, so
+re-running them at a higher tier on a low score is redundant for v1. The
+escalation/heartbeat/state machinery is preserved in the base for the
+release-team case and future consumers, but kept off the v1 critical path
+to keep the first dogfood small. Revisit if a consumer wants score-driven
+escalation.
+
+---
+
+## Cross-references
+
+- `.claude/rules/attune/removing-dead-code.md` — generalize the working
+  sibling; never revive `SDKAgent`/`StubAgent` (R7 guard).
+- `docs/specs/spec-gate-real-review/decisions.md` — the #1096 reversal
+  and the deferred non-goal this spec fulfills.
+- Lift sources: `agents/release/base_agent.py` (`ReleaseAgent`),
+  `agents/release/release_prep_team.py` (`ReleasePrepTeam`,
+  `QualityGate` via `release_models`), `pipeline/orchestrator.py`
+  (`_run_quality_gate`, `_extract_score`, `_SCORE_RE`).

--- a/docs/specs/generic-agent-teams/decisions.md
+++ b/docs/specs/generic-agent-teams/decisions.md
@@ -115,6 +115,43 @@ escalation.
 
 ---
 
+## D9 — ReleasePrepTeam re-seat: take the R6 fallback (2026-06-26, execution)
+
+`ReleasePrepTeam` keeps its bespoke `_evaluate_quality_gates` /
+`_identify_issues` and is **not** re-seated onto `AgentTeam`. It already
+shares the single `QualityGate` definition (see the D6 clarification
+below). R6's documented fallback is exercised.
+
+**Why:** the release team's four gates are heterogeneous in a way the
+slim v1 `GateSpec` (D6: `actual >= threshold`) does not model:
+
+- **Security** is a *max* gate — `critical_issues <= max_critical_issues`
+  (lower is better), not a min-score threshold.
+- **Quality** is on a **0–10** scale (`min_quality_score = 7.0`), not the
+  0–100 the team scorer assumes.
+- Each gate reads a **different findings key** (`critical_issues`,
+  `coverage_percent`, `quality_score`), not a uniform `score`.
+
+Re-seating faithfully would require expanding `GateSpec` with a
+comparison direction and per-agent finding extractors — adding v1 design
+surface the primary consumer (`/spec`) never needed, and risking drift on
+a **working, fully-tested** release path (`test_release_prep_team.py`,
+`test_release_prep_team_report.py`) for **zero behavior change**. That is
+precisely the risk R6's fallback clause guards against. The richer
+comparator model is deferred to a follow-up if a second consumer needs it.
+
+**Realized D6 — shared home is `release_models`, not `team.py`.** D6/design
+proposed moving `QualityGate` into `team.py` with `release_models`
+re-exporting. Realized the other way: `QualityGate` stays defined in
+`agents/release/release_models.py` and `agents/team.py` imports it from
+there. Moving it into `team.py` would make `release_models` import from
+`team.py` while `team.py` imports from `release_models` — a circular
+import. Keeping the definition in `release_models` gives the single shared
+source D6 wanted with no cycle and no churn to the widely-imported
+release module.
+
+---
+
 ## Cross-references
 
 - `.claude/rules/attune/removing-dead-code.md` — generalize the working

--- a/docs/specs/generic-agent-teams/design.md
+++ b/docs/specs/generic-agent-teams/design.md
@@ -1,0 +1,307 @@
+# Design: Generic parallel agent teams
+
+**Status:** APPROVED (2026-06-26) — ready to execute (T1)
+**Requirements:** [requirements.md](requirements.md) ·
+**Decisions:** [decisions.md](decisions.md)
+
+---
+
+## Architecture
+
+A team is an explicit list of agents plus a declarative gate spec. The
+coordinator fans out, aggregates, and gates. Nothing more — no plan,
+no DAG (D2).
+
+```text
+AgentTeam(agents=[...], gates=[GateSpec, ...])
+  .run(target) -> TeamReport
+    await gather(agent.run(target) for agent in agents)   # D7 async
+      WorkflowAgent.run(target) -> AgentResult            # D1 wraps a BaseWorkflow
+        run wrapped workflow over target's file(s),
+        extract 0-100 score (D5), sum cost
+    evaluate GateSpecs against AgentResults -> QualityGate[] (D6)
+    split critical-fail -> blockers, non-critical -> warnings
+    verdict = no blockers and no critical gate failures
+```
+
+### The contract (async, D7)
+
+```python
+class TeamAgent(Protocol):
+    key: str
+    async def run(self, target: TeamTarget) -> AgentResult: ...
+```
+
+`WorkflowAgent` implements it natively async. A sync agent (the
+subprocess release agents) implements the same `run` by offloading its
+existing `process()` via `loop.run_in_executor` — the shim lives in the
+agent, not the coordinator.
+
+### Data classes (new, in `agents/team.py`)
+
+```python
+@dataclass
+class AgentResult:
+    key: str            # "code-review"
+    score: float        # 0-100 (min across files for multi-file targets)
+    cost: float
+    success: bool       # False if the wrapped workflow errored
+    details: dict[str, Any]
+
+@dataclass
+class GateSpec:         # declarative input
+    name: str           # "Code Quality"
+    agent_key: str      # "code-review"
+    threshold: float    # 70.0
+    critical: bool = True
+
+@dataclass
+class TeamReport:
+    passed: bool
+    gates: list[QualityGate]      # reuse existing dataclass (D6)
+    results: list[AgentResult]
+    blockers: list[str]
+    warnings: list[str]
+    cost: float
+```
+
+`QualityGate` (name, threshold, actual, passed, critical, message) is
+**lifted** from `agents/release/release_models.py` to a shared home so
+both the team and the release models import it from one place.
+
+### Shared score extractor (D5)
+
+Lift `_extract_score` / `_SCORE_RE` out of `pipeline/orchestrator.py`
+into `agents/team.py` as the default `WorkflowAgent` scorer:
+`findings["score"]` → `metadata["score"]` → `score:\s*N/100` regex →
+configured default. A `WorkflowAgent(score_fn=...)` overrides it.
+
+---
+
+## Seam 1 — `/spec` quality gate (D3, the first consumer)
+
+`_run_quality_gate` today: per-file fan-out of two workflows, min per
+dimension, threshold 70. It becomes an `AgentTeam` of two agents, each
+running its workflow over the file set and returning the **min** score
+(behavior-preserving — R4):
+
+```python
+team = AgentTeam(
+    agents=[
+        WorkflowAgent("code-review", CodeReviewWorkflow, files=files),
+        WorkflowAgent("security-audit", SecurityAuditWorkflow, files=files),
+    ],
+    gates=[
+        GateSpec("Code Quality", "code-review", self._GATE_THRESHOLD),
+        GateSpec("Security", "security-audit", self._GATE_THRESHOLD),
+    ],
+)
+report = await team.run(files)
+return (report.passed, report_to_gate_details(report), report.cost)
+```
+
+The empty-file trivial-pass, the `_GATE_MAX_FILES` cap, and the
+fail-closed-on-error semantics are preserved — the per-file min and the
+try/except move into `WorkflowAgent.run`.
+
+## Seam 2 — `ReleasePrepTeam` re-seat (R6)
+
+`ReleasePrepTeam` keeps its four subprocess agents but builds an
+`AgentTeam` to run them: each release agent gains an async `run()`
+shim around its sync `process()`, and `_evaluate_quality_gates`
+becomes a list of `GateSpec`s. Observable `release-prep` output is
+unchanged (R6 verifies via the existing report). If the re-seat proves
+to add risk for no behavior change, the fallback is to document why
+`ReleasePrepTeam` stays as-is and have it merely *import* the shared
+`QualityGate` — but the default is to re-seat.
+
+---
+
+## File plan
+
+### Create
+
+- `src/attune/agents/team.py` — `TeamAgent` protocol, `WorkflowAgent`,
+  `AgentTeam`, `GateSpec`, `AgentResult`, `TeamReport`, default scorer.
+- `tests/unit/agents/test_team.py` — unit coverage for the scorer,
+  gate evaluation (critical vs warning split), parallel run, and
+  fail-closed on a raising workflow.
+- `tests/integration/test_agent_team_dogfood.py` — **non-mocked** R5
+  receipt.
+
+### Modify
+
+- `src/attune/agents/release/release_models.py` — `QualityGate` moves
+  to the shared home; re-export here for back-compat.
+- `src/attune/pipeline/orchestrator.py` — `_run_quality_gate` re-seated
+  onto `AgentTeam`; `_extract_score`/`_SCORE_RE`/`_min_score`/
+  `_result_cost` delegate to the shared scorer (or are removed once
+  lifted).
+- `src/attune/agents/release/release_prep_team.py` — build an
+  `AgentTeam`; release agents gain async `run()` shims.
+- `CHANGELOG.md` — `### Added` generic agent-team infrastructure.
+
+---
+
+## Tasks
+
+```xml
+<task id="1" name="generic-team-module">
+  <objective>
+    Create the generic parallel agent-team abstraction: a BaseWorkflow-
+    wrapping agent and an async coordinator that fans out, aggregates,
+    and gates. No consumer rewired yet — pure new infrastructure.
+  </objective>
+  <context>
+    <existing-code path="src/attune/agents/release/base_agent.py">
+      ReleaseAgent — the working escalation/LLM/state/heartbeat base to
+      generalize from. Do NOT revive StubAgent/SDKAgent.
+    </existing-code>
+    <existing-code path="src/attune/pipeline/orchestrator.py">
+      _extract_score / _SCORE_RE / _min_score / _result_cost — the score
+      logic to lift into the shared default scorer (D5).
+    </existing-code>
+    <existing-code path="src/attune/agents/release/release_models.py">
+      QualityGate dataclass — lift to a shared home, re-export here.
+    </existing-code>
+  </context>
+  <files-to-create>
+    <file path="src/attune/agents/team.py">
+      TeamAgent (Protocol, async run), WorkflowAgent(key, workflow_cls,
+      *, files=None, score_fn=None, escalate=False), AgentTeam(agents,
+      gates), GateSpec, AgentResult, TeamReport, default extract_score().
+      WorkflowAgent.run runs the workflow over each file, mins scores,
+      sums cost, fails closed on exception (success=False, score=0).
+    </file>
+    <file path="tests/unit/agents/test_team.py">
+      Scorer precedence; GateSpec eval splits blockers (critical) vs
+      warnings (non-critical); AgentTeam.run gathers in parallel; a
+      raising workflow -> success=False, gate fails closed.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>pytest tests/unit/agents/test_team.py green</check>
+    <check>AgentTeam with a fake passing + fake failing agent yields
+      passed=False with the failing one in blockers</check>
+    <check>grep -rn "StubAgent|DynamicTeam|SDKAgent" src/attune/agents/team.py
+      is empty (R7)</check>
+  </validation>
+  <risks>
+    <risk severity="low">Score-shape variance across workflows — mitigated
+      by the regex fallback + score_fn override (D5).</risk>
+  </risks>
+</task>
+
+<task id="2" name="reseat-spec-gate">
+  <objective>
+    Re-seat /spec's _run_quality_gate onto AgentTeam, preserving the
+    empty-file trivial pass, the file cap, the per-dimension min, and
+    fail-closed-on-error. Ship the non-mocked dogfood receipt (R5).
+  </objective>
+  <context>
+    <existing-code path="src/attune/pipeline/orchestrator.py">
+      _run_quality_gate (post-#1094). Behavior to preserve exactly;
+      only the mechanism changes from inline gather to AgentTeam.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/pipeline/orchestrator.py">
+      <change location="_run_quality_gate">
+        BEFORE: inline jobs = [_review(cr, p)...] + [_review(sa, p)...]
+        AFTER: build AgentTeam([WorkflowAgent code-review, security-audit],
+        gates) and await team.run(files); map TeamReport -> existing
+        (passed, details, cost) tuple shape.
+      </change>
+    </file>
+  </files-to-modify>
+  <files-to-create>
+    <file path="tests/integration/test_agent_team_dogfood.py">
+      Non-mocked: AgentTeam of real CodeReviewWorkflow + SecurityAuditWorkflow
+      over a deliberately-bad temp file (eval() / hardcoded secret) returns
+      passed=False, a score < 70, cost > 0. Gated/skipped per the keyless-CI
+      convention if it needs a key.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Existing /spec gate tests still green (behavior parity)</check>
+    <check>A trivial task with no files still trivially passes</check>
+    <check>The dogfood test produces a blocked verdict with real scores</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Behavior drift from the per-file min when it
+      moves into the agent — covered by the parity tests + dogfood.</risk>
+  </risks>
+</task>
+
+<task id="3" name="reseat-release-team">
+  <objective>
+    Re-seat ReleasePrepTeam onto AgentTeam (R6): its four subprocess
+    agents gain async run() shims; quality gates become GateSpecs.
+    release-prep observable output unchanged.
+  </objective>
+  <context>
+    <existing-code path="src/attune/agents/release/release_prep_team.py">
+      assess_readiness (run_in_executor fan-out) and
+      _evaluate_quality_gates (four hardcoded gates) to express via
+      AgentTeam + GateSpec.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/agents/release/release_prep_team.py">
+      <change location="ReleasePrepTeam.assess_readiness">
+        Build an AgentTeam from the four agents (async run() shim around
+        sync process()) and GateSpecs; keep the bespoke
+        ReleaseReadinessReport conversion.
+      </change>
+    </file>
+    <file path="src/attune/agents/release/base_agent.py">
+      <change location="ReleaseAgent">
+        Add async run(target) -> AgentResult that offloads process()
+        via run_in_executor and maps ReleaseAgentResult -> AgentResult.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>release-prep workflow output unchanged (existing tests green)</check>
+    <check>ReleasePrepTeam builds and runs via AgentTeam</check>
+  </validation>
+  <risks>
+    <risk severity="low">If re-seat adds risk with zero behavior change,
+      fall back to importing the shared QualityGate only and document it
+      in decisions.md.</risk>
+  </risks>
+</task>
+
+<task id="4" name="finalize-docs-guard">
+  <objective>
+    Lock the spec: decisions.md final, CHANGELOG entry, and a guard test
+    asserting no deleted-engine symbol returns (R7).
+  </objective>
+  <files-to-modify>
+    <file path="CHANGELOG.md">
+      <change location="[Unreleased] ### Added">
+        Generic parallel agent-team infrastructure (attune.agents.team);
+        /spec quality gate re-seated onto it.
+      </change>
+    </file>
+  </files-to-modify>
+  <files-to-create>
+    <file path="tests/unit/agents/test_no_revived_dead_code.py">
+      Assert grep of src/ for StubAgent|DynamicTeam|SDKAgent stays empty
+      (regression guard for the generalize-not-revive constraint).
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Full suite green; import attune.orchestration clean (R8)</check>
+    <check>health-check workflow still runs (R8 no collateral damage)</check>
+  </validation>
+</task>
+```
+
+---
+
+## Sequencing
+
+T1 (abstraction) → T2 (first consumer + R5 dogfood, the keystone) →
+T3 (generalization proof) → T4 (lock). T1+T2 alone deliver a real,
+dogfooded capability; T3+T4 prove and seal it.

--- a/docs/specs/generic-agent-teams/requirements.md
+++ b/docs/specs/generic-agent-teams/requirements.md
@@ -1,0 +1,177 @@
+# Spec: Generic parallel agent teams
+
+**Status:** APPROVED (2026-06-26) — ready to execute (T1)
+**Owner:** Patrick + agent
+**Fulfills the deferred non-goal of:**
+`spec-gate-real-review` ("Building a general agent-team feature …
+generalize the working `ReleasePrepTeam`, not the deleted `SDKAgent`")
+
+---
+
+## Problem
+
+Two live code paths run a parallel set of analysis workflows,
+aggregate their scores, and gate on the result — and each
+re-implements the same fan-out/aggregate/gate logic inline:
+
+- **`ReleasePrepTeam`** (`agents/release/release_prep_team.py`) —
+  four agents (`SecurityAuditor`, `TestCoverage`, `CodeQuality`,
+  `Documentation`) run via `asyncio.gather` + `run_in_executor`,
+  then `_evaluate_quality_gates` applies thresholds.
+- **The `/spec` quality gate** (`pipeline/orchestrator.py::
+  _run_quality_gate`, post-#1094) — instantiates `CodeReviewWorkflow`
+  + `SecurityAuditWorkflow`, runs them over each task's files via
+  `asyncio.gather`, extracts 0–100 scores, fails **closed** on error,
+  and gates on min-score thresholds.
+
+The `/spec` gate is, structurally, a hardcoded two-agent parallel
+team. `ReleasePrepTeam` is the same pattern with four agents and a
+reusable escalation/state/heartbeat base (`ReleaseAgent`,
+`AgentStateStore`). The team abstraction already exists — it is just
+welded to one use case and duplicated inline at the other.
+
+There is no reusable way to say "run these N workflows as a team and
+gate on their scores." Each new consumer copies the gather/aggregate
+glue.
+
+### Why this is not the engine that was removed
+
+This spec deliberately **generalizes the working sibling**, per
+`.claude/rules/attune/removing-dead-code.md`. The deleted
+`DynamicTeam`/`StubAgent` engine (removed in #1096; see
+`docs/specs/spec-gate-real-review/decisions.md`) was a fake-success
+stub with orphaned motivation — `StubAgent.process()` returned
+`success=True, cost=0, findings={}` and did no work. The `ReleaseAgent`
+base does real work (shells out to bandit/pytest/ruff, real LLM calls
+with cost tracking, real tier escalation). v1 lifts the **proven**
+base, never resurrects the stub.
+
+---
+
+## Goals
+
+1. **Extract a generic `WorkflowAgent` base** from `ReleaseAgent` —
+   tier escalation, optional LLM call, Redis heartbeat, and
+   `AgentStateStore` persistence — whose unit of work is a
+   `BaseWorkflow` run over a target path, yielding a 0–100 score.
+2. **Extract a generic `AgentTeam` coordinator** from
+   `ReleasePrepTeam` — takes an explicit list of agents plus a
+   declarative gate spec, runs them in parallel (fan-out only),
+   aggregates scores, and produces a pass/fail verdict with
+   blockers/warnings.
+3. **Make the `/spec` quality gate the first real consumer.**
+   `_run_quality_gate` becomes an `AgentTeam` of a `code-review`
+   agent + a `security-audit` agent over the task's files, gated on
+   the existing thresholds — replacing the inline gather glue with
+   the shared abstraction.
+4. **Re-seat `ReleasePrepTeam` on the generic base** so it becomes
+   one configuration of `AgentTeam`, proving the abstraction covers
+   the richer four-agent case without behavior change.
+
+---
+
+## Non-goals
+
+- **Sequential / DAG topology.** v1 is parallel fan-out only
+  (decision D2). Pipelines where stage N feeds stage N+1 are deferred
+  to a follow-up; no plan/DAG representation in v1.
+- **A user-facing `/team` CLI or MCP run surface.** v1 is library
+  infrastructure with two live in-process consumers. A user-facing
+  "run an ad-hoc team" command is a separate spec with its own
+  motivation (avoiding the run-surface-for-an-unproven-engine pattern
+  that got reversed in #1093).
+- **Reviving any deleted symbol.** `SDKAgent`, `StubAgent`,
+  `DynamicTeam`, `team_builder`, `workflow_composer`,
+  `meta_orchestrator` stay deleted. If a behavior is wanted, it is
+  rebuilt on the working base, not restored.
+- **Changing `AgentStateStore` / `AgentRecoveryManager`.** Reused
+  as-is.
+
+---
+
+## Decisions already made (carried into design)
+
+- **D1 — Agent unit of work is a `BaseWorkflow`.** Each agent wraps a
+  registered workflow; `_execute_tier` runs it and extracts its score.
+  Maximum leverage — reuses all workflow infra and matches what the
+  fixed `/spec` gate already does ad-hoc.
+- **D2 — Parallel fan-out only for v1.** `asyncio.gather` + aggregate
+  + gate, exactly like `ReleasePrepTeam` today. Ship and dogfood this
+  before adding any sequential/DAG complexity.
+- **D3 — First consumer is the `/spec` quality gate.** Live,
+  already-dogfooded on every `/spec` run; no orphaned-motivation risk.
+
+---
+
+## End state (Done when)
+
+- A generic `WorkflowAgent` + `AgentTeam` exist (location settled in
+  design.md), each agent wrapping a `BaseWorkflow` and the team running
+  agents in parallel with a declarative gate spec.
+- `/spec`'s `_run_quality_gate` runs through `AgentTeam`
+  (`code-review` + `security-audit`) and preserves current behavior:
+  bad task → gate fails; review error → fails closed, never fake-pass.
+- `ReleasePrepTeam` is re-seated on `AgentTeam` (or documented why
+  not) with no change to its observable `release-prep` output.
+- A **non-mocked** dogfood receipt: a real `AgentTeam` of `code-review`
+  + `security-audit` run over a deliberately-bad file returns a
+  **blocked** verdict with real scores < threshold and non-zero cost.
+- `decisions.md` records D1–D3, the generalize-don't-revive constraint,
+  and the chosen module location; references the #1096 reversal.
+- Full suite green; `health-check` still runs (no collateral damage to
+  live strategies).
+
+---
+
+## Acceptance criteria
+
+| # | Criterion | Verify |
+|---|-----------|--------|
+| R1 | Generic base does real work | `WorkflowAgent` runs a `BaseWorkflow` and returns its real 0–100 score (not a stub constant) |
+| R2 | Team runs parallel + gates | `AgentTeam` runs N agents via `asyncio.gather`, aggregates, applies declarative thresholds |
+| R3 | `/spec` gate re-seated | `_run_quality_gate` builds an `AgentTeam`; trivial task still completes |
+| R4 | Gate honest on error | A review workflow raising → gate fails closed, not fake-pass (preserves #1094 behavior) |
+| R5 | Non-mocked dogfood | Real `code-review` + `security-audit` team on a bad file → blocked, scores < threshold, cost > 0 |
+| R6 | ReleasePrepTeam re-seated | `release-prep` output unchanged; team built on generic base |
+| R7 | No revived dead code | `grep -rn "StubAgent\|DynamicTeam\|SDKAgent" src/` stays empty |
+| R8 | No collateral damage | `health-check` runs; `import attune.orchestration` clean; full suite green |
+| R9 | Auditable | decisions.md records D1–D3 + generalize-not-revive + module location, references #1096 |
+
+---
+
+## Open questions (resolve in design.md)
+
+- **OQ1 — Module home.** Does the generic team live in
+  `attune.orchestration` (the natural namespace, but recently pruned
+  and semantically loaded by the dead engine) or `attune.agents`
+  (where the working base already lives)? Leaning `attune.agents`.
+- **OQ2 — Score extraction contract.** `_run_quality_gate` already has
+  `_extract_score` / `_SCORE_RE` fallback parsing. Does `WorkflowAgent`
+  own a single canonical "score from a `WorkflowResult`" extractor that
+  both consumers share, or does each agent supply its own scorer?
+- **OQ3 — Gate spec shape.** Reuse `ReleasePrepTeam`'s `QualityGate`
+  dataclass + threshold dict, or a slimmer declarative spec now that
+  there is no team-plan indirection?
+- **OQ4 — Sync vs async agents.** `ReleaseAgent.process()` is sync
+  (offloaded via `run_in_executor`); workflows are async. Settle
+  whether `WorkflowAgent` is natively async (gather directly) or keeps
+  the executor shim for parity with the sync release agents.
+
+---
+
+## Cross-references
+
+- `.claude/rules/attune/removing-dead-code.md` — the
+  generalize-the-working-sibling rule this spec follows.
+- `docs/specs/spec-gate-real-review/decisions.md` — the #1096 dead-
+  engine reversal and the deferred non-goal this spec fulfills.
+- `docs/specs/interactive-orchestration-access/decisions.md` — the
+  #1093 reversal (run-surface-for-dead-engine), motivating the
+  no-`/team`-CLI non-goal.
+- Working base to generalize: `agents/release/base_agent.py`
+  (`ReleaseAgent`), `agents/release/release_prep_team.py`
+  (`ReleasePrepTeam`), `agents/state/store.py` (`AgentStateStore`).
+- First consumer: `pipeline/orchestrator.py::_run_quality_gate`
+  (post-#1094 real-review gate).
+- `.claude/rules/attune/xml-enhanced-prompts.md` — the implementation
+  tasks (design phase) use XML-enhanced prompts.

--- a/docs/specs/generic-agent-teams/requirements.md
+++ b/docs/specs/generic-agent-teams/requirements.md
@@ -132,7 +132,7 @@ base, never resurrects the stub.
 | R3 | `/spec` gate re-seated | `_run_quality_gate` builds an `AgentTeam`; trivial task still completes |
 | R4 | Gate honest on error | A review workflow raising → gate fails closed, not fake-pass (preserves #1094 behavior) |
 | R5 | Non-mocked dogfood | Real `code-review` + `security-audit` team on a bad file → blocked, scores < threshold, cost > 0 |
-| R6 | ReleasePrepTeam re-seated | `release-prep` output unchanged; team built on generic base |
+| R6 | ReleasePrepTeam (fallback taken) | `release-prep` output unchanged. Full re-seat fallback taken — see D9: heterogeneous gate comparators (max-gate, 0–10 scale, per-finding keys) make a faithful re-seat add v1 `GateSpec` surface for zero behavior change; `QualityGate` is already the single shared definition both consumers import |
 | R7 | No revived dead code | `grep -rn "StubAgent\|DynamicTeam\|SDKAgent" src/` stays empty |
 | R8 | No collateral damage | `health-check` runs; `import attune.orchestration` clean; full suite green |
 | R9 | Auditable | decisions.md records D1–D3 + generalize-not-revive + module location, references #1096 |

--- a/src/attune/agents/team.py
+++ b/src/attune/agents/team.py
@@ -1,0 +1,349 @@
+"""Generic parallel agent teams.
+
+A team is an explicit list of agents plus a declarative gate spec. The
+coordinator fans the agents out via ``asyncio.gather``, aggregates their
+0-100 scores, and gates on the results — splitting critical failures into
+blockers and non-critical failures into warnings.
+
+This **generalizes the working ``ReleasePrepTeam`` pattern**; it does NOT
+revive the dead dynamic-team / stub-agent engine removed in #1096. Each
+agent does real work by wrapping a registered ``BaseWorkflow`` whose run
+yields an actual score — never a stub constant.
+
+See ``docs/specs/generic-agent-teams/`` for the design and decisions.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from attune.agents.release.release_models import QualityGate
+
+logger = logging.getLogger(__name__)
+
+#: Fallback score parse for reviews that produced no findings dict.
+#: Mirrors ``pipeline.orchestrator._SCORE_RE`` (lifted here per D5).
+_SCORE_RE = re.compile(r"\bscore:?\s*(\d{1,3})\s*/\s*100", re.IGNORECASE)
+
+#: A team target is one path or a list of paths.
+TeamTarget = str | list[str]
+
+
+# =============================================================================
+# Data models
+# =============================================================================
+
+
+@dataclass
+class AgentResult:
+    """Outcome of one agent's run over a target.
+
+    Attributes:
+        key: Agent identifier (e.g. ``"code-review"``).
+        score: Aggregated 0-100 score (min across files for a
+            multi-file target).
+        cost: Summed LLM cost in USD.
+        success: ``False`` if the wrapped workflow errored or produced
+            no score (the gate then fails closed).
+        details: Free-form diagnostic context.
+    """
+
+    key: str
+    score: float
+    cost: float
+    success: bool
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GateSpec:
+    """Declarative gate: which agent's score to threshold, and how.
+
+    Attributes:
+        name: Human-readable gate name (e.g. ``"Code Quality"``).
+        agent_key: ``AgentResult.key`` whose score this gate reads.
+        threshold: Minimum passing score (0-100).
+        critical: When ``True`` a failure is a blocker; otherwise a
+            warning.
+    """
+
+    name: str
+    agent_key: str
+    threshold: float
+    critical: bool = True
+
+
+@dataclass
+class TeamReport:
+    """Aggregated verdict from an :class:`AgentTeam` run.
+
+    Attributes:
+        passed: ``True`` only when no critical gate failed.
+        gates: Evaluated :class:`QualityGate` results, one per spec.
+        results: Per-agent :class:`AgentResult` outputs.
+        blockers: Messages from failed critical gates.
+        warnings: Messages from failed non-critical gates.
+        cost: Total LLM cost across all agents in USD.
+    """
+
+    passed: bool
+    gates: list[QualityGate]
+    results: list[AgentResult]
+    blockers: list[str]
+    warnings: list[str]
+    cost: float
+
+
+# =============================================================================
+# Score / cost extraction (shared default scorer, D5)
+# =============================================================================
+
+
+def extract_score(result: Any, default: float | None = None) -> float | None:
+    """Pull a 0-100 score from a workflow ``WorkflowResult``.
+
+    Precedence (D5): ``final_output["score"]`` → ``metadata["score"]`` →
+    a ``score: N/100`` regex over string output → ``default``. Returns
+    ``default`` (``None`` by default) when the workflow did not succeed
+    or carried no score, so the caller can fail the gate closed rather
+    than fake a pass.
+
+    Args:
+        result: A workflow result object (duck-typed: ``success``,
+            ``final_output``, optional ``metadata``).
+        default: Value returned when no score is present.
+
+    Returns:
+        The extracted score, or ``default`` if none could be found.
+    """
+    if not getattr(result, "success", False):
+        return default
+    output = getattr(result, "final_output", None)
+    if isinstance(output, dict) and output.get("score") is not None:
+        return float(output["score"])
+    metadata = getattr(result, "metadata", None)
+    if isinstance(metadata, dict) and metadata.get("score") is not None:
+        return float(metadata["score"])
+    if isinstance(output, str):
+        match = _SCORE_RE.search(output)
+        if match:
+            return float(match.group(1))
+    return default
+
+
+def _result_cost(result: Any) -> float:
+    """Best-effort cost of a workflow result, in USD."""
+    report = getattr(result, "cost_report", None)
+    return float(getattr(report, "total_cost", 0.0) or 0.0)
+
+
+def _min_score(scores: list[float | None]) -> float | None:
+    """Worst score across files; ``None`` if any file failed to score."""
+    if not scores or any(s is None for s in scores):
+        return None
+    return min(s for s in scores if s is not None)
+
+
+# =============================================================================
+# Agent contract + workflow-backed implementation
+# =============================================================================
+
+
+@runtime_checkable
+class TeamAgent(Protocol):
+    """A team member: an async unit of work that scores a target.
+
+    The contract is async (D7). A sync agent adapts by offloading its
+    work via ``loop.run_in_executor`` inside its own ``run`` — the shim
+    lives in the agent, never in the coordinator.
+    """
+
+    key: str
+
+    async def run(self, target: TeamTarget) -> AgentResult:  # pragma: no cover
+        """Run over ``target`` and return an :class:`AgentResult`."""
+        ...
+
+
+class WorkflowAgent:
+    """A team agent that runs a ``BaseWorkflow`` over a target and scores it.
+
+    Wraps a registered workflow class (D1). For a multi-file target it
+    runs the workflow over each file and reports the **min** score (the
+    worst file), matching the ``/spec`` gate's per-dimension behavior.
+    Fails closed: any exception, or a file that produces no score,
+    yields ``success=False`` and score ``0.0`` so a gate fails rather
+    than fake-passing.
+
+    Args:
+        key: Agent identifier; matched against :class:`GateSpec`.
+        workflow_cls: A ``BaseWorkflow`` subclass; instantiated per run.
+        files: Explicit file list to score. When ``None``, the paths
+            passed to :meth:`run` are used.
+        score_fn: Optional override for the default :func:`extract_score`
+            (D5 escape hatch for workflows that report differently).
+        default_score: Value the default scorer returns when no score is
+            present (``None`` → fail closed).
+        escalate: Reserved tier-escalation flag; off by default (D8).
+    """
+
+    def __init__(
+        self,
+        key: str,
+        workflow_cls: type,
+        *,
+        files: list[str] | None = None,
+        score_fn: Callable[[Any], float | None] | None = None,
+        default_score: float | None = None,
+        escalate: bool = False,
+    ) -> None:
+        """Initialize the workflow-backed agent."""
+        self.key = key
+        self.workflow_cls = workflow_cls
+        self.files = files
+        self.score_fn = score_fn
+        self.default_score = default_score
+        self.escalate = escalate  # D8: reserved, off by default
+
+    def _resolve_paths(self, target: TeamTarget) -> list[str]:
+        """Constructor ``files`` win; otherwise normalize ``target``."""
+        if self.files is not None:
+            return list(self.files)
+        if isinstance(target, str):
+            return [target]
+        return list(target or [])
+
+    async def run(self, target: TeamTarget) -> AgentResult:
+        """Run the wrapped workflow over each file and aggregate.
+
+        Args:
+            target: One path or a list of paths to score.
+
+        Returns:
+            An :class:`AgentResult` with the min score, summed cost, and
+            ``success=False`` on any error or missing score.
+        """
+        paths = self._resolve_paths(target)
+        if not paths:
+            # No files to score — nothing to gate on; trivially clean.
+            return AgentResult(
+                key=self.key,
+                score=0.0,
+                cost=0.0,
+                success=True,
+                details={"reason": "no files"},
+            )
+
+        scorer = self.score_fn or (lambda r: extract_score(r, self.default_score))
+        scores: list[float | None] = []
+        total_cost = 0.0
+        for path in paths:
+            try:
+                workflow = self.workflow_cls()
+                result = await workflow.execute(path=path)
+            except Exception as exc:  # noqa: BLE001
+                # INTENTIONAL: a workflow failure fails the gate closed;
+                # it must never crash the team or fake a pass.
+                logger.error("Agent %s failed on %s: %s", self.key, path, exc)
+                return AgentResult(
+                    key=self.key,
+                    score=0.0,
+                    cost=total_cost,
+                    success=False,
+                    details={"error": str(exc), "path": path},
+                )
+            scores.append(scorer(result))
+            total_cost += _result_cost(result)
+
+        score = _min_score(scores)
+        if score is None:
+            # A file produced no score — fail closed, do not fake-pass.
+            return AgentResult(
+                key=self.key,
+                score=0.0,
+                cost=total_cost,
+                success=False,
+                details={"reason": "no score", "files": paths},
+            )
+        return AgentResult(
+            key=self.key,
+            score=score,
+            cost=total_cost,
+            success=True,
+            details={"files": paths},
+        )
+
+
+# =============================================================================
+# Coordinator
+# =============================================================================
+
+
+class AgentTeam:
+    """Fan out agents in parallel, aggregate, and gate.
+
+    Runs each agent's ``run(target)`` concurrently via ``asyncio.gather``
+    (D2 fan-out only — no sequential/DAG topology), evaluates the
+    declarative :class:`GateSpec` list against the results, and splits
+    failures into blockers (critical) and warnings (non-critical). The
+    verdict passes only when no critical gate fails.
+
+    Args:
+        agents: The team members (anything satisfying :class:`TeamAgent`).
+        gates: Declarative gates evaluated against agent scores.
+    """
+
+    def __init__(self, agents: list[TeamAgent], gates: list[GateSpec]) -> None:
+        """Initialize the team with its agents and gate specs."""
+        self.agents = agents
+        self.gates = gates
+
+    async def run(self, target: TeamTarget) -> TeamReport:
+        """Run all agents over ``target`` and produce a gated verdict.
+
+        Args:
+            target: One path or a list of paths handed to each agent.
+
+        Returns:
+            A :class:`TeamReport` with the pass/fail verdict, evaluated
+            gates, per-agent results, blockers, warnings, and total cost.
+        """
+        results: list[AgentResult] = list(
+            await asyncio.gather(*(agent.run(target) for agent in self.agents))
+        )
+        by_key = {r.key: r for r in results}
+
+        gates: list[QualityGate] = []
+        blockers: list[str] = []
+        warnings: list[str] = []
+        for spec in self.gates:
+            result = by_key.get(spec.agent_key)
+            actual = result.score if result is not None else 0.0
+            passed = result is not None and result.success and actual >= spec.threshold
+            gate = QualityGate(
+                name=spec.name,
+                threshold=spec.threshold,
+                actual=actual,
+                passed=passed,
+                critical=spec.critical,
+            )
+            gates.append(gate)
+            if not passed:
+                (blockers if spec.critical else warnings).append(gate.message)
+
+        return TeamReport(
+            passed=not blockers,
+            gates=gates,
+            results=results,
+            blockers=blockers,
+            warnings=warnings,
+            cost=sum(r.cost for r in results),
+        )

--- a/src/attune/pipeline/orchestrator.py
+++ b/src/attune/pipeline/orchestrator.py
@@ -11,9 +11,7 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import re
 import subprocess
 import time
 from collections.abc import Awaitable, Callable
@@ -227,24 +225,24 @@ class PipelineOrchestrator:
     _GATE_THRESHOLD: float = 70.0
     #: Cap on files reviewed per gate to bound cost (logged when hit).
     _GATE_MAX_FILES: int = 10
-    #: Fallback score parse for reviews that produced no findings dict.
-    _SCORE_RE = re.compile(r"\bscore:?\s*(\d{1,3})\s*/\s*100", re.IGNORECASE)
 
     async def _run_quality_gate(
         self,
         task: DecomposedTask,
     ) -> tuple[bool, dict[str, Any], float]:
-        """Gate a task with real code review + security audit.
+        """Gate a task with a real code-review + security-audit team.
 
-        Runs ``CodeReviewWorkflow`` and ``SecurityAuditWorkflow`` over
-        the task's target files and gates on their actual 0-100 scores
-        against ``_GATE_THRESHOLD``. Fails closed: any review error or a
-        missing score yields a non-passing gate, never a fake pass.
+        Builds a two-agent ``AgentTeam`` (``code-review`` +
+        ``security-audit``) over the task's target files and gates on
+        their actual 0-100 scores against ``_GATE_THRESHOLD``. Fails
+        closed: any review error or a missing score makes the relevant
+        agent unsuccessful, which fails the gate — never a fake pass.
 
         Returns:
             Tuple of (passed, details_dict, cost).
 
         """
+        from attune.agents.team import AgentTeam, GateSpec, WorkflowAgent
         from attune.workflows.code_review import CodeReviewWorkflow
         from attune.workflows.security_audit import SecurityAuditWorkflow
 
@@ -263,36 +261,25 @@ class PipelineOrchestrator:
                 task.task_id,
             )
 
-        code_review = CodeReviewWorkflow()
-        security_audit = SecurityAuditWorkflow()
-
-        async def _review(workflow: Any, path: str) -> tuple[float | None, float]:
-            """Return (score, cost) for one workflow over one file."""
-            try:
-                result = await workflow.execute(path=path)
-            except Exception as exc:  # noqa: BLE001
-                # INTENTIONAL: a review failure fails the gate closed,
-                # it must not crash the pipeline or fake a pass.
-                logger.error("Gate review failed for %s: %s", path, exc)
-                return (None, 0.0)
-            return (self._extract_score(result), self._result_cost(result))
-
-        # Both dimensions over every file, concurrently.
-        jobs = [_review(code_review, p) for p in files]
-        jobs += [_review(security_audit, p) for p in files]
-        outcomes = await asyncio.gather(*jobs)
-
-        n = len(files)
-        quality_score = self._min_score(outcomes[:n])
-        security_score = self._min_score(outcomes[n:])
-        cost = sum(c for _, c in outcomes)
-
-        passed = (
-            quality_score is not None
-            and security_score is not None
-            and quality_score >= self._GATE_THRESHOLD
-            and security_score >= self._GATE_THRESHOLD
+        # Each agent runs its workflow over the file set and reports the
+        # worst (min) score; fail-closed-on-error lives in WorkflowAgent.
+        team = AgentTeam(
+            agents=[
+                WorkflowAgent("code-review", CodeReviewWorkflow, files=files),
+                WorkflowAgent("security-audit", SecurityAuditWorkflow, files=files),
+            ],
+            gates=[
+                GateSpec("Code Quality", "code-review", self._GATE_THRESHOLD),
+                GateSpec("Security", "security-audit", self._GATE_THRESHOLD),
+            ],
         )
+        report = await team.run(files)
+
+        by_key = {r.key: r for r in report.results}
+        quality = by_key.get("code-review")
+        security = by_key.get("security-audit")
+        quality_score = quality.score if quality and quality.success else None
+        security_score = security.score if security and security.success else None
 
         details = {
             "gate_results": {
@@ -308,43 +295,21 @@ class PipelineOrchestrator:
             "files_reviewed": files,
             "scored": quality_score is not None and security_score is not None,
         }
-        return (passed, details, cost)
+        return (report.passed, details, report.cost)
 
     @classmethod
     def _extract_score(cls, result: Any) -> float | None:
         """Pull the 0-100 score from a review ``WorkflowResult``.
 
-        ``final_output`` is a ``WorkflowReport`` dict (with a top-level
-        ``score``) only when the review parsed findings; a clean review
-        with no findings leaves ``final_output`` as raw markdown, so we
-        also regex the text for ``score: N/100``. Returns None when the
-        review did not succeed or carried no score, so the caller fails
-        the gate closed.
+        Delegates to the shared ``attune.agents.team.extract_score`` (D5),
+        the single canonical extractor both the team and this gate use.
+        Retained as a stable entry point for callers and tests. Returns
+        None when the review did not succeed or carried no score, so the
+        caller fails the gate closed.
         """
-        if not getattr(result, "success", False):
-            return None
-        output = getattr(result, "final_output", None)
-        if isinstance(output, dict) and output.get("score") is not None:
-            return float(output["score"])
-        if isinstance(output, str):
-            match = cls._SCORE_RE.search(output)
-            if match:
-                return float(match.group(1))
-        return None
+        from attune.agents.team import extract_score
 
-    @staticmethod
-    def _result_cost(result: Any) -> float:
-        """Best-effort cost of a review ``WorkflowResult``."""
-        report = getattr(result, "cost_report", None)
-        return float(getattr(report, "total_cost", 0.0) or 0.0)
-
-    @staticmethod
-    def _min_score(outcomes: list[tuple[float | None, float]]) -> float | None:
-        """Worst score across files; None if any file failed to score."""
-        scores = [s for s, _ in outcomes]
-        if not scores or any(s is None for s in scores):
-            return None
-        return min(s for s in scores if s is not None)
+        return extract_score(result)
 
     def _find_test_files(
         self,

--- a/tests/integration/test_agent_team_dogfood.py
+++ b/tests/integration/test_agent_team_dogfood.py
@@ -1,0 +1,83 @@
+"""Non-mocked dogfood receipt for the generic agent team (R5).
+
+Proves the keystone claim of ``docs/specs/generic-agent-teams``: a real
+``AgentTeam`` of ``code-review`` + ``security-audit`` run over a
+deliberately-vulnerable file returns a **blocked** verdict, with at
+least one dimension scoring below threshold and non-zero LLM cost.
+
+Per "registered != working", mocked unit tests do NOT close R5 — this
+test exercises the real workflows end-to-end. It requires a live
+``ANTHROPIC_API_KEY`` and skips when none is configured (the keyless-CI
+convention: CI sets the key to the empty string, so the skip fires and
+no spend happens in per-PR lanes).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+# Pick up a local key from ~/.attune/anthropic.env style .env files.
+load_dotenv()
+
+#: A file that should fail both review dimensions: a path-traversal-style
+#: arbitrary eval of user input plus a hardcoded credential.
+_VULNERABLE_SOURCE = '''
+"""Intentionally insecure module (test fixture, not real code)."""
+
+import os
+
+# A hardcoded secret — security audit must flag this.
+API_KEY = "sk-ant-api03-FAKE-not-a-real-key-000000000000"  # pragma: allowlist secret
+
+
+def run_user_formula(user_input):
+    # Arbitrary code execution — the canonical CWE-95 finding.
+    return eval(user_input)  # noqa
+
+
+def delete(path):
+    os.system("rm -rf " + path)  # noqa: shell injection, also bad
+'''
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="non-mocked dogfood needs a live ANTHROPIC_API_KEY (keyless CI skips)",
+)
+async def test_real_team_blocks_vulnerable_file(tmp_path):
+    """A real code-review + security-audit team blocks a bad file (R5)."""
+    from attune.agents.team import AgentTeam, GateSpec, WorkflowAgent
+    from attune.workflows.code_review import CodeReviewWorkflow
+    from attune.workflows.security_audit import SecurityAuditWorkflow
+
+    bad_file = tmp_path / "vulnerable.py"
+    bad_file.write_text(_VULNERABLE_SOURCE)
+
+    team = AgentTeam(
+        agents=[
+            WorkflowAgent("code-review", CodeReviewWorkflow, files=[str(bad_file)]),
+            WorkflowAgent("security-audit", SecurityAuditWorkflow, files=[str(bad_file)]),
+        ],
+        gates=[
+            GateSpec("Code Quality", "code-review", 70.0),
+            GateSpec("Security", "security-audit", 70.0),
+        ],
+    )
+
+    report = await team.run([str(bad_file)])
+
+    # Blocked verdict — never a fake pass on a file with eval() + a secret.
+    assert report.passed is False
+    assert report.blockers, "a vulnerable file must produce at least one blocker"
+    # At least one dimension scored below the 70 threshold (real signal).
+    assert min(g.actual for g in report.gates) < 70.0
+    # Real work happened: non-zero LLM cost.
+    assert report.cost > 0.0

--- a/tests/unit/agents/test_no_revived_dead_code.py
+++ b/tests/unit/agents/test_no_revived_dead_code.py
@@ -1,0 +1,48 @@
+"""Regression guard: the dead orchestration engine stays deleted (R7).
+
+The generic-agent-teams spec generalizes the *working* ReleasePrepTeam
+pattern; it must never resurrect the fake-success engine removed in
+#1096. This guard asserts that the deleted symbols do not reappear
+anywhere under ``src/`` — if a future change re-introduces one (even in
+a docstring), this test fails loudly.
+
+See ``.claude/rules/attune/removing-dead-code.md`` and
+``docs/specs/generic-agent-teams/decisions.md``.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+#: Symbols from the engine removed in #1096 — must stay deleted.
+_DEAD_SYMBOLS = ("StubAgent", "DynamicTeam", "SDKAgent")
+
+
+def _src_root() -> Path:
+    """Locate the ``src/attune`` package root from this test file."""
+    # tests/unit/agents/test_no_revived_dead_code.py -> repo root is parents[3]
+    root = Path(__file__).resolve().parents[3] / "src" / "attune"
+    assert root.is_dir(), f"expected package root at {root}"
+    return root
+
+
+@pytest.mark.parametrize("symbol", _DEAD_SYMBOLS)
+def test_dead_engine_symbol_absent_from_src(symbol):
+    """No deleted-engine symbol appears anywhere under src/ (R7)."""
+    offenders: list[str] = []
+    for py_file in _src_root().rglob("*.py"):
+        text = py_file.read_text(encoding="utf-8", errors="ignore")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if symbol in line:
+                offenders.append(f"{py_file}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        f"Revived dead symbol '{symbol}' found in src/ — the engine removed "
+        f"in #1096 must stay deleted (generalize the working sibling, never "
+        f"resurrect the stub):\n" + "\n".join(offenders)
+    )

--- a/tests/unit/agents/test_team.py
+++ b/tests/unit/agents/test_team.py
@@ -1,0 +1,250 @@
+"""Unit tests for the generic parallel agent team (``attune.agents.team``).
+
+Covers the shared score extractor's precedence, the gate evaluation's
+critical-vs-warning split, parallel fan-out, and fail-closed behavior
+when a wrapped workflow raises or produces no score.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from attune.agents.team import (
+    AgentResult,
+    AgentTeam,
+    GateSpec,
+    WorkflowAgent,
+    extract_score,
+)
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+def _result(*, success=True, final_output=None, metadata=None, cost=0.0):
+    """Build a duck-typed workflow result."""
+    return SimpleNamespace(
+        success=success,
+        final_output=final_output,
+        metadata=metadata,
+        cost_report=SimpleNamespace(total_cost=cost),
+    )
+
+
+def _workflow(*, result=None, raises=None):
+    """Return a no-arg workflow class whose ``execute`` returns/raises."""
+
+    class _W:
+        async def execute(self, path):  # noqa: ANN001
+            if raises is not None:
+                raise raises
+            return result
+
+    return _W
+
+
+class _FakeAgent:
+    """A team agent returning a preset :class:`AgentResult`."""
+
+    def __init__(self, key, score, *, success=True, cost=0.0):
+        self.key = key
+        self._result = AgentResult(key, score, cost, success, {})
+
+    async def run(self, target):  # noqa: ANN001
+        return self._result
+
+
+# ---------------------------------------------------------------------------
+# extract_score — precedence (D5)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_score_prefers_final_output_dict():
+    assert extract_score(_result(final_output={"score": 91})) == 91.0
+
+
+def test_extract_score_falls_back_to_metadata():
+    r = _result(final_output="no score here", metadata={"score": 64})
+    assert extract_score(r) == 64.0
+
+
+def test_extract_score_regex_on_string_output():
+    assert extract_score(_result(final_output="Review score: 42/100 done")) == 42.0
+
+
+def test_extract_score_returns_default_when_absent():
+    assert extract_score(_result(final_output="nothing"), default=None) is None
+    assert extract_score(_result(final_output="nothing"), default=50.0) == 50.0
+
+
+def test_extract_score_returns_default_when_unsuccessful():
+    # A failed workflow never yields a score, regardless of output.
+    assert extract_score(_result(success=False, final_output={"score": 99})) is None
+
+
+# ---------------------------------------------------------------------------
+# WorkflowAgent — scoring, min across files, fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_scores_single_file():
+    agent = WorkflowAgent(
+        "code-review",
+        _workflow(result=_result(final_output={"score": 88}, cost=0.01)),
+    )
+    out = await agent.run("a.py")
+    assert out.success is True
+    assert out.score == 88.0
+    assert out.cost == pytest.approx(0.01)
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_reports_min_across_files():
+    class _PerPath:
+        scores = {"a.py": 90.0, "b.py": 50.0}
+
+        async def execute(self, path):  # noqa: ANN001
+            return _result(final_output={"score": _PerPath.scores[path]}, cost=0.02)
+
+    agent = WorkflowAgent("code-review", _PerPath, files=["a.py", "b.py"])
+    out = await agent.run("ignored")
+    assert out.score == 50.0  # worst file wins
+    assert out.cost == pytest.approx(0.04)  # summed across files
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_fails_closed_on_raise():
+    agent = WorkflowAgent("sec", _workflow(raises=RuntimeError("boom")))
+    out = await agent.run("a.py")
+    assert out.success is False
+    assert out.score == 0.0
+    assert "boom" in out.details["error"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_fails_closed_on_missing_score():
+    agent = WorkflowAgent("sec", _workflow(result=_result(final_output="no score")))
+    out = await agent.run("a.py")
+    assert out.success is False
+    assert out.score == 0.0
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_no_files_is_trivially_clean():
+    agent = WorkflowAgent("sec", _workflow(), files=[])
+    out = await agent.run("ignored")
+    assert out.success is True
+    assert out.details["reason"] == "no files"
+
+
+@pytest.mark.asyncio
+async def test_workflow_agent_score_fn_override():
+    agent = WorkflowAgent(
+        "x",
+        _workflow(result=_result(final_output={"score": 10})),
+        score_fn=lambda r: 99.0,
+    )
+    out = await agent.run("a.py")
+    assert out.score == 99.0
+
+
+# ---------------------------------------------------------------------------
+# AgentTeam — gate split, verdict, parallelism
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_team_passes_when_all_gates_met():
+    team = AgentTeam(
+        agents=[_FakeAgent("cr", 90.0), _FakeAgent("sa", 85.0)],
+        gates=[
+            GateSpec("Code Quality", "cr", 70.0),
+            GateSpec("Security", "sa", 70.0),
+        ],
+    )
+    report = await team.run("x")
+    assert report.passed is True
+    assert report.blockers == []
+    assert all(g.passed for g in report.gates)
+
+
+@pytest.mark.asyncio
+async def test_team_critical_failure_is_a_blocker():
+    team = AgentTeam(
+        agents=[_FakeAgent("cr", 90.0), _FakeAgent("sa", 40.0)],
+        gates=[
+            GateSpec("Code Quality", "cr", 70.0),
+            GateSpec("Security", "sa", 70.0, critical=True),
+        ],
+    )
+    report = await team.run("x")
+    assert report.passed is False
+    assert len(report.blockers) == 1
+    assert "Security" in report.blockers[0]
+    assert report.warnings == []
+
+
+@pytest.mark.asyncio
+async def test_team_noncritical_failure_is_a_warning_not_blocker():
+    team = AgentTeam(
+        agents=[_FakeAgent("cr", 40.0)],
+        gates=[GateSpec("Style", "cr", 70.0, critical=False)],
+    )
+    report = await team.run("x")
+    assert report.passed is True  # warnings do not block
+    assert report.blockers == []
+    assert len(report.warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_team_fails_closed_when_agent_unsuccessful():
+    # A high score but success=False must still fail the gate closed.
+    team = AgentTeam(
+        agents=[_FakeAgent("cr", 100.0, success=False)],
+        gates=[GateSpec("Code Quality", "cr", 70.0)],
+    )
+    report = await team.run("x")
+    assert report.passed is False
+    assert len(report.blockers) == 1
+
+
+@pytest.mark.asyncio
+async def test_team_sums_cost_across_agents():
+    team = AgentTeam(
+        agents=[_FakeAgent("cr", 90.0, cost=0.03), _FakeAgent("sa", 90.0, cost=0.05)],
+        gates=[GateSpec("Code Quality", "cr", 70.0)],
+    )
+    report = await team.run("x")
+    assert report.cost == pytest.approx(0.08)
+
+
+@pytest.mark.asyncio
+async def test_team_runs_agents_in_parallel():
+    order: list[str] = []
+
+    class _SlowAgent:
+        def __init__(self, key, delay):
+            self.key = key
+            self.delay = delay
+
+        async def run(self, target):  # noqa: ANN001
+            order.append(f"{self.key}-start")
+            await asyncio.sleep(self.delay)
+            order.append(f"{self.key}-end")
+            return AgentResult(self.key, 100.0, 0.0, True, {})
+
+    team = AgentTeam(
+        agents=[_SlowAgent("a", 0.02), _SlowAgent("b", 0.0)],
+        gates=[GateSpec("A", "a", 70.0)],
+    )
+    await team.run("x")
+    # Both agents started before the slow one finished → concurrent.
+    assert order[:2] == ["a-start", "b-start"]

--- a/tests/unit/pipeline/test_orchestrator.py
+++ b/tests/unit/pipeline/test_orchestrator.py
@@ -274,7 +274,14 @@ class TestRunGatesForTask:
 
     @pytest.mark.asyncio
     async def test_gate_constructor_error_fails_gracefully(self):
-        """An error constructing a review workflow is caught by the gate."""
+        """An error constructing a review workflow fails the gate closed.
+
+        Post-re-seat (generic-agent-teams T2) the WorkflowAgent catches
+        workflow construction/execution errors at the agent boundary and
+        reports ``success=False``, so the gate fails closed there rather
+        than propagating to the orchestrator's outer "Gate error" handler.
+        The R4 invariant — a review error never fake-passes — is preserved.
+        """
         orch = PipelineOrchestrator(
             ".claude/plans/pipeline-orchestrator.md",
             skip_tests=True,
@@ -286,7 +293,8 @@ class TestRunGatesForTask:
             result = await orch.run_gates_for_task(task)
 
         assert result.quality_gate_passed is False
-        assert "Gate error" in result.error
+        # The failing dimension scores 0.0 in the gate details.
+        assert result.gate_details["gate_results"]["min_quality"]["score"] == 0.0
 
 
 class TestExtractScoreRealAdapter:


### PR DESCRIPTION
## Summary

Builds the approved `docs/specs/generic-agent-teams/` spec: a reusable
parallel agent-team abstraction that **generalizes the working
`ReleasePrepTeam` pattern** — it does NOT revive the dead engine removed
in #1096.

- **T1 — `attune.agents.team`** (new): `WorkflowAgent` wraps a
  `BaseWorkflow` and scores its run (min across files, fail-closed on
  error); `AgentTeam` fans agents out via `asyncio.gather`, aggregates,
  and gates on declarative `GateSpec`s (critical → blocker, else
  warning). Shared `extract_score` lifts the `/spec` gate's precedence
  (D5); `QualityGate` reused from `release_models` (D6).
- **T2 — `/spec` gate re-seated** (the keystone): `_run_quality_gate`
  now builds a two-agent `AgentTeam` (`code-review` + `security-audit`).
  Behavior preserved exactly — empty-file trivial pass, `_GATE_MAX_FILES`
  cap, per-file min, fail-closed-on-error (36/36 orchestrator tests
  green). One refinement: workflow errors now fail closed at the agent
  boundary, not the outer handler (R4 invariant preserved).
- **T3 — ReleasePrepTeam: R6 fallback taken** (D9). Its four gates are
  heterogeneous (Security is a max-gate on a count; Quality is 0–10;
  each reads a different findings key), so a faithful re-seat would
  expand the slim v1 `GateSpec` for zero behavior change and risk drift
  on a working, tested path. `QualityGate` is already the single shared
  definition both consumers import.
- **T4 — guard + CHANGELOG**: parametrized regression guard asserting
  the deleted-engine symbols never reappear under `src/` (R7).

## R5 dogfood receipt (non-mocked, real API)

A live `AgentTeam` of real `code-review` + `security-audit` over a
deliberately-vulnerable file returned:

| field | value |
|---|---|
| `passed` | **false** (blocked) |
| code-review score | 8.0 / 100 |
| security-audit score | 8.0 / 100 |
| blockers | both gates |
| cost | $0.866 |

Per "registered ≠ working", mocked tests don't close R5 — this is the
real end-to-end receipt. The integration test skips under keyless CI.

## Acceptance (requirements R1–R9)

- R1–R5 ✓ (R5 receipt above) · R6 fallback (D9) · R7 guard ✓ ·
  R8 `import attune.orchestration` clean + `health-check` loads ✓ ·
  R9 decisions.md records D1–D9.
- 342 unit tests green across `agents`/`pipeline`/`spec`.

## Test plan

- [x] `tests/unit/agents/test_team.py` (17)
- [x] `tests/unit/pipeline/test_orchestrator.py` (36, behavior parity)
- [x] `tests/unit/agents/test_no_revived_dead_code.py` (R7)
- [x] `tests/integration/test_agent_team_dogfood.py` (R5; skips keyless)
- [x] ReleasePrepTeam suites unchanged + green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
