### PR TITLE
ci: quiet cosmetic cancelled-guard red X on security scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   security:


### PR DESCRIPTION
## What

Change the workflow-level concurrency setting in
`.github/workflows/security.yml` from `cancel-in-progress: true` to
`cancel-in-progress: false`. One-line change.

## Why

The `security` check (workflow **Security Scan**) intermittently shows a
red ✗ on PRs. Investigation shows the job is **cancelled before a runner
is assigned** (`runner: ""`, 0 steps, ~1s duration, conclusion
`cancelled`) — a concurrency/webhook race, **not** a real scan failure.

It is **not a required check** (the 8 required checks are pre-commit,
lint, code-quality, coverage, platform-compat, test (ubuntu-latest,
3.12), CodeQL, default-install-smoke), so it cannot block merges — but
the red ✗ appears on every PR and is confusing.

The security scan (bandit + safety) is cheap (~1-2 min) and rarely runs
concurrently, so allowing the occasional duplicate run is strictly
better than the cosmetic cancelled red ✗. This is the documented remedy
for this exact noise.

## Scope

Single-line CI hygiene fix. No Python tests affected — only a YAML
workflow change (`check-yaml` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
