### PR TITLE
docs(lessons): import-stripper is harness ruff --fix; unfixable rejected

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -194,6 +194,22 @@ files.
   the import in the SAME edit that first uses it; (2) scope the
   import inside the function body that uses it (the detector
   never fires even mid-edit) — more robust for tests.
+  - **Confirmed actor (2026-06-26): Claude Code's harness-level
+    `ruff --fix`, NOT a project hook.** The project's PostToolUse
+    `Edit|Write` hooks only run `security_guard.py` (+
+    `worktree_path_guard.py`) — neither formats. A throwaway probe
+    (one unused `import os` + two used imports written out of order)
+    came back with `os` stripped AND the rest isort-reordered — both
+    fixes = `ruff --fix` (F401 + I), not autoflake (no reorder) or
+    black (neither). So the formatter is the harness running the
+    repo's ruff; there is no project "ruff hook" to reconfigure.
+  - **`unfixable = ["F401"]` in pyproject was investigated and
+    REJECTED — do not re-propose.** It would make ruff report but
+    not auto-remove unused imports, killing the strip — but it trades
+    a rare, bounded, multi-region-edit footgun for FREQUENT team-wide
+    manual import cleanup (every genuinely-unused import becomes a
+    hand-removal across all dev). Cure worse than disease; the
+    add-usage-first / same-edit discipline is the right answer.
 
 - **Ruff rule gotchas — rules that fire on correct code**:
   - **`pytest.ini` parsed as Python** — committing `pytest.ini`


### PR DESCRIPTION
## Summary

Addendum to the existing edit-formatter import-strip lesson, from a
verify-first investigation this session:

- **Confirmed actor:** Claude Code's harness-level `ruff --fix` (F401 +
  isort), **not** a project hook. The project's PostToolUse `Edit|Write`
  hooks only run `security_guard.py` (+ `worktree_path_guard.py`) — neither
  formats. A probe (one unused import + two used imports written out of
  order) came back with the unused one stripped AND the rest isort-reordered
  — both fixes are ruff (not autoflake, which wouldn't reorder; not black,
  which does neither).
- **`unfixable = ["F401"]` investigated and rejected:** it would stop the
  silent strip, but trades a rare multi-region-edit footgun for frequent
  team-wide manual import cleanup. Cure worse than disease — recorded so a
  future session doesn't re-propose it. The add-usage-first / same-edit
  discipline remains the answer.

One-line-ish doc change; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
