### PR TITLE
docs(lessons): core-mirror — cancelled-security noise is policy-bound, not config-fixable

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -640,8 +640,10 @@ this section only if core-worthy (and then keep both copies in sync).
   red check as blocking; (2) read the actual review gate; (3)
   grep workflow `if: github.actor ==` guards against the real
   `gh api user` login before trusting them. The cosmetic
-  CANCELLED noise (separate, low-priority) is quietable with
-  `cancel-in-progress: false` in the scan workflow.
+  CANCELLED noise (separate, low-priority) is policy-bound,
+  NOT config-fixable — `cancel-in-progress: false` is INVALID
+  (`tests/unit/ci/test_workflow_yaml.py` requires it `true`;
+  PR #1100 closed); clear it per-PR with `gh run rerun <run-id>`.
 
 - **Branch-vs-worktree commit tangle — committing from a worktree
   that's on the WRONG branch lands the commit elsewhere and ships

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -5827,8 +5827,10 @@ files.
   red check as blocking; (2) read the actual review gate; (3)
   grep workflow `if: github.actor ==` guards against the real
   `gh api user` login before trusting them. The cosmetic
-  CANCELLED noise (separate, low-priority) is quietable with
-  `cancel-in-progress: false` in the scan workflow.
+  CANCELLED noise (separate, low-priority) is policy-bound,
+  NOT config-fixable — `cancel-in-progress: false` is INVALID
+  (`tests/unit/ci/test_workflow_yaml.py` requires it `true`;
+  PR #1100 closed); clear it per-PR with `gh run rerun <run-id>`.
 
 - **Advisory CI lanes don't gate — for test/docs-only PRs, merge on
   the required greens; don't WAIT on Windows/macOS (and right-size the


### PR DESCRIPTION
## What

Corrects the "Verify-first applies to infra/config diagnoses" lesson in
**both** copies (the `.claude/CLAUDE.md` core mirror and its
`.claude/lessons.md` twin). The entry still ended with the now-wrong
advice that the cosmetic CANCELLED `security` check is "quietable with
`cancel-in-progress: false`".

## Why

- **#1100 closed** — `cancel-in-progress: false` on `security.yml` is
  INVALID: `tests/unit/ci/test_workflow_yaml.py` requires it `true`.
- **#1101 merged** — established the noise is policy-bound and cleared
  per-PR with `gh run rerun <run-id>`.

This was the deferred core-mirror correction noted in the session
starter (§2).

## Verification

- `tests/unit/lessons/test_core_mirror.py` — 3 passed (both copies
  verbatim-identical, drift guard satisfied).
- Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)