### PR TITLE
docs(spec): record OQ1-OQ3 resolutions for orchestration-doc-fiction-cleanup

### DIFF
--- a/docs/specs/orchestration-doc-fiction-cleanup/decisions.md
+++ b/docs/specs/orchestration-doc-fiction-cleanup/decisions.md
@@ -93,14 +93,18 @@ the acceptance grep.
 
 ---
 
-## Open questions (resolve at spec review)
+## Open questions — RESOLVED (Patrick, 2026-06-26)
 
-- OQ1. `multi-agent-team-coordination.md` (18 DynamicTeam refs, a pure
-  team tutorial) — **rewrite** to AgentTeam, or **delete** as
-  redundant with the rewritten `ORCHESTRATION_API.md`? Lean: rewrite
-  (it's the only worked end-to-end team example).
-- OQ2. `META_ORCHESTRATION_TUTORIAL.md` carries 21 surviving-symbol
-  refs (templates) under a dead premise. Delete whole (lean), or
-  salvage the template section into an existing templates doc?
-- OQ3. Nav/index references to deleted files (mkdocs nav, cross-links)
-  — sweep and prune in the same PR (yes, to avoid build breaks).
+- OQ1 → **rewrite.** `multi-agent-team-coordination.md` (18 DynamicTeam
+  refs) is rewritten to the AgentTeam API — it is the only worked
+  end-to-end team example, worth keeping.
+- OQ2 → **delete whole, but salvage the template section** if it can be
+  folded into an existing templates doc in a way that maintains or
+  improves quality/efficiency. `META_ORCHESTRATION_TUTORIAL.md` is
+  deleted; before deleting, evaluate its 21 surviving-symbol (template)
+  references — if that template walkthrough is better than what current
+  templates docs carry, lift it into the canonical templates reference
+  rather than discarding it. Never resurrect MetaOrchestrator framing
+  while salvaging.
+- OQ3 → **yes.** Nav/cross-link references to deleted files are pruned
+  in the same execution PR to avoid `mkdocs build` breaks.

--- a/docs/specs/orchestration-doc-fiction-cleanup/tasks.md
+++ b/docs/specs/orchestration-doc-fiction-cleanup/tasks.md
@@ -34,11 +34,14 @@ refs, `surv` = surviving-symbol refs) verified against `origin/main`
 
 ## Phased execution
 
-### Phase 0 — resolve open questions
+### Phase 0 — open questions RESOLVED (2026-06-26)
 
-- Confirm OQ1 (rewrite vs delete multi-agent-team-coordination.md),
-  OQ2 (delete META_ORCHESTRATION_TUTORIAL.md whole), OQ3 (nav/cross-link
-  prune in same PR). Defaults in `decisions.md`.
+- OQ1 → rewrite `multi-agent-team-coordination.md` to AgentTeam.
+- OQ2 → delete `META_ORCHESTRATION_TUTORIAL.md` whole, salvaging its
+  template section into the canonical templates reference only if that
+  maintains/improves quality (no MetaOrchestrator framing).
+- OQ3 → prune nav/cross-links to deleted files in the execution PR.
+  See `decisions.md` for full text.
 
 ### Phase 1 — rewrite DynamicTeam → AgentTeam
 


### PR DESCRIPTION
Follow-up to #1104 (which auto-merged the draft before these answers
were recorded). Lands Patrick's resolutions into the spec:

- **OQ1 → rewrite** `multi-agent-team-coordination.md` to the AgentTeam API.
- **OQ2 → delete whole, salvage the template section** into the
  canonical templates reference if it maintains/improves quality (no
  MetaOrchestrator framing).
- **OQ3 → yes** — prune nav/cross-links to deleted files in the
  execution PR.

Updates `decisions.md` (Open Questions → RESOLVED) and `tasks.md`
(Phase 0). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)