### PR TITLE
docs: remove dead EmpathyOS + HealthcareWizard import fences

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -701,13 +701,13 @@ class HybridCache:
 
 For healthcare deployments:
 
-```python
-from attune.wizards import HealthcareWizard
-
-wizard = HealthcareWizard()
-# Automatic PHI detection and de-identification
-# Encrypted storage with 90-day retention
-# Comprehensive audit trail (HIPAA §164.312(b))
+```text
+# PLANNED — not yet implemented; illustrative pseudocode only.
+# A future `HealthcareWizard` would provide, for healthcare
+# deployments:
+#   - Automatic PHI detection and de-identification
+#   - Encrypted storage with 90-day retention
+#   - Comprehensive audit trail (HIPAA §164.312(b))
 ```
 
 ---

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -10,8 +10,6 @@
 
 - [Overview](#overview)
 - [Core Framework](#core-framework)
-  - [EmpathyOS](#empathyos)
-  - [InteractionResponse](#interactionresponse)
   - [Exceptions](#exceptions)
 - [Configuration](#configuration)
   - [AttuneConfig](#attuneconfig)
@@ -111,83 +109,6 @@ pip install 'attune-ai[redis]'       # Redis-backed memory + AMS plugin
 ---
 
 ## Core Framework
-
-### EmpathyOS
-
-`attune.core.EmpathyOS`
-
-Main orchestration class for the five-level empathy model.
-
-```python
-from attune import EmpathyOS
-
-empathy = EmpathyOS(user_id="developer@company.com")
-```
-
-#### Constructor
-
-```python
-EmpathyOS(user_id: str)
-```
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `user_id` | `str` | Unique identifier for the user |
-
-#### Methods
-
-```python
-# Level 1: Reactive (simple Q&A)
-response = empathy.level_1_reactive(
-    user_input: str,
-    context: dict | None = None
-) -> InteractionResponse
-
-# Level 2: Guided (contextual with clarifying questions)
-response = empathy.level_2_guided(
-    user_input: str,
-    context: dict,
-    history: list[dict]
-) -> InteractionResponse
-
-# Level 3: Proactive (pattern detection)
-response = empathy.level_3_proactive(
-    user_input: str,
-    context: dict,
-    history: list[dict]
-) -> InteractionResponse
-
-# Level 4: Anticipatory (trajectory prediction)
-response = empathy.level_4_anticipatory(
-    user_input: str,
-    context: dict,
-    history: list[dict]
-) -> InteractionResponse
-
-# Memory shortcuts
-empathy.stash(key: str, value: Any) -> bool
-empathy.persist_pattern(
-    content: str,
-    pattern_type: str
-) -> dict
-```
-
----
-
-### InteractionResponse
-
-`attune.core.InteractionResponse`
-
-Dataclass returned by all EmpathyOS level methods.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `level` | `int` | Empathy level used (1-5) |
-| `response` | `str` | Generated response text |
-| `confidence` | `float` | Confidence score (0.0-1.0) |
-| `predictions` | `list[str] \| None` | Predicted next actions (Level 4+) |
-
----
 
 ### Exceptions
 
@@ -1206,7 +1127,7 @@ msg = format_error(
 
 | Module | Purpose | Key Export |
 |--------|---------|-----------|
-| `attune` | Core framework | `EmpathyOS` |
+| `attune` | Core framework | `AttuneConfig` |
 | `attune.config` | Configuration | `AttuneConfig`, `load_config` |
 | `attune.memory` | Two-tier memory | `UnifiedMemory` |
 | `attune.workflows` | SDK-native pipelines | `BaseWorkflow`, 15 workflows |


### PR DESCRIPTION
## What

Two documentation code fences referenced symbols removed in the
9.0.0 empathy-framework retirement ([#1073](https://github.com/Smart-AI-Memory/attune-ai/pull/1073))
and raised `ImportError` when copy-pasted. Found during the
orchestration-doc-fiction-cleanup work (these are separate, non-
orchestration doc fiction).

## Changes (docs-only)

- **`docs/reference/API_REFERENCE.md`** — the `from attune import
  EmpathyOS` fence lived inside an entire `attune.core` EmpathyOS
  section (class + constructor + methods) plus an
  `InteractionResponse` section, all documenting the deleted
  `attune.core` module. Removed both dead subsections, their TOC
  entries, and repointed the Module Summary `attune` key export
  from `EmpathyOS` to the live `AttuneConfig`. The Exceptions
  table, `EmpathyConfig`, and `EmpathyMCPServer` still exist and
  are untouched.
- **`docs/ARCHITECTURE.md`** — the `from attune.wizards import
  HealthcareWizard` fence sits under a "Status: Planned — not yet
  implemented" heading. Converted to a non-importable `text`
  pseudocode placeholder so it no longer reads as runnable code,
  preserving the aspirational design note.

## Verification

Both imports are now absent as runnable code:

```
PYTHONPATH=src python -c "from attune import EmpathyOS"                 # symbol gone from docs
PYTHONPATH=src python -c "from attune.wizards import HealthcareWizard"  # symbol gone from docs
```

`mkdocs build` passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
