### PR TITLE
docs(blog): fix invented ParallelTeam example in framework comparison

### DIFF
--- a/content/blog/attune-ai-vs-crewai-vs-langchain.md
+++ b/content/blog/attune-ai-vs-crewai-vs-langchain.md
@@ -144,21 +144,28 @@ You need to understand agents, tools, chains, memory, and prompting. Lots of con
 All three support multi-agent teams, but in different ways.
 
 ### Attune AI
-Defines patterns explicitly:
-- **Sequential**: Agent A → Agent B → Agent C
-- **Parallel**: A, B, C run simultaneously, results merged
-- **Conditional**: If condition, run A, else run B
-- **Rollback**: If final result fails, restore previous state
+Runs a parallel team of workflow-backed agents behind quality gates
+(`AgentTeam`), plus a library of composition strategies:
+- **Parallel teams** (`AgentTeam`): agents run simultaneously, each
+  scored, then gated
+- **Execution strategies**: Sequential, Parallel, Debate, Teaching,
+  Refinement, Adaptive, Conditional — reusable `ExecutionStrategy`
+  classes
 
 Code:
 ```python
-from attune.orchestration import ParallelTeam
+from attune.agents.team import AgentTeam, GateSpec, WorkflowAgent
+from attune.workflows.code_review import CodeReviewWorkflow
+from attune.workflows.security_audit import SecurityAuditWorkflow
 
-team = ParallelTeam(
-    agents=[ReviewAgent(), TestAgent(), DocAgent()],
-    merge_strategy="union"  # or "intersection", custom function
+team = AgentTeam(
+    agents=[
+        WorkflowAgent("code-review", CodeReviewWorkflow, files=["src/"]),
+        WorkflowAgent("security-audit", SecurityAuditWorkflow, files=["src/"]),
+    ],
+    gates=[GateSpec("Code Quality", "code-review", 80.0)],
 )
-result = team.execute(code)
+report = await team.run(["src/"])
 ```
 
 ### CrewAI


### PR DESCRIPTION
## Summary

Follow-up to the orchestration-doc-fiction-cleanup (#1107) blog-import audit. A full sweep of every published `content/blog/*.md` (rendered on the website via `website/lib/blog.ts`) found **exactly one** post with a non-importing code fence.

`attune-ai-vs-crewai-vs-langchain.md` used `from attune.orchestration import ParallelTeam` with fictional `ReviewAgent()`/`TestAgent()`/`DocAgent()` and a `merge_strategy` kwarg. `git log -S 'class ParallelTeam'` confirms the symbol was **hallucinated** (never defined in any commit) — copy-pasting it always ImportError'd.

## Change

- Repointed the fence to the real fan-out + gate `AgentTeam` API (`attune.agents.team`).
- Dropped the adjacent fictional **"Rollback"** capability bullet (no such strategy) and the `merge_strategy` framing.

## Verification

- ✅ New fence imports + constructs against `main` (`AgentTeam`/`WorkflowAgent`/`GateSpec` + `CodeReviewWorkflow`/`SecurityAuditWorkflow`)
- ✅ Audit re-run: **0 broken imports** across all 5 blog posts (the other 4 were already clean)

The other audit-class findings (two unrelated stale imports — `EmpathyOS`, `HealthcareWizard`) remain a separate tracked task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
