### PR TITLE
docs: 9.0.0 migration guide (EmpathyOS -> workflows, DynamicTeam -> AgentTeam)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed (BREAKING)
 
+> **Upgrading from 8.x?** See the
+> [9.0.0 migration guide](docs/migration/9.0.0.md) for before/after
+> code recipes (`EmpathyOS` → workflows, `DynamicTeam` → `AgentTeam`,
+> etc.).
+
 - **Legacy "Empathy" framework runtime (~3,400 LOC).** `EmpathyOS`
   (`core.py` + the `core_modules/` mixins), the five-level maturity
   model (`Level1Reactive`…`Level5Systems` / `levels.py`),

--- a/docs/migration/9.0.0.md
+++ b/docs/migration/9.0.0.md
@@ -1,0 +1,224 @@
+# Migrating to 9.0.0
+
+9.0.0 is a **major, breaking** release. It removes two legacy
+subsystems that had no live callers left:
+
+- The original **"Empathy" framework** runtime — `EmpathyOS`, the
+  five-level maturity model, and the `FeedbackLoopDetector` /
+  `LeveragePointAnalyzer` analyzers.
+- The dead **dynamic-team / meta-orchestrator** engine in
+  `attune.orchestration` (`DynamicTeam`, `MetaOrchestrator`, and
+  friends).
+
+The full list of removed symbols is in the
+[CHANGELOG](https://github.com/Smart-AI-Memory/attune-ai/blob/main/CHANGELOG.md) under **Removed (BREAKING)**. This page
+is the *cookbook*: for each thing you might have imported, what to write
+instead.
+
+---
+
+## Am I affected?
+
+You are **not** affected if you only use the Claude Code plugin, the
+`attune` CLI, the MCP tools, or the workflow classes. The auth/tier
+routing, memory, help, and telemetry systems are unchanged.
+
+You **are** affected if your Python code imports any of the removed
+symbols. Check with:
+
+```bash
+grep -rE 'EmpathyOS|DynamicTeam|DynamicTeamBuilder|MetaOrchestrator|WorkflowComposer|WorkflowAgentAdapter|FeedbackLoopDetector|LeveragePointAnalyzer|TeamSpecification|TeamStore' your_code/
+```
+
+Any hit needs a change below. (Accessing a removed symbol now raises
+`AttributeError` / `ImportError` — they emitted a `DeprecationWarning`
+since 8.10.0.)
+
+---
+
+## Empathy framework → workflows, memory, and `EmpathyLLM`
+
+`EmpathyOS` was the god-object entry point. It did three jobs; each has
+a direct, live successor.
+
+### Running a workflow
+
+`EmpathyOS` as a workflow runner → import the workflow class directly.
+
+Before:
+
+<!-- doc-import-skip: 9.0.0-removed API, shown for migration -->
+```python
+from attune import EmpathyOS
+
+empathy = EmpathyOS(user_id="me")
+result = empathy.run_workflow("security-audit", path="src/")
+```
+
+After:
+
+```python
+import asyncio
+
+from attune.workflows.security_audit import SecurityAuditWorkflow
+
+result = asyncio.run(SecurityAuditWorkflow().execute(path="src/"))
+```
+
+Discover the available workflows with
+`python -c "from attune.workflows import list_workflows; [print(w['name']) for w in list_workflows()]"`.
+
+### Memory / patterns
+
+`EmpathyOS` as a memory accessor → the memory API is unchanged; just
+drop `EmpathyOS` from the import and use the live entry points.
+
+Before:
+
+<!-- doc-import-skip: 9.0.0-removed API, shown for migration -->
+```python
+from attune import EmpathyOS, get_redis_memory
+
+empathy = EmpathyOS(user_id="me")
+empathy.stash("key", {"value": 1})
+```
+
+After:
+
+```python
+from attune import AccessTier, get_redis_memory
+from attune.memory import UnifiedMemory
+
+memory = UnifiedMemory(user_id="me", access_tier=AccessTier.CONTRIBUTOR)
+memory.stash("key", {"value": 1})
+```
+
+`get_redis_memory`, `AccessTier`, `PatternLibrary`, `Pattern`,
+`StagedPattern`, and `AttuneConfig` all still import from `attune`.
+
+### LLM calls
+
+For direct LLM interaction, use `attune.llm.EmpathyLLM`. Despite the
+shared "Empathy" name it is **live** workflow infrastructure — it was
+*not* removed.
+
+```python
+from attune.llm import EmpathyLLM
+
+llm = EmpathyLLM(provider="anthropic")  # needs ANTHROPIC_API_KEY
+```
+
+### The five-level maturity model
+
+The `Level1Reactive … Level5Systems` model (`levels.py`) is gone with no
+successor — it was a conceptual framework, not a runtime API. Note that
+`EmpathyLLM` still accepts a `target_level: int` parameter (default 3);
+that surviving knob is unrelated to the removed maturity model.
+
+### `FeedbackLoopDetector` / `LeveragePointAnalyzer`
+
+These systems-thinking analyzers are **removed with no direct
+replacement**. For code analysis, use the workflow suite (e.g.
+`BugPredictionWorkflow`, `PerformanceAuditWorkflow`,
+`CodeReviewWorkflow`) via `attune.workflows`. (Note: the live
+`attune.telemetry.FeedbackLoop` is a *different*, unrelated component.)
+
+---
+
+## Orchestration engine → `AgentTeam`
+
+The `DynamicTeam` / `MetaOrchestrator` engine in `attune.orchestration`
+is removed. The agent-template registry and the execution-strategy
+library it sat on top of are **unchanged**.
+
+### Multi-agent teams
+
+`DynamicTeam` / `DynamicTeamBuilder` / `WorkflowComposer` → the live
+fan-out + gate primitive `attune.agents.team.AgentTeam`.
+
+Before:
+
+<!-- doc-import-skip: 9.0.0-removed API, shown for migration -->
+```python
+from attune.orchestration import DynamicTeamBuilder
+
+builder = DynamicTeamBuilder(state_store=store)
+team = builder.build_from_plan(plan)
+result = await team.execute(input_data)
+```
+
+After:
+
+```python
+import asyncio
+
+from attune.agents.team import AgentTeam, GateSpec, WorkflowAgent
+from attune.workflows.code_review import CodeReviewWorkflow
+from attune.workflows.security_audit import SecurityAuditWorkflow
+
+team = AgentTeam(
+    agents=[
+        WorkflowAgent("code-review", CodeReviewWorkflow, files=["src/"]),
+        WorkflowAgent("security-audit", SecurityAuditWorkflow, files=["src/"]),
+    ],
+    gates=[
+        GateSpec("Code Quality", "code-review", 80.0),
+        GateSpec("Security", "security-audit", 80.0),
+    ],
+)
+report = asyncio.run(team.run(["src/"]))
+print(report.passed, report.blockers, report.warnings)
+```
+
+`AgentTeam` is **fan-out + gate only** — it runs the agents in parallel
+and gates on their real 0–100 scores. It has no sequential/DAG topology,
+no `strategy=` parameter, and no `build_from_plan`. If you relied on
+those, model the steps explicitly instead.
+
+### Meta-orchestration (auto-composition)
+
+`MetaOrchestrator` — which analyzed a task and *chose* agents and a
+pattern for you — is removed with **no successor**. There is no
+drop-in replacement for automatic team composition. Instead:
+
+- Build an explicit `AgentTeam` (above) — you choose the agents and
+  gates.
+- For composition patterns, the `ExecutionStrategy` library survives:
+
+```python
+from attune.orchestration import get_strategy
+
+strategy = get_strategy("parallel")  # sequential, debate, teaching, ...
+```
+
+The same-named `MetaOrchestrator` in
+`attune.workflows.progressive.orchestrator` is a **different**, live
+tier-escalation class — not a replacement for the removed one.
+
+---
+
+## What is NOT changing
+
+To avoid over-correcting: these survive 9.0.0 untouched.
+
+- The Claude Code plugin, CLI (`attune …`), and all MCP tools.
+- Every workflow in `attune.workflows`.
+- Auth / tier routing (`attune.models`), memory
+  (`get_redis_memory`, `UnifiedMemory`, `PatternLibrary`), telemetry,
+  and the help system.
+- `attune.orchestration` agent templates (`get_template`,
+  `get_all_templates`, …) and execution strategies (`get_strategy`,
+  `ParallelStrategy`, …).
+- `attune.llm.EmpathyLLM` and the security helpers (`PIIScrubber`,
+  `SecretsDetector`, `AuditLogger`).
+
+---
+
+## See also
+
+- [CHANGELOG](https://github.com/Smart-AI-Memory/attune-ai/blob/main/CHANGELOG.md) — the authoritative removed-symbol
+  list.
+- [Orchestration reference](../reference/orchestration.md) — the live
+  `AgentTeam` / templates / strategies API.
+- [Choose your path](../getting-started/choose-your-path.md) — current
+  entry points for new code.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,6 +249,8 @@ nav:
   # Information-oriented
   - Reference:
       - reference/index.md
+      - Migration:
+          - Upgrade to 9.0.0: migration/9.0.0.md
       - API:
           - Overview: reference/API_REFERENCE.md
           - Configuration: reference/configuration.md


### PR DESCRIPTION
## Summary

The single most important missing 9.0.0 release artifact: a **user-facing migration guide**. 9.0.0 removes `EmpathyOS` (the documented "main entry point") + the empathy framework + the DynamicTeam/MetaOrchestrator engine. The CHANGELOG already documents *what* was removed; this is the *how-to-migrate* cookbook so 8.x users can survive the upgrade.

`docs/migration/9.0.0.md` — before/after code recipes for every removed public symbol, **verified against main**:
- EmpathyOS (workflow runner / memory / LLM) -> `attune.workflows` / `UnifiedMemory` / `attune.llm.EmpathyLLM`
- DynamicTeam family -> `attune.agents.team.AgentTeam`
- MetaOrchestrator / 5-level model / FeedbackLoopDetector / LeveragePointAnalyzer -> removed, no successor (stated honestly)
- an "Am I affected?" grep + a "What is NOT changing" reassurance section

Also: CHANGELOG `Removed (BREAKING)` now links to the guide; nav entry under Reference > Migration.

## Verification
- Every **after** fence imports against main; every **before** fence (removed API) carries `<!-- doc-import-skip -->` — dogfoods the doc-import gate (#1111): 8 fences, 3 skipped, **0 unresolved**.
- `mkdocs build --strict` exit 0; wiring-audit 0 findings.

Refs #1073, #1096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)