### PR TITLE
docs: fix broken attune imports in published reference docs

### DIFF
--- a/docs/EXCEPTION_HANDLING_GUIDE.md
+++ b/docs/EXCEPTION_HANDLING_GUIDE.md
@@ -26,7 +26,7 @@ description: Exception Handling Best Practices: Step-by-step tutorial with examp
 ### Authentication Operations
 
 ```python
-from attune.exceptions import AuthenticationError, ServiceUnavailableError
+# Example exception types — replace with your application's exceptions
 
 try:
     user = authenticate_user(credentials)
@@ -44,7 +44,7 @@ except ValueError as e:
 ### Security Scanning
 
 ```python
-from attune.exceptions import SecurityScanException
+# Example exception types — replace with your application's exceptions
 
 try:
     vulnerabilities = scan_code(source_code)
@@ -64,7 +64,7 @@ except OSError as e:
 ### Compliance Operations
 
 ```python
-from attune.exceptions import ComplianceError
+# Example exception types — replace with your application's exceptions
 
 try:
     result = validate_compliance(data)
@@ -107,7 +107,7 @@ except UnicodeEncodeError as e:
 ### Database Operations
 
 ```python
-from attune.exceptions import DatabaseError
+# Example exception types — replace with your application's exceptions
 
 try:
     result = db.execute(query, params)

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -97,7 +97,7 @@ registry = HookRegistry(config=config)
 Matchers determine when hooks fire:
 
 ```python
-from attune.hooks import HookMatcher
+from attune.hooks.config import HookMatcher
 
 # Match specific tool
 tool_matcher = HookMatcher(tool="Edit")

--- a/docs/reference/TROUBLESHOOTING.md
+++ b/docs/reference/TROUBLESHOOTING.md
@@ -207,10 +207,10 @@ pip install --upgrade attune-ai
 **3. Check import statement matches docs:**
 ```python
 # Old (might be outdated):
-from attune_llm.providers import AnthropicProvider
+from attune.llm.providers import AnthropicProvider
 
 # Current (check docs for latest):
-from attune_llm import EmpathyLLM
+from attune.llm import EmpathyLLM
 ```
 
 ---
@@ -295,7 +295,7 @@ curl https://api.anthropic.com/v1/messages \
 from dotenv import load_dotenv
 load_dotenv()  # Call this BEFORE importing framework
 
-from attune_llm import EmpathyLLM
+from attune.llm import EmpathyLLM
 ```
 
 **2. Export in shell before running:**
@@ -400,7 +400,7 @@ import nest_asyncio
 nest_asyncio.apply()
 
 import asyncio
-from attune_llm import EmpathyLLM
+from attune.llm import EmpathyLLM
 
 async def main():
     llm = EmpathyLLM(provider="anthropic", target_level=4)
@@ -453,7 +453,7 @@ llm = EmpathyLLM(
 
 **2. Enable prompt caching (Claude only):**
 ```python
-from attune_llm.providers import AnthropicProvider
+from attune.llm.providers import AnthropicProvider
 
 provider = AnthropicProvider(
     use_prompt_caching=True,  # 90% faster on repeated prompts
@@ -572,7 +572,7 @@ for file_path in large_codebase:
 
 **2. Use Claude's 200K context window:**
 ```python
-from attune_llm.providers import AnthropicProvider
+from attune.llm.providers import AnthropicProvider
 
 provider = AnthropicProvider(
     model="claude-3-5-sonnet-20241022",  # 200K context
@@ -1020,7 +1020,7 @@ echo $ANTHROPIC_API_KEY | cut -c1-10  # First 10 chars only
 echo $OPENAI_API_KEY | cut -c1-10
 
 # Test imports
-python -c "from attune_llm import EmpathyLLM; print('Core: OK')"
+python -c "from attune.llm import EmpathyLLM; print('Core: OK')"
 python -c "from coach_wizards import SecurityWizard; print('Wizards: OK')"
 ```
 


### PR DESCRIPTION
Clears the doc-import gate findings in the **served** docs (surfaced by #1111).

- `reference/TROUBLESHOOTING.md` (6): old package name `attune_llm` → `attune.llm` / `attune.llm.providers`.
- `hooks.md` (1): `from attune.hooks import HookMatcher` → `from attune.hooks.config import HookMatcher` (HookMatcher is real, just not re-exported — verified in `src/attune/hooks/config.py`).
- `EXCEPTION_HANDLING_GUIDE.md` (4): pattern-template fences falsely imported illustrative exceptions from `attune.exceptions` → replaced with a clarifying comment.

Scoped to published surfaces (in-nav-or-not-excluded). Orphaned/unpublished docs (`pitch/`, `docs/blog/social/`, `extending-composition-patterns`) are out of scope per the gate scoping in #1111. Every kept fence imports against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)