### PR TITLE
docs: correct EmpathyLLMExecutor 'dead' claim + add doc-fiction triage checklist

### DIFF
--- a/.claude/rules/attune/doc-fiction-triage.md
+++ b/.claude/rules/attune/doc-fiction-triage.md
@@ -1,0 +1,119 @@
+# Doc-Fiction Triage — pre-flight checklist before a doc cleanup
+
+**Created:** 2026-06-26
+**Source:** the orchestration / empathy doc-fiction cleanups. Three
+traps recurred — scope undercount, "dead" claims that were actually
+LIVE symbols at a different path, and policing orphaned docs — each
+costing rework or shipping a wrong claim to a committed spec. This is
+the checklist that prevents them.
+
+Run this BEFORE deleting/rewriting any doc that references a "removed"
+symbol. It is the human/agent counterpart to the CI
+[doc-import-gate](./doc-import-gate.md) and pairs with
+[removing-dead-code](./removing-dead-code.md) (the delete-vs-rewrite
+decision once a symbol is confirmed dead).
+
+---
+
+## 1. Inventory with the FULL property, not one symbol
+
+The single biggest scope error: grepping for ONE name
+(`import EmpathyOS`) when the real surface is a SET. You will undercount
+and re-discover the rest mid-execution.
+
+- Build the complete dead-symbol set first (every removed class, every
+  removed alias, the old package name).
+- Inventory with `git grep -lnE '<full|set|here>' -- docs/ content/
+  plugin/help/` and treat THAT file list as the scope.
+- Re-grep the full set after each batch (stray copies hide in
+  `examples/` vs `tutorials/examples/`, JSON blobs, ASCII diagrams,
+  and line-wrapped identifiers a single-line grep misses).
+
+## 2. NEVER label a symbol "dead" without locating it in `src/`
+
+Deadness is a CODE fact — verify it, never infer it from a related
+framework's removal or a shared name. The same trap hit
+`target_level` (a live param read as fiction), `HookMatcher` (real,
+just not re-exported), and `EmpathyLLMExecutor` (alive at
+`attune.models.empathy_executor`, wrongly called dead in a committed
+spec — see empathy-doc-fiction-cleanup D7).
+
+For each symbol the docs reference, classify it:
+
+```bash
+grep -rnE "class <Sym>\b|def <Sym>\b|^<Sym> ?=" src/        # defined?
+git log --oneline -S "class <Sym>" -- src/                  # ever real?
+```
+```python
+import importlib, inspect
+# probe likely module paths AND submodules, not just the top level:
+for m in ["attune", "attune.x", "attune.x.submodule"]:
+    mod = importlib.import_module(m); print(m, hasattr(mod, "<Sym>"))
+inspect.signature(Cls.__init__)   # is the "dead" kwarg actually a live param?
+```
+
+Then bucket — only **(c)** is a delete:
+
+| Bucket | Tell | Fix |
+|--------|------|-----|
+| (a) wrong import path / not re-exported | imports from a SUBMODULE but not the package | repoint the import (one line) |
+| (b) old package name | `attune_llm` → `attune.llm` (pre-rename) | repoint |
+| (c) genuinely removed | `git log -S` shows it deleted, no successor | delete fence + prose (per removing-dead-code) |
+| (d) live param / live class read as fiction | `inspect.signature` / `hasattr` says alive | KEEP — do not touch |
+
+A no-API-key `ValueError` or a missing-dep `ImportError` is a runtime
+gate, NOT a dead symbol. A construct that gets past the signature is
+alive.
+
+## 3. Verify the REPLACEMENT before writing it
+
+Every "after" fence must import against the live code
+(`PYTHONPATH=src python -c "<imports>"` → exit 0) BEFORE it ships.
+Construct the canonical example once, verify it, then reuse it. Don't
+fake a removed API's shape onto its successor (e.g. AgentTeam is
+fan-out+gate ONLY — no `strategy=`/`build_from_*`).
+
+## 4. Scope to PUBLISHED surfaces
+
+A stale import in an orphaned/unserved doc is not a reader-facing bug.
+Don't burn effort polishing it; don't let it block.
+
+- Served = in mkdocs `nav` OR not in `exclude_docs` (the two conflict;
+  nav wins — see doc-import-gate.md).
+- `content/blog` is the website source (the Next.js site reads
+  `content/blog`, NOT `docs/blog`). `docs/blog/social/*` is an
+  unpublished orphan.
+- `docs/specs/**`, archives, and generated bundles are append-only /
+  built artifacts — never the cleanup target.
+
+## 5. Delegate wide, but CENTRALLY verify — never trust self-reports
+
+Parallel subagents are fine for per-file rewrites, but a subagent
+reporting "grep 0, fences verified" is necessary-not-sufficient
+("registered ≠ working"). After the fan-out, re-run the WHOLE
+acceptance set yourself:
+
+- `git grep` the full dead set → zero outside history.
+- Extract every `attune` import from every touched fence → all resolve.
+- Surviving-symbol counts did not DROP (section surgery can silently
+  delete live content — the audit's whole point).
+- `mkdocs build --strict` green; `audit_docs_wiring.py` 0 findings
+  (catches cross-file anchor breaks from deletions);
+  `audit_doc_imports.py` 0 on served surfaces.
+
+## 6. Record decisions truthfully — and audit them
+
+A "dead" claim in a `decisions.md` is load-bearing: it spawns follow-up
+work and is cited later. If you write one, it must pass §2 first. When
+a prior decision is found wrong, CORRECT it in place with a dated note
+(don't silently rewrite, don't leave it) — see empathy D7.
+
+---
+
+## Cross-references
+
+- [removing-dead-code.md](./removing-dead-code.md) — the
+  delete-vs-rewrite / should-it-exist gate (after §2 confirms dead).
+- [doc-import-gate.md](./doc-import-gate.md) — the CI enforcement of §3.
+- [website-content-accuracy.md](./website-content-accuracy.md) — verify
+  counts/claims against live code (the website counterpart).

--- a/.claude/rules/attune/removing-dead-code.md
+++ b/.claude/rules/attune/removing-dead-code.md
@@ -80,6 +80,9 @@ generalize those, do not revive `SDKAgent`.)
 
 ## Cross-references
 
+- `.claude/rules/attune/doc-fiction-triage.md` — the pre-flight
+  checklist for DOC cleanups: confirm a symbol is actually dead (and
+  where its live form lives) BEFORE applying this delete-vs-rewrite gate.
 - `.claude/rules/attune/plugin-reference-validation.md` — the forward
   "references resolve" check; this rule is the reverse "should it exist"
   check.

--- a/docs/specs/empathy-doc-fiction-cleanup/decisions.md
+++ b/docs/specs/empathy-doc-fiction-cleanup/decisions.md
@@ -47,9 +47,10 @@ are alive and are real workflow infra. The "Empathy" name collides with
 the dead framework but the code is current. `reference/llm-toolkit.md`
 is therefore **repoint/excise, NOT delete**: keep the `EmpathyLLM` /
 `PIIScrubber` / `SecretsDetector` / `AuditLogger` content; remove the
-dead `EmpathyOS` integration, the fictional `encrypt_phi`, the dead
-`EmpathyLLMExecutor`, and the unsupported HIPAA/GDPR/SOC2 "compliance
-feature" claims.
+dead `EmpathyOS` integration, the fictional `encrypt_phi`, and the
+unsupported HIPAA/GDPR/SOC2 "compliance feature" claims. (This line
+originally also listed `EmpathyLLMExecutor` as dead — it is NOT; see
+D7. llm-toolkit.md never documented it, so nothing changed in practice.)
 
 ---
 
@@ -99,3 +100,36 @@ set instead of the initial `import EmpathyOS` inventory:
    fix + regen), so it is tracked as its own follow-up rather than
    sprawling this PR. Lesson: inventory with the FULL acceptance grep,
    not one symbol (pairs with "spec scope drifts from code reality").
+
+---
+
+## D7 — CORRECTION of D6: `EmpathyLLMExecutor` is ALIVE, not dead (decisions-deadness-audit, 2026-06-26)
+
+D6 (and requirements.md G1 + the Deferred note + tasks.md) asserted
+`EmpathyLLMExecutor` is a "distinct dead symbol ... gone from
+`attune.models`." **That is wrong.** Verified:
+
+```text
+from attune.models import EmpathyLLMExecutor            # works
+from attune.models.empathy_executor import EmpathyLLMExecutor  # works
+type(EmpathyLLMExecutor) is type  # a real class, module attune.models.empathy_executor
+```
+
+Consequences, all benign:
+
+- **No content was lost.** `reference/llm-toolkit.md` never documented
+  `EmpathyLLMExecutor` (checked the pre-#1109 revision — zero mentions),
+  so the cleanup removed nothing real. Its `EmpathyLLM` / `PIIScrubber`
+  / `SecretsDetector` / `AuditLogger` content is intact and correct.
+- **The orphaned doc was never broken.**
+  `enhanced_escalation_architecture.md:365`'s
+  `from attune.models.empathy_executor import EmpathyLLMExecutor`
+  imports fine; the social/generated references likewise.
+- **The deferred chip (`task_673b87a1`) is moot** — there is no dead
+  `EmpathyLLMExecutor` to clean.
+
+Root cause: deadness was INFERRED from the empathy-framework removal +
+the shared "Empathy" name, not verified by import — the exact trap D6
+itself warned about for `target_level`, repeated one symbol over. This
+is why the doc-fiction triage now requires locating the symbol in `src/`
+(`grep "class <Sym>"` + probe submodule paths) before ANY "dead" label.

--- a/docs/specs/empathy-doc-fiction-cleanup/requirements.md
+++ b/docs/specs/empathy-doc-fiction-cleanup/requirements.md
@@ -46,16 +46,24 @@ Two fiction layers, two dispositions (see `decisions.md`):
   `attune.llm.EmpathyLLM`, `attune.memory.PIIScrubber`,
   `attune.memory.SecretsDetector`, `attune.memory.security.AuditLogger`.
 
-Also dead (remove, no successor): `AgentCoordinator`,
-`EmpathyLLMExecutor`, `encrypt_phi`, and HIPAA/GDPR/SOC2 "compliance
-feature" claims.
+Also dead (remove, no successor): `AgentCoordinator`, `encrypt_phi`,
+and HIPAA/GDPR/SOC2 "compliance feature" claims.
+
+> **CORRECTION (2026-06-26, decisions-deadness-audit):**
+> `EmpathyLLMExecutor` was originally listed here (and in G1 + the
+> Deferred note + `tasks.md`) as dead. **It is ALIVE** — a real class at
+> `attune.models.empathy_executor`, re-exported as
+> `attune.models.EmpathyLLMExecutor`; both import paths resolve. No
+> served doc lost content (`llm-toolkit.md` never documented it), and the
+> orphaned doc that imports it was never broken. See decisions.md D7.
 
 ---
 
 ## Goals
 
 - G1. No user-facing doc presents `EmpathyOS` (or `AgentCoordinator` /
-  `encrypt_phi` / `EmpathyLLMExecutor`) as a live API.
+  `encrypt_phi`) as a live API. (`EmpathyLLMExecutor` was struck from
+  this list — it is alive; see the correction above.)
 - G2. No user-facing doc is framed on the removed "Empathy Level N"
   model.
 - G3. Every surviving code fence imports against `origin/main`
@@ -90,12 +98,12 @@ feature" claims.
   --strict` green.
 - One PR, docs-only, CI green.
 
-**Deferred to a follow-up (decisions.md D6):** `EmpathyLLMExecutor` — a
-DISTINCT dead symbol from `EmpathyOS` — survives in
-`docs/architecture/enhanced_escalation_architecture.md`,
-`docs/blog/social/{reddit,twitter}_claude_costs.md`, and the generated
-`plugin/help/generated/faqs/models.md`. Separate cleanup (social +
-generated-help-regen surfaces), not folded into this PR.
+**~~Deferred to a follow-up (decisions.md D6): `EmpathyLLMExecutor`~~ —
+WITHDRAWN (2026-06-26 audit).** `EmpathyLLMExecutor` is NOT dead — it is
+a live class at `attune.models.empathy_executor`. The references in
+`enhanced_escalation_architecture.md` and the social/generated files
+import it correctly and were never broken. The "deferred cleanup" was
+based on a false premise; its chip is moot. See decisions.md D7.
 
 ---
 

--- a/docs/specs/empathy-doc-fiction-cleanup/tasks.md
+++ b/docs/specs/empathy-doc-fiction-cleanup/tasks.md
@@ -17,7 +17,7 @@ imported alongside `EmpathyOS`.
 | pitch/HEALTHCARE_ONE_PAGER.md | 0 | 46 | **Delete** (healthcare-feature pitch, no such feature) |
 | examples/adaptive-learning-system.md | 12 | 23 | **Delete** (empathy-level premise) + nav prune |
 | tutorials/examples/adaptive-learning-system.md | 11 | 23 | **Delete** (dup) + nav prune |
-| reference/llm-toolkit.md | 0 | 16 | **Repoint/excise** — keep EmpathyLLM/PIIScrubber/SecretsDetector/AuditLogger; drop EmpathyOS, encrypt_phi, EmpathyLLMExecutor, HIPAA/GDPR/SOC2 claims (D3) |
+| reference/llm-toolkit.md | 0 | 16 | **Repoint/excise** — keep EmpathyLLM/PIIScrubber/SecretsDetector/AuditLogger; drop EmpathyOS, encrypt_phi, HIPAA/GDPR/SOC2 claims (D3). (EmpathyLLMExecutor was listed here as dead — it is NOT; see D7. Moot: llm-toolkit never documented it.) |
 | reference/glossary.md | 4 | 5 | **Repoint/excise** — drop EmpathyOS; remove "Empathy Level" glossary entries |
 | reference/multi-agent.md | 0 | 0 | **Repoint** — drop EmpathyOS, keep PatternLibrary/Pattern |
 | reference/pattern-library.md | 0 | 0 | **Repoint** |


### PR DESCRIPTION
Two related process-hygiene items from the session retro:

## 1. Deadness audit of committed `decisions.md` (found 1 error)
Audited the doc-fiction specs for unverified "dead" claims by probing every backtick symbol against live code. **One error, pervasive:** `EmpathyLLMExecutor` was labeled a "distinct dead symbol" across the empathy spec (requirements G1 + 'also dead' + Deferred; decisions D3 + D6; tasks). **It is ALIVE** — a real class at `attune.models.empathy_executor`, re-exported as `attune.models.EmpathyLLMExecutor`; both import paths resolve. No regression (`llm-toolkit.md` never documented it; the orphaned doc that imports it was never broken). The deferred chip `task_673b87a1` is moot. Corrected in place with a dated D7; struck the wrong claims. (All other symbols checked out — genuinely-dead ones correctly dead, live ones correctly preserved.)

## 2. New `doc-fiction-triage.md` rule
A pre-flight checklist that codifies the traps this session hit: inventory the full dead-set (not one symbol), **locate every symbol in `src/` before labeling it dead** (the bucket that caught `target_level`/`HookMatcher`/`EmpathyLLMExecutor`), verify replacements import, scope to published surfaces, centrally verify subagent output, and audit recorded decisions. Cross-referenced from `removing-dead-code.md`.

Root cause across both: deadness *inferred* from a framework removal or shared name, not *verified* by import. The checklist makes verification mandatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)