### PR TITLE
chore(release): 9.0.0 — version bump + changelog promotion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "8.10.0"
+    "version": "9.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "8.10.0",
+      "version": "9.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v8.10.0
+# Attune AI Framework v9.0.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 8.10.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 9.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0] — 2026-06-26
+
+### Security
+
+- **`aiohttp` floor raised to `>=3.14.1`** in the `[all]` extra's
+  transitive-constraint overrides, clearing 20 GHSA advisories that the
+  prior `>=3.10.0` floor permitted (it resolved to 3.13.3). Dev/CI
+  scope — `aiohttp` is not a core runtime dependency.
+
 ### Fixed
 
 - **SDK workflows no longer report a false failure on a teardown

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 8.10.0
+**Version:** 9.0.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 8.10.0 | **License:** Apache 2.0
+**Version:** 9.0.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "8.10.0"
+    "version": "9.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "8.10.0",
+      "version": "9.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "8.10.0",
+  "version": "9.0.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "8.10.0"
+__version__ = "9.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "8.10.0"
+version = "9.0.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "8.10.0"
+version = "9.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## 9.0.0 release prep

The major, breaking release. Bumps all **11 version surfaces** 8.10.0 → 9.0.0
(`scripts/bump_version.py`) and promotes CHANGELOG `[Unreleased]` →
`[9.0.0] — 2026-06-26`.

### What ships in 9.0.0
- **Removed (BREAKING):** legacy Empathy framework runtime (~3,400 LOC) +
  the dead dynamic-team / meta-orchestrator engine. Migration cookbook:
  `docs/migration/9.0.0.md`.
- **Added:** generic `AgentTeam` infra; catalog-completeness guard;
  `personal-memory`, `image-analysis`, `bulk`, `catalog`, `discovery-sweep`
  skills + `list_capabilities` / `discovery_sweep` MCP tools.
- **Fixed:** SDK teardown-exit-1 false-failure guard (8 workflows); wizard
  confirm/review crash.
- **Security:** `aiohttp` floor → `>=3.14.1` (clears 20 GHSA advisories, #1117).
- **Deprecated:** `StateManager`.

### Pre-merge checklist (from the readiness audit)
- [x] All 11 version surfaces consistent at 9.0.0 (`test_all_versions_match` green locally)
- [x] CHANGELOG promoted + dated
- [x] Migration guide covers every user-facing removed symbol
- [x] Dependency audit clear (aiohttp 3.14.1)
- [ ] CI green on this commit ← gating tag/publish

### After merge
Tag `v9.0.0` from the **merge SHA** (not this branch SHA), then the publish
workflow runs and waits at the PyPI environment approval gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)