### PR TITLE
chore(ci): retire the 8-core-runner-restore follow-up comment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,14 +102,12 @@ jobs:
 
   test:
     needs: [changes, setup-matrix]
-    # TEMPORARY (2026-06-07): ubuntu matrix entries run on default
-    # GitHub-hosted `ubuntu-latest` runners. The 8-core/32GB larger
-    # runner (`ubuntu-8core-or-linux-32gb`) was de-provisioned, which left
-    # the ubuntu Tests jobs unschedulable (no runner matched the label) —
-    # so the routing was reverted to unblock CI. Follow-up: re-provision a
-    # working larger runner and restore the conditional routing for the
-    # ~2x parallelism + memory headroom (see the larger-runners spec).
-    # macOS and Windows stay on default runners as before.
+    # All lanes run on free GitHub-hosted standard runners by design. An
+    # 8-core/32GB larger runner (`ubuntu-8core-or-linux-32gb`) was
+    # de-provisioned 2026-06-07; restoring it was evaluated 2026-06-26 and
+    # declined — ubuntu lanes already finish in ~4 min, and the recurring
+    # runner-hang it might have helped is an xdist finalize-deadlock, not
+    # memory pressure, so the headroom would not fix it.
     runs-on: ${{ matrix.os }}
     # ci-runner-hang spec: tightened from 75 so a wedged pytest step fails
     # in bounded time (and is rerun-recoverable) instead of stalling for


### PR DESCRIPTION
Comment-only change to `tests.yml`. Records the 2026-06-26 decision to keep ubuntu lanes on free standard runners (decline the larger-runner restore) instead of leaving a stale 'Follow-up: re-provision' note. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)