### PR TITLE
feat: declare and test Python 3.14 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
       shell: bash
       run: |
         if [ "${{ needs.changes.outputs.src }}" = "true" ]; then
-          echo 'matrix={"os":["ubuntu-latest","macos-latest","windows-latest"],"python-version":["3.10","3.11","3.12","3.13"]}' >> "$GITHUB_OUTPUT"
+          echo 'matrix={"os":["ubuntu-latest","macos-latest","windows-latest"],"python-version":["3.10","3.11","3.12","3.13","3.14"]}' >> "$GITHUB_OUTPUT"
         else
           # slim (D1): the required ubuntu-3.12 lane + one Windows smoke
           echo 'matrix={"os":["ubuntu-latest","windows-latest"],"python-version":["3.12"]}' >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Tests](https://img.shields.io/badge/tests-20%2C000%2B%20passing-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/tests.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/Smart-AI-Memory/attune-ai?branch=main)](https://codecov.io/gh/Smart-AI-Memory/attune-ai)
 [![Security](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml/badge.svg)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml)
-[![Python](https://img.shields.io/badge/python-3.10+-blue)](https://www.python.org)
+[![Python](https://img.shields.io/badge/python-3.10--3.14-blue)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/Smart-AI-Memory/attune-ai/blob/main/LICENSE)
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Environment :: Console",
     "Typing :: Typed",


### PR DESCRIPTION
Adds the `Programming Language :: Python :: 3.14` classifier and a 3.14 lane to the full CI matrix, **together**, so the support claim is validated by CI not just asserted (website-accuracy discipline).

- `requires-python` already `>=3.10` (includes 3.14); badge already says `3.10+`. This closes the gap where 3.14 was implied but neither declared nor tested.
- The full matrix now runs 3.10–3.14 on ubuntu/macos/windows. `test_workflow_yaml.py` invariants hold (still 2 variants; ubuntu-3.12 lane preserved).
- **Gate:** if any pinned dep lacks 3.14 wheels, the 3.14 lanes go red and this PR won't merge — declare-only-if-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)