### PR TITLE
feat(devex): stale-starter reconciler hook + auditor dep-classification

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,12 @@
             "command": "python $(git rev-parse --show-toplevel)/src/attune/hooks/scripts/starter_prompt_nudge.py",
             "timeout": 3,
             "statusMessage": "Checking for cross-session handoff..."
+          },
+          {
+            "type": "command",
+            "command": "python $(git rev-parse --show-toplevel)/src/attune/hooks/scripts/starter_reconciler.py",
+            "timeout": 12,
+            "statusMessage": "Reconciling handoff freshness..."
           }
         ]
       }

--- a/plugin/agents/release-prep-auditor.md
+++ b/plugin/agents/release-prep-auditor.md
@@ -32,7 +32,19 @@ record pass/fail with evidence:
 5. **Security** — a quick scan for `eval(`/`exec(`/`subprocess(... shell=True`/
    hardcoded secrets in changed code (defer a deep pass to `security-reviewer`).
 6. **Dependencies** — lockfile in sync (no drift); a vuln audit if available
-   (`pip-audit`), noting known-broken tooling rather than blocking on it.
+   (`pip-audit`). Two rules, both verify-first — never report a dependency
+   fact from memory:
+   - **Classify by section, by READING `pyproject.toml`.** For every
+     flagged dependency, state whether it lives in `[project].dependencies`
+     (a **core** dep — exposed to every `pip install <pkg>` user) or under
+     `[project.optional-dependencies].<extra>` (only reaches users who opt
+     into that `<extra>`). `grep` the actual section; do not assume from the
+     package name. A vuln in an optional extra has a smaller blast radius
+     than the same vuln in core — say which, and who is exposed.
+   - **Counts and fix versions come from `pip-audit` output, not memory.**
+     Report the exact advisory count and the minimum fixed version each
+     advisory names, quoting the tool. If `pip-audit` itself is broken,
+     note it as known-infra (not a vuln) rather than blocking or guessing.
 7. **Version-bump consistency** — if a bump is intended, the version is
    consistent across all the files that must change together
    (e.g. `pyproject.toml` + `plugin.json` + lockfile).
@@ -61,6 +73,12 @@ End with a single verdict the human can act on:
 
 Distinguish **real blockers** from **known-infra noise** (e.g. a flaky non-required
 check, broken pip-audit) — don't fail a release on a non-required flake.
+
+Keep the final report compact — the verdict line, the table, and the blockers
+list. Put evidence in the table's Notes cells, not in long per-check transcripts;
+a verbose dump risks the structured verdict being truncated. If you need to show
+raw `pip-audit` / CI output, summarize it to the count and the fix version rather
+than pasting it whole.
 
 ## Examples
 

--- a/src/attune/hooks/scripts/starter_reconciler.py
+++ b/src/attune/hooks/scripts/starter_reconciler.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""SessionStart hook: reconcile next_session_starter.md threads vs reality.
+
+The companion to ``starter_prompt_nudge.py``. That hook *surfaces* the
+cross-session handoff file; this one *fact-checks* it. A handoff goes
+stale on arrival when its headline "do this big thing" item is already
+done — e.g. the starter says "merge PR #1118" but #1118 merged hours
+ago, or "ship 9.0.0" but 9.0.0 is already on PyPI. Reconciling that by
+hand (branch exists? PR merged? version published?) is ~5 minutes of
+archaeology every session. This hook turns it into a glance.
+
+It parses the starter's *named threads* — ``#PR`` numbers, branch names,
+and ``X.Y.Z`` version strings — and checks each against git / ``gh`` /
+PyPI in parallel, then prints a one-block freshness banner:
+
+    [starter-reconcile] ~/.attune/next_session_starter.md
+      PRs: #1116 MERGED · #1117 MERGED · #1121 MERGED
+      branches: claude/foo GONE
+      PyPI attune-ai latest=9.0.0 (starter mentions: 9.0.0, 8.5.0)
+
+A MERGED PR / GONE branch / already-published version is the tell that
+the headline action is done — read the banner before trusting the lead.
+
+Bounded for SessionStart: thread counts are capped and all network
+checks run concurrently under a hard wall-clock budget; anything that
+doesn't finish (or errors) is reported ``unverified`` rather than
+blocking. Exit code is always 0 — a reconciler failure must never stop
+a session from starting.
+
+Lives under the enforcement framework at
+``docs/specs/enforcement-vs-documentation/`` as a soft, informational
+surfacing (no exit 2), so it doesn't count against the enforcement cap.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+STARTER_PATH = Path.home() / ".attune" / "next_session_starter.md"
+
+#: Relative location of a per-repo handoff, under the git toplevel.
+PROJECT_STARTER_RELPATH = Path(".attune") / "next_session_starter.md"
+
+# --- Bounds (keep SessionStart snappy) -------------------------------
+#: Cap how many of each thread we verify, newest-mentioned first.
+MAX_PRS = 6
+MAX_BRANCHES = 4
+#: Per-subprocess timeout for a single git/gh call (seconds).
+SUBPROC_TIMEOUT = 4
+#: Total wall-clock budget for ALL network checks combined (seconds).
+WALL_BUDGET = 8
+#: urlopen timeout for the single PyPI lookup (seconds).
+HTTP_TIMEOUT = 4
+
+# --- Thread extraction patterns --------------------------------------
+#: ``#1121`` PR references (markdown headings always have a space after
+#: ``#`` so ``# Heading`` never matches; ``#1121`` does).
+PR_RE = re.compile(r"#(\d{1,6})\b")
+#: Branch names — restricted to the prefixes this project actually uses
+#: for branches, to avoid matching doc paths like ``docs/specs/...``.
+BRANCH_RE = re.compile(r"\b(?:release|hotfix|claude|feat|fix)/[A-Za-z0-9._/-]+")
+#: ``X.Y.Z`` semantic versions.
+VERSION_RE = re.compile(r"\b\d+\.\d+\.\d+\b")
+
+
+def _find_project_starter(start: Path | None = None) -> Path | None:
+    """Return ``<git-toplevel>/.attune/next_session_starter.md`` or None.
+
+    Mirrors ``starter_prompt_nudge._find_project_starter`` — walks up
+    from ``start`` (default cwd) to the repo root and returns the
+    project-local starter if it exists. ``start`` is a parameter so
+    tests can pin the search root.
+    """
+    if start is None:
+        start = Path.cwd()
+    for parent in [start, *start.parents]:
+        if (parent / ".git").exists():
+            candidate = parent / PROJECT_STARTER_RELPATH
+            return candidate if candidate.is_file() else None
+    return None
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    """De-duplicate preserving first-seen order."""
+    return list(dict.fromkeys(items))
+
+
+def extract_threads(text: str) -> tuple[list[int], list[str], list[str]]:
+    """Pull (pr_numbers, branches, versions) from starter ``text``.
+
+    PR numbers and branches are capped (``MAX_PRS`` / ``MAX_BRANCHES``)
+    so the reconciler's network fan-out stays bounded; versions are not
+    capped (no per-version network call — one PyPI lookup serves all).
+    """
+    prs = [int(n) for n in _dedupe(PR_RE.findall(text))][:MAX_PRS]
+    branches = _dedupe(BRANCH_RE.findall(text))[:MAX_BRANCHES]
+    versions = _dedupe(VERSION_RE.findall(text))
+    return prs, branches, versions
+
+
+def _package_name(repo_root: Path | None) -> str | None:
+    """Best-effort package name from ``pyproject.toml`` (regex, no toml).
+
+    Avoids a ``tomllib`` dependency so the hook runs under the user's
+    ``python`` even when that's < 3.11. Returns None if no pyproject /
+    no ``name = "..."`` line is found.
+    """
+    if repo_root is None:
+        return None
+    pyproject = repo_root / "pyproject.toml"
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r'(?m)^\s*name\s*=\s*["\']([^"\']+)["\']', text)
+    return match.group(1) if match else None
+
+
+def _run(cmd: list[str], cwd: Path | None) -> subprocess.CompletedProcess | None:
+    """Run ``cmd``, returning the result or None on timeout / OS error."""
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=SUBPROC_TIMEOUT,
+            cwd=str(cwd) if cwd else None,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def check_pr(num: int, cwd: Path | None) -> str:
+    """Return a PR's state (``MERGED`` / ``OPEN`` / ``CLOSED``) or ``unverified``."""
+    result = _run(["gh", "pr", "view", str(num), "--json", "state", "-q", ".state"], cwd)
+    if result is None or result.returncode != 0:
+        return "unverified"
+    return result.stdout.strip().upper() or "unverified"
+
+
+def check_branch(name: str, cwd: Path | None) -> str:
+    """Return ``exists`` / ``gone`` for a remote branch, or ``unverified``."""
+    result = _run(["git", "ls-remote", "--heads", "origin", name], cwd)
+    if result is None or result.returncode != 0:
+        return "unverified"
+    return "exists" if result.stdout.strip() else "gone"
+
+
+def pypi_latest(pkg: str) -> str | None:
+    """Return the latest version string for ``pkg`` on PyPI, or None."""
+    url = f"https://pypi.org/pypi/{pkg}/json"
+    try:
+        # noqa: S310 / nosec B310 — hardcoded https PyPI URL, scheme is fixed.
+        with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310  # nosec B310
+            data = json.load(resp)
+        return data["info"]["version"]
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: any PyPI hiccup (offline, 404, parse) is non-fatal
+        # — the version line is simply omitted from the banner.
+        return None
+
+
+def reconcile(text: str, pkg: str | None, cwd: Path | None) -> dict:
+    """Check every extracted thread concurrently under ``WALL_BUDGET``.
+
+    Returns a dict with ``prs`` / ``branches`` (name → status), the
+    ``pypi`` latest version (or None), and the ``versions`` mentioned in
+    the starter. Threads whose check doesn't finish within the budget
+    are reported ``unverified``.
+    """
+    prs, branches, versions = extract_threads(text)
+    results: dict = {
+        "prs": dict.fromkeys(prs, "unverified"),
+        "branches": dict.fromkeys(branches, "unverified"),
+        "pypi": None,
+        "versions": versions,
+    }
+    if not prs and not branches and not pkg:
+        return results
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=8)
+    futures: dict = {}
+    for num in prs:
+        futures[executor.submit(check_pr, num, cwd)] = ("pr", num)
+    for branch in branches:
+        futures[executor.submit(check_branch, branch, cwd)] = ("branch", branch)
+    if pkg:
+        futures[executor.submit(pypi_latest, pkg)] = ("pypi", None)
+
+    done, _ = concurrent.futures.wait(futures, timeout=WALL_BUDGET)
+    for future in done:
+        kind, key = futures[future]
+        try:
+            value = future.result()
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: a single check raising must not sink the others.
+            continue
+        if kind == "pr":
+            results["prs"][key] = value
+        elif kind == "branch":
+            results["branches"][key] = value
+        elif kind == "pypi":
+            results["pypi"] = value
+
+    # Don't block the session on stragglers — their subprocesses are
+    # already timeout-bounded; abandon any still running.
+    executor.shutdown(wait=False, cancel_futures=True)
+    return results
+
+
+def format_banner(results: dict, label: str, path: Path) -> str | None:
+    """Render the freshness banner, or None if nothing to report."""
+    prs = results["prs"]
+    branches = results["branches"]
+    pypi = results["pypi"]
+    versions = results["versions"]
+    if not prs and not branches and pypi is None:
+        return None
+
+    lines = [f"[starter-reconcile:{label}] {path}"]
+    if prs:
+        joined = " · ".join(f"#{num} {state}" for num, state in prs.items())
+        lines.append(f"  PRs: {joined}")
+    if branches:
+        joined = " · ".join(f"{name} {state}" for name, state in branches.items())
+        lines.append(f"  branches: {joined}")
+    if pypi is not None:
+        suffix = f" (starter mentions: {', '.join(versions)})" if versions else ""
+        pkg = results.get("pkg") or ""
+        label_pkg = f"PyPI {pkg}".rstrip()
+        lines.append(f"  {label_pkg} latest={pypi}{suffix}")
+    return "\n".join(lines)
+
+
+def _reconcile_and_emit(path: Path, label: str, repo_root: Path | None) -> bool:
+    """Reconcile a single starter file and print its banner if any.
+
+    Returns True if a banner was printed, False on any no-op.
+    """
+    try:
+        if not path.is_file() or path.stat().st_size == 0:
+            return False
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+    pkg = _package_name(repo_root)
+    results = reconcile(text, pkg, repo_root)
+    results["pkg"] = pkg or ""
+    banner = format_banner(results, label, path)
+    if banner is None:
+        return False
+    print(banner)
+    return True
+
+
+def _repo_root(start: Path | None = None) -> Path | None:
+    """Return the git toplevel walking up from ``start`` (default cwd)."""
+    if start is None:
+        start = Path.cwd()
+    for parent in [start, *start.parents]:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def main() -> int:
+    """Reconcile the project-local then global starter, if present."""
+    repo_root = _repo_root()
+    project_path = _find_project_starter()
+    if project_path is not None:
+        _reconcile_and_emit(project_path, "project", repo_root)
+
+    if project_path is None or STARTER_PATH.resolve() != project_path.resolve():
+        _reconcile_and_emit(STARTER_PATH, "global", repo_root)
+    return 0
+
+
+if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: hook errors must never block session start.
+        print(
+            f"[starter-reconcile] hook error (continuing): " f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)

--- a/tests/unit/hooks/test_starter_reconciler.py
+++ b/tests/unit/hooks/test_starter_reconciler.py
@@ -1,0 +1,279 @@
+"""Tests for starter_reconciler.py SessionStart hook.
+
+Covers:
+
+- Thread extraction (PR numbers, branches, versions) with caps + dedupe
+- Package-name parse from pyproject.toml (regex, no tomllib dep)
+- Per-thread check functions (gh / git / PyPI) with subprocess stubbed
+- reconcile() aggregates concurrent checks and degrades to "unverified"
+- format_banner() rendering, including the empty-package and no-op cases
+- main() no-ops cleanly on missing/empty files and never raises
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "attune"
+    / "hooks"
+    / "scripts"
+    / "starter_reconciler.py"
+)
+
+
+@pytest.fixture(scope="module")
+def hook_module():
+    spec = importlib.util.spec_from_file_location("_starter_reconciler", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_starter_reconciler"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- Thread extraction -----------------------------------------------
+
+
+class TestExtractThreads:
+    def test_extracts_prs_branches_versions(self, hook_module):
+        text = (
+            "Merged PR #1118 and #1121; branch claude/foo-bar was deleted.\n"
+            "Shipped 9.0.0 to PyPI (was 8.5.0)."
+        )
+        prs, branches, versions = hook_module.extract_threads(text)
+        assert prs == [1118, 1121]
+        assert branches == ["claude/foo-bar"]
+        assert versions == ["9.0.0", "8.5.0"]
+
+    def test_markdown_heading_not_matched_as_pr(self, hook_module):
+        # "# Heading" has a space after '#', so it is not a PR ref.
+        prs, _, _ = hook_module.extract_threads("# Status\n## Section 9\n")
+        assert prs == []
+
+    def test_dedupe_preserves_order(self, hook_module):
+        prs, _, versions = hook_module.extract_threads("#5 #5 #3 1.0.0 1.0.0")
+        assert prs == [5, 3]
+        assert versions == ["1.0.0"]
+
+    def test_pr_and_branch_caps(self, hook_module):
+        text = " ".join(f"#{n}" for n in range(100, 120))
+        text += " " + " ".join(f"fix/b{n}" for n in range(20))
+        prs, branches, _ = hook_module.extract_threads(text)
+        assert len(prs) == hook_module.MAX_PRS
+        assert len(branches) == hook_module.MAX_BRANCHES
+
+    def test_doc_paths_not_matched_as_branches(self, hook_module):
+        # 'docs/' and 'chore/' are deliberately excluded to avoid
+        # matching doc paths like docs/specs/usage-signals.
+        _, branches, _ = hook_module.extract_threads(
+            "see docs/specs/usage-signals/ and chore/cleanup/notes"
+        )
+        assert branches == []
+
+
+# --- Package name parse ----------------------------------------------
+
+
+class TestPackageName:
+    def test_reads_name_from_pyproject(self, hook_module, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "my-pkg"\nversion = "1.0.0"\n', encoding="utf-8"
+        )
+        assert hook_module._package_name(tmp_path) == "my-pkg"
+
+    def test_none_when_no_pyproject(self, hook_module, tmp_path):
+        assert hook_module._package_name(tmp_path) is None
+
+    def test_none_when_no_name_field(self, hook_module, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+        assert hook_module._package_name(tmp_path) is None
+
+    def test_none_when_repo_root_none(self, hook_module):
+        assert hook_module._package_name(None) is None
+
+
+# --- Per-thread checks (subprocess / urllib stubbed) -----------------
+
+
+class _FakeProc:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+class TestCheckPr:
+    def test_returns_state_uppercased(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: _FakeProc("merged\n", 0))
+        assert hook_module.check_pr(1118, None) == "MERGED"
+
+    def test_unverified_on_nonzero(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: _FakeProc("", 1))
+        assert hook_module.check_pr(1, None) == "unverified"
+
+    def test_unverified_when_run_none(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: None)
+        assert hook_module.check_pr(1, None) == "unverified"
+
+
+class TestCheckBranch:
+    def test_exists_when_ls_remote_has_output(self, hook_module, monkeypatch):
+        monkeypatch.setattr(
+            hook_module, "_run", lambda *a, **k: _FakeProc("abc123\trefs/heads/x", 0)
+        )
+        assert hook_module.check_branch("x", None) == "exists"
+
+    def test_gone_when_ls_remote_empty(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: _FakeProc("", 0))
+        assert hook_module.check_branch("x", None) == "gone"
+
+    def test_unverified_when_run_none(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: None)
+        assert hook_module.check_branch("x", None) == "unverified"
+
+
+class TestRun:
+    def test_run_returns_none_on_timeout(self, hook_module, monkeypatch):
+        def boom(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="x", timeout=1)
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        assert hook_module._run(["git", "status"], None) is None
+
+    def test_run_returns_none_on_oserror(self, hook_module, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("no such binary")
+
+        monkeypatch.setattr(subprocess, "run", boom)
+        assert hook_module._run(["nope"], None) is None
+
+
+class TestPypiLatest:
+    def test_returns_none_on_error(self, hook_module, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("offline")
+
+        monkeypatch.setattr(hook_module.urllib.request, "urlopen", boom)
+        assert hook_module.pypi_latest("attune-ai") is None
+
+
+# --- reconcile() aggregation -----------------------------------------
+
+
+class TestReconcile:
+    def test_aggregates_all_checks(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "check_pr", lambda n, c: "MERGED")
+        monkeypatch.setattr(hook_module, "check_branch", lambda b, c: "gone")
+        monkeypatch.setattr(hook_module, "pypi_latest", lambda p: "9.0.0")
+        text = "PR #1118 on branch claude/foo shipped 9.0.0"
+        results = hook_module.reconcile(text, "attune-ai", None)
+        assert results["prs"] == {1118: "MERGED"}
+        assert results["branches"] == {"claude/foo": "gone"}
+        assert results["pypi"] == "9.0.0"
+
+    def test_no_network_when_nothing_to_check(self, hook_module, monkeypatch):
+        called = {"n": 0}
+
+        def tracker(*a, **k):
+            called["n"] += 1
+            return "x"
+
+        monkeypatch.setattr(hook_module, "check_pr", tracker)
+        monkeypatch.setattr(hook_module, "check_branch", tracker)
+        monkeypatch.setattr(hook_module, "pypi_latest", tracker)
+        results = hook_module.reconcile("no threads here", None, None)
+        assert called["n"] == 0
+        assert results["prs"] == {} and results["branches"] == {}
+        assert results["pypi"] is None
+
+    def test_check_exception_does_not_sink_others(self, hook_module, monkeypatch):
+        def boom(n, c):
+            raise RuntimeError("gh exploded")
+
+        monkeypatch.setattr(hook_module, "check_pr", boom)
+        monkeypatch.setattr(hook_module, "pypi_latest", lambda p: "1.2.3")
+        results = hook_module.reconcile("#42 v1.2.3", "pkg", None)
+        # PR stays at its "unverified" seed; PyPI still resolves.
+        assert results["prs"][42] == "unverified"
+        assert results["pypi"] == "1.2.3"
+
+
+# --- format_banner() --------------------------------------------------
+
+
+class TestFormatBanner:
+    def test_none_when_empty(self, hook_module, tmp_path):
+        results = {"prs": {}, "branches": {}, "pypi": None, "versions": []}
+        assert hook_module.format_banner(results, "global", tmp_path / "s.md") is None
+
+    def test_renders_all_sections(self, hook_module, tmp_path):
+        results = {
+            "prs": {1118: "MERGED"},
+            "branches": {"claude/foo": "gone"},
+            "pypi": "9.0.0",
+            "versions": ["9.0.0", "8.5.0"],
+            "pkg": "attune-ai",
+        }
+        out = hook_module.format_banner(results, "global", tmp_path / "s.md")
+        assert "[starter-reconcile:global]" in out
+        assert "#1118 MERGED" in out
+        assert "claude/foo gone" in out
+        assert "PyPI attune-ai latest=9.0.0" in out
+        assert "starter mentions: 9.0.0, 8.5.0" in out
+
+    def test_empty_package_has_no_double_space(self, hook_module, tmp_path):
+        results = {
+            "prs": {},
+            "branches": {},
+            "pypi": "1.0.0",
+            "versions": [],
+            "pkg": "",
+        }
+        out = hook_module.format_banner(results, "global", tmp_path / "s.md")
+        assert "PyPI  latest" not in out
+        assert "PyPI latest=1.0.0" in out
+
+
+# --- main() lifecycle -------------------------------------------------
+
+
+class TestMain:
+    def test_missing_files_no_output(self, hook_module, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(hook_module, "STARTER_PATH", tmp_path / "nope.md")
+        monkeypatch.setattr(hook_module, "_find_project_starter", lambda *a, **k: None)
+        assert hook_module.main() == 0
+        assert capsys.readouterr().out == ""
+
+    def test_empty_file_no_output(self, hook_module, tmp_path, monkeypatch, capsys):
+        starter = tmp_path / "starter.md"
+        starter.write_text("", encoding="utf-8")
+        monkeypatch.setattr(hook_module, "STARTER_PATH", starter)
+        monkeypatch.setattr(hook_module, "_find_project_starter", lambda *a, **k: None)
+        assert hook_module.main() == 0
+        assert capsys.readouterr().out == ""
+
+    def test_emits_banner_for_global(self, hook_module, tmp_path, monkeypatch, capsys):
+        starter = tmp_path / "starter.md"
+        starter.write_text("Merged PR #1118.\n", encoding="utf-8")
+        monkeypatch.setattr(hook_module, "STARTER_PATH", starter)
+        monkeypatch.setattr(hook_module, "_find_project_starter", lambda *a, **k: None)
+        monkeypatch.setattr(hook_module, "_repo_root", lambda *a, **k: None)
+        monkeypatch.setattr(hook_module, "check_pr", lambda n, c: "MERGED")
+        hook_module.main()
+        out = capsys.readouterr().out
+        assert "[starter-reconcile:global]" in out
+        assert "#1118 MERGED" in out
+
+    def test_emit_swallows_oserror(self, hook_module, monkeypatch):
+        class _Boom:
+            def is_file(self):
+                raise OSError("vanished")
+
+        assert hook_module._reconcile_and_emit(_Boom(), "global", None) is False


### PR DESCRIPTION
Two post-9.0.0 devex fixes, both born from the 9.0.0 release cycle's friction (green-lit 2026-06-26).

## 1. SessionStart starter-reconciler hook

`starter_prompt_nudge.py` *surfaces* the cross-session handoff file; the new `starter_reconciler.py` *fact-checks* it. A handoff goes stale on arrival when its headline action is already done ("merge PR #1118" / "ship 9.0.0" — both already landed). This hook parses the starter's named threads (`#PR` numbers, branch names, `X.Y.Z` versions) and checks each against git / `gh` / PyPI **in parallel under a wall-clock budget**, then prints a freshness banner:

```
[starter-reconcile:global] ~/.attune/next_session_starter.md
  PRs: #1116 MERGED · #1117 MERGED · #1121 MERGED
  PyPI attune-ai latest=9.0.0 (starter mentions: 9.0.0, 8.5.0)
```

A MERGED PR / GONE branch / already-published version is the tell that the headline is done — turns ~5 min of manual archaeology into a glance.

- **Bounded for SessionStart:** capped thread counts, per-call timeouts, concurrent checks, unfinished/errored checks reported `unverified`, always exit 0.
- **No `tomllib` dep** (regex pyproject parse) so it runs under the user's `python` < 3.11.
- Wired as a third `SessionStart` hook in `.claude/settings.json`.
- 28 unit tests; live smoke against the real starter (~0.7s) correctly flagged all 4 headline PRs MERGED + PyPI already at 9.0.0.

## 2. release-prep-auditor agent prompt tweak

The 9.0.0 readiness audit was confidently wrong on two dependency facts (caught only by verify-first): it called `aiohttp` a **core** dep when it's a constraint in the `[all]` extra, and reported the wrong advisory count. The prompt now requires:

- **Classify each flagged dep by READING its `pyproject.toml` section** — core `[project].dependencies` vs an optional extra — stating blast radius, never assuming from the name.
- **Report advisory counts + fix versions from actual `pip-audit` output**, not memory.
- Keep the final report compact to avoid the structured verdict being truncated.

## Test plan

- `pytest tests/unit/hooks/test_starter_reconciler.py` — 28 passed
- `pytest tests/unit/hooks tests/unit/plugins/test_sdk_subprocess_gate.py tests/unit/plugins/test_plugin_reference_validation.py` — green
- black / ruff / bandit (medium) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
