### PR TITLE
docs(spec): elicitation-form-surface — Phase 0 + design + salvage (D4–D6)

### DIFF
--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -98,13 +98,33 @@ re-fuses the spec with its sibling
 SDK user-input docs (`code.claude.com/.../agent-sdk/user-input`);
 live `AskUserQuestion` tool schema.
 
-## Open (to be decided in design)
+## D5 — v1 design approved (first-target + rule relaxation)
 
-- **First integrated flow (G3)** — leaning Socratic discovery flow
-  (Patrick 2026-06-27); confirmed in design.
-- **One-question-rule relaxation** — define *when* a multi-question
-  `AskUserQuestion` turn is warranted (compound intake) vs the default
-  single ask; must compose with `socratic-ambiguity-calibration`.
+**Date:** 2026-06-27 · **Status:** decided · see [design.md](design.md)
+
+Patrick signed off on the v1 design as drafted:
+
+- **First integrated flow (G3) = the `/attune` Socratic discovery
+  scoping turn** (goal + scope + focus — today sequential buttons).
+  Dogfooded end-to-end per R5.
+- **One-question-rule relaxation (design §4) approved.** Batch 2–4
+  fields into one form-turn *only when all hold*: independent
+  dimensions of one decision · answers don't branch · each field is
+  genuinely ambiguous per `socratic-ambiguity-calibration`; otherwise
+  stay single-question. Composition: the sibling rule decides *which*
+  fields are worth asking, the form decides *whether* they're batched —
+  the form never adds a field the ambiguity rule wouldn't already ask.
+  This is the guardrail against richer forms amplifying Socratic
+  fatigue.
+- **v1 artifact types** = select / multiselect / text (via the "Other"
+  free-text escape). slider/date/number/color are valid artifact types
+  but deferred to the widget enhancement (D4).
+
+Build scope now fully specified: a declarative-form renderer onto
+`AskUserQuestion` + the §4 batching rule. No new infrastructure.
+
+## Open
+
 - **Confirm CC elicitation support** — low priority (elicitation is
   rejected regardless for lacking multi-select), but worth nailing if
   the widget/enhancement phase is ever revisited.

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -123,6 +123,37 @@ Patrick signed off on the v1 design as drafted:
 Build scope now fully specified: a declarative-form renderer onto
 `AskUserQuestion` + the §4 batching rule. No new infrastructure.
 
+## D6 — Salvage: reuse the existing form model; the live wiring is the gap
+
+**Date:** 2026-06-27 · **Status:** decided · see
+[salvage-assessment.md](salvage-assessment.md)
+
+A bounded salvage pass found that most of v1 **already exists** and is
+proven, so v1 is even smaller than D5 implied:
+
+- **REUSE** `meta_workflows/models.py` — `FormSchema`/`FormQuestion`/
+  `QuestionType` (incl. `MULTI_SELECT`)/`FormResponse` +
+  `to_ask_user_format()` + `get_question_batches(4)` + validation. This
+  *is* the D3 artifact + the D5 §2 renderer mapping. Do not duplicate.
+- **The gap is the live wiring.** `SocraticFormEngine`'s
+  `ask_user_callback` path has **no live caller** (no `/wizard` skill /
+  command / CLI handler — confirmed; only a docstring placeholder +
+  test mocks). `AskUserQuestion` is an agent tool, not a Python API, so
+  the engine never reaches the user; today's questioning is
+  markdown-driven. v1's real new work = the model→tool bridge.
+- **Florence (`Deep-Study-AI/ai-nurse-florence-v3.1`) proves D3.** The
+  in-repo model was built (pre-AskUserQuestion) to support that app's
+  ~20 clinical multi-step web forms — the same declarative model
+  already drove a *web* surface in production. That web rendering is
+  the **v2 target**; v1 just drives the same model through
+  `AskUserQuestion`.
+
+**Open — bridge nature (deferred per Patrick, decide before building):**
+**A** pure-markdown skill (model unused at runtime; defers D3 to v2) vs
+**B** skill + thin Python bridge (an MCP tool runs the real model →
+`AskUserQuestion` → validated `FormResponse`; the true stepping stone).
+Agent recommends **B**. See salvage-assessment.md.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -52,14 +52,62 @@ architectural choice locked this session; the designer and data binding
 themselves are explicitly out of v1 scope. Also makes forms
 surface-agnostic, which de-risks the Phase 0 surface fork (D1).
 
-## Open (to be decided in design, after Phase 0)
+## D4 — Phase 0 outcome: AskUserQuestion-first; elicitation rejected, widget deferred
+
+**Date:** 2026-06-27 · **Status:** decided (Phase 0 Q0.4) · **Resolves D1**
+
+Phase 0 research (cited findings below) **overturned the spec's
+premise** and resolves the surface fork. v1 builds on the built-in
+**`AskUserQuestion`** tool; MCP elicitation is rejected; the rendered
+widget is deferred to a later enhancement.
+
+**Findings (verify-first; confidence flagged):**
+
+- **`AskUserQuestion` already supports the two priority controls.**
+  `multiSelect: true` per question = choose-many; the `questions` array
+  takes **up to 4 questions in one call** = multi-field in a single
+  pass; the return is a clean structured dict (no message-parsing).
+  *Confirmed against the live tool schema — documented.* The premise
+  that "AskUserQuestion is buttons-only, one question per turn" was
+  wrong: the one-question habit is **attune's own question-shape rule**
+  (`feedback_question_shape` / `ask_question_format_guard`), not a
+  platform limit.
+- **MCP elicitation cannot express multi-select.** The 2025-06-18 spec
+  restricts `requestedSchema` to flat objects of primitives
+  (string/number/boolean/enum); arrays/multi-select are excluded *by
+  design*. *Documented.* And Claude Code client support for elicitation
+  is **unconfirmed (likely absent)** — undocumented in the CC/SDK docs.
+  Either way it fails the priority-1 control, so it is rejected.
+- **The rich palette (slider/textarea/date) has no portable surface.**
+  Only the `visualize`-style widget renders it, and that is an
+  Anthropic surface with a fragile post-JSON-back return — **not an
+  MCP-server capability** attune can own. Deferred, not core.
+
+**Decision:** v1 = a declarative form (D3) rendered onto
+`AskUserQuestion` at its full extent (multi-select + ≤4 questions/pass),
+plus **relaxing attune's one-question rule** where a genuinely compound
+intake warrants a multi-question turn. Rich-control widget = deferred
+enhancement off the *same* declarative artifact. This collapses the
+build to a renderer + a rule change — no new infrastructure — and
+re-fuses the spec with its sibling
+[socratic-ambiguity-calibration](../socratic-ambiguity-calibration/requirements.md)
+(the lever is *how we question*, not new plumbing).
+
+**Sources:** MCP spec 2025-06-18 elicitation
+(`modelcontextprotocol.io/.../client/elicitation`); Claude Code Agent
+SDK user-input docs (`code.claude.com/.../agent-sdk/user-input`);
+live `AskUserQuestion` tool schema.
+
+## Open (to be decided in design)
 
 - **First integrated flow (G3)** — leaning Socratic discovery flow
   (Patrick 2026-06-27); confirmed in design.
-- **Result-return mechanism + parsing** — delegated to the agent's
-  design-time judgement after Phase 0 grounds the surfaces (Patrick
-  2026-06-27); R6/D3 (declarative artifact) holds regardless.
-- **Final surface decision** (Phase 0 Q0.4).
+- **One-question-rule relaxation** — define *when* a multi-question
+  `AskUserQuestion` turn is warranted (compound intake) vs the default
+  single ask; must compose with `socratic-ambiguity-calibration`.
+- **Confirm CC elicitation support** — low priority (elicitation is
+  rejected regardless for lacking multi-select), but worth nailing if
+  the widget/enhancement phase is ever revisited.
 - **Revisit the `socratic-ambiguity-calibration` "ask only when
   genuinely ambiguous" rule** — Patrick endorses it now but is open to
   changing it with more feedback. Future discussion, not a v1 change.

--- a/docs/specs/elicitation-form-surface/design.md
+++ b/docs/specs/elicitation-form-surface/design.md
@@ -1,0 +1,109 @@
+# Elicitation Form Surface — Design (v1)
+
+Design for the [requirements](requirements.md), post-Phase 0. Surface
+decision is [decisions.md](decisions.md) **D4**: AskUserQuestion-first,
+elicitation rejected, widget deferred. v1 = a declarative-form artifact
+(D3) + a renderer onto `AskUserQuestion` + a rule that says *when* to
+batch fields into one multi-question turn. No new infrastructure.
+
+## 1. The form artifact (D3 — form as data)
+
+A form is a serializable object — never imperative agent code — so the
+same artifact can render today, be human-authored later, and bind to
+data later (North star), at no extra cost now.
+
+```python
+Form     = {title: str, fields: list[Field]}
+Field    = {
+    id: str,                 # stable key in the result
+    label: str,              # the question text shown
+    type: "select" | "multiselect" | "text",   # v1 types
+    options: list[str] = [], # for (multi)select; 0 for text
+    required: bool = True,
+    default: str | list[str] | None = None,
+    help: str | None = None,
+}
+```
+
+v1 renders **select / multiselect / text**. `slider`, `date`,
+`number`, `color` are valid artifact types but **out of v1** (no
+portable AskUserQuestion control — deferred to the widget enhancement);
+the renderer rejects them with a clear error rather than silently
+coercing.
+
+## 2. Renderer — form → `AskUserQuestion`
+
+Mapping rules:
+
+- **field → question.** Each field becomes one entry in the
+  `questions` array; `id` keys the returned answer.
+- **type → control.** `select` → `multiSelect: false`; `multiselect`
+  → `multiSelect: true`; `text` → a question whose options are any
+  curated suggestions plus the built-in **"Other" free-text** escape
+  (the only way to collect arbitrary text on this surface in v1).
+- **≤4 fields per call.** `AskUserQuestion` takes 1–4 questions. A form
+  with >4 fields renders as **sequential passes** of ≤4 (the result is
+  still one merged object). v1 may cap forms at 4 fields and revisit.
+- **2–4 options per question.** A (multi)select field with >4 options
+  uses the established **two-tier picker** (category → item) rather than
+  overflowing — reuses the existing large-catalog pattern.
+- **recommendation-first.** Per `feedback_question_shape`, each field's
+  first option is the recommended one (label ends "(Recommended)").
+
+## 3. Result + validation (R1, R4)
+
+`AskUserQuestion` returns `answers` keyed by question text; the renderer
+maps it back to a `{field.id: value}` object (value = str for select,
+list[str] for multiselect, str for text/Other). Before the flow
+consumes it, validate types + `required` against the artifact; a
+missing required field re-asks just that field, never silently passes
+malformed input.
+
+## 4. When to render a multi-field form (the rule relaxation)
+
+This is the behavioral change and the part needing sign-off. Today's
+`feedback_question_shape` rule is "ask ONE question per turn." The
+relaxation:
+
+**Batch 2–4 fields into one form-turn only when ALL hold:**
+
+- the fields are **independent dimensions of one decision** the user
+  must make together (e.g. spec kickoff: outcome + approach +
+  concerns), AND
+- answers **don't branch** on each other (no field's relevance depends
+  on another's answer — branching ⇒ stay sequential), AND
+- each field is **genuinely ambiguous/unknown** per the sibling rule
+  `socratic-ambiguity-calibration` — a field the user already specified
+  is omitted, not asked.
+
+**Stay single-question when** only one dimension is genuinely unknown,
+or a later question depends on an earlier answer, or batching would
+feel like a bureaucratic intake for a simple ask.
+
+Composition, stated plainly: **`socratic-ambiguity-calibration` decides
+*which* fields are worth asking; this form decides *whether* those
+fields are batched into one turn or asked one at a time.** The form
+never adds fields the ambiguity rule wouldn't already ask.
+
+## 5. First integrated flow (G3)
+
+Recommendation: the **`/attune` Socratic discovery scoping turn** — the
+headline differentiator and the most frequent genuine multi-dimension
+intake (goal + scope + focus, today asked as sequential buttons). It is
+the cleanest demonstration of "N button-turns → one form" and exercises
+multiselect (focus/concerns) natively. Dogfood it end-to-end (R5) —
+a real round-trip, not a mock.
+
+## 6. Out of v1 (deferred)
+
+- Rich controls with no AskUserQuestion home: slider, date, number,
+  color → the widget-enhancement phase (off the *same* artifact).
+- User-authored forms + data-bound options (North star).
+- The widget surface itself (fragile post-back return — D4).
+
+## Open — for sign-off
+
+- **First-target flow** — `/attune` discovery recommended (§5); confirm
+  or redirect (wizard step / `/spec` intake are alternatives).
+- **Rule-relaxation criteria** (§4) — the behavioral change; needs
+  explicit OK, since it edits attune's Socratic question-shape habit.

--- a/docs/specs/elicitation-form-surface/requirements.md
+++ b/docs/specs/elicitation-form-surface/requirements.md
@@ -24,15 +24,19 @@ multiple-choice primitive. Two costs:
    sequential button-questions. A single intake form would collect all
    of it in one pass. (Observed live: one session asked ~8 separate
    button-questions to gather less than a single form holds.)
-2. **The control palette is impoverished.** HTML forms have text,
-   textarea, number, range, select, multi-select, radio, checkbox,
-   toggle, date, color. `AskUserQuestion` has buttons. Inputs that are
-   natural as a slider (budget cap, fan-out, severity threshold), a
-   multi-select (the concerns palette), or free text (spec outcome) are
-   today either coerced into buttons or parsed out of prose.
+2. **The control palette is narrow** — but less than first assumed
+   (corrected by Phase 0, see [decisions.md](decisions.md) D4).
+   `AskUserQuestion` is *not* buttons-only: it natively supports
+   **multi-select** (`multiSelect: true`) and **up to 4 questions in one
+   pass**, with a clean structured return. The genuine remaining gaps
+   are (a) richer controls HTML has and it lacks — slider (budget cap,
+   fan-out), free textarea (spec outcome), date/number — and (b)
+   attune's own one-question-per-turn habit, which suppresses the
+   multi-question capability the platform already offers.
 
-Multi-select is the headline gap: it is the control Patrick reached for
-first and the one buttons most obviously cannot express.
+Multi-select is still the headline want — but Phase 0 found it already
+delivered by `AskUserQuestion`'s `multiSelect`, so v1 is mostly about
+*using the surface fully*, not building a new one.
 
 ## Goals
 
@@ -58,12 +62,21 @@ first and the one buttons most obviously cannot express.
 - Building every HTML control. Color and other low-value inputs are
   explicitly out of the v1 target set (G2).
 
-## Phase 0 — Research spike (gate before requirements firm up)
+## Phase 0 — Research spike (DONE 2026-06-27 → see decisions.md D4)
+
+**Outcome:** the spike overturned the premise. `AskUserQuestion` already
+delivers the two priority controls (multi-select + ≤4 questions/pass,
+clean return); MCP elicitation cannot express multi-select (spec
+excludes arrays) and its Claude-Code client support is unconfirmed;
+the rich-control widget has no portable MCP-owned surface. **Surface
+decision: AskUserQuestion-first; elicitation rejected; widget
+deferred** — full rationale + citations in
+[decisions.md](decisions.md) D4. The original research questions are
+retained below for the record.
 
 Chosen 2026-06-27: do not spec on unverified assumptions about the
-delivery surface. Phase 0 grounds the surface decision; R-numbers below
-are provisional until it lands. Verify against real docs/SDK, never
-from memory (the claims in the bullets are the *questions*, not facts).
+delivery surface. Phase 0 grounded the surface decision; verify against
+real docs/SDK, never from memory.
 
 - **Q0.1 — MCP elicitation reality.** Does MCP native elicitation
   exist in the client(s) attune targets? What JSON-schema field types

--- a/docs/specs/elicitation-form-surface/salvage-assessment.md
+++ b/docs/specs/elicitation-form-surface/salvage-assessment.md
@@ -1,0 +1,91 @@
+# Elicitation Form Surface — Salvage Assessment
+
+A bounded "does it exist / does it work" pass (per
+`.claude/rules/attune/removing-dead-code.md`) before building v1.
+Outcome: **most of v1 already exists as a proven, surface-agnostic form
+model; only the live AskUserQuestion wiring is missing.** Feeds
+[decisions.md](decisions.md) D6.
+
+## What exists in-repo
+
+`src/attune/meta_workflows/` + `src/attune/wizards/`:
+
+- **`models.py`** — `FormSchema`, `FormQuestion`, `QuestionType`
+  (`TEXT_INPUT` / `SINGLE_SELECT` / `MULTI_SELECT` / boolean→Yes-No),
+  `FormResponse`, plus `to_ask_user_format()`, `get_question_batches(4)`,
+  and validation (required + multi-select membership).
+- **`form_engine.py`** — `SocraticFormEngine.ask_questions(schema, …)`:
+  batch ≤4 → `to_ask_user_format` → `_ask_batch` via an
+  `ask_user_callback` (or defaults).
+- **`wizards/base.py`** + builtin wizards (debug/security/refactor/
+  release_prep) consume `FormQuestion`/`FormSchema`.
+
+## Verdict — reuse / fix / discard
+
+**REUSE (high value, proven):** the form **data model** in `models.py`
+— `FormSchema`/`FormQuestion`/`QuestionType` (incl. `MULTI_SELECT`),
+`FormResponse`, `to_ask_user_format()`, `get_question_batches(4)`,
+validation. This *is* the declarative artifact (D3) and the renderer
+mapping (D5 §2) the design called for — already multi-select-capable,
+already ≤4-batching, already validated. v1 builds on it; do **not**
+duplicate it.
+
+**FIX — the genuine gap: the live wiring is absent.** The
+`ask_user_callback` interactive path has **no live caller** — only a
+docstring placeholder (`wizards/__init__.py:16` `my_callback`) and test
+mocks. The `/wizard` check confirmed it: **no `plugin/skills/wizard/`,
+no `plugin/commands/wizard.md`, no CLI handler** wiring a real callback
+(`cli_minimal.py:682` `/wizard run` is help text only). Expected:
+`AskUserQuestion` is an **agent tool**, not a Python-callable API, so a
+Python "engine + callback" cannot reach the user. Today's live
+questioning is **markdown-driven** (e.g. `attune-hub`/`/attune` calls
+`AskUserQuestion` from the skill), not engine-driven. v1's real new
+work is the bridge from the model to the live tool.
+
+**DISCARD / irrelevant:** the wizard-run + agent-team orchestration
+already removed (#1093); the XML task-decomposition (repaired #1097) is
+a separate concern from form collection.
+
+## Florence — the v2 precedent (external)
+
+`Deep-Study-AI/ai-nurse-florence-v3.1` (Patrick's separately-built
+healthcare app; the in-repo form model was built to support it,
+**before** AskUserQuestion — `form_engine.py` header: "v4.3.0 — Real
+AskUserQuestion integration", a later adapter). It contains ~20 working
+clinical-form wizards (`src/routers/wizards/`: SBAR, SOAP, nursing
+assessment, discharge summary, care plan, medication reconciliation,
+…). Pattern: server-driven **multi-step forms** — per-step field
+definitions, session state, progress %, validation — rendered as **web
+forms** by the frontend.
+
+Significance:
+
+- **D3 is proven, not hypothetical.** The same kind of declarative form
+  model already drove a *non-AskUserQuestion* surface (web) in
+  production. The artifact is genuinely surface-agnostic by birth.
+- **Florence's web rendering is the v2 target.** The rich HTML palette
+  Patrick misses is not new to invent — the same model drove it once.
+  v2 = bring that renderer back; v1 = drive the same model through
+  `AskUserQuestion`.
+
+## v1 implication + the open fork
+
+v1 shrinks to **wiring the existing model to the live tool** for the
+`/attune` discovery flow (D5 §5). The model + validation carry
+multi-select for free; v2's richer types already exist in
+`QuestionType`'s space.
+
+**Open — bridge nature (decide before building):**
+
+- **A — pure-markdown skill.** Agent assembles compound
+  `AskUserQuestion` calls from skill guidance; the Python model is
+  unused at runtime. Fast; defers all D3 reuse to v2; model stays
+  unproven.
+- **B — skill + thin Python bridge.** A small MCP tool drives the real
+  `FormSchema` (`to_ask_user_format` + validation) →
+  `AskUserQuestion` → validated `FormResponse`. Runs the salvaged model
+  in v1; v2 swaps only the render adapter. More work; the true stepping
+  stone.
+
+Agent recommends **B** (aligns with v1-as-stepping-stone + makes D3
+load-bearing now); decision deferred per Patrick 2026-06-27.


### PR DESCRIPTION
Advances the `elicitation-form-surface` spec from draft → build-ready, through three verified milestones. **Docs-only.**

## D4 — Phase 0 (surface decision)
Research spike overturned the premise: `AskUserQuestion` already supports **multi-select** + **up to 4 questions per pass** with a clean structured return. MCP elicitation can't express multi-select (spec excludes arrays) and CC client support is unconfirmed → rejected. Rich widget has no portable MCP surface → deferred. **Surface: AskUserQuestion-first.**

## D5 — Design + sign-off
Declarative form artifact (D3) → renderer onto `AskUserQuestion` (field→question, multiselect→`multiSelect:true`, text→"Other", >4 options→two-tier, >4 fields→sequential, recommendation-first) + validation. First-target = `/attune` discovery. The §4 batching rule (the guardrail against richer forms amplifying Socratic fatigue).

## D6 — Salvage assessment
Most of v1 **already exists and is proven**: `meta_workflows/models.py` (`FormSchema`/`FormQuestion`/`QuestionType` incl. `MULTI_SELECT`, `to_ask_user_format`, `get_question_batches(4)`, validation) — the D3 artifact + D5 renderer, already built. The gap is the **live AskUserQuestion wiring** (no `/wizard` skill/command/CLI handler — confirmed orphaned; `AskUserQuestion` is an agent tool, not a Python API). Florence (`Deep-Study-AI/ai-nurse-florence-v3.1`, ~20 clinical multi-step web forms) **proves D3 across surfaces** and is the v2 rendering target.

**Open:** bridge nature — A (pure-markdown) vs B (skill + thin Python bridge that runs the salvaged model). Agent recommends B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
