### PR TITLE
feat(elicitation): form bridge MCP tools + elicit skill (Option B)

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -59,6 +59,12 @@ intent so Claude matches the right skill:
 | "plan", "feature", "architecture" | planning skill |
 | "refactor", "tech debt", "simplify" | refactor-plan skill |
 | "spec", "brainstorm", "plan and execute" | spec skill |
+| "scope this", "ask me everything at once", "discovery form" | elicit skill |
+
+When the scoping turn has **2–4 independent, non-branching, genuinely
+open dimensions** (e.g. goal + scope + focus), gather them as one form
+via the `elicit` skill instead of sequential buttons. Stay
+single-question when only one dimension is unknown or answers branch.
 
 ## Single-referent resolution
 
@@ -102,6 +108,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | catalog | catalog, list capabilities, browse, what can attune do |
 | personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
+| elicit | scope this, discovery form, ask me everything at once, multi-select question |
 
 ## MCP Server Not Running
 

--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elicit
-description: "Form-driven Socratic discovery — batch independent decision dimensions into one multi-select-capable form instead of N button-turns. Triggers on: scope this, discovery form, ask me everything at once, multi-select question, gather requirements as a form."
+description: "Form-driven Socratic discovery — batch independent decision dimensions into one multi-select-capable form instead of N button-turns. Triggers on: scope this, discovery form, ask me everything at once, multi-select question."
 ---
 # Elicit — form-driven Socratic discovery
 
@@ -87,7 +87,13 @@ Also:
 - **>4 options** — use the two-tier picker (category → item), don't
   overflow a single question.
 
-Then call `AskUserQuestion` with all the batch's entries at once.
+Then call `AskUserQuestion` with all the batch's entries at once. When a
+batch has **more than one question**, set `metadata` to
+`{"source": "elicit-form"}` — that marker is the deliberate opt-in the
+one-question-per-turn guard requires for a §4 batched form. Without it,
+a multi-question call is blocked (the default discipline). Multi-select
+questions need no "(Recommended)" first option; single-select questions
+still lead with the recommended choice.
 
 ## Step 4 — collect and validate (R4)
 

--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: elicit
+description: "Form-driven Socratic discovery — batch independent decision dimensions into one multi-select-capable form instead of N button-turns. Triggers on: scope this, discovery form, ask me everything at once, multi-select question, gather requirements as a form."
+---
+# Elicit — form-driven Socratic discovery
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Elicit** — Gathering the independent dimensions of your decision
+> as one form (multi-select where it fits), instead of asking one
+> button at a time.
+
+This skill turns a **declarative form** (data, not code) into a real
+`AskUserQuestion` turn and validates the answers. It is the live wiring
+of `attune.elicitation` via two MCP tools:
+
+- `elicitation_render_form` — validate the form, get batched payloads.
+- `elicitation_collect_response` — validate the answers (R4).
+
+## When to render a multi-field form (the batching rule)
+
+Batch 2–4 fields into **one** form-turn only when ALL hold:
+
+- the fields are **independent dimensions of one decision** the user
+  makes together (e.g. spec kickoff: goal + scope + focus), AND
+- answers **don't branch** on each other (if a field's relevance
+  depends on another's answer, stay sequential), AND
+- each field is **genuinely ambiguous** — a dimension the user already
+  specified is omitted, not asked.
+
+**Stay single-question** when only one dimension is unknown, a later
+question depends on an earlier answer, or batching would feel like a
+bureaucratic intake for a simple ask. The form never adds fields the
+ordinary Socratic-ambiguity judgement wouldn't already ask.
+
+## Step 1 — build the declarative form (D3)
+
+A form is plain serializable data:
+
+```json
+{
+  "title": "Scope this work",
+  "description": "Optional one-liner",
+  "fields": [
+    {"id": "goal", "text": "What are you trying to accomplish?",
+     "type": "single_select",
+     "options": ["Fix a bug", "Add a feature", "Refactor", "Investigate"]},
+    {"id": "focus", "text": "Which areas matter here?",
+     "type": "multi_select",
+     "options": ["correctness", "security", "performance", "tests"]}
+  ]
+}
+```
+
+Field `type` is one of `single_select`, `multi_select`, `boolean`,
+`text_input`. `id` is the stable key the answer comes back under.
+
+## Step 2 — render it
+
+Call `elicitation_render_form` with `{ "form": <the form> }`.
+
+- Success → `{ "success": true, "batches": [[ <payload>, … ]] }`. Each
+  batch is one `AskUserQuestion` call (≤4 questions).
+- Failure → `{ "success": false, "problems": [ … ] }`. Fix the form
+  definition and re-render; do not hand-roll the questions.
+
+## Step 3 — ask, mapping each payload to AskUserQuestion
+
+For each payload in a batch, build one `AskUserQuestion` entry:
+
+| Payload field | AskUserQuestion |
+| ------------- | --------------- |
+| `question` | `question` |
+| `type: "multi_select"` | `multiSelect: true` |
+| `type: "single_select"` / `"boolean"` | `multiSelect: false` |
+| `options` (list of strings) | `options: [{label, description}]` |
+| `question_id` | track it — it keys the answer in step 4 |
+
+Also:
+
+- **header** — a short tag (≤12 chars) derived from the question.
+- **recommendation-first** — if there's a sensible default, make it the
+  first option and end its label with " (Recommended)".
+- **free text** — for a `text_input` field, offer any curated
+  suggestions as options; the user types anything via the built-in
+  **"Other"** escape `AskUserQuestion` always provides.
+- **>4 options** — use the two-tier picker (category → item), don't
+  overflow a single question.
+
+Then call `AskUserQuestion` with all the batch's entries at once.
+
+## Step 4 — collect and validate (R4)
+
+Assemble the answers into `{ field_id: value }` (a string for
+single-select/boolean/text, a list of strings for multi-select), then
+call `elicitation_collect_response` with `{ "form": <the form>,
+"answers": <that map> }`.
+
+- Success → `{ "success": true, "responses": { … } }`. Use those
+  values — they are validated against the form.
+- Failure → `{ "success": false, "problems": [ … ] }` names exactly
+  which fields are missing-required or out-of-option. **Re-ask only
+  those fields** (a one-field form) — never silently proceed.
+
+## Worked example — `/attune` discovery in one turn
+
+The headline use: the `/attune` scoping turn that today asks goal, then
+scope, then focus as three sequential buttons. Gather them as one form
+when each is genuinely open (drop any the user already stated):
+
+```json
+{
+  "title": "What do you want to do?",
+  "fields": [
+    {"id": "goal", "text": "What are you trying to accomplish?",
+     "type": "single_select",
+     "options": ["Run a workflow", "Manage memory", "Configure settings",
+                 "Learn what attune does"]},
+    {"id": "scope", "text": "Where should it focus?",
+     "type": "text_input", "options": ["src/", "tests/", "whole project"]},
+    {"id": "concerns", "text": "Which concerns matter?",
+     "type": "multi_select", "required": false,
+     "options": ["security", "quality", "performance", "tests"]}
+  ]
+}
+```
+
+Render → ask (one `AskUserQuestion`, `concerns` as multi-select) →
+collect → route on `responses["goal"]` (see the attune-hub skill's
+routing table) scoped by `responses["scope"]` and `responses["concerns"]`.

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -61,6 +61,12 @@ intent so Claude matches the right skill:
 | "plan", "feature", "architecture" | planning skill |
 | "refactor", "tech debt", "simplify" | refactor-plan skill |
 | "spec", "brainstorm", "plan and execute" | spec skill |
+| "scope this", "ask me everything at once", "discovery form" | elicit skill |
+
+When the scoping turn has **2–4 independent, non-branching, genuinely
+open dimensions** (e.g. goal + scope + focus), gather them as one form
+via the `elicit` skill instead of sequential buttons. Stay
+single-question when only one dimension is unknown or answers branch.
 
 ## Single-referent resolution
 
@@ -104,6 +110,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | catalog | catalog, list capabilities, browse, what can attune do |
 | personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
+| elicit | scope this, discovery form, ask me everything at once, multi-select question |
 
 ## MCP Server Not Running
 

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: elicit
+description: "Form-driven Socratic discovery — batch independent decision dimensions into one multi-select-capable form instead of N button-turns. Triggers on: scope this, discovery form, ask me everything at once, multi-select question, gather requirements as a form."
+argument-hint: "<what you're scoping, e.g. 'a new feature' or 'this session'>"
+---
+
+# Elicit — form-driven Socratic discovery
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Elicit** — Gathering the independent dimensions of your decision
+> as one form (multi-select where it fits), instead of asking one
+> button at a time.
+
+This skill turns a **declarative form** (data, not code) into a real
+`AskUserQuestion` turn and validates the answers. It is the live wiring
+of `attune.elicitation` via two MCP tools:
+
+- `elicitation_render_form` — validate the form, get batched payloads.
+- `elicitation_collect_response` — validate the answers (R4).
+
+## When to render a multi-field form (the batching rule)
+
+Batch 2–4 fields into **one** form-turn only when ALL hold:
+
+- the fields are **independent dimensions of one decision** the user
+  makes together (e.g. spec kickoff: goal + scope + focus), AND
+- answers **don't branch** on each other (if a field's relevance
+  depends on another's answer, stay sequential), AND
+- each field is **genuinely ambiguous** — a dimension the user already
+  specified is omitted, not asked.
+
+**Stay single-question** when only one dimension is unknown, a later
+question depends on an earlier answer, or batching would feel like a
+bureaucratic intake for a simple ask. The form never adds fields the
+ordinary Socratic-ambiguity judgement wouldn't already ask.
+
+## Step 1 — build the declarative form (D3)
+
+A form is plain serializable data:
+
+```json
+{
+  "title": "Scope this work",
+  "description": "Optional one-liner",
+  "fields": [
+    {"id": "goal", "text": "What are you trying to accomplish?",
+     "type": "single_select",
+     "options": ["Fix a bug", "Add a feature", "Refactor", "Investigate"]},
+    {"id": "focus", "text": "Which areas matter here?",
+     "type": "multi_select",
+     "options": ["correctness", "security", "performance", "tests"]}
+  ]
+}
+```
+
+Field `type` is one of `single_select`, `multi_select`, `boolean`,
+`text_input`. `id` is the stable key the answer comes back under.
+
+## Step 2 — render it
+
+Call `elicitation_render_form` with `{ "form": <the form> }`.
+
+- Success → `{ "success": true, "batches": [[ <payload>, … ]] }`. Each
+  batch is one `AskUserQuestion` call (≤4 questions).
+- Failure → `{ "success": false, "problems": [ … ] }`. Fix the form
+  definition and re-render; do not hand-roll the questions.
+
+## Step 3 — ask, mapping each payload to AskUserQuestion
+
+For each payload in a batch, build one `AskUserQuestion` entry:
+
+| Payload field | AskUserQuestion |
+| ------------- | --------------- |
+| `question` | `question` |
+| `type: "multi_select"` | `multiSelect: true` |
+| `type: "single_select"` / `"boolean"` | `multiSelect: false` |
+| `options` (list of strings) | `options: [{label, description}]` |
+| `question_id` | track it — it keys the answer in step 4 |
+
+Also:
+
+- **header** — a short tag (≤12 chars) derived from the question.
+- **recommendation-first** — if there's a sensible default, make it the
+  first option and end its label with " (Recommended)".
+- **free text** — for a `text_input` field, offer any curated
+  suggestions as options; the user types anything via the built-in
+  **"Other"** escape `AskUserQuestion` always provides.
+- **>4 options** — use the two-tier picker (category → item), don't
+  overflow a single question.
+
+Then call `AskUserQuestion` with all the batch's entries at once.
+
+## Step 4 — collect and validate (R4)
+
+Assemble the answers into `{ field_id: value }` (a string for
+single-select/boolean/text, a list of strings for multi-select), then
+call `elicitation_collect_response` with `{ "form": <the form>,
+"answers": <that map> }`.
+
+- Success → `{ "success": true, "responses": { … } }`. Use those
+  values — they are validated against the form.
+- Failure → `{ "success": false, "problems": [ … ] }` names exactly
+  which fields are missing-required or out-of-option. **Re-ask only
+  those fields** (a one-field form) — never silently proceed.
+
+## Worked example — `/attune` discovery in one turn
+
+The headline use: the `/attune` scoping turn that today asks goal, then
+scope, then focus as three sequential buttons. Gather them as one form
+when each is genuinely open (drop any the user already stated):
+
+```json
+{
+  "title": "What do you want to do?",
+  "fields": [
+    {"id": "goal", "text": "What are you trying to accomplish?",
+     "type": "single_select",
+     "options": ["Run a workflow", "Manage memory", "Configure settings",
+                 "Learn what attune does"]},
+    {"id": "scope", "text": "Where should it focus?",
+     "type": "text_input", "options": ["src/", "tests/", "whole project"]},
+    {"id": "concerns", "text": "Which concerns matter?",
+     "type": "multi_select", "required": false,
+     "options": ["security", "quality", "performance", "tests"]}
+  ]
+}
+```
+
+Render → ask (one `AskUserQuestion`, `concerns` as multi-select) →
+collect → route on `responses["goal"]` (see the attune-hub skill's
+routing table) scoped by `responses["scope"]` and `responses["concerns"]`.

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elicit
-description: "Form-driven Socratic discovery — batch independent decision dimensions into one multi-select-capable form instead of N button-turns. Triggers on: scope this, discovery form, ask me everything at once, multi-select question, gather requirements as a form."
+description: "Form-driven Socratic discovery — batch independent decision dimensions into one multi-select-capable form instead of N button-turns. Triggers on: scope this, discovery form, ask me everything at once, multi-select question."
 argument-hint: "<what you're scoping, e.g. 'a new feature' or 'this session'>"
 ---
 
@@ -89,7 +89,13 @@ Also:
 - **>4 options** — use the two-tier picker (category → item), don't
   overflow a single question.
 
-Then call `AskUserQuestion` with all the batch's entries at once.
+Then call `AskUserQuestion` with all the batch's entries at once. When a
+batch has **more than one question**, set `metadata` to
+`{"source": "elicit-form"}` — that marker is the deliberate opt-in the
+one-question-per-turn guard requires for a §4 batched form. Without it,
+a multi-question call is blocked (the default discipline). Multi-select
+questions need no "(Recommended)" first option; single-select questions
+still lead with the recommended choice.
 
 ## Step 4 — collect and validate (R4)
 

--- a/src/attune/elicitation/__init__.py
+++ b/src/attune/elicitation/__init__.py
@@ -1,0 +1,38 @@
+"""Declarative form → AskUserQuestion bridge (elicitation v1).
+
+The load-bearing core of the ``elicitation-form-surface`` spec (Option
+B): it runs the salvaged, surface-agnostic ``FormSchema`` model
+(:mod:`attune.meta_workflows.models`) against the live
+``AskUserQuestion`` tool. These are pure transforms — no agent/tool
+dependency — so they are fully testable, and they are the same seam a
+future richer (v2) renderer plugs into.
+
+Public surface:
+
+- :func:`form_from_dict` — build the declarative artifact (D3) from
+  plain serializable data.
+- :func:`form_to_askuserquestion` — batched ``AskUserQuestion`` payloads
+  (≤4 questions per call).
+- :func:`collect_form_response` — validate raw answers (required +
+  option membership) and map them into a ``FormResponse`` (R4 — never
+  silently accept malformed input).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from attune.elicitation.bridge import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_to_askuserquestion,
+)
+
+__all__ = [
+    "FormValidationError",
+    "collect_form_response",
+    "form_from_dict",
+    "form_to_askuserquestion",
+]

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -1,0 +1,226 @@
+"""Declarative-form ↔ AskUserQuestion transforms.
+
+See :mod:`attune.elicitation` for the package overview. This module
+holds the three pure functions that build, render, and collect a
+declarative form, reusing the surface-agnostic model in
+:mod:`attune.meta_workflows.models` (decision D6 — reuse, don't
+duplicate).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from attune.meta_workflows.models import (
+    FormQuestion,
+    FormResponse,
+    FormSchema,
+    QuestionType,
+)
+
+#: The answer values accepted for a BOOLEAN question (its
+#: ``to_ask_user_format`` renders as a Yes/No single-select).
+_BOOLEAN_OPTIONS = ("Yes", "No")
+
+
+class FormValidationError(ValueError):
+    """Raised when a form definition or a set of answers is invalid.
+
+    Carries a list of human-readable problems so a caller (or the agent)
+    can re-ask exactly the offending fields rather than guess.
+    """
+
+    def __init__(self, problems: list[str]) -> None:
+        self.problems = problems
+        super().__init__("; ".join(problems))
+
+
+def form_from_dict(data: dict[str, Any]) -> FormSchema:
+    """Build a :class:`FormSchema` from plain serializable data (D3).
+
+    The declarative artifact a skill / future designer / data source
+    produces. Validates the form *definition* (not answers) and raises
+    :class:`FormValidationError` listing every problem.
+
+    Args:
+        data: ``{"title": str, "description"?: str, "fields": [ ... ]}``.
+            Each field: ``{"id": str, "text": str, "type": str,
+            "options"?: list[str], "default"?: str, "help_text"?: str,
+            "required"?: bool}``. ``"label"`` is accepted as an alias for
+            ``"text"``; ``"questions"`` as an alias for ``"fields"``.
+
+    Returns:
+        A validated :class:`FormSchema`.
+
+    Raises:
+        FormValidationError: If the definition is malformed.
+    """
+    problems: list[str] = []
+
+    if not isinstance(data, dict):
+        raise FormValidationError(["form must be a mapping"])
+
+    title = data.get("title")
+    if not title or not isinstance(title, str):
+        problems.append("form 'title' is required and must be a string")
+
+    raw_fields = data.get("fields", data.get("questions"))
+    if not isinstance(raw_fields, list) or not raw_fields:
+        problems.append("form must have a non-empty 'fields' list")
+        raw_fields = []
+
+    seen_ids: set[str] = set()
+    questions: list[FormQuestion] = []
+    for idx, raw in enumerate(raw_fields):
+        where = f"field[{idx}]"
+        if not isinstance(raw, dict):
+            problems.append(f"{where} must be a mapping")
+            continue
+
+        fid = raw.get("id")
+        if not fid or not isinstance(fid, str):
+            problems.append(f"{where} 'id' is required and must be a string")
+        elif fid in seen_ids:
+            problems.append(f"{where} duplicate id {fid!r}")
+        else:
+            seen_ids.add(fid)
+
+        text = raw.get("text", raw.get("label"))
+        if not text or not isinstance(text, str):
+            problems.append(f"{where} 'text' (or 'label') is required")
+
+        type_str = raw.get("type")
+        try:
+            qtype = QuestionType(type_str)
+        except ValueError:
+            valid = ", ".join(t.value for t in QuestionType)
+            problems.append(f"{where} invalid type {type_str!r} (use one of: {valid})")
+            continue
+
+        options = raw.get("options", [])
+        if not isinstance(options, list) or not all(isinstance(o, str) for o in options):
+            problems.append(f"{where} 'options' must be a list of strings")
+            options = []
+        if qtype in (QuestionType.SINGLE_SELECT, QuestionType.MULTI_SELECT) and not options:
+            problems.append(f"{where} type {qtype.value} requires non-empty 'options'")
+
+        if fid and text and isinstance(fid, str) and isinstance(text, str):
+            questions.append(
+                FormQuestion(
+                    id=fid,
+                    text=text,
+                    type=qtype,
+                    options=options,
+                    default=raw.get("default"),
+                    help_text=raw.get("help_text"),
+                    required=bool(raw.get("required", True)),
+                )
+            )
+
+    if problems:
+        raise FormValidationError(problems)
+
+    return FormSchema(
+        title=title,
+        description=data.get("description", "") or "",
+        questions=questions,
+    )
+
+
+def form_to_askuserquestion(form: FormSchema, batch_size: int = 4) -> list[list[dict[str, Any]]]:
+    """Render a form to batched ``AskUserQuestion`` payloads.
+
+    Thin reuse of the model's own batching + per-question conversion.
+    Each inner list is one ``AskUserQuestion`` call (≤ ``batch_size``
+    questions, the tool's limit).
+
+    Args:
+        form: The form to render.
+        batch_size: Max questions per call (the tool caps at 4).
+
+    Returns:
+        A list of batches; each batch a list of question payload dicts.
+    """
+    return [
+        [question.to_ask_user_format() for question in batch]
+        for batch in form.get_question_batches(batch_size)
+    ]
+
+
+def _validate_answer(question: FormQuestion, value: Any) -> str | None:
+    """Return a problem string for one answer, or None if it is valid."""
+    if question.type == QuestionType.MULTI_SELECT:
+        if not isinstance(value, list):
+            return f"{question.id!r} expects a list (multi-select)"
+        bad = [v for v in value if v not in question.options]
+        if bad:
+            return f"{question.id!r} has out-of-option value(s): {bad}"
+        return None
+
+    if question.type == QuestionType.SINGLE_SELECT:
+        if value not in question.options:
+            return f"{question.id!r} value {value!r} not in options"
+        return None
+
+    if question.type == QuestionType.BOOLEAN:
+        if value not in _BOOLEAN_OPTIONS:
+            return f"{question.id!r} boolean value {value!r} must be 'Yes' or 'No'"
+        return None
+
+    # TEXT_INPUT
+    if not isinstance(value, str):
+        return f"{question.id!r} expects a string"
+    return None
+
+
+def collect_form_response(
+    form: FormSchema,
+    raw_answers: dict[str, Any],
+    template_id: str = "",
+) -> FormResponse:
+    """Validate raw answers and map them into a :class:`FormResponse`.
+
+    Implements R4 — no silent acceptance of malformed input. A missing
+    required field with no default, or a value outside a select's
+    options, raises :class:`FormValidationError` naming every problem so
+    the caller can re-ask just those fields. Missing optional fields fall
+    back to the question's ``default`` (omitted if none).
+
+    Args:
+        form: The form the answers are for.
+        raw_answers: ``{question_id: value}`` as returned by the agent.
+        template_id: Identifier stored on the response.
+
+    Returns:
+        A validated :class:`FormResponse`.
+
+    Raises:
+        FormValidationError: If any answer is missing-required or invalid.
+    """
+    problems: list[str] = []
+    responses: dict[str, Any] = {}
+
+    for question in form.questions:
+        provided = question.id in raw_answers
+        value = raw_answers.get(question.id)
+
+        if not provided or value is None or value == "" or value == []:
+            if question.required and question.default is None:
+                problems.append(f"{question.id!r} is required")
+            elif question.default is not None:
+                responses[question.id] = question.default
+            continue
+
+        problem = _validate_answer(question, value)
+        if problem:
+            problems.append(problem)
+        else:
+            responses[question.id] = value
+
+    if problems:
+        raise FormValidationError(problems)
+
+    return FormResponse(template_id=template_id, responses=responses)

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -26,6 +26,7 @@ from mcp.types import (
 from attune.mcp.memory_handlers import MemoryHandlersMixin
 from attune.mcp.rate_limiter import RateLimiter
 from attune.mcp.tool_schemas import (
+    get_elicitation_tools,
     get_help_tools,
     get_memory_tools,
     get_personal_memory_tools,
@@ -186,6 +187,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         tools.update(get_memory_tools())
         tools.update(get_personal_memory_tools())
         tools.update(get_utility_tools())
+        tools.update(get_elicitation_tools())
         tools.update(get_help_tools())
         return tools
 
@@ -304,6 +306,8 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             "context_get": self._handle_context_get,
             "context_set": self._handle_context_set,
             "list_capabilities": lambda _args: self._handle_list_capabilities(),
+            "elicitation_render_form": self._handle_elicitation_render_form,
+            "elicitation_collect_response": self._handle_elicitation_collect_response,
             "help_lookup": self._handle_help_lookup,
             "help_maintain": self._handle_help_maintain,
             "help_init": self._handle_help_init,
@@ -679,6 +683,75 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             "success": True,
             "key": key,
             "value": value,
+        }
+
+    async def _handle_elicitation_render_form(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Validate a declarative form and return batched question payloads.
+
+        Live wiring of :func:`attune.elicitation.form_from_dict` and
+        :func:`attune.elicitation.form_to_askuserquestion`. A malformed
+        form definition returns ``{"success": False, "problems": [...]}``
+        rather than raising, so the agent can re-fix the definition.
+
+        Args:
+            args: Must contain ``form`` (the declarative form dict).
+
+        Returns:
+            ``{"success": True, "title", "description", "batches"}`` or
+            ``{"success": False, "problems": [...]}``.
+
+        """
+        from attune.elicitation import (
+            FormValidationError,
+            form_from_dict,
+            form_to_askuserquestion,
+        )
+
+        try:
+            form = form_from_dict(args.get("form", {}))
+        except FormValidationError as e:
+            return {"success": False, "problems": e.problems}
+
+        return {
+            "success": True,
+            "title": form.title,
+            "description": form.description,
+            "batches": form_to_askuserquestion(form),
+        }
+
+    async def _handle_elicitation_collect_response(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Validate user answers against a declarative form (R4).
+
+        Live wiring of :func:`attune.elicitation.collect_form_response`.
+        Missing-required or out-of-option answers return
+        ``{"success": False, "problems": [...]}`` naming exactly which
+        fields to re-ask — never silently accepts malformed input.
+
+        Args:
+            args: Must contain ``form`` (the form dict) and ``answers``
+                (``{field_id: value}``).
+
+        Returns:
+            ``{"success": True, "responses", "response_id"}`` or
+            ``{"success": False, "problems": [...]}``.
+
+        """
+        from attune.elicitation import (
+            FormValidationError,
+            collect_form_response,
+            form_from_dict,
+        )
+
+        try:
+            form = form_from_dict(args.get("form", {}))
+            response = collect_form_response(form, args.get("answers", {}))
+        except FormValidationError as e:
+            return {"success": False, "problems": e.problems}
+
+        return {
+            "success": True,
+            "responses": response.responses,
+            "response_id": response.response_id,
         }
 
     async def _handle_help_lookup(self, args: dict[str, Any]) -> dict[str, Any]:

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -377,6 +377,91 @@ def get_utility_tools() -> dict[str, dict[str, Any]]:
     }
 
 
+def get_elicitation_tools() -> dict[str, dict[str, Any]]:
+    """Tool definitions for the declarative-form ↔ AskUserQuestion bridge.
+
+    Live wiring of ``attune.elicitation`` (the salvaged, surface-agnostic
+    ``FormSchema`` model). ``render_form`` validates a declarative form
+    and returns batched question payloads; ``collect_response`` validates
+    the answers. The agent calls the real ``AskUserQuestion`` tool in
+    between — the surface mapping rules live in the driving skill (D6).
+    """
+    field_schema = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Stable key for the answer"},
+            "text": {"type": "string", "description": "Question text shown to the user"},
+            "type": {
+                "type": "string",
+                "enum": ["text_input", "single_select", "multi_select", "boolean"],
+                "description": "Control type; multi_select is the headline v1 control",
+            },
+            "options": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Choices for (multi_)select fields",
+            },
+            "default": {"type": "string", "description": "Default value if unanswered"},
+            "help_text": {"type": "string", "description": "Supplemental help"},
+            "required": {"type": "boolean", "description": "Defaults to true"},
+        },
+        "required": ["id", "text", "type"],
+    }
+    form_schema = {
+        "type": "object",
+        "description": "Declarative form artifact (data, not code — D3).",
+        "properties": {
+            "title": {"type": "string", "description": "Form title"},
+            "description": {"type": "string", "description": "Optional form description"},
+            "fields": {
+                "type": "array",
+                "items": field_schema,
+                "description": "The form's fields (alias: 'questions')",
+            },
+        },
+        "required": ["title", "fields"],
+    }
+    return {
+        "elicitation_render_form": {
+            "description": (
+                "Validate a declarative form and return batched question "
+                "payloads (<=4 per batch) ready for the AskUserQuestion tool. "
+                "Use to turn N sequential button-turns into one multi-question "
+                "form for Socratic discovery. Returns {success, batches} or "
+                "{success: false, problems} so you re-fix the definition. "
+                "Map each payload to AskUserQuestion per the driving skill: "
+                "type multi_select -> multiSelect true; recommendation-first; "
+                "free text via the built-in 'Other' option."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {"form": form_schema},
+                "required": ["form"],
+            },
+        },
+        "elicitation_collect_response": {
+            "description": (
+                "Validate the user's answers against a declarative form and "
+                "return a normalized {field_id: value} response. Enforces "
+                "required fields and option membership (R4 — never silently "
+                "accept malformed input); returns {success: false, problems} "
+                "listing exactly which fields to re-ask."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "form": form_schema,
+                    "answers": {
+                        "type": "object",
+                        "description": "{field_id: value} the user selected/typed",
+                    },
+                },
+                "required": ["form", "answers"],
+            },
+        },
+    }
+
+
 def get_help_tools() -> dict[str, dict[str, Any]]:
     """Tool definitions for contextual help and progressive documentation."""
     return {

--- a/tests/unit/elicitation/test_bridge.py
+++ b/tests/unit/elicitation/test_bridge.py
@@ -1,0 +1,272 @@
+"""Tests for the elicitation declarative-form bridge.
+
+Covers:
+
+- form_from_dict: construction, aliases, and every validation problem
+- form_to_askuserquestion: ≤4 batching + per-type payload shape
+- collect_form_response: valid answers, defaults, and every reject path
+- FormValidationError carries the problem list
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_to_askuserquestion,
+)
+from attune.meta_workflows.models import QuestionType
+
+
+def _form_dict(**overrides):
+    base = {
+        "title": "Intake",
+        "description": "test",
+        "fields": [
+            {"id": "outcome", "text": "Outcome?", "type": "text_input"},
+            {
+                "id": "approach",
+                "text": "Approach?",
+                "type": "single_select",
+                "options": ["spec", "inline"],
+            },
+            {
+                "id": "concerns",
+                "text": "Concerns?",
+                "type": "multi_select",
+                "options": ["impl", "test", "docs"],
+            },
+            {"id": "specfirst", "text": "Spec-first?", "type": "boolean"},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+# --- form_from_dict ---------------------------------------------------
+
+
+class TestFormFromDict:
+    def test_builds_all_types(self):
+        form = form_from_dict(_form_dict())
+        assert form.title == "Intake"
+        assert [q.id for q in form.questions] == [
+            "outcome",
+            "approach",
+            "concerns",
+            "specfirst",
+        ]
+        assert form.questions[2].type == QuestionType.MULTI_SELECT
+
+    def test_label_and_questions_aliases(self):
+        data = {
+            "title": "T",
+            "questions": [{"id": "a", "label": "A?", "type": "text_input"}],
+        }
+        form = form_from_dict(data)
+        assert form.questions[0].text == "A?"
+
+    def test_optional_attrs_passthrough(self):
+        data = {
+            "title": "T",
+            "fields": [
+                {
+                    "id": "a",
+                    "text": "A?",
+                    "type": "text_input",
+                    "default": "x",
+                    "help_text": "h",
+                    "required": False,
+                }
+            ],
+        }
+        q = form_from_dict(data).questions[0]
+        assert q.default == "x" and q.help_text == "h" and q.required is False
+
+    def test_not_a_mapping(self):
+        with pytest.raises(FormValidationError, match="mapping"):
+            form_from_dict(["nope"])  # type: ignore[arg-type]
+
+    def test_missing_title(self):
+        with pytest.raises(FormValidationError, match="title"):
+            form_from_dict(_form_dict(title=""))
+
+    def test_empty_fields(self):
+        with pytest.raises(FormValidationError, match="non-empty 'fields'"):
+            form_from_dict({"title": "T", "fields": []})
+
+    def test_field_not_mapping(self):
+        with pytest.raises(FormValidationError, match=r"field\[0\] must be a mapping"):
+            form_from_dict({"title": "T", "fields": ["x"]})
+
+    def test_missing_id_and_text(self):
+        with pytest.raises(FormValidationError) as exc:
+            form_from_dict({"title": "T", "fields": [{"type": "text_input"}]})
+        assert any("'id'" in p for p in exc.value.problems)
+        assert any("'text'" in p for p in exc.value.problems)
+
+    def test_duplicate_id(self):
+        data = {
+            "title": "T",
+            "fields": [
+                {"id": "a", "text": "A?", "type": "text_input"},
+                {"id": "a", "text": "B?", "type": "text_input"},
+            ],
+        }
+        with pytest.raises(FormValidationError, match="duplicate id"):
+            form_from_dict(data)
+
+    def test_invalid_type(self):
+        with pytest.raises(FormValidationError, match="invalid type"):
+            form_from_dict({"title": "T", "fields": [{"id": "a", "text": "A?", "type": "slider"}]})
+
+    def test_select_requires_options(self):
+        with pytest.raises(FormValidationError, match="requires non-empty 'options'"):
+            form_from_dict(
+                {"title": "T", "fields": [{"id": "a", "text": "A?", "type": "single_select"}]}
+            )
+
+    def test_options_must_be_list_of_strings(self):
+        with pytest.raises(FormValidationError, match="list of strings"):
+            form_from_dict(
+                {
+                    "title": "T",
+                    "fields": [
+                        {"id": "a", "text": "A?", "type": "single_select", "options": [1, 2]}
+                    ],
+                }
+            )
+
+
+# --- form_to_askuserquestion ------------------------------------------
+
+
+class TestFormToAskUserQuestion:
+    def test_batches_at_four(self):
+        fields = [{"id": f"q{i}", "text": f"Q{i}?", "type": "text_input"} for i in range(9)]
+        form = form_from_dict({"title": "T", "fields": fields})
+        batches = form_to_askuserquestion(form)
+        assert [len(b) for b in batches] == [4, 4, 1]
+
+    def test_payload_shapes_per_type(self):
+        form = form_from_dict(_form_dict())
+        flat = [q for batch in form_to_askuserquestion(form) for q in batch]
+        by_id = {q["question_id"]: q for q in flat}
+        assert by_id["concerns"]["type"] == "multi_select"
+        assert by_id["approach"]["options"] == ["spec", "inline"]
+        # boolean renders as a Yes/No single-select
+        assert by_id["specfirst"]["type"] == "single_select"
+        assert by_id["specfirst"]["options"] == ["Yes", "No"]
+
+    def test_custom_batch_size(self):
+        form = form_from_dict(_form_dict())
+        batches = form_to_askuserquestion(form, batch_size=2)
+        assert [len(b) for b in batches] == [2, 2]
+
+
+# --- collect_form_response --------------------------------------------
+
+
+class TestCollectFormResponse:
+    def test_valid_answers(self):
+        form = form_from_dict(_form_dict())
+        resp = collect_form_response(
+            form,
+            {
+                "outcome": "ship it",
+                "approach": "spec",
+                "concerns": ["impl", "test"],
+                "specfirst": "Yes",
+            },
+            template_id="t1",
+        )
+        assert resp.template_id == "t1"
+        assert resp.responses["concerns"] == ["impl", "test"]
+        assert resp.get("approach") == "spec"
+
+    def test_missing_required_raises(self):
+        form = form_from_dict(_form_dict())
+        with pytest.raises(FormValidationError, match="'outcome' is required"):
+            collect_form_response(form, {"approach": "spec", "concerns": [], "specfirst": "No"})
+
+    def test_optional_missing_uses_default(self):
+        data = {
+            "title": "T",
+            "fields": [
+                {
+                    "id": "a",
+                    "text": "A?",
+                    "type": "text_input",
+                    "required": False,
+                    "default": "fallback",
+                }
+            ],
+        }
+        form = form_from_dict(data)
+        resp = collect_form_response(form, {})
+        assert resp.responses["a"] == "fallback"
+
+    def test_optional_missing_no_default_omitted(self):
+        data = {
+            "title": "T",
+            "fields": [{"id": "a", "text": "A?", "type": "text_input", "required": False}],
+        }
+        resp = collect_form_response(form_from_dict(data), {})
+        assert "a" not in resp.responses
+
+    def test_multiselect_non_list_rejected(self):
+        form = form_from_dict(_form_dict())
+        with pytest.raises(FormValidationError, match="expects a list"):
+            collect_form_response(
+                form,
+                {"outcome": "x", "approach": "spec", "concerns": "impl", "specfirst": "No"},
+            )
+
+    def test_multiselect_out_of_option_rejected(self):
+        form = form_from_dict(_form_dict())
+        with pytest.raises(FormValidationError, match="out-of-option"):
+            collect_form_response(
+                form,
+                {"outcome": "x", "approach": "spec", "concerns": ["nope"], "specfirst": "No"},
+            )
+
+    def test_single_select_out_of_option_rejected(self):
+        form = form_from_dict(_form_dict())
+        with pytest.raises(FormValidationError, match="not in options"):
+            collect_form_response(
+                form,
+                {"outcome": "x", "approach": "wat", "concerns": [], "specfirst": "No"},
+            )
+
+    def test_boolean_invalid_rejected(self):
+        form = form_from_dict(_form_dict())
+        with pytest.raises(FormValidationError, match="must be 'Yes' or 'No'"):
+            collect_form_response(
+                form,
+                {"outcome": "x", "approach": "spec", "concerns": [], "specfirst": "maybe"},
+            )
+
+    def test_text_non_string_rejected(self):
+        form = form_from_dict(_form_dict())
+        with pytest.raises(FormValidationError, match="expects a string"):
+            collect_form_response(
+                form,
+                {"outcome": 123, "approach": "spec", "concerns": [], "specfirst": "No"},
+            )
+
+    def test_multiple_problems_collected(self):
+        form = form_from_dict(_form_dict())
+        with pytest.raises(FormValidationError) as exc:
+            collect_form_response(form, {})
+        # outcome required + approach required + specfirst required (3 of 4;
+        # concerns is multi-select, empty list → required miss too)
+        assert len(exc.value.problems) >= 3
+
+
+def test_validation_error_carries_problems():
+    err = FormValidationError(["a", "b"])
+    assert err.problems == ["a", "b"]
+    assert "a" in str(err) and "b" in str(err)

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -302,8 +302,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 22, (
-            f"Expected 22 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 23, (
+            f"Expected 23 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -24,15 +24,15 @@ def server():
 
 
 class TestToolRegistration:
-    """Verify all tools are registered (43 core + 5 optional redis plugin)."""
+    """Verify all tools are registered (45 core + 5 optional redis plugin)."""
 
     def test_tools_list_returns_at_least_core_count(self, server: EmpathyMCPServer):
-        """Core tools (43) are always registered; attune-redis adds 5 more."""
+        """Core tools (45) are always registered; attune-redis adds 5 more."""
         tools = server.get_tool_list()
         tool_names = {t["name"] for t in tools}
 
-        # 43 core tools must always be present
-        assert len(tools) >= 43
+        # 45 core tools must always be present
+        assert len(tools) >= 45
 
         # When attune-redis plugin is installed, all 5 redis tools are present
         redis_tools = {
@@ -43,7 +43,7 @@ class TestToolRegistration:
             "redis_memory_store",
         }
         if redis_tools.issubset(tool_names):
-            assert len(tools) == 48, f"Expected 48 tools with redis plugin, got {len(tools)}"
+            assert len(tools) == 50, f"Expected 50 tools with redis plugin, got {len(tools)}"
 
     def test_memory_tools_registered(self, server: EmpathyMCPServer):
         """Test that all memory tools are in the tool list."""


### PR DESCRIPTION
## What

Finishes **Option B** of the elicitation-form-surface spec: live-wire the
declarative-form bridge (`attune.elicitation`) so a skill can drive Socratic
discovery as a **form** (multi-select capable) instead of N sequential
button-turns.

Commit 1 (dc64c7dff) is the **bridge core**: `form_from_dict` /
`form_to_askuserquestion` / `collect_form_response`, 26 tests at 100%
line+branch coverage. Commit 2 (f2b585fd7) is the **live wiring** below.

## Changes (live wiring)

- **Two MCP tools** — pure reuse of the bridge's three functions, no new
  surface-specific translation to retest:
  - `elicitation_render_form` — validate a declarative form, return batched
    `AskUserQuestion` payloads (≤4/batch); malformed form → `{success:false,
    problems}`.
  - `elicitation_collect_response` — validate answers (R4: required +
    option membership), return normalized `{field_id: value}` or `problems`
    naming exactly which fields to re-ask.
- **`elicit` skill** — carries the surface-mapping rules (D6: the live path
  is skill-driven; `AskUserQuestion` is an agent tool, not a Python API) and
  the §4 batching rule; worked example is the `/attune` goal+scope+focus
  discovery turn (design §5).
- **attune-hub** routes to `elicit` for multi-dimension scoping.
- Tool count 43→45 core (48→50 with redis); `test_mcp_memory_tools.py`
  updated. `.agents/` synced.

## Dogfood (R5) — and a finding

A **real `AskUserQuestion` round-trip** validated end-to-end through the
live bridge (render → real answer → collect). It surfaced a genuine
conflict the unit tests can't see:

> The **global** one-question-per-turn guard
> (`~/.claude/hooks/ask_question_format_guard.py`) hard-blocks §4's
> multi-**field** batching (goal+scope+focus in one turn = multiple
> questions).

- **Multi-select itself (D2, priority-1) is unaffected** — `multiSelect:
  true` is one question and works today.
- The **N-fields→one-form** value needs that guard relaxed. The design
  flagged §4 as "needs explicit sign-off"; this shows it's also an
  *enforcement* change (a personal-config edit, separate from this repo).
  **Patrick owns the §4 sign-off** — tracked as follow-up, not in this PR.

## Test

`128 passed, 3 skipped` across the MCP, plugin-reference, registry-coverage,
sync-agents-skills, and elicitation suites. black + ruff clean.

## Notes

Docs-only spec decisions (D4–D7) live with spec PR #1127 (separate branch),
so this PR doesn't touch `decisions.md` to avoid a divergent-file tangle.
Likely hits the path-gated trap (no `doc-import-audit`/`wiring-audit` on
code+skill changes) → may need `--admin` merge.
