### PR TITLE
docs(spec): elicitation V2.0 — surface spike, D8 (elicitation leads), D7 restore

### DIFF
--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -189,6 +189,44 @@ the habit.** A live, **global** PreToolUse guard
   relaxed guard + the real batched round-trip were dogfooded green. (The
   guard is personal config, not in the repo.)
 
+## D8 — v2 surface: MCP elicitation leads; show_widget is the escape hatch
+
+**Date:** 2026-06-27 · **Status:** decided (Patrick ratified) · see
+[v2-phase0-requirements.md](v2-phase0-requirements.md) +
+[v2-phase0-findings.md](v2-phase0-findings.md)
+
+The V2.0 surface-grounding spike (research + thin PoC) settles the v2
+rendering surface and **partially overturns D4**.
+
+- **D4's elicitation rejection is STALE.** The MCP spec 2025-11-25 adds
+  multi-select to elicitation (`type:array` + `items.enum`,
+  `minItems`/`maxItems`) with a **structured, keyed** return
+  (`action` accept/decline/cancel + `content`). The disqualifier that
+  sent v1 to `AskUserQuestion` (no multi-select) is gone.
+- **PoC evidence (task v2.0-3).** S2: the artifact maps to a valid
+  elicitation `requestedSchema` and the keyed `content` flows straight
+  into `collect_form_response` with zero parsing (round-trip green). S1:
+  a live `show_widget` form rendered the same artifact and posted answers
+  back via the free-text `sendPrompt` — workable, but exactly the
+  "round-trip via posted JSON" D4 named (confirmed for S1 only).
+
+**Decision:**
+
+- **Lead surface = S2 (MCP native elicitation).** Best return path
+  (structured/keyed), native + portable (Claude Code/Desktop/web, with
+  `capabilities.elicitation` negotiation), reuses the v1 validation seam
+  (`collect_form_response`) behind one artifact→schema transform.
+- **Escape hatch = S1 (`show_widget`).** For controls elicitation can't
+  express (true slider, color, rich layout), accepting the free-text
+  `sendPrompt` postback.
+- **S3 (standalone web)** stays the **V2.3 / North-star** horizon (user-
+  designed, data-bound), not a v2 build target.
+
+D4 verdict: **(a) elicitation-lacks-multi-select OVERTURNED;
+(b) widget-return-fragile CONFIRMED for S1 only, N/A for the chosen S2
+lead.** V2.1 (rich controls on the artifact) and V2.2 (the elicitation
+renderer + live round-trip) inherit this.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -154,6 +154,41 @@ proven, so v1 is even smaller than D5 implied:
 `AskUserQuestion` → validated `FormResponse`; the true stepping stone).
 Agent recommends **B**. See salvage-assessment.md.
 
+## D7 — Option B built; two MCP tools + skill-driven mapping; §4 needs a guard relaxation
+
+**Date:** 2026-06-27 · **Status:** decided · built in PR #1128
+
+The bridge-nature fork (open at the end of D6) is resolved as **B**, and
+Option B is built ([PR #1128](https://github.com/Smart-AI-Memory/attune-ai/pull/1128)).
+Shape of the build:
+
+- **Two MCP tools, pure reuse of the bridge's three functions** — no new
+  surface-specific translation to retest: `elicitation_render_form`
+  (validate definition + batched payloads) and
+  `elicitation_collect_response` (validate answers, R4). The bridge core
+  (`attune.elicitation`, 26 tests, 100% line+branch) is the locked spine.
+- **The surface mapping lives in the skill, not Python (D6).**
+  `AskUserQuestion` is an agent tool, not a Python API, so the new
+  `elicit` skill carries the mapping rules (type→`multiSelect`,
+  recommendation-first, "Other" free-text escape, ≤4 batching, two-tier
+  picker for >4 options). attune-hub routes to it.
+
+**The dogfood (R5) caught a real conflict — the §4 enforcement, not just
+the habit.** A live, **global** PreToolUse guard
+(`~/.claude/hooks/ask_question_format_guard.py`) hard-blocks any
+`AskUserQuestion` with >1 question. Consequences:
+
+- **Multi-select itself (D2, priority-1) is unaffected** — `multiSelect:
+  true` is one question and ships today.
+- **§4 multi-*field* batching was blocked** until the guard was relaxed.
+  Patrick approved §4 and the relaxation: the guard now permits a
+  **deliberate** batched form — opt-in via `metadata.source` containing
+  "form" (the `elicit` skill sets `"elicit-form"`), still capped at 4 —
+  while the one-question default holds for everything else; multi-select
+  questions are exempted from the recommendation-first requirement. The
+  relaxed guard + the real batched round-trip were dogfooded green. (The
+  guard is personal config, not in the repo.)
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/v2-phase0-findings.md
+++ b/docs/specs/elicitation-form-surface/v2-phase0-findings.md
@@ -89,3 +89,24 @@ schema-mapping transform. Keep **S1 (show_widget)** as the escape hatch
 for controls elicitation can't express (true slider, color, rich
 layout). **S3** stays the North-star horizon (V2.3), not a v2 build
 target. Final pick is **D8** after the task v2.0-3 PoC.
+
+## PoC results (task v2.0-3)
+
+Both surfaces were proven with a real round-trip (R5), not a mock.
+
+- **S2 (elicitation) — schema transform + clean return.** A thin
+  `form_to_elicitation_schema(form)` mapped the declarative artifact to a
+  valid MCP `requestedSchema`: single-select → `string`+`enum`,
+  **multi-select → `array`+`items.enum`+`minItems`**, boolean →
+  `boolean`. The elicitation `accept` response's keyed `content` (e.g.
+  `{"goal":"Add a feature","focus":["tests","docs"],"ship_today":"Yes"}`)
+  passed **straight into `collect_form_response` with zero parsing** —
+  `success: true`. This is the C2 win, demonstrated.
+- **S1 (show_widget) — live form + free-text postback.** A real
+  interactive widget rendered the same artifact (radio goal, checkbox
+  multi-select focus, Yes/No toggle), previewed its payload, and on
+  submit called `sendPrompt(...)` carrying the answers as a chat message
+  — confirming S1's return path works but is free-text-carrying-JSON, not
+  structured.
+
+Conclusion → **D8** (decisions.md): S2 leads, S1 is the escape hatch.

--- a/docs/specs/elicitation-form-surface/v2-phase0-findings.md
+++ b/docs/specs/elicitation-form-surface/v2-phase0-findings.md
@@ -1,0 +1,91 @@
+# Elicitation v2 — Phase 0 findings (V2.0 tasks 1–2)
+
+Grounded inventory of the three candidate surfaces against the
+[V2.0 rubric](v2-phase0-requirements.md) (C1–C5), plus the D4
+return-path re-validation. Every claim is sourced (verify-first, D1).
+
+## Headline finding — D4's elicitation rejection is now STALE
+
+v1 rejected MCP native elicitation because it lacked multi-select (D4).
+**The MCP spec 2025-11-25 adds multi-select**, and its return path is
+**structured and keyed by field** — the cleanest C2 of all three
+surfaces. The surface v1 ruled out is now arguably the *leading*
+candidate. This is the kind of premise-drift the Phase 0 spike exists
+to catch.
+
+## Surface × criteria
+
+| | S1 show_widget / Cowork | S2 MCP elicitation | S3 standalone web |
+|---|---|---|---|
+| **C1 controls** | Best — arbitrary HTML (any control) | Good — string/number/bool/enum + **multi-select**; date/email via string `format`; no true slider/color | Best — arbitrary web UI |
+| **C2 return path** | Free-text postback (`sendPrompt`) carrying JSON the agent parses | **Best — structured `{field: value}`, accept/decline/cancel** | Structured, but out-of-band (POSTs to a backend, not the chat loop) |
+| **C3 portability** | Widget-capable clients (Cowork/claude.ai); CSP/CDN-sandboxed | Native; Claude Code/Desktop/web support form+url; needs runtime capability negotiation | Heavy — needs hosting; client just opens a URL |
+| **C4 reuse** | Render HTML from artifact; parse postback → `collect_form_response` | Map artifact → elicitation JSON schema; keyed response → `collect_form_response` (clean) | New web infra; backend owns the response |
+| **C5 north-star fit** | HTML can host a designer later | Flat-primitives only — caps rich/designer ambitions | Closest to the Florence horizon (user-designed, data-bound) |
+
+## Evidence
+
+### S2 — MCP elicitation (spec 2025-11-25)
+
+- **Multi-select supported:** `{"type":"array","items":{"type":"string",
+  "enum":[...]},"minItems":1,"maxItems":2}` (spec example). Single-select
+  via `enum` / `oneOf`+`const`+`title`.
+- **Types:** flat object of primitives only — string (formats: email,
+  uri, date, date-time; pattern, min/maxLength), number/integer
+  (min/max), boolean, enum (single+multi). No nested objects; no native
+  slider/color.
+- **Return path (structured):** client returns `{"action":"accept"|
+  "decline"|"cancel","content":{<field>:<value>}}` — keyed by schema
+  property, NOT free text.
+- **Client support:** Claude Code / Desktop / web support form+url modes;
+  server must check `capabilities.elicitation` at init and not send
+  unsupported modes.
+- Source: <https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation.md>
+
+### S1 — show_widget / Cowork preview
+
+- Renders arbitrary HTML fragments inline (full control palette possible),
+  but sandboxed: CSP/CDN allowlist, no `position:fixed`, scripts run
+  post-stream.
+- **Return path:** the only postback is the global `sendPrompt(text)` —
+  "sends a message to chat as if the user typed it." So answers come back
+  as a **free-text chat message** (the widget would serialize a JSON
+  string into it) that the agent then parses — not a structured callback.
+- Source: `mcp__visualize__read_me` (interactive module) — `sendPrompt`
+  section.
+
+### S3 — standalone web (Florence-style)
+
+- Arbitrary web UI → best control coverage and the closest fit to the
+  North-star (user-designed, data-bound) horizon.
+- **Return path:** form POSTs to a web backend — structured, but the
+  submission lands in a server, out of the chat agent's loop; needs
+  hosting + new infra. Reference: `Deep-Study-AI/ai-nurse-florence-v3.1`
+  (~20 clinical web forms on the same declarative model).
+
+## D4 re-validation verdict (task v2.0-2)
+
+**D4 is partially OVERTURNED.** D4 deferred the rich surface on two
+premises: (a) MCP elicitation lacks multi-select, and (b) a widget's
+return path is fragile posted-JSON.
+
+- **(a) OVERTURNED** — elicitation now supports multi-select with a
+  *structured, keyed* return. The disqualifier is gone.
+- **(b) CONFIRMED for the HTML-widget surface (S1)** — its only postback
+  is a free-text `sendPrompt`, i.e. exactly the "round-trip via posted
+  JSON" D4 named; workable but the weakest return path. NOT confirmed for
+  elicitation (S2), whose return is structured.
+
+**Net:** the return-path objection that drove v1 to `AskUserQuestion`
+does not apply to MCP elicitation. S2 leads on C2/C3/C4; S1 leads on
+C1/C5 (rich controls, designer headroom); S3 is the heavy North-star
+surface.
+
+## Recommendation (pre-D8)
+
+Lead with **S2 (MCP elicitation)** for v2's general form surface — best
+return path, native/portable, reuses `collect_form_response` with only a
+schema-mapping transform. Keep **S1 (show_widget)** as the escape hatch
+for controls elicitation can't express (true slider, color, rich
+layout). **S3** stays the North-star horizon (V2.3), not a v2 build
+target. Final pick is **D8** after the task v2.0-3 PoC.

--- a/docs/specs/elicitation-form-surface/v2-phase0-requirements.md
+++ b/docs/specs/elicitation-form-surface/v2-phase0-requirements.md
@@ -1,0 +1,169 @@
+# Elicitation v2 — Phase 0 (V2.0): ground the surface fork
+
+Requirements for the v2 surface-grounding spike. v1 (Option B) shipped
+the declarative artifact + the `AskUserQuestion` bridge
+([requirements.md](requirements.md), [design.md](design.md),
+[decisions.md](decisions.md) D1–D7). v2 renders the **same** artifact on
+a rich interactive surface. This phase decides **which** surface and
+**proves the return path** before any renderer is built.
+
+## Context
+
+- The form artifact is declarative and surface-agnostic (D3/R6) — v2
+  reuses it unchanged, along with `form_from_dict` and
+  `collect_form_response` (the R4 validation seam).
+- v1 deliberately drove the artifact through `AskUserQuestion` because
+  it natively supports multi-select (D4); the widget surface was
+  deferred because its return path looked fragile (D4 — "client-
+  dependent, round-tripping via posted JSON").
+- That deferral predates the `show_widget`/Cowork `sendPrompt(text)`
+  postback, so the "fragile return path" premise may be stale. We
+  verify, not assert (the v1 Phase 0 discipline — D1).
+
+## Problem
+
+Before committing the v2 renderer (V2.2), we do not actually know
+(a) which surface can render the full control palette (multi-select +
+the V2.1 rich controls), and (b) whether any of them offers a **clean,
+validated return path** from rendered form to `collect_form_response`.
+D4's return-path worry is the crux and is currently unverified.
+
+## Goals
+
+- **G1** Evaluate three candidate surfaces against a fixed rubric
+  (below), grounded in real docs/SDK/behaviour — not memory.
+- **G2** Empirically prove a single **render → submit → validated
+  response** round-trip on the leading surface (a thin PoC), so the
+  return-path risk is retired with evidence.
+- **G3** Record the surface decision (**D8**) and re-validate (confirm
+  or overturn) D4's return-path premise.
+
+## Surfaces in scope (Patrick, 2026-06-27)
+
+- **S1 — `show_widget` / Cowork preview pane.** Renders HTML inline;
+  has a `sendPrompt(text)` postback to chat. Leading candidate.
+- **S2 — MCP native elicitation.** Re-check whether multi-select
+  support changed since v1 rejected it.
+- **S3 — Standalone web app (Florence-style).** A separate web surface
+  like `ai-nurse-florence`; heaviest, closest to the North-star horizon.
+
+Excluded: the `attune-gui` FastAPI sidecar (Patrick deprioritized it
+for this evaluation).
+
+## Evaluation rubric (criteria each surface is scored on)
+
+- **C1 Control coverage** — can it render multi-select **and** the V2.1
+  rich controls (slider, number, date, textarea, toggle)?
+- **C2 Return path** — is there a clean path from a submitted form to a
+  `{field_id: value}` map that `collect_form_response` validates? (the
+  crux — the thing D4 worried about).
+- **C3 Portability** — client-independent? works in Claude Code /
+  Cowork without bespoke setup?
+- **C4 Reuse** — plugs into the existing artifact +
+  `collect_form_response` with no new infrastructure?
+- **C5 North-star fit** — keeps the `options_source` seam reachable
+  (V2.3 horizon) without building it.
+
+## End state (acceptance)
+
+- A **findings doc** scoring S1–S3 on C1–C5, each claim backed by a
+  verification (doc link, SDK introspection, or observed behaviour).
+- A **thin PoC** on the leading surface: renders a real declarative
+  form (via `form_from_dict`) and returns answers that pass
+  `collect_form_response` — a genuine round-trip (R5), not a mock.
+- **D8 recorded** in `decisions.md`: chosen surface + rationale, and an
+  explicit confirm/overturn verdict on D4's return-path premise.
+
+## Out of scope
+
+- V2.1 rich-control **implementation** (this phase only checks each
+  surface *can* host them; building them is V2.1).
+- V2.2 full renderer.
+- V2.3 designer / data-bound options (HELD per the 2026-06-27 scope
+  decision — a documented horizon + the `options_source` seam only; any
+  designer/data-binding needs its own spec with a named consumer).
+
+## Tasks
+
+<task id="v2.0-1" name="surface-inventory">
+  <objective>
+    Score S1–S3 against the C1–C5 rubric, grounding every claim in real
+    docs/SDK/behaviour (verify-first — no assertions from memory).
+  </objective>
+  <context>
+    <surfaces>S1 show_widget/Cowork (sendPrompt postback), S2 MCP
+    elicitation, S3 standalone web (Florence-style).</surfaces>
+    <rubric>C1 control coverage, C2 return path, C3 portability,
+    C4 reuse, C5 north-star fit.</rubric>
+  </context>
+  <files-to-create>
+    <file path="docs/specs/elicitation-form-surface/v2-phase0-findings.md">
+      A surface×criteria table; each cell cites its evidence.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Every C-score links a doc, an introspection, or an observed
+    behaviour — not a memory claim.</check>
+    <check>C2 (return path) is answered concretely for each surface.</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Confabulating SDK/surface capabilities from
+    memory — the exact failure D1 guards against. Introspect/read first.</risk>
+  </risks>
+</task>
+
+<task id="v2.0-2" name="revalidate-d4-return-path">
+  <objective>
+    Resolve D4's premise specifically: can the leading surface's postback
+    (e.g. show_widget `sendPrompt`) carry a structured form submission
+    back as a clean {field_id: value} map?
+  </objective>
+  <validation>
+    <check>A concrete yes/no with evidence on whether the postback
+    delivers structured answers (not just free text).</check>
+  </validation>
+  <risks>
+    <risk severity="high">If NO clean return path exists on any surface,
+    V2.2 is blocked — surface that finding loudly rather than papering
+    over it.</risk>
+  </risks>
+</task>
+
+<task id="v2.0-3" name="thin-postback-poc">
+  <objective>
+    On the leading surface, render a real declarative form and round-trip
+    its answers through collect_form_response — a genuine R5 receipt that
+    the return path works end to end.
+  </objective>
+  <context>
+    <reuse>form_from_dict + collect_form_response (attune.elicitation) —
+    no new validation logic.</reuse>
+  </context>
+  <validation>
+    <check>A real (non-mocked) render → submit → validated-response
+    round-trip is demonstrated.</check>
+    <check>Malformed answers are rejected by collect_form_response (R4),
+    not silently accepted.</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Scope creep into V2.2 — keep the PoC thin
+    (one form, prove the path), do not build the general renderer.</risk>
+  </risks>
+</task>
+
+<task id="v2.0-4" name="record-d8-decision">
+  <objective>
+    Record D8 in decisions.md: the chosen surface + rationale, and an
+    explicit confirm/overturn verdict on D4's return-path premise. Note
+    what V2.1/V2.2 inherit.
+  </objective>
+  <files-to-modify>
+    <file path="docs/specs/elicitation-form-surface/decisions.md">
+      <change location="append after D7">Add the D8 decision block.</change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>D8 names the surface, cites the PoC evidence, and states
+    whether D4 is confirmed or overturned.</check>
+  </validation>
+</task>


### PR DESCRIPTION
## What

Executes **V2.0** — the v2 surface-grounding spike (research + thin PoC)
from the approved [requirements](docs/specs/elicitation-form-surface/v2-phase0-requirements.md).
Decides the v2 rendering surface and proves the return path before any
renderer is built. Docs + decisions only — no product code.

## Headline finding — D4 is partially overturned

v1 sent forms through `AskUserQuestion` because MCP elicitation lacked
multi-select (D4). **The MCP spec 2025-11-25 added multi-select to
elicitation, with a structured keyed return** — the disqualifier is gone,
and elicitation now has the *cleanest* return path of the three surfaces.
Exactly the premise-drift a Phase 0 spike exists to catch.

## Tasks delivered

- **v2.0-1 inventory** — S1 (show_widget) / S2 (MCP elicitation) / S3
  (standalone web) scored on the C1–C5 rubric, every claim sourced
  ([findings](docs/specs/elicitation-form-surface/v2-phase0-findings.md)).
- **v2.0-2 D4 re-validation** — (a) elicitation-lacks-multi-select
  OVERTURNED; (b) widget-return-fragile CONFIRMED for S1 only.
- **v2.0-3 PoC (both, per Patrick)** — S2: artifact → elicitation schema,
  keyed `content` → `collect_form_response` zero-parse round-trip (green).
  S1: a live `show_widget` form posting answers back via `sendPrompt`.
- **v2.0-4 D8** (Patrick ratified) — **S2 MCP elicitation leads**, **S1
  show_widget is the escape hatch**, **S3 stays the V2.3 horizon**.

## Also

Restores **D7** (Option B + §4 guard relaxation), which was orphaned when
spec PR #1127 merged seconds before D7's push landed on that branch — so
D7 + D8 both reach main here.

## Scope held

V2.1 (rich controls), V2.2 (the elicitation renderer + live round-trip),
and V2.3 (designer / data-binding — no named consumer) are all out of
this phase. Docs-only PR; likely needs `--admin` (path-gated).
