### PR TITLE
feat(elicitation): v2.1 rich controls — number/date/textarea on the artifact

### DIFF
--- a/docs/specs/elicitation-form-surface/v2-1-requirements.md
+++ b/docs/specs/elicitation-form-surface/v2-1-requirements.md
@@ -1,0 +1,114 @@
+# Elicitation v2 — Phase 2.1 (V2.1): rich controls on the artifact
+
+Requirements for extending the declarative form artifact with the rich
+controls the **lead surface (MCP elicitation, D8)** supports natively.
+Model + validation only — the elicitation renderer is V2.2.
+
+## Context
+
+- D8 chose MCP elicitation as the v2 lead surface. Its schema supports
+  string (with `format`, `pattern`, `min/maxLength`), number/integer
+  (`min/max`), boolean, and enums (single + multi) —
+  [findings](v2-phase0-findings.md).
+- The artifact today (`QuestionType` in `meta_workflows/models.py`)
+  supports `text_input`, `single_select`, `multi_select`, `boolean`.
+- The v1 bridge (`attune.elicitation`) is the locked validation seam
+  (`form_from_dict`, `collect_form_response`) — V2.1 extends it, reuses
+  its shape.
+
+## Problem
+
+The artifact can't yet express numeric, date, or multi-line-text fields,
+so a v2 form is stuck with selects/booleans/short text. These are the
+rich controls elicitation can host — the first concrete payoff of D8.
+
+## Goals
+
+- **G1** Add `number`, `date`, `textarea` to `QuestionType` plus the
+  constraints elicitation honours (`minimum`/`maximum` for number,
+  `max_length` for text/textarea).
+- **G2** Validate them on both sides: `form_from_dict` rejects malformed
+  *definitions*; `collect_form_response` rejects malformed *answers*
+  (R4 — never silently accept).
+- **G3** Pure model + validation, fully unit-tested (like the v1 bridge,
+  100% line+branch on new logic). No renderer.
+
+## Scope
+
+In: `number` (optional `minimum`/`maximum`), `date` (ISO-8601 `YYYY-MM-DD`
+string), `textarea` (optional `max_length`).
+
+Deferred (no native elicitation control → the `show_widget` escape hatch,
+a later sub-phase): `slider`, `color`. v1's `AskUserQuestion` renderer is
+left as-is — rich-typed forms target the elicitation surface (V2.2); their
+`AskUserQuestion` rendering is best-effort, out of scope here.
+
+## End state (acceptance)
+
+- `QuestionType` has `NUMBER`, `DATE`, `TEXTAREA`; `FormQuestion` carries
+  optional `minimum`, `maximum`, `max_length` (backward-compatible —
+  trailing defaulted fields).
+- `form_from_dict` parses the new fields and rejects a bad definition
+  (e.g. `minimum > maximum`, non-numeric bound, negative `max_length`).
+- `collect_form_response` validates answers: number is numeric and in
+  range; date parses as `YYYY-MM-DD`; textarea is a string within
+  `max_length`.
+- Tests cover every new type + every new failure path.
+
+## Out of scope
+
+V2.2 (elicitation renderer + live round-trip), slider/color, V2.3.
+
+## Tasks
+
+<task id="v2.1-1" name="extend-artifact-model">
+  <objective>
+    Add NUMBER/DATE/TEXTAREA to QuestionType and optional minimum/maximum/
+    max_length to FormQuestion (trailing defaulted fields — backward
+    compatible).
+  </objective>
+  <files-to-modify>
+    <file path="src/attune/meta_workflows/models.py">
+      <change location="QuestionType + FormQuestion">Add enum members and
+      constraint fields; keep to_ask_user_format non-crashing.</change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>Existing FormQuestion construction sites still work (new fields
+    default to None).</check>
+  </validation>
+</task>
+
+<task id="v2.1-2" name="extend-bridge-validation">
+  <objective>
+    Teach form_from_dict to parse + validate the new fields, and
+    _validate_answer to validate number/date/textarea answers (R4).
+  </objective>
+  <files-to-modify>
+    <file path="src/attune/elicitation/bridge.py">
+      <change location="form_from_dict, _validate_answer">Parse
+      constraints, reject bad definitions and bad answers with named
+      problems.</change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>minimum>maximum, non-numeric bound, negative max_length → defn
+    error.</check>
+    <check>out-of-range number, unparseable date, over-length text,
+    wrong-type → answer problem.</check>
+  </validation>
+</task>
+
+<task id="v2.1-3" name="tests">
+  <objective>
+    Unit tests for every new type and failure path; keep 100% line+branch
+    on the new bridge logic.
+  </objective>
+  <files-to-modify>
+    <file path="tests/unit/elicitation/">Add cases for number/date/
+    textarea definition + answer validation.</file>
+  </files-to-modify>
+  <validation>
+    <check>All new paths covered; suite green.</check>
+  </validation>
+</task>

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -12,6 +12,7 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from attune.meta_workflows.models import (
@@ -24,6 +25,14 @@ from attune.meta_workflows.models import (
 #: The answer values accepted for a BOOLEAN question (its
 #: ``to_ask_user_format`` renders as a Yes/No single-select).
 _BOOLEAN_OPTIONS = ("Yes", "No")
+
+#: ISO-8601 calendar-date format used by DATE questions.
+_DATE_FORMAT = "%Y-%m-%d"
+
+
+def _is_number(value: Any) -> bool:
+    """True if ``value`` is a real number (int or float, but not bool)."""
+    return isinstance(value, int | float) and not isinstance(value, bool)
 
 
 class FormValidationError(ValueError):
@@ -107,6 +116,24 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
         if qtype in (QuestionType.SINGLE_SELECT, QuestionType.MULTI_SELECT) and not options:
             problems.append(f"{where} type {qtype.value} requires non-empty 'options'")
 
+        # v2.1 rich-control constraints (number range, text length).
+        minimum = raw.get("minimum")
+        if minimum is not None and not _is_number(minimum):
+            problems.append(f"{where} 'minimum' must be a number")
+            minimum = None
+        maximum = raw.get("maximum")
+        if maximum is not None and not _is_number(maximum):
+            problems.append(f"{where} 'maximum' must be a number")
+            maximum = None
+        if _is_number(minimum) and _is_number(maximum) and minimum > maximum:
+            problems.append(f"{where} 'minimum' {minimum} exceeds 'maximum' {maximum}")
+        max_length = raw.get("max_length")
+        if max_length is not None and (
+            not isinstance(max_length, int) or isinstance(max_length, bool) or max_length <= 0
+        ):
+            problems.append(f"{where} 'max_length' must be a positive integer")
+            max_length = None
+
         if fid and text and isinstance(fid, str) and isinstance(text, str):
             questions.append(
                 FormQuestion(
@@ -117,6 +144,9 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
                     default=raw.get("default"),
                     help_text=raw.get("help_text"),
                     required=bool(raw.get("required", True)),
+                    minimum=minimum,
+                    maximum=maximum,
+                    max_length=max_length,
                 )
             )
 
@@ -170,9 +200,29 @@ def _validate_answer(question: FormQuestion, value: Any) -> str | None:
             return f"{question.id!r} boolean value {value!r} must be 'Yes' or 'No'"
         return None
 
-    # TEXT_INPUT
+    if question.type == QuestionType.NUMBER:
+        if not _is_number(value):
+            return f"{question.id!r} expects a number"
+        if question.minimum is not None and value < question.minimum:
+            return f"{question.id!r} {value} is below minimum {question.minimum}"
+        if question.maximum is not None and value > question.maximum:
+            return f"{question.id!r} {value} is above maximum {question.maximum}"
+        return None
+
+    if question.type == QuestionType.DATE:
+        if not isinstance(value, str):
+            return f"{question.id!r} expects an ISO date string (YYYY-MM-DD)"
+        try:
+            datetime.strptime(value, _DATE_FORMAT)
+        except ValueError:
+            return f"{question.id!r} {value!r} is not a valid YYYY-MM-DD date"
+        return None
+
+    # TEXT_INPUT / TEXTAREA — a string, optionally length-bounded.
     if not isinstance(value, str):
         return f"{question.id!r} expects a string"
+    if question.max_length is not None and len(value) > question.max_length:
+        return f"{question.id!r} exceeds max_length {question.max_length}"
     return None
 
 

--- a/src/attune/meta_workflows/models.py
+++ b/src/attune/meta_workflows/models.py
@@ -22,12 +22,21 @@ from typing import Any
 
 
 class QuestionType(str, Enum):
-    """Types of form questions supported."""
+    """Types of form questions supported.
+
+    The first four are v1 controls (rendered via AskUserQuestion). The
+    last three are v2.1 rich controls — natively expressible on the MCP
+    elicitation surface (D8): number (with min/max), date (ISO-8601
+    string), and textarea (multi-line string with max_length).
+    """
 
     TEXT_INPUT = "text_input"
     SINGLE_SELECT = "single_select"
     MULTI_SELECT = "multi_select"
     BOOLEAN = "boolean"
+    NUMBER = "number"
+    DATE = "date"
+    TEXTAREA = "textarea"
 
 
 class TierStrategy(str, Enum):
@@ -56,6 +65,9 @@ class FormQuestion:
         default: Default value if user doesn't provide one
         help_text: Additional help text shown to user
         required: Whether this question must be answered
+        minimum: Lower bound for NUMBER answers (inclusive); None = none
+        maximum: Upper bound for NUMBER answers (inclusive); None = none
+        max_length: Max character length for TEXT_INPUT/TEXTAREA; None = none
 
     """
 
@@ -66,6 +78,9 @@ class FormQuestion:
     default: str | None = None
     help_text: str | None = None
     required: bool = True
+    minimum: float | None = None
+    maximum: float | None = None
+    max_length: int | None = None
 
     def to_ask_user_format(self) -> dict[str, Any]:
         """Convert to format compatible with AskUserQuestion tool.

--- a/tests/unit/elicitation/test_rich_controls.py
+++ b/tests/unit/elicitation/test_rich_controls.py
@@ -1,0 +1,192 @@
+"""Tests for v2.1 rich controls on the elicitation artifact.
+
+Covers the new QuestionType values (number, date, textarea) and their
+constraints (minimum/maximum/max_length) on both sides:
+
+- form_from_dict: definition parsing + every new definition-reject path
+- collect_form_response: valid answers + every new answer-reject path
+
+The lead surface for these controls is MCP elicitation (D8); this layer
+is model + validation only (no renderer — that is V2.2).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+)
+from attune.meta_workflows.models import QuestionType
+
+
+def _form(field: dict) -> dict:
+    return {"title": "T", "fields": [field]}
+
+
+# ---------------------------------------------------------------------------
+# Definition parsing (form_from_dict)
+# ---------------------------------------------------------------------------
+
+
+class TestRichDefinitions:
+    def test_number_with_bounds_parses(self):
+        form = form_from_dict(
+            _form({"id": "age", "text": "Age", "type": "number", "minimum": 0, "maximum": 120})
+        )
+        q = form.questions[0]
+        assert q.type == QuestionType.NUMBER
+        assert q.minimum == 0
+        assert q.maximum == 120
+
+    def test_number_without_bounds_parses(self):
+        form = form_from_dict(_form({"id": "n", "text": "N", "type": "number"}))
+        q = form.questions[0]
+        assert q.minimum is None and q.maximum is None
+
+    def test_date_needs_no_options(self):
+        form = form_from_dict(_form({"id": "d", "text": "When", "type": "date"}))
+        assert form.questions[0].type == QuestionType.DATE
+
+    def test_textarea_with_max_length_parses(self):
+        form = form_from_dict(
+            _form({"id": "bio", "text": "Bio", "type": "textarea", "max_length": 280})
+        )
+        assert form.questions[0].max_length == 280
+
+    def test_float_bounds_allowed(self):
+        form = form_from_dict(
+            _form({"id": "p", "text": "Price", "type": "number", "minimum": 0.5, "maximum": 9.5})
+        )
+        assert form.questions[0].minimum == 0.5
+
+    def test_minimum_exceeds_maximum_rejected(self):
+        with pytest.raises(FormValidationError, match="exceeds 'maximum'"):
+            form_from_dict(
+                _form({"id": "n", "text": "N", "type": "number", "minimum": 5, "maximum": 1})
+            )
+
+    def test_non_numeric_minimum_rejected(self):
+        with pytest.raises(FormValidationError, match="'minimum' must be a number"):
+            form_from_dict(_form({"id": "n", "text": "N", "type": "number", "minimum": "lo"}))
+
+    def test_non_numeric_maximum_rejected(self):
+        with pytest.raises(FormValidationError, match="'maximum' must be a number"):
+            form_from_dict(_form({"id": "n", "text": "N", "type": "number", "maximum": []}))
+
+    def test_bool_bound_rejected(self):
+        # bool is an int subclass but must not pass as a number.
+        with pytest.raises(FormValidationError, match="'minimum' must be a number"):
+            form_from_dict(_form({"id": "n", "text": "N", "type": "number", "minimum": True}))
+
+    @pytest.mark.parametrize("bad", [-3, 0, 2.5, True])
+    def test_bad_max_length_rejected(self, bad):
+        with pytest.raises(FormValidationError, match="'max_length' must be a positive integer"):
+            form_from_dict(_form({"id": "t", "text": "T", "type": "textarea", "max_length": bad}))
+
+
+# ---------------------------------------------------------------------------
+# Answer validation (collect_form_response)
+# ---------------------------------------------------------------------------
+
+
+class TestNumberAnswers:
+    def _form(self, **extra):
+        return form_from_dict(_form({"id": "age", "text": "Age", "type": "number", **extra}))
+
+    def test_valid_in_range(self):
+        form = self._form(minimum=0, maximum=120)
+        assert collect_form_response(form, {"age": 42}).responses == {"age": 42}
+
+    def test_zero_is_not_treated_as_empty(self):
+        form = self._form(minimum=0, maximum=10)
+        assert collect_form_response(form, {"age": 0}).responses == {"age": 0}
+
+    def test_float_accepted(self):
+        form = self._form()
+        assert collect_form_response(form, {"age": 3.14}).responses == {"age": 3.14}
+
+    def test_below_minimum_rejected(self):
+        form = self._form(minimum=18)
+        with pytest.raises(FormValidationError, match="below minimum 18"):
+            collect_form_response(form, {"age": 5})
+
+    def test_above_maximum_rejected(self):
+        form = self._form(maximum=120)
+        with pytest.raises(FormValidationError, match="above maximum 120"):
+            collect_form_response(form, {"age": 200})
+
+    def test_non_number_rejected(self):
+        form = self._form()
+        with pytest.raises(FormValidationError, match="expects a number"):
+            collect_form_response(form, {"age": "old"})
+
+    def test_bool_rejected(self):
+        form = self._form()
+        with pytest.raises(FormValidationError, match="expects a number"):
+            collect_form_response(form, {"age": True})
+
+    def test_unbounded_accepts_any_number(self):
+        form = self._form()
+        assert collect_form_response(form, {"age": -9999}).responses == {"age": -9999}
+
+    def test_required_missing(self):
+        form = self._form(minimum=0)
+        with pytest.raises(FormValidationError, match="'age' is required"):
+            collect_form_response(form, {})
+
+
+class TestDateAnswers:
+    def _form(self):
+        return form_from_dict(_form({"id": "d", "text": "When", "type": "date"}))
+
+    def test_valid_iso_date(self):
+        assert collect_form_response(self._form(), {"d": "2026-06-27"}).responses == {
+            "d": "2026-06-27"
+        }
+
+    def test_non_string_rejected(self):
+        with pytest.raises(FormValidationError, match="expects an ISO date"):
+            collect_form_response(self._form(), {"d": 20260627})
+
+    def test_bad_format_rejected(self):
+        with pytest.raises(FormValidationError, match="not a valid YYYY-MM-DD"):
+            collect_form_response(self._form(), {"d": "06/27/2026"})
+
+    def test_impossible_date_rejected(self):
+        with pytest.raises(FormValidationError, match="not a valid YYYY-MM-DD"):
+            collect_form_response(self._form(), {"d": "2026-13-40"})
+
+
+class TestTextLengthAnswers:
+    def test_textarea_within_limit(self):
+        form = form_from_dict(
+            _form({"id": "bio", "text": "Bio", "type": "textarea", "max_length": 5})
+        )
+        assert collect_form_response(form, {"bio": "hi"}).responses == {"bio": "hi"}
+
+    def test_textarea_over_limit_rejected(self):
+        form = form_from_dict(
+            _form({"id": "bio", "text": "Bio", "type": "textarea", "max_length": 5})
+        )
+        with pytest.raises(FormValidationError, match="exceeds max_length 5"):
+            collect_form_response(form, {"bio": "way too long"})
+
+    def test_textarea_non_string_rejected(self):
+        form = form_from_dict(_form({"id": "bio", "text": "Bio", "type": "textarea"}))
+        with pytest.raises(FormValidationError, match="expects a string"):
+            collect_form_response(form, {"bio": 42})
+
+    def test_text_input_respects_max_length(self):
+        form = form_from_dict(
+            _form({"id": "name", "text": "Name", "type": "text_input", "max_length": 3})
+        )
+        with pytest.raises(FormValidationError, match="exceeds max_length 3"):
+            collect_form_response(form, {"name": "Patrick"})
+
+    def test_textarea_unbounded_accepts_any_length(self):
+        form = form_from_dict(_form({"id": "bio", "text": "Bio", "type": "textarea"}))
+        big = "x" * 10_000
+        assert collect_form_response(form, {"bio": big}).responses == {"bio": big}


### PR DESCRIPTION
## What

**V2.1** — extend the declarative form artifact with the rich controls
the v2 lead surface (MCP elicitation, D8) supports natively. Model +
validation only; the elicitation renderer is V2.2.

## Changes

- **Artifact** (`meta_workflows/models.py`): `QuestionType` gains
  `NUMBER`, `DATE`, `TEXTAREA`; `FormQuestion` gains optional `minimum`,
  `maximum` (number range) and `max_length` (text/textarea) — all
  trailing-defaulted, so existing construction is unaffected.
- **Validation** (`elicitation/bridge.py`):
  - `form_from_dict` parses the new fields and rejects bad *definitions*
    (`minimum > maximum`, non-numeric bound, non-positive/non-int
    `max_length`).
  - `collect_form_response` validates *answers* (R4): number is numeric
    and in range; date parses as `YYYY-MM-DD`; text/textarea within
    `max_length`. (bool is correctly rejected as a number.)
- **Tests**: 31 new cases; `bridge.py` stays **100% line + branch**.

## Scope

`slider` / `color` deferred — no native elicitation control, so they
belong to the `show_widget` escape hatch in a later sub-phase. The v1
`AskUserQuestion` renderer is untouched (rich-typed forms target the
elicitation surface, V2.2); the MCP `render_form` tool still advertises
the v1 control set on purpose. V2.2 (renderer + live round-trip) and V2.3
(designer/data-binding) remain out of scope.

## Test

Full elicitation suite 57 passed; meta_workflows + MCP + plugins 960
passed (1 unrelated keyed live-API test fails locally, skipped in CI).
black + pinned-ruff clean.
