### PR TITLE
feat(elicitation): v2.2 renderer — elicitation_ask MCP tool + schema transform

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -53,7 +53,23 @@ A form is plain serializable data:
 ```
 
 Field `type` is one of `single_select`, `multi_select`, `boolean`,
-`text_input`. `id` is the stable key the answer comes back under.
+`text_input`, `number` (with `minimum`/`maximum`), `date` (ISO
+`YYYY-MM-DD`), or `textarea` (with `max_length`). `id` is the stable key
+the answer comes back under. The last three are **rich controls** — they
+only render on the native elicitation surface below, not AskUserQuestion.
+
+## Choosing a surface
+
+- **Rich / native — one call:** `elicitation_ask` renders the form as a
+  native MCP elicitation dialog (supports number/date/textarea +
+  multi-select with a structured return) and returns the validated
+  answers in a single call — no manual `AskUserQuestion` mapping. Prefer
+  it when the client supports elicitation or the form uses a rich
+  control. It returns `{success: false, action: "unsupported"}` if the
+  client can't elicit — then fall back to the portable path.
+- **Portable — AskUserQuestion:** steps 2–4 below map the form onto
+  `AskUserQuestion` (selects/booleans/short text only). Use this as the
+  fallback, or when you want the recommendation-first button UX.
 
 ## Step 2 — render it
 

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -227,6 +227,39 @@ D4 verdict: **(a) elicitation-lacks-multi-select OVERTURNED;
 lead.** V2.1 (rich controls on the artifact) and V2.2 (the elicitation
 renderer + live round-trip) inherit this.
 
+## D9 — V2.2 renderer shipped; live round-trip pending a server restart
+
+**Date:** 2026-06-27 · **Status:** decided · see
+[v2-2-requirements.md](v2-2-requirements.md)
+
+V2.2 productionizes the elicitation renderer on the lead surface (D8).
+Grounded against the installed MCP SDK (verify-first):
+``ServerSession.elicit_form(message, requestedSchema, related_request_id)
+-> ElicitResult{action, content}``, reachable from a tool handler via
+``Server.request_context`` (`.session`, `.request_id`).
+
+Shipped:
+
+- **`form_to_elicitation_schema(form)`** (`attune.elicitation`) — the
+  artifact → elicitation ``requestedSchema`` transform for all 7
+  controls; 100% line+branch.
+- **`elicitation_ask` MCP tool** — the full server-side round-trip: build
+  the schema, ``await session.elicit_form(...)``, and on ``accept``
+  validate the structured ``content`` through ``collect_form_response``
+  (R4). ``decline``/``cancel`` return cleanly; a missing/incapable
+  session returns ``action: "unsupported"``/``"error"`` so the caller
+  falls back to ``elicitation_render_form`` (AskUserQuestion). Validated
+  with a mocked session across every path.
+
+**R5 caveat (as in V2.0):** the *true* live round-trip needs an
+elicitation-capable client AND the MCP server running V2.2 code (the
+session's server is started per-session; new tools appear only after a
+restart). The mocked-session test proves the transform + emit + collect
+path end to end; the live dogfood is deferred to the next session that
+boots the updated server. This is the v2 build's renderer — V2.0–V2.2
+(the three build phases) are now complete; V2.3 (designer/data-binding)
+stays held.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/v2-2-requirements.md
+++ b/docs/specs/elicitation-form-surface/v2-2-requirements.md
@@ -1,0 +1,114 @@
+# Elicitation v2 — Phase 2.2 (V2.2): the MCP elicitation renderer
+
+Requirements for rendering the declarative artifact as a real MCP
+`elicitation/create` request on the lead surface (D8), and validating the
+structured response back through the v1 seam.
+
+## Context
+
+- D8 chose **MCP native elicitation** as the v2 lead surface — structured
+  keyed return, native/portable, reuses `collect_form_response`.
+- V2.1 extended the artifact with rich controls (number/date/textarea).
+- The V2.0 PoC proved the transform; this phase productionizes it and
+  wires the live emit path.
+
+## Grounding (verify-first, confirmed against the installed SDK)
+
+- `ServerSession.elicit_form(message, requestedSchema, related_request_id)
+  -> ElicitResult` sends form-mode `elicitation/create`. `requestedSchema`
+  is `dict[str, Any]`; `ElicitResult` is `{action: accept|decline|cancel,
+  content: {field: value} | None}`.
+- A tool handler reaches the live session via
+  `Server.request_context` (`.session`, `.request_id`) — both available
+  inside an in-flight `call_tool`.
+
+## Goals
+
+- **G1** `form_to_elicitation_schema(form)` — map every `QuestionType` to
+  a valid elicitation `requestedSchema` (flat object of primitives).
+- **G2** An `elicitation_ask` MCP tool that does the full server-side
+  round-trip: build schema → `session.elicit_form(...)` → on `accept`,
+  validate `content` via `collect_form_response`; on `decline`/`cancel`,
+  return that cleanly. Graceful fallback when the client lacks the
+  elicitation capability.
+- **G3** Unit-tested transform (all 7 types) + handler (accept/decline/
+  cancel + capability-error paths) with a mocked session. Live round-trip
+  documented as needing an elicitation-capable client + a server restart.
+
+## Type → schema mapping
+
+| QuestionType | elicitation schema |
+|---|---|
+| single_select | `{type: string, enum: options}` |
+| multi_select | `{type: array, items: {type: string, enum: options}, minItems if required}` |
+| boolean | `{type: boolean}` |
+| number | `{type: number, minimum?, maximum?}` |
+| date | `{type: string, format: "date"}` |
+| textarea / text_input | `{type: string, maxLength?}` |
+
+Every property carries `title` (the question text), plus `description`
+(help_text) and `default` when present. `required` lists the required
+field ids.
+
+## End state (acceptance)
+
+- `form_to_elicitation_schema` in `attune.elicitation`, exported, covering
+  all 7 types + constraints; 100% line+branch.
+- `elicitation_ask` MCP tool (schema + handler + dispatch + count test);
+  handler validated with a mocked session across accept/decline/cancel +
+  capability-error.
+- Tool count bumped; `test_mcp_memory_tools.py` updated.
+- Findings/decisions note the renderer is live-pending a restart (R5
+  caveat), as in V2.0.
+
+## Out of scope
+
+- The `show_widget` escape-hatch renderer (S1) for slider/color.
+- V2.3 (designer / data-binding).
+- Changing the v1 AskUserQuestion tools (`render_form`/`collect_response`)
+  — they stay; `elicitation_ask` is the elicitation-surface sibling.
+
+## Tasks
+
+<task id="v2.2-1" name="form-to-elicitation-schema">
+  <objective>
+    Productionize form_to_elicitation_schema(form) in attune.elicitation:
+    all 7 QuestionTypes → a valid elicitation requestedSchema.
+  </objective>
+  <validation>
+    <check>multi_select → array+items.enum; number → number+min/max; date
+    → string+format:date; textarea/text → string+maxLength.</check>
+    <check>title/description/default threaded; required list correct.</check>
+  </validation>
+</task>
+
+<task id="v2.2-2" name="elicitation-ask-tool">
+  <objective>
+    Add the elicitation_ask MCP tool: schema + handler that builds the
+    schema, awaits session.elicit_form, and on accept validates content via
+    collect_form_response; handles decline/cancel + capability error.
+  </objective>
+  <files-to-modify>
+    <file path="src/attune/mcp/tool_schemas.py">add elicitation_ask schema</file>
+    <file path="src/attune/mcp/server.py">handler + dispatch + register</file>
+    <file path="tests/unit/test_mcp_memory_tools.py">bump tool count</file>
+  </files-to-modify>
+  <validation>
+    <check>handler builds the right requestedSchema and returns validated
+    responses on accept; clean status on decline/cancel; graceful error
+    when the session can't elicit.</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Live round-trip needs an elicitation-capable
+    client + server restart — prove the path with a mocked session, defer
+    the true live R5 (document it, as V2.0 did).</risk>
+  </risks>
+</task>
+
+<task id="v2.2-3" name="tests-and-decision">
+  <objective>
+    Unit tests for the transform (all types) and the handler (mocked
+    session: accept/decline/cancel/capability-error). Record D9 (renderer
+    shipped; live-pending restart).
+  </objective>
+</task>

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -55,7 +55,23 @@ A form is plain serializable data:
 ```
 
 Field `type` is one of `single_select`, `multi_select`, `boolean`,
-`text_input`. `id` is the stable key the answer comes back under.
+`text_input`, `number` (with `minimum`/`maximum`), `date` (ISO
+`YYYY-MM-DD`), or `textarea` (with `max_length`). `id` is the stable key
+the answer comes back under. The last three are **rich controls** — they
+only render on the native elicitation surface below, not AskUserQuestion.
+
+## Choosing a surface
+
+- **Rich / native — one call:** `elicitation_ask` renders the form as a
+  native MCP elicitation dialog (supports number/date/textarea +
+  multi-select with a structured return) and returns the validated
+  answers in a single call — no manual `AskUserQuestion` mapping. Prefer
+  it when the client supports elicitation or the form uses a rich
+  control. It returns `{success: false, action: "unsupported"}` if the
+  client can't elicit — then fall back to the portable path.
+- **Portable — AskUserQuestion:** steps 2–4 below map the form onto
+  `AskUserQuestion` (selects/booleans/short text only). Use this as the
+  fallback, or when you want the recommendation-first button UX.
 
 ## Step 2 — render it
 

--- a/src/attune/elicitation/__init__.py
+++ b/src/attune/elicitation/__init__.py
@@ -29,10 +29,12 @@ from attune.elicitation.bridge import (
     form_from_dict,
     form_to_askuserquestion,
 )
+from attune.elicitation.elicitation_schema import form_to_elicitation_schema
 
 __all__ = [
     "FormValidationError",
     "collect_form_response",
     "form_from_dict",
     "form_to_askuserquestion",
+    "form_to_elicitation_schema",
 ]

--- a/src/attune/elicitation/elicitation_schema.py
+++ b/src/attune/elicitation/elicitation_schema.py
@@ -1,0 +1,78 @@
+"""Declarative form → MCP elicitation ``requestedSchema``.
+
+The v2 lead surface (decision D8) is MCP native elicitation: the server
+sends an ``elicitation/create`` request whose ``requestedSchema`` is a
+flat object of primitive properties, and the client returns a structured,
+keyed response that drops straight into
+:func:`attune.elicitation.collect_form_response`.
+
+This module holds the pure transform — the artifact's
+:class:`~attune.meta_workflows.models.FormSchema` to that schema dict.
+The live emit (``session.elicit_form``) lives in the MCP server; keeping
+the transform here makes it fully unit-testable and surface-agnostic.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from attune.meta_workflows.models import FormQuestion, FormSchema, QuestionType
+
+
+def _property_for(question: FormQuestion) -> dict[str, Any]:
+    """Build the elicitation schema property for one question.
+
+    Maps each :class:`QuestionType` to the matching MCP elicitation
+    primitive (flat object, primitives only — spec 2025-11-25).
+    """
+    prop: dict[str, Any] = {"title": question.text}
+
+    if question.type == QuestionType.SINGLE_SELECT:
+        prop.update(type="string", enum=list(question.options))
+    elif question.type == QuestionType.MULTI_SELECT:
+        prop.update(type="array", items={"type": "string", "enum": list(question.options)})
+        if question.required:
+            prop["minItems"] = 1
+    elif question.type == QuestionType.BOOLEAN:
+        prop["type"] = "boolean"
+    elif question.type == QuestionType.NUMBER:
+        prop["type"] = "number"
+        if question.minimum is not None:
+            prop["minimum"] = question.minimum
+        if question.maximum is not None:
+            prop["maximum"] = question.maximum
+    elif question.type == QuestionType.DATE:
+        prop.update(type="string", format="date")
+    else:  # TEXT_INPUT, TEXTAREA
+        prop["type"] = "string"
+        if question.max_length is not None:
+            prop["maxLength"] = question.max_length
+
+    if question.help_text:
+        prop["description"] = question.help_text
+    if question.default is not None:
+        prop["default"] = question.default
+    return prop
+
+
+def form_to_elicitation_schema(form: FormSchema) -> dict[str, Any]:
+    """Map a :class:`FormSchema` to an MCP elicitation ``requestedSchema``.
+
+    The result is a JSON-Schema object: ``{"type": "object",
+    "properties": {field_id: <property>, ...}, "required": [...]}``, ready
+    to pass to ``ServerSession.elicit_form``. The client's keyed
+    ``content`` response maps straight back through
+    :func:`collect_form_response` (the v1 validation seam).
+
+    Args:
+        form: The declarative form to render.
+
+    Returns:
+        The elicitation ``requestedSchema`` dict.
+    """
+    properties = {q.id: _property_for(q) for q in form.questions}
+    required = [q.id for q in form.questions if q.required]
+    return {"type": "object", "properties": properties, "required": required}

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -308,6 +308,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             "list_capabilities": lambda _args: self._handle_list_capabilities(),
             "elicitation_render_form": self._handle_elicitation_render_form,
             "elicitation_collect_response": self._handle_elicitation_collect_response,
+            "elicitation_ask": self._handle_elicitation_ask,
             "help_lookup": self._handle_help_lookup,
             "help_maintain": self._handle_help_maintain,
             "help_init": self._handle_help_init,
@@ -750,6 +751,93 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
 
         return {
             "success": True,
+            "responses": response.responses,
+            "response_id": response.response_id,
+        }
+
+    @staticmethod
+    def _elicitation_session() -> tuple[Any, Any]:
+        """Return ``(session, request_id)`` for the in-flight request.
+
+        The live MCP request context (set by the SDK during a tool call)
+        carries the session that can send an ``elicitation/create``
+        request. Returns ``(None, None)`` outside a request — the handler
+        treats that as "client can't elicit" and signals a fallback.
+        """
+        try:
+            ctx = _mcp_server.request_context
+        except (LookupError, RuntimeError, NameError):
+            return None, None
+        return getattr(ctx, "session", None), getattr(ctx, "request_id", None)
+
+    async def _handle_elicitation_ask(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Render a form as a native MCP elicitation and return answers.
+
+        The v2 rich surface (decision D8): builds an elicitation
+        ``requestedSchema`` from the declarative artifact, sends
+        ``elicitation/create`` via the live session, and on ``accept``
+        validates the structured response through
+        :func:`attune.elicitation.collect_form_response` (R4). On
+        ``decline``/``cancel`` returns that status; if the client cannot
+        elicit, returns ``action: "unsupported"`` so the caller can fall
+        back to ``elicitation_render_form`` (AskUserQuestion).
+
+        Args:
+            args: ``form`` (the declarative form dict) and optional
+                ``message`` (prompt shown above the form).
+
+        Returns:
+            ``{"success": True, "action": "accept", "responses", ...}`` or
+            ``{"success": False, "action"|"problems": ...}``.
+
+        """
+        from attune.elicitation import (
+            FormValidationError,
+            collect_form_response,
+            form_from_dict,
+            form_to_elicitation_schema,
+        )
+
+        try:
+            form = form_from_dict(args.get("form", {}))
+        except FormValidationError as e:
+            return {"success": False, "problems": e.problems}
+
+        schema = form_to_elicitation_schema(form)
+        message = args.get("message") or form.title or "Please complete this form."
+
+        session, request_id = self._elicitation_session()
+        if session is None:
+            return {
+                "success": False,
+                "action": "unsupported",
+                "error": "No MCP elicitation session available (client cannot elicit).",
+            }
+
+        try:
+            result = await session.elicit_form(message, schema, request_id)
+        except Exception as e:  # noqa: BLE001
+            # INTENTIONAL: any elicit failure (unsupported capability,
+            # transport) degrades to a fallback signal, never crashes.
+            logger.exception("Elicitation request failed")
+            return {
+                "success": False,
+                "action": "error",
+                "error": f"Elicitation failed: {type(e).__name__}",
+            }
+
+        action = getattr(result, "action", None)
+        if action != "accept":
+            return {"success": False, "action": action or "cancel", "responses": {}}
+
+        try:
+            response = collect_form_response(form, getattr(result, "content", None) or {})
+        except FormValidationError as e:
+            return {"success": False, "action": "accept", "problems": e.problems}
+
+        return {
+            "success": True,
+            "action": "accept",
             "responses": response.responses,
             "response_id": response.response_id,
         }

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -459,6 +459,31 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
                 "required": ["form", "answers"],
             },
         },
+        "elicitation_ask": {
+            "description": (
+                "Render a declarative form as a NATIVE MCP elicitation "
+                "dialog and return the user's validated answers in one call "
+                "(the v2 rich surface — supports number/date/textarea + "
+                "multi-select with a structured return). Builds the "
+                "requestedSchema, sends elicitation/create, and on accept "
+                "validates the response via collect_form_response. Returns "
+                "{success, action, responses} or {success: false, problems}. "
+                "If the client can't elicit, returns {success: false, "
+                "action: 'unsupported'} — fall back to elicitation_render_form "
+                "(AskUserQuestion)."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "form": form_schema,
+                    "message": {
+                        "type": "string",
+                        "description": "Optional prompt shown above the form",
+                    },
+                },
+                "required": ["form"],
+            },
+        },
     }
 
 

--- a/tests/unit/elicitation/test_elicitation_schema.py
+++ b/tests/unit/elicitation/test_elicitation_schema.py
@@ -1,0 +1,94 @@
+"""Tests for form_to_elicitation_schema — artifact → MCP requestedSchema.
+
+Covers every QuestionType mapping plus title/description/default/required
+threading. The lead v2 surface (D8) consumes this schema via
+``ServerSession.elicit_form``.
+"""
+
+from __future__ import annotations
+
+from attune.elicitation import form_from_dict, form_to_elicitation_schema
+
+
+def _schema(field: dict) -> dict:
+    form = form_from_dict({"title": "T", "fields": [field]})
+    return form_to_elicitation_schema(form)
+
+
+def _prop(field: dict) -> dict:
+    return _schema(field)["properties"][field["id"]]
+
+
+class TestTypeMapping:
+    def test_single_select(self):
+        p = _prop({"id": "g", "text": "Goal", "type": "single_select", "options": ["a", "b"]})
+        assert p == {"title": "Goal", "type": "string", "enum": ["a", "b"]}
+
+    def test_multi_select_required_sets_min_items(self):
+        p = _prop({"id": "f", "text": "Focus", "type": "multi_select", "options": ["x", "y"]})
+        assert p["type"] == "array"
+        assert p["items"] == {"type": "string", "enum": ["x", "y"]}
+        assert p["minItems"] == 1
+
+    def test_multi_select_optional_no_min_items(self):
+        p = _prop(
+            {
+                "id": "f",
+                "text": "Focus",
+                "type": "multi_select",
+                "options": ["x", "y"],
+                "required": False,
+            }
+        )
+        assert "minItems" not in p
+
+    def test_boolean(self):
+        p = _prop({"id": "b", "text": "Ship?", "type": "boolean"})
+        assert p == {"title": "Ship?", "type": "boolean"}
+
+    def test_number_with_bounds(self):
+        p = _prop({"id": "n", "text": "Age", "type": "number", "minimum": 0, "maximum": 120})
+        assert p == {"title": "Age", "type": "number", "minimum": 0, "maximum": 120}
+
+    def test_number_without_bounds(self):
+        p = _prop({"id": "n", "text": "Age", "type": "number"})
+        assert p == {"title": "Age", "type": "number"}
+
+    def test_date(self):
+        p = _prop({"id": "d", "text": "When", "type": "date"})
+        assert p == {"title": "When", "type": "string", "format": "date"}
+
+    def test_textarea_with_max_length(self):
+        p = _prop({"id": "t", "text": "Bio", "type": "textarea", "max_length": 280})
+        assert p == {"title": "Bio", "type": "string", "maxLength": 280}
+
+    def test_text_input_without_max_length(self):
+        p = _prop({"id": "t", "text": "Name", "type": "text_input"})
+        assert p == {"title": "Name", "type": "string"}
+
+
+class TestSchemaShape:
+    def test_help_text_becomes_description(self):
+        p = _prop({"id": "n", "text": "Age", "type": "number", "help_text": "Years since birth"})
+        assert p["description"] == "Years since birth"
+
+    def test_default_threaded(self):
+        p = _prop(
+            {"id": "g", "text": "Goal", "type": "single_select", "options": ["a"], "default": "a"}
+        )
+        assert p["default"] == "a"
+
+    def test_object_shape_and_required_list(self):
+        form = form_from_dict(
+            {
+                "title": "T",
+                "fields": [
+                    {"id": "req", "text": "R", "type": "text_input"},
+                    {"id": "opt", "text": "O", "type": "text_input", "required": False},
+                ],
+            }
+        )
+        schema = form_to_elicitation_schema(form)
+        assert schema["type"] == "object"
+        assert set(schema["properties"]) == {"req", "opt"}
+        assert schema["required"] == ["req"]

--- a/tests/unit/mcp/handlers/test_elicitation_ask.py
+++ b/tests/unit/mcp/handlers/test_elicitation_ask.py
@@ -1,0 +1,131 @@
+"""Tests for the elicitation_ask MCP handler (the v2 renderer).
+
+Drives the full server-side round-trip with a mocked session: build the
+requestedSchema, await session.elicit_form, and map the structured result
+back through collect_form_response. Covers accept (valid + R4-invalid),
+decline, cancel, capability-unsupported, elicit-raises, and a malformed
+form definition.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from attune.mcp.server import EmpathyMCPServer
+
+_FORM = {
+    "title": "Scope",
+    "fields": [
+        {"id": "goal", "text": "Goal?", "type": "single_select", "options": ["a", "b"]},
+        {"id": "age", "text": "Age", "type": "number", "minimum": 0, "maximum": 10},
+    ],
+}
+
+
+def _make_server() -> EmpathyMCPServer:
+    with patch.object(EmpathyMCPServer, "_register_plugin_tools"):
+        with patch("attune.mcp.version_check.check_for_updates", return_value=None):
+            return EmpathyMCPServer()
+
+
+class _Result:
+    def __init__(self, action, content=None):
+        self.action = action
+        self.content = content
+
+
+class _Session:
+    """Fake ServerSession capturing the elicit_form call."""
+
+    def __init__(self, result=None, raises=None):
+        self._result = result
+        self._raises = raises
+        self.calls = []
+
+    async def elicit_form(self, message, schema, request_id):
+        self.calls.append({"message": message, "schema": schema, "request_id": request_id})
+        if self._raises:
+            raise self._raises
+        return self._result
+
+
+def _with_session(server, session, request_id="req-1"):
+    server._elicitation_session = lambda: (session, request_id)
+
+
+class TestElicitationAsk:
+    @pytest.mark.asyncio
+    async def test_accept_valid_returns_responses(self):
+        server = _make_server()
+        sess = _Session(_Result("accept", {"goal": "a", "age": 5}))
+        _with_session(server, sess)
+        out = await server._handle_elicitation_ask({"form": _FORM, "message": "hi"})
+        assert out["success"] is True
+        assert out["action"] == "accept"
+        assert out["responses"] == {"goal": "a", "age": 5}
+        # the built schema reached the session, keyed by field id
+        assert sess.calls[0]["schema"]["properties"]["age"]["maximum"] == 10
+        assert sess.calls[0]["message"] == "hi"
+        assert sess.calls[0]["request_id"] == "req-1"
+
+    @pytest.mark.asyncio
+    async def test_accept_invalid_returns_problems(self):
+        server = _make_server()
+        _with_session(server, _Session(_Result("accept", {"goal": "zzz", "age": 99})))
+        out = await server._handle_elicitation_ask({"form": _FORM})
+        assert out["success"] is False
+        assert out["action"] == "accept"
+        assert any("goal" in p for p in out["problems"])
+        assert any("age" in p for p in out["problems"])
+
+    @pytest.mark.asyncio
+    async def test_message_defaults_to_form_title(self):
+        server = _make_server()
+        sess = _Session(_Result("accept", {"goal": "a", "age": 0}))
+        _with_session(server, sess)
+        await server._handle_elicitation_ask({"form": _FORM})
+        assert sess.calls[0]["message"] == "Scope"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("action", ["decline", "cancel"])
+    async def test_decline_or_cancel(self, action):
+        server = _make_server()
+        _with_session(server, _Session(_Result(action, None)))
+        out = await server._handle_elicitation_ask({"form": _FORM})
+        assert out["success"] is False
+        assert out["action"] == action
+        assert out["responses"] == {}
+
+    @pytest.mark.asyncio
+    async def test_unsupported_when_no_session(self):
+        server = _make_server()
+        server._elicitation_session = lambda: (None, None)
+        out = await server._handle_elicitation_ask({"form": _FORM})
+        assert out["success"] is False
+        assert out["action"] == "unsupported"
+
+    @pytest.mark.asyncio
+    async def test_elicit_raises_degrades_to_error(self):
+        server = _make_server()
+        _with_session(server, _Session(raises=RuntimeError("no elicitation capability")))
+        out = await server._handle_elicitation_ask({"form": _FORM})
+        assert out["success"] is False
+        assert out["action"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_malformed_form_rejected_before_eliciting(self):
+        server = _make_server()
+        sess = _Session(_Result("accept", {}))
+        _with_session(server, sess)
+        # missing options on a select → bad definition
+        bad = {"title": "T", "fields": [{"id": "g", "text": "G", "type": "single_select"}]}
+        out = await server._handle_elicitation_ask({"form": bad})
+        assert out["success"] is False
+        assert "problems" in out
+        assert sess.calls == []  # never reached the session
+
+    def test_elicitation_session_outside_request_returns_none(self):
+        # No live MCP request context → (None, None), the fallback signal.
+        assert EmpathyMCPServer._elicitation_session() == (None, None)

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -24,15 +24,15 @@ def server():
 
 
 class TestToolRegistration:
-    """Verify all tools are registered (45 core + 5 optional redis plugin)."""
+    """Verify all tools are registered (46 core + 5 optional redis plugin)."""
 
     def test_tools_list_returns_at_least_core_count(self, server: EmpathyMCPServer):
-        """Core tools (45) are always registered; attune-redis adds 5 more."""
+        """Core tools (46) are always registered; attune-redis adds 5 more."""
         tools = server.get_tool_list()
         tool_names = {t["name"] for t in tools}
 
-        # 45 core tools must always be present
-        assert len(tools) >= 45
+        # 46 core tools must always be present
+        assert len(tools) >= 46
 
         # When attune-redis plugin is installed, all 5 redis tools are present
         redis_tools = {
@@ -43,7 +43,7 @@ class TestToolRegistration:
             "redis_memory_store",
         }
         if redis_tools.issubset(tool_names):
-            assert len(tools) == 50, f"Expected 50 tools with redis plugin, got {len(tools)}"
+            assert len(tools) == 51, f"Expected 51 tools with redis plugin, got {len(tools)}"
 
     def test_memory_tools_registered(self, server: EmpathyMCPServer):
         """Test that all memory tools are in the tool list."""


### PR DESCRIPTION
## What

**V2.2** — the MCP elicitation renderer. Renders the declarative artifact
as a native `elicitation/create` dialog (the v2 lead surface, D8) and
returns the user's validated answers in one tool call. Completes the v2
build (V2.0 surface decision → V2.1 rich controls → V2.2 renderer).

## Grounding (verify-first, confirmed against the installed MCP SDK)

`ServerSession.elicit_form(message, requestedSchema, related_request_id)
-> ElicitResult{action, content}` sends form-mode elicitation;
`requestedSchema` is a plain dict; the structured keyed `content` maps
straight into the v1 validation seam. A tool handler reaches the live
session via `Server.request_context` (`.session`, `.request_id`).

## Changes

- **`form_to_elicitation_schema(form)`** (`attune.elicitation`, new
  module): artifact → elicitation `requestedSchema` for all 7 controls —
  single→`string`+`enum`, multi→`array`+`items.enum` (`minItems` when
  required), number→`number`+`minimum`/`maximum`, date→`string`
  `format:date`, textarea/text→`string`+`maxLength`, boolean→`boolean`;
  `title`/`description`/`default`/`required` threaded. 100% line+branch.
- **`elicitation_ask` MCP tool**: the full server-side round-trip — build
  the schema, `await session.elicit_form(...)`, and on `accept` validate
  `content` via `collect_form_response` (R4). `decline`/`cancel` return
  cleanly; a missing/incapable session returns `action: "unsupported"` /
  `"error"` so callers fall back to `elicitation_render_form`
  (AskUserQuestion). Mocked-session tests cover every path.
- Tool count 45→46 core (50→51 redis); `elicit` skill documents the
  rich-native vs portable surface choice; D9 recorded.

## R5 caveat

The *true* live round-trip needs an elicitation-capable client AND the
MCP server running this code (the session's server boots per session, so
new tools surface only after a restart). The mocked-session test proves
the transform + emit + collect path end to end; the live dogfood is the
first action of the next session that boots the updated server — same
pattern V2.0 used.

## Test

Elicitation + new handler + MCP memory suites: 118 passed; mcp + plugins
481 passed (1 unrelated keyed live-API test fails locally, skipped in CI).
New transform 100% line+branch. black + pinned-ruff clean.
