### PR TITLE
feat(elicitation): S1 show_widget rich surface + D10 enum fix

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -56,17 +56,30 @@ Field `type` is one of `single_select`, `multi_select`, `boolean`,
 `text_input`, `number` (with `minimum`/`maximum`), `date` (ISO
 `YYYY-MM-DD`), or `textarea` (with `max_length`). `id` is the stable key
 the answer comes back under. The last three are **rich controls** — they
-only render on the native elicitation surface below, not AskUserQuestion.
+render on the native elicitation (`elicitation_ask`) and widget
+(`elicitation_render_widget`) surfaces below, but degrade to plain text
+on AskUserQuestion.
 
 ## Choosing a surface
 
 - **Rich / native — one call:** `elicitation_ask` renders the form as a
   native MCP elicitation dialog (supports number/date/textarea +
   multi-select with a structured return) and returns the validated
-  answers in a single call — no manual `AskUserQuestion` mapping. Prefer
-  it when the client supports elicitation or the form uses a rich
-  control. It returns `{success: false, action: "unsupported"}` if the
-  client can't elicit — then fall back to the portable path.
+  answers in a single call — no manual `AskUserQuestion` mapping. It
+  returns `{success: false, action: "unsupported"}` when the client
+  can't elicit. **Caveat (Claude Code, observed 2026-06-27, decisions
+  D10):** some clients advertise elicitation but **auto-decline form
+  requests without rendering** — you get `action: "decline"` and no
+  dialog. Treat a `decline` you didn't see the user make as
+  "surface unavailable" and fall back; don't report it as the user
+  saying no.
+- **Rich / widget — `show_widget`:** `elicitation_render_widget` returns
+  inline HTML that renders ALL 7 controls richly (number spinner, date
+  picker, multi-line textarea, multi-select checkboxes). Pass its `html`
+  straight to `mcp__visualize__show_widget`; the user submits and the
+  widget posts the answers back (see "Widget surface" below). Best
+  rich surface on widget-capable clients (Cowork/claude.ai) when native
+  elicitation doesn't render.
 - **Portable — AskUserQuestion:** steps 2–4 below map the form onto
   `AskUserQuestion` (selects/booleans/short text only). Use this as the
   fallback, or when you want the recommendation-first button UX.
@@ -123,6 +136,25 @@ call `elicitation_collect_response` with `{ "form": <the form>,
 - Failure → `{ "success": false, "problems": [ … ] }` names exactly
   which fields are missing-required or out-of-option. **Re-ask only
   those fields** (a one-field form) — never silently proceed.
+
+## Widget surface — `show_widget` round-trip
+
+Use this instead of steps 2–4 when you want the rich controls on a
+widget-capable client:
+
+1. Call `elicitation_render_widget` with `{ "form": <the form> }`. On
+   success you get `{ "html", "title", "field_ids" }`; on a bad form,
+   `{ "success": false, "problems": [...] }` — fix and re-render.
+2. Pass `html` verbatim to `mcp__visualize__show_widget`.
+3. The user fills the form and submits. The widget posts a chat message
+   containing a fenced JSON block marked `__elicitation_response__`,
+   e.g. `{"__elicitation_response__": true, "title": "...", "answers":
+   {<field_id>: <value>}}` (multi-select → list, number → number,
+   date → `YYYY-MM-DD`, boolean → `"Yes"`/`"No"`).
+4. When that message arrives, parse the JSON block and call
+   `elicitation_collect_response` with `{ "form": <the same form>,
+   "answers": <the payload's answers> }` to validate (R4). Re-ask only
+   the fields it flags as problems — never proceed on raw widget output.
 
 ## Worked example — `/attune` discovery in one turn
 

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -353,6 +353,44 @@ D9/D10). Next session: render a form, submit it, confirm the
 `sendPrompt` JSON parses → `collect_form_response`. Tests prove the
 transform + emit; the live receipt is deferred.
 
+## D12 — adoption gap: the enhanced form is consumed by ONE path, and most features are not fits
+
+**Date:** 2026-06-27 · **Status:** finding (recorded at Patrick's
+request) · grounded by grep, not assumed
+
+The v1/v2 elicitation surface is built and validated standalone, but a
+grep of `plugin/skills` + `plugin/commands` for consumers shows
+**adoption = one path**: the `elicit` skill itself, reachable only via
+the `attune-hub` routing table (`"scope this" → elicit`). **No feature
+workflow has adopted it**, and the design's named first integration —
+`/attune` discovery (design.md §5, G3, "for sign-off") — was never
+wired. Classic "registered ≠ working" adoption gap.
+
+But "wire it everywhere" is the wrong conclusion — the §4 batching rule
+itself says stay single-question when only one dimension is unknown.
+The features split:
+
+- **Genuine fits (multi-dimension intake) — the real adoption targets:**
+  - `/spec` — does the heaviest interactive scoping of any feature, all
+    **raw one-at-a-time `AskUserQuestion`** (mode / plan-approval /
+    between-stage gates). Its kickoff (goal + scope + focus) is
+    *literally* the elicit worked example, yet unconverted. Highest
+    payoff.
+  - `/attune` discovery — goal + scope + concerns; design's named first
+    target.
+  - `/planning` — feature/tdd/architecture + scope (maybe).
+- **Not fits (single-arg / path-scoped) — should stay one-question:**
+  `/code-quality`, `/security-audit`, `/bug-predict`, `/smart-test`,
+  `/release-prep` each take one `argument-hint` (a path/version). At
+  most one genuine question; a multi-field form there is the
+  "bureaucratic intake" the rule warns against.
+
+**Takeaway:** the gap is ~2–3 genuinely multi-dimension flows (not 22),
+and the highest-value one (`/spec`) is the design's own showcase still
+running the old way. A real first-consumer integration — not another
+surface — is the next move that would prove the form earns its keep.
+Needs its own scoping (which flow, behind the §4 rule); not started.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -260,6 +260,99 @@ boots the updated server. This is the v2 build's renderer — V2.0–V2.2
 (the three build phases) are now complete; V2.3 (designer/data-binding)
 stays held.
 
+## D10 — live R5 dogfood: native form rendering NOT supported by the CC client
+
+**Date:** 2026-06-27 · **Status:** decided (Patrick observed the live run)
+
+The deferred R5 receipt from D9 finally ran: a fresh session booted the
+MCP server on V2.2 code, so `mcp__attune-ai__elicitation_ask` was live.
+Two declarative forms were sent through it.
+
+**Result — the lead surface (D8) does NOT render on Claude Code today.**
+The client advertises an elicitation session (so the handler did *not*
+short-circuit to `unsupported` — `session is not None`), `elicit_form`
+was sent, and the client returned `action: "decline"` with **no dialog
+shown** (Patrick confirmed nothing appeared on screen). So:
+
+- Server-side mechanics are proven live: artifact → `requestedSchema`
+  → `elicit_form` → structured `ElicitResult` → clean non-accept
+  handling, no crash. The emit + decline path round-trips end to end.
+- Native form **rendering** is unproven — this CC build auto-declines
+  form elicitation instead of presenting it. D8's "MCP elicitation
+  leads" bet is **not validated on this client**; the AskUserQuestion
+  fallback (v1's choice) remains the only working surface here.
+- **Design gap:** `elicitation_ask` only self-falls-back when
+  `session is None` (→ `unsupported`). An unrendered auto-`decline`
+  is indistinguishable from a real user "no", so the caller never
+  falls back to `elicitation_render_form`. The lead surface silently
+  no-ops as a decline. (server.py:810–831.)
+
+**Bug found — rich controls unreachable through the MCP front door.**
+A form with a `date`/`number` field is rejected at input validation:
+`'date' is not one of ['text_input','single_select','multi_select',
+'boolean']`. `elicitation_ask` reuses the v1 `field_schema`
+(tool_schemas.py:389–409, shared with the AskUserQuestion bridge),
+whose `type` enum was never widened — even though V2.1 added
+number/date/textarea to the artifact, V2.2's
+`form_to_elicitation_schema` handles all 7, and the tool's own
+description advertises them. Fix is NOT a global enum widen (v1
+`render_form`/`collect_response` intentionally support 4 — AskUser
+Question has no native number/date); `elicitation_ask` needs its own
+7-type field schema.
+
+This closes the "registered ≠ working" gap for v2 honestly: the
+plumbing works, the lead-surface premise does not hold on CC, and the
+front door rejects the very controls V2.1 added.
+
+## D11 — S1 (`show_widget`) built as the rich surface; D10 enum fix shipped with it
+
+**Date:** 2026-06-27 · **Status:** decided (Patrick chose "build S1,
+existing 7 first")
+
+D10 showed native elicitation does not render on Claude Code, which
+promotes S1 (`show_widget`) from "escape hatch" to the **working rich
+surface**. Scope chosen: render the existing **7** controls; the new
+`slider`/`color` types stay deferred (they'd touch the locked D3 model
+— a clean follow-up).
+
+Shipped:
+
+- **`form_to_widget_html(form, message)`** (`attune.elicitation.widget`)
+  — the pure `FormSchema → HTML` transform. Self-contained (scoped
+  CDS-token styles, transparent bg, no `position:fixed`), one control
+  per type (number spinner / date picker / multi-line textarea /
+  multi-select checkboxes / Yes-No select). Injection-safe: all
+  form text is `html.escape`d and the submit script reads the DOM by
+  `data-*` attributes — no form data is interpolated into executable JS.
+- **Postback shape (S1, per D4/D8):** on submit the widget calls the
+  global `sendPrompt` with a sentinel-marked fenced JSON block
+  (`__elicitation_response__`, `WIDGET_RESPONSE_MARKER`); number →
+  number, multi-select → list, date → `YYYY-MM-DD`, boolean →
+  `Yes`/`No`. The agent parses it and validates through the EXISTING
+  `collect_form_response` (R4) — no new collection logic.
+- **`elicitation_render_widget` MCP tool** — returns `{html, title,
+  field_ids}`; agent passes `html` to `mcp__visualize__show_widget`.
+- **`elicit` skill** — added the "Choosing a surface" widget bullet +
+  a "Widget surface" round-trip section, and the D10 caveat (a CC
+  `decline` you didn't see the user make = surface unavailable, fall
+  back; don't read it as the user saying no).
+
+**D10 finding #2 fixed as a prerequisite.** `elicitation_render_widget`
+(and `elicitation_ask`) now use a **`rich_form_schema`** whose `type`
+enum lists all 7 controls + `minimum`/`maximum`/`max_length`; v1
+`render_form`/`collect_response` stay on the 4-type schema
+(AskUserQuestion has no native number/date). Without this the rich
+controls
+were rejected at the MCP boundary for the widget tool too, so the fix
+had to land here. Guarded by `test_tool_schemas` (v2 = 7, v1 = 4).
+
+**Not done (live S1 dogfood):** the show_widget round-trip itself is
+unproven *this* session — `elicitation_render_widget` reaches the MCP
+server only after a restart (same per-session-server constraint as
+D9/D10). Next session: render a form, submit it, confirm the
+`sendPrompt` JSON parses → `collect_form_response`. Tests prove the
+transform + emit; the live receipt is deferred.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -58,17 +58,30 @@ Field `type` is one of `single_select`, `multi_select`, `boolean`,
 `text_input`, `number` (with `minimum`/`maximum`), `date` (ISO
 `YYYY-MM-DD`), or `textarea` (with `max_length`). `id` is the stable key
 the answer comes back under. The last three are **rich controls** — they
-only render on the native elicitation surface below, not AskUserQuestion.
+render on the native elicitation (`elicitation_ask`) and widget
+(`elicitation_render_widget`) surfaces below, but degrade to plain text
+on AskUserQuestion.
 
 ## Choosing a surface
 
 - **Rich / native — one call:** `elicitation_ask` renders the form as a
   native MCP elicitation dialog (supports number/date/textarea +
   multi-select with a structured return) and returns the validated
-  answers in a single call — no manual `AskUserQuestion` mapping. Prefer
-  it when the client supports elicitation or the form uses a rich
-  control. It returns `{success: false, action: "unsupported"}` if the
-  client can't elicit — then fall back to the portable path.
+  answers in a single call — no manual `AskUserQuestion` mapping. It
+  returns `{success: false, action: "unsupported"}` when the client
+  can't elicit. **Caveat (Claude Code, observed 2026-06-27, decisions
+  D10):** some clients advertise elicitation but **auto-decline form
+  requests without rendering** — you get `action: "decline"` and no
+  dialog. Treat a `decline` you didn't see the user make as
+  "surface unavailable" and fall back; don't report it as the user
+  saying no.
+- **Rich / widget — `show_widget`:** `elicitation_render_widget` returns
+  inline HTML that renders ALL 7 controls richly (number spinner, date
+  picker, multi-line textarea, multi-select checkboxes). Pass its `html`
+  straight to `mcp__visualize__show_widget`; the user submits and the
+  widget posts the answers back (see "Widget surface" below). Best
+  rich surface on widget-capable clients (Cowork/claude.ai) when native
+  elicitation doesn't render.
 - **Portable — AskUserQuestion:** steps 2–4 below map the form onto
   `AskUserQuestion` (selects/booleans/short text only). Use this as the
   fallback, or when you want the recommendation-first button UX.
@@ -125,6 +138,25 @@ call `elicitation_collect_response` with `{ "form": <the form>,
 - Failure → `{ "success": false, "problems": [ … ] }` names exactly
   which fields are missing-required or out-of-option. **Re-ask only
   those fields** (a one-field form) — never silently proceed.
+
+## Widget surface — `show_widget` round-trip
+
+Use this instead of steps 2–4 when you want the rich controls on a
+widget-capable client:
+
+1. Call `elicitation_render_widget` with `{ "form": <the form> }`. On
+   success you get `{ "html", "title", "field_ids" }`; on a bad form,
+   `{ "success": false, "problems": [...] }` — fix and re-render.
+2. Pass `html` verbatim to `mcp__visualize__show_widget`.
+3. The user fills the form and submits. The widget posts a chat message
+   containing a fenced JSON block marked `__elicitation_response__`,
+   e.g. `{"__elicitation_response__": true, "title": "...", "answers":
+   {<field_id>: <value>}}` (multi-select → list, number → number,
+   date → `YYYY-MM-DD`, boolean → `"Yes"`/`"No"`).
+4. When that message arrives, parse the JSON block and call
+   `elicitation_collect_response` with `{ "form": <the same form>,
+   "answers": <the payload's answers> }` to validate (R4). Re-ask only
+   the fields it flags as problems — never proceed on raw widget output.
 
 ## Worked example — `/attune` discovery in one turn
 

--- a/src/attune/elicitation/__init__.py
+++ b/src/attune/elicitation/__init__.py
@@ -30,11 +30,14 @@ from attune.elicitation.bridge import (
     form_to_askuserquestion,
 )
 from attune.elicitation.elicitation_schema import form_to_elicitation_schema
+from attune.elicitation.widget import WIDGET_RESPONSE_MARKER, form_to_widget_html
 
 __all__ = [
+    "WIDGET_RESPONSE_MARKER",
     "FormValidationError",
     "collect_form_response",
     "form_from_dict",
     "form_to_askuserquestion",
     "form_to_elicitation_schema",
+    "form_to_widget_html",
 ]

--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -1,0 +1,233 @@
+"""Declarative-form → ``show_widget`` HTML renderer (elicitation v2 / S1).
+
+The "escape hatch" surface from decision D8: render the SAME declarative
+artifact (D3) as an inline HTML form for the ``mcp__visualize__show_widget``
+tool. Unlike the AskUserQuestion bridge (v1) and native MCP elicitation
+(v2 lead surface), this surface renders the v2.1 rich controls
+(``number``/``date``/``textarea`` with real spinner/date-picker/multiline
+widgets) and is the home for controls no other surface can express.
+
+Return path (the S1-specific shape — D4/D8): the widget has no structured
+callback, only the global ``sendPrompt(text)``. On submit it serializes the
+answers to JSON inside a sentinel-marked message; the agent parses that and
+re-uses the existing :func:`attune.elicitation.collect_form_response`
+validation seam (R4). This module owns ONLY the pure
+``FormSchema -> html`` transform — no agent or tool dependency — so it is
+fully testable.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from html import escape
+
+from attune.meta_workflows.models import FormQuestion, FormSchema, QuestionType
+
+#: Sentinel key the submit payload carries so the agent can recognise a
+#: form postback among ordinary chat messages and route it to
+#: ``collect_form_response``. Kept in sync with the ``elicit`` skill.
+WIDGET_RESPONSE_MARKER = "__elicitation_response__"
+
+#: The Yes/No values a BOOLEAN control posts (``collect_form_response``
+#: validates a boolean answer against exactly these).
+_BOOLEAN_OPTIONS = ("Yes", "No")
+
+
+def _esc(value: object) -> str:
+    """HTML-escape a value for safe use in text or a quoted attribute."""
+    return escape(str(value), quote=True)
+
+
+def _control_html(q: FormQuestion) -> str:
+    """Render the input control for one question (no label/wrapper).
+
+    Every control carries ``data-control`` so the submit script can find
+    it generically; numeric/length bounds are mirrored onto the native
+    attributes for in-widget feedback, but the authoritative check is
+    still server-side ``collect_form_response`` (R4).
+
+    Args:
+        q: The question to render a control for.
+
+    Returns:
+        An HTML fragment for the control.
+    """
+    if q.type == QuestionType.MULTI_SELECT:
+        boxes = "".join(
+            f'<label class="ae-check"><input type="checkbox" data-control '
+            f'value="{_esc(opt)}"{_checked(q, opt)}> {_esc(opt)}</label>'
+            for opt in q.options
+        )
+        return f'<div class="ae-checks">{boxes}</div>'
+
+    if q.type == QuestionType.SINGLE_SELECT:
+        opts = '<option value="">— choose —</option>' + "".join(
+            f'<option value="{_esc(opt)}"{_selected(q, opt)}>{_esc(opt)}</option>'
+            for opt in q.options
+        )
+        return f'<select data-control class="ae-input">{opts}</select>'
+
+    if q.type == QuestionType.BOOLEAN:
+        opts = '<option value="">—</option>' + "".join(
+            f'<option value="{_esc(o)}"{_selected(q, o)}>{_esc(o)}</option>'
+            for o in _BOOLEAN_OPTIONS
+        )
+        return f'<select data-control class="ae-input">{opts}</select>'
+
+    if q.type == QuestionType.NUMBER:
+        bounds = ""
+        if q.minimum is not None:
+            bounds += f' min="{_esc(q.minimum)}"'
+        if q.maximum is not None:
+            bounds += f' max="{_esc(q.maximum)}"'
+        default = f' value="{_esc(q.default)}"' if q.default is not None else ""
+        return (
+            f'<input type="number" step="any" data-control class="ae-input"' f"{bounds}{default}>"
+        )
+
+    if q.type == QuestionType.DATE:
+        default = f' value="{_esc(q.default)}"' if q.default is not None else ""
+        return f'<input type="date" data-control class="ae-input"{default}>'
+
+    if q.type == QuestionType.TEXTAREA:
+        maxlen = f' maxlength="{_esc(q.max_length)}"' if q.max_length else ""
+        default = _esc(q.default) if q.default is not None else ""
+        return (
+            f'<textarea data-control class="ae-input ae-textarea" rows="3"'
+            f"{maxlen}>{default}</textarea>"
+        )
+
+    # TEXT_INPUT (default).
+    maxlen = f' maxlength="{_esc(q.max_length)}"' if q.max_length else ""
+    default = f' value="{_esc(q.default)}"' if q.default is not None else ""
+    return f'<input type="text" data-control class="ae-input"{maxlen}{default}>'
+
+
+def _checked(q: FormQuestion, opt: str) -> str:
+    """Return ``checked`` if ``opt`` is the question's default selection."""
+    return " checked" if q.default is not None and opt == q.default else ""
+
+
+def _selected(q: FormQuestion, opt: str) -> str:
+    """Return ``selected`` if ``opt`` is the question's default value."""
+    return " selected" if q.default is not None and opt == q.default else ""
+
+
+def _field_html(q: FormQuestion) -> str:
+    """Render one labelled field (label + optional help + control)."""
+    req = '<span class="ae-req" title="required">*</span>' if q.required else ""
+    help_html = f'<div class="ae-help">{_esc(q.help_text)}</div>' if q.help_text else ""
+    return (
+        f'<div class="ae-field" data-fid="{_esc(q.id)}" '
+        f'data-ftype="{_esc(q.type.value)}">'
+        f'<label class="ae-label">{_esc(q.text)}{req}</label>'
+        f"{help_html}{_control_html(q)}</div>"
+    )
+
+
+def form_to_widget_html(form: FormSchema, message: str = "") -> str:
+    """Render a declarative form as an inline ``show_widget`` HTML form.
+
+    The S1 surface (D8). The returned HTML is self-contained (scoped
+    styles + a submit script) and theme-native (Claude Design System CSS
+    variables, transparent background, no ``position: fixed``). On submit
+    it posts a sentinel-marked JSON payload via the global
+    ``sendPrompt`` so the agent can validate it through
+    :func:`collect_form_response`.
+
+    All form-supplied text is HTML-escaped, and no form data is
+    interpolated into executable script — the submit handler reads the
+    DOM generically by ``data-*`` attributes — so a malicious label or
+    option cannot inject markup or script.
+
+    Args:
+        form: The validated form to render (build it with
+            :func:`form_from_dict` first).
+        message: Optional prompt shown above the form.
+
+    Returns:
+        An HTML string ready to pass straight to
+        ``mcp__visualize__show_widget``.
+    """
+    intro = f'<p class="ae-msg">{_esc(message)}</p>' if message else ""
+    desc = f'<p class="ae-desc">{_esc(form.description)}</p>' if form.description else ""
+    fields = "".join(_field_html(q) for q in form.questions)
+
+    return f"""<h2 class="sr-only">{_esc(form.title)} — interactive form</h2>
+<form id="attune-elicit-form" data-form-title="{_esc(form.title)}">
+<style>
+#attune-elicit-form {{ display:block; width:100%; padding:1rem 0;
+  color:var(--text-primary); line-height:1.5; }}
+#attune-elicit-form .sr-only {{ position:absolute; width:1px; height:1px;
+  overflow:hidden; clip:rect(0 0 0 0); }}
+#attune-elicit-form h3 {{ font-size:18px; font-weight:500; margin:0 0 .25rem; }}
+#attune-elicit-form .ae-msg {{ margin:0 0 .5rem; color:var(--text-secondary); }}
+#attune-elicit-form .ae-desc {{ margin:0 0 1rem; color:var(--text-muted);
+  font-size:15px; }}
+#attune-elicit-form .ae-field {{ margin:0 0 1rem; }}
+#attune-elicit-form .ae-label {{ display:block; font-weight:500;
+  margin:0 0 .35rem; }}
+#attune-elicit-form .ae-req {{ color:var(--text-accent); margin-left:2px; }}
+#attune-elicit-form .ae-help {{ font-size:13px; color:var(--text-muted);
+  margin:0 0 .35rem; }}
+#attune-elicit-form .ae-input {{ width:100%; box-sizing:border-box;
+  padding:.5rem .6rem; font-size:15px; color:var(--text-primary);
+  background:var(--surface-1); border:1px solid var(--border);
+  border-radius:var(--radius); }}
+#attune-elicit-form .ae-textarea {{ resize:vertical; min-height:3.5rem; }}
+#attune-elicit-form .ae-checks {{ display:flex; flex-direction:column;
+  gap:.35rem; }}
+#attune-elicit-form .ae-check {{ display:flex; align-items:center; gap:.5rem;
+  font-weight:400; }}
+#attune-elicit-form .ae-submit {{ margin-top:.5rem; padding:.55rem 1.1rem;
+  font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary);
+  background:var(--bg-accent); border:1px solid var(--border-accent);
+  border-radius:var(--radius); }}
+#attune-elicit-form .ae-submit:disabled {{ opacity:.6; cursor:default; }}
+#attune-elicit-form .ae-error {{ margin-top:.5rem; font-size:14px;
+  color:var(--text-accent); }}
+</style>
+<h3>{_esc(form.title)}</h3>
+{intro}{desc}
+{fields}
+<button type="button" id="ae-submit" class="ae-submit">Submit</button>
+<div id="ae-error" class="ae-error" role="alert"></div>
+<script>
+(function() {{
+  var form = document.getElementById('attune-elicit-form');
+  var btn = document.getElementById('ae-submit');
+  var err = document.getElementById('ae-error');
+  if (!form || !btn) return;
+  btn.addEventListener('click', function() {{
+    var answers = {{}};
+    form.querySelectorAll('.ae-field').forEach(function(f) {{
+      var fid = f.getAttribute('data-fid');
+      var ftype = f.getAttribute('data-ftype');
+      if (ftype === 'multi_select') {{
+        var vals = [];
+        f.querySelectorAll('[data-control]:checked').forEach(function(c) {{
+          vals.push(c.value);
+        }});
+        answers[fid] = vals;
+      }} else {{
+        var el = f.querySelector('[data-control]');
+        if (!el || el.value === '') return;
+        answers[fid] = (ftype === 'number') ? Number(el.value) : el.value;
+      }}
+    }});
+    var payload = {{ {WIDGET_RESPONSE_MARKER!r}: true,
+      title: form.getAttribute('data-form-title'), answers: answers }};
+    if (typeof sendPrompt === 'function') {{
+      sendPrompt('Elicitation form submitted — parse and validate this '
+        + 'response:\\n```json\\n' + JSON.stringify(payload) + '\\n```');
+      btn.disabled = true; btn.textContent = 'Submitted \\u2713';
+    }} else {{
+      err.textContent = 'This surface cannot post back (sendPrompt '
+        + 'unavailable). Use the AskUserQuestion fallback.';
+    }}
+  }});
+}})();
+</script>
+</form>"""

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -309,6 +309,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             "elicitation_render_form": self._handle_elicitation_render_form,
             "elicitation_collect_response": self._handle_elicitation_collect_response,
             "elicitation_ask": self._handle_elicitation_ask,
+            "elicitation_render_widget": self._handle_elicitation_render_widget,
             "help_lookup": self._handle_help_lookup,
             "help_maintain": self._handle_help_maintain,
             "help_init": self._handle_help_init,
@@ -718,6 +719,43 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             "title": form.title,
             "description": form.description,
             "batches": form_to_askuserquestion(form),
+        }
+
+    async def _handle_elicitation_render_widget(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Render a declarative form as inline HTML for ``show_widget`` (S1).
+
+        Live wiring of :func:`attune.elicitation.form_to_widget_html` — the
+        v2 escape-hatch surface (D8). Returns the self-contained HTML for
+        ``mcp__visualize__show_widget``; on submit the widget posts a
+        sentinel-marked JSON block via ``sendPrompt`` which the agent
+        validates through ``elicitation_collect_response`` (R4). A malformed
+        form definition returns ``{"success": False, "problems": [...]}``.
+
+        Args:
+            args: ``form`` (the declarative form dict) and optional
+                ``message`` (prompt shown above the form).
+
+        Returns:
+            ``{"success": True, "html", "title", "field_ids"}`` or
+            ``{"success": False, "problems": [...]}``.
+
+        """
+        from attune.elicitation import (
+            FormValidationError,
+            form_from_dict,
+            form_to_widget_html,
+        )
+
+        try:
+            form = form_from_dict(args.get("form", {}))
+        except FormValidationError as e:
+            return {"success": False, "problems": e.problems}
+
+        return {
+            "success": True,
+            "html": form_to_widget_html(form, args.get("message") or ""),
+            "title": form.title,
+            "field_ids": [q.id for q in form.questions],
         }
 
     async def _handle_elicitation_collect_response(self, args: dict[str, Any]) -> dict[str, Any]:

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -421,6 +421,54 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
         },
         "required": ["title", "fields"],
     }
+    # The v2 rich surfaces (elicitation_ask, render_widget) render all 7
+    # controls, so their field schema exposes the full type enum + the
+    # v2.1 numeric/length bounds. v1 (render_form/collect_response) stays on
+    # the 4-type schema above — AskUserQuestion has no native number/date,
+    # so it would only degrade them to free text (D10 enum-honesty fix).
+    rich_field_schema = {
+        "type": "object",
+        "properties": {
+            **field_schema["properties"],
+            "type": {
+                "type": "string",
+                "enum": [
+                    "text_input",
+                    "textarea",
+                    "single_select",
+                    "multi_select",
+                    "boolean",
+                    "number",
+                    "date",
+                ],
+                "description": (
+                    "Control type. v1: text_input/single_select/multi_select/"
+                    "boolean. v2.1 rich: textarea, number (min/max), date "
+                    "(YYYY-MM-DD)."
+                ),
+            },
+            "minimum": {"type": "number", "description": "Lower bound for number"},
+            "maximum": {"type": "number", "description": "Upper bound for number"},
+            "max_length": {
+                "type": "integer",
+                "description": "Max length for text_input/textarea",
+            },
+        },
+        "required": ["id", "text", "type"],
+    }
+    rich_form_schema = {
+        "type": "object",
+        "description": "Declarative form artifact (data, not code — D3).",
+        "properties": {
+            **form_schema["properties"],
+            "fields": {
+                "type": "array",
+                "items": rich_field_schema,
+                "description": "The form's fields (alias: 'questions')",
+            },
+        },
+        "required": ["title", "fields"],
+    }
     return {
         "elicitation_render_form": {
             "description": (
@@ -475,7 +523,34 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
             "input_schema": {
                 "type": "object",
                 "properties": {
-                    "form": form_schema,
+                    "form": rich_form_schema,
+                    "message": {
+                        "type": "string",
+                        "description": "Optional prompt shown above the form",
+                    },
+                },
+                "required": ["form"],
+            },
+        },
+        "elicitation_render_widget": {
+            "description": (
+                "Render a declarative form as an inline HTML form for "
+                "show_widget (the v2 rich surface for clients that render "
+                "widgets, e.g. Cowork/claude.ai). Returns {success, html, "
+                "title, field_ids} — pass 'html' straight to "
+                "mcp__visualize__show_widget. The form renders ALL 7 controls "
+                "richly (number spinner, date picker, multi-line textarea, "
+                "multi-select checkboxes) and posts answers back via "
+                "sendPrompt as a sentinel-marked JSON block "
+                "('__elicitation_response__'); parse that block and validate "
+                "it with elicitation_collect_response (R4). Returns {success: "
+                "false, problems} on a malformed form. Use when native MCP "
+                "elicitation is unavailable but the client can render widgets."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "form": rich_form_schema,
                     "message": {
                         "type": "string",
                         "description": "Optional prompt shown above the form",

--- a/tests/unit/elicitation/test_widget.py
+++ b/tests/unit/elicitation/test_widget.py
@@ -1,0 +1,184 @@
+"""Tests for the show_widget HTML renderer (elicitation v2 / S1).
+
+Covers the pure ``form_to_widget_html`` transform: one control per type,
+HTML-escaping of form-supplied text, native bound attributes, the
+sentinel postback payload, and the sendPrompt wiring.
+"""
+
+from __future__ import annotations
+
+from attune.elicitation import (
+    WIDGET_RESPONSE_MARKER,
+    form_from_dict,
+    form_to_widget_html,
+)
+
+
+def _render(fields: list[dict], **form_extra: object) -> str:
+    form = form_from_dict({"title": "T", "fields": fields, **form_extra})
+    return form_to_widget_html(form)
+
+
+class TestStructure:
+    def test_includes_title_and_form_shell(self):
+        html = _render([{"id": "a", "text": "A?", "type": "text_input"}])
+        assert 'id="attune-elicit-form"' in html
+        assert "<h3>T</h3>" in html
+        assert 'data-form-title="T"' in html
+        assert 'id="ae-submit"' in html
+
+    def test_message_and_description_render_when_present(self):
+        form = form_from_dict(
+            {
+                "title": "T",
+                "description": "Desc here",
+                "fields": [{"id": "a", "text": "A?", "type": "text_input"}],
+            }
+        )
+        html = form_to_widget_html(form, message="Please fill")
+        assert "Please fill" in html
+        assert "Desc here" in html
+
+    def test_sr_only_summary_present(self):
+        html = _render([{"id": "a", "text": "A?", "type": "text_input"}])
+        assert 'class="sr-only"' in html
+
+    def test_field_carries_id_and_type_attrs(self):
+        html = _render([{"id": "goal", "text": "Goal?", "type": "text_input"}])
+        assert 'data-fid="goal"' in html
+        assert 'data-ftype="text_input"' in html
+
+
+class TestControls:
+    def test_text_input_renders_text_field(self):
+        html = _render([{"id": "a", "text": "A?", "type": "text_input"}])
+        assert '<input type="text"' in html
+
+    def test_textarea_renders_textarea(self):
+        html = _render([{"id": "a", "text": "A?", "type": "textarea", "max_length": 200}])
+        assert "<textarea" in html
+        assert 'maxlength="200"' in html
+
+    def test_number_renders_with_bounds(self):
+        html = _render(
+            [
+                {
+                    "id": "n",
+                    "text": "N?",
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 9,
+                }
+            ]
+        )
+        assert '<input type="number"' in html
+        assert 'min="1"' in html
+        assert 'max="9"' in html
+
+    def test_date_renders_date_input(self):
+        html = _render([{"id": "d", "text": "When?", "type": "date"}])
+        assert '<input type="date"' in html
+
+    def test_single_select_renders_select_with_options(self):
+        html = _render(
+            [
+                {
+                    "id": "s",
+                    "text": "Pick",
+                    "type": "single_select",
+                    "options": ["x", "y"],
+                }
+            ]
+        )
+        assert "<select" in html
+        assert "<option" in html
+        assert ">x<" in html and ">y<" in html
+
+    def test_multi_select_renders_checkboxes(self):
+        html = _render(
+            [
+                {
+                    "id": "m",
+                    "text": "Pick many",
+                    "type": "multi_select",
+                    "options": ["x", "y"],
+                }
+            ]
+        )
+        assert html.count('type="checkbox"') == 2
+
+    def test_boolean_renders_yes_no_select(self):
+        html = _render([{"id": "b", "text": "OK?", "type": "boolean"}])
+        assert ">Yes<" in html and ">No<" in html
+
+    def test_default_preselected_for_single_select(self):
+        html = _render(
+            [
+                {
+                    "id": "s",
+                    "text": "Pick",
+                    "type": "single_select",
+                    "options": ["x", "y"],
+                    "default": "y",
+                }
+            ]
+        )
+        assert 'value="y" selected' in html
+
+    def test_required_marker_only_when_required(self):
+        html = _render(
+            [
+                {"id": "r", "text": "Req", "type": "text_input"},
+                {
+                    "id": "o",
+                    "text": "Opt",
+                    "type": "text_input",
+                    "required": False,
+                },
+            ]
+        )
+        # one required field -> exactly one required marker
+        assert html.count('class="ae-req"') == 1
+
+
+class TestPostback:
+    def test_marker_embedded_as_js_key(self):
+        html = _render([{"id": "a", "text": "A?", "type": "text_input"}])
+        assert WIDGET_RESPONSE_MARKER in html
+        # embedded as a quoted JS object key
+        assert f"'{WIDGET_RESPONSE_MARKER}'" in html
+
+    def test_sendprompt_wired(self):
+        html = _render([{"id": "a", "text": "A?", "type": "text_input"}])
+        assert "sendPrompt(" in html
+        assert "JSON.stringify(payload)" in html
+
+    def test_number_value_coerced_to_number(self):
+        html = _render([{"id": "n", "text": "N?", "type": "number"}])
+        assert "Number(el.value)" in html
+
+
+class TestEscaping:
+    def test_malicious_label_is_escaped(self):
+        html = _render([{"id": "a", "text": "<script>alert(1)</script>", "type": "text_input"}])
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_malicious_option_is_escaped(self):
+        html = _render(
+            [
+                {
+                    "id": "s",
+                    "text": "Pick",
+                    "type": "single_select",
+                    "options": ['"><img src=x onerror=alert(1)>'],
+                }
+            ]
+        )
+        assert "onerror=alert(1)>" not in html
+        assert "&lt;img" in html
+
+    def test_quote_in_id_does_not_break_attribute(self):
+        html = _render([{"id": 'a"x', "text": "A?", "type": "text_input"}])
+        assert 'data-fid="a"x"' not in html
+        assert "&quot;" in html

--- a/tests/unit/mcp/handlers/test_elicitation_render_widget.py
+++ b/tests/unit/mcp/handlers/test_elicitation_render_widget.py
@@ -1,0 +1,56 @@
+"""Tests for the elicitation_render_widget MCP handler (S1 surface).
+
+Thin wiring of ``form_to_widget_html``: a valid form returns the HTML +
+metadata; a malformed form returns problems instead of raising.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from attune.mcp.server import EmpathyMCPServer
+
+_FORM = {
+    "title": "Scope",
+    "fields": [
+        {"id": "goal", "text": "Goal?", "type": "single_select", "options": ["a", "b"]},
+        {"id": "note", "text": "Note", "type": "textarea", "required": False},
+        {"id": "n", "text": "How many?", "type": "number", "minimum": 1, "maximum": 9},
+        {"id": "when", "text": "When?", "type": "date", "required": False},
+    ],
+}
+
+
+def _make_server() -> EmpathyMCPServer:
+    with patch.object(EmpathyMCPServer, "_register_plugin_tools"):
+        with patch("attune.mcp.version_check.check_for_updates", return_value=None):
+            return EmpathyMCPServer()
+
+
+class TestRenderWidgetHandler:
+    @pytest.mark.asyncio
+    async def test_valid_form_returns_html_and_metadata(self):
+        server = _make_server()
+        out = await server._handle_elicitation_render_widget({"form": _FORM, "message": "fill it"})
+        assert out["success"] is True
+        assert out["title"] == "Scope"
+        assert out["field_ids"] == ["goal", "note", "n", "when"]
+        assert 'id="attune-elicit-form"' in out["html"]
+        assert "fill it" in out["html"]
+        # the v2.1 rich controls render (D10 enum-honesty fix)
+        assert '<input type="number"' in out["html"]
+        assert '<input type="date"' in out["html"]
+
+    @pytest.mark.asyncio
+    async def test_registered_in_dispatch_table(self):
+        server = _make_server()
+        assert "elicitation_render_widget" in server._build_dispatch_table()
+
+    @pytest.mark.asyncio
+    async def test_malformed_form_returns_problems(self):
+        server = _make_server()
+        out = await server._handle_elicitation_render_widget({"form": {"title": ""}})
+        assert out["success"] is False
+        assert out["problems"]

--- a/tests/unit/mcp/test_tool_schemas.py
+++ b/tests/unit/mcp/test_tool_schemas.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from attune.mcp.tool_schemas import (
     _path_tool,
+    get_elicitation_tools,
     get_help_tools,
     get_memory_tools,
     get_prompts,
@@ -24,6 +25,13 @@ from attune.mcp.tool_schemas import (
     get_utility_tools,
     get_workflow_tools,
 )
+
+
+def _field_types(tools: dict, name: str) -> list[str]:
+    """Return the field-type enum for a tool's form schema."""
+    items = tools[name]["input_schema"]["properties"]["form"]["properties"]["fields"]["items"]
+    return items["properties"]["type"]["enum"]
+
 
 # -- _path_tool ------------------------------------------------------
 
@@ -299,3 +307,48 @@ class TestGetPrompts:
         prompt = get_prompts()["test-gen"]
         batch_arg = next(a for a in prompt["arguments"] if a["name"] == "batch")
         assert batch_arg.get("required") is False
+
+
+# -- get_elicitation_tools -------------------------------------------
+
+
+class TestGetElicitationTools:
+    """Field-type enum surfaces: v2 rich tools expose 7, v1 stays at 4."""
+
+    def test_v2_tools_present(self) -> None:
+        tools = get_elicitation_tools()
+        assert "elicitation_render_widget" in tools
+        assert "elicitation_ask" in tools
+
+    def test_v1_render_form_stays_four_types(self) -> None:
+        # AskUserQuestion has no native number/date — v1 must NOT claim them.
+        assert _field_types(get_elicitation_tools(), "elicitation_render_form") == [
+            "text_input",
+            "single_select",
+            "multi_select",
+            "boolean",
+        ]
+
+    def test_v2_tools_expose_all_seven_types(self) -> None:
+        # D10 enum-honesty fix: render_widget / ask accept the rich controls.
+        tools = get_elicitation_tools()
+        expected = {
+            "text_input",
+            "textarea",
+            "single_select",
+            "multi_select",
+            "boolean",
+            "number",
+            "date",
+        }
+        assert set(_field_types(tools, "elicitation_render_widget")) == expected
+        assert set(_field_types(tools, "elicitation_ask")) == expected
+
+    def test_v2_field_schema_has_numeric_bounds(self) -> None:
+        tools = get_elicitation_tools()
+        items = tools["elicitation_render_widget"]["input_schema"]["properties"]["form"][
+            "properties"
+        ]["fields"]["items"]["properties"]
+        assert "minimum" in items
+        assert "maximum" in items
+        assert "max_length" in items

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -27,12 +27,12 @@ class TestToolRegistration:
     """Verify all tools are registered (46 core + 5 optional redis plugin)."""
 
     def test_tools_list_returns_at_least_core_count(self, server: EmpathyMCPServer):
-        """Core tools (46) are always registered; attune-redis adds 5 more."""
+        """Core tools (47) are always registered; attune-redis adds 5 more."""
         tools = server.get_tool_list()
         tool_names = {t["name"] for t in tools}
 
-        # 46 core tools must always be present
-        assert len(tools) >= 46
+        # 47 core tools must always be present (incl. elicitation_render_widget)
+        assert len(tools) >= 47
 
         # When attune-redis plugin is installed, all 5 redis tools are present
         redis_tools = {
@@ -43,7 +43,7 @@ class TestToolRegistration:
             "redis_memory_store",
         }
         if redis_tools.issubset(tool_names):
-            assert len(tools) == 51, f"Expected 51 tools with redis plugin, got {len(tools)}"
+            assert len(tools) == 52, f"Expected 52 tools with redis plugin, got {len(tools)}"
 
     def test_memory_tools_registered(self, server: EmpathyMCPServer):
         """Test that all memory tools are in the tool list."""


### PR DESCRIPTION
## Summary

Native MCP form elicitation **auto-declines on Claude Code without rendering** (D10 live dogfood), so **S1 (`show_widget`) becomes the working rich surface**. This builds the show_widget renderer for the existing 7 controls (`slider`/`color` deferred — they'd touch the locked D3 artifact).

- **`form_to_widget_html(form, message)`** (`attune.elicitation.widget`) — pure `FormSchema → HTML` transform. CDS-token styled, transparent bg, no `position:fixed`. **Injection-safe**: all form text `html.escape`d, submit script reads the DOM by `data-*` attrs (no form data interpolated into JS).
- **Postback (S1 shape, per D4/D8):** widget `sendPrompt`s a sentinel-marked (`__elicitation_response__`) JSON block → agent parses → existing `collect_form_response` (R4). No new collection logic.
- **`elicitation_render_widget` MCP tool** → `{html, title, field_ids}`; agent passes `html` to `mcp__visualize__show_widget`.
- **`elicit` skill** — widget surface + round-trip section + the "a `decline` you didn't see the user make = surface unavailable, fall back" caveat. Mirror synced to `.agents/`.

### D10 enum-honesty fix (prerequisite)

`elicitation_render_widget`/`elicitation_ask` now use a **`rich_form_schema`** (7-type enum + `minimum`/`maximum`/`max_length`); v1 `render_form`/`collect_response` stay at 4 (AskUserQuestion has no native number/date). Without this, the rich controls were rejected at the MCP boundary for the widget tool too — so the fix had to land here.

## Tests

- Renderer (22), handler, schema regression (v2=7 / v1=4) — all green.
- 465 mcp + elicitation + plugin-reference tests pass; ruff + pinned black clean; plugin config validation 29 ✓.

## Not done (deferred)

- **Live S1 round-trip** — `elicitation_render_widget` reaches the MCP server only after a restart (same per-session-server constraint as D9/D10). Recorded as **D11**; next session renders → submits → confirms the parse.
- **D12** records the adoption gap: the enhanced form has one consumer (the `elicit` skill via attune-hub); `/spec` is the highest-value unconverted target. No feature workflow uses it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)