### PR TITLE
chore(release): 9.1.0 — declarative form elicitation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "9.0.0"
+    "version": "9.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "17 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v9.0.0
+# Attune AI Framework v9.1.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 9.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 9.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0] — 2026-06-27
+
+### Added
+
+- **Declarative form elicitation.** A new `elicit` skill and MCP tool
+  family for gathering several inputs as one form instead of asking one
+  question at a time. Forms are plain data (a `FormSchema`), so the same
+  definition renders on whichever surface the client supports:
+  - `elicitation_render_form` — maps a form onto `AskUserQuestion`
+    (portable; works in any client, including the terminal).
+  - `elicitation_ask` — renders a form as a **native MCP elicitation**
+    dialog with a structured return, where the client supports it.
+  - `elicitation_render_widget` — renders a form as an inline HTML
+    **widget** (`show_widget`) with the full control palette, for
+    widget-capable clients (Cowork / claude.ai).
+  - `elicitation_collect_response` — validates answers (R4): enforces
+    required fields, option membership, number bounds, and date format,
+    and names exactly which fields to re-ask — never silently accepts
+    malformed input.
+- **Rich form controls** on the artifact: `number` (with
+  `minimum`/`maximum`), `date` (ISO `YYYY-MM-DD`), and `textarea` (with
+  `max_length`), alongside text, single-/multi-select, and boolean.
+
+### Changed
+
+- **`/spec` kickoff is now a single form.** Starting a new spec gathers
+  its independent dimensions — outcome, scope, concerns — in one batched
+  turn via the `elicit` skill, instead of sequential button-presses. The
+  mode picker and the review/approve/execute gates remain single
+  questions (they branch on the prior answer).
+
 ### Fixed
 
+- **The widget round-trip rejected rich controls.** Forms containing
+  `number`/`date`/`textarea` were rejected at the MCP boundary;
+  `elicitation_collect_response` and the rich surfaces now accept all
+  seven control types.
 - **Plugin no longer shows a false "help templates may be stale"
   notice on session start.** The `help_freshness_check.py` SessionStart
   hook resolved the help bundle's `source_manifest.json` paths (which
@@ -21,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   versioned artifact in a user's world and can't drift relative to
   anything they control; repo-side staleness is already covered by the
   dev `.help` freshness nudge plus pre-commit regen and CI.
+
+### Security
+
+- The widget renderer escapes all form-supplied text and never
+  interpolates form data into executable JavaScript, so untrusted form
+  definitions (labels, options) cannot inject markup or script.
 
 ## [9.0.0] — 2026-06-26
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 9.0.0
+**Version:** 9.1.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 9.0.0 | **License:** Apache 2.0
+**Version:** 9.1.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "9.0.0"
+    "version": "9.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "9.0.0"
+__version__ = "9.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "9.0.0"
+version = "9.1.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "9.0.0"
+version = "9.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release 9.1.0 — declarative form elicitation

Minor, purely additive. Ships the elicitation arc (#1127–#1135).

### Bump (5 files)
- `pyproject.toml`, `plugin/core/__init__.py`, `.claude/CLAUDE.md` (×2), `uv.lock`: `9.0.0` → `9.1.0`
- `CHANGELOG.md`: `9.1.0` entry (folds in the existing help-templates fix from `[Unreleased]`)

`src/attune/__init__.py` derives `__version__` from package metadata. README test badge ("20,000+ passing") + dynamic codecov badge still accurate.

### What ships
- **Declarative form elicitation** — `elicit` skill + MCP tools: `elicitation_render_form` (AskUserQuestion), `elicitation_ask` (native MCP elicitation), `elicitation_render_widget` (show_widget), `elicitation_collect_response` (R4).
- **Rich controls** — number (min/max), date, textarea (max_length).
- **`/spec` kickoff** batches independent dimensions into one form (first real consumer).
- **Fix** — widget round-trip accepts all 7 control types at the MCP boundary (#1135).
- **Security** — widget renderer escapes all form text; no form data in executable JS.

### Verified
- Feature dogfooded **live** this session (render → submit → `sendPrompt` → `collect_response`).
- Branch is off updated main (includes #1133/#1134/#1135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)