### PR TITLE
chore(website): refresh for 9.1.0 — version + verified counts

### DIFF
--- a/content/features/plugin.md
+++ b/content/features/plugin.md
@@ -75,7 +75,7 @@ component type:
 | `.mcp.json` | MCP server registration | 1 server |
 
 `commands/` ships `handoff` (the `/handoff` resume-prompt command).
-The 17 skills are the developer-workflow surface (`spec`,
+The 23 skills are the developer-workflow surface (`spec`,
 `security-audit`, `code-quality`, `smart-test`, `release-prep`, …). The
 6 agents are read-only or planning subagents
 (`security-reviewer`, `refactor-planner`, `release-prep-auditor`,
@@ -95,7 +95,7 @@ are part of the bundle.
 
 `plugin/core/` exists so the plugin can carry a version for standalone
 operation; `plugin/core/__init__.py` is just
-`__version__ = "8.9.2"`. The real runtime is the pip-installed
+`__version__ = "9.1.0"`. The real runtime is the pip-installed
 `attune-ai` package, which the `.mcp.json` server pulls via
 `uvx --from attune-ai`.
 
@@ -110,7 +110,7 @@ claude plugin install attune-ai@attune-ai
 
 The first command registers this repo as a marketplace; the second
 installs the `attune-ai` plugin from it. After install, Claude Code
-auto-discovers the components — the slash command, the 17 skills, the 6
+auto-discovers the components — the slash command, the 23 skills, the 6
 agents, the hooks, and the MCP server — and they become available in
 your session.
 
@@ -152,7 +152,7 @@ cat plugin/.claude-plugin/plugin.json
 
 **Verify:** `name` is `attune-ai`, `license` is `Apache-2.0`, and
 `keywords` include `claude-code`. The `version` here is the plugin
-bundle version (`8.9.2`); the sibling `marketplace.json` carries a
+bundle version (`9.1.0`); the sibling `marketplace.json` carries a
 matching version in `metadata.version` and `plugins[0].version`.
 
 ### List the components Claude Code will discover
@@ -183,7 +183,7 @@ and the component folder layout.
 | Field | Value / Purpose |
 |-------|-----------------|
 | `name` | `attune-ai` — the plugin name. |
-| `version` | Plugin bundle version (`8.9.2`). |
+| `version` | Plugin bundle version (`9.1.0`). |
 | `description` | One-line plugin summary shown in Claude Code. |
 | `author` | `{name, email}` — Smart AI Memory. |
 | `homepage` / `repository` | Project links. |
@@ -289,7 +289,7 @@ inside it. Install the box and Claude Code unpacks every component.
   `attune-ai` plugin — so the plugin name appears on both sides.
 - **Q:** What does the plugin actually contain?
   **A:** A manifest plus auto-discovered components: 1 slash command
-  (`/handoff`), 17 skills, 6 agents, the hook scripts, the help bundle,
+  (`/handoff`), 23 skills, 6 agents, the hook scripts, the help bundle,
   and an `.mcp.json` that registers the MCP server.
 - **Q:** Is the plugin the same as the MCP server?
   **A:** No. The plugin is the bundle; the MCP server is one component

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -176,7 +176,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    17 multi-stage workflows, 17 skills, 41 MCP tools.
+                    19 multi-stage workflows, 23 skills, 47 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -505,7 +505,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 Install from the marketplace. Progressive help, project
-                bootstrapping, and 17 skills right in your terminal.
+                bootstrapping, and 23 skills right in your terminal.
               </p>
 
               <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 mb-8">
@@ -571,9 +571,9 @@ export default function DocsPage() {
                 Workflows &amp; Skills
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                The build half of the loop: 17 multi-stage workflows
-                (20 workflows total), 17 auto-triggering Claude Code skills,
-                and an MCP server with 41 registered tools — review, tests,
+                The build half of the loop: 19 multi-stage workflows
+                (22 workflows total), 23 auto-triggering Claude Code skills,
+                and an MCP server with 47 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>
 
@@ -599,7 +599,7 @@ export default function DocsPage() {
 
                 <div>
                   <h3 className="font-bold text-lg mb-4">
-                    17 Claude Code Skills
+                    23 Claude Code Skills
                   </h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-4">
                     Skills auto-invoke from natural language. Type the topic

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -30,11 +30,11 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What are the four pillars?',
-        answer: 'Attune AI is built on four pillars, each a real, shipped capability: AI workflows (17 multi-stage workflows for review, tests, bug prediction, and refactors), Project memory (cross-session findings and a retrievable lessons corpus), Retrieval grounding (citations back to your source via attune-rag), and Verification (fact-checking generated content before it reaches main).',
+        answer: 'Attune AI is built on four pillars, each a real, shipped capability: AI workflows (19 multi-stage workflows for review, tests, bug prediction, and refactors), Project memory (cross-session findings and a retrievable lessons corpus), Retrieval grounding (citations back to your source via attune-rag), and Verification (fact-checking generated content before it reaches main).',
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 20 workflows (17 multi-stage), 41 MCP tools, 17 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 23 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v8.7.0</span>
+                  <span>v9.1.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>
@@ -449,7 +449,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Full framework. Workflows, staleness detection, MCP server, and 17 auto-triggering skills for Claude Code.
+                Full framework. Workflows, staleness detection, MCP server, and 23 auto-triggering skills for Claude Code.
               </p>
             </div>
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -46,8 +46,8 @@ export const PRODUCTS: Product[] = [
       "Generate concept, task, and reference templates",
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
-      "17 Claude Code skills included",
-      "MCP server with 41 registered tools",
+      "23 Claude Code skills included",
+      "MCP server with 47 registered tools",
     ],
   },
   {
@@ -117,7 +117,7 @@ export const PRODUCTS: Product[] = [
       "/coach status — check template freshness",
       "/coach maintain — regenerate stale templates",
       "Auto-triggers on natural language (help, explain, learn)",
-      "17 auto-triggering skills (security, testing, review, etc.)",
+      "23 auto-triggering skills (security, testing, review, etc.)",
     ],
   },
 ];
@@ -262,9 +262,9 @@ export const DIFFERENTIATORS: Differentiator[] = [
  * and no page consumed them.)
  */
 export const CAPABILITIES = {
-  workflows: 17,
-  skills: 17,
-  mcpTools: 41,
+  workflows: 19,
+  skills: 23,
+  mcpTools: 47,
   templateKinds: 15,
   wizards: 5,
 } as const;
@@ -305,7 +305,7 @@ export const RELIABILITY_LOOP: LoopStage[] = [
     n: "03",
     name: "Build",
     description:
-      "17 multi-stage workflows: review, tests, bug prediction, refactor.",
+      "19 multi-stage workflows: review, tests, bug prediction, refactor.",
   },
   {
     n: "04",
@@ -343,7 +343,7 @@ export const PILLARS: Pillar[] = [
     tag: "AI workflows",
     title: "Specialist teams, not one prompt",
     description:
-      "17 multi-stage workflows run teams of 2–6 Claude subagents to " +
+      "19 multi-stage workflows run teams of 2–6 Claude subagents to " +
       "review code, surface vulnerabilities, generate tests, and plan " +
       "refactors — with cost-tiered model routing.",
     points: [


### PR DESCRIPTION
## Website refresh for 9.1.0

The site was 4 versions behind (`v8.7.0` on the homepage, `8.9.2` in the plugin feature page) with several stale counts. Corrected against **live code** per the website-content-accuracy rule.

| | Was | Now | Source of truth |
|---|---|---|---|
| Version | v8.7.0 / 8.9.2 | **9.1.0** | pyproject / plugin.json |
| Workflows | 20 total / 17 multi-stage | **22 / 19** | `list_workflows()` w/ stages |
| Skills | 17 | **23** | `plugin/skills/` (all auto-trigger) |
| MCP tools | 41 | **47** | `get_*_tools()` total |
| Wizards | 5 | 5 ✓ | `list_wizards()` |
| Agents | 6 | 6 ✓ | `plugin/agents/` |
| Template kinds | 15 | 15 (left — couldn't verify cleanly) | — |

### Files
- `website/lib/features.ts` — the `CAPABILITIES` single source + descriptive strings.
- `website/app/page.tsx`, `docs/page.tsx`, `faq/page.tsx` — the hardcoded copies (pages don't import `CAPABILITIES`).
- `content/features/plugin.md` — bundle version + skill count.

No changelog (website-only, per `website/CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)