### PR TITLE
feat(hooks): starter-reconciler flags newer-than-starter merges on main

### DIFF
--- a/src/attune/hooks/scripts/starter_reconciler.py
+++ b/src/attune/hooks/scripts/starter_reconciler.py
@@ -17,9 +17,16 @@ PyPI in parallel, then prints a one-block freshness banner:
       PRs: #1116 MERGED · #1117 MERGED · #1121 MERGED
       branches: claude/foo GONE
       PyPI attune-ai latest=9.0.0 (starter mentions: 9.0.0, 8.5.0)
+      ⚠ main has NEWER merges the starter omits: #1136 #1135 #1134 #1133
+        (starter's newest: #1132) — work may have landed since it was written
 
 A MERGED PR / GONE branch / already-published version is the tell that
 the headline action is done — read the banner before trusting the lead.
+The ``⚠ NEWER merges`` line catches the *other* staleness shape: the
+starter is behind reality because PRs landed on ``main`` that it never
+names — exactly what a named-thread check can't see (you can't verify a
+thread the starter forgot to mention). Newest-PR-on-main > the starter's
+highest mentioned PR is the tell.
 
 Bounded for SessionStart: thread counts are capped and all network
 checks run concurrently under a hard wall-clock budget; anything that
@@ -54,6 +61,10 @@ PROJECT_STARTER_RELPATH = Path(".attune") / "next_session_starter.md"
 #: Cap how many of each thread we verify, newest-mentioned first.
 MAX_PRS = 6
 MAX_BRANCHES = 4
+#: How many recent ``origin/main`` commits to scan for merged-PR markers.
+MAIN_LOG_SCAN = 40
+#: Cap how many newer-than-starter merges we list in the banner.
+MAX_NEWER_MERGES = 6
 #: Per-subprocess timeout for a single git/gh call (seconds).
 SUBPROC_TIMEOUT = 4
 #: Total wall-clock budget for ALL network checks combined (seconds).
@@ -70,6 +81,10 @@ PR_RE = re.compile(r"#(\d{1,6})\b")
 BRANCH_RE = re.compile(r"\b(?:release|hotfix|claude|feat|fix)/[A-Za-z0-9._/-]+")
 #: ``X.Y.Z`` semantic versions.
 VERSION_RE = re.compile(r"\b\d+\.\d+\.\d+\b")
+#: ``(#NNNN)`` PR markers in squash-merge commit subjects on main, e.g.
+#: ``feat(x): thing (#1133)``. The parentheses distinguish a real merge
+#: marker from an inline ``#1133`` cross-reference in prose.
+MERGE_PR_RE = re.compile(r"\(#(\d{1,6})\)")
 
 
 def _find_project_starter(start: Path | None = None) -> Path | None:
@@ -155,6 +170,48 @@ def check_branch(name: str, cwd: Path | None) -> str:
     return "exists" if result.stdout.strip() else "gone"
 
 
+def merged_prs_on_main(cwd: Path | None, limit: int = MAIN_LOG_SCAN) -> list[int]:
+    """Return PR numbers squash-merged to ``origin/main``, newest first.
+
+    Parses ``(#NNNN)`` markers from the most recent ``limit``
+    ``origin/main`` commit subjects. Pure-git and offline — it reads
+    whatever ``origin/main`` the last fetch left, so a stale ref simply
+    yields fewer/older numbers (it can never invent a *newer* one, so it
+    cannot produce a false staleness warning). Returns ``[]`` on any git
+    error — the widening is best-effort and never blocks.
+    """
+    result = _run(["git", "log", "origin/main", f"-{limit}", "--format=%s"], cwd)
+    if result is None or result.returncode != 0:
+        return []
+    nums: list[int] = []
+    for line in result.stdout.splitlines():
+        match = MERGE_PR_RE.search(line)
+        if match:
+            nums.append(int(match.group(1)))
+    return nums
+
+
+def newer_unmentioned(text: str, merged_main_prs: list[int]) -> list[int]:
+    """Merged-on-main PRs newer than the starter's highest mentioned PR.
+
+    The named-thread checks can only verify PRs the starter *names*; this
+    catches the inverse blind spot — PRs that landed on ``main`` which
+    the starter never mentions, the tell that work shipped after it was
+    written. ``text`` is the full starter (we read every ``#NNNN``, not
+    the capped/extracted subset, so the ceiling is the true frontier).
+
+    Returns the unmentioned numbers above that ceiling, newest first,
+    capped at ``MAX_NEWER_MERGES``. Empty when the starter names no PR
+    (no frontier to compare) or git yielded nothing.
+    """
+    mentioned = {int(n) for n in PR_RE.findall(text)}
+    if not mentioned or not merged_main_prs:
+        return []
+    ceiling = max(mentioned)
+    newer = {n for n in merged_main_prs if n > ceiling and n not in mentioned}
+    return sorted(newer, reverse=True)[:MAX_NEWER_MERGES]
+
+
 def pypi_latest(pkg: str) -> str | None:
     """Return the latest version string for ``pkg`` on PyPI, or None."""
     url = f"https://pypi.org/pypi/{pkg}/json"
@@ -183,7 +240,18 @@ def reconcile(text: str, pkg: str | None, cwd: Path | None) -> dict:
         "branches": dict.fromkeys(branches, "unverified"),
         "pypi": None,
         "versions": versions,
+        "newer_merges": [],
+        "pr_ceiling": None,
     }
+    # Widening: a starter is also stale when newer PRs landed on main that
+    # it never names. Only worth a git call if it names *any* PR (else
+    # there's no frontier to compare against) — keeps the no-threads path
+    # network-free. The ceiling is the true max over ALL mentioned PRs
+    # (not the capped extract), matching what newer_unmentioned compares.
+    if prs:
+        all_mentioned = [int(n) for n in PR_RE.findall(text)]
+        results["pr_ceiling"] = max(all_mentioned)
+        results["newer_merges"] = newer_unmentioned(text, merged_prs_on_main(cwd))
     if not prs and not branches and not pkg:
         return results
 
@@ -223,7 +291,8 @@ def format_banner(results: dict, label: str, path: Path) -> str | None:
     branches = results["branches"]
     pypi = results["pypi"]
     versions = results["versions"]
-    if not prs and not branches and pypi is None:
+    newer = results.get("newer_merges") or []
+    if not prs and not branches and pypi is None and not newer:
         return None
 
     lines = [f"[starter-reconcile:{label}] {path}"]
@@ -233,6 +302,14 @@ def format_banner(results: dict, label: str, path: Path) -> str | None:
     if branches:
         joined = " · ".join(f"{name} {state}" for name, state in branches.items())
         lines.append(f"  branches: {joined}")
+    if newer:
+        ceiling = results.get("pr_ceiling")
+        listed = " ".join(f"#{n}" for n in newer)
+        tail = f" (starter's newest: #{ceiling})" if ceiling is not None else ""
+        lines.append(
+            f"  ⚠ main has NEWER merges the starter omits: {listed}{tail}"
+            " — work may have landed since it was written"
+        )
     if pypi is not None:
         suffix = f" (starter mentions: {', '.join(versions)})" if versions else ""
         pkg = results.get("pkg") or ""

--- a/tests/unit/hooks/test_starter_reconciler.py
+++ b/tests/unit/hooks/test_starter_reconciler.py
@@ -172,6 +172,8 @@ class TestReconcile:
         monkeypatch.setattr(hook_module, "check_pr", lambda n, c: "MERGED")
         monkeypatch.setattr(hook_module, "check_branch", lambda b, c: "gone")
         monkeypatch.setattr(hook_module, "pypi_latest", lambda p: "9.0.0")
+        # Keep the widening's git call hermetic.
+        monkeypatch.setattr(hook_module, "merged_prs_on_main", lambda c: [])
         text = "PR #1118 on branch claude/foo shipped 9.0.0"
         results = hook_module.reconcile(text, "attune-ai", None)
         assert results["prs"] == {1118: "MERGED"}
@@ -199,6 +201,7 @@ class TestReconcile:
 
         monkeypatch.setattr(hook_module, "check_pr", boom)
         monkeypatch.setattr(hook_module, "pypi_latest", lambda p: "1.2.3")
+        monkeypatch.setattr(hook_module, "merged_prs_on_main", lambda c: [])
         results = hook_module.reconcile("#42 v1.2.3", "pkg", None)
         # PR stays at its "unverified" seed; PyPI still resolves.
         assert results["prs"][42] == "unverified"
@@ -389,3 +392,137 @@ class TestReconcileAndEmitNoThreads:
         # repo_root=None → pkg=None → no PyPI lookup → empty banner → False.
         assert hook_module._reconcile_and_emit(starter, "global", None) is False
         assert capsys.readouterr().out == ""
+
+
+# --- widening: newer-merges-on-main staleness -------------------------
+
+
+class TestMergedPrsOnMain:
+    def test_parses_pr_markers_newest_first(self, hook_module, monkeypatch):
+        log = (
+            "feat(x): a (#1136)\n"
+            "fix(y): b (#1135)\n"
+            "chore: no marker here\n"
+            "feat(z): c (#1133)\n"
+        )
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: _FakeProc(log, 0))
+        assert hook_module.merged_prs_on_main(None) == [1136, 1135, 1133]
+
+    def test_empty_on_git_error(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: _FakeProc("", 1))
+        assert hook_module.merged_prs_on_main(None) == []
+
+    def test_empty_when_run_none(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: None)
+        assert hook_module.merged_prs_on_main(None) == []
+
+    def test_bare_hash_without_parens_ignored(self, hook_module, monkeypatch):
+        # A bare '#1140' (cross-ref, not a squash marker) is NOT counted;
+        # only the parenthesized '(#1141)' is.
+        monkeypatch.setattr(
+            hook_module,
+            "_run",
+            lambda *a, **k: _FakeProc("revert: drop #1140 hack (#1141)\n", 0),
+        )
+        assert hook_module.merged_prs_on_main(None) == [1141]
+
+
+class TestNewerUnmentioned:
+    def test_returns_newer_than_ceiling(self, hook_module):
+        text = "Merged #1130, #1132. Working on #1127."
+        merged = [1136, 1135, 1134, 1133, 1132, 1130, 1127]
+        assert hook_module.newer_unmentioned(text, merged) == [1136, 1135, 1134, 1133]
+
+    def test_high_mentioned_pr_raises_the_bar(self, hook_module):
+        # The ceiling is max over ALL mentioned PRs, so mentioning #1135
+        # raises the bar — #1134 (below it) is no longer "newer", and the
+        # mentioned #1135 itself is excluded.
+        text = "ceiling #1132 and also #1135"
+        merged = [1136, 1135, 1134]
+        assert hook_module.newer_unmentioned(text, merged) == [1136]
+
+    def test_empty_when_no_prs_mentioned(self, hook_module):
+        assert hook_module.newer_unmentioned("no prs", [1, 2, 3]) == []
+
+    def test_empty_when_no_merged(self, hook_module):
+        assert hook_module.newer_unmentioned("#10", []) == []
+
+    def test_capped_at_max(self, hook_module):
+        merged = list(range(200, 180, -1))  # 20 numbers, all > 100
+        out = hook_module.newer_unmentioned("#100", merged)
+        assert len(out) == hook_module.MAX_NEWER_MERGES
+        assert out[0] == 200  # newest first
+
+    def test_uses_full_text_ceiling_not_capped_extract(self, hook_module):
+        # >MAX_PRS mentions; the true max (#900) is beyond the first 6, so
+        # the ceiling must come from the full text, not extract_threads.
+        text = " ".join(f"#{n}" for n in [10, 11, 12, 13, 14, 15, 900])
+        merged = [901, 900, 800]
+        assert hook_module.newer_unmentioned(text, merged) == [901]
+
+
+class TestFormatBannerNewerMerges:
+    def test_renders_newer_merges_line(self, hook_module, tmp_path):
+        results = {
+            "prs": {1132: "MERGED"},
+            "branches": {},
+            "pypi": None,
+            "versions": [],
+            "pkg": "",
+            "newer_merges": [1136, 1135, 1133],
+            "pr_ceiling": 1132,
+        }
+        out = hook_module.format_banner(results, "global", tmp_path / "s.md")
+        assert "NEWER merges the starter omits: #1136 #1135 #1133" in out
+        assert "starter's newest: #1132" in out
+
+    def test_newer_merges_alone_still_emits(self, hook_module, tmp_path):
+        # A newer-merge finding alone (no verifiable PR/branch/pypi state)
+        # is enough to surface a banner.
+        results = {
+            "prs": {},
+            "branches": {},
+            "pypi": None,
+            "versions": [],
+            "pkg": "",
+            "newer_merges": [1136],
+            "pr_ceiling": 1132,
+        }
+        out = hook_module.format_banner(results, "global", tmp_path / "s.md")
+        assert out is not None
+        assert "#1136" in out
+
+    def test_no_line_when_no_newer_merges(self, hook_module, tmp_path):
+        results = {
+            "prs": {1132: "MERGED"},
+            "branches": {},
+            "pypi": None,
+            "versions": [],
+            "pkg": "",
+            "newer_merges": [],
+            "pr_ceiling": 1132,
+        }
+        out = hook_module.format_banner(results, "global", tmp_path / "s.md")
+        assert "NEWER merges" not in out
+
+
+class TestReconcileWidening:
+    def test_flags_newer_merges(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "check_pr", lambda n, c: "MERGED")
+        monkeypatch.setattr(hook_module, "merged_prs_on_main", lambda c: [1136, 1135, 1134, 1132])
+        results = hook_module.reconcile("Merged #1132.", None, None)
+        assert results["newer_merges"] == [1136, 1135, 1134]
+        assert results["pr_ceiling"] == 1132
+
+    def test_no_git_call_without_mentioned_prs(self, hook_module, monkeypatch):
+        called = {"n": 0}
+
+        def tracker(*a, **k):
+            called["n"] += 1
+            return []
+
+        monkeypatch.setattr(hook_module, "merged_prs_on_main", tracker)
+        results = hook_module.reconcile("no prs here", None, None)
+        assert called["n"] == 0
+        assert results["newer_merges"] == []
+        assert results["pr_ceiling"] is None


### PR DESCRIPTION
## Problem

The `starter_reconciler` SessionStart hook only fact-checked the threads
the starter **named** — PR numbers, branches, versions. It's blind to
the *other* staleness shape: PRs that landed on `main` which the starter
never mentions. This session is the canonical case — the starter topped
out at #1132 while #1133–#1136 had already merged (including the 9.1.0
release), and the reconciler said nothing. The staleness was caught only
by hand-grepping `git log`.

## Change

- `merged_prs_on_main()` — parse `(#NNNN)` squash-merge markers from
  recent `origin/main` subjects. Pure-git, offline, bounded; returns
  `[]` on any git error.
- `newer_unmentioned()` — PRs above the starter's highest mentioned PR
  (ceiling computed over the **full** text, not the capped extract).
- Banner gains a `⚠ main has NEWER merges the starter omits` line.

**No false positives by construction:** a stale local `origin/main` ref
can only yield *fewer/older* numbers, never a newer one — so it can only
*suppress* the warning, never invent one. The git call is skipped
entirely when the starter names no PR (no frontier to compare).

## Verification

- 54 unit tests pass (8 new: marker parse, ceiling logic, full-text
  ceiling, banner rendering, reconcile gating).
- Live against tonight's real starter: flags `#1136 #1135 #1134 #1133`,
  ceiling `#1132` — exactly the merges it omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)