### PR TITLE
fix(config): skip non-section ATTUNE_* env vars in loader

### DIFF
--- a/src/attune/config/loader.py
+++ b/src/attune/config/loader.py
@@ -207,6 +207,19 @@ class ConfigLoader:
                 continue
 
             section_name, setting_name = parts
+
+            # Skip standalone ATTUNE_* vars that aren't section overrides
+            # (e.g. ATTUNE_MAX_BUDGET_USD, ATTUNE_SPEND_GATE) — these are
+            # read directly by their consumers, not mapped to a config
+            # section, so a missing section here is expected, not an error.
+            if getattr(config, section_name, None) is None:
+                logger.debug(
+                    "Skipping non-section env var %s (no '%s' config section)",
+                    key,
+                    section_name,
+                )
+                continue
+
             dot_key = f"{section_name}.{setting_name}"
 
             try:

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,6 +1,7 @@
 """Tests for attune.config.loader module."""
 
 import json
+import logging
 
 import pytest
 
@@ -119,6 +120,24 @@ class TestConfigLoaderEnvOverrides:
         monkeypatch.setenv("ATTUNE_JUSTONEPART", "value")
         result = ConfigLoader.apply_env_overrides(config)
         assert isinstance(result, UnifiedConfig)
+
+    def test_non_section_var_skipped_without_warning(self, monkeypatch, caplog):
+        """Standalone ATTUNE_* knobs (read directly by their consumers,
+        not config-section overrides) are skipped silently — no warning."""
+        config = UnifiedConfig()
+        monkeypatch.setenv("ATTUNE_MAX_BUDGET_USD", "10.00")
+        with caplog.at_level(logging.WARNING, logger="attune.config.loader"):
+            ConfigLoader.apply_env_overrides(config)
+        assert "ATTUNE_MAX_BUDGET_USD" not in caplog.text
+
+    def test_known_section_bad_setting_still_warns(self, monkeypatch, caplog):
+        """A real section with a bogus setting is a genuine misconfig and
+        must still warn — the skip above must not over-suppress."""
+        config = UnifiedConfig()
+        monkeypatch.setenv("ATTUNE_AUTH_BOGUSSETTING", "x")
+        with caplog.at_level(logging.WARNING, logger="attune.config.loader"):
+            ConfigLoader.apply_env_overrides(config)
+        assert "ATTUNE_AUTH_BOGUSSETTING" in caplog.text
 
 
 class TestConvenienceFunctions:


### PR DESCRIPTION
## What

`ConfigLoader.apply_env_overrides` treated **every** `ATTUNE_*` environment
variable as an `ATTUNE_<SECTION>_<SETTING>` config override. Standalone knobs
that are read directly by their consumers — `ATTUNE_MAX_BUDGET_USD`,
`ATTUNE_SPEND_GATE`, `ATTUNE_SDK_SUBPROCESS` — parsed to a non-existent section
and logged a spurious warning on **every** CLI invocation:

```
WARNING: Failed to apply env override ATTUNE_MAX_BUDGET_USD: 'Unknown section: max'
```

## Fix

Skip (debug-log) any `ATTUNE_*` var whose section isn't a real config section.
A bogus setting inside a **known** section still warns, so genuine misconfig is
not over-suppressed.

## Not a behavior change

The budget cap itself was never affected — `get_max_budget_usd()` reads
`ATTUNE_MAX_BUDGET_USD` directly via `os.environ` (`agent_sdk_adapter.py:976`),
independent of the config loader. This PR only removes the misleading log noise.

## Tests

- `test_non_section_var_skipped_without_warning` — `ATTUNE_MAX_BUDGET_USD` stays silent
- `test_known_section_bad_setting_still_warns` — `ATTUNE_AUTH_BOGUSSETTING` still warns

All 18 in `tests/unit/test_config_loader.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)