### PR TITLE
fix(website): correct stale package versions + counts, add drift guard

### DIFF
--- a/.github/workflows/website-accuracy.yml
+++ b/.github/workflows/website-accuracy.yml
@@ -1,0 +1,48 @@
+name: Website Accuracy
+
+# Guards the website's version/count claims against reality. Two checks:
+#   - the deterministic pytest guard (features.ts attune-ai version ==
+#     this repo's pyproject.toml; homepage badge matches), and
+#   - the PyPI audit script for the external packages (attune-help/-author).
+# Advisory (not in required_status_checks): a confirmed drift turns it red
+# so it's caught in review; a PyPI hiccup reports "unverified" and passes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/lib/features.ts'
+      - 'website/app/page.tsx'
+      - 'pyproject.toml'
+      - 'scripts/audit_website_versions.py'
+      - 'tests/unit/test_website_version_accuracy.py'
+      - '.github/workflows/website-accuracy.yml'
+  pull_request:
+    paths:
+      - 'website/lib/features.ts'
+      - 'website/app/page.tsx'
+      - 'pyproject.toml'
+      - 'scripts/audit_website_versions.py'
+      - 'tests/unit/test_website_version_accuracy.py'
+      - '.github/workflows/website-accuracy.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  website-accuracy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+      - name: Install pytest
+        run: pip install pytest
+      - name: Deterministic version guard (features.ts vs pyproject)
+        run: python -m pytest tests/unit/test_website_version_accuracy.py -q
+      - name: PyPI version audit (external packages)
+        run: python scripts/audit_website_versions.py

--- a/.github/workflows/website-accuracy.yml
+++ b/.github/workflows/website-accuracy.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install pytest
         run: pip install pytest
       - name: Deterministic version guard (features.ts vs pyproject)
-        run: python -m pytest tests/unit/test_website_version_accuracy.py -q
+        # --noconftest: this guard is self-contained (reads files + imports
+        # the audit script via importlib, no attune/pydantic), so skip the
+        # repo conftest's dependency-heavy warm-up and keep the job dep-light.
+        run: python -m pytest tests/unit/test_website_version_accuracy.py -q --noconftest
       - name: PyPI version audit (external packages)
         run: python scripts/audit_website_versions.py

--- a/.github/workflows/website-accuracy.yml
+++ b/.github/workflows/website-accuracy.yml
@@ -1,29 +1,26 @@
 name: Website Accuracy
 
-# Guards the website's version/count claims against reality. Two checks:
-#   - the deterministic pytest guard (features.ts attune-ai version ==
-#     this repo's pyproject.toml; homepage badge matches), and
-#   - the PyPI audit script for the external packages (attune-help/-author).
-# Advisory (not in required_status_checks): a confirmed drift turns it red
-# so it's caught in review; a PyPI hiccup reports "unverified" and passes.
+# Guards the website's package-version claims against PyPI for the
+# EXTERNAL packages (attune-help / attune-author) that the main suite
+# can't check. The deterministic features.ts-vs-pyproject guard for
+# attune-ai's own version runs in the normal test suite
+# (tests/unit/test_website_version_accuracy.py) with full deps, so it is
+# NOT duplicated here — this job stays stdlib-only and dep-free.
+# Advisory (not in required_status_checks): a confirmed drift turns it
+# red so it's caught in review; a PyPI hiccup reports "unverified" and
+# passes.
 
 on:
   push:
     branches: [main]
     paths:
       - 'website/lib/features.ts'
-      - 'website/app/page.tsx'
-      - 'pyproject.toml'
       - 'scripts/audit_website_versions.py'
-      - 'tests/unit/test_website_version_accuracy.py'
       - '.github/workflows/website-accuracy.yml'
   pull_request:
     paths:
       - 'website/lib/features.ts'
-      - 'website/app/page.tsx'
-      - 'pyproject.toml'
       - 'scripts/audit_website_versions.py'
-      - 'tests/unit/test_website_version_accuracy.py'
       - '.github/workflows/website-accuracy.yml'
 
 concurrency:
@@ -40,12 +37,6 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
-      - name: Install pytest
-        run: pip install pytest
-      - name: Deterministic version guard (features.ts vs pyproject)
-        # --noconftest: this guard is self-contained (reads files + imports
-        # the audit script via importlib, no attune/pydantic), so skip the
-        # repo conftest's dependency-heavy warm-up and keep the job dep-light.
-        run: python -m pytest tests/unit/test_website_version_accuracy.py -q --noconftest
       - name: PyPI version audit (external packages)
+        # Stdlib-only (urllib/json/re) — no pip install needed.
         run: python scripts/audit_website_versions.py

--- a/scripts/audit_website_versions.py
+++ b/scripts/audit_website_versions.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Audit website package-version claims against PyPI (advisory).
+
+``website/lib/features.ts`` PRODUCTS hardcode the published version of
+THREE separate PyPI packages (attune-ai, attune-help, attune-author).
+Nothing syncs them, so they drift — caught 2026-06-28: attune-ai shown
+as 8.7.0 while PyPI was 9.1.0, attune-author 0.21.0 vs 0.22.0. This
+script reads each ``(pypiName, version)`` pair and compares to PyPI's
+latest.
+
+Network-tolerant: a PyPI hiccup reports ``unverified`` (never a
+failure), so CI flakes don't break the build; only a CONFIRMED mismatch
+exits 1. The attune-ai self-version additionally has a deterministic,
+network-free guard in
+``tests/unit/website/test_website_version_accuracy.py`` (it compares
+``features.ts`` to this repo's own ``pyproject.toml``).
+
+Usage:
+    python scripts/audit_website_versions.py
+    python scripts/audit_website_versions.py --format json
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+FEATURES = REPO / "website" / "lib" / "features.ts"
+
+#: A PRODUCTS entry lists ``pypiName`` immediately before ``version``;
+#: ``\s+`` spans the newline + indent between the two fields.
+PAIR_RE = re.compile(r'pypiName:\s*"([^"]+)",\s+version:\s*"([^"]+)"')
+
+HTTP_TIMEOUT = 5
+
+
+def parse_products(text: str) -> list[tuple[str, str]]:
+    """Return ``(pypiName, version)`` pairs from a features.ts source."""
+    return PAIR_RE.findall(text)
+
+
+def pypi_latest(pkg: str) -> str | None:
+    """Return the latest version of ``pkg`` on PyPI, or None on any error."""
+    url = f"https://pypi.org/pypi/{pkg}/json"
+    try:
+        # noqa: S310 / nosec B310 — hardcoded https PyPI URL, scheme fixed.
+        with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT) as resp:  # noqa: S310  # nosec B310
+            return json.load(resp)["info"]["version"]
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: any PyPI hiccup (offline, 404, parse) is non-fatal —
+        # the package is reported "unverified" rather than failing the audit.
+        return None
+
+
+def audit(text: str, fetch=pypi_latest) -> list[dict]:
+    """Compare each product's claimed version to PyPI.
+
+    ``fetch`` is injectable so tests can run hermetically. One PyPI
+    lookup per distinct package (cached). Each row is
+    ``{package, site, pypi, status}`` where status is ok/drift/unverified.
+    """
+    rows: list[dict] = []
+    cache: dict[str, str | None] = {}
+    for name, version in parse_products(text):
+        if name not in cache:
+            cache[name] = fetch(name)
+        latest = cache[name]
+        if latest is None:
+            status = "unverified"
+        elif latest == version:
+            status = "ok"
+        else:
+            status = "drift"
+        rows.append({"package": name, "site": version, "pypi": latest, "status": status})
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Exit 1 iff any version CONFIRMED-drifted from PyPI."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--features", type=Path, default=FEATURES)
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    args = parser.parse_args(argv)
+    try:
+        text = args.features.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: cannot read {args.features}: {exc}", file=sys.stderr)
+        return 1
+
+    rows = audit(text)
+    if args.format == "json":
+        print(json.dumps(rows, indent=2))
+    else:
+        marks = {"ok": "✓", "drift": "✗", "unverified": "?"}
+        for r in rows:
+            print(f"  {marks[r['status']]} {r['package']:16} site={r['site']:8} pypi={r['pypi']}")
+
+    drift = [r for r in rows if r["status"] == "drift"]
+    if drift:
+        names = ", ".join(f"{r['package']} ({r['site']}->{r['pypi']})" for r in drift)
+        print(
+            f"\n{len(drift)} version(s) drifted from PyPI: {names}\n"
+            "Update website/lib/features.ts to match.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_website_version_accuracy.py
+++ b/tests/unit/test_website_version_accuracy.py
@@ -1,0 +1,130 @@
+"""Guards for website version/accuracy claims.
+
+Lives flat in tests/unit/ (NOT tests/unit/website/) because pytest.ini's
+``norecursedirs`` excludes any ``website`` directory — a subdir there
+would be silently uncollected (caught by test_workflow_yaml's
+norecursedirs guard).
+
+Two layers:
+
+1. **Deterministic, network-free** — the attune-ai version claimed in
+   ``website/lib/features.ts`` (and the homepage badge) MUST equal this
+   repo's own ``pyproject.toml`` version. This is the guard that prevents
+   the exact drift caught 2026-06-28 (website stuck at 8.7.0 while the
+   package shipped 9.1.0). It runs in the normal suite — so any release
+   that advances pyproject past the website turns this red.
+
+2. **Hermetic tests of the PyPI audit script** —
+   ``scripts/audit_website_versions.py`` parses the PRODUCTS list and
+   compares every package (incl. external attune-help/-author) to PyPI;
+   here its parse + compare logic is exercised with an injected fetch
+   (no network).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+FEATURES = REPO / "website" / "lib" / "features.ts"
+HOMEPAGE = REPO / "website" / "app" / "page.tsx"
+PYPROJECT = REPO / "pyproject.toml"
+
+SCRIPT_PATH = REPO / "scripts" / "audit_website_versions.py"
+
+
+def _pkg_version() -> str:
+    match = re.search(r'^version = "(\d+\.\d+\.\d+)"', PYPROJECT.read_text(encoding="utf-8"), re.M)
+    assert match, 'pyproject.toml: no `version = "X.Y.Z"` line'
+    return match.group(1)
+
+
+# --- Layer 1: deterministic self-version guard ------------------------
+
+
+@pytest.mark.skipif(not FEATURES.is_file(), reason="website/ not present")
+class TestFeaturesVersionSync:
+    def test_attune_ai_product_versions_match_package(self):
+        pkg = _pkg_version()
+        text = FEATURES.read_text(encoding="utf-8")
+        pairs = re.findall(r'pypiName:\s*"([^"]+)",\s+version:\s*"([^"]+)"', text)
+        attune = {v for name, v in pairs if name == "attune-ai"}
+        assert attune, "no attune-ai product entry found in features.ts"
+        assert attune == {pkg}, (
+            f"features.ts attune-ai version(s) {attune} != package {pkg} — "
+            "bump website/lib/features.ts on release"
+        )
+
+    @pytest.mark.skipif(not HOMEPAGE.is_file(), reason="homepage not present")
+    def test_homepage_badge_includes_package_version(self):
+        pkg = _pkg_version()
+        found = set(re.findall(r"v(\d+\.\d+\.\d+)", HOMEPAGE.read_text(encoding="utf-8")))
+        assert pkg in found, (
+            f"homepage badge versions {found} do not include package {pkg} — "
+            "update the <span>vX.Y.Z</span> badge in website/app/page.tsx"
+        )
+
+
+# --- Layer 2: hermetic tests of the PyPI audit script -----------------
+
+
+@pytest.fixture(scope="module")
+def audit_module():
+    spec = importlib.util.spec_from_file_location("_audit_website_versions", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+SAMPLE = """
+export const PRODUCTS = [
+  {
+    id: "attune-ai",
+    pypiName: "attune-ai",
+    version: "9.1.0",
+  },
+  {
+    id: "attune-help",
+    pypiName: "attune-help",
+    version: "0.11.1",
+  },
+];
+"""
+
+
+class TestAuditScript:
+    def test_parse_products_extracts_pairs_in_order(self, audit_module):
+        pairs = audit_module.parse_products(SAMPLE)
+        assert pairs == [("attune-ai", "9.1.0"), ("attune-help", "0.11.1")]
+
+    def test_audit_flags_drift(self, audit_module):
+        rows = audit_module.audit(SAMPLE, fetch=lambda pkg: "9.9.9")
+        assert {r["package"]: r["status"] for r in rows} == {
+            "attune-ai": "drift",
+            "attune-help": "drift",
+        }
+
+    def test_audit_ok_when_matching(self, audit_module):
+        latest = {"attune-ai": "9.1.0", "attune-help": "0.11.1"}
+        rows = audit_module.audit(SAMPLE, fetch=lambda pkg: latest[pkg])
+        assert all(r["status"] == "ok" for r in rows)
+
+    def test_network_failure_is_unverified_not_drift(self, audit_module):
+        rows = audit_module.audit(SAMPLE, fetch=lambda pkg: None)
+        assert all(r["status"] == "unverified" for r in rows)
+
+    def test_one_fetch_per_distinct_package(self, audit_module):
+        calls = {"n": 0}
+
+        def counting_fetch(pkg):
+            calls["n"] += 1
+            return "9.1.0"
+
+        dup = SAMPLE + SAMPLE  # attune-ai + attune-help appear twice
+        audit_module.audit(dup, fetch=counting_fetch)
+        assert calls["n"] == 2  # cached: one lookup per distinct name

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -176,7 +176,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    17 multi-stage workflows, 17 skills, 41 MCP tools.
+                    19 multi-stage workflows, 17 skills, 47 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -571,9 +571,9 @@ export default function DocsPage() {
                 Workflows &amp; Skills
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                The build half of the loop: 17 multi-stage workflows
-                (20 workflows total), 17 auto-triggering Claude Code skills,
-                and an MCP server with 41 registered tools — review, tests,
+                The build half of the loop: 19 multi-stage workflows
+                (22 workflows total), 17 auto-triggering Claude Code skills,
+                and an MCP server with 47 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>
 

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -30,11 +30,11 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What are the four pillars?',
-        answer: 'Attune AI is built on four pillars, each a real, shipped capability: AI workflows (17 multi-stage workflows for review, tests, bug prediction, and refactors), Project memory (cross-session findings and a retrievable lessons corpus), Retrieval grounding (citations back to your source via attune-rag), and Verification (fact-checking generated content before it reaches main).',
+        answer: 'Attune AI is built on four pillars, each a real, shipped capability: AI workflows (19 multi-stage workflows for review, tests, bug prediction, and refactors), Project memory (cross-session findings and a retrievable lessons corpus), Retrieval grounding (citations back to your source via attune-rag), and Verification (fact-checking generated content before it reaches main).',
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 20 workflows (17 multi-stage), 41 MCP tools, 17 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 17 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v8.7.0</span>
+                  <span>v9.1.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "8.7.0",
+    version: "9.1.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -47,7 +47,7 @@ export const PRODUCTS: Product[] = [
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
       "17 Claude Code skills included",
-      "MCP server with 41 registered tools",
+      "MCP server with 47 registered tools",
     ],
   },
   {
@@ -76,7 +76,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-author",
     name: "Attune Author",
     pypiName: "attune-author",
-    version: "0.21.0",
+    version: "0.22.0",
     tagline: "Author and polish help content with AI",
     installCommand: "pip install 'attune-author[plugin]'",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "8.7.0",
+    version: "9.1.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",
@@ -248,8 +248,8 @@ export const DIFFERENTIATORS: Differentiator[] = [
 /**
  * Counts that appear in prose and stat callouts across the
  * site. Verified against the live Python code per the
- * website-content-accuracy rule (last verified 2026-06-22,
- * attune-ai 8.7.0):
+ * website-content-accuracy rule (last verified 2026-06-28,
+ * attune-ai 9.1.0):
  *
  *   workflows: attune.workflows.list_workflows() with stages
  *   skills: plugin/skills/ directory count (test_skill_count)
@@ -262,9 +262,9 @@ export const DIFFERENTIATORS: Differentiator[] = [
  * and no page consumed them.)
  */
 export const CAPABILITIES = {
-  workflows: 17,
+  workflows: 19,
   skills: 17,
-  mcpTools: 41,
+  mcpTools: 47,
   templateKinds: 15,
   wizards: 5,
 } as const;
@@ -305,7 +305,7 @@ export const RELIABILITY_LOOP: LoopStage[] = [
     n: "03",
     name: "Build",
     description:
-      "17 multi-stage workflows: review, tests, bug prediction, refactor.",
+      "19 multi-stage workflows: review, tests, bug prediction, refactor.",
   },
   {
     n: "04",
@@ -343,7 +343,7 @@ export const PILLARS: Pillar[] = [
     tag: "AI workflows",
     title: "Specialist teams, not one prompt",
     description:
-      "17 multi-stage workflows run teams of 2–6 Claude subagents to " +
+      "19 multi-stage workflows run teams of 2–6 Claude subagents to " +
       "review code, surface vulnerabilities, generate tests, and plan " +
       "refactors — with cost-tiered model routing.",
     points: [


### PR DESCRIPTION
## Problem

Patrick flagged the website's package versions as wrong. An audit of
every versioned/countable claim (verified against live 9.1.0 code from
`origin/main`, not a stale checkout) found multiple stale values across
`features.ts` and the faq/docs pages.

## Corrected

**Package versions** (`features.ts` PRODUCTS + homepage `<span>` badge):

| Package | Was | Now (PyPI) |
|---|---|---|
| attune-ai | 8.7.0 | **9.1.0** |
| attune-author | 0.21.0 | **0.22.0** |
| attune-help | 0.11.1 | 0.11.1 (already correct) |

**Counts** (`CAPABILITIES` + prose on faq/docs):

| Claim | Was | Now (live) |
|---|---|---|
| workflows total | 20 | **22** |
| workflows multi-stage | 17 | **19** |
| MCP tools | 41 | **47** |
| skills / wizards / template kinds | 17 / 5 / 15 | unchanged (correct) |

## Root cause + guard

`features.ts` manually tracks three *separate* PyPI packages' versions,
and pages hardcode counts instead of importing `CAPABILITIES`, with
nothing syncing them. Added a durable guard so this can't silently recur:

- **`tests/unit/test_website_version_accuracy.py`** — deterministic,
  network-free: the attune-ai version in `features.ts` + homepage badge
  **must** equal this repo's `pyproject.toml` (so any release that
  advances the package past the website turns this red). Plus hermetic
  tests of the audit script. (Flat in `tests/unit/` — a
  `tests/unit/website/` subdir is silently uncollected by `pytest.ini`
  `norecursedirs`, which the workflow-yaml guard caught.)
- **`scripts/audit_website_versions.py`** — checks all three packages vs
  PyPI; network-tolerant (`unverified` on hiccup, exit 1 only on
  confirmed drift).
- **`.github/workflows/website-accuracy.yml`** — advisory CI running both.

## Verification

- Live PyPI audit: all 4 product entries ✓ after the fix.
- `tests/unit/test_website_version_accuracy.py` — 7 pass (no false skips).
- `tests/unit/ci/test_workflow_yaml.py` — 265 pass (new workflow conforms
  to SHA-pin / concurrency / pip-cache conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)