### PR TITLE
fix(website): correct skills count to 23 (verified)

### DIFF
--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -45,7 +45,7 @@ const faqItems = [
   {
     question: 'What Claude Code skills are included?',
     answer:
-      '17 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, the coach help system, and the attune hub router.',
+      '23 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, and the attune hub router.',
   },
   {
     question: 'Where do I install attune-help and attune-author from?',
@@ -66,14 +66,15 @@ const workflows = [
   { name: 'Release Prep', description: 'Changelog, version bump, health checks' },
 ];
 
-// The 17 plugin skills — keep in sync with plugin/skills/
+// The 23 plugin skills — keep in sync with plugin/skills/
 // (test_skill_count asserts the directory count).
 const skills = [
   'security-audit', 'smart-test', 'code-quality', 'bug-predict',
   'doc-gen', 'refactor-plan', 'release-prep', 'planning',
   'spec', 'fix-test', 'workflow-orchestration', 'rag-code-gen',
-  'verify', 'recall', 'memory-and-context', 'coach',
-  'attune-hub',
+  'verify', 'recall', 'memory-and-context', 'personal-memory',
+  'image-analysis', 'bulk', 'catalog', 'discovery-sweep',
+  'elicit', 'coach', 'attune-hub',
 ];
 
 export default function DocsPage() {
@@ -176,7 +177,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    19 multi-stage workflows, 17 skills, 47 MCP tools.
+                    19 multi-stage workflows, 23 skills, 47 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -505,7 +506,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 Install from the marketplace. Progressive help, project
-                bootstrapping, and 17 skills right in your terminal.
+                bootstrapping, and 23 skills right in your terminal.
               </p>
 
               <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 mb-8">
@@ -572,7 +573,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 The build half of the loop: 19 multi-stage workflows
-                (22 workflows total), 17 auto-triggering Claude Code skills,
+                (22 workflows total), 23 auto-triggering Claude Code skills,
                 and an MCP server with 47 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>
@@ -599,7 +600,7 @@ export default function DocsPage() {
 
                 <div>
                   <h3 className="font-bold text-lg mb-4">
-                    17 Claude Code Skills
+                    23 Claude Code Skills
                   </h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-4">
                     Skills auto-invoke from natural language. Type the topic

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -34,7 +34,7 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 17 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 23 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -449,7 +449,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Full framework. Workflows, staleness detection, MCP server, and 17 auto-triggering skills for Claude Code.
+                Full framework. Workflows, staleness detection, MCP server, and 23 auto-triggering skills for Claude Code.
               </p>
             </div>
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -46,7 +46,7 @@ export const PRODUCTS: Product[] = [
       "Generate concept, task, and reference templates",
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
-      "17 Claude Code skills included",
+      "23 Claude Code skills included",
       "MCP server with 47 registered tools",
     ],
   },
@@ -117,7 +117,7 @@ export const PRODUCTS: Product[] = [
       "/coach status — check template freshness",
       "/coach maintain — regenerate stale templates",
       "Auto-triggers on natural language (help, explain, learn)",
-      "17 auto-triggering skills (security, testing, review, etc.)",
+      "23 auto-triggering skills (security, testing, review, etc.)",
     ],
   },
 ];
@@ -263,7 +263,7 @@ export const DIFFERENTIATORS: Differentiator[] = [
  */
 export const CAPABILITIES = {
   workflows: 19,
-  skills: 17,
+  skills: 23,
   mcpTools: 47,
   templateKinds: 15,
   wizards: 5,


### PR DESCRIPTION
## Problem

The website advertised **17** auto-triggering skills, but the plugin
actually ships **23** — enforced by
`tests/unit/plugins/test_plugin_config_validation.py::test_skill_count`
(`== 23`, green on main). Six shipped skills were missing from the
public list: `bulk`, `catalog`, `discovery-sweep`, `elicit`,
`image-analysis`, `personal-memory`.

#1141 refreshed the site to 9.1.0 and claimed "skills … unchanged
(correct)", but its drift guard only checks the package **version**
against `pyproject.toml` — not the skill count — so the undercount
slipped through.

## Fix

Corrected `17 → 23` everywhere in source and expanded the
`docs/page.tsx` skills array + prose enumeration to list all 23:

- `website/lib/features.ts` — `CAPABILITIES.skills`, two feature bullets
- `website/app/docs/page.tsx` — FAQ enumeration, `skills[]` array + comment, three count strings
- `website/app/faq/page.tsx`, `website/app/page.tsx` — prose counts

Generated `framework-docs/*.html` bundles still say 17 — those are
build artifacts, regenerated separately.

## Verification

- `plugin/skills/` at `origin/main` = 23 SKILL.md dirs; `test_skill_count` asserts 23 (passing).
- `grep` confirms no `17.*skill` strings remain in website source.

Website-only — no changelog per `website/CLAUDE.md`.

## Context

Closes the gap left by #1137 (closed as superseded by #1141, but it was
the only PR that had the count right).

🤖 Generated with [Claude Code](https://claude.com/claude-code)