### PR TITLE
test(website): guard CAPABILITIES counts against live registries

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -11922,3 +11922,31 @@ files.
     `timeout-minutes` per job, a `concurrency` block with
     `cancel-in-progress: true`, and `cache: 'pip'` on setup-python —
     copy an existing workflow's exact pins rather than `@v4`.
+
+- **A "drift guard" only guards the field(s) it actually asserts —
+  its existence is NOT proof the adjacent claims are accurate**: hit
+  2026-06-28. PR #1141 refreshed the website to 9.1.0, added a "drift
+  guard," and declared the capability counts "unchanged (correct)."
+  But the guard (`tests/unit/test_website_version_accuracy.py` Layer 1)
+  only asserts the attune-ai *version* in `features.ts` equals
+  `pyproject.toml` — it never looked at the *counts*. So `features.ts`
+  kept advertising **17** skills while `plugin/skills/` shipped **23**
+  (itself test-enforced by `test_plugin_config_validation.py::
+  test_skill_count == 23`, green the whole time), and the enumeration
+  in `docs/page.tsx` silently omitted 6 real skills (bulk, catalog,
+  discovery-sweep, elicit, image-analysis, personal-memory). The
+  version-only guard stayed green because the two facts are
+  independent. **Durable fix (#1143 + the count-guard PR):** correct
+  the count, then EXTEND the guard to assert every `CAPABILITIES` field
+  against its live registry (skills → `plugin/skills/` dirs; workflows
+  → multi-stage `list_workflows()`; wizards → `list_wizards()`;
+  mcpTools → `tool_schemas` `get_*_tools()` total; templateKinds →
+  `attune_author._ALL_TEMPLATE_NAMES`, `importorskip` since that
+  package isn't in attune-ai CI). General rule: when you see "guard
+  added," read WHICH fields it asserts before trusting any neighbor;
+  a guard that covers one dimension is a *false-safety* surface for
+  the others. The meta-version of `website-content-accuracy.md`
+  (verify counts against live code) — here, verify the *verifier's*
+  scope. Pairs with the existing `norecursedirs` sub-lesson above
+  (a guard that silently doesn't run is the same failure: green ≠
+  guarding).

--- a/tests/unit/test_website_version_accuracy.py
+++ b/tests/unit/test_website_version_accuracy.py
@@ -5,20 +5,30 @@ Lives flat in tests/unit/ (NOT tests/unit/website/) because pytest.ini's
 would be silently uncollected (caught by test_workflow_yaml's
 norecursedirs guard).
 
-Two layers:
+Three layers:
 
-1. **Deterministic, network-free** — the attune-ai version claimed in
-   ``website/lib/features.ts`` (and the homepage badge) MUST equal this
-   repo's own ``pyproject.toml`` version. This is the guard that prevents
-   the exact drift caught 2026-06-28 (website stuck at 8.7.0 while the
-   package shipped 9.1.0). It runs in the normal suite — so any release
-   that advances pyproject past the website turns this red.
+1. **Deterministic version sync, network-free** — the attune-ai version
+   claimed in ``website/lib/features.ts`` (and the homepage badge) MUST
+   equal this repo's own ``pyproject.toml`` version. This is the guard
+   that prevents the exact drift caught 2026-06-28 (website stuck at
+   8.7.0 while the package shipped 9.1.0). It runs in the normal suite —
+   so any release that advances pyproject past the website turns this red.
 
 2. **Hermetic tests of the PyPI audit script** —
    ``scripts/audit_website_versions.py`` parses the PRODUCTS list and
    compares every package (incl. external attune-help/-author) to PyPI;
    here its parse + compare logic is exercised with an injected fetch
    (no network).
+
+3. **Deterministic count sync, network-free** — every field of
+   ``features.ts`` ``CAPABILITIES`` MUST equal the live Python registry
+   it claims to mirror (skills → ``plugin/skills/`` dirs; workflows →
+   multi-stage ``list_workflows()``; wizards → ``list_wizards()``;
+   mcpTools → ``tool_schemas`` ``get_*_tools()`` total; templateKinds →
+   ``attune_author.generator._ALL_TEMPLATE_NAMES``). This closes the
+   blind spot that let the website advertise 17 skills while the plugin
+   shipped 23: the version-only guard (Layer 1) was green the whole time
+   because it never looked at the counts.
 """
 
 from __future__ import annotations
@@ -128,3 +138,78 @@ class TestAuditScript:
         dup = SAMPLE + SAMPLE  # attune-ai + attune-help appear twice
         audit_module.audit(dup, fetch=counting_fetch)
         assert calls["n"] == 2  # cached: one lookup per distinct name
+
+
+# --- Layer 3: deterministic CAPABILITIES count sync -------------------
+
+
+def _capabilities() -> dict[str, int]:
+    """Parse the integer fields of features.ts ``CAPABILITIES``."""
+    text = FEATURES.read_text(encoding="utf-8")
+    block = re.search(r"export const CAPABILITIES = \{(.*?)\} as const;", text, re.S)
+    assert block, "CAPABILITIES object not found in features.ts"
+    caps = {k: int(v) for k, v in re.findall(r"(\w+):\s*(\d+)", block.group(1))}
+    assert caps, "CAPABILITIES parsed empty — check the object shape"
+    return caps
+
+
+def _live_skill_count() -> int:
+    skills_dir = REPO / "plugin" / "skills"
+    return sum(1 for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists())
+
+
+@pytest.mark.skipif(not FEATURES.is_file(), reason="website/ not present")
+class TestCapabilityCountsSync:
+    """features.ts CAPABILITIES MUST equal the live registries it mirrors.
+
+    The mapping is documented in the CAPABILITIES doc-comment in
+    features.ts. Each field is checked independently so a drift names the
+    exact count that went stale. Registries are imported lazily inside
+    each test (no import cost at collection, no failure if an optional
+    registry is absent).
+    """
+
+    def test_skills_count_matches_plugin_dir(self):
+        assert _capabilities()["skills"] == _live_skill_count(), (
+            "features.ts CAPABILITIES.skills != plugin/skills/ dir count — "
+            "update website/lib/features.ts (and the prose on faq/docs/home). "
+            "This is the exact drift caught 2026-06-28 (advertised 17, shipped 23)."
+        )
+
+    def test_workflows_count_matches_registry(self):
+        from attune.workflows import list_workflows
+
+        live = sum(1 for w in list_workflows() if w.get("stages"))
+        assert _capabilities()["workflows"] == live, (
+            f"CAPABILITIES.workflows != live multi-stage workflow count ({live}) — "
+            "update website/lib/features.ts"
+        )
+
+    def test_wizards_count_matches_registry(self):
+        from attune.wizards import list_wizards
+
+        live = len(list_wizards())
+        assert _capabilities()["wizards"] == live, (
+            f"CAPABILITIES.wizards != live list_wizards() count ({live}) — "
+            "update website/lib/features.ts"
+        )
+
+    def test_mcp_tools_count_matches_schemas(self):
+        from attune.mcp import tool_schemas as ts
+
+        getters = [getattr(ts, n) for n in dir(ts) if n.startswith("get_") and n.endswith("_tools")]
+        live = sum(len(fn()) for fn in getters)
+        assert _capabilities()["mcpTools"] == live, (
+            f"CAPABILITIES.mcpTools != live get_*_tools() total ({live}) — "
+            "update website/lib/features.ts"
+        )
+
+    def test_template_kinds_matches_generator(self):
+        pytest.importorskip("attune_author", reason="attune_author not installed")
+        from attune_author.generator import _ALL_TEMPLATE_NAMES
+
+        live = len(_ALL_TEMPLATE_NAMES)
+        assert _capabilities()["templateKinds"] == live, (
+            f"CAPABILITIES.templateKinds != _ALL_TEMPLATE_NAMES length ({live}) — "
+            "update website/lib/features.ts"
+        )

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -45,7 +45,7 @@ const faqItems = [
   {
     question: 'What Claude Code skills are included?',
     answer:
-      '17 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, the coach help system, and the attune hub router.',
+      '23 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, and the attune hub router.',
   },
   {
     question: 'Where do I install attune-help and attune-author from?',
@@ -66,14 +66,15 @@ const workflows = [
   { name: 'Release Prep', description: 'Changelog, version bump, health checks' },
 ];
 
-// The 17 plugin skills — keep in sync with plugin/skills/
+// The 23 plugin skills — keep in sync with plugin/skills/
 // (test_skill_count asserts the directory count).
 const skills = [
   'security-audit', 'smart-test', 'code-quality', 'bug-predict',
   'doc-gen', 'refactor-plan', 'release-prep', 'planning',
   'spec', 'fix-test', 'workflow-orchestration', 'rag-code-gen',
-  'verify', 'recall', 'memory-and-context', 'coach',
-  'attune-hub',
+  'verify', 'recall', 'memory-and-context', 'personal-memory',
+  'image-analysis', 'bulk', 'catalog', 'discovery-sweep',
+  'elicit', 'coach', 'attune-hub',
 ];
 
 export default function DocsPage() {
@@ -176,7 +177,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    19 multi-stage workflows, 17 skills, 47 MCP tools.
+                    19 multi-stage workflows, 23 skills, 47 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -505,7 +506,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 Install from the marketplace. Progressive help, project
-                bootstrapping, and 17 skills right in your terminal.
+                bootstrapping, and 23 skills right in your terminal.
               </p>
 
               <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 mb-8">
@@ -572,7 +573,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 The build half of the loop: 19 multi-stage workflows
-                (22 workflows total), 17 auto-triggering Claude Code skills,
+                (22 workflows total), 23 auto-triggering Claude Code skills,
                 and an MCP server with 47 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>
@@ -599,7 +600,7 @@ export default function DocsPage() {
 
                 <div>
                   <h3 className="font-bold text-lg mb-4">
-                    17 Claude Code Skills
+                    23 Claude Code Skills
                   </h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-4">
                     Skills auto-invoke from natural language. Type the topic

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -34,7 +34,7 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 17 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 23 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -449,7 +449,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Full framework. Workflows, staleness detection, MCP server, and 17 auto-triggering skills for Claude Code.
+                Full framework. Workflows, staleness detection, MCP server, and 23 auto-triggering skills for Claude Code.
               </p>
             </div>
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -46,7 +46,7 @@ export const PRODUCTS: Product[] = [
       "Generate concept, task, and reference templates",
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
-      "17 Claude Code skills included",
+      "23 Claude Code skills included",
       "MCP server with 47 registered tools",
     ],
   },
@@ -117,7 +117,7 @@ export const PRODUCTS: Product[] = [
       "/coach status — check template freshness",
       "/coach maintain — regenerate stale templates",
       "Auto-triggers on natural language (help, explain, learn)",
-      "17 auto-triggering skills (security, testing, review, etc.)",
+      "23 auto-triggering skills (security, testing, review, etc.)",
     ],
   },
 ];
@@ -263,7 +263,7 @@ export const DIFFERENTIATORS: Differentiator[] = [
  */
 export const CAPABILITIES = {
   workflows: 19,
-  skills: 17,
+  skills: 23,
   mcpTools: 47,
   templateKinds: 15,
   wizards: 5,


### PR DESCRIPTION
## Why

#1141 added a website "drift guard" and declared the capability counts
correct — but the guard (`test_website_version_accuracy.py` **Layer 1**)
only asserts the attune-ai **version** in `features.ts` equals
`pyproject.toml`. It never looked at the **counts**. That blind spot let
the site advertise **17** skills while `plugin/skills/` shipped **23**
(itself enforced by `test_plugin_config_validation.py::test_skill_count
== 23`, green the whole time). See #1143 for the count correction.

## What

Adds **Layer 3** to `tests/unit/test_website_version_accuracy.py` —
`TestCapabilityCountsSync`. Every `features.ts` `CAPABILITIES` field is
asserted against the live registry its doc-comment documents:

| Field | Live source |
|---|---|
| `skills` | `plugin/skills/` dirs with `SKILL.md` |
| `workflows` | multi-stage `list_workflows()` |
| `wizards` | `list_wizards()` |
| `mcpTools` | `tool_schemas` `get_*_tools()` total (auto-discovered) |
| `templateKinds` | `attune_author._ALL_TEMPLATE_NAMES` (`importorskip`) |

Network-free, deterministic, runs in the normal suite — so a future
count drift turns CI red the way a version drift already does. Registries
are imported lazily per-test (no collection cost, graceful skip when an
optional package like `attune_author` is absent).

Also records the durable lesson in `.claude/lessons.md`: *a drift guard
only guards the field(s) it actually asserts — its existence is not proof
adjacent claims are accurate.*

## Verification

`tests/unit/test_website_version_accuracy.py` — 12 pass (7 prior + 5 new)
against live 9.1.0 registries (19 / 23 / 5 / 47 / 15). Core-mirror test green.

## ⚠️ Stacked on #1143

Built on `fix/website-skills-count-23` because on `main` `features.ts`
still says `skills: 17` while the code ships 23 — the new skills
assertion needs #1143's correction first. **Merge #1143 before this.**
Once #1143 lands, this PR's diff reduces to just the test + lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)