### PR TITLE
feat(skills): adopt S1 show_widget rich surface in spec/attune/planning kickoffs

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -63,8 +63,12 @@ intent so Claude matches the right skill:
 
 When the scoping turn has **2–4 independent, non-branching, genuinely
 open dimensions** (e.g. goal + scope + focus), gather them as one form
-via the `elicit` skill instead of sequential buttons. Stay
-single-question when only one dimension is unknown or answers branch.
+via the `elicit` skill instead of sequential buttons — **preferring the
+rich widget surface** (`elicitation_render_widget` → `show_widget`, so
+free-text dimensions are textareas and concerns are multi-select
+checkboxes), with the AskUserQuestion mapping as the fallback (see the
+`elicit` skill's "Choosing a surface"). Stay single-question when only
+one dimension is unknown or answers branch.
 
 ## Single-referent resolution
 

--- a/.agents/skills/planning/SKILL.md
+++ b/.agents/skills/planning/SKILL.md
@@ -52,6 +52,16 @@ Before running, ask:
    - Architecture: "What system? Any specific concerns?"
 3. **Scope**: "How deep? Quick outline or detailed plan?"
 
+**Surface.** The **Subject** phrasing branches on **Type**, so don't
+batch all three — ask **Type** first (a single `AskUserQuestion`) when
+it isn't already given by the `<what to plan>` argument. Once the type
+is known, **Subject** (a textarea) and **Scope** (quick / detailed) are
+independent and open: gather *those two* as one form via the `elicit`
+skill, **preferring the rich widget surface** (`elicitation_render_widget`
+→ `show_widget`) with the AskUserQuestion mapping as fallback. If only
+one dimension is open, ask it as a single question — never force a
+one-field form (the §4 batching rule).
+
 ## Execution
 
 1. Use `EnterPlanMode` to create a structured plan

--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -93,14 +93,30 @@ When the user chooses "Start a new spec":
      (multi-select: correctness, security, performance,
      tests, docs)
 
-   Build the declarative form, render it with
-   `elicitation_render_form`, ask the batch in one
-   `AskUserQuestion` call with `metadata:
-   {"source": "elicit-form"}` (the opt-in the
-   one-question-per-turn guard requires), then validate
-   the answers with `elicitation_collect_response`. The
-   `elicit` skill owns the exact render → ask → collect
-   steps; this stage just supplies the three fields.
+   Build the declarative form, then **prefer the rich
+   widget surface** so the kickoff renders as one form
+   with the controls each dimension deserves —
+   `outcome`/`scope` as multi-line textareas and
+   `concerns` as a multi-select checkbox group, instead
+   of three flat button turns. Render it with
+   `elicitation_render_widget` and pass the returned
+   `html` to `mcp__visualize__show_widget`; when the
+   user submits, parse the `__elicitation_response__`
+   postback and validate with
+   `elicitation_collect_response`.
+
+   **Fall back to the portable AskUserQuestion mapping**
+   — `elicitation_render_form` → one `AskUserQuestion`
+   call with `metadata: {"source": "elicit-form"}` (the
+   opt-in the one-question-per-turn guard requires) →
+   `elicitation_collect_response` — when the widget
+   surface is unavailable. Per decisions D10, treat an
+   elicitation `decline` you did **not** see the user
+   make as "surface unavailable" and fall back; never
+   read it as the user saying no. The `elicit` skill
+   owns both round-trips (its "Widget surface" section
+   and steps 2–4); this stage just supplies the three
+   fields.
 
    **Omit any dimension the user already stated** — the
    `<what to build>` argument usually answers `outcome`,

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12005,3 +12005,30 @@ files.
   them. Surfacing the conflict (rather than silently building the
   chosen-but-contradicting scope) is the pushback discipline working —
   but reading decisions first would have avoided the detour entirely.
+
+- **Editing any `plugin/skills/<n>/SKILL.md` requires running
+  `scripts/sync_agents_skills.py` and committing the regenerated
+  `.agents/skills/<n>/SKILL.md` mirror — NO pre-commit hook syncs it, so
+  the edit passes pre-commit + the plugin validators locally yet fails
+  `test_sync_agents_skills` in CI across `coverage` + every `test`/
+  `clock-tz` lane.** 2026-06-28, the spec/attune-hub/planning widget
+  edits (#1147) were markdown-only and green on
+  `test_plugin_reference_validation` / `test_plugin_config_validation`
+  locally, but CI failed `coverage` + `test (ubuntu-latest, 3.12)` +
+  both `clock-tz` lanes with `AssertionError: spec: out of sync. Run:
+  python scripts/sync_agents_skills.py` (and `spec/SKILL.md body
+  differs`). The `.agents/skills/` copies are GENERATED mirrors of
+  `plugin/skills/`, guarded by `test_sync_agents_skills.py`
+  (`test_frontmatter_in_sync` + `test_skill_body_content_matches`), and
+  the sync is enforced only at test time — not at pre-commit (unlike the
+  `.help` regen hook). **Rule:** after editing any `plugin/skills`
+  SKILL.md, run `PYTHONPATH=src python scripts/sync_agents_skills.py` and
+  stage the regenerated `.agents/skills/` files in the SAME commit.
+  **Diagnostic tells:** (1) a markdown-only PR failing `coverage` +
+  `test` + `clock-tz` *together* is a real shared test failure, not a
+  flake/runner-hang (hangs show `pending`/`cancelled`, not `fail`); (2)
+  `gh run view --log-failed` returns nothing while the run is
+  `in_progress`, but `gh api repos/<o>/<r>/actions/jobs/<id>/logs` DOES
+  return a failed job's full log mid-run — fetch it and grep `^FAILED `.
+  Pairs with "a skill can live at `.agents/skills/` OR `plugin/skills/`
+  — check both dirs".

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -11981,3 +11981,27 @@ files.
   Shipped in `fix/docs-checks-always-report`. Pairs with the
   `tests.yml` matrix comment ("a required check that never runs reports
   as missing → the PR is blocked forever").
+
+- **Read the owning spec's `decisions.md` BEFORE presenting scope
+  OPTIONS to the user — an option you offer can contradict a ratified
+  decision, and the user may pick it.** 2026-06-28, scoping "use more
+  advanced elicitation features in `spec` amongst others": I offered
+  "analysis skills" (`code-quality`/`security-audit`/`smart-test`/…) as
+  an `AskUserQuestion` option and Patrick selected it — only THEN did
+  reading `docs/specs/elicitation-form-surface/decisions.md` **D12**
+  reveal those skills were explicitly ruled OUT ("not fits — a
+  multi-field form there is the 'bureaucratic intake' the §4 rule warns
+  against"); the named fits were `/spec`, `/attune`, `/planning`. Caught
+  before building, but only after a wasted option-turn and a
+  contradiction I had to walk back. **Rule:** when a feature has an
+  owning spec, read its `decisions.md` (not just requirements/design)
+  BEFORE constructing the `AskUserQuestion` options — the options you
+  present must be consistent with ratified decisions, or you risk the
+  user choosing a path their own spec argues against. If you DO offer an
+  option a decision rules out, label it an override ("overrides D12") so
+  the choice is informed. Extends "re-validate a spec's premise before
+  executing" to the earlier *option-presentation* step: the premise
+  check belongs before you frame the choices, not just before you act on
+  them. Surfacing the conflict (rather than silently building the
+  chosen-but-contradicting scope) is the pushback discipline working —
+  but reading decisions first would have avoided the detour entirely.

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -403,6 +403,40 @@ running the old way. A real first-consumer integration — not another
 surface — is the next move that would prove the form earns its keep.
 Needs its own scoping (which flow, behind the §4 rule); not started.
 
+## D13 — first-consumer adoption: S1 widget surface wired into the 3 D12-fit flows
+
+**Date:** 2026-06-28 · **Status:** decided (Patrick chose "Follow D12:
+attune + planning", after an initial "analysis skills" pick was
+reconciled against D12)
+
+D12 named the genuine multi-dimension fits (`/spec`, `/attune`
+discovery, `/planning`) and explicitly ruled the path-scoped analysis
+skills (`code-quality`/`security-audit`/`smart-test`/`bug-predict`/
+`release-prep`) **out** — a multi-field form there is the "bureaucratic
+intake" the §4 rule warns against. When the adoption work was scoped,
+the first instinct was to add forms to the analysis skills; reading D12
+overturned that. We wire the **S1 `show_widget` rich surface** (the
+only one that renders on Claude Code — D10) into exactly the three D12
+fits, no further:
+
+- **`spec`** — kickoff (`outcome`/`scope` textareas + `concerns`
+  multi-select) now **prefers** `elicitation_render_widget` →
+  `show_widget`, falling back to the AskUserQuestion-portable mapping
+  when the widget surface is unavailable (and per D10, an unseen
+  `decline` = surface unavailable, not a user "no").
+- **`attune-hub`** — the existing "2–4 open dimensions → one form" note
+  now prefers the widget surface (textareas + multi-select) with the
+  AskUserQuestion fallback.
+- **`planning`** — the **Subject** phrasing branches on **Type**, so it
+  is NOT a clean 3-field batch: ask **Type** first (or take it from the
+  argument), then gather the independent **Subject** + **Scope** as one
+  widget form. Faithful to §4; D12 flagged planning "(maybe)" for this
+  reason.
+
+Native MCP elicitation (`elicitation_ask`) stays a non-option until a
+CC client renders it (D10). The analysis skills stay single-question.
+Surface-only change (skill markdown) — the engine (D11) is unchanged.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -65,8 +65,12 @@ intent so Claude matches the right skill:
 
 When the scoping turn has **2–4 independent, non-branching, genuinely
 open dimensions** (e.g. goal + scope + focus), gather them as one form
-via the `elicit` skill instead of sequential buttons. Stay
-single-question when only one dimension is unknown or answers branch.
+via the `elicit` skill instead of sequential buttons — **preferring the
+rich widget surface** (`elicitation_render_widget` → `show_widget`, so
+free-text dimensions are textareas and concerns are multi-select
+checkboxes), with the AskUserQuestion mapping as the fallback (see the
+`elicit` skill's "Choosing a surface"). Stay single-question when only
+one dimension is unknown or answers branch.
 
 ## Single-referent resolution
 

--- a/plugin/skills/planning/SKILL.md
+++ b/plugin/skills/planning/SKILL.md
@@ -54,6 +54,16 @@ Before running, ask:
    - Architecture: "What system? Any specific concerns?"
 3. **Scope**: "How deep? Quick outline or detailed plan?"
 
+**Surface.** The **Subject** phrasing branches on **Type**, so don't
+batch all three — ask **Type** first (a single `AskUserQuestion`) when
+it isn't already given by the `<what to plan>` argument. Once the type
+is known, **Subject** (a textarea) and **Scope** (quick / detailed) are
+independent and open: gather *those two* as one form via the `elicit`
+skill, **preferring the rich widget surface** (`elicitation_render_widget`
+→ `show_widget`) with the AskUserQuestion mapping as fallback. If only
+one dimension is open, ask it as a single question — never force a
+one-field form (the §4 batching rule).
+
 ## Execution
 
 1. Use `EnterPlanMode` to create a structured plan

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -95,14 +95,30 @@ When the user chooses "Start a new spec":
      (multi-select: correctness, security, performance,
      tests, docs)
 
-   Build the declarative form, render it with
-   `elicitation_render_form`, ask the batch in one
-   `AskUserQuestion` call with `metadata:
-   {"source": "elicit-form"}` (the opt-in the
-   one-question-per-turn guard requires), then validate
-   the answers with `elicitation_collect_response`. The
-   `elicit` skill owns the exact render → ask → collect
-   steps; this stage just supplies the three fields.
+   Build the declarative form, then **prefer the rich
+   widget surface** so the kickoff renders as one form
+   with the controls each dimension deserves —
+   `outcome`/`scope` as multi-line textareas and
+   `concerns` as a multi-select checkbox group, instead
+   of three flat button turns. Render it with
+   `elicitation_render_widget` and pass the returned
+   `html` to `mcp__visualize__show_widget`; when the
+   user submits, parse the `__elicitation_response__`
+   postback and validate with
+   `elicitation_collect_response`.
+
+   **Fall back to the portable AskUserQuestion mapping**
+   — `elicitation_render_form` → one `AskUserQuestion`
+   call with `metadata: {"source": "elicit-form"}` (the
+   opt-in the one-question-per-turn guard requires) →
+   `elicitation_collect_response` — when the widget
+   surface is unavailable. Per decisions D10, treat an
+   elicitation `decline` you did **not** see the user
+   make as "surface unavailable" and fall back; never
+   read it as the user saying no. The `elicit` skill
+   owns both round-trips (its "Widget surface" section
+   and steps 2–4); this stage just supplies the three
+   fields.
 
    **Omit any dimension the user already stated** — the
    `<what to build>` argument usually answers `outcome`,


### PR DESCRIPTION
## What

Wires the **S1 `show_widget` rich surface** (multi-line textareas,
multi-select checkboxes, number/date — the only advanced elicitation
surface that renders on Claude Code, per **D10**) into the three
multi-dimension scoping flows the spec's **D12** endorsed:

| Skill | Change |
|---|---|
| **spec** | Kickoff (`outcome`/`scope` textareas + `concerns` multi-select) now **prefers** `elicitation_render_widget` → `show_widget`, with the AskUserQuestion-portable mapping as fallback (D10 caveat: an unseen `decline` = surface unavailable, not a user "no"). |
| **attune-hub** | The existing "2–4 open dimensions → one form" note prefers the widget surface with AskUserQuestion fallback. |
| **planning** | `Subject` branches on `Type`, so it's *not* a clean 3-field batch — `Type` stays a single question; the independent `Subject`+`Scope` batch as a widget form. Faithful to the §4 rule. |

## Scope decision (the interesting part)

The initial instinct was to add forms to the **analysis skills**
(`code-quality`/`security-audit`/`smart-test`/…). Reading the spec's
**D12** overturned that: those are path-scoped single-arg flows D12
explicitly names as **not fits** — a multi-field form there is the
"bureaucratic intake" the §4 batching rule exists to prevent. So this PR
sticks to D12's endorsed fits and leaves the analysis skills
single-question. Recorded as **D13**.

## Surface-only

Skill markdown only — the elicitation engine (D11: `form_to_widget_html`,
`elicitation_render_widget`, postback → `collect_form_response`) is
unchanged. Native MCP elicitation (`elicitation_ask`) stays a non-option
until a CC client renders it.

## Verification

- `tests/unit/plugins/test_plugin_reference_validation.py` +
  `test_plugin_config_validation.py` — 49 pass / 3 skip (all referenced
  MCP tools resolve; skill descriptions within limits).
- **Dogfooded live:** rendered the real `spec` kickoff form through
  `elicitation_render_widget` → `show_widget` — `success: true`, all
  rich controls present (textarea, text, multi-select checkboxes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)