### PR TITLE
refactor(widgets): shared findings_widget primitive (FR-1)

### DIFF
--- a/src/attune/workflows/discovery_sweep/board.py
+++ b/src/attune/workflows/discovery_sweep/board.py
@@ -14,40 +14,20 @@ The agent passes the returned HTML straight to
 
 from __future__ import annotations
 
-import html
 from typing import Any
 
-# Severity → accent colour. Mid-tone hues that stay legible on both
-# light and dark backgrounds; used only for a small dot + left border,
-# never as text colour, so contrast never depends on the hue.
-_SEV_COLOUR: dict[str, str] = {
-    "critical": "#e5484d",
-    "high": "#f76808",
-    "medium": "#ffb224",
-    "low": "#46a758",
-    "info": "#8b8d98",
-}
-_SEV_ORDER = ["critical", "high", "medium", "low", "info"]
-
-
-def _esc(value: Any) -> str:
-    """HTML-escape any value (None → empty string)."""
-    return html.escape("" if value is None else str(value))
-
-
-def _location(finding: dict[str, Any]) -> str:
-    """``file:line`` (escaped) or ``"—"`` when the finding has no location."""
-    file = finding.get("file")
-    if not file:
-        return "—"
-    line = finding.get("line")
-    loc = f"{file}:{line}" if line else str(file)
-    return _esc(loc)
+# Shared findings-widget primitives (spec FR-1). Private aliases keep the
+# rest of this module unchanged — a pure de-dup, no behaviour change.
+from attune.workflows.findings_widget import SEV_ORDER as _SEV_ORDER
+from attune.workflows.findings_widget import colour_for as _colour_for
+from attune.workflows.findings_widget import esc as _esc
+from attune.workflows.findings_widget import location as _location
+from attune.workflows.findings_widget import severity_of as _severity_of
 
 
 def _finding_card(finding: dict[str, Any], extra: str = "") -> str:
-    sev = str(finding.get("severity", "info")).lower()
-    colour = _SEV_COLOUR.get(sev, _SEV_COLOUR["info"])
+    sev = _severity_of(finding)
+    colour = _colour_for(finding)
     conf = finding.get("confidence")
     conf_txt = f" · {round(float(conf) * 100)}% conf" if conf is not None else ""
     return (

--- a/src/attune/workflows/findings_widget.py
+++ b/src/attune/workflows/findings_widget.py
@@ -1,0 +1,63 @@
+"""Shared primitives for findings-based ``show_widget`` surfaces.
+
+Extracted (spec: docs/specs/analysis-workflow-output-widgets/ FR-1) from
+the two shipped consumers — the discovery-sweep triage board
+(``discovery_sweep.board``) and the security-audit severity dashboard
+(``security_audit_dashboard``) — which each carried a private copy of
+the severity palette + escaping + location helpers. This is the one
+place to change them; every Family-A widget builds on it.
+
+All consumers keep the same injection-safety contract: display-only (no
+``<script>``), every finding-derived string ``html.escape``d, CDS design
+tokens, transparent background, no ``position: fixed``.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+# Severity → accent colour. Mid-tone hues that stay legible on both
+# light and dark backgrounds; used only for a dot / left border / chip
+# border, never as text colour, so contrast never depends on the hue.
+SEV_COLOUR: dict[str, str] = {
+    "critical": "#e5484d",
+    "high": "#f76808",
+    "medium": "#ffb224",
+    "low": "#46a758",
+    "info": "#8b8d98",
+}
+
+# Canonical severity ordering, most-severe first.
+SEV_ORDER: list[str] = ["critical", "high", "medium", "low", "info"]
+
+
+def esc(value: Any) -> str:
+    """HTML-escape any value (``None`` → empty string)."""
+    return html.escape("" if value is None else str(value))
+
+
+def severity_of(finding: dict[str, Any]) -> str:
+    """Lower-cased severity of a finding dict, defaulting to ``info``."""
+    return str(finding.get("severity", "info")).lower()
+
+
+def severity_rank(finding: dict[str, Any]) -> int:
+    """Sort key: index into :data:`SEV_ORDER`, unknown severities last."""
+    sev = severity_of(finding)
+    return SEV_ORDER.index(sev) if sev in SEV_ORDER else len(SEV_ORDER)
+
+
+def colour_for(finding: dict[str, Any]) -> str:
+    """Accent colour for a finding's severity."""
+    return SEV_COLOUR.get(severity_of(finding), SEV_COLOUR["info"])
+
+
+def location(finding: dict[str, Any]) -> str:
+    """``file:line`` (escaped) or ``"—"`` when the finding has no file."""
+    file = finding.get("file")
+    if not file:
+        return "—"
+    line = finding.get("line")
+    loc = f"{file}:{line}" if line else str(file)
+    return esc(loc)

--- a/src/attune/workflows/security_audit_dashboard.py
+++ b/src/attune/workflows/security_audit_dashboard.py
@@ -21,24 +21,16 @@ main they collapse into one shared ``findings_widget`` primitive
 
 from __future__ import annotations
 
-import html
 from typing import Any
 
-# Severity → accent colour. Mid-tone hues legible on both light and dark
-# backgrounds; used only for a dot / left border / chip border, never as
-# text colour, so contrast never depends on the hue.
-_SEV_COLOUR: dict[str, str] = {
-    "critical": "#e5484d",
-    "high": "#f76808",
-    "medium": "#ffb224",
-    "low": "#46a758",
-    "info": "#8b8d98",
-}
-_SEV_ORDER = ["critical", "high", "medium", "low", "info"]
-
-
-def _esc(value: Any) -> str:
-    return html.escape("" if value is None else str(value))
+# Shared findings-widget primitives (spec FR-1). Private aliases keep the
+# rest of this module unchanged — a pure de-dup, no behaviour change.
+from attune.workflows.findings_widget import SEV_COLOUR as _SEV_COLOUR
+from attune.workflows.findings_widget import SEV_ORDER as _SEV_ORDER
+from attune.workflows.findings_widget import esc as _esc
+from attune.workflows.findings_widget import location as _location
+from attune.workflows.findings_widget import severity_of as _sev
+from attune.workflows.findings_widget import severity_rank as _sev_rank
 
 
 def _normalize(finding: Any) -> dict[str, Any]:
@@ -58,24 +50,6 @@ def _normalize(finding: Any) -> dict[str, Any]:
         "line": None,
         "code": None,
     }
-
-
-def _sev(finding: dict[str, Any]) -> str:
-    return str(finding.get("severity", "info")).lower()
-
-
-def _location(finding: dict[str, Any]) -> str:
-    file = finding.get("file")
-    if not file:
-        return "—"
-    line = finding.get("line")
-    loc = f"{file}:{line}" if line else str(file)
-    return _esc(loc)
-
-
-def _sev_rank(finding: dict[str, Any]) -> int:
-    sev = _sev(finding)
-    return _SEV_ORDER.index(sev) if sev in _SEV_ORDER else len(_SEV_ORDER)
 
 
 def _chip(label: str, count: int, colour: str) -> str:

--- a/tests/unit/workflows/test_findings_widget.py
+++ b/tests/unit/workflows/test_findings_widget.py
@@ -1,0 +1,57 @@
+"""Tests for the shared findings-widget primitives (spec FR-1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.workflows import findings_widget as fw
+
+pytestmark = pytest.mark.unit
+
+
+class TestEsc:
+    def test_escapes_html(self):
+        assert fw.esc("<script>") == "&lt;script&gt;"
+        assert fw.esc("a&b") == "a&amp;b"
+
+    def test_none_is_empty(self):
+        assert fw.esc(None) == ""
+
+    def test_non_str_coerced(self):
+        assert fw.esc(42) == "42"
+
+
+class TestSeverity:
+    def test_severity_of_defaults_info(self):
+        assert fw.severity_of({}) == "info"
+        assert fw.severity_of({"severity": "HIGH"}) == "high"
+
+    def test_rank_orders_critical_first(self):
+        assert fw.severity_rank({"severity": "critical"}) < fw.severity_rank({"severity": "low"})
+
+    def test_unknown_severity_ranks_last(self):
+        assert fw.severity_rank({"severity": "bogus"}) == len(fw.SEV_ORDER)
+
+    def test_colour_for_known_and_unknown(self):
+        assert fw.colour_for({"severity": "critical"}) == fw.SEV_COLOUR["critical"]
+        assert fw.colour_for({"severity": "bogus"}) == fw.SEV_COLOUR["info"]
+
+
+class TestLocation:
+    def test_file_and_line(self):
+        assert fw.location({"file": "src/x.py", "line": 10}) == "src/x.py:10"
+
+    def test_file_without_line(self):
+        assert fw.location({"file": "src/x.py", "line": None}) == "src/x.py"
+
+    def test_missing_file_is_dash(self):
+        assert fw.location({"file": None, "line": 5}) == "—"
+
+    def test_location_escapes(self):
+        assert fw.location({"file": "a<b>", "line": 1}) == "a&lt;b&gt;:1"
+
+
+class TestPaletteShape:
+    def test_order_matches_colour_keys(self):
+        assert set(fw.SEV_ORDER) == set(fw.SEV_COLOUR)
+        assert fw.SEV_ORDER[0] == "critical"


### PR DESCRIPTION
## What

**FR-1** of the analysis-workflow-output-widgets spec (#1150): extract
the severity palette + `esc`/`location`/severity helpers — duplicated in
the discovery-sweep triage board (#1148) and the security-audit severity
dashboard (#1149) — into a single `attune.workflows.findings_widget`, and
migrate both consumers onto it.

## How

- New `findings_widget` module: `SEV_COLOUR`, `SEV_ORDER`, `esc`,
  `severity_of`, `severity_rank`, `colour_for`, `location`.
- `board.py` and `security_audit_dashboard.py` import them via private
  aliases — **pure de-dup, zero behaviour change** (the rest of each
  module is untouched). Net **−46 lines**.

## Verification

- Both existing suites stay green (27 tests: 14 board + 13 dashboard).
- 12 new `test_findings_widget.py` tests cover the primitives (escaping,
  severity ordering, unknown-severity handling, location edge cases,
  palette/order consistency).

Every Family-A widget (perf-audit, bug-predict next) now builds on this
one module instead of copying the palette a third time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)