### PR TITLE
fix(security-audit): don't render a failed audit as "clean"

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12058,3 +12058,39 @@ files.
   "markdown-only PR failing coverage+test+clock-tz together is ONE
   shared failure" and the `sync_agents_skills` lessons above — same
   "broad red, single cause" family.
+
+- **An output widget/consumer "tested" against hand-built fixtures that
+  match its OWN assumed input shape proves nothing about the real
+  PRODUCER's payload — dogfood the actual workflow output before
+  building, or you ship a widget that degrades on real data.** 2026-06-28,
+  the analysis-workflow-output-widgets program: I shipped #1148
+  (discovery-sweep board) and #1149 (security-audit severity dashboard)
+  with helpers consuming `Finding{severity,file,line,message}` dicts, and
+  unit-tested them with hand-authored structured findings matching the
+  helper's expected shape — all green, demoed beautifully via
+  `show_widget`. Then a live dogfood + reading
+  `agent_sdk_adapter._parse_findings` revealed the REAL output of every
+  SDK-native workflow (security-audit, perf-audit, bug-predict,
+  code-review, …) is `dict[category → list[str]]`
+  (security/quality/performance/architecture → bullet STRINGS), NOT
+  structured Findings. ONLY discovery-sweep builds real `Finding` objects
+  (deterministic source adapters). So #1149's dashboard degrades on real
+  data — `_normalize` wraps each bullet as a flat `info` card, none of the
+  demo's severity colours / `file:line` / sorting. The synthetic fixtures
+  passed precisely because they assumed the shape the widget wanted: they
+  tested the consumer against ITSELF, never the producer. Rules: (1)
+  before building a consumer that assumes input shape X, dogfood the REAL
+  producer ONCE and inspect the actual payload — markdown→structure
+  extraction (`_parse_findings`) rarely yields the rich shape you'd design
+  for; (2) a unit test whose fixture you hand-authored to match the
+  consumer is necessary-not-sufficient — it cannot catch a
+  producer/consumer shape mismatch; (3) **empty output on FAILURE must not
+  render as success** — #1149 showed "no findings — clean" when the audit
+  returned `success:false, findings:[]` (auth failure), a false all-clear
+  on a security surface (fixed #1152 with a `succeeded` flag). (4)
+  **nested SDK workflows can't auth** from a direct `python` run OR the
+  MCP tool inside a worktree session (both returned `success:false`,
+  cost 0) — capturing a real payload needs a CI `integration-auth` job or
+  the user running it in a normal auth'd session. Same "dogfood the real
+  loop, not synthetic data" family as the "registered ≠ working" core
+  lesson — this is the output-widget-shape instance.

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -405,6 +405,10 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         response["dashboard_html"] = security_findings_dashboard_html(
             response.get("findings") or [],
             score=response.get("health_score"),
+            # A failed audit with empty findings must NOT render as
+            # "clean" — that would be a false all-clear on a security
+            # surface (observed when the workflow can't auth).
+            succeeded=bool(response.get("success", True)),
         )
         return response
 

--- a/src/attune/workflows/security_audit_dashboard.py
+++ b/src/attune/workflows/security_audit_dashboard.py
@@ -82,6 +82,7 @@ def security_findings_dashboard_html(
     findings: list[dict[str, Any]],
     score: int | None = None,
     message: str = "",
+    succeeded: bool = True,
 ) -> str:
     """Render a list of security findings as a severity dashboard.
 
@@ -90,10 +91,25 @@ def security_findings_dashboard_html(
             ``security_audit`` tool's ``findings`` list (already dicts).
         score: Optional health score (0-100) for the header chip.
         message: Optional caption shown above the dashboard.
+        succeeded: Whether the audit actually ran. When ``False``, an
+            empty ``findings`` list means the run FAILED, not that the
+            code is clean — render an explicit "did not complete" state
+            instead of a false "no findings — clean" all-clear.
 
     Returns:
         Self-contained HTML for ``mcp__visualize__show_widget``.
     """
+    if not succeeded:
+        caption = f'<p class="sa-msg-top">{_esc(message)}</p>' if message else ""
+        return (
+            '<div id="sa-dash">'
+            + _STYLE
+            + caption
+            + '<div class="sa-summary"><span class="sa-fail">⚠ Audit did not '
+            + "complete — no results to show. This is NOT a clean bill of "
+            + "health; check the run/auth status and re-run.</span></div></div>"
+        )
+
     findings = [_normalize(f) for f in (findings or [])]
 
     # Counts by severity, in canonical order; skip zero-count severities.
@@ -141,6 +157,7 @@ _STYLE = """<style>
   color:var(--text-primary); background:var(--bg-accent);
   border:1px solid var(--border-accent); border-radius:var(--radius); }
 #sa-dash .sa-empty { font-size:13px; color:var(--text-muted); font-style:italic; }
+#sa-dash .sa-fail { font-size:13.5px; font-weight:500; color:#e5484d; }
 #sa-dash .sa-dot { width:.55em; height:.55em; border-radius:50%; flex:0 0 auto;
   display:inline-block; }
 #sa-dash .sa-list { display:flex; flex-direction:column; gap:.5rem; }

--- a/tests/unit/workflows/test_security_audit_dashboard.py
+++ b/tests/unit/workflows/test_security_audit_dashboard.py
@@ -105,3 +105,27 @@ class TestInjectionSafety:
 
     def test_no_script_tag_in_output(self):
         assert "<script" not in security_findings_dashboard_html([_f()]).lower()
+
+
+class TestFailedAudit:
+    """A failed/incomplete audit must never read as a clean all-clear."""
+
+    def test_failed_empty_is_not_clean(self):
+        html = security_findings_dashboard_html([], succeeded=False)
+        assert "did not complete" in html
+        assert "no findings — clean" not in html
+        assert "sa-fail" in html
+
+    def test_failed_ignores_any_leaked_findings(self):
+        html = security_findings_dashboard_html([_f()], succeeded=False)
+        assert "did not complete" in html
+        # the normal severity card list is NOT rendered on failure
+        assert '<div class="sa-list">' not in html
+
+    def test_succeeded_empty_still_reads_clean(self):
+        html = security_findings_dashboard_html([], succeeded=True)
+        assert "no findings — clean" in html
+
+    def test_default_succeeded_true(self):
+        # back-compat: omitting succeeded keeps the clean path
+        assert "no findings — clean" in security_findings_dashboard_html([])


### PR DESCRIPTION
## The bug (found by dogfooding)

Dogfooding the live `security_audit` MCP tool surfaced a real issue:
when the workflow fails (e.g. it can't auth — `success: false`), it
returns `findings: []`, and the severity dashboard rendered **"no
findings — clean."** That's a dangerous **false all-clear** on a
security surface — it looks like the audit *passed* when it never ran.

## Fix

`security_findings_dashboard_html` now takes `succeeded` (default
`True`); the handler passes `response["success"]`. On a failed run it
renders an explicit **"⚠ Audit did not complete — NOT a clean bill of
health; check the run/auth status and re-run"** state instead of the
clean message. A *successful* run with genuinely zero findings still
reads "clean."

## Verification

- 4 new tests (failed→not-clean, failed-ignores-leaked-findings,
  succeeded-empty-still-clean, default-succeeded-true).
- The legacy exact-dict response guard (`test_workflow_response.py`)
  stays green — the success path is unchanged.

## Context

Part of the `analysis-workflow-output-widgets` program (#1150). The same
dogfood confirmed (via the code) that SDK-native workflows emit
**category-bullets**, not structured findings — a spec re-scope follows
separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)