### PR TITLE
docs(skills): analysis skills prefer the universal panel_html output

### DIFF
--- a/.agents/skills/bug-predict/SKILL.md
+++ b/.agents/skills/bug-predict/SKILL.md
@@ -40,6 +40,13 @@ uv run attune workflow run bug-predict --path <target>
 
 ## Output
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 Present results as a markdown table grouped by severity
 (HIGH first):
 

--- a/.agents/skills/code-quality/SKILL.md
+++ b/.agents/skills/code-quality/SKILL.md
@@ -50,6 +50,13 @@ deep_review(path="<user-specified path>")
 
 ## Output Format
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 ```markdown
 ## Code Quality Report
 

--- a/.agents/skills/doc-gen/SKILL.md
+++ b/.agents/skills/doc-gen/SKILL.md
@@ -62,6 +62,13 @@ doc_orchestrator(path="<target>")
 
 ## Output Format
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 ```markdown
 ## Documentation Report
 

--- a/.agents/skills/refactor-plan/SKILL.md
+++ b/.agents/skills/refactor-plan/SKILL.md
@@ -76,6 +76,13 @@ simplify_code(path="<target file>")
 
 ## Output
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 - Prioritized issue list
 - Refactoring steps (ordered)
 - Risk assessment per change

--- a/.agents/skills/smart-test/SKILL.md
+++ b/.agents/skills/smart-test/SKILL.md
@@ -55,6 +55,13 @@ test_gen_parallel(top=10)
 
 ## Output Format
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 ```markdown
 ## Test Gap Analysis
 

--- a/plugin/skills/bug-predict/SKILL.md
+++ b/plugin/skills/bug-predict/SKILL.md
@@ -42,6 +42,13 @@ uv run attune workflow run bug-predict --path <target>
 
 ## Output
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 Present results as a markdown table grouped by severity
 (HIGH first):
 

--- a/plugin/skills/code-quality/SKILL.md
+++ b/plugin/skills/code-quality/SKILL.md
@@ -52,6 +52,13 @@ deep_review(path="<user-specified path>")
 
 ## Output Format
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 ```markdown
 ## Code Quality Report
 

--- a/plugin/skills/doc-gen/SKILL.md
+++ b/plugin/skills/doc-gen/SKILL.md
@@ -64,6 +64,13 @@ doc_orchestrator(path="<target>")
 
 ## Output Format
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 ```markdown
 ## Documentation Report
 

--- a/plugin/skills/refactor-plan/SKILL.md
+++ b/plugin/skills/refactor-plan/SKILL.md
@@ -78,6 +78,13 @@ simplify_code(path="<target file>")
 
 ## Output
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 - Prioritized issue list
 - Refactoring steps (ordered)
 - Risk assessment per change

--- a/plugin/skills/smart-test/SKILL.md
+++ b/plugin/skills/smart-test/SKILL.md
@@ -57,6 +57,13 @@ test_gen_parallel(top=10)
 
 ## Output Format
 
+**Prefer the rich panel.** If the tool response includes `panel_html`,
+pass it to `mcp__visualize__show_widget` — the universal report panel
+(title, score, findings/category sections; from
+`attune.workflows.report_panel`). It shows an explicit "did not
+complete" state on failure, never a false "clean". Fall back to the
+markdown below when the widget surface is unavailable.
+
 ```markdown
 ## Test Gap Analysis
 


### PR DESCRIPTION
## What

Closes out "enhance all analysis workflows" end-to-end. #1153 put
`panel_html` on every report-producing workflow's response; this adds a
uniform **"prefer the rich panel"** note to the Output sections of the
skills that drive them — `code-quality`, `bug-predict`, `refactor-plan`,
`smart-test`, `doc-gen` — so each explicitly renders `panel_html` via
`show_widget` with a markdown fallback (security-audit was the exemplar
in #1153).

Skill markdown only; `.agents/skills` mirrors synced (so
`test_sync_agents_skills` stays green). 82 plugin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)