### PR TITLE
feat(report-panel): wonderful polish — category colours, CWE badges, file refs

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12094,3 +12094,30 @@ files.
   the user running it in a normal auth'd session. Same "dogfood the real
   loop, not synthetic data" family as the "registered ≠ working" core
   lesson — this is the output-widget-shape instance.
+
+- **When the real producer is BLOCKED (auth/env), don't retry it a third
+  time — verify the PIPELINE by feeding realistic input through the
+  PRODUCTION parse/render code, substituting ONLY the blocked component,
+  and be transparent about the substitution.** 2026-06-28, closing the
+  "last inch" on the report panel: the production security_audit LLM call
+  was auth-blocked (nested-SDK limitation — failed twice). Re-running it
+  was the tar-pit (same input, same wall). Instead: I (a capable LLM, the
+  same kind that powers the workflow) wrote a real security analysis of a
+  real file in the agent's markdown format, then ran it through the EXACT
+  production `AgentSDKResultAdapter._parse_findings → _to_workflow_report
+  → report_to_panel_html`. Every parse/render line is production code;
+  only the analysis-author is substituted. This is STRICTLY better than
+  synthetic fixtures (it exercises the real parser + report builder +
+  renderer with realistic content, proving the `markdown → category-list
+  sections → panel` path) and honest (the one substituted component is
+  named). The genuinely-final inch (the producer's OWN output) stays the
+  user's to confirm in an auth'd session — but the consumer is already
+  proven against real-shaped input. Rule: a blocked live run is not a
+  dead end; isolate the blocked unit, drive its real surroundings, and
+  say which inch is still owed. Pairs with the "synthetic fixtures hide
+  producer/consumer mismatch" lesson above (its constructive other half)
+  and the tar-pit / "if the same approach failed twice, change strategy"
+  discipline. (Bonus: when you escape-then-regex-highlight bullet text —
+  CWE badges, file:line pills — `html.escape` FIRST so the regex only
+  ever wraps already-escaped runs; verify with a `<script>`-in-a-bullet
+  test.)

--- a/src/attune/workflows/report_panel.py
+++ b/src/attune/workflows/report_panel.py
@@ -25,9 +25,48 @@ transparent background, no ``position: fixed``.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from attune.workflows.findings_widget import colour_for, esc, location, severity_of, severity_rank
+
+# Accent colour per analysis category. Mid-tone hues legible in both
+# light and dark; used only on a left border + heading dot, never as text.
+_CAT_COLOUR: dict[str, str] = {
+    "security": "#e5484d",
+    "quality": "#0090ff",
+    "performance": "#f76808",
+    "architecture": "#8e4ec6",
+}
+_CAT_DEFAULT = "#8b8d98"
+
+_CWE_RE = re.compile(r"\b(CWE-\d+)\b")
+# A file reference with a line number, e.g. ``pkg/mod.py:88``.
+_REF_RE = re.compile(r"\b([\w./-]+\.[A-Za-z]\w*:\d+)\b")
+
+
+def _cat_colour(title: str) -> str:
+    return _CAT_COLOUR.get(title.strip().lower(), _CAT_DEFAULT)
+
+
+def _highlight(text: Any) -> str:
+    """Escape a bullet, then accent CWE codes and ``file:line`` refs.
+
+    Injection-safe: ``esc`` runs first, so the regexes only ever wrap
+    already-escaped alphanumeric/punctuation runs in our own markup.
+    """
+    t = esc(text)
+    t = _CWE_RE.sub(r'<span class="rp-cwe">\1</span>', t)
+    t = _REF_RE.sub(r'<span class="rp-ref">\1</span>', t)
+    return t
+
+
+def _sec_head(title: str, colour: str, count: int) -> str:
+    return (
+        f'<div class="rp-sec-head">'
+        f'<span class="rp-cat-dot" style="background:{colour};"></span>'
+        f'{esc(title)} <span class="rp-cat-n">{count}</span></div>'
+    )
 
 
 def _finding_card(f: dict[str, Any]) -> str:
@@ -39,26 +78,31 @@ def _finding_card(f: dict[str, Any]) -> str:
         f'<span class="rp-sev">{esc(severity_of(f))}</span>'
         f'<span class="rp-loc">{location(f)}</span>'
         f"</div>"
-        f'<div class="rp-msg">{esc(f.get("message"))}</div>'
+        f'<div class="rp-msg">{_highlight(f.get("message"))}</div>'
         f"</div>"
     )
 
 
 def _section_html(section: dict[str, Any]) -> str:
     kind = section.get("kind")
-    title = esc(section.get("title"))
-    head = f'<div class="rp-sec-head">{title}</div>' if title else ""
+    raw_title = str(section.get("title") or "")
+    colour = _cat_colour(raw_title)
+
+    def _wrap(count: int, body: str) -> str:
+        head = _sec_head(raw_title, colour, count) if raw_title else ""
+        return f'<div class="rp-sec" style="border-left:3px solid {colour};">{head}{body}</div>'
 
     if kind == "findings":
-        findings = section.get("findings") or []
-        body = "".join(_finding_card(f) for f in sorted(findings, key=severity_rank))
-        body = body or '<div class="rp-empty">none</div>'
-        return f'<div class="rp-sec">{head}{body}</div>'
+        findings = sorted(section.get("findings") or [], key=severity_rank)
+        body = "".join(_finding_card(f) for f in findings) or '<div class="rp-empty">none</div>'
+        return _wrap(len(findings), body)
 
     if kind == "list":
         items = section.get("items") or []
-        lis = "".join(f"<li>{esc(i)}</li>" for i in items) or '<li class="rp-empty">none</li>'
-        return f'<div class="rp-sec">{head}<ul class="rp-list">{lis}</ul></div>'
+        lis = (
+            "".join(f"<li>{_highlight(i)}</li>" for i in items) or '<li class="rp-empty">none</li>'
+        )
+        return _wrap(len(items), f'<ul class="rp-list">{lis}</ul>')
 
     if kind == "next-steps":
         items = section.get("items") or []
@@ -67,19 +111,19 @@ def _section_html(section: dict[str, Any]) -> str:
             text = a.get("text") if isinstance(a, dict) else str(a)
             cmd = a.get("command") if isinstance(a, dict) else None
             cmd_html = f' <code class="rp-cmd">{esc(cmd)}</code>' if cmd else ""
-            lis += f"<li>{esc(text)}{cmd_html}</li>"
+            lis += f"<li>{_highlight(text)}{cmd_html}</li>"
         lis = lis or '<li class="rp-empty">none</li>'
-        return f'<div class="rp-sec">{head}<ul class="rp-list">{lis}</ul></div>'
+        return _wrap(len(items), f'<ul class="rp-list">{lis}</ul>')
 
     # Generic fallback for any other section kind (callout/prose/table):
     # render the title plus any string items, escaped. Never produced by
     # the analysis-workflow path today, but keeps the panel robust.
     items = section.get("items") or []
     if items:
-        lis = "".join(f"<li>{esc(i)}</li>" for i in items)
-        return f'<div class="rp-sec">{head}<ul class="rp-list">{lis}</ul></div>'
+        lis = "".join(f"<li>{_highlight(i)}</li>" for i in items)
+        return _wrap(len(items), f'<ul class="rp-list">{lis}</ul>')
     text = section.get("text") or section.get("body") or ""
-    return f'<div class="rp-sec">{head}<div class="rp-prose">{esc(text)}</div></div>'
+    return _wrap(0, f'<div class="rp-prose">{esc(text)}</div>')
 
 
 def report_to_panel_html(report: dict[str, Any], succeeded: bool = True, message: str = "") -> str:
@@ -144,11 +188,23 @@ _STYLE = """<style>
   border:1px solid var(--border-accent); border-radius:var(--radius); }
 #rp-panel .rp-summary { margin:0 0 1rem; color:var(--text-secondary);
   white-space:pre-wrap; }
-#rp-panel .rp-sec { margin:0 0 1rem; }
-#rp-panel .rp-sec-head { font-weight:600; font-size:13px; text-transform:uppercase;
+#rp-panel .rp-sec { margin:0 0 1rem; padding:.1rem 0 .1rem .7rem; }
+#rp-panel .rp-sec-head { display:flex; align-items:center; gap:.4rem;
+  font-weight:600; font-size:13px; text-transform:uppercase;
   letter-spacing:.03em; color:var(--text-secondary); margin-bottom:.4rem; }
+#rp-panel .rp-cat-dot { width:.55em; height:.55em; border-radius:50%;
+  flex:0 0 auto; display:inline-block; }
+#rp-panel .rp-cat-n { min-width:1.4em; text-align:center; padding:0 .35em;
+  font-size:11px; color:var(--text-primary); background:var(--surface-1);
+  border:1px solid var(--border); border-radius:var(--radius); }
+#rp-panel .rp-cwe { font-size:11.5px; font-weight:600; padding:0 .35em;
+  color:#e5484d; background:var(--surface-1); border:1px solid var(--border);
+  border-radius:3px; white-space:nowrap; }
+#rp-panel .rp-ref { font-family:ui-monospace,monospace; font-size:12.5px;
+  color:var(--text-primary); background:var(--surface-2,var(--surface-1));
+  padding:0 .25em; border-radius:3px; }
 #rp-panel .rp-list { margin:0; padding-left:1.2rem; }
-#rp-panel .rp-list li { margin:.15rem 0; }
+#rp-panel .rp-list li { margin:.25rem 0; }
 #rp-panel .rp-card { padding:.5rem .6rem; margin:.4rem 0; background:var(--surface-1);
   border:1px solid var(--border); border-radius:var(--radius); }
 #rp-panel .rp-card-head { display:flex; align-items:center; gap:.4rem;

--- a/tests/unit/workflows/test_report_panel.py
+++ b/tests/unit/workflows/test_report_panel.py
@@ -37,7 +37,9 @@ class TestCategoryBullets:
         assert [s["kind"] for s in d["sections"]] == ["list", "list"]
         html = report_to_panel_html(d)
         assert "Security" in html and "Quality" in html
-        assert "Hardcoded key in config.py:88" in html
+        assert "Hardcoded key in" in html
+        # file:line refs are accented into their own span
+        assert 'class="rp-ref">config.py:88' in html
         assert "bare except" in html
         assert "<ul" in html
 
@@ -51,6 +53,35 @@ class TestCategoryBullets:
         html = report_to_panel_html(d)
         assert "Performance" not in html
         assert "Security" in html
+
+
+class TestPolish:
+    """The 'wonderful' touches — category accents, CWE badges, file refs."""
+
+    def test_cwe_codes_badged(self):
+        html = report_to_panel_html(_report({"security": ["leak (CWE-798) bad"]}))
+        assert 'class="rp-cwe">CWE-798</span>' in html
+
+    def test_file_line_refs_accented(self):
+        html = report_to_panel_html(_report({"security": ["issue at src/app.py:42 here"]}))
+        assert 'class="rp-ref">src/app.py:42</span>' in html
+
+    def test_category_dot_and_count(self):
+        html = report_to_panel_html(_report({"security": ["a", "b", "c"]}))
+        assert "rp-cat-dot" in html
+        assert 'class="rp-cat-n">3</span>' in html
+
+    def test_known_category_gets_colour(self):
+        # security category → red accent on the section border
+        html = report_to_panel_html(_report({"security": ["x"]}))
+        assert "border-left:3px solid #e5484d" in html
+
+    def test_highlight_escapes_before_wrapping(self):
+        # a CWE inside an injection attempt: tag escaped, CWE still badged
+        html = report_to_panel_html(_report({"security": ["<b>x</b> CWE-1"]}))
+        assert "<b>x</b>" not in html
+        assert "&lt;b&gt;" in html
+        assert 'class="rp-cwe">CWE-1</span>' in html
 
 
 class TestStructuredFindings:


### PR DESCRIPTION
## What

Makes the universal report panel genuinely *wonderful* — and verified
against the real content pipeline, not synthetic data.

- **Category accents**: each analysis category gets a colour (security
  red / quality blue / performance orange / architecture purple) on a
  left border + heading dot + per-category **count** badge.
- **In-bullet highlighting**: `CWE-NNN` codes are badged; `file.py:line`
  references are accented into monospace pills. Turns gray prose bullets
  into scannable, rich content.
- **Injection-safe**: every bullet is `html.escape`d **first**, then the
  regexes only ever wrap already-escaped runs in our own markup.

## The "last inch" — closed honestly

The production workflow's own LLM call can't run in this environment
(nested-SDK auth is structurally blocked — I pushed back on re-trying it).
So I produced a **real** security analysis of a real file and fed it
through the **production** `AgentSDKResultAdapter._parse_findings` →
`_to_workflow_report` → `report_to_panel_html`. Every parse/render line is
production code; only the analysis-author is me standing in for the
workflow's LLM. That confirms the full content path (markdown →
category-bullets → panel) with realistic input — and the result is the
panel rendered above.

The remaining true-final inch (the workflow's *own* LLM output) is yours
to confirm in an auth'd `/security` session — at which point the panel is
already proven to render real content beautifully.

## Verification

41 tests pass, incl. new coverage for CWE badges, file-ref accenting,
category colour/count, and **escape-before-highlight** injection safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)