### PR TITLE
fix(discovery-sweep): track real per-source API spend

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12121,3 +12121,45 @@ files.
   CWE badges, file:line pills — `html.escape` FIRST so the regex only
   ever wraps already-escaped runs; verify with a `<script>`-in-a-bullet
   test.)
+
+- **A fan-out meta-workflow can silently drop its sub-workflows' cost,
+  reporting $0.00 while spending real money — and a $0.00-derived budget
+  cap is non-functional**: dogfooding `discovery-sweep` (full LLM, 7
+  sources, 5.7 min) the board footer read `$0.00 / $8.00 spent`. Root
+  cause was a two-link drop: each LLM source's `discover()` called
+  `workflow.execute()` (whose `result.cost_report.total_cost` is live)
+  but extracted ONLY findings via `findings_from_workflow_result(result,
+  …)`, discarding cost; and `_build_sweep_result` then HARDCODED
+  `spent_usd=0.0` with a stale comment ("no sources ran") on the SUCCESS
+  path. Because the cap reads `spent_usd`, a sweep could overspend its
+  `budget_usd` without limit (separately, the per-source allocation is a
+  documented v1 no-op — sources receive `budget_usd` but call
+  `execute(path, depth)`). Fix: `LLMSource._record_cost(result)`
+  accumulates `cost_report.total_cost` per instance; the engine sums
+  `getattr(s,"spent_usd",0.0)` post-`gather` into the metadata + the
+  `WorkflowResult.cost_report`. **General rule**: when a meta-workflow
+  aggregates sub-results, the cost channel is the easiest thing to drop
+  at the adapter boundary (the return type is usually `list[Finding]`,
+  not `(findings, cost)`) — assert non-zero spend in a dogfood, never
+  trust a green unit suite whose fixtures don't carry cost. Same
+  "registered ≠ working / dogfood the real loop" family; the cost-
+  tracking instance. Found ONLY because the footer was inspected on a
+  REAL run.
+
+- **CORRECTION to the prior "nested SDK workflows can't auth" lesson —
+  the de-nest workaround makes them run inside a Claude Code session**:
+  the widget-shape lesson's point (4) ("nested SDK workflows can't auth
+  from a direct python run OR the MCP tool … capturing a real payload
+  needs CI or a normal auth'd session") is now SUPERSEDED for local
+  dogfooding. Scrubbing the inherited gateway/OAuth env
+  (`ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, the
+  `CLAUDE_CODE_SDK_HAS_*_REFRESH` flags, `CLAUDECODE`,
+  `CLAUDE_CODE_ENTRYPOINT/SESSION_ID/EXECPATH`) and sourcing a raw
+  `sk-ant-` key from `~/.attune/anthropic.env` lets the spawned CLI run
+  as a fresh non-nested session — `security-audit` returned
+  `success:true, cost=$1.42`, and the full sweep populated all buckets.
+  Write the result (incl. `panel_html`/`board_html`) to disk INSIDE the
+  coroutine before `asyncio.run` returns, so a teardown exit-1 can't
+  discard it. See [[project_sdk_workflows_blocked_nested]] (workaround
+  confirmed 2026-06-26, re-confirmed this session for the widget
+  dogfood). Real API spend — keep runs single-shot.

--- a/src/attune/workflows/discovery_sweep/llm_source_base.py
+++ b/src/attune/workflows/discovery_sweep/llm_source_base.py
@@ -253,3 +253,26 @@ class LLMSource:
 
     is_llm: bool = True
     budget_multiplier: float = 1.0
+    spent_usd: float = 0.0
+
+    def _record_cost(self, result: object) -> None:
+        """Accumulate one workflow result's API cost onto this source.
+
+        After the fan-out, the sweep engine sums ``spent_usd`` across
+        sources to populate ``SweepMetadata.spent_usd`` (the footer's
+        ``$X / $Y`` line and the workflow ``CostReport``). Without this
+        the wrapped workflows' real spend is silently discarded and the
+        sweep always reports ``$0.00``.
+
+        Sources are constructed fresh per sweep by ``default_sources()``,
+        so the running total never leaks across runs. A result with no
+        ``cost_report`` (or a zero cost) contributes nothing.
+
+        Args:
+            result: A WorkflowResult (or duck-typed equivalent) whose
+                ``cost_report.total_cost`` is the API spend to record.
+        """
+        cost_report = getattr(result, "cost_report", None)
+        if cost_report is None:
+            return
+        self.spent_usd += float(getattr(cost_report, "total_cost", 0.0) or 0.0)

--- a/src/attune/workflows/discovery_sweep/sources/bug_predict.py
+++ b/src/attune/workflows/discovery_sweep/sources/bug_predict.py
@@ -85,6 +85,8 @@ class BugPredictSource(LLMSource):
                 findings.append(_path_failed_finding(self.name, path, exc))
                 continue
 
+            self._record_cost(result)
+
             if not getattr(result, "success", False):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue

--- a/src/attune/workflows/discovery_sweep/sources/dependency_check.py
+++ b/src/attune/workflows/discovery_sweep/sources/dependency_check.py
@@ -94,6 +94,8 @@ class DependencyCheckSource(LLMSource):
                 findings.append(_path_failed_finding(self.name, path, exc))
                 continue
 
+            self._record_cost(result)
+
             if not getattr(result, "success", False):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue

--- a/src/attune/workflows/discovery_sweep/sources/doc_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/doc_audit.py
@@ -93,6 +93,8 @@ class DocAuditSource(LLMSource):
                 findings.append(_path_failed_finding(self.name, path, exc))
                 continue
 
+            self._record_cost(result)
+
             if not getattr(result, "success", False):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue

--- a/src/attune/workflows/discovery_sweep/sources/perf_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/perf_audit.py
@@ -92,6 +92,8 @@ class PerfAuditSource(LLMSource):
                 findings.append(_path_failed_finding(self.name, path, exc))
                 continue
 
+            self._record_cost(result)
+
             if not getattr(result, "success", False):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue

--- a/src/attune/workflows/discovery_sweep/sources/security_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/security_audit.py
@@ -94,6 +94,8 @@ class SecurityAuditSource(LLMSource):
                 findings.append(_path_failed_finding(self.name, path, exc))
                 continue
 
+            self._record_cost(result)
+
             if not getattr(result, "success", False):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue

--- a/src/attune/workflows/discovery_sweep/sources/test_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/test_audit.py
@@ -94,6 +94,8 @@ class TestAuditSource(LLMSource):
                 findings.append(_path_failed_finding(self.name, path, exc))
                 continue
 
+            self._record_cost(result)
+
             if not getattr(result, "success", False):
                 findings.append(_workflow_unsuccessful_finding(self.name, path, result))
                 continue

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -587,10 +587,18 @@ class DiscoverySweepWorkflow(BaseWorkflow):
         duration_ms = int((time.perf_counter() - t0) * 1000)
         completed_at = datetime.now()
 
+        # Sum the API spend each LLM source accumulated during the
+        # fan-out (LLMSource._record_cost). Non-LLM / deterministic
+        # sources carry no spent_usd attribute and default to 0.0.
+        # Without this the wrapped workflows' real cost is discarded
+        # and the sweep always reports $0.00 spent.
+        spent_usd = sum(getattr(s, "spent_usd", 0.0) for s in sources)
+
         sweep = self._build_sweep_result(
             gathered=gathered,
             budget_usd=budget_usd,
             duration_ms=duration_ms,
+            spent_usd=spent_usd,
         )
 
         # Phase 1b: emit the final SweepResult JSON as the last
@@ -660,6 +668,7 @@ class DiscoverySweepWorkflow(BaseWorkflow):
         gathered: list[tuple[str, list[Finding] | BaseException]],
         budget_usd: float,
         duration_ms: int,
+        spent_usd: float = 0.0,
     ) -> SweepResult:
         all_findings: list[Finding] = []
         failures: list[str] = []
@@ -692,7 +701,10 @@ class DiscoverySweepWorkflow(BaseWorkflow):
                 rejected.append(RejectedFinding(finding=finding, rule=decision.rule))
 
         metadata = SweepMetadata(
-            spent_usd=0.0,  # error/empty path — no sources ran, no spend.
+            # Real API spend summed from each LLM source's cost_report
+            # by the engine (see execute()). 0.0 only when no LLM source
+            # ran (--no-llm, error/empty path) or all costs were zero.
+            spent_usd=spent_usd,
             budget_usd=budget_usd,
             sources=ran,
             failures=failures,

--- a/tests/unit/workflows/discovery_sweep/test_engine.py
+++ b/tests/unit/workflows/discovery_sweep/test_engine.py
@@ -40,6 +40,9 @@ class FakeSource:
     raises: BaseException | None = None
     received_budget: float | None = None
     received_paths: list[str] | None = None
+    # Mirrors LLMSource.spent_usd — what each real source accumulates via
+    # ``_record_cost`` and the engine sums into ``SweepMetadata.spent_usd``.
+    spent_usd: float = 0.0
 
     def __post_init__(self) -> None:
         if self.budget_multiplier is None:
@@ -151,6 +154,58 @@ class TestBudgetAllocation:
 
     def test_default_budget_is_ten_dollars(self) -> None:
         assert DEFAULT_BUDGET_USD == 10.00
+
+
+class TestSpentUsdTracking:
+    """Regression guard: real per-source API spend must reach both the
+    ``SweepMetadata`` footer and the ``WorkflowResult`` cost_report.
+
+    Before this guard, ``_build_sweep_result`` hardcoded
+    ``spent_usd=0.0`` and every LLM source discarded its
+    ``result.cost_report``, so a sweep that spent real money always
+    reported ``$0.00``.
+    """
+
+    def test_engine_sums_source_spent_usd(self) -> None:
+        # Two LLM sources accumulated spend during their fan-out; the
+        # non-LLM source carries the default 0.0.
+        a = FakeSource(name="a", is_llm=True, findings=[], spent_usd=1.50)
+        b = FakeSource(name="b", is_llm=True, findings=[], spent_usd=2.25)
+        pattern = FakeSource(name="pattern", is_llm=False, findings=[])
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[a, b, pattern]))
+        sweep: SweepResult = res.metadata["sweep"]
+        assert sweep.metadata.spent_usd == pytest.approx(3.75)
+        # The WorkflowResult cost_report mirrors the same total.
+        assert res.cost_report.total_cost == pytest.approx(3.75)
+
+    def test_zero_spend_reports_zero(self) -> None:
+        # Pattern-only / --no-llm sweep: no source accrued cost.
+        src = FakeSource(name="pattern", is_llm=False, findings=[])
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[src]))
+        sweep: SweepResult = res.metadata["sweep"]
+        assert sweep.metadata.spent_usd == pytest.approx(0.0)
+
+    def test_llmsource_record_cost_accumulates(self) -> None:
+        from types import SimpleNamespace
+
+        from attune.workflows.discovery_sweep.llm_source_base import LLMSource
+
+        source = LLMSource()
+        source._record_cost(SimpleNamespace(cost_report=SimpleNamespace(total_cost=0.40)))
+        source._record_cost(SimpleNamespace(cost_report=SimpleNamespace(total_cost=1.10)))
+        assert source.spent_usd == pytest.approx(1.50)
+
+    def test_record_cost_ignores_missing_or_null_cost_report(self) -> None:
+        from types import SimpleNamespace
+
+        from attune.workflows.discovery_sweep.llm_source_base import LLMSource
+
+        source = LLMSource()
+        source._record_cost(SimpleNamespace())  # no cost_report attribute
+        source._record_cost(SimpleNamespace(cost_report=None))
+        assert source.spent_usd == pytest.approx(0.0)
 
 
 class TestPathExpansion:


### PR DESCRIPTION
## Problem

`discovery-sweep` always reported **`$0.00` spent** in its board footer
and `WorkflowResult.cost_report`, even on a full LLM sweep that ran 7
sources for ~6 minutes and incurred real API cost. Because the
`budget_usd` cap reads `spent_usd`, the cap was also non-functional.

Found by dogfooding a real full sweep — the footer read
`$0.00 / $8.00 spent` after a 5.7-minute run that clearly spent money.

## Root cause (two links)

1. Each LLM source's `discover()` called `workflow.execute()` — whose
   `result.cost_report.total_cost` is live — but extracted **only**
   findings via `findings_from_workflow_result(result, …)`, discarding
   the cost.
2. `_build_sweep_result` then **hardcoded `spent_usd=0.0`** with a stale
   `# error/empty path — no sources ran` comment on the success path.

## Fix

- `LLMSource._record_cost(result)` — accumulates `cost_report.total_cost`
  onto the source instance (sources are constructed fresh per sweep by
  `default_sources()`, so the running total never leaks across runs;
  a missing/null `cost_report` contributes nothing).
- All 6 LLM sources (`security-audit`, `bug-predict`, `dependency-check`,
  `perf-audit`, `doc-audit`, `test-audit`) call it right after
  `execute()` — capturing cost on both successful and
  unsuccessful-but-completed results.
- The engine sums `getattr(s, "spent_usd", 0.0)` after the
  `asyncio.gather` fan-out and threads it into both
  `SweepMetadata.spent_usd` and the `WorkflowResult.cost_report`.
- Corrects the stale `spent_usd=0.0` comment.

## Out of scope (documented deferral)

Per-source budget **enforcement** stays a v1 deferral — the source
docstrings already note sources receive `budget_usd` but call
`execute(path, depth)`, ignoring it. Real enforcement needs sequential
spend-gating or cooperative cancellation across the concurrent fan-out,
which is a design choice worth its own spec.

## Verification

Real single-source sweep (`security-audit` on
`src/attune/security/path_validation.py`):

| | Before | After |
|---|--------|-------|
| `metadata.spent_usd` | `$0.00` | `$1.4665` |
| `cost_report.total_cost` | `$0.00` | `$1.4665` (matches) |

204 `discovery_sweep` unit tests pass, including **4 new regression
guards** (engine summation, cost_report mirror, zero-spend, the real
`_record_cost` accumulation + null-guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
