### PR TITLE
docs(spec): discovery-sweep budget enforcement (per-source hard cap)

### DIFF
--- a/docs/specs/discovery-sweep-budget-enforcement/decisions.md
+++ b/docs/specs/discovery-sweep-budget-enforcement/decisions.md
@@ -1,0 +1,80 @@
+# Discovery-Sweep Budget Enforcement — decisions
+
+**Status:** approved (2026-06-28) — D1/D3/D4/D5 settled; D2 per-path
+division left open to the design phase · **Owner:** Patrick + agent
+
+## D1 — Enforcement mechanism: per-source hard cap
+
+**Decision (Patrick, 2026-06-28):** plumb each source's existing
+proportional allocation down into the wrapped workflow's
+`max_budget_usd`, so each sub-workflow self-limits via the SDK's own
+USD cap. Keep the `asyncio.gather` concurrent fan-out.
+
+**Why:** the allocation logic (`_allocate_budget`) and the per-call USD
+cap primitive (`get_max_budget_usd` → SDK `max_budget_usd`) BOTH already
+exist; this connects two wires rather than building a new system. It
+preserves concurrency and bounds the worst case to `sum(allocations) ==
+budget_usd` (modulo D3). No single source can run away.
+
+**Rejected alternatives:**
+
+- **Cooperative cancellation** (run concurrently, cancel remaining /
+  in-flight sources once a running total crosses `budget_usd`). A hard
+  global ceiling, but cancellation mid-LLM-call is racy and in-flight
+  sources overshoot before observing the signal — more surface, weaker
+  guarantee than it appears. Deferred to a possible later spec.
+- **Sequential spend-gating** (one source at a time, check running total
+  before each). Simplest hard global cap but serializes the fan-out —
+  unacceptable wall-clock regression (a 6-min concurrent sweep becomes
+  the sum of all sources). Rejected.
+- **Hybrid (per-source cap + global gate).** Best enforcement, most
+  surface. The per-source cap (this spec) already bounds the worst case;
+  add the global gate only if telemetry shows it's needed.
+
+## D2 — Per-path budget division within a source
+
+**Decision:** a source divides its allocation **evenly across its
+`paths`** and passes `allocation / len(paths)` as `max_budget_usd` to
+each `execute()` call. When `paths` is empty the source emits its
+existing "no files matched" finding and spends nothing.
+
+**Why:** even division is the simplest defensible policy and keeps the
+source-level total at its allocation. Weighting by per-path size/LOC is
+a refinement deferred until telemetry justifies it (most sweeps target a
+single path or a small dir, where even-split == whole allocation).
+
+**Open question (for review):** several sources today iterate
+`for path in paths` and call `execute()` once per path. Confirm whether
+a single `execute()` over the whole `paths` list is preferable (one
+capped run vs N capped runs). If a source can accept a path LIST, one
+run with the full allocation is simpler and avoids division entirely —
+revisit per source in design.
+
+## D3 — Overshoot tolerance
+
+**Decision:** the cap is best-effort at the SDK boundary — a run can
+exceed `max_budget_usd` by up to the cost of the final in-flight turn
+before truncation. Acceptance asserts `spent_usd ≤ budget_usd * 1.15`
+(15% headroom) for a real sweep; tighten once observed overshoot is
+measured.
+
+**Why:** the SDK truncates between turns, not mid-token, so a small
+deterministic overshoot is unavoidable without hard cancellation (D1
+rejected). 15% is a starting guard, not a contract — the design phase
+sets the real number from a measured dogfood.
+
+## D4 — Dependency on cost-tracking fix (#1156)
+
+**Decision:** this spec lands AFTER PR #1156 (real `spent_usd`).
+Enforcement is untestable and unobservable while the footer reports
+`$0.00` — the cost fix is the prerequisite that makes "did we stay under
+budget?" a real, measurable question.
+
+## D5 — Verification discipline
+
+**Decision:** the acceptance dogfood runs the REAL sweep (de-nested per
+[[project_sdk_workflows_blocked_nested]]) with a low `budget_usd` and
+asserts the truthful `spent_usd` stays within D3 tolerance. Mocked unit
+tests (fake workflow capturing the `max_budget_usd` kwarg) are
+necessary-not-sufficient — the "registered ≠ working / dogfood the real
+loop" rule applies, the same way it surfaced the original $0.00 bug.

--- a/docs/specs/discovery-sweep-budget-enforcement/requirements.md
+++ b/docs/specs/discovery-sweep-budget-enforcement/requirements.md
@@ -1,0 +1,101 @@
+# Discovery-Sweep Budget Enforcement — requirements
+
+**Status:** approved (2026-06-28) · **Owner:** Patrick + agent
+
+Make `discovery-sweep`'s `budget_usd` an actual spend cap. Today it is
+decorative: the engine splits `budget_usd` across sources by
+`budget_multiplier` and passes each source its share, but every LLM
+source `discover()` does `del budget_usd` and calls
+`workflow.execute(path, depth)` — so the share is ignored and a sweep
+can spend without limit.
+
+This is the v2 follow-up the source docstrings already promise: *"A
+later PR can plumb the per-source share down once the wrapped workflows
+accept an explicit per-call cap."* The chosen mechanism (D1) is a
+**per-source hard cap** — each source's allocation becomes the wrapped
+workflow's `max_budget_usd`, preserving the concurrent fan-out.
+
+**Depends on** the cost-tracking fix (PR #1156): `spent_usd` must report
+real per-source spend before enforcement is meaningful or testable.
+
+## Grounding (verified against code, not docstrings)
+
+- `DiscoverySweepWorkflow._allocate_budget` (`workflow.py:636`) already
+  splits `budget_usd * (mult / total_mult)` per source and the engine
+  passes it to `discover(paths, allocations[s.name])`
+  (`workflow.py:573-585`). The allocation is correct; it is just dropped.
+- Every LLM source's `discover()` opens with `del budget_usd`
+  (e.g. `sources/security_audit.py:69`) and calls
+  `workflow.execute(path=path, depth=self.depth)` — `budget_usd` never
+  reaches `execute()`.
+- The wrapped workflows ALREADY have a USD cap primitive:
+  `get_max_budget_usd(depth)` (`agent_sdk_adapter.py:955`) returns a
+  per-depth cap, and e.g. `security_audit.py:255` passes
+  `max_budget_usd=get_max_budget_usd(depth)` into the SDK agent options.
+  Today that cap is derived from `depth` only, NOT from the sweep
+  allocation. Enforcement = let the sweep allocation OVERRIDE it.
+- A source may call `execute()` **once per path** (the `for path in
+  paths` loop), so the per-source allocation must be divided across the
+  source's paths, not handed in full to each call (else N paths overshoot
+  Nx).
+- `PatternScanSource` is deterministic (`is_llm=False`,
+  `budget_multiplier=0.0`) — it has no spend and is out of scope.
+
+## Functional requirements
+
+- **FR-1 (execute accepts an explicit cap).** Each SDK-native analysis
+  workflow's `execute()` accepts an optional `max_budget_usd: float |
+  None` kwarg. When provided it is used as the SDK `max_budget_usd`;
+  when `None` it falls back to today's `get_max_budget_usd(depth)`. No
+  behavior change for non-sweep callers (default `None`).
+
+- **FR-2 (sources plumb their allocation down).** Each LLM source's
+  `discover(paths, budget_usd)` stops discarding `budget_usd`: it
+  divides the allocation across its `paths` and passes the per-call
+  share to `execute(..., max_budget_usd=share)`. Division policy in D2.
+
+- **FR-3 (cap is a true ceiling, not an estimate).** When a wrapped
+  workflow reaches its `max_budget_usd`, it returns partial findings
+  (the SDK already truncates the run); the source surfaces this as an
+  `info`-severity Finding noting the cap was hit (per the existing
+  `FindingSource` Protocol contract, `workflow.py:202-204`), rather than
+  overspending or raising.
+
+- **FR-4 (telemetry parity).** The board footer `$X / $Y spent` (now
+  truthful after #1156) must show `X ≤ Y` for a well-behaved sweep. A
+  best-effort overshoot tolerance is defined in D3; any overshoot beyond
+  it is a test failure, not a silent pass.
+
+## Non-functional requirements
+
+- **NFR-1 (concurrency preserved).** The fan-out stays
+  `asyncio.gather`-concurrent. No sequential serialization (rejected
+  alternative, D1).
+- **NFR-2 (no new MCP surface / kwargs to the tool).** The
+  `discovery_sweep` MCP tool signature (`path`, `budget_usd`, `no_llm`)
+  is unchanged; enforcement is internal.
+- **NFR-3 (graceful degradation).** If the SDK/CLI does not honor
+  `max_budget_usd` (older binary), the sweep still runs — enforcement
+  degrades to today's behavior, logged once, never crashes.
+
+## Out of scope
+
+- **Global dynamic running-total cap / cancellation.** A hard global
+  ceiling that cancels in-flight sources mid-call (D1 alternatives 2/4)
+  is deferred — racy and higher surface. Per-source caps bound the worst
+  case to `sum(allocations) == budget_usd` modulo the D3 tolerance.
+- **Re-balancing unspent allocation** from cheap sources to expensive
+  ones. Static proportional allocation stays; a later spec can add
+  dynamic re-allocation if telemetry shows chronic under-spend.
+- **PatternScanSource** (no spend).
+
+## Acceptance criteria
+
+- A sweep with a deliberately low `budget_usd` over a multi-finding
+  target reports `spent_usd ≤ budget_usd * (1 + tolerance)` (D3), proven
+  by a real (de-nested) dogfood — not only mocks.
+- Unit tests: each source forwards a per-call `max_budget_usd` derived
+  from its allocation (assert via a fake workflow capturing the kwarg);
+  `execute(max_budget_usd=None)` reproduces today's depth-derived cap.
+- No change to the MCP tool schema or the 47-tool count guard.
+- `spent_usd` (from #1156) and the footer stay truthful.


### PR DESCRIPTION
## What

Approved spec to make `discovery-sweep`'s `budget_usd` an actual spend
cap. Today the per-source allocation is computed and handed to
`discover()`, but every LLM source does `del budget_usd` and ignores it —
so the cap is decorative and a sweep can spend without limit.

Spec at `docs/specs/discovery-sweep-budget-enforcement/`
(`requirements.md` **approved**, `decisions.md`).

## Mechanism (D1, approved)

Per-source **hard cap** — plumb each source's existing proportional
allocation down into the wrapped workflow's `max_budget_usd`. Both wires
already exist (`_allocate_budget` ↔ `get_max_budget_usd` / SDK
`max_budget_usd`); this connects them and preserves the concurrent
`asyncio.gather` fan-out. Sequential gating (serializes, slow) and
cooperative cancellation (racy) are recorded as rejected alternatives.

## Notes

- **Depends on #1156** (cost-tracking fix): enforcement is untestable
  while the footer reports `$0.00`. Land #1156 first.
- **D2 open:** per-path budget division (even split vs single capped run
  over the whole `paths` list) is left to the design phase.
- Docs-only PR — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
