### PR TITLE
fix(mcp): drop nonexistent environment kwarg crashing memory tools

### DIFF
--- a/src/attune/mcp/memory_handlers.py
+++ b/src/attune/mcp/memory_handlers.py
@@ -42,7 +42,6 @@ class MemoryHandlersMixin:
 
             self._memory = UnifiedMemory(
                 user_id=getattr(self, "_user_id", "mcp-session"),
-                environment="development",
             )
         return self._memory
 

--- a/tests/unit/mcp/handlers/test_memory_handlers.py
+++ b/tests/unit/mcp/handlers/test_memory_handlers.py
@@ -468,3 +468,45 @@ class TestHandleMemoryForget:
         result = await server._handle_memory_forget({"key": "target_key"})
 
         assert result["key"] == "target_key"
+
+
+# ---------------------------------------------------------------------------
+# Non-mocked regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestGetMemoryRealConstruction:
+    """Construct the REAL UnifiedMemory through _get_memory().
+
+    Every other test in this module mocks UnifiedMemory, so a constructor
+    signature drift (e.g. passing a kwarg the dataclass does not accept)
+    slips through green. These tests exercise the actual class to guard the
+    `_get_memory()` call shape — see the `environment=` kwarg regression
+    (TypeError: UnifiedMemory.__init__() got an unexpected keyword
+    argument 'environment').
+    """
+
+    def test_get_memory_constructs_real_unified_memory(self, tmp_path, monkeypatch):
+        """_get_memory() builds a real UnifiedMemory without TypeError."""
+        # Real UnifiedMemory creates a storage dir in cwd; isolate it.
+        monkeypatch.chdir(tmp_path)
+        server = _make_server()
+
+        memory = server._get_memory()
+
+        from attune.memory import UnifiedMemory
+
+        assert isinstance(memory, UnifiedMemory)
+        assert server._memory is memory
+
+    @pytest.mark.asyncio
+    async def test_memory_search_round_trip_real_backend(self, tmp_path, monkeypatch):
+        """memory_search runs end-to-end against the real backend."""
+        monkeypatch.chdir(tmp_path)
+        server = _make_server()
+
+        result = await server._handle_memory_search({"query": "code review"})
+
+        assert result["success"] is True
+        assert "results" in result
+        assert "count" in result


### PR DESCRIPTION
## What

All four MCP memory tools (`memory_store`, `memory_search`, `memory_retrieve`, `memory_forget`) crashed with:

```
TypeError: UnifiedMemory.__init__() got an unexpected keyword argument 'environment'
```

`_get_memory()` in `src/attune/mcp/memory_handlers.py` passed `environment="development"`, but `UnifiedMemory` is a dataclass whose only init fields are `user_id`, `config`, and `access_tier`. `config` already defaults from `MemoryConfig.from_environment`, so the bogus kwarg is simply removed (one line).

## Why it slipped through

Every existing test in `test_memory_handlers.py` mocks `UnifiedMemory`, so the real constructor signature was never exercised — classic "registered ≠ working".

## Regression guard

Adds `TestGetMemoryRealConstruction` — a **non-mocked** class that:

- constructs the real `UnifiedMemory` through `_get_memory()`
- runs `memory_search` end-to-end against the real backend

Both new tests fail with the original `TypeError` when the fix is reverted, and pass with it. Full file: 33 passed.

## Discovery

Found while dogfooding the `/attune-hub` routing — hub routing itself works 4/4 directions; the memory direction surfaced this crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
