### PR TITLE
feat(discovery-sweep): enforce per-source budget cap (#1157)

### DIFF
--- a/docs/specs/discovery-sweep-budget-enforcement/decisions.md
+++ b/docs/specs/discovery-sweep-budget-enforcement/decisions.md
@@ -1,7 +1,9 @@
 # Discovery-Sweep Budget Enforcement — decisions
 
-**Status:** approved (2026-06-28) — D1/D3/D4/D5 settled; D2 per-path
-division left open to the design phase · **Owner:** Patrick + agent
+**Status:** IMPLEMENTED + dogfooded (2026-06-28) — D1–D5 settled; D2
+resolved (even-split + floor guard); D6 (cap precedence), D7 (cap-hit
+detection), D8 (dogfood result + FR-3 premise correction) added in
+design/build. D5 acceptance PASSED. · **Owner:** Patrick + agent
 
 ## D1 — Enforcement mechanism: per-source hard cap
 
@@ -43,12 +45,32 @@ source-level total at its allocation. Weighting by per-path size/LOC is
 a refinement deferred until telemetry justifies it (most sweeps target a
 single path or a small dir, where even-split == whole allocation).
 
-**Open question (for review):** several sources today iterate
-`for path in paths` and call `execute()` once per path. Confirm whether
-a single `execute()` over the whole `paths` list is preferable (one
-capped run vs N capped runs). If a source can accept a path LIST, one
-run with the full allocation is simpler and avoids division entirely —
-revisit per source in design.
+**Open question RESOLVED (design, 2026-06-28):** keep even-split; do
+NOT widen wrapped `execute()` to accept a path list. Grounding from the
+code:
+
+- `_expand_path(path)` (`workflow.py:422`) returns `[path]` (single
+  element) UNLESS the user passes an explicit glob (`src/**/*.py`). A
+  normal directory sweep is one path — the wrapped workflow recurses
+  internally. So `len(paths) == 1` in the common case and even-split ==
+  full allocation (a no-op division).
+- Each source loops `for path in paths` and calls `execute(path=path)`
+  — singular. The "single execute over the whole list" alternative would
+  require widening all 6 wrapped workflows' `execute()` to accept a path
+  LIST and changing their scan semantics — outside FR-1's "add one
+  `max_budget_usd` kwarg" scope, for a minority (explicit-glob) case.
+
+Even-split keeps the per-source total bounded to its allocation
+regardless of path count (the D1 guarantee) with minimal surface.
+
+**Floor guard (added to D2 scope):** when `allocation / len(paths)`
+falls below a minimum viable per-call cap (a glob of N files against a
+small budget drives each call's share toward ~$0, so every call
+truncates instantly into garbage), the source emits one `info` Finding
+("budget too small to scan N paths at $X each") instead of firing N
+doomed near-zero runs. This folds into FR-3's cap-hit surfacing. The
+floor constant is set in design (start conservative, e.g. a few cents)
+and is itself best-effort, not a contract.
 
 ## D3 — Overshoot tolerance
 
@@ -78,3 +100,73 @@ asserts the truthful `spent_usd` stays within D3 tolerance. Mocked unit
 tests (fake workflow capturing the `max_budget_usd` kwarg) are
 necessary-not-sufficient — the "registered ≠ working / dogfood the real
 loop" rule applies, the same way it surfaced the original $0.00 bug.
+
+## D6 — FR-1 cap precedence (explicit > env > depth)
+
+**Decision (design, 2026-06-28):** `get_max_budget_usd(depth,
+explicit=None)` resolves in this order: an `explicit` caller-supplied
+cap wins outright; else the `ATTUNE_MAX_BUDGET_USD` env var; else the
+depth default. The sweep passes each source's allocation as `explicit`,
+so a sweep's `budget_usd` is the user's ceiling for that sweep.
+
+**Why:** matches FR-1 verbatim ("when provided it is used"). The env var
+is intentionally NOT a hard ceiling over `explicit` — an org wanting a
+hard cap on sweeps caps the sweep's `budget_usd` input, not a
+per-workflow env var. Non-sweep callers pass `None` and keep today's
+env/depth behavior unchanged.
+
+**Known edge (deferred):** if an org relied on `ATTUNE_MAX_BUDGET_USD`
+as a per-workflow hard ceiling, a sweep allocation above it would
+override it. No current consumer does this; revisit with `min(explicit,
+env)` semantics only if telemetry shows it's needed.
+
+## D7 — Cap-hit detection: cost-proximity, not an SDK signal
+
+**Decision (design, 2026-06-28):** the FR-3 per-call "cap reached" note
+fires when a run's truthful `cost_report.total_cost` (PR #1156) reaches
+`_CAP_PROXIMITY` (0.95) of its `max_budget_usd` share. Worded "at the
+budget ceiling," not "was truncated" — cost alone cannot distinguish a
+truncated run from one that finished naturally at its allocation, and in
+tight-budget mode (allocation ≈ spend) "this source spent its whole
+allocation, raise --budget" is the true, useful message either way.
+
+**Why:** SDK-version independent — no guessed `subtype`/`stop_reason`
+string. The dogfood (D5) captures the real SDK truncation signal; a
+follow-up may swap the heuristic for it if it proves cleaner. Both
+budget findings carry `file=None` + a `budget-cap` tag so they route to
+the `questions` bucket (verification rule 1); an `info` finding WITH a
+file would fail the severity threshold (rule 2) and be rejected/hidden.
+
+## D8 — Dogfood result + FR-3 premise correction (observed behavior)
+
+**Verified (real de-nested dogfood, 2026-06-28, security-audit single
+source on `llm_source_base.py`, depth=quick):**
+
+| `budget_usd` | outcome | `spent_usd` | within `budget×1.15`? |
+|---|---|---|---|
+| 0.10 | capped → exit-1 at exhaustion (21 s) | 0.00 | yes |
+| 0.50 | capped → exit-1 at exhaustion (52 s) | 0.00 | yes |
+| 2.00 | completes (368 s) — 8 findings | 1.168 | yes (≤ 2.30) |
+
+Duration scaled with budget (21→52→368 s), proving the explicit
+per-source cap reaches the SDK's `max_budget_usd` and binds the run —
+FR-1/FR-2 are live end-to-end, not just mocked. The completing run
+shows truthful `spent_usd` (PR #1156) on the happy path; the cap-hit
+note correctly did NOT fire (1.168 < 0.95 × 2.00). **D5 acceptance
+PASSED.**
+
+**FR-3 premise correction:** the spec assumed the SDK "already truncates
+the run" and "returns partial findings" at the cap. Observed: at
+exhaustion the claude CLI **exits 1 (the SDK raises)**, it does NOT
+return partial findings, and the errored run reports **`spent=0`** (no
+`ResultMessage`, so no cost). The source's existing try/except catches
+it and surfaces an `info` finding (the `_workflow_unsuccessful_finding`
+path) — so FR-3's SAFETY intent holds (no crash, no overspend, the
+sweep continues), but "partial findings" does not happen on the
+error-at-exhaustion path. The cost-proximity cap-hit note (D7) therefore
+fires only on near-cap **completing** runs, never the exhaustion-error
+path (which the error-handling already covers). `spent` for a
+capped-out run understates (reads 0), never overstates — safe direction.
+Recorded honestly per the "registered ≠ working / dogfood the real loop"
+rule; a follow-up could map the exit-1-budget signal to a cleaner
+"capped" finding if telemetry shows it's worth it.

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -952,17 +952,29 @@ def _last_subprocess_argv(exc: BaseException) -> list[str]:
     return []
 
 
-def get_max_budget_usd(depth: str = "standard") -> float | None:
+def get_max_budget_usd(
+    depth: str = "standard",
+    explicit: float | None = None,
+) -> float | None:
     """Get budget cap for a workflow depth.
 
     Acts as a cost cap for API-key users and a complexity
     bound for subscription users. Priority:
 
-    1. ``ATTUNE_MAX_BUDGET_USD`` env var (set to 0 to disable)
-    2. Depth-based default from ``_DEFAULT_BUDGET_USD``
+    1. ``explicit`` caller-supplied cap (e.g. a discovery-sweep
+       source's per-call allocation). When not ``None`` it wins
+       outright — the caller has already decided the ceiling.
+    2. ``ATTUNE_MAX_BUDGET_USD`` env var (set to 0 to disable)
+    3. Depth-based default from ``_DEFAULT_BUDGET_USD``
 
     Args:
         depth: Analysis depth — "quick", "standard", or "deep".
+        explicit: Caller-supplied USD cap that overrides both the
+            env var and the depth default. Used by discovery-sweep
+            to plumb each source's budget allocation down into the
+            wrapped workflow (budget-enforcement spec, FR-1). A
+            non-sweep caller passes ``None`` and gets today's
+            env/depth-derived behavior unchanged.
 
     Returns:
         Budget cap in USD, or None if caps are disabled.
@@ -971,8 +983,15 @@ def get_max_budget_usd(depth: str = "standard") -> float | None:
         For pre-release audits where the default caps feel too
         restrictive, export ``ATTUNE_MAX_BUDGET_USD=0`` to let
         multi-subagent workflows run to completion. Subscription
-        users pay no per-request cost for these runs.
+        users pay no per-request cost for these runs. The env
+        var is NOT a hard ceiling over ``explicit`` — a sweep
+        passing a per-source allocation overrides it (the sweep's
+        ``budget_usd`` is the user's ceiling for that sweep). See
+        the budget-enforcement spec ``decisions.md`` for the
+        precedence rationale.
     """
+    if explicit is not None:
+        return explicit
     override = os.environ.get("ATTUNE_MAX_BUDGET_USD")
     if override is not None:
         val = float(override)

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -166,11 +166,17 @@ class BugPredictionWorkflow(BaseWorkflow):
 
         resolved_path = str(Path(path_arg).resolve())
         max_turns = _DEPTH_MAX_TURNS.get(depth, 20)
+        # Optional explicit per-call USD cap (discovery-sweep plumbs each
+        # source's allocation down here; budget-enforcement spec FR-1).
+        # None → today's depth-derived cap, no behavior change.
+        max_budget_usd: float | None = kwargs.get("max_budget_usd")
 
         started_at = datetime.now()
 
         try:
-            run_result = await self._run_agent_predict(resolved_path, max_turns, depth)
+            run_result = await self._run_agent_predict(
+                resolved_path, max_turns, depth, max_budget_usd=max_budget_usd
+            )
             self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
 
@@ -222,7 +228,11 @@ class BugPredictionWorkflow(BaseWorkflow):
             )
 
     async def _run_agent_predict(
-        self, resolved_path: str, max_turns: int, depth: str = "standard"
+        self,
+        resolved_path: str,
+        max_turns: int,
+        depth: str = "standard",
+        max_budget_usd: float | None = None,
     ) -> AgentRunResult:
         """Run the Agent SDK prediction and return result text.
 
@@ -248,7 +258,7 @@ class BugPredictionWorkflow(BaseWorkflow):
                     **sdk_isolation_kwargs(),
                     system_prompt=system_prompt,
                     cwd=resolve_cwd_for_path(resolved_path),
-                    max_budget_usd=get_max_budget_usd(depth),
+                    max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
                     allowed_tools=["Read", "Glob", "Grep", "Agent"],
                     permission_mode="default",
                     max_turns=max_turns,

--- a/src/attune/workflows/dependency_check.py
+++ b/src/attune/workflows/dependency_check.py
@@ -155,11 +155,17 @@ class DependencyCheckWorkflow(BaseWorkflow):
 
         resolved_path = str(Path(path_arg).resolve())
         max_turns = _DEPTH_MAX_TURNS.get(depth, 20)
+        # Optional explicit per-call USD cap (discovery-sweep plumbs each
+        # source's allocation down here; budget-enforcement spec FR-1).
+        # None → today's depth-derived cap, no behavior change.
+        max_budget_usd: float | None = kwargs.get("max_budget_usd")
 
         started_at = datetime.now()
 
         try:
-            run_result = await self._run_agent_check(resolved_path, max_turns, depth)
+            run_result = await self._run_agent_check(
+                resolved_path, max_turns, depth, max_budget_usd=max_budget_usd
+            )
             self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
@@ -207,7 +213,11 @@ class DependencyCheckWorkflow(BaseWorkflow):
             )
 
     async def _run_agent_check(
-        self, resolved_path: str, max_turns: int, depth: str = "standard"
+        self,
+        resolved_path: str,
+        max_turns: int,
+        depth: str = "standard",
+        max_budget_usd: float | None = None,
     ) -> AgentRunResult:
         """Run the Agent SDK dependency check and return result text.
 
@@ -229,7 +239,7 @@ class DependencyCheckWorkflow(BaseWorkflow):
                     **sdk_isolation_kwargs(),
                     system_prompt=system_prompt,
                     cwd=resolve_cwd_for_path(resolved_path),
-                    max_budget_usd=get_max_budget_usd(depth),
+                    max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
                     allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
                     permission_mode="default",
                     max_turns=max_turns,

--- a/src/attune/workflows/discovery_sweep/llm_source_base.py
+++ b/src/attune/workflows/discovery_sweep/llm_source_base.py
@@ -39,6 +39,22 @@ _VALID_SEVERITIES = frozenset(
     {"critical", "high", "medium", "low", "info"},
 )
 
+# Budget-enforcement spec (D2 floor guard + FR-3). Below this per-call
+# USD cap a wrapped workflow truncates before doing useful work, so the
+# source skips the run(s) and surfaces one info Finding instead of firing
+# N doomed near-zero runs. Best-effort, not a contract — tune from
+# telemetry. The common single-path sweep never trips it (share ==
+# whole allocation, well above the floor).
+MIN_PER_CALL_BUDGET_USD: float = 0.05
+
+# A per-call run whose real cost reaches this fraction of its cap was
+# almost certainly budget-bound (truncated with partial findings) rather
+# than finishing naturally under budget — surfaced as an info Finding so
+# the user knows results for that path may be partial (FR-3). SDK-version
+# independent: keyed off the truthful ``cost_report`` (PR #1156), never a
+# guessed SDK ``subtype``/``stop_reason`` string.
+_CAP_PROXIMITY: float = 0.95
+
 # Non-greedy + DOTALL per design.md so multiple blocks parse cleanly
 # and re.findall returns them in source order (we use the last).
 _JSON_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
@@ -239,6 +255,107 @@ def findings_from_workflow_result(result: object, source_name: str) -> list[Find
         final_output = str(final_output)
 
     return parse_findings_json(raw_text or final_output, source_name)
+
+
+def budget_too_small_finding(
+    source_name: str,
+    n_paths: int,
+    share: float,
+    allocation: float,
+) -> Finding:
+    """Floor-guard Finding: the per-call share is below the useful minimum.
+
+    Emitted (per FR-3 / D2) when a source's budget allocation divided
+    across its ``paths`` falls below :data:`MIN_PER_CALL_BUDGET_USD`, so
+    the source skips its runs entirely rather than firing N runs that
+    truncate before doing useful work. ``file=None`` + no ``file-level``
+    tag routes this to the sweep's ``questions`` bucket (verification
+    rule 1 — an ``info`` finding WITH a file would fail rule 2's
+    severity threshold and land in ``rejected``), where the user sees
+    the sweep was under-funded.
+
+    Args:
+        source_name: The calling adapter's ``name``.
+        n_paths: Number of paths the allocation was split across.
+        share: The computed per-call share (``allocation / n_paths``).
+        allocation: This source's total budget allocation.
+
+    Returns:
+        A single ``info``-severity Finding.
+    """
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name}: budget too small to scan {n_paths} path(s)",
+        description=(
+            f"This source's ${allocation:.4f} allocation split across "
+            f"{n_paths} path(s) is ${share:.4f} each — below the "
+            f"${MIN_PER_CALL_BUDGET_USD:.2f} minimum for a useful run. "
+            f"Skipped to avoid spending on runs that truncate immediately. "
+            f"Raise --budget or narrow the path glob."
+        ),
+        file=None,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("budget-cap",),
+    )
+
+
+def cap_hit_finding_if_bound(
+    source_name: str,
+    path: str,
+    result: object,
+    share: float | None,
+) -> Finding | None:
+    """Return an info Finding when a run spent ~all of its cap, else None.
+
+    Per FR-3: when a wrapped workflow's real cost reaches
+    :data:`_CAP_PROXIMITY` of its per-call ``max_budget_usd`` share, the
+    source maxed its allocation on ``path`` — the run sat at the budget
+    ceiling and its findings may be partial. Worded as "at the ceiling"
+    rather than "was truncated" because cost alone cannot distinguish a
+    truncated run from one that finished naturally at its allocation;
+    either way "this source spent its whole allocation, raise --budget
+    for more" is the true, useful message. Keyed off the truthful
+    ``cost_report.total_cost`` (PR #1156), never a guessed SDK signal.
+
+    ``file=None`` (path goes in the description) so this routes to the
+    ``questions`` bucket via verification rule 1 — an ``info`` finding
+    WITH a file would be rejected by the severity threshold (rule 2).
+
+    Args:
+        source_name: The calling adapter's ``name``.
+        path: The path whose run is being assessed.
+        result: The WorkflowResult (or duck-typed equivalent).
+        share: The per-call USD cap passed to this run, or ``None`` when
+            no cap was applied (returns ``None`` — nothing to note).
+
+    Returns:
+        An ``info``-severity Finding, or ``None`` when the run finished
+        comfortably under its cap (or no cap was set).
+    """
+    if share is None or share <= 0.0:
+        return None
+    cost_report = getattr(result, "cost_report", None)
+    cost = float(getattr(cost_report, "total_cost", 0.0) or 0.0)
+    if cost < share * _CAP_PROXIMITY:
+        return None
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name}: budget allocation exhausted on {path}",
+        description=(
+            f"This run spent ${cost:.4f} of its ${share:.4f} allocation "
+            f"(≥{_CAP_PROXIMITY:.0%}) — at the budget ceiling; findings "
+            f"for {path} may be partial. Raise --budget for a fuller scan."
+        ),
+        file=None,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("budget-cap",),
+    )
 
 
 class LLMSource:

--- a/src/attune/workflows/discovery_sweep/sources/bug_predict.py
+++ b/src/attune/workflows/discovery_sweep/sources/bug_predict.py
@@ -22,8 +22,11 @@ import logging
 from dataclasses import dataclass
 
 from ..llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
     STRUCTURED_EMIT_FOOTER,
     LLMSource,
+    budget_too_small_finding,
+    cap_hit_finding_if_bound,
     findings_from_workflow_result,
 )
 from ..workflow import Finding
@@ -52,17 +55,24 @@ class BugPredictSource(LLMSource):
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run BugPredictionWorkflow on each path and parse findings.
 
-        ``budget_usd`` is informational for v1 — the wrapped workflow
-        self-limits via the SDK's own ``max_budget_usd`` derived from
-        ``depth`` (see :func:`get_max_budget_usd`). A later PR can
-        plumb the per-source share down once the wrapped workflows
-        accept an explicit per-call cap.
+        ``budget_usd`` is this source's allocation from the sweep
+        engine. Per the budget-enforcement spec (FR-2 / D2) it is split
+        evenly across ``paths`` and passed down as each wrapped
+        ``execute()``'s ``max_budget_usd``, so the source self-limits to
+        its allocation. Below the per-call floor the source skips its
+        runs and surfaces one info Finding (FR-3) instead of firing N
+        runs that truncate before doing useful work.
         """
-        del budget_usd  # See docstring — wrapped workflow caps itself.
-
         if not paths:
             logger.warning("bug-predict: no paths to scan")
             return [_empty_paths_finding(self.name)]
+
+        # Budget-enforcement spec FR-2 / D2: even-split the allocation
+        # across paths. Single-path sweeps (the common case) get the
+        # whole allocation. Below the floor, skip rather than truncate.
+        share = budget_usd / len(paths)
+        if share < MIN_PER_CALL_BUDGET_USD:
+            return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this module's
         # import graph and lets unit tests patch the workflow class at
@@ -75,7 +85,7 @@ class BugPredictSource(LLMSource):
                 system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
             )
             try:
-                result = await workflow.execute(path=path, depth=self.depth)
+                result = await workflow.execute(path=path, depth=self.depth, max_budget_usd=share)
             except Exception as exc:  # noqa: BLE001
                 # INTENTIONAL: per spec NFR-1 a single path failure
                 # must not abort the whole source — log and continue,
@@ -92,6 +102,11 @@ class BugPredictSource(LLMSource):
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
+
+            # FR-3: note when this path's run sat at its budget ceiling.
+            cap_note = cap_hit_finding_if_bound(self.name, path, result, share)
+            if cap_note is not None:
+                findings.append(cap_note)
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/dependency_check.py
+++ b/src/attune/workflows/discovery_sweep/sources/dependency_check.py
@@ -28,8 +28,11 @@ import logging
 from dataclasses import dataclass
 
 from ..llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
     STRUCTURED_EMIT_FOOTER,
     LLMSource,
+    budget_too_small_finding,
+    cap_hit_finding_if_bound,
     findings_from_workflow_result,
 )
 from ..workflow import Finding
@@ -60,17 +63,24 @@ class DependencyCheckSource(LLMSource):
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run DependencyCheckWorkflow on each path and parse findings.
 
-        ``budget_usd`` is informational for v1 — the wrapped
-        workflow self-limits via the SDK's own
-        ``max_budget_usd`` derived from ``depth``. A later PR can
-        plumb the per-source share down once the wrapped workflows
-        accept an explicit per-call cap.
+        ``budget_usd`` is this source's allocation from the sweep
+        engine. Per the budget-enforcement spec (FR-2 / D2) it is split
+        evenly across ``paths`` and passed down as each wrapped
+        ``execute()``'s ``max_budget_usd``, so the source self-limits to
+        its allocation. Below the per-call floor the source skips its
+        runs and surfaces one info Finding (FR-3) instead of firing N
+        runs that truncate before doing useful work.
         """
-        del budget_usd  # See docstring — wrapped workflow caps itself.
-
         if not paths:
             logger.warning("dependency-check: no paths to scan")
             return [_empty_paths_finding(self.name)]
+
+        # Budget-enforcement spec FR-2 / D2: even-split the allocation
+        # across paths. Single-path sweeps (the common case) get the
+        # whole allocation. Below the floor, skip rather than truncate.
+        share = budget_usd / len(paths)
+        if share < MIN_PER_CALL_BUDGET_USD:
+            return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this
         # module's import graph and lets unit tests patch the
@@ -84,7 +94,7 @@ class DependencyCheckSource(LLMSource):
                 system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
             )
             try:
-                result = await workflow.execute(path=path, depth=self.depth)
+                result = await workflow.execute(path=path, depth=self.depth, max_budget_usd=share)
             except Exception as exc:  # noqa: BLE001
                 # INTENTIONAL: per spec NFR-1 a single path failure
                 # must not abort the whole source — log and
@@ -101,6 +111,11 @@ class DependencyCheckSource(LLMSource):
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
+
+            # FR-3: note when this path's run sat at its budget ceiling.
+            cap_note = cap_hit_finding_if_bound(self.name, path, result, share)
+            if cap_note is not None:
+                findings.append(cap_note)
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/doc_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/doc_audit.py
@@ -28,8 +28,11 @@ import logging
 from dataclasses import dataclass
 
 from ..llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
     STRUCTURED_EMIT_FOOTER,
     LLMSource,
+    budget_too_small_finding,
+    cap_hit_finding_if_bound,
     findings_from_workflow_result,
 )
 from ..workflow import Finding
@@ -59,17 +62,24 @@ class DocAuditSource(LLMSource):
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run DocAuditWorkflow on each path and parse findings.
 
-        ``budget_usd`` is informational for v1 — the wrapped
-        workflow self-limits via the SDK's own
-        ``max_budget_usd`` derived from ``depth``. A later PR can
-        plumb the per-source share down once the wrapped workflows
-        accept an explicit per-call cap.
+        ``budget_usd`` is this source's allocation from the sweep
+        engine. Per the budget-enforcement spec (FR-2 / D2) it is split
+        evenly across ``paths`` and passed down as each wrapped
+        ``execute()``'s ``max_budget_usd``, so the source self-limits to
+        its allocation. Below the per-call floor the source skips its
+        runs and surfaces one info Finding (FR-3) instead of firing N
+        runs that truncate before doing useful work.
         """
-        del budget_usd  # See docstring — wrapped workflow caps itself.
-
         if not paths:
             logger.warning("doc-audit: no paths to scan")
             return [_empty_paths_finding(self.name)]
+
+        # Budget-enforcement spec FR-2 / D2: even-split the allocation
+        # across paths. Single-path sweeps (the common case) get the
+        # whole allocation. Below the floor, skip rather than truncate.
+        share = budget_usd / len(paths)
+        if share < MIN_PER_CALL_BUDGET_USD:
+            return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this
         # module's import graph and lets unit tests patch the
@@ -83,7 +93,7 @@ class DocAuditSource(LLMSource):
                 system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
             )
             try:
-                result = await workflow.execute(path=path, depth=self.depth)
+                result = await workflow.execute(path=path, depth=self.depth, max_budget_usd=share)
             except Exception as exc:  # noqa: BLE001
                 # INTENTIONAL: per spec NFR-1 a single path failure
                 # must not abort the whole source — log and
@@ -100,6 +110,11 @@ class DocAuditSource(LLMSource):
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
+
+            # FR-3: note when this path's run sat at its budget ceiling.
+            cap_note = cap_hit_finding_if_bound(self.name, path, result, share)
+            if cap_note is not None:
+                findings.append(cap_note)
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/perf_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/perf_audit.py
@@ -27,8 +27,11 @@ import logging
 from dataclasses import dataclass
 
 from ..llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
     STRUCTURED_EMIT_FOOTER,
     LLMSource,
+    budget_too_small_finding,
+    cap_hit_finding_if_bound,
     findings_from_workflow_result,
 )
 from ..workflow import Finding
@@ -58,17 +61,24 @@ class PerfAuditSource(LLMSource):
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run PerformanceAuditWorkflow on each path and parse findings.
 
-        ``budget_usd`` is informational for v1 — the wrapped
-        workflow self-limits via the SDK's own
-        ``max_budget_usd`` derived from ``depth``. A later PR can
-        plumb the per-source share down once the wrapped workflows
-        accept an explicit per-call cap.
+        ``budget_usd`` is this source's allocation from the sweep
+        engine. Per the budget-enforcement spec (FR-2 / D2) it is split
+        evenly across ``paths`` and passed down as each wrapped
+        ``execute()``'s ``max_budget_usd``, so the source self-limits to
+        its allocation. Below the per-call floor the source skips its
+        runs and surfaces one info Finding (FR-3) instead of firing N
+        runs that truncate before doing useful work.
         """
-        del budget_usd  # See docstring — wrapped workflow caps itself.
-
         if not paths:
             logger.warning("perf-audit: no paths to scan")
             return [_empty_paths_finding(self.name)]
+
+        # Budget-enforcement spec FR-2 / D2: even-split the allocation
+        # across paths. Single-path sweeps (the common case) get the
+        # whole allocation. Below the floor, skip rather than truncate.
+        share = budget_usd / len(paths)
+        if share < MIN_PER_CALL_BUDGET_USD:
+            return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this
         # module's import graph and lets unit tests patch the
@@ -82,7 +92,7 @@ class PerfAuditSource(LLMSource):
                 system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
             )
             try:
-                result = await workflow.execute(path=path, depth=self.depth)
+                result = await workflow.execute(path=path, depth=self.depth, max_budget_usd=share)
             except Exception as exc:  # noqa: BLE001
                 # INTENTIONAL: per spec NFR-1 a single path failure
                 # must not abort the whole source — log and
@@ -99,6 +109,11 @@ class PerfAuditSource(LLMSource):
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
+
+            # FR-3: note when this path's run sat at its budget ceiling.
+            cap_note = cap_hit_finding_if_bound(self.name, path, result, share)
+            if cap_note is not None:
+                findings.append(cap_note)
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/security_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/security_audit.py
@@ -28,8 +28,11 @@ import logging
 from dataclasses import dataclass
 
 from ..llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
     STRUCTURED_EMIT_FOOTER,
     LLMSource,
+    budget_too_small_finding,
+    cap_hit_finding_if_bound,
     findings_from_workflow_result,
 )
 from ..workflow import Finding
@@ -60,17 +63,24 @@ class SecurityAuditSource(LLMSource):
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run SecurityAuditWorkflow on each path and parse findings.
 
-        ``budget_usd`` is informational for v1 — the wrapped
-        workflow self-limits via the SDK's own ``max_budget_usd``
-        derived from ``depth``. A later PR can plumb the per-source
-        share down once the wrapped workflows accept an explicit
-        per-call cap.
+        ``budget_usd`` is this source's allocation from the sweep
+        engine. Per the budget-enforcement spec (FR-2 / D2) it is
+        split evenly across ``paths`` and passed down as each wrapped
+        ``execute()``'s ``max_budget_usd``, so the source self-limits
+        to its allocation. Below the per-call floor the source skips
+        its runs and surfaces one info Finding (FR-3) instead of firing
+        N runs that truncate before doing useful work.
         """
-        del budget_usd  # See docstring — wrapped workflow caps itself.
-
         if not paths:
             logger.warning("security-audit: no paths to scan")
             return [_empty_paths_finding(self.name)]
+
+        # Budget-enforcement spec FR-2 / D2: even-split the allocation
+        # across paths. Single-path sweeps (the common case) get the
+        # whole allocation. Below the floor, skip rather than truncate.
+        share = budget_usd / len(paths)
+        if share < MIN_PER_CALL_BUDGET_USD:
+            return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this
         # module's import graph and lets unit tests patch the
@@ -84,7 +94,7 @@ class SecurityAuditSource(LLMSource):
                 system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
             )
             try:
-                result = await workflow.execute(path=path, depth=self.depth)
+                result = await workflow.execute(path=path, depth=self.depth, max_budget_usd=share)
             except Exception as exc:  # noqa: BLE001
                 # INTENTIONAL: per spec NFR-1 a single path failure
                 # must not abort the whole source — log and
@@ -101,6 +111,11 @@ class SecurityAuditSource(LLMSource):
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
+
+            # FR-3: note when this path's run sat at its budget ceiling.
+            cap_note = cap_hit_finding_if_bound(self.name, path, result, share)
+            if cap_note is not None:
+                findings.append(cap_note)
 
         return findings
 

--- a/src/attune/workflows/discovery_sweep/sources/test_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/test_audit.py
@@ -29,8 +29,11 @@ import logging
 from dataclasses import dataclass
 
 from ..llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
     STRUCTURED_EMIT_FOOTER,
     LLMSource,
+    budget_too_small_finding,
+    cap_hit_finding_if_bound,
     findings_from_workflow_result,
 )
 from ..workflow import Finding
@@ -60,17 +63,24 @@ class TestAuditSource(LLMSource):
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run TestAuditWorkflow on each path and parse findings.
 
-        ``budget_usd`` is informational for v1 — the wrapped
-        workflow self-limits via the SDK's own
-        ``max_budget_usd`` derived from ``depth``. A later PR can
-        plumb the per-source share down once the wrapped workflows
-        accept an explicit per-call cap.
+        ``budget_usd`` is this source's allocation from the sweep
+        engine. Per the budget-enforcement spec (FR-2 / D2) it is split
+        evenly across ``paths`` and passed down as each wrapped
+        ``execute()``'s ``max_budget_usd``, so the source self-limits to
+        its allocation. Below the per-call floor the source skips its
+        runs and surfaces one info Finding (FR-3) instead of firing N
+        runs that truncate before doing useful work.
         """
-        del budget_usd  # See docstring — wrapped workflow caps itself.
-
         if not paths:
             logger.warning("test-audit: no paths to scan")
             return [_empty_paths_finding(self.name)]
+
+        # Budget-enforcement spec FR-2 / D2: even-split the allocation
+        # across paths. Single-path sweeps (the common case) get the
+        # whole allocation. Below the floor, skip rather than truncate.
+        share = budget_usd / len(paths)
+        if share < MIN_PER_CALL_BUDGET_USD:
+            return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this
         # module's import graph and lets unit tests patch the
@@ -84,7 +94,7 @@ class TestAuditSource(LLMSource):
                 system_prompt_suffix=STRUCTURED_EMIT_FOOTER,
             )
             try:
-                result = await workflow.execute(path=path, depth=self.depth)
+                result = await workflow.execute(path=path, depth=self.depth, max_budget_usd=share)
             except Exception as exc:  # noqa: BLE001
                 # INTENTIONAL: per spec NFR-1 a single path failure
                 # must not abort the whole source — log and
@@ -101,6 +111,11 @@ class TestAuditSource(LLMSource):
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
+
+            # FR-3: note when this path's run sat at its budget ceiling.
+            cap_note = cap_hit_finding_if_bound(self.name, path, result, share)
+            if cap_note is not None:
+                findings.append(cap_note)
 
         return findings
 

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -133,11 +133,17 @@ class DocAuditWorkflow(BaseWorkflow):
 
         resolved_path = str(Path(path_arg).resolve())
         max_turns = _DEPTH_MAX_TURNS.get(depth, 20)
+        # Optional explicit per-call USD cap (discovery-sweep plumbs each
+        # source's allocation down here; budget-enforcement spec FR-1).
+        # None → today's depth-derived cap, no behavior change.
+        max_budget_usd: float | None = kwargs.get("max_budget_usd")
 
         started_at = datetime.now()
 
         try:
-            run_result = await self._run_agent_audit(resolved_path, max_turns, depth=depth)
+            run_result = await self._run_agent_audit(
+                resolved_path, max_turns, depth=depth, max_budget_usd=max_budget_usd
+            )
             self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
@@ -179,7 +185,11 @@ class DocAuditWorkflow(BaseWorkflow):
             )
 
     async def _run_agent_audit(
-        self, resolved_path: str, max_turns: int, depth: str = "standard"
+        self,
+        resolved_path: str,
+        max_turns: int,
+        depth: str = "standard",
+        max_budget_usd: float | None = None,
     ) -> AgentRunResult:
         """Run the Agent SDK audit and return result text.
 
@@ -202,7 +212,7 @@ class DocAuditWorkflow(BaseWorkflow):
                 **sdk_isolation_kwargs(),
                 system_prompt=system_prompt,
                 cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth),
+                max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
                 allowed_tools=["Read", "Glob", "Grep", "Agent"],
                 permission_mode="default",
                 max_turns=max_turns,

--- a/src/attune/workflows/perf_audit.py
+++ b/src/attune/workflows/perf_audit.py
@@ -152,11 +152,17 @@ class PerformanceAuditWorkflow(BaseWorkflow):
 
         resolved_path = str(Path(path_arg).resolve())
         max_turns = _DEPTH_MAX_TURNS.get(depth, 20)
+        # Optional explicit per-call USD cap (discovery-sweep plumbs each
+        # source's allocation down here; budget-enforcement spec FR-1).
+        # None → today's depth-derived cap, no behavior change.
+        max_budget_usd: float | None = kwargs.get("max_budget_usd")
 
         started_at = datetime.now()
 
         try:
-            run_result = await self._run_agent_audit(resolved_path, max_turns, depth)
+            run_result = await self._run_agent_audit(
+                resolved_path, max_turns, depth, max_budget_usd=max_budget_usd
+            )
             self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
 
@@ -208,7 +214,11 @@ class PerformanceAuditWorkflow(BaseWorkflow):
             )
 
     async def _run_agent_audit(
-        self, resolved_path: str, max_turns: int, depth: str = "standard"
+        self,
+        resolved_path: str,
+        max_turns: int,
+        depth: str = "standard",
+        max_budget_usd: float | None = None,
     ) -> AgentRunResult:
         """Run the Agent SDK audit and return result text.
 
@@ -230,7 +240,7 @@ class PerformanceAuditWorkflow(BaseWorkflow):
                     **sdk_isolation_kwargs(),
                     system_prompt=system_prompt,
                     cwd=resolve_cwd_for_path(resolved_path),
-                    max_budget_usd=get_max_budget_usd(depth),
+                    max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
                     allowed_tools=["Read", "Glob", "Grep", "Agent"],
                     permission_mode="default",
                     max_turns=max_turns,

--- a/src/attune/workflows/security_audit.py
+++ b/src/attune/workflows/security_audit.py
@@ -147,11 +147,17 @@ class SecurityAuditWorkflow(BaseWorkflow):
 
         resolved_path = str(Path(path_arg).resolve())
         max_turns = _DEPTH_MAX_TURNS.get(depth, 20)
+        # Optional explicit per-call USD cap (discovery-sweep plumbs each
+        # source's allocation down here; budget-enforcement spec FR-1).
+        # None → today's depth-derived cap, no behavior change.
+        max_budget_usd: float | None = kwargs.get("max_budget_usd")
 
         started_at = datetime.now()
 
         try:
-            run_result = await self._run_agent_audit(resolved_path, max_turns, depth)
+            run_result = await self._run_agent_audit(
+                resolved_path, max_turns, depth, max_budget_usd=max_budget_usd
+            )
             self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
 
@@ -217,7 +223,11 @@ class SecurityAuditWorkflow(BaseWorkflow):
             )
 
     async def _run_agent_audit(
-        self, resolved_path: str, max_turns: int, depth: str = "standard"
+        self,
+        resolved_path: str,
+        max_turns: int,
+        depth: str = "standard",
+        max_budget_usd: float | None = None,
     ) -> AgentRunResult:
         """Run the Agent SDK audit and return result text.
 
@@ -252,7 +262,7 @@ class SecurityAuditWorkflow(BaseWorkflow):
                     **sdk_isolation_kwargs(),
                     system_prompt=system_prompt,
                     cwd=resolve_cwd_for_path(resolved_path),
-                    max_budget_usd=get_max_budget_usd(depth),
+                    max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
                     allowed_tools=["Read", "Glob", "Grep", "Agent"],
                     permission_mode="default",
                     max_turns=max_turns,

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -164,11 +164,17 @@ class TestAuditWorkflow(BaseWorkflow):
 
         resolved_path = str(Path(path_arg).resolve())
         max_turns = _DEPTH_MAX_TURNS.get(depth, 20)
+        # Optional explicit per-call USD cap (discovery-sweep plumbs each
+        # source's allocation down here; budget-enforcement spec FR-1).
+        # None → today's depth-derived cap, no behavior change.
+        max_budget_usd: float | None = kwargs.get("max_budget_usd")
 
         started_at = datetime.now()
 
         try:
-            run_result = await self._run_agent_audit(resolved_path, max_turns, depth=depth)
+            run_result = await self._run_agent_audit(
+                resolved_path, max_turns, depth=depth, max_budget_usd=max_budget_usd
+            )
             self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
 
             completed_at = datetime.now()
@@ -210,7 +216,11 @@ class TestAuditWorkflow(BaseWorkflow):
             )
 
     async def _run_agent_audit(
-        self, resolved_path: str, max_turns: int, depth: str = "standard"
+        self,
+        resolved_path: str,
+        max_turns: int,
+        depth: str = "standard",
+        max_budget_usd: float | None = None,
     ) -> AgentRunResult:
         """Run the Agent SDK audit and return result text.
 
@@ -232,7 +242,7 @@ class TestAuditWorkflow(BaseWorkflow):
                 **sdk_isolation_kwargs(),
                 system_prompt=system_prompt,
                 cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth),
+                max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
                 allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
                 permission_mode="default",
                 max_turns=max_turns,

--- a/tests/unit/workflows/discovery_sweep/test_budget_enforcement.py
+++ b/tests/unit/workflows/discovery_sweep/test_budget_enforcement.py
@@ -1,0 +1,247 @@
+"""Unit tests for discovery-sweep budget enforcement.
+
+Covers the budget-enforcement spec
+(``docs/specs/discovery-sweep-budget-enforcement/``):
+
+* **FR-1** — ``get_max_budget_usd(depth, explicit=...)`` precedence:
+  an explicit cap wins; ``None`` falls back to today's env/depth cap.
+* **FR-2 / D2** — a source even-splits its allocation across ``paths``
+  and passes each share down as the wrapped ``execute()``'s
+  ``max_budget_usd``.
+* **FR-3** — the floor guard skips runs (one info Finding, no
+  ``execute()`` calls) when the per-call share is below
+  :data:`MIN_PER_CALL_BUDGET_USD`; the cap-hit note fires when a run
+  spent ~all of its share.
+
+These are necessary-not-sufficient (mocks): the real spend ceiling is
+proven by the de-nested dogfood (D5). ``SecurityAuditSource`` stands in
+for all six LLM sources — the plumbing is identical across them.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from unittest.mock import patch
+
+import pytest
+
+from attune.workflows.agent_sdk_adapter import get_max_budget_usd
+from attune.workflows.discovery_sweep.llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
+    budget_too_small_finding,
+    cap_hit_finding_if_bound,
+)
+from attune.workflows.discovery_sweep.sources.security_audit import (
+    SecurityAuditSource,
+)
+
+_WF_PATH = "attune.workflows.security_audit.SecurityAuditWorkflow"
+
+
+# ---------------------------------------------------------------------------
+# Fakes — record execute() kwargs and carry an optional cost_report
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCostReport:
+    total_cost: float = 0.0
+
+
+@dataclass
+class _FakeResult:
+    success: bool = True
+    final_output: str = ""
+    cost_report: _FakeCostReport | None = None
+
+
+@dataclass
+class _RecordedCall:
+    execute_kwargs: dict
+
+
+@dataclass
+class _FakeWorkflowFactory:
+    """Stand-in for ``SecurityAuditWorkflow`` recording execute() calls."""
+
+    results: list[_FakeResult] = field(default_factory=list)
+    calls: list[_RecordedCall] = field(default_factory=list)
+
+    def __call__(self, **_init_kwargs):
+        index = len(self.calls)
+        recorded = _RecordedCall(execute_kwargs={})
+
+        async def _execute(**execute_kwargs):
+            recorded.execute_kwargs = execute_kwargs
+            if index < len(self.results):
+                return self.results[index]
+            return _FakeResult(success=True, final_output="")
+
+        self.calls.append(recorded)
+        return type("FakeInstance", (), {"execute": staticmethod(_execute)})()
+
+
+def _empty_findings_output() -> str:
+    return f"prose\n\n```json\n{json.dumps({'findings': []})}\n```\n"
+
+
+# ---------------------------------------------------------------------------
+# FR-1 — get_max_budget_usd precedence
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_cap_wins_over_env_and_depth(monkeypatch) -> None:
+    """An explicit cap overrides both the env var and the depth default."""
+    monkeypatch.setenv("ATTUNE_MAX_BUDGET_USD", "9.99")
+    assert get_max_budget_usd("standard", explicit=0.25) == 0.25
+
+
+def test_explicit_none_falls_back_to_env(monkeypatch) -> None:
+    """``explicit=None`` preserves today's env-override behavior."""
+    monkeypatch.setenv("ATTUNE_MAX_BUDGET_USD", "3.5")
+    assert get_max_budget_usd("standard") == 3.5
+
+
+def test_explicit_none_falls_back_to_depth_default(monkeypatch) -> None:
+    """No env var + ``explicit=None`` → the depth-derived default."""
+    monkeypatch.delenv("ATTUNE_MAX_BUDGET_USD", raising=False)
+    assert get_max_budget_usd("standard") is not None
+
+
+# ---------------------------------------------------------------------------
+# FR-2 / D2 — even-split across paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_path_passes_whole_allocation() -> None:
+    """One path → the wrapped execute() gets the full allocation as its cap."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(final_output=_empty_findings_output())],
+    )
+    with patch(_WF_PATH, new=factory):
+        await SecurityAuditSource().discover(["src/"], budget_usd=4.0)
+
+    assert factory.calls[0].execute_kwargs["max_budget_usd"] == 4.0
+
+
+@pytest.mark.asyncio
+async def test_multi_path_even_splits_allocation() -> None:
+    """N paths → each execute() gets ``allocation / N`` as its cap (D2)."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(final_output=_empty_findings_output()),
+            _FakeResult(final_output=_empty_findings_output()),
+            _FakeResult(final_output=_empty_findings_output()),
+        ],
+    )
+    with patch(_WF_PATH, new=factory):
+        await SecurityAuditSource().discover(["a/", "b/", "c/"], budget_usd=6.0)
+
+    assert len(factory.calls) == 3
+    for call in factory.calls:
+        assert call.execute_kwargs["max_budget_usd"] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# FR-3 — floor guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_floor_guard_skips_all_runs() -> None:
+    """Per-call share below the floor → one info Finding, zero execute()s."""
+    n_paths = 100
+    factory = _FakeWorkflowFactory()
+    with patch(_WF_PATH, new=factory):
+        # 100 paths share $1 → $0.01 each, below the $0.05 floor.
+        findings = await SecurityAuditSource().discover(
+            [f"p{i}/" for i in range(n_paths)], budget_usd=1.0
+        )
+
+    assert factory.calls == []  # no doomed near-zero runs fired
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert "budget-cap" in only.tags
+    # file=None + no file-level tag → routes to the questions bucket.
+    assert only.file is None
+    assert "file-level" not in only.tags
+
+
+def test_budget_too_small_finding_shape() -> None:
+    """The floor-guard Finding is info-severity and questions-routable."""
+    finding = budget_too_small_finding("security-audit", 50, 0.02, 1.0)
+    assert finding.severity == "info"
+    assert finding.file is None
+    assert finding.tags == ("budget-cap",)
+
+
+@pytest.mark.asyncio
+async def test_floor_boundary_share_at_min_runs() -> None:
+    """A share exactly at the floor runs (the guard is strict ``<``)."""
+    factory = _FakeWorkflowFactory(
+        results=[_FakeResult(final_output=_empty_findings_output())],
+    )
+    with patch(_WF_PATH, new=factory):
+        # single path, allocation == floor → share == floor → not below → runs.
+        await SecurityAuditSource().discover(["src/"], budget_usd=MIN_PER_CALL_BUDGET_USD)
+
+    assert len(factory.calls) == 1
+    assert factory.calls[0].execute_kwargs["max_budget_usd"] == MIN_PER_CALL_BUDGET_USD
+
+
+# ---------------------------------------------------------------------------
+# FR-3 — cap-hit note (cost-proximity, SDK-independent)
+# ---------------------------------------------------------------------------
+
+
+def test_cap_hit_finding_when_cost_near_share() -> None:
+    """Cost ≥ 95% of the share → an info Finding flagging the ceiling."""
+    result = _FakeResult(cost_report=_FakeCostReport(total_cost=0.97))
+    finding = cap_hit_finding_if_bound("security-audit", "src/", result, 1.0)
+    assert finding is not None
+    assert finding.severity == "info"
+    assert finding.file is None  # questions-routable
+    assert "budget-cap" in finding.tags
+
+
+def test_no_cap_hit_when_cost_low() -> None:
+    """Cost well under the share → no note (the run finished comfortably)."""
+    result = _FakeResult(cost_report=_FakeCostReport(total_cost=0.10))
+    assert cap_hit_finding_if_bound("security-audit", "src/", result, 1.0) is None
+
+
+def test_no_cap_hit_when_no_cap_applied() -> None:
+    """``share=None`` (no cap) → never a cap-hit note."""
+    result = _FakeResult(cost_report=_FakeCostReport(total_cost=9.0))
+    assert cap_hit_finding_if_bound("security-audit", "src/", result, None) is None
+
+
+def test_no_cap_hit_when_no_cost_report() -> None:
+    """A result without a cost_report contributes no cap-hit note."""
+    result = _FakeResult(cost_report=None)
+    assert cap_hit_finding_if_bound("security-audit", "src/", result, 1.0) is None
+
+
+@pytest.mark.asyncio
+async def test_cap_hit_note_appended_after_findings() -> None:
+    """A near-cap run yields its parsed findings PLUS one cap-hit note."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(
+                final_output=_empty_findings_output(),
+                cost_report=_FakeCostReport(total_cost=4.0),
+            ),
+        ],
+    )
+    with patch(_WF_PATH, new=factory):
+        findings = await SecurityAuditSource().discover(["src/"], budget_usd=4.0)
+
+    cap_notes = [f for f in findings if "budget-cap" in f.tags]
+    assert len(cap_notes) == 1
+    assert cap_notes[0].severity == "info"

--- a/tests/unit/workflows/discovery_sweep/test_bug_predict_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_bug_predict_source.py
@@ -152,7 +152,11 @@ async def test_single_path_returns_parsed_findings() -> None:
         )
     ]
     assert len(factory.calls) == 1
-    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "standard"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "src/",
+        "depth": "standard",
+        "max_budget_usd": 1.0,
+    }
 
 
 @pytest.mark.asyncio
@@ -186,7 +190,11 @@ async def test_custom_depth_is_passed_to_execute() -> None:
     ):
         await BugPredictSource(depth="quick").discover(["src/"], budget_usd=1.0)
 
-    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "quick"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "src/",
+        "depth": "quick",
+        "max_budget_usd": 1.0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/discovery_sweep/test_bug_predict_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_bug_predict_source.py
@@ -17,7 +17,10 @@ import pytest
 
 from attune.workflows.discovery_sweep import Finding
 from attune.workflows.discovery_sweep.cli_workflow import default_sources
-from attune.workflows.discovery_sweep.llm_source_base import STRUCTURED_EMIT_FOOTER
+from attune.workflows.discovery_sweep.llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
+    STRUCTURED_EMIT_FOOTER,
+)
 from attune.workflows.discovery_sweep.sources.bug_predict import BugPredictSource
 
 # ---------------------------------------------------------------------------
@@ -31,6 +34,7 @@ class _FakeResult:
 
     success: bool = True
     final_output: str = ""
+    cost_report: object | None = None
 
 
 @dataclass
@@ -362,3 +366,64 @@ async def test_empty_final_output_falls_back() -> None:
 
     assert len(findings) == 1
     assert findings[0].tags == ("text-only-fallback",)
+
+
+# ---------------------------------------------------------------------------
+# discover() budget-enforcement paths
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCostReport:
+    """Minimal stand-in for ``WorkflowResult.cost_report``."""
+
+    total_cost: float = 0.0
+
+
+@pytest.mark.asyncio
+async def test_budget_below_floor_skips_runs_and_emits_finding() -> None:
+    """Per-call share under the floor → skip every run, one info finding."""
+    factory = _FakeWorkflowFactory()
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover(
+            ["src/"], budget_usd=MIN_PER_CALL_BUDGET_USD / 2
+        )
+
+    assert factory.calls == []
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.tags == ("budget-cap",)
+    assert only.file is None
+
+
+@pytest.mark.asyncio
+async def test_run_at_budget_ceiling_appends_cap_finding() -> None:
+    """Cost ≥95% of the per-call share → append an info 'ceiling' finding."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(_wellformed_payload()),
+                cost_report=_FakeCostReport(total_cost=1.0),
+            )
+        ],
+    )
+
+    with patch(
+        "attune.workflows.bug_predict.BugPredictionWorkflow",
+        new=factory,
+    ):
+        findings = await BugPredictSource().discover(["src/"], budget_usd=1.0)
+
+    # The path's own finding plus one appended cap-ceiling note.
+    assert len(findings) == 2
+    cap = findings[-1]
+    assert cap.severity == "info"
+    assert cap.tags == ("budget-cap",)
+    assert cap.file is None
+    assert "src/" in cap.description

--- a/tests/unit/workflows/discovery_sweep/test_dependency_check_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_dependency_check_source.py
@@ -149,7 +149,11 @@ async def test_single_path_returns_parsed_findings() -> None:
         )
     ]
     assert len(factory.calls) == 1
-    assert factory.calls[0].execute_kwargs == {"path": "./", "depth": "standard"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "./",
+        "depth": "standard",
+        "max_budget_usd": 0.5,
+    }
 
 
 @pytest.mark.asyncio
@@ -183,7 +187,11 @@ async def test_custom_depth_is_passed_to_execute() -> None:
     ):
         await DependencyCheckSource(depth="quick").discover(["./"], budget_usd=0.5)
 
-    assert factory.calls[0].execute_kwargs == {"path": "./", "depth": "quick"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "./",
+        "depth": "quick",
+        "max_budget_usd": 0.5,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/discovery_sweep/test_dependency_check_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_dependency_check_source.py
@@ -21,7 +21,10 @@ import pytest
 
 from attune.workflows.discovery_sweep import Finding
 from attune.workflows.discovery_sweep.cli_workflow import default_sources
-from attune.workflows.discovery_sweep.llm_source_base import STRUCTURED_EMIT_FOOTER
+from attune.workflows.discovery_sweep.llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
+    STRUCTURED_EMIT_FOOTER,
+)
 from attune.workflows.discovery_sweep.sources.dependency_check import (
     DependencyCheckSource,
 )
@@ -35,6 +38,7 @@ class _FakeResult:
 
     success: bool = True
     final_output: str = ""
+    cost_report: object | None = None
 
 
 @dataclass
@@ -358,3 +362,64 @@ async def test_empty_final_output_falls_back() -> None:
 
     assert len(findings) == 1
     assert findings[0].tags == ("text-only-fallback",)
+
+
+# ---------------------------------------------------------------------------
+# discover() budget-enforcement paths
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCostReport:
+    """Minimal stand-in for ``WorkflowResult.cost_report``."""
+
+    total_cost: float = 0.0
+
+
+@pytest.mark.asyncio
+async def test_budget_below_floor_skips_runs_and_emits_finding() -> None:
+    """Per-call share under the floor → skip every run, one info finding."""
+    factory = _FakeWorkflowFactory()
+
+    with patch(
+        "attune.workflows.dependency_check.DependencyCheckWorkflow",
+        new=factory,
+    ):
+        findings = await DependencyCheckSource().discover(
+            ["./"], budget_usd=MIN_PER_CALL_BUDGET_USD / 2
+        )
+
+    assert factory.calls == []
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.tags == ("budget-cap",)
+    assert only.file is None
+
+
+@pytest.mark.asyncio
+async def test_run_at_budget_ceiling_appends_cap_finding() -> None:
+    """Cost ≥95% of the per-call share → append an info 'ceiling' finding."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(_wellformed_payload()),
+                cost_report=_FakeCostReport(total_cost=1.0),
+            )
+        ],
+    )
+
+    with patch(
+        "attune.workflows.dependency_check.DependencyCheckWorkflow",
+        new=factory,
+    ):
+        findings = await DependencyCheckSource().discover(["./"], budget_usd=1.0)
+
+    # The path's own finding plus one appended cap-ceiling note.
+    assert len(findings) == 2
+    cap = findings[-1]
+    assert cap.severity == "info"
+    assert cap.tags == ("budget-cap",)
+    assert cap.file is None
+    assert "./" in cap.description

--- a/tests/unit/workflows/discovery_sweep/test_doc_audit_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_doc_audit_source.py
@@ -19,7 +19,10 @@ import pytest
 
 from attune.workflows.discovery_sweep import Finding
 from attune.workflows.discovery_sweep.cli_workflow import default_sources
-from attune.workflows.discovery_sweep.llm_source_base import STRUCTURED_EMIT_FOOTER
+from attune.workflows.discovery_sweep.llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
+    STRUCTURED_EMIT_FOOTER,
+)
 from attune.workflows.discovery_sweep.sources.doc_audit import DocAuditSource
 
 SOURCE = "doc-audit"
@@ -29,6 +32,7 @@ SOURCE = "doc-audit"
 class _FakeResult:
     success: bool = True
     final_output: str = ""
+    cost_report: object | None = None
 
 
 @dataclass
@@ -352,3 +356,64 @@ async def test_empty_final_output_falls_back() -> None:
 
     assert len(findings) == 1
     assert findings[0].tags == ("text-only-fallback",)
+
+
+# ---------------------------------------------------------------------------
+# discover() budget-enforcement paths
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCostReport:
+    """Minimal stand-in for ``WorkflowResult.cost_report``."""
+
+    total_cost: float = 0.0
+
+
+@pytest.mark.asyncio
+async def test_budget_below_floor_skips_runs_and_emits_finding() -> None:
+    """Per-call share under the floor → skip every run, one info finding."""
+    factory = _FakeWorkflowFactory()
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover(
+            ["docs/"], budget_usd=MIN_PER_CALL_BUDGET_USD / 2
+        )
+
+    assert factory.calls == []
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.tags == ("budget-cap",)
+    assert only.file is None
+
+
+@pytest.mark.asyncio
+async def test_run_at_budget_ceiling_appends_cap_finding() -> None:
+    """Cost ≥95% of the per-call share → append an info 'ceiling' finding."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(_wellformed_payload()),
+                cost_report=_FakeCostReport(total_cost=1.0),
+            )
+        ],
+    )
+
+    with patch(
+        "attune.workflows.doc_audit.workflow.DocAuditWorkflow",
+        new=factory,
+    ):
+        findings = await DocAuditSource().discover(["docs/"], budget_usd=1.0)
+
+    # The path's own finding plus one appended cap-ceiling note.
+    assert len(findings) == 2
+    cap = findings[-1]
+    assert cap.severity == "info"
+    assert cap.tags == ("budget-cap",)
+    assert cap.file is None
+    assert "docs/" in cap.description

--- a/tests/unit/workflows/discovery_sweep/test_doc_audit_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_doc_audit_source.py
@@ -143,7 +143,11 @@ async def test_single_path_returns_parsed_findings() -> None:
         )
     ]
     assert len(factory.calls) == 1
-    assert factory.calls[0].execute_kwargs == {"path": "docs/", "depth": "standard"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "docs/",
+        "depth": "standard",
+        "max_budget_usd": 1.0,
+    }
 
 
 @pytest.mark.asyncio
@@ -177,7 +181,11 @@ async def test_custom_depth_is_passed_to_execute() -> None:
     ):
         await DocAuditSource(depth="quick").discover(["docs/"], budget_usd=1.0)
 
-    assert factory.calls[0].execute_kwargs == {"path": "docs/", "depth": "quick"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "docs/",
+        "depth": "quick",
+        "max_budget_usd": 1.0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/discovery_sweep/test_perf_audit_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_perf_audit_source.py
@@ -145,7 +145,11 @@ async def test_single_path_returns_parsed_findings() -> None:
         )
     ]
     assert len(factory.calls) == 1
-    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "standard"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "src/",
+        "depth": "standard",
+        "max_budget_usd": 1.0,
+    }
 
 
 @pytest.mark.asyncio
@@ -179,7 +183,11 @@ async def test_custom_depth_is_passed_to_execute() -> None:
     ):
         await PerfAuditSource(depth="quick").discover(["src/"], budget_usd=1.0)
 
-    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "quick"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "src/",
+        "depth": "quick",
+        "max_budget_usd": 1.0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/discovery_sweep/test_perf_audit_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_perf_audit_source.py
@@ -19,7 +19,10 @@ import pytest
 
 from attune.workflows.discovery_sweep import Finding
 from attune.workflows.discovery_sweep.cli_workflow import default_sources
-from attune.workflows.discovery_sweep.llm_source_base import STRUCTURED_EMIT_FOOTER
+from attune.workflows.discovery_sweep.llm_source_base import (
+    MIN_PER_CALL_BUDGET_USD,
+    STRUCTURED_EMIT_FOOTER,
+)
 from attune.workflows.discovery_sweep.sources.perf_audit import PerfAuditSource
 
 SOURCE = "perf-audit"
@@ -31,6 +34,7 @@ class _FakeResult:
 
     success: bool = True
     final_output: str = ""
+    cost_report: object | None = None
 
 
 @dataclass
@@ -354,3 +358,64 @@ async def test_empty_final_output_falls_back() -> None:
 
     assert len(findings) == 1
     assert findings[0].tags == ("text-only-fallback",)
+
+
+# ---------------------------------------------------------------------------
+# discover() budget-enforcement paths
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeCostReport:
+    """Minimal stand-in for ``WorkflowResult.cost_report``."""
+
+    total_cost: float = 0.0
+
+
+@pytest.mark.asyncio
+async def test_budget_below_floor_skips_runs_and_emits_finding() -> None:
+    """Per-call share under the floor → skip every run, one info finding."""
+    factory = _FakeWorkflowFactory()
+
+    with patch(
+        "attune.workflows.perf_audit.PerformanceAuditWorkflow",
+        new=factory,
+    ):
+        findings = await PerfAuditSource().discover(
+            ["src/"], budget_usd=MIN_PER_CALL_BUDGET_USD / 2
+        )
+
+    assert factory.calls == []
+    assert len(findings) == 1
+    only = findings[0]
+    assert only.severity == "info"
+    assert only.tags == ("budget-cap",)
+    assert only.file is None
+
+
+@pytest.mark.asyncio
+async def test_run_at_budget_ceiling_appends_cap_finding() -> None:
+    """Cost ≥95% of the per-call share → append an info 'ceiling' finding."""
+    factory = _FakeWorkflowFactory(
+        results=[
+            _FakeResult(
+                success=True,
+                final_output=_wrap_json(_wellformed_payload()),
+                cost_report=_FakeCostReport(total_cost=1.0),
+            )
+        ],
+    )
+
+    with patch(
+        "attune.workflows.perf_audit.PerformanceAuditWorkflow",
+        new=factory,
+    ):
+        findings = await PerfAuditSource().discover(["src/"], budget_usd=1.0)
+
+    # The path's own finding plus one appended cap-ceiling note.
+    assert len(findings) == 2
+    cap = findings[-1]
+    assert cap.severity == "info"
+    assert cap.tags == ("budget-cap",)
+    assert cap.file is None
+    assert "src/" in cap.description

--- a/tests/unit/workflows/discovery_sweep/test_security_audit_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_security_audit_source.py
@@ -158,7 +158,11 @@ async def test_single_path_returns_parsed_findings() -> None:
         )
     ]
     assert len(factory.calls) == 1
-    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "standard"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "src/",
+        "depth": "standard",
+        "max_budget_usd": 4.0,
+    }
 
 
 @pytest.mark.asyncio
@@ -192,7 +196,11 @@ async def test_custom_depth_is_passed_to_execute() -> None:
     ):
         await SecurityAuditSource(depth="quick").discover(["src/"], budget_usd=4.0)
 
-    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "quick"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "src/",
+        "depth": "quick",
+        "max_budget_usd": 4.0,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/workflows/discovery_sweep/test_test_audit_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_test_audit_source.py
@@ -142,7 +142,11 @@ async def test_single_path_returns_parsed_findings() -> None:
         )
     ]
     assert len(factory.calls) == 1
-    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "standard"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "src/",
+        "depth": "standard",
+        "max_budget_usd": 1.0,
+    }
 
 
 @pytest.mark.asyncio
@@ -176,7 +180,11 @@ async def test_custom_depth_is_passed_to_execute() -> None:
     ):
         await TestAuditSource(depth="quick").discover(["src/"], budget_usd=1.0)
 
-    assert factory.calls[0].execute_kwargs == {"path": "src/", "depth": "quick"}
+    assert factory.calls[0].execute_kwargs == {
+        "path": "src/",
+        "depth": "quick",
+        "max_budget_usd": 1.0,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Makes discovery-sweep's `budget_usd` an **actual spend cap**, implementing the approved spec at `docs/specs/discovery-sweep-budget-enforcement/`. Previously each LLM source did `del budget_usd` and ignored its allocation — a sweep could spend without limit. Builds on #1156 (real `spent_usd`), which made enforcement testable.

## How

- **FR-1** — every SDK-native workflow's `execute()` accepts an optional `max_budget_usd` kwarg. `get_max_budget_usd(depth, explicit=...)` resolves explicit → env → depth (D6). Threaded through all 6 wrapped workflows. Default `None` → unchanged for non-sweep callers.
- **FR-2 / D2** — each LLM source even-splits its allocation across `paths` and passes `allocation / len(paths)` down. Single-path sweeps (the common case) pass the whole allocation; the wrapped workflow self-limits via the SDK cap.
- **FR-3** — a floor guard (`MIN_PER_CALL_BUDGET_USD = $0.05`) skips runs and surfaces one info Finding when the per-call share is too small to be useful. A cost-proximity note (D7) flags a path whose run sat at its budget ceiling, keyed off the truthful `cost_report` — no guessed SDK signal. Both findings route to the `questions` bucket (`file=None` + `budget-cap` tag).
- **NFR-2** preserved — no change to the `discovery_sweep` MCP tool schema or the 47-tool count guard.

## Verification

**Mocked** (`tests/unit/workflows/discovery_sweep/test_budget_enforcement.py`, 13 new tests): precedence, even-split, floor guard, cap-hit helper; plus 12 existing source-test assertions updated. 430 affected tests green.

**Real de-nested dogfood (D5)** — security-audit single source, depth=quick:

| `budget_usd` | outcome | `spent_usd` | ≤ `budget×1.15` |
|---|---|---|---|
| 0.10 | capped → exit-1 at exhaustion (21 s) | 0.00 | ✅ |
| 0.50 | capped → exit-1 at exhaustion (52 s) | 0.00 | ✅ |
| 2.00 | **completes** (368 s) — 8 findings | **1.168** | ✅ (≤ 2.30) |

Duration scaling with budget proves the explicit per-source cap reaches the SDK and binds the run — FR-1/FR-2 are live end-to-end, not just mocked. **D5 PASSED.**

**FR-3 premise correction (D8):** at exhaustion the CLI **exits 1 (raises)**, it does not truncate-with-partial-findings as the spec assumed; the source catches it gracefully (no crash, no overspend) and `spent` for a capped-out run reads 0 (understates, never overstates — safe direction). Recorded honestly in `decisions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
