### PR TITLE
fix(telemetry): self-heal stale usage summary (signature-validated cache)

### DIFF
--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -245,40 +245,91 @@ class UsageTracker:
         """
         try:
             if self._summary_file.exists():
+                data = None
                 try:
                     with open(self._summary_file, encoding="utf-8") as f:
                         data = json.load(f)
+                except (OSError, json.JSONDecodeError):
+                    data = None
+
+                # The summary is a DERIVED cache of ``usage*.jsonl``. Trust it
+                # only when it was built against the current log files —
+                # compare the source signature. A mismatch means the logs
+                # changed since the summary was written (appends from this or
+                # another process, log rotation, manual edits, or a
+                # concurrent-writer race that persisted an incomplete
+                # summary), so rebuild instead of silently undercounting.
+                # Legacy summaries with no ``source_sig`` always rebuild.
+                if data is not None and data.get("source_sig") == self._source_signature():
                     self._daily_summary = data.get("days", {})
                     return
-                except (OSError, json.JSONDecodeError):
-                    self._daily_summary = {}
 
-            # No summary file — build from existing disk data (migration path)
+            # No summary file, unreadable, or stale — rebuild from disk.
             self._rebuild_summary_from_disk()
         except OSError:
             # Telemetry dir unreadable (e.g. read-only) — disable gracefully.
             logger.debug("Failed to load telemetry summary: %s", self.telemetry_dir)
             self._daily_summary = {}
 
-    def _rebuild_summary_from_disk(self) -> None:
-        """Scan all JSONL files to build the daily summary.
+    def _source_signature(self) -> dict[str, int]:
+        """Cheap fingerprint of the source JSONL logs (filename -> byte size).
 
-        Called once when no summary file exists. Result is saved to disk
-        so subsequent runs use the fast O(days) load path.
+        The daily summary is a derived cache; this signature lets a reader
+        detect when ``usage*.jsonl`` changed since the summary was built so
+        a stale or race-corrupted summary is rebuilt rather than trusted.
+        Byte size (not mtime) is used because the logs are append-only: any
+        new record grows the file, and size avoids mtime-resolution flukes.
+        Best-effort — returns ``{}`` if the directory is unreadable.
         """
+        sig: dict[str, int] = {}
+        try:
+            for f in sorted(self.telemetry_dir.glob("usage*.jsonl")):
+                try:
+                    sig[f.name] = f.stat().st_size
+                except OSError:
+                    continue
+        except OSError:
+            return {}
+        return sig
+
+    def _rebuild_summary_from_disk(self) -> None:
+        """Scan all JSONL files to build the daily summary from scratch.
+
+        The authoritative path: a full scan of the append-only logs always
+        produces a COMPLETE summary, so it is the only writer of the summary
+        file (the buffered write path never persists a partial summary —
+        that is what allowed concurrent writers to corrupt it). Result is
+        saved with a source signature so subsequent loads take the fast
+        O(days) path until the logs change again.
+        """
+        # Capture the signature BEFORE scanning. If a writer appends during
+        # the scan, the saved signature is smaller than the real file, so the
+        # next load sees a mismatch and rebuilds — a harmless re-scan, never a
+        # silent under-count (fail toward rebuild, never toward stale-trust).
+        sig = self._source_signature()
+        self._daily_summary = {}
         for file in sorted(self.telemetry_dir.glob("usage*.jsonl")):
             for entry in self._iter_jsonl(file):
                 self._update_summary_entry(entry)
 
         if self._daily_summary:
-            self._save_summary()
+            self._save_summary(source_sig=sig)
 
-    def _save_summary(self) -> None:
-        """Persist daily summary to disk atomically (best-effort)."""
+    def _save_summary(self, source_sig: dict[str, int] | None = None) -> None:
+        """Persist daily summary to disk atomically (best-effort).
+
+        Args:
+            source_sig: The source-log signature this summary was built
+                against (see :meth:`_source_signature`). Persisted so a
+                later load can detect staleness. When ``None`` it is
+                computed now — only correct for callers that have just
+                folded in every on-disk record.
+        """
         try:
             data = {
                 "v": "1.0",
                 "updated": self._utcnow_iso(),
+                "source_sig": source_sig if source_sig is not None else self._source_signature(),
                 "days": self._daily_summary,
             }
             tmp = self._summary_file.with_suffix(".tmp")
@@ -425,10 +476,16 @@ class UsageTracker:
                 self._buffer = entries + self._buffer
             raise
 
-        # Update in-memory summary and persist it (after successful disk write)
+        # Update the IN-MEMORY summary for this process's own get_stats()
+        # fast path. Deliberately do NOT persist the summary here: another
+        # process may have appended records this instance never saw, so its
+        # in-memory summary is incomplete relative to the shared log —
+        # writing it would clobber the file with partial data (the original
+        # lost-update bug). The summary file is written only by a full
+        # rebuild (_rebuild_summary_from_disk), which always sees every
+        # record; readers self-heal via the signature check in _load_summary.
         with self._lock:
             self._update_summary(entries)
-            self._save_summary()
 
         return len(entries)
 

--- a/tests/unit/telemetry/test_usage_tracker.py
+++ b/tests/unit/telemetry/test_usage_tracker.py
@@ -1468,13 +1468,19 @@ class TestGetCacheStats:
 
 class TestSummaryLoadSave:
     def test_load_existing_summary_file(self, temp_dir):
-        """Lines 190-191: existing summary file is parsed and assigned."""
+        """A summary whose source_sig matches the logs is parsed and assigned.
+
+        With no ``usage*.jsonl`` in the dir the signature is empty, so a
+        summary carrying ``source_sig: {}`` is current and taken via the
+        fast path (not rebuilt).
+        """
         summary_path = temp_dir / "usage_summary.json"
         summary_path.write_text(
             json.dumps(
                 {
                     "v": "1.0",
                     "updated": "2025-01-01T00:00:00Z",
+                    "source_sig": {},
                     "days": {
                         "2025-01-01": {
                             "calls": 5,
@@ -1509,6 +1515,111 @@ class TestSummaryLoadSave:
         with patch("builtins.open", side_effect=OSError("disk full")):
             # Should not raise
             tracker._save_summary()
+
+    @staticmethod
+    def _rec(ts: str, cost: float) -> dict:
+        """A minimal usage record for log-reconciliation tests."""
+        return {
+            "ts": ts,
+            "workflow": "w",
+            "tier": "SDK",
+            "provider": "anthropic",
+            "cost": cost,
+            "tokens": {"input": 1, "output": 1},
+            "cache": {"hit": False},
+        }
+
+    def test_stale_summary_is_rebuilt_when_log_has_more(self, temp_dir):
+        """Regression: a summary out of sync with the log is rebuilt, not trusted.
+
+        Reproduces the MCP/dashboard under-count — a summary persisted while
+        the log was shorter (or a concurrent writer clobbered it with partial
+        data) carries a stale ``source_sig``; the reader must reconcile
+        against the full log instead of reporting the stale total.
+        """
+        usage = temp_dir / "usage.jsonl"
+        usage.write_text(
+            json.dumps(self._rec("2025-02-01T00:00:00Z", 1.0))
+            + "\n"
+            + json.dumps(self._rec("2025-02-01T01:00:00Z", 2.0))
+            + "\n"
+        )
+        # Stale summary: knows only the first record, wrong source_sig.
+        (temp_dir / "usage_summary.json").write_text(
+            json.dumps(
+                {
+                    "v": "1.0",
+                    "updated": "2025-02-01T00:00:01Z",
+                    "source_sig": {"usage.jsonl": 1},  # wrong size → stale
+                    "days": {
+                        "2025-02-01": {
+                            **UsageTracker._empty_day(),
+                            "calls": 1,
+                            "cost": 1.0,
+                        }
+                    },
+                }
+            )
+        )
+
+        t = UsageTracker(telemetry_dir=temp_dir, retention_days=3650)
+        stats = t.get_stats(days=3650)
+
+        # Reconciled with the full log: both records ($3.00), not stale $1.00.
+        assert stats["total_calls"] == 2
+        assert stats["total_cost"] == 3.0
+
+    def test_legacy_summary_without_sig_is_rebuilt(self, temp_dir):
+        """A pre-fix summary (no ``source_sig``) is never trusted — rebuilt."""
+        usage = temp_dir / "usage.jsonl"
+        usage.write_text(json.dumps(self._rec("2025-03-01T00:00:00Z", 5.0)) + "\n")
+        (temp_dir / "usage_summary.json").write_text(
+            json.dumps(
+                {
+                    "v": "1.0",
+                    "updated": "x",
+                    "days": {
+                        "2025-03-01": {
+                            **UsageTracker._empty_day(),
+                            "calls": 99,
+                            "cost": 99.0,
+                        }
+                    },
+                }
+            )
+        )
+
+        t = UsageTracker(telemetry_dir=temp_dir, retention_days=3650)
+        stats = t.get_stats(days=3650)
+
+        assert stats["total_calls"] == 1
+        assert stats["total_cost"] == 5.0
+
+    def test_flush_does_not_persist_partial_summary(self, tracker, temp_dir):
+        """flush updates the in-memory summary but does NOT write the file.
+
+        The summary file is owned solely by full rebuilds; a buffered flush
+        from a process that hasn't seen other writers' records must not
+        clobber it with partial data (the lost-update root cause).
+        """
+        tracker.track_llm_call(
+            workflow="w",
+            stage=None,
+            tier="SDK",
+            model="m",
+            provider="anthropic",
+            cost=1.0,
+            tokens={"input": 1, "output": 1},
+            cache_hit=False,
+            cache_type=None,
+            duration_ms=1,
+        )
+        tracker.flush()
+
+        # No summary file written by flush...
+        assert not (temp_dir / "usage_summary.json").exists()
+        # ...but the same process still sees its own data via the in-memory path.
+        assert tracker.get_stats(days=3650)["total_calls"] == 1
 
 
 class TestFlushEdgeCases:

--- a/tests/unit/telemetry/test_usage_tracker.py
+++ b/tests/unit/telemetry/test_usage_tracker.py
@@ -1621,6 +1621,40 @@ class TestSummaryLoadSave:
         # ...but the same process still sees its own data via the in-memory path.
         assert tracker.get_stats(days=3650)["total_calls"] == 1
 
+    def test_load_summary_swallows_oserror_from_unreadable_dir(self, tracker):
+        """Outer OSError guard: an unreadable telemetry dir disables gracefully."""
+        from unittest.mock import MagicMock
+
+        bad = MagicMock()
+        bad.exists.side_effect = OSError("dir unreadable")
+        tracker._summary_file = bad
+        tracker._daily_summary = {"2025-01-01": tracker._empty_day()}
+
+        tracker._load_summary()  # must not raise
+
+        assert tracker._daily_summary == {}
+
+    def test_source_signature_skips_unstatable_file(self, tracker):
+        """Per-file OSError on stat() is skipped (glob succeeds), not fatal."""
+        from unittest.mock import MagicMock
+
+        # glob succeeds and yields a file, but stat() on it fails — exercises
+        # the per-file inner guard (not the outer glob guard).
+        bad_file = MagicMock()
+        bad_file.name = "usage.jsonl"
+        bad_file.stat.side_effect = OSError("no stat")
+
+        with patch.object(Path, "glob", return_value=[bad_file]):
+            sig = tracker._source_signature()
+
+        # The single file was skipped → empty signature, no raise.
+        assert sig == {}
+
+    def test_source_signature_returns_empty_on_glob_error(self, tracker):
+        """A glob() failure on the telemetry dir degrades to an empty signature."""
+        with patch.object(Path, "glob", side_effect=OSError("glob failed")):
+            assert tracker._source_signature() == {}
+
 
 class TestFlushEdgeCases:
     def test_flush_empty_buffer_returns_zero(self, tracker):


### PR DESCRIPTION
## Problem

`telemetry_stats` (MCP tool / dashboard) under-reported spend: it showed
**$62.83 / 252 calls** while the authoritative `~/.attune/telemetry/usage.jsonl`
held **$97.01 / 413** — $34 / 161 calls silently dropped, all on two
high-concurrency days.

## Root cause

`UsageTracker.get_stats()` reads a pre-aggregated `usage_summary.json`, and
`_load_summary()` only rebuilt from the log when the summary file was
**absent**. The summary is mutated by every process with a
read-modify-write-save cycle guarded by an **in-process** lock only — so
concurrent workflow runs clobber each other's increments (classic lost
update), and the corrupted summary is then trusted indefinitely.

| Day | summary$ | log$ |
|-----|---------:|-----:|
| 06-23 | $0.00 | $16.28 |
| 06-25 | $0.01 | $17.92 |

## Fix — summary is a derived cache, validated against the append-only log

- **`_source_signature()`** — cheap `{filename: byte-size}` fingerprint of
  `usage*.jsonl` (append-only ⇒ size strictly grows).
- **`_load_summary()`** — trust the summary only when its persisted
  `source_sig` matches the current logs; otherwise rebuild. Legacy
  summaries (no sig) always rebuild, so existing drift heals on first read.
- **`_rebuild_summary_from_disk()`** — now the *only* writer of the summary
  file (a full scan is always complete). Captures the signature **before**
  scanning, so a concurrent append during the scan fails toward a re-scan,
  never a stale under-count.
- **`flush()`** — keeps the in-memory update for same-process `get_stats`
  but no longer persists a (possibly cross-process-incomplete) summary.

## Verification

- Dogfooded against live `~/.attune`: `get_stats` now returns **413 / $97.01**,
  matching the raw log (and healed the live stale summary).
- New regression tests: signature-mismatch rebuild, legacy no-sig rebuild,
  flush-no-longer-persists-partial-summary. Full suite: **87 passed**.
- black + ruff clean.

## Trade-off

Cross-process readers now rebuild when the log changed since the last
rebuild (bounded by the 10 MB rotation cap — milliseconds). Correctness
over the stale fast path; same-process reads keep the in-memory fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
