### PR TITLE
fix(telemetry): address usage_tracker code-review findings

### DIFF
--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -13,6 +13,7 @@ import hmac
 import json
 import logging
 import os
+import secrets
 import threading
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
@@ -23,6 +24,15 @@ logger = logging.getLogger(__name__)
 
 # Magic limit sentinel — callers that need "all entries" use this
 _ALL_ENTRIES = 1_000_000
+
+# Anthropic prompt-cache reads are billed at 10% of the base input rate,
+# so a cache read saves 90% of what the tokens would otherwise have cost.
+# https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+_CACHE_READ_DISCOUNT = 0.9
+
+# Fallback per-call PREMIUM cost (USD) used only when no PREMIUM entries
+# exist to derive a real average from. Rough order-of-magnitude baseline.
+_DEFAULT_PREMIUM_COST_USD = 0.05
 
 
 class UsageTracker:
@@ -87,9 +97,23 @@ class UsageTracker:
         # Pre-aggregated daily stats keyed by "YYYY-MM-DD"
         self._daily_summary: dict[str, dict[str, Any]] = {}
 
-        # Create directory if needed (gracefully handle permission errors)
+        # Cached HMAC secret (resolved once per instance) and per-user-id
+        # hash memo — _hash_user_id runs on every tracked call, so neither
+        # the env/secret-file lookup nor the HMAC is repeated.
+        self._hmac_secret: bytes | None = None
+        self._hash_cache: dict[str, str] = {}
+
+        # Create directory if needed (gracefully handle permission errors).
+        # mode=0o700 keeps telemetry (token counts, hashed ids) unreadable by
+        # co-tenants on shared/CI hosts; a 0700 parent protects every file
+        # inside regardless of per-file umask. exist_ok=True won't tighten an
+        # already-loose dir, so chmod it explicitly too (best-effort).
         try:
-            self.telemetry_dir.mkdir(parents=True, exist_ok=True)
+            self.telemetry_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            try:
+                self.telemetry_dir.chmod(0o700)
+            except OSError:
+                pass  # best-effort hardening; not fatal
         except (OSError, PermissionError):
             # Can't create directory - telemetry will be disabled
             logger.debug("Failed to create telemetry directory: %s", self.telemetry_dir)
@@ -227,6 +251,26 @@ class UsageTracker:
         """Return current UTC time as ISO 8601 string."""
         return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
+    @staticmethod
+    def _parse_ts(ts: str | None) -> datetime | None:
+        """Parse a stored ISO-8601 timestamp to an aware UTC datetime.
+
+        Single source of truth for reading the ``ts`` field (entries are
+        written with a trailing ``Z`` by :meth:`_utcnow_iso`). Accepts the
+        ``Z`` suffix or an explicit offset, and coerces a naive value to
+        UTC so comparisons never raise. Returns ``None`` for missing or
+        unparseable values, which callers treat as "skip this entry".
+        """
+        if not ts:
+            return None
+        try:
+            parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except (AttributeError, ValueError):
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+
     # =========================================================================
     # Summary file — fast stats without full JSONL scans
     # =========================================================================
@@ -244,6 +288,9 @@ class UsageTracker:
         raise — the same contract as the guarded ``mkdir`` in __init__.
         """
         try:
+            # Computed at most once and reused for the rebuild below, so the
+            # stale path doesn't fingerprint the logs twice.
+            source_sig: dict[str, int] | None = None
             if self._summary_file.exists():
                 data = None
                 try:
@@ -260,12 +307,14 @@ class UsageTracker:
                 # concurrent-writer race that persisted an incomplete
                 # summary), so rebuild instead of silently undercounting.
                 # Legacy summaries with no ``source_sig`` always rebuild.
-                if data is not None and data.get("source_sig") == self._source_signature():
+                source_sig = self._source_signature()
+                if data is not None and data.get("source_sig") == source_sig:
                     self._daily_summary = data.get("days", {})
                     return
 
-            # No summary file, unreadable, or stale — rebuild from disk.
-            self._rebuild_summary_from_disk()
+            # No summary file, unreadable, or stale — rebuild from disk,
+            # reusing the signature already computed on the stale path.
+            self._rebuild_summary_from_disk(source_sig=source_sig)
         except OSError:
             # Telemetry dir unreadable (e.g. read-only) — disable gracefully.
             logger.debug("Failed to load telemetry summary: %s", self.telemetry_dir)
@@ -292,7 +341,7 @@ class UsageTracker:
             return {}
         return sig
 
-    def _rebuild_summary_from_disk(self) -> None:
+    def _rebuild_summary_from_disk(self, source_sig: dict[str, int] | None = None) -> None:
         """Scan all JSONL files to build the daily summary from scratch.
 
         The authoritative path: a full scan of the append-only logs always
@@ -301,12 +350,17 @@ class UsageTracker:
         that is what allowed concurrent writers to corrupt it). Result is
         saved with a source signature so subsequent loads take the fast
         O(days) path until the logs change again.
+
+        Args:
+            source_sig: Signature captured by the caller BEFORE this scan
+                (``_load_summary`` reuses the one it computed for the
+                staleness check). When ``None`` it is computed here.
         """
         # Capture the signature BEFORE scanning. If a writer appends during
         # the scan, the saved signature is smaller than the real file, so the
         # next load sees a mismatch and rebuilds — a harmless re-scan, never a
         # silent under-count (fail toward rebuild, never toward stale-trust).
-        sig = self._source_signature()
+        sig = source_sig if source_sig is not None else self._source_signature()
         self._daily_summary = {}
         for file in sorted(self.telemetry_dir.glob("usage*.jsonl")):
             for entry in self._iter_jsonl(file):
@@ -400,12 +454,13 @@ class UsageTracker:
             prompt_cache_read_tokens: Tokens read from Anthropic cache
 
         """
-        # Build entry
-        UsageTracker._seq_counter += 1
+        # Build entry. The monotonic seq is assigned under the lock below
+        # (with the buffer append) — incrementing the shared class counter
+        # here would race: two threads could read the same value and emit
+        # duplicate seqs, corrupting the timestamp-tiebreaker sort.
         entry: dict[str, Any] = {
             "v": "1.0",
             "ts": self._utcnow_iso(),
-            "seq": UsageTracker._seq_counter,
             "workflow": workflow,
             "tier": tier,
             "model": model,
@@ -431,9 +486,12 @@ class UsageTracker:
                 "read_tokens": prompt_cache_read_tokens,
             }
 
-        # Buffer entry (no disk I/O per-call)
+        # Buffer entry (no disk I/O per-call). Assign seq inside the lock so
+        # the shared counter increment and the buffer append are atomic.
         should_flush = False
         with self._lock:
+            UsageTracker._seq_counter += 1
+            entry["seq"] = UsageTracker._seq_counter
             self._buffer.append(entry)
             should_flush = len(self._buffer) >= self.buffer_size
 
@@ -489,11 +547,63 @@ class UsageTracker:
 
         return len(entries)
 
+    def _get_hmac_secret(self) -> bytes:
+        """Resolve the HMAC secret used to hash user ids, once per instance.
+
+        Resolution order:
+        1. ``TELEMETRY_SECRET`` env var, if set (explicit deployment secret).
+        2. A per-install random secret persisted at ``<dir>/.secret`` (0600),
+           generated on first use. Reused across runs so the same user id
+           hashes stably on one machine.
+        3. An ephemeral process-local random secret if the file can't be
+           read/written (e.g. read-only dir) — still per-process-unique,
+           never a shared constant.
+
+        A per-install random secret (not a constant baked into the repo) is
+        what actually makes the hash resist a precomputed/rainbow-table
+        reversal: without the secret, an attacker can't recompute the digest
+        of a guessed user id.
+        """
+        if self._hmac_secret is not None:
+            return self._hmac_secret
+
+        from attune.config.env_compat import get_attune_env
+
+        env_secret = get_attune_env("TELEMETRY_SECRET")
+        if env_secret:
+            self._hmac_secret = env_secret.encode()
+            return self._hmac_secret
+
+        secret_file = self.telemetry_dir / ".secret"
+        try:
+            if secret_file.exists():
+                self._hmac_secret = secret_file.read_bytes()
+            else:
+                generated = secrets.token_bytes(32)
+                # O_EXCL so a concurrent creator doesn't get clobbered; 0600
+                # so the secret itself is owner-only even within the 0700 dir.
+                try:
+                    fd = os.open(secret_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                    with os.fdopen(fd, "wb") as f:
+                        f.write(generated)
+                    self._hmac_secret = generated
+                except FileExistsError:
+                    # Lost the create race — read the winner's secret.
+                    self._hmac_secret = secret_file.read_bytes()
+        except OSError:
+            # Can't persist (read-only dir, etc.) — ephemeral per-process
+            # secret. Still far better than a shared committed constant.
+            self._hmac_secret = secrets.token_bytes(32)
+
+        return self._hmac_secret
+
     def _hash_user_id(self, user_id: str) -> str:
         """Hash user ID with HMAC-SHA256 for privacy.
 
-        Uses a deployment-specific secret to prevent rainbow table
-        attacks. Falls back to a default key if no secret is configured.
+        Uses a per-install secret (see :meth:`_get_hmac_secret`) so the
+        digest can't be reversed via a precomputed table. The result is
+        memoized per ``user_id`` — this runs on every tracked call and the
+        identity is constant within a process.
 
         Args:
             user_id: User identifier to hash
@@ -502,10 +612,15 @@ class UsageTracker:
             First 16 characters of HMAC-SHA256 hex digest
 
         """
-        from attune.config.env_compat import get_attune_env
+        cached = self._hash_cache.get(user_id)
+        if cached is not None:
+            return cached
 
-        secret = (get_attune_env("TELEMETRY_SECRET") or "attune-default-telemetry-key").encode()
-        return hmac.new(secret, user_id.encode(), hashlib.sha256).hexdigest()[:16]
+        digest = hmac.new(self._get_hmac_secret(), user_id.encode(), hashlib.sha256).hexdigest()[
+            :16
+        ]
+        self._hash_cache[user_id] = digest
+        return digest
 
     def _write_entry(self, entry: dict[str, Any]) -> None:
         """Write a single entry directly to disk (bypasses buffer).
@@ -528,15 +643,16 @@ class UsageTracker:
         Rotates usage.jsonl -> usage.YYYY-MM-DD.jsonl
         Also cleans up files older than retention_days.
         """
-        if not self.usage_file.exists():
-            return
-
-        # Check file size
-        size_mb = self.usage_file.stat().st_size / (1024 * 1024)
-        if size_mb < self.max_file_size_mb:
-            return
-
         with self._lock:
+            # Re-validate existence AND size INSIDE the lock: a check outside
+            # it is a TOCTOU — two threads could both pass the size guard and
+            # then race on replace(), rotating twice / losing the new file.
+            if not self.usage_file.exists():
+                return
+            size_mb = self.usage_file.stat().st_size / (1024 * 1024)
+            if size_mb < self.max_file_size_mb:
+                return
+
             # Rotate: usage.jsonl -> usage.YYYY-MM-DD.jsonl
             timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
             rotated_file = self.telemetry_dir / f"usage.{timestamp}.jsonl"
@@ -553,15 +669,37 @@ class UsageTracker:
             # Clean up old files
             self._cleanup_old_files()
 
+    @staticmethod
+    def _rotated_file_date(name: str) -> datetime | None:
+        """Extract the rotation date from ``usage.YYYY-MM-DD[.N].jsonl``.
+
+        Returns an aware UTC datetime at midnight of that date, or ``None``
+        if the name carries no parseable date (e.g. the live ``usage.jsonl``).
+        """
+        parts = name.split(".")
+        if len(parts) < 3:
+            return None  # e.g. "usage.jsonl" — the live file, not rotated
+        try:
+            return datetime.strptime(parts[1], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+
     def _cleanup_old_files(self) -> None:
-        """Remove files older than retention_days."""
-        cutoff = datetime.now(timezone.utc) - timedelta(days=self.retention_days)
+        """Remove rotated files older than retention_days.
+
+        Retention is keyed off the date embedded in the rotated filename,
+        not mtime — mtime is mutable (a ``touch`` or a restore-from-backup
+        resets it and lets a stale file escape retention forever). Falls
+        back to mtime only when the name has no parseable date.
+        """
+        cutoff = self._utcnow() - timedelta(days=self.retention_days)
 
         for file in self.telemetry_dir.glob("usage.*.jsonl"):
             try:
-                # Get file modification time
-                mtime = datetime.fromtimestamp(file.stat().st_mtime, tz=timezone.utc)
-                if mtime < cutoff:
+                file_dt = self._rotated_file_date(file.name)
+                if file_dt is None:
+                    file_dt = datetime.fromtimestamp(file.stat().st_mtime, tz=timezone.utc)
+                if file_dt < cutoff:
                     file.unlink()
                     logger.debug("Deleted old telemetry file: %s", file.name)
             except (OSError, ValueError):
@@ -595,11 +733,8 @@ class UsageTracker:
         for file in files:
             for entry in self._iter_jsonl(file):
                 if cutoff_time:
-                    try:
-                        ts = datetime.fromisoformat(entry["ts"].replace("Z", "+00:00"))
-                        if ts < cutoff_time:
-                            continue
-                    except (KeyError, ValueError):
+                    ts = self._parse_ts(entry.get("ts"))
+                    if ts is None or ts < cutoff_time:
                         continue
                 entries.append(entry)
 
@@ -609,13 +744,8 @@ class UsageTracker:
 
         for entry in buffer_snapshot:
             if cutoff_time:
-                try:
-                    ts = datetime.fromisoformat(entry["ts"].rstrip("Z")).replace(
-                        tzinfo=timezone.utc
-                    )
-                    if ts < cutoff_time:
-                        continue
-                except (KeyError, ValueError):
+                ts = self._parse_ts(entry.get("ts"))
+                if ts is None or ts < cutoff_time:
                     continue
             entries.append(entry)
 
@@ -681,11 +811,8 @@ class UsageTracker:
 
         # Include buffered entries not yet reflected in the summary
         for entry in buffer_snapshot:
-            try:
-                ts = datetime.fromisoformat(entry["ts"].replace("Z", "+00:00"))
-            except (KeyError, ValueError):
-                continue
-            if ts < cutoff_dt:
+            ts = self._parse_ts(entry.get("ts"))
+            if ts is None or ts < cutoff_dt:
                 continue
             self._accumulate_entry(acc, entry)
 
@@ -744,7 +871,11 @@ class UsageTracker:
 
         # Calculate baseline cost (all PREMIUM)
         premium_costs = [e.get("cost", 0.0) for e in entries if e.get("tier") == "PREMIUM"]
-        avg_premium_cost = (sum(premium_costs) / len(premium_costs)) if premium_costs else 0.05
+        avg_premium_cost = (
+            (sum(premium_costs) / len(premium_costs))
+            if premium_costs
+            else _DEFAULT_PREMIUM_COST_USD
+        )
         baseline_cost = len(entries) * avg_premium_cost
 
         # Tier distribution
@@ -865,7 +996,7 @@ class UsageTracker:
                     pricing_cache[model_id] = get_pricing_for_model(model_id) if model_id else None
                 pricing = pricing_cache[model_id]
                 cost_per_token = (pricing["input"] if pricing else 3.00) / 1_000_000
-                total_savings += read_tokens * cost_per_token * 0.9
+                total_savings += read_tokens * cost_per_token * _CACHE_READ_DISCOUNT
 
             # Per-workflow stats
             workflow = entry.get("workflow", "unknown")

--- a/tests/unit/telemetry/test_usage_tracker.py
+++ b/tests/unit/telemetry/test_usage_tracker.py
@@ -9,6 +9,8 @@ Tests the core telemetry tracking functionality including:
 - Savings calculation
 """
 
+import hashlib
+import hmac
 import json
 import os
 import tempfile
@@ -678,61 +680,37 @@ class TestRetentionPolicy:
             tracker._cleanup_old_files()
 
 
-class TestAtomicWrites:
-    """Test atomic write operations."""
+class TestWriteEntry:
+    """Test the direct-to-disk write helper (`_write_entry`).
 
-    def test_write_entry_atomic_rename(self, tracker):
-        """Test that write uses atomic rename when file doesn't exist."""
-        entry = {
-            "v": "1.0",
-            "ts": datetime.now(timezone.utc).isoformat(),
-            "workflow": "test",
-            "tier": "CAPABLE",
-            "model": "model",
-            "cost": 0.01,
-        }
+    `_write_entry` is an APPEND helper (one JSON line per call) — it does
+    NOT do a temp-file + atomic-rename. These tests assert that real
+    behavior; the previous suite asserted a temp-file dance that never
+    existed, so it passed vacuously.
+    """
 
-        # Ensure usage file doesn't exist
+    def test_write_entry_appends_one_line_per_call(self, tracker):
+        """Each call appends exactly one JSON line; no temp file is created."""
         if tracker.usage_file.exists():
             tracker.usage_file.unlink()
 
-        tracker._write_entry(entry)
+        first = {"v": "1.0", "ts": datetime.now(timezone.utc).isoformat(), "workflow": "a"}
+        second = {"v": "1.0", "ts": datetime.now(timezone.utc).isoformat(), "workflow": "b"}
+        tracker._write_entry(first)
+        tracker._write_entry(second)
 
-        # File should exist
-        assert tracker.usage_file.exists()
+        lines = tracker.usage_file.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        assert [json.loads(line)["workflow"] for line in lines] == ["a", "b"]
 
-        # Temp file should be cleaned up
-        temp_file = tracker.usage_file.with_suffix(".tmp")
-        assert not temp_file.exists()
+        # It is a plain append — there is no sibling .tmp file.
+        assert not tracker.usage_file.with_suffix(".tmp").exists()
 
-    def test_write_entry_cleanup_on_error(self, tracker):
-        """Test that temp file is cleaned up on write error."""
-        entry = {"test": "data"}
-
-        # Mock file operations to trigger cleanup path
+    def test_write_entry_propagates_oserror(self, tracker):
+        """A write failure propagates (no silent swallow)."""
         with patch("builtins.open", side_effect=OSError("Write failed")):
-            with pytest.raises(OSError):
-                tracker._write_entry(entry)
-
-        # Temp file should be cleaned up
-        temp_file = tracker.usage_file.with_suffix(".tmp")
-        assert not temp_file.exists()
-
-    def test_write_entry_handles_temp_file_cleanup_error(self, tracker):
-        """Test that errors during temp file cleanup are handled."""
-        entry = {"test": "data"}
-        temp_file = tracker.usage_file.with_suffix(".tmp")
-
-        # Create a temp file
-        temp_file.write_text("test")
-
-        # Mock open to raise error on write
-        with patch("builtins.open", side_effect=OSError("Write failed")):
-            # Mock unlink to also fail (simulating nested error handling)
-            with patch.object(Path, "unlink", side_effect=OSError("Cleanup failed")):
-                # The outer OSError should still be raised
-                with pytest.raises(OSError, match="Write failed"):
-                    tracker._write_entry(entry)
+            with pytest.raises(OSError, match="Write failed"):
+                tracker._write_entry({"test": "data"})
 
 
 class TestDataRetrieval:
@@ -1052,6 +1030,48 @@ class TestConcurrency:
         entries = tracker.get_recent_entries(limit=100)
         assert len(entries) == 50
 
+    def test_concurrent_writes_produce_unique_seq(self, temp_dir):
+        """Regression: seq numbers must be unique under concurrency.
+
+        The seq counter is now incremented inside the lock alongside the
+        buffer append. Before the fix it was incremented outside the lock,
+        so two threads could read the same value and emit duplicate seqs —
+        corrupting the timestamp tiebreaker in get_recent_entries.
+
+        A large buffer keeps every entry in memory (no auto-flush) so this
+        isolates the counter race from disk-write concurrency.
+        """
+        import threading
+
+        tracker = UsageTracker(telemetry_dir=temp_dir, buffer_size=10_000)
+        per_thread, n_threads = 40, 8
+
+        def track_many(thread_id):
+            for _ in range(per_thread):
+                tracker.track_llm_call(
+                    workflow=f"t{thread_id}",
+                    stage=None,
+                    tier="CAPABLE",
+                    model="model",
+                    provider="test",
+                    cost=0.01,
+                    tokens={"input": 1, "output": 1},
+                    cache_hit=False,
+                    cache_type=None,
+                    duration_ms=1,
+                )
+
+        threads = [threading.Thread(target=track_many, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        expected = per_thread * n_threads
+        seqs = [e["seq"] for e in tracker.get_recent_entries(limit=10_000)]
+        assert len(seqs) == expected
+        assert len(set(seqs)) == expected, "duplicate seq — counter raced outside the lock"
+
 
 class TestEdgeCases:
     """Test edge cases and corner scenarios."""
@@ -1075,17 +1095,22 @@ class TestEdgeCases:
             tracker._cleanup_old_files()
 
     def test_cleanup_with_value_error(self, tracker, temp_dir):
-        """Test cleanup handles ValueError from timestamp parsing."""
-        # Create a file
-        test_file = temp_dir / "usage.2020-01-01.jsonl"
-        test_file.write_text('{"test": "data"}\n')
+        """Cleanup swallows a ValueError from the mtime fallback.
 
-        # Mock fromtimestamp to raise ValueError
+        A name with no parseable date (``usage.notadate.jsonl``) falls back
+        to mtime; if ``fromtimestamp`` raises, cleanup must not propagate.
+        Real ``strptime``/``now`` are kept so only the fallback path fails.
+        """
+        bad = temp_dir / "usage.notadate.jsonl"
+        bad.write_text('{"test": "data"}\n')
+
         with patch("attune.telemetry.usage_tracker.datetime") as mock_dt:
-            mock_dt.now.return_value = datetime.now()
+            mock_dt.now.return_value = datetime.now(timezone.utc)
+            mock_dt.strptime.side_effect = datetime.strptime  # real -> None for bad name
             mock_dt.fromtimestamp.side_effect = ValueError("Invalid timestamp")
-            # Should not raise exception
-            tracker._cleanup_old_files()
+            tracker._cleanup_old_files()  # must not raise
+
+        assert bad.exists()  # not deleted when its age is unknown
 
     def test_get_recent_entries_with_deleted_file_during_iteration(self, tracker, temp_dir):
         """Test handling when file is deleted during iteration."""
@@ -1970,3 +1995,97 @@ class TestUsagePingAtExitWiring:
         monkeypatch.setattr(usage_ping, "run_sync_at_exit", _boom)
         # Must not propagate — telemetry can't affect process exit.
         UsageTracker._atexit_usage_ping()
+
+
+class TestHmacSecret:
+    """Per-install HMAC secret (replaces the shared committed constant)."""
+
+    OLD_CONSTANT = b"attune-default-telemetry-key"
+
+    def test_per_install_secret_file_created_0600(self, temp_dir):
+        """First hash with no env secret writes a 0600 per-install .secret."""
+        with patch("attune.config.env_compat.get_attune_env", return_value=None):
+            digest = UsageTracker(telemetry_dir=temp_dir)._hash_user_id("default")
+
+        secret_file = temp_dir / ".secret"
+        assert secret_file.exists()
+        assert (secret_file.stat().st_mode & 0o777) == 0o600
+        assert isinstance(digest, str) and len(digest) == 16
+
+    def test_secret_stable_across_instances_same_dir(self, temp_dir):
+        """Two installs sharing a dir reuse the .secret → identical hash."""
+        with patch("attune.config.env_compat.get_attune_env", return_value=None):
+            h1 = UsageTracker(telemetry_dir=temp_dir)._hash_user_id("alice")
+            h2 = UsageTracker(telemetry_dir=temp_dir)._hash_user_id("alice")
+        assert h1 == h2
+
+    def test_secret_differs_across_installs(self, temp_dir):
+        """Different install dirs get different secrets → uncorrelatable hashes."""
+        with patch("attune.config.env_compat.get_attune_env", return_value=None):
+            h1 = UsageTracker(telemetry_dir=temp_dir / "i1")._hash_user_id("alice")
+            h2 = UsageTracker(telemetry_dir=temp_dir / "i2")._hash_user_id("alice")
+        assert h1 != h2
+
+    def test_env_secret_overrides_file(self, temp_dir):
+        """TELEMETRY_SECRET wins and no .secret file is written."""
+        with patch("attune.config.env_compat.get_attune_env", return_value="my-secret"):
+            digest = UsageTracker(telemetry_dir=temp_dir)._hash_user_id("alice")
+        assert not (temp_dir / ".secret").exists()
+        expected = hmac.new(b"my-secret", b"alice", hashlib.sha256).hexdigest()[:16]
+        assert digest == expected
+
+    def test_not_the_old_constant_key(self, temp_dir):
+        """Regression: the digest is no longer the reversible shared constant."""
+        with patch("attune.config.env_compat.get_attune_env", return_value=None):
+            digest = UsageTracker(telemetry_dir=temp_dir)._hash_user_id("default")
+        old = hmac.new(self.OLD_CONSTANT, b"default", hashlib.sha256).hexdigest()[:16]
+        assert digest != old
+
+    def test_hash_is_memoized(self, temp_dir):
+        """Repeat hashes of the same id don't recompute the HMAC."""
+        with patch("attune.config.env_compat.get_attune_env", return_value=None):
+            tracker = UsageTracker(telemetry_dir=temp_dir)
+            tracker._hash_user_id("bob")  # populate cache
+            with patch("attune.telemetry.usage_tracker.hmac.new") as mock_new:
+                again = tracker._hash_user_id("bob")
+                mock_new.assert_not_called()
+        assert isinstance(again, str)
+
+
+class TestParseTs:
+    """The single timestamp-parsing helper."""
+
+    def test_parses_z_suffix(self):
+        dt = UsageTracker._parse_ts("2024-01-15T12:00:00.000000Z")
+        assert dt is not None and dt.tzinfo is not None and dt.year == 2024
+
+    def test_parses_explicit_offset(self):
+        dt = UsageTracker._parse_ts("2024-01-15T12:00:00+00:00")
+        assert dt is not None and dt.utcoffset().total_seconds() == 0
+
+    def test_naive_coerced_to_utc(self):
+        dt = UsageTracker._parse_ts("2024-01-15T12:00:00")
+        assert dt is not None and dt.tzinfo == timezone.utc
+
+    def test_missing_or_garbage_returns_none(self):
+        assert UsageTracker._parse_ts(None) is None
+        assert UsageTracker._parse_ts("") is None
+        assert UsageTracker._parse_ts("not-a-timestamp") is None
+
+
+class TestRotatedFileDate:
+    """Filename-date parsing used for retention."""
+
+    def test_parses_dated_name(self):
+        dt = UsageTracker._rotated_file_date("usage.2024-01-15.jsonl")
+        assert dt is not None and (dt.year, dt.month, dt.day) == (2024, 1, 15)
+
+    def test_parses_dated_name_with_counter(self):
+        dt = UsageTracker._rotated_file_date("usage.2024-01-15.3.jsonl")
+        assert dt is not None and dt.day == 15
+
+    def test_live_file_returns_none(self):
+        assert UsageTracker._rotated_file_date("usage.jsonl") is None
+
+    def test_unparseable_date_returns_none(self):
+        assert UsageTracker._rotated_file_date("usage.notadate.jsonl") is None


### PR DESCRIPTION
Acts on a `code-review` pass of `src/attune/telemetry/usage_tracker.py`. Each finding was **verified against the code** before fixing; the large architectural items (god-class split, de-singleton, typed `UsageRecord` schema, `atexit` hoist) are intentionally **deferred to a separate spec** — this PR is the low-risk, self-contained batch.

## Fixed

| Class | Fix |
|-------|-----|
| 🔴 Concurrency | `seq` is now assigned **inside the lock** with the buffer append (was incremented outside → duplicate seqs corrupting the ts tiebreaker). |
| 🔴 Security | Per-install random `.secret` (0600) replaces the committed constant HMAC key; `TELEMETRY_SECRET` still overrides. The constant made the hashed `user_id` reversible — contradicting the docstring. |
| 🟡 Security | Telemetry dir created `0o700` (+ chmod existing) — co-tenants can't read it on shared/CI hosts. |
| 🟡 Perf | Cache resolved HMAC secret + memoize per-id hash (was recomputed every call); reuse the source signature on the stale-summary path (no double fingerprint). |
| 🟡 Quality | One `_parse_ts()` helper for 3 divergent idioms; named constants (`_CACHE_READ_DISCOUNT`, `_DEFAULT_PREMIUM_COST_USD`); retention by rotated-filename date (mtime is mutable); `_rotate_if_needed` re-validates size inside the lock (TOCTOU). |
| 🟡 Tests | The "atomic write" tests asserted a temp-file/rename dance `_write_entry` never did (vacuous) — rewritten to test the real append. |

## Tests
- New regression tests: unique-seq under 8-thread load, per-install HMAC secret (file 0600, env override, cross-install difference, not-the-old-constant, memoization), `_parse_ts`, `_rotated_file_date`.
- Full suite green: `tests/unit/telemetry/` + telemetry callers (mcp/cli/workflows) — **950+ passing**, black + ruff clean.

## Follow-ups (out of scope, noted)
- **Discovered latent bug:** `flush()` writes outside the lock and `json.dump` streams an entry over multiple `write()`s, so concurrent flushes can interleave and corrupt lines (silently dropped on read). Low severity (telemetry is best-effort) but real — worth a follow-up.
- Architectural refactor (god-class / de-singleton / typed schema) → separate spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)