### PR TITLE
fix(models,telemetry,help): address step-2 code-review findings

### DIFF
--- a/src/attune/help/feedback.py
+++ b/src/attune/help/feedback.py
@@ -146,7 +146,10 @@ def get_usage_weights(days: int = 30) -> dict[str, float]:
     try:
         from attune.telemetry.usage_tracker import UsageTracker
 
-        tracker = UsageTracker()
+        # Use the singleton — a fresh UsageTracker() re-pays constructor I/O
+        # (mkdir + summary load/scan) on every search_by_tag/list_tags call
+        # that sorts by usage.
+        tracker = UsageTracker.get_instance()
         stats = tracker.get_stats(days=days)
     except Exception:  # noqa: BLE001
         # INTENTIONAL: telemetry is optional

--- a/src/attune/models/auth_strategy.py
+++ b/src/attune/models/auth_strategy.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import tempfile
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -150,10 +152,14 @@ class AuthStrategy:
         # Polish: premium tier, ~10K tokens
         # API Reference: cheap tier, ~5K tokens
 
-        outline_cost = 0.003 * 0.00025  # 3K tokens * $0.25/M input
-        write_cost = 0.015 * 0.003  # 15K tokens * $3/M input
-        polish_cost = 0.010 * 0.015  # 10K tokens * $15/M input
-        api_ref_cost = 0.005 * 0.00025  # 5K tokens * $0.25/M input
+        # Each term is (tokens-in-millions) * ($-per-million-input-tokens).
+        # The rate factors were previously 1000x too small (e.g. 0.00025
+        # instead of 0.25 for $0.25/M), making the estimate read ~$0.0002
+        # when the real figure is ~$0.20 — see get_pros_cons prose.
+        outline_cost = 0.003 * 0.25  # 3K tokens * $0.25/M input
+        write_cost = 0.015 * 3.0  # 15K tokens * $3/M input
+        polish_cost = 0.010 * 15.0  # 10K tokens * $15/M input
+        api_ref_cost = 0.005 * 0.25  # 5K tokens * $0.25/M input
 
         total_api_cost = outline_cost + write_cost + polish_cost + api_ref_cost
 
@@ -215,7 +221,7 @@ class AuthStrategy:
                 ],
                 "cons": [
                     "Requires API key setup",
-                    "Pay-per-token ($0.10-0.15 per module)",
+                    "Pay-per-token (~$0.20 per module)",
                     "Separate authentication",
                 ],
                 "estimate": api_estimate,
@@ -269,13 +275,35 @@ class AuthStrategy:
         )
 
     def save(self, path: Path | None = None) -> None:
-        """Save authentication strategy to file."""
+        """Save authentication strategy to file (owner-only, atomic).
+
+        The config records the resolved auth tier/mode, so it is written
+        0600 inside a 0700 directory to keep it unreadable by co-tenants on
+        shared/CI hosts. The path is validated BEFORE any directory is
+        created, so a rejected path can never create attacker-controlled
+        directories first.
+        """
         if path is None:
             path = AUTH_STRATEGY_FILE
-        path.parent.mkdir(parents=True, exist_ok=True)
         validated_path = _validate_file_path(str(path))
-        with open(validated_path, "w") as f:
-            json.dump(self.to_dict(), f, indent=2)
+        validated_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+        payload = json.dumps(self.to_dict(), indent=2)
+        # mkstemp creates the temp file 0600; write then atomically replace
+        # so a partial write never leaves a half-readable config.
+        fd, tmp_name = tempfile.mkstemp(
+            dir=str(validated_path.parent), prefix=".auth_strategy.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+            os.replace(tmp_name, validated_path)
+        except OSError:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
 
     @classmethod
     def load(cls, path: Path | None = None) -> AuthStrategy:

--- a/src/attune/models/registry.py
+++ b/src/attune/models/registry.py
@@ -20,9 +20,9 @@ from typing import Any
 class ModelTier(Enum):
     """Model tier classification for routing.
 
-    CHEAP: Fast, low-cost models for simple tasks (~$0.15-1.00/M input)
-    CAPABLE: Balanced models for most development work (~$2.50-3.00/M input)
-    PREMIUM: Highest capability for complex reasoning (~$15.00/M input)
+    CHEAP: Fast, low-cost models for simple tasks (~$1.00/M input)
+    CAPABLE: Balanced models for most development work (~$3.00/M input)
+    PREMIUM: Highest capability for complex reasoning (~$5.00/M input)
     """
 
     CHEAP = "cheap"
@@ -125,7 +125,7 @@ class ModelInfo:
 MODEL_REGISTRY: dict[str, dict[str, ModelInfo]] = {
     # -------------------------------------------------------------------------
     # Anthropic Claude Models
-    # Intelligent fallback: Sonnet 4.6 → Opus 4.6 (5x cost increase for complex tasks)
+    # Intelligent fallback: Sonnet 4.6 → Opus 4.8 (~1.67x input cost: $3 → $5/M)
     # -------------------------------------------------------------------------
     "anthropic": {
         "cheap": ModelInfo(
@@ -366,7 +366,7 @@ class ModelRegistry:
 
             >>> pricing = registry.get_pricing_for_model("claude-opus-4-8")
             >>> print(f"${pricing['input']}/M input, ${pricing['output']}/M output")
-            $15.0/M input, $75.0/M output
+            $5.0/M input, $25.0/M output
 
         """
         model = self.get_model_by_id(model_id)

--- a/src/attune/telemetry/usage_ping.py
+++ b/src/attune/telemetry/usage_ping.py
@@ -91,6 +91,17 @@ def _env_truthy(value: str | None) -> bool:
     return value is not None and value.strip().lower() in _TRUTHY
 
 
+def _is_do_not_track(env: Mapping[str, str]) -> bool:
+    """True if ``DO_NOT_TRACK`` is set to a non-empty, non-false value.
+
+    Single source of truth for the opt-out predicate. Duplicating this
+    check invites divergence, and divergence in a privacy opt-out is a
+    privacy regression by definition.
+    """
+    dnt = env.get("DO_NOT_TRACK")
+    return dnt is not None and dnt.strip().lower() not in {"", "0", "false"}
+
+
 def is_enabled(usage_ping_flag: bool, env: Mapping[str, str] | None = None) -> bool:
     """Return whether usage pinging is enabled.
 
@@ -111,8 +122,7 @@ def is_enabled(usage_ping_flag: bool, env: Mapping[str, str] | None = None) -> b
         True if pings should be sent.
     """
     env = os.environ if env is None else env
-    dnt = env.get("DO_NOT_TRACK")
-    if dnt is not None and dnt.strip().lower() not in {"", "0", "false"}:
+    if _is_do_not_track(env):
         return False
     override = env.get("ATTUNE_USAGE_PING")
     if override is not None:
@@ -370,8 +380,7 @@ def run_sync_at_exit(
     try:
         env = os.environ if env is None else env
         # Hard opt-outs short-circuit before touching disk.
-        dnt = env.get("DO_NOT_TRACK")
-        if dnt is not None and dnt.strip().lower() not in {"", "0", "false"}:
+        if _is_do_not_track(env):
             return 0
         override = env.get("ATTUNE_USAGE_PING")
         if override is not None and not _env_truthy(override):
@@ -531,8 +540,7 @@ def maybe_prompt_consent(
     env = os.environ if env is None else env
 
     # An explicit env signal already settles it — never prompt over one.
-    dnt = env.get("DO_NOT_TRACK")
-    if dnt is not None and dnt.strip().lower() not in {"", "0", "false"}:
+    if _is_do_not_track(env):
         return None
     if env.get("ATTUNE_USAGE_PING") is not None:
         return None

--- a/tests/unit/help/test_usage_weights.py
+++ b/tests/unit/help/test_usage_weights.py
@@ -39,7 +39,7 @@ class TestGetUsageWeightsImportFailure:
         mock_tracker.get_stats.side_effect = RuntimeError("boom")
 
         mock_module = MagicMock()
-        mock_module.UsageTracker.return_value = mock_tracker
+        mock_module.UsageTracker.get_instance.return_value = mock_tracker
 
         with patch.dict(
             "sys.modules",
@@ -61,7 +61,7 @@ class TestGetUsageWeightsEmpty:
         mock_tracker.get_stats.return_value = {"by_workflow": {}}
 
         mock_module = MagicMock()
-        mock_module.UsageTracker.return_value = mock_tracker
+        mock_module.UsageTracker.get_instance.return_value = mock_tracker
 
         with patch.dict(
             "sys.modules",
@@ -84,7 +84,7 @@ class TestGetUsageWeightsEmpty:
         }
 
         mock_module = MagicMock()
-        mock_module.UsageTracker.return_value = mock_tracker
+        mock_module.UsageTracker.get_instance.return_value = mock_tracker
 
         with patch.dict(
             "sys.modules",
@@ -111,7 +111,7 @@ class TestGetUsageWeightsNormalization:
         }
 
         mock_module = MagicMock()
-        mock_module.UsageTracker.return_value = mock_tracker
+        mock_module.UsageTracker.get_instance.return_value = mock_tracker
 
         # Mock cross_links to map workflows to template IDs
         cross_links = {
@@ -148,7 +148,7 @@ class TestGetUsageWeightsNormalization:
         mock_tracker.get_stats.return_value = {"by_workflow": {}}
 
         mock_module = MagicMock()
-        mock_module.UsageTracker.return_value = mock_tracker
+        mock_module.UsageTracker.get_instance.return_value = mock_tracker
 
         with patch.dict(
             "sys.modules",
@@ -171,7 +171,7 @@ class TestGetUsageWeightsNormalization:
         }
 
         mock_module = MagicMock()
-        mock_module.UsageTracker.return_value = mock_tracker
+        mock_module.UsageTracker.get_instance.return_value = mock_tracker
 
         cross_links = {
             "workflow_map": {

--- a/tests/unit/models/test_auth_strategy_coverage_boost.py
+++ b/tests/unit/models/test_auth_strategy_coverage_boost.py
@@ -266,9 +266,10 @@ class TestAuthStrategyCostEstimationExactness:
 
         result = strategy.estimate_cost(1000, AuthMode.API)
 
-        # 0.003*0.00025 + 0.015*0.003 + 0.010*0.015 + 0.005*0.00025
-        # = 0.000197, rounded to 4 places.
-        assert result["monetary_cost"] == 0.0002
+        # (tokens-in-millions) * ($/M input), summed across the four stages:
+        # 0.003*0.25 + 0.015*3.0 + 0.010*15.0 + 0.005*0.25
+        # = 0.00075 + 0.045 + 0.15 + 0.00125 = 0.197
+        assert result["monetary_cost"] == 0.197
         assert result["quota_cost"] is None
 
     def test_estimate_cost_subscription_fits_in_context_boundary(self):
@@ -666,6 +667,22 @@ class TestAuthStrategyPersistence:
             strategy.save(filepath)
 
             assert filepath.exists()
+
+    def test_save_writes_owner_only_file_in_private_dir(self):
+        """Regression: config is 0600 inside a 0700 dir (no co-tenant reads)."""
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("POSIX file modes")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "telemetry" / "auth_strategy.json"
+
+            AuthStrategy().save(filepath)
+
+            assert (filepath.stat().st_mode & 0o777) == 0o600
+            assert (filepath.parent.stat().st_mode & 0o777) == 0o700
+            # No leftover temp file from the atomic write.
+            assert not list(filepath.parent.glob(".auth_strategy.*.tmp"))
 
     def test_save_creates_parent_directories(self):
         """Test that save creates parent directories if needed."""

--- a/tests/unit/telemetry/test_usage_ping.py
+++ b/tests/unit/telemetry/test_usage_ping.py
@@ -602,3 +602,18 @@ def test_run_sync_at_exit_swallows_all_errors(monkeypatch, tmp_path):
 
     monkeypatch.setattr(ConfigLoader, "load", _boom)
     assert usage_ping.run_sync_at_exit(env={"ATTUNE_USAGE_ENDPOINT": "https://x/api"}) == 0
+
+
+class TestIsDoNotTrack:
+    """The single opt-out predicate (deduplicated from three call sites)."""
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", " on "])
+    def test_set_to_truthy_opts_out(self, value):
+        assert usage_ping._is_do_not_track({"DO_NOT_TRACK": value}) is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "FALSE", " "])
+    def test_empty_or_false_does_not_opt_out(self, value):
+        assert usage_ping._is_do_not_track({"DO_NOT_TRACK": value}) is False
+
+    def test_unset_does_not_opt_out(self):
+        assert usage_ping._is_do_not_track({}) is False


### PR DESCRIPTION
Acts on the step-2 `code-review` pass of four hot files (auth_strategy, registry, usage_ping, feedback). Verified-as-fixed, low-risk only; architectural items (SRP splits, dependency inversion, pricing single-source) deferred to a spec.

## Fixed

| Class | Fix |
|-------|-----|
| 🔴 Critical (verified) | `auth_strategy.estimate_cost` was **1000× too low** — rate factors `0.00025/0.003/0.015` should be `0.25/3.0/15.0` ($/M input). Real ≈ **$0.197/module**, not $0.0002. Fixed constants + the test that pinned the wrong value + the "$0.10-0.15" prose. |
| 🟡 Security | `auth_strategy.save()` validates path **before** mkdir, dir `0700`, config written `0600` via temp + atomic replace (was world-readable via umask). |
| 🟡 Privacy | `usage_ping`: triplicated `DO_NOT_TRACK` opt-out predicate → one `_is_do_not_track()` helper (divergence in an opt-out = privacy regression). |
| 🟡 Perf | `help/feedback`: `UsageTracker.get_instance()` instead of `UsageTracker()` — no re-paid constructor I/O on search-by-usage. |
| 🟢 Docs | `registry`: stale pricing docstrings (opus-4-8 is $5/$25 per M, not $15/$75; Sonnet→Opus ~1.67× not 5×). |

## Tests
New regression tests: cost-math exactness ($0.197), `save()` 0600-file/0700-dir, `_is_do_not_track` truth table. Updated the `get_usage_weights` mocks for `get_instance`. Full models/telemetry/help suites green (1500+), black + ruff clean.

## Deferred to spec (architectural, overlaps usage_tracker)
SRP god-module splits, telemetry→config dependency inversion, the 4-site pricing single-source consolidation (`project_model_pricing_three_sites`), typed schemas. I'll fold these + the usage_tracker architecture items into one **"telemetry/models layering + pricing single-source"** spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)