### PR TITLE
chore: weekly report 2026-06-29

### DIFF
--- a/weekly-reports/2026-06-29.md
+++ b/weekly-reports/2026-06-29.md
@@ -1,0 +1,169 @@
+# Anthropic Ecosystem Weekly — 2026-06-29
+
+## Summary
+
+Nine Claude Code releases shipped this week (v2.1.186–v2.1.195). Two API
+changes: rate limits consolidated to three tiers and Opus 4.7 fast mode
+deprecated with a July 24 removal. The biggest stack-relevant item is the
+new 5-minute MCP tool idle timeout (v2.1.187) — `research_synthesis` and
+`discovery_sweep` will hit it. The hook matcher precision fix in v2.1.195
+is technically breaking for hyphenated MCP identifiers, but the current
+settings aren't affected.
+
+---
+
+## Recommendations
+
+**1. Set `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` for long-running tools
+(v2.1.187, June 23)**
+
+Remote MCP tool calls now abort after 5 minutes of no response and return
+an error. This is a hardcoded default, not a timeout you can negotiate
+per-call. `research_synthesis`, `discovery_sweep` (multi-source runs), and
+`test_gen_parallel` all routinely exceed 5 minutes.
+
+Set the env var in any environment where attune-ai's MCP server runs
+headlessly — CI, Claude Code Remote, scheduled jobs:
+
+```bash
+export CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=600  # seconds; adjust to taste
+```
+
+This is not configurable from inside the MCP server itself; it must be set
+in the Claude Code process environment. If you're using a `.env` or a
+setup script, add it there.
+
+- **Applies to:** any environment running `attune-ai` MCP tools via Claude
+  Code, especially `research_synthesis`, `discovery_sweep`, `test_gen_parallel`
+- **Urgency:** Medium — silent abort with error; users will hit this on
+  long-running tool calls without realizing why.
+- **Alternative:** Split long workflow calls into smaller sub-calls, but
+  that's significant refactoring for an env var fix.
+
+---
+
+**2. Verify hook matchers if you use hyphenated MCP tool names (v2.1.195,
+June 26)**
+
+Hook matchers with hyphenated identifiers changed from substring-match to
+exact-match semantics. The current project `.claude/settings.json` uses
+`"Bash"` and `"Edit|Write"` — both are unaffected.
+
+However, if any user-level `~/.claude/settings.json` (Patrick's local
+machine or CI environments) has hooks matching on `mcp__attune-ai` to
+catch all attune-ai tools as a group, that pattern now silently won't fire.
+The fix is to use `mcp__attune-ai__.*` (glob-style with `.*`).
+
+Also worth knowing from v2.1.191 (June 24): comma-separated matchers like
+`"Bash,PowerShell"` were silently never firing — that's fixed. Check for
+this pattern in any local hook configs.
+
+- **Applies to:** `.claude/settings.json` at project or user level; any
+  hook using MCP tool patterns or comma-separated matchers
+- **Urgency:** Low — only breaks hook configs that relied on substring
+  behavior with hyphenated names; the current project config is fine.
+
+---
+
+**3. Be aware that `autoMode.classifyAllShell` is now available — and
+reinforces last week's Rec #1 (v2.1.193, June 25)**
+
+New setting routes ALL Bash/PowerShell commands through the auto-mode
+classifier, not just commands that match arbitrary-code-execution patterns.
+This is opt-in (disabled by default), so no immediate action. But it
+signals that Anthropic is tightening auto-mode's classifier coverage.
+
+This makes last week's June-22 Rec #1 (auditing release workflows for
+commands that stall in auto mode) more urgent: if someone enables
+`autoMode.classifyAllShell`, even routine shell calls in release scripts
+will go through the classifier. Denial reasons now appear in transcripts
+and `/permissions` → "Recently denied" so debugging is easier.
+
+- **Applies to:** unattended release runs; `.claude/hooks/` scripts that
+  invoke shell commands in auto mode
+- **Urgency:** Low now, medium if `classifyAllShell` gets enabled.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open. Rec #3 above adds context — `classifyAllShell` makes this more urgent when enabled. |
+| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` / unblock attune-author cache | Open. No new info. |
+| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open. Low urgency. |
+| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CLIENT_PRESENCE_FILE` for scheduled runs | Open. Low urgency. |
+| June-15 Rec #1 | 2026-06-15 | Handle `stop_reason: "refusal"` before adding Fable 5 | Open. Fable 5 suspended by US govt (see Watch list). Defer until access restored. |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (4 weeks). Still low urgency; no new platform info. |
+| May-25 #2 | 2026-05-25 | attune-ops: switch to `claude agents --json` | Open (5 weeks). v2.1.193 improved background agent stability — more reason to migrate. |
+| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish pipeline | Open (8 weeks). **Escalating.** This is old enough to either act on or close. If cache misses on the polish pipeline aren't causing pain, close it explicitly. |
+| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open (8 weeks — one-liner edit). |
+| May-11 #6 | 2026-05-11 | 1-hour cache TTL for attune-author polish | Open (11 weeks). Close this if the cache miss rate isn't hurting you. |
+| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | Open (11 weeks). Close if not hitting it in practice. |
+
+The May-11 items are 11 weeks old. They've been carried without being acted on or explicitly closed. If they're not causing active pain, close them — they're noise in this table.
+
+---
+
+## Watch list
+
+- **Fable 5 / Mythos 5 suspended by US export control directive (June 12).**
+  On June 12 at 5:21pm ET, the US government issued an export control
+  directive ordering Anthropic to suspend all foreign-national access to
+  Fable 5 and Mythos 5. Anthropic disabled both models for all customers
+  to ensure compliance, disagreeing with the directive but complying while
+  they work to restore access. No attune-ai impact today (Fable 5 not in
+  the registry), but it's the biggest industry story of the week. Watch
+  `www.anthropic.com/news/fable-mythos-access` for restoration status.
+  When Fable 5 is back, June-15 Rec #1 (`stop_reason: "refusal"` handling)
+  becomes relevant.
+
+- **Opus 4.7 fast mode removal July 24.** No attune-ai code calls Opus 4.7
+  fast mode (confirmed via grep). No action needed, but if `adaptive_routing.py`
+  is ever updated to include Opus 4.7, confirm fast mode isn't used before
+  July 24.
+
+- **`/rewind` command (v2.1.191).** Lets users resume a conversation from
+  before `/clear` was run. No plugin surface, but relevant to sessions using
+  `/clear` for context management. No action needed.
+
+- **OTEL `claude_code.assistant_response` log event (v2.1.193).** New event
+  containing response text, redacted by default. Enabled with
+  `OTEL_LOG_ASSISTANT_RESPONSES=1`. If attune-ai ever adds OTEL integration,
+  this gives a new signal for response quality monitoring.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Rate limits raised to 3 tiers (June 26) | Good news, no action — higher limits reduce throttling risk. |
+| Opus 4.7 fast mode deprecated (June 25) | No Opus 4.7 fast mode in stack (confirmed via grep). |
+| Voice dictation fixes (v2.1.195) | No voice mode in stack |
+| Mouse click controls in fullscreen (v2.1.195, v2.1.187) | UI only |
+| Background agent improvements (v2.1.186, v2.1.193) | No Claude Code native agents in stack |
+| `/install-github-app` GitHub Actions now optional (v2.1.187) | No GitHub App setup in attune-ai |
+| Sub-agents up to 5 levels deep (v2.1.172) | SDK adapter uses Python SDK agents, not Claude Code native |
+| Fable 5 name normalization (strip `[1m]`) (v2.1.173) | Fable 5 not in registry |
+| AWS region from `~/.aws` config (v2.1.172) | No AWS region usage in stack |
+| Claude Tag (Slack, June 23) | Slack product feature; no Python SDK impact |
+| `/rewind` command (v2.1.191) | UX-only; no plugin surface |
+| Plugin marketplace search bar (v2.1.172) | UI only |
+| Sandbox glob performance fix on Linux (v2.1.179) | No large sandbox directories |
+| CPU streaming ~37% reduction (v2.1.191) | Claude Code runtime improvement; no code change needed |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` (through June 26, 2026)
+- `releasebot.io/updates/anthropic/claude-code` (v2.1.186–v2.1.195, June
+  23–27, 2026)
+- `code.claude.com/docs/en/changelog` (v2.1.186–v2.1.195)
+- `anthropic.com/news/fable-mythos-access` (Fable 5 suspension, June 12)
+- `anthropic.com/news/introducing-claude-tag` (Claude Tag, June 23)
+- Grep: `grep -rn "opus-4-7\|fast.*mode\|speed.*fast" src/attune/`
+- Grep: `grep -rn "fable\|mythos" src/attune/models/`
+- `.claude/settings.json` hook config review
+- Prior report: `weekly-reports/2026-06-22.md`


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-06-29

## Summary

Nine Claude Code releases shipped this week (v2.1.186–v2.1.195). Two API
changes: rate limits consolidated to three tiers and Opus 4.7 fast mode
deprecated with a July 24 removal. The biggest stack-relevant item is the
new 5-minute MCP tool idle timeout (v2.1.187) — `research_synthesis` and
`discovery_sweep` will hit it. The hook matcher precision fix in v2.1.195
is technically breaking for hyphenated MCP identifiers, but the current
settings aren't affected.

---

## Recommendations

**1. Set `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` for long-running tools
(v2.1.187, June 23)**

Remote MCP tool calls now abort after 5 minutes of no response and return
an error. This is a hardcoded default, not a timeout you can negotiate
per-call. `research_synthesis`, `discovery_sweep` (multi-source runs), and
`test_gen_parallel` all routinely exceed 5 minutes.

Set the env var in any environment where attune-ai's MCP server runs
headlessly — CI, Claude Code Remote, scheduled jobs:

```bash
export CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=600  # seconds; adjust to taste
```

This is not configurable from inside the MCP server itself; it must be set
in the Claude Code process environment. If you're using a `.env` or a
setup script, add it there.

- **Applies to:** any environment running `attune-ai` MCP tools via Claude
  Code, especially `research_synthesis`, `discovery_sweep`, `test_gen_parallel`
- **Urgency:** Medium — silent abort with error; users will hit this on
  long-running tool calls without realizing why.
- **Alternative:** Split long workflow calls into smaller sub-calls, but
  that's significant refactoring for an env var fix.

---

**2. Verify hook matchers if you use hyphenated MCP tool names (v2.1.195,
June 26)**

Hook matchers with hyphenated identifiers changed from substring-match to
exact-match semantics. The current project `.claude/settings.json` uses
`"Bash"` and `"Edit|Write"` — both are unaffected.

However, if any user-level `~/.claude/settings.json` (Patrick's local
machine or CI environments) has hooks matching on `mcp__attune-ai` to
catch all attune-ai tools as a group, that pattern now silently won't fire.
The fix is to use `mcp__attune-ai__.*` (glob-style with `.*`).

Also worth knowing from v2.1.191 (June 24): comma-separated matchers like
`"Bash,PowerShell"` were silently never firing — that's fixed. Check for
this pattern in any local hook configs.

- **Applies to:** `.claude/settings.json` at project or user level; any
  hook using MCP tool patterns or comma-separated matchers
- **Urgency:** Low — only breaks hook configs that relied on substring
  behavior with hyphenated names; the current project config is fine.

---

**3. Be aware that `autoMode.classifyAllShell` is now available — and
reinforces last week's Rec #1 (v2.1.193, June 25)**

New setting routes ALL Bash/PowerShell commands through the auto-mode
classifier, not just commands that match arbitrary-code-execution patterns.
This is opt-in (disabled by default), so no immediate action. But it
signals that Anthropic is tightening auto-mode's classifier coverage.

This makes last week's June-22 Rec #1 (auditing release workflows for
commands that stall in auto mode) more urgent: if someone enables
`autoMode.classifyAllShell`, even routine shell calls in release scripts
will go through the classifier. Denial reasons now appear in transcripts
and `/permissions` → "Recently denied" so debugging is easier.

- **Applies to:** unattended release runs; `.claude/hooks/` scripts that
  invoke shell commands in auto mode
- **Urgency:** Low now, medium if `classifyAllShell` gets enabled.

---

## Carry-overs

| # | First raised | Recommendation | Status |
|---|---|---|---|
| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open. Rec #3 above adds context — `classifyAllShell` makes this more urgent when enabled. |
| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` / unblock attune-author cache | Open. No new info. |
| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open. Low urgency. |
| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CLIENT_PRESENCE_FILE` for scheduled runs | Open. Low urgency. |
| June-15 Rec #1 | 2026-06-15 | Handle `stop_reason: "refusal"` before adding Fable 5 | Open. Fable 5 suspended by US govt (see Watch list). Defer until access restored. |
| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (4 weeks). Still low urgency; no new platform info. |
| May-25 #2 | 2026-05-25 | attune-ops: switch to `claude agents --json` | Open (5 weeks). v2.1.193 improved background agent stability — more reason to migrate. |
| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish pipeline | Open (8 weeks). **Escalating.** This is old enough to either act on or close. If cache misses on the polish pipeline aren't causing pain, close it explicitly. |
| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | Open (8 weeks — one-liner edit). |
| May-11 #6 | 2026-05-11 | 1-hour cache TTL for attune-author polish | Open (11 weeks). Close this if the cache miss rate isn't hurting you. |
| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | Open (11 weeks). Close if not hitting it in practice. |

The May-11 items are 11 weeks old. They've been carried without being acted on or explicitly closed. If they're not causing active pain, close them — they're noise in this table.

---

## Watch list

- **Fable 5 / Mythos 5 suspended by US export control directive (June 12).**
  On June 12 at 5:21pm ET, the US government issued an export control
  directive ordering Anthropic to suspend all foreign-national access to
  Fable 5 and Mythos 5. Anthropic disabled both models for all customers
  to ensure compliance, disagreeing with the directive but complying while
  they work to restore access. No attune-ai impact today (Fable 5 not in
  the registry), but it's the biggest industry story of the week. Watch
  `www.anthropic.com/news/fable-mythos-access` for restoration status.
  When Fable 5 is back, June-15 Rec #1 (`stop_reason: "refusal"` handling)
  becomes relevant.

- **Opus 4.7 fast mode removal July 24.** No attune-ai code calls Opus 4.7
  fast mode (confirmed via grep). No action needed, but if `adaptive_routing.py`
  is ever updated to include Opus 4.7, confirm fast mode isn't used before
  July 24.

- **`/rewind` command (v2.1.191).** Lets users resume a conversation from
  before `/clear` was run. No plugin surface, but relevant to sessions using
  `/clear` for context management. No action needed.

- **OTEL `claude_code.assistant_response` log event (v2.1.193).** New event
  containing response text, redacted by default. Enabled with
  `OTEL_LOG_ASSISTANT_RESPONSES=1`. If attune-ai ever adds OTEL integration,
  this gives a new signal for response quality monitoring.

---

## No-ops

| Item | Why skipped |
|---|---|
| Rate limits raised to 3 tiers (June 26) | Good news, no action — higher limits reduce throttling risk. |
| Opus 4.7 fast mode deprecated (June 25) | No Opus 4.7 fast mode in stack (confirmed via grep). |
| Voice dictation fixes (v2.1.195) | No voice mode in stack |
| Mouse click controls in fullscreen (v2.1.195, v2.1.187) | UI only |
| Background agent improvements (v2.1.186, v2.1.193) | No Claude Code native agents in stack |
| `/install-github-app` GitHub Actions now optional (v2.1.187) | No GitHub App setup in attune-ai |
| Sub-agents up to 5 levels deep (v2.1.172) | SDK adapter uses Python SDK agents, not Claude Code native |
| Fable 5 name normalization (strip `[1m]`) (v2.1.173) | Fable 5 not in registry |
| AWS region from `~/.aws` config (v2.1.172) | No AWS region usage in stack |
| Claude Tag (Slack, June 23) | Slack product feature; no Python SDK impact |
| `/rewind` command (v2.1.191) | UX-only; no plugin surface |
| Plugin marketplace search bar (v2.1.172) | UI only |
| Sandbox glob performance fix on Linux (v2.1.179) | No large sandbox directories |
| CPU streaming ~37% reduction (v2.1.191) | Claude Code runtime improvement; no code change needed |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/api` (through June 26, 2026)
- `releasebot.io/updates/anthropic/claude-code` (v2.1.186–v2.1.195, June
  23–27, 2026)
- `code.claude.com/docs/en/changelog` (v2.1.186–v2.1.195)
- `anthropic.com/news/fable-mythos-access` (Fable 5 suspension, June 12)
- `anthropic.com/news/introducing-claude-tag` (Claude Tag, June 23)
- Grep: `grep -rn "opus-4-7\|fast.*mode\|speed.*fast" src/attune/`
- Grep: `grep -rn "fable\|mythos" src/attune/models/`
- `.claude/settings.json` hook config review
- Prior report: `weekly-reports/2026-06-22.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbqPp3NqmcV7Xhn6yqq2wZ)_