### PR TITLE
test(telemetry): gate per-install-secret mode assertion to POSIX

### DIFF
--- a/tests/unit/telemetry/test_usage_tracker.py
+++ b/tests/unit/telemetry/test_usage_tracker.py
@@ -2003,14 +2003,19 @@ class TestHmacSecret:
     OLD_CONSTANT = b"attune-default-telemetry-key"
 
     def test_per_install_secret_file_created_0600(self, temp_dir):
-        """First hash with no env secret writes a 0600 per-install .secret."""
+        """First hash with no env secret writes a per-install .secret (0600 on POSIX)."""
+        import sys
+
         with patch("attune.config.env_compat.get_attune_env", return_value=None):
             digest = UsageTracker(telemetry_dir=temp_dir)._hash_user_id("default")
 
         secret_file = temp_dir / ".secret"
         assert secret_file.exists()
-        assert (secret_file.stat().st_mode & 0o777) == 0o600
         assert isinstance(digest, str) and len(digest) == 16
+        # File-mode bits are POSIX-only — Windows maps os.open() modes to
+        # 0o666 regardless, so the permission assertion is gated to POSIX.
+        if sys.platform != "win32":
+            assert (secret_file.stat().st_mode & 0o777) == 0o600
 
     def test_secret_stable_across_instances_same_dir(self, temp_dir):
         """Two installs sharing a dir reuse the .secret → identical hash."""


### PR DESCRIPTION
Fixes a real Windows-lane failure introduced in #1167. `test_per_install_secret_file_created_0600` asserts `st_mode & 0o777 == 0o600`, but Windows reports `0o666` for `os.open`-created files (POSIX mode bits don't apply). The production code is correct — the secret file is created and private on POSIX; only the *assertion* was platform-specific.

Keeps the file-existence + digest checks cross-platform; gates only the mode assertion to non-Windows. The two auth_strategy mode asserts (#1168) were already inside a win32-skipped test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)