### PR TITLE
fix(mcp): surface swallowed workflow error in _workflow_response

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12454,3 +12454,51 @@ files.
   `find` / `git grep` instead of bare shell globs for "maybe-absent"
   patterns; or `setopt nullglob` / the `(N)` qualifier; or isolate the
   risky glob in its own command so its failure can't take down the rest.
+
+- **Two auth layers: a valid `ANTHROPIC_API_KEY` fixes DIRECT-provider
+  workflows but NOT claude-agent-sdk (SDK-native) ones — and
+  `_workflow_response` USED to swallow the real error so the difference
+  was invisible**: surfaced 2026-06-29 in a QA/dogfood session. Every
+  SDK-native MCP workflow (`security_audit`, `bug_predict`,
+  `discovery_sweep`, …) returned `{success:false, findings:[], cost:0}`
+  with NO error field. `cost:0` = it never reached an LLM (setup-time
+  failure, not teardown). Root-cause chain, each step verified:
+  - **`~/.attune/anthropic.env` held a REVOKED key.** Importing `attune`
+    runs `load_dotenv`, injecting that key into every attune process
+    (and any subprocess it spawns). Direct API call → `401
+    authentication_error` (`invalid x-api-key`). Replacing it with a
+    valid key (validate with a 1-token `messages` call, print STATUS
+    ONLY, never the value) → HTTP 200, which unblocked the
+    **direct-Anthropic-SDK** workflows (`analyze_image` via
+    `attune.llm.providers.anthropic`, x-api-key path).
+  - **SDK-native workflows still 401.** They route through
+    `claude-agent-sdk`, which spawns the `claude` CLI subprocess. That
+    subprocess auths through Claude Code's OWN credentials
+    (OAuth/subscription + the api-key approval cache), NOT the raw
+    `ANTHROPIC_API_KEY`. Proof: `claude -p` returned an identical 401
+    WITH the valid env key and WITHOUT it (`env -u ANTHROPIC_API_KEY`),
+    while the SDK path gave the distinct "Invalid API key · Fix external
+    API key" (the CLI's unapproved-key message). So a valid env key is
+    necessary-not-sufficient for SDK-native workflows; they need a CLI
+    re-auth / key approval (the user's interactive action — don't drive
+    a login flow). (The EXACT subprocess blocker — expired OAuth vs
+    unapproved-new-key — was NOT fully pinned; verify before asserting a
+    mechanism.)
+  - **The swallow that hid all of it (the product bug, fixed in #1173):**
+    `attune.mcp.workflow_handlers._workflow_response` built the response
+    from `success`/score/findings/cost but never read the error. The
+    canonical signal is `result.error`; SDK-native failures leave that
+    `None` and carry the message in `result.metadata`
+    (`is_error` + `raw_result_text`). Fix: surface `error`/`error_type`
+    when `result.success is False or metadata["is_error"]`, accepting
+    only `str` messages (so a `MagicMock` result can't inject a spurious
+    key — the existing strict-equality success-path tests stay green).
+    A `success:false / cost:0 / empty-findings / no-error` MCP result is
+    the tell for an SDK setup failure — repro directly
+    (`PYTHONPATH=<worktree>/src <main-venv>/bin/python -c "... await
+    Workflow().execute(path=...)"`) and read `metadata['raw_result_text']`
+    for the real reason. Also seen: the SDK adapter can report
+    `success:True` while `is_error:True` (subtype-based logic) — a
+    separate, deeper mislabel left out of #1173's scope. Pairs with the
+    "registered ≠ working" and `removing-dead-code.md`
+    fake-success-signature lessons.

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -127,6 +127,29 @@ def _workflow_response(
     response["cost"] = cost_report.total_cost if cost_report is not None else 0.0
     if include_provider:
         response["provider"] = result.provider
+
+    # Surface the real failure reason. Without this, an errored run is
+    # indistinguishable from a clean empty result (success=false,
+    # findings=[], cost=0) — the swallowed-error trap (see
+    # removing-dead-code.md "fake-success signature"). The canonical
+    # signal is result.error; SDK-native runs leave that None and carry
+    # the message in metadata instead (is_error + raw_result_text), e.g.
+    # an auth failure surfacing as "Invalid API key". Only str messages
+    # are accepted so a mocked result never injects a spurious key.
+    meta = getattr(result, "metadata", None) or {}
+    if result.success is False or meta.get("is_error"):
+        candidates = (
+            getattr(result, "error", None),
+            meta.get("raw_result_text") if meta.get("is_error") else None,
+            meta.get("errors"),
+        )
+        error_msg = next((c for c in candidates if isinstance(c, str) and c.strip()), None)
+        if error_msg is not None:
+            response["error"] = error_msg
+            error_type = getattr(result, "error_type", None)
+            if isinstance(error_type, str):
+                response["error_type"] = error_type
+
     return response
 
 

--- a/tests/unit/mcp/handlers/test_workflow_response.py
+++ b/tests/unit/mcp/handlers/test_workflow_response.py
@@ -224,6 +224,71 @@ class TestWorkflowResponseReport:
 
 
 # ==================================================================
+# _workflow_response — errored runs surface the real reason
+# ==================================================================
+
+
+class TestWorkflowResponseError:
+    """An errored run must carry the real failure message, never swallow it.
+
+    Regression for the QA session 2026-06-29 finding: an SDK-native auth
+    failure came back as {success:false, findings:[], cost:0} with NO
+    error field, indistinguishable from a clean empty result.
+    """
+
+    def test_sdk_is_error_surfaces_raw_result_text(self):
+        # SDK-native failure: result.error is None, message lives in metadata.
+        result = _make_result(
+            success=False,
+            final_output="",
+            total_cost=0.0,
+            metadata={"is_error": True, "raw_result_text": "Invalid API key"},
+        )
+        result.error = None
+        out = _workflow_response(result, findings=("findings", []))
+
+        assert out["success"] is False
+        assert out["error"] == "Invalid API key"
+
+    def test_is_error_surfaces_even_when_success_true(self):
+        # Adapter can mark success=True while is_error=True; still surface it.
+        result = _make_result(
+            success=True,
+            final_output="",
+            metadata={"is_error": True, "raw_result_text": "boom"},
+        )
+        result.error = None
+        out = _workflow_response(result)
+
+        assert out["error"] == "boom"
+
+    def test_canonical_error_field_takes_precedence(self):
+        result = _make_result(success=False, final_output="")
+        result.error = "config: missing path"
+        result.error_type = "config"
+        out = _workflow_response(result)
+
+        assert out["error"] == "config: missing path"
+        assert out["error_type"] == "config"
+
+    def test_clean_success_has_no_error_key(self):
+        result = _make_result(final_output={"health_score": 90})
+        result.error = None
+        out = _workflow_response(result, score="health_score")
+
+        assert "error" not in out
+        assert "error_type" not in out
+
+    def test_errored_without_message_omits_error_key(self):
+        # No extractable str message -> don't inject a garbage/empty error.
+        result = _make_result(success=False, final_output="")
+        result.error = None
+        out = _workflow_response(result)
+
+        assert "error" not in out
+
+
+# ==================================================================
 # Handler-level round-trips
 # ==================================================================
 


### PR DESCRIPTION
## Problem

When an MCP workflow run errored, `_workflow_response` returned
`{success: false, findings: [], cost: 0}` with **no error field** —
indistinguishable from a clean, empty result. SDK-native failures
(e.g. an auth `401`) leave `result.error` as `None` and carry the
message in `result.metadata` (`is_error` + `raw_result_text`), which
`_workflow_response` never read. The real reason was swallowed (the
[`removing-dead-code`](.claude/rules/attune/removing-dead-code.md)
"fake-success signature").

Found during a QA/dogfood session: every SDK workflow came back
`success:false / cost:0` and the actual cause (`Invalid API key`) was
only visible via a direct repro.

## Fix

Surface the real failure reason as an `error` field (plus `error_type`)
whenever a run errored — gated on `result.success is False` or
`metadata["is_error"]`. Only `str` messages are accepted, so a mocked
result never injects a spurious key. The **success-path response shape
is unchanged** (strict-equality tests still pass).

## Verification

- 5 new regression tests in `test_workflow_response.py`
- Full `tests/unit/mcp/` suite green (367 passed; the one failure was a
  live network test unrelated to this change)
- Non-mocked round-trip: a real failing workflow now returns
  `error: "Failed to authenticate. API Error: 401 …"` instead of a
  silent empty result

## Out of scope (flagged separately)

The SDK adapter can report `success: True` while `is_error: True`
(subtype-based logic in `agent_sdk_adapter`). This PR surfaces the
error regardless of that flag; fixing the mislabel itself is a deeper,
separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
