### PR TITLE
feat(elicitation): decision construct (communication grammar, V3)

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -54,11 +54,55 @@ A form is plain serializable data:
 
 Field `type` is one of `single_select`, `multi_select`, `boolean`,
 `text_input`, `number` (with `minimum`/`maximum`), `date` (ISO
-`YYYY-MM-DD`), or `textarea` (with `max_length`). `id` is the stable key
-the answer comes back under. The last three are **rich controls** — they
-render on the native elicitation (`elicitation_ask`) and widget
+`YYYY-MM-DD`), `textarea` (with `max_length`), or `decision` (see "The
+decision construct" below). `id` is the stable key the answer comes back
+under. The rich controls — `number`/`date`/`textarea` — render on the
+native elicitation (`elicitation_ask`) and widget
 (`elicitation_render_widget`) surfaces below, but degrade to plain text
 on AskUserQuestion.
+
+## The decision construct (v3)
+
+A `decision` is a presentation-enriched single-select: the agent offers
+a **recommended** option with a **rationale** and per-option
+**tradeoffs**, and the user picks one. Use it to *offer a choice*, not to
+*gather intake* — it is the agent-to-user half of the grammar (the
+constructs above gather input). See
+`.claude/rules/attune/communication-grammar.md`.
+
+Extra field keys (all optional):
+
+- `recommended` — the option to badge "Recommended" and order first
+  (must be one of `options`).
+- `rationale` — the "why this recommendation" callout shown beneath the
+  cards.
+- `option_notes` — `{option: one-line tradeoff}` shown under each card.
+
+```json
+{
+  "title": "Focused session plan",
+  "fields": [
+    {"id": "approach", "text": "How should we spend this session?",
+     "type": "decision",
+     "options": ["Verifiable backlog loop", "Behind a verify gate",
+                 "Non-LLM backlog"],
+     "recommended": "Verifiable backlog loop",
+     "rationale": "Building LLM features blind manufactures unverified work.",
+     "option_notes": {"Verifiable backlog loop": "Real progress now",
+                      "Behind a verify gate": "Parked until the key returns",
+                      "Non-LLM backlog": "Fully provable today"}}
+  ]
+}
+```
+
+**Surface:** the rich card layout (badge + tradeoffs + rationale) renders
+on the **widget** surface (`elicitation_render_widget` → `show_widget`);
+the answer is one selected option, validated like a single-select.
+
+**AskUserQuestion fallback:** a `decision` maps to a `single_select` with
+the recommended option ordered first and " (Recommended)" appended to its
+label; fold each `option_notes` tradeoff into that option's
+`description`, and use the `rationale` as the question's lead-in.
 
 ## Choosing a surface
 

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12264,3 +12264,29 @@ files.
   atomic `write()` per record) so concurrent appends can't interleave. A
   count-mismatch-but-all-unique result in a concurrency test is the tell
   for partial-write corruption, not a counter race.
+
+- **A session that explores a "new" idea may actually be the next phase
+  of an EXISTING, far-more-advanced spec hidden by a STALE WORKTREE —
+  check `origin/main` (not just the worktree) for prior work BEFORE
+  drafting a fresh spec**: 2026-06-29, a session to spec "dynamic
+  conversations to enhance agent↔user communication" nearly became a
+  greenfield `communication-grammar` spec. The worktree was **327
+  commits behind main** (8.5.0 vs 9.2.0), so the user's "we've done a
+  lot of work on this" was invisible: a repo-wide `grep elicit` in the
+  worktree found nothing, while `origin/main` carried a heavily-iterated
+  `docs/specs/elicitation-form-surface/` (D1–D13 + v2-1/v2-2/phase0) plus
+  shipped `attune.elicitation` code, a live `elicit` skill, and a proven
+  widget round-trip. The "new" idea was just the next construct (a
+  decision/opening-shape form) on that existing substrate; the spec
+  folded in as V3 instead of duplicating shipped work. Diagnostic recipe
+  before speccing anything that "feels new" (especially when the user
+  says we've worked on it): (1) `git rev-list --count HEAD..origin/main`
+  — a large number means the worktree cannot see recent work; (2) `git
+  ls-tree -r --name-only origin/main | grep <topic>` to find existing
+  specs/code; (3) `git show origin/main:<path>` to read them WITHOUT a
+  checkout; (4) relocate to a fresh branch off origin/main before
+  building. The user's recollection was RIGHT — the stale worktree just
+  hid the receipts. Pairs with the worktree-vs-main MAPPING lessons
+  (execute-side), "spec-named scope drifts from code reality", and
+  "next-session starter can be stale on arrival" — same family: main is
+  ground truth; the worktree (and memory of "we worked on this") is not.

--- a/.claude/rules/attune/communication-grammar.md
+++ b/.claude/rules/attune/communication-grammar.md
@@ -1,0 +1,109 @@
+# Communication Grammar
+
+**Created:** 2026-06-29
+**Spec:** [docs/specs/elicitation-form-surface/](../../../docs/specs/elicitation-form-surface/)
+(V3 — decisions.md D14, v3-requirements.md)
+
+---
+
+## What this is
+
+A small, growing **family of conversational constructs** the agent
+composes to communicate with the user — structured shapes instead of
+freeform prose. Each construct is a member of one declarative-form
+substrate (`attune.meta_workflows.models.FormSchema`), so the same
+artifact renders on every surface and validates the same way.
+
+The grammar is **agent-to-user expression** (how the agent structures
+what it offers). It is not user-to-agent command syntax, and it does not
+replace the terse reply vocab (`y` / `go` / `1`) — those are the
+*answers* to a construct.
+
+Constructs fire **reactively**, in the live conversation — never on a
+schedule. When a construct fires (e.g. the decision construct on a
+non-trivial choice) is governed by
+[decision-routine.md](decision-routine.md), not here; this file is the
+*shape*, not the *when*.
+
+---
+
+## The substrate (shared by every construct)
+
+- **One artifact** — a `FormSchema` of `FormQuestion`s, built from plain
+  data via `attune.elicitation.form_from_dict` (D3).
+- **Renderers** — `form_to_widget_html` (the widget surface, the rich
+  one that renders on Claude Code, D10/D11); the `AskUserQuestion`
+  fallback (`form_to_askuserquestion`); native MCP elicitation
+  (`form_to_elicitation_schema`, currently non-rendering on CC).
+- **One validator** — `collect_form_response` (R4): never silently
+  accept malformed input; re-ask only the offending fields.
+
+A construct adds **meaning and presentation** on top of this substrate;
+it almost never adds a new round-trip or validator.
+
+---
+
+## Members
+
+### intake-form (v1 / v2 — shipped)
+
+Gather the independent dimensions of one decision as a single
+(multi-select-capable) form. Driven by the `elicit` skill; adopted into
+`/spec`, `/attune`, `/planning` (D13). Question types: `single_select`,
+`multi_select`, `boolean`, `text_input`, `number`, `date`, `textarea`.
+
+### decision / opening-shape (v3)
+
+The agent offers a **recommended** option with a **rationale** and
+per-option **tradeoffs**; the user picks one. A `QuestionType.DECISION`
+is a presentation-enriched single-select — the answer is one option,
+validated exactly as a single-select. Extra `FormQuestion` slots:
+`recommended`, `rationale`, `option_notes`. Renders as cards (badge +
+tradeoffs + rationale) on the widget surface; falls back to a
+recommendation-first single-select on `AskUserQuestion`.
+
+---
+
+## How to add the next construct (#3)
+
+Keep it additive and substrate-reusing. The decision construct (v3) is
+the worked example to copy.
+
+1. **Decide the shape.** Does it compose existing question types, or
+   need a new `QuestionType`? Prefer composing. A new type is justified
+   only when rendering or answer-meaning genuinely differs.
+2. **Extend the model additively** (`meta_workflows/models.py`). Add the
+   `QuestionType` member and any *optional* `FormQuestion` fields
+   (defaults `None`), so every existing form is unaffected.
+3. **Reuse the answer path.** Map the new type's answer validation to an
+   existing validator in `bridge.py::_validate_answer` if the answer is
+   shaped like one already (a decision validates as a single-select).
+   Only add validation logic for a genuinely new answer shape.
+4. **Render it.** Add a branch to `widget.py::_control_html` (and the
+   submit-script reader if the control isn't a plain input), plus any
+   styles. Keep the `sendPrompt` guard so it degrades to a readable
+   static card.
+5. **Definition validation.** Extend `bridge.py::form_from_dict` to
+   parse and validate the new fields (e.g. a referenced option must
+   exist).
+6. **Surfaces.** Widen the rich enum in `mcp/tool_schemas.py` (update
+   the count guard in `tests/unit/mcp/test_tool_schemas.py`), map it in
+   `elicitation_schema.py` if native elicitation should carry it, and
+   document the construct + its `AskUserQuestion` fallback in the
+   `elicit` skill (both `plugin/` and `.agents/` copies).
+7. **Prove it.** Add a test module under `tests/unit/elicitation/`
+   (model + definition validation + render + round-trip + fallback) and
+   **dogfood the live widget round-trip** — render a real form, submit,
+   and validate the postback (the receipt). The widget path makes no
+   Anthropic API call, so this is provable without credits.
+
+---
+
+## Cross-references
+
+- [decision-routine.md](decision-routine.md) — when the decision
+  construct fires (the trigger discipline; this file is the shape).
+- `plugin/skills/elicit/SKILL.md` — the live skill that drives the
+  substrate and carries the per-surface mapping rules.
+- [docs/specs/elicitation-form-surface/](../../../docs/specs/elicitation-form-surface/)
+  — the full decision log (D1–D14) and phase requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Decision construct (communication grammar).** The elicitation form
+  surface gains a `decision` control (`QuestionType.DECISION`): the agent
+  offers a recommended option with a rationale and per-option tradeoffs,
+  rendered as cards on the `show_widget` surface and degrading to a
+  recommendation-first single-select on `AskUserQuestion`. The answer is
+  one selected option, validated like a single-select — no new
+  round-trip. New optional `FormQuestion` fields: `rationale`,
+  `option_notes`, `recommended`. Folded into the elicitation-form-surface
+  spec as V3; see `.claude/rules/attune/communication-grammar.md`.
+
 ## [9.2.0] — 2026-06-28
 
 ### Added

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -437,6 +437,33 @@ Native MCP elicitation (`elicitation_ask`) stays a non-option until a
 CC client renders it (D10). The analysis skills stay single-question.
 Surface-only change (skill markdown) — the engine (D11) is unchanged.
 
+## D14 — V3: the decision construct (communication grammar)
+
+**Date:** 2026-06-29 · **Status:** decided (Patrick chose "fold") ·
+see [v3-requirements.md](v3-requirements.md)
+
+A session exploring "dynamic conversations to enhance agent-user
+communication" produced a live decision form (recommendation +
+rationale + ranked alternatives) Patrick flagged as a breakthrough.
+Grounding it against this spec showed it is not greenfield — it is the
+next member of THIS spec's declarative-form family. Folded in as
+**V3**.
+
+Reconciles three premises from the exploratory draft:
+
+- schema home → already `FormSchema` / `attune.elicitation`; extend,
+  do not invent.
+- renderer → the S1 widget (D11), not MCP elicitation (D10).
+- "second construct = scope form" → the scope/intake form already
+  ships and is adopted (D13); the genuinely new construct is the
+  **decision** (opening-shape) itself.
+
+Design: a decision is a presentation-enriched `SINGLE_SELECT` — the
+answer path (round-trip + `collect_form_response`) is unchanged; V3
+adds a model field-set + a widget card renderer + the grammar doc.
+The widget surface makes no Anthropic API call, so V3 is fully
+buildable and dogfoodable without API credits.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/v3-requirements.md
+++ b/docs/specs/elicitation-form-surface/v3-requirements.md
@@ -1,0 +1,104 @@
+# Elicitation Form Surface — V3 Requirements
+
+## The decision construct (communication grammar)
+
+V3 adds the first **non-intake** member of this spec's declarative-form
+family. V1/V2 built the substrate for *intake* (gather input across
+dimensions) and proved the S1 widget round-trip live (D11), adopted into
+`/spec`, `/attune`, `/planning` (D13). V3 adds a **decision** construct:
+the agent offers a recommended choice with rationale and ranked
+alternatives; the user picks one.
+
+This is the "opening-shape" Patrick reacted to in session (2026-06-29).
+Naming the family of constructs over the proven substrate is the
+"communication grammar." Folded here from a standalone draft per D14.
+
+## What already exists — reuse, do not rebuild
+
+- `FormSchema` / `FormQuestion` / `QuestionType` / `FormResponse`
+  (`meta_workflows/models.py`).
+- `form_to_widget_html` (`elicitation/widget.py`) — the S1 renderer,
+  live round-trip proven (D11).
+- `collect_form_response` validation (R4).
+- The `elicit` skill surface-mapping + AskUserQuestion fallback (D7).
+
+## The gap — confirmed against widget.py + models.py
+
+A decision is a presentation-enriched `SINGLE_SELECT`. The substrate
+cannot today express:
+
+- a recommended option (marker / badge),
+- per-option one-line tradeoffs,
+- a rationale / "why it matters" callout distinct from `help_text`.
+
+`SINGLE_SELECT` renders a flat `<select>`: no card layout, no
+recommendation, no rationale slot.
+
+## Key insight — the answer path is unchanged
+
+A decision's answer is exactly one selected option, which is what
+`SINGLE_SELECT` already validates (membership). So the round-trip
+(sentinel JSON → `collect_form_response`) and validation are reused
+**untouched**. V3 is presentation plus a thin, additive model
+extension only.
+
+This surface makes **no Anthropic API call** (`form_to_widget_html` →
+`show_widget` → `sendPrompt` → `collect_form_response` are all pure /
+client-side), so V3 is fully buildable and dogfoodable with no API
+credits.
+
+## Requirements
+
+- RV3.1 — Add `QuestionType.DECISION` (an enriched single-select).
+- RV3.2 — Additive optional `FormQuestion` fields: `rationale`
+  (`str | None`), `option_notes` (`dict[str, str] | None`, option →
+  tradeoff), `recommended` (`str | None`, must be one of `options`).
+  All optional; existing forms unaffected.
+- RV3.3 — `widget.py` renders `DECISION` as cards: a badged
+  recommended card first, ranked alternatives, a rationale callout;
+  the answer posts as the selected option (same payload shape).
+- RV3.4 — AskUserQuestion fallback (`elicit` skill): `DECISION` maps
+  to a `single_select`, recommendation-first ordering (already the
+  skill's convention, D7), tradeoffs folded into option help.
+- RV3.5 — Degrades to a readable static card where `sendPrompt` is
+  absent (inherits the widget's behavior).
+- RV3.6 — A "communication grammar" doc names the construct family
+  and how to add the next construct.
+- RV3.7 — `collect_form_response` and the round-trip are unchanged;
+  guarded by reusing the existing validation tests.
+
+## Acceptance criteria
+
+- AC1 — `DECISION` type + fields added; existing form tests stay green
+  (additive, backward-compatible).
+- AC2 — A real decision renders as the card layout (recommended badge
+  + tradeoffs + rationale) AND as the AskUserQuestion fallback, from
+  one `FormSchema`.
+- AC3 — Round-trip proven: `form_to_widget_html` → `show_widget` →
+  pick → `sendPrompt` sentinel → `collect_form_response` success (the
+  receipt; mirrors D11). Function + `show_widget` level provable in
+  session; the full MCP-tool path on next server boot (D9/D11
+  pattern).
+- AC4 — Static fallback verified (`sendPrompt` undefined → readable).
+- AC5 — Keyboard accessible (role / tabindex / Enter + Space) on the
+  option cards.
+- AC6 — Grammar doc explains the family and how to add construct #3.
+
+## Out of scope
+
+- New surfaces — native MCP elicitation stays out (D10).
+- `slider` / `color` controls (still deferred).
+- The trigger discipline (when a decision fires) lives in
+  `decision-routine.md`, unchanged. V3 is the rendering / artifact,
+  not the when.
+
+## Tasks (for review)
+
+- T1 — model: `QuestionType.DECISION` + 3 optional fields +
+  validation (`recommended` in `options`).
+- T2 — `widget.py`: `_control_html` `DECISION` branch (cards + badge +
+  rationale callout) + accessibility.
+- T3 — `elicit` skill: `DECISION` → AskUserQuestion fallback mapping.
+- T4 — communication-grammar doc (family + how to extend).
+- T5 — tests: model (additive), widget render (structure), round-trip
+  reuse; plus the live dogfood receipt (AC3).

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -56,11 +56,55 @@ A form is plain serializable data:
 
 Field `type` is one of `single_select`, `multi_select`, `boolean`,
 `text_input`, `number` (with `minimum`/`maximum`), `date` (ISO
-`YYYY-MM-DD`), or `textarea` (with `max_length`). `id` is the stable key
-the answer comes back under. The last three are **rich controls** — they
-render on the native elicitation (`elicitation_ask`) and widget
+`YYYY-MM-DD`), `textarea` (with `max_length`), or `decision` (see "The
+decision construct" below). `id` is the stable key the answer comes back
+under. The rich controls — `number`/`date`/`textarea` — render on the
+native elicitation (`elicitation_ask`) and widget
 (`elicitation_render_widget`) surfaces below, but degrade to plain text
 on AskUserQuestion.
+
+## The decision construct (v3)
+
+A `decision` is a presentation-enriched single-select: the agent offers
+a **recommended** option with a **rationale** and per-option
+**tradeoffs**, and the user picks one. Use it to *offer a choice*, not to
+*gather intake* — it is the agent-to-user half of the grammar (the
+constructs above gather input). See
+`.claude/rules/attune/communication-grammar.md`.
+
+Extra field keys (all optional):
+
+- `recommended` — the option to badge "Recommended" and order first
+  (must be one of `options`).
+- `rationale` — the "why this recommendation" callout shown beneath the
+  cards.
+- `option_notes` — `{option: one-line tradeoff}` shown under each card.
+
+```json
+{
+  "title": "Focused session plan",
+  "fields": [
+    {"id": "approach", "text": "How should we spend this session?",
+     "type": "decision",
+     "options": ["Verifiable backlog loop", "Behind a verify gate",
+                 "Non-LLM backlog"],
+     "recommended": "Verifiable backlog loop",
+     "rationale": "Building LLM features blind manufactures unverified work.",
+     "option_notes": {"Verifiable backlog loop": "Real progress now",
+                      "Behind a verify gate": "Parked until the key returns",
+                      "Non-LLM backlog": "Fully provable today"}}
+  ]
+}
+```
+
+**Surface:** the rich card layout (badge + tradeoffs + rationale) renders
+on the **widget** surface (`elicitation_render_widget` → `show_widget`);
+the answer is one selected option, validated like a single-select.
+
+**AskUserQuestion fallback:** a `decision` maps to a `single_select` with
+the recommended option ordered first and " (Recommended)" appended to its
+label; fold each `option_notes` tradeoff into that option's
+`description`, and use the `rationale` as the question's lead-in.
 
 ## Choosing a surface
 

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -113,7 +113,10 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
         if not isinstance(options, list) or not all(isinstance(o, str) for o in options):
             problems.append(f"{where} 'options' must be a list of strings")
             options = []
-        if qtype in (QuestionType.SINGLE_SELECT, QuestionType.MULTI_SELECT) and not options:
+        if (
+            qtype in (QuestionType.SINGLE_SELECT, QuestionType.MULTI_SELECT, QuestionType.DECISION)
+            and not options
+        ):
             problems.append(f"{where} type {qtype.value} requires non-empty 'options'")
 
         # v2.1 rich-control constraints (number range, text length).
@@ -134,6 +137,31 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
             problems.append(f"{where} 'max_length' must be a positive integer")
             max_length = None
 
+        # v3 DECISION extras: rationale callout + recommended option +
+        # per-option tradeoffs. Parsed generically; only DECISION renders
+        # them. recommended must be an option; option_notes keys too.
+        rationale = raw.get("rationale")
+        if rationale is not None and not isinstance(rationale, str):
+            problems.append(f"{where} 'rationale' must be a string")
+            rationale = None
+        recommended = raw.get("recommended")
+        if recommended is not None and not isinstance(recommended, str):
+            problems.append(f"{where} 'recommended' must be a string")
+            recommended = None
+        elif recommended is not None and options and recommended not in options:
+            problems.append(f"{where} 'recommended' {recommended!r} not in options")
+        option_notes = raw.get("option_notes")
+        if option_notes is not None and (
+            not isinstance(option_notes, dict)
+            or not all(isinstance(k, str) and isinstance(v, str) for k, v in option_notes.items())
+        ):
+            problems.append(f"{where} 'option_notes' must be a map of strings")
+            option_notes = None
+        elif isinstance(option_notes, dict) and options:
+            stray = [k for k in option_notes if k not in options]
+            if stray:
+                problems.append(f"{where} 'option_notes' keys not in options: {stray}")
+
         if fid and text and isinstance(fid, str) and isinstance(text, str):
             questions.append(
                 FormQuestion(
@@ -147,6 +175,9 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
                     minimum=minimum,
                     maximum=maximum,
                     max_length=max_length,
+                    rationale=rationale,
+                    option_notes=option_notes,
+                    recommended=recommended,
                 )
             )
 
@@ -190,7 +221,7 @@ def _validate_answer(question: FormQuestion, value: Any) -> str | None:
             return f"{question.id!r} has out-of-option value(s): {bad}"
         return None
 
-    if question.type == QuestionType.SINGLE_SELECT:
+    if question.type in (QuestionType.SINGLE_SELECT, QuestionType.DECISION):
         if value not in question.options:
             return f"{question.id!r} value {value!r} not in options"
         return None

--- a/src/attune/elicitation/elicitation_schema.py
+++ b/src/attune/elicitation/elicitation_schema.py
@@ -30,7 +30,7 @@ def _property_for(question: FormQuestion) -> dict[str, Any]:
     """
     prop: dict[str, Any] = {"title": question.text}
 
-    if question.type == QuestionType.SINGLE_SELECT:
+    if question.type in (QuestionType.SINGLE_SELECT, QuestionType.DECISION):
         prop.update(type="string", enum=list(question.options))
     elif question.type == QuestionType.MULTI_SELECT:
         prop.update(type="array", items={"type": "string", "enum": list(question.options)})

--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -54,6 +54,26 @@ def _control_html(q: FormQuestion) -> str:
     Returns:
         An HTML fragment for the control.
     """
+    if q.type == QuestionType.DECISION:
+        notes = q.option_notes or {}
+        ordered = list(q.options)
+        if q.recommended and q.recommended in ordered:
+            ordered = [q.recommended] + [o for o in ordered if o != q.recommended]
+        cards = ""
+        for opt in ordered:
+            is_rec = opt == q.recommended
+            badge = '<span class="ae-rec-badge">Recommended</span>' if is_rec else ""
+            note = f'<span class="ae-card-note">{_esc(notes[opt])}</span>' if opt in notes else ""
+            checked = " checked" if q.default == opt else ""
+            cls = "ae-card ae-card-rec" if is_rec else "ae-card"
+            cards += (
+                f'<label class="{cls}">'
+                f'<input type="radio" name="{_esc(q.id)}" data-control '
+                f'value="{_esc(opt)}"{checked}>'
+                f'{badge}<span class="ae-card-title">{_esc(opt)}</span>{note}</label>'
+            )
+        return f'<div class="ae-cards" role="radiogroup">{cards}</div>'
+
     if q.type == QuestionType.MULTI_SELECT:
         boxes = "".join(
             f'<label class="ae-check"><input type="checkbox" data-control '
@@ -116,14 +136,24 @@ def _selected(q: FormQuestion, opt: str) -> str:
 
 
 def _field_html(q: FormQuestion) -> str:
-    """Render one labelled field (label + optional help + control)."""
+    """Render one labelled field (label + optional help + control).
+
+    For a DECISION question a ``rationale`` callout ("why this
+    recommendation") is rendered beneath the option cards.
+    """
     req = '<span class="ae-req" title="required">*</span>' if q.required else ""
     help_html = f'<div class="ae-help">{_esc(q.help_text)}</div>' if q.help_text else ""
+    rationale_html = (
+        f'<div class="ae-rationale"><span class="ae-rationale-h">Why</span>'
+        f"{_esc(q.rationale)}</div>"
+        if q.rationale
+        else ""
+    )
     return (
         f'<div class="ae-field" data-fid="{_esc(q.id)}" '
         f'data-ftype="{_esc(q.type.value)}">'
         f'<label class="ae-label">{_esc(q.text)}{req}</label>'
-        f"{help_html}{_control_html(q)}</div>"
+        f"{help_html}{_control_html(q)}{rationale_html}</div>"
     )
 
 
@@ -181,6 +211,23 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
   gap:.35rem; }}
 #attune-elicit-form .ae-check {{ display:flex; align-items:center; gap:.5rem;
   font-weight:400; }}
+#attune-elicit-form .ae-cards {{ display:flex; flex-direction:column; gap:.5rem; }}
+#attune-elicit-form .ae-card {{ position:relative; display:flex;
+  flex-direction:column; gap:.15rem; padding:.6rem 1.9rem .6rem .75rem;
+  border:1px solid var(--border); border-radius:var(--radius); cursor:pointer; }}
+#attune-elicit-form .ae-card:hover {{ border-color:var(--text-muted); }}
+#attune-elicit-form .ae-card-rec {{ border-color:var(--border-accent); }}
+#attune-elicit-form .ae-card input {{ position:absolute; top:.7rem; right:.6rem; }}
+#attune-elicit-form .ae-card-title {{ font-weight:500; }}
+#attune-elicit-form .ae-card-note {{ font-size:13px; color:var(--text-muted); }}
+#attune-elicit-form .ae-rec-badge {{ font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }}
+#attune-elicit-form .ae-rationale {{ margin:.6rem 0 0; padding:.4rem 0 .4rem .75rem;
+  font-size:13px; color:var(--text-secondary);
+  border-left:2px solid var(--border-accent); }}
+#attune-elicit-form .ae-rationale-h {{ display:block; font-weight:600;
+  font-size:11px; text-transform:uppercase; letter-spacing:.03em;
+  color:var(--text-accent); margin-bottom:.15rem; }}
 #attune-elicit-form .ae-submit {{ margin-top:.5rem; padding:.55rem 1.1rem;
   font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary);
   background:var(--bg-accent); border:1px solid var(--border-accent);
@@ -211,6 +258,9 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
           vals.push(c.value);
         }});
         answers[fid] = vals;
+      }} else if (ftype === 'decision') {{
+        var picked = f.querySelector('[data-control]:checked');
+        if (picked) answers[fid] = picked.value;
       }} else {{
         var el = f.querySelector('[data-control]');
         if (!el || el.value === '') return;

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -440,11 +440,13 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
                     "boolean",
                     "number",
                     "date",
+                    "decision",
                 ],
                 "description": (
                     "Control type. v1: text_input/single_select/multi_select/"
                     "boolean. v2.1 rich: textarea, number (min/max), date "
-                    "(YYYY-MM-DD)."
+                    "(YYYY-MM-DD). v3: decision (a recommended single-select "
+                    "with rationale + per-option tradeoffs, widget surface)."
                 ),
             },
             "minimum": {"type": "number", "description": "Lower bound for number"},
@@ -452,6 +454,18 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
             "max_length": {
                 "type": "integer",
                 "description": "Max length for text_input/textarea",
+            },
+            "rationale": {
+                "type": "string",
+                "description": "decision: the 'why this recommendation' callout",
+            },
+            "recommended": {
+                "type": "string",
+                "description": "decision: option to badge recommended (must be in options)",
+            },
+            "option_notes": {
+                "type": "object",
+                "description": "decision: {option: one-line tradeoff} shown under each card",
             },
         },
         "required": ["id", "text", "type"],

--- a/src/attune/meta_workflows/models.py
+++ b/src/attune/meta_workflows/models.py
@@ -37,6 +37,11 @@ class QuestionType(str, Enum):
     NUMBER = "number"
     DATE = "date"
     TEXTAREA = "textarea"
+    # v3 (communication grammar): a presentation-enriched single-select.
+    # The agent offers a recommended option with rationale + per-option
+    # tradeoffs; the answer is one selected option (validated exactly as a
+    # single-select). The rich card layout is widget-surface only.
+    DECISION = "decision"
 
 
 class TierStrategy(str, Enum):
@@ -68,6 +73,12 @@ class FormQuestion:
         minimum: Lower bound for NUMBER answers (inclusive); None = none
         maximum: Upper bound for NUMBER answers (inclusive); None = none
         max_length: Max character length for TEXT_INPUT/TEXTAREA; None = none
+        rationale: DECISION only — the "why this recommendation" callout
+            rendered beneath the options; None = none
+        option_notes: DECISION only — {option: one-line tradeoff} shown
+            under each option card; None = none
+        recommended: DECISION only — the option to badge as recommended
+            and order first; must be one of options; None = none
 
     """
 
@@ -81,6 +92,9 @@ class FormQuestion:
     minimum: float | None = None
     maximum: float | None = None
     max_length: int | None = None
+    rationale: str | None = None
+    option_notes: dict[str, str] | None = None
+    recommended: str | None = None
 
     def to_ask_user_format(self) -> dict[str, Any]:
         """Convert to format compatible with AskUserQuestion tool.
@@ -89,6 +103,22 @@ class FormQuestion:
             Dictionary with question data for AskUserQuestion
 
         """
+        # Decision (v3) falls back to a single-select with the recommended
+        # option ordered first (the richer card layout is widget-only); the
+        # answer is one selected option.
+        if self.type == QuestionType.DECISION:
+            opts = list(self.options)
+            if self.recommended and self.recommended in opts:
+                opts = [self.recommended] + [o for o in opts if o != self.recommended]
+            return {
+                "question_id": self.id,
+                "question": self.text,
+                "type": "single_select",
+                "options": opts,
+                "default": self.default or self.recommended,
+                "help_text": self.help_text,
+            }
+
         # Boolean questions convert to Yes/No select
         if self.type == QuestionType.BOOLEAN:
             return {

--- a/tests/unit/elicitation/test_decision_construct.py
+++ b/tests/unit/elicitation/test_decision_construct.py
@@ -1,0 +1,155 @@
+"""Tests for the V3 decision construct (communication grammar).
+
+A DECISION is a presentation-enriched single-select: the agent offers a
+recommended option with a rationale and per-option tradeoffs; the answer
+is one selected option, validated exactly as a single-select. These tests
+cover the model extension, definition validation, the widget card render,
+the answer round-trip, the AskUserQuestion fallback, and the elicitation
+schema mapping. See docs/specs/elicitation-form-surface/v3-requirements.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_to_widget_html,
+)
+from attune.elicitation.bridge import form_to_askuserquestion
+from attune.elicitation.elicitation_schema import form_to_elicitation_schema
+from attune.meta_workflows.models import FormQuestion, QuestionType
+
+
+def _decision(**override) -> dict:
+    """Build a one-field decision form dict, overriding the field."""
+    field = {
+        "id": "approach",
+        "text": "Which approach?",
+        "type": "decision",
+        "options": ["X", "Y", "Z"],
+        "recommended": "Y",
+        "rationale": "Y is the safest.",
+        "option_notes": {"X": "fast", "Y": "safe", "Z": "cheap"},
+    }
+    field.update(override)
+    return {"title": "Pick one", "fields": [field]}
+
+
+class TestDecisionModel:
+    def test_questiontype_has_decision(self) -> None:
+        assert QuestionType.DECISION.value == "decision"
+
+    def test_formquestion_decision_fields_default_none(self) -> None:
+        q = FormQuestion(id="a", text="t", type=QuestionType.DECISION)
+        assert q.rationale is None
+        assert q.option_notes is None
+        assert q.recommended is None
+
+
+class TestDecisionFormFromDict:
+    def test_builds_decision_with_extras(self) -> None:
+        form = form_from_dict(_decision())
+        q = form.questions[0]
+        assert q.type == QuestionType.DECISION
+        assert q.recommended == "Y"
+        assert q.rationale == "Y is the safest."
+        assert q.option_notes == {"X": "fast", "Y": "safe", "Z": "cheap"}
+
+    def test_decision_requires_options(self) -> None:
+        with pytest.raises(FormValidationError, match="requires non-empty 'options'"):
+            form_from_dict(_decision(options=[]))
+
+    def test_recommended_must_be_an_option(self) -> None:
+        with pytest.raises(FormValidationError, match="'recommended' 'Ghost' not in options"):
+            form_from_dict(_decision(recommended="Ghost"))
+
+    def test_option_notes_keys_must_be_options(self) -> None:
+        with pytest.raises(FormValidationError, match="'option_notes' keys not in options"):
+            form_from_dict(_decision(option_notes={"Nope": "x"}))
+
+    def test_option_notes_must_be_string_map(self) -> None:
+        with pytest.raises(FormValidationError, match="'option_notes' must be a map of strings"):
+            form_from_dict(_decision(option_notes={"X": 5}))
+
+    def test_recommended_and_notes_optional(self) -> None:
+        # A decision with neither recommendation nor notes is valid.
+        form = form_from_dict(_decision(recommended=None, option_notes=None, rationale=None))
+        q = form.questions[0]
+        assert q.recommended is None and q.option_notes is None
+
+
+class TestDecisionAnswer:
+    def test_collect_accepts_selected_option(self) -> None:
+        form = form_from_dict(_decision())
+        resp = collect_form_response(form, {"approach": "Y"})
+        assert resp.responses == {"approach": "Y"}
+
+    def test_collect_rejects_out_of_option(self) -> None:
+        form = form_from_dict(_decision())
+        with pytest.raises(FormValidationError, match="not in options"):
+            collect_form_response(form, {"approach": "nope"})
+
+    def test_fallback_maps_to_single_select_recommended_first(self) -> None:
+        form = form_from_dict(_decision())
+        payload = form_to_askuserquestion(form)[0][0]
+        assert payload["type"] == "single_select"
+        # Recommended option is ordered first.
+        assert payload["options"][0] == "Y"
+        assert payload["default"] == "Y"
+
+
+class TestDecisionWidget:
+    def test_renders_cards_badge_rationale(self) -> None:
+        html = form_to_widget_html(form_from_dict(_decision()))
+        assert 'class="ae-cards"' in html
+        assert 'role="radiogroup"' in html
+        assert "Recommended" in html
+        assert 'class="ae-rationale"' in html
+        assert "Y is the safest." in html
+        assert "safe" in html  # an option_note
+
+    def test_recommended_ordered_first(self) -> None:
+        html = form_to_widget_html(form_from_dict(_decision()))
+        assert html.index('value="Y"') < html.index('value="X"')
+
+    def test_data_ftype_is_decision(self) -> None:
+        html = form_to_widget_html(form_from_dict(_decision()))
+        assert 'data-ftype="decision"' in html
+
+    def test_submit_script_has_decision_branch(self) -> None:
+        html = form_to_widget_html(form_from_dict(_decision()))
+        assert "ftype === 'decision'" in html
+        assert "[data-control]:checked" in html
+
+    def test_static_fallback_guard_present(self) -> None:
+        html = form_to_widget_html(form_from_dict(_decision()))
+        assert "typeof sendPrompt === 'function'" in html
+
+    def test_no_recommended_no_badge(self) -> None:
+        html = form_to_widget_html(form_from_dict(_decision(recommended=None, option_notes=None)))
+        assert "Recommended" not in html
+        assert 'class="ae-cards"' in html
+
+    def test_escapes_option_text(self) -> None:
+        html = form_to_widget_html(
+            form_from_dict(
+                _decision(
+                    options=["A & <b>", "Y", "Z"],
+                    recommended="Y",
+                    option_notes=None,
+                )
+            )
+        )
+        assert "A &amp; &lt;b&gt;" in html
+        assert "<b>" not in html
+
+
+class TestDecisionElicitationSchema:
+    def test_decision_maps_to_string_enum(self) -> None:
+        schema = form_to_elicitation_schema(form_from_dict(_decision()))
+        prop = schema["properties"]["approach"]
+        assert prop["type"] == "string"
+        assert prop["enum"] == ["X", "Y", "Z"]

--- a/tests/unit/mcp/test_tool_schemas.py
+++ b/tests/unit/mcp/test_tool_schemas.py
@@ -313,7 +313,7 @@ class TestGetPrompts:
 
 
 class TestGetElicitationTools:
-    """Field-type enum surfaces: v2 rich tools expose 7, v1 stays at 4."""
+    """Field-type enum surfaces: v2 rich tools expose 8, v1 stays at 4."""
 
     def test_v2_tools_present(self) -> None:
         tools = get_elicitation_tools()
@@ -329,8 +329,9 @@ class TestGetElicitationTools:
             "boolean",
         ]
 
-    def test_v2_tools_expose_all_seven_types(self) -> None:
-        # D10 enum-honesty fix: render_widget / ask accept the rich controls.
+    def test_v2_tools_expose_all_eight_types(self) -> None:
+        # D10 enum-honesty fix + V3 decision construct: render_widget / ask
+        # accept the rich controls plus decision.
         tools = get_elicitation_tools()
         expected = {
             "text_input",
@@ -340,6 +341,7 @@ class TestGetElicitationTools:
             "boolean",
             "number",
             "date",
+            "decision",
         }
         assert set(_field_types(tools, "elicitation_render_widget")) == expected
         assert set(_field_types(tools, "elicitation_ask")) == expected
@@ -357,6 +359,7 @@ class TestGetElicitationTools:
             "boolean",
             "number",
             "date",
+            "decision",
         }
         assert (
             set(_field_types(get_elicitation_tools(), "elicitation_collect_response")) == expected

--- a/tests/unit/ops/test_specs_routes.py
+++ b/tests/unit/ops/test_specs_routes.py
@@ -194,12 +194,19 @@ def test_specrecord_post_init_computes_lifecycle():
         SpecPhase(name="tasks", file="tasks.md", exists=False, status=None),
         SpecPhase(name="decisions", file="decisions.md", exists=False, status=None),
     ]
+    # Use a recently-modified timestamp (1 day ago) rather than a fixed
+    # calendar date: derive_lifecycle marks anything older than
+    # STALE_THRESHOLD_DAYS (30) as "stale", so a hardcoded date eventually
+    # ages past the window and flips this test from "active" to "stale".
+    from datetime import datetime, timedelta, timezone
+
+    recent = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
     record = SpecRecord(
         slug="example",
         root="/r",
         path="/r/example",
         phases=phases,
-        last_modified="2026-05-31T00:00:00+00:00",
+        last_modified=recent,
     )
     # requirements approved, no tasks file → falls to Rule 6 (Active)
     assert record.lifecycle == "active"


### PR DESCRIPTION
## What

Adds the **decision construct** to the elicitation form surface — the
first non-intake member of the declarative-form family (the
"communication grammar"). The agent offers a recommended option with a
rationale and per-option tradeoffs; the user picks one.

Folded into the `elicitation-form-surface` spec as **V3** (D14 +
`v3-requirements.md`) rather than a standalone spec, since it builds
directly on the shipped V1/V2 substrate.

## How

A `decision` is a **presentation-enriched single-select** — the answer
is one selected option, validated exactly like a single-select, so the
round-trip (`collect_form_response`) and validation are reused untouched.

- `QuestionType.DECISION` + optional `FormQuestion` fields `rationale`,
  `option_notes`, `recommended` (additive — existing forms unaffected).
- `widget.py` renders cards (recommended badge, per-option tradeoffs, a
  rationale callout) in a `role="radiogroup"`, with a radio-aware submit
  script and the existing `sendPrompt`-guarded static fallback.
- Rich MCP tool schema gains `decision` (count guard updated 7 → 8) so
  `elicitation_render_widget` accepts it on next server boot.
- `elicit` skill (both copies) documents the construct + its
  AskUserQuestion fallback; new `.claude/rules/attune/communication-grammar.md`
  names the family and how to add construct #3.

## Verification

- Affected suite: **559 passed, 3 skipped** (`tests/unit/elicitation/`,
  `tests/unit/meta_workflows/`, `tests/unit/mcp/test_tool_schemas.py`,
  plugin reference validation). New `test_decision_construct.py` covers
  model, definition + answer validation, widget render, round-trip,
  fallback, and schema mapping.
- Widget round-trip **dogfooded live via `show_widget`** (render →
  pick → `sendPrompt` sentinel → `collect_form_response`). This surface
  makes **no Anthropic API call**, so it is fully verifiable without API
  credits.

## Deferred (by design)

The full MCP-tool live dogfood (`elicitation_render_widget` through the
running server) needs a server boot on this code — deferred per the
established D9/D11 pattern, **not** blocked by anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
