### PR TITLE
fix(tests): de-time-bomb SpecRecord lifecycle test (unblocks all PRs)

### DIFF
--- a/tests/unit/ops/test_specs_routes.py
+++ b/tests/unit/ops/test_specs_routes.py
@@ -194,12 +194,19 @@ def test_specrecord_post_init_computes_lifecycle():
         SpecPhase(name="tasks", file="tasks.md", exists=False, status=None),
         SpecPhase(name="decisions", file="decisions.md", exists=False, status=None),
     ]
+    # Use a recently-modified timestamp (1 day ago) rather than a fixed
+    # calendar date: derive_lifecycle marks anything older than
+    # STALE_THRESHOLD_DAYS (30) as "stale", so a hardcoded date eventually
+    # ages past the window and flips this test from "active" to "stale".
+    from datetime import datetime, timedelta, timezone
+
+    recent = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
     record = SpecRecord(
         slug="example",
         root="/r",
         path="/r/example",
         phases=phases,
-        last_modified="2026-05-31T00:00:00+00:00",
+        last_modified=recent,
     )
     # requirements approved, no tasks file → falls to Rule 6 (Active)
     assert record.lifecycle == "active"


### PR DESCRIPTION
## What

`tests/unit/ops/test_specs_routes.py::test_specrecord_post_init_computes_lifecycle`
hardcoded `last_modified="2026-05-31T00:00:00+00:00"` and asserted
`lifecycle == "active"`.

`derive_lifecycle` marks anything older than `STALE_THRESHOLD_DAYS` (30)
as `"stale"`. As of 2026-06-30 that fixed date is >30 days old, so the
assertion flips to `"stale"` and the test fails in **every** CI lane
(all OS × Python matrix + `clock-tz`), turning the required `coverage`
and `test (...)` checks red on **every open PR**.

## Fix

Use a relative recent timestamp (1 day ago) so the test's intent —
recently-modified spec → `active` — holds on any calendar day.

Verified: full `test_specs_routes.py` (64 tests) green; CI macOS lane on
the affected branch showed exactly this one failure
(`1 failed, 20417 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)