### PR TITLE
feat(elicitation): pushback construct (communication grammar member #3, V4)

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -104,6 +104,52 @@ the recommended option ordered first and " (Recommended)" appended to its
 label; fold each `option_notes` tradeoff into that option's
 `description`, and use the `rationale` as the question's lead-in.
 
+## The pushback construct (v4)
+
+A `pushback` is a `decision` framed as **dissent**: the agent disagrees
+with the user's stated approach and offers a concrete alternative. Use it
+when a user-stated choice looks weaker than an alternative you can render
+concretely — the decision-routine "pushback discipline". Same
+single-select answer path as `decision`; only the framing differs. When
+it fires is governed by
+`.claude/rules/attune/decision-routine.md`.
+
+Extra field keys (all optional; reuses the decision keys plus one):
+
+- `user_position` — the option that is the user's stated approach; it is
+  tagged "your approach" (must be one of `options`).
+- `recommended` — the agent's alternative; badged "I'd suggest instead"
+  and ordered first (must be one of `options`).
+- `rationale` — the disagreement, shown beneath the cards under a "Why
+  I'd push back" header.
+- `option_notes` — `{option: one-line tradeoff}` shown under each card.
+
+```json
+{
+  "title": "Retry strategy",
+  "fields": [
+    {"id": "retries", "text": "How should we handle transient failures?",
+     "type": "pushback",
+     "options": ["Fixed 3x retry", "Exponential backoff + jitter"],
+     "user_position": "Fixed 3x retry",
+     "recommended": "Exponential backoff + jitter",
+     "rationale": "Fixed retries hammer a struggling service; backoff is gentler and avoids a thundering herd.",
+     "option_notes": {"Exponential backoff + jitter": "Industry default"}}
+  ]
+}
+```
+
+**Surface:** the dissent card layout renders on the **widget** surface
+(`elicitation_render_widget` → `show_widget`); the answer is one selected
+option (overrule = the user's approach, switch = the alternative),
+validated like a single-select.
+
+**AskUserQuestion fallback:** a `pushback` maps to a `single_select` with
+the agent's alternative ordered first; label the `user_position` option
+clearly as the user's current approach, fold each `option_notes` tradeoff
+into the matching option's `description`, and use the `rationale` (the
+disagreement) as the question's lead-in.
+
 ## Choosing a surface
 
 - **Rich / native — one call:** `elicitation_ask` renders the form as a

--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -165,6 +165,23 @@ When the user chooses "Start a new spec":
    - "I want to edit the plan file"
    - "Start over"
 
+5. **Pushback gate — a `pushback` construct.** If the user's
+   edit/rejection makes the plan *weaker* than what you drafted
+   AND you can render the concrete alternative (the
+   decision-routine "pushback discipline"), do not silently
+   comply — surface the disagreement as a `pushback` construct
+   (the user's approach tagged "your approach", your alternative
+   badged "I'd suggest instead", a "Why I'd push back"
+   rationale) via the `elicit` skill's widget surface
+   (`elicitation_render_widget` → `show_widget`), falling back to
+   its `AskUserQuestion` mapping (alternative first, rationale as
+   the lead-in) when the widget surface is unavailable. The
+   `elicit` skill owns the round-trip and validation — see its
+   "pushback construct" section. The user overrules (keeps their
+   edit) or switches with one pick. Skip this gate when you
+   genuinely agree with the edit, or when you cannot render a
+   concrete alternative — pushback without an artifact is hedging.
+
 ## Stage 3: Approve
 
 Show final summary: task count, scope, risks. Then:

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12290,3 +12290,31 @@ files.
   (execute-side), "spec-named scope drifts from code reality", and
   "next-session starter can be stale on arrival" — same family: main is
   ground truth; the worktree (and memory of "we worked on this") is not.
+
+- **Adding a communication-grammar construct that "reuses the
+  single-select answer path" still requires registering the new
+  `QuestionType` at SEVERAL enumeration sites — "reuse the answer path"
+  is not zero-touch**: building the V4 `pushback` construct (a
+  `decision`-shaped single-select, 2026-06-30), the model + widget +
+  field-definition validation all worked and 79/80 tests passed — but
+  `test_collect_rejects_out_of_option` FAILED because
+  `bridge.py::_validate_answer` listed only `(SINGLE_SELECT, DECISION)`
+  in its option-membership branch, so a PUSHBACK answer skipped
+  membership validation entirely (accepted garbage). The
+  `communication-grammar.md` how-to-extend step 3 ("map the answer to an
+  existing validator… only add validation logic for a genuinely new
+  answer shape") UNDERSOLD it: even when the answer shape is identical,
+  the new enum member must be ADDED to every type-tuple that enumerates
+  select-likes. In this codebase that is FOUR sites beyond the model:
+  (1) `bridge.py::_validate_answer` membership branch, (2)
+  `bridge.py::form_from_dict` options-required tuple, (3) `widget.py`
+  submit-script `ftype === 'decision'` reader condition, (4)
+  `elicitation_schema.py` string-enum tuple — plus the
+  `mcp/tool_schemas.py` rich enum and its `test_tool_schemas.py` count
+  guard. Diagnostic before declaring a new construct done: `grep -rn
+  "QuestionType.DECISION" src/attune/{elicitation,meta_workflows,mcp}`
+  and confirm the new member sits beside `DECISION` at EACH hit. A
+  per-type reject-out-of-option unit test is the cheap guard that
+  catches the miss. Pairs with "Registered ≠ working — dogfood the live
+  loop" (same discipline, applied to the validation layer of a
+  pure-logic reuse).

--- a/.claude/rules/attune/communication-grammar.md
+++ b/.claude/rules/attune/communication-grammar.md
@@ -62,12 +62,30 @@ validated exactly as a single-select. Extra `FormQuestion` slots:
 tradeoffs + rationale) on the widget surface; falls back to a
 recommendation-first single-select on `AskUserQuestion`.
 
+### pushback (v4)
+
+The agent **disagrees** with the user's stated approach and offers a
+concrete alternative + a disagreement rationale; the user picks one
+(overrule = keep their approach, or switch). A `QuestionType.PUSHBACK`
+is — like `decision` — a presentation-enriched single-select; the
+answer is one option, validated exactly as a single-select. It adds one
+optional slot, `user_position` (the option that is the user's stated
+approach), and reuses `recommended` (= the agent's alternative),
+`rationale`, and `option_notes`. The dissent framing is what
+distinguishes it from `decision`: the `user_position` card is tagged
+"your approach", the `recommended` card is badged "I'd suggest instead"
+(not "Recommended") and ordered first, and the rationale callout is
+headed "Why I'd push back". Falls back to a recommendation-first
+single-select on `AskUserQuestion`. When the pushback construct fires is
+governed by [decision-routine.md](decision-routine.md)'s pushback
+discipline — this is the shape, not the when.
+
 ---
 
-## How to add the next construct (#3)
+## How to add the next construct (#4)
 
-Keep it additive and substrate-reusing. The decision construct (v3) is
-the worked example to copy.
+Keep it additive and substrate-reusing. The decision (v3) and pushback
+(v4) constructs are the worked examples to copy.
 
 1. **Decide the shape.** Does it compose existing question types, or
    need a new `QuestionType`? Prefer composing. A new type is justified

--- a/.claude/rules/attune/decision-routine.md
+++ b/.claude/rules/attune/decision-routine.md
@@ -129,6 +129,15 @@ without a concrete artifact is hedging, creates friction, and
 carries no value. If I can't render the alternative, execute the
 user's plan and learn the boundary later.
 
+The concrete artifact this discipline requires has a first-class
+shape: the **pushback construct** (communication grammar member #3 —
+see [communication-grammar.md](communication-grammar.md)). When the
+surface can render it, present the disagreement AS a `pushback` (the
+user's approach tagged "your approach", my alternative badged "I'd
+suggest instead", a "Why I'd push back" rationale) rather than as
+prose — the user overrules or switches with one pick. `/spec`'s
+Stage 2 review is the worked consumer.
+
 ---
 
 ## Cross-references

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -490,6 +490,56 @@ The dogfood doubled as the parked construct-#3 product question
 (below): Patrick chose the **pushback construct**. No Anthropic API
 call on any step — the entire receipt cost zero credits.
 
+## D16 — V4: the pushback construct (grammar member #3)
+
+**Date:** 2026-06-30 · **Status:** built · see
+[v4-requirements.md](v4-requirements.md)
+
+Construct #3 is the **pushback** construct: agent-to-user, surfaces a
+disagreement with the user's stated approach + a concrete alternative
+and rationale. Two product choices Patrick made (2026-06-30, both via
+the live decision construct — dogfooding the grammar to extend it):
+
+- **#3 = pushback**, not a status/progress construct. Pushback reuses
+  the V3 substrate almost verbatim and encodes the standing
+  "pushback welcomed" working agreement.
+- **A new `QuestionType.PUSHBACK`**, not composing `decision`. The
+  value of pushback over decision is the *dissent framing* (the user's
+  approach shown as the status quo, the alternative badged "I'd suggest
+  instead", a "Why I'd push back" rationale). Composing `decision`
+  would be a doc convention, not a visible construct —
+  `communication-grammar.md` step 1 ("a new type is justified when
+  rendering OR answer-meaning genuinely differ") is cleared on the
+  rendering axis.
+- **Scope = substrate + one consumer.** Mirrors V3's footprint (model
+  + widget + round-trip + tests + dogfood) AND wires one real
+  consumer — the `/spec` Stage 2 review gate — so the construct proves
+  end-to-end value, the way `decision` got its consumer in #1176.
+
+Design parallels V3 exactly: the answer is one selected option, so
+`SINGLE_SELECT` validation and the round-trip are reused — V4 adds one
+optional field (`user_position`), a widget branch, and the consumer
+wiring. No Anthropic API call on any surface.
+
+**Build note — reuse gap caught by the dogfood discipline:**
+`_validate_answer` (`bridge.py`) listed only `SINGLE_SELECT`/`DECISION`
+for option-membership, so a PUSHBACK answer initially skipped
+validation. The unit test `test_collect_rejects_out_of_option` caught
+it; fixed by adding `PUSHBACK` to that tuple. "Reuse the answer path"
+needed one explicit line, not zero.
+
+**AC3 receipt status:** function-level + `show_widget`-level round-trip
+proven this session with a **real human submit** — real
+`form_to_widget_html` output rendered via `show_widget` (dissent
+framing intact), Patrick picked the alternative (a "switch"), the
+`__elicitation_response__` sentinel posted back, and
+`collect_form_response` validated it (`resp-20260630-013130`); it also
+rejects out-of-option picks. The full **MCP-tool** path
+(`elicitation_render_widget` / `elicitation_collect_response`) is
+blocked until this merges and the server reboots — the running server's
+enums lack `pushback` (the same D10/D11 / D15 pattern). Closes
+next-session like D15 did for `decision`.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/v4-requirements.md
+++ b/docs/specs/elicitation-form-surface/v4-requirements.md
@@ -1,0 +1,145 @@
+# Elicitation Form Surface — V4 Requirements
+
+## The pushback construct (communication grammar member #3)
+
+V4 adds the **pushback** construct — the third member of this spec's
+declarative-form family and the second non-intake one (after V3's
+`decision`). Where a `decision` offers a *neutral* recommendation, a
+pushback frames **dissent**: the agent disagrees with the user's stated
+approach and presents a concrete alternative + rationale, and the user
+chooses to overrule or switch.
+
+Patrick chose this as construct #3 (2026-06-30) over a status/progress
+construct, and chose **a new `QuestionType.PUSHBACK`** over composing
+the existing `decision` type — because the whole value of pushback over
+decision is the dissent framing; composing would be a doc note, not a
+construct. Scope is **substrate + one consumer**.
+
+## What already exists — reuse, do not rebuild
+
+- `FormSchema` / `FormQuestion` / `QuestionType` / `FormResponse`
+  (`meta_workflows/models.py`).
+- The V3 `decision` machinery: `rationale` / `option_notes` /
+  `recommended` fields (`models.py:95-97`), the card renderer
+  (`widget.py:_control_html` DECISION branch, `:57-75`), the rationale
+  callout (`widget.py:141-156`), and `form_from_dict` validation of the
+  decision extras (`bridge.py:140-179`).
+- `collect_form_response` validation (R4) and the live round-trip
+  (`form_to_widget_html` → `show_widget` → `sendPrompt` sentinel →
+  `collect_form_response`), proven for `decision` in D15.
+- The `elicit` skill surface-mapping + AskUserQuestion fallback (D7).
+
+## The gap — confirmed against models.py + widget.py + bridge.py
+
+A pushback is a presentation-enriched `SINGLE_SELECT` like `decision`,
+but the substrate cannot express the dissent framing:
+
+- which option is **the user's stated approach** (the status-quo card),
+  vs the agent's preferred alternative;
+- the dissent labels — a "your approach" tag on the user's option, an
+  "I'd suggest instead" badge on the alternative (not "Recommended"),
+  and a "Why I'd push back" rationale header (not "Why").
+
+`decision` renders all alternatives as peers with one neutral
+"Recommended" badge — it cannot show *which* option the user already
+chose, so it reads as advice, not disagreement.
+
+## Key insight — the answer path is unchanged
+
+A pushback's answer is exactly one selected option (overrule = the
+user's approach; switch = the alternative), which `SINGLE_SELECT`
+already validates by membership. The round-trip (sentinel JSON →
+`collect_form_response`) and validation are reused **untouched**. V4 is
+the dissent presentation plus a thin, additive model extension —
+exactly the V3 shape.
+
+This surface makes **no Anthropic API call**, so V4 is fully buildable
+and dogfoodable with no API credits (same as V3).
+
+## Requirements
+
+- RV4.1 — Add `QuestionType.PUSHBACK` (an enriched single-select with
+  dissent framing).
+- RV4.2 — One additive optional `FormQuestion` field: `user_position`
+  (`str | None`, must be one of `options` when set) — the option that
+  is the user's stated approach. Reuse `recommended` (= the agent's
+  alternative), `rationale` (= the disagreement rationale), and
+  `option_notes` (= per-option tradeoffs) unchanged. All optional;
+  existing forms unaffected.
+- RV4.3 — `widget.py` renders `PUSHBACK` as cards: the `user_position`
+  card tagged "your approach", the `recommended` card badged "I'd
+  suggest instead" and ordered first, a "Why I'd push back" rationale
+  callout. The answer posts as the selected option (same payload
+  shape; reuse the decision JS reader).
+- RV4.4 — AskUserQuestion fallback (`elicit` skill): `PUSHBACK` maps to
+  a `single_select`, agent's alternative first (recommendation-first,
+  D7), the user's approach clearly labelled, rationale folded into the
+  question text / option help.
+- RV4.5 — Degrades to a readable static card where `sendPrompt` is
+  absent (inherits the widget's behavior).
+- RV4.6 — `form_from_dict` (`bridge.py`) validates the pushback fields:
+  `user_position` and `recommended` must each be in `options`; reuse
+  the decision validation for `rationale` / `option_notes`.
+- RV4.7 — `collect_form_response` and the round-trip are unchanged;
+  guarded by reusing the existing validation tests.
+- RV4.8 — **Consumer (substrate + one consumer):** wire pushback into
+  the `/spec` task-review gate — when the user rejects/edits a task in
+  a way the agent assesses as weaker AND it can render the concrete
+  alternative, present a `pushback` instead of prose (the
+  decision-routine "pushback discipline"). `decision-routine.md` gains
+  a pointer naming the pushback construct as THE concrete artifact its
+  discipline requires. (Exact gate confirmed at task review — see T6.)
+- RV4.9 — Surfaces: widen the rich enum in `mcp/tool_schemas.py` to
+  include `pushback` and update the count guard in
+  `tests/unit/mcp/test_tool_schemas.py`; map it in
+  `elicitation_schema.py` if native elicitation should carry it; keep
+  `.agents/` skill mirrors synced (`scripts/sync_agents_skills.py`).
+
+## Acceptance criteria
+
+- AC1 — `PUSHBACK` type + `user_position` field added; existing form
+  tests stay green (additive, backward-compatible).
+- AC2 — A real pushback renders as the dissent card layout ("your
+  approach" tag + "I'd suggest instead" badge + "Why I'd push back"
+  rationale) AND as the AskUserQuestion fallback, from one
+  `FormSchema`.
+- AC3 — Round-trip proven live: `elicitation_render_widget` →
+  `show_widget` → pick → `sendPrompt` sentinel →
+  `elicitation_collect_response` success (the receipt; mirrors D15).
+- AC4 — Static fallback verified (`sendPrompt` undefined → readable).
+- AC5 — Keyboard accessible (radiogroup / Enter + Space) on the cards.
+- AC6 — The consumer fires: the `/spec` task-review gate renders a
+  pushback when the agent disagrees, and `decision-routine.md` points
+  to the construct.
+- AC7 — `communication-grammar.md` lists pushback as member #3 and the
+  "how to add the next construct" worked example still holds.
+
+## Out of scope
+
+- New surfaces — native MCP elicitation stays a non-renderer on CC
+  (D10); only the enum/mapping is touched for forward-compat.
+- `slider` / `color` controls (still deferred).
+- The trigger discipline (WHEN to push back) lives in
+  `decision-routine.md`; V4 supplies the artifact + one wired gate, not
+  a rewrite of the discipline.
+- A status/progress construct (the option not chosen) — future #4.
+
+## Tasks (for review)
+
+- T1 — model: `QuestionType.PUSHBACK` + `user_position` field +
+  `to_askuserquestion` fallback (recommendation-first, like decision).
+- T2 — `bridge.py`: `form_from_dict` validates `PUSHBACK`
+  (`user_position` ∈ options; reuse decision extras validation).
+- T3 — `widget.py`: `_control_html` `PUSHBACK` cards (your-approach tag
+  + "I'd suggest instead" badge + "Why I'd push back" callout) + CSS +
+  accessibility; reuse the decision JS reader.
+- T4 — `elicit` skill: `PUSHBACK` → AskUserQuestion fallback mapping
+  (+ `.agents/` mirror via `sync_agents_skills.py`).
+- T5 — surfaces: `mcp/tool_schemas.py` enum + `test_tool_schemas.py`
+  count guard; `elicitation_schema.py` map (forward-compat).
+- T6 — consumer: wire pushback into the `/spec` task-review gate +
+  `decision-routine.md` pointer (RV4.8; confirm exact gate here).
+- T7 — `communication-grammar.md`: add pushback as member #3.
+- T8 — tests: model (additive) + bridge validation + widget render
+  (dissent structure) + round-trip reuse; plus the live dogfood
+  receipt (AC3).

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -106,6 +106,52 @@ the recommended option ordered first and " (Recommended)" appended to its
 label; fold each `option_notes` tradeoff into that option's
 `description`, and use the `rationale` as the question's lead-in.
 
+## The pushback construct (v4)
+
+A `pushback` is a `decision` framed as **dissent**: the agent disagrees
+with the user's stated approach and offers a concrete alternative. Use it
+when a user-stated choice looks weaker than an alternative you can render
+concretely — the decision-routine "pushback discipline". Same
+single-select answer path as `decision`; only the framing differs. When
+it fires is governed by
+`.claude/rules/attune/decision-routine.md`.
+
+Extra field keys (all optional; reuses the decision keys plus one):
+
+- `user_position` — the option that is the user's stated approach; it is
+  tagged "your approach" (must be one of `options`).
+- `recommended` — the agent's alternative; badged "I'd suggest instead"
+  and ordered first (must be one of `options`).
+- `rationale` — the disagreement, shown beneath the cards under a "Why
+  I'd push back" header.
+- `option_notes` — `{option: one-line tradeoff}` shown under each card.
+
+```json
+{
+  "title": "Retry strategy",
+  "fields": [
+    {"id": "retries", "text": "How should we handle transient failures?",
+     "type": "pushback",
+     "options": ["Fixed 3x retry", "Exponential backoff + jitter"],
+     "user_position": "Fixed 3x retry",
+     "recommended": "Exponential backoff + jitter",
+     "rationale": "Fixed retries hammer a struggling service; backoff is gentler and avoids a thundering herd.",
+     "option_notes": {"Exponential backoff + jitter": "Industry default"}}
+  ]
+}
+```
+
+**Surface:** the dissent card layout renders on the **widget** surface
+(`elicitation_render_widget` → `show_widget`); the answer is one selected
+option (overrule = the user's approach, switch = the alternative),
+validated like a single-select.
+
+**AskUserQuestion fallback:** a `pushback` maps to a `single_select` with
+the agent's alternative ordered first; label the `user_position` option
+clearly as the user's current approach, fold each `option_notes` tradeoff
+into the matching option's `description`, and use the `rationale` (the
+disagreement) as the question's lead-in.
+
 ## Choosing a surface
 
 - **Rich / native — one call:** `elicitation_ask` renders the form as a

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -167,6 +167,23 @@ When the user chooses "Start a new spec":
    - "I want to edit the plan file"
    - "Start over"
 
+5. **Pushback gate — a `pushback` construct.** If the user's
+   edit/rejection makes the plan *weaker* than what you drafted
+   AND you can render the concrete alternative (the
+   decision-routine "pushback discipline"), do not silently
+   comply — surface the disagreement as a `pushback` construct
+   (the user's approach tagged "your approach", your alternative
+   badged "I'd suggest instead", a "Why I'd push back"
+   rationale) via the `elicit` skill's widget surface
+   (`elicitation_render_widget` → `show_widget`), falling back to
+   its `AskUserQuestion` mapping (alternative first, rationale as
+   the lead-in) when the widget surface is unavailable. The
+   `elicit` skill owns the round-trip and validation — see its
+   "pushback construct" section. The user overrules (keeps their
+   edit) or switches with one pick. Skip this gate when you
+   genuinely agree with the edit, or when you cannot render a
+   concrete alternative — pushback without an artifact is hedging.
+
 ## Stage 3: Approve
 
 Show final summary: task count, scope, risks. Then:

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -114,7 +114,13 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
             problems.append(f"{where} 'options' must be a list of strings")
             options = []
         if (
-            qtype in (QuestionType.SINGLE_SELECT, QuestionType.MULTI_SELECT, QuestionType.DECISION)
+            qtype
+            in (
+                QuestionType.SINGLE_SELECT,
+                QuestionType.MULTI_SELECT,
+                QuestionType.DECISION,
+                QuestionType.PUSHBACK,
+            )
             and not options
         ):
             problems.append(f"{where} type {qtype.value} requires non-empty 'options'")
@@ -162,6 +168,16 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
             if stray:
                 problems.append(f"{where} 'option_notes' keys not in options: {stray}")
 
+        # v4 PUSHBACK extra: user_position — the option that is the user's
+        # stated approach (tagged "your approach"). Parsed generically; only
+        # PUSHBACK renders it. Must be one of options when set.
+        user_position = raw.get("user_position")
+        if user_position is not None and not isinstance(user_position, str):
+            problems.append(f"{where} 'user_position' must be a string")
+            user_position = None
+        elif user_position is not None and options and user_position not in options:
+            problems.append(f"{where} 'user_position' {user_position!r} not in options")
+
         if fid and text and isinstance(fid, str) and isinstance(text, str):
             questions.append(
                 FormQuestion(
@@ -178,6 +194,7 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
                     rationale=rationale,
                     option_notes=option_notes,
                     recommended=recommended,
+                    user_position=user_position,
                 )
             )
 
@@ -221,7 +238,11 @@ def _validate_answer(question: FormQuestion, value: Any) -> str | None:
             return f"{question.id!r} has out-of-option value(s): {bad}"
         return None
 
-    if question.type in (QuestionType.SINGLE_SELECT, QuestionType.DECISION):
+    if question.type in (
+        QuestionType.SINGLE_SELECT,
+        QuestionType.DECISION,
+        QuestionType.PUSHBACK,
+    ):
         if value not in question.options:
             return f"{question.id!r} value {value!r} not in options"
         return None

--- a/src/attune/elicitation/elicitation_schema.py
+++ b/src/attune/elicitation/elicitation_schema.py
@@ -30,7 +30,11 @@ def _property_for(question: FormQuestion) -> dict[str, Any]:
     """
     prop: dict[str, Any] = {"title": question.text}
 
-    if question.type in (QuestionType.SINGLE_SELECT, QuestionType.DECISION):
+    if question.type in (
+        QuestionType.SINGLE_SELECT,
+        QuestionType.DECISION,
+        QuestionType.PUSHBACK,
+    ):
         prop.update(type="string", enum=list(question.options))
     elif question.type == QuestionType.MULTI_SELECT:
         prop.update(type="array", items={"type": "string", "enum": list(question.options)})

--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -74,6 +74,32 @@ def _control_html(q: FormQuestion) -> str:
             )
         return f'<div class="ae-cards" role="radiogroup">{cards}</div>'
 
+    if q.type == QuestionType.PUSHBACK:
+        # Dissent framing: the agent's alternative (``recommended``) is badged
+        # "I'd suggest instead" and ordered first; the user's stated approach
+        # (``user_position``) carries a muted "your approach" tag. Same radio
+        # answer path as DECISION.
+        notes = q.option_notes or {}
+        ordered = list(q.options)
+        if q.recommended and q.recommended in ordered:
+            ordered = [q.recommended] + [o for o in ordered if o != q.recommended]
+        cards = ""
+        for opt in ordered:
+            is_rec = opt == q.recommended
+            is_user = opt == q.user_position
+            badge = '<span class="ae-rec-badge">I&#x27;d suggest instead</span>' if is_rec else ""
+            tag = '<span class="ae-yours-tag">your approach</span>' if is_user else ""
+            note = f'<span class="ae-card-note">{_esc(notes[opt])}</span>' if opt in notes else ""
+            checked = " checked" if q.default == opt else ""
+            cls = "ae-card ae-card-rec" if is_rec else "ae-card"
+            cards += (
+                f'<label class="{cls}">'
+                f'<input type="radio" name="{_esc(q.id)}" data-control '
+                f'value="{_esc(opt)}"{checked}>'
+                f'{badge}{tag}<span class="ae-card-title">{_esc(opt)}</span>{note}</label>'
+            )
+        return f'<div class="ae-cards" role="radiogroup">{cards}</div>'
+
     if q.type == QuestionType.MULTI_SELECT:
         boxes = "".join(
             f'<label class="ae-check"><input type="checkbox" data-control '
@@ -139,12 +165,14 @@ def _field_html(q: FormQuestion) -> str:
     """Render one labelled field (label + optional help + control).
 
     For a DECISION question a ``rationale`` callout ("why this
-    recommendation") is rendered beneath the option cards.
+    recommendation") is rendered beneath the option cards; for a PUSHBACK
+    the same callout is headed "Why I'd push back".
     """
     req = '<span class="ae-req" title="required">*</span>' if q.required else ""
     help_html = f'<div class="ae-help">{_esc(q.help_text)}</div>' if q.help_text else ""
+    rationale_h = "Why I&#x27;d push back" if q.type == QuestionType.PUSHBACK else "Why"
     rationale_html = (
-        f'<div class="ae-rationale"><span class="ae-rationale-h">Why</span>'
+        f'<div class="ae-rationale"><span class="ae-rationale-h">{rationale_h}</span>'
         f"{_esc(q.rationale)}</div>"
         if q.rationale
         else ""
@@ -222,6 +250,8 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
 #attune-elicit-form .ae-card-note {{ font-size:13px; color:var(--text-muted); }}
 #attune-elicit-form .ae-rec-badge {{ font-size:11px; font-weight:600;
   text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }}
+#attune-elicit-form .ae-yours-tag {{ font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-muted); }}
 #attune-elicit-form .ae-rationale {{ margin:.6rem 0 0; padding:.4rem 0 .4rem .75rem;
   font-size:13px; color:var(--text-secondary);
   border-left:2px solid var(--border-accent); }}
@@ -258,7 +288,7 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
           vals.push(c.value);
         }});
         answers[fid] = vals;
-      }} else if (ftype === 'decision') {{
+      }} else if (ftype === 'decision' || ftype === 'pushback') {{
         var picked = f.querySelector('[data-control]:checked');
         if (picked) answers[fid] = picked.value;
       }} else {{

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -441,12 +441,15 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
                     "number",
                     "date",
                     "decision",
+                    "pushback",
                 ],
                 "description": (
                     "Control type. v1: text_input/single_select/multi_select/"
                     "boolean. v2.1 rich: textarea, number (min/max), date "
                     "(YYYY-MM-DD). v3: decision (a recommended single-select "
-                    "with rationale + per-option tradeoffs, widget surface)."
+                    "with rationale + per-option tradeoffs, widget surface). "
+                    "v4: pushback (decision framed as dissent — the user's "
+                    "approach vs the agent's alternative, widget surface)."
                 ),
             },
             "minimum": {"type": "number", "description": "Lower bound for number"},
@@ -466,6 +469,11 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
             "option_notes": {
                 "type": "object",
                 "description": "decision: {option: one-line tradeoff} shown under each card",
+            },
+            "user_position": {
+                "type": "string",
+                "description": "pushback: the option that is the user's stated approach "
+                "(tagged 'your approach'; must be in options)",
             },
         },
         "required": ["id", "text", "type"],

--- a/src/attune/meta_workflows/models.py
+++ b/src/attune/meta_workflows/models.py
@@ -42,6 +42,13 @@ class QuestionType(str, Enum):
     # tradeoffs; the answer is one selected option (validated exactly as a
     # single-select). The rich card layout is widget-surface only.
     DECISION = "decision"
+    # v4 (communication grammar member #3): a pushback — the agent
+    # disagrees with the user's stated approach (``user_position``) and
+    # offers a concrete alternative (``recommended``) + a disagreement
+    # ``rationale``. Same enriched-single-select answer path as DECISION;
+    # only the dissent framing (your-approach tag, "I'd suggest instead"
+    # badge, "Why I'd push back" callout) differs. Widget-surface only.
+    PUSHBACK = "pushback"
 
 
 class TierStrategy(str, Enum):
@@ -77,8 +84,12 @@ class FormQuestion:
             rendered beneath the options; None = none
         option_notes: DECISION only — {option: one-line tradeoff} shown
             under each option card; None = none
-        recommended: DECISION only — the option to badge as recommended
-            and order first; must be one of options; None = none
+        recommended: DECISION/PUSHBACK — the option to badge (recommended,
+            or the agent's alternative for PUSHBACK) and order first; must
+            be one of options; None = none
+        user_position: PUSHBACK only — the option that is the user's stated
+            approach (tagged "your approach"); must be one of options;
+            None = none
 
     """
 
@@ -95,6 +106,7 @@ class FormQuestion:
     rationale: str | None = None
     option_notes: dict[str, str] | None = None
     recommended: str | None = None
+    user_position: str | None = None
 
     def to_ask_user_format(self) -> dict[str, Any]:
         """Convert to format compatible with AskUserQuestion tool.
@@ -103,10 +115,11 @@ class FormQuestion:
             Dictionary with question data for AskUserQuestion
 
         """
-        # Decision (v3) falls back to a single-select with the recommended
-        # option ordered first (the richer card layout is widget-only); the
-        # answer is one selected option.
-        if self.type == QuestionType.DECISION:
+        # Decision (v3) and pushback (v4) both fall back to a single-select
+        # with the recommended option (the agent's alternative, for pushback)
+        # ordered first — the richer card layout is widget-only; the answer
+        # is one selected option either way.
+        if self.type in (QuestionType.DECISION, QuestionType.PUSHBACK):
             opts = list(self.options)
             if self.recommended and self.recommended in opts:
                 opts = [self.recommended] + [o for o in opts if o != self.recommended]

--- a/tests/unit/elicitation/test_pushback_construct.py
+++ b/tests/unit/elicitation/test_pushback_construct.py
@@ -1,0 +1,166 @@
+"""Tests for the V4 pushback construct (communication grammar member #3).
+
+A PUSHBACK is a DECISION framed as dissent: the agent disagrees with the
+user's stated approach (``user_position``) and offers a concrete
+alternative (``recommended``) with a disagreement ``rationale``. The
+answer is one selected option, validated exactly as a single-select.
+These tests cover the model extension, definition validation, the dissent
+widget render, the answer round-trip, the AskUserQuestion fallback, and
+the elicitation schema mapping. See
+docs/specs/elicitation-form-surface/v4-requirements.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_to_widget_html,
+)
+from attune.elicitation.bridge import form_to_askuserquestion
+from attune.elicitation.elicitation_schema import form_to_elicitation_schema
+from attune.meta_workflows.models import FormQuestion, QuestionType
+
+
+def _pushback(**override) -> dict:
+    """Build a one-field pushback form dict, overriding the field."""
+    field = {
+        "id": "retries",
+        "text": "How should we handle transient failures?",
+        "type": "pushback",
+        "options": ["Fixed 3x retry", "Exponential backoff + jitter"],
+        "user_position": "Fixed 3x retry",
+        "recommended": "Exponential backoff + jitter",
+        "rationale": "Fixed retries hammer a struggling service.",
+        "option_notes": {"Exponential backoff + jitter": "Industry default"},
+    }
+    field.update(override)
+    return {"title": "Retry strategy", "fields": [field]}
+
+
+class TestPushbackModel:
+    def test_questiontype_has_pushback(self) -> None:
+        assert QuestionType.PUSHBACK.value == "pushback"
+
+    def test_formquestion_user_position_defaults_none(self) -> None:
+        q = FormQuestion(id="a", text="t", type=QuestionType.PUSHBACK)
+        assert q.user_position is None
+        assert q.recommended is None
+        assert q.rationale is None
+
+
+class TestPushbackFormFromDict:
+    def test_builds_pushback_with_extras(self) -> None:
+        form = form_from_dict(_pushback())
+        q = form.questions[0]
+        assert q.type == QuestionType.PUSHBACK
+        assert q.user_position == "Fixed 3x retry"
+        assert q.recommended == "Exponential backoff + jitter"
+        assert q.rationale == "Fixed retries hammer a struggling service."
+
+    def test_pushback_requires_options(self) -> None:
+        with pytest.raises(FormValidationError, match="requires non-empty 'options'"):
+            form_from_dict(_pushback(options=[]))
+
+    def test_user_position_must_be_an_option(self) -> None:
+        with pytest.raises(FormValidationError, match="'user_position' 'Ghost' not in options"):
+            form_from_dict(_pushback(user_position="Ghost"))
+
+    def test_user_position_must_be_a_string(self) -> None:
+        with pytest.raises(FormValidationError, match="'user_position' must be a string"):
+            form_from_dict(_pushback(user_position=5))
+
+    def test_recommended_must_be_an_option(self) -> None:
+        with pytest.raises(FormValidationError, match="'recommended' 'Ghost' not in options"):
+            form_from_dict(_pushback(recommended="Ghost"))
+
+    def test_user_position_optional(self) -> None:
+        # A pushback with no explicit user_position is still valid.
+        form = form_from_dict(_pushback(user_position=None))
+        assert form.questions[0].user_position is None
+
+
+class TestPushbackAnswer:
+    def test_collect_accepts_selected_option(self) -> None:
+        form = form_from_dict(_pushback())
+        resp = collect_form_response(form, {"retries": "Exponential backoff + jitter"})
+        assert resp.responses == {"retries": "Exponential backoff + jitter"}
+
+    def test_collect_accepts_overrule(self) -> None:
+        # Picking the user's own position (overrule) is a valid answer.
+        form = form_from_dict(_pushback())
+        resp = collect_form_response(form, {"retries": "Fixed 3x retry"})
+        assert resp.responses == {"retries": "Fixed 3x retry"}
+
+    def test_collect_rejects_out_of_option(self) -> None:
+        form = form_from_dict(_pushback())
+        with pytest.raises(FormValidationError, match="not in options"):
+            collect_form_response(form, {"retries": "nope"})
+
+    def test_fallback_maps_to_single_select_alternative_first(self) -> None:
+        form = form_from_dict(_pushback())
+        payload = form_to_askuserquestion(form)[0][0]
+        assert payload["type"] == "single_select"
+        # The agent's alternative (recommended) is ordered first.
+        assert payload["options"][0] == "Exponential backoff + jitter"
+        assert payload["default"] == "Exponential backoff + jitter"
+
+
+class TestPushbackWidget:
+    def test_renders_dissent_framing(self) -> None:
+        html = form_to_widget_html(form_from_dict(_pushback()))
+        assert 'class="ae-cards"' in html
+        assert 'role="radiogroup"' in html
+        assert "I&#x27;d suggest instead" in html  # alternative badge
+        assert "your approach" in html  # user_position tag
+        assert "Why I&#x27;d push back" in html  # rationale header
+        assert "Fixed retries hammer a struggling service." in html
+
+    def test_alternative_ordered_first(self) -> None:
+        html = form_to_widget_html(form_from_dict(_pushback()))
+        assert html.index('value="Exponential backoff + jitter"') < html.index(
+            'value="Fixed 3x retry"'
+        )
+
+    def test_data_ftype_is_pushback(self) -> None:
+        html = form_to_widget_html(form_from_dict(_pushback()))
+        assert 'data-ftype="pushback"' in html
+
+    def test_submit_script_handles_pushback(self) -> None:
+        html = form_to_widget_html(form_from_dict(_pushback()))
+        assert "ftype === 'pushback'" in html
+        assert "[data-control]:checked" in html
+
+    def test_static_fallback_guard_present(self) -> None:
+        html = form_to_widget_html(form_from_dict(_pushback()))
+        assert "typeof sendPrompt === 'function'" in html
+
+    def test_not_decision_recommended_badge(self) -> None:
+        # A pushback must NOT use the neutral "Recommended" badge — that is
+        # the decision construct's framing; pushback is dissent.
+        html = form_to_widget_html(form_from_dict(_pushback()))
+        assert ">Recommended<" not in html
+
+    def test_escapes_option_text(self) -> None:
+        html = form_to_widget_html(
+            form_from_dict(
+                _pushback(
+                    options=["A & <b>", "Exponential backoff + jitter"],
+                    user_position="A & <b>",
+                    option_notes=None,
+                )
+            )
+        )
+        assert "A &amp; &lt;b&gt;" in html
+        assert "<b>" not in html
+
+
+class TestPushbackElicitationSchema:
+    def test_pushback_maps_to_string_enum(self) -> None:
+        schema = form_to_elicitation_schema(form_from_dict(_pushback()))
+        prop = schema["properties"]["retries"]
+        assert prop["type"] == "string"
+        assert prop["enum"] == ["Fixed 3x retry", "Exponential backoff + jitter"]

--- a/tests/unit/mcp/test_tool_schemas.py
+++ b/tests/unit/mcp/test_tool_schemas.py
@@ -313,7 +313,7 @@ class TestGetPrompts:
 
 
 class TestGetElicitationTools:
-    """Field-type enum surfaces: v2 rich tools expose 8, v1 stays at 4."""
+    """Field-type enum surfaces: v2 rich tools expose 9, v1 stays at 4."""
 
     def test_v2_tools_present(self) -> None:
         tools = get_elicitation_tools()
@@ -329,9 +329,10 @@ class TestGetElicitationTools:
             "boolean",
         ]
 
-    def test_v2_tools_expose_all_eight_types(self) -> None:
-        # D10 enum-honesty fix + V3 decision construct: render_widget / ask
-        # accept the rich controls plus decision.
+    def test_v2_tools_expose_all_nine_types(self) -> None:
+        # D10 enum-honesty fix + V3 decision + V4 pushback constructs:
+        # render_widget / ask accept the rich controls plus decision and
+        # pushback.
         tools = get_elicitation_tools()
         expected = {
             "text_input",
@@ -342,6 +343,7 @@ class TestGetElicitationTools:
             "number",
             "date",
             "decision",
+            "pushback",
         }
         assert set(_field_types(tools, "elicitation_render_widget")) == expected
         assert set(_field_types(tools, "elicitation_ask")) == expected
@@ -360,6 +362,7 @@ class TestGetElicitationTools:
             "number",
             "date",
             "decision",
+            "pushback",
         }
         assert (
             set(_field_types(get_elicitation_tools(), "elicitation_collect_response")) == expected


### PR DESCRIPTION
## What

Adds the **pushback** construct — member #3 of the communication grammar (`docs/specs/elicitation-form-surface/`, V4 / decision D16). A `QuestionType.PUSHBACK` is a `decision` framed as **dissent**: the agent disagrees with the user's stated approach and offers a concrete alternative + rationale; the user overrules or switches with one pick.

Follows the V3 `decision` construct's footprint exactly (#1174 substrate, #1176 consumer). The answer is one selected option, so single-select validation and the round-trip are **reused** — V4 adds one optional field, a widget branch, and one consumer.

## Design (Patrick's two product picks, 2026-06-30)

- **New `QuestionType.PUSHBACK`**, not composing `decision` — the value is the dissent framing (the user's approach tagged "your approach", the alternative badged "I'd suggest instead", a "Why I'd push back" rationale). Cleared `communication-grammar.md` step 1 on the rendering axis.
- **Scope = substrate + one consumer** — wired into the `/spec` Stage 2 review gate.

## Changes

- `models.py` — `QuestionType.PUSHBACK` + `user_position` field + alternative-first `AskUserQuestion` fallback.
- `bridge.py` — `form_from_dict` validates `user_position` ∈ options; `_validate_answer` enforces membership for PUSHBACK.
- `widget.py` — dissent card render + CSS + submit reader.
- `tool_schemas.py` — rich enum 8 → 9 types + `user_position`; `elicitation_schema.py` maps PUSHBACK (forward-compat).
- Consumer: `/spec` Stage 2 review gate + `decision-routine.md` pushback-discipline pointer; documented in the `elicit` skill (+ `.agents/` mirror).
- `communication-grammar.md` — pushback as member #3.
- Tests: `tests/unit/elicitation/test_pushback_construct.py` + tool-schema count guard.

## Dogfood receipt (AC3)

Function + `show_widget` round-trip proven this session with a **real human submit** — real `form_to_widget_html` output rendered via `show_widget`, the alternative picked (a "switch"), sentinel posted back, `collect_form_response` validated (`resp-20260630-013130`). The reuse claim was load-bearing: the dogfood caught that `_validate_answer` skipped membership for PUSHBACK — fixed + regression-tested. The full **MCP-tool** path closes after merge + server reboot (the D10/D11/D15 pattern). **No Anthropic API call** on any surface.

## Sequencing

Sibling of (not stacked on) the now-merged D15 PR #1177; builds on D15 (merged into this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)