### PR TITLE
docs(spec): record AC3 live-MCP pushback-construct receipt (D16)

### DIFF
--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -528,17 +528,26 @@ validation. The unit test `test_collect_rejects_out_of_option` caught
 it; fixed by adding `PUSHBACK` to that tuple. "Reuse the answer path"
 needed one explicit line, not zero.
 
-**AC3 receipt status:** function-level + `show_widget`-level round-trip
-proven this session with a **real human submit** — real
-`form_to_widget_html` output rendered via `show_widget` (dissent
-framing intact), Patrick picked the alternative (a "switch"), the
-`__elicitation_response__` sentinel posted back, and
-`collect_form_response` validated it (`resp-20260630-013130`); it also
-rejects out-of-option picks. The full **MCP-tool** path
-(`elicitation_render_widget` / `elicitation_collect_response`) is
-blocked until this merges and the server reboots — the running server's
-enums lack `pushback` (the same D10/D11 / D15 pattern). Closes
-next-session like D15 did for `decision`.
+**AC3 receipt status — CLOSED 2026-06-30.** Proven on both surfaces
+with **real human submits**:
+
+- **`show_widget` / function level** (build session): real
+  `form_to_widget_html` output rendered via `show_widget`, dissent
+  framing intact, Patrick picked the alternative (a "switch"), the
+  `__elicitation_response__` sentinel posted back, and
+  `collect_form_response` validated it (`resp-20260630-013130`); it also
+  rejects out-of-option picks.
+- **Full MCP-tool path** (next session, after #1178 merged
+  `1cd7707be` and the server rebooted on main): the live
+  `mcp__attune-ai__elicitation_render_widget` schema enum now carries
+  `"pushback"` (9 types) + `user_position`/`recommended`/`rationale`/
+  `option_notes`. Rendered a real pushback form through that tool →
+  `show_widget` → Patrick submitted → `elicitation_collect_response`
+  validated it: `success: true`, `resp-20260630-015652`. This submit
+  was an **overrule** (Patrick kept his own approach — "Build construct
+  #4"), the complementary arm to the build session's "switch", so both
+  pushback outcomes are now exercised end-to-end. The D10/D11 / D15
+  "registered ≠ working until the server reboots" pattern held exactly.
 
 ## Open
 


### PR DESCRIPTION
Closes the pushback construct's MCP-tool AC3 dogfood (the deferred thread from #1178 / D16).

## What

After #1178 merged (`1cd7707be`) and the MCP server rebooted on main, the live `mcp__attune-ai__elicitation_render_widget` schema enum now carries `"pushback"` (9 types) + `user_position`/`recommended`/`rationale`/`option_notes`. Ran the full MCP-tool round-trip:

1. `elicitation_render_widget` with a real `pushback` form → `html`
2. `show_widget` → **human submit**
3. `elicitation_collect_response` validated → `success: true`, `resp-20260630-015652`

The submit was an **overrule** (Patrick kept his own approach), the complementary arm to the build session's "switch" — so both pushback outcomes are now exercised end-to-end.

This records the receipt in D16 of `docs/specs/elicitation-form-surface/decisions.md` and flips AC3 to **CLOSED**. Mirrors D15 for the `decision` construct.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)