### PR TITLE
feat(elicitation): progress construct (communication grammar member #4, V5)

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -150,6 +150,58 @@ clearly as the user's current approach, fold each `option_notes` tradeoff
 into the matching option's `description`, and use the `rationale` (the
 disagreement) as the question's lead-in.
 
+## The progress construct (v5)
+
+A `progress` is a **report**, not a fork: the agent reports a set of items
+by status — `done` / `in_flight` / `blocked` — and surfaces the **blocked**
+items as a single-select picker ("which blocker do you want to tackle?").
+Use it to report where multi-step work stands while keeping the next move
+one pick away. Same single-select answer path as `decision` (the answer is
+one blocked item); when nothing is blocked it degrades to a pure status
+display with no answer.
+
+Extra field keys (all optional; reuses the decision keys plus one):
+
+- `progress_items` — the reported items as `{label, status, detail?}` dicts,
+  `status` ∈ `done` / `in_flight` / `blocked`. **The blocked subset's labels
+  must equal `options`** (the picker offers exactly the actionable items);
+  `done`/`in_flight` items are reported but not pickable.
+- `recommended` — the blocked item to suggest tackling first; badged
+  "suggested next" and ordered first (must be one of `options`).
+- `rationale` — a one-line report summary, shown under a "Summary" header.
+- `option_notes` — `{blocked-option: one-line detail}` shown under each card
+  (a blocked item's `detail` is used as a fallback note when absent).
+
+```json
+{
+  "title": "Spec execution",
+  "fields": [
+    {"id": "exec", "text": "Where execution stands", "type": "progress",
+     "options": ["T6 consumer wiring"],
+     "recommended": "T6 consumer wiring",
+     "rationale": "1 of 8 tasks blocked on a quality gate.",
+     "progress_items": [
+       {"label": "T1 model", "status": "done"},
+       {"label": "T3 widget", "status": "in_flight", "detail": "rendering cards"},
+       {"label": "T6 consumer wiring", "status": "blocked", "detail": "gate failed: score 42"}
+     ]}
+  ]
+}
+```
+
+When nothing is blocked, set `options: []` and `required: false` — the
+report renders as a status display with no picker.
+
+**Surface:** the three-bucket layout (static done/in_flight rows + the
+blocked radiogroup picker) renders on the **widget** surface
+(`elicitation_render_widget` → `show_widget`); the answer is the one
+selected blocked item, validated like a single-select.
+
+**AskUserQuestion fallback:** a `progress` folds the done/in_flight/blocked
+summary into the question text and maps the **blocked** items to a
+`single_select` with the `recommended` item ordered first. When there are
+no blocked items there is nothing to ask — just narrate the report.
+
 ## Choosing a surface
 
 - **Rich / native — one call:** `elicitation_ask` renders the form as a

--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -262,6 +262,36 @@ For each pending task:
    save_state(state)
    ```
 
+### Execution status report — a `progress` construct
+
+At a multi-task checkpoint — **on resume** (Stage 5), and **after an
+"Auto-run remaining tasks" batch finishes** — report where the run
+stands as a `progress` construct rather than prose. This is the
+multi-task overview; it complements the per-task `decision` gate above
+(that gates ONE task; this summarizes ALL of them).
+
+Build one `progress` field and render it via the `elicit` skill's widget
+surface (`elicitation_render_widget` → `show_widget`), falling back to
+its `AskUserQuestion` mapping — see the `elicit` skill's "progress
+construct" section:
+
+- `progress_items`: one `{label, status, detail?}` per task — `done`
+  for completed tasks, `in_flight` for the current task, `blocked` for
+  any task that failed a high-severity gate and was deferred
+  ("Acknowledge risk and continue"). Use the task name as `label` and
+  the failing gate + score as `detail`.
+- `options`: the labels of the `blocked` tasks (must equal the blocked
+  subset). The picker asks **"which blocked task to fix/retry?"** —
+  selecting one re-enters the per-task implement + gate flow for it.
+- `recommended`: the blocked task to tackle first (e.g. highest
+  severity); badged "suggested next".
+- `rationale`: a one-line run summary (e.g. "6/8 done, 2 deferred on
+  gate failures").
+
+When **no task is blocked**, build it display-only (`options: []`,
+`required: false`) — it renders as a clean done/in_flight status board
+with no picker.
+
 ## Stage 5: Resume
 
 On invocation, check for resumable plans:

--- a/.claude/rules/attune/communication-grammar.md
+++ b/.claude/rules/attune/communication-grammar.md
@@ -80,12 +80,36 @@ single-select on `AskUserQuestion`. When the pushback construct fires is
 governed by [decision-routine.md](decision-routine.md)'s pushback
 discipline — this is the shape, not the when.
 
+### progress (v5)
+
+The agent **reports** a set of items by status — `done` / `in_flight` /
+`blocked` — and surfaces the **blocked** items as a single-select picker
+("which blocker do you want to tackle?"); the user picks one. It is the
+first member that is a *report* rather than a fork. A
+`QuestionType.PROGRESS` is — like `decision` / `pushback` — a
+presentation-enriched single-select whose answer is one blocked option,
+validated exactly as a single-select. It adds one optional slot,
+`progress_items` (the reported items as `{label, status, detail?}` dicts;
+the `blocked` subset's labels must equal `options`), and reuses
+`recommended` (= the blocked item to tackle first, badged "suggested
+next"), `rationale` (= a "Summary" callout), and `option_notes`. The
+widget renders three buckets: `done`/`in_flight` items as static rows,
+`blocked` items as the radiogroup picker. When **nothing is blocked**
+(`options` empty) it degrades to a pure status display with no answer —
+so "pure display" is a sub-state of one construct, not a separate member,
+and the substrate stays answer-validated whenever there is something
+actionable. Falls back to a recommendation-first single-select over the
+blocked items on `AskUserQuestion` (the done/in_flight summary folds into
+the question text). First consumer: the `/spec` execute gate (done =
+completed tasks, in_flight = current task, blocked = quality-gate
+failures; the picker = "which blocked task to fix/retry").
+
 ---
 
-## How to add the next construct (#4)
+## How to add the next construct (#5)
 
-Keep it additive and substrate-reusing. The decision (v3) and pushback
-(v4) constructs are the worked examples to copy.
+Keep it additive and substrate-reusing. The decision (v3), pushback
+(v4), and progress (v5) constructs are the worked examples to copy.
 
 1. **Decide the shape.** Does it compose existing question types, or
    need a new `QuestionType`? Prefer composing. A new type is justified

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -549,6 +549,66 @@ with **real human submits**:
   pushback outcomes are now exercised end-to-end. The D10/D11 / D15
   "registered ≠ working until the server reboots" pattern held exactly.
 
+## D17 — V5: the progress construct (grammar member #4)
+
+**Date:** 2026-06-30 · **Status:** built · see
+[v5-requirements.md](v5-requirements.md)
+
+Construct #4 is the **progress** construct: agent-to-user, reports a set
+of items by status (`done` / `in_flight` / `blocked`) and surfaces the
+blocked items as a single-select picker. It is the first member that is a
+*report* rather than a fork. Three product choices Patrick made
+(2026-06-30, all via the live decision construct — dogfooding the grammar
+to extend it):
+
+- **Build construct #4**, not stop the grammar. (The "Build construct #4"
+  click in the D16 AC3 dogfood was a throwaway receipt, per the
+  next-session starter; this is the real directive made via a fresh
+  decision form.)
+- **Answer path = report + blocked-item picker**, not a pure display or a
+  bare acknowledge. This keeps the construct answer-validated: the
+  blocked items become the `options` of a `SINGLE_SELECT`, so the answer
+  is one selected blocker, validated by membership — the V3/V4 answer
+  path reused untouched. A pure display would never run the validator
+  (markdown-in-a-form, the weakest substrate fit). A consequence falls
+  out cleanly: when **nothing is blocked**, `options` is empty and the
+  construct degrades to a pure status display — so "pure display" is a
+  sub-state of one construct, not a separate member.
+- **First consumer = the `/spec` execute gate**, not session-start
+  orientation or the workflow sweep. The execute loop already has the
+  done/in_flight/blocked shape natively (completed tasks, the current
+  task, tasks that fail a quality gate), and the blocked-item picker maps
+  exactly onto "which blocked task to fix/retry". Tightest, most
+  dogfoodable wiring — mirrors how V4 wired into the Stage 2 review gate.
+
+A new `QuestionType.PROGRESS` is justified on the rendering axis
+(`communication-grammar.md` step 1): the three-bucket status board with
+static done/in_flight rows + a blocked radiogroup is genuinely new
+rendering, even though the answer-meaning is a single-select. V5 adds one
+optional field (`progress_items`), a widget branch, the enum
+(`tool_schemas` 9→10), and the consumer wiring. No Anthropic API call on
+any surface.
+
+**Build note — invariant caught at design, not after.** Because
+`options` carries only the *answerable* (blocked) subset while
+`progress_items` carries *all* items, the two can disagree. The bridge
+enforces `set(blocked labels) == set(options)` in `form_from_dict`, and a
+unit test (`test_blocked_subset_must_equal_options`) guards it — the
+picker can never offer a non-existent blocker or omit a real one.
+
+**AC3 receipt status — widget render PROVEN; full MCP path PENDING reboot.**
+The widget path makes no API call, so the production render was dogfooded
+live this session: real `form_to_widget_html` output (8 tasks: 6 done, 1
+in-flight, 1 blocked) rendered via `show_widget` — three buckets, the
+"suggested next" badge on the blocked picker, the "Summary" callout, all
+intact. `collect_form_response` round-trip + the empty-blocked degrade
+are proven by unit tests (85 pass). The full
+`mcp__attune-ai__elicitation_render_widget` → human submit →
+`elicitation_collect_response` receipt closes next session once #<this PR>
+merges and the live server reboots with the `"progress"` enum (10 types)
+— the exact D15/D16 "registered ≠ working until the server reboots"
+pattern.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/v5-requirements.md
+++ b/docs/specs/elicitation-form-surface/v5-requirements.md
@@ -1,0 +1,182 @@
+# Elicitation Form Surface — V5 Requirements
+
+## The progress construct (communication grammar member #4)
+
+V5 adds the **progress** construct — the fourth member of this spec's
+declarative-form family and the first that is a *report* rather than a
+fork. Where `intake` (#1), `decision` (#2), and `pushback` (#3) each ask
+the user to choose, a progress construct **reports** the state of a set
+of items — done / in-flight / blocked — agent→user, and surfaces the
+**blocked** items as a single-select picker ("which blocker do you want
+to tackle?").
+
+Patrick chose this as construct #4 (2026-06-30) over stopping the
+grammar, chose the **report + blocked-item picker** answer path over a
+pure display or a bare acknowledge, and chose the **`/spec` execute
+gate** as the first consumer. Scope is **substrate + one consumer**.
+
+## Why it still fits the substrate
+
+The substrate (`FormSchema` of `FormQuestion`s + `collect_form_response`
+validation, R4) is built around *questions with answers*. A pure status
+display would never run the validator — markdown-in-a-form, the weakest
+fit. The chosen shape keeps the construct answer-validated: the report's
+**blocked** items become the `options` of a `SINGLE_SELECT`, so the
+answer is exactly one selected blocker — validated by membership,
+**reusing the decision/pushback answer path untouched**.
+
+When there are **zero blocked items**, `options` is empty and the
+construct degrades to a pure status *display* (no radiogroup, no answer).
+That makes "pure display" a natural sub-state of one construct, not a
+separate member — the substrate stays answer-validated whenever there is
+something actionable.
+
+This surface makes **no Anthropic API call**, so V5 is fully buildable
+and dogfoodable with no API credits (same as V3/V4).
+
+## What already exists — reuse, do not rebuild
+
+- `FormSchema` / `FormQuestion` / `QuestionType` / `FormResponse`
+  (`meta_workflows/models.py`).
+- The single-select answer path: `to_ask_user_format`
+  (`models.py:119-131`, recommendation-first ordering) and
+  `collect_form_response` membership validation (R4).
+- The V3/V4 card machinery: `recommended` / `rationale` / `option_notes`
+  fields (`models.py:106-109`), the card renderer and rationale callout
+  (`widget.py:_control_html`), and `form_from_dict` validation of the
+  decision/pushback extras (`bridge.py`).
+- The live round-trip (`form_to_widget_html` → `show_widget` →
+  `sendPrompt` sentinel → `collect_form_response`), proven for
+  `decision` (D15) and `pushback` (D16).
+- The `elicit` skill surface-mapping + AskUserQuestion fallback (D7).
+
+## The gap — confirmed against models.py + widget.py + bridge.py
+
+A progress report is a `SINGLE_SELECT` over its blocked items, but the
+substrate cannot express the report itself:
+
+- the **non-answerable** items — everything that is `done` or
+  `in_flight` is reported but is NOT a pickable option;
+- the per-item **status** (`done` / `in_flight` / `blocked`) that drives
+  the three-bucket layout and the status badges.
+
+`option_notes` carries per-option detail but only for items that ARE
+options; there is no way to carry items that are reported-but-not-
+answerable, nor their status. That is the one genuinely new piece of
+data V5 adds.
+
+## Naming
+
+New enum member `QuestionType.PROGRESS = "progress"` (single word, like
+`DECISION` / `PUSHBACK`). The grammar member is the "progress" /
+"status-report" construct.
+
+## Requirements
+
+- RV5.1 — Add `QuestionType.PROGRESS` (a report that renders three
+  status buckets and offers its blocked items as an enriched
+  single-select picker).
+- RV5.2 — One additive optional `FormQuestion` field: `progress_items`
+  (`list[dict[str, str]] | None`), each item `{label, status, detail?}`
+  with `status` ∈ {`done`, `in_flight`, `blocked`}. Reuse `recommended`
+  (= the blocked item to suggest tackling first), `rationale` (= the
+  report summary / "why this next" callout), and `option_notes` (=
+  per-blocked-item detail) unchanged. All optional; existing forms
+  unaffected.
+- RV5.3 — Invariant: `options` MUST equal the set of `progress_items`
+  whose `status == "blocked"` (the picker offers exactly the actionable
+  items). `recommended`, when set, MUST be one of `options`.
+- RV5.4 — `widget.py` renders `PROGRESS` as three buckets — Done (✓),
+  In-flight (◐), Blocked (✕) — with status badges. `done`/`in_flight`
+  items are **static rows** (not selectable); `blocked` items are the
+  **selectable radiogroup cards** (the picker), `recommended` ordered
+  first with a "suggested next" badge, optional `rationale` callout. The
+  answer posts as the selected option (same payload shape; reuse the
+  decision JS reader).
+- RV5.5 — Empty-blocked degrade: when no item is `blocked` (`options`
+  empty), render a pure status display — no radiogroup, no answer
+  control — and the round-trip is a no-op (display only).
+- RV5.6 — AskUserQuestion fallback (`elicit` skill): `PROGRESS` folds
+  the done/in-flight/blocked summary into the question text and maps the
+  blocked items to a `single_select` (suggested-first, D7). When there
+  are no blocked items there is no AskUserQuestion to ask — the agent
+  narrates the report.
+- RV5.7 — Degrades to a readable static report where `sendPrompt` is
+  absent (inherits the widget's behavior).
+- RV5.8 — `form_from_dict` (`bridge.py`) validates the progress fields:
+  each `progress_items` entry has a valid `status`; the blocked subset
+  equals `options` (RV5.3); `recommended` ∈ `options`; reuse the
+  decision validation for `rationale` / `option_notes`.
+- RV5.9 — `collect_form_response` and the round-trip are unchanged (the
+  answer is a single-select membership check); guarded by reusing the
+  existing validation tests.
+- RV5.10 — **Consumer (substrate + one consumer):** wire `progress`
+  into the `/spec` execute gate — render a progress report at the
+  execute loop's reporting point: `done` = completed tasks, `in_flight`
+  = the current task, `blocked` = tasks that failed a quality gate
+  (severity-gated). The blocked-item picker = "which blocked task to
+  fix/retry", and selecting one routes to the fix-and-retry path. (Exact
+  integration point confirmed at task review — see T6.)
+- RV5.11 — Surfaces: widen the rich enum in `mcp/tool_schemas.py` to
+  include `progress` (9→10) and add `progress_items`; update the count
+  guard in `tests/unit/mcp/test_tool_schemas.py`; map it in
+  `elicitation_schema.py` (forward-compat); keep `.agents/` skill
+  mirrors synced (`scripts/sync_agents_skills.py`).
+
+## Acceptance criteria
+
+- AC1 — `PROGRESS` type + `progress_items` field added; existing form
+  tests stay green (additive, backward-compatible).
+- AC2 — A real progress report renders as the three-bucket layout
+  (done/in-flight static rows + blocked radiogroup picker with
+  "suggested next" badge) AND as the AskUserQuestion fallback, from one
+  `FormSchema`.
+- AC3 — Round-trip proven live: `elicitation_render_widget` →
+  `show_widget` → pick a blocked item → `sendPrompt` sentinel →
+  `elicitation_collect_response` success (the receipt; mirrors D15/D16).
+- AC4 — Empty-blocked degrade verified: a report with no blocked items
+  renders as a pure display (no picker) and is a round-trip no-op.
+- AC5 — Static fallback verified (`sendPrompt` undefined → readable
+  report).
+- AC6 — Keyboard accessible (radiogroup / Enter + Space) on the blocked
+  cards.
+- AC7 — The consumer fires: the `/spec` execute gate renders a progress
+  report with the blocked-task picker.
+- AC8 — `communication-grammar.md` lists progress as member #4 and the
+  "how to add the next construct" worked example still holds.
+
+## Out of scope
+
+- New surfaces — native MCP elicitation stays a non-renderer on CC
+  (D10); only the enum/mapping is touched for forward-compat.
+- `slider` / `color` controls (still deferred).
+- Multi-select over blocked items (tackle several at once) — the picker
+  is single-select to reuse the answer path untouched; batch-fix is a
+  future refinement, not V5.
+- Live/streaming progress updates — the construct is a point-in-time
+  report rendered when the consumer reaches its reporting point, not a
+  continuously-updating widget.
+
+## Tasks (for review)
+
+- T1 — model: `QuestionType.PROGRESS` + `progress_items` field +
+  `to_ask_user_format` fallback (blocked items → single-select,
+  suggested-first).
+- T2 — `bridge.py`: `form_from_dict` validates `PROGRESS`
+  (`progress_items` statuses; blocked subset == options; recommended ∈
+  options; reuse decision extras validation).
+- T3 — `widget.py`: `_control_html` `PROGRESS` three-bucket render
+  (done/in-flight static rows + blocked radiogroup cards + "suggested
+  next" badge + rationale callout) + CSS + accessibility + empty-blocked
+  degrade; reuse the decision JS reader.
+- T4 — `elicit` skill: `PROGRESS` → AskUserQuestion fallback mapping
+  (+ `.agents/` mirror via `sync_agents_skills.py`).
+- T5 — surfaces: `mcp/tool_schemas.py` enum (9→10) + `progress_items` +
+  `test_tool_schemas.py` count guard; `elicitation_schema.py` map
+  (forward-compat).
+- T6 — consumer: wire progress into the `/spec` execute gate +
+  confirm the exact reporting point (RV5.10).
+- T7 — `communication-grammar.md`: add progress as member #4.
+- T8 — tests: model (additive) + bridge validation + widget render
+  (three-bucket + empty-blocked degrade) + round-trip reuse; plus the
+  live dogfood receipt (AC3).

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -152,6 +152,58 @@ clearly as the user's current approach, fold each `option_notes` tradeoff
 into the matching option's `description`, and use the `rationale` (the
 disagreement) as the question's lead-in.
 
+## The progress construct (v5)
+
+A `progress` is a **report**, not a fork: the agent reports a set of items
+by status — `done` / `in_flight` / `blocked` — and surfaces the **blocked**
+items as a single-select picker ("which blocker do you want to tackle?").
+Use it to report where multi-step work stands while keeping the next move
+one pick away. Same single-select answer path as `decision` (the answer is
+one blocked item); when nothing is blocked it degrades to a pure status
+display with no answer.
+
+Extra field keys (all optional; reuses the decision keys plus one):
+
+- `progress_items` — the reported items as `{label, status, detail?}` dicts,
+  `status` ∈ `done` / `in_flight` / `blocked`. **The blocked subset's labels
+  must equal `options`** (the picker offers exactly the actionable items);
+  `done`/`in_flight` items are reported but not pickable.
+- `recommended` — the blocked item to suggest tackling first; badged
+  "suggested next" and ordered first (must be one of `options`).
+- `rationale` — a one-line report summary, shown under a "Summary" header.
+- `option_notes` — `{blocked-option: one-line detail}` shown under each card
+  (a blocked item's `detail` is used as a fallback note when absent).
+
+```json
+{
+  "title": "Spec execution",
+  "fields": [
+    {"id": "exec", "text": "Where execution stands", "type": "progress",
+     "options": ["T6 consumer wiring"],
+     "recommended": "T6 consumer wiring",
+     "rationale": "1 of 8 tasks blocked on a quality gate.",
+     "progress_items": [
+       {"label": "T1 model", "status": "done"},
+       {"label": "T3 widget", "status": "in_flight", "detail": "rendering cards"},
+       {"label": "T6 consumer wiring", "status": "blocked", "detail": "gate failed: score 42"}
+     ]}
+  ]
+}
+```
+
+When nothing is blocked, set `options: []` and `required: false` — the
+report renders as a status display with no picker.
+
+**Surface:** the three-bucket layout (static done/in_flight rows + the
+blocked radiogroup picker) renders on the **widget** surface
+(`elicitation_render_widget` → `show_widget`); the answer is the one
+selected blocked item, validated like a single-select.
+
+**AskUserQuestion fallback:** a `progress` folds the done/in_flight/blocked
+summary into the question text and maps the **blocked** items to a
+`single_select` with the `recommended` item ordered first. When there are
+no blocked items there is nothing to ask — just narrate the report.
+
 ## Choosing a surface
 
 - **Rich / native — one call:** `elicitation_ask` renders the form as a

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -264,6 +264,36 @@ For each pending task:
    save_state(state)
    ```
 
+### Execution status report — a `progress` construct
+
+At a multi-task checkpoint — **on resume** (Stage 5), and **after an
+"Auto-run remaining tasks" batch finishes** — report where the run
+stands as a `progress` construct rather than prose. This is the
+multi-task overview; it complements the per-task `decision` gate above
+(that gates ONE task; this summarizes ALL of them).
+
+Build one `progress` field and render it via the `elicit` skill's widget
+surface (`elicitation_render_widget` → `show_widget`), falling back to
+its `AskUserQuestion` mapping — see the `elicit` skill's "progress
+construct" section:
+
+- `progress_items`: one `{label, status, detail?}` per task — `done`
+  for completed tasks, `in_flight` for the current task, `blocked` for
+  any task that failed a high-severity gate and was deferred
+  ("Acknowledge risk and continue"). Use the task name as `label` and
+  the failing gate + score as `detail`.
+- `options`: the labels of the `blocked` tasks (must equal the blocked
+  subset). The picker asks **"which blocked task to fix/retry?"** —
+  selecting one re-enters the per-task implement + gate flow for it.
+- `recommended`: the blocked task to tackle first (e.g. highest
+  severity); badged "suggested next".
+- `rationale`: a one-line run summary (e.g. "6/8 done, 2 deferred on
+  gate failures").
+
+When **no task is blocked**, build it display-only (`options: []`,
+`required: false`) — it renders as a clean done/in_flight status board
+with no picker.
+
 ## Stage 5: Resume
 
 On invocation, check for resumable plans:

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -178,6 +178,43 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
         elif user_position is not None and options and user_position not in options:
             problems.append(f"{where} 'user_position' {user_position!r} not in options")
 
+        # v5 PROGRESS extra: progress_items — the reported items keyed by
+        # status. Parsed generically; only PROGRESS renders them. Each item
+        # is {label, status, detail?}; status ∈ {done, in_flight, blocked};
+        # the blocked subset's labels must equal options (the picker offers
+        # exactly the actionable items). PROGRESS allows empty options (when
+        # nothing is blocked it degrades to a pure status display).
+        progress_items = raw.get("progress_items")
+        if progress_items is not None:
+            if not isinstance(progress_items, list) or not all(
+                isinstance(it, dict) for it in progress_items
+            ):
+                problems.append(f"{where} 'progress_items' must be a list of dicts")
+                progress_items = None
+            else:
+                valid_status = {"done", "in_flight", "blocked"}
+                blocked_labels = []
+                for idx, item in enumerate(progress_items):
+                    label = item.get("label")
+                    status = item.get("status")
+                    if not isinstance(label, str) or not label:
+                        problems.append(f"{where} progress_items[{idx}] needs a 'label' string")
+                    if status not in valid_status:
+                        problems.append(
+                            f"{where} progress_items[{idx}] 'status' must be one of {valid_status}"
+                        )
+                    if "detail" in item and not isinstance(item["detail"], str):
+                        problems.append(f"{where} progress_items[{idx}] 'detail' must be a string")
+                    if status == "blocked" and isinstance(label, str):
+                        blocked_labels.append(label)
+                if qtype is QuestionType.PROGRESS and set(blocked_labels) != set(options):
+                    problems.append(
+                        f"{where} PROGRESS blocked items {sorted(set(blocked_labels))} "
+                        f"must equal options {sorted(set(options))}"
+                    )
+        elif qtype is QuestionType.PROGRESS:
+            problems.append(f"{where} type progress requires 'progress_items'")
+
         if fid and text and isinstance(fid, str) and isinstance(text, str):
             questions.append(
                 FormQuestion(
@@ -195,6 +232,7 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
                     option_notes=option_notes,
                     recommended=recommended,
                     user_position=user_position,
+                    progress_items=progress_items,
                 )
             )
 
@@ -242,6 +280,10 @@ def _validate_answer(question: FormQuestion, value: Any) -> str | None:
         QuestionType.SINGLE_SELECT,
         QuestionType.DECISION,
         QuestionType.PUSHBACK,
+        # PROGRESS: a provided answer is one selected blocked item, validated
+        # by membership. When nothing is blocked the form is built display-
+        # only (required=False, empty options) and no answer is collected.
+        QuestionType.PROGRESS,
     ):
         if value not in question.options:
             return f"{question.id!r} value {value!r} not in options"

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -194,17 +194,21 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
             else:
                 valid_status = {"done", "in_flight", "blocked"}
                 blocked_labels = []
-                for idx, item in enumerate(progress_items):
+                for progress_idx, item in enumerate(progress_items):
                     label = item.get("label")
                     status = item.get("status")
                     if not isinstance(label, str) or not label:
-                        problems.append(f"{where} progress_items[{idx}] needs a 'label' string")
+                        problems.append(
+                            f"{where} progress_items[{progress_idx}] needs a 'label' string"
+                        )
                     if status not in valid_status:
                         problems.append(
-                            f"{where} progress_items[{idx}] 'status' must be one of {valid_status}"
+                            f"{where} progress_items[{progress_idx}] 'status' must be one of {valid_status}"
                         )
                     if "detail" in item and not isinstance(item["detail"], str):
-                        problems.append(f"{where} progress_items[{idx}] 'detail' must be a string")
+                        problems.append(
+                            f"{where} progress_items[{progress_idx}] 'detail' must be a string"
+                        )
                     if status == "blocked" and isinstance(label, str):
                         blocked_labels.append(label)
                 if qtype is QuestionType.PROGRESS and set(blocked_labels) != set(options):

--- a/src/attune/elicitation/elicitation_schema.py
+++ b/src/attune/elicitation/elicitation_schema.py
@@ -34,6 +34,10 @@ def _property_for(question: FormQuestion) -> dict[str, Any]:
         QuestionType.SINGLE_SELECT,
         QuestionType.DECISION,
         QuestionType.PUSHBACK,
+        # PROGRESS's answer is one blocked option — a string enum, like the
+        # other enriched single-selects (forward-compat; native elicitation
+        # is a non-renderer on CC, D10).
+        QuestionType.PROGRESS,
     ):
         prop.update(type="string", enum=list(question.options))
     elif question.type == QuestionType.MULTI_SELECT:

--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -100,6 +100,60 @@ def _control_html(q: FormQuestion) -> str:
             )
         return f'<div class="ae-cards" role="radiogroup">{cards}</div>'
 
+    if q.type == QuestionType.PROGRESS:
+        # A status report: done/in_flight items render as static rows; the
+        # blocked items become the radiogroup picker (recommended first,
+        # "suggested next" badge). With no blocked items the picker is
+        # omitted and the control is a pure status display.
+        items = q.progress_items or []
+        notes = q.option_notes or {}
+        by_status: dict[str, list[dict[str, str]]] = {"done": [], "in_flight": [], "blocked": []}
+        for it in items:
+            st = it.get("status", "")
+            if st in by_status:
+                by_status[st].append(it)
+        rows = ""
+        for status_key, icon, sr in (("done", "✓", "done"), ("in_flight", "◐", "in progress")):
+            for it in by_status[status_key]:
+                detail = (
+                    f'<span class="ae-prog-detail">{_esc(it["detail"])}</span>'
+                    if it.get("detail")
+                    else ""
+                )
+                rows += (
+                    f'<div class="ae-prog-row ae-prog-{status_key}">'
+                    f'<span class="ae-prog-icon" aria-hidden="true">{icon}</span>'
+                    f'<span class="ae-prog-label">{_esc(it.get("label", ""))}</span>{detail}'
+                    f'<span class="sr-only"> ({sr})</span></div>'
+                )
+        ordered = list(q.options)
+        if q.recommended and q.recommended in ordered:
+            ordered = [q.recommended] + [o for o in ordered if o != q.recommended]
+        detail_by_label = {it.get("label"): it.get("detail") for it in by_status["blocked"]}
+        cards = ""
+        for opt in ordered:
+            is_rec = opt == q.recommended
+            badge = '<span class="ae-rec-badge">suggested next</span>' if is_rec else ""
+            note_text = notes.get(opt) or detail_by_label.get(opt)
+            note = f'<span class="ae-card-note">{_esc(note_text)}</span>' if note_text else ""
+            checked = " checked" if q.default == opt else ""
+            cls = "ae-card ae-card-rec" if is_rec else "ae-card"
+            cards += (
+                f'<label class="{cls}">'
+                f'<input type="radio" name="{_esc(q.id)}" data-control '
+                f'value="{_esc(opt)}"{checked}>'
+                f'<span class="ae-prog-icon ae-prog-blocked" aria-hidden="true">✕</span>'
+                f'{badge}<span class="ae-card-title">{_esc(opt)}</span>{note}</label>'
+            )
+        picker = (
+            '<div class="ae-prog-blocked-h">Blocked — pick one to tackle:</div>'
+            f'<div class="ae-cards" role="radiogroup">{cards}</div>'
+            if cards
+            else ""
+        )
+        rows_html = f'<div class="ae-prog-rows">{rows}</div>' if rows else ""
+        return f'<div class="ae-progress">{rows_html}{picker}</div>'
+
     if q.type == QuestionType.MULTI_SELECT:
         boxes = "".join(
             f'<label class="ae-check"><input type="checkbox" data-control '
@@ -166,11 +220,16 @@ def _field_html(q: FormQuestion) -> str:
 
     For a DECISION question a ``rationale`` callout ("why this
     recommendation") is rendered beneath the option cards; for a PUSHBACK
-    the same callout is headed "Why I'd push back".
+    the same callout is headed "Why I'd push back"; for a PROGRESS report
+    it is headed "Summary".
     """
     req = '<span class="ae-req" title="required">*</span>' if q.required else ""
     help_html = f'<div class="ae-help">{_esc(q.help_text)}</div>' if q.help_text else ""
-    rationale_h = "Why I&#x27;d push back" if q.type == QuestionType.PUSHBACK else "Why"
+    rationale_headers = {
+        QuestionType.PUSHBACK: "Why I&#x27;d push back",
+        QuestionType.PROGRESS: "Summary",
+    }
+    rationale_h = rationale_headers.get(q.type, "Why")
     rationale_html = (
         f'<div class="ae-rationale"><span class="ae-rationale-h">{rationale_h}</span>'
         f"{_esc(q.rationale)}</div>"
@@ -258,6 +317,22 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
 #attune-elicit-form .ae-rationale-h {{ display:block; font-weight:600;
   font-size:11px; text-transform:uppercase; letter-spacing:.03em;
   color:var(--text-accent); margin-bottom:.15rem; }}
+#attune-elicit-form .ae-progress {{ display:flex; flex-direction:column; gap:.5rem; }}
+#attune-elicit-form .ae-prog-rows {{ display:flex; flex-direction:column; gap:.25rem; }}
+#attune-elicit-form .ae-prog-row {{ display:flex; align-items:baseline; gap:.5rem;
+  font-size:14px; color:var(--text-secondary); }}
+#attune-elicit-form .ae-prog-icon {{ flex:none; font-weight:700; width:1.1em;
+  text-align:center; }}
+#attune-elicit-form .ae-prog-done .ae-prog-icon {{ color:var(--text-success,#3fb950); }}
+#attune-elicit-form .ae-prog-in_flight .ae-prog-icon {{ color:var(--text-accent); }}
+#attune-elicit-form .ae-prog-blocked {{ color:var(--text-accent); }}
+#attune-elicit-form .ae-prog-detail {{ font-size:13px; color:var(--text-muted); }}
+#attune-elicit-form .ae-prog-label {{ color:var(--text-primary); }}
+#attune-elicit-form .ae-prog-done .ae-prog-label {{ text-decoration:line-through;
+  color:var(--text-muted); }}
+#attune-elicit-form .ae-prog-blocked-h {{ font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }}
+#attune-elicit-form .ae-card .ae-prog-icon {{ margin-right:.15rem; }}
 #attune-elicit-form .ae-submit {{ margin-top:.5rem; padding:.55rem 1.1rem;
   font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary);
   background:var(--bg-accent); border:1px solid var(--border-accent);
@@ -288,7 +363,9 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
           vals.push(c.value);
         }});
         answers[fid] = vals;
-      }} else if (ftype === 'decision' || ftype === 'pushback') {{
+      }} else if (ftype === 'decision' || ftype === 'pushback' || ftype === 'progress') {{
+        // progress: the answer is the selected blocked item; when nothing
+        // is blocked there is no radio and no answer is posted (display-only).
         var picked = f.querySelector('[data-control]:checked');
         if (picked) answers[fid] = picked.value;
       }} else {{

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -442,6 +442,7 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
                     "date",
                     "decision",
                     "pushback",
+                    "progress",
                 ],
                 "description": (
                     "Control type. v1: text_input/single_select/multi_select/"
@@ -449,7 +450,9 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
                     "(YYYY-MM-DD). v3: decision (a recommended single-select "
                     "with rationale + per-option tradeoffs, widget surface). "
                     "v4: pushback (decision framed as dissent — the user's "
-                    "approach vs the agent's alternative, widget surface)."
+                    "approach vs the agent's alternative, widget surface). "
+                    "v5: progress (a done/in_flight/blocked status report whose "
+                    "blocked items are a single-select picker, widget surface)."
                 ),
             },
             "minimum": {"type": "number", "description": "Lower bound for number"},
@@ -474,6 +477,11 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
                 "type": "string",
                 "description": "pushback: the option that is the user's stated approach "
                 "(tagged 'your approach'; must be in options)",
+            },
+            "progress_items": {
+                "type": "array",
+                "description": "progress: reported items as {label, status, detail?} dicts, "
+                "status in done/in_flight/blocked; the blocked subset must equal options",
             },
         },
         "required": ["id", "text", "type"],

--- a/src/attune/meta_workflows/models.py
+++ b/src/attune/meta_workflows/models.py
@@ -49,6 +49,13 @@ class QuestionType(str, Enum):
     # only the dissent framing (your-approach tag, "I'd suggest instead"
     # badge, "Why I'd push back" callout) differs. Widget-surface only.
     PUSHBACK = "pushback"
+    # v5 (communication grammar member #4): a progress report — the agent
+    # reports a set of items by status (done / in_flight / blocked) via
+    # ``progress_items`` and offers the blocked items as a single-select
+    # picker ("which blocker to tackle?"). The answer is one selected
+    # blocked option (validated exactly as a single-select); when nothing
+    # is blocked it degrades to a pure status display. Widget-surface only.
+    PROGRESS = "progress"
 
 
 class TierStrategy(str, Enum):
@@ -90,6 +97,10 @@ class FormQuestion:
         user_position: PUSHBACK only — the option that is the user's stated
             approach (tagged "your approach"); must be one of options;
             None = none
+        progress_items: PROGRESS only — the reported items as a list of
+            {label, status, detail?} dicts, status ∈ {done, in_flight,
+            blocked}. The blocked subset must equal options (the picker);
+            done/in_flight items are reported but not answerable. None = none
 
     """
 
@@ -107,6 +118,7 @@ class FormQuestion:
     option_notes: dict[str, str] | None = None
     recommended: str | None = None
     user_position: str | None = None
+    progress_items: list[dict[str, str]] | None = None
 
     def to_ask_user_format(self) -> dict[str, Any]:
         """Convert to format compatible with AskUserQuestion tool.
@@ -115,11 +127,18 @@ class FormQuestion:
             Dictionary with question data for AskUserQuestion
 
         """
-        # Decision (v3) and pushback (v4) both fall back to a single-select
-        # with the recommended option (the agent's alternative, for pushback)
-        # ordered first — the richer card layout is widget-only; the answer
-        # is one selected option either way.
-        if self.type in (QuestionType.DECISION, QuestionType.PUSHBACK):
+        # Decision (v3), pushback (v4), and progress (v5) all fall back to a
+        # single-select with the recommended option ordered first — the
+        # richer card layout is widget-only; the answer is one selected
+        # option either way. For progress the options are the blocked items
+        # (done/in_flight items are reported in the text, not pickable); when
+        # options is empty there is nothing to ask and the caller narrates
+        # the report instead.
+        if self.type in (
+            QuestionType.DECISION,
+            QuestionType.PUSHBACK,
+            QuestionType.PROGRESS,
+        ):
             opts = list(self.options)
             if self.recommended and self.recommended in opts:
                 opts = [self.recommended] + [o for o in opts if o != self.recommended]

--- a/tests/unit/elicitation/test_progress_construct.py
+++ b/tests/unit/elicitation/test_progress_construct.py
@@ -1,0 +1,216 @@
+"""Tests for the V5 progress construct (communication grammar member #4).
+
+A PROGRESS is a status report: the agent reports a set of items by status
+(``done`` / ``in_flight`` / ``blocked``) via ``progress_items`` and offers
+the ``blocked`` items as a single-select picker. The answer is one selected
+blocked option, validated exactly as a single-select; with no blocked items
+it degrades to a pure status display. These tests cover the model extension,
+definition validation (including the blocked-subset==options invariant), the
+three-bucket widget render, the empty-blocked degrade, the answer round-trip,
+the AskUserQuestion fallback, and the elicitation schema mapping. See
+docs/specs/elicitation-form-surface/v5-requirements.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_to_widget_html,
+)
+from attune.elicitation.bridge import form_to_askuserquestion
+from attune.elicitation.elicitation_schema import form_to_elicitation_schema
+from attune.meta_workflows.models import FormQuestion, QuestionType
+
+
+def _progress(**override) -> dict:
+    """Build a one-field progress form dict, overriding the field."""
+    field = {
+        "id": "exec",
+        "text": "Where execution stands",
+        "type": "progress",
+        "options": ["T6 consumer wiring", "T5 surfaces"],
+        "recommended": "T6 consumer wiring",
+        "rationale": "6/8 done, 2 deferred on gate failures.",
+        "option_notes": {"T6 consumer wiring": "gate failed: score 42"},
+        "progress_items": [
+            {"label": "T1 model", "status": "done"},
+            {"label": "T3 widget", "status": "in_flight", "detail": "rendering cards"},
+            {"label": "T6 consumer wiring", "status": "blocked", "detail": "gate failed: score 42"},
+            {"label": "T5 surfaces", "status": "blocked"},
+        ],
+    }
+    field.update(override)
+    return {"title": "Spec execution", "fields": [field]}
+
+
+def _display_only(**override) -> dict:
+    """A progress report with nothing blocked — display only, no picker."""
+    field = {
+        "id": "exec",
+        "text": "Where execution stands",
+        "type": "progress",
+        "options": [],
+        "required": False,
+        "progress_items": [
+            {"label": "T1 model", "status": "done"},
+            {"label": "T2 bridge", "status": "in_flight"},
+        ],
+    }
+    field.update(override)
+    return {"title": "Spec execution", "fields": [field]}
+
+
+class TestProgressModel:
+    def test_questiontype_has_progress(self) -> None:
+        assert QuestionType.PROGRESS.value == "progress"
+
+    def test_formquestion_progress_items_defaults_none(self) -> None:
+        q = FormQuestion(id="a", text="t", type=QuestionType.PROGRESS)
+        assert q.progress_items is None
+        assert q.recommended is None
+        assert q.rationale is None
+
+
+class TestProgressFormFromDict:
+    def test_builds_progress_with_items(self) -> None:
+        form = form_from_dict(_progress())
+        q = form.questions[0]
+        assert q.type == QuestionType.PROGRESS
+        assert q.progress_items is not None and len(q.progress_items) == 4
+        assert q.recommended == "T6 consumer wiring"
+
+    def test_requires_progress_items(self) -> None:
+        with pytest.raises(FormValidationError, match="requires 'progress_items'"):
+            form_from_dict(_progress(progress_items=None))
+
+    def test_progress_items_must_be_list_of_dicts(self) -> None:
+        with pytest.raises(FormValidationError, match="must be a list of dicts"):
+            form_from_dict(_progress(progress_items=["nope"]))
+
+    def test_status_must_be_valid(self) -> None:
+        bad = [{"label": "X", "status": "halfway"}]
+        with pytest.raises(FormValidationError, match="'status' must be one of"):
+            form_from_dict(_progress(options=[], required=False, progress_items=bad))
+
+    def test_item_needs_label(self) -> None:
+        bad = [{"status": "done"}]
+        with pytest.raises(FormValidationError, match="needs a 'label' string"):
+            form_from_dict(_progress(options=[], required=False, progress_items=bad))
+
+    def test_blocked_subset_must_equal_options(self) -> None:
+        # options names a blocker that is not in progress_items.
+        with pytest.raises(FormValidationError, match="must equal options"):
+            form_from_dict(_progress(options=["Ghost blocker"]))
+
+    def test_recommended_must_be_an_option(self) -> None:
+        with pytest.raises(FormValidationError, match="'recommended' 'Ghost' not in options"):
+            form_from_dict(_progress(recommended="Ghost"))
+
+    def test_display_only_is_valid(self) -> None:
+        # No blocked items, empty options — a pure status display.
+        form = form_from_dict(_display_only())
+        q = form.questions[0]
+        assert q.options == []
+        assert q.progress_items is not None and len(q.progress_items) == 2
+
+
+class TestProgressAnswer:
+    def test_collect_accepts_blocked_option(self) -> None:
+        form = form_from_dict(_progress())
+        resp = collect_form_response(form, {"exec": "T5 surfaces"})
+        assert resp.responses == {"exec": "T5 surfaces"}
+
+    def test_collect_rejects_non_blocked_item(self) -> None:
+        # A done/in_flight item is reported but not a valid answer.
+        form = form_from_dict(_progress())
+        with pytest.raises(FormValidationError, match="not in options"):
+            collect_form_response(form, {"exec": "T1 model"})
+
+    def test_collect_rejects_out_of_option(self) -> None:
+        form = form_from_dict(_progress())
+        with pytest.raises(FormValidationError, match="not in options"):
+            collect_form_response(form, {"exec": "nope"})
+
+    def test_display_only_needs_no_answer(self) -> None:
+        # required=False + empty options → no answer collected, no error.
+        form = form_from_dict(_display_only())
+        resp = collect_form_response(form, {})
+        assert resp.responses == {}
+
+    def test_fallback_maps_to_single_select_suggested_first(self) -> None:
+        form = form_from_dict(_progress())
+        payload = form_to_askuserquestion(form)[0][0]
+        assert payload["type"] == "single_select"
+        # Only blocked items are pickable; recommended ordered first.
+        assert payload["options"] == ["T6 consumer wiring", "T5 surfaces"]
+        assert payload["default"] == "T6 consumer wiring"
+
+
+class TestProgressWidget:
+    def test_renders_three_bucket_structure(self) -> None:
+        html = form_to_widget_html(form_from_dict(_progress()))
+        assert 'class="ae-progress"' in html
+        assert 'class="ae-prog-rows"' in html  # static done/in_flight rows
+        assert 'role="radiogroup"' in html  # blocked picker
+        assert "suggested next" in html  # recommended badge
+        assert "Blocked — pick one to tackle:" in html
+        assert "Summary" in html  # rationale header
+        assert "T1 model" in html  # a done item rendered
+        assert "rendering cards" in html  # an in_flight detail rendered
+
+    def test_blocked_items_ordered_recommended_first(self) -> None:
+        html = form_to_widget_html(form_from_dict(_progress()))
+        assert html.index('value="T6 consumer wiring"') < html.index('value="T5 surfaces"')
+
+    def test_done_in_flight_not_selectable(self) -> None:
+        # Only the two blocked items get radio inputs; done/in_flight don't.
+        html = form_to_widget_html(form_from_dict(_progress()))
+        assert html.count('type="radio"') == 2
+
+    def test_display_only_has_no_picker(self) -> None:
+        html = form_to_widget_html(form_from_dict(_display_only()))
+        assert "radiogroup" not in html
+        assert 'type="radio"' not in html
+        assert 'class="ae-prog-rows"' in html
+
+    def test_data_ftype_is_progress(self) -> None:
+        html = form_to_widget_html(form_from_dict(_progress()))
+        assert 'data-ftype="progress"' in html
+
+    def test_submit_script_handles_progress(self) -> None:
+        html = form_to_widget_html(form_from_dict(_progress()))
+        assert "ftype === 'progress'" in html
+        assert "[data-control]:checked" in html
+
+    def test_static_fallback_guard_present(self) -> None:
+        html = form_to_widget_html(form_from_dict(_progress()))
+        assert "typeof sendPrompt === 'function'" in html
+
+    def test_escapes_item_text(self) -> None:
+        html = form_to_widget_html(
+            form_from_dict(
+                _progress(
+                    options=["A & <b>"],
+                    recommended="A & <b>",
+                    option_notes=None,
+                    progress_items=[
+                        {"label": "T1 model", "status": "done"},
+                        {"label": "A & <b>", "status": "blocked"},
+                    ],
+                )
+            )
+        )
+        assert "A &amp; &lt;b&gt;" in html
+        assert "<b>" not in html
+
+
+class TestProgressElicitationSchema:
+    def test_progress_maps_to_string_enum(self) -> None:
+        schema = form_to_elicitation_schema(form_from_dict(_progress()))
+        prop = schema["properties"]["exec"]
+        assert prop["type"] == "string"
+        assert prop["enum"] == ["T6 consumer wiring", "T5 surfaces"]

--- a/tests/unit/mcp/test_tool_schemas.py
+++ b/tests/unit/mcp/test_tool_schemas.py
@@ -313,7 +313,7 @@ class TestGetPrompts:
 
 
 class TestGetElicitationTools:
-    """Field-type enum surfaces: v2 rich tools expose 9, v1 stays at 4."""
+    """Field-type enum surfaces: v2 rich tools expose 10, v1 stays at 4."""
 
     def test_v2_tools_present(self) -> None:
         tools = get_elicitation_tools()
@@ -329,10 +329,10 @@ class TestGetElicitationTools:
             "boolean",
         ]
 
-    def test_v2_tools_expose_all_nine_types(self) -> None:
-        # D10 enum-honesty fix + V3 decision + V4 pushback constructs:
-        # render_widget / ask accept the rich controls plus decision and
-        # pushback.
+    def test_v2_tools_expose_all_ten_types(self) -> None:
+        # D10 enum-honesty fix + V3 decision + V4 pushback + V5 progress
+        # constructs: render_widget / ask accept the rich controls plus
+        # decision, pushback, and progress.
         tools = get_elicitation_tools()
         expected = {
             "text_input",
@@ -344,6 +344,7 @@ class TestGetElicitationTools:
             "date",
             "decision",
             "pushback",
+            "progress",
         }
         assert set(_field_types(tools, "elicitation_render_widget")) == expected
         assert set(_field_types(tools, "elicitation_ask")) == expected
@@ -363,6 +364,7 @@ class TestGetElicitationTools:
             "date",
             "decision",
             "pushback",
+            "progress",
         }
         assert (
             set(_field_types(get_elicitation_tools(), "elicitation_collect_response")) == expected


### PR DESCRIPTION
## What

V5 of `docs/specs/elicitation-form-surface` — the **progress construct**,
the fourth member of the communication grammar and the first that is a
*report* rather than a fork. The agent reports a set of items by status
(`done` / `in_flight` / `blocked`) and surfaces the blocked items as a
single-select picker ("which blocker to tackle?"). When nothing is
blocked it degrades to a pure status display.

Patrick's three scoping choices (all via the live decision construct,
2026-06-30 — dogfooding the grammar to extend it):

- **Build construct #4** (not stop the grammar).
- **Answer path = report + blocked-item picker** — keeps it
  answer-validated (blocked items are the `options`, reusing the V3/V4
  single-select path untouched); empty-blocked → pure display.
- **First consumer = the `/spec` execute gate** (done = completed tasks,
  in_flight = current task, blocked = quality-gate failures; picker =
  "which blocked task to fix/retry").

Recorded in decisions **D17**.

## Why it fits the substrate

A pure status display would never run the `collect_form_response`
validator (markdown-in-a-form). Making the blocked items a `SINGLE_SELECT`
keeps the construct answer-validated and reuses the answer path verbatim —
the new type is justified on the *rendering* axis only (the three-bucket
status board). One new optional field (`progress_items`), additive and
backward-compatible. **No Anthropic API call on any surface.**

## Changes

- `models.py`: `QuestionType.PROGRESS` + `progress_items` field +
  AskUserQuestion fallback.
- `bridge.py`: `form_from_dict` validation (statuses; blocked-subset ==
  options invariant); `_validate_answer` membership.
- `widget.py`: three-bucket render (static done/in_flight rows + blocked
  radiogroup picker + "suggested next" badge + "Summary" callout) + CSS +
  empty-blocked degrade; submit JS reads the selected blocked item.
- `elicit` skill: progress construct section + AskUserQuestion mapping
  (+ `.agents/` mirror); `/spec` skill: execute-gate status report.
- surfaces: `tool_schemas` rich enum 9→10 + `progress_items` + count
  guard; `elicitation_schema` string-enum map (forward-compat).
- `communication-grammar.md`: progress as member #4; recipe → #5.

## Tests

- `tests/unit/elicitation/test_progress_construct.py` (new): model, bridge
  validation (incl. the invariant), three-bucket render, empty-blocked
  degrade, answer round-trip, AskUserQuestion fallback, schema map.
- `test_tool_schemas.py`: count guard 9→10.
- 542 elicitation+meta_workflows tests green; 85 in the targeted set;
  ruff + black clean.

## Dogfood receipt

The widget render path makes no API call, so it was dogfooded **live**
this session: a real `form_to_widget_html` report (6 done, 1 in-flight, 1
blocked) rendered via `show_widget` — three buckets, the blocked picker,
the Summary callout, all intact. The full
`elicitation_render_widget` → human submit → `elicitation_collect_response`
receipt (AC3) closes next session once this merges and the live server
reboots with the `"progress"` enum — the D15/D16
"registered ≠ working until the server reboots" pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
