### PR TITLE
chore(release): 9.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "9.2.0"
+    "version": "9.3.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "23 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "9.2.0",
+      "version": "9.3.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v9.2.0
+# Attune AI Framework v9.3.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 9.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 9.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.3.0] — 2026-06-30
+
+The communication grammar — the agent-to-user construct family on the
+elicitation form surface — grows from one member to four: `decision`
+(V3), `pushback` (V4), and `progress` (V5) join the original `intake`
+form. Each is additive and backward-compatible: a new `QuestionType`,
+optional `FormQuestion` fields, and a widget renderer, reusing the
+existing validation and round-trip untouched. See
+`.claude/rules/attune/communication-grammar.md`.
+
 ### Added
 
 - **Decision construct (communication grammar).** The elicitation form
@@ -17,7 +27,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one selected option, validated like a single-select — no new
   round-trip. New optional `FormQuestion` fields: `rationale`,
   `option_notes`, `recommended`. Folded into the elicitation-form-surface
-  spec as V3; see `.claude/rules/attune/communication-grammar.md`.
+  spec as V3 (#1176).
+- **Pushback construct (communication grammar).** A `pushback` control
+  (`QuestionType.PUSHBACK`) for when the agent disagrees with the user's
+  stated approach: the user's approach is tagged "your approach", the
+  agent's alternative is badged "I'd suggest instead" and ordered first,
+  under a "Why I'd push back" rationale. Like `decision` it is a
+  presentation-enriched single-select — the answer is one option,
+  validated identically — and adds one optional field, `user_position`.
+  Falls back to a recommendation-first single-select on `AskUserQuestion`.
+  Spec V4 (#1178).
+- **Progress construct (communication grammar).** A `progress` control
+  (`QuestionType.PROGRESS`): the agent reports a set of items by status
+  (`done` / `in_flight` / `blocked`) as a three-bucket status board,
+  surfacing the blocked items as a single-select picker. The first member
+  that is a *report* rather than a fork; when nothing is blocked it
+  degrades to a pure status display. New optional `FormQuestion` field
+  `progress_items`; the MCP tool-schema `type` enum grows 9 → 10. The
+  widget render is dogfooded and unit-tested (85 tests); the full-MCP
+  served round-trip (AC3 receipt) is pending a server reboot to expose
+  the new enum. Spec V5 (#1181).
 
 ### Changed
 
@@ -27,6 +56,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AskUserQuestion` menu — high-severity gates recommend "Fix and
   retry", medium/low recommend "Approve and continue". The first
   real consumer of the V3 construct.
+- **`/spec` Stage 2 review uses the `pushback` construct.** When the
+  agent disagrees with a user-stated approach during plan review, the
+  disagreement renders as a `pushback` (overrule = keep their approach,
+  or switch) instead of prose. The first real consumer of V4.
+- **`/spec` execute gate uses the `progress` construct.** The execute
+  loop's done / in-flight / blocked task shape renders as a `progress`
+  board, the blocked-item picker mapping onto "which blocked task to
+  fix/retry". The first real consumer of V5.
 
 ## [9.2.0] — 2026-06-28
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 9.2.0
+**Version:** 9.3.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 9.2.0 | **License:** Apache 2.0
+**Version:** 9.3.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "9.2.0"
+    "version": "9.3.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "9.2.0",
+      "version": "9.3.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "9.2.0",
+  "version": "9.3.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "9.2.0"
+__version__ = "9.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "9.2.0"
+version = "9.3.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "9.2.0"
+version = "9.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1394,7 +1394,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v9.2.0</span>
+                  <span>v9.3.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "9.2.0",
+    version: "9.3.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "9.2.0",
+    version: "9.3.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Release **9.3.0** (minor) — communication grammar grows from one member
to four.

## What ships

Three additive, backward-compatible constructs on the elicitation form
surface, accumulated since 9.2.0:

| Construct | PR | `QuestionType` | New optional fields |
|-----------|----|----------------|---------------------|
| decision (V3) | #1176 | `DECISION` | `rationale`, `option_notes`, `recommended` |
| pushback (V4) | #1178 | `PUSHBACK` | `user_position` |
| progress (V5) | #1181 | `PROGRESS` | `progress_items` |

Each reuses the existing validation + round-trip untouched; the MCP
tool-schema `type` enum grows to 10. Each wires into a `/spec` stage
(approval gate / Stage 2 review / execute gate).

## Notes

- **Bump rationale:** new public API (enum members, MCP schema enum
  values, `FormQuestion` fields) → MINOR under semver, not patch.
- **Progress AC3 caveat:** the full-MCP *served* round-trip is pending a
  server reboot to expose the new `"progress"` enum. The widget render is
  dogfooded and the construct is covered by 85 unit tests; publishing is
  the path that lets a rebooted server capture the receipt.
- No `src/` changes — version sites + CHANGELOG + lockfile only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)