### PR TITLE
docs(readme,website): stress dynamic human/AI communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.3.0] — 2026-06-30
 
-The communication grammar — the agent-to-user construct family on the
-elicitation form surface — grows from one member to four: `decision`
+**Dynamic communication to improve the human/AI exchange.** Attune now
+dynamically shapes each exchange to fit the moment — rendering an
+interactive form in response to a prompt whenever a structured turn
+communicates better than prose (one-click multi-part questions, weighable
+recommendation cards, side-by-side disagreements). The mechanism is a
+communication grammar that grows from one member to four: `decision`
 (V3), `pushback` (V4), and `progress` (V5) join the original `intake`
 form. Each is additive and backward-compatible: a new `QuestionType`,
 optional `FormQuestion` fields, and a widget renderer, reusing the

--- a/README.md
+++ b/README.md
@@ -129,11 +129,16 @@ workflow brainstorms, then plans, then executes. `planning` clarifies
 scope before writing a line of code. This eliminates the most common
 failure mode: confidently solving the wrong problem.
 
-**Dynamic forms — a communication grammar.** When a prompt calls for
-it, Attune renders the exchange as an interactive form instead of a
-wall of prose, so a multi-part question becomes one structured turn you
-answer with a click. The agent picks the right *construct* for the
-moment:
+**Dynamic communication — the agent adapts how it talks to you.**
+A deliberate effort to *improve human/AI communication*: instead of a
+fixed wall of prose, Attune now *dynamically* shapes each exchange to
+fit the moment — rendering an interactive form in response to your
+prompt whenever a structured turn communicates better than text. A
+multi-part question becomes one form you answer with a click; a
+recommendation arrives as weighable cards; a disagreement is shown
+side-by-side so you can overrule it in one tap. The back-and-forth gets
+faster, clearer, and less ambiguous. The agent picks the right
+*construct* for the moment:
 
 - **intake** — gathers several independent decisions as a single
   (multi-select-capable) form, instead of N back-and-forth questions.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,33 @@ developer workflow hub; `attune-gui` is the docs hub.
 
 ---
 
+## New in 9.3.0 — Dynamic communication
+
+**The agent adapts how it talks to you.** A deliberate effort to
+*improve human/AI communication*: instead of a fixed wall of prose,
+Attune now *dynamically* shapes each exchange to fit the moment —
+rendering an interactive form in response to your prompt whenever a
+structured turn communicates better than text. A multi-part question
+becomes one form you answer with a click; a recommendation arrives as
+weighable cards; a disagreement is shown side-by-side so you can
+overrule it in one tap. The back-and-forth gets faster, clearer, and
+less ambiguous. The agent picks the right *construct* for the moment:
+
+- **intake** — gather several independent decisions in one form
+- **decision** — a recommended option with rationale + per-option
+  tradeoffs (`/spec` approval gate)
+- **pushback** — agent dissent shown as "your approach" vs "I'd suggest
+  instead"; overrule or switch in one pick (`/spec` plan review)
+- **progress** — a done / in-progress / blocked board whose blocked
+  items are a fix-next picker (`/spec` execute)
+
+All constructs share one declarative form model and validator, render
+richly on widget-capable surfaces (e.g. claude.ai / Cowork) and degrade
+gracefully to a recommendation-first menu elsewhere. The terse reply
+vocab (`y` / `go` / `1`) answers any of them.
+
+---
+
 ## Ecosystem
 
 | Package | Role | Install |
@@ -128,33 +155,6 @@ Workflows ask questions before executing, not after. The `spec`
 workflow brainstorms, then plans, then executes. `planning` clarifies
 scope before writing a line of code. This eliminates the most common
 failure mode: confidently solving the wrong problem.
-
-**Dynamic communication — the agent adapts how it talks to you.**
-A deliberate effort to *improve human/AI communication*: instead of a
-fixed wall of prose, Attune now *dynamically* shapes each exchange to
-fit the moment — rendering an interactive form in response to your
-prompt whenever a structured turn communicates better than text. A
-multi-part question becomes one form you answer with a click; a
-recommendation arrives as weighable cards; a disagreement is shown
-side-by-side so you can overrule it in one tap. The back-and-forth gets
-faster, clearer, and less ambiguous. The agent picks the right
-*construct* for the moment:
-
-- **intake** — gathers several independent decisions as a single
-  (multi-select-capable) form, instead of N back-and-forth questions.
-- **decision** — offers a *recommended* option with a rationale and
-  per-option tradeoffs, rendered as cards (consumed by the `/spec`
-  approval gate).
-- **pushback** — when the agent disagrees with your stated approach, it
-  shows "your approach" beside "I'd suggest instead" with a "why", and
-  you overrule or switch with one pick (`/spec` plan review).
-- **progress** — a done / in-progress / blocked status board whose
-  blocked items are a picker for what to fix next (`/spec` execute).
-
-All constructs share one declarative form model and validator, render
-richly on widget-capable surfaces (e.g. claude.ai / Cowork) and degrade
-gracefully to a recommendation-first menu elsewhere. The terse reply
-vocab (`y` / `go` / `1`) answers any of them.
 
 ### 4. RAG-grounded generation
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -355,6 +355,24 @@ export const PILLARS: Pillar[] = [
     color: "primary",
   },
   {
+    id: "communication",
+    tag: "Dynamic communication",
+    title: "The agent adapts how it talks to you",
+    description:
+      "When a structured turn communicates better than prose, Attune " +
+      "renders the exchange as an interactive form — a multi-part " +
+      "question becomes one click, a recommendation arrives as " +
+      "weighable cards, a disagreement is shown side-by-side. A " +
+      "deliberate effort to improve human/AI communication.",
+    points: [
+      "Intake, decision, pushback, and progress constructs",
+      "Rich on widget surfaces, graceful menu fallback elsewhere",
+      "Answer with one click — or the terse y / go / 1 vocab",
+    ],
+    icon: "💬",
+    color: "accent",
+  },
+  {
     id: "memory",
     tag: "Project memory",
     title: "Your agent stops starting from zero",

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -339,6 +339,26 @@ export interface Pillar {
 
 export const PILLARS: Pillar[] = [
   {
+    id: "communication",
+    tag: "Dynamic communication",
+    title: "The agent adapts how it talks to you",
+    description:
+      "A deliberate effort to improve human/AI communication: instead " +
+      "of a fixed wall of prose, Attune dynamically shapes each " +
+      "exchange to fit the moment — rendering an interactive form " +
+      "whenever a structured turn communicates better than text. A " +
+      "multi-part question becomes one click; a recommendation arrives " +
+      "as weighable cards; a disagreement is shown side-by-side so you " +
+      "overrule it in one tap.",
+    points: [
+      "Intake, decision, pushback, and progress constructs",
+      "Rich on widget surfaces, graceful menu fallback elsewhere",
+      "Answer with one click — or the terse y / go / 1 vocab",
+    ],
+    icon: "💬",
+    color: "primary",
+  },
+  {
     id: "workflows",
     tag: "AI workflows",
     title: "Specialist teams, not one prompt",
@@ -353,24 +373,6 @@ export const PILLARS: Pillar[] = [
     ],
     icon: "⚙️",
     color: "primary",
-  },
-  {
-    id: "communication",
-    tag: "Dynamic communication",
-    title: "The agent adapts how it talks to you",
-    description:
-      "When a structured turn communicates better than prose, Attune " +
-      "renders the exchange as an interactive form — a multi-part " +
-      "question becomes one click, a recommendation arrives as " +
-      "weighable cards, a disagreement is shown side-by-side. A " +
-      "deliberate effort to improve human/AI communication.",
-    points: [
-      "Intake, decision, pushback, and progress constructs",
-      "Rich on widget surfaces, graceful menu fallback elsewhere",
-      "Answer with one click — or the terse y / go / 1 vocab",
-    ],
-    icon: "💬",
-    color: "accent",
   },
   {
     id: "memory",


### PR DESCRIPTION
Foregrounds the 9.3.0 headline value on both surfaces: **Attune
dynamically adapts how it communicates** — rendering interactive forms in
response to prompts, when appropriate, to *improve human/AI
communication*. The four constructs (intake / decision / pushback /
progress) are framed as the mechanism behind that value, not the value
itself.

- **README** — rewrites the section lead under "Socratic before
  execution" to open with the human/AI-communication value (the merged
  #1183 used a weaker, mechanical "grammar grows to four members"
  framing).
- **website/lib/features.ts** — adds a homepage `PILLARS` entry,
  "The agent adapts how it talks to you", rendered by the existing
  pillar-card loop.

Docs/website only. The Vercel preview build validates the homepage
render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)