### PR TITLE
docs(readme,website): name forms as the lever for human/AI comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,17 @@ developer workflow hub; `attune-gui` is the docs hub.
 
 ---
 
-## New in 9.3.0 — Dynamic communication
+## New in 9.3.0 — Dynamic forms that improve human/AI communication
 
-**The agent adapts how it talks to you.** A deliberate effort to
-*improve human/AI communication*: instead of a fixed wall of prose,
-Attune now *dynamically* shapes each exchange to fit the moment —
-rendering an interactive form in response to your prompt whenever a
-structured turn communicates better than text. A multi-part question
-becomes one form you answer with a click; a recommendation arrives as
-weighable cards; a disagreement is shown side-by-side so you can
-overrule it in one tap. The back-and-forth gets faster, clearer, and
-less ambiguous. The agent picks the right *construct* for the moment:
+**Attune now improves how you and the AI communicate by dynamically
+using interactive forms.** The form *is* the improvement: instead of a
+fixed wall of prose, Attune renders the right form in response to your
+prompt whenever a structured turn communicates better than text — so a
+multi-part question becomes one form you answer with a click, a
+recommendation arrives as weighable cards, and a disagreement is shown
+side-by-side so you can overrule it in one tap. The exchange gets
+faster, clearer, and less ambiguous. The agent picks the right *form*
+for the moment:
 
 - **intake** — gather several independent decisions in one form
 - **decision** — a recommended option with rationale + per-option

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -340,16 +340,16 @@ export interface Pillar {
 export const PILLARS: Pillar[] = [
   {
     id: "communication",
-    tag: "Dynamic communication",
-    title: "The agent adapts how it talks to you",
+    tag: "Dynamic forms",
+    title: "Forms that improve how you and the AI talk",
     description:
-      "A deliberate effort to improve human/AI communication: instead " +
-      "of a fixed wall of prose, Attune dynamically shapes each " +
-      "exchange to fit the moment — rendering an interactive form " +
-      "whenever a structured turn communicates better than text. A " +
-      "multi-part question becomes one click; a recommendation arrives " +
-      "as weighable cards; a disagreement is shown side-by-side so you " +
-      "overrule it in one tap.",
+      "Attune improves human/AI communication by dynamically using " +
+      "interactive forms: instead of a fixed wall of prose, it renders " +
+      "the right form in response to your prompt whenever a structured " +
+      "turn communicates better than text. A multi-part question " +
+      "becomes one click; a recommendation arrives as weighable cards; " +
+      "a disagreement is shown side-by-side so you overrule it in one " +
+      "tap.",
     points: [
       "Intake, decision, pushback, and progress constructs",
       "Rich on widget surfaces, graceful menu fallback elsewhere",


### PR DESCRIPTION
Follow-up to #1184. The 9.3.0 section led with "dynamic communication"
but didn't emphasize that **interactive forms** are *how* the human/AI
exchange is improved. This reframes both surfaces so forms are the named
mechanism.

- **README** — heading → "Dynamic forms that improve human/AI
  communication"; lead → "Attune now improves how you and the AI
  communicate by dynamically using interactive forms. The form *is* the
  improvement."
- **website pillar** — title → "Forms that improve how you and the AI
  talk"; description leads with forms-as-lever.

Docs/website only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)