### PR TITLE
docs(spec,lessons): V5 AC3 live MCP receipt + cd-to-main trap

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12318,3 +12318,29 @@ files.
   catches the miss. Pairs with "Registered ≠ working — dogfood the live
   loop" (same discipline, applied to the validation layer of a
   pure-logic reuse).
+
+- **A `cd /path/to/MAIN-checkout && git commit …` inside a single Bash
+  tool call from a WORKTREE session commits to the MAIN checkout, not
+  your worktree — and the harness resets cwd back to the worktree AFTER
+  the command, so it looks like you never left.** Hit 2026-06-30 amending
+  a README commit during the 9.3.0 ship: the edit was made (via the Edit
+  tool) in the worktree, but the commit command was prefixed
+  `cd /Users/patrickroebuck/attune-ai && git commit …`, so git ran in the
+  MAIN checkout (which happened to be detached on a PARALLEL session's
+  HEAD). It printed `no changes added to commit` (the worktree's modified
+  README wasn't there) and the would-be commit landed nowhere; the
+  worktree edit sat uncommitted. Distinct from two existing lessons:
+  "Write to an absolute /Users/.../attune-ai path lands on main" is the
+  WRITE surface; "branch-vs-worktree commit tangle" is wrong-branch-
+  SAME-checkout. THIS one is the `cd` in a COMPOUND Bash command silently
+  retargeting git to a DIFFERENT checkout. Diagnostic: after a surprising
+  `no changes added` or an unexpected HEAD SHA, run `git branch
+  --show-current` and `git log --oneline -1` with NO `cd` (they use the
+  worktree cwd) and compare against what the cd'd command reported —
+  divergence = you committed in the wrong tree. Fix: never `cd` to the
+  main checkout for git WRITE ops in a worktree session; run git from the
+  worktree cwd (the harness keeps you there). Reserve `cd /main` for
+  read-only `gh`/inspection only. Recovery: re-create the branch+edit in
+  the worktree and commit there; if you disturbed the main checkout,
+  restore it to its found state (`git checkout <found-sha>` +
+  `git stash pop`) so a parallel session is undisturbed.

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -623,18 +623,28 @@ enforces `set(blocked labels) == set(options)` in `form_from_dict`, and a
 unit test (`test_blocked_subset_must_equal_options`) guards it — the
 picker can never offer a non-existent blocker or omit a real one.
 
-**AC3 receipt status — widget render PROVEN; full MCP path PENDING reboot.**
-The widget path makes no API call, so the production render was dogfooded
-live this session: real `form_to_widget_html` output (8 tasks: 6 done, 1
-in-flight, 1 blocked) rendered via `show_widget` — three buckets, the
-"suggested next" badge on the blocked picker, the "Summary" callout, all
-intact. `collect_form_response` round-trip + the empty-blocked degrade
-are proven by unit tests (85 pass). The full
-`mcp__attune-ai__elicitation_render_widget` → human submit →
-`elicitation_collect_response` receipt closes next session once #<this PR>
-merges and the live server reboots with the `"progress"` enum (10 types)
-— the exact D15/D16 "registered ≠ working until the server reboots"
-pattern.
+**AC3 receipt status — MCP render + collect PROVEN LIVE on 9.3.0
+(2026-06-30); human pixel-click still surface-gated.** Function-level
+render was dogfooded at build time: real `form_to_widget_html` output
+(8 tasks: 6 done, 1 in-flight, 1 blocked) via `show_widget` — three
+buckets, "suggested next" badge, "Summary" callout intact; plus unit
+coverage (85 tests) for `collect_form_response` + the empty-blocked
+degrade. After v9.3.0 published and the MCP server reconnected on 9.3.0,
+the **full MCP-tool path** was exercised — verified first (the D15/D16
+"registered ≠ working until reboot" gate) that the live
+`mcp__attune-ai__elicitation_render_widget` schema enum carries
+`"progress"` (10 types) + `progress_items`. A real progress form
+(4 done / 1 in_flight / 3 blocked) rendered through that tool →
+`success: true` with the correct three-bucket HTML; the postback then
+validated live through `mcp__attune-ai__elicitation_collect_response` →
+`success: true`, `next_action` membership-checked,
+**`resp-20260630-055649`**. Honest gap vs. V3/V4: those receipts include
+a real **rendered-widget human click**; this session ran in a terminal
+where `mcp__visualize__show_widget` was NOT connected, so the literal
+pixel-render + mouse-click atom is still owed — it needs a widget-capable
+surface (claude.ai/code or Cowork). Render-logic + validation are proven
+end-to-end live on 9.3.0; only the human click on a rendered widget
+remains.
 
 ## Open
 

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -623,8 +623,8 @@ enforces `set(blocked labels) == set(options)` in `form_from_dict`, and a
 unit test (`test_blocked_subset_must_equal_options`) guards it — the
 picker can never offer a non-existent blocker or omit a real one.
 
-**AC3 receipt status — MCP render + collect PROVEN LIVE on 9.3.0
-(2026-06-30); human pixel-click still surface-gated.** Function-level
+**AC3 receipt status — FULLY CLOSED 2026-06-30 (real rendered-widget
+human click).** Function-level
 render was dogfooded at build time: real `form_to_widget_html` output
 (8 tasks: 6 done, 1 in-flight, 1 blocked) via `show_widget` — three
 buckets, "suggested next" badge, "Summary" callout intact; plus unit
@@ -638,13 +638,17 @@ the **full MCP-tool path** was exercised — verified first (the D15/D16
 `success: true` with the correct three-bucket HTML; the postback then
 validated live through `mcp__attune-ai__elicitation_collect_response` →
 `success: true`, `next_action` membership-checked,
-**`resp-20260630-055649`**. Honest gap vs. V3/V4: those receipts include
-a real **rendered-widget human click**; this session ran in a terminal
-where `mcp__visualize__show_widget` was NOT connected, so the literal
-pixel-render + mouse-click atom is still owed — it needs a widget-capable
-surface (claude.ai/code or Cowork). Render-logic + validation are proven
-end-to-end live on 9.3.0; only the human click on a rendered widget
-remains.
+**`resp-20260630-055649`**. Then the **rendered-widget human click** —
+the V3/V4-parity atom — landed same-session: `mcp__visualize__show_widget`
+was available after all (the earlier "not connected" was a deferred-only
+ToolSearch miss — `show_widget` is a primary tool, not a deferred one,
+so ToolSearch returning nothing is not evidence of absence). The same
+progress form rendered live in chat via `show_widget`, Patrick clicked a
+blocked card and Submit, the `__elicitation_response__` sentinel posted
+back through `sendPrompt`, and `elicitation_collect_response` validated it
+— `success: true`, **`resp-20260630-060453`**. All three V5 surfaces
+(function-level, full MCP tool, rendered-widget human click) are now
+receipted, matching V3/V4. AC3 is closed.
 
 ## Open
 


### PR DESCRIPTION
Closes the V5 progress construct's AC3 thread to the extent this terminal
session allows, and records a new git-worktree trap.

**D18 AC3 receipt (decisions.md).** After 9.3.0 published and the MCP
server reconnected on 9.3.0:
- Verified the live `elicitation_render_widget` enum carries `"progress"`
  (10 types) + `progress_items` — the D15/D16 "registered ≠ working until
  reboot" gate.
- Rendered a real progress form through the tool → `success: true`,
  correct three-bucket HTML.
- Validated the postback through `elicitation_collect_response` →
  `success: true`, membership-checked, **`resp-20260630-055649`**.
- **Honest gap recorded:** the literal rendered-widget human click is
  still owed — `mcp__visualize__show_widget` was not connected in this
  terminal session, so render-logic + validation are proven live, but the
  pixel-click atom needs a widget-capable surface (claude.ai/code or
  Cowork). Not overclaimed as a V3/V4-style human-click receipt.

**lessons.md.** New trap: `cd /main && git commit` from a worktree
session commits to the MAIN checkout (the README-amend-landed-nowhere
failure during the 9.3.0 ship).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)