### PR TITLE
feat(elicitation): list_style render variant + D19

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -61,6 +61,14 @@ native elicitation (`elicitation_ask`) and widget
 (`elicitation_render_widget`) surfaces below, but degrade to plain text
 on AskUserQuestion.
 
+**List render (`list_style`).** On a `single_select` or `multi_select`,
+set `"list_style": "ordered"` (numbered) or `"unordered"` (bulleted) to
+render the options as the familiar intro-sentence-plus-list shape —
+each item pickable by mouse or the `1`/`2`/`3` reply vocab — instead of
+the default dropdown/checkboxes. Presentation only: the answer and its
+validation are unchanged (it is **not** a separate construct — see
+decisions.md D19). Only valid on the two select types.
+
 ## The decision construct (v3)
 
 A `decision` is a presentation-enriched single-select: the agent offers

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -652,7 +652,7 @@ receipted, matching V3/V4. AC3 is closed.
 
 ## D19 — construct #5 REJECTED: a list element is a render variant of select, not a new member
 
-**Date:** 2026-06-30 · **Status:** decided (build parked) · **owner:**
+**Date:** 2026-06-30 · **Status:** decided + BUILT (same PR) · **owner:**
 patrick · reached via a live **pushback** form, Patrick **switched** to
 the agent's alternative (`resp-20260630-061842`).
 
@@ -686,9 +686,14 @@ grammar) and Patrick agreed.
   "validate new infrastructure against user value before extending"
   discipline.
 
-Build PARKED (Patrick's `record`-and-revisit call at the end of a long
-session). Pick up as a focused PR: the `list_style` field + `widget.py`
-branch + a render test.
+BUILT in this PR (Patrick said "build"): an optional `list_style`
+(`"ordered"` | `"unordered"`) on `FormQuestion`, rendered by `widget.py`
+as an `<ol>`/`<ul>` of radios (single) or checkboxes (multi); the submit
+script reads a checked radio for single-select-as-list. Bridge validates
+it (select-only, value-checked); MCP tool-schema carries it; the `elicit`
+skill documents it; `tests/unit/elicitation/test_list_style.py` covers
+render + round-trip + definition validation (11 tests). Zero new
+`QuestionType`, zero answer-path change.
 
 ## Open
 

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -650,6 +650,46 @@ back through `sendPrompt`, and `elicitation_collect_response` validated it
 (function-level, full MCP tool, rendered-widget human click) are now
 receipted, matching V3/V4. AC3 is closed.
 
+## D19 — construct #5 REJECTED: a list element is a render variant of select, not a new member
+
+**Date:** 2026-06-30 · **Status:** decided (build parked) · **owner:**
+patrick · reached via a live **pushback** form, Patrick **switched** to
+the agent's alternative (`resp-20260630-061842`).
+
+Patrick proposed a fifth construct: an introductory sentence that
+introduces an ordered/unordered list whose items are easy to select by
+keyboard or mouse — a shape he reaches for constantly. The agent pushed
+back (dogfooding the `pushback` construct to decide whether to extend the
+grammar) and Patrick agreed.
+
+- **Not a 5th `QuestionType`.** An "intro + selectable list" is already a
+  `single_select` / `multi_select`: the intro sentence is the field
+  `text`, the list items are the `options`, each pickable by mouse or the
+  `1`/`2`/`3` terse-reply vocab. The grammar's how-to-extend gate
+  (`communication-grammar.md` step 1) only justifies a new member when
+  **rendering OR answer-meaning genuinely differs** — here the
+  answer-meaning is identical to select and only the *look* differs.
+- **Most "intro + list" responses are expository** (no answer expected) —
+  those stay plain markdown (zero tool calls, render everywhere including
+  a bare terminal); wrapping them in a form would only add a Submit step.
+  So the value is in the *interactive* subset, which select already
+  covers.
+- **Chosen shape — a list-render option on the existing select types.** A
+  field hint (e.g. `list_style: "ordered" | "unordered"`, default = the
+  current card render); `widget.py` renders the options as a
+  numbered/bulleted selectable list instead of cards. **Zero** new
+  `QuestionType`, **zero** changes to the answer path or validators — a
+  render branch + one optional field, ~1/5 the surface of a new member.
+- **Meta-note worth keeping:** the grammar earned its keep here by
+  *shrinking* the work — a live `pushback` talked the owner out of
+  writing unnecessary code, the inverse of feature-creep. Pairs with the
+  "validate new infrastructure against user value before extending"
+  discipline.
+
+Build PARKED (Patrick's `record`-and-revisit call at the end of a long
+session). Pick up as a focused PR: the `list_style` field + `widget.py`
+branch + a render test.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -63,6 +63,14 @@ native elicitation (`elicitation_ask`) and widget
 (`elicitation_render_widget`) surfaces below, but degrade to plain text
 on AskUserQuestion.
 
+**List render (`list_style`).** On a `single_select` or `multi_select`,
+set `"list_style": "ordered"` (numbered) or `"unordered"` (bulleted) to
+render the options as the familiar intro-sentence-plus-list shape —
+each item pickable by mouse or the `1`/`2`/`3` reply vocab — instead of
+the default dropdown/checkboxes. Presentation only: the answer and its
+validation are unchanged (it is **not** a separate construct — see
+decisions.md D19). Only valid on the two select types.
+
 ## The decision construct (v3)
 
 A `decision` is a presentation-enriched single-select: the agent offers

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -219,6 +219,21 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
         elif qtype is QuestionType.PROGRESS:
             problems.append(f"{where} type progress requires 'progress_items'")
 
+        # Render variant: list_style — render select options as an
+        # ordered/unordered selectable list. Only valid on the select types;
+        # pure presentation, the answer and its validation are unchanged.
+        list_style = raw.get("list_style")
+        if list_style is not None:
+            if list_style not in ("ordered", "unordered"):
+                problems.append(f"{where} 'list_style' must be 'ordered' or 'unordered'")
+                list_style = None
+            elif qtype not in (QuestionType.SINGLE_SELECT, QuestionType.MULTI_SELECT):
+                problems.append(
+                    f"{where} 'list_style' is only valid on single_select / "
+                    f"multi_select (got {qtype.value})"
+                )
+                list_style = None
+
         if fid and text and isinstance(fid, str) and isinstance(text, str):
             questions.append(
                 FormQuestion(
@@ -237,6 +252,7 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
                     recommended=recommended,
                     user_position=user_position,
                     progress_items=progress_items,
+                    list_style=list_style,
                 )
             )
 

--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -40,6 +40,38 @@ def _esc(value: object) -> str:
     return escape(str(value), quote=True)
 
 
+def _list_html(q: FormQuestion, *, multi: bool) -> str:
+    """Render select options as an ordered/unordered selectable list.
+
+    A presentation variant of SINGLE_SELECT (radios) / MULTI_SELECT
+    (checkboxes) used when ``q.list_style`` is set: the items render as
+    ``<ol>``/``<ul>`` entries, each pickable by mouse or keyboard. The
+    answer path is unchanged — the inputs still carry ``data-control`` and
+    the submit script reads them the same way it reads any select.
+
+    Args:
+        q: The select question to render.
+        multi: True for MULTI_SELECT (checkboxes), False for SINGLE_SELECT
+            (radios).
+
+    Returns:
+        An HTML fragment for the list control.
+    """
+    tag = "ol" if q.list_style == "ordered" else "ul"
+    input_type = "checkbox" if multi else "radio"
+    name = "" if multi else f' name="{_esc(q.id)}"'
+    role = "" if multi else ' role="radiogroup"'
+    items = ""
+    for opt in q.options:
+        items += (
+            f'<li class="ae-list-item"><label>'
+            f'<input type="{input_type}"{name} data-control '
+            f'value="{_esc(opt)}"{_checked(q, opt)}> '
+            f"<span>{_esc(opt)}</span></label></li>"
+        )
+    return f'<{tag} class="ae-list"{role}>{items}</{tag}>'
+
+
 def _control_html(q: FormQuestion) -> str:
     """Render the input control for one question (no label/wrapper).
 
@@ -155,6 +187,8 @@ def _control_html(q: FormQuestion) -> str:
         return f'<div class="ae-progress">{rows_html}{picker}</div>'
 
     if q.type == QuestionType.MULTI_SELECT:
+        if q.list_style:
+            return _list_html(q, multi=True)
         boxes = "".join(
             f'<label class="ae-check"><input type="checkbox" data-control '
             f'value="{_esc(opt)}"{_checked(q, opt)}> {_esc(opt)}</label>'
@@ -163,6 +197,8 @@ def _control_html(q: FormQuestion) -> str:
         return f'<div class="ae-checks">{boxes}</div>'
 
     if q.type == QuestionType.SINGLE_SELECT:
+        if q.list_style:
+            return _list_html(q, multi=False)
         opts = '<option value="">— choose —</option>' + "".join(
             f'<option value="{_esc(opt)}"{_selected(q, opt)}>{_esc(opt)}</option>'
             for opt in q.options
@@ -298,6 +334,10 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
   gap:.35rem; }}
 #attune-elicit-form .ae-check {{ display:flex; align-items:center; gap:.5rem;
   font-weight:400; }}
+#attune-elicit-form .ae-list {{ margin:0; padding-left:1.6rem;
+  display:flex; flex-direction:column; gap:.3rem; }}
+#attune-elicit-form .ae-list-item label {{ display:inline-flex;
+  align-items:baseline; gap:.45rem; cursor:pointer; font-weight:400; }}
 #attune-elicit-form .ae-cards {{ display:flex; flex-direction:column; gap:.5rem; }}
 #attune-elicit-form .ae-card {{ position:relative; display:flex;
   flex-direction:column; gap:.15rem; padding:.6rem 1.9rem .6rem .75rem;
@@ -370,8 +410,15 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
         if (picked) answers[fid] = picked.value;
       }} else {{
         var el = f.querySelector('[data-control]');
-        if (!el || el.value === '') return;
-        answers[fid] = (ftype === 'number') ? Number(el.value) : el.value;
+        if (!el) return;
+        if (el.type === 'radio') {{
+          // single_select rendered as a list (list_style) — read the
+          // checked radio, not the first control.
+          var picked = f.querySelector('[data-control]:checked');
+          if (picked) answers[fid] = picked.value;
+        }} else if (el.value !== '') {{
+          answers[fid] = (ftype === 'number') ? Number(el.value) : el.value;
+        }}
       }}
     }});
     var payload = {{ {WIDGET_RESPONSE_MARKER!r}: true,

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -483,6 +483,13 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
                 "description": "progress: reported items as {label, status, detail?} dicts, "
                 "status in done/in_flight/blocked; the blocked subset must equal options",
             },
+            "list_style": {
+                "type": "string",
+                "enum": ["ordered", "unordered"],
+                "description": "single/multi_select only: render options as an ordered "
+                "(numbered) or unordered (bulleted) selectable list instead of the "
+                "default dropdown/checkboxes. Presentation only; answer unchanged.",
+            },
         },
         "required": ["id", "text", "type"],
     }

--- a/src/attune/meta_workflows/models.py
+++ b/src/attune/meta_workflows/models.py
@@ -101,6 +101,11 @@ class FormQuestion:
             {label, status, detail?} dicts, status ∈ {done, in_flight,
             blocked}. The blocked subset must equal options (the picker);
             done/in_flight items are reported but not answerable. None = none
+        list_style: SINGLE_SELECT/MULTI_SELECT only — render the options as
+            an "ordered" (numbered) or "unordered" (bulleted) selectable
+            list instead of the default dropdown/checkboxes. Pure
+            presentation: the answer and its validation are unchanged.
+            None = the default render.
 
     """
 
@@ -119,6 +124,7 @@ class FormQuestion:
     recommended: str | None = None
     user_position: str | None = None
     progress_items: list[dict[str, str]] | None = None
+    list_style: str | None = None
 
     def to_ask_user_format(self) -> dict[str, Any]:
         """Convert to format compatible with AskUserQuestion tool.

--- a/tests/unit/elicitation/test_list_style.py
+++ b/tests/unit/elicitation/test_list_style.py
@@ -1,0 +1,201 @@
+"""Tests for the ``list_style`` render variant (D19).
+
+A presentation-only option on ``single_select`` / ``multi_select`` that
+renders the options as an ordered (numbered) or unordered (bulleted)
+selectable list instead of the default dropdown/checkboxes. The answer
+shape and its validation are unchanged — these tests assert both the new
+render branch and that the existing answer path still validates a pick.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_to_widget_html,
+)
+
+
+def _render(field: dict) -> str:
+    form = form_from_dict({"title": "T", "fields": [field]})
+    return form_to_widget_html(form)
+
+
+class TestRender:
+    def test_single_select_ordered_renders_ol_with_radios(self):
+        html = _render(
+            {
+                "id": "s",
+                "text": "Pick",
+                "type": "single_select",
+                "options": ["x", "y"],
+                "list_style": "ordered",
+            }
+        )
+        assert '<ol class="ae-list"' in html
+        assert html.count('type="radio"') == 2
+        # not the default dropdown
+        assert "<select" not in html
+
+    def test_single_select_unordered_renders_ul(self):
+        html = _render(
+            {
+                "id": "s",
+                "text": "Pick",
+                "type": "single_select",
+                "options": ["x", "y"],
+                "list_style": "unordered",
+            }
+        )
+        assert '<ul class="ae-list"' in html
+        assert html.count('type="radio"') == 2
+
+    def test_multi_select_ordered_renders_ol_with_checkboxes(self):
+        html = _render(
+            {
+                "id": "m",
+                "text": "Pick many",
+                "type": "multi_select",
+                "options": ["x", "y", "z"],
+                "list_style": "ordered",
+            }
+        )
+        assert '<ol class="ae-list"' in html
+        assert html.count('type="checkbox"') == 3
+        assert '<div class="ae-checks"' not in html
+
+    def test_radios_share_name_for_single_select(self):
+        html = _render(
+            {
+                "id": "pick",
+                "text": "Pick",
+                "type": "single_select",
+                "options": ["x", "y"],
+                "list_style": "ordered",
+            }
+        )
+        # one radio group: both radios carry the field id as name
+        assert html.count('name="pick"') == 2
+
+    def test_default_render_unaffected_when_absent(self):
+        html = _render(
+            {
+                "id": "s",
+                "text": "Pick",
+                "type": "single_select",
+                "options": ["x", "y"],
+            }
+        )
+        assert "<select" in html
+        assert '<ol class="ae-list"' not in html
+        assert '<ul class="ae-list"' not in html
+
+    def test_option_label_is_escaped_in_list(self):
+        html = _render(
+            {
+                "id": "s",
+                "text": "Pick",
+                "type": "single_select",
+                "options": ['<img src=x onerror="alert(1)">'],
+                "list_style": "unordered",
+            }
+        )
+        assert "<img" not in html
+        assert "&lt;img" in html
+
+
+class TestRoundTrip:
+    def test_list_style_preserved_on_question(self):
+        form = form_from_dict(
+            {
+                "title": "T",
+                "fields": [
+                    {
+                        "id": "s",
+                        "text": "Pick",
+                        "type": "single_select",
+                        "options": ["x", "y"],
+                        "list_style": "ordered",
+                    }
+                ],
+            }
+        )
+        assert form.questions[0].list_style == "ordered"
+
+    def test_answer_path_unchanged_validates_pick(self):
+        # list_style is presentation-only — a normal single-select answer
+        # still validates by option membership.
+        form = form_from_dict(
+            {
+                "title": "T",
+                "fields": [
+                    {
+                        "id": "s",
+                        "text": "Pick",
+                        "type": "single_select",
+                        "options": ["x", "y"],
+                        "list_style": "ordered",
+                    }
+                ],
+            }
+        )
+        resp = collect_form_response(form, {"s": "y"})
+        assert resp.responses["s"] == "y"
+
+    def test_answer_path_still_rejects_out_of_option(self):
+        form = form_from_dict(
+            {
+                "title": "T",
+                "fields": [
+                    {
+                        "id": "s",
+                        "text": "Pick",
+                        "type": "single_select",
+                        "options": ["x", "y"],
+                        "list_style": "unordered",
+                    }
+                ],
+            }
+        )
+        with pytest.raises(FormValidationError):
+            collect_form_response(form, {"s": "z"})
+
+
+class TestDefinitionValidation:
+    def test_rejects_list_style_on_non_select_type(self):
+        with pytest.raises(FormValidationError) as exc:
+            form_from_dict(
+                {
+                    "title": "T",
+                    "fields": [
+                        {
+                            "id": "t",
+                            "text": "Say",
+                            "type": "text_input",
+                            "list_style": "ordered",
+                        }
+                    ],
+                }
+            )
+        assert "list_style" in str(exc.value)
+
+    def test_rejects_invalid_list_style_value(self):
+        with pytest.raises(FormValidationError) as exc:
+            form_from_dict(
+                {
+                    "title": "T",
+                    "fields": [
+                        {
+                            "id": "s",
+                            "text": "Pick",
+                            "type": "single_select",
+                            "options": ["x"],
+                            "list_style": "fancy",
+                        }
+                    ],
+                }
+            )
+        assert "list_style" in str(exc.value)


### PR DESCRIPTION
Records **and implements** the design decision reached this session via a
live `pushback` form (Patrick **switched** to the agent's alternative,
`resp-20260630-061842`): the proposed "intro + selectable list" is a
**render variant** of `single_select`/`multi_select`, not a 5th construct.

## Implementation

- `models.py` — optional `FormQuestion.list_style` (`"ordered"` |
  `"unordered"`)
- `widget.py` — `_list_html` renders `<ol>`/`<ul>` of radios (single) or
  checkboxes (multi); the submit script reads the checked radio for
  single-select-as-list; `.ae-list` styles
- `bridge.py` — `form_from_dict` validates `list_style` (select-only,
  value-checked) and threads it through
- `tool_schemas.py` — `list_style` on the rich form-field schema
- `elicit` SKILL.md (+ `.agents` mirror) — documents the option
- `tests/unit/elicitation/test_list_style.py` — 11 tests (render
  ordered/unordered, single + multi, round-trip, answer-path unchanged,
  definition validation)

**Zero** new `QuestionType`, **zero** answer-path/validator change. D19
recorded in decisions.md (status → built). 203 elicitation + tool-schema
tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)