### PR TITLE
spec(feature-page-scaffolder): one command for single-source authoring

### DIFF
--- a/docs/specs/feature-page-scaffolder/decisions.md
+++ b/docs/specs/feature-page-scaffolder/decisions.md
@@ -1,0 +1,69 @@
+# Feature-Page Scaffolder — Decisions
+
+**Status:** draft (2026-06-30) · log for
+[requirements.md](requirements.md) / [design.md](design.md).
+
+## D1 — Scaffold the skeleton, never generate the body
+
+**Decided.** The tool writes frontmatter + section headings + the
+manifest entry; it does NOT write prose. The master stays human/LLM-
+authored and fact-checked against live code. This is non-negotiable: it
+is the exact property that makes single-source trustworthy (the
+generation path emits systematic fiction — that lesson is why the
+projector is deterministic and why this tool stays out of the body). A
+"helpful" content stub would reintroduce the failure mode.
+
+## D2 — Insert the `features.yaml` entry by append, preserving comments
+
+**Decided.** `.help/features.yaml` is heavily commented (each entry has a
+paragraph explaining `status: manual`). A naive parse-and-re-emit YAML
+round-trip drops those comments. So `scaffold` appends a well-formed
+block under `features:` textually (anchored on the `features:` key /
+last entry), then re-parses to validate — rather than rewriting the whole
+file. Correctness is checked by the re-parse; comments survive.
+
+## D3 — Two verbs (`scaffold` then `build`), not one command
+
+**Decided.** The flow has an irreducible human step — filling the prose.
+A single command would either (a) generate the body (violates D1) or
+(b) stop and require resumption anyway. Two explicit verbs make the human
+gap a first-class part of the contract: `scaffold` sets up, the author
+writes, `build` distributes + verifies.
+
+## D4 — The skeleton lives in a versioned `_TEMPLATE.md`, not a string
+
+**Decided.** The canonical section contract (which headings, in what
+order, that the projector maps to kinds) is the thing most likely to
+drift. Keeping it as `content/features/_TEMPLATE.md` makes it reviewable
+and diff-able like any content, and gives the projector's contract one
+visible home. Leading underscore keeps it out of feature enumeration.
+
+## D5 — A script for v1, a CLI wrapper later
+
+**Decided.** `scripts/new_feature.py` beside `project_features.py` /
+`sync_help_bundle.py` — the trio it composes. A `attune feature new` CLI
+subcommand is a thin future wrapper; coupling to the CLI router now would
+widen the blast radius for no v1 benefit. Out of scope, not rejected.
+
+## D6 — `build` verifies postconditions, not exit codes
+
+**Decided.** Per R6 and the "registered ≠ working" discipline, each stage
+asserts its real effect: project → the output files exist; sync →
+`sync_help_bundle.py --check` exits 0 (re-verified, not inferred from the
+write); audits → exit 0 on the actually-new pages. A green wrapper means
+the artifacts are provably coherent, not that four subprocesses returned
+zero.
+
+## Open
+
+- **Fact-check gate (sibling, not here).** Promoting
+  `validate_master_file` from warn-only to blocking — and making it
+  robust across the editable-install mapping confusion — is the natural
+  partner improvement (the master is the single point of truth *and*
+  failure). Tracked as its own effort; this spec assumes the fact-check
+  stays advisory.
+- **`source_globs` → drift-propose (future vision).** The richer prize is
+  the fact-checker proposing diffs to the master's API tables when the
+  globbed code moves — the "staleness-aware mirror" realized. Far out of
+  this spec's scope; noted so the scaffolder's template leaves the API
+  tables in a shape that a future drift-proposer can target.

--- a/docs/specs/feature-page-scaffolder/design.md
+++ b/docs/specs/feature-page-scaffolder/design.md
@@ -1,0 +1,128 @@
+# Feature-Page Scaffolder — Design
+
+**Status:** draft (2026-06-30) · pairs with
+[requirements.md](requirements.md).
+
+## Shape: two verbs, a human gap between them
+
+The authoring flow has a deliberate human step in the middle — filling
+the prose. So the tool is two verbs, not one:
+
+```text
+scaffold  →  [ human/LLM fills the master's prose ]  →  build
+```
+
+- **`scaffold <slug> --summary … --tags … --globs …`** — writes
+  `content/features/<slug>.md` (frontmatter + empty section skeleton) and
+  inserts the `.help/features.yaml` entry. Stops. Prints "now fill the
+  master, then run `build <slug>`."
+- **`build <slug>`** — runs `project_features.py <slug>` →
+  `sync_help_bundle.py` → `audit_doc_imports.py` (scoped to the new
+  pages) → `audit_docs_wiring.py`, asserting each stage's postcondition,
+  and prints a per-stage report.
+
+This keeps R1 honest: the tool never authors prose; it brackets the
+human's authoring with correct setup and correct distribution.
+
+## Where it lives
+
+A single script `scripts/new_feature.py` with `scaffold` / `build`
+subcommands (argparse), mirroring the existing
+`scripts/project_features.py` and `scripts/sync_help_bundle.py`. Reasons:
+
+- It composes those two scripts; living beside them keeps the trio
+  discoverable.
+- Repo-root resolution copies `project_features.py`'s
+  `Path(__file__).resolve().parent.parent` idiom, so it works from any
+  worktree.
+- A CLI subcommand (`attune feature new`) is a thin future wrapper, not a
+  v1 requirement (kept out of scope to avoid coupling to the CLI router).
+
+## `scaffold` internals
+
+1. **Validate the slug** (R5): kebab-case `^[a-z][a-z0-9-]*$`, and
+   `content/features/<slug>.md` must not already exist, and `<slug>` must
+   not already key `features:` in `.help/features.yaml`. Any violation →
+   exit non-zero with the reason.
+2. **Render the master from a template** (R2/R3). The template is a
+   constant in the script (or a `content/features/_TEMPLATE.md` the script
+   reads — preferred, so the canonical skeleton is itself reviewable and
+   versioned). Substitute `feature`, `summary`, `tags`, `source_globs`.
+   The `nav` block is fixed (`how-to`/`architecture`/`reference`). The
+   body is the section headings the projector maps to kinds, each followed
+   by a single `<!-- fill: … -->` placeholder line.
+3. **Insert the manifest entry** (R2). Append under `features:` in
+   `.help/features.yaml`:
+
+   ```yaml
+     <slug>:
+       description: <summary>
+       tags: [<tags>]
+       status: manual
+   ```
+
+   Insertion is structural (parse YAML, add key, re-emit) to avoid
+   brittle text splicing; preserve the file's comment header by appending
+   the block rather than rewriting the whole file if the YAML round-trip
+   would drop comments. (Decision: see decisions.md D2.)
+
+## `build` internals
+
+Run the four stages as subprocesses (or in-process where the module is
+importable), capturing each stage's result:
+
+| Stage | Command | Postcondition asserted |
+|-------|---------|------------------------|
+| project | `project_features.py <slug>` | N output files exist on disk |
+| sync | `sync_help_bundle.py` | `sync_help_bundle.py --check` exits 0 |
+| imports | `audit_doc_imports.py --paths <the 4 new docs pages>` | exit 0 |
+| wiring | `audit_docs_wiring.py` | exit 0 |
+
+R6: each stage's success is *verified*, not assumed from a zero exit
+alone (e.g. project asserts the files exist; sync re-runs `--check`).
+
+### The `attune_author` env resolution (R4)
+
+`project_features.py` imports `attune_author`, absent from the worktree
+venv. `build` resolves a usable interpreter in this order:
+
+1. the current interpreter, if `import attune_author` succeeds;
+2. an explicit `--python <path>` argument;
+3. a discovered sibling main-checkout venv
+   (`<repo-parent-or-main>/.venv/bin/python`) that imports
+   `attune_author`;
+
+and if none works, exits with the exact remedy ("install attune-author in
+this venv, or pass `--python <main-venv-python>`") rather than a raw
+`ModuleNotFoundError`. This turns the silent gotcha into an actionable
+message.
+
+## The template file
+
+`content/features/_TEMPLATE.md` — the canonical skeleton, leading
+underscore so it is ignored by feature enumeration (the projector and
+manifest key on real slugs). It is the single place the section contract
+lives; `scaffold` substitutes into it. Keeping it as a file (not a string
+constant) means the skeleton is reviewed like any other content and stays
+in step with what the projector expects.
+
+## Testing
+
+- **Unit:** `scaffold` on a throwaway slug writes a master whose
+  frontmatter parses and whose sections match the template; rejects an
+  existing slug; rejects a bad slug; inserts a well-formed yaml entry.
+- **Integration / regression (R7 acceptance):** scaffold a throwaway
+  feature, fill it from a fixture body, `build` it, and assert the
+  produced `.help` + docs + bundle outputs are byte-identical to running
+  `project_features.py` + `sync_help_bundle.py` by hand — proving the
+  wrapper adds no drift. Clean up the throwaway artifacts in teardown.
+- The throwaway slug (e.g. `_scaffolder_probe`) is `.gitignore`-safe or
+  removed in teardown so it never lands in `features.yaml`.
+
+## Rollout
+
+1. Ship `scripts/new_feature.py` + `_TEMPLATE.md` + tests.
+2. Update the lessons playbook entry to lead with
+   `python scripts/new_feature.py scaffold|build` and demote the manual
+   5 steps to "what it does under the hood" (R7).
+3. (Future, out of scope) thin `attune feature new` CLI wrapper.

--- a/docs/specs/feature-page-scaffolder/requirements.md
+++ b/docs/specs/feature-page-scaffolder/requirements.md
@@ -1,0 +1,108 @@
+# Feature-Page Scaffolder — Requirements
+
+**Status:** draft (2026-06-30) · **Owner:** Patrick + agent
+**Born:** authoring the `elicitation-forms` feature page (PR #1188)
+surfaced that adding one single-source page is a 5-step procedure with
+enough tribal knowledge that it needed its own lessons entry (the
+"API-free single-source feature-page playbook"). A procedure that needs
+a playbook to remember is a procedure that should be a command.
+
+Direct follow-on to
+[help-docs-single-source](../help-docs-single-source/): that program
+built the deterministic projector; this spec removes the friction of
+*using* it for a new feature.
+
+## Problem
+
+Adding a new single-source feature page today means executing, in order
+and from memory:
+
+1. hand-author `content/features/<F>.md` with the exact frontmatter
+   schema (`feature`/`summary`/`tags`/`source_globs`/`nav`) and the
+   canonical section skeleton (Overview / Concepts / Quickstart / Tasks /
+   Reference / …), copied from an existing page;
+2. add a `.help/features.yaml` entry (`status: manual`, no `files:`);
+3. run `python scripts/project_features.py <F>` — with the **main** venv
+   python, because the worktree venv lacks `attune_author`;
+4. run `python scripts/sync_help_bundle.py` — or
+   `test_help_bundle_sync` fails;
+5. verify with `audit_doc_imports.py`, `audit_docs_wiring.py`, and the
+   help test suite.
+
+Three costs:
+
+1. **Knowledge cliff.** None of steps 1–5 is discoverable from the repo;
+   they live in a lessons entry. A first-time contributor (or a fresh
+   agent session) cannot add a page without that out-of-band knowledge.
+2. **Silent-failure traps.** Forgetting step 4 produces a red CI that
+   names a sync script, not a cause; running step 3 with the wrong venv
+   produces a `ModuleNotFoundError` that looks like a missing dependency.
+3. **Skeleton drift.** Hand-copying frontmatter and section headings from
+   a sibling page invites subtle divergence (a dropped nav kind, a missing
+   section the projector expects) that only surfaces at projection time.
+
+The projector already proves the *distribution* is mechanizable. The
+*authoring entry* is the remaining manual surface.
+
+## Goal
+
+One command scaffolds a correct, empty-but-complete feature master and its
+manifest entry; a second mechanizes the project → sync → audit chain. The
+human (or a verifying LLM) fills only the prose — never the plumbing.
+
+## Requirements
+
+- **R1 — Scaffold, never generate.** The tool creates the master's
+  *frontmatter and section skeleton* and the `.help/features.yaml` entry.
+  It MUST NOT write body prose. (Generation is the failure mode
+  single-source exists to avoid; the master stays human/LLM-authored and
+  fact-checked.)
+- **R2 — Correct-by-construction frontmatter.** The scaffolded master
+  carries valid frontmatter for the given slug: `feature`, a `summary`
+  and `tags` from arguments, `source_globs` from arguments, and a `nav`
+  block with exactly the kinds the projector emits (`how-to`,
+  `architecture`, `reference` — **not** `tutorial`).
+- **R3 — Section skeleton matches the projector contract.** The skeleton
+  contains exactly the section headings the projector maps to kinds, in
+  canonical order, each with a one-line placeholder comment, so a filled
+  master projects without "missing section" surprises.
+- **R4 — One mechanical build step.** A single invocation runs
+  `project_features.py` → `sync_help_bundle.py` → the doc audits, and
+  reports pass/fail per stage. It resolves the projector's `attune_author`
+  dependency itself (or fails with an actionable message), so the
+  main-venv gotcha never reaches the user.
+- **R5 — Safe and idempotent.** Refuse to overwrite an existing
+  `content/features/<F>.md` or a duplicate `features.yaml` entry; validate
+  the slug (kebab-case, matches an allowed pattern). A re-run of the build
+  step on an unchanged master is a no-op.
+- **R6 — Self-verifying.** The tool's own output asserts the
+  postconditions it can check (master exists, yaml entry present, N
+  outputs projected, bundle in sync, audits clean) — it does not declare
+  success on a tool-call that didn't verify its effect.
+- **R7 — Documented as the playbook's replacement.** When R1–R6 ship, the
+  lessons playbook entry is updated to point at the command as the
+  canonical path, keeping the manual steps only as the "what it does
+  under the hood" reference.
+
+## Non-goals
+
+- **Not a content generator.** No LLM, no API. (Same constraint that
+  makes the projector trustworthy.)
+- **Not a fact-checker upgrade.** Strengthening `validate_master_file`
+  from warn-only to a gate is a *sibling* opportunity (see the
+  single-source insights discussion), tracked separately — not this spec.
+- **Not a docs-nav editor.** The mkdocs Features nav is auto-wired by
+  `docs/hooks/feature_nav.py`; the scaffolder relies on that, doesn't
+  touch `mkdocs.yml`.
+
+## Acceptance
+
+- A contributor with **no playbook knowledge** can run two commands
+  (`scaffold`, then `build`) with a filled-in master between them and
+  land a green feature-page PR.
+- Running the build step omitting the bundle sync is impossible (it's one
+  step), so the `test_help_bundle_sync` red can no longer be reached by
+  forgetting.
+- The `feature new` path spends zero API credits.
+- A regression test drives the scaffolder on a throwaway slug and asserts
+  the projected + synced outputs match the projector's own output.

--- a/docs/specs/feature-page-scaffolder/tasks.md
+++ b/docs/specs/feature-page-scaffolder/tasks.md
@@ -1,0 +1,62 @@
+# Feature-Page Scaffolder — Tasks
+
+**Status:** draft (2026-06-30) · implements
+[design.md](design.md). Each task names its acceptance.
+
+## T1 — Template + `scaffold` verb
+
+- Add `content/features/_TEMPLATE.md`: fixed `nav`
+  (`how-to`/`architecture`/`reference`), substitutable
+  `feature`/`summary`/`tags`/`source_globs`, and the canonical section
+  skeleton (Overview / Concepts / Quickstart / Tasks / Reference /
+  Comparison / Failure modes / FAQ seeds / Notes & tips / Design &
+  extension), each with one `<!-- fill: … -->` line.
+- `scripts/new_feature.py scaffold <slug> --summary … --tags … --globs …`:
+  validate slug (R5), render the master from the template, append the
+  `features.yaml` entry preserving comments (D2).
+- **Acceptance:** scaffolding a throwaway slug yields a master whose
+  frontmatter parses and whose section set equals the projector's
+  expected sections; a duplicate slug and a non-kebab slug both exit
+  non-zero with a clear reason; the new `features.yaml` re-parses.
+
+## T2 — `build` verb + env resolution
+
+- `scripts/new_feature.py build <slug>`: run project → sync → import
+  audit (scoped to the 4 new docs pages) → wiring audit, each with its
+  postcondition asserted (D6).
+- Resolve a `attune_author`-capable interpreter (current → `--python` →
+  discovered main venv); on failure, exit with the actionable remedy, not
+  a raw `ModuleNotFoundError` (R4).
+- **Acceptance:** on a filled throwaway master, `build` exits 0 and the
+  bundle-sync `--check` is clean; with `attune_author` unavailable and no
+  `--python`, it exits non-zero naming the fix.
+
+## T3 — Tests
+
+- Unit (T1 surface): render correctness, slug rejection, yaml insertion.
+- Integration / regression: scaffold a throwaway feature, fill from a
+  fixture body, `build`, and assert the produced `.help` + docs + bundle
+  outputs are byte-identical to a hand-run `project_features.py` +
+  `sync_help_bundle.py` — the wrapper adds no drift. Teardown removes the
+  throwaway slug and all its artifacts (incl. the `features.yaml` entry)
+  so nothing leaks into the repo.
+- **Acceptance:** the suite is green and the throwaway slug is absent from
+  `features.yaml` after the run.
+
+## T4 — Retire the playbook into the command
+
+- Update the lessons entry ("API-free single-source feature-page
+  playbook") to lead with `scripts/new_feature.py scaffold|build` and
+  demote the manual 5 steps to "under the hood".
+- Add a short `content/features/_TEMPLATE.md`-adjacent note or a
+  `docs/how-to/` pointer so the command is discoverable in-repo (closing
+  the "knowledge cliff" R1 names).
+- **Acceptance:** a reader who finds the lessons entry or the how-to is
+  routed to the command first; the manual steps remain only as
+  explanation.
+
+## Sequencing
+
+T1 → T2 are the build order; T3 lands with each (unit alongside T1,
+integration alongside T2). T4 is the closeout once T1–T3 are green. No
+task depends on the sibling fact-check-gate work (decisions.md Open).


### PR DESCRIPTION
Specs the `feature new` scaffolder we discussed — the most concrete of
the single-source insights: retire the manual feature-page playbook into
a command, so adding a page needs no out-of-band knowledge.

## Shape

`scaffold <slug> …` → *(human/LLM fills the prose)* → `build <slug>`

- **scaffold** writes the frontmatter + section skeleton (from a
  versioned `_TEMPLATE.md`) + the `features.yaml` entry. **Never prose**
  (D1 — generation is the failure mode single-source exists to avoid).
- **build** runs project → sync → doc audits with each postcondition
  *verified* (D6), and resolves the `attune_author`-env gotcha itself
  (R4) instead of emitting a raw `ModuleNotFoundError`.

## Files

`requirements.md` (R1–R7 + non-goals + acceptance), `design.md` (the two
verbs, where it lives, env resolution, testing), `decisions.md` (D1–D6 +
the sibling fact-check-gate and drift-propose opportunities left open),
`tasks.md` (T1–T4).

Spec only — **for your review / the approval loop** before any code. The
two "Open" items (promote `validate_master_file` to a blocking gate;
`source_globs` → drift-propose) are noted as sibling efforts, not folded
in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)