### PR TITLE
spec(master-factcheck-gate): make master verification trustworthy

### DIFF
--- a/docs/specs/master-factcheck-gate/decisions.md
+++ b/docs/specs/master-factcheck-gate/decisions.md
@@ -1,0 +1,57 @@
+# Master Fact-Check — Decisions
+
+**Status:** draft (2026-06-30) · log for
+[requirements.md](requirements.md) / [design.md](design.md).
+
+## D1 — Fix resolution attune-ai-side; don't re-engineer `attune_author` first
+
+**Decided.** The false positive is the editable-install mapping; the cure
+is the authoritative repo-`src`-on-`sys.path` resolver that
+`audit_doc_imports.py` already implements in attune-ai. Extract that
+resolver and have `project_features.py` call it, rather than reaching into
+the sibling `attune_author.check_python_refs`. Keeps the blast radius in
+one repo and reuses proven, already-required machinery. A sibling change
+is a fallback only if R1/R2 genuinely can't be met attune-ai-side.
+
+## D2 — Gate only measured-reliable checks; deep checks stay advisory
+
+**Decided.** The doc-import-gate deliberately scoped to import resolution
+because deeper checking (method calls, claim accuracy) is high-false-
+positive. This spec holds that line: a check becomes blocking only with a
+measured near-zero false-positive rate on the 27-master corpus. An
+LLM-grounded fact-checker never blocks merge on its own authority.
+
+## D3 — This spec is partly investigative; let the corpus decide
+
+**Decided.** Whether anything `check_python_refs` does beyond imports is
+worth gating is **unknown** until measured against the real masters (Step
+2). The spec does not pre-commit to "add a gate." Pre-committing would
+repeat the exact mistake the premise-verification just caught — asserting
+a gap that the evidence might not support.
+
+## D4 — "Retire the duplicate" is a valid — even preferred — outcome
+
+**Decided.** If the measurement shows the projector's check adds no
+reliable coverage beyond the required gate, the right move is to *remove*
+the redundant/flaky check, not to harden it. The single-source program's
+own value is fewer trustworthy surfaces, not more machinery. A spec that
+can conclude "delete code" is healthier than one that must ship a feature.
+
+## Context: why the premise was only *partly* right
+
+The insights discussion framed the verification half as "advisory and
+backwards." Verification found that the *import* half is in fact already
+authoritative and **required** (doc-import-audit + wiring-audit were
+promoted into branch protection). The genuinely-weak surface is narrower:
+a redundant warn-only checker that false-positives. Recording this so the
+spec is not read as "the masters are unverified" — they are; the gap is a
+trust bug in a secondary checker, not a missing gate.
+
+## Open
+
+- **`source_globs` → drift-propose (the bigger prize).** The richer
+  follow-on remains: when globbed code moves, *propose* the diff to the
+  master's API tables — the staleness-aware-mirror vision. Strictly out of
+  scope here; this spec is about making the *existing* verification
+  trustworthy, which is the prerequisite for trusting an auto-proposer
+  later.

--- a/docs/specs/master-factcheck-gate/design.md
+++ b/docs/specs/master-factcheck-gate/design.md
@@ -1,0 +1,99 @@
+# Master Fact-Check — Design
+
+**Status:** draft (2026-06-30) · pairs with
+[requirements.md](requirements.md).
+
+## The shape of the fix: make the projector agree with the gate
+
+The required gate (`audit_doc_imports.py`) is already the authority on
+master imports. The projector's warn-only check is the unreliable
+duplicate. So the design is *subtraction toward a single source of
+truth*, not a new gate bolted on top.
+
+```text
+project_features.py
+  ├─ import resolution  → DEFER to the authoritative resolver
+  │                        (repo src on sys.path), not the editable map
+  └─ non-import refs     → keep advisory, with the SAME resolver,
+                           until R3 measures whether any is gate-worthy
+```
+
+## Step 1 — Authoritative resolution (R1/R2)
+
+`audit_doc_imports.py` already owns the correct mechanism: it adds the
+in-repo `src/` to `sys.path` and resolves `attune` imports there, immune
+to the editable-install mapping. Extract that resolver into a small
+importable helper (it is currently script-internal) and have
+`project_features.py` call it for the master's import lines — instead of
+`attune_author.validate_master_file`'s editable-mapping import.
+
+Result: the projector's import verdict is byte-for-byte the gate's
+verdict. The line-115-style false positive disappears because the same
+authoritative path is used. Single source of truth on imports (R2).
+
+The change is attune-ai-side (the driver + a helper extraction); no
+`attune_author` change is needed for the import half (D1).
+
+## Step 2 — Characterize the incremental checks (R3)
+
+Before touching `check_python_refs`'s *non-import* behavior, measure it:
+
+1. Run the current `check_python_refs` across all 27 masters; collect
+   every finding.
+2. Run `audit_doc_imports.py` across the same; collect findings.
+3. The **delta** (in `check_python_refs` but not the gate) is the
+   incremental coverage — symbol references in prose, bare names,
+   method-ish refs.
+4. For each delta finding, hand-classify: *true positive* (a real stale
+   ref), *false positive* (resolves fine / not actually a code ref), or
+   *import-redundant* (already the gate's job).
+
+This is an investigation task with a written output
+(`incremental-findings.md`), not an assumption. It decides Step 3.
+
+## Step 3 — Gate the reliable subset, or retire the duplicate (R4)
+
+Two honest outcomes, chosen by the Step 2 measurement:
+
+- **If the delta contains a near-zero-false-positive check** (e.g. "a
+  bare `attune.X.Y` symbol reference in prose resolves"): fold it into the
+  authoritative resolver / `audit_doc_imports.py` and ride the
+  advisory→required promotion path (advisory on main until a green
+  streak, then added to branch protection — the exact play `doc-import`
+  and `wiring` already followed).
+- **If the delta is empty or all high-false-positive:** the correct result
+  is *removal*, not addition — drop the redundant/flaky import check from
+  the projector (Step 1 already moved imports to the authoritative path),
+  leaving the projector's advisory output trustworthy-by-subtraction.
+  "Less verification machinery, more trust" is a legitimate, even
+  preferred, outcome (D4).
+
+Method-call accuracy and prose-claim accuracy are **out** either way
+(non-goal; high false-positive; the doc-import-gate line).
+
+## Step 4 — One author-facing message (R5)
+
+After Steps 1–3 the projector prints the authoritative resolver's
+findings only (no contradictory second opinion), located at the master
+(file + line). The required gate remains the blocking authority in CI; the
+projector surfaces the same verdict earlier, at authoring time, so the
+error is caught before projection fans it to 14 outputs.
+
+## Testing
+
+- **Resolution (R1):** a master with a valid multi-line
+  `from attune.elicitation import (…)` produces zero "not importable"
+  findings from the projector (the exact regression that motivated this
+  spec).
+- **Agreement (R2):** a property/parametrized test that the projector's
+  import verdict equals `audit_doc_imports.py`'s on a fixture set
+  including resolvable, unresolvable, and skip-marked fences.
+- **Promotion guard (R4):** if a delta check is gated, a test that it
+  fires on a known-bad master and is silent on the 27 real ones.
+
+## Sequencing note
+
+Step 2 (measurement) is the pivot — Step 3's direction (gate vs. retire)
+is unknown until the delta is measured. So this spec is **partly
+investigative**: do not pre-commit to adding a gate; let the corpus
+decide (D3).

--- a/docs/specs/master-factcheck-gate/requirements.md
+++ b/docs/specs/master-factcheck-gate/requirements.md
@@ -1,0 +1,103 @@
+# Master Fact-Check — Reconciliation & Trust
+
+**Status:** draft (2026-06-30) · **Owner:** Patrick + agent
+**Born:** the single-source insights discussion. The claim on the table
+was "the projection is deterministic and trusted, but the master's
+verification is warn-only and pointed backwards." Verifying that claim
+before speccing (the spec-premise discipline) **partly refuted it** — and
+the refutation is the spec.
+
+## What verifying the premise found
+
+The master's verification is split across two mechanisms with
+**overlapping scope and opposite reliability**:
+
+| Mechanism | Where | Scope | Reliability | Status |
+|-----------|-------|-------|-------------|--------|
+| `audit_doc_imports.py` | attune-ai | `attune` imports in `content/features/**` + served docs | **authoritative** — adds repo `src/` to `sys.path` | **REQUIRED** (promoted from advisory) |
+| `check_python_refs` (via `validate_master_file`) | `attune_author`, run by `project_features.py` | python refs in master fences | **flaky** — resolves against the editable-install mapping | warn-only |
+
+So the part everyone worried was ungated — *do the master's imports
+resolve?* — **is already gated and required**, and it covers masters. The
+real problem is the *other* checker: it is (a) **partly redundant** with
+the required gate, and (b) **unreliable** in a way that actively erodes
+trust — authoring `elicitation-forms.md` it flagged a valid multi-line
+`from attune.elicitation import …` as "module not importable" while the
+required gate passed the same line. An author who believes the scary
+warning either chases a non-bug or learns to ignore the checker entirely
+— the worst outcome for a verification tool.
+
+## Problem
+
+1. **A false-positive checker is worse than no checker.** The projector's
+   warn-only fact-check emits "not importable" on imports that *do*
+   resolve, because it imports against the main venv's editable mapping
+   (possibly-stale `src`) instead of the authoritative repo-`src`-on-path
+   mechanism the required gate uses. The fix the editable-mapping lesson
+   already prescribes — "trust the audit, not the convenient import" —
+   should be *built into the tool*, not left to the author to know.
+2. **Two checkers, one question, no single source of truth on imports.**
+   Imports are checked twice (authoritatively by the required gate,
+   flakily by the projector). The author shouldn't reconcile two answers.
+3. **The genuinely-incremental coverage is undefined.** Whatever
+   `check_python_refs` does *beyond* import resolution (symbol refs in
+   prose, method names) is the only part with marginal value — and it has
+   never been separated from the redundant import check or assessed for
+   false-positive rate. Per the doc-import-gate lesson, deeper-than-import
+   checking is high-false-positive and was deliberately left ungated.
+
+## Goal
+
+One trustworthy verification story for a master: **the required gate is
+the authority on imports; the projector's advisory check is either made
+to agree with it or defers to it; and any check beyond imports is gated
+only if it is reliable, advisory otherwise.** When a master is wrong, the
+author gets one correct message, at the master, before projection fans
+the error to 14 outputs.
+
+## Requirements
+
+- **R1 — Kill the false positive.** The projector's pre-projection
+  python-ref check MUST resolve imports the authoritative way (repo `src/`
+  on `sys.path`, as `audit_doc_imports.py` does) — never against the
+  editable-install mapping. A valid import must never be flagged.
+- **R2 — No double jeopardy on imports.** The projector does not
+  re-adjudicate what the required gate already authoritatively checks. It
+  either reuses the gate's resolver or defers imports to it, so there is a
+  single source of truth on "do the imports resolve."
+- **R3 — Separate and characterize the incremental checks.** Identify what
+  `check_python_refs` asserts *beyond* import resolution. For each such
+  check, measure its false-positive behavior on the existing 27 masters
+  before deciding its fate.
+- **R4 — Gate only the reliable subset.** Promote to blocking (or fold
+  into the required gate) only checks with a demonstrated near-zero
+  false-positive rate. Genuinely-ambiguous checks (method-call accuracy,
+  prose-claim accuracy) stay **advisory by design** — the same line the
+  doc-import-gate drew, for the same reason.
+- **R5 — One author-facing message.** A master that fails verification
+  produces a single, actionable error at the master (file + line + what
+  doesn't resolve), at authoring/projection time — not 14 downstream
+  failures and not a contradictory pair of warnings.
+
+## Non-goals
+
+- **Not method-signature or claim-accuracy gating.** High false-positive,
+  deliberately ungated (doc-import-gate precedent). May stay advisory;
+  never blocking on the strength of an LLM-grounded fact-checker alone.
+- **Not a rewrite of `attune_author`.** Prefer fixing the resolution in
+  the attune-ai-side driver (`project_features.py`) — e.g. calling the
+  in-repo authoritative resolver — over re-engineering the sibling
+  package, unless R1/R2 genuinely require a sibling change.
+- **Not the scaffolder.** Sibling spec
+  [feature-page-scaffolder](../feature-page-scaffolder/) (PR #1190);
+  independent.
+
+## Acceptance
+
+- Re-authoring any of the 27 existing masters surfaces **zero** false
+  "not importable" warnings.
+- The projector and the required gate never disagree on whether a
+  master's imports resolve.
+- Any check that beyond-imports verification gates has a documented
+  false-positive measurement on the current corpus justifying the
+  promotion; everything unproven stays advisory.

--- a/docs/specs/master-factcheck-gate/tasks.md
+++ b/docs/specs/master-factcheck-gate/tasks.md
@@ -1,0 +1,47 @@
+# Master Fact-Check — Tasks
+
+**Status:** draft (2026-06-30) · implements [design.md](design.md).
+
+## T1 — Extract the authoritative resolver (R1/R2)
+
+- Lift `audit_doc_imports.py`'s repo-`src`-on-`sys.path` import resolver
+  into a small importable helper (keep the script as a thin caller).
+- Point `project_features.py`'s pre-projection check at that helper for
+  import lines; stop importing against the editable mapping.
+- **Acceptance:** the multi-line `from attune.elicitation import (…)`
+  regression yields zero "not importable" findings; the projector's
+  import verdict equals `audit_doc_imports.py`'s on a fixture set.
+
+## T2 — Measure the incremental coverage (R3)
+
+- Run `check_python_refs` and `audit_doc_imports.py` across all 27
+  masters; compute the delta; hand-classify each delta finding
+  (true / false / import-redundant).
+- Write `incremental-findings.md` in this spec dir with the table.
+- **Acceptance:** the measurement exists and classifies every delta
+  finding; T3's direction is chosen from it, not assumed.
+
+## T3 — Gate the reliable subset OR retire the duplicate (R4/D4)
+
+- If a near-zero-false-positive check exists: fold it into the
+  authoritative resolver and put it on the advisory→required promotion
+  path; add a fires-on-bad / silent-on-good test.
+- Else: remove the redundant/flaky import check from the projector
+  (imports already moved to the authoritative path in T1).
+- **Acceptance:** either a new advisory check with a passing promotion
+  guard, or a net deletion — and in both cases the projector emits one
+  authoritative verdict (R5).
+
+## T4 — Author-facing message + docs (R5)
+
+- Ensure the projector prints the authoritative findings located at the
+  master (file + line); update the single-source playbook lesson to note
+  the projector's verdict now matches the required gate.
+- **Acceptance:** a wrong master gives one actionable message at
+  authoring time; no contradictory pair of warnings.
+
+## Sequencing
+
+T1 first (the trust fix, valuable alone). T2 is the pivot; T3 follows its
+result. T4 closes. None depends on the scaffolder spec or the
+drift-propose Open item.


### PR DESCRIPTION
You picked (1) — the verification half. Speccing it started by **verifying
its own premise**, which partly refuted the framing from our discussion
(and that refutation is the spec):

- `audit_doc_imports.py` **already covers `content/features/**` masters**,
  and `doc-import-audit` + `wiring-audit` are **now required checks**. So
  the authoritative import gate on masters already exists and blocks merge.
- The line-115 false positive I hit was the **projector's** warn-only
  `check_python_refs` (resolves against the stale editable-install
  mapping) — not the required gate, which passed.

So the real gap is narrower and sharper: a **redundant, flaky advisory
checker eroding trust** in an area the required gate already owns. A
false-positive checker is worse than none — the author either chases a
non-bug or learns to ignore it.

## The fix (subtraction toward one source of truth)

1. Point the projector's import check at the **authoritative resolver**
   (repo `src` on `sys.path`) — kill the false positive (T1).
2. **Measure** what `check_python_refs` does *beyond* imports against all
   27 masters (T2 — investigative, written output).
3. **Gate only the measured-reliable subset** via the advisory→required
   path — *or retire the duplicate entirely* if the delta adds no reliable
   coverage (D4: "delete code" is a valid, even preferred, outcome).

Deep checks (method/claim accuracy) stay advisory by design — the
doc-import-gate line.

Spec only — for your review. Sibling of #1190 (scaffolder); the bigger
`source_globs`→drift-propose prize is noted Open, not folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)