### PR TITLE
spec(attune-author): consolidate + retire — the authoring-vs-mechanics split

### DIFF
--- a/docs/specs/attune-author-consolidation/decisions.md
+++ b/docs/specs/attune-author-consolidation/decisions.md
@@ -1,0 +1,73 @@
+# attune-author Consolidation — Decisions
+
+**Status:** draft (2026-06-30) · log for
+[requirements.md](requirements.md) / [design.md](design.md).
+
+## D1 — The split is authoring vs. mechanics, not "the package"
+
+**Decided.** The unit of the retire/absorb decision is not the package but
+the *kind of work* each part does. Authoring (judgment) → the driving
+session + a skill; mechanics (deterministic transform/hash/verify) → code
+in attune-ai. A model is the right tool for the first and the wrong tool
+for the second, because the second's value is invariance. This is the line
+the whole spec follows; everything else is bookkeeping.
+
+## D2 — Absorb the projector/staleness/fact-check; do NOT replace them with instructions
+
+**Decided.** Pushback resolved: "replace code with instructions" is right
+for the LLM authoring machinery and *wrong* for the deterministic
+distribution machinery. The projector's value is that the fan-out can't
+vary; staleness is a hash comparison; the import gate is deterministic
+truth. Replacing any of these with model judgment reintroduces the drift
+single-source exists to eliminate. They move as code.
+
+## D3 — Retire the authoring machinery; the session replaces it
+
+**Decided.** `generator`/`polish`/`doc_gen`/`maintenance_batch`/
+`faithfulness` and the `ai` deps are deleted, not absorbed. The lesson is
+empirical: the keyless regen is a content-*stripping* regression and the
+driving session is a *superior* polish layer that also catches correctness
+bugs the API polish cannot. We are deleting a measured-worse path.
+
+## D4 — Fold #1191's T1 into the move, don't bolt it on
+
+**Decided.** #1191 (merged spec) called for an authoritative resolver. Its
+T1 originally meant "wire attune-ai's resolver across the package line."
+Once the fact-check moves *into* attune-ai (D2), the resolver is just a
+shared in-repo helper — strictly cleaner. So #1191's implementation
+happens *inside* this consolidation (design Step 2 / T2), not as a separate
+cross-package patch. The merged #1191 spec stays the rationale; this spec
+is its execution venue.
+
+## D5 — Code move and package retirement are SEPARATE decisions
+
+**Decided.** Moving the code into attune-ai (reversible, low-risk) and
+yanking the `attune-author` PyPI package (irreversible-ish) are decoupled.
+Capture the architectural win first (T1–T3); make the package's fate a
+deliberate, later step (T4). Because there are no adopters (confirmed
+beta), archive-and-yank is viable — but it's still its own PR so the
+irreversible action is intentional.
+
+## D6 — `polish_template` degrades, by design
+
+**Decided.** `personal.py`'s optional polish (the one non-docs consumer of
+the LLM path) drops to its existing `_build_skeleton` fallback. It is safe
+(already `try/except → None`) and consistent with the thesis (no API
+polish; the session is the polish layer). Named as a behavior change in
+the changelog, not discovered silently later.
+
+## D7 — Absorb staleness as-is; fixing it is a separate spec
+
+**Decided.** `staleness.py`'s known weaknesses (single-file hash, no
+completeness check — lessons corpus) are real but out of scope. Absorbing
+and then rewriting in one move would balloon the change and couple a
+mechanical migration to a behavioral redesign. Absorb first; the staleness
+hardening is a tracked follow-on.
+
+## Open
+
+- **Where exactly the absorbed module lives** — `attune.authoring` vs.
+  `attune.single_source` vs. folding into an existing package. Naming
+  decision for the design review; doesn't change the substance.
+- **Shim vs. archive** for the package (T4) — decide with the (near-zero)
+  download numbers in hand at execution time.

--- a/docs/specs/attune-author-consolidation/design.md
+++ b/docs/specs/attune-author-consolidation/design.md
@@ -1,0 +1,130 @@
+# attune-author Consolidation — Design
+
+**Status:** draft (2026-06-30) · pairs with
+[requirements.md](requirements.md).
+
+## The new home
+
+A single internal package `src/attune/authoring/` holding the absorbed
+distribution machinery:
+
+```text
+attune/authoring/
+  projector.py        # from attune_author.projector (project_feature, validate_master_file)
+  staleness.py        # from attune_author.staleness  (check_staleness)
+  manifest.py         # from attune_author.manifest   (load_manifest, Manifest)
+  fact_check/         # reliable checkers only:
+    python_refs.py    #   — but import resolution defers to the authoritative resolver (R2)
+    cli_refs.py
+    tutorial_static_check.py
+    doc_examples.py
+    import_repair.py
+  maintenance.py      # run_hook only (the deterministic post-commit hook)
+  freshness/symbols.py
+```
+
+Not moved (deleted instead): `generator`, `polish`, `polish_prompts`,
+`doc_gen`, `maintenance_batch`, `faithfulness`, the package `cli`/`mcp`,
+`auth`, `editor_launcher`, `bootstrap`, `skill_export`, `meta_templates`
+that exist only for the LLM path. (Audit each against the absorb list
+before deleting — anything the absorbed modules import transitively comes
+too; anything only the LLM path imports goes.)
+
+## Step 1 — Absorb + repoint (the mechanical core)
+
+Move the absorb-list modules into `attune/authoring/`, preserving public
+callable names. Then repoint each consumer (requirements table):
+
+| Consumer | Before | After |
+|---|---|---|
+| `project_features.py` | `from attune_author.projector import …` | `from attune.authoring.projector import …` |
+| `help_post_commit.py` hook | `from attune_author.maintenance import run_hook` | `from attune.authoring.maintenance import run_hook` |
+| staleness scripts | `from attune_author import check_staleness, load_manifest` | `from attune.authoring import …` |
+| `regenerate_help_templates.py` | `from attune_author import load_manifest` | `from attune.authoring import load_manifest` |
+| `ops/help_data.py` | parses `attune-author status` CLI | call the in-repo `check_staleness` directly (drop the CLI-text parse) |
+
+The projector's output must be **byte-identical** pre/post move — a golden
+test on an existing master is the guard.
+
+## Step 2 — Fold in #1191 (the resolver, R2)
+
+The absorbed `fact_check/python_refs.py` no longer resolves imports
+against the editable mapping. Extract `audit_doc_imports.py`'s
+src-on-`sys.path` resolver into a shared helper
+(`attune.authoring.fact_check.imports`) and have both the audit script and
+the absorbed checker call it. Result: one authoritative import verdict,
+the line-115 false positive gone — #1191's T1, done where the code now
+lives. (Supersedes #1191's "bolt a second resolver across the package
+line" shape.)
+
+## Step 3 — Retire the authoring machinery (R3)
+
+Delete the LLM surface. Guard the deletion:
+
+- `grep` attune-ai for any import of a to-be-deleted module — there must
+  be none except `personal.py`'s `polish_template` (handled in Step 4)
+  and `help_data.py`'s CLI parse (handled in Step 1).
+- Remove the `[author]` extra's `anthropic` / `claude-agent-sdk` deps
+  from the authoring path; confirm nothing else in attune-ai's base or
+  `[author]` install needs them (workflows have their own SDK dep — leave
+  that untouched).
+
+## Step 4 — `polish_template` behavior change (R6)
+
+`personal.py::_load_author` already returns `None` when the import fails.
+Two clean options:
+
+- **(a) Drop the polish hook** — delete `_load_author`'s polish call; rely
+  on `_build_skeleton`. The driving session (or the authoring skill)
+  polishes memory entries if wanted, consistent with the whole thesis.
+- **(b) Keep a tiny in-repo `polish_template` shim** that is a no-op
+  pass-through (returns input unchanged) for callers that still reference
+  it.
+
+Recommend **(a)** — it's the thesis applied (no API polish; the session is
+the polish layer). Name it in the changelog as a behavior change.
+
+## Step 5 — Retire the package (R7, reversible, separate)
+
+After Steps 1–4, no attune-ai code imports `attune_author`. Then:
+
+- **Archive** the `attune-author` repo (beta, no adopters — confirmed) and
+  **yank/deprecate** the PyPI package, OR
+- leave a **thin shim** release that re-exports the absorbed callables from
+  attune-ai for any stray external user.
+
+Given no adopters, archive is the simpler endpoint. Keep this a *distinct
+PR/decision* from the code move so the irreversible step (yank) is
+deliberate.
+
+## Tasks / sequencing
+
+1. **T1 — Absorb + repoint** (Steps 1): move modules, repoint the six
+   consumers, golden projector test. Acceptance: `git grep attune_author`
+   in attune-ai is clean except `personal.py`; projector output identical.
+2. **T2 — Resolver fold-in** (Step 2 = #1191 T1): shared authoritative
+   resolver; the line-115 regression test passes.
+3. **T3 — Retire authoring machinery + drop deps** (Steps 3-4): delete the
+   LLM surface, drop `anthropic`/`claude-agent-sdk` from the author path,
+   handle `polish_template` per Step 4(a).
+4. **T4 — Retire the package** (Step 5): archive repo / yank PyPI or ship a
+   shim. Its own PR + decision.
+5. **T5 — Docs** : update #1189's playbook lesson + any `attune-author`
+   references in docs to the in-repo module; the
+   [single-source-authoring](../single-source-authoring/) skill lands in
+   parallel to cover the authoring half.
+
+T1+T2 land first (they capture the architectural win and #1191). T3 is the
+deletion. T4 is the deliberate, reversible package decision. T5 closes.
+
+## Testing
+
+- **Golden projector:** an existing master projects byte-identically
+  before and after the move.
+- **Resolver agreement:** the absorbed checker and `audit_doc_imports`
+  agree on a fixture set (resolvable / unresolvable / skip-marked); the
+  multi-line `from attune.elicitation import (…)` yields zero findings.
+- **Consumer smoke:** `project_features.py`, the staleness scripts, and
+  the post-commit hook run green against the in-repo module.
+- **Dep guard:** a test (or CI grep) that the authoring path imports no
+  `anthropic` / `claude_agent_sdk`.

--- a/docs/specs/attune-author-consolidation/requirements.md
+++ b/docs/specs/attune-author-consolidation/requirements.md
@@ -1,0 +1,109 @@
+# attune-author Consolidation & Retirement — Requirements
+
+**Status:** draft (2026-06-30) · **Owner:** Patrick + agent
+**Born:** the single-source insights discussion. Patrick: "attune-author
+is going to have to be either retired or redesigned." Verification of the
+package's scope (it is beta, no real adopters, retire-able) plus the
+authoring-vs-mechanics analysis resolved the framing: **absorb the
+deterministic distribution machinery into attune-ai, retire the LLM
+authoring machinery and the standalone package.**
+
+Sibling spec: [single-source-authoring](../single-source-authoring/) —
+the skill that *replaces* the authoring machinery this spec deletes. The
+two are one move seen from two sides: delete the authoring code there →
+absorb the distribution code here.
+
+## The principle this rests on
+
+**Instructions/the driving session for AUTHORING (judgment — what to say,
+how to say it well); code for MECHANICS (transform, hash, verify —
+anything that must be byte-identical every run).** attune-author's
+original error was using an LLM for authoring (it hallucinated — six
+documented shapes) while bundling that with genuinely-deterministic
+machinery. The split below follows that line exactly.
+
+## What the assessment found
+
+attune-author is ~15k LOC across three subsystems with opposite verdicts:
+
+- **Authoring machinery (DELETE):** `generator.py` (1,754), `polish.py`
+  (882), `polish_prompts.py` (652), `doc_gen/_anthropic*` (~600),
+  `maintenance_batch.py` (727, LLM batch), `faithfulness/` (323), the
+  package's own `mcp/` + LLM `cli` commands, and the `ai` extra
+  (`anthropic`, `claude-agent-sdk`). The driving session + a skill
+  replace it (the lesson: the session is a *superior* polish layer and
+  the only one that catches correctness bugs).
+- **Distribution machinery (ABSORB as code):** `projector.py` (508,
+  deterministic fan-out), `staleness.py` (514, sha256 drift), `manifest.py`
+  (348), the reliable `fact_check/*` (`python_refs`, `cli_refs`,
+  `tutorial_static_check`, `doc_examples`, `import_repair` ≈ 1,060), the
+  maintenance *hook* (`maintenance.py` run_hook, 356), `freshness/symbols`
+  (233). Deps: just `jinja2`.
+
+**Net: the delete list is larger than the absorb list** — the
+consolidation simplifies, it doesn't grow attune-ai.
+
+## attune-ai's actual consumption surface (the repoint targets)
+
+| Consumer in attune-ai | Imports from attune_author |
+|---|---|
+| `scripts/project_features.py` | `projector.project_feature`, `validate_master_file` |
+| `plugins/attune-author/hooks/help_post_commit.py` | `maintenance.run_hook` |
+| `scripts/help_aggregator_prototype.py`, `scripts/list_stale_help_features.py` | `check_staleness`, `load_manifest` |
+| `scripts/regenerate_help_templates.py` | `load_manifest` |
+| `src/attune/memory/personal.py` | `polish.polish_template` (lazy, optional) |
+| `src/attune/ops/help_data.py` | parses `attune-author status` CLI output |
+
+## Requirements
+
+- **R1 — Absorb the distribution machinery into attune-ai** as an internal
+  module (e.g. `attune.authoring` / `attune.single_source`), behind the
+  same callables the consumers already use, so the driver and hooks barely
+  change.
+- **R2 — One resolver.** The absorbed import fact-check uses attune-ai's
+  authoritative repo-`src`-on-`sys.path` resolver (the `audit_doc_imports`
+  mechanism), not the editable-mapping import. This *is* #1191's T1, now
+  done in-repo where it belongs (D-ref).
+- **R3 — Retire the authoring machinery,** not absorb it. Delete the LLM
+  generator/polish/doc_gen/batch/faithfulness/MCP/CLI-generation surface;
+  the [single-source-authoring](../single-source-authoring/) skill
+  replaces its function.
+- **R4 — Repoint every consumer** (the table above) to the in-repo module;
+  no attune-ai code path imports `attune_author` after this lands.
+- **R5 — Drop the heavy deps.** `anthropic` / `claude-agent-sdk` leave the
+  authoring path entirely (they remain only where attune-ai already needs
+  them for workflows); `jinja2` is the only dep the absorbed projector
+  needs.
+- **R6 — Graceful behavior-change naming.** `personal.py`'s optional
+  `polish_template` degrades to its existing raw-skeleton fallback
+  (`_build_skeleton`); name this change explicitly — it is safe (already
+  `try/except → None`) but it is a behavior change, not a silent one.
+- **R7 — Retire the *package* as a separate, reversible step.** After the
+  code moves and consumers repoint, attune-author the PyPI package either
+  becomes a thin shim (re-export from attune-ai) or is yanked/archived.
+  Because there are no adopters (confirmed), full retirement is on the
+  table; keep it a distinct decision from the code move (D-ref).
+
+## Non-goals
+
+- **Not a staleness rewrite.** `staleness.py` is absorbed *as-is*. Its
+  known weaknesses (hash-on-one-file, no completeness check — see lessons)
+  are a separate, scoped follow-on, not this spec.
+- **Not the authoring skill.** That is the sibling spec; this spec only
+  *deletes* the machinery it replaces and assumes it exists.
+- **Not a re-test of every absorbed line.** Absorb with its existing test
+  intent; add tests only where the move changes a surface (the resolver
+  swap, the consumer repoints).
+
+## Acceptance
+
+- `git grep attune_author` in attune-ai returns only history/specs — no
+  live import.
+- `project_features.py`, the help hooks, and the staleness scripts run
+  against the in-repo module with unchanged behavior (the projector's
+  output is byte-identical pre/post move).
+- The `anthropic` / `claude-agent-sdk` deps no longer enter via the
+  authoring path.
+- `#1191`'s T1 is satisfied *inside* this move (one authoritative
+  resolver; the line-115 false positive gone).
+- A decision is recorded on the package's fate (shim vs. archive).

--- a/docs/specs/single-source-authoring/decisions.md
+++ b/docs/specs/single-source-authoring/decisions.md
@@ -1,0 +1,55 @@
+# Single-Source Authoring — Decisions
+
+**Status:** draft (2026-06-30) · log for
+[requirements.md](requirements.md) / [design.md](design.md).
+
+## D1 — The session authors; a skill supplies the discipline
+
+**Decided.** The replacement for the retired generator is not a smaller
+generator — it is the driving session, made reliable by a skill that
+encodes the authoring discipline (#1188's practices). The lesson is
+empirical: the session is a *superior* polish layer and the only one that
+catches correctness bugs. The skill's job is to make that quality
+*repeatable* by any session, not to automate the prose.
+
+## D2 — Verification is the spine, because it's the only thing separating authoring from fiction
+
+**Decided.** The generator failed by writing confident, unverified prose
+(six hallucination shapes). The session succeeds by *grounding every claim
+in code first*. So the skill's load-bearing instruction is "find the truth
+before you write it" — grep the symbol, run the audit, fix the master.
+Without that, session-authoring is just a slower generator with the same
+failure mode.
+
+## D3 — Instructions for judgment, code for mechanics (shared with the consolidation)
+
+**Decided.** Same principle as
+[attune-author-consolidation D1](../attune-author-consolidation/decisions.md):
+this skill is *instructions* because authoring is judgment; the projector,
+scaffolder, and audits stay *code* because they must be invariant. The
+skill never re-implements a deterministic tool — it calls it.
+
+## D4 — Author against the manual baseline; repoint on consolidation
+
+**Decided.** The skill can ship before the consolidation by naming today's
+manual steps (#1189 playbook). Its *judgment content* (author + verify) is
+independent of whether the projector lives in `attune_author` or
+`attune.authoring`; only the tool paths it references change. So it isn't
+blocked on the consolidation — repoint the references when that lands.
+
+## D5 — Self-demonstration is the acceptance bar
+
+**Decided.** The skill is "done" only when a fresh session, given *only*
+the skill, reproduces the #1188 outcome (a green, code-accurate page) with
+no out-of-band knowledge. That dogfood (T3) is the receipt — consistent
+with "registered ≠ working; dogfood the live loop."
+
+## Open
+
+- **Skill name** — `single-source-authoring` vs. `author-feature` vs.
+  folding into the existing `elicit`/docs skill family. Naming call for
+  the design review.
+- **Boundary with the scaffolder** — the skill *calls* the scaffolder;
+  confirm at build time there's no overlap where both try to own the
+  features.yaml entry or the build chain. (They shouldn't: scaffolder owns
+  mechanics, skill owns judgment.)

--- a/docs/specs/single-source-authoring/design.md
+++ b/docs/specs/single-source-authoring/design.md
@@ -1,0 +1,83 @@
+# Single-Source Authoring — Design
+
+**Status:** draft (2026-06-30) · pairs with
+[requirements.md](requirements.md).
+
+## Shape: a skill that orchestrates judgment between two deterministic tools
+
+```text
+scaffolder.scaffold   →   [ SKILL: author + verify the master ]   →   scaffolder.build
+   (mechanical)                    (judgment — this spec)              (mechanical)
+```
+
+The skill is the disciplined middle. It does not generate; it *walks the
+session* through authoring a master that is correct by verification, then
+hands off to the deterministic build.
+
+## The skill's flow (what `SKILL.md` encodes)
+
+1. **Locate or scaffold.** If no master exists, invoke the scaffolder
+   (`scaffold <slug> …`) to lay down frontmatter + the section skeleton.
+   If revising, open the existing master.
+2. **Author section by section, grounded in code.** For each section the
+   projector expects, the skill instructs: *find the truth first.* Before
+   an API table — `grep` the `__all__`, the enum, the tool schema. Before
+   a CLI example — confirm the flag. The skill names the canonical
+   verification commands (the ones #1188 used) so the session doesn't
+   improvise.
+3. **Verify continuously.** Run `audit_doc_imports.py --paths <master>`
+   and the projector `--dry-run`; fix findings *at the master*. The skill
+   frames a fact-check finding as "fix the claim," never "ship the
+   warning."
+4. **Build + confirm.** Hand off to `scaffolder build <slug>` (project →
+   sync → audits) and confirm green.
+5. **Preview before commit.** Show the projected hub/pages to the user
+   before staging (the "show generated output sooner" discipline).
+
+## What the skill explicitly does NOT do
+
+- It does not write prose for the user to approve blindly — the model
+  authors *with* verification, not from imagination.
+- It does not call any LLM-polish/generation path (none will exist
+  post-consolidation).
+- It does not re-implement the projector, the audits, or the scaffolder —
+  it *calls* them.
+
+## Relationship to the three pieces
+
+| Piece | Kind | Owns |
+|---|---|---|
+| scaffolder (#1190) | deterministic code | mechanical setup + build chain |
+| projector (consolidation) | deterministic code | the master → 14 artifacts fan-out |
+| **this skill** | **instructions** | **the judgment: author + verify the master** |
+
+This is the authoring-vs-mechanics split made concrete: two tools that
+must be invariant, one skill that supplies the judgment between them.
+
+## Tasks / sequencing
+
+1. **T1 — Author the skill.** `plugin/skills/single-source-authoring/
+   SKILL.md` (name TBD): the flow above, the canonical verification
+   commands, the section contract, the "fix the master not the output"
+   framing. Sync the `.agents/` mirror.
+2. **T2 — Wire the references.** Point the skill at the post-consolidation
+   in-repo machinery (`attune.authoring.*`, `scripts/new_feature.py` from
+   the scaffolder spec, the audits). If the scaffolder isn't built yet,
+   the skill names the manual `project_features.py` + `sync_help_bundle.py`
+   steps and is updated when the scaffolder lands.
+3. **T3 — Dogfood.** A fresh session (or a clean transcript) uses only the
+   skill to author a throwaway feature page; it must project clean and
+   pass the gates on the first real attempt (R5). Record the receipt.
+4. **T4 — Retire the playbook lesson into the skill.** #1189's playbook
+   lesson points to the skill as the canonical authoring path (parallels
+   the scaffolder's T4 for the mechanical half).
+
+## Dependency note
+
+This skill's *content* assumes the consolidation has moved the projector
+in-repo (so it references `attune.authoring`, not `attune_author`). It can
+be authored against today's paths and updated on consolidation, or
+sequenced after T1–T2 of the consolidation. Recommend: author the skill
+now against the *manual* steps (#1189 baseline), repoint its references
+when the consolidation lands — the judgment content doesn't change, only
+the tool paths it names.

--- a/docs/specs/single-source-authoring/requirements.md
+++ b/docs/specs/single-source-authoring/requirements.md
@@ -1,0 +1,83 @@
+# Single-Source Authoring (session-as-author) — Requirements
+
+**Status:** draft (2026-06-30) · **Owner:** Patrick + agent
+**Born:** Patrick — "I think you can replace much of the code with
+instructions that support your authoring polished content." Correct for
+the *authoring* half (the pushback that resolved it is recorded in
+[attune-author-consolidation/decisions.md](../attune-author-consolidation/decisions.md)
+D1–D3). This spec is the replacement: a skill that makes the driving
+session a disciplined author of single-source masters.
+
+Sibling specs: [attune-author-consolidation](../attune-author-consolidation/)
+deletes the LLM authoring machinery this skill replaces;
+[feature-page-scaffolder](../feature-page-scaffolder/) automates the
+*mechanical* setup/build around it. This spec owns the *judgment* in the
+middle.
+
+## Why a skill, not a generator
+
+The LLM authoring machinery (`generator`/`polish`) is being retired
+because the empirical result is in: the **driving session is a superior
+polish layer to the API pass, and the only one that catches correctness
+bugs** (lessons). #1188 proved it — a hand-authored, code-verified master
+projected clean on the first try. The gap is that this depended on *me
+knowing* the discipline (read the code, verify every symbol, run the
+audits). A skill encodes that discipline so any session — or any
+contributor — authors to the same standard, with no API and no credits.
+
+## What "authoring discipline" means (the thing to encode)
+
+The verifiable practices #1188 used, which a generator cannot do but a
+guided session can:
+
+1. **Ground every claim in live code** — grep the exports, the enum, the
+   tool names *before* writing the API tables; never confabulate a symbol.
+2. **Fit the projector's section contract** — the canonical headings, so
+   the master projects without "missing section" surprises.
+3. **Run the gates as you go** — `audit_doc_imports`, the projector
+   `--dry-run`, the bundle sync — and fix at the master, not the outputs.
+4. **Verify, don't trust** — a master is the single point of *failure*;
+   its claims get checked against the code they describe.
+
+## Requirements
+
+- **R1 — A skill drives master authoring.** Triggered when a feature needs
+  a single-source page (or a master needs revision), it walks the session
+  through: scaffold (or locate) the master → author each section grounded
+  in live code → verify → project → audit. No API, no `attune-author
+  generate`.
+- **R2 — Verification is the skill's spine, not an afterthought.** The
+  skill makes "grep the symbol before you write it" and "run the audit
+  before you commit" explicit steps, because that discipline is the only
+  thing separating session-authoring from the generator's fiction.
+- **R3 — Composes with the scaffolder and the projector.** The skill calls
+  the [scaffolder](../feature-page-scaffolder/) for the mechanical
+  setup/build and the (now in-repo, per consolidation) projector for the
+  fan-out — it owns judgment, not plumbing.
+- **R4 — Surface-correct.** Ships in both `plugin/skills/` and the
+  `.agents/` mirror (synced via `sync_agents_skills.py`), like every other
+  skill.
+- **R5 — Self-demonstrating.** The skill's own acceptance is that a fresh
+  session, given only the skill, can reproduce the #1188 outcome — a
+  green, code-accurate feature page — without out-of-band knowledge.
+
+## Non-goals
+
+- **Not a generator.** It does not emit prose for the session to rubber-
+  stamp; it *guides* the session to author and verify. The judgment stays
+  with the model-in-the-loop, grounded in code.
+- **Not the projector or the scaffolder.** Those are deterministic code
+  (sibling specs); this is instructions.
+- **Not auto-fact-check-on-write.** The skill *prompts* verification and
+  runs the existing gates; it does not add a new gate (that's the gate
+  specs' job).
+
+## Acceptance
+
+- A session with no prior single-source knowledge, handed the skill,
+  authors a master that projects byte-clean and passes `doc-import-audit`
+  + the bundle sync on the first real attempt.
+- The skill references only live, in-repo machinery (post-consolidation:
+  `attune.authoring.*`, the scaffolder, the audits) — no `attune-author`
+  generate/polish.
+- Zero API credits across the authoring flow.


### PR DESCRIPTION
You said "spec both of them based on your best judgement." Two specs, one
move — the authoring-vs-mechanics split we landed:

## [attune-author-consolidation](../../docs/specs/attune-author-consolidation/)

Absorb the **deterministic distribution machinery** into attune-ai
(`attune.authoring`): the projector (508), staleness (514), manifest, the
reliable fact-checks, the post-commit hook — deps shrink to just `jinja2`.
**Retire the LLM authoring machinery** (`generator`/`polish`/`doc_gen`/
batch/faithfulness + `anthropic`/`claude-agent-sdk`) and the beta package
(no adopters, confirmed). Net: the delete list is **larger** than the
absorb list — the move *simplifies* attune-ai.

Key decisions: D2 absorb-don't-instructionize the deterministic half (the
pushback you asked for); D4 **#1191's resolver folds in here** (no more
cross-package bolt-on); D5 code-move and package-yank are separate,
reversible-first steps; D6 `polish_template` degrades gracefully (named,
not silent).

## [single-source-authoring](../../docs/specs/single-source-authoring/)

The **instructions half**: a skill that makes the driving session a
disciplined master author — verify-every-claim-against-code as its spine —
replacing the retired generator. Backed by your own lesson: the session is
a *superior* polish layer and the only one that catches correctness bugs.
#1188 was the proof; the skill makes it repeatable.

## The trio

| Piece | Kind | Owns |
|---|---|---|
| scaffolder (#1190) | code | mechanical setup + build |
| projector (consolidation) | code | master → 14 artifacts |
| authoring skill | instructions | the judgment between them |

Spec only — for your review / approval loop. Nothing built. The split
also reshapes the not-yet-written #1191 T1 (it happens *inside* the
consolidation now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)