### PR TITLE
test(authoring): bring upstream tests for absorbed modules, remove coverage omit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -663,12 +663,6 @@ omit = [
     "*/agent_factory/memory_integration.py",  # Optional integration module
     "*/agent_factory/resilient.py",  # Optional resilience module
     "*/*_example.py",  # Example files
-    # attune-author consolidation (docs/specs/attune-author-consolidation/):
-    # absorbed VERBATIM from attune-author, golden-verified byte-identical;
-    # the upstream native test suites are brought in a follow-up slice, at
-    # which point this omit is removed. tests/unit/authoring/ guards the
-    # public surface meanwhile. (justified-other — transitional)
-    "*/attune/authoring/*",  # absorbed verbatim; upstream-tested; native tests follow
     # Utility modules with low criticality
     "*/utils/tokens.py",  # Token utilities
     "*/memory/security/audit_logger.py",  # Optional audit logging

--- a/tests/unit/authoring/fact_check/test_check_polished_file.py
+++ b/tests/unit/authoring/fact_check/test_check_polished_file.py
@@ -1,0 +1,124 @@
+"""Integration tests for the top-level ``check_polished_file`` entry."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from attune.authoring.fact_check import (
+    apply_soft_fail,
+    check_polished_file,
+    cli_refs,
+)
+from attune.authoring.fact_check.report import (
+    CHECK_CLI_REFS,
+    CHECK_MD_LINKS,
+    CHECK_PYTHON_REFS,
+    FactCheckConfig,
+    FactCheckError,
+)
+
+
+def _write(tmp_path: Path, body: str, name: str = "polished.md") -> Path:
+    f = tmp_path / name
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def _fake_run(stdout: str, returncode: int = 0) -> Any:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout)
+
+
+def test_check_polished_file_aggregates_findings_across_checks(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: a file with three error classes surfaces them all."""
+    body = (
+        "# Polished\n\n"
+        "```python\n"
+        "from attune.ops._readers import Bad\n"
+        "```\n\n"
+        "Run `attune ops --allow-run` to enable.\n\n"
+        "See [details](missing.md) for more.\n"
+    )
+    help_text = "Options:\n  --read-only\n"
+    with (
+        patch.object(cli_refs.shutil, "which", return_value="/fake/attune"),
+        patch.object(cli_refs.subprocess, "run", return_value=_fake_run(help_text)),
+        patch.object(cli_refs, "_installed_version", return_value="6.8.0"),
+    ):
+        report = check_polished_file(_write(tmp_path, body), project_root=tmp_path)
+
+    checks_hit = {f.check for f in report.findings}
+    assert CHECK_PYTHON_REFS in checks_hit
+    assert CHECK_CLI_REFS in checks_hit
+    assert CHECK_MD_LINKS in checks_hit
+    assert report.has_errors()
+
+
+def test_apply_soft_fail_appends_block(tmp_path: Path) -> None:
+    """Soft-fail mode rewrites the file with the unresolved block."""
+    body = "# Polished\n\nSee [x](nope.md).\n"
+    file = _write(tmp_path, body)
+    report = check_polished_file(file, project_root=tmp_path)
+    assert report.has_errors()
+
+    appended = apply_soft_fail(file, report)
+    assert appended is True
+
+    text = file.read_text(encoding="utf-8")
+    assert "## Unresolved references" in text
+    assert "nope.md" in text
+
+
+def test_apply_soft_fail_noop_on_empty_report(tmp_path: Path) -> None:
+    """Empty report → file untouched, returns False."""
+    body = "# Polished\n\nAll good.\n"
+    file = _write(tmp_path, body)
+    report = check_polished_file(file, project_root=tmp_path)
+    assert not report.has_errors()
+
+    assert apply_soft_fail(file, report) is False
+    assert file.read_text(encoding="utf-8") == body
+
+
+def test_strict_mode_raises_via_explicit_check(tmp_path: Path) -> None:
+    """Callers gate on ``report.has_errors()`` to raise ``FactCheckError``."""
+    body = "See [x](nope.md).\n"
+    file = _write(tmp_path, body)
+    report = check_polished_file(file, project_root=tmp_path)
+
+    raised = False
+    try:
+        if report.has_errors():
+            raise FactCheckError(f"{len(report.findings)} unresolved refs")
+    except FactCheckError as exc:
+        raised = True
+        assert "unresolved" in str(exc)
+    assert raised is True
+
+
+def test_config_disabled_skips_all_checks(tmp_path: Path) -> None:
+    """``enabled = False`` short-circuits before any check runs."""
+    body = "See [x](nope.md).\n"
+    file = _write(tmp_path, body)
+    cfg = FactCheckConfig(enabled=False)
+    report = check_polished_file(file, project_root=tmp_path, config=cfg)
+    assert report.findings == []
+
+
+def test_per_file_skip_disables_specific_check(tmp_path: Path) -> None:
+    """``skip`` opts a single file out of one check while keeping others."""
+    body = "```python\nfrom attune.ops._readers import X\n```\n[y](nope.md)\n"
+    (tmp_path / "docs").mkdir()
+    file = tmp_path / "docs" / "x.md"
+    file.write_text(body, encoding="utf-8")
+
+    cfg = FactCheckConfig(skip={"docs/x.md": [CHECK_MD_LINKS]})
+    report = check_polished_file(file, project_root=tmp_path, config=cfg)
+    checks_hit = {f.check for f in report.findings}
+    # python_refs still fires, md_links suppressed.
+    assert CHECK_PYTHON_REFS in checks_hit
+    assert CHECK_MD_LINKS not in checks_hit

--- a/tests/unit/authoring/fact_check/test_checks_against_fixtures.py
+++ b/tests/unit/authoring/fact_check/test_checks_against_fixtures.py
@@ -1,0 +1,330 @@
+"""Run each fact-check against the ops-dashboard regression fixture.
+
+This is the spec's exit gate for Phase 1: "5/6 ops-dashboard errors
+caught" against ``tests/fixtures/fact_check_ops_dashboard/pre_fix/``,
+zero findings against ``post_fix/``.
+
+The fixture is hand-crafted from the original error catalog in
+``docs/specs/polish-fact-check/requirements.md`` (the six failure
+classes from the 2026-05-14 attune-ai PR #351 regen). Each test
+exercises one check module against a pre-fix file and asserts the
+specific finding type appears, then runs the same check against
+the post-fix counterpart and asserts zero findings.
+
+External dependencies (``attune <cmd> --help``,
+filesystem-level template counts) are monkey-patched so tests
+are deterministic regardless of which version of attune-ai is
+installed in the dev environment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.authoring.fact_check import (
+    CHECK_CLI_REFS,
+    CHECK_MD_LINKS,
+    CHECK_NUMERIC_REFS,
+    CHECK_PYTHON_REFS,
+    cli_refs,
+    md_links,
+    numeric_refs,
+    python_refs,
+)
+
+# -----------------------------------------------------------------
+# Fixtures
+# -----------------------------------------------------------------
+
+
+FIXTURE_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "fact_check_ops_dashboard"
+
+
+@pytest.fixture
+def pre_fix_dir() -> Path:
+    return FIXTURE_ROOT / "pre_fix"
+
+
+@pytest.fixture
+def post_fix_dir() -> Path:
+    return FIXTURE_ROOT / "post_fix"
+
+
+@pytest.fixture
+def fake_project(tmp_path: Path) -> Path:
+    """A minimal project_root the CLI / numeric checks can resolve
+    against. Contains a tiny ``.help/features.yaml`` and a templates
+    dir so numeric checks have something to count."""
+    (tmp_path / ".help").mkdir()
+    (tmp_path / ".help" / "features.yaml").write_text(
+        "features:\n" "  ops-dashboard:\n" "    title: Ops dashboard\n",
+    )
+    templates = tmp_path / ".help" / "templates"
+    templates.mkdir()
+    # 259 stub template files — matches the real ground-truth count
+    # in the regression fixture (the pre-fix claim was 498).
+    for i in range(259):
+        (templates / f"t{i:03d}.md").write_text("# template\n")
+    return tmp_path
+
+
+# -----------------------------------------------------------------
+# python_refs: catches hallucinated private-module imports
+# -----------------------------------------------------------------
+
+
+class TestPythonRefs:
+    def test_catches_underscore_module_imports(self, pre_fix_dir: Path):
+        findings = python_refs.check(pre_fix_dir / "tutorial.md")
+        assert findings, "expected at least one finding for _readers / _models"
+        # Both `attune.ops._readers` and `attune.ops._models` should
+        # surface — they don't exist in the real package.
+        messages = " ".join(f.message for f in findings)
+        assert "_readers" in messages or "_models" in messages
+        assert all(f.check == CHECK_PYTHON_REFS for f in findings)
+        # All should be error severity (unresolvable import).
+        assert all(f.severity == "error" for f in findings)
+
+    def test_clean_on_post_fix(self, post_fix_dir: Path):
+        findings = python_refs.check(post_fix_dir / "tutorial.md")
+        assert findings == [], f"unexpected findings: {findings}"
+
+
+# -----------------------------------------------------------------
+# cli_refs: catches invented `--flag` references
+# -----------------------------------------------------------------
+
+
+# Canned `--help` output for `attune ops`. The pre-fix fixture
+# references `--allow-run` (real) in `attune ops --allow-run`
+# context but the pre-fix ALSO uses it in a misleading "read-only
+# mode" framing. Note: the actual hallucination in PR #351 was
+# inverted semantics, not a flag that doesn't exist. For the
+# fact-check at this layer, only the flag's EXISTENCE matters —
+# semantic correctness is for the faithfulness judge (Phase 3).
+#
+# We use a synthetic case here: the pre-fix invents a flag that
+# DOESN'T exist. The fixture refers to `--allow-run` which IS in
+# this help; to make the test exercise the catch path, we point
+# at a different file that uses a non-existent flag.
+_FAKE_OPS_HELP = """usage: attune ops [--port PORT] [--allow-run] [--read-only]
+
+options:
+  --port PORT      Port to bind
+  --allow-run      Allow workflow execution
+  --read-only      Disable execution
+"""
+
+
+class TestCliRefs:
+    def test_catches_invented_flag(
+        self,
+        tmp_path: Path,
+        fake_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Write a polished file that references a definitely-fake flag.
+        polished = tmp_path / "doc.md"
+        polished.write_text(
+            "Use `attune ops --turbo` to enable turbo mode.\n",
+        )
+        # Pin the resolved CLI + its help output deterministically.
+        monkeypatch.setattr(cli_refs, "_resolve_cli_name", lambda root: "attune")
+        # `shutil.which("attune")` returns None in CI (attune-ai isn't in
+        # attune-author's dev deps), making the check bail before any
+        # finding can surface. Stub `shutil.which` so the check proceeds.
+        monkeypatch.setattr(cli_refs.shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+        monkeypatch.setattr(
+            cli_refs,
+            "_help_text",
+            lambda cli, chain, timeout=5: _FAKE_OPS_HELP,
+        )
+        monkeypatch.setattr(
+            cli_refs,
+            "_installed_version",
+            lambda cli: "6.8.0",
+        )
+        findings = cli_refs.check(polished, fake_project)
+        assert findings, "expected --turbo to surface"
+        assert any("--turbo" in f.message for f in findings)
+        assert all(f.check == CHECK_CLI_REFS for f in findings)
+
+    def test_version_coupling_block_present(
+        self,
+        tmp_path: Path,
+        fake_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        polished = tmp_path / "doc.md"
+        polished.write_text("Run `attune ops --nope-not-real`.\n")
+        monkeypatch.setattr(cli_refs, "_resolve_cli_name", lambda root: "attune")
+        # `shutil.which("attune")` returns None in CI (attune-ai isn't in
+        # attune-author's dev deps), making the check bail before any
+        # finding can surface. Stub `shutil.which` so the check proceeds.
+        monkeypatch.setattr(cli_refs.shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+        monkeypatch.setattr(
+            cli_refs,
+            "_help_text",
+            lambda cli, chain, timeout=5: _FAKE_OPS_HELP,
+        )
+        monkeypatch.setattr(cli_refs, "_installed_version", lambda cli: "6.8.0")
+        findings = cli_refs.check(polished, fake_project)
+        assert findings
+        # Spec §1.4: each cli-ref finding must include version-
+        # coupling messaging so the user knows WHICH attune-ai
+        # version was probed and how to pin a different one.
+        msg = findings[0].message
+        assert "6.8.0" in msg, "installed version missing from finding"
+
+    def test_clean_on_post_fix(
+        self,
+        post_fix_dir: Path,
+        fake_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(cli_refs, "_resolve_cli_name", lambda root: "attune")
+        # `shutil.which("attune")` returns None in CI (attune-ai isn't in
+        # attune-author's dev deps), making the check bail before any
+        # finding can surface. Stub `shutil.which` so the check proceeds.
+        monkeypatch.setattr(cli_refs.shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+        monkeypatch.setattr(
+            cli_refs,
+            "_help_text",
+            lambda cli, chain, timeout=5: _FAKE_OPS_HELP,
+        )
+        monkeypatch.setattr(cli_refs, "_installed_version", lambda cli: "6.8.0")
+        findings = cli_refs.check(post_fix_dir / "how-to.md", fake_project)
+        # Post-fix uses --allow-run which IS in the help → no findings.
+        unresolved = [f for f in findings if f.severity == "error"]
+        assert unresolved == [], f"unexpected error findings: {unresolved}"
+
+
+# -----------------------------------------------------------------
+# md_links: catches broken relative-link targets
+# -----------------------------------------------------------------
+
+
+class TestMdLinks:
+    def test_catches_missing_target(self, pre_fix_dir: Path):
+        findings = md_links.check(pre_fix_dir / "architecture.md")
+        # The pre-fix architecture file links to four "Concept: ..."
+        # docs that don't exist. All four should surface.
+        assert len(findings) >= 4, f"expected >=4 missing links, got {len(findings)}"
+        assert all(f.check == CHECK_MD_LINKS for f in findings)
+        # Severity should be error — broken links are user-visible bugs.
+        assert all(f.severity == "error" for f in findings)
+
+    def test_skips_external_urls(self, tmp_path: Path):
+        polished = tmp_path / "doc.md"
+        polished.write_text(
+            "See [external](https://example.com/page).\n"
+            "Or [anchor only](#section).\n"
+            "Or [mailto](mailto:test@example.com).\n",
+        )
+        # All three are external/non-file; none should fire.
+        findings = md_links.check(polished)
+        assert findings == []
+
+    def test_clean_on_post_fix(self, post_fix_dir: Path):
+        # Post-fix architecture removes the broken cross-refs.
+        findings = md_links.check(post_fix_dir / "architecture.md")
+        assert findings == [], f"unexpected findings: {findings}"
+
+
+# -----------------------------------------------------------------
+# numeric_refs: catches invented counts
+# -----------------------------------------------------------------
+
+
+class TestNumericRefs:
+    def test_catches_invented_count(
+        self,
+        pre_fix_dir: Path,
+        fake_project: Path,
+    ):
+        # The pre-fix reference doc claims "498 templates"; the
+        # fake_project fixture has 259 actual template files.
+        findings = numeric_refs.check(pre_fix_dir / "reference.md", fake_project)
+        # At least one error finding about the 498 vs 259 mismatch.
+        error_findings = [f for f in findings if f.severity == "error"]
+        assert error_findings, "expected error finding for 498 vs 259"
+        messages = " ".join(f.message for f in error_findings)
+        # The finding should mention BOTH the claimed and actual counts
+        # so the editor can see what to fix.
+        assert (
+            "498" in messages and "259" in messages
+        ), f"finding should cite both counts: {messages!r}"
+        assert all(f.check == CHECK_NUMERIC_REFS for f in error_findings)
+
+    def test_clean_on_post_fix(
+        self,
+        post_fix_dir: Path,
+        fake_project: Path,
+    ):
+        # Post-fix reference removes the count claim entirely.
+        findings = numeric_refs.check(post_fix_dir / "reference.md", fake_project)
+        error_findings = [f for f in findings if f.severity == "error"]
+        assert error_findings == [], f"unexpected error findings: {error_findings}"
+
+
+# -----------------------------------------------------------------
+# Aggregate gate: 5/6 errors caught (the spec's Phase 1 exit
+# criterion)
+# -----------------------------------------------------------------
+
+
+class TestPhase1ExitGate:
+    """Spec exit gate: 5 of 6 ops-dashboard errors caught.
+
+    The 6th (insecure-example for ``host="0.0.0.0"``) is explicitly
+    Phase 3 scope per the requirements doc. The 5 in Phase 1's
+    scope:
+
+    - Python refs: 2 (private-module imports in tutorial)
+    - CLI refs:    1 (invented flag — synthetic in test_cli_refs)
+    - Markdown:    1+ (broken cross-refs in architecture)
+    - Numeric:     1 (498 vs 259 in reference)
+    """
+
+    def test_catches_phase_1_error_classes(
+        self,
+        pre_fix_dir: Path,
+        fake_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(cli_refs, "_resolve_cli_name", lambda root: "attune")
+        # `shutil.which("attune")` returns None in CI (attune-ai isn't in
+        # attune-author's dev deps), making the check bail before any
+        # finding can surface. Stub `shutil.which` so the check proceeds.
+        monkeypatch.setattr(cli_refs.shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+        monkeypatch.setattr(
+            cli_refs,
+            "_help_text",
+            lambda cli, chain, timeout=5: _FAKE_OPS_HELP,
+        )
+        monkeypatch.setattr(cli_refs, "_installed_version", lambda cli: "6.8.0")
+
+        all_findings: list = []
+        for name in ("how-to.md", "tutorial.md", "reference.md", "architecture.md"):
+            path = pre_fix_dir / name
+            all_findings.extend(python_refs.check(path))
+            all_findings.extend(cli_refs.check(path, fake_project))
+            all_findings.extend(md_links.check(path))
+            all_findings.extend(numeric_refs.check(path, fake_project))
+
+        by_check = dict.fromkeys(
+            (CHECK_PYTHON_REFS, CHECK_CLI_REFS, CHECK_MD_LINKS, CHECK_NUMERIC_REFS), 0
+        )
+        for f in all_findings:
+            if f.severity == "error":
+                by_check[f.check] += 1
+
+        # Python: 2+, MD: 4+ (architecture's 4 broken refs +
+        # tutorial's 1), Numeric: 1+, CLI: 0 (the fixture
+        # references --allow-run which IS in the canned help —
+        # caught semantically in Phase 3).
+        assert by_check[CHECK_PYTHON_REFS] >= 2, by_check
+        assert by_check[CHECK_MD_LINKS] >= 4, by_check
+        assert by_check[CHECK_NUMERIC_REFS] >= 1, by_check

--- a/tests/unit/authoring/fact_check/test_cli_refs.py
+++ b/tests/unit/authoring/fact_check/test_cli_refs.py
@@ -1,0 +1,124 @@
+"""Tests for the cli-refs check.
+
+Subprocess calls are mocked so tests are deterministic and don't
+depend on the installed attune-ai version.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from attune.authoring.fact_check import cli_refs
+from attune.authoring.fact_check.report import CHECK_CLI_REFS
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    f = tmp_path / "polished.md"
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def _fake_run(stdout: str, returncode: int = 0) -> Any:
+    """Build a fake CompletedProcess."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout)
+
+
+def test_catches_invented_flag(tmp_path: Path) -> None:
+    """The ``--allow-run`` (real: ``--read-only``) regression."""
+    help_text = (
+        "Usage: attune ops [OPTIONS]\n\n"
+        "Options:\n"
+        "  --read-only  run in read-only mode\n"
+        "  --port INT   port to bind\n"
+    )
+    body = "Run with `attune ops --allow-run` to enable.\n"
+    with (
+        patch.object(cli_refs.shutil, "which", return_value="/fake/attune"),
+        patch.object(cli_refs.subprocess, "run", return_value=_fake_run(help_text)),
+    ):
+        findings = cli_refs.check(_write(tmp_path, body), tmp_path)
+
+    assert any(
+        f.check == CHECK_CLI_REFS and f.severity == "error" and "--allow-run" in f.message
+        for f in findings
+    )
+
+
+def test_finding_includes_version_coupling_block(tmp_path: Path) -> None:
+    """Each CLI-ref finding carries the version + override snippet
+    per spec §1.4 and §1.11.1."""
+    help_text = "Options:\n  --port INT\n"
+    body = "Use `attune ops --bogus` here.\n"
+    with (
+        patch.object(cli_refs.shutil, "which", return_value="/fake/attune"),
+        patch.object(cli_refs.subprocess, "run", return_value=_fake_run(help_text)),
+        patch.object(cli_refs, "_installed_version", return_value="6.8.0"),
+    ):
+        findings = cli_refs.check(_write(tmp_path, body), tmp_path)
+
+    assert findings, "expected at least one finding"
+    message = findings[0].message
+    # Version coupling messaging must include the installed version
+    # and the per-file override snippet.
+    assert "6.8.0" in message
+    assert "[tool.attune-author.fact-check.skip]" in message
+    assert "check_cli_refs" in message
+    assert "--skip-check" in message
+
+
+def test_accepts_known_flag(tmp_path: Path) -> None:
+    help_text = "Options:\n  --read-only  desc\n  --port INT\n"
+    body = "Run `attune ops --read-only` to enable.\n"
+    with (
+        patch.object(cli_refs.shutil, "which", return_value="/fake/attune"),
+        patch.object(cli_refs.subprocess, "run", return_value=_fake_run(help_text)),
+    ):
+        findings = cli_refs.check(_write(tmp_path, body), tmp_path)
+    assert findings == []
+
+
+def test_handles_subcommand_chain(tmp_path: Path) -> None:
+    """``attune workflow run X --flag`` resolves the full chain."""
+    help_text = "Options:\n  --path PATH\n  --strict\n"
+    body = "Run `attune workflow run security-audit --path src/`.\n"
+    with (
+        patch.object(cli_refs.shutil, "which", return_value="/fake/attune"),
+        patch.object(cli_refs.subprocess, "run", return_value=_fake_run(help_text)) as mock_run,
+    ):
+        findings = cli_refs.check(_write(tmp_path, body), tmp_path)
+    # Help was probed with the full chain — confirms we route correctly.
+    call_args = mock_run.call_args
+    assert call_args is not None
+    cmd = call_args[0][0] if call_args[0] else call_args.kwargs.get("args")
+    assert cmd[:4] == ["attune", "workflow", "run", "security-audit"]
+    assert findings == []
+
+
+def test_unknown_subcommand_surfaces_finding(tmp_path: Path) -> None:
+    """A nonexistent subcommand chain (--help exits nonzero) is a finding."""
+    body = "See `attune ghost --some-flag` for context.\n"
+    with (
+        patch.object(cli_refs.shutil, "which", return_value="/fake/attune"),
+        patch.object(
+            cli_refs.subprocess,
+            "run",
+            return_value=_fake_run("error: no such command", returncode=2),
+        ),
+        patch.object(cli_refs, "_installed_version", return_value="6.8.0"),
+    ):
+        findings = cli_refs.check(_write(tmp_path, body), tmp_path)
+    assert any("subcommand not found" in f.message for f in findings)
+
+
+def test_missing_cli_short_circuits(tmp_path: Path) -> None:
+    """No CLI on PATH → no findings, no crash."""
+    body = "Use `attune ops --whatever`.\n"
+    with patch.object(cli_refs.shutil, "which", return_value=None):
+        findings = cli_refs.check(_write(tmp_path, body), tmp_path)
+    # When we can't resolve, treat as ambiguous: no findings raised
+    # (we'd be guessing). The version-coupling messaging is still
+    # documented for the call sites that do find flags.
+    assert findings == []

--- a/tests/unit/authoring/fact_check/test_config.py
+++ b/tests/unit/authoring/fact_check/test_config.py
@@ -1,0 +1,65 @@
+"""Tests for the pyproject.toml config loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.authoring.fact_check.config import load_config
+from attune.authoring.fact_check.report import CHECK_MD_LINKS
+
+
+def test_load_config_no_pyproject_returns_defaults(tmp_path: Path) -> None:
+    """Empty project root → all-enabled, soft-fail defaults."""
+    cfg = load_config(tmp_path)
+    assert cfg.enabled is True
+    assert cfg.soft_fail is True
+    assert cfg.check_python_refs is True
+    assert cfg.check_cli_refs is True
+    assert cfg.check_md_links is True
+    assert cfg.check_numeric_refs is True
+    assert cfg.skip == {}
+
+
+def test_load_config_disables_individual_checks(tmp_path: Path) -> None:
+    """Per-check booleans flip from the table."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.attune-author.fact-check]\n"
+        "check_md_links = false\n"
+        "check_numeric_refs = false\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.check_md_links is False
+    assert cfg.check_numeric_refs is False
+    # Untouched checks stay on.
+    assert cfg.check_python_refs is True
+
+
+def test_load_config_skip_table(tmp_path: Path) -> None:
+    """The ``skip`` sub-table populates ``cfg.skip``."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.attune-author.fact-check.skip]\n" '"docs/foo.md" = ["check_md_links"]\n',
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.skip == {"docs/foo.md": [CHECK_MD_LINKS]}
+
+
+def test_load_config_strict_mode(tmp_path: Path) -> None:
+    """``soft_fail = false`` round-trips."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.attune-author.fact-check]\nsoft_fail = false\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.soft_fail is False
+
+
+def test_load_config_ignores_unknown_keys(tmp_path: Path) -> None:
+    """Forward-compat: unknown keys are silently ignored."""
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.attune-author.fact-check]\nfuture_phase_2_toggle = true\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.enabled is True

--- a/tests/unit/authoring/fact_check/test_doc_examples.py
+++ b/tests/unit/authoring/fact_check/test_doc_examples.py
@@ -1,0 +1,125 @@
+"""Tests for the doc-examples check (compile + coroutine misuse).
+
+Covers help-docs-single-source follow-up P5. The check derives
+"is this callable async?" from each block's *own* imports (no
+hardcoded package list), so the tests import real coroutine functions
+(stdlib ``asyncio.sleep``) and a purpose-built local module to exercise
+the ``from M import f``, ``import M``, and class-method paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.authoring.fact_check import doc_examples
+from attune.authoring.fact_check.report import CHECK_DOC_EXAMPLES
+
+
+def _md(tmp_path: Path, *blocks: str) -> Path:
+    """Write a markdown file whose body is the given python blocks."""
+    parts = ["# Doc\n"]
+    for block in blocks:
+        parts.append("```python\n" + block.strip("\n") + "\n```\n")
+    path = tmp_path / "doc.md"
+    path.write_text("\n".join(parts), encoding="utf-8")
+    return path
+
+
+# --- coroutine misuse (bare ``from M import f`` path) -----------------------
+
+
+def test_flags_coroutine_called_without_await(tmp_path):
+    path = _md(tmp_path, "from asyncio import sleep\n\nsleep(1)\n")
+    findings = doc_examples.check(path)
+    assert len(findings) == 1
+    assert findings[0].check == CHECK_DOC_EXAMPLES
+    assert findings[0].severity == "error"
+    assert "sleep()" in findings[0].message
+
+
+def test_awaited_coroutine_is_clean(tmp_path):
+    # Top-level await is an illustrative fragment — compiled wrapped in
+    # ``async def`` and recognised as correctly awaited.
+    path = _md(tmp_path, "from asyncio import sleep\n\nawait sleep(1)\n")
+    assert doc_examples.check(path) == []
+
+
+def test_scheduled_coroutine_is_clean(tmp_path):
+    path = _md(tmp_path, "import asyncio\nfrom asyncio import sleep\n\nasyncio.run(sleep(1))\n")
+    assert doc_examples.check(path) == []
+
+
+def test_aliased_import_is_tracked(tmp_path):
+    path = _md(tmp_path, "from asyncio import sleep as nap\n\nnap(1)\n")
+    findings = doc_examples.check(path)
+    assert len(findings) == 1
+    assert "nap()" in findings[0].message
+
+
+# --- ``import M`` + class-method paths via a local module -------------------
+
+
+def _write_async_module(tmp_path: Path, monkeypatch) -> None:
+    """Create an importable module with a coroutine fn and a class
+    whose method is a coroutine, and put it on ``sys.path``."""
+    (tmp_path / "mymod.py").write_text(
+        "async def fetch():\n"
+        "    return 1\n"
+        "\n\n"
+        "class Client:\n"
+        "    async def call(self):\n"
+        "        return 2\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+
+def test_flags_module_attr_coroutine(tmp_path, monkeypatch):
+    _write_async_module(tmp_path, monkeypatch)
+    path = _md(tmp_path, "import mymod\n\nmymod.fetch()\n")
+    findings = doc_examples.check(path)
+    assert len(findings) == 1
+    assert "fetch()" in findings[0].message
+
+
+def test_flags_class_method_coroutine(tmp_path, monkeypatch):
+    _write_async_module(tmp_path, monkeypatch)
+    path = _md(tmp_path, "from mymod import Client\n\nc = Client()\nc.call()\n")
+    findings = doc_examples.check(path)
+    assert len(findings) == 1
+    assert "call()" in findings[0].message
+
+
+def test_awaited_class_method_is_clean(tmp_path, monkeypatch):
+    _write_async_module(tmp_path, monkeypatch)
+    path = _md(tmp_path, "from mymod import Client\n\nc = Client()\nawait c.call()\n")
+    assert doc_examples.check(path) == []
+
+
+# --- tolerance + edge cases -------------------------------------------------
+
+
+def test_sync_call_is_not_flagged(tmp_path):
+    path = _md(tmp_path, "from math import sqrt\n\nsqrt(4)\n")
+    assert doc_examples.check(path) == []
+
+
+def test_unimportable_module_is_skipped_silently(tmp_path):
+    # A doc importing a module this venv lacks must not crash or flag a
+    # coroutine — python_refs owns the "module not importable" finding.
+    path = _md(tmp_path, "from totally_made_up_pkg import go\n\ngo()\n")
+    assert doc_examples.check(path) == []
+
+
+def test_non_compiling_block_is_a_warning(tmp_path):
+    path = _md(tmp_path, "def broken(:\n    pass\n")
+    findings = doc_examples.check(path)
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert "does not compile" in findings[0].message
+
+
+def test_no_python_blocks_is_clean(tmp_path):
+    path = tmp_path / "prose.md"
+    path.write_text("# Title\n\nJust prose, no code.\n", encoding="utf-8")
+    assert doc_examples.check(path) == []

--- a/tests/unit/authoring/fact_check/test_import_repair.py
+++ b/tests/unit/authoring/fact_check/test_import_repair.py
@@ -1,0 +1,187 @@
+"""Tests for deterministic import-path repair.
+
+Covers the bug class where the polish pass emits ``from pipeline
+import …`` (directory basename) instead of the real package path
+``from attune.pipeline import …``. The repair restores the canonical
+dotted module deterministically, before the fact-check pass runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from attune.authoring.fact_check.import_repair import (
+    _file_to_module,
+    build_symbol_module_map,
+    repair_imports,
+)
+
+
+@dataclass
+class _FakeSourceInfo:
+    """Minimal stand-in for the generator's ``_SourceInfo``."""
+
+    public_functions: list[dict] = field(default_factory=list)
+    public_classes: list[dict] = field(default_factory=list)
+    module_constants: list[dict] = field(default_factory=list)
+
+
+# --- _file_to_module -------------------------------------------------
+
+
+def test_file_to_module_strips_src_and_extension() -> None:
+    """``src/attune/spec/runner.py`` -> ``attune.spec.runner``."""
+    assert _file_to_module("src/attune/spec/runner.py") == "attune.spec.runner"
+
+
+def test_file_to_module_collapses_init() -> None:
+    """A package ``__init__.py`` maps to the package itself."""
+    assert _file_to_module("src/attune/pipeline/__init__.py") == "attune.pipeline"
+
+
+def test_file_to_module_handles_windows_separators() -> None:
+    """Backslash paths resolve the same as posix ones."""
+    assert _file_to_module("src\\attune\\pipeline\\models.py") == "attune.pipeline.models"
+
+
+# --- build_symbol_module_map ----------------------------------------
+
+
+def test_build_map_prefers_reexporting_parent_package() -> None:
+    """A symbol re-exported by its package uses the shallow path."""
+
+    def importer(name: str) -> object:
+        # attune.pipeline re-exports PipelineOrchestrator.
+        return {"attune.pipeline": type("M", (), {"PipelineOrchestrator": 1})()}[name]
+
+    info = _FakeSourceInfo(
+        public_classes=[
+            {"name": "PipelineOrchestrator", "file": "src/attune/pipeline/orchestrator.py"}
+        ]
+    )
+    result = build_symbol_module_map(info, importer=importer)
+    assert result == {"PipelineOrchestrator": "attune.pipeline"}
+
+
+def test_build_map_falls_back_to_defining_module_when_not_reexported() -> None:
+    """A symbol the package does NOT re-export keeps the submodule."""
+
+    def importer(name: str) -> object:
+        # attune.spec does NOT expose execute_with_approval.
+        return type("M", (), {})()
+
+    info = _FakeSourceInfo(
+        public_functions=[{"name": "execute_with_approval", "file": "src/attune/spec/runner.py"}]
+    )
+    result = build_symbol_module_map(info, importer=importer)
+    assert result == {"execute_with_approval": "attune.spec.runner"}
+
+
+def test_build_map_degrades_to_defining_module_on_import_error() -> None:
+    """Import failures degrade to the defining module, not a crash."""
+
+    def importer(name: str) -> object:
+        raise ImportError(name)
+
+    info = _FakeSourceInfo(
+        public_functions=[{"name": "read_spec", "file": "src/attune/pipeline/spec_reader.py"}]
+    )
+    result = build_symbol_module_map(info, importer=importer)
+    assert result == {"read_spec": "attune.pipeline.spec_reader"}
+
+
+def test_build_map_includes_constants_and_skips_incomplete_entries() -> None:
+    """Module constants are mapped; entries missing name/file skip."""
+
+    def importer(name: str) -> object:
+        raise ImportError(name)
+
+    info = _FakeSourceInfo(
+        module_constants=[
+            {"name": "ALLOWED_TOKENS", "file": "src/attune/spec/state.py"},
+            {"file": "src/attune/spec/state.py"},  # no name -> skipped
+        ]
+    )
+    result = build_symbol_module_map(info, importer=importer)
+    assert result == {"ALLOWED_TOKENS": "attune.spec.state"}
+
+
+# --- repair_imports --------------------------------------------------
+
+_MAP = {
+    "PipelineOrchestrator": "attune.pipeline",
+    "read_spec": "attune.pipeline",
+    "execute_with_approval": "attune.spec.runner",
+    "find_resumable_plans": "attune.spec",
+    "load_state": "attune.spec",
+}
+
+
+def test_repair_rewrites_bare_module_to_package() -> None:
+    """A single bare-module import is rewritten to the real package."""
+    content = "```python\nfrom pipeline import PipelineOrchestrator\n```\n"
+    out = repair_imports(content, _MAP)
+    assert "from attune.pipeline import PipelineOrchestrator" in out
+    assert "from pipeline import" not in out
+
+
+def test_repair_splits_group_across_resolved_modules() -> None:
+    """Symbols resolving to different modules split into separate lines."""
+    content = "```python\nfrom spec import execute_with_approval, find_resumable_plans\n```\n"
+    out = repair_imports(content, _MAP)
+    assert "from attune.spec.runner import execute_with_approval" in out
+    assert "from attune.spec import find_resumable_plans" in out
+    assert "from spec import" not in out
+
+
+def test_repair_preserves_aliases_and_indentation() -> None:
+    """``as`` aliases and leading indentation survive the rewrite."""
+    content = "```python\n    from spec import load_state as ls\n```\n"
+    out = repair_imports(content, _MAP)
+    assert "    from attune.spec import load_state as ls" in out
+
+
+def test_repair_leaves_unmapped_symbols_untouched() -> None:
+    """Stdlib / unknown symbols are not rewritten (still fact-checkable)."""
+    content = "```python\nfrom os import path\nimport json\n```\n"
+    out = repair_imports(content, _MAP)
+    assert out == content
+
+
+def test_repair_is_idempotent_on_correct_imports() -> None:
+    """An already-correct import is a no-op (no double-prefixing)."""
+    content = "```python\nfrom attune.pipeline import PipelineOrchestrator\n```\n"
+    out = repair_imports(content, _MAP)
+    assert out == content
+
+
+def test_repair_ignores_prose_and_non_python_fences() -> None:
+    """Matching text outside python fences is left alone."""
+    content = (
+        "Use `from pipeline import PipelineOrchestrator` in prose.\n\n"
+        "```text\nfrom pipeline import PipelineOrchestrator\n```\n"
+    )
+    out = repair_imports(content, _MAP)
+    assert out == content
+
+
+def test_repair_empty_map_is_noop() -> None:
+    """An empty symbol map returns content unchanged."""
+    content = "```python\nfrom pipeline import PipelineOrchestrator\n```\n"
+    assert repair_imports(content, {}) == content
+
+
+def test_repair_preserves_missing_trailing_newline() -> None:
+    """Content without a trailing newline stays that way."""
+    content = "```python\nfrom pipeline import PipelineOrchestrator\n```"
+    out = repair_imports(content, _MAP)
+    assert not out.endswith("\n")
+    assert "from attune.pipeline import PipelineOrchestrator" in out
+
+
+def test_repair_mixed_group_keeps_unmapped_under_original() -> None:
+    """A group with one mapped + one unknown splits, unknown stays put."""
+    content = "```python\nfrom spec import load_state, mystery_symbol\n```\n"
+    out = repair_imports(content, _MAP)
+    assert "from attune.spec import load_state" in out
+    assert "from spec import mystery_symbol" in out

--- a/tests/unit/authoring/fact_check/test_md_links.py
+++ b/tests/unit/authoring/fact_check/test_md_links.py
@@ -1,0 +1,58 @@
+"""Tests for the md-links check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.authoring.fact_check import md_links
+from attune.authoring.fact_check.report import CHECK_MD_LINKS
+
+
+def _write(tmp_path: Path, body: str, name: str = "polished.md") -> Path:
+    f = tmp_path / name
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def test_catches_missing_relative_target(tmp_path: Path) -> None:
+    """Missing-target regression — the ``See also`` class of bug."""
+    body = "See [Concept](concepts/template-patterns.md) for context.\n"
+    findings = md_links.check(_write(tmp_path, body))
+    assert any(
+        f.check == CHECK_MD_LINKS and f.severity == "error" and "template-patterns.md" in f.message
+        for f in findings
+    )
+
+
+def test_accepts_existing_relative_target(tmp_path: Path) -> None:
+    """A link whose target exists on disk produces no finding."""
+    (tmp_path / "sibling.md").write_text("# sibling\n", encoding="utf-8")
+    body = "See [sibling](sibling.md).\n"
+    assert md_links.check(_write(tmp_path, body)) == []
+
+
+def test_skips_external_urls(tmp_path: Path) -> None:
+    """``http://`` and ``mailto:`` are out of scope for Phase 1."""
+    body = "Check [Anthropic](https://anthropic.com) " "or email [me](mailto:dev@example.com).\n"
+    assert md_links.check(_write(tmp_path, body)) == []
+
+
+def test_skips_pure_anchor_links(tmp_path: Path) -> None:
+    """``[See above](#section)`` doesn't reference another file."""
+    body = "[Jump](#somewhere)\n"
+    assert md_links.check(_write(tmp_path, body)) == []
+
+
+def test_anchor_in_relative_target_strips_for_existence_check(
+    tmp_path: Path,
+) -> None:
+    """``path.md#anchor`` checks only that ``path.md`` exists."""
+    (tmp_path / "real.md").write_text("# real\n", encoding="utf-8")
+    body = "[See real](real.md#section-2)\n"
+    assert md_links.check(_write(tmp_path, body)) == []
+
+
+def test_deduplicates_repeated_missing_target(tmp_path: Path) -> None:
+    body = "[a](missing.md)\n" "[b](missing.md)\n"
+    findings = md_links.check(_write(tmp_path, body))
+    assert len([f for f in findings if "missing.md" in f.message]) == 1

--- a/tests/unit/authoring/fact_check/test_numeric_refs.py
+++ b/tests/unit/authoring/fact_check/test_numeric_refs.py
@@ -1,0 +1,71 @@
+"""Tests for the numeric-refs check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.authoring.fact_check import numeric_refs
+from attune.authoring.fact_check.report import CHECK_NUMERIC_REFS
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    f = tmp_path / "polished.md"
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def _scaffold_help_tree(root: Path, template_count: int, feature_count: int) -> None:
+    """Create ``.help/templates/`` + ``.help/features.yaml`` with N entries."""
+    templates = root / ".help" / "templates"
+    templates.mkdir(parents=True)
+    for i in range(template_count):
+        feat = templates / f"feat-{i}"
+        feat.mkdir()
+        (feat / "concept.md").write_text("# x\n", encoding="utf-8")
+    features = {f"feat-{i}": {"name": f"feat-{i}"} for i in range(feature_count)}
+    import yaml
+
+    (root / ".help" / "features.yaml").write_text(
+        yaml.safe_dump({"features": features}), encoding="utf-8"
+    )
+
+
+def test_catches_mismatched_template_count(tmp_path: Path) -> None:
+    """The ``498 templates`` regression."""
+    _scaffold_help_tree(tmp_path, template_count=3, feature_count=2)
+    body = "There are 498 templates in this corpus.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert any(
+        f.check == CHECK_NUMERIC_REFS
+        and f.severity == "error"
+        and "498" in f.message
+        and "actual count is 3" in f.message
+        for f in findings
+    )
+
+
+def test_accepts_correct_feature_count(tmp_path: Path) -> None:
+    _scaffold_help_tree(tmp_path, template_count=3, feature_count=2)
+    body = "Currently 2 features are tracked.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert not any(f.severity == "error" and "2 features" in f.message for f in findings)
+
+
+def test_unverifiable_noun_surfaces_warning(tmp_path: Path) -> None:
+    """``5 workflows`` has no deterministic resolver — warn the human."""
+    _scaffold_help_tree(tmp_path, template_count=1, feature_count=1)
+    body = "Ships with 5 workflows.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert any(f.severity == "warning" and "5 workflows" in f.message for f in findings)
+
+
+def test_no_help_dir_warns_rather_than_errors(tmp_path: Path) -> None:
+    """When the consumer has no ``.help/`` tree, resolvers return None.
+
+    The check should NOT spuriously fire an error claiming a count
+    mismatch; it should warn so the human can confirm.
+    """
+    body = "Cap is 11 kinds.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    # No deterministic verifier (or one that returned None) → warning, not error
+    assert all(f.severity != "error" for f in findings)

--- a/tests/unit/authoring/fact_check/test_python_refs.py
+++ b/tests/unit/authoring/fact_check/test_python_refs.py
@@ -1,0 +1,78 @@
+"""Tests for the python-refs check.
+
+Uses real ``importlib`` against stdlib + attune_author modules
+so the test exercises the same code path as production. The
+regression fixture for ``attune.ops._readers`` (the ops-dashboard
+class of bug) is documented in the docstring of each test —
+those paths really don't exist in the active venv, which is
+exactly the behavior the check is designed to catch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.authoring.fact_check import python_refs
+from attune.authoring.fact_check.report import CHECK_PYTHON_REFS
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    f = tmp_path / "polished.md"
+    f.write_text(body, encoding="utf-8")
+    return f
+
+
+def test_catches_unresolvable_module_in_code_fence(tmp_path: Path) -> None:
+    """The headline regression: ``from attune.ops._readers import …``."""
+    body = "# Polished\n\n" "```python\n" "from attune.ops._readers import ReadOnlyFinder\n" "```\n"
+    findings = python_refs.check(_write(tmp_path, body))
+    assert any(
+        f.check == CHECK_PYTHON_REFS
+        and f.severity == "error"
+        and "attune.ops._readers" in f.message
+        for f in findings
+    )
+
+
+def test_catches_missing_attribute_on_real_module(tmp_path: Path) -> None:
+    """Module exists; specific name does not — distinct error path."""
+    body = "```python\n" "from attune import DefinitelyNotAClassHere\n" "```\n"
+    findings = python_refs.check(_write(tmp_path, body))
+    assert any("DefinitelyNotAClassHere" in f.message for f in findings)
+
+
+def test_catches_unresolvable_prose_dotted(tmp_path: Path) -> None:
+    """Prose ref ``attune.ops._readers.Foo`` resolves to nothing."""
+    body = "See `attune.ops._readers.ReadOnlyFinder` for details.\n"
+    findings = python_refs.check(_write(tmp_path, body))
+    assert any(f.severity == "error" and "attune.ops._readers" in f.message for f in findings)
+
+
+def test_clean_imports_produce_no_findings(tmp_path: Path) -> None:
+    """A correct import (``from pathlib import Path``) is silent."""
+    body = "```python\n" "from pathlib import Path\n" "import json\n" "```\n"
+    findings = python_refs.check(_write(tmp_path, body))
+    assert findings == []
+
+
+def test_skips_invalid_python_in_fence(tmp_path: Path) -> None:
+    """Snippets like ``...`` or partial assignments don't ast-parse;
+    we silently skip rather than spuriously flag."""
+    body = "```python\n" "result = foo(\n" "    ...,\n" "```\n"
+    findings = python_refs.check(_write(tmp_path, body))
+    assert findings == []
+
+
+def test_deduplicates_repeated_same_module(tmp_path: Path) -> None:
+    """The same unresolvable module mentioned twice surfaces once."""
+    body = (
+        "```python\n"
+        "from attune.ops._readers import A\n"
+        "```\n"
+        "```python\n"
+        "from attune.ops._readers import B\n"
+        "```\n"
+    )
+    findings = python_refs.check(_write(tmp_path, body))
+    msgs = [f.message for f in findings if "attune.ops._readers" in f.message]
+    assert len(msgs) == 1

--- a/tests/unit/authoring/fact_check/test_report.py
+++ b/tests/unit/authoring/fact_check/test_report.py
@@ -1,0 +1,103 @@
+"""Tests for the shared report/config types."""
+
+from __future__ import annotations
+
+from attune.authoring.fact_check.report import (
+    CHECK_CLI_REFS,
+    CHECK_MD_LINKS,
+    CHECK_PYTHON_REFS,
+    FactCheckConfig,
+    FactCheckReport,
+    Finding,
+    format_unresolved_block,
+)
+
+
+def test_report_has_errors_distinguishes_severity() -> None:
+    """``has_errors`` returns True only for ``error`` severity."""
+    report = FactCheckReport()
+    assert report.has_errors() is False
+
+    report.extend(
+        [
+            Finding(
+                check=CHECK_MD_LINKS,
+                severity="warning",
+                location="Line 1",
+                message="warn",
+            )
+        ]
+    )
+    assert report.has_errors() is False
+
+    report.extend(
+        [
+            Finding(
+                check=CHECK_MD_LINKS,
+                severity="error",
+                location="Line 2",
+                message="err",
+            )
+        ]
+    )
+    assert report.has_errors() is True
+
+
+def test_format_unresolved_block_empty_returns_empty() -> None:
+    """No findings → empty string so callers can append unconditionally."""
+    assert format_unresolved_block([]) == ""
+
+
+def test_format_unresolved_block_renders_table() -> None:
+    """The block contains a heading, a table, and one row per finding."""
+    findings = [
+        Finding(
+            check=CHECK_PYTHON_REFS,
+            severity="error",
+            location="Line 77 (code fence)",
+            message="`from attune.ops._readers import …` — module not importable",
+        ),
+        Finding(
+            check=CHECK_MD_LINKS,
+            severity="warning",
+            location="Line 124",
+            message="`[Concept](concepts/template-patterns.md)` — target does not exist",
+        ),
+    ]
+    block = format_unresolved_block(findings)
+    assert "## Unresolved references" in block
+    assert "| Location | Severity | Issue |" in block
+    assert "Line 77 (code fence)" in block
+    assert "Line 124" in block
+    # Severity rendered.
+    assert "| error |" in block
+    assert "| warning |" in block
+
+
+def test_format_unresolved_block_escapes_pipes() -> None:
+    """Pipe characters in messages are escaped so the table doesn't break."""
+    findings = [
+        Finding(
+            check=CHECK_CLI_REFS,
+            severity="error",
+            location="Line 1",
+            message="oops | this would break the table",
+        )
+    ]
+    block = format_unresolved_block(findings)
+    assert "oops \\| this would break" in block
+
+
+def test_config_is_check_enabled_respects_global_toggle() -> None:
+    """A False global toggle disables the check regardless of skip list."""
+    cfg = FactCheckConfig(check_python_refs=False)
+    assert cfg.is_check_enabled(CHECK_PYTHON_REFS) is False
+    assert cfg.is_check_enabled(CHECK_PYTHON_REFS, "any.md") is False
+
+
+def test_config_is_check_enabled_respects_skip_list() -> None:
+    """Per-file skip turns off the check only for the matching path."""
+    cfg = FactCheckConfig(skip={"docs/foo.md": [CHECK_MD_LINKS]})
+    assert cfg.is_check_enabled(CHECK_MD_LINKS, "docs/foo.md") is False
+    assert cfg.is_check_enabled(CHECK_MD_LINKS, "docs/bar.md") is True
+    assert cfg.is_check_enabled(CHECK_PYTHON_REFS, "docs/foo.md") is True

--- a/tests/unit/authoring/fact_check/test_tutorial_static_check.py
+++ b/tests/unit/authoring/fact_check/test_tutorial_static_check.py
@@ -1,0 +1,296 @@
+"""Tests for the Phase 4 tutorial code-fence static check."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import patch
+
+from attune.authoring.fact_check.tutorial_static_check import (
+    CHECK_TUTORIAL_STATIC,
+    check,
+    is_tutorial_path,
+    strip_skip_directives_in_file,
+)
+
+# ---------------------------------------------------------------------------
+# is_tutorial_path
+# ---------------------------------------------------------------------------
+
+
+def test_is_tutorial_path_true_for_tutorials_dir() -> None:
+    assert is_tutorial_path(Path("docs/tutorials/ops.md")) is True
+
+
+def test_is_tutorial_path_false_for_other_kinds() -> None:
+    assert is_tutorial_path(Path("docs/how-to/ops.md")) is False
+    assert is_tutorial_path(Path("docs/architecture/ops.md")) is False
+    assert is_tutorial_path(Path("README.md")) is False
+
+
+# ---------------------------------------------------------------------------
+# strip_skip_directives_in_file
+# ---------------------------------------------------------------------------
+
+
+def test_strip_skip_directive_first_line() -> None:
+    src = dedent(
+        """\
+        Prose.
+
+        ```python
+        # attune-author: skip-mypy
+        do_thing()
+        ```
+
+        More prose.
+        """
+    )
+    out = strip_skip_directives_in_file(src)
+    assert "# attune-author: skip-mypy" not in out
+    assert "do_thing()" in out
+
+
+def test_strip_skip_directive_only_strips_when_first_line() -> None:
+    """A trailing directive in a later position is NOT stripped."""
+    src = dedent(
+        """\
+        ```python
+        thing()
+        # attune-author: skip-mypy
+        ```
+        """
+    )
+    out = strip_skip_directives_in_file(src)
+    assert "# attune-author: skip-mypy" in out
+
+
+def test_strip_skip_directive_no_op_when_absent() -> None:
+    src = "```python\nprint('hi')\n```\n"
+    assert strip_skip_directives_in_file(src) == src
+
+
+# ---------------------------------------------------------------------------
+# check — syntax-error path
+# ---------------------------------------------------------------------------
+
+
+def test_check_flags_syntax_error_in_fence(tmp_path: Path) -> None:
+    p = tmp_path / "docs/tutorials/feat.md"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        dedent(
+            """\
+            Body text.
+
+            ```python
+            def broken(
+            ```
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    # Patch mypy out so the syntax-error branch is the only thing exercised.
+    with patch("attune.authoring.fact_check.tutorial_static_check._run_mypy", return_value=[]):
+        findings = check(p)
+
+    assert len(findings) == 1
+    assert findings[0].severity == "error"
+    assert "SyntaxError" in findings[0].message
+    assert findings[0].check == CHECK_TUTORIAL_STATIC
+
+
+def test_check_clean_when_no_python_fences(tmp_path: Path) -> None:
+    p = tmp_path / "docs/tutorials/empty.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("# Just prose.\n", encoding="utf-8")
+
+    assert check(p) == []
+
+
+def test_check_unreadable_file_returns_empty(tmp_path: Path) -> None:
+    p = tmp_path / "missing.md"
+    assert check(p) == []
+
+
+# ---------------------------------------------------------------------------
+# check — mypy path (subprocess mocked)
+# ---------------------------------------------------------------------------
+
+
+def _completed(returncode: int, stdout: str = "", stderr: str = ""):
+    return subprocess.CompletedProcess(
+        args=["mypy"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_check_calls_mypy_for_valid_fence(tmp_path: Path) -> None:
+    p = tmp_path / "docs/tutorials/feat.md"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        dedent(
+            """\
+            Intro.
+
+            ```python
+            x: int = "wrong type"
+            ```
+            """
+        ),
+        encoding="utf-8",
+    )
+    mypy_output = "/tmp/x.py:1: error: Incompatible types in assignment  [assignment]\n"
+    with patch(
+        "attune.authoring.fact_check.tutorial_static_check.subprocess.run",
+        return_value=_completed(1, mypy_output),
+    ):
+        findings = check(p)
+
+    assert len(findings) == 1
+    assert findings[0].check == CHECK_TUTORIAL_STATIC
+    assert findings[0].severity == "error"
+    assert "Incompatible types" in findings[0].message
+    # mypy reported "line 1" inside the fence, fence body starts on line 4
+    # of the markdown (intro + blank + ``` ).
+    assert "Line 4" in findings[0].location
+
+
+def test_check_skips_fence_with_directive(tmp_path: Path) -> None:
+    p = tmp_path / "docs/tutorials/feat.md"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        dedent(
+            """\
+            ```python
+            # attune-author: skip-mypy
+            illustrative_pseudocode()
+            ```
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with patch("attune.authoring.fact_check.tutorial_static_check.subprocess.run") as mock_run:
+        findings = check(p)
+
+    assert findings == []
+    mock_run.assert_not_called()
+
+
+def test_check_handles_mypy_missing(tmp_path: Path) -> None:
+    p = tmp_path / "docs/tutorials/feat.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("```python\nx = 1\n```\n", encoding="utf-8")
+    with patch(
+        "attune.authoring.fact_check.tutorial_static_check.subprocess.run",
+        side_effect=FileNotFoundError("mypy not installed"),
+    ):
+        findings = check(p)
+    assert findings == []
+
+
+def test_check_handles_mypy_timeout(tmp_path: Path) -> None:
+    p = tmp_path / "docs/tutorials/feat.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("```python\nx = 1\n```\n", encoding="utf-8")
+    with patch(
+        "attune.authoring.fact_check.tutorial_static_check.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["mypy"], timeout=10),
+    ):
+        findings = check(p)
+    assert findings == []
+
+
+def test_check_handles_unexpected_mypy_exit(tmp_path: Path) -> None:
+    """mypy exit codes other than 0/1 should drop findings silently."""
+    p = tmp_path / "docs/tutorials/feat.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("```python\nx = 1\n```\n", encoding="utf-8")
+    with patch(
+        "attune.authoring.fact_check.tutorial_static_check.subprocess.run",
+        return_value=_completed(2, stderr="usage error"),
+    ):
+        findings = check(p)
+    assert findings == []
+
+
+def test_check_clean_when_mypy_returns_zero(tmp_path: Path) -> None:
+    p = tmp_path / "docs/tutorials/feat.md"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        dedent(
+            """\
+            ```python
+            x: int = 1
+            ```
+            """
+        ),
+        encoding="utf-8",
+    )
+    with patch(
+        "attune.authoring.fact_check.tutorial_static_check.subprocess.run",
+        return_value=_completed(0),
+    ):
+        findings = check(p)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: check_polished_file routes to the static check only for
+# tutorial paths
+# ---------------------------------------------------------------------------
+
+
+def test_check_polished_file_routes_to_tutorial_static_only_for_tutorials(
+    tmp_path: Path,
+) -> None:
+    from attune.authoring.fact_check import FactCheckConfig, check_polished_file
+
+    tutorial = tmp_path / "docs/tutorials/feat.md"
+    tutorial.parent.mkdir(parents=True)
+    tutorial.write_text("```python\ndef broken(\n```\n", encoding="utf-8")
+
+    how_to = tmp_path / "docs/how-to/feat.md"
+    how_to.parent.mkdir(parents=True)
+    how_to.write_text("```python\ndef broken(\n```\n", encoding="utf-8")
+
+    cfg = FactCheckConfig(
+        enabled=True,
+        check_python_refs=False,
+        check_cli_refs=False,
+        check_md_links=False,
+        check_numeric_refs=False,
+        check_doc_examples=False,
+        check_tutorial_static=True,
+    )
+
+    with patch("attune.authoring.fact_check.tutorial_static_check._run_mypy", return_value=[]):
+        tutorial_report = check_polished_file(tutorial, project_root=tmp_path, config=cfg)
+        how_to_report = check_polished_file(how_to, project_root=tmp_path, config=cfg)
+
+    assert len(tutorial_report.findings) == 1
+    assert tutorial_report.findings[0].check == CHECK_TUTORIAL_STATIC
+    assert how_to_report.findings == []
+
+
+def test_check_polished_file_disabled_when_toggle_off(tmp_path: Path) -> None:
+    from attune.authoring.fact_check import FactCheckConfig, check_polished_file
+
+    tutorial = tmp_path / "docs/tutorials/feat.md"
+    tutorial.parent.mkdir(parents=True)
+    tutorial.write_text("```python\ndef broken(\n```\n", encoding="utf-8")
+
+    cfg = FactCheckConfig(
+        enabled=True,
+        check_python_refs=False,
+        check_cli_refs=False,
+        check_md_links=False,
+        check_numeric_refs=False,
+        check_doc_examples=False,
+        check_tutorial_static=False,
+    )
+
+    report = check_polished_file(tutorial, project_root=tmp_path, config=cfg)
+    assert report.findings == []

--- a/tests/unit/authoring/fixtures/fact_check_ops_dashboard/post_fix/architecture.md
+++ b/tests/unit/authoring/fixtures/fact_check_ops_dashboard/post_fix/architecture.md
@@ -1,0 +1,19 @@
+# Architecture: Ops dashboard
+
+A high-level view of how the dashboard's pieces connect.
+
+## Components
+
+The dashboard is composed of:
+
+- A FastAPI application serving HTML pages + JSON endpoints
+- A ``RunnerService`` managing subprocess execution + SSE streams
+- A persistence layer writing run records to
+  ``~/.attune/ops/runs/<workflow>/<id>.json``
+
+## Run lifecycle
+
+1. POST `/workflows/{name}/run` enqueues a workflow
+2. The runner spawns ``attune workflow run <name>`` as a subprocess
+3. stdout is captured line-by-line and broadcast over SSE
+4. On completion, the run record is persisted

--- a/tests/unit/authoring/fixtures/fact_check_ops_dashboard/post_fix/how-to.md
+++ b/tests/unit/authoring/fixtures/fact_check_ops_dashboard/post_fix/how-to.md
@@ -1,0 +1,32 @@
+# How to run the ops dashboard
+
+This page walks through common operator tasks against the
+attune ops dashboard.
+
+## Start the dashboard
+
+```bash
+attune ops --port 8765
+```
+
+The dashboard binds to ``127.0.0.1`` by default. Workflow
+execution is disabled by default; pass ``--allow-run`` to
+enable it.
+
+## Allow workflow execution
+
+```bash
+attune ops --port 8765 --allow-run
+```
+
+To run with workflow execution disabled (the default), omit the
+flag.
+
+## Persist run history
+
+By default, runs are persisted under ``~/.attune/ops/runs/``.
+See [Storage layout](./storage-layout.md) for details.
+
+## More
+
+- [Configure the dashboard](./configure.md)

--- a/tests/unit/authoring/fixtures/fact_check_ops_dashboard/post_fix/reference.md
+++ b/tests/unit/authoring/fixtures/fact_check_ops_dashboard/post_fix/reference.md
@@ -1,0 +1,19 @@
+# Reference: Ops dashboard API
+
+The ops dashboard exposes a small REST + SSE surface for
+inspecting and (optionally) running workflows.
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/` | Home page |
+| POST | `/workflows/{name}/run` | Start a workflow run |
+| GET | `/runs/{run_id}` | Fetch a single run record as JSON |
+| GET | `/runs/{run_id}/stream` | SSE stream for a live run |
+| GET | `/api/runs/{workflow}` | List persisted runs for a workflow |
+
+## Configuration
+
+See [Configure the dashboard](../how-to/configure.md) for
+details.

--- a/tests/unit/authoring/fixtures/fact_check_ops_dashboard/post_fix/tutorial.md
+++ b/tests/unit/authoring/fixtures/fact_check_ops_dashboard/post_fix/tutorial.md
@@ -1,0 +1,32 @@
+# Tutorial: extending the ops dashboard
+
+A walkthrough of adding a custom panel to the ops dashboard.
+
+## Configure a custom panel
+
+The dashboard reads custom panel definitions from
+``.attune/ops/panels.json``. The schema is a list of panel
+records; each record carries a ``title``, a ``kind`` discriminator,
+and a body string.
+
+A minimal example:
+
+```json
+{
+  "panels": [
+    {
+      "title": "Build status",
+      "kind": "callout",
+      "body": "All systems green",
+      "emphasis": "ok"
+    }
+  ]
+}
+```
+
+The panel renders to the structured report area above the
+process log when a run completes.
+
+## See also
+
+- [Storage layout](../how-to/storage-layout.md)

--- a/tests/unit/authoring/fixtures/fact_check_ops_dashboard/pre_fix/architecture.md
+++ b/tests/unit/authoring/fixtures/fact_check_ops_dashboard/pre_fix/architecture.md
@@ -1,0 +1,28 @@
+# Architecture: Ops dashboard
+
+A high-level view of how the dashboard's pieces connect.
+
+## Components
+
+The dashboard is composed of:
+
+- A FastAPI application serving HTML pages + JSON endpoints
+- A ``RunnerService`` managing subprocess execution + SSE streams
+- A persistence layer writing run records to
+  ``~/.attune/ops/runs/<workflow>/<id>.json``
+
+## Run lifecycle
+
+1. POST `/run` enqueues a workflow
+2. The runner spawns ``attune workflow run <name>`` as a subprocess
+3. stdout is captured line-by-line and broadcast over SSE
+4. On completion, the run record is persisted
+
+## Related design notes
+
+For deeper background see:
+
+- [Concept: Template design patterns](../concepts/template-design-patterns.md)
+- [Concept: Subagent topology](../concepts/subagent-topology.md)
+- [Concept: Stream multiplexing](../concepts/stream-multiplexing.md)
+- [Concept: Persistence schema evolution](../concepts/persistence-schema-evolution.md)

--- a/tests/unit/authoring/fixtures/fact_check_ops_dashboard/pre_fix/how-to.md
+++ b/tests/unit/authoring/fixtures/fact_check_ops_dashboard/pre_fix/how-to.md
@@ -1,0 +1,42 @@
+# How to run the ops dashboard
+
+This page walks through common operator tasks against the
+attune ops dashboard.
+
+## Start the dashboard
+
+```bash
+attune ops --port 8765
+```
+
+The dashboard binds to ``127.0.0.1`` by default.
+
+## Run the dashboard in read-only mode
+
+Use the `--allow-run` flag to allow workflow execution from the
+dashboard UI. Operators who want a strict observation-only
+deployment should omit it.
+
+```bash
+attune ops --port 8765 --allow-run
+```
+
+To run with workflow execution disabled, omit the flag.
+
+## Bind to a specific interface
+
+For development you might bind to all interfaces:
+
+```bash
+attune ops --host 0.0.0.0 --port 8765
+```
+
+## Persist run history
+
+By default, runs are persisted under ``~/.attune/ops/runs/``.
+See [Storage layout](./storage-layout.md) for details.
+
+## More
+
+- [Configure the dashboard](./configure.md)
+- [Concept: Template design patterns](../concepts/template-design-patterns.md)

--- a/tests/unit/authoring/fixtures/fact_check_ops_dashboard/pre_fix/reference.md
+++ b/tests/unit/authoring/fixtures/fact_check_ops_dashboard/pre_fix/reference.md
@@ -1,0 +1,27 @@
+# Reference: Ops dashboard API
+
+The ops dashboard exposes a small REST + SSE surface for
+inspecting and (optionally) running workflows.
+
+## Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/` | Home page |
+| POST | `/run` | Start a workflow run |
+| GET | `/runs/{run_id}` | Fetch a single run record as JSON |
+| GET | `/runs/{run_id}/stream` | SSE stream for a live run |
+| GET | `/api/runs/{workflow}` | List persisted runs for a workflow |
+
+## Templates
+
+The ops dashboard ships with 498 templates pre-registered across
+its help corpus. Each template carries a ``kind`` discriminator
+(concept, how-to, tutorial, reference, etc.) used for
+display dispatch.
+
+## Configuration
+
+See [Configure the dashboard](../how-to/configure.md) and
+[Concept: Workflow taxonomy](../concepts/workflow-taxonomy.md)
+for details.

--- a/tests/unit/authoring/fixtures/fact_check_ops_dashboard/pre_fix/tutorial.md
+++ b/tests/unit/authoring/fixtures/fact_check_ops_dashboard/pre_fix/tutorial.md
@@ -1,0 +1,56 @@
+# Tutorial: extending the ops dashboard
+
+A walkthrough of adding a custom panel to the ops dashboard.
+
+## Read the run state
+
+The ``RunsReader`` class loads persisted run records from disk
+and yields them sorted by completion time.
+
+```python
+from attune.ops._readers import RunsReader
+
+reader = RunsReader()
+for run in reader.iter_completed(limit=20):
+    print(run.id, run.status)
+```
+
+## Construct a Run record manually
+
+For tests or scripted seeding, build a ``RunRecord`` directly:
+
+```python
+from attune.ops._models import RunRecord
+
+record = RunRecord(
+    id="abc123",
+    workflow="release-prep",
+    status="completed",
+)
+```
+
+## Render a panel
+
+Panels render to the structured report area above the process
+log.
+
+```python
+from attune.workflows.output import WorkflowReport, CalloutSection
+
+report = WorkflowReport(
+    title="Custom panel",
+    sections=[
+        CalloutSection(
+            title="Status",
+            tier="essential",
+            text="All systems green",
+            emphasis="ok",
+        ),
+    ],
+)
+```
+
+## See also
+
+- [Reference: Run API endpoints](../reference/run-api.md)
+- [Concept: Template design patterns](../concepts/template-design-patterns.md)

--- a/tests/unit/authoring/fixtures/spec-engine.md
+++ b/tests/unit/authoring/fixtures/spec-engine.md
@@ -1,0 +1,504 @@
+---
+feature: spec-engine
+summary: Spec-driven development with approval loops
+tags: [spec, planning]
+source_globs: [src/attune/spec/**, src/attune/pipeline/**]
+nav:
+  help: spec-engine
+  mkdocs:
+    how-to: how-to/spec-engine
+    tutorial: tutorials/spec-engine
+    architecture: architecture/spec-engine
+    reference: reference/spec-engine
+---
+
+## Overview
+
+The spec engine turns a plan file — an XML task list stored in
+`.claude/plans/` — into executed, gate-checked code. It owns two
+distinct concerns: running the pipeline (`pipeline.*`) and managing
+interactive, approval-gated execution with persistent state
+(`spec.*`).
+
+It is **not** responsible for authoring plan files, running the
+Socratic brainstorm / decompose / review phases, or displaying output
+in the Claude Code UI — those belong to the skill layer above it.
+
+The engine matters whenever you need to understand why a run stopped,
+how to resume it, or how quality-gate outcomes map to the `severity`
+and `gate_score` fields on a `TaskResult`. If you are writing code
+that hooks into execution — an `on_task_complete` callback or a custom
+presenter — these are the types and functions you work with directly.
+
+## Concepts
+
+A spec plan is an XML file under `.claude/plans/`. When you trigger
+execution, the engine works through four concerns in sequence:
+
+1. **Reading** — `read_spec(plan_path)` parses the plan file and
+   returns a list of `DecomposedTask` objects.
+2. **Orchestrating** — `PipelineOrchestrator` iterates those tasks,
+   calls quality gates after each via `run_gates_for_task`, and
+   collects results into a `PipelineResult`.
+3. **Gating** — each task produces a `TaskResult` with fields like
+   `quality_gate_passed`, `tests_passed`, `gate_score`, and the
+   `severity` property. The orchestrator uses these to decide whether
+   to continue, pause for approval, or surface an error.
+4. **State tracking** — `SpecState` records which task IDs are
+   `completed` and which is `current`. `save_state` writes this back
+   into an HTML comment inside the plan file itself, so the file is
+   the single source of truth. `get_pending_tasks` filters the full
+   task list down to whatever hasn't finished, enabling resumption
+   mid-run.
+
+### Core data structures
+
+| Type | What it represents |
+|------|--------------------|
+| `TaskResult` | The outcome of one task: whether it executed, whether `quality_gate_passed` and `tests_passed` are satisfied, the `gate_score` (float), and any `error` string. The `severity` property classifies the gate result for display. |
+| `PipelineResult` | The rolled-up outcome across all tasks: `spec_path`, every `TaskResult` in `tasks`, `total_cost`, `duration_ms`, and `success` (true only when all tasks executed and passed gates). |
+| `SpecState` | Durable progress record: `plan_path`, the list of `completed` task IDs, the `current` task ID, and an `auto_run` flag that controls whether the engine prompts for approval between tasks. |
+
+### How the two packages fit together
+
+The engine spans two packages, each with a distinct role:
+
+- **`pipeline`** owns execution. `PipelineOrchestrator` reads an XML
+  plan file, runs tasks one at a time, and evaluates quality gates
+  after each. `read_spec()` parses a plan file into `DecomposedTask`
+  objects. `TaskResult` and `PipelineResult` carry the outcome data.
+- **`spec`** owns state and presentation. `SpecState` tracks progress;
+  `load_state` / `save_state` / `clear_state` manage the embedded
+  state comment; the presenter functions render engine output for
+  display; and `execute_with_approval` (in `spec.runner`) wraps the
+  orchestrator with a per-task approval loop.
+
+### State lifecycle
+
+```text
+load_state(plan_path)             # returns SpecState | None
+    │
+    ▼
+get_pending_tasks(tasks, state)   # filters out completed IDs
+    │
+    ▼
+[execute tasks, update state.completed after each]
+    │
+    ├─ save_state(state)          # persists progress into the plan file
+    │
+    └─ clear_state(plan_path)     # removes state when the run finishes
+```
+
+`find_resumable_plans(plans_dir)` scans `.claude/plans/` (the default)
+for any plan file that still carries a `SpecState` comment, giving you
+a list of interrupted runs you can pick back up.
+
+## Quickstart
+
+Run a spec plan end-to-end with quality gates in a single Python call:
+
+```python
+from attune.pipeline import PipelineOrchestrator, PipelineResult
+
+orchestrator = PipelineOrchestrator(".claude/plans/my-feature.md")
+result: PipelineResult = orchestrator.run_all()
+
+print(result.summary)   # human-readable run summary
+print(result.success)   # True if all tasks executed and passed gates
+```
+
+`summary` and `success` are properties — read them, don't call them.
+Running this produces a `PipelineResult` with per-task outcomes, total
+cost, and duration.
+
+To skip quality gates during a quick smoke test, pass
+`skip_gates=True` to the constructor.
+
+## Tasks
+
+### Run a plan programmatically with progress output
+
+**Goal:** read a plan, run every task through quality gates, print a
+progress bar after each task, and exit non-zero if any gate failed.
+
+**Steps:**
+
+```python
+from attune.pipeline import (
+    PipelineOrchestrator,
+    PipelineResult,
+    TaskResult,
+    read_spec,
+)
+from attune.spec import present_tasks, present_task_result, format_progress_bar, load_state
+
+PLAN_PATH = ".claude/plans/my-feature.md"
+
+tasks = read_spec(PLAN_PATH)
+state = load_state(PLAN_PATH)          # None if no prior run exists
+print(present_tasks(tasks, state))     # inspect the plan before running
+
+completed_count = 0
+
+def on_task_complete(task, task_result: TaskResult) -> None:
+    global completed_count
+    completed_count += 1
+    print(format_progress_bar(completed_count, len(tasks)))
+    print(present_task_result(task, task_result))
+
+orchestrator = PipelineOrchestrator(PLAN_PATH)
+result: PipelineResult = orchestrator.run_all(on_task_complete=on_task_complete)
+
+print(result.summary)
+
+if not result.success:
+    raise SystemExit(1)
+```
+
+**Verify:** a fully passing run prints the summary and exits `0`. The
+separation between reading (`read_spec`, `present_tasks`) and running
+(`run_all`) is intentional — you can inspect the full plan before
+committing to a run.
+
+### Resume an interrupted run
+
+**Goal:** find plans that didn't finish and continue them from where
+they stopped.
+
+**Steps:**
+
+```python
+from attune.pipeline import PipelineOrchestrator, read_spec
+from attune.spec import get_pending_tasks, find_resumable_plans
+
+resumable = find_resumable_plans(".claude/plans")
+
+for spec_state in resumable:
+    tasks = read_spec(spec_state.plan_path)
+    pending = get_pending_tasks(tasks, spec_state)
+    if not pending:
+        continue
+    completed_ids = set(spec_state.completed)
+    orchestrator = PipelineOrchestrator(spec_state.plan_path)
+    result = orchestrator.run_all(skip_task_ids=completed_ids)
+    print(result.summary)
+```
+
+**Verify:** `get_pending_tasks` returns only the tasks whose IDs are
+not in `SpecState.completed`. Passing those IDs as `skip_task_ids`
+prevents re-running completed work.
+
+### Run with per-task approval
+
+**Goal:** pause after each task for human sign-off instead of running
+the whole plan unattended.
+
+**Steps:**
+
+```python
+import asyncio
+from attune.spec.runner import execute_with_approval
+
+async def main():
+    result = await execute_with_approval(
+        ".claude/plans/my-feature.md",
+        on_task_complete,
+        skip_gates=False,
+        skip_tests=False,
+        skip_simplify=False,
+    )
+    print(result.summary)
+
+asyncio.run(main())
+```
+
+`execute_with_approval` is an async coroutine — `await` it (or drive
+it with `asyncio.run`). It accepts the same `skip_gates`,
+`skip_tests`, and `skip_simplify` flags as `PipelineOrchestrator`, and
+returns the same `PipelineResult`. Flip `SpecState.auto_run = True` to
+skip the per-task pause for the rest of the run.
+
+**Verify:** the loop pauses after each task. An interrupted approval
+run leaves a resumable `SpecState` in the plan file.
+
+### Re-run a subset of tasks without restarting
+
+**Goal:** re-run specific tasks without clearing state and reprocessing
+the whole plan.
+
+**Steps:** pass a `set[str]` of already-completed task IDs to
+`run_all(skip_task_ids=...)`:
+
+```python
+result = orchestrator.run_all(skip_task_ids={"task-1", "task-2"})
+```
+
+**Verify:** skipping completed tasks preserves `SpecState.completed`
+and keeps `total_cost` and `duration_ms` accurate in the final
+`PipelineResult`. You are responsible for knowing which IDs to skip —
+if a skipped task produced an artifact a later task depends on, check
+`TaskResult.quality_gate_passed` and `gate_score` on the result before
+assuming success.
+
+## Reference
+
+The spec engine exposes its public API through two packages:
+`attune.pipeline` (execution) and `attune.spec` (state and
+presentation). `execute_with_approval` lives in `attune.spec.runner`.
+
+### Pipeline execution
+
+| Symbol | Purpose |
+|--------|---------|
+| `PipelineOrchestrator(spec_path, *, skip_gates=False, skip_tests=False, skip_simplify=False)` | Load a plan file and prepare tasks for execution with optional gate overrides. |
+| `PipelineOrchestrator.run_all(*, on_task_complete=None, skip_task_ids=None)` | Execute all tasks, firing an optional callback after each; returns a `PipelineResult`. |
+| `PipelineOrchestrator.run_gates_for_task(task)` | Run quality gates for a single `DecomposedTask` and return a `TaskResult`. |
+| `read_spec(plan_path)` | Parse a plan file and extract its XML task blocks into `DecomposedTask` objects. Raises `FileNotFoundError` (missing file) or `ValueError` (empty path). |
+| `execute_with_approval(spec_path, on_task_complete, *, skip_gates=False, skip_tests=False, skip_simplify=False)` | **Async.** Execute a spec with an interactive per-task approval loop. Import from `attune.spec.runner`. |
+
+### State management
+
+| Symbol | Purpose |
+|--------|---------|
+| `load_state(plan_path)` | Read a `SpecState` from the HTML comment embedded in a plan file; returns `None` if no state exists. |
+| `save_state(state)` | Write or update the spec-state comment in a plan file. |
+| `clear_state(plan_path)` | Remove the spec-state comment from a plan file. |
+| `find_resumable_plans(plans_dir='.claude/plans')` | Return all `SpecState` objects whose plans have incomplete execution. |
+| `get_pending_tasks(tasks, state)` | Filter a task list to those whose IDs are not in `state.completed`. |
+
+### Presentation
+
+| Symbol | Purpose |
+|--------|---------|
+| `present_tasks(tasks, state)` | Format a task list as a markdown table, optionally annotated with completion state. |
+| `present_task_detail(task)` | Format a single task with its full acceptance criteria and metadata. |
+| `present_task_result(task, gate_result)` | Format execution output including quality-gate status and score. |
+| `format_progress_bar(completed, total)` | Render a visual progress indicator for a running pipeline. |
+
+### Result fields
+
+`TaskResult` fields you'll inspect most often:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `quality_gate_passed` | `bool \| None` | Gate outcome; `None` when gates were skipped. |
+| `tests_passed` | `bool \| None` | Test outcome; `None` when tests were skipped. |
+| `gate_score` | `float \| None` | Numeric quality score from the gate. |
+| `severity` | `str` (property) | Classified severity of the gate result. |
+| `error` | `str \| None` | Error message if the task failed to execute. |
+| `cost` | `float` | Cost attributed to this task. |
+
+`PipelineResult` top-level members:
+
+| Member | Type | Meaning |
+|--------|------|---------|
+| `success` | `bool` (property) | `True` only when all tasks executed and passed gates. |
+| `summary` | `str` (property) | Human-readable run summary. |
+| `tasks` | `list[TaskResult]` | Per-task outcomes. |
+| `total_cost` | `float` | Aggregated cost across all tasks. |
+| `duration_ms` | `int` | Wall-clock time for the full run. |
+
+### Example output
+
+An approval run prints a progress bar, per-task gate results, and a
+final summary:
+
+```text
+[========--] 4/5 tasks
+
+✔ task-1  add-jwt-config          gate: passed  score: 92.0  cost: $0.003
+✔ task-2  token-service           gate: passed  score: 87.5  cost: $0.004
+✔ task-3  auth-middleware         gate: passed  score: 81.0  cost: $0.005
+✔ task-4  wire-routes             gate: passed  score: 78.3  cost: $0.004
+  task-5  integration-tests       pending
+
+Pipeline complete: 4/5 tasks executed  total_cost: $0.016  duration: 18402ms
+```
+
+## Comparison
+
+The engine exposes two layers for running spec-driven workflows: a
+high-level interactive layer (`spec.runner.execute_with_approval`) and
+a low-level pipeline layer (`PipelineOrchestrator`). Both execute the
+same tasks with the same quality gates, but differ in who controls the
+approval loop and how much state they manage for you.
+
+| Capability | `spec` layer (`execute_with_approval`) | `pipeline` layer (`PipelineOrchestrator`) |
+|---|---|---|
+| **Import path** | `from attune.spec.runner import execute_with_approval` | `from attune.pipeline import PipelineOrchestrator` |
+| **Approval loop** | Per-task, interactive — pauses after each task | Batch — runs all tasks unless you pass `skip_task_ids` |
+| **Resume support** | Yes — `load_state` / `save_state` / `find_resumable_plans` persist `SpecState` | No built-in persistence; caller owns resumability |
+| **Progress feedback** | Presenter functions render live output | Callback only — wire `on_task_complete` yourself |
+| **Skip flags** | `skip_gates`, `skip_tests`, `skip_simplify` | Same flags on `__init__` |
+| **Task filtering** | `get_pending_tasks` against persisted state | Pass `skip_task_ids: set[str]` to `run_all` |
+| **Result model** | `PipelineResult` (shared) | `PipelineResult` (shared) |
+| **Concurrency** | Async coroutine — `await` it | Synchronous call |
+| **Typical caller** | Conversational / interactive session | Automated scripts, CI pipelines |
+
+**Use the `spec` layer** when a human approves each task, you want
+automatic resume support, and you want formatted output without
+writing presenter logic. **Use the `pipeline` layer** when running in
+CI with no interactive step, when you need to skip tasks by ID at call
+time, or when you want to inspect gate results programmatically with
+no display logic in the way.
+
+When in doubt, start with the `spec` layer. The `pipeline` layer is
+the better fit only when you are certain you do not need state
+persistence or interactive approval — and are prepared to manage both
+yourself.
+
+## Failure modes
+
+| Symptom | Cause | Fix | Severity |
+|---|---|---|---|
+| `ValueError: plan_path must be a non-empty string` | Empty string or `None` passed to `read_spec` / `PipelineOrchestrator` | Resolve the path before passing it | high |
+| `FileNotFoundError: Plan file not found` | The plan file does not exist at the given path | Verify the path; use `os.path.abspath` to be sure | high |
+| `PipelineResult.success` is `False` | One or more tasks failed to execute or failed a gate | Iterate `result.tasks`; check each `TaskResult.error`, `quality_gate_passed`, `tests_passed` | high |
+| A task never appears in output | The XML task block is malformed or absent | Call `read_spec` directly and inspect the returned list | medium |
+| Execution resumes from the wrong task | `SpecState.completed` / `current` is stale | `load_state` to inspect, then `clear_state` to reset | medium |
+| `get_pending_tasks` returns `[]` unexpectedly | `SpecState.completed` already holds all task IDs | State is stale or the plan finished; `clear_state` to start fresh | medium |
+| Quality gate always passes | `skip_gates=True` left in from development | Remove the flag to re-enable gates | medium |
+| State comment vanished after editing the plan | An editor/formatter/VCS step stripped HTML comments | Ensure tooling preserves HTML comments in `.md`; confirm the comment is present after `save_state` | medium |
+
+### Risk areas
+
+- **Resuming re-runs tasks when state drifts.** `get_pending_tasks`
+  matches `task_id` values from `SpecState.completed` against the task
+  list from `read_spec`. If task IDs are renumbered or reordered
+  between sessions, completed tasks can look pending and run twice.
+  Treat plan files as append-only once execution starts; if you must
+  edit mid-run, `clear_state` first.
+- **Skip flags silently lower quality guarantees.** `skip_gates`,
+  `skip_tests`, and `skip_simplify` set the corresponding `TaskResult`
+  fields to `None`/`False` rather than raising. `PipelineResult.success`
+  still returns `True` if all tasks executed, even with gates skipped.
+  After any skip-flag run, inspect `quality_gate_passed`,
+  `tests_passed`, and `gate_score` explicitly.
+- **`read_spec` does not warn on empty task lists.** A valid file with
+  no parseable XML task blocks returns `[]` silently, and downstream
+  orchestration completes with nothing to do. Check for a non-empty
+  list before orchestrating.
+- **`on_task_complete` errors abort the pipeline.** An unhandled
+  exception in the callback stops the run at that task; the saved
+  state marks it `current`, so resuming re-runs it. Wrap callback
+  logic in `try`/`except` and check `TaskResult.error` before acting.
+
+### Diagnosis order
+
+1. Reproduce with a minimal `read_spec(plan_path)` call — if it
+   raises, the problem is the path or the plan file.
+2. Inspect persisted state: `load_state(plan_path)`; check
+   `completed`, `current`, `schema_version`.
+3. Clear stale state and retry: `clear_state(plan_path)`.
+4. Re-run with `skip_gates=True` to isolate gate failures from task
+   logic. If `success` flips to `True`, the gate thresholds or scores
+   are the cause — inspect `gate_details`.
+5. Iterate `result.tasks` and print each failing `TaskResult`
+   (`error`, `gate_score`, `gate_details`, `tests_passed`).
+6. Run the related tests: `pytest -k "spec" -v`.
+
+## FAQ seeds
+
+> **Channel-4 input, not a rendered FAQ.** The FAQ is a dynamic
+> source of truth fed by four channels — unmatched user queries,
+> telemetry error-frequency, GitHub issues, and these author-curated
+> seeds — merged, deduplicated, and frequency-ranked by the FAQ
+> Generator (see doc-stack D3, and this spec's
+> [decisions.md](../../docs/specs/help-docs-single-source/decisions.md)
+> D6). This section is **not** projected verbatim as the FAQ; it
+> contributes the feature's author-curated seed questions to the
+> Generator. Keep entries to genuine, feature-specific seeds — do not
+> mirror the dynamic channels here.
+
+- **Q:** What is the spec engine?
+  **A:** The runtime layer that reads a decomposed plan file, executes
+  each task in order, runs quality gates after each, and tracks
+  progress so a run can be paused and resumed.
+- **Q:** When should I use it?
+  **A:** When you have a plan file with XML task blocks under
+  `.claude/plans/` and want to execute those tasks with quality gates
+  and approval checkpoints. If you're still brainstorming or
+  decomposing, you don't need the engine yet.
+- **Q:** What's the main entry point?
+  **A:** Load and parse a plan — `read_spec(plan_path)`. Run the full
+  pipeline programmatically — `PipelineOrchestrator(spec_path).run_all()`.
+  Run with per-task approval — `await execute_with_approval(spec_path,
+  on_task_complete)`.
+- **Q:** How do quality gates work?
+  **A:** After each task, `run_gates_for_task` evaluates the result and
+  returns a `TaskResult`. `quality_gate_passed` says whether the task
+  met its acceptance criteria; `gate_score` gives a numeric score;
+  `severity` classifies the outcome. If `quality_gate_passed` is
+  `False`, the pipeline stops unless auto-run is active
+  (`SpecState.auto_run = True`).
+- **Q:** Can I skip tasks or resume a partial run?
+  **A:** Yes. Pass a set of task IDs to `run_all(skip_task_ids=...)` to
+  exclude them. To resume, call `get_pending_tasks(tasks, state)` — it
+  filters out IDs already in `SpecState.completed` — then orchestrate
+  the remaining tasks.
+- **Q:** How do I check whether the whole pipeline succeeded?
+  **A:** Inspect the `PipelineResult`. `success` is `True` only when
+  all tasks executed and passed their gates; `summary` is the
+  human-readable summary; `total_cost` and `duration_ms` are available
+  for observability.
+
+## Notes & tips
+
+- **Depend only on the public API.** `pipeline` exports
+  `PipelineOrchestrator`, `PipelineResult`, `TaskResult`, and
+  `read_spec`. `spec` exports `SpecState`, `clear_state`,
+  `find_resumable_plans`, `format_progress_bar`, `get_pending_tasks`,
+  `load_state`, `present_task_detail`, `present_task_result`,
+  `present_tasks`, and `save_state`. `execute_with_approval` lives in
+  `attune.spec.runner`. Private helpers can change without notice.
+- **Presenter functions are pure.** `present_tasks`,
+  `present_task_detail`, `present_task_result`, and
+  `format_progress_bar` accept `pipeline` data types, hold no state,
+  and have no coupling to the pipeline layer — safe to call anywhere.
+- **Prefer `skip_task_ids` over `clear_state` for re-runs.** Clearing
+  state is irreversible mid-run; skipping completed tasks preserves
+  your `completed` list and keeps `total_cost` / `duration_ms`
+  accurate.
+
+## Design & extension
+
+### Design decisions
+
+- **State embedded in the plan file, not a sidecar.** `save_state` and
+  `load_state` read and write `SpecState` as an HTML comment block
+  inside the `.md` plan file rather than a separate JSON file. This
+  keeps the plan and its progress co-located — the plan file is the
+  single artifact needed to resume. The trade-off is that plan files
+  are mutable after authoring, so the state block is versioned
+  (`schema_version`) to survive format changes.
+- **`skip_gates`, `skip_tests`, `skip_simplify` as constructor flags,
+  not subclasses.** The three concerns are tightly coupled inside a
+  single task execution; separating them into composable strategies
+  would add indirection without simplifying the gate logic. The flags
+  propagate transparently through `execute_with_approval`.
+- **`SpecState.completed` is a list of task IDs, not a count.**
+  `get_pending_tasks` filters by ID, so tasks can be skipped
+  non-linearly via `skip_task_ids` in `run_all` without corrupting
+  resume behavior. A simple counter could not support this.
+
+### Extension points
+
+- **Add a new quality-gate check:** extend
+  `PipelineOrchestrator.run_gates_for_task()`. It returns a
+  `TaskResult`; add fields to the `TaskResult` dataclass in
+  `pipeline/models.py` if the new gate produces data callers must
+  inspect.
+- **Hook into task completion:** pass an `on_task_complete` callback
+  to `run_all()`. It receives a `TaskResult` after each task — the
+  intended integration point for custom reporting, logging, or
+  approval UIs, without modifying the orchestrator.
+- **Resume or skip tasks selectively:** pass `skip_task_ids: set[str]`
+  to `run_all()`. Task IDs come from the `DecomposedTask` objects
+  returned by `read_spec()`.
+- **Add a new presenter format:** add a function alongside the
+  existing presenters in `spec/presenter.py`. Presenters are pure
+  functions over `DecomposedTask` and `TaskResult`.
+- **Find or restore interrupted runs:** use
+  `find_resumable_plans(plans_dir)` to list `SpecState` objects for
+  incomplete plans, then pass `plan_path` to `execute_with_approval()`
+  to resume.

--- a/tests/unit/authoring/test_projector.py
+++ b/tests/unit/authoring/test_projector.py
@@ -1,0 +1,358 @@
+"""Tests for the deterministic master-file projector (T2).
+
+See ``docs/specs/help-docs-single-source/t2-projector-build.md`` in
+attune-ai. The fixture mirrors attune-ai's
+``content/features/spec-engine.md`` (merged in attune-ai #960) so the
+test is hermetic and runnable in attune-author CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.authoring.projector import (
+    DOCS_PAGE_SECTIONS,
+    HELP_FRONTMATTER_KEYS,
+    HELP_KIND_SECTIONS,
+    parse_master_file,
+    project_feature,
+    validate_master_file,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "spec-engine.md"
+
+#: The 10 H2 sections the spec-engine master file declares, in order.
+MASTER_SECTIONS = [
+    "Overview",
+    "Concepts",
+    "Quickstart",
+    "Tasks",
+    "Reference",
+    "Comparison",
+    "Failure modes",
+    "FAQ seeds",
+    "Notes & tips",
+    "Design & extension",
+]
+
+
+def _parse_help_frontmatter(content: str) -> dict[str, str]:
+    """Pull the leading ``---`` frontmatter block into a flat dict."""
+    assert content.startswith("---\n")
+    _, block, _ = content.split("---\n", 2)
+    out: dict[str, str] = {}
+    for line in block.strip().splitlines():
+        key, _, value = line.partition(":")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def _help_body(content: str) -> str:
+    """Return the markdown body after the leading ``---`` frontmatter."""
+    assert content.startswith("---\n")
+    _, _, body = content.split("---\n", 2)
+    return body.lstrip("\n")
+
+
+# --- parse_master_file ------------------------------------------------------
+
+
+def test_parse_master_file_yields_all_sections():
+    master = parse_master_file(FIXTURE)
+    assert master.feature == "spec-engine"
+    assert list(master.sections.keys()) == MASTER_SECTIONS
+    assert len(master.sections) == 10
+    # Bodies are captured, not just headings.
+    assert "spec engine" in master.sections["Overview"].lower()
+    assert "| Type |" in master.sections["Concepts"]
+
+
+def test_parse_ignores_h2_inside_code_fences():
+    # The Tasks section is heavy with fenced python; none of its
+    # in-fence lines should have spawned phantom sections.
+    master = parse_master_file(FIXTURE)
+    assert list(master.sections.keys()) == MASTER_SECTIONS
+
+
+# --- project_feature: planning ---------------------------------------------
+
+
+def test_dry_run_plans_ten_help_kinds_and_three_docs(tmp_path):
+    result = project_feature(FIXTURE, tmp_path, tmp_path / ".help", dry_run=True)
+    help_outputs = [o for o in result.outputs if o.target == "help"]
+    docs_outputs = [o for o in result.outputs if o.target == "docs" and o.kind != "hub"]
+    hub_outputs = [o for o in result.outputs if o.kind == "hub"]
+
+    assert len(help_outputs) == 10
+    assert len(docs_outputs) == 3
+    # The hub is additive — exactly one per feature with docs pages.
+    assert len(hub_outputs) == 1
+    assert {o.kind for o in help_outputs} == set(HELP_KIND_SECTIONS)
+    assert {o.kind for o in docs_outputs} == set(DOCS_PAGE_SECTIONS)
+    # faq is never planned (D7).
+    assert "faq" not in {o.kind for o in help_outputs}
+    # tutorial is never projected (D10) — hand-authored.
+    assert "tutorial" not in {o.kind for o in docs_outputs}
+    # dry-run writes nothing.
+    assert result.written == []
+    assert not any(tmp_path.rglob("*.md"))
+
+
+def test_help_frontmatter_has_seven_keys_and_depth_equals_kind(tmp_path):
+    result = project_feature(FIXTURE, tmp_path, tmp_path / ".help", dry_run=True)
+    for out in result.outputs:
+        if out.target != "help":
+            continue
+        fm = _parse_help_frontmatter(out.content)
+        assert set(fm) == set(HELP_FRONTMATTER_KEYS)
+        assert fm["depth"] == out.kind
+        assert fm["type"] == out.kind
+        assert fm["name"] == f"spec-engine-{out.kind}"
+        assert fm["feature"] == "spec-engine"
+        assert fm["status"] == "generated"
+        assert fm["source_hash"]  # non-empty
+
+
+def test_help_body_opens_with_h1_title(tmp_path):
+    # Every projected .help body must open with an `# H1` so attune-ai's
+    # ops dashboard (_title_from_content) recovers a real card title
+    # instead of degrading to "<feature> / <kind>" (P1).
+    result = project_feature(FIXTURE, tmp_path, tmp_path / ".help", dry_run=True)
+    help_outputs = [o for o in result.outputs if o.target == "help"]
+    assert help_outputs
+    for out in help_outputs:
+        body = _help_body(out.content)
+        first_line = body.splitlines()[0]
+        assert first_line.startswith("# ")
+        assert not first_line.startswith("## ")
+        # The H1 is the feature summary (frontmatter), not the slug.
+        assert first_line == "# Spec-driven development with approval loops"
+
+
+def test_docs_pages_carry_footer(tmp_path):
+    result = project_feature(FIXTURE, tmp_path, tmp_path / ".help", dry_run=True)
+    # The hub is a nav surface, not a staleness-tracked projection — it
+    # carries no footer (asserted separately).
+    docs = [o for o in result.outputs if o.target == "docs" and o.kind != "hub"]
+    assert docs
+    for out in docs:
+        assert "<!-- attune-generated:" in out.content
+        assert "feature=spec-engine" in out.content
+        assert f"kind={out.kind}" in out.content
+        # No YAML frontmatter on docs pages.
+        assert not out.content.startswith("---\n")
+
+
+# --- project_feature: writing ----------------------------------------------
+
+
+def test_project_feature_writes_to_disk(tmp_path):
+    help_dir = tmp_path / ".help"
+    result = project_feature(FIXTURE, tmp_path, help_dir, dry_run=False)
+
+    assert len(result.written) == 14
+    assert (help_dir / "templates" / "spec-engine" / "concept.md").exists()
+    assert (help_dir / "templates" / "spec-engine" / "reference.md").exists()
+    # docs land at their nav.mkdocs paths.
+    assert (tmp_path / "docs" / "how-to" / "spec-engine.md").exists()
+    assert (tmp_path / "docs" / "architecture" / "spec-engine.md").exists()
+    assert (tmp_path / "docs" / "reference" / "spec-engine.md").exists()
+    # the additive Variant-1 hub page (D11).
+    assert (tmp_path / "docs" / "features" / "spec-engine.md").exists()
+    # faq is never written (D7 / DD5); tutorial is hand-authored (D10).
+    assert not (help_dir / "templates" / "spec-engine" / "faq.md").exists()
+    assert not (tmp_path / "docs" / "tutorials" / "spec-engine.md").exists()
+
+
+# --- tolerate missing sections ---------------------------------------------
+
+
+def test_missing_section_skips_only_dependent_outputs(tmp_path):
+    # A minimal master with only Overview, Concepts, and Notes & tips:
+    # concept/note/tip render; every output depending on an absent
+    # section is skipped — never an error.
+    master = tmp_path / "tiny.md"
+    master.write_text(
+        "---\n"
+        "feature: tiny\n"
+        "summary: x\n"
+        "---\n\n"
+        "## Overview\n\nthe overview\n\n"
+        "## Concepts\n\nthe concepts\n\n"
+        "## Notes & tips\n\nthe notes\n",
+        encoding="utf-8",
+    )
+
+    result = project_feature(master, tmp_path, tmp_path / ".help", dry_run=True)
+    rendered = {o.kind for o in result.outputs}
+
+    assert rendered == {"concept", "note", "tip"}
+    # Dependent outputs are recorded as skipped, with the missing
+    # section named.
+    assert any(s.startswith("reference") for s in result.skipped)
+    assert any(s.startswith("comparison") for s in result.skipped)
+    assert any(s.startswith("error") for s in result.skipped)
+    assert any(s.startswith("docs/how-to") for s in result.skipped)
+    assert any(s.startswith("docs/architecture") for s in result.skipped)
+
+
+# --- project_feature: hub page (D11 / Variant 1) ---------------------------
+
+
+def _hub_content(result) -> str:
+    """Return the single hub output's rendered content."""
+    hubs = [o for o in result.outputs if o.kind == "hub"]
+    assert len(hubs) == 1
+    return hubs[0].content
+
+
+def _degraded_master(tmp_path) -> Path:
+    """A master that declares how-to/reference/architecture but NO
+    tutorial — exercising the degraded how-to-hero branch (`models`)."""
+    master = tmp_path / "models.md"
+    master.write_text(
+        "---\n"
+        "feature: models\n"
+        "summary: Model registry and selection\n"
+        "nav:\n"
+        "  mkdocs:\n"
+        "    how-to: how-to/models\n"
+        "    architecture: architecture/models\n"
+        "    reference: reference/models\n"
+        "---\n\n"
+        "## Overview\n\nthe overview\n\n"
+        "## Concepts\n\nthe concepts\n\n"
+        "## Quickstart\n\nthe quickstart\n\n"
+        "## Tasks\n\nthe tasks\n\n"
+        "## Reference\n\nthe reference\n\n"
+        "## Design & extension\n\nthe design\n",
+        encoding="utf-8",
+    )
+    return master
+
+
+def test_hub_tutorial_hero_links_tutorial_and_omits_it_from_cards(tmp_path):
+    # spec-engine's master declares nav.mkdocs.tutorial → the hero links
+    # the tutorial path; the tutorial is NOT repeated as a card.
+    result = project_feature(FIXTURE, tmp_path, tmp_path / ".help", dry_run=True)
+    hub = _hub_content(result)
+
+    assert hub.startswith("# Spec Engine\n")
+    assert "Spec-driven development with approval loops" in hub
+    # Hero "Start here" admonition points at the tutorial.
+    assert '!!! tip "Start here"' in hub
+    assert "[Tutorial](../tutorials/spec-engine.md)" in hub
+    # Card grid uses Material idioms and lists how-to/reference/architecture.
+    assert '<div class="grid cards" markdown>' in hub
+    assert "[Open the how-to guide](../how-to/spec-engine.md)" in hub
+    assert "[Open the reference](../reference/spec-engine.md)" in hub
+    assert "[Open the architecture](../architecture/spec-engine.md)" in hub
+    # The tutorial is the hero, never a card.
+    assert "Open the tutorial" not in hub
+    assert hub.count("../tutorials/spec-engine.md") == 1
+
+
+def test_hub_degraded_how_to_hero_when_no_tutorial(tmp_path):
+    # No tutorial declared → hero degrades to how-to; cards are the
+    # remaining present pages (reference, architecture). No tutorial card.
+    master = _degraded_master(tmp_path)
+    result = project_feature(master, tmp_path, tmp_path / ".help", dry_run=True)
+    hub = _hub_content(result)
+
+    assert hub.startswith("# Models\n")
+    assert '!!! tip "Start here"' in hub
+    # Hero is the how-to, not a tutorial.
+    assert "[How-to guide](../how-to/models.md)" in hub
+    assert "tutorial" not in hub.lower()
+    # Remaining pages become cards; the hero how-to is not repeated.
+    assert "[Open the reference](../reference/models.md)" in hub
+    assert "[Open the architecture](../architecture/models.md)" in hub
+    assert "Open the how-to" not in hub
+
+
+def test_hub_skipped_when_no_nav_pages(tmp_path):
+    # A master with no nav.mkdocs pages → hub recorded in result.skipped,
+    # no hub output, no file written.
+    master = tmp_path / "barebones.md"
+    master.write_text(
+        "---\nfeature: barebones\nsummary: x\n---\n\n## Overview\n\nprose\n",
+        encoding="utf-8",
+    )
+
+    result = project_feature(master, tmp_path, tmp_path / ".help", dry_run=False)
+
+    assert "hub (no docs pages)" in result.skipped
+    assert not any(o.kind == "hub" for o in result.outputs)
+    assert not (tmp_path / "docs" / "features" / "barebones.md").exists()
+
+
+def test_hub_dry_run_writes_nothing_but_is_in_outputs(tmp_path):
+    # dry_run=True: hub content is planned in result.outputs but no file
+    # is written.
+    result = project_feature(FIXTURE, tmp_path, tmp_path / ".help", dry_run=True)
+
+    assert any(o.kind == "hub" for o in result.outputs)
+    assert result.written == []
+    assert not (tmp_path / "docs" / "features" / "spec-engine.md").exists()
+
+
+# --- validate_master_file (warn-only) --------------------------------------
+
+
+def _write_master_with_mispathed_import(tmp_path) -> Path:
+    """A project_root with a source module and a master file whose
+    example imports it by the wrong (basename-guessed) module path."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "mymod.py").write_text(
+        '"""A module."""\n\n\ndef do_thing():\n    """Do the thing."""\n    return 1\n',
+        encoding="utf-8",
+    )
+    master = tmp_path / "feat.md"
+    master.write_text(
+        "---\n"
+        "feature: feat\n"
+        "summary: A feature\n"
+        "source_globs: [pkg/*.py]\n"
+        "---\n\n"
+        "## Tasks\n\n"
+        "```python\n"
+        # Wrong module path: real module is pkg.mymod, not bare mymod.
+        "from mymod import do_thing\n" "\n" "do_thing()\n" "```\n",
+        encoding="utf-8",
+    )
+    return master
+
+
+def test_validate_master_file_flags_import_repair_and_is_warn_only(tmp_path):
+    master = _write_master_with_mispathed_import(tmp_path)
+
+    findings = validate_master_file(master, tmp_path)
+
+    # Never raises — the pilot is warn-only; it returns a plain list.
+    assert isinstance(findings, list)
+    # The import_repair probe surfaces a warning that the example import
+    # would be rewritten to its canonical module path.
+    repair = [f for f in findings if "import_repair would rewrite" in f.message]
+    assert len(repair) == 1
+    assert repair[0].severity == "warning"
+
+
+def test_validate_master_file_clean_when_no_source_globs(tmp_path):
+    # No source_globs -> import_repair probe degrades to None; a clean
+    # master with no fishy refs yields no import_repair finding.
+    master = tmp_path / "clean.md"
+    master.write_text(
+        "---\n"
+        "feature: clean\n"
+        "summary: Clean feature\n"
+        "---\n\n"
+        "## Overview\n\nJust prose, no code, no references.\n",
+        encoding="utf-8",
+    )
+
+    findings = validate_master_file(master, tmp_path)
+
+    assert isinstance(findings, list)
+    assert not any("import_repair would rewrite" in f.message for f in findings)

--- a/tests/unit/authoring/test_source_extractors.py
+++ b/tests/unit/authoring/test_source_extractors.py
@@ -1,0 +1,454 @@
+"""Unit tests for the new AST extractors in generator.py.
+
+Covers:
+- _extract_raises: exception classes raised by a function
+- _extract_literal_values: Literal[...] allowed string values
+- _extract_param_literals: per-param literal enumerations
+- _is_dataclass: @dataclass decorator detection
+- _extract_dataclass_fields: field name/type/default for dataclasses
+
+These feed the polish LLM so the reference template can render
+defaults, raises, enum members, and dataclass field tables — the
+four gaps the v0.3.6 hallucination benchmark surfaced.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from attune.authoring.source_introspection import (
+    _extract_class_properties,
+    _extract_dataclass_fields,
+    _extract_literal_values,
+    _extract_module_constant,
+    _extract_param_literals,
+    _extract_raises,
+    _extract_return_data,
+    _is_dataclass,
+)
+
+# -- return-data extraction -----------------------------------------
+
+
+def _extract_return_data_from_src(src: str) -> object | None:
+    tree = ast.parse(src)
+    node = tree.body[0]
+    assert isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    return _extract_return_data(node)
+
+
+class TestExtractReturnData:
+    def test_dict_literal(self) -> None:
+        src = "def f():\n    return {'a': 1, 'b': 2}"
+        assert _extract_return_data_from_src(src) == {"a": 1, "b": 2}
+
+    def test_nested_dict_literal(self) -> None:
+        src = (
+            "def get_tools():\n"
+            "    return {\n"
+            "        'author_lookup': {\n"
+            "            'description': 'Look up help',\n"
+            "            'input_schema': {'query': 'str'},\n"
+            "        },\n"
+            "    }"
+        )
+        result = _extract_return_data_from_src(src)
+        assert isinstance(result, dict)
+        assert result["author_lookup"]["description"] == "Look up help"
+        assert result["author_lookup"]["input_schema"] == {"query": "str"}
+
+    def test_list_literal(self) -> None:
+        src = "def f():\n    return [1, 2, 3]"
+        assert _extract_return_data_from_src(src) == [1, 2, 3]
+
+    def test_tuple_literal(self) -> None:
+        src = "def f():\n    return ('a', 'b')"
+        assert _extract_return_data_from_src(src) == ("a", "b")
+
+    def test_constant_literal(self) -> None:
+        src = "def f():\n    return 42"
+        assert _extract_return_data_from_src(src) == 42
+
+    def test_computed_return_none(self) -> None:
+        """Function calls, name references, and operators are not
+        literal — we deliberately don't surface dynamic returns."""
+        src = "def f():\n    return some_func()"
+        assert _extract_return_data_from_src(src) is None
+
+    def test_name_reference_returns_none(self) -> None:
+        src = "def f():\n    x = 1\n    return x"
+        assert _extract_return_data_from_src(src) is None
+
+    def test_dict_with_name_values_returns_none(self) -> None:
+        """Dict with computed values fails literal_eval — safe."""
+        src = "def f():\n    return {'a': some_var}"
+        assert _extract_return_data_from_src(src) is None
+
+    def test_no_return_statement(self) -> None:
+        src = "def f():\n    pass"
+        assert _extract_return_data_from_src(src) is None
+
+    def test_nested_return_transparent_guard_clause_ignored(self) -> None:
+        """Returns inside nested blocks (if/try/etc) are transparent.
+
+        A factory like ``if legacy: return legacy_tools(); return {...}``
+        should still surface the literal schema — the guard clause
+        isn't what the reference is documenting.
+        """
+        src = "def f(x):\n    if x:\n        return None\n    return {'a': 1}"
+        assert _extract_return_data_from_src(src) == {"a": 1}
+
+    def test_top_level_non_literal_return_aborts(self) -> None:
+        """A top-level non-literal return DOES abort extraction.
+
+        If the first thing the function does is return a computed
+        value, we don't want to surface a later literal — the
+        function isn't a literal-data factory.
+        """
+        src = "def f():\n    return compute()"
+        assert _extract_return_data_from_src(src) is None
+
+    def test_bool_and_none_preserved(self) -> None:
+        src = "def f():\n" "    return {'ok': True, 'err': False, 'val': None}"
+        assert _extract_return_data_from_src(src) == {
+            "ok": True,
+            "err": False,
+            "val": None,
+        }
+
+
+# -- class property extraction --------------------------------------
+
+
+class TestExtractClassProperties:
+    def test_single_property(self) -> None:
+        src = (
+            "class C:\n"
+            "    @property\n"
+            "    def count(self) -> int:\n"
+            "        '''Count of items.'''\n"
+            "        return 0"
+        )
+        assert _extract_class_properties(_cls(src)) == [
+            {"name": "count", "return_type": "int", "doc": "Count of items."}
+        ]
+
+    def test_regular_method_not_property(self) -> None:
+        src = "class C:\n" "    def do_it(self) -> int:\n" "        return 0"
+        assert _extract_class_properties(_cls(src)) == []
+
+    def test_underscore_property_skipped(self) -> None:
+        src = "class C:\n" "    @property\n" "    def _private(self) -> int:\n" "        return 0"
+        assert _extract_class_properties(_cls(src)) == []
+
+    def test_multiple_properties(self) -> None:
+        src = (
+            "class C:\n"
+            "    @property\n"
+            "    def a(self) -> int:\n"
+            "        return 0\n"
+            "    @property\n"
+            "    def b(self) -> str:\n"
+            "        return ''\n"
+            "    def regular(self) -> None:\n"
+            "        return None"
+        )
+        props = _extract_class_properties(_cls(src))
+        assert [p["name"] for p in props] == ["a", "b"]
+        assert [p["return_type"] for p in props] == ["int", "str"]
+
+    def test_property_without_return_type(self) -> None:
+        src = "class C:\n" "    @property\n" "    def count(self):\n" "        return 0"
+        props = _extract_class_properties(_cls(src))
+        assert props == [{"name": "count", "return_type": "", "doc": ""}]
+
+
+def _fn(src: str) -> ast.FunctionDef:
+    tree = ast.parse(src)
+    node = tree.body[0]
+    assert isinstance(node, ast.FunctionDef)
+    return node
+
+
+def _cls(src: str) -> ast.ClassDef:
+    tree = ast.parse(src)
+    node = tree.body[0]
+    assert isinstance(node, ast.ClassDef)
+    return node
+
+
+# -- raises ----------------------------------------------------------
+
+
+class TestExtractRaises:
+    def test_single_raise(self) -> None:
+        assert _extract_raises(_fn("def f():\n    raise ValueError('x')")) == [
+            {"class_name": "ValueError", "message": "x"}
+        ]
+
+    def test_bare_raise_is_ignored(self) -> None:
+        src = "def f():\n    try:\n        pass\n    except Exception:\n        raise"
+        assert _extract_raises(_fn(src)) == []
+
+    def test_same_class_different_messages_preserved(self) -> None:
+        """Functions that raise the same class with multiple distinct
+        diagnostics (e.g. ``validate_file_path``) need every message
+        surfaced — the rendered reference should list each diagnostic
+        a caller might see. Exact duplicate pairs still collapse."""
+        src = (
+            "def f(x):\n"
+            "    if x < 0:\n"
+            "        raise ValueError('neg')\n"
+            "    if x > 100:\n"
+            "        raise ValueError('big')\n"
+            "    if x == 0:\n"
+            "        raise ValueError('neg')\n"  # dupe, should collapse
+            "    raise TypeError('no')\n"
+        )
+        assert _extract_raises(_fn(src)) == [
+            {"class_name": "ValueError", "message": "neg"},
+            {"class_name": "ValueError", "message": "big"},
+            {"class_name": "TypeError", "message": "no"},
+        ]
+
+    def test_dotted_exception_name(self) -> None:
+        src = "def f():\n    raise subprocess.TimeoutExpired('cmd', 1)"
+        assert _extract_raises(_fn(src)) == [
+            {"class_name": "subprocess.TimeoutExpired", "message": "cmd"}
+        ]
+
+    def test_exception_without_call(self) -> None:
+        src = "def f():\n    raise StopIteration"
+        assert _extract_raises(_fn(src)) == [{"class_name": "StopIteration", "message": ""}]
+
+    def test_call_without_args(self) -> None:
+        src = "def f():\n    raise RuntimeError()"
+        assert _extract_raises(_fn(src)) == [{"class_name": "RuntimeError", "message": ""}]
+
+    def test_nested_function_raises_counted(self) -> None:
+        src = "def f():\n" "    def inner():\n" "        raise RuntimeError('x')\n" "    inner()\n"
+        assert _extract_raises(_fn(src)) == [{"class_name": "RuntimeError", "message": "x"}]
+
+    def test_fstring_message_literal_prefix_preserved(self) -> None:
+        """f-string messages keep the literal prefix and replace
+        interpolated parts with ``{...}`` — so the diagnostic stem
+        users grep for remains verifiable."""
+        src = "def f(name):\n" "    raise ValueError(f'Invalid feature name: {name!r}')"
+        assert _extract_raises(_fn(src)) == [
+            {"class_name": "ValueError", "message": "Invalid feature name: {...}"}
+        ]
+
+    def test_fstring_only_interpolation_gives_placeholder(self) -> None:
+        src = "def f(x):\n    raise ValueError(f'{x}')"
+        assert _extract_raises(_fn(src)) == [{"class_name": "ValueError", "message": "{...}"}]
+
+    def test_computed_message_returns_empty(self) -> None:
+        """Non-literal first arg (name, call, concatenation) is
+        unverifiable and surfaces as empty message."""
+        src = "def f():\n    msg = 'x'\n    raise ValueError(msg)"
+        assert _extract_raises(_fn(src)) == [{"class_name": "ValueError", "message": ""}]
+
+
+# -- Literal values --------------------------------------------------
+
+
+class TestExtractLiteralValues:
+    def test_literal_tuple(self) -> None:
+        ann = ast.parse("x: Literal['a', 'b', 'c']", mode="exec").body[0].annotation
+        assert _extract_literal_values(ann) == ["a", "b", "c"]
+
+    def test_literal_single_value(self) -> None:
+        ann = ast.parse("x: Literal['only']", mode="exec").body[0].annotation
+        assert _extract_literal_values(ann) == ["only"]
+
+    def test_typing_qualified(self) -> None:
+        ann = ast.parse("x: typing.Literal['a', 'b']", mode="exec").body[0].annotation
+        assert _extract_literal_values(ann) == ["a", "b"]
+
+    def test_non_literal_returns_none(self) -> None:
+        ann = ast.parse("x: str", mode="exec").body[0].annotation
+        assert _extract_literal_values(ann) is None
+
+    def test_none_annotation_returns_none(self) -> None:
+        assert _extract_literal_values(None) is None
+
+    def test_int_literal_rejected(self) -> None:
+        """Non-string literal members are intentionally skipped.
+
+        Users ask about string enums (depths, doc_type, etc) —
+        numeric literals are rare and muddy the rendered table.
+        """
+        ann = ast.parse("x: Literal[1, 2, 3]", mode="exec").body[0].annotation
+        assert _extract_literal_values(ann) is None
+
+
+class TestExtractParamLiterals:
+    def test_mixed_params(self) -> None:
+        node = _fn(
+            "def f(depth: Literal['concept', 'task', 'reference'], name: str) -> None:\n    pass"
+        )
+        assert _extract_param_literals(node) == {
+            "depth": ["concept", "task", "reference"],
+        }
+
+    def test_kwonly_literal(self) -> None:
+        node = _fn("def f(*, mode: Literal['r', 'w']) -> None:\n    pass")
+        assert _extract_param_literals(node) == {"mode": ["r", "w"]}
+
+    def test_no_literal_params(self) -> None:
+        node = _fn("def f(x: int, y: str) -> None:\n    pass")
+        assert _extract_param_literals(node) == {}
+
+
+# -- dataclass detection --------------------------------------------
+
+
+class TestIsDataclass:
+    def test_plain_decorator(self) -> None:
+        assert _is_dataclass(_cls("@dataclass\nclass C:\n    x: int = 0")) is True
+
+    def test_call_decorator(self) -> None:
+        src = "@dataclass(frozen=True)\nclass C:\n    x: int = 0"
+        assert _is_dataclass(_cls(src)) is True
+
+    def test_qualified_decorator(self) -> None:
+        src = "@dataclasses.dataclass\nclass C:\n    x: int = 0"
+        assert _is_dataclass(_cls(src)) is True
+
+    def test_qualified_call_decorator(self) -> None:
+        src = "@dataclasses.dataclass(frozen=True)\nclass C:\n    x: int = 0"
+        assert _is_dataclass(_cls(src)) is True
+
+    def test_no_decorator(self) -> None:
+        assert _is_dataclass(_cls("class C:\n    pass")) is False
+
+    def test_unrelated_decorator(self) -> None:
+        assert _is_dataclass(_cls("@property\nclass C:\n    pass")) is False
+
+
+# -- dataclass fields ------------------------------------------------
+
+
+class TestExtractDataclassFields:
+    def test_fields_with_types_and_defaults(self) -> None:
+        src = (
+            "@dataclass\n"
+            "class C:\n"
+            "    name: str\n"
+            "    count: int = 0\n"
+            "    tags: list[str] = field(default_factory=list)\n"
+        )
+        assert _extract_dataclass_fields(_cls(src)) == [
+            {"name": "name", "type": "str", "default": ""},
+            {"name": "count", "type": "int", "default": "0"},
+            {"name": "tags", "type": "list[str]", "default": "field(default_factory=list)"},
+        ]
+
+    def test_underscore_fields_skipped(self) -> None:
+        src = "@dataclass\nclass C:\n    public: int = 0\n    _private: int = 0"
+        assert _extract_dataclass_fields(_cls(src)) == [
+            {"name": "public", "type": "int", "default": "0"},
+        ]
+
+    def test_empty_dataclass(self) -> None:
+        src = "@dataclass\nclass C:\n    pass"
+        assert _extract_dataclass_fields(_cls(src)) == []
+
+    def test_plain_assignments_skipped(self) -> None:
+        """Non-annotated class-level assignments are not fields."""
+        src = "@dataclass\nclass C:\n    FOO = 1\n    bar: int = 0"
+        assert _extract_dataclass_fields(_cls(src)) == [
+            {"name": "bar", "type": "int", "default": "0"},
+        ]
+
+
+# -- module-level string constants ----------------------------------
+
+
+def _module_const(src: str) -> dict | None:
+    """Parse ``src`` as a single statement and extract its constant record."""
+    tree = ast.parse(src)
+    node = tree.body[0]
+    assert isinstance(node, ast.Assign | ast.AnnAssign)
+    return _extract_module_constant(node)
+
+
+class TestExtractModuleConstant:
+    def test_scalar_string(self) -> None:
+        assert _module_const('STRICT_ENV_VAR = "ATTUNE_AUTHOR_STRICT_POLISH"') == {
+            "name": "STRICT_ENV_VAR",
+            "kind": "str",
+            "values": ["ATTUNE_AUTHOR_STRICT_POLISH"],
+        }
+
+    def test_tuple_of_strings(self) -> None:
+        assert _module_const('_UNSAFE = ("/", "\\\\", "..", "\\x00")') == {
+            "name": "_UNSAFE",
+            "kind": "tuple",
+            "values": ["/", "\\", "..", "\x00"],
+        }
+
+    def test_list_of_strings(self) -> None:
+        assert _module_const('NAMES = ["a", "b"]') == {
+            "name": "NAMES",
+            "kind": "list",
+            "values": ["a", "b"],
+        }
+
+    def test_set_of_strings(self) -> None:
+        assert _module_const('NAMES = {"a", "b"}') == {
+            "name": "NAMES",
+            "kind": "set",
+            "values": ["a", "b"],
+        }
+
+    def test_frozenset_call_with_set_literal(self) -> None:
+        assert _module_const('_FALSY = frozenset({"0", "false", "no", "off"})') == {
+            "name": "_FALSY",
+            "kind": "frozenset",
+            "values": ["0", "false", "no", "off"],
+        }
+
+    def test_frozenset_call_with_list_literal(self) -> None:
+        assert _module_const('F = frozenset(["a", "b"])') == {
+            "name": "F",
+            "kind": "frozenset",
+            "values": ["a", "b"],
+        }
+
+    def test_set_call_with_tuple_literal(self) -> None:
+        assert _module_const('S = set(("a", "b"))') == {
+            "name": "S",
+            "kind": "set",
+            "values": ["a", "b"],
+        }
+
+    def test_annotated_assign(self) -> None:
+        assert _module_const('NAMES: tuple[str, ...] = ("a", "b")') == {
+            "name": "NAMES",
+            "kind": "tuple",
+            "values": ["a", "b"],
+        }
+
+    def test_int_constant_returns_none(self) -> None:
+        """Non-string scalar constants are intentionally skipped."""
+        assert _module_const("COUNT = 42") is None
+
+    def test_mixed_type_collection_returns_none(self) -> None:
+        """Mixed-type collections are skipped — we only surface string enums."""
+        assert _module_const('MIX = ("a", 1, "b")') is None
+
+    def test_tuple_unpacking_returns_none(self) -> None:
+        """Multi-target assignment doesn't produce a constant record."""
+        assert _module_const('A, B = "x", "y"') is None
+
+    def test_name_reference_returns_none(self) -> None:
+        """Assignments to non-literal expressions are skipped."""
+        assert _module_const("FOO = bar") is None
+
+    def test_annotated_assign_without_value_returns_none(self) -> None:
+        """Bare type declarations (no RHS) aren't constants."""
+        assert _module_const("FOO: str") is None
+
+    def test_non_string_frozenset_returns_none(self) -> None:
+        assert _module_const("NUMS = frozenset({1, 2, 3})") is None


### PR DESCRIPTION
Follow-up to #1193. **Studies and brings the existing attune-author
tests** for the absorbed modules — the path we agreed beats `/test-gen`
(proven, intent-encoding, golden, free) — and **removes the transitional
coverage omit**.

## Brought (repointed `attune_author` → `attune.authoring`)

- `test_projector.py` + `spec-engine.md` fixture master
- `test_source_extractors.py` — AST introspection (lifts
  `source_introspection` **46% → 83%**)
- the `fact_check/` suite (12 files) + `fact_check_ops_dashboard` fixture
- **adapted:** `test_python_refs` probes `attune`, not `attune_author`
- **dropped:** tests of deleted/not-absorbed code (retired CLI, generator
  polish/scaffold-skip, generator-wired pipeline)

## Result

`attune.authoring` now **90% covered (174 tests)** → the
`*/attune/authoring/*` omit is **removed**; the absorbed code is genuinely
measured. Calibrated, not exhaustive (single-dev steer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)