### PR TITLE
feat(skills): author-feature — single-source authoring skill (T1)

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -113,6 +113,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
 | elicit | scope this, discovery form, ask me everything at once, multi-select question |
+| author-feature | author a feature page, single-source doc, new feature master, draft docs without an api |
 
 ## MCP Server Not Running
 

--- a/.agents/skills/author-feature/SKILL.md
+++ b/.agents/skills/author-feature/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: author-feature
+description: "Author a single-source feature page — a code-verified master that projects to .help kinds + docs pages, no API credits. Triggers on: author a feature page, single-source doc, new feature master, draft docs without an api."
+---
+# Author-feature — single-source authoring, verified
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Author-feature** — I'll author a single-source master for this
+> feature, grounding every claim in live code and running the gates as
+> I go, then project it to the help kinds + docs pages. No LLM
+> generation, no API credits.
+
+This skill makes the driving session a disciplined author of a
+**single-source master** (`content/features/<feature>.md`). One master
+projects deterministically to 10 `.help` kinds + 4 `docs/` pages — no
+generator, no API. The empirical result that motivates it: the session
+is a *superior* polish layer to an LLM pass and the only one that
+catches correctness bugs (PR #1188). The risk it manages: a master is a
+single point of *failure*, so **verification is the spine** — grep the
+symbol before you write it, run the audit before you commit, fix the
+master not the output.
+
+This is *judgment*, not plumbing. It calls the deterministic tools (the
+in-repo projector, the audits); it never re-implements them and never
+emits prose for blind rubber-stamping.
+
+## The flow
+
+```text
+locate/scaffold  →  author section-by-section (grounded in code)
+                 →  verify continuously  →  project  →  preview  →  commit
+```
+
+### Step 1 — locate or scaffold the master
+
+The master lives at `content/features/<feature>.md`. If it exists,
+you're revising — open it. If not, create it by **copying a canonical
+projected page for structure** — e.g. `content/features/security-audit.md`
+— then replacing its content. Do not invent the layout; the projector
+expects a fixed section contract (below).
+
+Frontmatter (required):
+
+```yaml
+---
+feature: <slug>
+summary: <one line>
+tags: [<tag>, <tag>]
+source_globs:
+  - src/attune/workflows/<feature>.py
+nav:
+  help: <slug>
+  mkdocs:
+    how-to: how-to/<slug>
+    architecture: architecture/<slug>
+    reference: reference/<slug>
+---
+```
+
+Declare `how-to` / `architecture` / `reference` but **not** `tutorial`:
+the projector drops tutorial (a guided tutorial resists pure section
+projection — it stays hand-authored).
+
+Then add a `.help/features.yaml` entry under `features:` with
+`description`, `tags`, and **`status: manual`** — and **no `files:`**.
+`manual` means projector-owned, so staleness/maintenance never
+overwrites it with LLM output.
+
+### Step 2 — author section by section, grounded in code
+
+Write each section the projector expects (the **section contract**):
+
+| Heading | Holds |
+| --- | --- |
+| `## Overview` | what the feature is, 1–2 paragraphs |
+| `## Concepts` | the model — `### subsections` for each idea |
+| `## Quickstart` | the shortest real path to using it |
+| `## Tasks` | `### task` blocks with runnable CLI / Python |
+| `## Reference` | API tables — classes, params, entry points |
+| `## Comparison` | when to use this vs the alternatives |
+| `## Failure modes` | risk areas + diagnosis order |
+| `## FAQ seeds` | seed Q&A (the FAQ kind is projector-skipped today) |
+| `## Notes & tips` | operational asides |
+| `## Design & extension` | design decisions + extension points |
+
+**Verification is the spine of this step (D2).** Before you write a
+claim, find the truth:
+
+- **Before an API table** — `grep` the `__all__`, the class, the enum,
+  the tool schema. Never confabulate a symbol or a field.
+  - `grep -rn "class <Name>" src/attune/`
+  - `grep -n "<Name>" src/attune/workflows/__init__.py` (re-exports)
+  - `python -c "import inspect, attune.X as m; print(inspect.signature(m.Cls.__init__))"`
+- **Before a CLI example** — confirm the flag actually exists
+  (`attune <cmd> --help`, or grep the argparse).
+- **Symbols re-exported at the package** must be cited at the package,
+  not the submodule — `import_repair` canonicalizes
+  `from attune.workflows.foo import Bar` → `from attune.workflows import
+  Bar` and the fact-check flags the un-canonical form. Write the
+  package-level import.
+
+### Step 3 — verify continuously (fix the master, never the output)
+
+Run the gates as you author, not at the end. A fact-check finding means
+**fix the claim in the master** — never "ship the warning."
+
+```bash
+# Dry-run the projection: fact-check + example check + plan, no writes.
+python scripts/project_features.py <feature> --dry-run
+
+# Authoritative import resolution (repo src on sys.path).
+python scripts/audit_doc_imports.py --paths content/features/<feature>.md
+```
+
+The dry-run runs the in-repo projector
+(`attune.authoring.projector.validate_master_file` + `project_feature`)
+and prints fact-check findings + runnable-example problems alongside the
+planned outputs. Resolve every `error`-severity finding before building.
+
+### Step 4 — project for real, then sync the served bundle
+
+```bash
+python scripts/project_features.py <feature>     # writes 10 .help kinds + 4 docs pages
+python scripts/sync_help_bundle.py               # copy templates → served bundle
+```
+
+`sync_help_bundle.py` is **required** — it copies the projected
+templates into `plugin/help/generated/` (the bundle that reaches pip
+users; `.help/templates` is only the source). Skipping it fails
+`tests/unit/help/test_help_bundle_sync.py` ("N bundle file(s) out of
+sync"). The mkdocs `build` job auto-wires the new hub via
+`docs/hooks/feature_nav.py` — no manual `mkdocs.yml` nav edit.
+
+### Step 5 — preview, then verify green, then commit
+
+Show the projected hub + pages to the user **before staging** (the
+"show generated output sooner" discipline), then confirm the gates:
+
+```bash
+python scripts/audit_doc_imports.py
+python scripts/audit_docs_wiring.py
+pytest tests/unit/help
+```
+
+## Gotchas (these bit #1188)
+
+- **ENV — make `attune` importable.** The projector is in-repo
+  (`attune.authoring`, pure — no jinja/anthropic), so from a worktree the
+  robust invocation is `PYTHONPATH=src python scripts/project_features.py
+  <feature>` — it puts the worktree's own `src/` ahead of the editable
+  mapping. (The audits already do this themselves.) If you skip
+  `PYTHONPATH=src`, a bare `python` resolving via the editable mapping
+  can miss worktree-only modules.
+- **Trust the audit, not a bare `python -c`.** From a worktree a bare
+  `python -c "from attune.X import …"` can falsely `ModuleNotFoundError`
+  (the editable MAPPING points at main's possibly-older `src/`) WHILE
+  `scripts/audit_doc_imports.py` (which puts the worktree `src/` on
+  `sys.path`) correctly reports all imports resolve. The audit is
+  authoritative.
+- **Zero API credits.** The whole flow is deterministic projection +
+  hand-authored prose. If you find yourself reaching for `attune-author
+  generate` or any LLM-polish path, stop — that path is retired; the
+  session is the author.
+
+## What this skill does NOT do
+
+- It does **not** generate prose for blind approval — you author *with*
+  verification, grounded in code.
+- It does **not** call any LLM-generation or polish path.
+- It does **not** re-implement the projector, the audits, or the (future)
+  scaffolder — it *calls* them.
+
+## Acceptance (self-demonstration)
+
+The skill is "done" for a feature when a fresh session, given only this
+skill, authors a master that **projects byte-clean and passes
+`doc-import-audit` + the bundle sync on the first real attempt** — the
+#1188 outcome, reproduced without out-of-band knowledge. Registered ≠
+working: dogfood the real flow; the green projection is the receipt.

--- a/docs/specs/single-source-authoring/decisions.md
+++ b/docs/specs/single-source-authoring/decisions.md
@@ -44,11 +44,37 @@ the skill, reproduces the #1188 outcome (a green, code-accurate page) with
 no out-of-band knowledge. That dogfood (T3) is the receipt — consistent
 with "registered ≠ working; dogfood the live loop."
 
+## D6 — Name: `author-feature`; T1 shipped against post-consolidation paths
+
+**Decided (2026-06-30).** The skill is named **`author-feature`** —
+verb-noun, matching the existing family (`bug-predict`, `fix-test`,
+`refactor-plan`, `security-audit`), and most distinct from the
+LLM-based `doc-gen` skill. T1 (author the skill + `.agents/` mirror)
+landed: `plugin/skills/author-feature/SKILL.md` encodes the #1188/#1189
+playbook with verification as the spine (D2), referencing the
+**post-consolidation in-repo** projector (`attune.authoring.projector`
+via `scripts/project_features.py`), the bundle sync
+(`scripts/sync_help_bundle.py`), and the audits
+(`audit_doc_imports.py`, `audit_docs_wiring.py`). Because the projector
+already moved in-repo (#1193), D4's "repoint on consolidation" is
+already satisfied for the projector path — the skill names
+`attune.authoring`, not `attune_author`. The scaffolder
+(`new_feature.py`) is **not** built yet, so the skill names the manual
+project→sync→audit steps (D4 baseline); repoint to the scaffolder when
+it lands. Guards: `plugin/skills` count 23→24; attune-hub Skills
+Reference row added; 131 plugin tests green. The skill's own ENV/verify
+gotchas were dogfood-confirmed live (bare `python -c` fails on the
+editable mapping; `PYTHONPATH=src` + the audit resolve correctly).
+
+**Still open:** T3 dogfood (R5/D5 self-demonstration — a fresh session
+authors a throwaway feature page green on the first real attempt) and
+T4 (retire #1189's playbook lesson into the skill) remain.
+
 ## Open
 
-- **Skill name** — `single-source-authoring` vs. `author-feature` vs.
-  folding into the existing `elicit`/docs skill family. Naming call for
-  the design review.
+- **Boundary with the scaffolder** — the skill *calls* the scaffolder
+  (once built); confirm at build time there's no overlap where both try
+  to own the `features.yaml` entry or the build chain.
 - **Boundary with the scaffolder** — the skill *calls* the scaffolder;
   confirm at build time there's no overlap where both try to own the
   features.yaml entry or the build chain. (They shouldn't: scaffolder owns

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -115,6 +115,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | personal-memory | remember this for me, capture this decision, save to personal memory, my saved topics, forget topic |
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
 | elicit | scope this, discovery form, ask me everything at once, multi-select question |
+| author-feature | author a feature page, single-source doc, new feature master, draft docs without an api |
 
 ## MCP Server Not Running
 

--- a/plugin/skills/author-feature/SKILL.md
+++ b/plugin/skills/author-feature/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: author-feature
+description: "Author a single-source feature page — a code-verified master that projects to .help kinds + docs pages, no API credits. Triggers on: author a feature page, single-source doc, new feature master, draft docs without an api."
+argument-hint: "<feature slug, e.g. 'discovery-sweep'>"
+---
+
+# Author-feature — single-source authoring, verified
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Author-feature** — I'll author a single-source master for this
+> feature, grounding every claim in live code and running the gates as
+> I go, then project it to the help kinds + docs pages. No LLM
+> generation, no API credits.
+
+This skill makes the driving session a disciplined author of a
+**single-source master** (`content/features/<feature>.md`). One master
+projects deterministically to 10 `.help` kinds + 4 `docs/` pages — no
+generator, no API. The empirical result that motivates it: the session
+is a *superior* polish layer to an LLM pass and the only one that
+catches correctness bugs (PR #1188). The risk it manages: a master is a
+single point of *failure*, so **verification is the spine** — grep the
+symbol before you write it, run the audit before you commit, fix the
+master not the output.
+
+This is *judgment*, not plumbing. It calls the deterministic tools (the
+in-repo projector, the audits); it never re-implements them and never
+emits prose for blind rubber-stamping.
+
+## The flow
+
+```text
+locate/scaffold  →  author section-by-section (grounded in code)
+                 →  verify continuously  →  project  →  preview  →  commit
+```
+
+### Step 1 — locate or scaffold the master
+
+The master lives at `content/features/<feature>.md`. If it exists,
+you're revising — open it. If not, create it by **copying a canonical
+projected page for structure** — e.g. `content/features/security-audit.md`
+— then replacing its content. Do not invent the layout; the projector
+expects a fixed section contract (below).
+
+Frontmatter (required):
+
+```yaml
+---
+feature: <slug>
+summary: <one line>
+tags: [<tag>, <tag>]
+source_globs:
+  - src/attune/workflows/<feature>.py
+nav:
+  help: <slug>
+  mkdocs:
+    how-to: how-to/<slug>
+    architecture: architecture/<slug>
+    reference: reference/<slug>
+---
+```
+
+Declare `how-to` / `architecture` / `reference` but **not** `tutorial`:
+the projector drops tutorial (a guided tutorial resists pure section
+projection — it stays hand-authored).
+
+Then add a `.help/features.yaml` entry under `features:` with
+`description`, `tags`, and **`status: manual`** — and **no `files:`**.
+`manual` means projector-owned, so staleness/maintenance never
+overwrites it with LLM output.
+
+### Step 2 — author section by section, grounded in code
+
+Write each section the projector expects (the **section contract**):
+
+| Heading | Holds |
+| --- | --- |
+| `## Overview` | what the feature is, 1–2 paragraphs |
+| `## Concepts` | the model — `### subsections` for each idea |
+| `## Quickstart` | the shortest real path to using it |
+| `## Tasks` | `### task` blocks with runnable CLI / Python |
+| `## Reference` | API tables — classes, params, entry points |
+| `## Comparison` | when to use this vs the alternatives |
+| `## Failure modes` | risk areas + diagnosis order |
+| `## FAQ seeds` | seed Q&A (the FAQ kind is projector-skipped today) |
+| `## Notes & tips` | operational asides |
+| `## Design & extension` | design decisions + extension points |
+
+**Verification is the spine of this step (D2).** Before you write a
+claim, find the truth:
+
+- **Before an API table** — `grep` the `__all__`, the class, the enum,
+  the tool schema. Never confabulate a symbol or a field.
+  - `grep -rn "class <Name>" src/attune/`
+  - `grep -n "<Name>" src/attune/workflows/__init__.py` (re-exports)
+  - `python -c "import inspect, attune.X as m; print(inspect.signature(m.Cls.__init__))"`
+- **Before a CLI example** — confirm the flag actually exists
+  (`attune <cmd> --help`, or grep the argparse).
+- **Symbols re-exported at the package** must be cited at the package,
+  not the submodule — `import_repair` canonicalizes
+  `from attune.workflows.foo import Bar` → `from attune.workflows import
+  Bar` and the fact-check flags the un-canonical form. Write the
+  package-level import.
+
+### Step 3 — verify continuously (fix the master, never the output)
+
+Run the gates as you author, not at the end. A fact-check finding means
+**fix the claim in the master** — never "ship the warning."
+
+```bash
+# Dry-run the projection: fact-check + example check + plan, no writes.
+python scripts/project_features.py <feature> --dry-run
+
+# Authoritative import resolution (repo src on sys.path).
+python scripts/audit_doc_imports.py --paths content/features/<feature>.md
+```
+
+The dry-run runs the in-repo projector
+(`attune.authoring.projector.validate_master_file` + `project_feature`)
+and prints fact-check findings + runnable-example problems alongside the
+planned outputs. Resolve every `error`-severity finding before building.
+
+### Step 4 — project for real, then sync the served bundle
+
+```bash
+python scripts/project_features.py <feature>     # writes 10 .help kinds + 4 docs pages
+python scripts/sync_help_bundle.py               # copy templates → served bundle
+```
+
+`sync_help_bundle.py` is **required** — it copies the projected
+templates into `plugin/help/generated/` (the bundle that reaches pip
+users; `.help/templates` is only the source). Skipping it fails
+`tests/unit/help/test_help_bundle_sync.py` ("N bundle file(s) out of
+sync"). The mkdocs `build` job auto-wires the new hub via
+`docs/hooks/feature_nav.py` — no manual `mkdocs.yml` nav edit.
+
+### Step 5 — preview, then verify green, then commit
+
+Show the projected hub + pages to the user **before staging** (the
+"show generated output sooner" discipline), then confirm the gates:
+
+```bash
+python scripts/audit_doc_imports.py
+python scripts/audit_docs_wiring.py
+pytest tests/unit/help
+```
+
+## Gotchas (these bit #1188)
+
+- **ENV — make `attune` importable.** The projector is in-repo
+  (`attune.authoring`, pure — no jinja/anthropic), so from a worktree the
+  robust invocation is `PYTHONPATH=src python scripts/project_features.py
+  <feature>` — it puts the worktree's own `src/` ahead of the editable
+  mapping. (The audits already do this themselves.) If you skip
+  `PYTHONPATH=src`, a bare `python` resolving via the editable mapping
+  can miss worktree-only modules.
+- **Trust the audit, not a bare `python -c`.** From a worktree a bare
+  `python -c "from attune.X import …"` can falsely `ModuleNotFoundError`
+  (the editable MAPPING points at main's possibly-older `src/`) WHILE
+  `scripts/audit_doc_imports.py` (which puts the worktree `src/` on
+  `sys.path`) correctly reports all imports resolve. The audit is
+  authoritative.
+- **Zero API credits.** The whole flow is deterministic projection +
+  hand-authored prose. If you find yourself reaching for `attune-author
+  generate` or any LLM-polish path, stop — that path is retired; the
+  session is the author.
+
+## What this skill does NOT do
+
+- It does **not** generate prose for blind approval — you author *with*
+  verification, grounded in code.
+- It does **not** call any LLM-generation or polish path.
+- It does **not** re-implement the projector, the audits, or the (future)
+  scaffolder — it *calls* them.
+
+## Acceptance (self-demonstration)
+
+The skill is "done" for a feature when a fresh session, given only this
+skill, authors a master that **projects byte-clean and passes
+`doc-import-audit` + the bundle sync on the first real attempt** — the
+#1188 outcome, reproduced without out-of-band knowledge. Registered ≠
+working: dogfood the real flow; the green projection is the receipt.

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -302,8 +302,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 23, (
-            f"Expected 23 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 24, (
+            f"Expected 24 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -45,7 +45,7 @@ const faqItems = [
   {
     question: 'What Claude Code skills are included?',
     answer:
-      '23 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, and the attune hub router.',
+      '24 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, the attune hub router, and single-source feature-page authoring.',
   },
   {
     question: 'Where do I install attune-help and attune-author from?',
@@ -66,7 +66,7 @@ const workflows = [
   { name: 'Release Prep', description: 'Changelog, version bump, health checks' },
 ];
 
-// The 23 plugin skills — keep in sync with plugin/skills/
+// The 24 plugin skills — keep in sync with plugin/skills/
 // (test_skill_count asserts the directory count).
 const skills = [
   'security-audit', 'smart-test', 'code-quality', 'bug-predict',
@@ -74,7 +74,7 @@ const skills = [
   'spec', 'fix-test', 'workflow-orchestration', 'rag-code-gen',
   'verify', 'recall', 'memory-and-context', 'personal-memory',
   'image-analysis', 'bulk', 'catalog', 'discovery-sweep',
-  'elicit', 'coach', 'attune-hub',
+  'elicit', 'coach', 'attune-hub', 'author-feature',
 ];
 
 export default function DocsPage() {
@@ -177,7 +177,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    19 multi-stage workflows, 23 skills, 47 MCP tools.
+                    19 multi-stage workflows, 24 skills, 47 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -506,7 +506,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 Install from the marketplace. Progressive help, project
-                bootstrapping, and 23 skills right in your terminal.
+                bootstrapping, and 24 skills right in your terminal.
               </p>
 
               <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 mb-8">
@@ -573,7 +573,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 The build half of the loop: 19 multi-stage workflows
-                (22 workflows total), 23 auto-triggering Claude Code skills,
+                (22 workflows total), 24 auto-triggering Claude Code skills,
                 and an MCP server with 47 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>
@@ -600,7 +600,7 @@ export default function DocsPage() {
 
                 <div>
                   <h3 className="font-bold text-lg mb-4">
-                    23 Claude Code Skills
+                    24 Claude Code Skills
                   </h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-4">
                     Skills auto-invoke from natural language. Type the topic

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -34,7 +34,7 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 23 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 24 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -449,7 +449,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Full framework. Workflows, staleness detection, MCP server, and 23 auto-triggering skills for Claude Code.
+                Full framework. Workflows, staleness detection, MCP server, and 24 auto-triggering skills for Claude Code.
               </p>
             </div>
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -46,7 +46,7 @@ export const PRODUCTS: Product[] = [
       "Generate concept, task, and reference templates",
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
-      "23 Claude Code skills included",
+      "24 Claude Code skills included",
       "MCP server with 47 registered tools",
     ],
   },
@@ -117,7 +117,7 @@ export const PRODUCTS: Product[] = [
       "/coach status — check template freshness",
       "/coach maintain — regenerate stale templates",
       "Auto-triggers on natural language (help, explain, learn)",
-      "23 auto-triggering skills (security, testing, review, etc.)",
+      "24 auto-triggering skills (security, testing, review, etc.)",
     ],
   },
 ];
@@ -263,7 +263,7 @@ export const DIFFERENTIATORS: Differentiator[] = [
  */
 export const CAPABILITIES = {
   workflows: 19,
-  skills: 23,
+  skills: 24,
   mcpTools: 47,
   templateKinds: 15,
   wizards: 5,


### PR DESCRIPTION
## What

Adds the **`author-feature`** skill — the [single-source-authoring](docs/specs/single-source-authoring/) spec's T1. It makes the driving session a disciplined author of a single-source feature **master** (`content/features/<feature>.md`) that projects deterministically to 10 `.help` kinds + 4 `docs/` pages, **zero API credits**.

This is the replacement for the retired LLM authoring machinery: the empirical result (PR #1188) is that the session is a *superior* polish layer and the only one that catches correctness bugs. The skill encodes that discipline so any session reaches the same standard.

## Why a skill, not a generator

Authoring is **judgment**; the projector/audits are **mechanics**. The skill supplies the judgment and *calls* the deterministic tools — it never generates prose for blind approval and never re-implements a tool. **Verification is its spine**: grep the symbol before you write it, run the audit before you commit, fix the master not the output.

## Contents

- `plugin/skills/author-feature/SKILL.md` + `.agents/` mirror (synced via `sync_agents_skills.py`)
- Encodes the #1188/#1189 playbook: frontmatter + section contract, the canonical verify commands, the build/sync chain, and the worktree ENV/verify gotchas
- References the **post-consolidation in-repo** projector (`attune.authoring.projector` via `scripts/project_features.py` — #1193), bundle sync (`scripts/sync_help_bundle.py`), and audits
- attune-hub Skills Reference row added; plugin skill count `23 → 24`
- Spec `decisions.md`: D6 logged (name `author-feature`), skill-name open item closed

## Verification

- 131 plugin guard tests green (`tests/unit/plugins/`): skill count, `.agents` sync `--check`, reference-validation (no orphaned skill), registry coverage
- Every script/path/symbol the skill names verified to exist
- The skill's own ENV/verify gotchas **dogfood-confirmed live**: a bare `python -c "from attune.authoring..."` fails on the stale editable mapping, while `PYTHONPATH=src` + `audit_doc_imports.py` resolve correctly — exactly the trap the skill documents

## Follow-ups (spec, not this PR)

- **T3 dogfood** — a fresh session uses *only* the skill to author a throwaway feature page green on the first real attempt (R5/D5 self-demonstration)
- **T4** — retire #1189's playbook lesson into the skill as the canonical authoring path
- Repoint the skill's build references to the **scaffolder** (`new_feature.py`) once that spec lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
