### PR TITLE
docs: update Sonnet model references to Claude Sonnet 5

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -72,7 +72,7 @@ python -m attune.models.cli provider
 Expected output:
 ```
 Current provider: anthropic
-Available models: claude-opus-4-8, claude-sonnet-4-6, claude-haiku-4-5
+Available models: claude-opus-4-8, claude-sonnet-5, claude-haiku-4-5
 API key configured
 ```
 

--- a/docs/how-to/agent-factory.md
+++ b/docs/how-to/agent-factory.md
@@ -232,7 +232,7 @@ importable) maps:
 | Tier      | Fallback model (Anthropic) |
 |-----------|----------------------------|
 | `cheap`   | `claude-haiku-4-5-20251001` |
-| `capable` | `claude-sonnet-4-6`         |
+| `capable` | `claude-sonnet-5`         |
 | `premium` | `claude-opus-4-8`           |
 
 These IDs are fallback constants — the live mapping is whatever

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -413,7 +413,7 @@ Central registry of available LLM models.
 ```python
 from attune.models import MODEL_REGISTRY
 
-model = MODEL_REGISTRY.get_model("claude-sonnet-4-6")
+model = MODEL_REGISTRY.get_model("claude-sonnet-5")
 models = MODEL_REGISTRY.list_models(tier="capable")
 ```
 
@@ -812,7 +812,7 @@ from attune.telemetry import UsageTracker
 
 tracker = UsageTracker()
 tracker.log_llm_call(
-    model="claude-sonnet-4-6",
+    model="claude-sonnet-5",
     input_tokens=1500,
     output_tokens=800,
     cost=0.012,

--- a/docs/reference/agent-factory-readme.md
+++ b/docs/reference/agent-factory-readme.md
@@ -225,7 +225,7 @@ Override with a specific model:
 ```python
 agent = factory.create_agent(
     name="specific",
-    model_override="claude-sonnet-4-6",
+    model_override="claude-sonnet-5",
 )
 ```
 

--- a/examples/config/attune.config.example.yml
+++ b/examples/config/attune.config.example.yml
@@ -21,7 +21,7 @@ model_routing:
   # Model assignments per tier
   models:
     cheap: "claude-haiku-4-5-20251001"     # Summaries, classification, triage
-    capable: "claude-sonnet-4-6"          # Code gen, bug fixes, reviews
+    capable: "claude-sonnet-5"          # Code gen, bug fixes, reviews
     premium: "claude-opus-4-8"            # Architecture, synthesis, coordination
 
   # Task-to-tier mapping overrides (optional)

--- a/website/content/blog/how-to-build-ai-agents-claude.mdx
+++ b/website/content/blog/how-to-build-ai-agents-claude.mdx
@@ -64,7 +64,7 @@ def run_agent(goal: str) -> str:
 
     while True:
         response = client.messages.create(
-            model="claude-sonnet-4-6",
+            model="claude-sonnet-5",
             max_tokens=4096,
             tools=tools,
             messages=messages,

--- a/website/content/blog/prompt-caching-save-90-percent.mdx
+++ b/website/content/blog/prompt-caching-save-90-percent.mdx
@@ -45,7 +45,7 @@ import anthropic
 client = anthropic.Anthropic()
 
 response = client.messages.create(
-    model="claude-sonnet-4-6",
+    model="claude-sonnet-5",
     max_tokens=1024,
     system=[
         {
@@ -76,7 +76,7 @@ for user_input in conversation_turns:
     messages.append({"role": "user", "content": user_input})
 
     response = client.messages.create(
-        model="claude-sonnet-4-6",
+        model="claude-sonnet-5",
         max_tokens=1024,
         system=[
             {


### PR DESCRIPTION
Follow-up to **#1198** (the src/tests Sonnet 5 swap). Updates the remaining `claude-sonnet-4-6` references on **user-facing surfaces** to `claude-sonnet-5`, so docs/examples/blog match the registry default.

## Changed (7 files)
- **docs/** served pages: installation model list, agent-factory capable table, API_REFERENCE + agent-factory-readme code examples
- **examples/config/attune.config.example.yml**
- **website/content/blog/*.mdx** code snippets

## Deliberately left untouched (historical / generated)
- `.claude/lessons.md` — uses the ID as an illustrative *stable-alias* example, not a current-config claim
- `.claude/plans/*` — dated planning docs
- `docs/archive/**`, `weekly-reports/**`, and the CHANGELOG entry that *introduced* 4.6 — history, not rewritten
- `website/public/framework-docs/**` — built mkdocs HTML, regenerated from `docs/` at build time (fix the source, not the artifact)

Pure ID swap, +9/−9, no prose drift. Docs/website-only — no changelog (the #1198 entry already records the Sonnet 5 move).

🤖 Generated with [Claude Code](https://claude.com/claude-code)