### PR TITLE
fix(models): resolve HIGH + MEDIUM findings from the models/ review

### DIFF
--- a/src/attune/models/adaptive_routing.py
+++ b/src/attune/models/adaptive_routing.py
@@ -15,11 +15,13 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
-import logging
+import time
 from dataclasses import dataclass
 from typing import Any
 
-logger = logging.getLogger(__name__)
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 # Lazy import to avoid circular dependency
 _model_registry = None
@@ -114,14 +116,21 @@ class AdaptiveModelRouter:
     # Recent window size for failure detection
     RECENT_WINDOW_SIZE = 20
 
-    def __init__(self, telemetry: Any):
+    def __init__(self, telemetry: Any, *, cache_ttl_seconds: float = 5.0):
         """Initialize adaptive router.
 
         Args:
             telemetry: UsageTracker instance for telemetry data access
+            cache_ttl_seconds: How long to reuse a fetched telemetry window
+                across routing decisions. ``recommend_tier_upgrade`` runs per
+                workflow stage; without this each stage re-scans up to 10k
+                entries. Set to 0 to disable caching (e.g. in tests).
 
         """
         self.telemetry = telemetry
+        self._cache_ttl = cache_ttl_seconds
+        # days -> (monotonic_fetch_time, entries oldest-first)
+        self._entries_cache: dict[int, tuple[float, list[dict[str, Any]]]] = {}
 
     def _get_default_model(self, tier: str = "CHEAP") -> str:
         """Get default Anthropic model for a tier from registry.
@@ -436,17 +445,40 @@ class AdaptiveModelRouter:
             List of telemetry entries
 
         """
-        # Get recent entries from telemetry tracker
-        all_entries = self.telemetry.get_recent_entries(limit=10000, days=days)
+        # Fetch the recent window once per (days) and reuse it across routing
+        # decisions within the TTL (recommend_tier_upgrade runs per stage).
+        all_entries = self._fetch_recent(days)
 
-        # Filter to this workflow
+        # Filter to this workflow (and stage). Entries are oldest-first, so a
+        # caller's ``entries[-RECENT_WINDOW_SIZE:]`` yields the MOST RECENT
+        # window.
         workflow_entries = [e for e in all_entries if e.get("workflow") == workflow]
-
-        # Filter to this stage if specified
         if stage is not None:
             workflow_entries = [e for e in workflow_entries if e.get("stage") == stage]
 
         return workflow_entries
+
+    def _fetch_recent(self, days: int) -> list[dict[str, Any]]:
+        """Fetch the recent telemetry window (oldest-first), cached by ``days``.
+
+        ``UsageTracker.get_recent_entries`` returns entries NEWEST-first; this
+        normalizes them to chronological (oldest-first) order so the callers'
+        ``[-RECENT_WINDOW_SIZE:]`` slices select the most recent calls, and
+        memoizes the result for ``cache_ttl_seconds`` to avoid re-scanning up
+        to 10k entries on every routing decision.
+        """
+        if self._cache_ttl > 0:
+            cached = self._entries_cache.get(days)
+            if cached is not None and (time.monotonic() - cached[0]) < self._cache_ttl:
+                return cached[1]
+
+        entries = self.telemetry.get_recent_entries(limit=10000, days=days)
+        # get_recent_entries is newest-first; normalize to chronological.
+        entries = list(reversed(entries))
+
+        if self._cache_ttl > 0:
+            self._entries_cache[days] = (time.monotonic(), entries)
+        return entries
 
 
 __all__ = ["AdaptiveModelRouter", "ModelPerformance"]

--- a/src/attune/models/auth_strategy.py
+++ b/src/attune/models/auth_strategy.py
@@ -449,7 +449,9 @@ def count_lines_of_code(file_path: str | Path) -> int:
         Number of lines (excluding blank lines and comments)
 
     """
-    path = Path(file_path)
+    # Validate before reading — file_path may be caller-controlled; block
+    # traversal / system paths per the "ALWAYS validate file paths" rule.
+    path = _validate_file_path(str(file_path))
     if not path.exists():
         return 0
 

--- a/src/attune/models/circuit_breaker.py
+++ b/src/attune/models/circuit_breaker.py
@@ -21,6 +21,7 @@ class CircuitBreakerState:
     last_failure: datetime | None = None
     is_open: bool = False
     opened_at: datetime | None = None
+    half_open_calls: int = 0
 
 
 class CircuitBreaker:
@@ -89,12 +90,17 @@ class CircuitBreaker:
         if not state.is_open:
             return True
 
-        # Check if recovery timeout has passed
-        if state.opened_at:
-            time_since_open = datetime.now() - state.opened_at
-            if time_since_open >= self.recovery_timeout:
-                # Half-open: allow limited calls
+        # Open: after the recovery timeout, enter the half-open state and
+        # allow up to ``half_open_calls`` probe calls to test recovery. A
+        # success closes the circuit; a failure re-opens it (see
+        # record_success / record_failure). Without this cap, every call
+        # after the timeout was let through — defeating the point of the
+        # half-open state under load.
+        if state.opened_at and (datetime.now() - state.opened_at) >= self.recovery_timeout:
+            if state.half_open_calls < self.half_open_calls:
+                state.half_open_calls += 1
                 return True
+            return False  # probe budget spent; wait for a probe result
 
         return False
 
@@ -108,10 +114,11 @@ class CircuitBreaker:
         """
         state = self._get_state(provider, tier)
 
-        # Reset on success
+        # Reset on success (closes the circuit).
         state.failure_count = 0
         state.is_open = False
         state.opened_at = None
+        state.half_open_calls = 0
 
     def record_failure(self, provider: str, tier: str | None = None) -> None:
         """Record a failed call.
@@ -129,6 +136,9 @@ class CircuitBreaker:
         if state.failure_count >= self.failure_threshold:
             state.is_open = True
             state.opened_at = datetime.now()
+            # Reset the probe budget so the next recovery window starts fresh
+            # (a failed half-open probe re-opens the circuit).
+            state.half_open_calls = 0
 
     def get_status(self) -> dict[str, dict[str, Any]]:
         """Get status of all tracked providers."""

--- a/src/attune/models/resilient_executor.py
+++ b/src/attune/models/resilient_executor.py
@@ -7,7 +7,7 @@ Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
 
-import time
+import asyncio
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -172,7 +172,7 @@ class ResilientExecutor:
 
                     if retry_policy.should_retry(error_type, attempt_num):
                         delay = retry_policy.get_delay_ms(attempt_num)
-                        time.sleep(delay / 1000)
+                        await asyncio.sleep(delay / 1000)
                         continue
 
                     # Record failure and move to next fallback
@@ -301,7 +301,7 @@ class ResilientExecutor:
 
                     if self.retry_policy.should_retry(error_type, attempt):
                         delay = self.retry_policy.get_delay_ms(attempt)
-                        time.sleep(delay / 1000)
+                        await asyncio.sleep(delay / 1000)
                         continue
 
                     # Record failure and move to next fallback

--- a/src/attune/models/telemetry/__init__.py
+++ b/src/attune/models/telemetry/__init__.py
@@ -40,12 +40,12 @@ def get_telemetry_store() -> TelemetryStore:
 
 def log_llm_call(record: LLMCallRecord):
     """Log an LLM API call."""
-    get_telemetry_store().log_llm_call(record)
+    get_telemetry_store().log_call(record)
 
 
 def log_workflow_run(record: WorkflowRunRecord):
     """Log a workflow run."""
-    get_telemetry_store().log_workflow_run(record)
+    get_telemetry_store().log_workflow(record)
 
 
 __all__ = [

--- a/src/attune/models/telemetry/backend.py
+++ b/src/attune/models/telemetry/backend.py
@@ -169,25 +169,3 @@ class TelemetryBackend(Protocol):
     def get_latest_file_test(self, file_path: str) -> "FileTestRecord | None":
         """Get the most recent test record for a specific file."""
         ...
-
-
-def _parse_timestamp(timestamp_str: str) -> datetime:
-    """Parse ISO format timestamp, handling 'Z' suffix for Python 3.10 compatibility.
-
-    Args:
-        timestamp_str: ISO format timestamp string, possibly with 'Z' suffix
-
-    Returns:
-        Parsed datetime object (timezone-aware UTC)
-
-    """
-    # Python 3.10's fromisoformat() doesn't handle 'Z' suffix
-    timestamp_str = timestamp_str.replace("Z", "+00:00")
-
-    dt = datetime.fromisoformat(timestamp_str)
-
-    # Ensure timezone-aware (assume UTC for naive timestamps)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-
-    return dt

--- a/src/attune/models/telemetry/storage.py
+++ b/src/attune/models/telemetry/storage.py
@@ -8,10 +8,13 @@ Licensed under the Apache License, Version 2.0
 
 import json
 import logging
+from collections import deque
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TypeVar
+
+from attune.security.path_validation import _validate_file_path
 
 from .backend import _parse_timestamp
 from .data_models import (
@@ -44,8 +47,14 @@ class TelemetryStore:
         Args:
             storage_dir: Directory for telemetry files
 
+        Raises:
+            ValueError: If storage_dir is invalid or targets a system directory
+                (prevents CWE-22 arbitrary-write via a caller-supplied path).
+
         """
-        self.storage_dir = Path(storage_dir)
+        # Validate before any filesystem op — storage_dir may come from a CLI
+        # arg (`--storage-dir`) or other caller-controlled input.
+        self.storage_dir = _validate_file_path(str(storage_dir))
         self.storage_dir.mkdir(parents=True, exist_ok=True)
 
         # Core telemetry files
@@ -87,17 +96,22 @@ class TelemetryStore:
             record_cls: Record class with a from_dict() classmethod
             since: Only return records after this time
             timestamp_field: Name of the timestamp attribute on the record
-            limit: Maximum records to return
+            limit: Maximum records to return (the MOST RECENT ``limit``)
             extra_filter: Optional predicate — return True to include
 
         Returns:
-            List of parsed and filtered records
+            The most recent ``limit`` matching records, oldest-first.
 
         """
         if not file.exists():
             return []
 
-        records: list[T] = []
+        # JSONL is appended chronologically (oldest first). A top-down read
+        # with an early ``break`` at ``limit`` returned the OLDEST matches —
+        # wrong for the "recent" contract callers rely on (e.g. records[-1]
+        # is meant to be the latest). A bounded deque keeps the last ``limit``
+        # matching records in O(limit) memory in a single pass.
+        records: deque[T] = deque(maxlen=limit)
         with file.open(encoding="utf-8") as f:
             for line in f:
                 if not line.strip():
@@ -115,13 +129,11 @@ class TelemetryStore:
                         continue
 
                     records.append(record)
-                    if len(records) >= limit:
-                        break
                 except (json.JSONDecodeError, KeyError):
                     logger.debug("Skipping malformed record in %s", file.name)
                     continue
 
-        return records
+        return list(records)
 
     # ------------------------------------------------------------------
     # Log methods

--- a/src/attune/telemetry/usage_ping.py
+++ b/src/attune/telemetry/usage_ping.py
@@ -26,11 +26,13 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import os
 import platform
 import sys
+import urllib.parse
 import urllib.request
 import uuid
 from collections.abc import Callable, Iterable, Mapping
@@ -134,6 +136,35 @@ def resolve_endpoint(env: Mapping[str, str] | None = None) -> str:
     """Return the collection endpoint (env override or default)."""
     env = os.environ if env is None else env
     return (env.get("ATTUNE_USAGE_ENDPOINT") or DEFAULT_ENDPOINT).strip()
+
+
+def _endpoint_host_blocked(url: str) -> bool:
+    """Return True if the endpoint host is a private/loopback/link-local
+    address that usage pings must never target (SSRF guard).
+
+    ``ATTUNE_USAGE_ENDPOINT`` is operator/env-controlled; without this a
+    misconfigured or compromised env could point pings at the cloud
+    metadata service (169.254.169.254) or an internal host. Blocks
+    loopback, link-local, and RFC-1918/ULA ranges plus ``localhost``. DNS
+    names are not resolved here, so a name resolving to a private IP is
+    not caught — the guard covers literal-IP and localhost endpoints, the
+    realistic misconfiguration.
+    """
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    if host in {"localhost", "ip6-localhost", "ip6-loopback"}:
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False  # not a literal IP; leave DNS names to the transport
+    return (
+        ip.is_loopback
+        or ip.is_link_local
+        or ip.is_private
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
 
 
 def new_install_id() -> str:
@@ -241,6 +272,9 @@ def sync(
         return 0
     if not (endpoint.startswith("https://") or endpoint.startswith("http://")):
         logger.debug("usage-ping: endpoint scheme not allowed: %r", endpoint)
+        return 0
+    if _endpoint_host_blocked(endpoint):
+        logger.debug("usage-ping: endpoint host not allowed: %r", endpoint)
         return 0
 
     sent = 0

--- a/tests/unit/models/test_adaptive_routing_coverage_boost.py
+++ b/tests/unit/models/test_adaptive_routing_coverage_boost.py
@@ -329,8 +329,9 @@ class TestRecommendTierUpgrade:
         """Test that upgrade is recommended when failure rate exceeds threshold."""
         mock_telemetry = MagicMock()
 
-        # 25 calls with 6 failures in last 20 (30% failure rate)
-        entries = [{"workflow": "test", "stage": "analysis", "success": i < 19} for i in range(25)]
+        # 25 calls, newest-first (matching UsageTracker.get_recent_entries):
+        # the 6 most-recent calls fail → 6/20 = 30% in the recent window.
+        entries = [{"workflow": "test", "stage": "analysis", "success": i >= 6} for i in range(25)]
         mock_telemetry.get_recent_entries.return_value = entries
 
         router = AdaptiveModelRouter(mock_telemetry)
@@ -344,8 +345,8 @@ class TestRecommendTierUpgrade:
         """Test that no upgrade when failure rate is acceptable."""
         mock_telemetry = MagicMock()
 
-        # 25 calls with only 2 failures in last 20 (10% failure rate)
-        entries = [{"workflow": "test", "stage": "analysis", "success": i < 23} for i in range(25)]
+        # 25 calls, newest-first: the 2 most-recent calls fail → 2/20 = 10%.
+        entries = [{"workflow": "test", "stage": "analysis", "success": i >= 2} for i in range(25)]
         mock_telemetry.get_recent_entries.return_value = entries
 
         router = AdaptiveModelRouter(mock_telemetry)
@@ -658,14 +659,14 @@ class TestAnalyzeModelPerformance:
         """Test that _analyze_model_performance counts recent failures."""
         mock_telemetry = MagicMock()
 
-        # 30 calls with 5 failures in last 20
+        # 30 calls, newest-first: the 5 most-recent calls fail → recent_failures == 5.
         entries = [
             {
                 "workflow": "test",
                 "stage": "analysis",
                 "model": "model1",
                 "tier": "CHEAP",
-                "success": i < 25,  # Last 5 are failures
+                "success": i >= 5,  # First 5 (most recent) are failures
                 "cost": 0.001,
                 "duration_ms": 500,
             }

--- a/tests/unit/models/test_models_review_fixes.py
+++ b/tests/unit/models/test_models_review_fixes.py
@@ -1,0 +1,165 @@
+"""Regression guards for the ``src/attune/models`` review fixes.
+
+Each test pins a specific HIGH/MEDIUM bug the code review found so it
+cannot silently return. See the review for context.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import attune.models.telemetry as tel
+from attune.models.adaptive_routing import AdaptiveModelRouter
+from attune.models.circuit_breaker import CircuitBreaker
+from attune.models.telemetry.data_models import LLMCallRecord
+from attune.models.telemetry.storage import TelemetryStore
+from attune.telemetry.usage_ping import _endpoint_host_blocked
+
+
+@pytest.mark.unit
+class TestTelemetryConvenienceFunctions:
+    """H1/H2: the module-level helpers called non-existent store methods
+    (``log_llm_call`` / ``log_workflow_run``) — an AttributeError on the
+    public API. They must call ``log_call`` / ``log_workflow``.
+    """
+
+    def test_helpers_call_the_real_store_methods(self, monkeypatch):
+        mock_store = MagicMock()
+        monkeypatch.setattr(tel, "get_telemetry_store", lambda: mock_store)
+
+        tel.log_llm_call("rec-a")
+        tel.log_workflow_run("rec-b")
+
+        mock_store.log_call.assert_called_once_with("rec-a")
+        mock_store.log_workflow.assert_called_once_with("rec-b")
+        # The old (broken) method names must never be used.
+        assert not mock_store.log_llm_call.called
+        assert not mock_store.log_workflow_run.called
+
+
+@pytest.mark.unit
+class TestTelemetryStoreSecurity:
+    """H4: storage_dir reached the filesystem with no path validation."""
+
+    def test_rejects_system_directory(self):
+        with pytest.raises(ValueError):
+            TelemetryStore(storage_dir="/etc/cron.d")
+
+    def test_allows_a_normal_directory(self, tmp_path):
+        store = TelemetryStore(storage_dir=str(tmp_path / "telemetry"))
+        assert store.storage_dir.exists()
+
+
+@pytest.mark.unit
+class TestReadJsonlRecency:
+    """M2: ``_read_jsonl`` truncated from the OLDEST records — "recent"
+    reads returned stale data once a log exceeded ``limit``.
+    """
+
+    def test_get_calls_returns_the_most_recent(self, tmp_path):
+        store = TelemetryStore(storage_dir=str(tmp_path))
+        for i in range(5):  # appended oldest -> newest
+            store.log_call(LLMCallRecord(call_id=str(i), timestamp=f"2026-01-0{i + 1}T00:00:00Z"))
+
+        recent = store.get_calls(limit=2)
+
+        assert {r.call_id for r in recent} == {"3", "4"}  # newest two, not {"0","1"}
+        assert recent[-1].call_id == "4"  # records[-1] is the latest
+
+
+@pytest.mark.unit
+class TestUsagePingSsrfGuard:
+    """M5: ``sync`` validated only the scheme, not the host."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://169.254.169.254/latest/meta-data",  # cloud metadata
+            "http://127.0.0.1:9000",
+            "http://localhost/collect",
+            "http://10.0.0.5/x",
+            "http://192.168.1.1/x",
+            "http://[::1]/x",
+        ],
+    )
+    def test_blocks_internal_hosts(self, url):
+        assert _endpoint_host_blocked(url) is True
+
+    def test_allows_a_public_host(self):
+        assert _endpoint_host_blocked("https://telemetry.example.com/collect") is False
+
+
+@pytest.mark.unit
+class TestCircuitBreakerHalfOpen:
+    """M8: ``half_open_calls`` was stored but never enforced — after the
+    recovery timeout every call was let through.
+    """
+
+    def test_half_open_limits_probe_calls(self):
+        cb = CircuitBreaker(failure_threshold=2, recovery_timeout_seconds=0, half_open_calls=1)
+        cb.record_failure("anthropic", "capable")
+        cb.record_failure("anthropic", "capable")  # opens the circuit
+
+        # recovery_timeout=0 -> immediately half-open; only ONE probe allowed
+        assert cb.is_available("anthropic", "capable") is True
+        assert cb.is_available("anthropic", "capable") is False  # budget spent
+
+        cb.record_success("anthropic", "capable")  # a probe succeeded -> closed
+        assert cb.is_available("anthropic", "capable") is True
+
+
+@pytest.mark.unit
+class TestAdaptiveRoutingLogging:
+    """H3: the module used a stdlib logger but called it with structlog
+    keyword events (``logger.warning("event", key=val)``) — a TypeError
+    the moment the no-candidates path emitted.
+    """
+
+    def test_no_candidates_path_does_not_crash(self):
+        telemetry = MagicMock()
+        telemetry.get_recent_entries.return_value = [
+            {
+                "workflow": "w",
+                "stage": "s",
+                "model": "m",
+                "tier": "capable",
+                "success": True,
+                "cost": 1.0,
+                "duration_ms": 100,
+            }
+            for _ in range(10)
+        ]
+        router = AdaptiveModelRouter(telemetry)
+
+        # An impossibly tight cost constraint filters every candidate out,
+        # forcing the logger.warning("adaptive_routing_no_candidates", ...) path.
+        result = router.get_best_model("w", "s", max_cost=0.0001)
+
+        assert isinstance(result, str) and result  # returns a fallback, no TypeError
+
+    def test_recent_window_counts_newest_calls(self):
+        # get_recent_entries is newest-first; the 5 most-recent are failures.
+        telemetry = MagicMock()
+        telemetry.get_recent_entries.return_value = [
+            {
+                "workflow": "w",
+                "stage": "s",
+                "model": "m",
+                "tier": "capable",
+                "success": i >= 5,
+                "cost": 0.001,
+                "duration_ms": 100,
+            }
+            for i in range(30)
+        ]
+        router = AdaptiveModelRouter(telemetry)
+
+        perfs = router._analyze_model_performance("w", "s")
+
+        assert len(perfs) == 1
+        assert perfs[0].recent_failures == 5


### PR DESCRIPTION
Fixes the confirmed **HIGH** and **MEDIUM** issues from the `src/attune/models` code review, each with a regression guard.

## HIGH
- **AttributeError on public API** — `telemetry.log_llm_call`/`log_workflow_run` called non-existent store methods; now call `.log_call`/`.log_workflow`.
- **TypeError in routing** — `adaptive_routing` used a stdlib logger with structlog-style kwargs; switched to `structlog`.
- **CWE-22** — `TelemetryStore(storage_dir)` wrote with no path validation; now `_validate_file_path`.

## MEDIUM
- **Async bug** — `resilient_executor` used `time.sleep()` in async retry loops → `await asyncio.sleep()`.
- **Stale reads** — `storage._read_jsonl` truncated the *oldest* records; bounded `deque` now returns the most-recent `limit`.
- **Hot-path rescan + inverted window** — `adaptive_routing` re-scanned 10k entries per decision; added a short-TTL fetch cache and normalized to oldest-first so the `[-N:]` recent-window slices actually pick the newest calls (`get_recent_entries` is newest-first).
- **SSRF** — `usage_ping.sync` validated only the scheme; added a host guard blocking loopback/link-local/RFC-1918 (incl. `169.254.169.254`).
- **Unvalidated read** — `auth_strategy.count_lines_of_code` now validates its path.
- **Dup code** — removed the duplicate `backend._parse_timestamp`.
- **Dead resilience feature** — `circuit_breaker.half_open_calls` was stored but never enforced; implemented the probe limit.

## Not a bug
**M4** (`tier1_summary` re-reads) was a **false positive** — each sub-method reads a *distinct* file once. No change (verify-first avoided a needless 5-method refactor).

## Tests
- New `tests/unit/models/test_models_review_fixes.py` — **14 regression guards** (the crashers had no prior coverage, which is why they shipped).
- Updated 3 order-sensitive adaptive-routing tests to the real **newest-first** `get_recent_entries` contract (they had encoded the buggy oldest-first assumption).
- Affected model/telemetry/routing suites green (~1200 tests). The only red locally is `test_sonnet_opus_fallback.py` — live-API integration tests (creditless key), skipped in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)