### PR TITLE
test(models): cover the review-fix branches Codecov flagged on #1200

### DIFF
--- a/tests/unit/models/test_models_review_fixes.py
+++ b/tests/unit/models/test_models_review_fixes.py
@@ -163,3 +163,76 @@ class TestAdaptiveRoutingLogging:
 
         assert len(perfs) == 1
         assert perfs[0].recent_failures == 5
+
+
+@pytest.mark.unit
+class TestAdaptiveRoutingFetchCache:
+    """M3: the telemetry-window fetch is cached per ``days`` window."""
+
+    def _entries(self):
+        return [{"workflow": "w", "stage": "s"} for _ in range(3)]
+
+    def test_second_fetch_uses_cache(self):
+        telemetry = MagicMock()
+        telemetry.get_recent_entries.return_value = self._entries()
+        router = AdaptiveModelRouter(telemetry)  # default TTL > 0
+
+        router._get_workflow_stage_entries("w", "s", days=7)
+        router._get_workflow_stage_entries("w", "s", days=7)  # cache hit
+
+        # Underlying scan happened only once despite two routing decisions.
+        assert telemetry.get_recent_entries.call_count == 1
+
+    def test_ttl_zero_disables_cache(self):
+        telemetry = MagicMock()
+        telemetry.get_recent_entries.return_value = self._entries()
+        router = AdaptiveModelRouter(telemetry, cache_ttl_seconds=0)
+
+        router._get_workflow_stage_entries("w", "s", days=7)
+        router._get_workflow_stage_entries("w", "s", days=7)
+
+        # With caching disabled, every decision re-scans.
+        assert telemetry.get_recent_entries.call_count == 2
+
+
+@pytest.mark.unit
+class TestSsrfGuardBranches:
+    """M5: cover the remaining address-classification branches."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://224.0.0.1/x",  # multicast
+            "http://240.0.0.1/x",  # reserved
+            "http://0.0.0.0/x",  # unspecified
+        ],
+    )
+    def test_blocks_other_internal_classes(self, url):
+        assert _endpoint_host_blocked(url) is True
+
+    def test_allows_public_ip(self):
+        assert _endpoint_host_blocked("http://8.8.8.8/x") is False
+
+    def test_url_without_host_is_allowed(self):
+        # No parseable host -> not a literal IP -> left to the transport.
+        assert _endpoint_host_blocked("not-a-url") is False
+
+    def test_sync_blocks_internal_endpoint_without_posting(self):
+        from attune.telemetry.usage_ping import sync
+
+        posted: list[str] = []
+
+        def poster(url, batch, timeout):
+            posted.append(url)
+            return True
+
+        sent = sync(
+            [{"workflow": "x", "ts": "2026-01-01T00:00:00Z"}],
+            endpoint="http://127.0.0.1:9000/collect",
+            install_id="i",
+            version="v",
+            poster=poster,
+        )
+
+        assert sent == 0
+        assert posted == []  # the SSRF guard short-circuits before any POST


### PR DESCRIPTION
Follow-up to **#1200** — closes the Codecov patch-coverage gap it reported (85.71%, 7 lines).

Adds tests for the branches that were exercised in production but not by the review-fix tests:

- **`adaptive_routing._fetch_recent`** — the cache-**hit** return (second decision reuses the window; asserts only one underlying scan) and the **cache-disabled** (`cache_ttl_seconds=0`) path (asserts every decision re-scans).
- **`usage_ping._endpoint_host_blocked`** — the remaining address classes (multicast / reserved / unspecified / public-IP / no-host), plus the guard's **call site inside `sync()`** (an internal endpoint returns 0 with no POST).

Verified locally: the previously-missing `adaptive_routing` lines (470–481) and the `usage_ping` guard/helper lines are now covered. 22 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)