### PR TITLE
docs(lessons): zsh no-word-split for-loop + unanchored-grep-exclusion footguns

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12502,3 +12502,25 @@ files.
     separate, deeper mislabel left out of #1173's scope. Pairs with the
     "registered ≠ working" and `removing-dead-code.md`
     fake-success-signature lessons.
+
+- **zsh does NOT word-split an unquoted `$var` in a `for` loop — a
+  multi-line file list runs the loop body ONCE with the whole blob as a
+  single argument, so a `sed`/`grep` sweep silently no-ops (looks like
+  it ran)**: 2026-06-30 doing the Sonnet-4.6→5 sweep, `files=$(grep -rl
+  … ); for f in $files; do sed -i '' 's/…/…/g' "$f"; done` printed
+  `sed: <all 65 filenames concatenated> : File name too long` and
+  changed NOTHING (the 169 target occurrences all remained). Root cause:
+  unlike bash, zsh performs NO word splitting on unquoted parameter
+  expansion, so `for f in $files` iterates a single time with `$f` = the
+  entire newline-joined list. The error is easy to skim past as "some
+  path issue" — the tell is the post-sweep verify count being unchanged
+  (always re-grep the target after a sweep; never trust the loop ran).
+  **Fix — pipe to `while IFS= read -r`:** `grep -rl … | grep -v <excl> |
+  while IFS= read -r f; do sed -i '' 's/…/…/g' "$f"; done` splits on
+  newlines correctly and tolerates spaces in paths. Pairs with the "zsh
+  unmatched-glob trap" lesson (#1196) — same family: this shell defaults
+  to different word-handling than bash, and the failure is a SILENT
+  no-op, not an error. (Companion footgun same session: an UNANCHORED
+  grep exclusion `grep -vE "…|site/"` also matched `webSITE/` and
+  silently dropped every `website/` path from a file list — anchor
+  path-segment excludes with a leading slash: `/site/`.)

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12524,3 +12524,26 @@ files.
   grep exclusion `grep -vE "…|site/"` also matched `webSITE/` and
   silently dropped every `website/` path from a file list — anchor
   path-segment excludes with a leading slash: `/site/`.)
+
+- **The format-on-write hook (ruff --fix) STRIPS an import that is
+  momentarily unused — so adding an import and its usage in SEPARATE
+  Edit calls loses the import, surfacing later as a runtime NameError,
+  not an import error**: hit repeatedly 2026-07-01 fixing the models/
+  review (asyncio, structlog, time, ipaddress, deque, _validate_file_path
+  across 5 files). The pattern: Edit #1 adds `import asyncio`; the
+  PostToolUse formatter runs ruff --fix, sees `asyncio` unused (the
+  usage isn't written yet) and DELETES the import; Edit #2 adds `await
+  asyncio.sleep(...)`. Result: the module imports fine (NameError is
+  runtime, not import-time), a smoke `import x` passes, and the failure
+  only appears when the function actually runs (tests: `NameError: name
+  'asyncio' is not defined`). Cost this session: a 101-failed / 79-error
+  cascade whose root was one stripped import (`_validate_file_path`),
+  plus three more stripped imports found only by exercising the code.
+  **Fixes:** (1) add the import AND its first usage in the SAME Edit
+  (ruff sees it used, keeps it); or (2) after any add-an-import Edit,
+  before moving on, `grep -n "^import <name>\|^from .* <name>"` the file
+  to confirm it survived; or (3) run an actual test that EXERCISES the
+  new line — a bare `python -c "import module"` is NOT enough (the
+  import resolves; the stripped-symbol call is what NameErrors). Pairs
+  with the "registered ≠ working — dogfood the live loop" lesson: the
+  module importing clean is necessary-not-sufficient; run the code.


### PR DESCRIPTION
Two silent-no-op shell traps hit during this session's Sonnet 5 sweep, added to `.claude/lessons.md`:

- **zsh does not word-split an unquoted `$var` in a `for` loop** — a multi-line file list runs the loop body once with the whole blob as one argument, so a `sed`/`grep` sweep silently changes nothing. Fix: pipe to `while IFS= read -r`.
- **an unanchored `grep -vE \"…|site/\"` exclusion matches \"webSITE/\"** — silently dropped every `website/` path from a file list. Anchor path-segment excludes with a leading slash.

Both fail silently; the tell is the post-sweep verify count being unchanged. Pairs with the #1196 zsh unmatched-glob lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)