### PR TITLE
fix(ops): treat attune-author status non-zero exit as "unknown", not "clean"

### DIFF
--- a/src/attune/ops/help_data.py
+++ b/src/attune/ops/help_data.py
@@ -491,9 +491,10 @@ def _attune_author_stale_features(project_root: Path, help_dir: Path) -> frozens
     Returns:
         - ``frozenset[str]``: feature names with source-hash drift,
           including the empty set when everything is in sync.
-        - ``None`` when attune-author isn't on PATH or its
-          subprocess fails — callers fall back to age-based
-          staleness in that case.
+        - ``None`` when attune-author isn't on PATH, its subprocess
+          raises, or the CLI exits non-zero — callers fall back to
+          age-based staleness in that case. A non-zero exit is treated
+          as "cannot determine drift", never as "nothing stale".
     """
     key = (str(project_root), str(help_dir))
     now = time.monotonic()
@@ -525,6 +526,19 @@ def _attune_author_stale_features(project_root: Path, help_dir: Path) -> frozens
         )
     except (OSError, subprocess.SubprocessError) as exc:
         logger.warning("help_data: attune-author status failed: %s", exc)
+        return None
+    if result.returncode != 0:
+        # A non-zero exit means the CLI itself failed (e.g. a broken
+        # shim raising ModuleNotFoundError), NOT "everything is in
+        # sync". Parsing the (typically empty) stdout here would return
+        # frozenset(), masking the crash as "nothing stale" and denying
+        # callers the age-based fallback. Return None so callers fall
+        # back — same signal as a missing binary or a raised exception.
+        logger.warning(
+            "help_data: attune-author status exited %s; using age fallback (stderr: %s)",
+            result.returncode,
+            (result.stderr or "").strip()[:200],
+        )
         return None
     stale = _parse_status_output(result.stdout)
     _staleness_cache[key] = (now, stale)

--- a/tests/unit/ops/test_help_data.py
+++ b/tests/unit/ops/test_help_data.py
@@ -785,6 +785,28 @@ class TestAttuneAuthorStaleFeatures:
         result = help_data._attune_author_stale_features(tmp_path, tmp_path / ".help")
         assert result == frozenset({"spec-engine", "smart-test"})
 
+    def test_nonzero_exit_returns_none_not_empty_set(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Regression: a CLI that runs but exits non-zero (e.g. a broken
+        shim raising ModuleNotFoundError) must return ``None`` (→ age
+        fallback), NOT ``frozenset()``. Previously ``check=False`` let the
+        crash's empty stdout parse to an empty set, masking the failure as
+        'nothing stale' and denying callers the fallback."""
+        from attune.ops import help_data
+
+        monkeypatch.setattr(help_data.shutil, "which", lambda _: "/fake/attune-author")
+
+        class _CrashResult:
+            stdout = ""
+            stderr = "ModuleNotFoundError: No module named 'attune_author'"
+            returncode = 1
+
+        monkeypatch.setattr(help_data.subprocess, "run", lambda *a, **kw: _CrashResult())
+        help_data._clear_staleness_cache()
+        result = help_data._attune_author_stale_features(tmp_path, tmp_path / ".help")
+        assert result is None
+
     def test_subprocess_failure_returns_none(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## What

`_attune_author_stale_features` (help_data.py, the ops dashboard's staleness
signal) shells out to `attune-author status` with `subprocess.run(check=False)`.
When the CLI shim crashes — e.g. it points at a Python without `attune_author`
installed → `ModuleNotFoundError`, exit 1, empty stdout — the empty output
parsed to `frozenset()`. A **crash read as "nothing stale"**, and because the
return was an empty set (not `None`), callers never reached the age-based
staleness fallback. A broken CLI silently reports every help feature fresh.

## Fix

Guard on `result.returncode`: a non-zero exit returns `None` — the same
"cannot determine drift → use age fallback" signal already used for a missing
binary or a raised `OSError`/`SubprocessError`. Only a clean (exit 0) run is
parsed for stale features.

## Test

`test_nonzero_exit_returns_none_not_empty_set` — mocks a crashing shim (exit 1,
empty stdout, ModuleNotFoundError on stderr) and asserts `None`, not
`frozenset()`. Full `TestAttuneAuthorStaleFeatures` class green (6 tests).

## Context

Surfaced by dogfooding the attune-author consolidation absorb
(`docs/specs/attune-author-consolidation/decisions.md` D8). D8 flagged this as
"small, shippable independent of the absorb" — this PR is that standalone fix.
The parked design call (glob-less/manual-feature staleness semantics) is
separate and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
