### PR TITLE
feat(memory): add curated cross-session memory NodeTypes

### DIFF
--- a/src/attune/memory/graph.py
+++ b/src/attune/memory/graph.py
@@ -154,8 +154,14 @@ class MemoryGraph:
     def add_finding(self, workflow: str, finding: dict[str, Any]) -> str:
         """Add a finding from any workflow, return node ID.
 
+        Also accepts curated cross-session memory (no workflow origin) via
+        the ``USER_CONTEXT``/``FEEDBACK``/``PROJECT_CONTEXT``/``REFERENCE``
+        node types - pass ``workflow=""`` for those (see
+        ``attune.memory.nodes`` module docstring).
+
         Args:
-            workflow: Name of the workflow adding this finding
+            workflow: Name of the workflow adding this finding, or "" for
+                a curated-memory node with no workflow origin.
             finding: Dict with at least 'type' and 'name' keys
 
         Returns:

--- a/src/attune/memory/nodes.py
+++ b/src/attune/memory/nodes.py
@@ -1,7 +1,14 @@
 """Memory Graph Node Types
 
-Defines node types for the cross-workflow knowledge graph.
-Each node represents an entity discovered by a workflow.
+Defines node types for the cross-workflow knowledge graph. Most nodes
+represent an entity discovered by a workflow (a bug, a fix, a test).
+The "Curated memory" category (below) is the exception: those nodes
+represent hand-curated cross-session memory - decisions, standing
+feedback, project context - that has no workflow origin and no
+resolution lifecycle. ``source_workflow`` stays empty and ``severity``
+stays unset for curated-memory nodes; ``status`` is reinterpreted as
+active/superseded/stale rather than open/investigating/resolved/wontfix
+(same field, no schema change).
 
 Copyright 2025 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0
@@ -46,6 +53,12 @@ class NodeType(Enum):
     # Dependencies
     DEPENDENCY = "dependency"
     LICENSE = "license"
+
+    # Curated memory (not workflow findings - see module docstring)
+    USER_CONTEXT = "user_context"
+    FEEDBACK = "feedback"
+    PROJECT_CONTEXT = "project_context"
+    REFERENCE = "reference"
 
 
 @dataclass

--- a/tests/memory/test_graph.py
+++ b/tests/memory/test_graph.py
@@ -56,8 +56,9 @@ class TestNodeTypeEnum:
         """Test total number of node types."""
         # FILE, FUNCTION, CLASS, MODULE, BUG, VULNERABILITY, PERFORMANCE_ISSUE,
         # CODE_SMELL, TECH_DEBT, PATTERN, FIX, REFACTOR, TEST, TEST_CASE,
-        # COVERAGE_GAP, DOC, API_ENDPOINT, DEPENDENCY, LICENSE
-        assert len(NodeType) == 19
+        # COVERAGE_GAP, DOC, API_ENDPOINT, DEPENDENCY, LICENSE,
+        # USER_CONTEXT, FEEDBACK, PROJECT_CONTEXT, REFERENCE
+        assert len(NodeType) == 23
 
     def test_node_type_from_string(self):
         """Test creating NodeType from string."""

--- a/tests/unit/memory/test_graph.py
+++ b/tests/unit/memory/test_graph.py
@@ -121,6 +121,38 @@ class TestGraphInitialization:
         graph = MemoryGraph(path=temp_graph_path)
         assert len(graph.nodes) == 0
 
+    def test_loads_curated_memory_node_via_real_add_finding(self, temp_graph_path):
+        """Regression guard: before NodeType.FEEDBACK/USER_CONTEXT/
+        PROJECT_CONTEXT/REFERENCE existed, reloading a graph containing one
+        of these types raised
+        ``ValueError: 'feedback' is not a valid NodeType`` inside
+        MemoryGraph._load() -> Node.from_dict() -> NodeType(data["type"]).
+        Exercises the real public API (add_finding, not manual Node
+        construction) end to end: add, save, reload in a fresh instance,
+        traverse via find_related."""
+        graph1 = MemoryGraph(path=temp_graph_path)
+        feedback_id = graph1.add_finding(
+            workflow="",
+            finding={
+                "type": "feedback",
+                "name": "Standing commitments to Patrick",
+                "status": "active",
+            },
+        )
+        project_id = graph1.add_finding(
+            workflow="",
+            finding={"type": "project_context", "name": "Memory subsystem motivation"},
+        )
+        graph1.add_edge(project_id, feedback_id, EdgeType.RELATED_TO)
+
+        # A fresh instance must reload without raising.
+        graph2 = MemoryGraph(path=temp_graph_path)
+
+        assert graph2.nodes[feedback_id].type == NodeType.FEEDBACK
+        assert graph2.nodes[project_id].type == NodeType.PROJECT_CONTEXT
+        related = graph2.find_related(project_id, edge_types=[EdgeType.RELATED_TO])
+        assert [n.id for n in related] == [feedback_id]
+
 
 # =============================================================================
 # NODE OPERATIONS

--- a/tests/unit/memory/test_nodes_coverage_boost.py
+++ b/tests/unit/memory/test_nodes_coverage_boost.py
@@ -63,6 +63,14 @@ class TestNodeTypeEnum:
         assert NodeType.DEPENDENCY.value == "dependency"
         assert NodeType.LICENSE.value == "license"
 
+    def test_node_type_enum_has_curated_memory_types(self):
+        """Test that NodeType enum includes curated cross-session memory
+        types (not workflow findings - see module docstring)."""
+        assert NodeType.USER_CONTEXT.value == "user_context"
+        assert NodeType.FEEDBACK.value == "feedback"
+        assert NodeType.PROJECT_CONTEXT.value == "project_context"
+        assert NodeType.REFERENCE.value == "reference"
+
     def test_node_type_can_be_created_from_string_value(self):
         """Test that NodeType can be created from string value."""
         node_type = NodeType("bug")
@@ -350,6 +358,33 @@ class TestNodeSerialization:
         assert restored.created_at == original.created_at
         assert restored.updated_at == original.updated_at
         assert restored.status == original.status
+
+    def test_curated_memory_node_roundtrip_serialization(self):
+        """Regression guard: before the curated-memory NodeType members
+        existed, Node.from_dict(node.to_dict()) on a FEEDBACK/USER_CONTEXT/
+        PROJECT_CONTEXT/REFERENCE node raised
+        ``ValueError: '<value>' is not a valid NodeType`` at reload time
+        (from_dict calls NodeType(data["type"]) against whatever the enum
+        actually contains). severity stays unset and status is
+        reinterpreted (active, not open/resolved) for these node types -
+        see the module docstring."""
+        original = Node(
+            id="feedback_my_commitments_to_patrick",
+            type=NodeType.FEEDBACK,
+            name="Standing commitments to Patrick",
+            description="Neutral curiosity, full attention, correction without ego.",
+            source_file="/memory/feedback_my_commitments_to_patrick.md",
+            severity="",
+            status="active",
+            tags=["relationship", "standing-commitment"],
+        )
+
+        restored = Node.from_dict(original.to_dict())
+
+        assert restored.type == NodeType.FEEDBACK
+        assert restored.severity == ""
+        assert restored.status == "active"
+        assert restored.source_workflow == ""
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Extends `MemoryGraph`'s `NodeType` enum with `USER_CONTEXT`/`FEEDBACK`/`PROJECT_CONTEXT`/`REFERENCE`, mapped 1:1 onto the harness auto-memory's own proven taxonomy (`user`/`feedback`/`project`/`reference`).
- These node types represent hand-curated cross-session memory (no workflow origin, no open/resolved lifecycle) — `severity` stays unset, `status` is reinterpreted as active/superseded/stale. No schema change.
- Adds regression guards for the exact pre-fix failure: reloading a saved graph containing one of these types raised `ValueError: '<value>' is not a valid NodeType` in `MemoryGraph._load() -> Node.from_dict() -> NodeType(data["type"])`.
- Recovered from uncommitted work left in a stale worktree — this PR is the landing of that WIP, rebased onto current main and verified.

This is prerequisite infrastructure for a follow-up structured one-shot evaluating whether `MemoryGraph` can hold curated cross-session memory as well as the harness's file-based auto-memory does.

## Test plan
- [x] `pytest tests/unit/memory/test_graph.py tests/unit/memory/test_nodes_coverage_boost.py tests/memory/test_graph.py` — 181 passed
- [x] Pre-commit hooks (black, ruff, bandit, help-template regen) all passed