### PR TITLE
fix(memory): durable curated-memory home + find_similar ergonomics

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12623,3 +12623,44 @@ files.
   data on stdout will be corrupted by structlog's PrintLogger default;
   either pass files/fds for data or reconfigure structlog to stderr in
   the child.
+
+- **No threshold rescues a scoring-function mismatch — short free-text
+  queries against verbose documents are structurally near-zero under
+  Jaccard; switch to containment (query-side normalization), don't
+  keep lowering the cutoff**: 2026-07-02, PR #1212. After fixing
+  `find_similar`'s default threshold 0.5 → 0.25 for dict paraphrase
+  queries, the very first live receipt (a question-shaped query
+  against the real curated graph) still returned `[]`: raw scores
+  topped out at 0.06–0.17 because Jaccard's union term grows with
+  node text length, so a 7-word query vs a 60-word node can never
+  score well no matter how good the match. The tell that it's a
+  scoring-shape problem, not a tuning problem: the ceiling moves with
+  DOCUMENT length, not with match quality. Fix: score free text by
+  containment — |query ∩ node| / |query| — which normalizes by the
+  query side only (the same reason IR uses asymmetric measures for
+  short-query-vs-document). Found ONLY because the capture script
+  included a live recall receipt after the write ("registered ≠
+  working" applied to a fix I had just shipped — receipt your own
+  fixes, not just features). Remaining known gap, logged as R4
+  evidence not fixed: no stemming ("fixes"/"fixed" miss) and
+  containment mildly favors verbose nodes.
+
+- **Local redis-stack 7.4 supports FUNCTION LOAD/FCALL (Lua stored
+  procedures) fine, and Redis-side recall is microsecond-class —
+  measured baselines: FCALL ~86μs median / FT.SEARCH ~181μs median,
+  but the FIRST FCALL costs ~3.6ms (warm it)**: 2026-07-02, memory
+  hydration prototype. Extends the existing "redis-stack 7.4 has
+  RediSearch 2.10, no INT8" lesson with what DOES work: `FUNCTION
+  LOAD REPLACE` via `redis-cli -x < file.lua` (shebang `#!lua
+  name=lib`), `redis.register_function{..., flags={'no-writes'}}`,
+  and module commands callable per normal. AMS already maintains FT
+  indexes (`memory_records`, `working_memory_idx`) — namespace new
+  ones (`idx:attune_memory`) and prefix keys (`attune:memory:*`) to
+  coexist. Also the repo-in-place pattern: when a durable data dir
+  (`~/.attune/memory/`) needs versioning, `git init` it where it
+  stands and `gh repo create --private --source <dir> --push` —
+  existing code paths that point at it stay valid, no migration.
+  Related: `attune.elicitation.form_from_dict` takes
+  `{"title", "fields": [{"id", "text", "type", ...}]}` — "questions"/
+  "label" are accepted aliases, but "question" as the text key is
+  not; the error message names the real keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`find_similar` now accepts a node ID or free text and matches
   paraphrases at the default threshold.** Passing a node ID builds the
   query from that node (excluding it from results, mirroring
-  `find_related`) instead of raising `AttributeError`; free text
-  matches against name and description. The default `threshold`
+  `find_related`) instead of raising `AttributeError`; free text is
+  scored by query-word containment against name and description
+  (short queries against verbose nodes score near zero under Jaccard,
+  so word-overlap scoring would return `[]` for realistic questions
+  at any sane threshold). The default `threshold`
   drops from 0.5 (near-verbatim only — realistic paraphrases were
   silently filtered) to 0.25. Friction C from the memory-nodetype
   friction log.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Curated memory gets a durable default home.**
+  `MemoryGraph.curated()` opens the cross-session curated-memory graph
+  at `~/.attune/memory/curated_graph.json` instead of the cwd-relative,
+  typically git-tracked `patterns/memory_graph.json` default (which is
+  shaped for per-project workflow findings). Friction A from the
+  memory-nodetype friction log.
+- **`find_similar` now accepts a node ID or free text and matches
+  paraphrases at the default threshold.** Passing a node ID builds the
+  query from that node (excluding it from results, mirroring
+  `find_related`) instead of raising `AttributeError`; free text
+  matches against name and description. The default `threshold`
+  drops from 0.5 (near-verbatim only — realistic paraphrases were
+  silently filtered) to 0.25. Friction C from the memory-nodetype
+  friction log.
+
 ### Changed
 
 - **Default "capable" model is now Claude Sonnet 5

--- a/docs/specs/memory-nodetype-friction-log/decisions.md
+++ b/docs/specs/memory-nodetype-friction-log/decisions.md
@@ -148,7 +148,21 @@ a fresh session surfaces at least the USER_CONTEXT priority node and
 any PROJECT_CONTEXT nodes relevant to the working repo without a
 manual query. Open question for the spec pass: relevance signal at
 session start (no query text yet — recency + type-weighting vs. cwd/
-repo tags). Not started — needs its own tasks entry or small spec.
+repo tags). **Prototyped 2026-07-02** (Patrick's fuller vision:
+git long-term → Redis short-term → widget recall): the private repo
+`silversurfer562/attune-agent-memory` (= `~/.attune/memory/`, so
+`MemoryGraph.curated()`'s path is unchanged) carries its own
+`hydrate.py` (rebuilds `attune:memory:*` hashes/sets + a RediSearch
+index) and `functions.lua` (`recall_digest` stored procedure via
+FCALL). Measured: FCALL median 86μs, FT.SEARCH median 181μs; the
+digest rendered live through `form_from_dict` →
+`form_to_widget_html` (progress construct, pure-display sub-state).
+Widget-shape evidence: memory facts aren't "done tasks" — the
+strikethrough styling reads wrong, which is early evidence for a
+dedicated recall-digest grammar primitive rather than reusing
+`progress`. Productionization (SessionStart hook registration,
+git-pull-before-hydrate, targeted FT.SEARCH procedures, the new
+primitive) goes to a spec written from this evidence.
 
 ---
 

--- a/docs/specs/memory-nodetype-friction-log/decisions.md
+++ b/docs/specs/memory-nodetype-friction-log/decisions.md
@@ -152,6 +152,41 @@ repo tags). Not started — needs its own tasks entry or small spec.
 
 ---
 
+## 2026-07-02 — Second real captures: 2 nodes via the NEW curated() path
+
+**What was recorded** (via `MemoryGraph.curated()` — dogfooding the
+friction-A fix itself, receipt-verified from a fresh instance):
+
+- `USER_CONTEXT` — the alignment decisions (goal framing: attune
+  memory is the product; fix-first verdict bias; read-wiring scoped)
+- `PROJECT_CONTEXT` — Frictions A+C fixed (PR #1212), B open by choice
+- Two `RELATED_TO` edges, including one linking the new goal-framing
+  node to the prior standing-priority node.
+
+**Clean fits:** `curated()` resolved the right path with no explicit
+path argument; both nodes round-tripped with `status="active"`; the
+taxonomy again matched without forcing.
+
+**New friction (found by the receipt, FIXED in-PR):** free-text
+`find_similar` queries scored by Jaccard topped out at ~0.06–0.17
+against these verbose curated nodes — a realistic question-shaped
+query ("what fixes shipped for the memory frictions") returned `[]`
+even at the new 0.25 default, because the union term grows with node
+text length. No threshold fixes that class. Fix: the free-text form
+(new in PR #1212, so no back-compat) scores by **containment** — the
+fraction of query words found in the node's name or description. The
+same query now returns 5 hits; "goal framing memory product" ranks the
+goal-framing node top at 0.50.
+
+**Remaining evidence for R4 (not fixed):** (a) no stemming —
+"fixes"/"fixed" and "friction"/"frictions" still count as misses, and
+containment ranking mildly favors verbose nodes (the dead query's top
+hit is the wordy priority node, not the frictions node); (b) Friction
+B's `direction="both"` read-time workaround still in use for the edge
+follow-up. If either keeps biting, they're the adjust/extend evidence.
+
+---
+
 ## Adjacent observations (not R1-scope — different subsystem)
 
 - **2026-07-01 — cross-project recall noise in the stash/recall

--- a/docs/specs/memory-nodetype-friction-log/decisions.md
+++ b/docs/specs/memory-nodetype-friction-log/decisions.md
@@ -102,6 +102,56 @@ it lives) — cost one failed import.
 
 ---
 
+## 2026-07-02 — Alignment pause + Frictions A and C fixed
+
+**Alignment (Patrick's answers, batched decision form):**
+
+- **Goal framing:** attune memory is the product; the harness
+  auto-memory files are scaffolding. Judge the curated graph against
+  "could this carry the agent's continuity." (A complementary
+  routing-rule framing was discussed as the *transition* protocol —
+  proposal pending Patrick's reaction, not yet a decision.)
+- **Fix order:** Friction A now, then Friction C. Friction B (edge
+  direction) deliberately stays open as R4 evidence.
+- **Read-side wiring:** scope it soon — R4 should judge a living
+  read/write loop, not a write-only log (see scope below).
+- **Verdict posture:** negative findings are acceptable but carry a
+  fix-first bias — propose "what would make it earn its keep" before
+  removal talk.
+
+**Friction A — FIXED.** `MemoryGraph.curated()` classmethod opens the
+graph at `~/.attune/memory/curated_graph.json` (the same durable home
+`personal.py` already uses as `_GLOBAL_ROOT`), leaving the constructor's
+cwd-relative default untouched for per-project workflow findings.
+Round-trip test across fresh instances included
+([graph.py](../../../src/attune/memory/graph.py),
+[test_graph.py](../../../tests/unit/memory/test_graph.py)).
+
+**Friction C — FIXED.** `find_similar` now accepts `dict | str`: a node
+ID builds the query from that node's fields and excludes it from
+results (mirroring `find_related`'s id-based signature); any other
+string is free text matched against name and description. Default
+`threshold` lowered 0.5 → 0.25 so natural paraphrases match (the
+observed 0.301 paraphrase score now clears the default). The one
+production caller (`agent_factory/memory_integration.py`) passes an
+explicit threshold, so the default change is additive. Regression
+guard asserts a paraphrase scoring < 0.5 matches at the default.
+
+**Read-side wiring — SCOPED (no engine work yet):** a session-start
+surface that queries the curated graph and injects relevant `active`
+nodes into agent context, so curated memory is READ under real
+conditions before the R4 verdict. Shape: reuse the existing
+SessionStart-hook pattern (the stash/recall hook), query
+`MemoryGraph.curated()` via `find_similar`/`find_by_type`, cap the
+injection (~5 nodes), and label provenance per node type. Acceptance:
+a fresh session surfaces at least the USER_CONTEXT priority node and
+any PROJECT_CONTEXT nodes relevant to the working repo without a
+manual query. Open question for the spec pass: relevance signal at
+session start (no query text yet — recency + type-weighting vs. cwd/
+repo tags). Not started — needs its own tasks entry or small spec.
+
+---
+
 ## Adjacent observations (not R1-scope — different subsystem)
 
 - **2026-07-01 — cross-project recall noise in the stash/recall

--- a/src/attune/memory/graph.py
+++ b/src/attune/memory/graph.py
@@ -85,6 +85,24 @@ class MemoryGraph:
 
         self._load()
 
+    @classmethod
+    def curated(cls) -> "MemoryGraph":
+        """Open the durable curated cross-session memory graph.
+
+        Curated memory (``USER_CONTEXT``/``FEEDBACK``/``PROJECT_CONTEXT``/
+        ``REFERENCE`` nodes - see ``attune.memory.nodes``) must survive
+        across sessions, repos, and worktrees, so it lives under the
+        user's home directory. The constructor's cwd-relative default
+        (``patterns/memory_graph.json``) is shaped for per-project
+        workflow findings and is typically git-tracked - the wrong home
+        for cross-session memory.
+
+        Returns:
+            MemoryGraph backed by ``~/.attune/memory/curated_graph.json``
+
+        """
+        return cls(path=Path.home() / ".attune" / "memory" / "curated_graph.json")
+
     def _load(self) -> None:
         """Load graph from JSON file."""
         if not self.path.exists():
@@ -157,7 +175,9 @@ class MemoryGraph:
         Also accepts curated cross-session memory (no workflow origin) via
         the ``USER_CONTEXT``/``FEEDBACK``/``PROJECT_CONTEXT``/``REFERENCE``
         node types - pass ``workflow=""`` for those (see
-        ``attune.memory.nodes`` module docstring).
+        ``attune.memory.nodes`` module docstring) and store them in the
+        durable home-directory graph (``MemoryGraph.curated()``), not a
+        cwd-relative per-project graph.
 
         Args:
             workflow: Name of the workflow adding this finding, or "" for
@@ -332,23 +352,45 @@ class MemoryGraph:
 
     def find_similar(
         self,
-        finding: dict[str, Any],
-        threshold: float = 0.5,
+        finding: dict[str, Any] | str,
+        threshold: float = 0.25,
         limit: int = 10,
     ) -> list[tuple[Node, float]]:
         """Find similar past findings.
 
-        Uses simple text similarity on name and description.
+        Uses simple text similarity (word overlap) on name and
+        description, with bonuses for type and file matches.
 
         Args:
-            finding: Dict with 'name' and/or 'description'
-            threshold: Minimum similarity score (0.0 - 1.0)
+            finding: What to match against. A dict with 'name' and/or
+                'description' (plus optional 'type'/'file'); a node ID
+                (the query is built from that node's fields and the node
+                itself is excluded from results, mirroring
+                ``find_related``); or free text (matched against both
+                name and description).
+            threshold: Minimum similarity score (0.0 - 1.0). The default
+                is tuned so natural-language paraphrases match; word
+                overlap above ~0.5 requires near-verbatim wording.
             limit: Maximum results to return
 
         Returns:
             List of (node, similarity_score) tuples
 
         """
+        exclude_id: str | None = None
+        if isinstance(finding, str):
+            source_node = self.nodes.get(finding)
+            if source_node is not None:
+                exclude_id = source_node.id
+                finding = {
+                    "name": source_node.name,
+                    "description": source_node.description,
+                    "type": source_node.type.value,
+                    "file": source_node.source_file,
+                }
+            else:
+                finding = {"name": finding, "description": finding}
+
         query_name = finding.get("name", "").lower()
         query_desc = finding.get("description", "").lower()
         query_type = finding.get("type")
@@ -357,6 +399,9 @@ class MemoryGraph:
         results: list[tuple[Node, float]] = []
 
         for node in self.nodes.values():
+            if node.id == exclude_id:
+                continue
+
             score = 0.0
             factors = 0.0
 

--- a/src/attune/memory/graph.py
+++ b/src/attune/memory/graph.py
@@ -366,8 +366,10 @@ class MemoryGraph:
                 'description' (plus optional 'type'/'file'); a node ID
                 (the query is built from that node's fields and the node
                 itself is excluded from results, mirroring
-                ``find_related``); or free text (matched against both
-                name and description).
+                ``find_related``); or free text (scored by containment -
+                the fraction of query words found in a node's name or
+                description - since short queries against verbose nodes
+                score near zero under word-overlap Jaccard).
             threshold: Minimum similarity score (0.0 - 1.0). The default
                 is tuned so natural-language paraphrases match; word
                 overlap above ~0.5 requires near-verbatim wording.
@@ -389,7 +391,7 @@ class MemoryGraph:
                     "file": source_node.source_file,
                 }
             else:
-                finding = {"name": finding, "description": finding}
+                return self._find_by_text(finding, threshold, limit)
 
         query_name = finding.get("name", "").lower()
         query_desc = finding.get("description", "").lower()
@@ -448,6 +450,33 @@ class MemoryGraph:
                 results.append((node, score))
 
         # Sort by score descending
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:limit]
+
+    def _find_by_text(
+        self,
+        text: str,
+        threshold: float,
+        limit: int,
+    ) -> list[tuple[Node, float]]:
+        """Score nodes by query-word containment for free-text recall.
+
+        Short queries against verbose nodes score near zero under
+        Jaccard (the union term grows with node text length), so free
+        text scores by containment instead: the fraction of query words
+        present in the node's name or description.
+        """
+        query_words = set(text.lower().split())
+        if not query_words:
+            return []
+
+        results: list[tuple[Node, float]] = []
+        for node in self.nodes.values():
+            node_words = set(node.name.lower().split()) | set(node.description.lower().split())
+            score = len(query_words & node_words) / len(query_words)
+            if score >= threshold:
+                results.append((node, score))
+
         results.sort(key=lambda x: x[1], reverse=True)
         return results[:limit]
 

--- a/src/attune/memory/nodes.py
+++ b/src/attune/memory/nodes.py
@@ -8,7 +8,9 @@ feedback, project context - that has no workflow origin and no
 resolution lifecycle. ``source_workflow`` stays empty and ``severity``
 stays unset for curated-memory nodes; ``status`` is reinterpreted as
 active/superseded/stale rather than open/investigating/resolved/wontfix
-(same field, no schema change).
+(same field, no schema change). Store curated nodes in the durable
+home-directory graph (``MemoryGraph.curated()``), not the cwd-relative
+per-project default.
 
 Copyright 2025 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0

--- a/tests/unit/memory/test_graph.py
+++ b/tests/unit/memory/test_graph.py
@@ -704,6 +704,20 @@ class TestFindSimilarErgonomics:
 
         assert any(node.id == bug_id for node, _score in results)
 
+    def test_free_text_question_matches_at_default_threshold(self, populated_graph):
+        """Test a question-shaped query clears the default threshold.
+
+        Regression guard for the dogfood finding that free text scored
+        by Jaccard tops out near 0.1 against verbose nodes (the union
+        term dominates), silently returning [] at any sane threshold.
+        Free text scores by query-word containment instead.
+        """
+        graph, bug_id, _, _ = populated_graph
+
+        results = graph.find_similar("what fixed the null pointer")
+
+        assert any(node.id == bug_id for node, _score in results)
+
     def test_default_threshold_admits_paraphrase(self, populated_graph):
         """Test a natural paraphrase clears the default threshold.
 

--- a/tests/unit/memory/test_graph.py
+++ b/tests/unit/memory/test_graph.py
@@ -637,3 +637,85 @@ class TestClearOperation:
         assert len(graph._nodes_by_type) == 0
         assert len(graph._nodes_by_workflow) == 0
         assert len(graph._edges_by_source) == 0
+
+
+# =============================================================================
+# CURATED MEMORY HOME (friction A) AND find_similar ERGONOMICS (friction C)
+# =============================================================================
+
+
+class TestCuratedGraphHome:
+    """Test the durable home-directory factory for curated memory."""
+
+    def test_curated_lives_under_home_attune_memory(self, monkeypatch, tmp_path):
+        """Test curated() resolves to ~/.attune/memory/curated_graph.json."""
+        from pathlib import Path
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        graph = MemoryGraph.curated()
+
+        assert graph.path == tmp_path / ".attune" / "memory" / "curated_graph.json"
+        assert graph.path.exists()
+
+    def test_curated_round_trips_across_instances(self, monkeypatch, tmp_path):
+        """Test a curated node written via one instance reloads in a fresh one."""
+        from pathlib import Path
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        writer = MemoryGraph.curated()
+        node_id = writer.add_finding(
+            workflow="",
+            finding={
+                "type": "feedback",
+                "name": "Prefer real round-trip tests over mocks",
+                "description": "Mock-blind bugs in attune.memory, 2026-07-01",
+                "status": "active",
+            },
+        )
+
+        reader = MemoryGraph.curated()
+        node = reader.get_node(node_id)
+
+        assert node is not None
+        assert node.type == NodeType.FEEDBACK
+        assert node.status == "active"
+
+
+class TestFindSimilarErgonomics:
+    """Test find_similar's string forms and paraphrase-friendly default."""
+
+    def test_accepts_node_id_and_excludes_self(self, populated_graph):
+        """Test passing a node ID builds the query from that node."""
+        graph, bug_id, fix_id, _ = populated_graph
+
+        results = graph.find_similar(bug_id, threshold=0.0)
+
+        returned_ids = [node.id for node, _score in results]
+        assert bug_id not in returned_ids  # self-match excluded
+        assert fix_id in returned_ids  # shares file + null-check wording
+
+    def test_accepts_free_text_query(self, populated_graph):
+        """Test a non-ID string is treated as free text."""
+        graph, bug_id, _, _ = populated_graph
+
+        results = graph.find_similar("null pointer in auth code", threshold=0.1)
+
+        assert any(node.id == bug_id for node, _score in results)
+
+    def test_default_threshold_admits_paraphrase(self, populated_graph):
+        """Test a natural paraphrase clears the default threshold.
+
+        Regression guard for the friction-log finding that the old
+        default (0.5) muted realistic paraphrases: this query scores
+        between 0.25 and 0.5 against the bug node, so it must match at
+        the default but would have been silently filtered before.
+        """
+        graph, bug_id, _, _ = populated_graph
+
+        results = graph.find_similar({"name": "null pointer error auth"})
+
+        match = next(((node, score) for node, score in results if node.id == bug_id), None)
+        assert match is not None
+        assert match[1] < 0.5  # would have been filtered at the old default

--- a/tests/unit/memory/test_graph.py
+++ b/tests/unit/memory/test_graph.py
@@ -704,6 +704,13 @@ class TestFindSimilarErgonomics:
 
         assert any(node.id == bug_id for node, _score in results)
 
+    def test_empty_free_text_returns_no_results(self, populated_graph):
+        """Test empty and whitespace-only free-text queries return []."""
+        graph, _, _, _ = populated_graph
+
+        assert graph.find_similar("") == []
+        assert graph.find_similar("   ") == []
+
     def test_free_text_question_matches_at_default_threshold(self, populated_graph):
         """Test a question-shaped query clears the default threshold.
 


### PR DESCRIPTION
## Summary

Fixes Frictions **A** and **C** from the memory-nodetype friction log
(`docs/specs/memory-nodetype-friction-log/decisions.md`), per the
2026-07-02 alignment: fix A and C now, leave B (edge direction) open as
R4 evidence.

### Friction A — durable home for curated memory

- `MemoryGraph.curated()` classmethod opens the cross-session curated
  graph at `~/.attune/memory/curated_graph.json` (same durable root
  `personal.py` already uses).
- The constructor's cwd-relative `patterns/memory_graph.json` default is
  untouched — it remains correct for per-project workflow findings.
- `nodes.py` / `add_finding` docstrings now route curated nodes there.

### Friction C — find_similar ergonomics

- Accepts `dict | str`: a node ID builds the query from that node's
  fields and **excludes it from results** (mirroring `find_related`'s
  id-based signature); any other string is free text matched against
  name and description. Previously a node ID died with
  `AttributeError: 'str' object has no attribute 'get'`.
- Default `threshold` lowered **0.5 → 0.25**: the old default only
  matched near-verbatim wording (observed paraphrase scores 0.301/0.125
  were silently filtered, reading like dead recall from outside). The
  sole production caller passes an explicit threshold, so this is
  additive.

### Tests (real round-trips, no mocks)

- `curated()` path resolution + cross-instance round-trip with
  `status="active"` reload.
- Node-ID query excludes self and finds the related fix node; free-text
  query finds the bug node.
- Regression guard: a paraphrase scoring <0.5 matches at the new
  default (would have been filtered at the old one).

2,732 tests across all `find_similar`/memory suites pass locally.

Also records the alignment decisions and the read-side wiring scope in
the friction-log decisions.md, and adds the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)