### PR TITLE
fix(hooks): allowlist intentional external trees in worktree_path_guard

### DIFF
--- a/src/attune/hooks/scripts/worktree_path_guard.py
+++ b/src/attune/hooks/scripts/worktree_path_guard.py
@@ -16,6 +16,15 @@ against it. Meets all three promotion criteria (recurrence ≥2
 distinct sessions, cost ≥10 min recovery, mechanical check
 available).
 
+Some non-project trees are deliberate Write/Edit targets (e.g. the
+curated-memory repo at ``~/.attune/memory`` — a second git tree that
+is the R1 deliverable home for
+docs/specs/curated-memory-productionization/). Those roots are
+allowlisted via ``DEFAULT_ALLOWED_EXTERNAL_ROOTS`` and can be
+extended per-machine with the ``ATTUNE_WORKTREE_GUARD_ALLOW`` env
+var (``os.pathsep``-separated roots). Everything else stays
+default-deny.
+
 Claude Code Protocol:
     stdin: JSON with tool_name and tool_input
     exit 0: allow tool call
@@ -32,6 +41,7 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -40,6 +50,46 @@ from typing import Any
 
 ENFORCEMENT_NAME = "worktree_path_guard"
 METRICS_LOG = Path.home() / ".attune" / "enforcement-metrics.jsonl"
+
+# Roots OUTSIDE any session worktree that are legitimate Write/Edit
+# targets. ~/.attune/memory is the curated-memory repo — a deliberate
+# second git tree (docs/specs/curated-memory-productionization/, D4).
+DEFAULT_ALLOWED_EXTERNAL_ROOTS: tuple[str, ...] = ("~/.attune/memory",)
+
+# Extend the allowlist without editing code: an os.pathsep-separated
+# list of additional allowed root directories.
+ALLOWLIST_ENV_VAR = "ATTUNE_WORKTREE_GUARD_ALLOW"
+
+
+def _allowed_external_roots() -> list[Path]:
+    """Return the allowlisted external roots, ``~``-expanded.
+
+    Combines ``DEFAULT_ALLOWED_EXTERNAL_ROOTS`` with any roots in the
+    ``ATTUNE_WORKTREE_GUARD_ALLOW`` env var (``os.pathsep``-separated).
+    """
+    raw = list(DEFAULT_ALLOWED_EXTERNAL_ROOTS)
+    raw.extend(os.environ.get(ALLOWLIST_ENV_VAR, "").split(os.pathsep))
+    return [Path(entry.strip()).expanduser() for entry in raw if entry.strip()]
+
+
+def _matched_allowlist_root(target: Path) -> Path | None:
+    """Return the allowlisted root containing ``target``, or ``None``.
+
+    Containment is checked on resolved paths so symlinks and ``..``
+    segments can't dodge (or spoof) a match, and a sibling like
+    ``~/.attune/memory-evil`` never matches ``~/.attune/memory``.
+    """
+    try:
+        resolved = target.resolve()
+    except (OSError, RuntimeError):
+        return None
+    for root in _allowed_external_roots():
+        try:
+            resolved.relative_to(root.resolve())
+        except (ValueError, OSError):
+            continue
+        return root
+    return None
 
 
 def _git_toplevel(start: Path) -> Path | None:
@@ -75,6 +125,8 @@ def _log_metric(outcome: str, session_root: Path | None, target_root: Path | Non
 
     - ``"fired"``: the hook blocked a wrong-tree write
     - ``"allowed"``: the hook ran and the paths matched (no block)
+    - ``"allowlisted"``: the target is under an allowlisted external
+      root (deliberate non-project tree; no block)
     - ``"unknown"``: couldn't determine session or target worktree
       (degraded mode; do not block in this case)
     """
@@ -114,6 +166,13 @@ def main(context: dict[str, Any]) -> int:
     if not target_path.is_absolute():
         return 0
 
+    # Allowlisted external trees (e.g. the curated-memory repo) are
+    # deliberate non-project targets — allow before any git comparison.
+    allowed_root = _matched_allowlist_root(target_path)
+    if allowed_root is not None:
+        _log_metric("allowlisted", None, allowed_root)
+        return 0
+
     # Determine the session's worktree (from cwd at hook invocation).
     session_root = _git_toplevel(Path.cwd())
 
@@ -138,6 +197,7 @@ def main(context: dict[str, Any]) -> int:
 
     # Mismatch — block.
     _log_metric("fired", session_root, target_root)
+    allow_roots = ", ".join(str(r) for r in _allowed_external_roots())
     msg = (
         f"\n[worktree-path-guard] BLOCKED Write/Edit to {file_path}\n"
         f"  Session worktree:  {session_root}\n"
@@ -146,8 +206,11 @@ def main(context: dict[str, Any]) -> int:
         "tree than the one you're working in.\n"
         "  Fix: change the path to use this session's worktree, "
         "or switch your session if you intended the other tree.\n"
-        "  Override: re-issue with the path you intended; if the "
-        "mismatch is intentional this hook will need tuning.\n"
+        "  Intentional external tree? Allowlisted roots bypass this "
+        f"guard (currently: {allow_roots}).\n"
+        f"  Extend via the {ALLOWLIST_ENV_VAR} env var "
+        "(os.pathsep-separated roots) or "
+        "DEFAULT_ALLOWED_EXTERNAL_ROOTS in worktree_path_guard.py.\n"
         "\n  (See docs/specs/enforcement-vs-documentation/ for "
         "the framework this enforcement runs under.)\n"
     )

--- a/tests/unit/hooks/test_worktree_path_guard.py
+++ b/tests/unit/hooks/test_worktree_path_guard.py
@@ -7,6 +7,9 @@ Covers:
 
 - Allow when target path matches session worktree
 - Block (exit 2) when target path is in a different worktree
+- Allow when target is under an allowlisted external root
+  (default ~/.attune/memory, extendable via
+  ATTUNE_WORKTREE_GUARD_ALLOW)
 - Allow when target file's directory doesn't exist yet (degraded)
 - Allow when tool isn't Edit/Write
 - Allow when path is relative (no wrong-tree risk)
@@ -20,6 +23,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import os
 import runpy
 import subprocess
 import sys
@@ -146,6 +150,111 @@ class TestDifferentWorktreeBlock:
             if line
         ]
         assert len(records) == 1
+        assert records[0]["outcome"] == "fired"
+
+
+# ---------------------------------------------------------------------
+# Allowlisted external roots → allow
+# ---------------------------------------------------------------------
+
+
+def _read_metrics(log_path: Path) -> list[dict]:
+    return [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+
+
+class TestAllowlist:
+    def test_default_allowlist_contains_attune_memory(self, hook_module):
+        """The shipped default allowlist covers the curated-memory repo."""
+        roots = hook_module._allowed_external_roots()
+        assert Path.home() / ".attune" / "memory" in roots
+
+    def test_default_attune_memory_write_passes(
+        self, hook_module, isolated_metrics_log, two_git_trees, monkeypatch, tmp_path
+    ):
+        """A write into ~/.attune/memory (a separate git tree) passes
+        via the default allowlist even from inside another worktree."""
+        tree_a, _ = two_git_trees
+        fake_home = tmp_path / "fake-home"
+        memory = fake_home / ".attune" / "memory"
+        memory.mkdir(parents=True)
+        subprocess.run(["git", "init", "--quiet"], cwd=memory, check=True, timeout=5)
+        # ~ expands via HOME on POSIX, USERPROFILE on Windows.
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
+        monkeypatch.chdir(tree_a)
+        target = memory / "note.md"
+        code = hook_module.main({"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+        assert code == 0
+        records = _read_metrics(isolated_metrics_log)
+        assert len(records) == 1
+        assert records[0]["outcome"] == "allowlisted"
+
+    def test_env_var_extends_allowlist(
+        self, hook_module, isolated_metrics_log, two_git_trees, monkeypatch
+    ):
+        """ATTUNE_WORKTREE_GUARD_ALLOW adds roots without a code edit."""
+        tree_a, tree_b = two_git_trees
+        monkeypatch.setenv(hook_module.ALLOWLIST_ENV_VAR, str(tree_b))
+        monkeypatch.chdir(tree_a)
+        target = tree_b / "external.md"
+        code = hook_module.main({"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+        assert code == 0
+        records = _read_metrics(isolated_metrics_log)
+        assert records[0]["outcome"] == "allowlisted"
+
+    def test_env_var_multiple_entries(
+        self, hook_module, isolated_metrics_log, two_git_trees, monkeypatch, tmp_path
+    ):
+        """The env var is os.pathsep-separated; a match in any entry allows."""
+        tree_a, tree_b = two_git_trees
+        other = tmp_path / "some-other-root"
+        other.mkdir()
+        monkeypatch.setenv(
+            hook_module.ALLOWLIST_ENV_VAR, os.pathsep.join([str(other), str(tree_b)])
+        )
+        monkeypatch.chdir(tree_a)
+        target = tree_b / "external.md"
+        code = hook_module.main({"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+        assert code == 0
+        records = _read_metrics(isolated_metrics_log)
+        assert records[0]["outcome"] == "allowlisted"
+
+    def test_non_allowlisted_cross_tree_still_blocks(
+        self, hook_module, isolated_metrics_log, two_git_trees, monkeypatch, tmp_path, capsys
+    ):
+        """Default-deny survives: a cross-tree write to a root NOT on the
+        allowlist still blocks, and the message names the allowlist."""
+        tree_a, tree_b = two_git_trees
+        unrelated = tmp_path / "unrelated-allowed-root"
+        unrelated.mkdir()
+        monkeypatch.setenv(hook_module.ALLOWLIST_ENV_VAR, str(unrelated))
+        monkeypatch.chdir(tree_a)
+        target = tree_b / "wrong_tree.py"
+        code = hook_module.main({"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "BLOCKED" in captured.err
+        assert hook_module.ALLOWLIST_ENV_VAR in captured.err
+        assert "DEFAULT_ALLOWED_EXTERNAL_ROOTS" in captured.err
+        records = _read_metrics(isolated_metrics_log)
+        assert records[0]["outcome"] == "fired"
+
+    def test_sibling_of_allowlisted_root_blocks(
+        self, hook_module, isolated_metrics_log, two_git_trees, monkeypatch
+    ):
+        """A sibling dir sharing the allowlisted root's name as a prefix
+        (memory vs memory-evil) must NOT match the allowlist."""
+        tree_a, tree_b = two_git_trees
+        allowed = tree_b / "memory"
+        sibling = tree_b / "memory-evil"
+        allowed.mkdir()
+        sibling.mkdir()
+        monkeypatch.setenv(hook_module.ALLOWLIST_ENV_VAR, str(allowed))
+        monkeypatch.chdir(tree_a)
+        target = sibling / "sneaky.md"
+        code = hook_module.main({"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+        assert code == 2
+        records = _read_metrics(isolated_metrics_log)
         assert records[0]["outcome"] == "fired"
 
 


### PR DESCRIPTION
## Summary

`worktree_path_guard.py` blocked legitimate writes to `~/.attune/memory` — the curated-memory repo (silversurfer562/attune-agent-memory), a deliberate second git tree that is the R1 deliverable home for the curated-memory-productionization spec (D4). The 2026-07-02 workaround (write to scratchpad, `cp` via Bash) defeated the guard without adding safety.

## Changes

- **Default allowlist**: `DEFAULT_ALLOWED_EXTERNAL_ROOTS = ("~/.attune/memory",)` — writes under it bypass the git-tree comparison.
- **Env-var extension**: `ATTUNE_WORKTREE_GUARD_ALLOW` (os.pathsep-separated roots) extends the allowlist per machine without a code edit.
- **Block message** now names both mechanisms so future sessions know how to extend instead of working around.
- **Metrics**: new `allowlisted` outcome so the enforcement-retirement review can distinguish these from plain same-tree allows.
- Containment is checked on resolved paths — symlinks/`..` can't dodge a match, and prefix siblings (`memory-evil`) never match `memory`.

Default-deny is unchanged for everything else — the guard still catches the parent-main-checkout write class it was built for.

## Tests

6 new tests in `tests/unit/hooks/test_worktree_path_guard.py` (22 total, all passing):

- default allowlist contains `~/.attune/memory`
- write into `~/.attune/memory` (a real second `git init` tree under a fake HOME, cross-platform via HOME+USERPROFILE) passes with outcome `allowlisted`
- env var extends the allowlist (single and multi-entry)
- non-allowlisted cross-tree write still blocks, and the block message names `ATTUNE_WORKTREE_GUARD_ALLOW` + `DEFAULT_ALLOWED_EXTERNAL_ROOTS`
- prefix-sibling of an allowlisted root still blocks
- worktree-internal writes unchanged (existing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)