### PR TITLE
release: 9.4.0 — restore personal-memory recall

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "9.3.0"
+    "version": "9.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "23 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "9.3.0",
+      "version": "9.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v9.3.0
+# Attune AI Framework v9.4.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 9.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 9.4.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12696,3 +12696,37 @@ files.
   `uv sync --all-extras` so the venv matches. Rule: before concluding
   "main doesn't have X" from the main checkout's tree, confirm the
   checkout is actually on main.
+
+- **"Fixed" ≠ "shipped" — audit user-facing features against the PyPI
+  artifact in a clean venv with an ISOLATED $HOME, not against the
+  checkout**: 2026-07-02, the three-ring memory audit found `attune
+  memory recall` broken on shipped 9.3.0 (`personal_memory_query_failed`
+  → "No results found" for content captured seconds earlier) while the
+  identical command against main worked — the #1208 fix had merged
+  2026-07-01 but v9.3.0 was tagged 2026-06-30, and ALL local testing
+  runs main so nobody noticed the release gap. Recipe that caught it:
+  `uv venv && uv pip install <pkg>` (real PyPI), then run the
+  round-trip with `HOME=<scratch>/fakehome` — the fake HOME matters
+  twice: (a) it simulates the true new-user condition, (b)
+  PersonalMemory's storage root is the GLOBAL shared `~/.attune/memory/`
+  — an un-isolated probe wrote `demo/decision.md` straight into the
+  curated-memory git repo and dirtied `summaries_by_path.json`
+  (recovered with `rm` + `git checkout --`). Standing rule: when a
+  user-facing bug is fixed, immediately ask "is the fix RELEASED?" —
+  if not, that's release pressure, and the bug is still live for every
+  real user.
+
+- **Release-prep must diff `git log v<last>..origin/main` against the
+  changelog — `[Unreleased]` completeness cannot be trusted**:
+  2026-07-02, preparing 9.4.0, `[Unreleased]` carried only 3 entries
+  while the tag-to-main log held ~40 commits including 11 user-facing
+  PRs with NO changelog entry (the headline recall fix #1208 among
+  them; also #1173, #1187, #1193/#1195/#1205, #1197, #1200/#1201,
+  #1203, #1207, #1209). Several sessions' PRs simply skipped the
+  changelog. Release step: enumerate the full commit list since the
+  last TAG (not since the last changelog section date), classify
+  user-facing vs internal, and write the missing entries as part of
+  the release PR. Related env note: `attune-author` can be a BROKEN
+  pyenv shim (`ModuleNotFoundError: attune_author`) even when `which`
+  finds it — probe the module, not the shim, before relying on the
+  docs-regen step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.4.0] — 2026-07-02
+
+Memory repair release: the headline fix restores `attune memory recall`
+(broken on 9.3.0 — captures succeeded but recall returned no results),
+alongside the curated cross-session memory foundation, the Sonnet 5
+default, and the in-process authoring consolidation.
+
 ### Fixed
 
+- **`attune memory recall` (PersonalMemory) returned "No results
+  found" for content it had just captured.** `PersonalMemory.query()`
+  read the RAG pipeline's result as a list of dicts, but
+  `RagPipeline.run()` returns a `RagResult` whose hits live at
+  `result.citation.hits` — every recall raised internally and was
+  swallowed into an empty answer (`personal_memory_query_failed`).
+  Capture, topics, and forget were unaffected. Verified by the
+  cross-process recall benchmark (hit@1 18/18). (#1208)
+- **`MemoryGraph.add_finding()` silently dropped `status`.** Every
+  node created through the public API got the dataclass default
+  instead of the caller's value — falsifying the curated-memory
+  design (#1207) for real writes. (#1208)
 - **Curated memory gets a durable default home.**
   `MemoryGraph.curated()` opens the cross-session curated-memory graph
   at `~/.attune/memory/curated_graph.json` instead of the cwd-relative,
   typically git-tracked `patterns/memory_graph.json` default (which is
-  shaped for per-project workflow findings). Friction A from the
-  memory-nodetype friction log.
+  shaped for per-project workflow findings). (#1212)
 - **`find_similar` now accepts a node ID or free text and matches
   paraphrases at the default threshold.** Passing a node ID builds the
   query from that node (excluding it from results, mirroring
   `find_related`) instead of raising `AttributeError`; free text is
   scored by query-word containment against name and description
-  (short queries against verbose nodes score near zero under Jaccard,
-  so word-overlap scoring would return `[]` for realistic questions
-  at any sane threshold). The default `threshold`
-  drops from 0.5 (near-verbatim only — realistic paraphrases were
-  silently filtered) to 0.25. Friction C from the memory-nodetype
-  friction log.
+  (short queries against verbose nodes score near zero under Jaccard).
+  The default `threshold` drops from 0.5 to 0.25. (#1212)
+- **MCP workflow tools no longer swallow workflow errors.**
+  `_workflow_response` surfaced a generic success shape even when the
+  underlying workflow failed; the real error now reaches the caller.
+  (#1173)
+- **models/ review findings resolved.** The HIGH and MEDIUM findings
+  from the models-layer code review (error-handling and validation
+  gaps), with follow-up branch coverage. (#1200, #1201)
+- **ops dashboard: a failing `attune-author status` probe now reads
+  "unknown" instead of "clean".** Non-zero exits were being treated
+  as a clean report. (#1203)
+
+### Added
+
+- **Curated cross-session memory NodeTypes.** `USER_CONTEXT`,
+  `FEEDBACK`, `PROJECT_CONTEXT`, and `REFERENCE` join the
+  `MemoryGraph` taxonomy so curated personal/project memory can be
+  modeled first-class alongside workflow findings, with
+  `active`/`superseded`/`stale` lifecycle statuses. (#1207)
+- **Elicitation forms: `list_style` render variant** for
+  single-select questions rendered as a compact radio list. (#1187)
+- **`author-feature` plugin skill** — single-source feature-page
+  authoring driven by the consolidated in-process pipeline. (#1197)
+- **Recall benchmark: cross-process persistence mode**
+  (`scripts/memory_recall_eval.py --phase persistence`) proving
+  file-backed recall survives process death. (#1209)
 
 ### Changed
 
@@ -34,7 +73,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry, adaptive routing, providers, telemetry, and token
   estimation. Pricing is unchanged ($3/$15 per MTok standard;
   introductory $2/$10 through 2026-08-31). 1M context, 128K max output,
-  adaptive thinking; `effort` defaults to `high`.
+  adaptive thinking; `effort` defaults to `high`. (#1198, #1199)
+- **attune-author's deterministic mechanics absorbed in-process.**
+  The projector and staleness modules now live in `attune.authoring`
+  (with their upstream tests), and `help_data` resolves in-process —
+  part of the attune-author consolidation (T1/T2a). (#1193, #1195,
+  #1205)
 
 ## [9.3.0] — 2026-06-30
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 9.3.0
+**Version:** 9.4.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 9.3.0 | **License:** Apache 2.0
+**Version:** 9.4.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "9.3.0"
+    "version": "9.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "9.3.0",
+      "version": "9.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "9.3.0"
+__version__ = "9.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "9.3.0"
+version = "9.4.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "9.3.0"
+version = "9.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v9.3.0</span>
+                  <span>v9.4.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "9.3.0",
+    version: "9.4.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "9.3.0",
+    version: "9.4.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## 9.4.0

**Headline: `attune memory recall` is broken on the shipped 9.3.0** — captures succeed, recall returns "No results found" (`PersonalMemory.query()` read `RagPipeline.run()`'s `RagResult` as a list; fixed in #1208 but never released). Verified today in a clean venv installing 9.3.0 from PyPI vs the identical command on main.

Also promotes the changelog entries that were missing for post-9.3.0 work: memory NodeTypes (#1207), add_finding status fix (#1208), MCP workflow-error surfacing (#1173), models review fixes (#1200/#1201), ops status probe fix (#1203), elicitation list_style (#1187), author-feature skill (#1197), authoring consolidation (#1193/#1195/#1205), Sonnet 5 default (#1198/#1199), plus the #1212 curated-memory fixes already listed.

Bump: minor (feature PRs present). All 9 version sites via `scripts/bump_version.py`; lockfile diff is exactly the version line.

Note: `.help` regen skipped — attune-author is a broken pyenv shim in this env (module not installed); freshness item rides a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)