### PR TITLE
feat(scripts): bump_version website sites + discipline article revision

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12787,8 +12787,8 @@ files.
   any CLI smoke: exit codes and boot are necessary-not-sufficient —
   round-trip one real feature and assert on its output content, via
   the SHIPPED artifact.
-- **bump_version.py covers the website version sites as of PR #1216
 
+- **bump_version.py covers the website version sites as of PR #1216
   (2026-07-02) — the "bump features.ts/page.tsx by hand on release"
   remedy is obsolete**: epilogue to the 9.2.0/9.4.0 website-version
   lessons. The script now writes 9 files including

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12787,3 +12787,38 @@ files.
   any CLI smoke: exit codes and boot are necessary-not-sufficient —
   round-trip one real feature and assert on its output content, via
   the SHIPPED artifact.
+- **bump_version.py covers the website version sites as of PR #1216
+
+  (2026-07-02) — the "bump features.ts/page.tsx by hand on release"
+  remedy is obsolete**: epilogue to the 9.2.0/9.4.0 website-version
+  lessons. The script now writes 9 files including
+  `website/lib/features.ts` (both attune-ai product entries, anchored
+  on `pypiName: "attune-ai"` so sibling products' independent versions
+  are never touched) and `website/app/page.tsx` (the `<span>vX.Y.Z</span>`
+  badge), and `TestVersionConsistency._get_versions` mirrors both so
+  the local `test_all_versions_match` backstop names website drift
+  without waiting for CI. If a future release still trips
+  `TestFeaturesVersionSync`, the site list drifted — fix the script,
+  don't hand-bump.
+
+- **"This published claim is factually wrong/stale" about VERSION
+  NUMBERS in an article may just be a dated case study — verify
+  against PyPI `upload_time` before editing**: 2026-07-02, the
+  discipline article's "Three PyPI releases (attune-author 0.14.1,
+  attune-gui 0.8.0, attune-ai 7.1.2)" was asserted wrong-or-stale;
+  all three verified as real same-morning uploads (2026-05-25,
+  13:36–13:57 UTC via `pypi.org/pypi/<pkg>/json` →
+  `releases[ver][0].upload_time`), cross-checked against local git
+  tags + CHANGELOG dates. Historical narrative doesn't go stale —
+  old versions in a dated case study are correct, not drift. The
+  REAL defect class to look for: the passage lacking its date at the
+  point of use (§1 said "one morning"; the date sat ~900 lines later
+  in §8), which invites the misreading. Extends doc-fiction-triage
+  §2 (verify deadness/staleness as a fact, never infer it) to
+  published version claims.
+
+- **zsh compound-command micro-traps: bare `===` separators and
+  `set -- $var`**: `echo ===` dies in zsh with `== not found` (`=cmd`
+  filename expansion) — use `echo ---`; and `set -- $spec` does NOT
+  word-split in zsh (unquoted vars don't split), so `$1` gets the
+  whole string — loop over explicit pairs in python instead.

--- a/attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md
+++ b/attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md
@@ -677,9 +677,9 @@ sessions hydrate it into a fast store at startup; the handoff layer
 is machine-reconciled against git and the package index at session
 start; and the first human review pass returned its verdicts
 through a rendered form — six keeps, one sharpened, zero wrong.
-This layer is also the honest answer to the deepest asymmetry in
+This layer is also the honest answer to the deepest imbalance in
 §2 — one party cannot natively remember past sessions. The
-asymmetry doesn't disappear; it gets scaffolded. And the
+imbalance doesn't disappear; it gets scaffolded. And the
 scaffolding has a property human memory never has: what the agent
 knows at minute zero of a session is a curated, reviewed, versioned
 artifact — inspectable, diffable, and correctable by the review

--- a/attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md
+++ b/attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md
@@ -1,15 +1,16 @@
 # The Discipline of Agent Collaboration
 
-> A counter-thesis to vibe coding, from someone shipping real work
+> An answer to vibe coding, from someone shipping real work
 > this way.
 
-"Vibe coding" is the shorthand the discourse has settled on for
+"Vibe coding" is the shorthand the blogs have settled on for
 AI-assisted development — and it's a real thing, useful for
 prototypes, exploration, and the bottom of the experience curve.
 This piece is about the other 80%: the work that needs to ship,
 persist across sessions, coordinate across packages, and not break
-under multi-month load. That work isn't vibing. It's a discipline.
-The good news: it's a learnable one.
+under multi-month load. Work that isn't vibing in that sense. It's
+an approach that delegates the actual coding to the AI as part of
+a collaborative team. The good news: it's a learnable one.
 
 ---
 
@@ -30,7 +31,7 @@ couldn't otherwise see. That space requires a different posture
 from both sides. This piece is the field manual for that other
 space.
 
-The thesis in one line: collaboration with an AI agent is not a
+The point in one line: collaboration with an AI agent is not a
 *tool* problem (find a better model, write better prompts) — it is
 a *discipline* problem. A mutual contract, a shared vocabulary,
 agreed artifact shapes, named failure modes. The disciplines are
@@ -39,8 +40,8 @@ individually boring. They compound.
 And the posture isn't exotic — it's ordinary team management
 applied to a teammate who happens to be an agent: an explicit
 contract, clear handoffs, named boundaries. Practiced together,
-the disciplines produce synergies tied to the discipline
-itself; the compounding is the point, not a bonus.
+the disciplines reinforce each other; the compounding is the
+point, not a bonus.
 
 Here is what that looks like on a real morning. The ops dashboard
 is up in a browser tab. The family snapshot shows five PyPI
@@ -85,11 +86,13 @@ proactive memory write that did not exist that morning.
 What made this efficient was not magic. Five mechanisms compound.
 **Clean small PRs** — each one single-purpose, easy to scope, easy
 to review, no mega-PRs that bundle six unrelated concerns.
-**AskUserQuestion at real decision points only** — scope expansion,
-version-bump shape, release-trigger choice, admin-merge
-authorization. Never at mechanical points like "should I now run
-pytest?" The agent does not interrupt the human to ask permission
-to do its job. **Admin-merge authorization durability** — granted
+**Decision surfaces at real decision points only** — scope
+expansion, version-bump shape, release-trigger choice, admin-merge
+authorization — each rendered in the form the fork deserves, from
+a plain option list up to a dynamically built form or interactive
+report. Never at mechanical points like "should I now run pytest?"
+The agent does not interrupt the human to ask permission to do its
+job. **Admin-merge authorization durability** — granted
 once at the top of a batch, persists for similar future merges,
 zero re-asking friction within the session. **Parallel work while
 CI runs** — the agent moves to the next surfaced thing while a
@@ -109,7 +112,7 @@ incrementally, on its own or together:
   and human-approves-every-line; and its asynchronous mode for the
   work an agent does while you're away.
 - **§3 — Pacing.** Sustainability as a skill: agents don't tire,
-  the humans they work with do; clean stops and a rested cadence
+  the humans they work with do; clean stops and a rested rhythm
   raise throughput over weeks rather than lowering it.
 - **§4 — Artifact discipline.** Specs nest XML-enhanced prompts
   nest implementation; pre-committed decision matrices route
@@ -136,25 +139,25 @@ High-functioning engineering teams have used explicit working
 agreements for decades — when the team will pair, how reviews work,
 what counts as a blocker, when interrupts are okay. What we are
 doing in this section is applying the same shape to human-agent
-collaboration. The asymmetries between the two parties force a more
+collaboration. The imbalances between the two parties force a more
 explicit version of the contract than human-only teams usually
 need: one party never tires; one party cannot read past sessions
 natively; one party owns all the side effects (commits, pushes,
 releases, merges); one party can be replaced wholesale at any
 moment without warning. The contract has to do more work because of
-those asymmetries, not less.
+those imbalances, not less.
 
 The contract has two halves.
 
 The human's half is *make the agent's job possible*. Concretely:
 declare the working mode at session start — advancing a measurable
 scope, executing a planned spec, firefighting a CI issue, or
-meta-reflection with no code changes expected. State the project
+reflection and planning with no code changes expected. State the project
 (the cwd is often not the project being worked on, especially with
 worktrees). State the outcome in one sentence — what should be true
 at the end of this session that isn't true now. State the done-when
 criteria — the acceptance condition that lets either side say the
-session has finished its scoped work. None of this is performative.
+session has finished its scoped work. None of this is for show.
 Each line saves the agent from inventing wrong context and lets the
 agent push back when the work begins drifting.
 
@@ -182,35 +185,22 @@ size suggests: **ask one question at a time**. When the agent
 bundles "do you need a break?" with "what direction next?" the
 human's answer to one collapses the other. The questions interact
 and corrupt each other. The discipline is to separate them,
-sequence them, ask the load-bearing one first, and use a structured
-decision-point surface as the default form. Number the options,
-label the recommendation, keep alternatives short. This is
-mechanical — not deep — but mechanical things compound.
+sequence them, ask the load-bearing one first, and put the
+question on a structured decision surface rather than burying it
+in prose. The floor of that surface is a plain option list
+(AskUserQuestion in our tooling) — options numbered, the
+recommended one labeled, alternatives short. The floor is the
+fallback, not the default; the second pattern below names what
+sits above it. This is mechanical — not deep — but mechanical
+things compound.
 
-The surface for those questions matures with the collaboration. It
-starts as a numbered list in chat. It can grow into a small
-*grammar* of rendered forms, one shape per kind of fork: a
-**decision** form (the recommended option with its rationale and
-per-option tradeoffs — pick one), a **pushback** form (the human's
-stated approach and the agent's alternative side by side, under a
-"why I'd push back" — overrule or switch with one pick), a
-**progress** form (done, in-flight, and blocked items, with the
-blocked ones as the picker for "which do we tackle?"). The shapes
-matter less than the property they share: the fork is *rendered*,
-with the recommendation and tradeoffs visible at the moment of
-choice, and the answer collapses to one pick instead of a
-paragraph. Any tooling that can put a structured choice in front of
-a human can do this; ours renders them as forms in the chat
-surface. This is the contract's decision points getting a surface
-of their own.
-
-> **Pattern: shorthand as vocabulary primitive.** A human
+> **Pattern: shorthand as a building block.** A human
 > collaborator says "give me feedback" — singular phrase, no
 > parameters. The agent reads it as a request for the full
 > discovery kit: opportunities, options, next steps, pros and
 > cons, anything load-bearing the agent noticed but didn't
 > surface. Re-specifying the kit each time would waste the
-> primitive — the shorthand IS the contract. The pattern
+> building block — the shorthand IS the contract. The pattern
 > generalizes: any phrase the human uses repeatedly should be
 > readable by the agent as a structured invocation, not as a
 > literal-string request. The agent's job is to learn the human's
@@ -218,6 +208,27 @@ of their own.
 > owes a memory write the first time it notices the shorthand
 > pattern — so future sessions inherit the vocabulary instead of
 > relearning it from scratch.
+
+> **Pattern: the form grammar.** The shorthand pattern above is
+> the human's half of a shared vocabulary. The agent's half is a
+> small grammar of structured surfaces it composes at forks: an
+> intake form that batches the independent dimensions of one
+> decision into a single multi-select surface; a decision card
+> carrying the recommended option, the rationale, and per-option
+> tradeoffs; a pushback card that sets the human's stated approach
+> beside the agent's alternative under "why I'd push back"; a
+> progress report that buckets work into done, in-flight, and
+> blocked, and makes the blocked items pickable. The shapes matter
+> less than the property they share: the fork is *rendered*, with
+> the recommendation and tradeoffs visible at the moment of
+> choice, and the answer collapses to one pick instead of a
+> paragraph. When the fork outgrows a list, the agent owes the
+> richer surface — a dynamically built form, a dashboard, an
+> interactive report — rather than the floor. Any tooling that can
+> put a structured choice in front of a human can do this; ours
+> renders forms in the chat surface. None of this violates
+> one-question-at-a-time: dimensions that are independent batch
+> into one form; questions that interact stay sequenced.
 
 The PR-and-approve cycle is where the contract lives at the
 day-to-day level. There are two failure modes flanking it. On one
@@ -294,8 +305,8 @@ altitude is the tell — tasks-level work survives an away-window;
 design-level work belongs in the synchronous window where you're
 present to answer. A compact invocation helps: in our tooling
 `auto: <specs or PRs>` reads as "these are execution-ready, run
-them to the boundary" — the same shorthand-as-vocabulary primitive
-from earlier in this section.
+them to the boundary" — the same shorthand-as-building-block
+pattern from earlier in this section.
 
 The agent's half is to narrow to what is genuinely safe and fresh;
 hold hard guardrails (no irreversible or outward-facing act — no
@@ -326,8 +337,8 @@ death-march anti-pattern and its predictably brittle output. The
 standard expectation in mature teams that velocity must be averaged
 over recovery time rather than measured in sprint peaks. The same
 evidence applies to human-agent collaboration, even though the
-asymmetry has shifted. Agents do not tire. The humans they work
-with do. Ignoring that asymmetry produces the downstream quality
+imbalance has shifted. Agents do not tire. The humans they work
+with do. Ignoring that imbalance produces the downstream quality
 cost it always has — but the cost can land later than expected
 because the agent's energy masks the human's exhaustion for hours
 past where the work should have stopped.
@@ -391,7 +402,7 @@ Because the shape of the work changes when you optimize for
 sustainability over throughput. You write better artifacts when you
 write them rested. You make fewer desperate decisions when you have
 the option to defer until tomorrow. The agent learns your real
-cadence rather than averaging across grinds, which means future
+rhythm rather than averaging across grinds, which means future
 sessions calibrate against the work you do *well* rather than the
 work you do *exhausted*. The compounding here is across weeks: the
 team (you, the agent, the codebase) gets better-shaped when each
@@ -493,8 +504,8 @@ formality for its own sake — each one pays specific rent:
 
 The four-file structure is small and the editing cost is low —
 most spec edits touch one or two files at a time. The discipline
-is that the files exist *before* implementation starts, not after
-as rationalization-of-already-shipped work.
+is that the files exist *before* implementation starts, not after,
+as excuses written for work that already shipped.
 
 **XML-enhanced prompt.** Right artifact when the work touches
 three or more files with dependencies, when the unit will be
@@ -562,8 +573,8 @@ unit. Each one stands alone (a locked design constraint). When a
 future session picks up the derivative-form work (LinkedIn post
 from §8, Discord drops from §3/§5/§7, Twitter thread from §6), the
 foundation piece is the source-of-truth and the derivative work
-reads one section at a time. The structure makes the work
-compositional.
+reads one section at a time. The structure lets each piece stand
+alone and combine.
 
 One more property to name: artifact discipline is what makes
 *handoffs* possible. A session ending at "spec approved, three
@@ -670,7 +681,7 @@ When the human teaches the agent something non-obvious —
 preference, pattern, validated approach — the agent's job is to
 *name the memory type AND implement the write*, in the same
 response. "I'll save this as a feedback memory" without the actual
-write is performative. The write without the naming leaves the
+write is for show. The write without the naming leaves the
 human guessing whether the agent actually got it. Both halves
 required. Both in the same response.
 
@@ -813,9 +824,9 @@ asks. Authorization durability is *not* permission to expand. It is
 permission to repeat the same pattern.
 
 > **Before adopting this pattern.** Admin-merge authorization
-> durability is an advanced move. It presumes preconditions an
-> inexperienced operator may not have, and adopting it without
-> them turns a safety mechanism into theater.
+> durability is an advanced move. It assumes conditions an
+> inexperienced operator may not yet have in place, and adopting
+> it without them turns a safety mechanism into theater.
 >
 > - **Trust history.** The human has watched the agent operate
 >   over many prior decision points — observed it push back, ask
@@ -890,7 +901,7 @@ opened as
 [attune-ai #469](https://github.com/Smart-AI-Memory/attune-ai/pull/469).
 
 The point of the worked example is the meta-shape. The article's
-central thesis — discipline produces better work faster — gets
+central claim — discipline produces better work faster — gets
 demonstrated by the act of using the discipline to address the
 discipline's own friction. The spec design AND the implementation
 AND this paragraph are all products of the same multi-hour session.
@@ -1011,7 +1022,7 @@ then X, if B then Y" matrix *before* measurement and the
 measurement automatically routes the decision: nothing to "review,"
 because the matrix says what to do, the measurement says which
 branch fires, and the decision follows mechanically. This
-eliminates the post-hoc rationalization where the human or the
+removes the after-the-fact excuse-making where the human or the
 agent finds reasons to favor the more interesting path against what
 the data actually says.
 
@@ -1054,7 +1065,7 @@ the strongest is the one that says the work is *true*, not merely
 faithfulness** on attune-rag's golden set — better than
 ninety-nine parts in a hundred of the individual claims the system
 makes are checkably traceable to a source. And it got there by
-structure, not by exhortation. That is what verification buys that
+structure, not by asking the model to try harder. That is what verification buys that
 taste cannot.
 
 ---
@@ -1172,7 +1183,8 @@ pace with the work instead of trailing it. A handful of clean stops
 at completion boundaries when the human signaled fatigue.
 
 The point of the case study is not that the morning was
-breathtaking. No single decision in that sequence was virtuoso. The
+breathtaking. No single decision in that sequence was a showpiece.
+The
 shipped releases were routine. The spec was small. The
 implementation was an hour and a half of focused work. What made
 the morning unusual was the *absence* of friction: no parallel-push
@@ -1228,8 +1240,8 @@ Drafting an earlier revision of this piece surfaced a friction
 none of the six disciplines quite covered; naming it produced a
 new spec by the end of that session. The discipline doesn't only
 describe the work. It constrains and improves its own
-construction. That is the synergy — tied to the discipline itself,
-not to any one tool.
+construction. That is the compounding — tied to the discipline
+itself, not to any one tool.
 
 That is the discipline of agent collaboration. We are still
 learning it. We hope this is useful.
@@ -1241,8 +1253,8 @@ learning it. We hope this is useful.
 This piece was written collaboratively. Patrick Roebuck (founder,
 Smart AI Memory) drafting, directing, and making every irreversible
 call; an AI agent helping to author under the discipline this
-article describes. Patrick brings three decades of software
-development plus earlier years in coordination-heavy roles outside
+article describes. Patrick brings two decades of developing online
+solutions plus earlier years in coordination-heavy roles outside
 engineering — patterns that shape his approach to contracts,
 pacing, and multi-party work. The past year-plus has been spent
 building the [attune-\* ecosystem](https://github.com/Smart-AI-Memory)

--- a/attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md
+++ b/attune-ai-dev/discipline/COLLABORATION_DISCIPLINE.md
@@ -83,7 +83,7 @@ pushback on the agent's own plan (running code-review on a
 config-only PR produces no signal — skip it, save the budget). One
 proactive memory write that did not exist that morning.
 
-What made this efficient was not magic. Five mechanisms compound.
+What made this efficient was not magic. Six mechanisms compound.
 **Clean small PRs** — each one single-purpose, easy to scope, easy
 to review, no mega-PRs that bundle six unrelated concerns.
 **Decision surfaces at real decision points only** — scope
@@ -100,8 +100,13 @@ twelve-platform matrix cycles, never serializing waiting time,
 because waiting is wasted human attention. **The dashboard as live
 state** — surfacing what changed, what's ready, what's anomalous,
 so the agent doesn't have to ask the human to re-explain context
-that is visible on screen. None of these is clever in isolation.
-The compounding is the discipline.
+that is visible on screen. **Verification attached to every
+"done"** — the agent does not report finished; it reports finished
+*with the receipt*: the CI state, the test output, the smoke-test
+result. The human approves on evidence, not on the agent's
+confidence. §7 gives this its own section because it is the
+discipline the others lean on. None of these is clever in
+isolation. The compounding is the discipline.
 
 The rest of this piece names the six disciplines that produce
 mornings like that — each its own section, each adoptable
@@ -255,6 +260,10 @@ human picks. The agent executes the mechanical span until the next
 decision point. Today's session had roughly twelve decision points
 across eight PRs. Each was a discrete surface from the agent, each
 got a discrete answer, the mechanical work between was hands-off.
+What made each approval cheap was the evidence attached to it —
+the CI state, the test run, the diff. An approval that rests on
+the agent's say-so is a guess with extra steps; an approval that
+rests on a receipt is a decision.
 
 The shape that makes this work is *the agent earning the human's
 trust at the mechanical layer*. When the human approves "go ship

--- a/attune-ai-dev/discipline/index.html
+++ b/attune-ai-dev/discipline/index.html
@@ -274,7 +274,7 @@ queued in CHANGELOG; the dependabot replacement). One in-session
 pushback on the agent's own plan (running code-review on a
 config-only PR produces no signal — skip it, save the budget). One
 proactive memory write that did not exist that morning.</p>
-<p>What made this efficient was not magic. Five mechanisms compound.
+<p>What made this efficient was not magic. Six mechanisms compound.
 <strong>Clean small PRs</strong> — each one single-purpose, easy to scope, easy
 to review, no mega-PRs that bundle six unrelated concerns.
 <strong>Decision surfaces at real decision points only</strong> — scope
@@ -291,8 +291,13 @@ twelve-platform matrix cycles, never serializing waiting time,
 because waiting is wasted human attention. <strong>The dashboard as live
 state</strong> — surfacing what changed, what's ready, what's anomalous,
 so the agent doesn't have to ask the human to re-explain context
-that is visible on screen. None of these is clever in isolation.
-The compounding is the discipline.</p>
+that is visible on screen. <strong>Verification attached to every
+&quot;done&quot;</strong> — the agent does not report finished; it reports finished
+<em>with the receipt</em>: the CI state, the test output, the smoke-test
+result. The human approves on evidence, not on the agent's
+confidence. §7 gives this its own section because it is the
+discipline the others lean on. None of these is clever in
+isolation. The compounding is the discipline.</p>
 <p>The rest of this piece names the six disciplines that produce
 mornings like that — each its own section, each adoptable
 incrementally, on its own or together:</p>
@@ -436,7 +441,11 @@ the decision points clearly with the recommendation labeled. The
 human picks. The agent executes the mechanical span until the next
 decision point. Today's session had roughly twelve decision points
 across eight PRs. Each was a discrete surface from the agent, each
-got a discrete answer, the mechanical work between was hands-off.</p>
+got a discrete answer, the mechanical work between was hands-off.
+What made each approval cheap was the evidence attached to it —
+the CI state, the test run, the diff. An approval that rests on
+the agent's say-so is a guess with extra steps; an approval that
+rests on a receipt is a decision.</p>
 <p>The shape that makes this work is <em>the agent earning the human's
 trust at the mechanical layer</em>. When the human approves &quot;go ship
 these three releases in simplest-first order,&quot; they are not

--- a/attune-ai-dev/discipline/index.html
+++ b/attune-ai-dev/discipline/index.html
@@ -855,9 +855,9 @@ sessions hydrate it into a fast store at startup; the handoff layer
 is machine-reconciled against git and the package index at session
 start; and the first human review pass returned its verdicts
 through a rendered form — six keeps, one sharpened, zero wrong.
-This layer is also the honest answer to the deepest asymmetry in
+This layer is also the honest answer to the deepest imbalance in
 §2 — one party cannot natively remember past sessions. The
-asymmetry doesn't disappear; it gets scaffolded. And the
+imbalance doesn't disappear; it gets scaffolded. And the
 scaffolding has a property human memory never has: what the agent
 knows at minute zero of a session is a curated, reviewed, versioned
 artifact — inspectable, diffable, and correctable by the review

--- a/attune-ai-dev/discipline/index.html
+++ b/attune-ai-dev/discipline/index.html
@@ -193,23 +193,24 @@
 </head>
 <body>
   <div class="draft-banner">
-    Revised 2026-07-02 &middot;
+    Draft v4 &middot; final edits in progress &middot;
     <a href="/">attune-ai.dev</a>
   </div>
   <article>
     <a class="home-link" href="/">&larr; attune-ai</a>
 <h1>The Discipline of Agent Collaboration</h1>
 <blockquote>
-<p>A counter-thesis to vibe coding, from someone shipping real work
+<p>An answer to vibe coding, from someone shipping real work
 this way.</p>
 </blockquote>
-<p>&quot;Vibe coding&quot; is the shorthand the discourse has settled on for
+<p>&quot;Vibe coding&quot; is the shorthand the blogs have settled on for
 AI-assisted development — and it's a real thing, useful for
 prototypes, exploration, and the bottom of the experience curve.
 This piece is about the other 80%: the work that needs to ship,
 persist across sessions, coordinate across packages, and not break
-under multi-month load. That work isn't vibing. It's a discipline.
-The good news: it's a learnable one.</p>
+under multi-month load. Work that isn't vibing in that sense. It's
+an approach that delegates the actual coding to the AI as part of
+a collaborative team. The good news: it's a learnable one.</p>
 <hr />
 <h2>§1 — The Premise: Why Discipline, Why Now</h2>
 <p>Most &quot;AI-assisted development&quot; stops at suggestion and accept. The
@@ -226,7 +227,7 @@ days, dashboards surfacing live state from sibling sessions you
 couldn't otherwise see. That space requires a different posture
 from both sides. This piece is the field manual for that other
 space.</p>
-<p>The thesis in one line: collaboration with an AI agent is not a
+<p>The point in one line: collaboration with an AI agent is not a
 <em>tool</em> problem (find a better model, write better prompts) — it is
 a <em>discipline</em> problem. A mutual contract, a shared vocabulary,
 agreed artifact shapes, named failure modes. The disciplines are
@@ -234,8 +235,8 @@ individually boring. They compound.</p>
 <p>And the posture isn't exotic — it's ordinary team management
 applied to a teammate who happens to be an agent: an explicit
 contract, clear handoffs, named boundaries. Practiced together,
-the disciplines produce synergies tied to the discipline
-itself; the compounding is the point, not a bonus.</p>
+the disciplines reinforce each other; the compounding is the
+point, not a bonus.</p>
 <p>Here is what that looks like on a real morning. The ops dashboard
 is up in a browser tab. The family snapshot shows five PyPI
 packages tracked. Telemetry shows yesterday's spend and today's.
@@ -276,11 +277,13 @@ proactive memory write that did not exist that morning.</p>
 <p>What made this efficient was not magic. Five mechanisms compound.
 <strong>Clean small PRs</strong> — each one single-purpose, easy to scope, easy
 to review, no mega-PRs that bundle six unrelated concerns.
-<strong>AskUserQuestion at real decision points only</strong> — scope expansion,
-version-bump shape, release-trigger choice, admin-merge
-authorization. Never at mechanical points like &quot;should I now run
-pytest?&quot; The agent does not interrupt the human to ask permission
-to do its job. <strong>Admin-merge authorization durability</strong> — granted
+<strong>Decision surfaces at real decision points only</strong> — scope
+expansion, version-bump shape, release-trigger choice, admin-merge
+authorization — each rendered in the form the fork deserves, from
+a plain option list up to a dynamically built form or interactive
+report. Never at mechanical points like &quot;should I now run pytest?&quot;
+The agent does not interrupt the human to ask permission to do its
+job. <strong>Admin-merge authorization durability</strong> — granted
 once at the top of a batch, persists for similar future merges,
 zero re-asking friction within the session. <strong>Parallel work while
 CI runs</strong> — the agent moves to the next surfaced thing while a
@@ -299,7 +302,7 @@ PR-and-approve cycle as the middle path between agent-acts-alone
 and human-approves-every-line; and its asynchronous mode for the
 work an agent does while you're away.</li>
 <li><strong>§3 — Pacing.</strong> Sustainability as a skill: agents don't tire,
-the humans they work with do; clean stops and a rested cadence
+the humans they work with do; clean stops and a rested rhythm
 raise throughput over weeks rather than lowering it.</li>
 <li><strong>§4 — Artifact discipline.</strong> Specs nest XML-enhanced prompts
 nest implementation; pre-committed decision matrices route
@@ -323,23 +326,23 @@ High-functioning engineering teams have used explicit working
 agreements for decades — when the team will pair, how reviews work,
 what counts as a blocker, when interrupts are okay. What we are
 doing in this section is applying the same shape to human-agent
-collaboration. The asymmetries between the two parties force a more
+collaboration. The imbalances between the two parties force a more
 explicit version of the contract than human-only teams usually
 need: one party never tires; one party cannot read past sessions
 natively; one party owns all the side effects (commits, pushes,
 releases, merges); one party can be replaced wholesale at any
 moment without warning. The contract has to do more work because of
-those asymmetries, not less.</p>
+those imbalances, not less.</p>
 <p>The contract has two halves.</p>
 <p>The human's half is <em>make the agent's job possible</em>. Concretely:
 declare the working mode at session start — advancing a measurable
 scope, executing a planned spec, firefighting a CI issue, or
-meta-reflection with no code changes expected. State the project
+reflection and planning with no code changes expected. State the project
 (the cwd is often not the project being worked on, especially with
 worktrees). State the outcome in one sentence — what should be true
 at the end of this session that isn't true now. State the done-when
 criteria — the acceptance condition that lets either side say the
-session has finished its scoped work. None of this is performative.
+session has finished its scoped work. None of this is for show.
 Each line saves the agent from inventing wrong context and lets the
 agent push back when the work begins drifting.</p>
 <p>The agent's half is <em>make the partnership durable</em>. Neutral
@@ -364,34 +367,22 @@ size suggests: <strong>ask one question at a time</strong>. When the agent
 bundles &quot;do you need a break?&quot; with &quot;what direction next?&quot; the
 human's answer to one collapses the other. The questions interact
 and corrupt each other. The discipline is to separate them,
-sequence them, ask the load-bearing one first, and use a structured
-decision-point surface as the default form. Number the options,
-label the recommendation, keep alternatives short. This is
-mechanical — not deep — but mechanical things compound.</p>
-<p>The surface for those questions matures with the collaboration. It
-starts as a numbered list in chat. It can grow into a small
-<em>grammar</em> of rendered forms, one shape per kind of fork: a
-<strong>decision</strong> form (the recommended option with its rationale and
-per-option tradeoffs — pick one), a <strong>pushback</strong> form (the human's
-stated approach and the agent's alternative side by side, under a
-&quot;why I'd push back&quot; — overrule or switch with one pick), a
-<strong>progress</strong> form (done, in-flight, and blocked items, with the
-blocked ones as the picker for &quot;which do we tackle?&quot;). The shapes
-matter less than the property they share: the fork is <em>rendered</em>,
-with the recommendation and tradeoffs visible at the moment of
-choice, and the answer collapses to one pick instead of a
-paragraph. Any tooling that can put a structured choice in front of
-a human can do this; ours renders them as forms in the chat
-surface. This is the contract's decision points getting a surface
-of their own.</p>
+sequence them, ask the load-bearing one first, and put the
+question on a structured decision surface rather than burying it
+in prose. The floor of that surface is a plain option list
+(AskUserQuestion in our tooling) — options numbered, the
+recommended one labeled, alternatives short. The floor is the
+fallback, not the default; the second pattern below names what
+sits above it. This is mechanical — not deep — but mechanical
+things compound.</p>
 <blockquote>
-<p><strong>Pattern: shorthand as vocabulary primitive.</strong> A human
+<p><strong>Pattern: shorthand as a building block.</strong> A human
 collaborator says &quot;give me feedback&quot; — singular phrase, no
 parameters. The agent reads it as a request for the full
 discovery kit: opportunities, options, next steps, pros and
 cons, anything load-bearing the agent noticed but didn't
 surface. Re-specifying the kit each time would waste the
-primitive — the shorthand IS the contract. The pattern
+building block — the shorthand IS the contract. The pattern
 generalizes: any phrase the human uses repeatedly should be
 readable by the agent as a structured invocation, not as a
 literal-string request. The agent's job is to learn the human's
@@ -399,6 +390,28 @@ vocabulary, not to demand it be re-specified. The agent also
 owes a memory write the first time it notices the shorthand
 pattern — so future sessions inherit the vocabulary instead of
 relearning it from scratch.</p>
+</blockquote>
+<blockquote>
+<p><strong>Pattern: the form grammar.</strong> The shorthand pattern above is
+the human's half of a shared vocabulary. The agent's half is a
+small grammar of structured surfaces it composes at forks: an
+intake form that batches the independent dimensions of one
+decision into a single multi-select surface; a decision card
+carrying the recommended option, the rationale, and per-option
+tradeoffs; a pushback card that sets the human's stated approach
+beside the agent's alternative under &quot;why I'd push back&quot;; a
+progress report that buckets work into done, in-flight, and
+blocked, and makes the blocked items pickable. The shapes matter
+less than the property they share: the fork is <em>rendered</em>, with
+the recommendation and tradeoffs visible at the moment of
+choice, and the answer collapses to one pick instead of a
+paragraph. When the fork outgrows a list, the agent owes the
+richer surface — a dynamically built form, a dashboard, an
+interactive report — rather than the floor. Any tooling that can
+put a structured choice in front of a human can do this; ours
+renders forms in the chat surface. None of this violates
+one-question-at-a-time: dimensions that are independent batch
+into one form; questions that interact stay sequenced.</p>
 </blockquote>
 <p>The PR-and-approve cycle is where the contract lives at the
 day-to-day level. There are two failure modes flanking it. On one
@@ -469,8 +482,8 @@ altitude is the tell — tasks-level work survives an away-window;
 design-level work belongs in the synchronous window where you're
 present to answer. A compact invocation helps: in our tooling
 <code>auto: &lt;specs or PRs&gt;</code> reads as &quot;these are execution-ready, run
-them to the boundary&quot; — the same shorthand-as-vocabulary primitive
-from earlier in this section.</p>
+them to the boundary&quot; — the same shorthand-as-building-block
+pattern from earlier in this section.</p>
 <p>The agent's half is to narrow to what is genuinely safe and fresh;
 hold hard guardrails (no irreversible or outward-facing act — no
 merge to a protected branch, no publish, no new repo, nothing
@@ -496,8 +509,8 @@ death-march anti-pattern and its predictably brittle output. The
 standard expectation in mature teams that velocity must be averaged
 over recovery time rather than measured in sprint peaks. The same
 evidence applies to human-agent collaboration, even though the
-asymmetry has shifted. Agents do not tire. The humans they work
-with do. Ignoring that asymmetry produces the downstream quality
+imbalance has shifted. Agents do not tire. The humans they work
+with do. Ignoring that imbalance produces the downstream quality
 cost it always has — but the cost can land later than expected
 because the agent's energy masks the human's exhaustion for hours
 past where the work should have stopped.</p>
@@ -555,7 +568,7 @@ Because the shape of the work changes when you optimize for
 sustainability over throughput. You write better artifacts when you
 write them rested. You make fewer desperate decisions when you have
 the option to defer until tomorrow. The agent learns your real
-cadence rather than averaging across grinds, which means future
+rhythm rather than averaging across grinds, which means future
 sessions calibrate against the work you do <em>well</em> rather than the
 work you do <em>exhausted</em>. The compounding here is across weeks: the
 team (you, the agent, the codebase) gets better-shaped when each
@@ -687,8 +700,8 @@ move the goalposts on past-you.</li>
 </ul>
 <p>The four-file structure is small and the editing cost is low —
 most spec edits touch one or two files at a time. The discipline
-is that the files exist <em>before</em> implementation starts, not after
-as rationalization-of-already-shipped work.</p>
+is that the files exist <em>before</em> implementation starts, not after,
+as excuses written for work that already shipped.</p>
 <p><strong>XML-enhanced prompt.</strong> Right artifact when the work touches
 three or more files with dependencies, when the unit will be
 executed by a subagent or future session, and when you want a
@@ -749,8 +762,8 @@ unit. Each one stands alone (a locked design constraint). When a
 future session picks up the derivative-form work (LinkedIn post
 from §8, Discord drops from §3/§5/§7, Twitter thread from §6), the
 foundation piece is the source-of-truth and the derivative work
-reads one section at a time. The structure makes the work
-compositional.</p>
+reads one section at a time. The structure lets each piece stand
+alone and combine.</p>
 <p>One more property to name: artifact discipline is what makes
 <em>handoffs</em> possible. A session ending at &quot;spec approved, three
 tasks queued as XML prompts&quot; can be picked up by a different agent
@@ -845,7 +858,7 @@ When the human teaches the agent something non-obvious —
 preference, pattern, validated approach — the agent's job is to
 <em>name the memory type AND implement the write</em>, in the same
 response. &quot;I'll save this as a feedback memory&quot; without the actual
-write is performative. The write without the naming leaves the
+write is for show. The write without the naming leaves the
 human guessing whether the agent actually got it. Both halves
 required. Both in the same response.</p>
 <p>The reason is that the teaching moment is the moment with the
@@ -972,9 +985,9 @@ asks. Authorization durability is <em>not</em> permission to expand. It is
 permission to repeat the same pattern.</p>
 <blockquote>
 <p><strong>Before adopting this pattern.</strong> Admin-merge authorization
-durability is an advanced move. It presumes preconditions an
-inexperienced operator may not have, and adopting it without
-them turns a safety mechanism into theater.</p>
+durability is an advanced move. It assumes conditions an
+inexperienced operator may not yet have in place, and adopting
+it without them turns a safety mechanism into theater.</p>
 <ul>
 <li><strong>Trust history.</strong> The human has watched the agent operate
 over many prior decision points — observed it push back, ask
@@ -1046,7 +1059,7 @@ smoke test against the live dashboard confirmed the cycle. The PR
 opened as
 <a href="https://github.com/Smart-AI-Memory/attune-ai/pull/469">attune-ai #469</a>.</p>
 <p>The point of the worked example is the meta-shape. The article's
-central thesis — discipline produces better work faster — gets
+central claim — discipline produces better work faster — gets
 demonstrated by the act of using the discipline to address the
 discipline's own friction. The spec design AND the implementation
 AND this paragraph are all products of the same multi-hour session.
@@ -1151,7 +1164,7 @@ then X, if B then Y&quot; matrix <em>before</em> measurement and the
 measurement automatically routes the decision: nothing to &quot;review,&quot;
 because the matrix says what to do, the measurement says which
 branch fires, and the decision follows mechanically. This
-eliminates the post-hoc rationalization where the human or the
+removes the after-the-fact excuse-making where the human or the
 agent finds reasons to favor the more interesting path against what
 the data actually says.</p>
 <h3>What holds the four together</h3>
@@ -1189,7 +1202,7 @@ the strongest is the one that says the work is <em>true</em>, not merely
 faithfulness</strong> on attune-rag's golden set — better than
 ninety-nine parts in a hundred of the individual claims the system
 makes are checkably traceable to a source. And it got there by
-structure, not by exhortation. That is what verification buys that
+structure, not by asking the model to try harder. That is what verification buys that
 taste cannot.</p>
 <hr />
 <h2>§8 — What This Looks Like When It Goes Right: A Twenty-Four-Hour Case Study</h2>
@@ -1294,7 +1307,8 @@ code rather than as a separate coverage push — verification kept
 pace with the work instead of trailing it. A handful of clean stops
 at completion boundaries when the human signaled fatigue.</p>
 <p>The point of the case study is not that the morning was
-breathtaking. No single decision in that sequence was virtuoso. The
+breathtaking. No single decision in that sequence was a showpiece.
+The
 shipped releases were routine. The spec was small. The
 implementation was an hour and a half of focused work. What made
 the morning unusual was the <em>absence</em> of friction: no parallel-push
@@ -1346,8 +1360,8 @@ Drafting an earlier revision of this piece surfaced a friction
 none of the six disciplines quite covered; naming it produced a
 new spec by the end of that session. The discipline doesn't only
 describe the work. It constrains and improves its own
-construction. That is the synergy — tied to the discipline itself,
-not to any one tool.</p>
+construction. That is the compounding — tied to the discipline
+itself, not to any one tool.</p>
 <p>That is the discipline of agent collaboration. We are still
 learning it. We hope this is useful.</p>
 <hr />
@@ -1355,8 +1369,8 @@ learning it. We hope this is useful.</p>
 <p>This piece was written collaboratively. Patrick Roebuck (founder,
 Smart AI Memory) drafting, directing, and making every irreversible
 call; an AI agent helping to author under the discipline this
-article describes. Patrick brings three decades of software
-development plus earlier years in coordination-heavy roles outside
+article describes. Patrick brings two decades of developing online
+solutions plus earlier years in coordination-heavy roles outside
 engineering — patterns that shape his approach to contracts,
 pacing, and multi-party work. The past year-plus has been spent
 building the <a href="https://github.com/Smart-AI-Memory">attune-* ecosystem</a>

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -15,14 +15,21 @@ surface). Writes, in one validated pass:
    footer (``**Version:** X``)
 7. ``docs/reference/API_REFERENCE.md`` — header and footer
    (``**Version:** X``)
+8. ``website/lib/features.ts`` — the two attune-ai product entries
+   (``pypiName: "attune-ai"`` + ``version: "X"``; other products'
+   versions are independent and never touched)
+9. ``website/app/page.tsx`` — homepage badge (``<span>vX</span>``)
 
 Every replacement is count-checked against the expected number of
 occurrences BEFORE any file is written; a mismatch aborts with no
 partial state. After writing, all sites are re-read and verified.
 
-Backstop guard: ``tests/unit/plugins/test_plugin_config_validation.py
+Backstop guards: ``tests/unit/plugins/test_plugin_config_validation.py
 ::TestVersionConsistency::test_all_versions_match`` (asserts all
-sites equal — fails with a pointer to this script).
+sites equal — fails with a pointer to this script) and
+``tests/unit/test_website_version_accuracy.py::TestFeaturesVersionSync``
+(website sites vs pyproject — the guard that turned every CI lane red
+on the 9.4.0 release when this script didn't yet cover the website).
 
 Usage:
     python scripts/bump_version.py 8.5.0
@@ -94,6 +101,21 @@ def _sites(root: Path) -> list[Site]:
             "**Version:** {v}",
             2,
             min_count=True,
+        ),
+        # Website sites — enforced by tests/unit/
+        # test_website_version_accuracy.py in the required CI lanes.
+        # The pattern is anchored on pypiName so the other products'
+        # independent versions (attune-help, attune-author) are never
+        # matched even if one coincides with the attune-ai version.
+        Site(
+            root / "website" / "lib" / "features.ts",
+            'pypiName: "attune-ai",\n    version: "{v}"',
+            2,
+        ),
+        Site(
+            root / "website" / "app" / "page.tsx",
+            "<span>v{v}</span>",
+            1,
         ),
     ]
 

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -420,6 +420,32 @@ class TestVersionConsistency:
         versions["docs/reference/API_REFERENCE.md:header"] = found[0]
         versions["docs/reference/API_REFERENCE.md:footer"] = found[-1]
 
+        # Website surfaces — the drift that turned every CI lane red on
+        # the 9.4.0 release (PR #1215): bump_version.py covered the
+        # package/plugin sites but not these, and the coupling test
+        # (tests/unit/test_website_version_accuracy.py) only caught it
+        # in CI. Mirrored here so this single local backstop names them
+        # too. Guarded like the sibling test: skip if website/ absent.
+        features = REPO_ROOT / "website" / "lib" / "features.ts"
+        if features.is_file():
+            text = features.read_text(encoding="utf-8")
+            found = re.findall(
+                r'pypiName: "attune-ai",\s+version: "(\d+\.\d+\.\d+)"',
+                text,
+            )
+            assert len(found) >= 2, "features.ts attune-ai version entries missing"
+            for i, v in enumerate(found):
+                versions[f"website/lib/features.ts:attune-ai[{i}]"] = v
+
+        homepage = REPO_ROOT / "website" / "app" / "page.tsx"
+        if homepage.is_file():
+            badge = re.search(
+                r"<span>v(\d+\.\d+\.\d+)</span>",
+                homepage.read_text(encoding="utf-8"),
+            )
+            assert badge, "page.tsx homepage version badge missing"
+            versions["website/app/page.tsx:badge"] = badge.group(1)
+
         return versions
 
     def test_all_versions_match(self) -> None:

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -1,7 +1,8 @@
 """Tests for scripts/bump_version.py (drift-guards-to-generators R4).
 
 Covers:
-- happy path: all 7 files / 9 sites rewritten, old version returned;
+- happy path: all 9 files rewritten (14 occurrences), old version
+  returned;
 - dry-run: validation runs, nothing written;
 - semver / same-version rejection;
 - count-mismatch aborts BEFORE any write (no partial state);
@@ -77,6 +78,36 @@ def fixture_root(tmp_path: Path) -> Path:
         f"# API\n\n**Version:** {OLD}\n\nbody\n\n**Version:** {OLD} | tail\n",
         encoding="utf-8",
     )
+    web_lib = tmp_path / "website" / "lib"
+    web_lib.mkdir(parents=True)
+    # Two attune-ai product entries plus a sibling product whose
+    # version must NOT be touched (the pypiName anchor guards it).
+    (web_lib / "features.ts").write_text(
+        "export const PRODUCTS = [\n"
+        "  {\n"
+        '    id: "attune-ai",\n'
+        '    pypiName: "attune-ai",\n'
+        f'    version: "{OLD}",\n'
+        "  },\n"
+        "  {\n"
+        '    id: "attune-help",\n'
+        '    pypiName: "attune-help",\n'
+        '    version: "0.1.0",\n'
+        "  },\n"
+        "  {\n"
+        '    id: "claude-code-plugin",\n'
+        '    pypiName: "attune-ai",\n'
+        f'    version: "{OLD}",\n'
+        "  },\n"
+        "];\n",
+        encoding="utf-8",
+    )
+    web_app = tmp_path / "website" / "app"
+    web_app.mkdir(parents=True)
+    (web_app / "page.tsx").write_text(
+        f"<div>\n  <span>v{OLD}</span>\n</div>\n",
+        encoding="utf-8",
+    )
     return tmp_path
 
 
@@ -91,6 +122,8 @@ def _all_texts(root: Path) -> str:
             root / "plugin" / "core" / "__init__.py",
             root / ".claude" / "CLAUDE.md",
             root / "docs" / "reference" / "API_REFERENCE.md",
+            root / "website" / "lib" / "features.ts",
+            root / "website" / "app" / "page.tsx",
         ]
     )
 
@@ -102,8 +135,12 @@ class TestBump:
         combined = _all_texts(fixture_root)
         assert OLD not in combined
         # 1 pyproject + 1 plugin.json + 2+2 marketplace + 1 __init__
-        # + 2 CLAUDE.md + 2 API_REFERENCE = 11 occurrences
-        assert combined.count(NEW) == 11
+        # + 2 CLAUDE.md + 2 API_REFERENCE + 2 features.ts
+        # + 1 page.tsx = 14 occurrences
+        assert combined.count(NEW) == 14
+        # The sibling product's independent version is untouched.
+        features = fixture_root / "website" / "lib" / "features.ts"
+        assert 'version: "0.1.0"' in features.read_text(encoding="utf-8")
 
     def test_dry_run_writes_nothing(self, mod, fixture_root: Path) -> None:
         before = _all_texts(fixture_root)


### PR DESCRIPTION
Three related units, one branch:

## 1. bump_version.py covers website version sites

`scripts/bump_version.py` wrote 9 version sites across 7 files but not the two website sites that `tests/unit/test_website_version_accuracy.py` enforces. On the 9.4.0 release (PR #1215) this turned every CI lane red until `website/lib/features.ts` and `website/app/page.tsx` were bumped by hand.

- New sites (now 9 files): the two attune-ai `version:` entries in features.ts (anchored on `pypiName: "attune-ai"` so sibling products are never touched) and the page.tsx homepage badge — same count-validate-before-write / verify-after discipline
- `TestVersionConsistency._get_versions` mirrors both, so the local `test_all_versions_match` backstop catches website drift without CI
- Script test fixture extended (occurrence count 11 → 14, sibling-product guard); real-repo dry run passes: "would bump 9.3.0 -> 999.0.0 across 9 files"

## 2. Discipline article revision (source + rebuilt index.html)

- Patrick's edits: "the blogs" for "the discourse", the opening now defines the approach plainly, authorship bio corrected
- The §1/§2 AskUserQuestion mentions are now mechanism-neutral (a plain option list is the floor of a decision surface, not the default) and a new "Pattern: the form grammar" callout names the intake / decision / pushback / progress constructs and the richer surfaces the agent owes when a fork outgrows a list
- Plain-English pass, all swaps user-approved: discourse, counter-thesis, thesis, synergies, performative, exhortation, virtuoso, meta-reflection, asymmetries, vocabulary primitive, compositional, rationalization (incl. post-hoc), cadence, presumes preconditions

## 3. Session lessons

Three entries in `.claude/lessons.md`: the bump_version website epilogue, verify-history-via-PyPI-upload_time before "fixing" a dated case study, and two zsh compound-command micro-traps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
