### PR TITLE
feat(ci): smoke gate probes memory recall round-trip + fix recall --json stdout pollution

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -533,7 +533,11 @@ jobs:
     # transitively imports an extras-only dependency (e.g. fastapi from the
     # [ops] extra) and crashes on startup — invisible to the rest of the
     # suite, which always installs the extras. 8.5.0 shipped exactly this
-    # (attune --help -> ModuleNotFoundError: fastapi). Self-contained (it
+    # (attune --help -> ModuleNotFoundError: fastapi). Also probes the
+    # personal-memory capture -> recall round-trip under a fake HOME,
+    # asserting on recall CONTENT: 9.3.0 shipped with recall broken
+    # (exit 0, "No results found.") while unit tests stayed green because
+    # they mocked the broken RAG layer. Self-contained (it
     # builds its own wheel) so it never skips on an upstream failure — a
     # skipped required check would block every merge.
     name: default-install-smoke

--- a/scripts/smoke_default_install.sh
+++ b/scripts/smoke_default_install.sh
@@ -15,6 +15,13 @@
 # This gate reproduces the real default-install environment and boots the
 # CLI, so that class can never ship again.
 #
+# It also probes the personal-memory capture -> recall round-trip against
+# the shipped wheel. 9.3.0 shipped with `attune memory recall` broken
+# (capture succeeded; recall printed "No results found." and exited 0)
+# while every unit test was green — the tests mocked the RAG layer that
+# was broken. The probe asserts on recall CONTENT under a fake HOME,
+# never on the exit code, so that class can't ship again either.
+#
 # Usage:
 #   scripts/smoke_default_install.sh [path/to/attune_ai-*.whl]
 #
@@ -61,4 +68,48 @@ ATTUNE="$WORK/venv/bin/attune"
 "$ATTUNE" --help >/dev/null
 "$ATTUNE" version
 
-echo "PASS: default-install CLI boots without extras"
+echo "== smoke: personal-memory capture -> recall must round-trip =="
+# The 9.3.0 regression class: recall exits 0 even with zero hits, so a
+# boot-only smoke can't see it. Probe under a fake HOME (isolated global
+# memory root, exactly the clean-venv + fake-HOME audit that caught the
+# original bug) and assert on the returned content. ANTHROPIC_API_KEY is
+# set EMPTY (not unset) so dotenv cannot inject a real key; the whole
+# round-trip is keyless (polish degrades gracefully without attune-author).
+PROBE_HOME="$WORK/home"
+mkdir -p "$PROBE_HOME"
+SENTINEL="smoke sentinel: the quarterly fox prefers decaf espresso"
+
+(
+  cd "$WORK"
+  HOME="$PROBE_HOME" ANTHROPIC_API_KEY="" \
+    "$ATTUNE" memory capture smoke-recall-probe "$SENTINEL" --kind reference
+)
+CAPTURED="$PROBE_HOME/.attune/memory/smoke-recall-probe/reference.md"
+if [[ ! -f "$CAPTURED" ]]; then
+  echo "FAIL: capture wrote nothing at $CAPTURED"
+  exit 1
+fi
+
+RECALL_JSON="$(
+  cd "$WORK"
+  HOME="$PROBE_HOME" ANTHROPIC_API_KEY="" \
+    "$ATTUNE" memory recall "quarterly fox decaf espresso" --json
+)"
+# NOTE: `python - <<HEREDOC` would consume stdin for the script itself,
+# leaving json.load(sys.stdin) an empty stream — pipe into `-c` instead.
+printf '%s' "$RECALL_JSON" | "$VPY" -c '
+import json
+import sys
+
+hits = json.load(sys.stdin)
+if not hits:
+    sys.exit(
+        "FAIL: recall returned zero hits for freshly captured content "
+        "(the 9.3.0 broken-round-trip class - exit code alone would not catch this)"
+    )
+if not any("smoke-recall-probe" in hit.get("path", "") for hit in hits):
+    sys.exit("FAIL: recall hits do not include the captured topic: %r" % hits)
+print("confirmed: recall round-trips (%d hit(s), top: %s)" % (len(hits), hits[0]["path"]))
+'
+
+echo "PASS: default-install CLI boots and personal memory round-trips without extras"

--- a/src/attune/cli_commands/memory_commands.py
+++ b/src/attune/cli_commands/memory_commands.py
@@ -154,17 +154,29 @@ def cmd_memory_recall(args: Namespace) -> int:
         0 on success, 1 on failure.
 
     """
+    import contextlib
+    import io
     import json as json_mod
+    import sys
 
     from attune.memory.personal import PersonalMemory
 
     try:
         pm = PersonalMemory(project_root=None)
-        hits = pm.query(
-            args.query,
-            k=getattr(args, "k", 3),
-            kind_filter=getattr(args, "kind_filter", None),
-        )
+        # The RAG layer logs to stdout (structlog's default PrintLogger),
+        # which pollutes `--json` output and breaks machine consumers
+        # (`attune memory recall ... --json | jq` fails on the log line).
+        # Capture anything the query writes to stdout and forward it to
+        # stderr, keeping stdout pure result output in both modes.
+        log_noise = io.StringIO()
+        with contextlib.redirect_stdout(log_noise):
+            hits = pm.query(
+                args.query,
+                k=getattr(args, "k", 3),
+                kind_filter=getattr(args, "kind_filter", None),
+            )
+        if log_noise.getvalue():
+            print(log_noise.getvalue(), file=sys.stderr, end="")
         if getattr(args, "json", False):
             print(json_mod.dumps(hits, indent=2))
             return 0

--- a/tests/unit/test_cli_memory_commands.py
+++ b/tests/unit/test_cli_memory_commands.py
@@ -411,6 +411,42 @@ class TestCmdMemoryRecall:
         parsed = json_mod.loads(out)
         assert parsed[0]["score"] == 0.9
 
+    @patch(_PERSONAL_MEM)
+    def test_json_output_survives_stdout_log_noise(self, MockPM, capsys) -> None:
+        """--json stdout stays parseable when the query layer logs to stdout.
+
+        Regression guard: the RAG layer logs via structlog's default
+        PrintLogger, which writes to stdout. That polluted `--json` output
+        (a `rag.run` info line ahead of the JSON), breaking machine
+        consumers like `attune memory recall ... --json | jq`. The handler
+        must forward that noise to stderr and keep stdout pure JSON.
+        """
+        import json as json_mod
+
+        from attune.cli_commands.memory_commands import cmd_memory_recall
+
+        hits = [{"path": "auth-design/decision.md", "score": 0.9}]
+
+        def noisy_query(*_args, **_kwargs):
+            print("2026-07-02 [info] rag.run retriever=KeywordRetriever")
+            return hits
+
+        MockPM.return_value.query.side_effect = noisy_query
+
+        args = MagicMock()
+        args.query = "auth"
+        args.k = 3
+        args.kind_filter = None
+        args.json = True
+
+        result = cmd_memory_recall(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        parsed = json_mod.loads(captured.out)  # raises if stdout is polluted
+        assert parsed[0]["score"] == 0.9
+        assert "rag.run" in captured.err  # noise forwarded, not swallowed
+
 
 class TestCmdMemoryTopics:
     """Tests for cmd_memory_topics."""


### PR DESCRIPTION
Institutionalizes the probe that caught the 9.3.0 broken-recall bug —
the required `default-install-smoke` gate now exercises the
personal-memory capture -> recall round-trip against the shipped
wheel, not just CLI boot. (Follow-through from the Discipline
article's C9: "dogfood the artifact you actually ship." #1218's §7
receipt is this bug's story; this PR makes the catch structural.)

## What

- **`scripts/smoke_default_install.sh`** — new probe: fake-HOME
  (isolated global memory root), keyless (`ANTHROPIC_API_KEY=""`,
  empty not unset), `attune memory capture` -> `recall --json`,
  asserting on returned CONTENT. Recall exits 0 even with zero hits
  ("No results found."), which is exactly why a boot-only gate missed
  9.3.0 — the assertion is on the JSON, never the exit code.
- **`src/attune/cli_commands/memory_commands.py`** — product bug the
  probe surfaced by dogfooding: the RAG layer logs to stdout
  (structlog default PrintLogger), so `recall --json` emitted a
  `rag.run` log line ahead of the JSON — `... --json | jq` was
  unparseable. Query-time stdout noise is now forwarded to stderr;
  stdout stays pure result output.
- **`tests/unit/test_cli_memory_commands.py`** — regression guard:
  `--json` stdout must parse as JSON even when the query layer prints
  log noise; the noise must land on stderr, not be swallowed.
- **`.github/workflows/tests.yml`** — job doc comment updated. Job
  id/name UNCHANGED (`default-install-smoke` is a required check).

## Receipts

- Full script run against a locally built 9.4.0 wheel: bare install,
  CLI boots, capture -> recall returns the captured content, log
  noise on stderr, stdout parses as pure JSON, `PASS`.
- `tests/unit/test_cli_memory_commands.py`: 30/30 green.
- `tests/unit/ci/test_workflow_yaml.py`: 261 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
