### PR TITLE
chore(usage-signals): 2026-07-02 reach snapshot + release lesson

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12730,3 +12730,15 @@ files.
   pyenv shim (`ModuleNotFoundError: attune_author`) even when `which`
   finds it — probe the module, not the shim, before relying on the
   docs-regen step.
+
+- **Right after a PyPI publish, `uv pip install <pkg>==<new>` fails
+  "no version of <pkg>==<new>" from uv's OWN index cache even while
+  the simple index already serves the wheel — add
+  `--refresh-package <pkg>`**: hit closing the 9.4.0 loop (2026-07-02):
+  the simple-index poll had confirmed wheel+sdist live, yet the
+  clean-venv verification install errored "we can conclude that your
+  requirements are unsatisfiable." Not a PyPI propagation delay — a
+  local uv cache; `uv pip install --refresh-package attune-ai -U
+  attune-ai==9.4.0` succeeded immediately. Applies to every
+  post-publish verification step; don't misread it as "publish didn't
+  work" (the simple-index poll is the authority on that).

--- a/docs/specs/usage-signals/snapshots/2026-07-02.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-02.json
@@ -1,0 +1,27 @@
+{
+  "date": "2026-07-02",
+  "github": {},
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 51,
+      "last_month": 3529,
+      "last_week": 906
+    },
+    "attune-author": {
+      "last_day": 23,
+      "last_month": 2714,
+      "last_week": 104
+    },
+    "attune-help": {
+      "last_day": 6,
+      "last_month": 316,
+      "last_week": 41
+    },
+    "attune-rag": {
+      "last_day": 459,
+      "last_month": 35324,
+      "last_week": 5463
+    }
+  },
+  "taken_at": "2026-07-02T17:02:41.418053+00:00"
+}


### PR DESCRIPTION
Reach baseline for the v9.4.0 release (usage-signals R4): pypistats for 4/5 packages — attune-verify stayed rate-limited across three spaced retries (penalty outlasts the documented 15-min cooldown); it joins the next snapshot rather than a fourth retry (tar-pit guard). attune-ai pre-release baseline: 51/day, 906/week, 3529/month.

Also carries the session's last lesson: uv's index cache reports "no such version" immediately post-publish — verify installs need --refresh-package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)