### PR TITLE
feat(publish): discipline article publish mode + smartaimemory.com/discipline alias

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12742,3 +12742,48 @@ files.
   attune-ai==9.4.0` succeeded immediately. Applies to every
   post-publish verification step; don't misread it as "publish didn't
   work" (the simple-index poll is the authority on that).
+
+- **PyPI's package-level JSON endpoint (`/pypi/<pkg>/json`) can serve
+  a STALE cached `info.version` (~1h+ after publish) — verify releases
+  via the version-specific endpoint or the simple index**: hit
+  2026-07-02 fact-checking the discipline article: `/pypi/attune-ai/
+  json` said latest=9.3.0 with "9.4.0 NOT ON PYPI" a while after
+  9.4.0's wheel was live, and I wrongly flagged the release claim as
+  failing verification. Authoritative checks: `/pypi/<pkg>/<ver>/json`
+  (200 + upload_time), the simple index (wheel filename listed),
+  `git ls-remote --tags`, and the publish run conclusion. Sibling of
+  the existing uv-cache lesson (local cache, opposite direction) —
+  BOTH directions of "the convenient endpoint lies near a publish
+  boundary": never assert a release exists/is-missing from the
+  package-level JSON alone.
+
+- **Two shell diagnostics that lie: `python - <<HEREDOC` eats the
+  stdin you piped in, and zsh MULTIOS invalidates `2>&1 1>/dev/null`
+  stream isolation**: both hit 2026-07-02 debugging the smoke-gate
+  recall probe. (1) `printf '%s' "$DATA" | python - <<'PY' ...
+  json.load(sys.stdin)` reads EMPTY — with `python -`, stdin IS the
+  script source (the heredoc overrides the pipe), so after the script
+  is read, sys.stdin is at EOF; symptom is `JSONDecodeError: Expecting
+  value: line 1 column 1 (char 0)`. Pipe into `python -c '<code>'`
+  instead. (2) Testing "is this on stderr?" with `cmd 2>&1 1>/dev/null
+  | head` under zsh shows stdout ANYWAY — zsh multios tees stdout to
+  both `/dev/null` AND the pipe, so the "stderr-only" view contains
+  stdout and you misattribute streams (I briefly concluded JSON was
+  printed to stderr). Use bash for stream-isolation tests, or
+  `1>/dev/null` via a wrapper script.
+
+- **A boot-only install smoke gate passes broken features — assert on
+  CONTENT of a real round-trip, because "no results" paths exit 0**:
+  9.3.0's broken `attune memory recall` (capture ok, recall empty)
+  sailed through the required default-install-smoke because the gate
+  only ran `attune --help` / `version`, and recall's zero-hit path
+  prints "No results found." with exit 0. Fixed 2026-07-02 (#1219):
+  the gate now does a fake-HOME capture -> `recall --json` and parses
+  the output asserting the captured topic is IN it. Dogfooding that
+  probe surfaced a second live bug: structlog's default PrintLogger
+  writes to STDOUT, so `recall --json` emitted a `rag.run` log line
+  ahead of the JSON (unparseable for `| jq`); fixed by forwarding
+  query-time stdout noise to stderr + regression test. Pattern for
+  any CLI smoke: exit codes and boot are necessary-not-sufficient —
+  round-trip one real feature and assert on its output content, via
+  the SHIPPED artifact.

--- a/attune-ai-dev/build_discipline.py
+++ b/attune-ai-dev/build_discipline.py
@@ -62,7 +62,7 @@ TEMPLATE = """<!doctype html>
 </head>
 <body>
   <div class="draft-banner">
-    {draft_label} &middot; final edits in progress &middot;
+    {banner_line}
     <a href="/">attune-ai.dev</a>
   </div>
   <article>
@@ -101,8 +101,16 @@ def _neutralize_relative_links(body_html: str) -> str:
     return _ANCHOR_RE.sub(repl, body_html)
 
 
-def render(draft_label: str) -> str:
-    """Render the source markdown into the branded HTML page."""
+def render(draft_label: str, published_label: str | None = None) -> str:
+    """Render the source markdown into the branded HTML page.
+
+    Args:
+        draft_label: Draft marker (e.g. "Draft v5"); banner reads
+            "<label> · final edits in progress".
+        published_label: When set (e.g. "Revised 2026-07-02"), publish
+            mode — the banner drops "final edits in progress" and shows
+            only this label.
+    """
     if not SOURCE.is_file():
         raise SystemExit(f"source not found: {SOURCE}")
 
@@ -111,12 +119,17 @@ def render(draft_label: str) -> str:
     md = MarkdownIt("commonmark", {"html": False, "linkify": True}).enable("table")
     body_html = _neutralize_relative_links(md.render(md_text))
 
+    if published_label:
+        banner_line = f"{published_label} &middot;"
+    else:
+        banner_line = f"{draft_label} &middot; final edits in progress &middot;"
+
     return TEMPLATE.format(
         brand_css=BRAND_CSS,
         title=PAGE_TITLE,
         desc=PAGE_DESC,
         canonical=CANONICAL,
-        draft_label=draft_label,
+        banner_line=banner_line,
         body=body_html,
     )
 
@@ -128,9 +141,18 @@ def main() -> int:
         default="Draft v4",
         help="Draft marker shown in the banner (default: 'Draft v4').",
     )
+    parser.add_argument(
+        "--published",
+        metavar="LABEL",
+        default=None,
+        help=(
+            "Publish mode: replace the draft banner with this label "
+            '(e.g. "Revised 2026-07-02") and drop "final edits in progress".'
+        ),
+    )
     args = parser.parse_args()
 
-    html = render(args.draft_label)
+    html = render(args.draft_label, published_label=args.published)
     OUTPUT.write_text(html, encoding="utf-8")
     print(f"wrote {OUTPUT} ({len(html):,} bytes)")
     return 0

--- a/attune-ai-dev/discipline/index.html
+++ b/attune-ai-dev/discipline/index.html
@@ -193,7 +193,7 @@
 </head>
 <body>
   <div class="draft-banner">
-    Draft v5 &middot; final edits in progress &middot;
+    Revised 2026-07-02 &middot;
     <a href="/">attune-ai.dev</a>
   </div>
   <article>

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -52,6 +52,11 @@ const nextConfig: NextConfig = {
       { source: '/book/', destination: '/docs/', permanent: true },
       { source: '/chapter-23/', destination: '/docs/', permanent: true },
       { source: '/plugins/', destination: '/docs/#plugin', permanent: true },
+      // The Discipline of Agent Collaboration — canonical home is
+      // attune-ai.dev/discipline (deployed from attune-ai-dev/ on every
+      // merge to main); this alias keeps the smartaimemory.com URL live.
+      { source: '/discipline/', destination: 'https://attune-ai.dev/discipline/', permanent: true },
+      { source: '/discipline/:path*/', destination: 'https://attune-ai.dev/discipline/:path*/', permanent: true },
     ];
   },
 };


### PR DESCRIPTION
Publishes the 2026-07-02 revision (#1218) to both requested surfaces.

- **attune-ai.dev/discipline** — already auto-deploys from `attune-ai-dev/` on merge; this PR flips the banner from "Draft v5 · final edits in progress" to **"Revised 2026-07-02"** via a new `--published LABEL` mode in `build_discipline.py` (draft mode unchanged for future drafts).
- **smartaimemory.com/discipline** — currently a 404; this PR adds a permanent redirect to the canonical `attune-ai.dev/discipline/`. Single source: the article redeploys automatically on every merge that touches it, and the smartaimemory URL stays live forever.

Verified on a local dev server: `/discipline/` → 308 → `https://attune-ai.dev/discipline/`; no server errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)